### PR TITLE
Limit Dependabot to minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "pip"
     directory: "/app/backend"
@@ -21,9 +25,22 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## What changed?

Updated Dependabot config to ignore semver-major updates across npm, pip, and GitHub Actions, while keeping grouped patch/minor update PRs.

## Why?

Dependabot opened a batch of major-version PRs immediately after the scaffold landed. This keeps the repo aligned with the documented policy: only conservative patch/minor Dependabot updates should be candidates for auto-merge after CI passes.

## Related issue

N/A

## Tests run

- scripts/check.sh

## Docs updated

N/A

## Generated-data check

- [x] I did not commit CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts.

## Product-direction check

- [x] This keeps CM1 as the source of truth.
- [x] Preview/reduced-model behavior, if touched, is clearly labeled as guidance only.
- [x] User-facing workflow remains product-shaped, not raw-namelist-shaped.