### PR TITLE
Complete generated data and repo structure guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Runtime data belongs outside the repo by default:
 
 `./local-data/` may be used as a gitignored development override, but generated CM1 runs and outputs should not live in source control.
 
+The top-level `data/` directory is placeholder/fixture-only. It is not the runtime data home.
+
 ## Initial Scope
 
 This scaffold does not implement the CM1 scenario UI, 3-D visualizer, CM1 run manager, CM1 vendoring, real NetCDF sample data, complex deployment, or heavy 3-D rendering dependencies.

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -194,6 +194,8 @@ Default runtime data belongs outside the repo:
 
 The repo may support `./local-data/` as a gitignored development override, but the default should remain `~/CloudChamber`.
 
+The top-level `data/` directory, if present, is reserved for documented tiny fixtures or placeholders only. It is not a runtime storage location.
+
 Optional ignored local development layout:
 
 ```text

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,6 +66,8 @@ Runtime data belongs outside the repo by default:
 
 Use `./local-data/` only as a gitignored development override. Do not commit generated CM1 run packages, NetCDF outputs, local validation reports, thumbnails, previews, or large visualization artifacts.
 
+If `data/` exists in the repo, treat it as placeholder/fixture-only. Runtime storage belongs in `~/CloudChamber`, not in the source tree.
+
 ## Whole Repo
 
 From the repo root:

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -25,6 +25,36 @@ echo "== Script syntax checks =="
 cd "$ROOT_DIR"
 find scripts -name "*.sh" -print0 | xargs -0 -r bash -n
 
+echo "== Forbidden tracked artifact checks =="
+forbidden_tracked="$(git ls-files \
+  'local-data/*' \
+  'runs/*' \
+  'local-runs/*' \
+  'cm1-runs/*' \
+  'generated-runs/*' \
+  'processed/*' \
+  'validation-reports/*' \
+  'local-validation-reports/*' \
+  'cm1r*/*' \
+  'LANDUSE.TBL' \
+  '*.nc' \
+  '*.nc4' \
+  '*.cdf' \
+  '*.netcdf' \
+  '*.vtk' \
+  '*.vti' \
+  '*.vtr' \
+  '*.vts' \
+  '*.vtu' \
+  '*.mp4' \
+  '*.mov' \
+  '*.webm')"
+if [[ -n "$forbidden_tracked" ]]; then
+  echo "Forbidden generated/local artifacts are tracked:" >&2
+  echo "$forbidden_tracked" >&2
+  exit 1
+fi
+
 echo "== Docs/JSON/YAML sanity checks =="
 "$BACKEND_PYTHON" - <<'PY'
 import json


### PR DESCRIPTION
## What changed?

- Documented that top-level data/ is placeholder/fixture-only, not runtime storage.
- Added a scripts/check.sh guard that fails if obvious generated CM1/runtime/visualization artifacts are tracked.

## Why?

This completes the remaining acceptance criteria for #12 and #13.

## Related issue

Closes #12
Closes #13

## Tests run

- scripts/check.sh

## Docs updated

- README.md
- docs/development.md
- docs/architecture-and-data-model.md

## Generated-data check

- [x] I did not commit CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts.

## Product-direction check

- [x] This keeps CM1 as the source of truth.
- [x] Preview/reduced-model behavior, if touched, is clearly labeled as guidance only.
- [x] User-facing workflow remains product-shaped, not raw-namelist-shaped.