### PR TITLE
Establish canonical local validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,40 @@ jobs:
           python-version: "3.12"
 
       - name: Shell syntax
-        run: find scripts -name "*.sh" -print0 | xargs -0 -r bash -n
+        run: |
+          test -x scripts/check.sh
+          find scripts -name "*.sh" -print0 | xargs -0 -r bash -n
+
+      - name: Forbidden tracked artifacts
+        run: |
+          forbidden_tracked="$(git ls-files \
+            'local-data/*' \
+            'runs/*' \
+            'local-runs/*' \
+            'cm1-runs/*' \
+            'generated-runs/*' \
+            'processed/*' \
+            'validation-reports/*' \
+            'local-validation-reports/*' \
+            'cm1r*/*' \
+            'LANDUSE.TBL' \
+            '*.nc' \
+            '*.nc4' \
+            '*.cdf' \
+            '*.netcdf' \
+            '*.vtk' \
+            '*.vti' \
+            '*.vtr' \
+            '*.vts' \
+            '*.vtu' \
+            '*.mp4' \
+            '*.mov' \
+            '*.webm')"
+          if [[ -n "$forbidden_tracked" ]]; then
+            echo "Forbidden generated/local artifacts are tracked:" >&2
+            echo "$forbidden_tracked" >&2
+            exit 1
+          fi
 
       - name: Docs, JSON, and YAML sanity
         run: |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ scripts/check.sh
 
 The script is executable and runs the same fast checks as CI.
 
+`scripts/check.sh` is the canonical local validation gate. Run it before opening PRs. It intentionally does not run real CM1, require a local CM1 installation, use NetCDF sample output, or create generated CM1 artifacts.
+
 ## Runtime Data
 
 Runtime data belongs outside the repo by default:

--- a/docs/ci-and-branch-protection.md
+++ b/docs/ci-and-branch-protection.md
@@ -9,6 +9,8 @@ The CI workflow should pass before merge:
 - frontend install, lint, test, and build
 - backend install, ruff format/check, mypy, and pytest
 - script syntax checks
+- `scripts/check.sh` executable-bit assertion
+- forbidden tracked artifact checks
 - docs/config JSON and YAML sanity checks
 - simple markdown sanity checks
 
@@ -19,6 +21,8 @@ Expected GitHub Actions check names from this workflow are:
 - `Scripts and config`
 
 Confirm the exact displayed names from the first PR before adding required checks to branch protection.
+
+`scripts/check.sh` is the canonical local validation gate. CI uses split equivalent jobs instead of calling only that script so required checks stay granular and readable in branch protection. When future fast checks are added locally, mirror them in CI or explicitly document why they only run in one place.
 
 ## Recommended GitHub Settings
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -78,6 +78,12 @@ scripts/check.sh
 
 This executable script runs the same fast checks as CI: frontend lint/test/build, backend ruff format/check, backend mypy, backend pytest, shell syntax checks, and basic docs/JSON/YAML sanity.
 
+`scripts/check.sh` is the canonical local validation gate for developers and Codex. It also checks for tracked generated/runtime artifacts and old user-facing product naming.
+
+CI keeps equivalent split jobs named `Frontend`, `Backend`, and `Scripts and config` so branch protection can require stable, readable check names. When adding future scenario-schema, run-manifest, dry-run-package, NetCDF-ingest, or visualizer-metadata checks, update both `scripts/check.sh` and the matching CI job or document why a CI-only/local-only split is necessary.
+
+The local gate intentionally does not run real CM1, require a local CM1 installation, require real NetCDF output, or create generated CM1 artifacts in the repo.
+
 ## Scaffold Scope
 
 Do not implement product features in this scaffold PR.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -10,6 +10,8 @@ Fast CI tests run on every pull request and push to `main`.
 - Backend ruff format/check, mypy, and pytest.
 - Shell script syntax checks.
 - JSON/YAML sanity checks where practical.
+- `scripts/check.sh` executable-bit assertion.
+- forbidden tracked artifact checks.
 
 Future fast tests should cover:
 
@@ -20,6 +22,8 @@ Future fast tests should cover:
 - frontend component tests for Scenario Builder behavior and state distinctions
 
 These tests must not require CM1 source, CM1 binaries, NetCDF output, generated run directories, or large local data.
+
+Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.
 
 ## Local CM1 Workflow Tests
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -4,18 +4,36 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BACKEND_PYTHON="${BACKEND_PYTHON:-python}"
 
+require_command() {
+  local command_name="$1"
+  local install_hint="$2"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Missing required command: $command_name" >&2
+    echo "$install_hint" >&2
+    exit 127
+  fi
+}
+
 if [[ -x "$ROOT_DIR/app/backend/.venv/bin/python" && "${BACKEND_PYTHON}" == "python" ]]; then
   BACKEND_PYTHON="$ROOT_DIR/app/backend/.venv/bin/python"
 fi
+require_command "$BACKEND_PYTHON" "Install Python, or set BACKEND_PYTHON to the Python executable for app/backend."
 
 echo "== Frontend checks =="
 cd "$ROOT_DIR/app/frontend"
+require_command npm "Install Node.js/npm, then run npm install in app/frontend."
 npm run lint
 npm run test
 npm run build
 
 echo "== Backend checks =="
 cd "$ROOT_DIR/app/backend"
+if ! "$BACKEND_PYTHON" -c "import mypy, pytest, ruff" >/dev/null 2>&1; then
+  echo "Missing backend development dependencies for $BACKEND_PYTHON." >&2
+  echo "Run: cd app/backend && python -m pip install -e '.[dev]'" >&2
+  exit 127
+fi
 "$BACKEND_PYTHON" -m ruff format --check .
 "$BACKEND_PYTHON" -m ruff check .
 "$BACKEND_PYTHON" -m mypy .
@@ -23,9 +41,11 @@ cd "$ROOT_DIR/app/backend"
 
 echo "== Script syntax checks =="
 cd "$ROOT_DIR"
+require_command bash "Install bash or run this script from an environment with bash available."
 find scripts -name "*.sh" -print0 | xargs -0 -r bash -n
 
 echo "== Forbidden tracked artifact checks =="
+require_command git "Install git before running the local validation gate."
 forbidden_tracked="$(git ls-files \
   'local-data/*' \
   'runs/*' \
@@ -56,6 +76,11 @@ if [[ -n "$forbidden_tracked" ]]; then
 fi
 
 echo "== Docs/JSON/YAML sanity checks =="
+if ! "$BACKEND_PYTHON" -c "import yaml" >/dev/null 2>&1; then
+  echo "Missing Python dependency: PyYAML." >&2
+  echo "Run: cd app/backend && python -m pip install -e '.[dev]'" >&2
+  exit 127
+fi
 "$BACKEND_PYTHON" - <<'PY'
 import json
 from pathlib import Path


### PR DESCRIPTION
## What changed?

- Hardened scripts/check.sh as the canonical local validation gate with clearer missing-tool messages.
- Added CI assertions that scripts/check.sh is executable and that forbidden generated/runtime artifacts are not tracked.
- Documented how scripts/check.sh relates to CI's split required checks.

## Why?

This completes issue #15 by making the local gate explicit, reliable, and aligned with branch-protection CI checks without adding any CM1/runtime dependency.

## Related issue

Closes #15

Follow-up checks are covered by existing startup issues:
- scenario schema validation: #20
- run manifest validation: #22
- dry-run package generation tests: #23
- tiny NetCDF ingest tests: #30
- visualizer metadata/provenance checks: #31

## Tests run

- scripts/check.sh

## Docs updated

- README.md
- docs/development.md
- docs/testing-and-validation.md
- docs/ci-and-branch-protection.md

## Generated-data check

- [x] I did not commit CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts.

## Product-direction check

- [x] This keeps CM1 as the source of truth.
- [x] Preview/reduced-model behavior, if touched, is clearly labeled as guidance only.
- [x] User-facing workflow remains product-shaped, not raw-namelist-shaped.