### PR TITLE
Audit foundation scaffold issues

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -1,0 +1,23 @@
+"""FastAPI application skeleton for local Cloud Chamber services."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from cloud_chamber.cli import ENGINE_NOTE
+
+app = FastAPI(
+    title="Cloud Chamber Backend",
+    summary="Local backend API for Cloud Chamber CM1 experiment workflows.",
+    version="0.1.0",
+)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Return a lightweight readiness response that does not require CM1."""
+    return {
+        "status": "ok",
+        "product": "Cloud Chamber",
+        "engine_note": ENGINE_NOTE,
+    }

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -7,10 +7,13 @@ name = "cloud-chamber-backend"
 version = "0.1.0"
 description = "Local backend tooling for Cloud Chamber CM1 experiments."
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+  "fastapi>=0.115",
+]
 
 [project.optional-dependencies]
 dev = [
+  "httpx>=0.27",
   "mypy>=1.10",
   "pytest>=8.2",
   "pyyaml>=6.0",

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from cloud_chamber.app import app
+
+
+def test_health_endpoint_identifies_scaffold_without_cm1() -> None:
+    response = TestClient(app).get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert response.json()["product"] == "Cloud Chamber"
+    assert "CM1 is the high-fidelity simulation engine" in response.json()["engine_note"]

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,6 +23,16 @@ The frontend uses TypeScript, React, Vite, Vitest, ESLint, and Prettier. Do not 
 From `app/backend`:
 
 ```sh
+uv sync --extra dev
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy .
+uv run pytest
+```
+
+If `uv` is not installed in a local environment yet, the current CI-compatible pip flow is:
+
+```sh
 python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
@@ -35,7 +45,7 @@ python -m pytest
 
 Normal backend checks must not require a local CM1 runtime. Real CM1 paths belong in local settings, not hard-coded app constants.
 
-Future backend implementation should use Python/FastAPI with `uv`, pytest, ruff, and mypy. Data/science work should prefer xarray, netCDF4 or h5netcdf, numpy, and pydantic when those layers are added.
+The backend skeleton uses Python/FastAPI with pytest, ruff, and mypy. Data/science work should prefer xarray, netCDF4 or h5netcdf, numpy, and pydantic when those layers are added.
 
 Backend work should assume one local CM1 run at a time for the MVP and should avoid large in-memory processing paths for local MacBook Air-scale machines.
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -42,6 +42,8 @@ Small fixtures may be committed when they are intentionally tiny and do not incl
 
 Committed NetCDF fixtures must be tiny, synthetic, intentional, and documented under a test fixture path. Real CM1 outputs are local/manual/offline artifacts and must stay out of git.
 
+If a tiny synthetic NetCDF fixture is needed later, create it with a deterministic test helper or fixture-generation script, keep only the smallest fields needed by the test, document the generating command and intended assertions next to the fixture, and confirm it is not copied from a real CM1 run. Do not commit broad sample outputs, local run directories, or generated validation reports.
+
 ## Real CM1 Validation
 
 Real CM1 runs are local/manual/offline validation. They are useful for scientific confidence but should not be required in CI.


### PR DESCRIPTION
Closes #16.
Closes #17.
Closes #18.

Summary:
- Audited issues #16, #17, and #18 against the current repo.
- Added the smallest missing backend scaffold piece for #16: a FastAPI app skeleton with a `/health` endpoint that does not require CM1.
- Added a focused backend health endpoint test.
- Clarified backend development commands with preferred `uv` usage plus the current CI-compatible pip fallback.
- Clarified the future tiny synthetic NetCDF fixture policy for #18.
- Confirmed #17 was already satisfied by the existing Vite/React/TypeScript/Vitest/ESLint frontend scaffold and render test.

What was intentionally not included:
- No scenario UI.
- No preview model.
- No CM1 run manager.
- No scenario schemas or package generation.
- No NetCDF ingest.
- No generated CM1 output or real sample data.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts were committed.
