### PR TITLE
Align Golden Path and results specs

### DIFF
--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -8,6 +8,8 @@ CM1 is the high-fidelity simulation engine; Cloud Chamber is the local experimen
 
 The first MVP target is a 2024 MacBook Air with 8GB RAM. Design for one local CM1 run at a time, conservative output handling, and backend-side processing/downsampling. Optional cloud compute can be researched later, but it is not part of the core architecture.
 
+Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later and should not drive the first result storage model.
+
 Recommended architecture:
 
 ```text
@@ -76,6 +78,8 @@ Responsibilities:
 - define run-size presets and one-control variation metadata around a baseline
 - define the physical question and learning goals
 
+Baseline Shallow Cumulus is the first hero case. Warm rain remains early but does not block the Golden Path.
+
 ### Configuration Builder
 
 Turns a scenario + user controls into:
@@ -84,6 +88,10 @@ Turns a scenario + user controls into:
 - `input_sounding`
 - `case_manifest.json`
 - run manifest
+- dry-run report
+- visualization defaults
+
+For the Baseline Shallow Cumulus Golden Path, the generated package should preserve the physical question, curated controls, run-size preset, expected diagnostics, expected output fields, and provenance labels before CM1 starts.
 
 ### Preview Engine
 
@@ -160,6 +168,8 @@ scenario + controls
 
 Runtime tier metadata should flow through this path: scenario templates define available run-size presets, generated run packages record the selected preset, run manifests preserve it during execution, and result metadata keeps it available for later inspection.
 
+If size/runtime estimates are not validated yet, manifests and reports should record that explicitly rather than presenting guessed precision.
+
 ### Execute Run
 
 ```text
@@ -203,6 +213,20 @@ result notebook entry
 ```
 
 These file names are conceptual for now. Implementation should choose concrete schemas when the result model is built.
+
+The result manifest should be able to answer:
+
+```text
+What scenario was this?
+What physical question was tested?
+What controls were used?
+What run-size preset was selected?
+What did CM1 do?
+What diagnostics summarize the cloud evolution?
+Can I replay it?
+Can I open it in the 3-D visualizer?
+Can I find it again later?
+```
 
 ## Storage Layout
 
@@ -290,9 +314,13 @@ running
 completed
 failed
 canceled
+ingested
+saved
 ```
 
 `packaged` means Cloud Chamber generated a dry-run package. It is not equivalent to queued, running, or completed CM1 output.
+
+`ingested` means Cloud Chamber has derived metadata or browser-friendly artifacts from completed CM1 output. `saved` means the user has a named/tagged experiment notebook entry. Neither state changes the underlying CM1 output provenance.
 
 ## Process Control
 
@@ -385,6 +413,8 @@ Rendering method examples:
 - isosurface
 - volume opacity interpretation
 
+Result-card metadata should include the same provenance labels used by visualization data so the Results Library and visualizer tell the same truth about the source model, run, processing, and rendering method.
+
 ## Testing Strategy
 
 Early tests should cover:
@@ -398,6 +428,8 @@ Early tests should cover:
 - result manifest generation
 - visualizer metadata loading
 - no generated outputs committed
+
+Golden Path implementation tests should use fake/minimal fixtures for scenario schema, package generation, manifest lifecycle, result-card serialization, and visualization metadata. Real CM1 validation remains local/manual/offline.
 
 ## Safety / Guardrails
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -12,6 +12,8 @@ Cloud Chamber's main flow should be product-shaped, not namelist-shaped. Friendl
 
 The first Golden Path case is Baseline Shallow Cumulus. Warm rain remains early, but it should not block completing that first end-to-end case.
 
+Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
+
 ## Personas
 
 ### Primary User
@@ -25,6 +27,59 @@ They are comfortable with long-running local jobs, but do not want to manually e
 A scientist/developer who wants a cleaner CM1 workflow for curated idealized cases and visual exploration.
 
 ## Key Workflows
+
+### Workflow 0 — Baseline Shallow Cumulus Golden Path
+
+The first complete product loop is:
+
+```text
+Pick Baseline Shallow Cumulus
+-> adjust curated controls
+-> choose run-size preset
+-> validate setup
+-> generate CM1 run package
+-> launch local CM1
+-> monitor logs/status
+-> ingest NetCDF output
+-> create result card / experiment notebook entry
+-> replay cloud evolution
+-> open 3-D visualizer
+-> save/name/tag result
+```
+
+Physical question:
+
+```text
+How do low-level moisture, surface heating, cap strength, cap height, dry air aloft, and mixing/entrainment affect shallow-cumulus formation, timing, depth, updraft strength, and cloud-water evolution?
+```
+
+Expected CM1-facing package contents:
+
+```text
+run_manifest.json
+scenario metadata / case_manifest.json
+namelist.input
+input_sounding or sounding/input profile file
+runtime file checklist
+dry-run report
+visualization defaults
+```
+
+Expected diagnostics:
+
+```text
+cloud formed / failed
+first cloud time
+cloud base
+cloud top
+max vertical velocity
+max or summary cloud water
+cloud-water time evolution
+rain onset if available
+main limiting factor or interpretation note
+```
+
+Exact morphology is not pass/fail. The acceptance question is whether the product honestly configures, runs, records, ingests, replays, inspects, and visualizes a credible idealized CM1 result.
 
 ### Workflow 1 — Choose Preset Experiment
 
@@ -123,6 +178,8 @@ This workflow is useful, but it is not the core first-MVP result behavior. Repla
 
 Runtime estimates are approximate until locally validated for a specific CM1 build, scenario, and machine. The first local hardware target is a 2024 MacBook Air with 8GB RAM, so the MVP should assume one local CM1 run at a time and conservative output handling.
 
+Runtime tier metadata should be carried through scenario templates, generated run packages, dry-run reports, run manifests, result metadata, and result cards. If estimate data is not locally validated yet, the UI/report should say `unknown until validated` instead of inventing precision.
+
 ## Preset Scenario Schema
 
 Each scenario should define:
@@ -158,6 +215,8 @@ run_size_presets:
   deep_overnight
 physical_question:
 learning_goals:
+variation_policy:
+  one_control_at_a_time_from_baseline: true
 validation_status:
   unrun | generated | accepted | needs_calibration
 notes:
@@ -171,6 +230,8 @@ Initial scenario templates should include:
 4. Humid vigorous cumulus / humid low-cloud contrast.
 5. Low stratus / low-cloud layer.
 6. Warm rain / precipitating shallow cloud.
+
+Baseline shallow cumulus is the first hero case. Warm rain remains early but does not block the Golden Path.
 
 ## Curated Controls And Diagnostics
 
@@ -205,6 +266,8 @@ main limiting factor
 
 First variations should favor one-control-at-a-time changes around Baseline Shallow Cumulus. Large arbitrary parameter sweeps are not the primary learning path.
 
+Shared controls are controls that can be compared across multiple lower-atmosphere scenarios, such as low-level humidity, surface heating, cap strength, cap height, dry air aloft, and mixing/entrainment. Scenario-specific controls should be introduced only when a scenario needs them to answer its physical question.
+
 ## Run Manifest Schema
 
 Each run should write a manifest like:
@@ -237,6 +300,10 @@ ingestion:
 visualization:
   default_view:
   thumbnails:
+result:
+  result_id:
+  diagnostics_summary:
+  key_frames:
 user:
   saved:
   tags:
@@ -253,6 +320,8 @@ running
 completed
 failed
 canceled
+ingested
+saved
 ```
 
 Dry-run packaged experiments must be distinct from queued/running/completed CM1 runs.
@@ -275,6 +344,16 @@ Saved result/notebook entry
 
 A preview or dry-run package is not a completed CM1 result. A visualization is an interpretation of CM1 output, not a new physical source of truth.
 
+Product copy and state names should prefer nouns that reveal provenance:
+
+- `Preview estimate`
+- `CM1 configuration package`
+- `CM1 run`
+- `Completed CM1 result`
+- `Ingested result metadata`
+- `Visualizer interpretation`
+- `Saved experiment notebook entry`
+
 ## Result Card / Experiment Notebook
 
 A completed run should produce a replayable saved result. It should feel like an experiment notebook entry, not a disposable job row.
@@ -282,23 +361,32 @@ A completed run should produce a replayable saved result. It should feel like an
 Result cards should support:
 
 ```text
+result_id
+run_id
 name
 tags
-scenario
+scenario_id
+scenario_name
 physical question
+created_at
+completed_at
 controls used
 run-size preset
-CM1 status
-run logs
+CM1 version/path metadata
+status
+generated config paths
 output paths
+run logs
 diagnostics summary
 first cloud time
 cloud base/top
-max updraft
-cloud water summary
+max vertical velocity
+cloud-water summary
 rain onset if available
 key frames or bookmarked times
+visualization defaults
 notes
+provenance labels
 open in visualizer action
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,6 +4,8 @@ Cloud Chamber is a local-first, personal-use CM1 experiment builder, run manager
 
 The first Golden Path is Baseline Shallow Cumulus. Saved results are meant to be replayed and inspected as experiment notebook entries. Optional remote compute is future research only, not a development dependency for the MVP.
 
+Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later. Warm rain remains early, but it does not block the Baseline Shallow Cumulus Golden Path.
+
 ## Frontend
 
 From `app/frontend`:
@@ -48,6 +50,8 @@ Normal backend checks must not require a local CM1 runtime. Real CM1 paths belon
 The backend skeleton uses Python/FastAPI with pytest, ruff, and mypy. Data/science work should prefer xarray, netCDF4 or h5netcdf, numpy, and pydantic when those layers are added.
 
 Backend work should assume one local CM1 run at a time for the MVP and should avoid large in-memory processing paths for local MacBook Air-scale machines.
+
+When implementing scenario, manifest, result, or visualization contracts, keep product state and provenance labels explicit: preview estimate, generated CM1 configuration, packaged dry-run output, running/completed CM1 result, ingested result metadata, visualizer interpretation, and saved result/notebook entry are different things.
 
 ## Repo Layout
 

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -85,6 +85,20 @@ Choose experiment
 → optionally create a new variation from the same setup
 ```
 
+Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
+
+## Golden Path Principle
+
+Baseline Shallow Cumulus is the first hero case because it can prove the whole Cloud Chamber loop with one scientifically honest, approachable CM1 experiment.
+
+The first hero case should answer:
+
+```text
+How do low-level moisture, surface heating, cap strength, and dry air aloft shape whether shallow cumulus forms, when it appears, how tall it gets, and how much cloud water develops?
+```
+
+Warm rain remains early, but it should not block the Golden Path. Precipitating shallow cloud workflows should build on the baseline loop after the baseline case can be configured, packaged, run locally, ingested, replayed, inspected, and opened in the visualizer.
+
 ## User-Facing Concepts
 
 The product should use atmospheric language first:
@@ -104,6 +118,17 @@ The product should use atmospheric language first:
 - cloud water
 
 Raw CM1 namelist settings belong in an advanced/developer view.
+
+The first controls should favor relative, teachable changes around a baseline:
+
+- drier / baseline / more humid low-level air
+- weaker / baseline / stronger surface heating
+- lower / baseline / higher cap
+- weaker / baseline / stronger cap
+- less dry / baseline / drier air aloft
+- weaker / baseline / stronger mixing/entrainment
+
+The first variation workflow should change one control at a time. This is a product teaching choice, not a claim that the atmosphere changes one variable at a time.
 
 ## Product Layers
 
@@ -194,14 +219,20 @@ Always distinguish:
 
 ```text
 Preview estimate
-CM1 run configuration
-CM1 running/completed result
+Generated CM1 configuration
+Packaged dry-run output
+Queued/running CM1 process
+Completed CM1 result
+Failed/canceled CM1 run
+Ingested result metadata
 Visualizer interpretation
+Saved result/notebook entry
 ```
 
 Never imply:
 
 - a preview is CM1 output
+- a dry-run package is a completed result
 - a visualization interpretation is a raw model field
 - CM1 runs live in browser
 - a scenario is validated if it has not been inspected

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -18,6 +18,8 @@ CM1 remains the source of truth. Preview estimates are guidance only, and visual
 
 Cloud Chamber is a personal, scientifically honest CM1 cloud playground: curated lower-atmosphere experiments, meaningful controls, local-first CM1 runs, replayable saved results, and a beautiful 3-D viewer.
 
+Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
+
 ## Golden Path: Baseline Shallow Cumulus
 
 Baseline Shallow Cumulus is the first complete product loop:
@@ -39,6 +41,37 @@ Pick Baseline Shallow Cumulus
 
 The Golden Path should test a clear physical question, expose curated lower-atmosphere controls, preserve CM1 as the source of truth, and make exact cloud morphology an inspection result rather than a brittle pass/fail expectation.
 
+Physical question:
+
+```text
+How do low-level moisture, surface heating, cap strength, cap height, dry air aloft, and mixing/entrainment affect shallow-cumulus formation, timing, depth, updraft strength, and cloud-water evolution?
+```
+
+Expected generated CM1-facing files:
+
+```text
+run_manifest.json
+case_manifest.json or scenario metadata
+namelist.input
+input_sounding or equivalent profile file
+runtime file checklist
+dry-run report
+visualization defaults
+```
+
+Expected diagnostics:
+
+```text
+cloud formed / failed
+first cloud time
+cloud base
+cloud top
+max vertical velocity
+cloud-water summary
+rain onset if present
+main limiting factor / interpretation note
+```
+
 ## Runtime Tiers
 
 Cloud Chamber should support run-size presets that make local cost and confidence visible:
@@ -48,6 +81,26 @@ Cloud Chamber should support run-size presets that make local cost and confidenc
 - **Deep / overnight**: longer richer runs that may take hours or overnight; used for prettier, more detailed, or higher-confidence result exploration.
 
 Runtime estimates are approximate until locally validated. The MVP should assume a 2024 MacBook Air with 8GB RAM, one local CM1 run at a time, conservative output handling, and backend-side processing/downsampling.
+
+Runtime tier metadata should be represented in scenario templates, generated package reports, run manifests, result metadata, and result cards. Unknown estimates should be labeled as unknown until locally validated.
+
+## Product State And Provenance Contract
+
+Implementation issues should preserve these product states and labels:
+
+```text
+Preview estimate
+Generated CM1 configuration
+Packaged dry-run output
+Queued/running CM1 process
+Completed CM1 result
+Failed/canceled CM1 run
+Ingested result metadata
+Visualizer interpretation
+Saved result/notebook entry
+```
+
+The UI and docs should not call a preview, dry-run package, or visualization interpretation a completed CM1 result.
 
 ## M0 Repo Foundation
 
@@ -84,6 +137,15 @@ Deliverables:
 - Preview placeholder.
 - Manual local validation loop documentation.
 
+Implementation anchors:
+
+- #20 should carry run-size presets, physical questions, learning goals, expected diagnostics, and one-control variation metadata.
+- #21 should mark Baseline Shallow Cumulus as the first hero case and keep warm rain early but non-blocking.
+- #22 should preserve lifecycle/provenance distinctions.
+- #23 should include run-size preset, physical question, expected diagnostics, visualization defaults, and explicit unknown estimate fields in dry-run reports.
+- #24 should map curated atmospheric controls to CM1-facing configuration without exposing raw namelist fields as the primary user language.
+- #25, #26, and #27 should use Golden Path wording and never imply a preview or dry-run package is a completed CM1 result.
+
 The dry-run package flow must be followed directly by local CM1 launch/monitoring work. Dry-run generation is a stepping stone, not a dead end.
 
 ## M1.5 Golden Path Manual CM1 Validation
@@ -115,6 +177,10 @@ Deliverables:
 - overwrite protection.
 - local/manual validation path.
 
+Implementation anchor:
+
+- #29 should assume one local CM1 run at a time, account for long/overnight runs, and preserve logs for result notebook entries.
+
 ## M3 Results Library + Experiment Notebook
 
 Goal: turn CM1 outputs into replayable, inspectable, searchable experiment notebook entries.
@@ -130,6 +196,10 @@ Deliverables:
 - open saved result in visualizer.
 - duplicate/tweak/rerun foundation later, after replay/inspect/save is reliable.
 
+Implementation anchor:
+
+- #30 should make replayable/inspectable saved result cards the core behavior. Duplicate/tweak/rerun should remain optional or later.
+
 ## M4 3-D Visualizer MVP
 
 Goal: deliver the main payoff: inspect CM1 cloud evolution in 3-D.
@@ -143,6 +213,10 @@ Deliverables:
 - horizontal/vertical slices.
 - cloud-water isosurface or opacity approximation.
 - simple lighting.
+
+Implementation anchor:
+
+- #31 should open from saved results, support time replay and camera exploration, avoid requiring reruns, and display provenance/rendering-method labels.
 
 ## M5 Visual Polish + Export
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -17,7 +17,10 @@ Future fast tests should cover:
 
 - scenario schema validation
 - quick/standard/deep runtime preset metadata validation
+- physical question and learning-goal metadata validation
+- one-control-at-a-time variation metadata validation
 - generated manifests
+- product state/provenance label validation
 - CM1 path/settings handling
 - run-package generation using temp directories
 - result-card / experiment-notebook metadata serialization
@@ -50,6 +53,10 @@ Real CM1 runs are local/manual/offline validation. They are useful for scientifi
 
 The Baseline Shallow Cumulus Golden Path is the first manual/local acceptance target. Quick/standard/deep runtime tiers should be validated in CI through schema/config tests, not by running CM1.
 
+Replay / inspect / save is core MVP and should be covered by future metadata, serialization, and UI tests. Duplicate / tweak / rerun is later and should not be required by first result-library tests.
+
+Warm rain remains early, but baseline shallow-cumulus tests and manual validation should not be blocked on warm-rain behavior.
+
 Manual validation should record:
 
 - the physical question being tested
@@ -69,17 +76,21 @@ Validation notes should be written as docs or issue comments when useful. Local 
 Manual baseline shallow-cumulus acceptance should capture:
 
 ```text
+physical question
 run-size preset
 CM1 version/path
 grid/domain
 runtime
 output cadence
+generated CM1-facing files reviewed
 first cloud time
 cloud base/top
 max updraft
 cloud water
 rain onset if present
 logs
+result card / notebook fields
+visualizer provenance labels
 visual inspection notes
 ```
 


### PR DESCRIPTION
Closes #37.
Closes #38.
Closes #39.
Closes #40.
Closes #41.

Summary:
- Defined the Baseline Shallow Cumulus Golden Path in product vision, product spec, roadmap, architecture, testing, and development docs.
- Added explicit physical question, expected CM1-facing package contents, expected diagnostics, and manual acceptance details.
- Tightened run-size preset propagation through scenario templates, generated packages, dry-run reports, run manifests, result metadata, and result cards.
- Expanded the curated lower-atmosphere controls and diagnostics contract, including one-control-at-a-time variation guidance.
- Codified product state/provenance distinctions from preview estimate through saved result/notebook entry.
- Expanded the Result Card / Experiment Notebook model and provenance expectations.
- Updated existing implementation issues #20, #21, #22, #23, #24, #25, #26, #27, #29, #30, and #31 to reference these decisions.

Required product statements:
- Replay / inspect / save is core MVP.
- Duplicate / tweak / rerun is later.
- Baseline Shallow Cumulus is the first hero case.
- Warm rain remains early but does not block the Golden Path.

What was intentionally not included:
- No backend feature code.
- No frontend feature code.
- No scenario schemas or CM1 package generation.
- No CM1 launcher, NetCDF ingest, visualizer, or cloud integration.
- No generated CM1 output or real sample data.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts were committed.
