### PR TITLE
Add local settings and CM1 discovery

### DIFF
--- a/app/backend/cloud_chamber/settings.py
+++ b/app/backend/cloud_chamber/settings.py
@@ -1,0 +1,162 @@
+"""Local settings and CM1 path discovery for Cloud Chamber."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_RUNTIME_HOME = Path("~/CloudChamber")
+SETTINGS_FILENAME = "settings.json"
+CLOUD_CHAMBER_CM1_ROOT = "CLOUD_CHAMBER_CM1_ROOT"
+CLOUD_CHAMBER_RUNTIME_HOME = "CLOUD_CHAMBER_RUNTIME_HOME"
+DEFAULT_CM1_PROBE_PATHS = (
+    Path("/Users/timpeterson/cm1r21.1"),
+    Path("/Users/timpeterson/cm1r21.1/run"),
+)
+
+
+@dataclass(frozen=True)
+class CloudChamberSettings:
+    runtime_home: Path
+    cm1_root: Path | None
+    cm1_run_dir: Path | None
+    cache_dir: Path
+    log_dir: Path
+
+
+@dataclass(frozen=True)
+class CM1DiscoveryStatus:
+    ready: bool
+    cm1_root: Path | None
+    cm1_run_dir: Path | None
+    message: str
+    missing: tuple[str, ...] = ()
+
+
+def default_runtime_home(environ: Mapping[str, str] | None = None) -> Path:
+    env = os.environ if environ is None else environ
+    configured = env.get(CLOUD_CHAMBER_RUNTIME_HOME)
+    if configured:
+        return Path(configured).expanduser()
+    return DEFAULT_RUNTIME_HOME.expanduser()
+
+
+def load_settings(
+    *,
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+    probe_paths: tuple[Path, ...] = DEFAULT_CM1_PROBE_PATHS,
+) -> CloudChamberSettings:
+    env = os.environ if environ is None else environ
+    runtime_home = (home or default_runtime_home(env)).expanduser()
+    saved = _read_saved_settings(runtime_home / SETTINGS_FILENAME)
+
+    cm1_root = _path_from_env_or_saved(env, saved, CLOUD_CHAMBER_CM1_ROOT, "cm1_root")
+    cm1_run_dir = _path_from_saved(saved, "cm1_run_dir")
+
+    if cm1_root is None:
+        cm1_root = _first_existing_path(probe_paths)
+    if cm1_run_dir is None and cm1_root is not None:
+        cm1_run_dir = _infer_run_dir(cm1_root)
+
+    return CloudChamberSettings(
+        runtime_home=runtime_home,
+        cm1_root=cm1_root,
+        cm1_run_dir=cm1_run_dir,
+        cache_dir=_path_from_saved(saved, "cache_dir") or runtime_home / "cache",
+        log_dir=_path_from_saved(saved, "log_dir") or runtime_home / "logs",
+    )
+
+
+def discover_cm1(settings: CloudChamberSettings) -> CM1DiscoveryStatus:
+    missing: list[str] = []
+
+    if settings.cm1_root is None:
+        missing.append("CM1 root path")
+    elif not settings.cm1_root.exists():
+        missing.append(f"CM1 root path does not exist: {settings.cm1_root}")
+
+    if settings.cm1_run_dir is None:
+        missing.append("CM1 run directory")
+    elif not settings.cm1_run_dir.exists():
+        missing.append(f"CM1 run directory does not exist: {settings.cm1_run_dir}")
+
+    cm1_executable = _cm1_executable(settings.cm1_run_dir)
+    if settings.cm1_run_dir is not None and cm1_executable is None:
+        missing.append(f"CM1 executable not found in run directory: {settings.cm1_run_dir}")
+
+    if missing:
+        return CM1DiscoveryStatus(
+            ready=False,
+            cm1_root=settings.cm1_root,
+            cm1_run_dir=settings.cm1_run_dir,
+            message=(
+                "CM1 is not ready. Set CLOUD_CHAMBER_CM1_ROOT or update "
+                f"{settings.runtime_home / SETTINGS_FILENAME} with local CM1 paths."
+            ),
+            missing=tuple(missing),
+        )
+
+    return CM1DiscoveryStatus(
+        ready=True,
+        cm1_root=settings.cm1_root,
+        cm1_run_dir=settings.cm1_run_dir,
+        message="CM1 runtime is ready for local use.",
+    )
+
+
+def _read_saved_settings(path: Path) -> Mapping[str, Any]:
+    if not path.exists():
+        return {}
+    loaded = json.loads(path.read_text())
+    if not isinstance(loaded, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return loaded
+
+
+def _path_from_env_or_saved(
+    environ: Mapping[str, str],
+    saved: Mapping[str, Any],
+    env_name: str,
+    saved_name: str,
+) -> Path | None:
+    configured = environ.get(env_name)
+    if configured:
+        return Path(configured).expanduser()
+    return _path_from_saved(saved, saved_name)
+
+
+def _path_from_saved(saved: Mapping[str, Any], name: str) -> Path | None:
+    configured = saved.get(name)
+    if configured is None:
+        return None
+    if not isinstance(configured, str):
+        raise ValueError(f"settings field {name!r} must be a string path")
+    return Path(configured).expanduser()
+
+
+def _first_existing_path(paths: tuple[Path, ...]) -> Path | None:
+    for path in paths:
+        expanded = path.expanduser()
+        if expanded.exists():
+            return expanded
+    return None
+
+
+def _infer_run_dir(cm1_root: Path) -> Path:
+    if cm1_root.name == "run":
+        return cm1_root
+    return cm1_root / "run"
+
+
+def _cm1_executable(cm1_run_dir: Path | None) -> Path | None:
+    if cm1_run_dir is None:
+        return None
+    candidate = cm1_run_dir / "cm1.exe"
+    if candidate.exists():
+        return candidate
+    return None

--- a/app/backend/tests/test_settings.py
+++ b/app/backend/tests/test_settings.py
@@ -1,0 +1,113 @@
+import json
+from pathlib import Path
+
+from cloud_chamber.settings import (
+    CLOUD_CHAMBER_CM1_ROOT,
+    CLOUD_CHAMBER_RUNTIME_HOME,
+    DEFAULT_RUNTIME_HOME,
+    discover_cm1,
+    load_settings,
+)
+
+
+def test_settings_default_to_cloud_chamber_runtime_home() -> None:
+    settings = load_settings(environ={}, probe_paths=())
+
+    assert settings.runtime_home == DEFAULT_RUNTIME_HOME.expanduser()
+    assert settings.cache_dir == DEFAULT_RUNTIME_HOME.expanduser() / "cache"
+    assert settings.log_dir == DEFAULT_RUNTIME_HOME.expanduser() / "logs"
+    assert settings.cm1_root is None
+    assert settings.cm1_run_dir is None
+
+
+def test_settings_load_saved_config_from_runtime_home(tmp_path: Path) -> None:
+    runtime_home = tmp_path / "CloudChamber"
+    cm1_root = tmp_path / "cm1"
+    cm1_run_dir = cm1_root / "run"
+    runtime_home.mkdir()
+    (runtime_home / "settings.json").write_text(
+        json.dumps(
+            {
+                "cm1_root": str(cm1_root),
+                "cm1_run_dir": str(cm1_run_dir),
+                "cache_dir": str(tmp_path / "cache"),
+                "log_dir": str(tmp_path / "logs"),
+            }
+        )
+    )
+
+    settings = load_settings(home=runtime_home, environ={}, probe_paths=())
+
+    assert settings.runtime_home == runtime_home
+    assert settings.cm1_root == cm1_root
+    assert settings.cm1_run_dir == cm1_run_dir
+    assert settings.cache_dir == tmp_path / "cache"
+    assert settings.log_dir == tmp_path / "logs"
+
+
+def test_environment_override_wins_over_saved_cm1_root(tmp_path: Path) -> None:
+    runtime_home = tmp_path / "CloudChamber"
+    runtime_home.mkdir()
+    saved_root = tmp_path / "saved-cm1"
+    env_root = tmp_path / "env-cm1"
+    (runtime_home / "settings.json").write_text(json.dumps({"cm1_root": str(saved_root)}))
+
+    settings = load_settings(
+        home=runtime_home,
+        environ={CLOUD_CHAMBER_CM1_ROOT: str(env_root)},
+        probe_paths=(),
+    )
+
+    assert settings.cm1_root == env_root
+    assert settings.cm1_run_dir == env_root / "run"
+
+
+def test_runtime_home_environment_override() -> None:
+    runtime_home = Path("/tmp/cloud-chamber-test-home")
+
+    settings = load_settings(
+        environ={CLOUD_CHAMBER_RUNTIME_HOME: str(runtime_home)},
+        probe_paths=(),
+    )
+
+    assert settings.runtime_home == runtime_home
+
+
+def test_probe_paths_are_defaults_not_requirements(tmp_path: Path) -> None:
+    cm1_root = tmp_path / "cm1r21.1"
+    (cm1_root / "run").mkdir(parents=True)
+
+    settings = load_settings(environ={}, probe_paths=(cm1_root,))
+
+    assert settings.cm1_root == cm1_root
+    assert settings.cm1_run_dir == cm1_root / "run"
+
+
+def test_cm1_discovery_reports_missing_paths_without_launching(tmp_path: Path) -> None:
+    settings = load_settings(home=tmp_path / "CloudChamber", environ={}, probe_paths=())
+
+    status = discover_cm1(settings)
+
+    assert not status.ready
+    assert "Set CLOUD_CHAMBER_CM1_ROOT" in status.message
+    assert "CM1 root path" in status.missing
+    assert "CM1 run directory" in status.missing
+
+
+def test_cm1_discovery_reports_ready_when_run_dir_has_executable(tmp_path: Path) -> None:
+    cm1_root = tmp_path / "cm1"
+    cm1_run_dir = cm1_root / "run"
+    cm1_run_dir.mkdir(parents=True)
+    (cm1_run_dir / "cm1.exe").write_text("")
+    settings = load_settings(
+        home=tmp_path / "CloudChamber",
+        environ={CLOUD_CHAMBER_CM1_ROOT: str(cm1_root)},
+        probe_paths=(),
+    )
+
+    status = discover_cm1(settings)
+
+    assert status.ready
+    assert status.cm1_root == cm1_root
+    assert status.cm1_run_dir == cm1_run_dir
+    assert status.missing == ()

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -274,6 +274,7 @@ Settings should support:
 - CM1 run directory path.
 - optional cache/log directories.
 - environment override such as `CLOUD_CHAMBER_CM1_ROOT`.
+- optional runtime-home override `CLOUD_CHAMBER_RUNTIME_HOME` for tests/local development.
 - saved config in `~/CloudChamber/settings.json`.
 
 Likely local CM1 probe paths may include:
@@ -284,6 +285,8 @@ Likely local CM1 probe paths may include:
 ```
 
 These are probes/defaults, not hard-coded requirements. If CM1 is missing, Cloud Chamber should fail clearly with settings guidance rather than silently pretending work succeeded.
+
+The backend settings model loads saved JSON config from the runtime home, lets `CLOUD_CHAMBER_CM1_ROOT` override saved CM1 root paths, infers `<cm1_root>/run` when only a root is provided, and reports a ready/missing CM1 discovery status without launching CM1 or writing runtime data into the repo.
 
 Committed scenario templates:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,6 +53,33 @@ Backend work should assume one local CM1 run at a time for the MVP and should av
 
 When implementing scenario, manifest, result, or visualization contracts, keep product state and provenance labels explicit: preview estimate, generated CM1 configuration, packaged dry-run output, running/completed CM1 result, ingested result metadata, visualizer interpretation, and saved result/notebook entry are different things.
 
+## Local Settings
+
+Cloud Chamber runtime settings are local-only. The default runtime home is:
+
+```text
+~/CloudChamber
+```
+
+The backend reads optional saved settings from:
+
+```text
+~/CloudChamber/settings.json
+```
+
+Supported settings fields include:
+
+```json
+{
+  "cm1_root": "/Users/timpeterson/cm1r21.1",
+  "cm1_run_dir": "/Users/timpeterson/cm1r21.1/run",
+  "cache_dir": "~/CloudChamber/cache",
+  "log_dir": "~/CloudChamber/logs"
+}
+```
+
+`CLOUD_CHAMBER_CM1_ROOT` can override the saved CM1 root for local development. `CLOUD_CHAMBER_RUNTIME_HOME` can point tests or local experiments at a different runtime home. These are local settings only; do not commit `settings.json`, CM1 binaries, CM1 source, generated run directories, or NetCDF output.
+
 ## Repo Layout
 
 Expected structure:


### PR DESCRIPTION
Closes #19.

Summary:
- Added a backend local settings model for runtime home, CM1 root, CM1 run directory, cache directory, and log directory.
- Added saved config loading from `~/CloudChamber/settings.json` and local overrides for `CLOUD_CHAMBER_CM1_ROOT` and `CLOUD_CHAMBER_RUNTIME_HOME`.
- Added optional CM1 probe paths for Tim's likely local CM1 install locations without making them requirements.
- Added CM1 discovery status reporting for ready/missing runtime state without launching CM1.
- Updated architecture and development docs for local settings behavior.

What was intentionally not included:
- No CM1 launch.
- No CM1 vendoring.
- No generated CM1 output.
- No scenario schema, package generation, or run manager work.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts were committed.
