### PR TITLE
Define scenario template schema

### DIFF
--- a/app/backend/cloud_chamber/scenario_schema.py
+++ b/app/backend/cloud_chamber/scenario_schema.py
@@ -1,0 +1,203 @@
+"""Scenario template schema and validation rules."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+
+class ControlAudience(StrEnum):
+    PRODUCT = "product"
+    ADVANCED = "advanced"
+
+
+class ControlType(StrEnum):
+    CHOICE = "choice"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+
+
+class RuntimeProfile(StrEnum):
+    QUICK_LOOK = "quick_look"
+    STANDARD = "standard"
+    DEEP_OVERNIGHT = "deep_overnight"
+
+
+class ScenarioValidationError(ValueError):
+    """Raised when a scenario template fails validation."""
+
+
+class ControlOption(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    value: str
+    label: str
+    description: str | None = None
+
+
+class NumericRange(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    min: float
+    max: float
+    step: float | None = None
+    units: str | None = None
+
+    @model_validator(mode="after")
+    def validate_range(self) -> NumericRange:
+        if self.max <= self.min:
+            raise ValueError("numeric range max must be greater than min")
+        if self.step is not None and self.step <= 0:
+            raise ValueError("numeric range step must be positive")
+        return self
+
+
+class ScenarioControl(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    label: str
+    description: str
+    type: ControlType
+    audience: ControlAudience = ControlAudience.PRODUCT
+    default: str | float | bool
+    options: list[ControlOption] = Field(default_factory=list)
+    range: NumericRange | None = None
+    validation: list[str] = Field(default_factory=list)
+    cm1_mapping_notes: str
+
+    @model_validator(mode="after")
+    def validate_control_shape(self) -> ScenarioControl:
+        if self.type == ControlType.CHOICE:
+            if not self.options:
+                raise ValueError(f"choice control {self.id!r} must define options")
+            option_values = {option.value for option in self.options}
+            if not isinstance(self.default, str) or self.default not in option_values:
+                raise ValueError(f"choice control {self.id!r} default must match an option value")
+        if self.type == ControlType.NUMBER:
+            if self.range is None:
+                raise ValueError(f"number control {self.id!r} must define a range")
+            if not isinstance(self.default, int | float):
+                raise ValueError(f"number control {self.id!r} default must be numeric")
+            if not self.range.min <= float(self.default) <= self.range.max:
+                raise ValueError(f"number control {self.id!r} default must be inside range")
+        if self.type == ControlType.BOOLEAN and not isinstance(self.default, bool):
+            raise ValueError(f"boolean control {self.id!r} default must be boolean")
+        return self
+
+
+class RunSizePreset(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: RuntimeProfile
+    label: str
+    purpose: str
+    expected_runtime: str
+    confidence: str
+    output_notes: str
+
+
+class ExpectedDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    cloud_formed: bool = True
+    first_cloud_time: str | None = None
+    cloud_base_top: str | None = None
+    max_updraft: str | None = None
+    cloud_water_summary: str | None = None
+    rain_onset: str | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
+class CM1TemplateReference(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    namelist_template: str
+    input_sounding_template: str
+    runtime_files_needed: list[str] = Field(default_factory=list)
+    mapping_notes: str
+
+
+class VariationPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    baseline_scenario_id: str
+    one_control_at_a_time: bool = True
+    suggested_controls: list[str] = Field(default_factory=list)
+    non_goals: list[str] = Field(default_factory=list)
+
+
+class VisualizationDefaults(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    primary_field: str
+    secondary_fields: list[str] = Field(default_factory=list)
+    camera: str
+    rendering_method: str
+    provenance_label: str = "Visualizer interpretation of CM1 output"
+
+
+class ScenarioTemplate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["1"]
+    id: str
+    display_name: str
+    category: str
+    description: str
+    physical_question: str
+    learning_goals: list[str]
+    intended_behavior: str
+    expected_behavior: str
+    controls: list[ScenarioControl]
+    run_size_presets: list[RunSizePreset]
+    expected_diagnostics: ExpectedDiagnostics
+    cm1_template: CM1TemplateReference
+    visualization_defaults: VisualizationDefaults
+    variation_policy: VariationPolicy | None = None
+    warnings: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+    advanced_settings_notes: str
+
+    @model_validator(mode="after")
+    def validate_template_contract(self) -> ScenarioTemplate:
+        product_controls = [
+            control for control in self.controls if control.audience == ControlAudience.PRODUCT
+        ]
+        if not product_controls:
+            raise ValueError("scenario must define at least one product-facing control")
+
+        preset_ids = {preset.id for preset in self.run_size_presets}
+        required_presets = set(RuntimeProfile)
+        if preset_ids != required_presets:
+            missing = ", ".join(sorted(profile.value for profile in required_presets - preset_ids))
+            extra = ", ".join(sorted(profile.value for profile in preset_ids - required_presets))
+            details = "; ".join(
+                part
+                for part in [
+                    f"missing {missing}" if missing else "",
+                    f"extra {extra}" if extra else "",
+                ]
+                if part
+            )
+            raise ValueError(
+                f"scenario run_size_presets must define quick/standard/deep profiles: {details}"
+            )
+
+        control_ids = {control.id for control in self.controls}
+        if self.variation_policy is not None:
+            unknown = sorted(set(self.variation_policy.suggested_controls) - control_ids)
+            if unknown:
+                raise ValueError(
+                    "variation policy references unknown controls: " + ", ".join(unknown)
+                )
+        return self
+
+
+def validate_scenario_template(data: object) -> ScenarioTemplate:
+    try:
+        return ScenarioTemplate.model_validate(data)
+    except ValidationError as exc:
+        raise ScenarioValidationError(str(exc)) from exc

--- a/app/backend/tests/test_scenario_schema.py
+++ b/app/backend/tests/test_scenario_schema.py
@@ -1,0 +1,155 @@
+from typing import Any
+
+import pytest
+
+from cloud_chamber.scenario_schema import ScenarioValidationError, validate_scenario_template
+
+
+def valid_template() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "id": "baseline-shallow-cumulus",
+        "display_name": "Baseline Shallow Cumulus",
+        "category": "lower-atmosphere",
+        "description": "A first hero case for shallow-cumulus exploration.",
+        "physical_question": "How do moisture and heating shape shallow cumulus?",
+        "learning_goals": ["Identify first cloud time", "Compare cloud base and top"],
+        "intended_behavior": "Credible idealized shallow cumulus.",
+        "expected_behavior": "Clouds may form after surface heating erodes inhibition.",
+        "controls": [
+            {
+                "id": "low_level_humidity",
+                "label": "Low-level humidity",
+                "description": "Relative low-level moisture around the baseline.",
+                "type": "choice",
+                "audience": "product",
+                "default": "baseline",
+                "options": [
+                    {"value": "drier", "label": "Drier"},
+                    {"value": "baseline", "label": "Baseline"},
+                    {"value": "more_humid", "label": "More humid"},
+                ],
+                "cm1_mapping_notes": "Maps toward sounding humidity profile adjustments.",
+            },
+            {
+                "id": "raw_namelist_note",
+                "label": "Developer namelist note",
+                "description": "Advanced/developer-only mapping detail.",
+                "type": "boolean",
+                "audience": "advanced",
+                "default": False,
+                "cm1_mapping_notes": "Documents future raw namelist mapping, not primary UI.",
+            },
+        ],
+        "run_size_presets": [
+            {
+                "id": "quick_look",
+                "label": "Quick look",
+                "purpose": "Sanity-check setup.",
+                "expected_runtime": "roughly 10-20 minutes when feasible",
+                "confidence": "lower confidence until locally validated",
+                "output_notes": "coarser output cadence is acceptable if labeled",
+            },
+            {
+                "id": "standard",
+                "label": "Standard",
+                "purpose": "Normal personal exploration.",
+                "expected_runtime": "normal local run",
+                "confidence": "balanced confidence and runtime",
+                "output_notes": "useful saved diagnostics",
+            },
+            {
+                "id": "deep_overnight",
+                "label": "Deep / overnight",
+                "purpose": "Richer result exploration.",
+                "expected_runtime": "may take hours or overnight",
+                "confidence": "higher confidence or detail",
+                "output_notes": "larger output should be explicit before launch",
+            },
+        ],
+        "expected_diagnostics": {
+            "cloud_formed": True,
+            "first_cloud_time": "expected after spin-up if clouds form",
+            "cloud_base_top": "record cloud base/top if clouds form",
+            "max_updraft": "record maximum vertical velocity",
+            "cloud_water_summary": "summarize cloud-water evolution",
+            "rain_onset": "not expected for the baseline, but record if present",
+        },
+        "cm1_template": {
+            "namelist_template": "namelist.input.j2",
+            "input_sounding_template": "input_sounding.j2",
+            "runtime_files_needed": ["LANDUSE.TBL"],
+            "mapping_notes": "CM1 remains the source of truth.",
+        },
+        "visualization_defaults": {
+            "primary_field": "qc",
+            "secondary_fields": ["w"],
+            "camera": "orbit shallow-cumulus domain",
+            "rendering_method": "cloud-water opacity approximation",
+        },
+        "variation_policy": {
+            "baseline_scenario_id": "baseline-shallow-cumulus",
+            "one_control_at_a_time": True,
+            "suggested_controls": ["low_level_humidity"],
+            "non_goals": ["arbitrary large parameter sweeps"],
+        },
+        "warnings": ["Preview estimates are guidance only."],
+        "limitations": ["Exact morphology is not pass/fail."],
+        "advanced_settings_notes": "Raw namelist settings belong in developer views.",
+    }
+
+
+def test_valid_scenario_template_supports_golden_path_contract() -> None:
+    template = validate_scenario_template(valid_template())
+
+    assert template.id == "baseline-shallow-cumulus"
+    assert template.physical_question
+    assert len(template.learning_goals) == 2
+    assert {preset.id.value for preset in template.run_size_presets} == {
+        "quick_look",
+        "standard",
+        "deep_overnight",
+    }
+    assert template.expected_diagnostics.cloud_water_summary is not None
+    assert template.variation_policy is not None
+    assert template.variation_policy.one_control_at_a_time
+
+
+def test_invalid_template_requires_product_facing_control() -> None:
+    data = valid_template()
+    controls = data["controls"]
+    assert isinstance(controls, list)
+    controls[0]["audience"] = "advanced"
+
+    with pytest.raises(ScenarioValidationError, match="product-facing control"):
+        validate_scenario_template(data)
+
+
+def test_invalid_template_requires_all_runtime_profiles() -> None:
+    data = valid_template()
+    presets = data["run_size_presets"]
+    assert isinstance(presets, list)
+    data["run_size_presets"] = presets[:2]
+
+    with pytest.raises(ScenarioValidationError, match="quick/standard/deep"):
+        validate_scenario_template(data)
+
+
+def test_invalid_choice_control_reports_useful_default_error() -> None:
+    data = valid_template()
+    controls = data["controls"]
+    assert isinstance(controls, list)
+    controls[0]["default"] = "bogus"
+
+    with pytest.raises(ScenarioValidationError, match="default must match an option"):
+        validate_scenario_template(data)
+
+
+def test_invalid_variation_policy_rejects_unknown_controls() -> None:
+    data = valid_template()
+    variation_policy = data["variation_policy"]
+    assert isinstance(variation_policy, dict)
+    variation_policy["suggested_controls"] = ["missing_control"]
+
+    with pytest.raises(ScenarioValidationError, match="unknown controls"):
+        validate_scenario_template(data)

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -80,6 +80,8 @@ Responsibilities:
 
 Baseline Shallow Cumulus is the first hero case. Warm rain remains early but does not block the Golden Path.
 
+Scenario templates are validated before package generation. The schema supports stable IDs, display names, descriptions, physical questions, learning goals, friendly controls, advanced/developer-only settings, run-size presets, expected diagnostics, CM1 mapping notes, visualization defaults, warnings, limitations, and one-control variation metadata. Invalid templates should fail with actionable validation messages before any CM1-facing files are generated.
+
 ### Configuration Builder
 
 Turns a scenario + user controls into:

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -182,7 +182,7 @@ Runtime tier metadata should be carried through scenario templates, generated ru
 
 ## Preset Scenario Schema
 
-Each scenario should define:
+Backend scenario templates are validated by the `ScenarioTemplate` contract. Each scenario should define:
 
 ```yaml
 id:
@@ -221,6 +221,17 @@ validation_status:
   unrun | generated | accepted | needs_calibration
 notes:
 ```
+
+Validation rules should reject templates that:
+
+- omit product-facing controls
+- define a choice control whose default is not one of its options
+- define a number control without a valid range
+- omit one of the quick / standard / deep run-size presets
+- reference unknown controls from the one-control variation policy
+- include undeclared fields
+
+The schema is intentionally product-first. Raw CM1/developer controls can exist as advanced metadata, but product-facing controls remain the primary path.
 
 Initial scenario templates should include:
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -28,6 +28,8 @@ Future fast tests should cover:
 
 These tests must not require CM1 source, CM1 binaries, NetCDF output, generated run directories, or large local data.
 
+Scenario-template tests should cover both valid templates and targeted invalid templates, including missing product-facing controls, invalid choice defaults, missing runtime profiles, and variation policies that reference unknown controls. These tests validate metadata only; they do not generate CM1 output or launch CM1.
+
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.
 
 ## Local CM1 Workflow Tests


### PR DESCRIPTION
Closes #20.

Summary:
- Added a backend `ScenarioTemplate` schema and validation helper for Cloud Chamber scenario templates.
- Modeled product-facing controls, advanced/developer controls, run-size presets, expected diagnostics, CM1 mapping notes, visualization defaults, and one-control variation metadata.
- Added focused unit tests for valid templates and invalid product-control, runtime-preset, choice-default, and variation-policy cases.
- Updated product spec, architecture, and testing docs.

What was intentionally not included:
- No concrete scenario templates; #21 will add those separately.
- No CM1 package generation.
- No CM1 launch.
- No generated CM1 output or NetCDF sample data.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts were committed.
