### PR TITLE
Add initial lower-atmosphere scenario templates

### DIFF
--- a/app/backend/tests/test_scenario_templates.py
+++ b/app/backend/tests/test_scenario_templates.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from cloud_chamber.scenario_schema import ScenarioValidationError, validate_scenario_template
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCENARIO_DIR = REPO_ROOT / "scenarios" / "lower-atmosphere"
+EXPECTED_SCENARIOS = {
+    "baseline-shallow-cumulus",
+    "dry-failed-cumulus",
+    "capped-suppressed-cumulus",
+    "humid-vigorous-cumulus",
+    "low-stratus",
+    "warm-rain",
+}
+
+
+def scenario_paths() -> list[Path]:
+    return sorted(SCENARIO_DIR.glob("*.json"))
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text())
+
+
+def test_all_initial_lower_atmosphere_templates_exist() -> None:
+    assert {path.stem for path in scenario_paths()} == EXPECTED_SCENARIOS
+
+
+@pytest.mark.parametrize("path", scenario_paths(), ids=lambda path: path.stem)
+def test_committed_lower_atmosphere_templates_validate(path: Path) -> None:
+    template = validate_scenario_template(load_json(path))
+
+    assert template.category == "lower-atmosphere"
+    assert template.physical_question
+    assert template.learning_goals
+    assert template.warnings
+    assert template.limitations
+
+
+def test_baseline_is_golden_path_hero_case() -> None:
+    template = validate_scenario_template(load_json(SCENARIO_DIR / "baseline-shallow-cumulus.json"))
+
+    assert template.id == "baseline-shallow-cumulus"
+    assert "First Golden Path hero case" in template.description
+    assert template.variation_policy is not None
+    assert template.variation_policy.baseline_scenario_id == "baseline-shallow-cumulus"
+
+
+def test_warm_rain_is_early_but_non_blocking() -> None:
+    template = validate_scenario_template(load_json(SCENARIO_DIR / "warm-rain.json"))
+
+    assert "does not block the baseline Golden Path" in template.expected_behavior
+    assert template.expected_diagnostics.rain_onset == "record rain onset if present"
+
+
+def test_malformed_committed_template_fails_validation() -> None:
+    data = load_json(SCENARIO_DIR / "baseline-shallow-cumulus.json")
+    assert isinstance(data, dict)
+    data["controls"] = []
+
+    with pytest.raises(ScenarioValidationError, match="product-facing control"):
+        validate_scenario_template(data)

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -244,6 +244,8 @@ Initial scenario templates should include:
 
 Baseline shallow cumulus is the first hero case. Warm rain remains early but does not block the Golden Path.
 
+The initial lower-atmosphere templates live under `scenarios/lower-atmosphere/` as validated JSON metadata. They are honest scenario definitions and teaching contracts, not final scientific calibration. CM1 mapping fields are placeholders until local/manual CM1 validation accepts the generated configurations.
+
 ## Curated Controls And Diagnostics
 
 The first lower-atmosphere controls should use atmospheric language:

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -245,6 +245,8 @@ M1 should include:
 
 Baseline shallow cumulus is the first hero case. Warm rain remains early, but it should not block the baseline Golden Path.
 
+Initial lower-atmosphere templates live under `scenarios/lower-atmosphere/` and should validate against the scenario schema before any package generation work uses them. The templates include teaching goals, expected diagnostics, run-size preset notes, limitations, and one-control variation metadata.
+
 Initial controls should be atmospheric and curated, such as low-level humidity, surface heating, surface moisture, cap strength, cap height, dry air aloft, and mixing/entrainment. Raw namelist fields belong in advanced/developer views.
 
 First variations should favor one-control-at-a-time changes around baseline rather than arbitrary large parameter sweeps.

--- a/scenarios/lower-atmosphere/baseline-shallow-cumulus.json
+++ b/scenarios/lower-atmosphere/baseline-shallow-cumulus.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": "1",
+  "id": "baseline-shallow-cumulus",
+  "display_name": "Baseline Shallow Cumulus",
+  "category": "lower-atmosphere",
+  "description": "First Golden Path hero case for a credible idealized shallow-cumulus experiment.",
+  "physical_question": "How do low-level moisture, surface heating, cap strength, cap height, dry air aloft, and mixing/entrainment affect shallow-cumulus formation, timing, depth, updraft strength, and cloud-water evolution?",
+  "learning_goals": [
+    "Recognize first cloud time and cloud depth in a baseline lower-atmosphere setup.",
+    "Use the baseline as the reference for one-control-at-a-time variations.",
+    "Understand that exact cloud morphology is inspected, not treated as a brittle pass/fail result."
+  ],
+  "intended_behavior": "A balanced shallow-cumulus case that can form clouds under local CM1 validation.",
+  "expected_behavior": "Clouds may form after heating and mixing erode inhibition; timing and depth remain subject to CM1 validation.",
+  "controls": [
+    {
+      "id": "low_level_humidity",
+      "label": "Low-level humidity",
+      "description": "Relative moisture in the lower atmosphere around the baseline profile.",
+      "type": "choice",
+      "audience": "product",
+      "default": "baseline",
+      "options": [
+        {"value": "drier", "label": "Drier"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "more_humid", "label": "More humid"}
+      ],
+      "cm1_mapping_notes": "Future mapping should adjust low-level sounding moisture while preserving scientific disclosure."
+    },
+    {
+      "id": "surface_heating",
+      "label": "Surface heating",
+      "description": "Relative daytime heating strength for boundary-layer growth.",
+      "type": "choice",
+      "audience": "product",
+      "default": "baseline",
+      "options": [
+        {"value": "weaker", "label": "Weaker"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "stronger", "label": "Stronger"}
+      ],
+      "cm1_mapping_notes": "Future mapping should adjust surface flux or related idealized forcing."
+    },
+    {
+      "id": "cap_strength",
+      "label": "Cap strength",
+      "description": "Relative resistance to rising thermals near the capping layer.",
+      "type": "choice",
+      "audience": "product",
+      "default": "baseline",
+      "options": [
+        {"value": "weaker", "label": "Weaker"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "stronger", "label": "Stronger"}
+      ],
+      "cm1_mapping_notes": "Future mapping should adjust sounding stability near the cap."
+    }
+  ],
+  "run_size_presets": [
+    {"id": "quick_look", "label": "Quick look", "purpose": "Sanity-check setup and rough cloud behavior.", "expected_runtime": "roughly 10-20 minutes when feasible on the local Mac", "confidence": "lower confidence until locally validated", "output_notes": "coarser output cadence is acceptable if clearly labeled"},
+    {"id": "standard", "label": "Standard", "purpose": "Normal personal exploration and useful saved diagnostics.", "expected_runtime": "normal local personal exploration run", "confidence": "balanced runtime and diagnostic value", "output_notes": "intended result-card/notebook source"},
+    {"id": "deep_overnight", "label": "Deep / overnight", "purpose": "Richer or prettier result exploration.", "expected_runtime": "may take hours or overnight", "confidence": "higher detail only after local validation", "output_notes": "larger output should be explicit before launch"}
+  ],
+  "expected_diagnostics": {
+    "cloud_formed": true,
+    "first_cloud_time": "record if and when shallow cumulus first appears",
+    "cloud_base_top": "record cloud base and cloud top if clouds form",
+    "max_updraft": "record maximum vertical velocity",
+    "cloud_water_summary": "summarize cloud-water maximum and time evolution",
+    "rain_onset": "not expected for baseline, but record if present",
+    "notes": ["Exact morphology is not pass/fail."]
+  },
+  "cm1_template": {
+    "namelist_template": "templates/lower-atmosphere/baseline-shallow-cumulus/namelist.input.j2",
+    "input_sounding_template": "templates/lower-atmosphere/baseline-shallow-cumulus/input_sounding.j2",
+    "runtime_files_needed": ["LANDUSE.TBL"],
+    "mapping_notes": "Mapping is a documented placeholder until manually validated against local CM1."
+  },
+  "visualization_defaults": {
+    "primary_field": "qc",
+    "secondary_fields": ["w", "qr"],
+    "camera": "orbit view over lower-atmosphere domain",
+    "rendering_method": "cloud-water opacity approximation"
+  },
+  "variation_policy": {
+    "baseline_scenario_id": "baseline-shallow-cumulus",
+    "one_control_at_a_time": true,
+    "suggested_controls": ["low_level_humidity", "surface_heating", "cap_strength"],
+    "non_goals": ["arbitrary large parameter sweeps", "publication-quality LES claims"]
+  },
+  "warnings": ["Preview estimates are guidance only; CM1 output is the source of truth."],
+  "limitations": ["Template mapping is not scientifically accepted until local/manual CM1 validation."],
+  "advanced_settings_notes": "Raw CM1 namelist fields belong in advanced/developer views."
+}

--- a/scenarios/lower-atmosphere/capped-suppressed-cumulus.json
+++ b/scenarios/lower-atmosphere/capped-suppressed-cumulus.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "1",
+  "id": "capped-suppressed-cumulus",
+  "display_name": "Capped / Suppressed Cumulus",
+  "category": "lower-atmosphere",
+  "description": "A contrast case focused on how a stronger cap can suppress or delay shallow cumulus.",
+  "physical_question": "How do cap strength and cap height limit rising thermals and cloud depth?",
+  "learning_goals": ["Identify cap-limited cloud behavior.", "Compare cap strength and cap height against the baseline."],
+  "intended_behavior": "A capped lower-atmosphere case with delayed, shallow, or suppressed clouds.",
+  "expected_behavior": "Clouds may remain shallow, form late, or fail if the cap is too strong.",
+  "controls": [
+    {
+      "id": "cap_strength",
+      "label": "Cap strength",
+      "description": "Relative strength of the stable layer above the mixed layer.",
+      "type": "choice",
+      "audience": "product",
+      "default": "stronger",
+      "options": [
+        {"value": "weaker", "label": "Weaker"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "stronger", "label": "Stronger"}
+      ],
+      "cm1_mapping_notes": "Future mapping should adjust stability near the cap."
+    },
+    {
+      "id": "cap_height",
+      "label": "Cap height",
+      "description": "Relative height of the capping layer.",
+      "type": "choice",
+      "audience": "product",
+      "default": "baseline",
+      "options": [
+        {"value": "lower", "label": "Lower"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "higher", "label": "Higher"}
+      ],
+      "cm1_mapping_notes": "Future mapping should adjust the vertical sounding structure."
+    }
+  ],
+  "run_size_presets": [
+    {"id": "quick_look", "label": "Quick look", "purpose": "Check cap-limited behavior.", "expected_runtime": "roughly 10-20 minutes when feasible", "confidence": "lower confidence until locally validated", "output_notes": "coarser cadence acceptable"},
+    {"id": "standard", "label": "Standard", "purpose": "Useful capped contrast result.", "expected_runtime": "normal local run", "confidence": "balanced confidence and runtime", "output_notes": "record cloud-top and updraft diagnostics"},
+    {"id": "deep_overnight", "label": "Deep / overnight", "purpose": "Longer capped-case exploration.", "expected_runtime": "may take hours or overnight", "confidence": "higher detail after validation", "output_notes": "output size must be explicit"}
+  ],
+  "expected_diagnostics": {
+    "cloud_formed": true,
+    "first_cloud_time": "record delayed or absent first cloud time",
+    "cloud_base_top": "record cap-limited cloud depth",
+    "max_updraft": "record maximum vertical velocity",
+    "cloud_water_summary": "summarize weak or capped cloud-water signal",
+    "rain_onset": "not expected",
+    "notes": ["Suppression can be a valid result."]
+  },
+  "cm1_template": {
+    "namelist_template": "templates/lower-atmosphere/capped-suppressed-cumulus/namelist.input.j2",
+    "input_sounding_template": "templates/lower-atmosphere/capped-suppressed-cumulus/input_sounding.j2",
+    "runtime_files_needed": ["LANDUSE.TBL"],
+    "mapping_notes": "Placeholder mapping until local CM1 validation."
+  },
+  "visualization_defaults": {
+    "primary_field": "qc",
+    "secondary_fields": ["w"],
+    "camera": "orbit view with vertical slice emphasis",
+    "rendering_method": "cloud-water opacity approximation"
+  },
+  "variation_policy": {
+    "baseline_scenario_id": "baseline-shallow-cumulus",
+    "one_control_at_a_time": true,
+    "suggested_controls": ["cap_strength", "cap_height"],
+    "non_goals": ["large parameter sweeps"]
+  },
+  "warnings": ["Preview estimates are guidance only."],
+  "limitations": ["Cap behavior requires local/manual CM1 validation."],
+  "advanced_settings_notes": "Raw CM1 settings remain advanced/developer-only."
+}

--- a/scenarios/lower-atmosphere/dry-failed-cumulus.json
+++ b/scenarios/lower-atmosphere/dry-failed-cumulus.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "1",
+  "id": "dry-failed-cumulus",
+  "display_name": "Dry Failed Cumulus",
+  "category": "lower-atmosphere",
+  "description": "A dry lower-atmosphere contrast case where shallow cumulus may fail to form.",
+  "physical_question": "How does insufficient low-level moisture limit cloud formation even with daytime heating?",
+  "learning_goals": ["Compare no-cloud or weak-cloud behavior against the baseline.", "Identify moisture limitation as a possible main limiting factor."],
+  "intended_behavior": "A drier contrast around the baseline shallow-cumulus setup.",
+  "expected_behavior": "Clouds may be delayed, shallow, or absent if the lower atmosphere is too dry.",
+  "controls": [
+    {
+      "id": "low_level_humidity",
+      "label": "Low-level humidity",
+      "description": "Lower-atmosphere moisture relative to the baseline.",
+      "type": "choice",
+      "audience": "product",
+      "default": "drier",
+      "options": [
+        {"value": "drier", "label": "Drier"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "more_humid", "label": "More humid"}
+      ],
+      "cm1_mapping_notes": "Future mapping should reduce low-level sounding moisture."
+    },
+    {
+      "id": "surface_heating",
+      "label": "Surface heating",
+      "description": "Heating strength available to grow thermals.",
+      "type": "choice",
+      "audience": "product",
+      "default": "baseline",
+      "options": [
+        {"value": "weaker", "label": "Weaker"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "stronger", "label": "Stronger"}
+      ],
+      "cm1_mapping_notes": "Future mapping should adjust idealized heating/flux forcing."
+    }
+  ],
+  "run_size_presets": [
+    {"id": "quick_look", "label": "Quick look", "purpose": "Check whether dry setup suppresses cloud formation.", "expected_runtime": "roughly 10-20 minutes when feasible", "confidence": "lower confidence until locally validated", "output_notes": "coarser cadence acceptable"},
+    {"id": "standard", "label": "Standard", "purpose": "Useful dry contrast result.", "expected_runtime": "normal local run", "confidence": "balanced confidence and runtime", "output_notes": "record failed/weak cloud diagnostics"},
+    {"id": "deep_overnight", "label": "Deep / overnight", "purpose": "Longer dry-case exploration.", "expected_runtime": "may take hours or overnight", "confidence": "higher detail after validation", "output_notes": "output size must be explicit"}
+  ],
+  "expected_diagnostics": {
+    "cloud_formed": false,
+    "first_cloud_time": "record if clouds unexpectedly form",
+    "cloud_base_top": "record if clouds form",
+    "max_updraft": "record maximum vertical velocity",
+    "cloud_water_summary": "summarize near-zero or weak cloud-water signal",
+    "rain_onset": "not expected",
+    "notes": ["Failed cloud formation can be a valid learning result."]
+  },
+  "cm1_template": {
+    "namelist_template": "templates/lower-atmosphere/dry-failed-cumulus/namelist.input.j2",
+    "input_sounding_template": "templates/lower-atmosphere/dry-failed-cumulus/input_sounding.j2",
+    "runtime_files_needed": ["LANDUSE.TBL"],
+    "mapping_notes": "Placeholder mapping until local CM1 validation."
+  },
+  "visualization_defaults": {
+    "primary_field": "qc",
+    "secondary_fields": ["w"],
+    "camera": "orbit view over lower-atmosphere domain",
+    "rendering_method": "cloud-water opacity approximation"
+  },
+  "variation_policy": {
+    "baseline_scenario_id": "baseline-shallow-cumulus",
+    "one_control_at_a_time": true,
+    "suggested_controls": ["low_level_humidity", "surface_heating"],
+    "non_goals": ["large parameter sweeps"]
+  },
+  "warnings": ["Preview estimates are guidance only."],
+  "limitations": ["Dry failure behavior requires local/manual CM1 validation."],
+  "advanced_settings_notes": "Raw CM1 settings remain advanced/developer-only."
+}

--- a/scenarios/lower-atmosphere/humid-vigorous-cumulus.json
+++ b/scenarios/lower-atmosphere/humid-vigorous-cumulus.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "1",
+  "id": "humid-vigorous-cumulus",
+  "display_name": "Humid Vigorous Cumulus",
+  "category": "lower-atmosphere",
+  "description": "A humid contrast case for stronger or deeper shallow-cumulus behavior.",
+  "physical_question": "How does additional low-level moisture change cloud timing, depth, updrafts, and cloud water?",
+  "learning_goals": ["Compare humid behavior against the baseline.", "Inspect stronger cloud-water and updraft signals without treating preview as truth."],
+  "intended_behavior": "A moister contrast with potentially earlier or deeper cloud development.",
+  "expected_behavior": "Clouds may form earlier, grow deeper, or show stronger cloud-water signals.",
+  "controls": [
+    {
+      "id": "low_level_humidity",
+      "label": "Low-level humidity",
+      "description": "Lower-atmosphere moisture relative to the baseline.",
+      "type": "choice",
+      "audience": "product",
+      "default": "more_humid",
+      "options": [
+        {"value": "drier", "label": "Drier"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "more_humid", "label": "More humid"}
+      ],
+      "cm1_mapping_notes": "Future mapping should increase low-level sounding moisture."
+    },
+    {
+      "id": "surface_heating",
+      "label": "Surface heating",
+      "description": "Heating strength available to grow thermals.",
+      "type": "choice",
+      "audience": "product",
+      "default": "baseline",
+      "options": [
+        {"value": "weaker", "label": "Weaker"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "stronger", "label": "Stronger"}
+      ],
+      "cm1_mapping_notes": "Future mapping should adjust idealized heating/flux forcing."
+    }
+  ],
+  "run_size_presets": [
+    {"id": "quick_look", "label": "Quick look", "purpose": "Check humid contrast behavior.", "expected_runtime": "roughly 10-20 minutes when feasible", "confidence": "lower confidence until locally validated", "output_notes": "coarser cadence acceptable"},
+    {"id": "standard", "label": "Standard", "purpose": "Useful humid result.", "expected_runtime": "normal local run", "confidence": "balanced confidence and runtime", "output_notes": "record updraft and cloud-water diagnostics"},
+    {"id": "deep_overnight", "label": "Deep / overnight", "purpose": "Longer humid-case exploration.", "expected_runtime": "may take hours or overnight", "confidence": "higher detail after validation", "output_notes": "output size must be explicit"}
+  ],
+  "expected_diagnostics": {
+    "cloud_formed": true,
+    "first_cloud_time": "record possibly earlier first cloud time",
+    "cloud_base_top": "record cloud depth",
+    "max_updraft": "record maximum vertical velocity",
+    "cloud_water_summary": "summarize stronger cloud-water evolution if present",
+    "rain_onset": "record if present, but warm rain has a separate scenario",
+    "notes": ["Humid vigorous behavior is subject to CM1 validation."]
+  },
+  "cm1_template": {
+    "namelist_template": "templates/lower-atmosphere/humid-vigorous-cumulus/namelist.input.j2",
+    "input_sounding_template": "templates/lower-atmosphere/humid-vigorous-cumulus/input_sounding.j2",
+    "runtime_files_needed": ["LANDUSE.TBL"],
+    "mapping_notes": "Placeholder mapping until local CM1 validation."
+  },
+  "visualization_defaults": {
+    "primary_field": "qc",
+    "secondary_fields": ["w", "qr"],
+    "camera": "orbit view over lower-atmosphere domain",
+    "rendering_method": "cloud-water opacity approximation"
+  },
+  "variation_policy": {
+    "baseline_scenario_id": "baseline-shallow-cumulus",
+    "one_control_at_a_time": true,
+    "suggested_controls": ["low_level_humidity", "surface_heating"],
+    "non_goals": ["large parameter sweeps"]
+  },
+  "warnings": ["Preview estimates are guidance only."],
+  "limitations": ["Humid behavior requires local/manual CM1 validation."],
+  "advanced_settings_notes": "Raw CM1 settings remain advanced/developer-only."
+}

--- a/scenarios/lower-atmosphere/low-stratus.json
+++ b/scenarios/lower-atmosphere/low-stratus.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "1",
+  "id": "low-stratus",
+  "display_name": "Low Stratus / Low-Cloud Layer",
+  "category": "lower-atmosphere",
+  "description": "A low-cloud contrast case for layer-like cloud behavior near the lower atmosphere.",
+  "physical_question": "How do surface moisture, cap height, and weak mixing favor lower cloud layers instead of isolated shallow cumulus?",
+  "learning_goals": ["Contrast layer-like low cloud with baseline shallow cumulus.", "Inspect cloud base/top and cloud-water distribution."],
+  "intended_behavior": "A low-cloud or stratus-like setup for later CM1 validation.",
+  "expected_behavior": "A lower, broader cloud layer may develop if moisture and stability support it.",
+  "controls": [
+    {
+      "id": "surface_moisture",
+      "label": "Surface moisture",
+      "description": "Relative moisture supply near the surface.",
+      "type": "choice",
+      "audience": "product",
+      "default": "moister",
+      "options": [
+        {"value": "drier", "label": "Drier"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "moister", "label": "Moister"}
+      ],
+      "cm1_mapping_notes": "Future mapping should adjust near-surface moisture or surface-flux assumptions."
+    },
+    {
+      "id": "mixing_entrainment",
+      "label": "Mixing / entrainment",
+      "description": "Relative mixing with air above the lower cloud layer.",
+      "type": "choice",
+      "audience": "product",
+      "default": "weaker",
+      "options": [
+        {"value": "weaker", "label": "Weaker"},
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "stronger", "label": "Stronger"}
+      ],
+      "cm1_mapping_notes": "Future mapping should document how this control affects idealized setup assumptions."
+    }
+  ],
+  "run_size_presets": [
+    {"id": "quick_look", "label": "Quick look", "purpose": "Check low-cloud setup.", "expected_runtime": "roughly 10-20 minutes when feasible", "confidence": "lower confidence until locally validated", "output_notes": "coarser cadence acceptable"},
+    {"id": "standard", "label": "Standard", "purpose": "Useful low-cloud result.", "expected_runtime": "normal local run", "confidence": "balanced confidence and runtime", "output_notes": "record cloud layer diagnostics"},
+    {"id": "deep_overnight", "label": "Deep / overnight", "purpose": "Longer low-cloud exploration.", "expected_runtime": "may take hours or overnight", "confidence": "higher detail after validation", "output_notes": "output size must be explicit"}
+  ],
+  "expected_diagnostics": {
+    "cloud_formed": true,
+    "first_cloud_time": "record low-cloud onset",
+    "cloud_base_top": "record low cloud base/top",
+    "max_updraft": "record weak or layered vertical velocity signals",
+    "cloud_water_summary": "summarize low-cloud water distribution",
+    "rain_onset": "not expected",
+    "notes": ["Layer-like morphology requires CM1 validation."]
+  },
+  "cm1_template": {
+    "namelist_template": "templates/lower-atmosphere/low-stratus/namelist.input.j2",
+    "input_sounding_template": "templates/lower-atmosphere/low-stratus/input_sounding.j2",
+    "runtime_files_needed": ["LANDUSE.TBL"],
+    "mapping_notes": "Placeholder mapping until local CM1 validation."
+  },
+  "visualization_defaults": {
+    "primary_field": "qc",
+    "secondary_fields": ["w"],
+    "camera": "low orbit view with horizontal slice emphasis",
+    "rendering_method": "cloud-water opacity approximation"
+  },
+  "variation_policy": {
+    "baseline_scenario_id": "baseline-shallow-cumulus",
+    "one_control_at_a_time": true,
+    "suggested_controls": ["surface_moisture", "mixing_entrainment"],
+    "non_goals": ["large parameter sweeps"]
+  },
+  "warnings": ["Preview estimates are guidance only."],
+  "limitations": ["Low-stratus behavior requires local/manual CM1 validation."],
+  "advanced_settings_notes": "Raw CM1 settings remain advanced/developer-only."
+}

--- a/scenarios/lower-atmosphere/warm-rain.json
+++ b/scenarios/lower-atmosphere/warm-rain.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "1",
+  "id": "warm-rain",
+  "display_name": "Warm Rain / Precipitating Shallow Cloud",
+  "category": "lower-atmosphere",
+  "description": "An early but non-blocking precipitating shallow-cloud scenario for later Golden Path extension.",
+  "physical_question": "When does a shallow warm cloud produce rain, and how do moisture and depth affect rain onset?",
+  "learning_goals": ["Track rain onset if present.", "Compare precipitating shallow cloud with the non-precipitating baseline."],
+  "intended_behavior": "A wetter/deeper shallow-cloud case where warm rain may occur after local CM1 validation.",
+  "expected_behavior": "Rain may form if the cloud becomes deep and moist enough; this remains early but does not block the baseline Golden Path.",
+  "controls": [
+    {
+      "id": "low_level_humidity",
+      "label": "Low-level humidity",
+      "description": "Lower-atmosphere moisture relative to the baseline.",
+      "type": "choice",
+      "audience": "product",
+      "default": "more_humid",
+      "options": [
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "more_humid", "label": "More humid"}
+      ],
+      "cm1_mapping_notes": "Future mapping should increase low-level sounding moisture."
+    },
+    {
+      "id": "cloud_depth_potential",
+      "label": "Cloud depth potential",
+      "description": "Relative tendency for a cloud to grow deep enough for warm rain.",
+      "type": "choice",
+      "audience": "product",
+      "default": "deeper",
+      "options": [
+        {"value": "baseline", "label": "Baseline"},
+        {"value": "deeper", "label": "Deeper"}
+      ],
+      "cm1_mapping_notes": "Future mapping should document cap, moisture, and microphysics assumptions."
+    }
+  ],
+  "run_size_presets": [
+    {"id": "quick_look", "label": "Quick look", "purpose": "Check whether rain behavior is plausible enough for further exploration.", "expected_runtime": "roughly 10-20 minutes when feasible", "confidence": "lower confidence until locally validated", "output_notes": "rain onset may require longer output"},
+    {"id": "standard", "label": "Standard", "purpose": "Useful precipitating shallow-cloud result.", "expected_runtime": "normal local run", "confidence": "balanced confidence and runtime", "output_notes": "record cloud-water and rain-water diagnostics"},
+    {"id": "deep_overnight", "label": "Deep / overnight", "purpose": "Richer rain-onset exploration.", "expected_runtime": "may take hours or overnight", "confidence": "higher detail after validation", "output_notes": "larger output should be explicit before launch"}
+  ],
+  "expected_diagnostics": {
+    "cloud_formed": true,
+    "first_cloud_time": "record first cloud time",
+    "cloud_base_top": "record cloud depth",
+    "max_updraft": "record maximum vertical velocity",
+    "cloud_water_summary": "summarize cloud-water evolution",
+    "rain_onset": "record rain onset if present",
+    "notes": ["Warm rain remains early but does not block the baseline Golden Path."]
+  },
+  "cm1_template": {
+    "namelist_template": "templates/lower-atmosphere/warm-rain/namelist.input.j2",
+    "input_sounding_template": "templates/lower-atmosphere/warm-rain/input_sounding.j2",
+    "runtime_files_needed": ["LANDUSE.TBL"],
+    "mapping_notes": "Placeholder mapping until local CM1 validation; do not claim precipitation authority before CM1 inspection."
+  },
+  "visualization_defaults": {
+    "primary_field": "qc",
+    "secondary_fields": ["qr", "w"],
+    "camera": "orbit view with rain-water field available",
+    "rendering_method": "cloud-water opacity approximation"
+  },
+  "variation_policy": {
+    "baseline_scenario_id": "baseline-shallow-cumulus",
+    "one_control_at_a_time": true,
+    "suggested_controls": ["low_level_humidity", "cloud_depth_potential"],
+    "non_goals": ["making warm rain block baseline shallow-cumulus delivery"]
+  },
+  "warnings": ["Preview estimates are guidance only; CM1 output is the source of truth."],
+  "limitations": ["Warm-rain behavior requires local/manual CM1 validation and may need longer runs."],
+  "advanced_settings_notes": "Raw microphysics and namelist settings remain advanced/developer-only."
+}


### PR DESCRIPTION
Closes #21.

Summary:
- Added validated lower-atmosphere scenario templates for baseline shallow cumulus, dry failed cumulus, capped/suppressed cumulus, humid vigorous cumulus, low stratus, and warm rain.
- Marked Baseline Shallow Cumulus as the first Golden Path hero case.
- Kept warm rain early but non-blocking for the baseline Golden Path.
- Included teaching goals, friendly controls, run-size preset notes, expected diagnostics, limitations, and likely one-control variations around baseline.
- Added tests that validate all committed templates and verify malformed template failure.
- Updated product spec and roadmap docs with the committed template path and validation role.

What was intentionally not included:
- No final CM1 mapping values.
- No generated CM1 run packages.
- No CM1 launch.
- No NetCDF or generated CM1 outputs.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts were committed.
