### PR TITLE
Define run manifest schema

### DIFF
--- a/app/backend/cloud_chamber/run_manifest.py
+++ b/app/backend/cloud_chamber/run_manifest.py
@@ -1,0 +1,186 @@
+"""Run manifest schema and lifecycle state validation."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+
+class RunManifestError(ValueError):
+    """Raised when a run manifest fails validation or parsing."""
+
+
+class LifecycleState(StrEnum):
+    CREATED = "created"
+    PACKAGED = "packaged"
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELED = "canceled"
+    INGESTED = "ingested"
+    SAVED = "saved"
+
+
+class ValidationStatus(StrEnum):
+    UNVALIDATED = "unvalidated"
+    VALID = "valid"
+    NEEDS_REVIEW = "needs_review"
+    FAILED = "failed"
+
+
+class ProductState(StrEnum):
+    PREVIEW_ESTIMATE = "preview_estimate"
+    GENERATED_CM1_CONFIGURATION = "generated_cm1_configuration"
+    PACKAGED_DRY_RUN_OUTPUT = "packaged_dry_run_output"
+    QUEUED_RUNNING_CM1_PROCESS = "queued_running_cm1_process"
+    COMPLETED_CM1_RESULT = "completed_cm1_result"
+    FAILED_CANCELED_CM1_RUN = "failed_canceled_cm1_run"
+    INGESTED_RESULT_METADATA = "ingested_result_metadata"
+    VISUALIZER_INTERPRETATION = "visualizer_interpretation"
+    SAVED_RESULT_NOTEBOOK_ENTRY = "saved_result_notebook_entry"
+
+
+class ScenarioReference(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    schema_version: str
+    template_path: str | None = None
+
+
+class GeneratedInputs(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_directory: str
+    manifest_path: str | None = None
+    namelist_input: str | None = None
+    input_sounding: str | None = None
+    dry_run_report: str | None = None
+    runtime_file_checklist: list[str] = Field(default_factory=list)
+
+
+class RuntimePaths(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    runtime_home: str
+    cm1_root: str | None = None
+    cm1_run_dir: str | None = None
+    cache_dir: str | None = None
+    log_dir: str | None = None
+
+
+class AppMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    app_version: str
+    commit: str | None = None
+    created_by: str = "Cloud Chamber"
+
+
+class ExecutionMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    command: list[str] = Field(default_factory=list)
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    exit_code: int | None = None
+    stdout_log: str | None = None
+    stderr_log: str | None = None
+
+
+class OutputMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    netcdf_paths: list[str] = Field(default_factory=list)
+    processed_artifacts: list[str] = Field(default_factory=list)
+    diagnostics_summary: str | None = None
+    visualization_defaults: str | None = None
+
+
+class ProvenanceMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_model: str = "CM1"
+    product_state: ProductState
+    preview_is_guidance_only: bool = True
+    visualizer_is_interpretation: bool = True
+
+
+class UserMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    tags: list[str] = Field(default_factory=list)
+    notes: str | None = None
+    saved: bool = False
+
+
+class RunManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    manifest_version: str = "1"
+    run_id: str
+    scenario: ScenarioReference
+    controls: dict[str, str | float | bool]
+    run_size_preset: str
+    physical_question: str
+    expected_diagnostics: list[str]
+    generated_inputs: GeneratedInputs
+    runtime_paths: RuntimePaths
+    app: AppMetadata
+    lifecycle_state: LifecycleState
+    validation_status: ValidationStatus
+    provenance: ProvenanceMetadata
+    created_at: datetime
+    updated_at: datetime
+    execution: ExecutionMetadata = Field(default_factory=ExecutionMetadata)
+    outputs: OutputMetadata = Field(default_factory=OutputMetadata)
+    user: UserMetadata
+
+    @model_validator(mode="after")
+    def validate_state_contract(self) -> RunManifest:
+        if self.updated_at < self.created_at:
+            raise ValueError("updated_at must not be earlier than created_at")
+        if self.lifecycle_state == LifecycleState.PACKAGED:
+            if self.provenance.product_state != ProductState.PACKAGED_DRY_RUN_OUTPUT:
+                raise ValueError("packaged manifests must use packaged dry-run product state")
+            if self.outputs.netcdf_paths:
+                raise ValueError("packaged dry-run manifests must not include NetCDF outputs")
+        if self.lifecycle_state in {
+            LifecycleState.COMPLETED,
+            LifecycleState.INGESTED,
+            LifecycleState.SAVED,
+        }:
+            if self.provenance.product_state == ProductState.PACKAGED_DRY_RUN_OUTPUT:
+                raise ValueError("completed/ingested/saved manifests cannot be dry-run packages")
+        if self.lifecycle_state == LifecycleState.SAVED and not self.user.saved:
+            raise ValueError("saved manifests must set user.saved")
+        return self
+
+    def to_json_text(self) -> str:
+        return self.model_dump_json(indent=2) + "\n"
+
+
+def validate_run_manifest(data: object) -> RunManifest:
+    try:
+        return RunManifest.model_validate(data)
+    except ValidationError as exc:
+        raise RunManifestError(str(exc)) from exc
+
+
+def run_manifest_from_json(text: str) -> RunManifest:
+    try:
+        data: Any = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise RunManifestError(str(exc)) from exc
+    return validate_run_manifest(data)
+
+
+def load_run_manifest(path: Path) -> RunManifest:
+    return run_manifest_from_json(path.read_text())

--- a/app/backend/tests/test_run_manifest.py
+++ b/app/backend/tests/test_run_manifest.py
@@ -1,0 +1,110 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cloud_chamber.run_manifest import (
+    LifecycleState,
+    ProductState,
+    RunManifestError,
+    run_manifest_from_json,
+    validate_run_manifest,
+)
+
+
+def valid_manifest_data() -> dict[str, object]:
+    created_at = datetime(2026, 5, 21, 12, 0, tzinfo=UTC).isoformat()
+    return {
+        "manifest_version": "1",
+        "run_id": "run-001",
+        "scenario": {
+            "id": "baseline-shallow-cumulus",
+            "schema_version": "1",
+            "template_path": "scenarios/lower-atmosphere/baseline-shallow-cumulus.json",
+        },
+        "controls": {"low_level_humidity": "baseline", "surface_heating": "baseline"},
+        "run_size_preset": "quick_look",
+        "physical_question": "How do moisture and heating shape shallow cumulus?",
+        "expected_diagnostics": ["first_cloud_time", "cloud_base_top", "cloud_water_summary"],
+        "generated_inputs": {
+            "run_directory": "~/CloudChamber/runs/run-001",
+            "manifest_path": "~/CloudChamber/runs/run-001/run_manifest.json",
+            "namelist_input": "~/CloudChamber/runs/run-001/namelist.input",
+            "input_sounding": "~/CloudChamber/runs/run-001/input_sounding",
+            "dry_run_report": "~/CloudChamber/runs/run-001/dry_run_report.json",
+            "runtime_file_checklist": ["LANDUSE.TBL"],
+        },
+        "runtime_paths": {
+            "runtime_home": "~/CloudChamber",
+            "cm1_root": "/Users/timpeterson/cm1r21.1",
+            "cm1_run_dir": "/Users/timpeterson/cm1r21.1/run",
+            "cache_dir": "~/CloudChamber/cache",
+            "log_dir": "~/CloudChamber/logs",
+        },
+        "app": {"app_version": "0.1.0", "commit": "abc123", "created_by": "Cloud Chamber"},
+        "lifecycle_state": "packaged",
+        "validation_status": "valid",
+        "provenance": {
+            "source_model": "CM1",
+            "product_state": "packaged_dry_run_output",
+            "preview_is_guidance_only": True,
+            "visualizer_is_interpretation": True,
+        },
+        "created_at": created_at,
+        "updated_at": created_at,
+        "execution": {"command": []},
+        "outputs": {"netcdf_paths": [], "processed_artifacts": []},
+        "user": {"name": "Baseline check", "tags": ["golden-path"], "saved": False},
+    }
+
+
+def test_valid_packaged_manifest_does_not_require_netcdf_output() -> None:
+    manifest = validate_run_manifest(valid_manifest_data())
+
+    assert manifest.lifecycle_state == LifecycleState.PACKAGED
+    assert manifest.provenance.product_state == ProductState.PACKAGED_DRY_RUN_OUTPUT
+    assert manifest.outputs.netcdf_paths == []
+
+
+def test_manifest_serializes_and_deserializes() -> None:
+    manifest = validate_run_manifest(valid_manifest_data())
+
+    round_tripped = run_manifest_from_json(manifest.to_json_text())
+
+    assert round_tripped == manifest
+
+
+def test_invalid_lifecycle_state_fails() -> None:
+    data = valid_manifest_data()
+    data["lifecycle_state"] = "almost_running"
+
+    with pytest.raises(RunManifestError, match="almost_running"):
+        validate_run_manifest(data)
+
+
+def test_packaged_manifest_cannot_include_netcdf_outputs() -> None:
+    data = valid_manifest_data()
+    outputs = data["outputs"]
+    assert isinstance(outputs, dict)
+    outputs["netcdf_paths"] = ["cm1out_000001.nc"]
+
+    with pytest.raises(RunManifestError, match="must not include NetCDF"):
+        validate_run_manifest(data)
+
+
+def test_saved_manifest_requires_user_saved_flag() -> None:
+    data = valid_manifest_data()
+    data["lifecycle_state"] = "saved"
+    provenance = data["provenance"]
+    assert isinstance(provenance, dict)
+    provenance["product_state"] = "saved_result_notebook_entry"
+
+    with pytest.raises(RunManifestError, match="must set user.saved"):
+        validate_run_manifest(data)
+
+
+def test_completed_manifest_cannot_be_dry_run_package() -> None:
+    data = valid_manifest_data()
+    data["lifecycle_state"] = "completed"
+
+    with pytest.raises(RunManifestError, match="cannot be dry-run packages"):
+        validate_run_manifest(data)

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -309,6 +309,8 @@ Run manifests should record the scenario template, adjusted controls, generated 
 
 Run manifests should also record the selected run-size preset, physical question, expected diagnostics, and visualization defaults when those concepts are available from the scenario template.
 
+The backend run-manifest schema records run ID, scenario reference/version, adjusted controls, generated CM1 input paths, CM1 root/run paths, app metadata, timestamps, lifecycle state, validation status, output paths, user notes/tags, and provenance labels. It serializes/deserializes as JSON and does not require NetCDF output.
+
 Lifecycle states:
 
 ```text

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -283,6 +283,8 @@ Shared controls are controls that can be compared across multiple lower-atmosphe
 
 ## Run Manifest Schema
 
+Run manifests are validated metadata records. They describe what Cloud Chamber generated, where it lives, how it maps toward CM1, and what product state it is in. They do not require NetCDF output to exist.
+
 Each run should write a manifest like:
 
 ```yaml
@@ -338,6 +340,8 @@ saved
 ```
 
 Dry-run packaged experiments must be distinct from queued/running/completed CM1 runs.
+
+Validation rules should reject packaged dry-run manifests that include NetCDF output paths, completed/saved manifests that still claim to be dry-run packages, unknown lifecycle states, and saved result entries that are not marked as user-saved.
 
 ## Product States And Provenance
 


### PR DESCRIPTION
Closes #22.

Summary:
- Added a backend `RunManifest` schema with lifecycle, validation status, runtime paths, generated input paths, app metadata, output placeholders, user metadata, and provenance labels.
- Added JSON serialization/deserialization helpers.
- Added lifecycle validation so dry-run packages stay distinct from completed/saved CM1 results and do not include NetCDF output paths.
- Added focused unit tests for valid manifests, invalid lifecycle states, dry-run/output separation, saved-entry validation, and JSON round trip.
- Updated architecture and product spec docs.

What was intentionally not included:
- No CM1 package generation.
- No CM1 launch.
- No NetCDF ingest.
- No generated CM1 outputs.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts were committed.
