### PR TITLE
Define CM1 input generation contract

### DIFF
--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -1,0 +1,204 @@
+"""CM1-facing input generation contract.
+
+This module defines deterministic metadata/fragments for future package generation.
+It does not launch CM1 and does not write generated files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from cloud_chamber.scenario_schema import ControlAudience, ScenarioTemplate
+
+
+class GeneratedFileRole(StrEnum):
+    RUN_MANIFEST = "run_manifest"
+    CASE_MANIFEST = "case_manifest"
+    NAMELIST = "namelist"
+    INPUT_SOUNDING = "input_sounding"
+    DRY_RUN_REPORT = "dry_run_report"
+    RUNTIME_FILE_CHECKLIST = "runtime_file_checklist"
+
+
+@dataclass(frozen=True)
+class CloudScaleDefaults:
+    horizontal_extent_km: int = 16
+    y_extent_km: int = 16
+    vertical_extent_km: int = 6
+    horizontal_spacing_m: int = 200
+    vertical_spacing_m: int = 125
+    runtime_seconds: int = 7200
+    output_cadence_seconds: int = 300
+
+
+@dataclass(frozen=True)
+class GeneratedFileSpec:
+    role: GeneratedFileRole
+    relative_path: str
+    description: str
+    scientific_status: str
+
+
+@dataclass(frozen=True)
+class ControlMappingFragment:
+    control_id: str
+    control_label: str
+    selected_value: str | float | bool
+    audience: ControlAudience
+    cm1_mapping_notes: str
+    scientific_status: str
+
+
+@dataclass(frozen=True)
+class CM1InputContract:
+    scenario_id: str
+    physical_question: str
+    run_size_preset: str
+    cloud_scale_defaults: CloudScaleDefaults
+    generated_files: tuple[GeneratedFileSpec, ...]
+    control_fragments: tuple[ControlMappingFragment, ...]
+    expected_diagnostics: tuple[str, ...]
+    visualization_defaults: dict[str, str | list[str]]
+    limitations: tuple[str, ...]
+
+
+GENERATED_FILE_SPECS = (
+    GeneratedFileSpec(
+        role=GeneratedFileRole.RUN_MANIFEST,
+        relative_path="run_manifest.json",
+        description=(
+            "Records scenario, controls, generated files, runtime paths, lifecycle state, "
+            "and provenance."
+        ),
+        scientific_status="metadata contract",
+    ),
+    GeneratedFileSpec(
+        role=GeneratedFileRole.CASE_MANIFEST,
+        relative_path="case_manifest.json",
+        description="Scenario-facing case metadata used to review the generated package.",
+        scientific_status="metadata contract",
+    ),
+    GeneratedFileSpec(
+        role=GeneratedFileRole.NAMELIST,
+        relative_path="namelist.input",
+        description="CM1 namelist input generated from validated scenario controls.",
+        scientific_status="placeholder until local/manual CM1 validation",
+    ),
+    GeneratedFileSpec(
+        role=GeneratedFileRole.INPUT_SOUNDING,
+        relative_path="input_sounding",
+        description="CM1 sounding/profile input generated from validated scenario controls.",
+        scientific_status="placeholder until local/manual CM1 validation",
+    ),
+    GeneratedFileSpec(
+        role=GeneratedFileRole.DRY_RUN_REPORT,
+        relative_path="dry_run_report.json",
+        description=(
+            "Human/reviewable report describing what would be run and what remains unknown."
+        ),
+        scientific_status="review artifact",
+    ),
+    GeneratedFileSpec(
+        role=GeneratedFileRole.RUNTIME_FILE_CHECKLIST,
+        relative_path="runtime_file_checklist.json",
+        description=(
+            "Checklist of external CM1 runtime files required locally, such as LANDUSE.TBL."
+        ),
+        scientific_status="runtime preflight metadata",
+    ),
+)
+
+
+def build_cm1_input_contract(
+    scenario: ScenarioTemplate,
+    selected_controls: dict[str, str | float | bool] | None = None,
+    run_size_preset: str = "quick_look",
+) -> CM1InputContract:
+    selected = selected_controls or {}
+    control_fragments = tuple(
+        ControlMappingFragment(
+            control_id=control.id,
+            control_label=control.label,
+            selected_value=selected.get(control.id, control.default),
+            audience=control.audience,
+            cm1_mapping_notes=control.cm1_mapping_notes,
+            scientific_status=(
+                "product-facing placeholder until local/manual CM1 validation"
+                if control.audience == ControlAudience.PRODUCT
+                else "advanced/developer metadata"
+            ),
+        )
+        for control in scenario.controls
+    )
+
+    return CM1InputContract(
+        scenario_id=scenario.id,
+        physical_question=scenario.physical_question,
+        run_size_preset=run_size_preset,
+        cloud_scale_defaults=CloudScaleDefaults(),
+        generated_files=GENERATED_FILE_SPECS,
+        control_fragments=control_fragments,
+        expected_diagnostics=_diagnostic_names(scenario),
+        visualization_defaults={
+            "primary_field": scenario.visualization_defaults.primary_field,
+            "secondary_fields": scenario.visualization_defaults.secondary_fields,
+            "camera": scenario.visualization_defaults.camera,
+            "rendering_method": scenario.visualization_defaults.rendering_method,
+            "provenance_label": scenario.visualization_defaults.provenance_label,
+        },
+        limitations=tuple(scenario.limitations),
+    )
+
+
+def render_namelist_fragment(contract: CM1InputContract) -> str:
+    defaults = contract.cloud_scale_defaults
+    lines = [
+        "# Cloud Chamber CM1 namelist fragment",
+        "# Status: placeholder until local/manual CM1 validation",
+        f"# scenario_id = {contract.scenario_id}",
+        "&cloud_chamber_domain",
+        f"  x_extent_km = {defaults.horizontal_extent_km},",
+        f"  y_extent_km = {defaults.y_extent_km},",
+        f"  z_extent_km = {defaults.vertical_extent_km},",
+        f"  dx_m = {defaults.horizontal_spacing_m},",
+        f"  dz_m = {defaults.vertical_spacing_m},",
+        f"  runtime_seconds = {defaults.runtime_seconds},",
+        f"  output_cadence_seconds = {defaults.output_cadence_seconds},",
+        "/",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_input_sounding_notes(contract: CM1InputContract) -> str:
+    lines = [
+        "# Cloud Chamber input_sounding notes",
+        "# Status: placeholder until local/manual CM1 validation",
+        f"# scenario_id = {contract.scenario_id}",
+        f"# physical_question = {contract.physical_question}",
+        "# Product controls:",
+    ]
+    for fragment in contract.control_fragments:
+        if fragment.audience == ControlAudience.PRODUCT:
+            lines.append(
+                f"# - {fragment.control_id} = {fragment.selected_value}: "
+                f"{fragment.cm1_mapping_notes}"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def _diagnostic_names(scenario: ScenarioTemplate) -> tuple[str, ...]:
+    diagnostics = scenario.expected_diagnostics
+    names = []
+    if diagnostics.cloud_formed:
+        names.append("cloud_formed")
+    for field_name in [
+        "first_cloud_time",
+        "cloud_base_top",
+        "max_updraft",
+        "cloud_water_summary",
+        "rain_onset",
+    ]:
+        if getattr(diagnostics, field_name) is not None:
+            names.append(field_name)
+    return tuple(names)

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -1,0 +1,97 @@
+import json
+from pathlib import Path
+
+from cloud_chamber.cm1_input_contract import (
+    GeneratedFileRole,
+    build_cm1_input_contract,
+    render_input_sounding_notes,
+    render_namelist_fragment,
+)
+from cloud_chamber.scenario_schema import (
+    ControlAudience,
+    ScenarioTemplate,
+    validate_scenario_template,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
+
+
+def baseline_scenario() -> ScenarioTemplate:
+    return validate_scenario_template(json.loads(BASELINE_TEMPLATE.read_text()))
+
+
+def test_cm1_contract_documents_expected_generated_files_and_defaults() -> None:
+    contract = build_cm1_input_contract(baseline_scenario(), run_size_preset="quick_look")
+
+    assert contract.scenario_id == "baseline-shallow-cumulus"
+    assert {file.role for file in contract.generated_files} == set(GeneratedFileRole)
+    assert contract.cloud_scale_defaults.horizontal_extent_km == 16
+    assert contract.cloud_scale_defaults.y_extent_km == 16
+    assert contract.cloud_scale_defaults.vertical_extent_km == 6
+    assert contract.cloud_scale_defaults.horizontal_spacing_m == 200
+    assert contract.cloud_scale_defaults.vertical_spacing_m == 125
+    assert contract.cloud_scale_defaults.runtime_seconds == 7200
+    assert contract.cloud_scale_defaults.output_cadence_seconds == 300
+
+
+def test_cm1_contract_keeps_product_controls_separate_from_mapping_notes() -> None:
+    scenario = baseline_scenario()
+    contract = build_cm1_input_contract(
+        scenario,
+        selected_controls={"low_level_humidity": "more_humid"},
+    )
+
+    low_level_humidity = next(
+        fragment
+        for fragment in contract.control_fragments
+        if fragment.control_id == "low_level_humidity"
+    )
+
+    assert low_level_humidity.audience == ControlAudience.PRODUCT
+    assert low_level_humidity.selected_value == "more_humid"
+    assert "sounding moisture" in low_level_humidity.cm1_mapping_notes
+    assert "placeholder until local/manual CM1 validation" in low_level_humidity.scientific_status
+
+
+def test_rendered_namelist_fragment_is_deterministic_snapshot() -> None:
+    contract = build_cm1_input_contract(baseline_scenario())
+
+    assert render_namelist_fragment(contract) == (
+        "# Cloud Chamber CM1 namelist fragment\n"
+        "# Status: placeholder until local/manual CM1 validation\n"
+        "# scenario_id = baseline-shallow-cumulus\n"
+        "&cloud_chamber_domain\n"
+        "  x_extent_km = 16,\n"
+        "  y_extent_km = 16,\n"
+        "  z_extent_km = 6,\n"
+        "  dx_m = 200,\n"
+        "  dz_m = 125,\n"
+        "  runtime_seconds = 7200,\n"
+        "  output_cadence_seconds = 300,\n"
+        "/\n"
+    )
+
+
+def test_rendered_sounding_notes_include_only_product_controls() -> None:
+    contract = build_cm1_input_contract(baseline_scenario())
+    notes = render_input_sounding_notes(contract)
+
+    assert "# physical_question = How do low-level moisture" in notes
+    assert "# - low_level_humidity = baseline" in notes
+    assert "# - surface_heating = baseline" in notes
+    assert "# - cap_strength = baseline" in notes
+    assert "advanced/developer" not in notes
+
+
+def test_cm1_contract_includes_expected_diagnostics_and_visualization_defaults() -> None:
+    contract = build_cm1_input_contract(baseline_scenario())
+
+    assert "first_cloud_time" in contract.expected_diagnostics
+    assert "cloud_base_top" in contract.expected_diagnostics
+    assert "max_updraft" in contract.expected_diagnostics
+    assert "cloud_water_summary" in contract.expected_diagnostics
+    assert contract.visualization_defaults["primary_field"] == "qc"
+    assert (
+        contract.visualization_defaults["rendering_method"] == "cloud-water opacity approximation"
+    )

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -95,6 +95,20 @@ Turns a scenario + user controls into:
 
 For the Baseline Shallow Cumulus Golden Path, the generated package should preserve the physical question, curated controls, run-size preset, expected diagnostics, expected output fields, and provenance labels before CM1 starts.
 
+The CM1 input generation contract is deterministic and testable before full package generation. It documents the expected generated files, preserves product-facing controls separately from raw namelist/developer settings, and marks namelist/sounding fragments as placeholders until local/manual CM1 validation accepts them.
+
+Cloud-scale defaults for the first lower-atmosphere contract are:
+
+```text
+domain: about 16 km x 16 km x 6 km
+horizontal spacing: about 200 m
+vertical spacing: about 125 m
+runtime: about 7200 s
+output cadence: about 300 s
+```
+
+Scenario-specific deviations from these defaults must be explicit in the scenario template or generated report.
+
 ### Preview Engine
 
 Fast reduced/light predictor.

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -246,6 +246,33 @@ Baseline shallow cumulus is the first hero case. Warm rain remains early but doe
 
 The initial lower-atmosphere templates live under `scenarios/lower-atmosphere/` as validated JSON metadata. They are honest scenario definitions and teaching contracts, not final scientific calibration. CM1 mapping fields are placeholders until local/manual CM1 validation accepts the generated configurations.
 
+## CM1 Input Generation Contract
+
+Generated run packages should eventually include:
+
+```text
+run_manifest.json
+case_manifest.json
+namelist.input
+input_sounding
+dry_run_report.json
+runtime_file_checklist.json
+```
+
+The current contract can render deterministic namelist and sounding fragments for review, but these fragments are scientific placeholders until local/manual CM1 validation. They must keep product-facing controls separate from advanced/developer CM1 settings.
+
+Default cloud-scale assumptions:
+
+```text
+16 km x 16 km x 6 km domain
+200 m horizontal spacing
+125 m vertical spacing
+7200 s runtime
+300 s output cadence
+```
+
+If a scenario needs different size, spacing, runtime, cadence, or runtime files, the deviation must be explicit and documented.
+
 ## Curated Controls And Diagnostics
 
 The first lower-atmosphere controls should use atmospheric language:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -30,6 +30,8 @@ These tests must not require CM1 source, CM1 binaries, NetCDF output, generated 
 
 Scenario-template tests should cover both valid templates and targeted invalid templates, including missing product-facing controls, invalid choice defaults, missing runtime profiles, and variation policies that reference unknown controls. These tests validate metadata only; they do not generate CM1 output or launch CM1.
 
+CM1 input contract tests should use structured/snapshot assertions for generated fragments such as namelist defaults and input-sounding notes. These tests must not write generated run packages into the repo, launch CM1, or require real CM1 runtime files.
+
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.
 
 ## Local CM1 Workflow Tests


### PR DESCRIPTION
Closes #24.

Summary:
- Added a deterministic CM1 input generation contract for expected generated files, cloud-scale defaults, control mapping fragments, diagnostics, and visualization defaults.
- Added placeholder namelist and input-sounding fragment renderers for structured review tests.
- Kept product-facing controls separate from advanced/developer CM1 mapping notes.
- Documented cloud-scale defaults: about 16 km x 16 km x 6 km, 200 m horizontal spacing, 125 m vertical spacing, 7200 s runtime, and 300 s output cadence.
- Updated architecture, product spec, and testing docs.

What was intentionally not included:
- No dry-run package writer yet; #23 comes next.
- No CM1 launch.
- No generated CM1 output.
- No generated run package committed to the repo.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts were committed.
