### PR TITLE
Implement dry-run package generation

### DIFF
--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -1,0 +1,210 @@
+"""Dry-run CM1 package generation.
+
+Writes reviewable package files without launching CM1 or requiring NetCDF output.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cloud_chamber import __version__
+from cloud_chamber.cm1_input_contract import (
+    CM1InputContract,
+    build_cm1_input_contract,
+    render_input_sounding_notes,
+    render_namelist_fragment,
+)
+from cloud_chamber.run_manifest import (
+    AppMetadata,
+    GeneratedInputs,
+    LifecycleState,
+    ProductState,
+    ProvenanceMetadata,
+    RunManifest,
+    RuntimePaths,
+    ScenarioReference,
+    UserMetadata,
+    ValidationStatus,
+)
+from cloud_chamber.scenario_schema import ScenarioTemplate, validate_scenario_template
+
+
+class DryRunPackageError(RuntimeError):
+    """Raised when a dry-run package cannot be generated."""
+
+
+@dataclass(frozen=True)
+class DryRunPackageResult:
+    run_id: str
+    package_dir: Path
+    manifest_path: Path
+    report_path: Path
+    generated_files: tuple[Path, ...]
+
+
+def generate_dry_run_package(
+    *,
+    scenario_data: object,
+    runtime_home: Path,
+    run_id: str,
+    controls: dict[str, str | float | bool] | None = None,
+    run_size_preset: str = "quick_look",
+    user_name: str | None = None,
+    allow_overwrite: bool = False,
+    app_commit: str | None = None,
+) -> DryRunPackageResult:
+    scenario = validate_scenario_template(scenario_data)
+    selected_controls = controls or {}
+    _validate_selected_controls(scenario, selected_controls)
+
+    package_dir = runtime_home.expanduser() / "runs" / run_id
+    if package_dir.exists() and not allow_overwrite:
+        raise DryRunPackageError(f"Run package already exists: {package_dir}")
+    package_dir.mkdir(parents=True, exist_ok=allow_overwrite)
+
+    contract = build_cm1_input_contract(
+        scenario,
+        selected_controls=selected_controls,
+        run_size_preset=run_size_preset,
+    )
+    now = datetime.now(UTC)
+
+    paths = {
+        "manifest": package_dir / "run_manifest.json",
+        "case_manifest": package_dir / "case_manifest.json",
+        "namelist": package_dir / "namelist.input",
+        "input_sounding": package_dir / "input_sounding",
+        "report": package_dir / "dry_run_report.json",
+        "runtime_checklist": package_dir / "runtime_file_checklist.json",
+    }
+
+    manifest = RunManifest(
+        run_id=run_id,
+        scenario=ScenarioReference(
+            id=scenario.id,
+            schema_version=scenario.schema_version,
+            template_path=scenario.cm1_template.namelist_template,
+        ),
+        controls=_effective_controls(scenario, selected_controls),
+        run_size_preset=run_size_preset,
+        physical_question=scenario.physical_question,
+        expected_diagnostics=list(contract.expected_diagnostics),
+        generated_inputs=GeneratedInputs(
+            run_directory=str(package_dir),
+            manifest_path=str(paths["manifest"]),
+            namelist_input=str(paths["namelist"]),
+            input_sounding=str(paths["input_sounding"]),
+            dry_run_report=str(paths["report"]),
+            runtime_file_checklist=[str(paths["runtime_checklist"])],
+        ),
+        runtime_paths=RuntimePaths(runtime_home=str(runtime_home.expanduser())),
+        app=AppMetadata(app_version=__version__, commit=app_commit),
+        lifecycle_state=LifecycleState.PACKAGED,
+        validation_status=ValidationStatus.VALID,
+        provenance=ProvenanceMetadata(product_state=ProductState.PACKAGED_DRY_RUN_OUTPUT),
+        created_at=now,
+        updated_at=now,
+        user=UserMetadata(name=user_name or scenario.display_name),
+    )
+
+    case_manifest = _case_manifest_payload(scenario, contract)
+    report = _dry_run_report_payload(
+        scenario=scenario,
+        manifest=manifest,
+        contract=contract,
+        generated_files=paths,
+    )
+    runtime_checklist = {
+        "status": "external_runtime_files_not_committed",
+        "required_files": scenario.cm1_template.runtime_files_needed,
+        "notes": (
+            "CM1 remains external to the repo; dry-run generation does not copy runtime files."
+        ),
+    }
+
+    _write_json(paths["manifest"], json.loads(manifest.to_json_text()))
+    _write_json(paths["case_manifest"], case_manifest)
+    paths["namelist"].write_text(render_namelist_fragment(contract))
+    paths["input_sounding"].write_text(render_input_sounding_notes(contract))
+    _write_json(paths["report"], report)
+    _write_json(paths["runtime_checklist"], runtime_checklist)
+
+    return DryRunPackageResult(
+        run_id=run_id,
+        package_dir=package_dir,
+        manifest_path=paths["manifest"],
+        report_path=paths["report"],
+        generated_files=tuple(paths.values()),
+    )
+
+
+def _validate_selected_controls(
+    scenario: ScenarioTemplate,
+    selected_controls: dict[str, str | float | bool],
+) -> None:
+    known_controls = {control.id for control in scenario.controls}
+    unknown_controls = sorted(set(selected_controls) - known_controls)
+    if unknown_controls:
+        raise DryRunPackageError("Unknown controls: " + ", ".join(unknown_controls))
+
+
+def _effective_controls(
+    scenario: ScenarioTemplate,
+    selected_controls: dict[str, str | float | bool],
+) -> dict[str, str | float | bool]:
+    return {
+        control.id: selected_controls.get(control.id, control.default)
+        for control in scenario.controls
+    }
+
+
+def _case_manifest_payload(
+    scenario: ScenarioTemplate,
+    contract: CM1InputContract,
+) -> dict[str, object]:
+    return {
+        "scenario_id": scenario.id,
+        "display_name": scenario.display_name,
+        "physical_question": scenario.physical_question,
+        "learning_goals": scenario.learning_goals,
+        "expected_behavior": scenario.expected_behavior,
+        "warnings": scenario.warnings,
+        "limitations": scenario.limitations,
+        "cm1_mapping_status": "placeholder until local/manual CM1 validation",
+        "contract": asdict(contract),
+    }
+
+
+def _dry_run_report_payload(
+    *,
+    scenario: ScenarioTemplate,
+    manifest: RunManifest,
+    contract: CM1InputContract,
+    generated_files: dict[str, Path],
+) -> dict[str, object]:
+    return {
+        "status": "dry_run_package_only",
+        "not_a_completed_cm1_result": True,
+        "cm1_was_launched": False,
+        "scenario_id": scenario.id,
+        "physical_question": scenario.physical_question,
+        "controls": manifest.controls,
+        "run_size_preset": manifest.run_size_preset,
+        "estimated_cost_or_size": "unknown until validated",
+        "expected_diagnostics": manifest.expected_diagnostics,
+        "visualization_defaults": contract.visualization_defaults,
+        "generated_files": {name: str(path) for name, path in generated_files.items()},
+        "provenance": {
+            "product_state": manifest.provenance.product_state.value,
+            "source_model": manifest.provenance.source_model,
+            "preview_is_guidance_only": manifest.provenance.preview_is_guidance_only,
+            "visualizer_is_interpretation": manifest.provenance.visualizer_is_interpretation,
+        },
+    }
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -1,0 +1,102 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from cloud_chamber.dry_run_package import DryRunPackageError, generate_dry_run_package
+from cloud_chamber.run_manifest import load_run_manifest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
+
+
+def load_baseline_template() -> object:
+    return json.loads(BASELINE_TEMPLATE.read_text())
+
+
+def test_generate_dry_run_package_writes_expected_files_to_temp_runtime_home(
+    tmp_path: Path,
+) -> None:
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-001",
+        controls={"low_level_humidity": "more_humid"},
+        run_size_preset="quick_look",
+    )
+
+    assert result.package_dir == tmp_path / "runs" / "run-001"
+    assert {path.name for path in result.generated_files} == {
+        "run_manifest.json",
+        "case_manifest.json",
+        "namelist.input",
+        "input_sounding",
+        "dry_run_report.json",
+        "runtime_file_checklist.json",
+    }
+    assert all(path.exists() for path in result.generated_files)
+    assert str(REPO_ROOT) not in str(result.package_dir)
+
+
+def test_dry_run_manifest_and_report_include_golden_path_metadata(tmp_path: Path) -> None:
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-002",
+        run_size_preset="standard",
+    )
+
+    manifest = load_run_manifest(result.manifest_path)
+    report = json.loads(result.report_path.read_text())
+
+    assert manifest.lifecycle_state.value == "packaged"
+    assert manifest.run_size_preset == "standard"
+    assert manifest.scenario.id == "baseline-shallow-cumulus"
+    assert "first_cloud_time" in manifest.expected_diagnostics
+    assert report["not_a_completed_cm1_result"] is True
+    assert report["cm1_was_launched"] is False
+    assert report["estimated_cost_or_size"] == "unknown until validated"
+    assert report["physical_question"] == manifest.physical_question
+    assert report["visualization_defaults"]["primary_field"] == "qc"
+
+
+def test_dry_run_package_refuses_to_overwrite_existing_run_dir(tmp_path: Path) -> None:
+    generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-003",
+    )
+
+    with pytest.raises(DryRunPackageError, match="already exists"):
+        generate_dry_run_package(
+            scenario_data=load_baseline_template(),
+            runtime_home=tmp_path,
+            run_id="run-003",
+        )
+
+
+def test_dry_run_package_validates_controls_before_writing(tmp_path: Path) -> None:
+    with pytest.raises(DryRunPackageError, match="Unknown controls"):
+        generate_dry_run_package(
+            scenario_data=load_baseline_template(),
+            runtime_home=tmp_path,
+            run_id="run-004",
+            controls={"missing_control": "value"},
+        )
+
+    assert not (tmp_path / "runs" / "run-004").exists()
+
+
+def test_dry_run_package_writes_placeholder_inputs_not_outputs(tmp_path: Path) -> None:
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-005",
+    )
+
+    assert (
+        "placeholder until local/manual CM1 validation"
+        in (result.package_dir / "namelist.input").read_text()
+    )
+    assert "Product controls" in (result.package_dir / "input_sounding").read_text()
+    assert not list(result.package_dir.glob("*.nc"))

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -109,6 +109,8 @@ output cadence: about 300 s
 
 Scenario-specific deviations from these defaults must be explicit in the scenario template or generated report.
 
+Dry-run package generation uses the validated scenario template and CM1 input contract to create a reviewable package under the configured runtime home, normally `~/CloudChamber/runs/<run-id>/`. The package writer should refuse to overwrite existing run directories, validate controls before writing, and produce only package inputs/reports, not CM1 output.
+
 ### Preview Engine
 
 Fast reduced/light predictor.

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -273,6 +273,17 @@ Default cloud-scale assumptions:
 
 If a scenario needs different size, spacing, runtime, cadence, or runtime files, the deviation must be explicit and documented.
 
+Dry-run package generation creates these files for review without launching CM1:
+
+- `run_manifest.json`
+- `case_manifest.json`
+- `namelist.input`
+- `input_sounding`
+- `dry_run_report.json`
+- `runtime_file_checklist.json`
+
+The dry-run report must state that it is not a completed CM1 result, record that CM1 was not launched, include selected run-size preset, include physical question and controls, include expected diagnostics and visualization defaults, and use `unknown until validated` for unvalidated cost/size estimates.
+
 ## Curated Controls And Diagnostics
 
 The first lower-atmosphere controls should use atmospheric language:

--- a/docs/development.md
+++ b/docs/development.md
@@ -113,6 +113,8 @@ Use `./local-data/` only as a gitignored development override. Do not commit gen
 
 If `data/` exists in the repo, treat it as placeholder/fixture-only. Runtime storage belongs in `~/CloudChamber`, not in the source tree.
 
+Dry-run package tests must point runtime home at a temporary directory. Do not run dry-run package generation against the repository root or commit generated package directories.
+
 ## Whole Repo
 
 From the repo root:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -32,6 +32,8 @@ Scenario-template tests should cover both valid templates and targeted invalid t
 
 CM1 input contract tests should use structured/snapshot assertions for generated fragments such as namelist defaults and input-sounding notes. These tests must not write generated run packages into the repo, launch CM1, or require real CM1 runtime files.
 
+Dry-run package tests should use temporary runtime homes and assert overwrite protection, manifest/report content, and absence of NetCDF output. A dry-run package is packaged metadata and placeholder CM1 inputs only; it is not a completed CM1 result.
+
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.
 
 ## Local CM1 Workflow Tests


### PR DESCRIPTION
Closes #23.

Summary:
- Added dry-run package generation from validated scenario templates and selected controls.
- Writes packages under a configured runtime home as `runs/<run-id>/` and refuses to overwrite existing run directories.
- Generates `run_manifest.json`, `case_manifest.json`, `namelist.input`, `input_sounding`, `dry_run_report.json`, and `runtime_file_checklist.json`.
- Dry-run report includes selected run-size preset, physical question, controls, expected diagnostics, visualization defaults, provenance, and `unknown until validated` cost/size notes.
- Added temp-dir tests for no repo-local generated paths, overwrite protection, unknown-control validation before writing, report/manifest content, and absence of NetCDF output.
- Updated architecture, product spec, development, and testing docs.

What was intentionally not included:
- No CM1 launch.
- No NetCDF ingest.
- No generated data committed to the repo.
- No CM1 source, binaries, or runtime files committed.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts were committed.
