### PR TITLE
Build first Scenario Builder flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Choose experiment
 -> optionally create a new variation from the same setup
 ```
 
-This repo is early-stage. The current code is project foundation, not the full product workflow.
+This repo is early-stage. The current app can load the first Scenario Builder flow, select Baseline Shallow Cumulus, show curated controls and the physical question, create a dry-run CM1 package for review, and label preview as not implemented. It does not launch CM1, ingest outputs, or visualize completed results yet.
 
 ## Docs
 
@@ -44,6 +44,7 @@ This repo is early-stage. The current code is project foundation, not the full p
 
 - Frontend: TypeScript, React, Vite, Vitest, ESLint, Prettier.
 - Backend/tooling: Python 3.12+, pytest, ruff, mypy.
+- First Scenario Builder flow: Baseline Shallow Cumulus selection, curated controls, physical question, dry-run package request, and generated-file review.
 - Local checks: `scripts/check.sh`.
 - CI: GitHub Actions jobs for frontend, backend, scripts, docs, and config sanity.
 
@@ -85,6 +86,6 @@ Runtime data belongs outside the repo by default:
 
 The top-level `data/` directory is placeholder/fixture-only. It is not the runtime data home.
 
-## Initial Scope
+## Current Near-Term Scope
 
-This scaffold does not implement the CM1 scenario UI, 3-D visualizer, CM1 run manager, CM1 vendoring, real NetCDF sample data, complex deployment, or heavy 3-D rendering dependencies.
+The first Scenario Builder and dry-run review flow exists. Cloud Chamber still does not implement preview physics, the 3-D visualizer, CM1 run manager, CM1 vendoring, real NetCDF sample data, complex deployment, or heavy 3-D rendering dependencies.

--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+from typing import Any
+from uuid import uuid4
+
 from fastapi import FastAPI
+from pydantic import BaseModel, Field
 
 from cloud_chamber.cli import ENGINE_NOTE
+from cloud_chamber.dry_run_package import generate_dry_run_package, read_dry_run_report
+from cloud_chamber.scenario_catalog import (
+    load_scenario_template,
+    load_scenario_templates,
+    scenario_summary,
+)
+from cloud_chamber.settings import load_settings
 
 app = FastAPI(
     title="Cloud Chamber Backend",
@@ -20,4 +31,40 @@ def health() -> dict[str, str]:
         "status": "ok",
         "product": "Cloud Chamber",
         "engine_note": ENGINE_NOTE,
+    }
+
+
+class DryRunRequest(BaseModel):
+    scenario_id: str = "baseline-shallow-cumulus"
+    controls: dict[str, str | float | bool] = Field(default_factory=dict)
+    run_size_preset: str = "quick_look"
+
+
+@app.get("/api/scenarios")
+def list_scenarios() -> dict[str, object]:
+    scenarios = [scenario_summary(scenario) for scenario in load_scenario_templates()]
+    return {
+        "golden_path_scenario_id": "baseline-shallow-cumulus",
+        "scenarios": scenarios,
+    }
+
+
+@app.post("/api/dry-run-package")
+def create_dry_run_package(request: DryRunRequest) -> dict[str, Any]:
+    scenario = load_scenario_template(request.scenario_id)
+    settings = load_settings()
+    result = generate_dry_run_package(
+        scenario_data=scenario.model_dump(mode="json"),
+        runtime_home=settings.runtime_home,
+        run_id=f"dry-run-{uuid4().hex[:12]}",
+        controls=request.controls,
+        run_size_preset=request.run_size_preset,
+    )
+    report = read_dry_run_report(result.report_path)
+    return {
+        "package_dir": str(result.package_dir),
+        "manifest_path": str(result.manifest_path),
+        "report_path": str(result.report_path),
+        "generated_files": [str(path) for path in result.generated_files],
+        "report": report,
     }

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -161,6 +161,13 @@ def _effective_controls(
     }
 
 
+def read_dry_run_report(path: Path) -> dict[str, object]:
+    loaded = json.loads(path.read_text())
+    if not isinstance(loaded, dict):
+        raise DryRunPackageError(f"Dry-run report must be a JSON object: {path}")
+    return loaded
+
+
 def _case_manifest_payload(
     scenario: ScenarioTemplate,
     contract: CM1InputContract,

--- a/app/backend/cloud_chamber/scenario_catalog.py
+++ b/app/backend/cloud_chamber/scenario_catalog.py
@@ -1,0 +1,70 @@
+"""Scenario catalog loading for committed scenario templates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cloud_chamber.scenario_schema import ScenarioTemplate, validate_scenario_template
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCENARIO_DIR = REPO_ROOT / "scenarios" / "lower-atmosphere"
+
+
+def load_scenario_templates(scenario_dir: Path = SCENARIO_DIR) -> list[ScenarioTemplate]:
+    return [
+        validate_scenario_template(json.loads(path.read_text()))
+        for path in sorted(scenario_dir.glob("*.json"))
+    ]
+
+
+def load_scenario_template(scenario_id: str, scenario_dir: Path = SCENARIO_DIR) -> ScenarioTemplate:
+    for scenario in load_scenario_templates(scenario_dir):
+        if scenario.id == scenario_id:
+            return scenario
+    raise KeyError(f"Unknown scenario: {scenario_id}")
+
+
+def scenario_summary(scenario: ScenarioTemplate) -> dict[str, object]:
+    return {
+        "id": scenario.id,
+        "display_name": scenario.display_name,
+        "description": scenario.description,
+        "physical_question": scenario.physical_question,
+        "intended_behavior": scenario.intended_behavior,
+        "expected_behavior": scenario.expected_behavior,
+        "learning_goals": scenario.learning_goals,
+        "warnings": scenario.warnings,
+        "limitations": scenario.limitations,
+        "controls": [
+            {
+                "id": control.id,
+                "label": control.label,
+                "description": control.description,
+                "type": control.type.value,
+                "audience": control.audience.value,
+                "default": control.default,
+                "options": [
+                    {
+                        "value": option.value,
+                        "label": option.label,
+                        "description": option.description,
+                    }
+                    for option in control.options
+                ],
+            }
+            for control in scenario.controls
+            if control.audience.value == "product"
+        ],
+        "run_size_presets": [
+            {
+                "id": preset.id.value,
+                "label": preset.label,
+                "purpose": preset.purpose,
+                "expected_runtime": preset.expected_runtime,
+                "confidence": preset.confidence,
+                "output_notes": preset.output_notes,
+            }
+            for preset in scenario.run_size_presets
+        ],
+    }

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
   "pytest>=8.2",
   "pyyaml>=6.0",
   "ruff>=0.5",
+  "uvicorn>=0.30",
 ]
 
 [project.scripts]

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+import pytest
 from fastapi.testclient import TestClient
 
 from cloud_chamber.app import app
@@ -10,3 +13,47 @@ def test_health_endpoint_identifies_scaffold_without_cm1() -> None:
     assert response.json()["status"] == "ok"
     assert response.json()["product"] == "Cloud Chamber"
     assert "CM1 is the high-fidelity simulation engine" in response.json()["engine_note"]
+
+
+def test_list_scenarios_includes_baseline_golden_path() -> None:
+    response = TestClient(app).get("/api/scenarios")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["golden_path_scenario_id"] == "baseline-shallow-cumulus"
+    baseline = next(
+        scenario
+        for scenario in payload["scenarios"]
+        if scenario["id"] == "baseline-shallow-cumulus"
+    )
+    assert baseline["display_name"] == "Baseline Shallow Cumulus"
+    assert "physical_question" in baseline
+    assert [control["id"] for control in baseline["controls"]] == [
+        "low_level_humidity",
+        "surface_heating",
+        "cap_strength",
+    ]
+
+
+def test_create_dry_run_package_api_uses_runtime_home_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLOUD_CHAMBER_RUNTIME_HOME", str(tmp_path))
+    response = TestClient(app).post(
+        "/api/dry-run-package",
+        json={
+            "scenario_id": "baseline-shallow-cumulus",
+            "controls": {"low_level_humidity": "more_humid"},
+            "run_size_preset": "quick_look",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["package_dir"].startswith(str(tmp_path))
+    assert payload["report"]["scenario_id"] == "baseline-shallow-cumulus"
+    assert payload["report"]["controls"]["low_level_humidity"] == "more_humid"
+    assert payload["report"]["not_a_completed_cm1_result"] is True
+    assert payload["report"]["cm1_was_launched"] is False
+    assert not list(tmp_path.glob("**/*.nc"))

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1,6 +1,6 @@
 :root {
-  color: #f4f7fb;
-  background: #10151f;
+  color: #edf4f8;
+  background: #111820;
   font-family:
     Inter,
     ui-sans-serif,
@@ -19,65 +19,210 @@ body {
   min-height: 100vh;
 }
 
-.app-shell {
-  display: grid;
-  gap: 2rem;
-  min-height: 100vh;
-  box-sizing: border-box;
-  padding: clamp(1.5rem, 4vw, 4rem);
-  background:
-    linear-gradient(160deg, rgba(69, 111, 139, 0.24), transparent 48%),
-    radial-gradient(circle at 76% 22%, rgba(207, 229, 233, 0.12), transparent 30%), #10151f;
+button,
+select {
+  font: inherit;
 }
 
-.intro {
-  max-width: 780px;
+.app-shell {
+  display: grid;
+  gap: 1.5rem;
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  background:
+    linear-gradient(160deg, rgba(73, 113, 132, 0.22), transparent 46%),
+    linear-gradient(0deg, rgba(104, 135, 119, 0.18), transparent 52%), #111820;
+}
+
+.topbar {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
 .eyebrow {
-  margin: 0 0 0.75rem;
-  color: #a9d8dc;
-  font-size: 0.8rem;
-  font-weight: 700;
+  margin: 0 0 0.45rem;
+  color: #abd7d6;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
   text-transform: uppercase;
 }
 
+h1,
+h2,
+h3,
+h4,
+p {
+  margin-top: 0;
+}
+
 h1 {
+  margin-bottom: 0;
+  font-size: clamp(2.3rem, 7vw, 4.8rem);
+  line-height: 0.98;
+}
+
+h2 {
+  margin-bottom: 0.65rem;
+  font-size: 1.8rem;
+}
+
+h3 {
+  margin-bottom: 0.6rem;
+  font-size: 1.05rem;
+}
+
+h4 {
+  margin-bottom: 0.45rem;
+}
+
+p,
+dd,
+li,
+small {
+  color: #cfdae0;
+  line-height: 1.5;
+}
+
+.state-chip {
+  flex: 0 0 auto;
   margin: 0;
-  font-size: clamp(3rem, 8vw, 6.5rem);
-  line-height: 0.95;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  padding: 0.55rem 0.75rem;
+  background: rgba(255, 255, 255, 0.07);
+  color: #f7fbff;
+  font-weight: 750;
 }
 
-.summary {
-  max-width: 680px;
-  margin: 1.25rem 0 0;
-  color: #d4dde8;
-  font-size: 1.2rem;
-  line-height: 1.6;
-}
-
-.module-grid {
+.builder-layout {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
-  align-self: end;
+  grid-template-columns: minmax(0, 1.45fr) minmax(300px, 0.85fr);
+  gap: 1rem;
+  align-items: start;
 }
 
-.module-card {
-  min-height: 5rem;
-  display: flex;
-  align-items: end;
+.builder-panel,
+.status-panel {
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 8px;
-  padding: 1rem;
-  background: rgba(255, 255, 255, 0.06);
-  color: #f7fbff;
-  font-weight: 700;
+  background: rgba(255, 255, 255, 0.07);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.18);
 }
 
-.engine-note {
-  max-width: 760px;
-  margin: 0;
-  color: #b7c6d3;
-  line-height: 1.6;
+.builder-panel {
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1rem, 2vw, 1.35rem);
+}
+
+.side-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.status-panel {
+  padding: 1rem;
+}
+
+.hero-case {
+  border-left: 4px solid #8fd8b6;
+  padding-left: 1rem;
+}
+
+.field-label,
+.control-row {
+  display: grid;
+  gap: 0.45rem;
+  color: #eff7fa;
+  font-weight: 800;
+}
+
+.control-row {
+  grid-template-columns: minmax(0, 1fr) minmax(170px, 0.35fr);
+  align-items: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  padding-top: 0.9rem;
+}
+
+.control-row small {
+  display: block;
+  margin-top: 0.25rem;
+  font-weight: 500;
+}
+
+select {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 8px;
+  padding: 0.65rem 0.7rem;
+  background: #192534;
+  color: #f7fbff;
+}
+
+button {
+  justify-self: start;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  background: #91d9b7;
+  color: #102018;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.validation {
+  border: 1px solid rgba(255, 206, 115, 0.55);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: rgba(255, 206, 115, 0.12);
+}
+
+.validation p {
+  margin-bottom: 0;
+}
+
+.dry-run-review dl {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0 0 1rem;
+}
+
+.dry-run-review dt {
+  color: #f7fbff;
+  font-weight: 800;
+}
+
+.dry-run-review dd {
+  margin: 0.15rem 0 0;
+  overflow-wrap: anywhere;
+}
+
+.dry-run-review ul {
+  margin: 0 0 1rem;
+  padding-left: 1.2rem;
+}
+
+@media (max-width: 860px) {
+  .topbar,
+  .builder-layout,
+  .control-row {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    display: grid;
+  }
+
+  .state-chip {
+    justify-self: start;
+  }
 }

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1,14 +1,159 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { App } from "./App";
 
+const scenarioResponse = {
+  golden_path_scenario_id: "baseline-shallow-cumulus",
+  scenarios: [
+    {
+      id: "baseline-shallow-cumulus",
+      display_name: "Baseline Shallow Cumulus",
+      description: "First Golden Path hero case for shallow cumulus.",
+      physical_question: "How do low-level moisture and surface heating shape shallow cumulus?",
+      intended_behavior: "A balanced shallow-cumulus case.",
+      expected_behavior: "Clouds may form after heating and mixing.",
+      learning_goals: ["Identify first cloud time"],
+      warnings: ["Preview estimates are guidance only."],
+      limitations: ["Template mapping is not scientifically accepted until validation."],
+      controls: [
+        {
+          id: "low_level_humidity",
+          label: "Low-level humidity",
+          description: "Relative moisture in the lower atmosphere.",
+          type: "choice",
+          default: "baseline",
+          options: [
+            { value: "drier", label: "Drier" },
+            { value: "baseline", label: "Baseline" },
+            { value: "more_humid", label: "More humid" },
+          ],
+        },
+        {
+          id: "surface_heating",
+          label: "Surface heating",
+          description: "Relative daytime heating strength.",
+          type: "choice",
+          default: "baseline",
+          options: [
+            { value: "weaker", label: "Weaker" },
+            { value: "baseline", label: "Baseline" },
+            { value: "stronger", label: "Stronger" },
+          ],
+        },
+      ],
+      run_size_presets: [
+        {
+          id: "quick_look",
+          label: "Quick look",
+          purpose: "Sanity check",
+          expected_runtime: "roughly 10-20 minutes",
+          confidence: "lower confidence",
+          output_notes: "coarser output",
+        },
+      ],
+    },
+  ],
+};
+
+const dryRunResponse = {
+  package_dir: "/tmp/CloudChamber/runs/dry-run-001",
+  manifest_path: "/tmp/CloudChamber/runs/dry-run-001/run_manifest.json",
+  report_path: "/tmp/CloudChamber/runs/dry-run-001/dry_run_report.json",
+  generated_files: [],
+  report: {
+    scenario_id: "baseline-shallow-cumulus",
+    physical_question: "How do low-level moisture and surface heating shape shallow cumulus?",
+    controls: {
+      low_level_humidity: "more_humid",
+      surface_heating: "baseline",
+    },
+    run_size_preset: "quick_look",
+    estimated_cost_or_size: "unknown until validated",
+    expected_diagnostics: ["first_cloud_time", "cloud_water_summary"],
+    visualization_defaults: { primary_field: "qc" },
+    generated_files: {
+      manifest: "/tmp/CloudChamber/runs/dry-run-001/run_manifest.json",
+      namelist: "/tmp/CloudChamber/runs/dry-run-001/namelist.input",
+      input_sounding: "/tmp/CloudChamber/runs/dry-run-001/input_sounding",
+      report: "/tmp/CloudChamber/runs/dry-run-001/dry_run_report.json",
+    },
+    not_a_completed_cm1_result: true,
+    cm1_was_launched: false,
+    provenance: {
+      product_state: "packaged_dry_run_output",
+      source_model: "CM1",
+      preview_is_guidance_only: true,
+      visualizer_is_interpretation: true,
+    },
+  },
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/dry-run-package") {
+        return Promise.resolve(new Response(JSON.stringify(dryRunResponse), { status: 200 }));
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe("App", () => {
-  it("renders Cloud Chamber identity and CM1 distinction", () => {
+  it("renders Baseline Shallow Cumulus controls and physical question", async () => {
     render(<App />);
 
-    expect(screen.getByRole("heading", { name: "Cloud Chamber" })).toBeInTheDocument();
-    expect(screen.getByText(/CM1 is the high-fidelity simulation engine/)).toBeInTheDocument();
-    expect(screen.getByText("Scenario builder")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Baseline Shallow Cumulus" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("First Golden Path hero case")).toBeInTheDocument();
+    expect(screen.getByText(/How do low-level moisture/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Low-level humidity")).toBeInTheDocument();
+    expect(screen.getByLabelText("Surface heating")).toBeInTheDocument();
+    expect(screen.queryByText(/namelist/i)).not.toBeInTheDocument();
+  });
+
+  it("labels preview as not implemented and not CM1 output", async () => {
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Preview not implemented" })).toBeInTheDocument();
+    expect(screen.getByText(/guidance only/)).toBeInTheDocument();
+    expect(screen.getByText(/not CM1 output/)).toBeInTheDocument();
+    expect(screen.getByText(/not a completed result/)).toBeInTheDocument();
+  });
+
+  it("requests a dry-run package and displays generated files without claiming CM1 ran", async () => {
+    render(<App />);
+
+    fireEvent.change(await screen.findByLabelText("Low-level humidity"), {
+      target: { value: "more_humid" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create dry-run package" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("/tmp/CloudChamber/runs/dry-run-001")).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("Packaged dry-run output")).toHaveLength(2);
+    expect(screen.getByText("No")).toBeInTheDocument();
+    expect(screen.getByText("unknown until validated")).toBeInTheDocument();
+    expect(screen.getByText("run_manifest.json")).toBeInTheDocument();
+    expect(screen.getByText("input_sounding")).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/dry-run-package",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("more_humid"),
+      }),
+    );
   });
 });

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,36 +1,344 @@
+import { useEffect, useMemo, useState } from "react";
+import type { FormEvent } from "react";
+
 import "./App.css";
 
-const productNote =
-  "CM1 is the high-fidelity simulation engine; Cloud Chamber is the local experiment builder, run manager, and visualizer.";
+type ControlOption = {
+  value: string;
+  label: string;
+  description?: string | null;
+};
+
+type ScenarioControl = {
+  id: string;
+  label: string;
+  description: string;
+  type: "choice";
+  default: string | number | boolean;
+  options: ControlOption[];
+};
+
+type RunSizePreset = {
+  id: string;
+  label: string;
+  purpose: string;
+  expected_runtime: string;
+  confidence: string;
+  output_notes: string;
+};
+
+type Scenario = {
+  id: string;
+  display_name: string;
+  description: string;
+  physical_question: string;
+  intended_behavior: string;
+  expected_behavior: string;
+  learning_goals: string[];
+  warnings: string[];
+  limitations: string[];
+  controls: ScenarioControl[];
+  run_size_presets: RunSizePreset[];
+};
+
+type ScenarioResponse = {
+  golden_path_scenario_id: string;
+  scenarios: Scenario[];
+};
+
+type DryRunReport = {
+  scenario_id: string;
+  physical_question: string;
+  controls: Record<string, string | number | boolean>;
+  run_size_preset: string;
+  estimated_cost_or_size: string;
+  expected_diagnostics: string[];
+  visualization_defaults: Record<string, unknown>;
+  generated_files: Record<string, string>;
+  not_a_completed_cm1_result: boolean;
+  cm1_was_launched: boolean;
+  provenance: {
+    product_state: string;
+    source_model: string;
+    preview_is_guidance_only: boolean;
+    visualizer_is_interpretation: boolean;
+  };
+};
+
+type DryRunResponse = {
+  package_dir: string;
+  manifest_path: string;
+  report_path: string;
+  generated_files: string[];
+  report: DryRunReport;
+};
+
+async function fetchScenarioCatalog(): Promise<ScenarioResponse> {
+  const response = await fetch("/api/scenarios");
+  if (!response.ok) {
+    throw new Error("Unable to load scenarios.");
+  }
+  return response.json() as Promise<ScenarioResponse>;
+}
+
+async function requestDryRunPackage(
+  scenarioId: string,
+  controls: Record<string, string | number | boolean>,
+  runSizePreset: string,
+): Promise<DryRunResponse> {
+  const response = await fetch("/api/dry-run-package", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      scenario_id: scenarioId,
+      controls,
+      run_size_preset: runSizePreset,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error("Unable to create dry-run package.");
+  }
+  return response.json() as Promise<DryRunResponse>;
+}
 
 export function App() {
+  const [scenarios, setScenarios] = useState<Scenario[]>([]);
+  const [selectedScenarioId, setSelectedScenarioId] = useState("baseline-shallow-cumulus");
+  const [controls, setControls] = useState<Record<string, string | number | boolean>>({});
+  const [runSizePreset, setRunSizePreset] = useState("quick_look");
+  const [dryRun, setDryRun] = useState<DryRunResponse | null>(null);
+  const [status, setStatus] = useState("Loading scenarios...");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetchScenarioCatalog()
+      .then((catalog) => {
+        if (!active) return;
+        setScenarios(catalog.scenarios);
+        setSelectedScenarioId(catalog.golden_path_scenario_id);
+        setStatus("Scenario setup");
+      })
+      .catch((caught: unknown) => {
+        if (!active) return;
+        setError(caught instanceof Error ? caught.message : "Unable to load scenarios.");
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const selectedScenario = useMemo(
+    () => scenarios.find((scenario) => scenario.id === selectedScenarioId) ?? scenarios[0],
+    [scenarios, selectedScenarioId],
+  );
+
+  useEffect(() => {
+    if (!selectedScenario) return;
+    const defaults = Object.fromEntries(
+      selectedScenario.controls.map((control) => [control.id, control.default]),
+    );
+    setControls(defaults);
+    setRunSizePreset(selectedScenario.run_size_presets[0]?.id ?? "quick_look");
+    setDryRun(null);
+  }, [selectedScenario]);
+
+  const validationMessages = useMemo(() => {
+    if (!selectedScenario) return [];
+    return selectedScenario.controls.flatMap((control) => {
+      const value = controls[control.id];
+      const optionValues = new Set(control.options.map((option) => option.value));
+      if (typeof value === "string" && optionValues.has(value)) return [];
+      return [`${control.label} needs one of the listed values.`];
+    });
+  }, [controls, selectedScenario]);
+
+  async function handleDryRun(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedScenario || validationMessages.length > 0) return;
+    setStatus("Creating dry-run package");
+    setError(null);
+    setDryRun(null);
+    try {
+      const result = await requestDryRunPackage(selectedScenario.id, controls, runSizePreset);
+      setDryRun(result);
+      setStatus("Packaged dry-run output");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to create dry-run package.");
+      setStatus("Scenario setup");
+    }
+  }
+
+  if (error && scenarios.length === 0) {
+    return (
+      <main className="app-shell">
+        <h1>Cloud Chamber</h1>
+        <p role="alert">{error}</p>
+      </main>
+    );
+  }
+
   return (
     <main className="app-shell">
-      <section className="intro">
-        <p className="eyebrow">Local CM1 experiment lab</p>
-        <h1>Cloud Chamber</h1>
-        <p className="summary">
-          Configure CM1 scenarios, manage local runs, ingest outputs, and prepare for beautiful
-          scientific 3-D cloud visualization.
-        </p>
-      </section>
+      <header className="topbar">
+        <div>
+          <p className="eyebrow">Local CM1 experiment lab</p>
+          <h1>Cloud Chamber</h1>
+        </div>
+        <p className="state-chip">{status}</p>
+      </header>
 
-      <section className="module-grid" aria-label="Core modules">
-        {[
-          "Scenario builder",
-          "Local CM1 run manager",
-          "Result library",
-          "3-D visualizer",
-          "Preview explainer",
-          "Data ingestion",
-        ].map((module) => (
-          <article className="module-card" key={module}>
-            {module}
-          </article>
-        ))}
-      </section>
+      <section className="builder-layout" aria-label="Scenario Builder">
+        <form className="builder-panel" onSubmit={handleDryRun}>
+          <label className="field-label" htmlFor="scenario">
+            Scenario
+          </label>
+          <select
+            id="scenario"
+            value={selectedScenarioId}
+            onChange={(event) => setSelectedScenarioId(event.target.value)}
+          >
+            {scenarios.map((scenario) => (
+              <option key={scenario.id} value={scenario.id}>
+                {scenario.display_name}
+              </option>
+            ))}
+          </select>
 
-      <p className="engine-note">{productNote}</p>
+          {selectedScenario && (
+            <>
+              <div className="hero-case">
+                <p className="eyebrow">First Golden Path hero case</p>
+                <h2>{selectedScenario.display_name}</h2>
+                <p>{selectedScenario.description}</p>
+              </div>
+
+              <section aria-labelledby="physical-question-title">
+                <h3 id="physical-question-title">Physical Question</h3>
+                <p>{selectedScenario.physical_question}</p>
+              </section>
+
+              <section aria-labelledby="controls-title">
+                <h3 id="controls-title">Curated Atmospheric Controls</h3>
+                {selectedScenario.controls.map((control) => (
+                  <div className="control-row" key={control.id}>
+                    <span>
+                      <label htmlFor={`control-${control.id}`}>
+                        <strong>{control.label}</strong>
+                      </label>
+                      <small>{control.description}</small>
+                    </span>
+                    <select
+                      id={`control-${control.id}`}
+                      value={String(controls[control.id] ?? control.default)}
+                      onChange={(event) =>
+                        setControls((current) => ({
+                          ...current,
+                          [control.id]: event.target.value,
+                        }))
+                      }
+                    >
+                      {control.options.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ))}
+              </section>
+
+              <label className="field-label" htmlFor="run-size">
+                Run-size preset
+              </label>
+              <select
+                id="run-size"
+                value={runSizePreset}
+                onChange={(event) => setRunSizePreset(event.target.value)}
+              >
+                {selectedScenario.run_size_presets.map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.label}
+                  </option>
+                ))}
+              </select>
+
+              {validationMessages.length > 0 && (
+                <div className="validation" role="alert">
+                  {validationMessages.map((message) => (
+                    <p key={message}>{message}</p>
+                  ))}
+                </div>
+              )}
+
+              <button type="submit" disabled={validationMessages.length > 0}>
+                Create dry-run package
+              </button>
+            </>
+          )}
+        </form>
+
+        <aside className="side-stack">
+          <section className="status-panel" aria-labelledby="preview-title">
+            <p className="eyebrow">Preview estimate</p>
+            <h3 id="preview-title">Preview not implemented</h3>
+            <p>
+              Future preview estimates will be guidance only. This panel is not CM1 output, not a
+              completed result, and not a visualization interpretation.
+            </p>
+          </section>
+
+          <section className="status-panel" aria-labelledby="review-title">
+            <p className="eyebrow">Dry-run review</p>
+            <h3 id="review-title">What will be generated</h3>
+            {dryRun ? (
+              <DryRunReview dryRun={dryRun} />
+            ) : (
+              <p>
+                Request a package to review the manifest, CM1 input placeholders, runtime checklist,
+                and dry-run report before any local CM1 launch exists.
+              </p>
+            )}
+          </section>
+        </aside>
+      </section>
     </main>
+  );
+}
+
+function DryRunReview({ dryRun }: { dryRun: DryRunResponse }) {
+  return (
+    <div className="dry-run-review">
+      <dl>
+        <div>
+          <dt>Package path</dt>
+          <dd>{dryRun.package_dir}</dd>
+        </div>
+        <div>
+          <dt>Validation status</dt>
+          <dd>{dryRun.report.not_a_completed_cm1_result ? "Packaged dry-run output" : "Unknown"}</dd>
+        </div>
+        <div>
+          <dt>CM1 launched</dt>
+          <dd>{dryRun.report.cm1_was_launched ? "Yes" : "No"}</dd>
+        </div>
+        <div>
+          <dt>Cost / size</dt>
+          <dd>{dryRun.report.estimated_cost_or_size}</dd>
+        </div>
+      </dl>
+
+      <h4>Generated files</h4>
+      <ul>
+        {Object.values(dryRun.report.generated_files).map((path) => (
+          <li key={path}>{path.split("/").at(-1)}</li>
+        ))}
+      </ul>
+
+      <h4>Manifest summary</h4>
+      <p>{dryRun.report.physical_question}</p>
+      <p>Run-size preset: {dryRun.report.run_size_preset}</p>
+      <p>Product state: {dryRun.report.provenance.product_state}</p>
+    </div>
   );
 }

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      "/api": "http://127.0.0.1:8000",
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -82,6 +82,8 @@ Baseline Shallow Cumulus is the first hero case. Warm rain remains early but doe
 
 Scenario templates are validated before package generation. The schema supports stable IDs, display names, descriptions, physical questions, learning goals, friendly controls, advanced/developer-only settings, run-size presets, expected diagnostics, CM1 mapping notes, visualization defaults, warnings, limitations, and one-control variation metadata. Invalid templates should fail with actionable validation messages before any CM1-facing files are generated.
 
+The local FastAPI backend exposes the implemented catalog through `GET /api/scenarios`. The response should include the Golden Path scenario ID and product-facing scenario summaries only; advanced/developer controls can remain in the template but should not appear in the primary Scenario Builder flow.
+
 ### Configuration Builder
 
 Turns a scenario + user controls into:
@@ -110,6 +112,8 @@ output cadence: about 300 s
 Scenario-specific deviations from these defaults must be explicit in the scenario template or generated report.
 
 Dry-run package generation uses the validated scenario template and CM1 input contract to create a reviewable package under the configured runtime home, normally `~/CloudChamber/runs/<run-id>/`. The package writer should refuse to overwrite existing run directories, validate controls before writing, and produce only package inputs/reports, not CM1 output.
+
+The implemented dry-run API is `POST /api/dry-run-package`. It accepts scenario ID, selected product controls, and run-size preset, then returns the package paths and dry-run report summary for UI review. It must not launch CM1, write NetCDF, or place generated packages inside the source tree during tests.
 
 ### Preview Engine
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -89,12 +89,26 @@ Exact morphology is not pass/fail. The acceptance question is whether the produc
 4. See expected behavior, controls, run cost, and output fields.
 5. Optionally adjust controls.
 
+The first implemented Scenario Builder flow is intentionally narrow: it loads validated scenario templates from the local backend, defaults to Baseline Shallow Cumulus, displays the scenario description and physical question, exposes only product-facing curated controls, lets the user choose a run-size preset, and requests a dry-run package for review.
+
+The UI must continue to avoid raw CM1 namelist fields in the primary flow. Raw generated files can be listed in dry-run review because they are outputs of the package step, not user-facing controls.
+
 ### Workflow 2 — Preview Setup
 
 1. Adjust controls.
 2. Placeholder preview panel reserves space for future guidance.
 3. Future preview diagnostics update quickly when implemented.
 4. User understands that preview is not CM1.
+
+Current behavior is a placeholder only. It must explicitly say preview is not implemented, not CM1 output, not a completed result, and not a visualization interpretation.
+
+### Workflow 2.5 — Review Dry-Run Package
+
+1. Request a dry-run package from the Scenario Builder.
+2. Backend validates the scenario template and selected controls.
+3. Backend writes package files under the configured runtime home, not the repo.
+4. UI displays package path, validation/product state, generated files, physical question, selected run-size preset, and cost/size notes.
+5. UI states that CM1 was not launched and the package is not a completed CM1 result.
 
 ### Workflow 3 — Launch CM1 Run
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,7 +18,9 @@ npm run test
 npm run build
 ```
 
-The frontend uses TypeScript, React, Vite, Vitest, ESLint, and Prettier. Do not add heavy 3-D rendering dependencies until the visualizer work starts.
+The frontend uses TypeScript, React, Vite, Vitest, ESLint, and Prettier. During local development, Vite proxies `/api` requests to `http://127.0.0.1:8000`.
+
+The current first Scenario Builder flow loads Baseline Shallow Cumulus from the backend, shows curated controls and the physical question, requests a dry-run package, and reviews generated files. Preview is explicitly not implemented and not CM1 output. Do not add heavy 3-D rendering dependencies until the visualizer work starts.
 
 ## Backend
 
@@ -26,6 +28,7 @@ From `app/backend`:
 
 ```sh
 uv sync --extra dev
+uv run python -m uvicorn cloud_chamber.app:app --reload
 uv run ruff format --check .
 uv run ruff check .
 uv run mypy .
@@ -39,6 +42,7 @@ python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install -e ".[dev]"
+python -m uvicorn cloud_chamber.app:app --reload
 python -m ruff format --check .
 python -m ruff check .
 python -m mypy .
@@ -46,6 +50,11 @@ python -m pytest
 ```
 
 Normal backend checks must not require a local CM1 runtime. Real CM1 paths belong in local settings, not hard-coded app constants.
+
+Implemented backend API endpoints:
+
+- `GET /api/scenarios` lists validated scenario templates for the Scenario Builder and marks Baseline Shallow Cumulus as the Golden Path scenario.
+- `POST /api/dry-run-package` validates selected controls and writes a reviewable dry-run package under the configured runtime home. It does not launch CM1, create NetCDF output, or write generated packages into the repo during tests.
 
 The backend skeleton uses Python/FastAPI with pytest, ruff, and mypy. Data/science work should prefer xarray, netCDF4 or h5netcdf, numpy, and pydantic when those layers are added.
 
@@ -133,11 +142,10 @@ The local gate intentionally does not run real CM1, require a local CM1 installa
 
 ## Scaffold Scope
 
-Do not implement product features in this scaffold PR.
+Do not rebuild the initial scaffold when doing issue work.
 
 Specifically do not:
 
-- build the CM1 scenario UI yet
 - implement the 3-D visualizer yet
 - implement the CM1 run manager yet
 - vendor CM1

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -13,18 +13,24 @@ Fast CI tests run on every pull request and push to `main`.
 - `scripts/check.sh` executable-bit assertion.
 - forbidden tracked artifact checks.
 
-Future fast tests should cover:
+Implemented fast tests cover:
 
 - scenario schema validation
 - quick/standard/deep runtime preset metadata validation
 - physical question and learning-goal metadata validation
 - one-control-at-a-time variation metadata validation
-- generated manifests
+- generated manifests and dry-run packages
 - product state/provenance label validation
-- CM1 path/settings handling
+- CM1 path/settings handling through local runtime settings
 - run-package generation using temp directories
+- frontend component tests for Scenario Builder behavior, dry-run review, and preview-not-implemented state distinctions
+
+Future fast tests should cover:
+
 - result-card / experiment-notebook metadata serialization
-- frontend component tests for Scenario Builder behavior and state distinctions
+- run-manager fake process execution
+- NetCDF ingest with tiny synthetic fixtures when that layer exists
+- visualizer metadata loading when that layer exists
 
 These tests must not require CM1 source, CM1 binaries, NetCDF output, generated run directories, or large local data.
 


### PR DESCRIPTION
Closes #25
Closes #26
Closes #27

Summary:
- Added the first Scenario Builder flow for Baseline Shallow Cumulus.
- Added backend APIs to list scenario templates and create dry-run CM1 packages from validated templates.
- Added dry-run review UI showing package path, validation/product state, generated files, selected run-size preset, and manifest summary.
- Kept preview explicitly not implemented, not CM1 output, not a completed result, and not a visualization interpretation.
- Updated docs for the implemented flow and local frontend/backend dev path.

What was intentionally not included:
- No CM1 launch or run manager work.
- No generated CM1 outputs, NetCDF files, CM1 source, or CM1 binaries.
- No 3-D visualizer or preview physics implementation.
- No heavy 3-D rendering dependencies.

Tests/checks run:
- scripts/check.sh passed.
- Frontend: eslint, Vitest component tests, TypeScript/Vite build.
- Backend: ruff format/check, mypy, pytest API tests.
- Script syntax, forbidden tracked artifact, docs/JSON/YAML sanity checks passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts were committed.
