### PR TITLE
Add local dev server helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Thumbs.db
 .env
 .env.*
 !.env.example
+.dev/
 
 # Python
 .venv/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ The script is executable and runs the same fast checks as CI.
 
 `scripts/check.sh` is the canonical local validation gate. Run it before opening PRs. It intentionally does not run real CM1, require a local CM1 installation, use NetCDF sample output, or create generated CM1 artifacts.
 
+## Local Dev Servers
+
+From the repo root:
+
+```sh
+scripts/dev.sh start
+scripts/dev.sh restart
+scripts/dev.sh stop
+```
+
+The helper runs the FastAPI backend on `http://127.0.0.1:8000` and the Vite frontend on `http://localhost:5173`, with logs and PID files under `.dev/`.
+
 ## Runtime Data
 
 Runtime data belongs outside the repo by default:

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,6 +22,22 @@ The frontend uses TypeScript, React, Vite, Vitest, ESLint, and Prettier. During 
 
 The current first Scenario Builder flow loads Baseline Shallow Cumulus from the backend, shows curated controls and the physical question, requests a dry-run package, and reviews generated files. Preview is explicitly not implemented and not CM1 output. Do not add heavy 3-D rendering dependencies until the visualizer work starts.
 
+## Dev Server Helper
+
+From the repo root:
+
+```sh
+scripts/dev.sh start
+scripts/dev.sh status
+scripts/dev.sh restart
+scripts/dev.sh stop
+scripts/dev.sh logs
+```
+
+The helper starts the backend at `http://127.0.0.1:8000` and the frontend at `http://localhost:5173`, tracks PIDs under `.dev/`, and writes logs to `.dev/backend.log` and `.dev/frontend.log`. Use `scripts/dev.sh restart` after UI or API changes when you want a clean local server state.
+
+The helper expects backend dev dependencies to be installed and `app/frontend/node_modules` to exist. It prefers `app/backend/.venv/bin/python` when present; set `BACKEND_PYTHON`, `BACKEND_PORT`, or `FRONTEND_PORT` to override local defaults.
+
 ## Backend
 
 From `app/backend`:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="$ROOT_DIR/.dev"
+BACKEND_PID_FILE="$STATE_DIR/backend.pid"
+FRONTEND_PID_FILE="$STATE_DIR/frontend.pid"
+BACKEND_LOG="$STATE_DIR/backend.log"
+FRONTEND_LOG="$STATE_DIR/frontend.log"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+FRONTEND_PORT="${FRONTEND_PORT:-5173}"
+BACKEND_PYTHON="${BACKEND_PYTHON:-python}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev.sh <command>
+
+Commands:
+  start     Start backend and frontend dev servers in the background.
+  stop      Stop backend and frontend dev servers.
+  restart   Stop, then start both dev servers.
+  status    Show server status and local URLs.
+  logs      Show log file locations.
+
+Environment:
+  BACKEND_PORT     Backend API port. Default: 8000
+  FRONTEND_PORT    Frontend Vite port. Default: 5173
+  BACKEND_PYTHON   Python executable. Default: app/backend/.venv/bin/python when present.
+
+USAGE
+}
+
+ensure_state_dir() {
+  mkdir -p "$STATE_DIR"
+}
+
+is_running() {
+  local pid="${1:-}"
+  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+pid_from_file() {
+  local pid_file="$1"
+  if [[ -f "$pid_file" ]]; then
+    cat "$pid_file"
+  fi
+}
+
+pids_on_port() {
+  local port="$1"
+  lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true
+}
+
+wait_for_port() {
+  local port="$1"
+  local label="$2"
+
+  for _attempt in {1..50}; do
+    if [[ -n "$(pids_on_port "$port")" ]]; then
+      return
+    fi
+    sleep 0.1
+  done
+
+  echo "$label did not start listening on port $port. Check logs with: scripts/dev.sh logs"
+}
+
+backend_python() {
+  if [[ -x "$ROOT_DIR/app/backend/.venv/bin/python" && "$BACKEND_PYTHON" == "python" ]]; then
+    echo "$ROOT_DIR/app/backend/.venv/bin/python"
+  else
+    echo "$BACKEND_PYTHON"
+  fi
+}
+
+stop_pid() {
+  local pid="$1"
+  local label="$2"
+
+  if ! is_running "$pid"; then
+    return
+  fi
+
+  echo "Stopping $label process $pid..."
+  kill "$pid" 2>/dev/null || true
+
+  for _attempt in {1..25}; do
+    if ! is_running "$pid"; then
+      return
+    fi
+    sleep 0.2
+  done
+
+  echo "$label process $pid did not exit after SIGTERM; sending SIGKILL."
+  kill -KILL "$pid" 2>/dev/null || true
+}
+
+stop_port() {
+  local port="$1"
+  local label="$2"
+  local pids
+
+  pids="$(pids_on_port "$port")"
+  if [[ -z "$pids" ]]; then
+    return
+  fi
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    stop_pid "$pid" "$label on port $port"
+  done <<< "$pids"
+}
+
+start_backend() {
+  local existing_pid port_pids python_bin
+  existing_pid="$(pid_from_file "$BACKEND_PID_FILE" || true)"
+  port_pids="$(pids_on_port "$BACKEND_PORT")"
+  python_bin="$(backend_python)"
+
+  if [[ -n "$port_pids" ]]; then
+    echo "Backend already running at http://127.0.0.1:$BACKEND_PORT (pid(s): ${port_pids//$'\n'/, })."
+    return
+  fi
+
+  if is_running "$existing_pid"; then
+    echo "Backend already running at http://127.0.0.1:$BACKEND_PORT (pid $existing_pid)."
+    return
+  fi
+
+  if ! command -v "$python_bin" >/dev/null 2>&1; then
+    echo "Missing backend Python: $python_bin" >&2
+    echo "Run backend setup from docs/development.md, or set BACKEND_PYTHON." >&2
+    exit 1
+  fi
+
+  if ! "$python_bin" -c "import uvicorn" >/dev/null 2>&1; then
+    echo "Missing backend dependency: uvicorn for $python_bin" >&2
+    echo "Run: cd app/backend && python -m pip install -e '.[dev]'" >&2
+    exit 1
+  fi
+
+  echo "Starting backend at http://127.0.0.1:$BACKEND_PORT..."
+  (
+    cd "$ROOT_DIR/app/backend"
+    exec "$python_bin" -m uvicorn cloud_chamber.app:app --host 127.0.0.1 --port "$BACKEND_PORT" --reload
+  ) >"$BACKEND_LOG" 2>&1 &
+  echo "$!" >"$BACKEND_PID_FILE"
+}
+
+start_frontend() {
+  local existing_pid port_pids
+  existing_pid="$(pid_from_file "$FRONTEND_PID_FILE" || true)"
+  port_pids="$(pids_on_port "$FRONTEND_PORT")"
+
+  if [[ -n "$port_pids" ]]; then
+    echo "Frontend already running at http://localhost:$FRONTEND_PORT (pid(s): ${port_pids//$'\n'/, })."
+    return
+  fi
+
+  if is_running "$existing_pid"; then
+    echo "Frontend already running at http://localhost:$FRONTEND_PORT (pid $existing_pid)."
+    return
+  fi
+
+  if [[ ! -d "$ROOT_DIR/app/frontend/node_modules" ]]; then
+    echo "Missing app/frontend/node_modules." >&2
+    echo "Run: cd app/frontend && npm install" >&2
+    exit 1
+  fi
+
+  echo "Starting frontend at http://localhost:$FRONTEND_PORT..."
+  (
+    cd "$ROOT_DIR/app/frontend"
+    exec npm run dev -- --host localhost --port "$FRONTEND_PORT"
+  ) >"$FRONTEND_LOG" 2>&1 &
+  echo "$!" >"$FRONTEND_PID_FILE"
+}
+
+start_all() {
+  ensure_state_dir
+  start_backend
+  start_frontend
+  wait_for_port "$BACKEND_PORT" "Backend"
+  wait_for_port "$FRONTEND_PORT" "Frontend"
+  status
+}
+
+stop_all() {
+  ensure_state_dir
+
+  local backend_pid frontend_pid
+  backend_pid="$(pid_from_file "$BACKEND_PID_FILE" || true)"
+  frontend_pid="$(pid_from_file "$FRONTEND_PID_FILE" || true)"
+
+  if is_running "$backend_pid"; then
+    stop_pid "$backend_pid" "backend"
+  fi
+  if is_running "$frontend_pid"; then
+    stop_pid "$frontend_pid" "frontend"
+  fi
+
+  stop_port "$BACKEND_PORT" "backend"
+  stop_port "$FRONTEND_PORT" "frontend"
+
+  rm -f "$BACKEND_PID_FILE" "$FRONTEND_PID_FILE"
+  echo "Stopped Cloud Chamber dev servers."
+}
+
+status() {
+  ensure_state_dir
+
+  local backend_pids frontend_pids
+  backend_pids="$(pids_on_port "$BACKEND_PORT")"
+  frontend_pids="$(pids_on_port "$FRONTEND_PORT")"
+
+  if [[ -n "$backend_pids" ]]; then
+    echo "Backend:  running on http://127.0.0.1:$BACKEND_PORT (pid(s): ${backend_pids//$'\n'/, })"
+  else
+    echo "Backend:  stopped"
+  fi
+
+  if [[ -n "$frontend_pids" ]]; then
+    echo "Frontend: running on http://localhost:$FRONTEND_PORT (pid(s): ${frontend_pids//$'\n'/, })"
+  else
+    echo "Frontend: stopped"
+  fi
+}
+
+logs() {
+  ensure_state_dir
+  echo "Backend log:  $BACKEND_LOG"
+  echo "Frontend log: $FRONTEND_LOG"
+}
+
+command="${1:-}"
+case "$command" in
+  start)
+    start_all
+    ;;
+  stop)
+    stop_all
+    ;;
+  restart)
+    stop_all
+    start_all
+    ;;
+  status)
+    status
+    ;;
+  logs)
+    logs
+    ;;
+  ""|-h|--help|help)
+    usage
+    ;;
+  *)
+    echo "Unknown command: $command"
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Summary:
- Added scripts/dev.sh to start, stop, restart, inspect status, and show logs for local Cloud Chamber dev servers.
- Runs FastAPI on http://127.0.0.1:8000 and Vite on http://localhost:5173.
- Tracks PID/log state under .dev/ and ignores that local runtime folder.
- Documented the helper in README.md and docs/development.md.

Verification:
- scripts/check.sh passed.
- scripts/dev.sh status passed.
- scripts/dev.sh logs passed.
- scripts/dev.sh start && scripts/dev.sh restart && scripts/dev.sh stop && scripts/dev.sh status passed after refreshing the local backend venv with the existing dev dependency set.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, or large visualization artifacts were committed.
