### PR TITLE
Document manual CM1 validation loop

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -140,6 +140,30 @@ If `data/` exists in the repo, treat it as placeholder/fixture-only. Runtime sto
 
 Dry-run package tests must point runtime home at a temporary directory. Do not run dry-run package generation against the repository root or commit generated package directories.
 
+## Manual CM1 Validation
+
+Before automated launch is trusted, use the Baseline Shallow Cumulus dry-run package as a manual/local/offline bridge into CM1.
+
+1. Create a dry-run package from the Scenario Builder or API.
+2. Inspect the generated package under `~/CloudChamber/runs/<run-id>/`.
+3. Confirm the package contains:
+   - `run_manifest.json`
+   - `case_manifest.json`
+   - `namelist.input`
+   - `input_sounding`
+   - `dry_run_report.json`
+   - `runtime_file_checklist.json`
+4. Confirm the report still says CM1 was not launched and is not a completed result.
+5. Confirm local CM1 settings:
+   - `CLOUD_CHAMBER_CM1_ROOT`, if set;
+   - `~/CloudChamber/settings.json`, if present;
+   - default probes such as `/Users/timpeterson/cm1r21.1` and `/Users/timpeterson/cm1r21.1/run`.
+6. Compare the package against local CM1 runtime needs, including `cm1.exe` and local-only runtime files such as `LANDUSE.TBL`.
+7. Run CM1 manually from the local runtime path when ready. Record the exact command, CM1 version/path, Cloud Chamber commit, run-size preset, controls, runtime, output cadence, log paths, output paths, and any warnings/errors.
+8. Keep generated packages, copied runtime files, logs, NetCDF output, and validation reports out of git unless a future policy explicitly creates a tiny synthetic fixture.
+
+The next implementation step is the automated local CM1 launcher and log/status monitor. It should preserve the same distinctions: dry-run package, queued/running CM1 process, completed/failed/canceled CM1 run, ingested metadata, and saved result/notebook entry are separate states.
+
 ## Whole Repo
 
 From the repo root:

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -158,11 +158,33 @@ Deliverables:
 - run-size preset notes from local/manual execution.
 - generated package inspection checklist.
 - launch/log/status checklist.
+- output and NetCDF detection checklist.
+- ingest readiness checklist.
+- result-card/notebook acceptance checklist.
+- first visualizer inspection checklist.
 - first diagnostics capture: first cloud time, cloud base/top, max updraft, cloud-water summary, and rain onset if present.
 - result-card/notebook acceptance notes.
 - visual inspection notes.
 
 This milestone remains local/manual/offline. CI should not run real CM1.
+
+Manual validation path:
+
+```text
+Generate Baseline Shallow Cumulus dry-run package
+-> inspect generated manifests, namelist, sounding notes, report, and runtime checklist
+-> compare package against local CM1 root/run-dir probes
+-> manually stage package into the local CM1 run workflow
+-> launch CM1 outside CI
+-> capture logs/status/runtime/output paths
+-> detect NetCDF output without committing it
+-> record diagnostics and limitations
+-> document ingest/result-card/visualizer readiness notes
+```
+
+Expected local probes include `CLOUD_CHAMBER_CM1_ROOT`, `~/CloudChamber/settings.json`, `/Users/timpeterson/cm1r21.1`, and `/Users/timpeterson/cm1r21.1/run`. Generated CM1 outputs, logs, NetCDF files, validation reports, copied runtime files, `LANDUSE.TBL`, and local run folders must stay gitignored.
+
+The direct follow-up is #29: automate the local CM1 launcher and status/log monitor with one local run at a time, explicit failure/cancel states, and tests that use fake subprocesses rather than real CM1.
 
 ## M2 Local CM1 Run Manager
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -106,6 +106,44 @@ visualizer provenance labels
 visual inspection notes
 ```
 
+### Baseline Shallow Cumulus Manual Smoke-Run Loop
+
+Use this loop after a dry-run package has been generated and before broader CM1 launcher work is trusted. This is a manual/local/offline validation path; do not run it in CI.
+
+1. Generate or identify a Baseline Shallow Cumulus dry-run package under the local runtime home, normally `~/CloudChamber/runs/<run-id>/`.
+2. Inspect the package before launch:
+   - confirm `run_manifest.json`, `case_manifest.json`, `namelist.input`, `input_sounding`, `dry_run_report.json`, and `runtime_file_checklist.json` exist;
+   - confirm the selected run-size preset, physical question, controls, expected diagnostics, and visualization defaults match the intended scenario;
+   - confirm `dry_run_report.json` says CM1 was not launched and is not a completed result.
+3. Compare generated files against the local CM1 runtime requirements:
+   - check `~/CloudChamber/settings.json`, `CLOUD_CHAMBER_CM1_ROOT`, or the default probe paths;
+   - expected local probes include `/Users/timpeterson/cm1r21.1` and `/Users/timpeterson/cm1r21.1/run`;
+   - confirm the CM1 run directory contains the local executable, normally `cm1.exe`;
+   - confirm required runtime files such as `LANDUSE.TBL` are available locally, but not copied into git.
+4. Manually stage the package for CM1 according to the local CM1 build's expected run-directory behavior. Record whether files were copied, symlinked, or run in place.
+5. Launch CM1 manually outside CI. Capture the exact command, CM1 version/path, start time, run-size preset, and Cloud Chamber commit.
+6. Watch status and logs:
+   - record queued/running/completed/failed/canceled observations;
+   - preserve stdout/stderr or CM1 log paths for the future result notebook entry;
+   - record warnings, errors, elapsed time, and any manual intervention.
+7. Detect outputs without committing them:
+   - record output directory and file names/counts;
+   - confirm whether NetCDF files appeared;
+   - estimate local output size;
+   - leave NetCDF, logs, validation reports, copied runtime files, and generated run folders out of git.
+8. If ingest tooling exists, run it locally and record the ingest status. Until then, note what a future ingest should read and any schema gaps found.
+9. Record result-card/notebook acceptance notes:
+   - scenario name and physical question;
+   - controls used;
+   - run-size preset;
+   - CM1 version/path metadata;
+   - output/log paths;
+   - first cloud time, cloud base/top, max vertical velocity, cloud-water summary, and rain onset if present;
+   - limitations and interpretation notes.
+10. If visualizer tooling exists, open the result and record first visual inspection notes. Until then, record the expected visualizer entry point and provenance labels that should be shown later.
+
+Exact cloud morphology is not a pass/fail criterion. The manual acceptance question is whether the generated package can lead to a scientifically honest local CM1 run whose logs, outputs, diagnostics, and limitations are recorded clearly enough for future replay/inspect/save behavior.
+
 ## Generated Output Policy
 
 Never commit:


### PR DESCRIPTION
Closes #28
Closes #42

Summary:
- Documented the manual/offline bridge from Baseline Shallow Cumulus dry-run packages to local CM1 smoke runs.
- Added generated package inspection, CM1 root/run-dir probe, runtime-file comparison, manual launch/log/status, output detection, ingest readiness, result-card, and visualizer inspection checklists.
- Clarified that real CM1 execution remains manual/local/offline and must not run in CI.
- Reaffirmed that generated CM1 outputs, logs, NetCDF files, validation reports, LANDUSE.TBL, copied runtime files, and local run folders stay out of git.
- Identified #29 as the next automated launcher/log monitor step.

Verification:
- scripts/check.sh passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, logs, validation reports, or large visualization artifacts were committed.
