### PR TITLE
Implement local CM1 launcher and status monitor

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from cloud_chamber.cli import ENGINE_NOTE
 from cloud_chamber.dry_run_package import generate_dry_run_package, read_dry_run_report
+from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError, RunStatus
 from cloud_chamber.scenario_catalog import (
     load_scenario_template,
     load_scenario_templates,
@@ -22,6 +24,8 @@ app = FastAPI(
     summary="Local backend API for Cloud Chamber CM1 experiment workflows.",
     version="0.1.0",
 )
+
+_local_run_manager: LocalRunManager | None = None
 
 
 @app.get("/health")
@@ -38,6 +42,10 @@ class DryRunRequest(BaseModel):
     scenario_id: str = "baseline-shallow-cumulus"
     controls: dict[str, str | float | bool] = Field(default_factory=dict)
     run_size_preset: str = "quick_look"
+
+
+class LaunchRunRequest(BaseModel):
+    manifest_path: str
 
 
 @app.get("/api/scenarios")
@@ -67,4 +75,50 @@ def create_dry_run_package(request: DryRunRequest) -> dict[str, Any]:
         "report_path": str(result.report_path),
         "generated_files": [str(path) for path in result.generated_files],
         "report": report,
+    }
+
+
+@app.post("/api/runs/launch")
+def launch_run(request: LaunchRunRequest) -> dict[str, object]:
+    try:
+        status = _get_local_run_manager().launch(Path(request.manifest_path).expanduser())
+    except LocalRunManagerError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _run_status_payload(status)
+
+
+@app.get("/api/runs/status")
+def run_status(manifest_path: str) -> dict[str, object]:
+    try:
+        status = _get_local_run_manager().status(Path(manifest_path).expanduser())
+    except LocalRunManagerError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _run_status_payload(status)
+
+
+@app.post("/api/runs/cancel")
+def cancel_run() -> dict[str, object]:
+    try:
+        status = _get_local_run_manager().cancel()
+    except LocalRunManagerError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _run_status_payload(status)
+
+
+def _get_local_run_manager() -> LocalRunManager:
+    global _local_run_manager
+    if _local_run_manager is None:
+        _local_run_manager = LocalRunManager(settings=load_settings())
+    return _local_run_manager
+
+
+def _run_status_payload(status: RunStatus) -> dict[str, object]:
+    return {
+        "run_id": status.run_id,
+        "lifecycle_state": status.lifecycle_state.value,
+        "manifest_path": str(status.manifest_path),
+        "command": list(status.command),
+        "stdout_log": str(status.stdout_log),
+        "stderr_log": str(status.stderr_log),
+        "exit_code": status.exit_code,
     }

--- a/app/backend/cloud_chamber/local_run_manager.py
+++ b/app/backend/cloud_chamber/local_run_manager.py
@@ -1,0 +1,302 @@
+"""Local CM1 launch and status monitoring.
+
+The manager launches an external CM1 executable from a generated run package.
+Tests inject fake processes; CI never requires a real CM1 runtime.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol, TextIO
+
+from cloud_chamber.run_manifest import (
+    ExecutionMetadata,
+    LifecycleState,
+    ProductState,
+    ProvenanceMetadata,
+    RunManifest,
+    RuntimePaths,
+    ValidationStatus,
+    load_run_manifest,
+    write_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings, discover_cm1
+
+
+class LocalRunManagerError(RuntimeError):
+    """Raised when a local CM1 launch or status update cannot proceed."""
+
+
+class ProcessHandle(Protocol):
+    def poll(self) -> int | None: ...
+
+    def wait(self, timeout: float | None = None) -> int: ...
+
+    def terminate(self) -> None: ...
+
+
+class ProcessFactory(Protocol):
+    def __call__(
+        self,
+        command: list[str],
+        *,
+        cwd: Path,
+        stdout: TextIO,
+        stderr: TextIO,
+    ) -> ProcessHandle: ...
+
+
+@dataclass(frozen=True)
+class RunStatus:
+    run_id: str
+    lifecycle_state: LifecycleState
+    manifest_path: Path
+    command: tuple[str, ...]
+    stdout_log: Path
+    stderr_log: Path
+    exit_code: int | None
+
+
+@dataclass
+class _ActiveRun:
+    manifest_path: Path
+    process: ProcessHandle
+    stdout_handle: TextIO
+    stderr_handle: TextIO
+
+
+def default_process_factory(
+    command: list[str],
+    *,
+    cwd: Path,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> ProcessHandle:
+    return subprocess.Popen(command, cwd=cwd, stdout=stdout, stderr=stderr, text=True)
+
+
+class LocalRunManager:
+    """Launch and monitor one local CM1 process at a time."""
+
+    def __init__(
+        self,
+        *,
+        settings: CloudChamberSettings,
+        process_factory: ProcessFactory = default_process_factory,
+    ) -> None:
+        self._settings = settings
+        self._process_factory = process_factory
+        self._active: _ActiveRun | None = None
+
+    def launch(self, manifest_path: Path) -> RunStatus:
+        self._refresh_active()
+        if self._active is not None:
+            active_manifest = load_run_manifest(self._active.manifest_path)
+            raise LocalRunManagerError(
+                f"Another local CM1 run is already active: {active_manifest.run_id}"
+            )
+
+        discovery = discover_cm1(self._settings)
+        if not discovery.ready:
+            missing = "; ".join(discovery.missing)
+            raise LocalRunManagerError(f"{discovery.message} Missing: {missing}")
+
+        manifest = load_run_manifest(manifest_path)
+        if manifest.lifecycle_state != LifecycleState.PACKAGED:
+            raise LocalRunManagerError(
+                f"Run {manifest.run_id} must be packaged before launch; "
+                f"found {manifest.lifecycle_state.value}."
+            )
+
+        run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
+        if not run_dir.exists():
+            raise LocalRunManagerError(f"Run package directory does not exist: {run_dir}")
+        if _existing_output_paths(run_dir):
+            raise LocalRunManagerError(
+                f"Refusing to launch because output-like files already exist in {run_dir}"
+            )
+        if self._settings.cm1_run_dir is None:
+            raise LocalRunManagerError("CM1 run directory is not configured.")
+
+        command = [str(self._settings.cm1_run_dir / "cm1.exe")]
+        log_dir = run_dir / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stdout_log = log_dir / "stdout.log"
+        stderr_log = log_dir / "stderr.log"
+
+        queued = self._with_state(
+            manifest,
+            state=LifecycleState.QUEUED,
+            product_state=ProductState.QUEUED_RUNNING_CM1_PROCESS,
+            command=command,
+            stdout_log=stdout_log,
+            stderr_log=stderr_log,
+        )
+        write_run_manifest(manifest_path, queued)
+
+        stdout_handle = stdout_log.open("w")
+        stderr_handle = stderr_log.open("w")
+        try:
+            process = self._process_factory(
+                command,
+                cwd=run_dir,
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+            )
+        except Exception as exc:
+            stdout_handle.close()
+            stderr_handle.close()
+            failed = self._with_state(
+                queued,
+                state=LifecycleState.FAILED,
+                product_state=ProductState.FAILED_CANCELED_CM1_RUN,
+                exit_code=None,
+            )
+            write_run_manifest(manifest_path, failed)
+            raise LocalRunManagerError(f"Failed to launch CM1 process: {exc}") from exc
+
+        running = self._with_state(
+            queued,
+            state=LifecycleState.RUNNING,
+            product_state=ProductState.QUEUED_RUNNING_CM1_PROCESS,
+        )
+        write_run_manifest(manifest_path, running)
+        self._active = _ActiveRun(manifest_path, process, stdout_handle, stderr_handle)
+        return _status_from_manifest(running, manifest_path)
+
+    def status(self, manifest_path: Path) -> RunStatus:
+        self._refresh_active()
+        return _status_from_manifest(load_run_manifest(manifest_path), manifest_path)
+
+    def cancel(self) -> RunStatus:
+        if self._active is None:
+            raise LocalRunManagerError("No local CM1 run is active.")
+
+        active = self._active
+        manifest = load_run_manifest(active.manifest_path)
+        active.process.terminate()
+        exit_code = active.process.wait(timeout=5)
+        self._close_active()
+
+        canceled = self._with_state(
+            manifest,
+            state=LifecycleState.CANCELED,
+            product_state=ProductState.FAILED_CANCELED_CM1_RUN,
+            exit_code=exit_code,
+        )
+        write_run_manifest(active.manifest_path, canceled)
+        return _status_from_manifest(canceled, active.manifest_path)
+
+    def _refresh_active(self) -> None:
+        if self._active is None:
+            return
+
+        exit_code = self._active.process.poll()
+        if exit_code is None:
+            return
+
+        active = self._active
+        self._close_active()
+        manifest = load_run_manifest(active.manifest_path)
+        completed_state = LifecycleState.COMPLETED if exit_code == 0 else LifecycleState.FAILED
+        product_state = (
+            ProductState.COMPLETED_CM1_RESULT
+            if exit_code == 0
+            else ProductState.FAILED_CANCELED_CM1_RUN
+        )
+        updated = self._with_state(
+            manifest,
+            state=completed_state,
+            product_state=product_state,
+            exit_code=exit_code,
+        )
+        write_run_manifest(active.manifest_path, updated)
+
+    def _close_active(self) -> None:
+        if self._active is None:
+            return
+        self._active.stdout_handle.close()
+        self._active.stderr_handle.close()
+        self._active = None
+
+    def _with_state(
+        self,
+        manifest: RunManifest,
+        *,
+        state: LifecycleState,
+        product_state: ProductState,
+        command: list[str] | None = None,
+        stdout_log: Path | None = None,
+        stderr_log: Path | None = None,
+        exit_code: int | None = None,
+    ) -> RunManifest:
+        now = datetime.now(UTC)
+        existing_execution = manifest.execution
+        started_at = existing_execution.started_at
+        if state in {LifecycleState.QUEUED, LifecycleState.RUNNING} and started_at is None:
+            started_at = now
+        finished_at = existing_execution.finished_at
+        if state in {LifecycleState.COMPLETED, LifecycleState.FAILED, LifecycleState.CANCELED}:
+            finished_at = now
+
+        runtime_paths = manifest.runtime_paths.model_copy(
+            update={
+                "runtime_home": str(self._settings.runtime_home),
+                "cm1_root": str(self._settings.cm1_root) if self._settings.cm1_root else None,
+                "cm1_run_dir": (
+                    str(self._settings.cm1_run_dir) if self._settings.cm1_run_dir else None
+                ),
+                "cache_dir": str(self._settings.cache_dir),
+                "log_dir": str(self._settings.log_dir),
+            }
+        )
+        execution = existing_execution.model_copy(
+            update={
+                "command": command or existing_execution.command,
+                "started_at": started_at,
+                "finished_at": finished_at,
+                "exit_code": exit_code,
+                "stdout_log": str(stdout_log) if stdout_log else existing_execution.stdout_log,
+                "stderr_log": str(stderr_log) if stderr_log else existing_execution.stderr_log,
+            }
+        )
+        validation_status = (
+            ValidationStatus.FAILED
+            if state in {LifecycleState.FAILED, LifecycleState.CANCELED}
+            else manifest.validation_status
+        )
+        return manifest.model_copy(
+            update={
+                "lifecycle_state": state,
+                "validation_status": validation_status,
+                "runtime_paths": RuntimePaths.model_validate(runtime_paths.model_dump()),
+                "execution": ExecutionMetadata.model_validate(execution.model_dump()),
+                "provenance": ProvenanceMetadata(product_state=product_state),
+                "updated_at": now,
+            }
+        )
+
+
+def _status_from_manifest(manifest: RunManifest, manifest_path: Path) -> RunStatus:
+    stdout_log = Path(manifest.execution.stdout_log or "")
+    stderr_log = Path(manifest.execution.stderr_log or "")
+    return RunStatus(
+        run_id=manifest.run_id,
+        lifecycle_state=manifest.lifecycle_state,
+        manifest_path=manifest_path,
+        command=tuple(manifest.execution.command),
+        stdout_log=stdout_log,
+        stderr_log=stderr_log,
+        exit_code=manifest.execution.exit_code,
+    )
+
+
+def _existing_output_paths(run_dir: Path) -> tuple[Path, ...]:
+    patterns = ("*.nc", "*.nc4", "*.cdf", "*.netcdf", "cm1out*")
+    paths: list[Path] = []
+    for pattern in patterns:
+        paths.extend(run_dir.glob(pattern))
+    return tuple(sorted(set(paths)))

--- a/app/backend/cloud_chamber/run_manifest.py
+++ b/app/backend/cloud_chamber/run_manifest.py
@@ -184,3 +184,7 @@ def run_manifest_from_json(text: str) -> RunManifest:
 
 def load_run_manifest(path: Path) -> RunManifest:
     return run_manifest_from_json(path.read_text())
+
+
+def write_run_manifest(path: Path, manifest: RunManifest) -> None:
+    path.write_text(manifest.to_json_text())

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -4,6 +4,40 @@ import pytest
 from fastapi.testclient import TestClient
 
 from cloud_chamber.app import app
+from cloud_chamber.local_run_manager import LocalRunManagerError, RunStatus
+from cloud_chamber.run_manifest import LifecycleState
+
+
+class FakeRunManager:
+    def __init__(self, status: RunStatus | None = None, error: Exception | None = None) -> None:
+        self.fake_status = status or RunStatus(
+            run_id="run-001",
+            lifecycle_state=LifecycleState.RUNNING,
+            manifest_path=Path("/tmp/run_manifest.json"),
+            command=("/tmp/cm1/run/cm1.exe",),
+            stdout_log=Path("/tmp/stdout.log"),
+            stderr_log=Path("/tmp/stderr.log"),
+            exit_code=None,
+        )
+        self.error = error
+        self.launched_manifest_path: Path | None = None
+
+    def launch(self, manifest_path: Path) -> RunStatus:
+        if self.error:
+            raise self.error
+        self.launched_manifest_path = manifest_path
+        return self.fake_status
+
+    def status(self, manifest_path: Path) -> RunStatus:
+        if self.error:
+            raise self.error
+        self.launched_manifest_path = manifest_path
+        return self.fake_status
+
+    def cancel(self) -> RunStatus:
+        if self.error:
+            raise self.error
+        return self.fake_status
 
 
 def test_health_endpoint_identifies_scaffold_without_cm1() -> None:
@@ -57,3 +91,35 @@ def test_create_dry_run_package_api_uses_runtime_home_override(
     assert payload["report"]["not_a_completed_cm1_result"] is True
     assert payload["report"]["cm1_was_launched"] is False
     assert not list(tmp_path.glob("**/*.nc"))
+
+
+def test_launch_run_api_returns_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_manager = FakeRunManager()
+    monkeypatch.setattr("cloud_chamber.app._local_run_manager", fake_manager)
+
+    response = TestClient(app).post(
+        "/api/runs/launch",
+        json={"manifest_path": "/tmp/run_manifest.json"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["run_id"] == "run-001"
+    assert payload["lifecycle_state"] == "running"
+    assert payload["command"] == ["/tmp/cm1/run/cm1.exe"]
+    assert fake_manager.launched_manifest_path == Path("/tmp/run_manifest.json")
+
+
+def test_launch_run_api_reports_clear_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "cloud_chamber.app._local_run_manager",
+        FakeRunManager(error=LocalRunManagerError("CM1 is not ready")),
+    )
+
+    response = TestClient(app).post(
+        "/api/runs/launch",
+        json={"manifest_path": "/tmp/run_manifest.json"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "CM1 is not ready"

--- a/app/backend/tests/test_local_run_manager.py
+++ b/app/backend/tests/test_local_run_manager.py
@@ -1,0 +1,197 @@
+import json
+from pathlib import Path
+from typing import TextIO
+
+import pytest
+
+from cloud_chamber.dry_run_package import generate_dry_run_package
+from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError
+from cloud_chamber.run_manifest import LifecycleState, ProductState, load_run_manifest
+from cloud_chamber.settings import CloudChamberSettings
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
+
+
+class FakeProcess:
+    def __init__(self) -> None:
+        self.exit_code: int | None = None
+        self.terminated = False
+
+    def poll(self) -> int | None:
+        return self.exit_code
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self.exit_code is None:
+            self.exit_code = -15
+        return self.exit_code
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.exit_code = -15
+
+
+class FakeProcessFactory:
+    def __init__(self, process: FakeProcess) -> None:
+        self.process = process
+        self.commands: list[list[str]] = []
+        self.cwd: Path | None = None
+
+    def __call__(
+        self,
+        command: list[str],
+        *,
+        cwd: Path,
+        stdout: TextIO,
+        stderr: TextIO,
+    ) -> FakeProcess:
+        self.commands.append(command)
+        self.cwd = cwd
+        stdout.write("fake cm1 stdout\n")
+        stdout.flush()
+        stderr.write("fake cm1 stderr\n")
+        stderr.flush()
+        return self.process
+
+
+def load_baseline_template() -> object:
+    return json.loads(BASELINE_TEMPLATE.read_text())
+
+
+def fake_settings(tmp_path: Path) -> CloudChamberSettings:
+    cm1_root = tmp_path / "cm1"
+    cm1_run_dir = cm1_root / "run"
+    cm1_run_dir.mkdir(parents=True)
+    (cm1_run_dir / "cm1.exe").write_text("# fake executable\n")
+    return CloudChamberSettings(
+        runtime_home=tmp_path / "CloudChamber",
+        cm1_root=cm1_root,
+        cm1_run_dir=cm1_run_dir,
+        cache_dir=tmp_path / "CloudChamber" / "cache",
+        log_dir=tmp_path / "CloudChamber" / "logs",
+    )
+
+
+def dry_run_manifest_path(tmp_path: Path, run_id: str = "run-001") -> Path:
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path / "CloudChamber",
+        run_id=run_id,
+    )
+    return result.manifest_path
+
+
+def test_launch_constructs_cm1_command_and_captures_logs(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    assert settings.cm1_run_dir is not None
+    manifest_path = dry_run_manifest_path(tmp_path)
+    fake_process = FakeProcess()
+    factory = FakeProcessFactory(fake_process)
+    manager = LocalRunManager(settings=settings, process_factory=factory)
+
+    status = manager.launch(manifest_path)
+
+    assert status.lifecycle_state == LifecycleState.RUNNING
+    assert factory.commands == [[str(settings.cm1_run_dir / "cm1.exe")]]
+    assert factory.cwd == tmp_path / "CloudChamber" / "runs" / "run-001"
+    assert status.stdout_log.read_text() == "fake cm1 stdout\n"
+    assert status.stderr_log.read_text() == "fake cm1 stderr\n"
+
+    manifest = load_run_manifest(manifest_path)
+    assert manifest.lifecycle_state == LifecycleState.RUNNING
+    assert manifest.provenance.product_state == ProductState.QUEUED_RUNNING_CM1_PROCESS
+    assert manifest.execution.command == [str(settings.cm1_run_dir / "cm1.exe")]
+
+
+def test_completed_process_updates_manifest_state(tmp_path: Path) -> None:
+    manifest_path = dry_run_manifest_path(tmp_path)
+    fake_process = FakeProcess()
+    manager = LocalRunManager(
+        settings=fake_settings(tmp_path),
+        process_factory=FakeProcessFactory(fake_process),
+    )
+    manager.launch(manifest_path)
+
+    fake_process.exit_code = 0
+    status = manager.status(manifest_path)
+
+    assert status.lifecycle_state == LifecycleState.COMPLETED
+    assert status.exit_code == 0
+    manifest = load_run_manifest(manifest_path)
+    assert manifest.lifecycle_state == LifecycleState.COMPLETED
+    assert manifest.provenance.product_state == ProductState.COMPLETED_CM1_RESULT
+
+
+def test_failed_process_updates_manifest_state(tmp_path: Path) -> None:
+    manifest_path = dry_run_manifest_path(tmp_path)
+    fake_process = FakeProcess()
+    manager = LocalRunManager(
+        settings=fake_settings(tmp_path),
+        process_factory=FakeProcessFactory(fake_process),
+    )
+    manager.launch(manifest_path)
+
+    fake_process.exit_code = 2
+    status = manager.status(manifest_path)
+
+    assert status.lifecycle_state == LifecycleState.FAILED
+    assert status.exit_code == 2
+    manifest = load_run_manifest(manifest_path)
+    assert manifest.validation_status.value == "failed"
+    assert manifest.provenance.product_state == ProductState.FAILED_CANCELED_CM1_RUN
+
+
+def test_cancel_updates_state_and_terminates_process(tmp_path: Path) -> None:
+    manifest_path = dry_run_manifest_path(tmp_path)
+    fake_process = FakeProcess()
+    manager = LocalRunManager(
+        settings=fake_settings(tmp_path),
+        process_factory=FakeProcessFactory(fake_process),
+    )
+    manager.launch(manifest_path)
+
+    status = manager.cancel()
+
+    assert fake_process.terminated
+    assert status.lifecycle_state == LifecycleState.CANCELED
+    assert status.exit_code == -15
+    manifest = load_run_manifest(manifest_path)
+    assert manifest.lifecycle_state == LifecycleState.CANCELED
+    assert manifest.provenance.product_state == ProductState.FAILED_CANCELED_CM1_RUN
+
+
+def test_manager_allows_only_one_active_local_run(tmp_path: Path) -> None:
+    fake_process = FakeProcess()
+    manager = LocalRunManager(
+        settings=fake_settings(tmp_path),
+        process_factory=FakeProcessFactory(fake_process),
+    )
+    manager.launch(dry_run_manifest_path(tmp_path, "run-001"))
+
+    with pytest.raises(LocalRunManagerError, match="already active"):
+        manager.launch(dry_run_manifest_path(tmp_path, "run-002"))
+
+
+def test_launch_refuses_missing_cm1_settings(tmp_path: Path) -> None:
+    settings = CloudChamberSettings(
+        runtime_home=tmp_path / "CloudChamber",
+        cm1_root=None,
+        cm1_run_dir=None,
+        cache_dir=tmp_path / "CloudChamber" / "cache",
+        log_dir=tmp_path / "CloudChamber" / "logs",
+    )
+    manager = LocalRunManager(settings=settings)
+
+    with pytest.raises(LocalRunManagerError, match="CM1 is not ready"):
+        manager.launch(dry_run_manifest_path(tmp_path))
+
+
+def test_launch_refuses_existing_output_like_files(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    manifest_path = dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-001"
+    (run_dir / "cm1out_000001.nc").write_text("local output placeholder")
+    manager = LocalRunManager(settings=settings)
+
+    with pytest.raises(LocalRunManagerError, match="output-like files already exist"):
+        manager.launch(manifest_path)

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -141,6 +141,18 @@ Responsibilities:
 - expose logs
 - prevent accidental overwrite
 
+The first implemented local run manager is intentionally conservative:
+
+- one local CM1 process may be active at a time;
+- launch requires valid local CM1 settings and a generated `run_manifest.json`;
+- command construction points at the configured local `cm1.exe`;
+- stdout and stderr are written into the run package `logs/` directory for later result notebook provenance;
+- lifecycle states move through queued, running, completed, failed, or canceled;
+- launch refuses packages that already contain output-like files such as NetCDF or `cm1out*`;
+- tests inject fake subprocesses, so CI never needs a real CM1 executable.
+
+Real CM1 execution remains a manual/local responsibility until the user has local settings and runtime files in place. The manager must fail clearly when CM1 paths are missing rather than pretending a run started.
+
 ### Output Ingester
 
 Responsibilities:

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,6 +71,11 @@ Implemented backend API endpoints:
 
 - `GET /api/scenarios` lists validated scenario templates for the Scenario Builder and marks Baseline Shallow Cumulus as the Golden Path scenario.
 - `POST /api/dry-run-package` validates selected controls and writes a reviewable dry-run package under the configured runtime home. It does not launch CM1, create NetCDF output, or write generated packages into the repo during tests.
+- `POST /api/runs/launch` starts one local CM1 run from a generated manifest when local CM1 settings validate.
+- `GET /api/runs/status?manifest_path=...` refreshes and returns lifecycle status/log metadata for a run manifest.
+- `POST /api/runs/cancel` cancels the active local run when technically practical.
+
+The local run manager assumes one active CM1 run at a time for the MVP. It captures stdout/stderr under the run package `logs/` directory, updates the run manifest through queued/running/completed/failed/canceled states, refuses output-like files before launch, and fails clearly when CM1 settings are missing. Normal tests use fake subprocesses; real CM1 execution remains manual/local and is not required in CI.
 
 The backend skeleton uses Python/FastAPI with pytest, ruff, and mypy. Data/science work should prefer xarray, netCDF4 or h5netcdf, numpy, and pydantic when those layers are added.
 
@@ -162,7 +167,7 @@ Before automated launch is trusted, use the Baseline Shallow Cumulus dry-run pac
 7. Run CM1 manually from the local runtime path when ready. Record the exact command, CM1 version/path, Cloud Chamber commit, run-size preset, controls, runtime, output cadence, log paths, output paths, and any warnings/errors.
 8. Keep generated packages, copied runtime files, logs, NetCDF output, and validation reports out of git unless a future policy explicitly creates a tiny synthetic fixture.
 
-The next implementation step is the automated local CM1 launcher and log/status monitor. It should preserve the same distinctions: dry-run package, queued/running CM1 process, completed/failed/canceled CM1 run, ingested metadata, and saved result/notebook entry are separate states.
+The automated local CM1 launcher/log monitor now follows this policy for the first MVP. It preserves the same distinctions: dry-run package, queued/running CM1 process, completed/failed/canceled CM1 run, ingested metadata, and saved result/notebook entry are separate states.
 
 ## Whole Repo
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -192,16 +192,19 @@ Goal: make Cloud Chamber actually launch and monitor local CM1 runs.
 
 Deliverables:
 
-- Local CM1 launcher.
-- stdout/stderr capture.
-- lifecycle state management.
-- cancel/failure handling.
-- overwrite protection.
+- Local CM1 launcher from generated run manifests.
+- one-local-run-at-a-time guard.
+- stdout/stderr capture into run package logs.
+- lifecycle state management for queued/running/completed/failed/canceled.
+- cancel/failure handling with clear manifest state.
+- overwrite protection for output-like files.
 - local/manual validation path.
 
 Implementation anchor:
 
 - #29 should assume one local CM1 run at a time, account for long/overnight runs, and preserve logs for result notebook entries.
+
+The first implementation uses fake subprocesses in automated tests and does not require real CM1 in CI. Real execution remains local/manual and depends on the user's configured CM1 root/run directory.
 
 ## M3 Results Library + Experiment Notebook
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -24,11 +24,11 @@ Implemented fast tests cover:
 - CM1 path/settings handling through local runtime settings
 - run-package generation using temp directories
 - frontend component tests for Scenario Builder behavior, dry-run review, and preview-not-implemented state distinctions
+- local CM1 launcher command construction, one-run-at-a-time behavior, manifest state transitions, log capture, cancellation, missing-settings failure, and overwrite protection with fake subprocesses
 
 Future fast tests should cover:
 
 - result-card / experiment-notebook metadata serialization
-- run-manager fake process execution
 - NetCDF ingest with tiny synthetic fixtures when that layer exists
 - visualizer metadata loading when that layer exists
 
@@ -39,6 +39,8 @@ Scenario-template tests should cover both valid templates and targeted invalid t
 CM1 input contract tests should use structured/snapshot assertions for generated fragments such as namelist defaults and input-sounding notes. These tests must not write generated run packages into the repo, launch CM1, or require real CM1 runtime files.
 
 Dry-run package tests should use temporary runtime homes and assert overwrite protection, manifest/report content, and absence of NetCDF output. A dry-run package is packaged metadata and placeholder CM1 inputs only; it is not a completed CM1 result.
+
+Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
 
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.
 


### PR DESCRIPTION
Closes #29

Summary:
- Implemented a conservative local CM1 run manager for generated run manifests.
- Enforced one active local CM1 run at a time.
- Added launch/status/cancel backend API endpoints.
- Added local CM1 settings validation before launch and clear missing-config failures.
- Constructed the CM1 command from the configured local run directory.
- Captured stdout/stderr into the run package logs directory for later result notebook provenance.
- Updated run manifests through queued, running, completed, failed, and canceled states.
- Added overwrite protection for output-like files such as NetCDF and cm1out* before launch.
- Updated architecture, development, testing, and roadmap docs.

What was intentionally not included:
- No real CM1 execution in CI.
- No frontend run-monitor UI.
- No NetCDF ingest or Results Library work.
- No CM1 vendoring, runtime-file copying, generated CM1 outputs, or sample NetCDF data.

Tests/checks run:
- scripts/check.sh passed.
- Added fake subprocess tests for command construction, log capture, one-local-run-at-a-time behavior, completed/failed/canceled transitions, missing settings failure, and overwrite protection.
- Added API tests for launch status payload and clear launch failure response.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, local runtime files, logs, validation reports, or large visualization artifacts were committed.
