### PR TITLE
Generate CM1-ready baseline package inputs

### DIFF
--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -1,6 +1,6 @@
 """CM1-facing input generation contract.
 
-This module defines deterministic metadata/fragments for future package generation.
+This module defines deterministic metadata and CM1-facing text for package generation.
 It does not launch CM1 and does not write generated files.
 """
 
@@ -83,13 +83,13 @@ GENERATED_FILE_SPECS = (
         role=GeneratedFileRole.NAMELIST,
         relative_path="namelist.input",
         description="CM1 namelist input generated from validated scenario controls.",
-        scientific_status="placeholder until local/manual CM1 validation",
+        scientific_status="CM1-ready provisional baseline derived from local CM1 BOMEX example",
     ),
     GeneratedFileSpec(
         role=GeneratedFileRole.INPUT_SOUNDING,
         relative_path="input_sounding",
         description="CM1 sounding/profile input generated from validated scenario controls.",
-        scientific_status="placeholder until local/manual CM1 validation",
+        scientific_status="CM1-readable provisional profile; baseline namelist uses built-in BOMEX",
     ),
     GeneratedFileSpec(
         role=GeneratedFileRole.DRY_RUN_REPORT,
@@ -124,7 +124,7 @@ def build_cm1_input_contract(
             audience=control.audience,
             cm1_mapping_notes=control.cm1_mapping_notes,
             scientific_status=(
-                "product-facing placeholder until local/manual CM1 validation"
+                "product-facing CM1 mapping is provisional until local/manual smoke-run validation"
                 if control.audience == ControlAudience.PRODUCT
                 else "advanced/developer metadata"
             ),
@@ -152,38 +152,364 @@ def build_cm1_input_contract(
 
 
 def render_namelist_fragment(contract: CM1InputContract) -> str:
+    return render_cm1_namelist(contract)
+
+
+def render_cm1_namelist(contract: CM1InputContract) -> str:
+    """Render a runnable CM1 namelist for the baseline shallow-cumulus package.
+
+    The first baseline uses CM1's built-in BOMEX shallow-cumulus analytic profile
+    (`testcase = 3`, `isnd = 19`) from the local CM1 reference case. The grid/runtime
+    are adjusted to Cloud Chamber's quick-look cloud-scale starting point.
+    """
+
     defaults = contract.cloud_scale_defaults
-    lines = [
-        "# Cloud Chamber CM1 namelist fragment",
-        "# Status: placeholder until local/manual CM1 validation",
-        f"# scenario_id = {contract.scenario_id}",
-        "&cloud_chamber_domain",
-        f"  x_extent_km = {defaults.horizontal_extent_km},",
-        f"  y_extent_km = {defaults.y_extent_km},",
-        f"  z_extent_km = {defaults.vertical_extent_km},",
-        f"  dx_m = {defaults.horizontal_spacing_m},",
-        f"  dz_m = {defaults.vertical_spacing_m},",
-        f"  runtime_seconds = {defaults.runtime_seconds},",
-        f"  output_cadence_seconds = {defaults.output_cadence_seconds},",
-        "/",
-    ]
-    return "\n".join(lines) + "\n"
+    nx = int(defaults.horizontal_extent_km * 1000 / defaults.horizontal_spacing_m)
+    ny = int(defaults.y_extent_km * 1000 / defaults.horizontal_spacing_m)
+    nz = int(defaults.vertical_extent_km * 1000 / defaults.vertical_spacing_m)
+    return f"""
+ &param0
+ nx           =      {nx},
+ ny           =      {ny},
+ nz           =      {nz},
+ ppnode       =     128,
+ timeformat   =       2,
+ timestats    =       1,
+ terrain_flag = .false.,
+ procfiles    = .false.,
+ /
+
+ &param1
+ dx     =   {float(defaults.horizontal_spacing_m):.1f},
+ dy     =   {float(defaults.horizontal_spacing_m):.1f},
+ dz     =   {float(defaults.vertical_spacing_m):.1f},
+ dtl    =   3.000,
+ timax  = {float(defaults.runtime_seconds):.1f},
+ run_time =  -999.9,
+ tapfrq =  {float(defaults.output_cadence_seconds):.1f},
+ rstfrq = -3600.0,
+ statfrq =   60.0,
+ prclfrq =   60.0,
+ /
+
+ &param2
+ cm1setup  =  1,
+ testcase  =  3,
+ adapt_dt  =  1,
+ irst      =  0,
+ rstnum    =  1,
+ iconly    =  0,
+ hadvordrs =  5,
+ vadvordrs =  5,
+ hadvordrv =  5,
+ vadvordrv =  5,
+ advwenos  =  2,
+ advwenov  =  2,
+ weno_order = 5,
+ apmasscon =  1,
+ idiff     =  0,
+ mdiff     =  0,
+ difforder =  6,
+ imoist    =  1,
+ ipbl      =  0,
+ sgsmodel  =  1,
+ tconfig   =  1,
+ bcturbs   =  1,
+ horizturb =  0,
+ doimpl    =  1,
+ irdamp    =  1,
+ hrdamp    =  0,
+ psolver   =  3,
+ ptype     =  5,
+ ihail     =  0,
+ iautoc    =  0,
+ icor      =  1,
+ lspgrad   =  2,
+ eqtset    =  2,
+ idiss     =  0,
+ efall     =  0,
+ rterm     =  0,
+ wbc       =  1,
+ ebc       =  1,
+ sbc       =  1,
+ nbc       =  1,
+ bbc       =  3,
+ tbc       =  1,
+ irbc      =  4,
+ roflux    =  0,
+ nudgeobc  =  0,
+ isnd      = 19,
+ iwnd      =  9,
+ itern     =  0,
+ iinit     =  0,
+ irandp    =  1,
+ ibalance  =  0,
+ iorigin   =  2,
+ axisymm   =  0,
+ imove     =  0,
+ iptra     =  0,
+ npt       =  1,
+ pdtra     =  1,
+ iprcl     =  0,
+ nparcels  =  1,
+ /
+
+ &param3
+ kdiff2  =   75.0,
+ kdiff6  =   0.040,
+ fcor    = 0.376e-4,
+ kdiv    = 0.10,
+ alph    = 0.60,
+ rdalpha = 3.3333333333e-3,
+ zd      =  2500.0,
+ xhd     = 100000.0,
+ alphobc = 60.0,
+ umove   = 12.5,
+ vmove   =  3.0,
+ v_t     =      7.0,
+ l_h     =      0.0,
+ lhref1  =      0.0,
+ lhref2  =      0.0,
+ l_inf   =     75.0,
+ ndcnst  =    100.0,
+ nt_c    =    250.0,
+ csound  =    300.0,
+ cstar   =     30.0,
+ /
+
+ &param11
+ radopt  =        0,
+ dtrad   =    300.0,
+ ctrlat  =    36.68,
+ ctrlon  =   -98.35,
+ year    =     2009,
+ month   =        5,
+ day     =       15,
+ hour    =       21,
+ minute  =       38,
+ second  =       00,
+ /
+
+ &param12
+ isfcflx    =      1,
+ sfcmodel   =      1,
+ oceanmodel =      1,
+ initsfc    =      1,
+ tsk0       = 299.28,
+ tmn0       = 297.28,
+ xland0     =    2.0,
+ lu0        =     16,
+ season     =      1,
+ cecd       =      3,
+ pertflx    =      0,
+ cnstce     =  0.001,
+ cnstcd     =  0.001,
+ isftcflx   =      0,
+ iz0tlnd    =      0,
+ oml_hml0   =   50.0,
+ oml_gamma  =   0.14,
+ set_flx    =      1,
+ cnst_shflx = 8.0e-3,
+ cnst_lhflx = 5.2e-5,
+ set_znt    =      0,
+ cnst_znt   =   0.00,
+ set_ust    =      1,
+ cnst_ust   =   0.28,
+ ramp_sgs   =      1,
+ ramp_time  = 1800.0,
+ t2p_avg   =       1,
+ /
+
+ &param4
+ stretch_x =      0,
+ dx_inner  =    1000.0,
+ dx_outer  =    7000.0,
+ nos_x_len =   40000.0,
+ tot_x_len =  120000.0,
+ /
+
+ &param5
+ stretch_y =      0,
+ dy_inner  =    1000.0,
+ dy_outer  =    7000.0,
+ nos_y_len =   40000.0,
+ tot_y_len =  120000.0,
+ /
+
+ &param6
+ stretch_z =  0,
+ ztop      =  {float(defaults.vertical_extent_km * 1000):.1f},
+ str_bot   =     0.0,
+ str_top   =  2000.0,
+ dz_bot    =   125.0,
+ dz_top    =   500.0,
+ /
+
+ &param7
+ bc_temp   = 1,
+ ptc_top   = 250.0,
+ ptc_bot   = 300.0,
+ viscosity = 25.0,
+ pr_num    = 0.72,
+ /
+
+ &param8
+ var1      =   0.0,
+ var2      =   0.0,
+ var3      =   0.0,
+ var4      =   0.0,
+ var5      =   0.0,
+ var6      =   0.0,
+ var7      =   0.0,
+ var8      =   0.0,
+ var9      =   0.0,
+ var10     =   0.0,
+ var11     =   0.0,
+ var12     =   0.0,
+ var13     =   0.0,
+ var14     =   0.0,
+ var15     =   0.0,
+ var16     =   0.0,
+ var17     =   0.0,
+ var18     =   0.0,
+ var19     =   0.0,
+ var20     =   0.0,
+ /
+
+ &param9
+ output_format    = 1,
+ output_filetype  = 2,
+ output_interp    = 0,
+ output_rain      = 1,
+ output_sfcflx    = 1,
+ output_sfcparams = 1,
+ output_sfcdiags  = 1,
+ output_psfc      = 1,
+ output_th        = 1,
+ output_prs       = 1,
+ output_tke       = 1,
+ output_km        = 1,
+ output_kh        = 1,
+ output_qv        = 1,
+ output_q         = 1,
+ output_dbz       = 1,
+ output_u         = 1,
+ output_uinterp   = 1,
+ output_v         = 1,
+ output_vinterp   = 1,
+ output_w         = 1,
+ output_winterp   = 1,
+ output_nm        = 1,
+ output_def       = 1,
+ output_lwp       = 1,
+ /
+
+ &param16
+ restart_format   = 1,
+ restart_filetype = 2,
+ restart_reset_frqtim  =  .true.,
+ /
+
+ &param10
+ stat_w        = 1,
+ stat_u        = 1,
+ stat_v        = 1,
+ stat_q        = 1,
+ stat_tke      = 1,
+ stat_km       = 1,
+ stat_kh       = 1,
+ stat_rh       = 1,
+ stat_cloud    = 1,
+ stat_cfl      = 1,
+ /
+
+ &param13
+ prcl_th       = 1,
+ prcl_t        = 1,
+ prcl_prs      = 1,
+ prcl_q        = 1,
+ prcl_dbz      = 1,
+ /
+
+ &param14
+ dodomaindiag   =    .false.,
+ diagfrq        =       60.0,
+ /
+
+ &param15
+ doazimavg        =    .false.,
+ azimavgfrq       =     3600.0,
+ rlen             =   300000.0,
+ do_adapt_move    =    .false.,
+ adapt_move_frq   =     3600.0,
+ /
+
+ &param17
+ les_subdomain_shape    =      1 ,
+ les_subdomain_xlen     =   200000.0,
+ les_subdomain_ylen     =   200000.0,
+ les_subdomain_dlen     =   200000.0,
+ les_subdomain_trnslen  =     5000.0,
+ /
+
+ &param18
+ do_recycle_w        =  .false.,
+ do_recycle_s        =  .false.,
+ do_recycle_e        =  .false.,
+ do_recycle_n        =  .false.,
+ /
+
+ &param19
+ do_lsnudge         =    .false.,
+ do_lsnudge_u       =    .false.,
+ do_lsnudge_v       =    .false.,
+ do_lsnudge_th      =    .false.,
+ do_lsnudge_qv      =    .false.,
+ /
+
+ &param20
+ do_ib        =    .false.,
+ /
+
+ &param21
+ hurr_vg       =      40.0,
+ hurr_rad      =   40000.0,
+ /
+
+ &nssl2mom_params
+   alphah  = 0,
+   alphahl = 0.5,
+   ccn     = 0.6e9,
+   cnor    = 8.e6,
+   cnoh    = 4.e4,
+ /
+""".lstrip()
 
 
 def render_input_sounding_notes(contract: CM1InputContract) -> str:
+    return render_cm1_input_sounding(contract)
+
+
+def render_cm1_input_sounding(contract: CM1InputContract) -> str:
+    """Render a CM1-readable external sounding profile.
+
+    The current baseline namelist uses CM1's built-in BOMEX sounding (`isnd = 19`),
+    so CM1 will not read this file for the first smoke run. We still generate a
+    numeric CM1/WRF-format profile so package preflight can reject notes-only
+    artifacts and future external-sounding experiments have a concrete starting point.
+    """
+
+    del contract
     lines = [
-        "# Cloud Chamber input_sounding notes",
-        "# Status: placeholder until local/manual CM1 validation",
-        f"# scenario_id = {contract.scenario_id}",
-        f"# physical_question = {contract.physical_question}",
-        "# Product controls:",
+        "1015.0 298.7 17.0",
+        "0.0 298.7 17.0 -8.75 0.0",
+        "520.0 298.7 16.3 -8.75 0.0",
+        "1480.0 302.4 10.7 -8.75 0.0",
+        "2000.0 308.2 4.2 -8.75 0.0",
+        "3000.0 311.8 3.0 -8.75 0.0",
+        "6000.0 330.0 1.0 -8.75 0.0",
+        "7000.0 340.0 0.5 -8.75 0.0",
     ]
-    for fragment in contract.control_fragments:
-        if fragment.audience == ControlAudience.PRODUCT:
-            lines.append(
-                f"# - {fragment.control_id} = {fragment.selected_value}: "
-                f"{fragment.cm1_mapping_notes}"
-            )
     return "\n".join(lines) + "\n"
 
 

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -121,7 +121,8 @@ def generate_dry_run_package(
         "status": "external_runtime_files_not_committed",
         "required_files": scenario.cm1_template.runtime_files_needed,
         "notes": (
-            "CM1 remains external to the repo; dry-run generation does not copy runtime files."
+            "CM1 remains external to the repo. Required runtime files are staged from the "
+            "configured local CM1 run directory at launch time, never committed to the repo."
         ),
     }
 
@@ -180,7 +181,10 @@ def _case_manifest_payload(
         "expected_behavior": scenario.expected_behavior,
         "warnings": scenario.warnings,
         "limitations": scenario.limitations,
-        "cm1_mapping_status": "placeholder until local/manual CM1 validation",
+        "cm1_mapping_status": (
+            "CM1-ready provisional baseline package; still pending local/manual smoke-run "
+            "scientific validation"
+        ),
         "contract": asdict(contract),
     }
 

--- a/app/backend/cloud_chamber/local_run_manager.py
+++ b/app/backend/cloud_chamber/local_run_manager.py
@@ -6,6 +6,8 @@ Tests inject fake processes; CI never requires a real CM1 runtime.
 
 from __future__ import annotations
 
+import json
+import shutil
 import subprocess
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -114,12 +116,14 @@ class LocalRunManager:
         run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
         if not run_dir.exists():
             raise LocalRunManagerError(f"Run package directory does not exist: {run_dir}")
+        _preflight_cm1_inputs(manifest)
         if _existing_output_paths(run_dir):
             raise LocalRunManagerError(
                 f"Refusing to launch because output-like files already exist in {run_dir}"
             )
         if self._settings.cm1_run_dir is None:
             raise LocalRunManagerError("CM1 run directory is not configured.")
+        _stage_required_runtime_files(manifest, self._settings.cm1_run_dir, run_dir)
 
         command = [str(self._settings.cm1_run_dir / "cm1.exe")]
         log_dir = run_dir / "logs"
@@ -300,3 +304,61 @@ def _existing_output_paths(run_dir: Path) -> tuple[Path, ...]:
     for pattern in patterns:
         paths.extend(run_dir.glob(pattern))
     return tuple(sorted(set(paths)))
+
+
+def _preflight_cm1_inputs(manifest: RunManifest) -> None:
+    checks = {
+        "namelist.input": manifest.generated_inputs.namelist_input,
+        "input_sounding": manifest.generated_inputs.input_sounding,
+    }
+    for label, configured_path in checks.items():
+        if configured_path is None:
+            raise LocalRunManagerError(f"Missing generated CM1 input path: {label}")
+        path = Path(configured_path).expanduser()
+        if not path.exists():
+            raise LocalRunManagerError(f"Generated CM1 input does not exist: {path}")
+        text = path.read_text()
+        if _is_placeholder_input(text):
+            raise LocalRunManagerError(
+                f"Refusing to launch placeholder-only CM1 input: {path.name}"
+            )
+
+
+def _is_placeholder_input(text: str) -> bool:
+    lowered = text.lower()
+    return (
+        "placeholder until local/manual cm1 validation" in lowered
+        or "cloud chamber input_sounding notes" in lowered
+        or "&cloud_chamber_domain" in lowered
+    )
+
+
+def _stage_required_runtime_files(
+    manifest: RunManifest,
+    cm1_run_dir: Path,
+    run_dir: Path,
+) -> None:
+    for required_file in _required_runtime_files(manifest):
+        source = cm1_run_dir / required_file
+        if not source.exists():
+            raise LocalRunManagerError(
+                f"Required CM1 runtime file is missing from configured run dir: {source}"
+            )
+        destination = run_dir / required_file
+        if not destination.exists():
+            shutil.copy2(source, destination)
+
+
+def _required_runtime_files(manifest: RunManifest) -> tuple[str, ...]:
+    required: list[str] = []
+    for checklist_path in manifest.generated_inputs.runtime_file_checklist:
+        path = Path(checklist_path).expanduser()
+        if not path.exists():
+            continue
+        loaded = json.loads(path.read_text())
+        if not isinstance(loaded, dict):
+            continue
+        files = loaded.get("required_files", [])
+        if isinstance(files, list):
+            required.extend(item for item in files if isinstance(item, str))
+    return tuple(dict.fromkeys(required))

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -51,37 +51,40 @@ def test_cm1_contract_keeps_product_controls_separate_from_mapping_notes() -> No
     assert low_level_humidity.audience == ControlAudience.PRODUCT
     assert low_level_humidity.selected_value == "more_humid"
     assert "sounding moisture" in low_level_humidity.cm1_mapping_notes
-    assert "placeholder until local/manual CM1 validation" in low_level_humidity.scientific_status
-
-
-def test_rendered_namelist_fragment_is_deterministic_snapshot() -> None:
-    contract = build_cm1_input_contract(baseline_scenario())
-
-    assert render_namelist_fragment(contract) == (
-        "# Cloud Chamber CM1 namelist fragment\n"
-        "# Status: placeholder until local/manual CM1 validation\n"
-        "# scenario_id = baseline-shallow-cumulus\n"
-        "&cloud_chamber_domain\n"
-        "  x_extent_km = 16,\n"
-        "  y_extent_km = 16,\n"
-        "  z_extent_km = 6,\n"
-        "  dx_m = 200,\n"
-        "  dz_m = 125,\n"
-        "  runtime_seconds = 7200,\n"
-        "  output_cadence_seconds = 300,\n"
-        "/\n"
+    assert "provisional until local/manual smoke-run validation" in (
+        low_level_humidity.scientific_status
     )
 
 
-def test_rendered_sounding_notes_include_only_product_controls() -> None:
+def test_rendered_namelist_is_cm1_ready_bomex_baseline() -> None:
     contract = build_cm1_input_contract(baseline_scenario())
-    notes = render_input_sounding_notes(contract)
+    namelist = render_namelist_fragment(contract)
 
-    assert "# physical_question = How do low-level moisture" in notes
-    assert "# - low_level_humidity = baseline" in notes
-    assert "# - surface_heating = baseline" in notes
-    assert "# - cap_strength = baseline" in notes
-    assert "advanced/developer" not in notes
+    assert "&param0" in namelist
+    assert "nx           =      80," in namelist
+    assert "ny           =      80," in namelist
+    assert "nz           =      48," in namelist
+    assert "dx     =   200.0," in namelist
+    assert "dy     =   200.0," in namelist
+    assert "dz     =   125.0," in namelist
+    assert "timax  = 7200.0," in namelist
+    assert "tapfrq =  300.0," in namelist
+    assert "testcase  =  3," in namelist
+    assert "isnd      = 19," in namelist
+    assert "&cloud_chamber_domain" not in namelist
+    assert "placeholder until local/manual CM1 validation" not in namelist
+
+
+def test_rendered_input_sounding_is_cm1_readable_not_notes() -> None:
+    contract = build_cm1_input_contract(baseline_scenario())
+    sounding = render_input_sounding_notes(contract)
+    lines = sounding.splitlines()
+
+    assert len(lines[0].split()) == 3
+    assert all(len(line.split()) == 5 for line in lines[1:])
+    assert float(lines[-1].split()[0]) > 6000
+    assert "Cloud Chamber input_sounding notes" not in sounding
+    assert "placeholder until local/manual CM1 validation" not in sounding
 
 
 def test_cm1_contract_includes_expected_diagnostics_and_visualization_defaults() -> None:

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -87,16 +87,19 @@ def test_dry_run_package_validates_controls_before_writing(tmp_path: Path) -> No
     assert not (tmp_path / "runs" / "run-004").exists()
 
 
-def test_dry_run_package_writes_placeholder_inputs_not_outputs(tmp_path: Path) -> None:
+def test_dry_run_package_writes_cm1_ready_inputs_not_outputs(tmp_path: Path) -> None:
     result = generate_dry_run_package(
         scenario_data=load_baseline_template(),
         runtime_home=tmp_path,
         run_id="run-005",
     )
+    namelist = (result.package_dir / "namelist.input").read_text()
+    sounding = (result.package_dir / "input_sounding").read_text()
 
-    assert (
-        "placeholder until local/manual CM1 validation"
-        in (result.package_dir / "namelist.input").read_text()
-    )
-    assert "Product controls" in (result.package_dir / "input_sounding").read_text()
+    assert "&param0" in namelist
+    assert "testcase  =  3," in namelist
+    assert "&cloud_chamber_domain" not in namelist
+    assert "placeholder until local/manual CM1 validation" not in namelist
+    assert len(sounding.splitlines()[0].split()) == 3
+    assert "Cloud Chamber input_sounding notes" not in sounding
     assert not list(result.package_dir.glob("*.nc"))

--- a/app/backend/tests/test_local_run_manager.py
+++ b/app/backend/tests/test_local_run_manager.py
@@ -63,6 +63,7 @@ def fake_settings(tmp_path: Path) -> CloudChamberSettings:
     cm1_run_dir = cm1_root / "run"
     cm1_run_dir.mkdir(parents=True)
     (cm1_run_dir / "cm1.exe").write_text("# fake executable\n")
+    (cm1_run_dir / "LANDUSE.TBL").write_text("fake local runtime file\n")
     return CloudChamberSettings(
         runtime_home=tmp_path / "CloudChamber",
         cm1_root=cm1_root,
@@ -94,8 +95,10 @@ def test_launch_constructs_cm1_command_and_captures_logs(tmp_path: Path) -> None
     assert status.lifecycle_state == LifecycleState.RUNNING
     assert factory.commands == [[str(settings.cm1_run_dir / "cm1.exe")]]
     assert factory.cwd == tmp_path / "CloudChamber" / "runs" / "run-001"
+    assert factory.cwd is not None
     assert status.stdout_log.read_text() == "fake cm1 stdout\n"
     assert status.stderr_log.read_text() == "fake cm1 stderr\n"
+    assert (factory.cwd / "LANDUSE.TBL").read_text() == "fake local runtime file\n"
 
     manifest = load_run_manifest(manifest_path)
     assert manifest.lifecycle_state == LifecycleState.RUNNING
@@ -194,4 +197,28 @@ def test_launch_refuses_existing_output_like_files(tmp_path: Path) -> None:
     manager = LocalRunManager(settings=settings)
 
     with pytest.raises(LocalRunManagerError, match="output-like files already exist"):
+        manager.launch(manifest_path)
+
+
+def test_launch_refuses_placeholder_only_inputs(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    manifest_path = dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-001"
+    (run_dir / "namelist.input").write_text(
+        "# Status: placeholder until local/manual CM1 validation\n&cloud_chamber_domain\n/\n"
+    )
+    manager = LocalRunManager(settings=settings)
+
+    with pytest.raises(LocalRunManagerError, match="placeholder-only CM1 input"):
+        manager.launch(manifest_path)
+
+
+def test_launch_reports_missing_runtime_file(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    assert settings.cm1_run_dir is not None
+    (settings.cm1_run_dir / "LANDUSE.TBL").unlink()
+    manifest_path = dry_run_manifest_path(tmp_path)
+    manager = LocalRunManager(settings=settings)
+
+    with pytest.raises(LocalRunManagerError, match="Required CM1 runtime file is missing"):
         manager.launch(manifest_path)

--- a/app/backend/tests/test_settings.py
+++ b/app/backend/tests/test_settings.py
@@ -10,12 +10,13 @@ from cloud_chamber.settings import (
 )
 
 
-def test_settings_default_to_cloud_chamber_runtime_home() -> None:
-    settings = load_settings(environ={}, probe_paths=())
+def test_settings_default_to_cloud_chamber_runtime_home(tmp_path: Path) -> None:
+    settings = load_settings(home=tmp_path / "CloudChamber", environ={}, probe_paths=())
 
-    assert settings.runtime_home == DEFAULT_RUNTIME_HOME.expanduser()
-    assert settings.cache_dir == DEFAULT_RUNTIME_HOME.expanduser() / "cache"
-    assert settings.log_dir == DEFAULT_RUNTIME_HOME.expanduser() / "logs"
+    assert DEFAULT_RUNTIME_HOME.expanduser().name == "CloudChamber"
+    assert settings.runtime_home == tmp_path / "CloudChamber"
+    assert settings.cache_dir == tmp_path / "CloudChamber" / "cache"
+    assert settings.log_dir == tmp_path / "CloudChamber" / "logs"
     assert settings.cm1_root is None
     assert settings.cm1_run_dir is None
 
@@ -77,7 +78,7 @@ def test_probe_paths_are_defaults_not_requirements(tmp_path: Path) -> None:
     cm1_root = tmp_path / "cm1r21.1"
     (cm1_root / "run").mkdir(parents=True)
 
-    settings = load_settings(environ={}, probe_paths=(cm1_root,))
+    settings = load_settings(home=tmp_path / "CloudChamber", environ={}, probe_paths=(cm1_root,))
 
     assert settings.cm1_root == cm1_root
     assert settings.cm1_run_dir == cm1_root / "run"

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -97,7 +97,9 @@ Turns a scenario + user controls into:
 
 For the Baseline Shallow Cumulus Golden Path, the generated package should preserve the physical question, curated controls, run-size preset, expected diagnostics, expected output fields, and provenance labels before CM1 starts.
 
-The CM1 input generation contract is deterministic and testable before full package generation. It documents the expected generated files, preserves product-facing controls separately from raw namelist/developer settings, and marks namelist/sounding fragments as placeholders until local/manual CM1 validation accepts them.
+The CM1 input generation contract is deterministic and testable before full package generation. It documents the expected generated files and preserves product-facing controls separately from raw namelist/developer settings.
+
+For Baseline Shallow Cumulus, the first CM1-facing package uses CM1's BOMEX shallow-cumulus reference behavior (`testcase = 3`, `isnd = 19`) with Cloud Chamber quick-look grid/runtime settings. The generated `input_sounding` is numeric and CM1-readable, but the baseline namelist uses CM1's built-in analytic BOMEX sounding by default. This is a runnable package candidate, not scientific acceptance; #56 must be retried locally before the case is treated as validated.
 
 Cloud-scale defaults for the first lower-atmosphere contract are:
 
@@ -149,6 +151,8 @@ The first implemented local run manager is intentionally conservative:
 - stdout and stderr are written into the run package `logs/` directory for later result notebook provenance;
 - lifecycle states move through queued, running, completed, failed, or canceled;
 - launch refuses packages that already contain output-like files such as NetCDF or `cm1out*`;
+- launch refuses placeholder-only `namelist.input` or notes-only `input_sounding` files;
+- launch stages required local runtime files such as `LANDUSE.TBL` from the configured CM1 run directory into the generated package directory;
 - tests inject fake subprocesses, so CI never needs a real CM1 executable.
 
 Real CM1 execution remains a manual/local responsibility until the user has local settings and runtime files in place. The manager must fail clearly when CM1 paths are missing rather than pretending a run started.

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -258,7 +258,7 @@ Initial scenario templates should include:
 
 Baseline shallow cumulus is the first hero case. Warm rain remains early but does not block the Golden Path.
 
-The initial lower-atmosphere templates live under `scenarios/lower-atmosphere/` as validated JSON metadata. They are honest scenario definitions and teaching contracts, not final scientific calibration. CM1 mapping fields are placeholders until local/manual CM1 validation accepts the generated configurations.
+The initial lower-atmosphere templates live under `scenarios/lower-atmosphere/` as validated JSON metadata. They are honest scenario definitions and teaching contracts, not final scientific calibration. Baseline Shallow Cumulus now has a CM1-facing package candidate, while broader control-to-CM1 mapping fields remain provisional until local/manual CM1 validation accepts them.
 
 ## CM1 Input Generation Contract
 
@@ -273,7 +273,7 @@ dry_run_report.json
 runtime_file_checklist.json
 ```
 
-The current contract can render deterministic namelist and sounding fragments for review, but these fragments are scientific placeholders until local/manual CM1 validation. They must keep product-facing controls separate from advanced/developer CM1 settings.
+The current Baseline Shallow Cumulus contract renders CM1-facing `namelist.input` using CM1's BOMEX shallow-cumulus reference path (`testcase = 3`, `isnd = 19`) with Cloud Chamber quick-look grid/runtime settings. It also writes a numeric CM1-readable `input_sounding` reference profile, although the baseline namelist uses CM1's built-in BOMEX analytic sounding rather than reading that file by default. These inputs are runnable package candidates, but remain scientifically provisional until the local/manual smoke run in #56 succeeds.
 
 Default cloud-scale assumptions:
 
@@ -297,6 +297,8 @@ Dry-run package generation creates these files for review without launching CM1:
 - `runtime_file_checklist.json`
 
 The dry-run report must state that it is not a completed CM1 result, record that CM1 was not launched, include selected run-size preset, include physical question and controls, include expected diagnostics and visualization defaults, and use `unknown until validated` for unvalidated cost/size estimates.
+
+Launch preflight must reject placeholder-only CM1-facing files, including old `&cloud_chamber_domain` fragments or notes-only `input_sounding` artifacts. Required external runtime files such as `LANDUSE.TBL` are copied from the configured local CM1 run directory into the generated runtime package at launch time. These staged files are local/generated artifacts and must not be committed.
 
 ## Curated Controls And Diagnostics
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,6 +77,10 @@ Implemented backend API endpoints:
 
 The local run manager assumes one active CM1 run at a time for the MVP. It captures stdout/stderr under the run package `logs/` directory, updates the run manifest through queued/running/completed/failed/canceled states, refuses output-like files before launch, and fails clearly when CM1 settings are missing. Normal tests use fake subprocesses; real CM1 execution remains manual/local and is not required in CI.
 
+Launch preflight also refuses placeholder-only CM1-facing files. Older packages containing `&cloud_chamber_domain` or notes-only `input_sounding` files must be regenerated before launch. For Baseline Shallow Cumulus, generated packages now use a CM1 BOMEX shallow-cumulus namelist path with quick-look grid/runtime settings; the package remains provisional until #56 is retried manually.
+
+Required runtime files such as `LANDUSE.TBL` are copied from the configured local CM1 run directory into the generated package at launch time. These copied files are local/generated artifacts under `~/CloudChamber/runs/<run-id>/`; do not commit them.
+
 The backend skeleton uses Python/FastAPI with pytest, ruff, and mypy. Data/science work should prefer xarray, netCDF4 or h5netcdf, numpy, and pydantic when those layers are added.
 
 Backend work should assume one local CM1 run at a time for the MVP and should avoid large in-memory processing paths for local MacBook Air-scale machines.
@@ -164,8 +168,9 @@ Before automated launch is trusted, use the Baseline Shallow Cumulus dry-run pac
    - `~/CloudChamber/settings.json`, if present;
    - default probes such as `/Users/timpeterson/cm1r21.1` and `/Users/timpeterson/cm1r21.1/run`.
 6. Compare the package against local CM1 runtime needs, including `cm1.exe` and local-only runtime files such as `LANDUSE.TBL`.
-7. Run CM1 manually from the local runtime path when ready. Record the exact command, CM1 version/path, Cloud Chamber commit, run-size preset, controls, runtime, output cadence, log paths, output paths, and any warnings/errors.
-8. Keep generated packages, copied runtime files, logs, NetCDF output, and validation reports out of git unless a future policy explicitly creates a tiny synthetic fixture.
+7. Regenerate any package that still contains placeholder-only `namelist.input` or notes-only `input_sounding` files.
+8. Run CM1 manually from the local runtime path when ready. Record the exact command, CM1 version/path, Cloud Chamber commit, run-size preset, controls, runtime, output cadence, log paths, output paths, and any warnings/errors.
+9. Keep generated packages, copied runtime files, logs, NetCDF output, and validation reports out of git unless a future policy explicitly creates a tiny synthetic fixture.
 
 The automated local CM1 launcher/log monitor now follows this policy for the first MVP. It preserves the same distinctions: dry-run package, queued/running CM1 process, completed/failed/canceled CM1 run, ingested metadata, and saved result/notebook entry are separate states.
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -206,6 +206,8 @@ Implementation anchor:
 
 The first implementation uses fake subprocesses in automated tests and does not require real CM1 in CI. Real execution remains local/manual and depends on the user's configured CM1 root/run directory.
 
+#56 found that the original dry-run package was still placeholder-only. The follow-up package-readiness work must keep #56 open/blocked until Baseline Shallow Cumulus packages generate CM1-facing inputs, reject placeholder-only packages before launch, stage local runtime files such as `LANDUSE.TBL`, and then retry the manual smoke run.
+
 ## M3 Results Library + Experiment Notebook
 
 Goal: turn CM1 outputs into replayable, inspectable, searchable experiment notebook entries.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -37,10 +37,12 @@ These tests must not require CM1 source, CM1 binaries, NetCDF output, generated 
 Scenario-template tests should cover both valid templates and targeted invalid templates, including missing product-facing controls, invalid choice defaults, missing runtime profiles, and variation policies that reference unknown controls. These tests validate metadata only; they do not generate CM1 output or launch CM1.
 
 CM1 input contract tests should use structured/snapshot assertions for generated fragments such as namelist defaults and input-sounding notes. These tests must not write generated run packages into the repo, launch CM1, or require real CM1 runtime files.
+Baseline Shallow Cumulus input tests should assert the generated `namelist.input` is no longer the old `&cloud_chamber_domain` placeholder fragment and that generated `input_sounding` is numeric/CM1-readable rather than notes-only.
 
-Dry-run package tests should use temporary runtime homes and assert overwrite protection, manifest/report content, and absence of NetCDF output. A dry-run package is packaged metadata and placeholder CM1 inputs only; it is not a completed CM1 result.
+Dry-run package tests should use temporary runtime homes and assert overwrite protection, manifest/report content, CM1-facing input readiness, and absence of NetCDF output. A dry-run package is packaged configuration and metadata only; it is not a launched process or completed CM1 result.
 
 Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
+They should also assert placeholder-only packages are rejected before launch and required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, not from the repo.
 
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.
 
@@ -116,7 +118,9 @@ Use this loop after a dry-run package has been generated and before broader CM1 
 2. Inspect the package before launch:
    - confirm `run_manifest.json`, `case_manifest.json`, `namelist.input`, `input_sounding`, `dry_run_report.json`, and `runtime_file_checklist.json` exist;
    - confirm the selected run-size preset, physical question, controls, expected diagnostics, and visualization defaults match the intended scenario;
-   - confirm `dry_run_report.json` says CM1 was not launched and is not a completed result.
+   - confirm `dry_run_report.json` says CM1 was not launched and is not a completed result;
+   - confirm `namelist.input` is not the old `&cloud_chamber_domain` placeholder fragment;
+   - confirm `input_sounding` is not notes-only.
 3. Compare generated files against the local CM1 runtime requirements:
    - check `~/CloudChamber/settings.json`, `CLOUD_CHAMBER_CM1_ROOT`, or the default probe paths;
    - expected local probes include `/Users/timpeterson/cm1r21.1` and `/Users/timpeterson/cm1r21.1/run`;


### PR DESCRIPTION
Closes #58

Summary:
- Recorded #56 as blocked_missing_tooling and kept #56 open for retry after package-readiness work.
- Replaced placeholder Baseline Shallow Cumulus `namelist.input` generation with a CM1-facing BOMEX shallow-cumulus package candidate using `testcase = 3`, `isnd = 19`, and Cloud Chamber quick-look grid/runtime settings.
- Replaced notes-only `input_sounding` with a numeric CM1-readable reference profile. The baseline namelist uses CM1's built-in BOMEX analytic sounding by default, so this file is generated for package readiness/future external-sounding paths rather than read by the baseline run.
- Added launch preflight checks that reject placeholder-only `namelist.input` / notes-only `input_sounding` packages.
- Implemented local runtime-file staging at launch time for required files such as `LANDUSE.TBL`, copied from the configured local CM1 run directory into the generated package outside the repo.
- Updated docs to clarify that the package is now a runnable candidate but remains scientifically provisional until #56 is retried manually.

Verification:
- `scripts/check.sh` passed.
- Temp package inspection confirmed `namelist.input` starts with CM1 `&param0` / `&param1` content and `input_sounding` is numeric.
- Verified #56 is open and #58 exists.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, or large visualization artifacts were committed.

Follow-up:
- Retry #56 manually with a newly generated Baseline Shallow Cumulus package. Exact cloud outcome remains unvalidated until that smoke run succeeds.
