### PR TITLE
Calibrate baseline damping and completion semantics

### DIFF
--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -261,7 +261,7 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  kdiv    = 0.10,
  alph    = 0.60,
  rdalpha = 3.3333333333e-3,
- zd      =  2500.0,
+ zd      =  4500.0,
  xhd     = 100000.0,
  alphobc = 60.0,
  umove   = 12.5,

--- a/app/backend/cloud_chamber/local_run_manager.py
+++ b/app/backend/cloud_chamber/local_run_manager.py
@@ -205,17 +205,23 @@ class LocalRunManager:
         active = self._active
         self._close_active()
         manifest = load_run_manifest(active.manifest_path)
+        run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
         completed_state = LifecycleState.COMPLETED if exit_code == 0 else LifecycleState.FAILED
-        product_state = (
-            ProductState.COMPLETED_CM1_RESULT
-            if exit_code == 0
-            else ProductState.FAILED_CANCELED_CM1_RUN
-        )
+        if exit_code == 0 and _usable_output_paths(run_dir):
+            product_state = ProductState.COMPLETED_CM1_RESULT
+            validation_status = manifest.validation_status
+        elif exit_code == 0:
+            product_state = ProductState.PROCESS_COMPLETED_NO_OUTPUT
+            validation_status = ValidationStatus.NEEDS_REVIEW
+        else:
+            product_state = ProductState.FAILED_CANCELED_CM1_RUN
+            validation_status = ValidationStatus.FAILED
         updated = self._with_state(
             manifest,
             state=completed_state,
             product_state=product_state,
             exit_code=exit_code,
+            validation_status=validation_status,
         )
         write_run_manifest(active.manifest_path, updated)
 
@@ -236,6 +242,7 @@ class LocalRunManager:
         stdout_log: Path | None = None,
         stderr_log: Path | None = None,
         exit_code: int | None = None,
+        validation_status: ValidationStatus | None = None,
     ) -> RunManifest:
         now = datetime.now(UTC)
         existing_execution = manifest.execution
@@ -267,7 +274,7 @@ class LocalRunManager:
                 "stderr_log": str(stderr_log) if stderr_log else existing_execution.stderr_log,
             }
         )
-        validation_status = (
+        next_validation_status = validation_status or (
             ValidationStatus.FAILED
             if state in {LifecycleState.FAILED, LifecycleState.CANCELED}
             else manifest.validation_status
@@ -275,7 +282,7 @@ class LocalRunManager:
         return manifest.model_copy(
             update={
                 "lifecycle_state": state,
-                "validation_status": validation_status,
+                "validation_status": next_validation_status,
                 "runtime_paths": RuntimePaths.model_validate(runtime_paths.model_dump()),
                 "execution": ExecutionMetadata.model_validate(execution.model_dump()),
                 "provenance": ProvenanceMetadata(product_state=product_state),
@@ -299,7 +306,14 @@ def _status_from_manifest(manifest: RunManifest, manifest_path: Path) -> RunStat
 
 
 def _existing_output_paths(run_dir: Path) -> tuple[Path, ...]:
-    patterns = ("*.nc", "*.nc4", "*.cdf", "*.netcdf", "cm1out*")
+    return _matching_paths(run_dir, ("*.nc", "*.nc4", "*.cdf", "*.netcdf", "cm1out*", "stats*"))
+
+
+def _usable_output_paths(run_dir: Path) -> tuple[Path, ...]:
+    return _matching_paths(run_dir, ("*.nc", "*.nc4", "*.cdf", "*.netcdf", "cm1out*", "stats*"))
+
+
+def _matching_paths(run_dir: Path, patterns: tuple[str, ...]) -> tuple[Path, ...]:
     paths: list[Path] = []
     for pattern in patterns:
         paths.extend(run_dir.glob(pattern))
@@ -322,6 +336,8 @@ def _preflight_cm1_inputs(manifest: RunManifest) -> None:
             raise LocalRunManagerError(
                 f"Refusing to launch placeholder-only CM1 input: {path.name}"
             )
+        if path.name == "namelist.input":
+            _validate_rayleigh_damping(text)
 
 
 def _is_placeholder_input(text: str) -> bool:
@@ -331,6 +347,45 @@ def _is_placeholder_input(text: str) -> bool:
         or "cloud chamber input_sounding notes" in lowered
         or "&cloud_chamber_domain" in lowered
     )
+
+
+def _validate_rayleigh_damping(namelist_text: str) -> None:
+    zd = _namelist_float(namelist_text, "zd")
+    maxz = _domain_top_m(namelist_text)
+    if zd is None or maxz is None:
+        return
+    if zd <= maxz / 2:
+        raise LocalRunManagerError(
+            "Rayleigh damping starts too low for the configured domain: "
+            f"zd={zd:g}, maxz={maxz:g}. Damping must not cover more than half the domain."
+        )
+
+
+def _domain_top_m(namelist_text: str) -> float | None:
+    ztop = _namelist_float(namelist_text, "ztop")
+    if ztop is not None:
+        return ztop
+    nz = _namelist_float(namelist_text, "nz")
+    dz = _namelist_float(namelist_text, "dz")
+    if nz is None or dz is None:
+        return None
+    return nz * dz
+
+
+def _namelist_float(namelist_text: str, name: str) -> float | None:
+    prefix = f"{name.lower()}"
+    for line in namelist_text.splitlines():
+        stripped = line.split("!", 1)[0].strip()
+        if not stripped.lower().startswith(prefix):
+            continue
+        if "=" not in stripped:
+            continue
+        value = stripped.split("=", 1)[1].split(",", 1)[0].strip()
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
 
 
 def _stage_required_runtime_files(

--- a/app/backend/cloud_chamber/run_manifest.py
+++ b/app/backend/cloud_chamber/run_manifest.py
@@ -40,6 +40,7 @@ class ProductState(StrEnum):
     PACKAGED_DRY_RUN_OUTPUT = "packaged_dry_run_output"
     QUEUED_RUNNING_CM1_PROCESS = "queued_running_cm1_process"
     COMPLETED_CM1_RESULT = "completed_cm1_result"
+    PROCESS_COMPLETED_NO_OUTPUT = "process_completed_no_output"
     FAILED_CANCELED_CM1_RUN = "failed_canceled_cm1_run"
     INGESTED_RESULT_METADATA = "ingested_result_metadata"
     VISUALIZER_INTERPRETATION = "visualizer_interpretation"

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -69,6 +69,8 @@ def test_rendered_namelist_is_cm1_ready_bomex_baseline() -> None:
     assert "dz     =   125.0," in namelist
     assert "timax  = 7200.0," in namelist
     assert "tapfrq =  300.0," in namelist
+    assert "zd      =  4500.0," in namelist
+    assert "ztop      =  6000.0," in namelist
     assert "testcase  =  3," in namelist
     assert "isnd      = 19," in namelist
     assert "&cloud_chamber_domain" not in namelist

--- a/app/backend/tests/test_local_run_manager.py
+++ b/app/backend/tests/test_local_run_manager.py
@@ -106,7 +106,7 @@ def test_launch_constructs_cm1_command_and_captures_logs(tmp_path: Path) -> None
     assert manifest.execution.command == [str(settings.cm1_run_dir / "cm1.exe")]
 
 
-def test_completed_process_updates_manifest_state(tmp_path: Path) -> None:
+def test_exit_zero_without_output_needs_review_not_completed_result(tmp_path: Path) -> None:
     manifest_path = dry_run_manifest_path(tmp_path)
     fake_process = FakeProcess()
     manager = LocalRunManager(
@@ -122,6 +122,28 @@ def test_completed_process_updates_manifest_state(tmp_path: Path) -> None:
     assert status.exit_code == 0
     manifest = load_run_manifest(manifest_path)
     assert manifest.lifecycle_state == LifecycleState.COMPLETED
+    assert manifest.validation_status.value == "needs_review"
+    assert manifest.provenance.product_state == ProductState.PROCESS_COMPLETED_NO_OUTPUT
+
+
+def test_exit_zero_with_output_marks_completed_result(tmp_path: Path) -> None:
+    manifest_path = dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-001"
+    fake_process = FakeProcess()
+    manager = LocalRunManager(
+        settings=fake_settings(tmp_path),
+        process_factory=FakeProcessFactory(fake_process),
+    )
+    manager.launch(manifest_path)
+    (run_dir / "cm1out_000001.nc").write_text("fake output")
+
+    fake_process.exit_code = 0
+    status = manager.status(manifest_path)
+
+    assert status.lifecycle_state == LifecycleState.COMPLETED
+    assert status.exit_code == 0
+    manifest = load_run_manifest(manifest_path)
+    assert manifest.validation_status.value == "valid"
     assert manifest.provenance.product_state == ProductState.COMPLETED_CM1_RESULT
 
 
@@ -210,6 +232,20 @@ def test_launch_refuses_placeholder_only_inputs(tmp_path: Path) -> None:
     manager = LocalRunManager(settings=settings)
 
     with pytest.raises(LocalRunManagerError, match="placeholder-only CM1 input"):
+        manager.launch(manifest_path)
+
+
+def test_launch_refuses_rayleigh_damping_over_half_domain(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    manifest_path = dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-001"
+    namelist = (run_dir / "namelist.input").read_text()
+    (run_dir / "namelist.input").write_text(
+        namelist.replace("zd      =  4500.0,", "zd      =  2500.0,")
+    )
+    manager = LocalRunManager(settings=settings)
+
+    with pytest.raises(LocalRunManagerError, match="Rayleigh damping starts too low"):
         manager.launch(manifest_path)
 
 

--- a/app/backend/tests/test_run_manifest.py
+++ b/app/backend/tests/test_run_manifest.py
@@ -108,3 +108,17 @@ def test_completed_manifest_cannot_be_dry_run_package() -> None:
 
     with pytest.raises(RunManifestError, match="cannot be dry-run packages"):
         validate_run_manifest(data)
+
+
+def test_completed_process_without_output_product_state_is_valid_needs_review() -> None:
+    data = valid_manifest_data()
+    data["lifecycle_state"] = "completed"
+    data["validation_status"] = "needs_review"
+    provenance = data["provenance"]
+    assert isinstance(provenance, dict)
+    provenance["product_state"] = "process_completed_no_output"
+
+    manifest = validate_run_manifest(data)
+
+    assert manifest.lifecycle_state == LifecycleState.COMPLETED
+    assert manifest.provenance.product_state == ProductState.PROCESS_COMPLETED_NO_OUTPUT

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -152,10 +152,12 @@ The first implemented local run manager is intentionally conservative:
 - lifecycle states move through queued, running, completed, failed, or canceled;
 - launch refuses packages that already contain output-like files such as NetCDF or `cm1out*`;
 - launch refuses placeholder-only `namelist.input` or notes-only `input_sounding` files;
+- launch rejects Rayleigh damping settings that start too low and would damp more than half the vertical domain;
 - launch stages required local runtime files such as `LANDUSE.TBL` from the configured CM1 run directory into the generated package directory;
+- process exit code 0 is not enough to mark a usable completed CM1 result; output-like files must exist before `completed_cm1_result` is used;
 - tests inject fake subprocesses, so CI never needs a real CM1 executable.
 
-Real CM1 execution remains a manual/local responsibility until the user has local settings and runtime files in place. The manager must fail clearly when CM1 paths are missing rather than pretending a run started.
+Real CM1 execution remains a manual/local responsibility until the user has local settings and runtime files in place. The manager must fail clearly when CM1 paths are missing rather than pretending a run started. If the process exits successfully but no NetCDF, `cm1out*`, or stats-style output exists, the manifest remains `completed` at the process level but uses `validation_status: needs_review` and `product_state: process_completed_no_output`.
 
 ### Output Ingester
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -79,6 +79,8 @@ The local run manager assumes one active CM1 run at a time for the MVP. It captu
 
 Launch preflight also refuses placeholder-only CM1-facing files. Older packages containing `&cloud_chamber_domain` or notes-only `input_sounding` files must be regenerated before launch. For Baseline Shallow Cumulus, generated packages now use a CM1 BOMEX shallow-cumulus namelist path with quick-look grid/runtime settings; the package remains provisional until #56 is retried manually.
 
+Baseline Shallow Cumulus currently uses `zd = 4500.0` for Rayleigh damping in the 6 km quick-look domain. Preflight rejects namelists where Rayleigh damping would begin at or below half the configured domain top. A CM1 process that exits `0` without NetCDF, `cm1out*`, or stats-style output is recorded as `validation_status: needs_review` and `product_state: process_completed_no_output`, not as a completed usable CM1 result.
+
 Required runtime files such as `LANDUSE.TBL` are copied from the configured local CM1 run directory into the generated package at launch time. These copied files are local/generated artifacts under `~/CloudChamber/runs/<run-id>/`; do not commit them.
 
 The backend skeleton uses Python/FastAPI with pytest, ruff, and mypy. Data/science work should prefer xarray, netCDF4 or h5netcdf, numpy, and pydantic when those layers are added.

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -208,6 +208,8 @@ The first implementation uses fake subprocesses in automated tests and does not 
 
 #56 found that the original dry-run package was still placeholder-only. The follow-up package-readiness work must keep #56 open/blocked until Baseline Shallow Cumulus packages generate CM1-facing inputs, reject placeholder-only packages before launch, stage local runtime files such as `LANDUSE.TBL`, and then retry the manual smoke run.
 
+The next calibration pass from #60 distinguishes process completion from usable CM1 result completion: exit code 0 without NetCDF, `cm1out*`, or stats-style output should be `needs_review`, not an accepted result.
+
 ## M3 Results Library + Experiment Notebook
 
 Goal: turn CM1 outputs into replayable, inspectable, searchable experiment notebook entries.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -42,7 +42,7 @@ Baseline Shallow Cumulus input tests should assert the generated `namelist.input
 Dry-run package tests should use temporary runtime homes and assert overwrite protection, manifest/report content, CM1-facing input readiness, and absence of NetCDF output. A dry-run package is packaged configuration and metadata only; it is not a launched process or completed CM1 result.
 
 Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
-They should also assert placeholder-only packages are rejected before launch and required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, not from the repo.
+They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.
 
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.
 
@@ -120,7 +120,8 @@ Use this loop after a dry-run package has been generated and before broader CM1 
    - confirm the selected run-size preset, physical question, controls, expected diagnostics, and visualization defaults match the intended scenario;
    - confirm `dry_run_report.json` says CM1 was not launched and is not a completed result;
    - confirm `namelist.input` is not the old `&cloud_chamber_domain` placeholder fragment;
-   - confirm `input_sounding` is not notes-only.
+   - confirm `input_sounding` is not notes-only;
+   - confirm Rayleigh damping starts above half the configured domain top.
 3. Compare generated files against the local CM1 runtime requirements:
    - check `~/CloudChamber/settings.json`, `CLOUD_CHAMBER_CM1_ROOT`, or the default probe paths;
    - expected local probes include `/Users/timpeterson/cm1r21.1` and `/Users/timpeterson/cm1r21.1/run`;


### PR DESCRIPTION
Closes #60

## Summary

- Updated #56 with the `needs_calibration` smoke-run result while leaving the validation issue open.
- Raised the generated Baseline Shallow Cumulus Rayleigh damping start height to `zd = 4500.0` for the 6 km quick-look domain.
- Added launch preflight validation that rejects CM1 namelists where Rayleigh damping covers more than half the vertical domain.
- Changed completion semantics so CM1 exit code `0` without NetCDF / `cm1out*` / stats output is `needs_review` with product state `process_completed_no_output`, not a usable completed CM1 result.
- Kept `completed_cm1_result` reserved for exit code `0` with usable output detected.
- Updated docs for damping calibration, output detection, and completed-result semantics.

## What was intentionally not included

- No CM1 run was launched by CI.
- No ingest, replay, or visualizer implementation was added.
- No generated CM1 output or local runtime files were committed.
- #56 remains open and should be retried after this calibration PR lands.

## Tests/checks run

- `scripts/check.sh` passed.

## Generated-data check

No CM1 source, binaries, `LANDUSE.TBL`, NetCDF outputs, generated run directories, logs, validation reports, or large visualization artifacts were committed.