### PR TITLE
Detect CM1 outputs and document NetCDF ingest preference

### DIFF
--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -377,7 +377,7 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  /
 
  &param9
- output_format    = 1,
+ output_format    = 2,
  output_filetype  = 2,
  output_interp    = 0,
  output_rain      = 1,

--- a/app/backend/cloud_chamber/local_run_manager.py
+++ b/app/backend/cloud_chamber/local_run_manager.py
@@ -17,6 +17,7 @@ from typing import Protocol, TextIO
 from cloud_chamber.run_manifest import (
     ExecutionMetadata,
     LifecycleState,
+    OutputMetadata,
     ProductState,
     ProvenanceMetadata,
     RunManifest,
@@ -68,6 +69,15 @@ class _ActiveRun:
     process: ProcessHandle
     stdout_handle: TextIO
     stderr_handle: TextIO
+
+
+NETCDF_OUTPUT_PATTERNS = ("*.nc", "*.nc4", "*.cdf", "*.netcdf")
+RAW_CM1_OUTPUT_PATTERNS = ("cm1out_*.dat", "cm1out_*.ctl")
+FLOATING_POINT_WARNING_FLAGS = (
+    "IEEE_INVALID_FLAG",
+    "IEEE_DIVIDE_BY_ZERO",
+    "IEEE_OVERFLOW_FLAG",
+)
 
 
 def default_process_factory(
@@ -206,8 +216,10 @@ class LocalRunManager:
         self._close_active()
         manifest = load_run_manifest(active.manifest_path)
         run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
+        output_metadata = _detect_output_metadata(run_dir, manifest.execution.stderr_log)
+        output_exists = bool(output_metadata.netcdf_paths or output_metadata.raw_cm1_artifacts)
         completed_state = LifecycleState.COMPLETED if exit_code == 0 else LifecycleState.FAILED
-        if exit_code == 0 and _usable_output_paths(run_dir):
+        if exit_code == 0 and output_exists:
             product_state = ProductState.COMPLETED_CM1_RESULT
             validation_status = manifest.validation_status
         elif exit_code == 0:
@@ -222,6 +234,7 @@ class LocalRunManager:
             product_state=product_state,
             exit_code=exit_code,
             validation_status=validation_status,
+            outputs=output_metadata,
         )
         write_run_manifest(active.manifest_path, updated)
 
@@ -243,6 +256,7 @@ class LocalRunManager:
         stderr_log: Path | None = None,
         exit_code: int | None = None,
         validation_status: ValidationStatus | None = None,
+        outputs: OutputMetadata | None = None,
     ) -> RunManifest:
         now = datetime.now(UTC)
         existing_execution = manifest.execution
@@ -285,6 +299,7 @@ class LocalRunManager:
                 "validation_status": next_validation_status,
                 "runtime_paths": RuntimePaths.model_validate(runtime_paths.model_dump()),
                 "execution": ExecutionMetadata.model_validate(execution.model_dump()),
+                "outputs": outputs or manifest.outputs,
                 "provenance": ProvenanceMetadata(product_state=product_state),
                 "updated_at": now,
             }
@@ -306,11 +321,34 @@ def _status_from_manifest(manifest: RunManifest, manifest_path: Path) -> RunStat
 
 
 def _existing_output_paths(run_dir: Path) -> tuple[Path, ...]:
-    return _matching_paths(run_dir, ("*.nc", "*.nc4", "*.cdf", "*.netcdf", "cm1out*", "stats*"))
+    return _output_artifact_paths(run_dir)
 
 
-def _usable_output_paths(run_dir: Path) -> tuple[Path, ...]:
-    return _matching_paths(run_dir, ("*.nc", "*.nc4", "*.cdf", "*.netcdf", "cm1out*", "stats*"))
+def _output_artifact_paths(run_dir: Path) -> tuple[Path, ...]:
+    return _matching_paths(run_dir, NETCDF_OUTPUT_PATTERNS + RAW_CM1_OUTPUT_PATTERNS)
+
+
+def _detect_output_metadata(run_dir: Path, stderr_log: str | None) -> OutputMetadata:
+    netcdf_paths = _matching_paths(run_dir, NETCDF_OUTPUT_PATTERNS)
+    raw_cm1_artifacts = _matching_paths(run_dir, RAW_CM1_OUTPUT_PATTERNS)
+    return OutputMetadata(
+        netcdf_paths=[str(path) for path in netcdf_paths],
+        raw_cm1_artifacts=[str(path) for path in raw_cm1_artifacts],
+        runtime_warnings=_runtime_warnings_from_stderr(stderr_log),
+    )
+
+
+def _runtime_warnings_from_stderr(stderr_log: str | None) -> list[str]:
+    if not stderr_log:
+        return []
+    path = Path(stderr_log).expanduser()
+    if not path.exists():
+        return []
+    text = path.read_text(errors="replace")
+    flags = [flag for flag in FLOATING_POINT_WARNING_FLAGS if flag in text]
+    if not flags:
+        return []
+    return ["CM1 stderr reported floating-point exception flags: " + ", ".join(flags)]
 
 
 def _matching_paths(run_dir: Path, patterns: tuple[str, ...]) -> tuple[Path, ...]:

--- a/app/backend/cloud_chamber/run_manifest.py
+++ b/app/backend/cloud_chamber/run_manifest.py
@@ -98,8 +98,10 @@ class ExecutionMetadata(BaseModel):
 class OutputMetadata(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    raw_cm1_artifacts: list[str] = Field(default_factory=list)
     netcdf_paths: list[str] = Field(default_factory=list)
     processed_artifacts: list[str] = Field(default_factory=list)
+    runtime_warnings: list[str] = Field(default_factory=list)
     diagnostics_summary: str | None = None
     visualization_defaults: str | None = None
 
@@ -151,8 +153,8 @@ class RunManifest(BaseModel):
         if self.lifecycle_state == LifecycleState.PACKAGED:
             if self.provenance.product_state != ProductState.PACKAGED_DRY_RUN_OUTPUT:
                 raise ValueError("packaged manifests must use packaged dry-run product state")
-            if self.outputs.netcdf_paths:
-                raise ValueError("packaged dry-run manifests must not include NetCDF outputs")
+            if self.outputs.netcdf_paths or self.outputs.raw_cm1_artifacts:
+                raise ValueError("packaged dry-run manifests must not include output artifacts")
         if self.lifecycle_state in {
             LifecycleState.COMPLETED,
             LifecycleState.INGESTED,

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -71,6 +71,8 @@ def test_rendered_namelist_is_cm1_ready_bomex_baseline() -> None:
     assert "tapfrq =  300.0," in namelist
     assert "zd      =  4500.0," in namelist
     assert "ztop      =  6000.0," in namelist
+    assert "output_format    = 2," in namelist
+    assert "output_filetype  = 2," in namelist
     assert "testcase  =  3," in namelist
     assert "isnd      = 19," in namelist
     assert "&cloud_chamber_domain" not in namelist

--- a/app/backend/tests/test_local_run_manager.py
+++ b/app/backend/tests/test_local_run_manager.py
@@ -32,8 +32,14 @@ class FakeProcess:
 
 
 class FakeProcessFactory:
-    def __init__(self, process: FakeProcess) -> None:
+    def __init__(
+        self,
+        process: FakeProcess,
+        *,
+        stderr_text: str = "fake cm1 stderr\n",
+    ) -> None:
         self.process = process
+        self.stderr_text = stderr_text
         self.commands: list[list[str]] = []
         self.cwd: Path | None = None
 
@@ -49,7 +55,7 @@ class FakeProcessFactory:
         self.cwd = cwd
         stdout.write("fake cm1 stdout\n")
         stdout.flush()
-        stderr.write("fake cm1 stderr\n")
+        stderr.write(self.stderr_text)
         stderr.flush()
         return self.process
 
@@ -124,9 +130,11 @@ def test_exit_zero_without_output_needs_review_not_completed_result(tmp_path: Pa
     assert manifest.lifecycle_state == LifecycleState.COMPLETED
     assert manifest.validation_status.value == "needs_review"
     assert manifest.provenance.product_state == ProductState.PROCESS_COMPLETED_NO_OUTPUT
+    assert manifest.outputs.netcdf_paths == []
+    assert manifest.outputs.raw_cm1_artifacts == []
 
 
-def test_exit_zero_with_output_marks_completed_result(tmp_path: Path) -> None:
+def test_exit_zero_with_netcdf_output_marks_completed_result(tmp_path: Path) -> None:
     manifest_path = dry_run_manifest_path(tmp_path)
     run_dir = tmp_path / "CloudChamber" / "runs" / "run-001"
     fake_process = FakeProcess()
@@ -145,6 +153,62 @@ def test_exit_zero_with_output_marks_completed_result(tmp_path: Path) -> None:
     manifest = load_run_manifest(manifest_path)
     assert manifest.validation_status.value == "valid"
     assert manifest.provenance.product_state == ProductState.COMPLETED_CM1_RESULT
+    assert manifest.outputs.netcdf_paths == [str(run_dir / "cm1out_000001.nc")]
+    assert manifest.outputs.raw_cm1_artifacts == []
+
+
+def test_exit_zero_with_dat_ctl_outputs_marks_completed_result(tmp_path: Path) -> None:
+    manifest_path = dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-001"
+    fake_process = FakeProcess()
+    manager = LocalRunManager(
+        settings=fake_settings(tmp_path),
+        process_factory=FakeProcessFactory(fake_process),
+    )
+    manager.launch(manifest_path)
+    (run_dir / "cm1out_000001_s.dat").write_text("fake scalar output")
+    (run_dir / "cm1out_s.ctl").write_text("fake descriptor")
+    (run_dir / "cm1out_stats.dat").write_text("fake stats")
+    (run_dir / "cm1out_metadata.ctl").write_text("fake metadata descriptor")
+
+    fake_process.exit_code = 0
+    status = manager.status(manifest_path)
+
+    assert status.lifecycle_state == LifecycleState.COMPLETED
+    manifest = load_run_manifest(manifest_path)
+    assert manifest.validation_status.value == "valid"
+    assert manifest.provenance.product_state == ProductState.COMPLETED_CM1_RESULT
+    assert manifest.outputs.netcdf_paths == []
+    assert manifest.outputs.raw_cm1_artifacts == [
+        str(run_dir / "cm1out_000001_s.dat"),
+        str(run_dir / "cm1out_metadata.ctl"),
+        str(run_dir / "cm1out_s.ctl"),
+        str(run_dir / "cm1out_stats.dat"),
+    ]
+
+
+def test_exit_zero_surfaces_stderr_floating_point_warnings(tmp_path: Path) -> None:
+    manifest_path = dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-001"
+    fake_process = FakeProcess()
+    manager = LocalRunManager(
+        settings=fake_settings(tmp_path),
+        process_factory=FakeProcessFactory(
+            fake_process,
+            stderr_text="Note: IEEE_INVALID_FLAG IEEE_DIVIDE_BY_ZERO IEEE_OVERFLOW_FLAG\n",
+        ),
+    )
+    manager.launch(manifest_path)
+    (run_dir / "cm1out_000001_s.dat").write_text("fake scalar output")
+
+    fake_process.exit_code = 0
+    manager.status(manifest_path)
+
+    manifest = load_run_manifest(manifest_path)
+    assert manifest.outputs.runtime_warnings == [
+        "CM1 stderr reported floating-point exception flags: "
+        "IEEE_INVALID_FLAG, IEEE_DIVIDE_BY_ZERO, IEEE_OVERFLOW_FLAG"
+    ]
 
 
 def test_failed_process_updates_manifest_state(tmp_path: Path) -> None:

--- a/app/backend/tests/test_run_manifest.py
+++ b/app/backend/tests/test_run_manifest.py
@@ -52,7 +52,12 @@ def valid_manifest_data() -> dict[str, object]:
         "created_at": created_at,
         "updated_at": created_at,
         "execution": {"command": []},
-        "outputs": {"netcdf_paths": [], "processed_artifacts": []},
+        "outputs": {
+            "raw_cm1_artifacts": [],
+            "netcdf_paths": [],
+            "processed_artifacts": [],
+            "runtime_warnings": [],
+        },
         "user": {"name": "Baseline check", "tags": ["golden-path"], "saved": False},
     }
 
@@ -81,13 +86,13 @@ def test_invalid_lifecycle_state_fails() -> None:
         validate_run_manifest(data)
 
 
-def test_packaged_manifest_cannot_include_netcdf_outputs() -> None:
+def test_packaged_manifest_cannot_include_output_artifacts() -> None:
     data = valid_manifest_data()
     outputs = data["outputs"]
     assert isinstance(outputs, dict)
-    outputs["netcdf_paths"] = ["cm1out_000001.nc"]
+    outputs["raw_cm1_artifacts"] = ["cm1out_000001_s.dat"]
 
-    with pytest.raises(RunManifestError, match="must not include NetCDF"):
+    with pytest.raises(RunManifestError, match="must not include output artifacts"):
         validate_run_manifest(data)
 
 
@@ -122,3 +127,30 @@ def test_completed_process_without_output_product_state_is_valid_needs_review() 
 
     assert manifest.lifecycle_state == LifecycleState.COMPLETED
     assert manifest.provenance.product_state == ProductState.PROCESS_COMPLETED_NO_OUTPUT
+
+
+def test_completed_manifest_serializes_output_artifact_metadata() -> None:
+    data = valid_manifest_data()
+    data["lifecycle_state"] = "completed"
+    provenance = data["provenance"]
+    assert isinstance(provenance, dict)
+    provenance["product_state"] = "completed_cm1_result"
+    outputs = data["outputs"]
+    assert isinstance(outputs, dict)
+    outputs["raw_cm1_artifacts"] = ["cm1out_000001_s.dat", "cm1out_s.ctl"]
+    outputs["netcdf_paths"] = ["cm1out_000001.nc"]
+    outputs["runtime_warnings"] = [
+        "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"
+    ]
+
+    manifest = validate_run_manifest(data)
+    round_tripped = run_manifest_from_json(manifest.to_json_text())
+
+    assert round_tripped.outputs.raw_cm1_artifacts == [
+        "cm1out_000001_s.dat",
+        "cm1out_s.ctl",
+    ]
+    assert round_tripped.outputs.netcdf_paths == ["cm1out_000001.nc"]
+    assert round_tripped.outputs.runtime_warnings == [
+        "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"
+    ]

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -150,20 +150,24 @@ The first implemented local run manager is intentionally conservative:
 - command construction points at the configured local `cm1.exe`;
 - stdout and stderr are written into the run package `logs/` directory for later result notebook provenance;
 - lifecycle states move through queued, running, completed, failed, or canceled;
-- launch refuses packages that already contain output-like files such as NetCDF or `cm1out*`;
+- launch refuses packages that already contain output-like files such as NetCDF,
+  `cm1out_*.dat`, or `cm1out_*.ctl`;
 - launch refuses placeholder-only `namelist.input` or notes-only `input_sounding` files;
 - launch rejects Rayleigh damping settings that start too low and would damp more than half the vertical domain;
 - launch stages required local runtime files such as `LANDUSE.TBL` from the configured CM1 run directory into the generated package directory;
-- process exit code 0 is not enough to mark a usable completed CM1 result; output-like files must exist before `completed_cm1_result` is used;
+- process exit code 0 is not enough to mark a usable completed CM1 result; NetCDF or raw CM1 `.dat/.ctl` output artifacts must exist before `completed_cm1_result` is used;
 - tests inject fake subprocesses, so CI never needs a real CM1 executable.
 
-Real CM1 execution remains a manual/local responsibility until the user has local settings and runtime files in place. The manager must fail clearly when CM1 paths are missing rather than pretending a run started. If the process exits successfully but no NetCDF, `cm1out*`, or stats-style output exists, the manifest remains `completed` at the process level but uses `validation_status: needs_review` and `product_state: process_completed_no_output`.
+Real CM1 execution remains a manual/local responsibility until the user has local settings and runtime files in place. The manager must fail clearly when CM1 paths are missing rather than pretending a run started. If the process exits successfully but no NetCDF or raw CM1 `.dat/.ctl` output exists, the manifest remains `completed` at the process level but uses `validation_status: needs_review` and `product_state: process_completed_no_output`.
+
+The first successful Baseline Shallow Cumulus smoke run produced GrADS/direct-access CM1 artifacts (`cm1out_*.dat` plus `.ctl` descriptors) rather than NetCDF. That proves local execution but is not full ingest. The manifest should catalog those raw artifacts separately from NetCDF paths and processed visualization artifacts. Floating-point exception flags reported in stderr should be surfaced as runtime warnings/caveats, not automatically treated as launch failure.
 
 ### Output Ingester
 
 Responsibilities:
 
-- inspect NetCDF outputs
+- inspect preferred NetCDF outputs
+- catalog raw CM1 `.dat/.ctl` artifacts until NetCDF ingest is verified
 - extract metadata and fields
 - produce app-friendly artifacts
 - compute diagnostics
@@ -349,6 +353,15 @@ Run manifests should also record the selected run-size preset, physical question
 
 The backend run-manifest schema records run ID, scenario reference/version, adjusted controls, generated CM1 input paths, CM1 root/run paths, app metadata, timestamps, lifecycle state, validation status, output paths, user notes/tags, and provenance labels. It serializes/deserializes as JSON and does not require NetCDF output.
 
+Output metadata distinguishes:
+
+- `raw_cm1_artifacts`: local CM1 `.dat/.ctl` files such as `cm1out_000001_s.dat`, `cm1out_s.ctl`, `cm1out_stats.dat`, and `cm1out_metadata.ctl`;
+- `netcdf_paths`: preferred self-describing CM1 output files such as `.nc`, `.nc4`, `.cdf`, or `.netcdf`;
+- `processed_artifacts`: future Cloud Chamber-derived browser/diagnostic artifacts;
+- `runtime_warnings`: caveats captured from logs, such as CM1 floating-point exception flags.
+
+Raw `.dat/.ctl` artifact detection is an honest catalog, not full ingest, diagnostics extraction, or visualization preprocessing.
+
 Lifecycle states:
 
 ```text
@@ -402,6 +415,10 @@ Do not vendor CM1.
 The app should avoid assuming large in-memory NetCDF processing. Ingestion should prefer selected fields, selected frames, chunking, downsampling, or other backend-side reductions before browser visualization.
 
 ## NetCDF And Visualization Data Contract
+
+NetCDF is Cloud Chamber's preferred ingest path because it is self-describing, portable, and well suited for Python/xarray diagnostics. CM1 can also write GrADS/direct-access `.dat/.ctl` output. Cloud Chamber should catalog those raw files, but the main product should not become a full `.dat/.ctl` parser unless NetCDF proves blocked or impractical.
+
+The current Baseline Shallow Cumulus generator sets CM1 `output_format = 2`, which CM1 documents as NetCDF output. The first successful local smoke run used the prior `.dat/.ctl` path, so the next manual validation should confirm whether the generated NetCDF configuration works with the local CM1 build.
 
 Raw NetCDF is authoritative CM1 output, but it is not ideal for direct browser rendering. The ingestion layer should create explicit metadata and browser-friendly derivatives that preserve provenance:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -79,7 +79,16 @@ The local run manager assumes one active CM1 run at a time for the MVP. It captu
 
 Launch preflight also refuses placeholder-only CM1-facing files. Older packages containing `&cloud_chamber_domain` or notes-only `input_sounding` files must be regenerated before launch. For Baseline Shallow Cumulus, generated packages now use a CM1 BOMEX shallow-cumulus namelist path with quick-look grid/runtime settings; the package remains provisional until #56 is retried manually.
 
-Baseline Shallow Cumulus currently uses `zd = 4500.0` for Rayleigh damping in the 6 km quick-look domain. Preflight rejects namelists where Rayleigh damping would begin at or below half the configured domain top. A CM1 process that exits `0` without NetCDF, `cm1out*`, or stats-style output is recorded as `validation_status: needs_review` and `product_state: process_completed_no_output`, not as a completed usable CM1 result.
+Baseline Shallow Cumulus currently uses `zd = 4500.0` for Rayleigh damping in the 6 km quick-look domain. Preflight rejects namelists where Rayleigh damping would begin at or below half the configured domain top. A CM1 process that exits `0` without NetCDF or raw CM1 `.dat/.ctl` artifacts is recorded as `validation_status: needs_review` and `product_state: process_completed_no_output`, not as a completed usable CM1 result.
+
+Generated Baseline Shallow Cumulus packages prefer CM1 NetCDF output with `output_format = 2` and `output_filetype = 2`. CM1 documents `output_format = 1` as GrADS/direct-access output and `output_format = 2` as NetCDF. The first successful smoke run produced `.dat/.ctl` files, so those are cataloged as raw CM1 artifacts while the next manual run should verify the NetCDF path.
+
+When a run completes, manifest output metadata should keep these buckets separate:
+
+- `raw_cm1_artifacts` for `.dat/.ctl` CM1 output files;
+- `netcdf_paths` for preferred NetCDF output;
+- `processed_artifacts` for future Cloud Chamber-derived ingest/visualization artifacts;
+- `runtime_warnings` for caveats surfaced from logs, such as CM1 floating-point exception flags.
 
 Required runtime files such as `LANDUSE.TBL` are copied from the configured local CM1 run directory into the generated package at launch time. These copied files are local/generated artifacts under `~/CloudChamber/runs/<run-id>/`; do not commit them.
 
@@ -172,7 +181,8 @@ Before automated launch is trusted, use the Baseline Shallow Cumulus dry-run pac
 6. Compare the package against local CM1 runtime needs, including `cm1.exe` and local-only runtime files such as `LANDUSE.TBL`.
 7. Regenerate any package that still contains placeholder-only `namelist.input` or notes-only `input_sounding` files.
 8. Run CM1 manually from the local runtime path when ready. Record the exact command, CM1 version/path, Cloud Chamber commit, run-size preset, controls, runtime, output cadence, log paths, output paths, and any warnings/errors.
-9. Keep generated packages, copied runtime files, logs, NetCDF output, and validation reports out of git unless a future policy explicitly creates a tiny synthetic fixture.
+9. Confirm whether the generated `output_format = 2` package produces NetCDF on the local CM1 build. If it does not, keep `.dat/.ctl` output cataloged as raw artifacts and document the blocker before changing ingest strategy.
+10. Keep generated packages, copied runtime files, logs, NetCDF output, `.dat/.ctl` output, and validation reports out of git unless a future policy explicitly creates a tiny synthetic fixture.
 
 The automated local CM1 launcher/log monitor now follows this policy for the first MVP. It preserves the same distinctions: dry-run package, queued/running CM1 process, completed/failed/canceled CM1 run, ingested metadata, and saved result/notebook entry are separate states.
 
@@ -190,7 +200,7 @@ This executable script runs the same fast checks as CI: frontend lint/test/build
 
 CI keeps equivalent split jobs named `Frontend`, `Backend`, and `Scripts and config` so branch protection can require stable, readable check names. When adding future scenario-schema, run-manifest, dry-run-package, NetCDF-ingest, or visualizer-metadata checks, update both `scripts/check.sh` and the matching CI job or document why a CI-only/local-only split is necessary.
 
-The local gate intentionally does not run real CM1, require a local CM1 installation, require real NetCDF output, or create generated CM1 artifacts in the repo.
+The local gate intentionally does not run real CM1, require a local CM1 installation, require real NetCDF or `.dat/.ctl` output, or create generated CM1 artifacts in the repo.
 
 ## Scaffold Scope
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -177,12 +177,12 @@ Generate Baseline Shallow Cumulus dry-run package
 -> manually stage package into the local CM1 run workflow
 -> launch CM1 outside CI
 -> capture logs/status/runtime/output paths
--> detect NetCDF output without committing it
+-> detect NetCDF or raw CM1 .dat/.ctl output without committing it
 -> record diagnostics and limitations
 -> document ingest/result-card/visualizer readiness notes
 ```
 
-Expected local probes include `CLOUD_CHAMBER_CM1_ROOT`, `~/CloudChamber/settings.json`, `/Users/timpeterson/cm1r21.1`, and `/Users/timpeterson/cm1r21.1/run`. Generated CM1 outputs, logs, NetCDF files, validation reports, copied runtime files, `LANDUSE.TBL`, and local run folders must stay gitignored.
+Expected local probes include `CLOUD_CHAMBER_CM1_ROOT`, `~/CloudChamber/settings.json`, `/Users/timpeterson/cm1r21.1`, and `/Users/timpeterson/cm1r21.1/run`. Generated CM1 outputs, logs, NetCDF files, `.dat/.ctl` files, validation reports, copied runtime files, `LANDUSE.TBL`, and local run folders must stay gitignored.
 
 The direct follow-up is #29: automate the local CM1 launcher and status/log monitor with one local run at a time, explicit failure/cancel states, and tests that use fake subprocesses rather than real CM1.
 
@@ -208,7 +208,9 @@ The first implementation uses fake subprocesses in automated tests and does not 
 
 #56 found that the original dry-run package was still placeholder-only. The follow-up package-readiness work must keep #56 open/blocked until Baseline Shallow Cumulus packages generate CM1-facing inputs, reject placeholder-only packages before launch, stage local runtime files such as `LANDUSE.TBL`, and then retry the manual smoke run.
 
-The next calibration pass from #60 distinguishes process completion from usable CM1 result completion: exit code 0 without NetCDF, `cm1out*`, or stats-style output should be `needs_review`, not an accepted result.
+#56 produced the first accepted-with-notes local CM1 execution from a Cloud Chamber-generated Baseline Shallow Cumulus package. That run produced `cm1out_*.dat` and `.ctl` artifacts rather than NetCDF, so #62 bridges M2 to M3 by cataloging raw CM1 output artifacts honestly while keeping NetCDF as the preferred ingest path.
+
+#60 distinguishes process completion from usable CM1 result completion: exit code 0 without NetCDF or raw CM1 `.dat/.ctl` output should be `needs_review`, not an accepted result.
 
 ## M3 Results Library + Experiment Notebook
 
@@ -217,6 +219,7 @@ Goal: turn CM1 outputs into replayable, inspectable, searchable experiment noteb
 Deliverables:
 
 - NetCDF ingest.
+- Raw CM1 `.dat/.ctl` artifact cataloging as a transitional/fallback record, not full ingest.
 - run metadata extraction.
 - diagnostics summary.
 - logs/result status.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -42,7 +42,7 @@ Baseline Shallow Cumulus input tests should assert the generated `namelist.input
 Dry-run package tests should use temporary runtime homes and assert overwrite protection, manifest/report content, CM1-facing input readiness, and absence of NetCDF output. A dry-run package is packaged configuration and metadata only; it is not a launched process or completed CM1 result.
 
 Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
-They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.
+They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, `.dat/.ctl` and NetCDF output artifacts are cataloged separately in the manifest, stderr floating-point flags are surfaced as runtime warnings, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.
 
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.
 
@@ -136,8 +136,10 @@ Use this loop after a dry-run package has been generated and before broader CM1 
 7. Detect outputs without committing them:
    - record output directory and file names/counts;
    - confirm whether NetCDF files appeared;
+   - if `.dat/.ctl` files appeared, record them as raw CM1 artifacts rather than ingested results;
    - estimate local output size;
-   - leave NetCDF, logs, validation reports, copied runtime files, and generated run folders out of git.
+   - surface stderr floating-point exception flags as caveats, not automatic failures;
+   - leave NetCDF, `.dat/.ctl` output, logs, validation reports, copied runtime files, and generated run folders out of git.
 8. If ingest tooling exists, run it locally and record the ingest status. Until then, note what a future ingest should read and any schema gaps found.
 9. Record result-card/notebook acceptance notes:
    - scenario name and physical question;


### PR DESCRIPTION
Closes #62

## Summary

- Added output artifact detection for completed local CM1 runs.
- Cataloged raw CM1 `.dat/.ctl` artifacts separately from NetCDF and processed artifacts in the run manifest.
- Preserved completed-result semantics only when CM1 exits successfully and output artifacts exist.
- Surfaced CM1 floating-point exception flags from stderr as runtime caveats where practical.
- Switched generated Baseline Shallow Cumulus output configuration to CM1 `output_format = 2` so the next manual run can verify the preferred NetCDF path.
- Documented NetCDF as Cloud Chamber's preferred ingest path while keeping `.dat/.ctl` detection as a transitional/fallback artifact catalog.
- Updated docs for the successful Baseline Shallow Cumulus smoke-run output format and next ingest decision.

## What was intentionally not included

- No full #30 ingest implementation.
- No diagnostics extraction.
- No visualizer implementation.
- No `.dat/.ctl` parser beyond artifact cataloging.
- No real CM1 execution in CI.

## Verification

- `scripts/check.sh` passed.

## Generated-data check

No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, or large visualization artifacts were committed.