### PR TITLE
Clarify Codex auto-merge guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,8 +16,8 @@
 
 - [ ] First CI run completed and exact GitHub Actions check names were noted, if this PR changes CI.
 - [ ] Branch protection/ruleset settings were created or updated manually, if this PR establishes CI.
-- [ ] Auto-merge remains limited to conservative Dependabot patch/minor updates after CI passes.
-- [ ] Feature PR review remains manual.
+- [ ] Auto-merge is appropriate after required CI passes, or this PR is explicitly marked for manual review.
+- [ ] High-risk/destructive behavior is called out, including cleanup, generated-data policy, CM1 runtime execution, scientific interpretation, or visualization semantics.
 
 ## Generated-data check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,8 @@ Do commit:
 - Update docs when architecture/workflow changes.
 - Use local fake fixtures in CI; do not require real CM1 in automated tests.
 - Do not weaken scientific honesty to make UI look better.
-- Do not auto-merge Codex feature PRs without user review.
+- For Codex issue work, enable auto-merge after required CI checks pass unless the user explicitly asks for manual review or the PR is high-risk/destructive.
+- Treat destructive cleanup, generated-data policy changes, scientific interpretation changes, and real CM1 execution changes as high-risk unless the user says otherwise.
 
 ## Initial Architecture Bias
 

--- a/docs/ci-and-branch-protection.md
+++ b/docs/ci-and-branch-protection.md
@@ -36,7 +36,7 @@ Configure these manually in GitHub for `main`:
 - Disallow force pushes to `main`.
 - Disallow direct pushes to `main` if practical.
 - Enable auto-merge only after required checks pass.
-- Keep feature PR review manual.
+- Allow Codex issue PRs to auto-merge after required checks pass unless the user marks a PR for manual review or the change is high-risk/destructive.
 
 ## Manual GitHub Settings After First CI Run
 
@@ -56,27 +56,31 @@ After the first PR exists and GitHub Actions has reported checks:
 12. Add the exact CI check names from the first PR.
 13. Block force pushes.
 14. Restrict deletions.
-15. Keep feature PR review manual.
+15. Allow Codex issue PRs to auto-merge after required checks pass unless the user marks a PR for manual review or the change is high-risk/destructive.
 16. Allow conservative Dependabot patch/minor auto-merge only after CI is stable.
 
 ## Auto-Merge Guidance
 
-Auto-merge is recommended only for Dependabot patch/minor updates after CI passes.
+Auto-merge is recommended for routine Codex issue PRs after required CI passes. This is the default workflow for this repo so issue work closes cleanly without a second manual merge step.
 
-If a Dependabot auto-merge workflow is added later, it must be conservative:
+Do not enable auto-merge when the user explicitly asks for manual review, or when the PR is high-risk/destructive. High-risk examples include:
+
+- destructive cleanup behavior
+- generated-data policy changes
+- CM1 runtime execution semantics
+- scientific interpretation or diagnostic definitions
+- visualization semantics that could misrepresent CM1 output
+- major dependency version bumps
+
+Dependabot auto-merge, if added later, must remain conservative:
 
 - Dependabot PRs only.
 - Patch/minor updates only.
 - Only after CI passes.
 - No major version bumps.
-- No feature PR auto-merge.
-- No Codex feature PR auto-merge.
 
 Do not auto-merge:
 
 - major version bumps
-- feature PRs
-- Codex feature PRs
-- changes that affect generated-data policy, CM1 runtime behavior, scientific interpretation, or visualization semantics
-
-Codex feature PRs should still be reviewed by the user.
+- PRs the user marked for manual review
+- high-risk/destructive changes unless the user says to proceed

--- a/docs/codex-project-setup.md
+++ b/docs/codex-project-setup.md
@@ -128,6 +128,7 @@ Do not hard-code this in app logic. Store in local settings.
 - Keep work scoped to the GitHub issue.
 - Add tests and docs with implementation changes.
 - Do not commit generated CM1 artifacts.
-- Do not auto-merge Codex feature PRs without user review.
+- For Codex issue work, enable auto-merge after required CI checks pass unless the user explicitly asks for manual review or the PR is high-risk/destructive.
+- Treat destructive cleanup, generated-data policy changes, scientific interpretation changes, and real CM1 execution changes as high-risk unless the user says otherwise.
 
 See also the root `AGENTS.md`.


### PR DESCRIPTION
## Summary

- Removed the conflicting guidance that Codex feature PRs must remain manual-review merges.
- Documented the repo default: routine Codex issue PRs should enable auto-merge after required CI passes.
- Kept an explicit manual-review/high-risk carveout for destructive cleanup, generated-data policy, CM1 runtime execution semantics, scientific interpretation, visualization semantics, major dependency bumps, or user-requested manual review.
- Updated `AGENTS.md`, Codex setup docs, CI/branch-protection guidance, and the PR template so they say the same thing.

## Verification

- `scripts/check.sh` passed.

## Generated-data check

No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, or large visualization artifacts were committed.