### PR TITLE
Implement NetCDF result ingest metadata

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -12,6 +12,12 @@ from pydantic import BaseModel, Field
 from cloud_chamber.cli import ENGINE_NOTE
 from cloud_chamber.dry_run_package import generate_dry_run_package, read_dry_run_report
 from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError, RunStatus
+from cloud_chamber.result_ingest import (
+    ResultIngestError,
+    get_result_metadata,
+    ingest_completed_run,
+    list_result_metadata,
+)
 from cloud_chamber.runtime_storage import (
     RuntimeStorageError,
     delete_runtime_run,
@@ -58,6 +64,10 @@ class DeleteRunRequest(BaseModel):
     dry_run: bool = True
     confirm: bool = False
     force_saved: bool = False
+
+
+class IngestResultRequest(BaseModel):
+    manifest_path: str
 
 
 @app.get("/api/scenarios")
@@ -135,6 +145,33 @@ def delete_run(request: DeleteRunRequest) -> dict[str, object]:
         )
     except RuntimeStorageError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.post("/api/results/ingest")
+def ingest_result(request: IngestResultRequest) -> dict[str, object]:
+    try:
+        result = ingest_completed_run(Path(request.manifest_path).expanduser())
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/results")
+def list_results() -> dict[str, object]:
+    return {
+        "results": [
+            result.model_dump(mode="json") for result in list_result_metadata(load_settings())
+        ]
+    }
+
+
+@app.get("/api/results/{result_id}")
+def get_result(result_id: str) -> dict[str, object]:
+    try:
+        result = get_result_metadata(load_settings(), result_id)
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return result.model_dump(mode="json")
 
 

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -1,0 +1,230 @@
+"""NetCDF result ingest metadata for completed CM1 runs."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.run_manifest import LifecycleState, ProductState, RunManifest, load_run_manifest
+from cloud_chamber.settings import CloudChamberSettings
+
+RESULT_METADATA_FILENAME = "result_metadata.json"
+
+
+class ResultIngestError(RuntimeError):
+    """Raised when a completed run cannot be ingested into result metadata."""
+
+
+class FieldMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    dimensions: list[str]
+    shape: list[int]
+    units: str | None = None
+
+
+class ResultMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    run_id: str
+    scenario_id: str
+    scenario_name: str | None = None
+    physical_question: str
+    controls: dict[str, str | float | bool]
+    run_size_preset: str
+    source_lifecycle_state: str
+    source_product_state: str
+    source_model: str
+    result_state: str = "ingested_result_metadata"
+    raw_cm1_artifacts: list[str] = Field(default_factory=list)
+    netcdf_paths: list[str] = Field(default_factory=list)
+    processed_artifacts: list[str] = Field(default_factory=list)
+    visualization_ready_artifacts: list[str] = Field(default_factory=list)
+    dimensions: dict[str, int] = Field(default_factory=dict)
+    coordinates: list[str] = Field(default_factory=list)
+    variables: list[str] = Field(default_factory=list)
+    fields_detected: list[FieldMetadata] = Field(default_factory=list)
+    time_coordinate: str | None = None
+    time_steps: int | None = None
+    grid_shape: list[int] | None = None
+    warnings: list[str] = Field(default_factory=list)
+    diagnostics_summary: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    def to_json_text(self) -> str:
+        return self.model_dump_json(indent=2) + "\n"
+
+
+def ingest_completed_run(manifest_path: Path) -> ResultMetadata:
+    """Create result metadata for a completed run with NetCDF output."""
+    manifest = load_run_manifest(manifest_path.expanduser())
+    if manifest.lifecycle_state != LifecycleState.COMPLETED:
+        raise ResultIngestError(
+            "Only completed CM1 runs can be ingested into result metadata; "
+            f"found {manifest.lifecycle_state.value}."
+        )
+    if manifest.provenance.product_state != ProductState.COMPLETED_CM1_RESULT:
+        raise ResultIngestError(
+            "Only completed CM1 result manifests can be ingested; "
+            f"found {manifest.provenance.product_state.value}."
+        )
+    run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
+    netcdf_paths = _netcdf_paths(manifest, run_dir)
+    if not netcdf_paths:
+        raise ResultIngestError(
+            "No NetCDF output artifacts found for ingest. Raw CM1 .dat/.ctl artifacts "
+            "may be cataloged on the run manifest, but they are not NetCDF ingest input."
+        )
+
+    dataset = _open_dataset(netcdf_paths[0])
+    try:
+        result = _result_from_dataset(manifest, netcdf_paths, dataset)
+    finally:
+        close = getattr(dataset, "close", None)
+        if callable(close):
+            close()
+
+    result_path = run_dir / RESULT_METADATA_FILENAME
+    result_path.write_text(result.to_json_text())
+    return result
+
+
+def list_result_metadata(settings: CloudChamberSettings) -> list[ResultMetadata]:
+    """List result metadata files under the configured runtime home."""
+    results_dir = settings.runtime_home.expanduser() / "runs"
+    if not results_dir.exists():
+        return []
+    results: list[ResultMetadata] = []
+    for path in sorted(results_dir.glob(f"*/{RESULT_METADATA_FILENAME}")):
+        try:
+            results.append(result_metadata_from_json(path.read_text()))
+        except (OSError, ValueError):
+            continue
+    return results
+
+
+def get_result_metadata(settings: CloudChamberSettings, result_id: str) -> ResultMetadata:
+    for result in list_result_metadata(settings):
+        if result.result_id == result_id:
+            return result
+    raise ResultIngestError(f"Result metadata not found: {result_id}")
+
+
+def result_metadata_from_json(text: str) -> ResultMetadata:
+    return ResultMetadata.model_validate(json.loads(text))
+
+
+def _netcdf_paths(manifest: RunManifest, run_dir: Path) -> list[Path]:
+    configured = [Path(path).expanduser() for path in manifest.outputs.netcdf_paths]
+    existing = [path for path in configured if path.exists()]
+    if existing:
+        return sorted(existing)
+    patterns = ("*.nc", "*.nc4", "*.cdf", "*.netcdf")
+    discovered: list[Path] = []
+    for pattern in patterns:
+        discovered.extend(run_dir.glob(pattern))
+    return sorted(set(discovered))
+
+
+def _open_dataset(path: Path) -> Any:
+    try:
+        xarray = importlib.import_module("xarray")
+        return xarray.open_dataset(path)
+    except Exception as exc:
+        raise ResultIngestError(f"Could not open NetCDF output {path}: {exc}") from exc
+
+
+def _result_from_dataset(
+    manifest: RunManifest,
+    netcdf_paths: list[Path],
+    dataset: Any,
+) -> ResultMetadata:
+    now = datetime.now(UTC)
+    dimensions = {str(name): int(size) for name, size in dataset.sizes.items()}
+    coordinates = _ordered_coordinate_names([str(name) for name in dataset.coords])
+    variables = [str(name) for name in dataset.data_vars]
+    fields = [
+        FieldMetadata(
+            name=str(name),
+            dimensions=[str(dimension) for dimension in data_array.dims],
+            shape=[int(size) for size in data_array.shape],
+            units=_attribute_as_string(data_array.attrs.get("units")),
+        )
+        for name, data_array in dataset.data_vars.items()
+    ]
+    time_coordinate = _first_present(("time", "mtime", "t"), coordinates)
+    time_steps = dimensions.get(time_coordinate) if time_coordinate else None
+    grid_shape = _grid_shape(dimensions)
+    warnings = list(manifest.outputs.runtime_warnings)
+    missing_expected = [
+        field for field in ("qc", "w") if field not in variables and field not in coordinates
+    ]
+    if missing_expected:
+        warnings.append(
+            "Expected fields missing from NetCDF metadata: " + ", ".join(missing_expected)
+        )
+
+    return ResultMetadata(
+        result_id=f"result-{manifest.run_id}",
+        run_id=manifest.run_id,
+        scenario_id=manifest.scenario.id,
+        scenario_name=None,
+        physical_question=manifest.physical_question,
+        controls=manifest.controls,
+        run_size_preset=manifest.run_size_preset,
+        source_lifecycle_state=manifest.lifecycle_state.value,
+        source_product_state=manifest.provenance.product_state.value,
+        source_model=manifest.provenance.source_model,
+        raw_cm1_artifacts=manifest.outputs.raw_cm1_artifacts,
+        netcdf_paths=[str(path) for path in netcdf_paths],
+        processed_artifacts=manifest.outputs.processed_artifacts,
+        dimensions=dimensions,
+        coordinates=coordinates,
+        variables=variables,
+        fields_detected=fields,
+        time_coordinate=time_coordinate,
+        time_steps=time_steps,
+        grid_shape=grid_shape,
+        warnings=warnings,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _attribute_as_string(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _first_present(candidates: tuple[str, ...], names: list[str]) -> str | None:
+    for candidate in candidates:
+        if candidate in names:
+            return candidate
+    return None
+
+
+def _ordered_coordinate_names(names: list[str]) -> list[str]:
+    preferred = [
+        name for name in ("time", "mtime", "t", "z", "zh", "y", "yh", "x", "xh") if name in names
+    ]
+    remaining = sorted(name for name in names if name not in preferred)
+    return preferred + remaining
+
+
+def _grid_shape(dimensions: dict[str, int]) -> list[int] | None:
+    preferred = [name for name in ("z", "zh", "y", "yh", "x", "xh") if name in dimensions]
+    if preferred:
+        return [dimensions[name] for name in preferred]
+    spatial = [
+        size for name, size in dimensions.items() if name.lower() not in {"time", "mtime", "t"}
+    ]
+    return spatial or None

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -9,6 +9,8 @@ description = "Local backend tooling for Cloud Chamber CM1 experiments."
 requires-python = ">=3.12"
 dependencies = [
   "fastapi>=0.115",
+  "scipy>=1.14",
+  "xarray>=2024.7",
 ]
 
 [project.optional-dependencies]

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -1,11 +1,24 @@
+import json
 from pathlib import Path
 
 import pytest
+import xarray as xr
 from fastapi.testclient import TestClient
 
 from cloud_chamber.app import app
+from cloud_chamber.dry_run_package import generate_dry_run_package
 from cloud_chamber.local_run_manager import LocalRunManagerError, RunStatus
-from cloud_chamber.run_manifest import LifecycleState
+from cloud_chamber.run_manifest import (
+    LifecycleState,
+    OutputMetadata,
+    ProductState,
+    ProvenanceMetadata,
+    load_run_manifest,
+    write_run_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
 
 
 class FakeRunManager:
@@ -177,3 +190,59 @@ def test_storage_delete_run_api_requires_explicit_confirm(
     assert deleted.status_code == 200
     assert deleted.json()["deleted"] is True
     assert not run_dir.exists()
+
+
+def test_results_ingest_and_lookup_api(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLOUD_CHAMBER_RUNTIME_HOME", str(tmp_path / "CloudChamber"))
+    package = generate_dry_run_package(
+        scenario_data=json.loads(BASELINE_TEMPLATE.read_text()),
+        runtime_home=tmp_path / "CloudChamber",
+        run_id="run-api-ingest",
+    )
+    netcdf_path = package.package_dir / "cm1out_000001.nc"
+    xr.Dataset(
+        data_vars={
+            "qc": (
+                ("time", "z", "y", "x"),
+                [[[[0.0]]]],
+                {"units": "kg/kg"},
+            ),
+            "w": (
+                ("time", "z", "y", "x"),
+                [[[[1.0]]]],
+                {"units": "m/s"},
+            ),
+        },
+        coords={"time": [0.0], "z": [125.0], "y": [0.0], "x": [0.0]},
+    ).to_netcdf(netcdf_path, engine="scipy")
+    manifest = load_run_manifest(package.manifest_path)
+    write_run_manifest(
+        package.manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": LifecycleState.COMPLETED,
+                "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+                "outputs": OutputMetadata(netcdf_paths=[str(netcdf_path)]),
+            }
+        ),
+    )
+
+    ingest_response = TestClient(app).post(
+        "/api/results/ingest",
+        json={"manifest_path": str(package.manifest_path)},
+    )
+    list_response = TestClient(app).get("/api/results")
+    get_response = TestClient(app).get("/api/results/result-run-api-ingest")
+
+    assert ingest_response.status_code == 200
+    assert ingest_response.json()["result_id"] == "result-run-api-ingest"
+    assert ingest_response.json()["variables"] == ["qc", "w"]
+    assert list_response.status_code == 200
+    assert [result["result_id"] for result in list_response.json()["results"]] == [
+        "result-run-api-ingest"
+    ]
+    assert get_response.status_code == 200
+    assert get_response.json()["run_id"] == "run-api-ingest"

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -1,0 +1,204 @@
+import json
+from pathlib import Path
+
+import pytest
+import xarray as xr
+
+from cloud_chamber.dry_run_package import generate_dry_run_package
+from cloud_chamber.result_ingest import (
+    RESULT_METADATA_FILENAME,
+    ResultIngestError,
+    get_result_metadata,
+    ingest_completed_run,
+    list_result_metadata,
+    result_metadata_from_json,
+)
+from cloud_chamber.run_manifest import (
+    LifecycleState,
+    OutputMetadata,
+    ProductState,
+    ProvenanceMetadata,
+    load_run_manifest,
+    write_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
+
+
+def fake_settings(tmp_path: Path) -> CloudChamberSettings:
+    runtime_home = tmp_path / "CloudChamber"
+    return CloudChamberSettings(
+        runtime_home=runtime_home,
+        cm1_root=tmp_path / "cm1r21.1",
+        cm1_run_dir=tmp_path / "cm1r21.1" / "run",
+        cache_dir=runtime_home / "cache",
+        log_dir=runtime_home / "logs",
+    )
+
+
+def create_manifest(tmp_path: Path, run_id: str = "run-ingest") -> Path:
+    result = generate_dry_run_package(
+        scenario_data=json.loads(BASELINE_TEMPLATE.read_text()),
+        runtime_home=tmp_path / "CloudChamber",
+        run_id=run_id,
+    )
+    return result.manifest_path
+
+
+def complete_manifest(
+    manifest_path: Path,
+    outputs: OutputMetadata,
+) -> None:
+    manifest = load_run_manifest(manifest_path)
+    updated = manifest.model_copy(
+        update={
+            "lifecycle_state": LifecycleState.COMPLETED,
+            "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+            "outputs": outputs,
+        }
+    )
+    write_run_manifest(manifest_path, updated)
+
+
+def write_tiny_netcdf(
+    path: Path,
+    *,
+    include_qc: bool = True,
+    include_w: bool = True,
+) -> None:
+    data_vars = {}
+    if include_qc:
+        data_vars["qc"] = (
+            ("time", "z", "y", "x"),
+            [[[[0.0, 0.1], [0.2, 0.3]], [[0.4, 0.5], [0.6, 0.7]]]],
+            {"units": "kg/kg"},
+        )
+    if include_w:
+        data_vars["w"] = (
+            ("time", "z", "y", "x"),
+            [[[[0.0, 1.0], [2.0, 3.0]], [[4.0, 5.0], [6.0, 7.0]]]],
+            {"units": "m/s"},
+        )
+    dataset = xr.Dataset(
+        data_vars=data_vars,
+        coords={
+            "time": [0.0],
+            "z": [125.0, 250.0],
+            "y": [0.0, 200.0],
+            "x": [0.0, 200.0],
+        },
+    )
+    dataset.to_netcdf(path, engine="scipy")
+
+
+def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
+    manifest_path = create_manifest(tmp_path)
+    run_dir = manifest_path.parent
+    netcdf_path = run_dir / "cm1out_000001.nc"
+    raw_path = run_dir / "cm1out_000001_s.dat"
+    write_tiny_netcdf(netcdf_path)
+    raw_path.write_text("raw CM1 artifact")
+    complete_manifest(
+        manifest_path,
+        OutputMetadata(
+            raw_cm1_artifacts=[str(raw_path)],
+            netcdf_paths=[str(netcdf_path)],
+            runtime_warnings=[
+                "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"
+            ],
+        ),
+    )
+
+    result = ingest_completed_run(manifest_path)
+
+    assert result.result_id == "result-run-ingest"
+    assert result.run_id == "run-ingest"
+    assert result.scenario_id == "baseline-shallow-cumulus"
+    assert result.physical_question
+    assert result.run_size_preset == "quick_look"
+    assert result.source_lifecycle_state == "completed"
+    assert result.source_product_state == "completed_cm1_result"
+    assert result.source_model == "CM1"
+    assert result.netcdf_paths == [str(netcdf_path)]
+    assert result.raw_cm1_artifacts == [str(raw_path)]
+    assert result.processed_artifacts == []
+    assert result.visualization_ready_artifacts == []
+    assert result.dimensions == {"time": 1, "z": 2, "y": 2, "x": 2}
+    assert result.coordinates == ["time", "z", "y", "x"]
+    assert result.variables == ["qc", "w"]
+    assert result.time_coordinate == "time"
+    assert result.time_steps == 1
+    assert result.grid_shape == [2, 2, 2]
+    assert [(field.name, field.units) for field in result.fields_detected] == [
+        ("qc", "kg/kg"),
+        ("w", "m/s"),
+    ]
+    assert result.diagnostics_summary is None
+    assert result.warnings == [
+        "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"
+    ]
+    assert (run_dir / RESULT_METADATA_FILENAME).exists()
+
+
+def test_result_metadata_serializes_and_lists_from_runtime_home(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    manifest_path = create_manifest(tmp_path)
+    netcdf_path = manifest_path.parent / "cm1out_000001.nc"
+    write_tiny_netcdf(netcdf_path)
+    complete_manifest(manifest_path, OutputMetadata(netcdf_paths=[str(netcdf_path)]))
+
+    result = ingest_completed_run(manifest_path)
+    round_tripped = result_metadata_from_json(result.to_json_text())
+    listed = list_result_metadata(settings)
+    found = get_result_metadata(settings, result.result_id)
+
+    assert round_tripped == result
+    assert listed == [result]
+    assert found == result
+
+
+def test_missing_netcdf_output_fails_gracefully(tmp_path: Path) -> None:
+    manifest_path = create_manifest(tmp_path)
+    raw_path = manifest_path.parent / "cm1out_000001_s.dat"
+    raw_path.write_text("raw CM1 artifact")
+    complete_manifest(
+        manifest_path,
+        OutputMetadata(raw_cm1_artifacts=[str(raw_path)]),
+    )
+
+    with pytest.raises(ResultIngestError, match="No NetCDF output artifacts"):
+        ingest_completed_run(manifest_path)
+
+
+def test_packaged_manifest_is_not_ingested(tmp_path: Path) -> None:
+    manifest_path = create_manifest(tmp_path)
+    netcdf_path = manifest_path.parent / "cm1out_000001.nc"
+    write_tiny_netcdf(netcdf_path)
+
+    with pytest.raises(ResultIngestError, match="Only completed CM1 runs"):
+        ingest_completed_run(manifest_path)
+
+
+def test_malformed_netcdf_fails_gracefully(tmp_path: Path) -> None:
+    manifest_path = create_manifest(tmp_path)
+    netcdf_path = manifest_path.parent / "cm1out_000001.nc"
+    netcdf_path.write_text("not a netcdf file")
+    complete_manifest(manifest_path, OutputMetadata(netcdf_paths=[str(netcdf_path)]))
+
+    with pytest.raises(ResultIngestError, match="Could not open NetCDF output"):
+        ingest_completed_run(manifest_path)
+
+
+def test_missing_expected_fields_are_warnings_not_claimed_diagnostics(tmp_path: Path) -> None:
+    manifest_path = create_manifest(tmp_path)
+    netcdf_path = manifest_path.parent / "cm1out_000001.nc"
+    write_tiny_netcdf(netcdf_path, include_qc=False, include_w=True)
+    complete_manifest(manifest_path, OutputMetadata(netcdf_paths=[str(netcdf_path)]))
+
+    result = ingest_completed_run(manifest_path)
+
+    assert result.variables == ["w"]
+    assert result.diagnostics_summary is None
+    assert result.warnings == ["Expected fields missing from NetCDF metadata: qc"]

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -193,11 +193,15 @@ Responsibilities:
 
 - inspect preferred NetCDF outputs
 - catalog raw CM1 `.dat/.ctl` artifacts until NetCDF ingest is verified
-- extract metadata and fields
+- extract NetCDF metadata and fields
 - produce app-friendly artifacts
 - compute diagnostics
 - create thumbnails/previews
 - record provenance
+
+The first implemented ingest step creates `result_metadata.json` in the completed run directory. It reads NetCDF with xarray and records result ID, run ID, scenario, physical question, controls, run-size preset, source lifecycle/product/provenance state, raw CM1 artifacts, NetCDF paths, processed artifact placeholders, dimensions, coordinates, variables, units, time coordinate, grid shape, warnings, and timestamps.
+
+This result metadata is not a Result Card UI, not diagnostics, and not visualization-ready data. It is the backend bridge that later diagnostics, result cards, and inspectors can consume. Raw `.dat/.ctl` artifacts remain cataloged on the run metadata but are not parsed as NetCDF ingest input.
 
 ### Result Library
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,6 +76,9 @@ Implemented backend API endpoints:
 - `POST /api/runs/cancel` cancels the active local run when technically practical.
 - `GET /api/storage/inventory` reports configured runtime-home disk usage and per-run metadata under `~/CloudChamber/runs/`.
 - `POST /api/storage/delete-run` previews or deletes one selected run directory under the configured runtime home.
+- `POST /api/results/ingest` creates result metadata from a completed run manifest with NetCDF output.
+- `GET /api/results` lists ingested result metadata under the configured runtime home.
+- `GET /api/results/{result_id}` returns one ingested result metadata record.
 
 The local run manager assumes one active CM1 run at a time for the MVP. It captures stdout/stderr under the run package `logs/` directory, updates the run manifest through queued/running/completed/failed/canceled states, refuses output-like files before launch, and fails clearly when CM1 settings are missing. Normal tests use fake subprocesses; real CM1 execution remains manual/local and is not required in CI.
 
@@ -101,6 +104,8 @@ The MVP storage warning threshold is 50 GB for the configured runtime home. Inve
 Run deletion is explicit and conservative. A preview request uses `dry_run: true`; a real delete requires `dry_run: false` and `confirm: true`. Cleanup only targets `~/CloudChamber/runs/<run-id>/`, refuses path traversal and symlink escapes, refuses running runs, and refuses saved/protected runs unless `force_saved: true` is supplied. Deleting a run removes its local generated package, output artifacts, copied runtime files, and logs. Cleanup must never target the source repo, home directory, runtime home itself, or the external CM1 installation.
 
 The backend skeleton uses Python/FastAPI with pytest, ruff, and mypy. Data/science work should prefer xarray, netCDF4 or h5netcdf, numpy, and pydantic when those layers are added.
+
+The first result ingest path uses xarray to read tiny or local NetCDF files and writes `result_metadata.json` next to the run manifest under the generated run directory. It extracts metadata only: dimensions, coordinates, variables, units, time coordinate, grid shape, source paths, provenance, and warnings. It does not compute diagnostics, create visualization-ready arrays, parse `.dat/.ctl` payloads, or copy real output into git.
 
 Backend work should assume one local CM1 run at a time for the MVP and should avoid large in-memory processing paths for local MacBook Air-scale machines.
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -233,6 +233,7 @@ Implementation anchor:
 
 - #30 should make replayable/inspectable saved result cards the core behavior. Duplicate/tweak/rerun should remain optional or later.
 - #64 adds the storage bridge needed after the first successful 852 MB smoke run: inventory runtime-home usage, warn at the 50 GB MVP threshold, classify runs conservatively, and delete only explicitly selected run directories under `~/CloudChamber/runs/`. Cleanup must never target the repo, home directory, runtime home itself, or the external CM1 installation, and threshold warnings must never auto-delete anything.
+- #68 establishes the backend NetCDF ingest bridge: read completed-run NetCDF output with xarray, write `result_metadata.json`, preserve raw `.dat/.ctl` artifact cataloging without parsing it, and leave diagnostics/result-card UI/visualization-ready data to follow-up issues.
 
 ## M4 3-D Visualizer MVP
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -29,7 +29,6 @@ Implemented fast tests cover:
 Future fast tests should cover:
 
 - result-card / experiment-notebook metadata serialization
-- NetCDF ingest with tiny synthetic fixtures when that layer exists
 - visualizer metadata loading when that layer exists
 
 These tests must not require CM1 source, CM1 binaries, NetCDF output, generated run directories, or large local data.
@@ -45,6 +44,8 @@ Local launcher tests must inject fake subprocess handles. They should assert com
 They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, `.dat/.ctl` and NetCDF output artifacts are cataloged separately in the manifest, stderr floating-point flags are surfaced as runtime warnings, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.
 
 Runtime storage tests must use temporary runtime homes only. They should cover total runtime-home size, the 50 GB warning-threshold fields, per-run sizes, largest-run ordering, valid manifest classification, missing and malformed manifests, dry-run delete previews, confirmed deletion of one selected run directory, and refusal cases for running runs, saved/protected runs, path traversal, runtime-home self-targeting, and symlink escapes. They must not read from or delete real `~/CloudChamber`, the source repo, or the external CM1 installation.
+
+NetCDF ingest tests use tiny synthetic NetCDF files in temporary run directories. They should assert valid metadata extraction, result metadata serialization, missing-output failures, malformed-NetCDF failures, missing expected field warnings, and that raw `.dat/.ctl` artifacts are cataloged but not treated as NetCDF input. These tests must not use real CM1 output.
 
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.
 


### PR DESCRIPTION
Closes #68

Summary:
- Added xarray/scipy-backed NetCDF result ingest metadata for completed CM1 runs.
- Added `result_metadata.json` with run/scenario/provenance/source artifact fields, dimensions, coordinates, variables, units, time/grid metadata, warnings, and timestamps.
- Added `POST /api/results/ingest`, `GET /api/results`, and `GET /api/results/{result_id}`.
- Cataloged raw `.dat/.ctl` artifacts separately from NetCDF and did not treat them as ingest input.
- Added temp-dir tiny synthetic NetCDF tests and API coverage.
- Updated docs for the metadata-only ingest boundary.

What was intentionally not included:
- No diagnostics extraction.
- No Results Library UI.
- No 2-D or 3-D visualization.
- No `.dat/.ctl` parser.
- No generated CM1 output committed.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, or large visualization artifacts were committed.
