### PR TITLE
Split 3-D visualizer MVP into staged issues

### DIFF
--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -228,6 +228,25 @@ Responsibilities:
 - field controls
 - rendering labels/provenance
 
+#31 has been superseded by staged visualizer implementation issues. The architecture should not treat a single broad visualizer issue as the implementation plan anymore.
+
+The staged dependency path is:
+
+```text
+NetCDF ingest (#68)
+-> diagnostics (#69)
+-> result cards / notebook entries (#70)
+-> Results Library UI (#71)
+-> visualization-ready data contract (#72)
+-> 2-D field inspection (#73)
+-> 3-D scene shell (#77)
+-> cloud-water rendering (#78)
+-> slice planes (#79)
+-> visual polish / fly-through / export later (#80)
+```
+
+The 3-D viewer should open from saved or ingested results and consume visualization-ready backend data. It should not parse raw NetCDF directly in the browser. Rendering remains a visualizer interpretation of CM1-derived output and must carry source model, run/result, field, processing, and rendering-method provenance.
+
 ## Data Flow
 
 ### Create Run
@@ -460,6 +479,8 @@ Raw NetCDF is authoritative CM1 output, but it is not ideal for direct browser r
 - rendering method
 
 Generated visualization artifacts are interpretations of CM1 data and must be labeled that way.
+
+The practical path before 3-D rendering is to define the visualization-ready data contract, then build a 2-D field inspector that can verify orientation, time indexing, field availability, units, and scaling. The 3-D scene shell, cloud-water rendering, and slice planes should build on that same contract.
 
 ## Visualization Data Strategy
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -160,6 +160,21 @@ The visualizer should support:
 - brightness/contrast
 - cloud appearance presets
 
+The broad original visualizer goal in #31 has been superseded by staged implementation issues. The visualizer should build from saved/ingested results and backend visualization-ready data, not from raw NetCDF parsing in the browser.
+
+Staged visualizer path:
+
+```text
+Visualization-ready data contract (#72)
+-> 2-D field inspection MVP (#73)
+-> 3-D scene shell (#77)
+-> cloud-water rendering MVP (#78)
+-> slice planes (#79)
+-> later visual polish / fly-through / export (#80)
+```
+
+Every visualizer stage must preserve provenance labels and make clear that rendered output is an interpretation of CM1-derived data.
+
 ### Workflow 7 — Duplicate / Tweak / Rerun
 
 1. Duplicate previous setup.
@@ -503,15 +518,13 @@ Completed results should be replayable and inspectable without rerunning CM1. Du
 
 Start with a practical visualizer, not a cinematic renderer.
 
-MVP visual modes:
+MVP visualizer work should be staged:
 
-1. Cloud water isosurface
-2. Cloud water volume/opacity approximation
-3. X/Z/Y slices
-4. Time replay
-5. Camera orbit/pan/zoom
-6. Field selector
-7. Simple lighting controls
+1. Visualization-ready backend data contract.
+2. 2-D field inspection for orientation, time indexing, scaling, and field availability.
+3. 3-D scene shell with orbit/pan/zoom, reset camera, time slider, field selector, and provenance/rendering labels.
+4. Cloud-water rendering MVP for `qc` using visualization-ready data.
+5. Horizontal and vertical slice planes for `qc` and `w`.
 
 Later:
 
@@ -523,6 +536,8 @@ Later:
 - cinematic export
 
 True fly-through or move-through should remain on the roadmap after the MVP. Orbit/pan/zoom, reset camera, time replay, slices, field selection, and cloud-water isosurface/opacity approximation are enough for the first visualizer.
+
+The browser should not parse raw CM1 NetCDF directly. Backend ingest and visualization-ready preprocessing should provide selected, provenance-labeled fields for inspection and rendering.
 
 ## Local Data Policy
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -251,7 +251,29 @@ Deliverables:
 
 Implementation anchor:
 
-- #31 should open from saved results, support time replay and camera exploration, avoid requiring reruns, and display provenance/rendering-method labels.
+- #31 has been superseded by staged visualizer implementation issues. It captured the right broad goal, but was too large to implement safely as one PR.
+- #72 defines the visualization-ready data contract. The browser should not parse raw NetCDF directly.
+- #73 builds the 2-D field inspection MVP before the full 3-D viewer so field orientation, time indexing, vertical coordinates, scaling, and basic cloud evolution can be checked.
+- #77 builds the 3-D scene shell with orbit/pan/zoom, reset camera, time slider, field selector, empty/error states, and provenance/rendering labels.
+- #78 renders the first cloud-water field from visualization-ready data.
+- #79 adds horizontal and vertical slice planes using the same provenance-labeled data path.
+
+Recommended implementation order:
+
+```text
+#68 NetCDF ingest
+-> #69 diagnostics
+-> #70 result cards / notebook entries
+-> #71 Results Library UI
+-> #72 visualization-ready data contract
+-> #73 2-D field inspection
+-> #77 3-D scene shell
+-> #78 cloud-water rendering
+-> #79 slice planes
+-> #80 visual polish / fly-through / export later
+```
+
+The 3-D visualizer should open from saved or ingested results, should not require rerunning CM1, and should label visual output as an interpretation of CM1-derived data with clear provenance and rendering-method labels.
 
 ## M5 Visual Polish + Export
 
@@ -266,6 +288,10 @@ Deliverables:
 - fly-through/move-through.
 - cinematic export.
 - thumbnails/previews with strict generated-artifact policy.
+
+Implementation anchor:
+
+- #80 plans post-MVP visual polish, fly-through/move-through, cinematic export, and generated thumbnail/preview policy. These are later features, not prerequisites for the first inspectable CM1 result loop.
 
 ## Initial Lower-Atmosphere Scenario Set
 


### PR DESCRIPTION
Closes #74

Summary:
- Created staged 3-D visualizer child issues:
  - #77 Build 3-D visualizer scene shell
  - #78 Render cloud-water field in 3-D visualizer MVP
  - #79 Add slice planes to 3-D visualizer MVP
  - #80 Plan visual polish and fly-through roadmap after 3-D MVP
- Updated product spec, architecture/data model, and roadmap to mark #31 as superseded by staged implementation work.
- Documented the sequence from visualization-ready data contract and 2-D inspection into the staged 3-D viewer.
- Reaffirmed that the visualizer opens from saved/ingested results, consumes backend visualization-ready data, and does not parse raw NetCDF directly in the browser.
- Reaffirmed that visual output is an interpretation of CM1-derived data with provenance/rendering labels.

What was intentionally not included:
- No 3-D rendering implementation.
- No rendering dependencies added.
- No visualizer UI code.
- No generated CM1 output or visualization artifacts.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, or generated visualization artifacts were committed.

Follow-up:
- After this PR merges, #31 will be closed as superseded / not planned with links to the staged issues.
