### PR TITLE
Extract baseline shallow-cumulus diagnostics

### DIFF
--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -1,0 +1,411 @@
+"""First-pass diagnostics for ingested CM1 NetCDF results."""
+
+from __future__ import annotations
+
+from math import isfinite
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+QC_CLOUD_THRESHOLD_KG_KG = 1e-6
+QR_RAIN_THRESHOLD_KG_KG = 1e-7
+MINIMUM_CLOUD_GRID_CELLS = 10
+
+TIME_DIMENSION_CANDIDATES = ("time", "mtime", "t")
+VERTICAL_COORDINATE_CANDIDATES = ("z", "zh", "height", "height_m")
+
+
+class TimeValue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time_seconds: float | None
+    value: float | None
+
+
+class TimeDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    fallback_used: bool
+    coordinate_name: str | None = None
+
+
+class CloudDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    formed: bool = False
+    qc_threshold_kg_kg: float = QC_CLOUD_THRESHOLD_KG_KG
+    minimum_cloud_grid_cells: int = MINIMUM_CLOUD_GRID_CELLS
+    first_cloud_time_seconds: float | None = None
+    cloud_base_m: float | None = None
+    cloud_top_m: float | None = None
+    max_qc_kg_kg: float | None = None
+    time_of_max_qc_seconds: float | None = None
+    qc_max_time_series: list[TimeValue] = Field(default_factory=list)
+    cloud_fraction_time_series: list[TimeValue] = Field(default_factory=list)
+    cloud_present_time_steps: list[float | None] = Field(default_factory=list)
+    available: bool = True
+
+
+class VerticalVelocityDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    max_w_m_s: float | None = None
+    time_of_max_w_seconds: float | None = None
+    min_w_m_s: float | None = None
+    time_of_min_w_seconds: float | None = None
+    w_max_time_series: list[TimeValue] = Field(default_factory=list)
+    w_min_time_series: list[TimeValue] = Field(default_factory=list)
+    units: str | None = None
+    available: bool = True
+
+
+class RainDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    present: bool = False
+    qr_threshold_kg_kg: float = QR_RAIN_THRESHOLD_KG_KG
+    first_rain_time_seconds: float | None = None
+    max_qr_kg_kg: float | None = None
+    time_of_max_qr_seconds: float | None = None
+    qr_max_time_series: list[TimeValue] = Field(default_factory=list)
+    user_message: str = "No rain detected."
+    available: bool = True
+    field_absent: bool = False
+
+
+class ResultDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    cloud: CloudDiagnostics
+    vertical_velocity: VerticalVelocityDiagnostics
+    rain: RainDiagnostics
+    time: TimeDiagnostics
+    caveats: list[str] = Field(default_factory=list)
+
+
+def compute_baseline_diagnostics(dataset: Any, inherited_caveats: list[str]) -> ResultDiagnostics:
+    """Compute MVP Baseline Shallow Cumulus diagnostics from an xarray dataset."""
+    caveats = list(inherited_caveats)
+    time_context = _time_context(dataset, _primary_time_dimension(dataset))
+    cloud = _cloud_diagnostics(dataset, time_context, caveats)
+    vertical_velocity = _vertical_velocity_diagnostics(dataset, time_context, caveats)
+    rain = _rain_diagnostics(dataset, time_context, caveats)
+    return ResultDiagnostics(
+        cloud=cloud,
+        vertical_velocity=vertical_velocity,
+        rain=rain,
+        time=time_context.diagnostics,
+        caveats=_dedupe(caveats),
+    )
+
+
+class _TimeContext(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    dimension: str | None
+    values: list[float | None]
+    diagnostics: TimeDiagnostics
+
+    def at(self, index: int) -> float | None:
+        if index < len(self.values):
+            return self.values[index]
+        return float(index)
+
+
+def _cloud_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> CloudDiagnostics:
+    if "qc" not in dataset.data_vars:
+        caveats.append("missing_qc_field")
+        return CloudDiagnostics(available=False)
+
+    qc = dataset["qc"]
+    _record_units_caveat(qc, "qc", "kg/kg", caveats)
+    if _non_finite_count(qc) > 0:
+        caveats.append("non_finite_values_detected_in_qc")
+    if not _has_finite_values(qc):
+        caveats.append("qc_field_entirely_non_finite")
+        return CloudDiagnostics(available=False)
+
+    series_arrays = _time_slices(qc, time.dimension)
+    qc_max_series: list[TimeValue] = []
+    cloud_fraction_series: list[TimeValue] = []
+    cloud_present_steps: list[float | None] = []
+    first_cloud_time: float | None = None
+    max_qc: float | None = None
+    time_of_max_qc: float | None = None
+
+    for index, array in enumerate(series_arrays):
+        time_seconds = time.at(index)
+        slice_max = _finite_max(array)
+        cloudy_count = _threshold_count(array, QC_CLOUD_THRESHOLD_KG_KG)
+        finite_count = _finite_count(array)
+        cloud_fraction = (cloudy_count / finite_count) if finite_count else None
+        qc_max_series.append(TimeValue(time_seconds=time_seconds, value=slice_max))
+        cloud_fraction_series.append(TimeValue(time_seconds=time_seconds, value=cloud_fraction))
+        if cloudy_count >= MINIMUM_CLOUD_GRID_CELLS:
+            cloud_present_steps.append(time_seconds)
+            if first_cloud_time is None:
+                first_cloud_time = time_seconds
+        if slice_max is not None and (max_qc is None or slice_max > max_qc):
+            max_qc = slice_max
+            time_of_max_qc = time_seconds
+
+    cloud_base, cloud_top = _cloud_base_top(qc, caveats)
+    return CloudDiagnostics(
+        formed=first_cloud_time is not None,
+        first_cloud_time_seconds=first_cloud_time,
+        cloud_base_m=cloud_base,
+        cloud_top_m=cloud_top,
+        max_qc_kg_kg=max_qc,
+        time_of_max_qc_seconds=time_of_max_qc,
+        qc_max_time_series=qc_max_series,
+        cloud_fraction_time_series=cloud_fraction_series,
+        cloud_present_time_steps=cloud_present_steps,
+    )
+
+
+def _vertical_velocity_diagnostics(
+    dataset: Any,
+    time: _TimeContext,
+    caveats: list[str],
+) -> VerticalVelocityDiagnostics:
+    if "w" not in dataset.data_vars:
+        caveats.append("missing_w_field")
+        return VerticalVelocityDiagnostics(available=False)
+
+    w = dataset["w"]
+    units = _attr_string(w, "units")
+    _record_units_caveat(w, "w", "m/s", caveats)
+    if _non_finite_count(w) > 0:
+        caveats.append("non_finite_values_detected_in_w")
+    if not _has_finite_values(w):
+        caveats.append("w_field_entirely_non_finite")
+        return VerticalVelocityDiagnostics(available=False, units=units)
+
+    max_series: list[TimeValue] = []
+    min_series: list[TimeValue] = []
+    max_w: float | None = None
+    time_of_max_w: float | None = None
+    min_w: float | None = None
+    time_of_min_w: float | None = None
+
+    for index, array in enumerate(_time_slices(w, time.dimension)):
+        time_seconds = time.at(index)
+        slice_max = _finite_max(array)
+        slice_min = _finite_min(array)
+        max_series.append(TimeValue(time_seconds=time_seconds, value=slice_max))
+        min_series.append(TimeValue(time_seconds=time_seconds, value=slice_min))
+        if slice_max is not None and (max_w is None or slice_max > max_w):
+            max_w = slice_max
+            time_of_max_w = time_seconds
+        if slice_min is not None and (min_w is None or slice_min < min_w):
+            min_w = slice_min
+            time_of_min_w = time_seconds
+
+    return VerticalVelocityDiagnostics(
+        max_w_m_s=max_w,
+        time_of_max_w_seconds=time_of_max_w,
+        min_w_m_s=min_w,
+        time_of_min_w_seconds=time_of_min_w,
+        w_max_time_series=max_series,
+        w_min_time_series=min_series,
+        units=units,
+    )
+
+
+def _rain_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> RainDiagnostics:
+    if "qr" not in dataset.data_vars:
+        caveats.append("qr_field_absent")
+        return RainDiagnostics(available=False, field_absent=True)
+
+    qr = dataset["qr"]
+    _record_units_caveat(qr, "qr", "kg/kg", caveats)
+    if _non_finite_count(qr) > 0:
+        caveats.append("non_finite_values_detected_in_qr")
+    if not _has_finite_values(qr):
+        caveats.append("qr_field_entirely_non_finite")
+        return RainDiagnostics(available=False)
+
+    max_series: list[TimeValue] = []
+    first_rain_time: float | None = None
+    max_qr: float | None = None
+    time_of_max_qr: float | None = None
+
+    for index, array in enumerate(_time_slices(qr, time.dimension)):
+        time_seconds = time.at(index)
+        slice_max = _finite_max(array)
+        max_series.append(TimeValue(time_seconds=time_seconds, value=slice_max))
+        if first_rain_time is None and _threshold_count(array, QR_RAIN_THRESHOLD_KG_KG) > 0:
+            first_rain_time = time_seconds
+        if slice_max is not None and (max_qr is None or slice_max > max_qr):
+            max_qr = slice_max
+            time_of_max_qr = time_seconds
+
+    present = first_rain_time is not None
+    return RainDiagnostics(
+        present=present,
+        first_rain_time_seconds=first_rain_time,
+        max_qr_kg_kg=max_qr,
+        time_of_max_qr_seconds=time_of_max_qr,
+        qr_max_time_series=max_series,
+        user_message="Rain detected." if present else "No rain detected.",
+    )
+
+
+def _cloud_base_top(qc: Any, caveats: list[str]) -> tuple[float | None, float | None]:
+    vertical_name = _first_present(VERTICAL_COORDINATE_CANDIDATES, list(qc.dims))
+    if vertical_name is None:
+        caveats.append("cloud_base_top_unavailable_missing_vertical_coordinate")
+        return None, None
+    vertical_values: list[float | None]
+    if vertical_name not in qc.coords:
+        caveats.append("cloud_base_top_vertical_coordinate_inferred_from_index")
+        vertical_values = [float(index) for index in range(int(qc.sizes[vertical_name]))]
+    else:
+        vertical_coord = qc.coords[vertical_name]
+        vertical_values = [_to_float_or_none(value) for value in vertical_coord.values.tolist()]
+        units = _attr_string(vertical_coord, "units")
+        if units is None:
+            caveats.append("cloud_base_top_vertical_units_missing_assumed_meters")
+        elif units not in {"m", "meter", "meters"}:
+            caveats.append(f"cloud_base_top_vertical_units_not_meters:{units}")
+    cloudy_by_vertical = (qc >= QC_CLOUD_THRESHOLD_KG_KG).any(
+        dim=[dimension for dimension in qc.dims if dimension != vertical_name],
+    )
+    cloudy_values: list[float] = []
+    for index, present in enumerate(cloudy_by_vertical.values.tolist()):
+        vertical_value = vertical_values[index]
+        if bool(present) and vertical_value is not None:
+            cloudy_values.append(vertical_value)
+    if not cloudy_values:
+        return None, None
+    return min(cloudy_values), max(cloudy_values)
+
+
+def _time_context(dataset: Any, time_dimension: str | None) -> _TimeContext:
+    if time_dimension is None:
+        return _TimeContext(
+            dimension=None,
+            values=[0.0],
+            diagnostics=TimeDiagnostics(
+                source="single_output_no_time_dimension", fallback_used=True
+            ),
+        )
+    size = int(dataset.sizes[time_dimension])
+    if time_dimension in dataset.coords:
+        values = [
+            _to_float_or_none(value) for value in dataset.coords[time_dimension].values.tolist()
+        ]
+        return _TimeContext(
+            dimension=time_dimension,
+            values=values,
+            diagnostics=TimeDiagnostics(
+                source="netcdf_time_coordinate",
+                fallback_used=False,
+                coordinate_name=time_dimension,
+            ),
+        )
+    return _TimeContext(
+        dimension=time_dimension,
+        values=[float(index) for index in range(size)],
+        diagnostics=TimeDiagnostics(
+            source="inferred_output_index",
+            fallback_used=True,
+            coordinate_name=time_dimension,
+        ),
+    )
+
+
+def _primary_time_dimension(dataset: Any) -> str | None:
+    for candidate in TIME_DIMENSION_CANDIDATES:
+        if candidate in dataset.sizes:
+            return candidate
+    for data_array in dataset.data_vars.values():
+        for candidate in TIME_DIMENSION_CANDIDATES:
+            if candidate in data_array.dims:
+                return candidate
+    return None
+
+
+def _time_slices(data_array: Any, time_dimension: str | None) -> list[Any]:
+    if time_dimension is None or time_dimension not in data_array.dims:
+        return [data_array]
+    return [
+        data_array.isel({time_dimension: index})
+        for index in range(data_array.sizes[time_dimension])
+    ]
+
+
+def _record_units_caveat(
+    data_array: Any, field_name: str, expected_units: str, caveats: list[str]
+) -> None:
+    units = _attr_string(data_array, "units")
+    if units is None:
+        caveats.append(f"{field_name}_units_missing_assumed_{expected_units}")
+    elif units != expected_units:
+        caveats.append(f"{field_name}_units_not_expected:{units}")
+
+
+def _attr_string(data_array: Any, name: str) -> str | None:
+    value = data_array.attrs.get(name)
+    if value is None:
+        return None
+    return str(value)
+
+
+def _finite_values(data_array: Any) -> list[float]:
+    values: list[float] = []
+    for value in data_array.values.reshape(-1).tolist():
+        parsed = _to_float_or_none(value)
+        if parsed is not None and isfinite(parsed):
+            values.append(parsed)
+    return values
+
+
+def _finite_count(data_array: Any) -> int:
+    return len(_finite_values(data_array))
+
+
+def _finite_max(data_array: Any) -> float | None:
+    values = _finite_values(data_array)
+    return max(values) if values else None
+
+
+def _finite_min(data_array: Any) -> float | None:
+    values = _finite_values(data_array)
+    return min(values) if values else None
+
+
+def _threshold_count(data_array: Any, threshold: float) -> int:
+    return sum(1 for value in _finite_values(data_array) if value >= threshold)
+
+
+def _non_finite_count(data_array: Any) -> int:
+    count = 0
+    for value in data_array.values.reshape(-1).tolist():
+        parsed = _to_float_or_none(value)
+        if parsed is None or not isfinite(parsed):
+            count += 1
+    return count
+
+
+def _has_finite_values(data_array: Any) -> bool:
+    return _finite_count(data_array) > 0
+
+
+def _to_float_or_none(value: object) -> float | None:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_present(candidates: tuple[str, ...], names: list[str]) -> str | None:
+    for candidate in candidates:
+        if candidate in names:
+            return candidate
+    return None
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from cloud_chamber.result_diagnostics import ResultDiagnostics, compute_baseline_diagnostics
 from cloud_chamber.run_manifest import LifecycleState, ProductState, RunManifest, load_run_manifest
 from cloud_chamber.settings import CloudChamberSettings
 
@@ -56,6 +57,7 @@ class ResultMetadata(BaseModel):
     grid_shape: list[int] | None = None
     warnings: list[str] = Field(default_factory=list)
     diagnostics_summary: str | None = None
+    diagnostics: ResultDiagnostics | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -171,6 +173,7 @@ def _result_from_dataset(
         warnings.append(
             "Expected fields missing from NetCDF metadata: " + ", ".join(missing_expected)
         )
+    diagnostics = compute_baseline_diagnostics(dataset, warnings)
 
     return ResultMetadata(
         result_id=f"result-{manifest.run_id}",
@@ -194,6 +197,8 @@ def _result_from_dataset(
         time_steps=time_steps,
         grid_shape=grid_shape,
         warnings=warnings,
+        diagnostics_summary=_diagnostics_summary(diagnostics),
+        diagnostics=diagnostics,
         created_at=now,
         updated_at=now,
     )
@@ -228,3 +233,9 @@ def _grid_shape(dimensions: dict[str, int]) -> list[int] | None:
         size for name, size in dimensions.items() if name.lower() not in {"time", "mtime", "t"}
     ]
     return spatial or None
+
+
+def _diagnostics_summary(diagnostics: ResultDiagnostics) -> str:
+    cloud_status = "cloud formed" if diagnostics.cloud.formed else "no cloud formed"
+    rain_status = "rain detected" if diagnostics.rain.present else "no rain detected"
+    return f"{cloud_status}; {rain_status}"

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -1,0 +1,267 @@
+from pathlib import Path
+
+import xarray as xr
+
+from cloud_chamber.result_diagnostics import compute_baseline_diagnostics
+
+
+def write_dataset(path: Path, dataset: xr.Dataset) -> xr.Dataset:
+    dataset.to_netcdf(path, engine="scipy")
+    return xr.open_dataset(path)
+
+
+def base_dataset(
+    *,
+    qc_values: list[list[list[list[float]]]] | None = None,
+    w_values: list[list[list[list[float]]]] | None = None,
+    qr_values: list[list[list[list[float]]]] | None = None,
+    include_time_coord: bool = True,
+) -> xr.Dataset:
+    coords: dict[str, list[float]] = {
+        "z": [500.0, 1500.0],
+        "y": [0.0, 200.0, 400.0],
+        "x": [0.0, 200.0, 400.0, 600.0],
+    }
+    if include_time_coord:
+        coords["time"] = [0.0, 300.0]
+    else:
+        coords["time"] = []
+    data_vars = {}
+    if qc_values is not None:
+        data_vars["qc"] = (
+            ("time", "z", "y", "x"),
+            qc_values,
+            {"units": "kg/kg"},
+        )
+    if w_values is not None:
+        data_vars["w"] = (
+            ("time", "z", "y", "x"),
+            w_values,
+            {"units": "m/s"},
+        )
+    if qr_values is not None:
+        data_vars["qr"] = (
+            ("time", "z", "y", "x"),
+            qr_values,
+            {"units": "kg/kg"},
+        )
+    if include_time_coord:
+        return xr.Dataset(data_vars=data_vars, coords=coords)
+    return xr.Dataset(
+        data_vars=data_vars,
+        coords={key: value for key, value in coords.items() if key != "time"},
+    )
+
+
+def zeros() -> list[list[list[list[float]]]]:
+    return [
+        [[[0.0 for _x in range(4)] for _y in range(3)] for _z in range(2)] for _time in range(2)
+    ]
+
+
+def with_cloud(cloudy_cells: int = 12) -> list[list[list[list[float]]]]:
+    values = zeros()
+    filled = 0
+    for y_index in range(3):
+        for x_index in range(4):
+            for z_index in range(2):
+                if filled < cloudy_cells:
+                    values[1][z_index][y_index][x_index] = 2e-6 + filled * 1e-6
+                    filled += 1
+    return values
+
+
+def w_field() -> list[list[list[list[float]]]]:
+    values = zeros()
+    values[0][0][0][0] = -1.5
+    values[0][1][2][3] = 2.5
+    values[1][0][0][0] = -3.0
+    values[1][1][2][3] = 4.0
+    return values
+
+
+def test_no_cloud_case(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "no_cloud.nc", base_dataset(qc_values=zeros(), w_values=w_field())
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.cloud.formed is False
+    assert diagnostics.cloud.first_cloud_time_seconds is None
+    assert diagnostics.cloud.cloud_present_time_steps == []
+    assert diagnostics.cloud.qc_max_time_series[-1].value == 0.0
+
+
+def test_cloud_formed_requires_ten_grid_cells_and_reports_base_top(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "cloud.nc",
+        base_dataset(qc_values=with_cloud(12), w_values=w_field()),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.cloud.formed is True
+    assert diagnostics.cloud.first_cloud_time_seconds == 300.0
+    assert diagnostics.cloud.cloud_base_m == 500.0
+    assert diagnostics.cloud.cloud_top_m == 1500.0
+    assert diagnostics.cloud.cloud_present_time_steps == [300.0]
+
+
+def test_fewer_than_ten_cloudy_grid_cells_does_not_count_as_cloud_formed(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "thin_cloud.nc",
+        base_dataset(qc_values=with_cloud(9), w_values=w_field()),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.cloud.formed is False
+    assert diagnostics.cloud.first_cloud_time_seconds is None
+    assert diagnostics.cloud.max_qc_kg_kg is not None
+    assert diagnostics.cloud.max_qc_kg_kg > 1e-6
+
+
+def test_qc_max_time_and_cloud_fraction_series(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "qc_summary.nc",
+        base_dataset(qc_values=with_cloud(12), w_values=w_field()),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.cloud.max_qc_kg_kg == 1.3e-5
+    assert diagnostics.cloud.time_of_max_qc_seconds == 300.0
+    assert [point.time_seconds for point in diagnostics.cloud.qc_max_time_series] == [0.0, 300.0]
+    assert [point.value for point in diagnostics.cloud.cloud_fraction_time_series] == [0.0, 0.5]
+
+
+def test_vertical_velocity_summary(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "w_summary.nc",
+        base_dataset(qc_values=zeros(), w_values=w_field()),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.vertical_velocity.max_w_m_s == 4.0
+    assert diagnostics.vertical_velocity.time_of_max_w_seconds == 300.0
+    assert diagnostics.vertical_velocity.min_w_m_s == -3.0
+    assert diagnostics.vertical_velocity.time_of_min_w_seconds == 300.0
+    assert [point.value for point in diagnostics.vertical_velocity.w_max_time_series] == [2.5, 4.0]
+    assert [point.value for point in diagnostics.vertical_velocity.w_min_time_series] == [
+        -1.5,
+        -3.0,
+    ]
+
+
+def test_qr_rain_present_and_threshold(tmp_path: Path) -> None:
+    qr = zeros()
+    qr[1][0][0][0] = 2e-7
+    dataset = write_dataset(
+        tmp_path / "rain.nc",
+        base_dataset(qc_values=zeros(), w_values=w_field(), qr_values=qr),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.rain.present is True
+    assert diagnostics.rain.first_rain_time_seconds == 300.0
+    assert diagnostics.rain.max_qr_kg_kg == 2e-7
+    assert diagnostics.rain.time_of_max_qr_seconds == 300.0
+    assert diagnostics.rain.user_message == "Rain detected."
+
+
+def test_qr_present_but_no_rain(tmp_path: Path) -> None:
+    qr = zeros()
+    qr[1][0][0][0] = 5e-8
+    dataset = write_dataset(
+        tmp_path / "no_rain.nc",
+        base_dataset(qc_values=zeros(), w_values=w_field(), qr_values=qr),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.rain.present is False
+    assert diagnostics.rain.max_qr_kg_kg == 5e-8
+    assert diagnostics.rain.user_message == "No rain detected."
+
+
+def test_qr_missing_is_no_rain_without_failure(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "missing_qr.nc",
+        base_dataset(qc_values=zeros(), w_values=w_field()),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.rain.present is False
+    assert diagnostics.rain.field_absent is True
+    assert diagnostics.rain.user_message == "No rain detected."
+    assert "qr_field_absent" in diagnostics.caveats
+
+
+def test_missing_qc_and_missing_w_are_graceful(tmp_path: Path) -> None:
+    dataset = write_dataset(tmp_path / "missing.nc", base_dataset())
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.cloud.available is False
+    assert diagnostics.vertical_velocity.available is False
+    assert "missing_qc_field" in diagnostics.caveats
+    assert "missing_w_field" in diagnostics.caveats
+
+
+def test_non_finite_values_are_ignored_and_recorded(tmp_path: Path) -> None:
+    qc = with_cloud(12)
+    qc[1][0][0][0] = float("nan")
+    w = w_field()
+    w[1][0][0][0] = float("inf")
+    dataset = write_dataset(
+        tmp_path / "non_finite.nc",
+        base_dataset(qc_values=qc, w_values=w),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.cloud.max_qc_kg_kg == 1.3e-5
+    assert diagnostics.vertical_velocity.max_w_m_s == 4.0
+    assert "non_finite_values_detected_in_qc" in diagnostics.caveats
+    assert "non_finite_values_detected_in_w" in diagnostics.caveats
+
+
+def test_entirely_non_finite_target_field_fails_gracefully(tmp_path: Path) -> None:
+    qc = [
+        [[[float("nan") for _x in range(4)] for _y in range(3)] for _z in range(2)]
+        for _time in range(2)
+    ]
+    dataset = write_dataset(
+        tmp_path / "all_nan.nc",
+        base_dataset(qc_values=qc, w_values=w_field()),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.cloud.available is False
+    assert diagnostics.cloud.max_qc_kg_kg is None
+    assert "qc_field_entirely_non_finite" in diagnostics.caveats
+
+
+def test_netcdf_time_coordinate_and_inferred_fallback(tmp_path: Path) -> None:
+    with_time = write_dataset(
+        tmp_path / "with_time.nc",
+        base_dataset(qc_values=with_cloud(12), w_values=w_field(), include_time_coord=True),
+    )
+    without_time = write_dataset(
+        tmp_path / "without_time.nc",
+        base_dataset(qc_values=with_cloud(12), w_values=w_field(), include_time_coord=False),
+    )
+
+    direct = compute_baseline_diagnostics(with_time, [])
+    inferred = compute_baseline_diagnostics(without_time, [])
+
+    assert direct.time.source == "netcdf_time_coordinate"
+    assert direct.time.fallback_used is False
+    assert inferred.time.source == "inferred_output_index"
+    assert inferred.time.fallback_used is True
+    assert inferred.cloud.first_cloud_time_seconds == 1.0

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -135,7 +135,10 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
         ("qc", "kg/kg"),
         ("w", "m/s"),
     ]
-    assert result.diagnostics_summary is None
+    assert result.diagnostics_summary == "no cloud formed; no rain detected"
+    assert result.diagnostics is not None
+    assert result.diagnostics.cloud.formed is False
+    assert result.diagnostics.rain.field_absent is True
     assert result.warnings == [
         "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"
     ]
@@ -200,5 +203,7 @@ def test_missing_expected_fields_are_warnings_not_claimed_diagnostics(tmp_path: 
     result = ingest_completed_run(manifest_path)
 
     assert result.variables == ["w"]
-    assert result.diagnostics_summary is None
+    assert result.diagnostics_summary == "no cloud formed; no rain detected"
+    assert result.diagnostics is not None
+    assert result.diagnostics.cloud.available is False
     assert result.warnings == ["Expected fields missing from NetCDF metadata: qc"]

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -201,7 +201,20 @@ Responsibilities:
 
 The first implemented ingest step creates `result_metadata.json` in the completed run directory. It reads NetCDF with xarray and records result ID, run ID, scenario, physical question, controls, run-size preset, source lifecycle/product/provenance state, raw CM1 artifacts, NetCDF paths, processed artifact placeholders, dimensions, coordinates, variables, units, time coordinate, grid shape, warnings, and timestamps.
 
-This result metadata is not a Result Card UI, not diagnostics, and not visualization-ready data. It is the backend bridge that later diagnostics, result cards, and inspectors can consume. Raw `.dat/.ctl` artifacts remain cataloged on the run metadata but are not parsed as NetCDF ingest input.
+The next implemented step attaches first-pass Baseline Shallow Cumulus diagnostics to that result metadata. Diagnostics read NetCDF fields through the backend and summarize `qc`, `w`, and optional `qr` without parsing raw `.dat/.ctl` artifacts. Raw `.dat/.ctl` artifacts remain cataloged on the run metadata but are not parsed as ingest input.
+
+Current diagnostics compute:
+
+- cloud formed yes/no using `qc >= 1e-6 kg/kg` and a minimum 10 cloudy grid-cell rule;
+- first cloud time from the NetCDF time coordinate when available, otherwise inferred output index;
+- first-pass cloud base/top from available vertical coordinates;
+- max `qc`, time of max `qc`, `qc` max time series, cloud fraction time series, and cloud-present time steps;
+- max/min `w`, time of max/min `w`, and `w` max/min time series;
+- optional rain summary from `qr >= 1e-7 kg/kg`.
+
+Diagnostics preserve runtime warnings from the run manifest/result metadata. CM1 floating-point exception flags are caveats, not automatic failure. The diagnostics also count non-finite values in target fields where practical, ignore NaN/infinity for finite summaries, and record field-specific caveats if `qc`, `w`, or `qr` are missing or entirely non-finite.
+
+This result metadata is not a Result Card UI and not visualization-ready data. It is the backend bridge that later result cards and inspectors can consume.
 
 ### Result Library
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -348,6 +348,33 @@ main limiting factor
 
 First variations should favor one-control-at-a-time changes around Baseline Shallow Cumulus. Large arbitrary parameter sweeps are not the primary learning path.
 
+### First Baseline Shallow Cumulus Diagnostics
+
+The first implemented diagnostics are personal-learning summaries, not publication-quality LES validation. Exact cloud morphology is not pass/fail.
+
+Cloud detection uses:
+
+```text
+qc_cloud_threshold_kg_kg = 1e-6
+minimum_cloud_grid_cells = 10
+```
+
+Cloud Chamber marks `cloud_formed` only when at least one output time has 10 or more finite grid cells with `qc >= 1e-6 kg/kg`. This avoids declaring cloud from one isolated noisy cell. First cloud time is the first output time meeting the same rule.
+
+Cloud-water diagnostics include max `qc`, time of max `qc`, a `qc` max time series, cloud fraction time series, cloud-present time steps, and first-pass cloud base/top when a vertical coordinate is available. Cloud fraction is the count of finite cells at or above the `qc` threshold divided by the count of finite `qc` cells. Cloud base/top is a grid-cell diagnostic: lowest/highest vertical coordinate where any finite grid cell has `qc` above threshold. It is not yet a polished meteorological cloud-base product.
+
+Vertical velocity diagnostics use `w` when present and compute max/min `w`, time of max/min `w`, and max/min time series while preserving units when available.
+
+Rain diagnostics use `qr` when present:
+
+```text
+qr_rain_threshold_kg_kg = 1e-7
+```
+
+If `qr` is absent, the user-facing result says `No rain detected.` and the metadata records that the `qr` field was absent. Missing `qr` does not fail the diagnostics.
+
+NaN and infinity values are ignored for finite min/max and fraction summaries. Field-specific caveats record non-finite values or entirely non-finite target fields. CM1 runtime floating-point exception flags are preserved as caveats and evaluated against the target diagnostic fields rather than treated as automatic run failure.
+
 Shared controls are controls that can be compared across multiple lower-atmosphere scenarios, such as low-level humidity, surface heating, cap strength, cap height, dry air aloft, and mixing/entrainment. Scenario-specific controls should be introduced only when a scenario needs them to answer its physical question.
 
 ## Run Manifest Schema

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -234,6 +234,7 @@ Implementation anchor:
 - #30 should make replayable/inspectable saved result cards the core behavior. Duplicate/tweak/rerun should remain optional or later.
 - #64 adds the storage bridge needed after the first successful 852 MB smoke run: inventory runtime-home usage, warn at the 50 GB MVP threshold, classify runs conservatively, and delete only explicitly selected run directories under `~/CloudChamber/runs/`. Cleanup must never target the repo, home directory, runtime home itself, or the external CM1 installation, and threshold warnings must never auto-delete anything.
 - #68 establishes the backend NetCDF ingest bridge: read completed-run NetCDF output with xarray, write `result_metadata.json`, preserve raw `.dat/.ctl` artifact cataloging without parsing it, and leave diagnostics/result-card UI/visualization-ready data to follow-up issues.
+- #69 adds first Baseline Shallow Cumulus diagnostics to ingested NetCDF result metadata: cloud formed yes/no with `qc >= 1e-6 kg/kg` and at least 10 cloudy grid cells, first cloud time, cloud base/top when vertical coordinates are available, `qc` summaries/time series/cloud fraction, `w` max/min summaries/time series, optional `qr` rain detection with `qr >= 1e-7 kg/kg`, and caveats for missing, inferred, or non-finite fields.
 
 ## M4 3-D Visualizer MVP
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -47,6 +47,10 @@ Runtime storage tests must use temporary runtime homes only. They should cover t
 
 NetCDF ingest tests use tiny synthetic NetCDF files in temporary run directories. They should assert valid metadata extraction, result metadata serialization, missing-output failures, malformed-NetCDF failures, missing expected field warnings, and that raw `.dat/.ctl` artifacts are cataloged but not treated as NetCDF input. These tests must not use real CM1 output.
 
+Baseline Shallow Cumulus diagnostics tests use tiny synthetic NetCDF fixtures only. They cover no-cloud and cloud-formed cases, the `qc >= 1e-6 kg/kg` threshold, the minimum 10 cloudy grid-cell rule, first cloud time, cloud base/top from vertical coordinates, max `qc`, `qc` max time series, cloud fraction time series, max/min `w`, optional `qr` rain detection with `qr >= 1e-7 kg/kg`, missing `qc`/`w`/`qr`, NaN/infinity handling, entirely non-finite fields, NetCDF time-coordinate use, and inferred output-index fallback. These diagnostics are learning summaries, not morphology validation.
+
+CM1 runtime floating-point exception flags such as `IEEE_INVALID_FLAG`, `IEEE_DIVIDE_BY_ZERO`, and `IEEE_OVERFLOW_FLAG` should be preserved as caveats. Automated diagnostics should then check whether target fields contain non-finite values. If `qc`, `w`, and `qr` are finite/usable, diagnostics can complete with the runtime warning still visible. If root-cause investigation requires CM1 source-level debugging, that belongs in a separate issue rather than CI.
+
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.
 
 ## Local CM1 Workflow Tests


### PR DESCRIPTION
Closes #69

Summary:
- Added first-pass Baseline Shallow Cumulus diagnostics for ingested NetCDF results.
- Computes cloud formed with `qc >= 1e-6 kg/kg` and the minimum 10 cloudy grid-cell rule.
- Computes first cloud time, first-pass cloud base/top, max `qc`, time of max `qc`, `qc` max time series, cloud fraction time series, and cloud-present time steps.
- Computes max/min `w`, time of max/min `w`, and `w` max/min time series.
- Computes optional `qr` rain diagnostics with `qr >= 1e-7 kg/kg`; missing `qr` remains a graceful `No rain detected.` result with an internal caveat.
- Preserves runtime warnings as diagnostics caveats and records missing, inferred, non-finite, or entirely non-finite target-field caveats.
- Attaches diagnostics and a concise diagnostics summary to ingested result metadata.
- Updated docs with diagnostic definitions, thresholds, NaN/Inf handling, runtime warning caveats, and limitations.

What was intentionally not included:
- No full scientific validation or morphology pass/fail logic.
- No result UI.
- No visualization work.
- No CM1 scenario tuning.
- No `.dat/.ctl` parser.
- No generated CM1 output committed.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, or generated visualization artifacts were committed.
