### PR TITLE
Define visualization-ready field slice API

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 from fastapi import FastAPI, HTTPException
@@ -34,6 +34,12 @@ from cloud_chamber.scenario_catalog import (
     scenario_summary,
 )
 from cloud_chamber.settings import load_settings
+from cloud_chamber.visualization_data import (
+    VisualizationDataError,
+    VisualizationOrientation,
+    field_catalog,
+    field_slice,
+)
 
 app = FastAPI(
     title="Cloud Chamber Backend",
@@ -193,6 +199,48 @@ def save_result(result_id: str) -> dict[str, object]:
         result = save_result_card(load_settings(), result_id)
     except ResultIngestError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/results/{result_id}/visualization/fields")
+def get_visualization_fields(result_id: str) -> dict[str, object]:
+    try:
+        result = field_catalog(load_settings(), result_id)
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except VisualizationDataError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/results/{result_id}/visualization/slice")
+def get_visualization_slice(
+    result_id: str,
+    field: str,
+    time_index: int = 0,
+    orientation: str = "horizontal",
+    level_index: int = 0,
+    encoding: str = "json",
+) -> dict[str, object]:
+    if orientation not in {"horizontal", "vertical_x", "vertical_y"}:
+        raise HTTPException(status_code=400, detail=f"Unsupported orientation: {orientation}")
+    if encoding != "json":
+        raise HTTPException(status_code=400, detail="Only encoding=json is supported.")
+    checked_orientation = cast(VisualizationOrientation, orientation)
+    try:
+        result = field_slice(
+            load_settings(),
+            result_id,
+            field=field,
+            time_index=time_index,
+            orientation=checked_orientation,
+            level_index=level_index,
+            encoding="json",
+        )
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except VisualizationDataError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return result.model_dump(mode="json")
 
 

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -1,0 +1,514 @@
+"""Visualization-ready CM1 field data contracts.
+
+This module keeps raw NetCDF/xarray access on the backend. Frontend inspectors
+and visualizers receive small, provenance-labeled payloads rather than parsing
+CM1 output directly in the browser.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.result_ingest import (
+    ResultMetadata,
+    get_result_metadata,
+)
+from cloud_chamber.settings import CloudChamberSettings
+
+VisualizationOrientation = Literal["horizontal", "vertical_x", "vertical_y"]
+VisualizationEncoding = Literal["json"]
+
+FIELD_DEFINITIONS: dict[str, tuple[str, str]] = {
+    "qc": ("cloud_water", "Cloud water"),
+    "w": ("vertical_velocity", "Vertical velocity"),
+    "qr": ("rain_water", "Rain water"),
+    "rain": ("accumulated_surface_rain", "Accumulated surface rain"),
+    "dbz": ("reflectivity", "Reflectivity"),
+}
+
+TIME_DIMENSION_CANDIDATES = ("time", "mtime", "t")
+VERTICAL_DIMENSION_CANDIDATES = ("zh", "zf", "z", "height", "height_m", "height_km")
+Y_DIMENSION_CANDIDATES = ("yh", "y")
+X_DIMENSION_CANDIDATES = ("xh", "x")
+
+
+class VisualizationDataError(RuntimeError):
+    """Raised when a visualization-ready payload cannot be produced."""
+
+
+class ProvenancePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_model: str
+    result_id: str
+    run_id: str
+    scenario_id: str
+    source_product_state: str
+    result_state: str
+    processing_method: str
+    rendering_method: str
+    provenance_label: str
+
+
+class FieldCoordinateMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time: str | None = None
+    vertical: str | None = None
+    y: str | None = None
+    x: str | None = None
+
+
+class VisualizableField(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    raw_field_name: str
+    canonical_field_name: str
+    display_name: str
+    units: str | None = None
+    dimensions: list[str]
+    shape: list[int]
+    native_grid: str
+    coordinate_names: FieldCoordinateMetadata
+    time_coordinate_values: list[float | str | None] = Field(default_factory=list)
+    provenance: ProvenancePayload
+    caveats: list[str] = Field(default_factory=list)
+
+
+class FieldCatalogResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    run_id: str
+    scenario_id: str
+    source_model: str
+    available_fields: list[VisualizableField]
+    provenance: ProvenancePayload
+    caveats: list[str] = Field(default_factory=list)
+
+
+class SliceSelectionMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time_index: int
+    time_seconds: float | None = None
+    orientation: VisualizationOrientation
+    selected_dimension: str
+    selected_index: int
+    selected_coordinate_value: float | str | None = None
+    level_units: str | None = None
+    level_coordinate_value: float | str | None = None
+    level_meters: float | None = None
+
+
+class SliceStats(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    min: float | None = None
+    max: float | None = None
+    mean: float | None = None
+    finite_count: int
+    non_finite_count: int
+
+
+class SliceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    run_id: str
+    scenario_id: str
+    field: VisualizableField
+    selection: SliceSelectionMetadata
+    coordinate_units: dict[str, str | None] = Field(default_factory=dict)
+    shape: list[int]
+    dimension_order: list[str]
+    data_encoding: VisualizationEncoding
+    values: list[list[float | None]]
+    stats: SliceStats
+    provenance: ProvenancePayload
+    caveats: list[str] = Field(default_factory=list)
+
+
+def field_catalog(settings: CloudChamberSettings, result_id: str) -> FieldCatalogResponse:
+    """Return visualizable field metadata for an ingested result."""
+    metadata = get_result_metadata(settings, result_id)
+    dataset, close_datasets = _open_dataset_sequence(metadata)
+    try:
+        fields = [
+            _visualizable_field(metadata, dataset, field_name)
+            for field_name in FIELD_DEFINITIONS
+            if field_name in dataset.data_vars
+        ]
+        return FieldCatalogResponse(
+            result_id=metadata.result_id,
+            run_id=metadata.run_id,
+            scenario_id=metadata.scenario_id,
+            source_model=metadata.source_model,
+            available_fields=fields,
+            provenance=_provenance(metadata),
+            caveats=_dedupe(_catalog_caveats(metadata, fields)),
+        )
+    finally:
+        _close_all(close_datasets)
+
+
+def field_slice(
+    settings: CloudChamberSettings,
+    result_id: str,
+    *,
+    field: str,
+    time_index: int,
+    orientation: VisualizationOrientation,
+    level_index: int,
+    encoding: VisualizationEncoding = "json",
+) -> SliceResponse:
+    """Return a small JSON 2-D slice payload for a visualizable field."""
+    if encoding != "json":
+        raise VisualizationDataError("Only encoding=json is supported for MVP 2-D slices.")
+
+    metadata = get_result_metadata(settings, result_id)
+    dataset, close_datasets = _open_dataset_sequence(metadata)
+    try:
+        if field not in FIELD_DEFINITIONS:
+            raise VisualizationDataError(f"Unsupported visualization field: {field}")
+        if field not in dataset.data_vars:
+            raise VisualizationDataError(f"Field is not available for this result: {field}")
+        data_array = dataset[field]
+        dims = _field_dimensions(data_array)
+        if not dims.time:
+            raise VisualizationDataError(f"Field {field} has no time dimension.")
+        _validate_index(time_index, int(data_array.sizes[dims.time]), "time_index")
+        at_time = data_array.isel({dims.time: time_index})
+        spatial_dims = [dimension for dimension in at_time.dims]
+        if len(spatial_dims) != 3:
+            raise VisualizationDataError(
+                f"Field {field} must have three native spatial dimensions after time selection."
+            )
+
+        sliced, selected_dimension = _slice_spatial_array(
+            at_time,
+            dims,
+            orientation=orientation,
+            level_index=level_index,
+        )
+        values = _json_values(sliced)
+        stats = _slice_stats(sliced)
+        visual_field = _visualizable_field(metadata, dataset, field)
+        selected_value = _coordinate_value(dataset, selected_dimension, level_index)
+        vertical_dim = dims.vertical
+        vertical_units = _coordinate_units(dataset, vertical_dim)
+        level_units = _coordinate_units(dataset, selected_dimension)
+        caveats = _dedupe(
+            [
+                *_field_caveats(field, visual_field.coordinate_names),
+                "native_grid_view_no_interpolation",
+                "json_numeric_slice_mvp",
+            ]
+        )
+        selection = SliceSelectionMetadata(
+            time_index=time_index,
+            time_seconds=_time_value_seconds(dataset, dims.time, time_index),
+            orientation=orientation,
+            selected_dimension=selected_dimension,
+            selected_index=level_index,
+            selected_coordinate_value=selected_value,
+            level_units=level_units,
+            level_coordinate_value=selected_value if selected_dimension == vertical_dim else None,
+            level_meters=_meters_if_safe(selected_value, level_units)
+            if selected_dimension == vertical_dim
+            else None,
+        )
+        coordinate_units = {
+            dimension: _coordinate_units(dataset, dimension) for dimension in sliced.dims
+        }
+        if vertical_dim and vertical_units and vertical_dim not in coordinate_units:
+            coordinate_units[vertical_dim] = vertical_units
+        return SliceResponse(
+            result_id=metadata.result_id,
+            run_id=metadata.run_id,
+            scenario_id=metadata.scenario_id,
+            field=visual_field,
+            selection=selection,
+            coordinate_units=coordinate_units,
+            shape=[int(size) for size in sliced.shape],
+            dimension_order=[str(dimension) for dimension in sliced.dims],
+            data_encoding=encoding,
+            values=values,
+            stats=stats,
+            provenance=_provenance(metadata),
+            caveats=caveats,
+        )
+    finally:
+        _close_all(close_datasets)
+
+
+def _open_dataset_sequence(metadata: ResultMetadata) -> tuple[Any, list[Any]]:
+    paths = [Path(path).expanduser() for path in metadata.model_output_paths]
+    if not paths:
+        paths = [Path(path).expanduser() for path in metadata.netcdf_paths]
+    if not paths:
+        raise VisualizationDataError("No NetCDF model-output paths are available for this result.")
+
+    xarray = importlib.import_module("xarray")
+    opened: list[Any] = []
+    normalized: list[Any] = []
+    for index, path in enumerate(paths):
+        try:
+            dataset = xarray.open_dataset(path)
+        except Exception as exc:
+            raise VisualizationDataError(f"Could not open NetCDF output {path}: {exc}") from exc
+        opened.append(dataset)
+        normalized.append(_normalize_time_dimension(dataset, index))
+
+    if len(normalized) == 1:
+        return normalized[0], opened
+    try:
+        combined = xarray.concat(normalized, dim="time")
+    except Exception as exc:
+        _close_all(opened)
+        raise VisualizationDataError(f"Could not combine NetCDF output sequence: {exc}") from exc
+    return combined, [*opened, combined]
+
+
+def _normalize_time_dimension(dataset: Any, file_index: int) -> Any:
+    if "time" not in dataset.dims:
+        return dataset.expand_dims(time=[float(file_index)])
+    if "time" not in dataset.coords:
+        size = int(dataset.sizes["time"])
+        return dataset.assign_coords(time=[float(file_index + offset) for offset in range(size)])
+    return dataset
+
+
+def _visualizable_field(
+    metadata: ResultMetadata,
+    dataset: Any,
+    field_name: str,
+) -> VisualizableField:
+    data_array = dataset[field_name]
+    canonical, display = FIELD_DEFINITIONS[field_name]
+    coordinates = _field_dimensions(data_array).coordinates
+    return VisualizableField(
+        raw_field_name=field_name,
+        canonical_field_name=canonical,
+        display_name=display,
+        units=_attr_string(data_array.attrs.get("units")),
+        dimensions=[str(dimension) for dimension in data_array.dims],
+        shape=[int(size) for size in data_array.shape],
+        native_grid=_native_grid_label(coordinates),
+        coordinate_names=coordinates,
+        time_coordinate_values=_coordinate_values(dataset, coordinates.time),
+        provenance=_provenance(metadata),
+        caveats=_field_caveats(field_name, coordinates),
+    )
+
+
+class _FieldDimensions(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time: str | None
+    vertical: str | None
+    y: str | None
+    x: str | None
+    coordinates: FieldCoordinateMetadata
+
+
+def _field_dimensions(data_array: Any) -> _FieldDimensions:
+    dimensions = [str(dimension) for dimension in data_array.dims]
+    time = _first_present(TIME_DIMENSION_CANDIDATES, dimensions)
+    vertical = _first_present(VERTICAL_DIMENSION_CANDIDATES, dimensions)
+    y = _first_present(Y_DIMENSION_CANDIDATES, dimensions)
+    x = _first_present(X_DIMENSION_CANDIDATES, dimensions)
+    return _FieldDimensions(
+        time=time,
+        vertical=vertical,
+        y=y,
+        x=x,
+        coordinates=FieldCoordinateMetadata(time=time, vertical=vertical, y=y, x=x),
+    )
+
+
+def _slice_spatial_array(
+    data_array: Any,
+    dims: _FieldDimensions,
+    *,
+    orientation: VisualizationOrientation,
+    level_index: int,
+) -> tuple[Any, str]:
+    if orientation == "horizontal":
+        selected_dimension = dims.vertical
+    elif orientation == "vertical_x":
+        selected_dimension = dims.y
+    else:
+        selected_dimension = dims.x
+    if selected_dimension is None:
+        raise VisualizationDataError(f"Cannot slice orientation {orientation}; missing dimension.")
+    _validate_index(level_index, int(data_array.sizes[selected_dimension]), "level_index")
+    return data_array.isel({selected_dimension: level_index}), selected_dimension
+
+
+def _validate_index(index: int, size: int, label: str) -> None:
+    if index < 0 or index >= size:
+        raise VisualizationDataError(f"{label}={index} is outside valid range 0..{size - 1}.")
+
+
+def _native_grid_label(coordinates: FieldCoordinateMetadata) -> str:
+    spatial = [coordinates.vertical, coordinates.y, coordinates.x]
+    if all(spatial):
+        return "/".join(str(dimension) for dimension in spatial)
+    return "unknown_native_grid"
+
+
+def _catalog_caveats(
+    metadata: ResultMetadata,
+    fields: list[VisualizableField],
+) -> list[str]:
+    available = {field.raw_field_name for field in fields}
+    caveats = list(metadata.warnings)
+    for required in ("qc", "w"):
+        if required not in available:
+            caveats.append(f"missing_visualization_field:{required}")
+    return caveats
+
+
+def _field_caveats(field_name: str, coordinates: FieldCoordinateMetadata) -> list[str]:
+    caveats = ["native_grid_view_no_interpolation"]
+    if field_name == "qc" and coordinates.vertical != "zh":
+        caveats.append("qc_native_vertical_grid_not_zh")
+    if field_name == "w" and coordinates.vertical != "zf":
+        caveats.append("w_native_vertical_grid_not_zf")
+    return caveats
+
+
+def _provenance(metadata: ResultMetadata) -> ProvenancePayload:
+    return ProvenancePayload(
+        source_model=metadata.source_model,
+        result_id=metadata.result_id,
+        run_id=metadata.run_id,
+        scenario_id=metadata.scenario_id,
+        source_product_state=metadata.source_product_state,
+        result_state=metadata.result_state,
+        processing_method="backend_xarray_native_grid_slice",
+        rendering_method="json_2d_slice_for_inspection",
+        provenance_label="CM1-derived visualization-ready data; native-grid view; no interpolation",
+    )
+
+
+def _coordinate_values(dataset: Any, coordinate_name: str | None) -> list[float | str | None]:
+    if coordinate_name is None or coordinate_name not in dataset.coords:
+        return []
+    values = dataset.coords[coordinate_name].values.reshape(-1).tolist()
+    return [_json_scalar(value) for value in values]
+
+
+def _coordinate_value(dataset: Any, coordinate_name: str, index: int) -> float | str | None:
+    values = _coordinate_values(dataset, coordinate_name)
+    if index < len(values):
+        return values[index]
+    return None
+
+
+def _time_value_seconds(dataset: Any, time_dimension: str | None, index: int) -> float | None:
+    if time_dimension is None:
+        return None
+    value = _coordinate_value(dataset, time_dimension, index)
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _coordinate_units(dataset: Any, coordinate_name: str | None) -> str | None:
+    if coordinate_name is None or coordinate_name not in dataset.coords:
+        return None
+    return _attr_string(dataset.coords[coordinate_name].attrs.get("units"))
+
+
+def _meters_if_safe(value: float | str | None, units: str | None) -> float | None:
+    try:
+        numeric = float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+    if numeric is None:
+        return None
+    normalized = units.lower() if units else ""
+    if normalized in {"m", "meter", "meters"}:
+        return numeric
+    if normalized in {"km", "kilometer", "kilometers"}:
+        return numeric * 1000.0
+    return None
+
+
+def _json_values(data_array: Any) -> list[list[float | None]]:
+    rows: list[list[float | None]] = []
+    values = data_array.values.tolist()
+    for row in values:
+        rows.append([_finite_json_number(value) for value in row])
+    return rows
+
+
+def _slice_stats(data_array: Any) -> SliceStats:
+    finite_values: list[float] = []
+    non_finite_count = 0
+    for value in data_array.values.reshape(-1).tolist():
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            non_finite_count += 1
+            continue
+        if math.isfinite(numeric):
+            finite_values.append(numeric)
+        else:
+            non_finite_count += 1
+    mean = (sum(finite_values) / len(finite_values)) if finite_values else None
+    return SliceStats(
+        min=min(finite_values) if finite_values else None,
+        max=max(finite_values) if finite_values else None,
+        mean=mean,
+        finite_count=len(finite_values),
+        non_finite_count=non_finite_count,
+    )
+
+
+def _finite_json_number(value: Any) -> float | None:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric if math.isfinite(numeric) else None
+
+
+def _json_scalar(value: Any) -> float | str | None:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return str(value) if value is not None else None
+    return numeric if math.isfinite(numeric) else None
+
+
+def _attr_string(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _first_present(candidates: tuple[str, ...], names: list[str]) -> str | None:
+    for candidate in candidates:
+        if candidate in names:
+            return candidate
+    return None
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+def _close_all(datasets: list[Any]) -> None:
+    for dataset in datasets:
+        close = getattr(dataset, "close", None)
+        if callable(close):
+            close()

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -1,0 +1,294 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+from fastapi.testclient import TestClient
+
+from cloud_chamber.app import app
+from cloud_chamber.dry_run_package import generate_dry_run_package
+from cloud_chamber.result_ingest import ingest_completed_run
+from cloud_chamber.run_manifest import (
+    LifecycleState,
+    OutputMetadata,
+    ProductState,
+    ProvenanceMetadata,
+    load_run_manifest,
+    write_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.visualization_data import field_catalog, field_slice
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
+
+
+def fake_settings(tmp_path: Path) -> CloudChamberSettings:
+    runtime_home = tmp_path / "CloudChamber"
+    return CloudChamberSettings(
+        runtime_home=runtime_home,
+        cm1_root=tmp_path / "cm1r21.1",
+        cm1_run_dir=tmp_path / "cm1r21.1" / "run",
+        cache_dir=runtime_home / "cache",
+        log_dir=runtime_home / "logs",
+    )
+
+
+def create_visualization_result(
+    tmp_path: Path,
+    *,
+    include_qc: bool = True,
+    include_w: bool = True,
+    run_id: str = "run-visualization",
+) -> tuple[CloudChamberSettings, str, Path]:
+    settings = fake_settings(tmp_path)
+    package = generate_dry_run_package(
+        scenario_data=json.loads(BASELINE_TEMPLATE.read_text()),
+        runtime_home=settings.runtime_home,
+        run_id=run_id,
+        run_size_preset="quick_look",
+    )
+    netcdf_path = package.package_dir / "cm1out_000001.nc"
+    write_visualization_netcdf(netcdf_path, include_qc=include_qc, include_w=include_w)
+    manifest = load_run_manifest(package.manifest_path)
+    write_run_manifest(
+        package.manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": LifecycleState.COMPLETED,
+                "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+                "outputs": OutputMetadata(netcdf_paths=[str(netcdf_path)]),
+            }
+        ),
+    )
+    result = ingest_completed_run(package.manifest_path)
+    return settings, result.result_id, package.package_dir
+
+
+def write_visualization_netcdf(
+    path: Path,
+    *,
+    include_qc: bool,
+    include_w: bool,
+) -> None:
+    data_vars = {}
+    if include_qc:
+        qc = np.arange(2 * 2 * 3 * 4, dtype=float).reshape(2, 2, 3, 4) * 1e-6
+        qc[0, 0, 0, 0] = np.nan
+        qc[1, 1, 2, 3] = np.inf
+        data_vars["qc"] = (
+            ("time", "zh", "yh", "xh"),
+            qc,
+            {"units": "kg/kg"},
+        )
+    if include_w:
+        w = np.arange(2 * 3 * 3 * 4, dtype=float).reshape(2, 3, 3, 4)
+        data_vars["w"] = (
+            ("time", "zf", "yh", "xh"),
+            w,
+            {"units": "m/s"},
+        )
+    data_vars["theta"] = (
+        ("time", "zh", "yh", "xh"),
+        np.zeros((2, 2, 3, 4), dtype=float),
+        {"units": "K"},
+    )
+    xr.Dataset(
+        data_vars=data_vars,
+        coords={
+            "time": ("time", [0.0, 900.0], {"units": "s"}),
+            "zh": ("zh", [0.4, 0.8], {"units": "km"}),
+            "zf": ("zf", [0.0, 0.4, 0.8], {"units": "km"}),
+            "yh": ("yh", [0.0, 1.0, 2.0], {"units": "km"}),
+            "xh": ("xh", [0.0, 1.0, 2.0, 3.0], {"units": "km"}),
+        },
+    ).to_netcdf(path, engine="scipy")
+
+
+def test_field_catalog_includes_qc_and_w_with_provenance(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    catalog = field_catalog(settings, result_id)
+
+    fields = {field.raw_field_name: field for field in catalog.available_fields}
+    assert set(fields) >= {"qc", "w"}
+    assert fields["qc"].canonical_field_name == "cloud_water"
+    assert fields["qc"].native_grid == "zh/yh/xh"
+    assert fields["qc"].coordinate_names.vertical == "zh"
+    assert fields["qc"].time_coordinate_values == [0.0, 900.0]
+    assert fields["w"].canonical_field_name == "vertical_velocity"
+    assert fields["w"].native_grid == "zf/yh/xh"
+    assert fields["w"].coordinate_names.vertical == "zf"
+    assert catalog.provenance.source_model == "CM1"
+    assert "native-grid view" in catalog.provenance.provenance_label
+
+
+def test_field_catalog_handles_missing_qc_and_missing_w(tmp_path: Path) -> None:
+    settings_qc_missing, result_id_qc_missing, _run_dir = create_visualization_result(
+        tmp_path / "qc-missing",
+        include_qc=False,
+        include_w=True,
+        run_id="run-qc-missing",
+    )
+    settings_w_missing, result_id_w_missing, _run_dir = create_visualization_result(
+        tmp_path / "w-missing",
+        include_qc=True,
+        include_w=False,
+        run_id="run-w-missing",
+    )
+
+    qc_missing = field_catalog(settings_qc_missing, result_id_qc_missing)
+    w_missing = field_catalog(settings_w_missing, result_id_w_missing)
+
+    assert "qc" not in {field.raw_field_name for field in qc_missing.available_fields}
+    assert "missing_visualization_field:qc" in qc_missing.caveats
+    assert "w" not in {field.raw_field_name for field in w_missing.available_fields}
+    assert "missing_visualization_field:w" in w_missing.caveats
+
+
+def test_horizontal_qc_slice_uses_json_values_and_counts_non_finite(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    sliced = field_slice(
+        settings,
+        result_id,
+        field="qc",
+        time_index=0,
+        orientation="horizontal",
+        level_index=0,
+    )
+
+    assert sliced.field.raw_field_name == "qc"
+    assert sliced.selection.orientation == "horizontal"
+    assert sliced.selection.selected_dimension == "zh"
+    assert sliced.selection.level_units == "km"
+    assert sliced.selection.level_coordinate_value == 0.4
+    assert sliced.selection.level_meters == 400.0
+    assert sliced.shape == [3, 4]
+    assert sliced.dimension_order == ["yh", "xh"]
+    assert sliced.data_encoding == "json"
+    assert sliced.values[0][0] is None
+    assert sliced.stats.non_finite_count == 1
+    assert sliced.stats.finite_count == 11
+    assert sliced.stats.max == 1.1e-05
+    assert "native_grid_view_no_interpolation" in sliced.caveats
+
+
+def test_vertical_qc_slices_have_stable_shape_and_order(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    vertical_x = field_slice(
+        settings,
+        result_id,
+        field="qc",
+        time_index=0,
+        orientation="vertical_x",
+        level_index=1,
+    )
+    vertical_y = field_slice(
+        settings,
+        result_id,
+        field="qc",
+        time_index=0,
+        orientation="vertical_y",
+        level_index=2,
+    )
+
+    assert vertical_x.selection.selected_dimension == "yh"
+    assert vertical_x.shape == [2, 4]
+    assert vertical_x.dimension_order == ["zh", "xh"]
+    assert vertical_y.selection.selected_dimension == "xh"
+    assert vertical_y.shape == [2, 3]
+    assert vertical_y.dimension_order == ["zh", "yh"]
+
+
+def test_w_slice_uses_native_zf_grid(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    sliced = field_slice(
+        settings,
+        result_id,
+        field="w",
+        time_index=1,
+        orientation="horizontal",
+        level_index=2,
+    )
+
+    assert sliced.field.raw_field_name == "w"
+    assert sliced.field.native_grid == "zf/yh/xh"
+    assert sliced.selection.selected_dimension == "zf"
+    assert sliced.selection.time_seconds == 900.0
+    assert sliced.selection.level_coordinate_value == 0.8
+    assert sliced.selection.level_meters == 800.0
+    assert sliced.shape == [3, 4]
+    assert sliced.stats.min == 60.0
+    assert sliced.stats.max == 71.0
+
+
+@pytest.mark.parametrize(
+    ("query", "message"),
+    [
+        (
+            {"field": "bad", "time_index": 0, "orientation": "horizontal", "level_index": 0},
+            "Unsupported",
+        ),
+        (
+            {"field": "qc", "time_index": 8, "orientation": "horizontal", "level_index": 0},
+            "time_index",
+        ),
+        (
+            {"field": "qc", "time_index": 0, "orientation": "horizontal", "level_index": 8},
+            "level_index",
+        ),
+    ],
+)
+def test_slice_endpoint_reports_clear_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    query: dict[str, str | int],
+    message: str,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+    monkeypatch.setenv("CLOUD_CHAMBER_RUNTIME_HOME", str(settings.runtime_home))
+
+    response = TestClient(app).get(
+        f"/api/results/{result_id}/visualization/slice",
+        params=query,
+    )
+
+    assert response.status_code == 400
+    assert message in response.json()["detail"]
+
+
+def test_visualization_api_returns_field_catalog_and_slice(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+    monkeypatch.setenv("CLOUD_CHAMBER_RUNTIME_HOME", str(settings.runtime_home))
+    client = TestClient(app)
+
+    catalog = client.get(f"/api/results/{result_id}/visualization/fields")
+    sliced = client.get(
+        f"/api/results/{result_id}/visualization/slice",
+        params={
+            "field": "qc",
+            "time_index": 0,
+            "orientation": "horizontal",
+            "level_index": 0,
+            "encoding": "json",
+        },
+    )
+
+    assert catalog.status_code == 200
+    assert catalog.json()["available_fields"][0]["provenance"]["source_model"] == "CM1"
+    assert sliced.status_code == 200
+    payload = sliced.json()
+    assert payload["field"]["canonical_field_name"] == "cloud_water"
+    assert payload["shape"] == [3, 4]
+    assert payload["dimension_order"] == ["yh", "xh"]
+    assert payload["stats"]["finite_count"] == 11
+    assert payload["stats"]["non_finite_count"] == 1

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -296,6 +296,43 @@ NetCDF ingest (#68)
 
 The 3-D viewer should open from saved or ingested results and consume visualization-ready backend data. It should not parse raw NetCDF directly in the browser. Rendering remains a visualizer interpretation of CM1-derived output and must carry source model, run/result, field, processing, and rendering-method provenance.
 
+### Visualization-Ready Field Slices
+
+The backend owns NetCDF/xarray field selection. Browsers should request
+visualization-ready payloads from ingested results instead of opening raw CM1
+NetCDF files.
+
+Implemented MVP endpoints:
+
+- `GET /api/results/{result_id}/visualization/fields`
+- `GET /api/results/{result_id}/visualization/slice`
+
+The field catalog exposes available visualizable fields, starting with `qc`
+and `w` and including `qr` when present. It maps raw CM1 field names to product
+canonical names such as `cloud_water` and `vertical_velocity`, includes native
+dimensions, coordinate names, units, time values, source model/run/result
+provenance, processing method, and rendering method labels.
+
+The slice endpoint returns JSON numeric arrays for the slice-first MVP. It
+supports horizontal slices and vertical `x`/`y` slices on native grids:
+
+- `qc`: `time, zh, yh, xh`
+- `w`: `time, zf, yh, xh`
+
+It does not interpolate staggered fields. Payloads include the selected time,
+orientation, level/index, dimension order, shape, min/max/mean, finite and
+non-finite counts, caveats, and provenance. Non-finite values are represented
+as `null` in JSON arrays and counted in stats.
+
+Vertical coordinate units are preserved. When a vertical coordinate is in
+kilometers, payloads may include a safe meter display conversion while still
+recording the native units and native value.
+
+Future 3-D block data should use JSON metadata plus binary `float32` arrays
+with explicit downsampling/max-voxel controls. That binary block contract should
+build on the same provenance labels and native-grid rules, but it is not needed
+for the first 2-D inspector.
+
 ## Data Flow
 
 ### Create Run
@@ -533,19 +570,24 @@ The practical path before 3-D rendering is to define the visualization-ready dat
 
 ## Visualization Data Strategy
 
-Raw NetCDF is not ideal for direct browser rendering.
+Raw NetCDF is not ideal for direct browser rendering, and the browser should
+not parse raw CM1 output. The local backend should load CM1 NetCDF through
+xarray, select only the requested field/time/slice, and return a bounded,
+provenance-labeled payload.
 
 Recommended staged path:
 
 1. Load/inspect NetCDF in backend.
 2. Extract selected fields and time frames.
-3. Downsample or chunk as needed.
-4. Store browser-friendly arrays.
-5. Load fields into Three.js/WebGL viewer.
+3. Return JSON 2-D slices for the slice-first MVP.
+4. Downsample or chunk as needed for future larger payloads.
+5. Use JSON metadata plus binary `float32` arrays for future 3-D blocks.
+6. Load fields into the 2-D inspector or later Three.js/WebGL viewer.
 
 Potential processed formats:
 
-- JSON metadata + binary float arrays
+- JSON numeric arrays for MVP 2-D slices
+- JSON metadata + binary `float32` arrays for future 3-D blocks
 - Zarr later
 - compressed chunks later
 - PNG/texture stacks for MVP if easier

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -612,6 +612,59 @@ True fly-through or move-through should remain on the roadmap after the MVP. Orb
 
 The browser should not parse raw CM1 NetCDF directly. Backend ingest and visualization-ready preprocessing should provide selected, provenance-labeled fields for inspection and rendering.
 
+## Visualization-Ready Data Contract
+
+The first visualization contract is slice-first and backend-owned. The browser
+does not parse raw NetCDF; it asks the local backend for selected,
+provenance-labeled field metadata and JSON slice payloads from an ingested CM1
+result.
+
+Implemented backend endpoints:
+
+```text
+GET /api/results/{result_id}/visualization/fields
+GET /api/results/{result_id}/visualization/slice
+```
+
+The field catalog supports `qc` and `w` first, with `qr` exposed when present.
+Initial canonical mapping:
+
+```text
+qc   -> cloud_water
+w    -> vertical_velocity
+qr   -> rain_water
+rain -> accumulated_surface_rain
+dbz  -> reflectivity
+```
+
+The slice endpoint supports:
+
+```text
+horizontal: fixed vertical level, y-x plane
+vertical_x: fixed y index, z-x plane
+vertical_y: fixed x index, z-y plane
+```
+
+MVP slices use native CM1 grids and do not interpolate staggered fields:
+
+```text
+qc: time, zh, yh, xh
+w:  time, zf, yh, xh
+```
+
+Every slice payload includes field metadata, selected time/index, shape,
+dimension order, JSON numeric values, min/max/mean, finite/non-finite counts,
+native coordinate units, caveats, and provenance/rendering/processing labels.
+Non-finite values are represented as `null` in JSON.
+
+Vertical coordinate units are preserved. If a vertical coordinate is in
+kilometers, Cloud Chamber may add a meter display value while still returning
+the native coordinate value and native units.
+
+Future 3-D block payloads should use JSON metadata plus binary `float32` arrays
+with max-voxel/downsampling controls. This is a future backend contract, not a
+requirement for the 2-D inspector.
+
 ## Local Data Policy
 
 Do not commit:

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -258,11 +258,11 @@ Deliverables:
 Implementation anchor:
 
 - #31 has been superseded by staged visualizer implementation issues. It captured the right broad goal, but was too large to implement safely as one PR.
-- #72 defines the visualization-ready data contract. The browser should not parse raw NetCDF directly.
-- #73 builds the 2-D field inspection MVP before the full 3-D viewer so field orientation, time indexing, vertical coordinates, scaling, and basic cloud evolution can be checked.
+- #72 defines and implements the backend visualization-ready data contract. The browser should not parse raw NetCDF directly; it should consume fields and JSON slice payloads from backend endpoints. The MVP supports `qc` and `w`, native grids (`zh/yh/xh` for `qc`, `zf/yh/xh` for `w`), provenance/rendering labels, finite/non-finite stats, and vertical unit display metadata without interpolation.
+- #73 builds the 2-D field inspection MVP on top of the #72 fields/slice API before the full 3-D viewer so field orientation, time indexing, vertical coordinates, scaling, and basic cloud evolution can be checked.
 - #77 builds the 3-D scene shell with orbit/pan/zoom, reset camera, time slider, field selector, empty/error states, and provenance/rendering labels.
-- #78 renders the first cloud-water field from visualization-ready data.
-- #79 adds horizontal and vertical slice planes using the same provenance-labeled data path.
+- #78 renders the first cloud-water field from visualization-ready data without reading raw NetCDF in the browser.
+- #79 adds horizontal and vertical slice planes using the same provenance-labeled data path and native-grid caveats.
 
 Recommended implementation order:
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -57,6 +57,14 @@ ingested metadata, listing/getting cards, updating name/tags/notes, saving and
 protecting cards, missing diagnostics, provenance labels, output file summary,
 and serialization round trips. They must not use real CM1 output.
 
+Visualization-ready data contract tests should use tiny synthetic NetCDF
+fixtures and temporary runtime homes only. They should cover the fields endpoint,
+`qc` and `w` availability, missing `qc`/`w`, horizontal and vertical slices,
+native `zh/yh/xh` and `zf/yh/xh` grids, bad field/time/level errors,
+provenance labels, JSON array shape/order, finite and non-finite stats, and
+safe vertical kilometer-to-meter display conversion. They must not implement UI,
+rendering, interpolation, or large-output processing.
+
 CM1 runtime floating-point exception flags such as `IEEE_INVALID_FLAG`, `IEEE_DIVIDE_BY_ZERO`, and `IEEE_OVERFLOW_FLAG` should be preserved as caveats. Automated diagnostics should then check whether target fields contain non-finite values. If `qc`, `w`, and `qr` are finite/usable, diagnostics can complete with the runtime warning still visible. If root-cause investigation requires CM1 source-level debugging, that belongs in a separate issue rather than CI.
 
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.


### PR DESCRIPTION
Closes #72

Summary:
- Added backend visualization-ready field catalog and JSON slice payload contracts for ingested CM1 results.
- Added `GET /api/results/{result_id}/visualization/fields` for available visualizable fields, including `qc` and `w` when present.
- Added `GET /api/results/{result_id}/visualization/slice` for horizontal, `vertical_x`, and `vertical_y` native-grid JSON slices.
- Preserved backend ownership of NetCDF/xarray field selection so the browser does not parse raw CM1 NetCDF.
- Added provenance, processing/rendering labels, native-grid caveats, min/max/mean, finite/non-finite counts, JSON nulls for non-finite values, and safe vertical km-to-meter display metadata.
- Documented slice-first MVP behavior, native-grid/no-interpolation rules, and future binary float32 3-D block direction.

What was intentionally not included:
- No Results Library UI.
- No 2-D inspector UI.
- No 3-D visualizer or rendering code.
- No interpolation of staggered fields.
- No rendering dependencies.
- No large or real CM1 output processing in tests.

Verification:
- `scripts/check.sh` passed.
- Frontend: lint, Vitest, production build passed.
- Backend: ruff format/check, mypy, pytest passed (`111 passed, 1 warning`).
- Script syntax, forbidden tracked artifact checks, and docs/JSON/YAML sanity passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, or generated visualization artifacts were committed.
