### PR TITLE
Build 3-D visualizer scene shell

### DIFF
--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -112,6 +112,7 @@ small {
 .table-panel,
 .notebook-card,
 .field-inspector,
+.visualizer-shell,
 .slice-panel {
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 8px;
@@ -379,6 +380,106 @@ td small {
   padding: 1rem;
 }
 
+.visualizer-shell {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.visualizer-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.6fr);
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.scene-container {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 420px;
+  overflow: hidden;
+  border: 1px solid rgba(171, 215, 214, 0.28);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(116, 172, 194, 0.18), transparent 46%),
+    linear-gradient(0deg, rgba(22, 37, 50, 0.92), rgba(17, 24, 32, 0.82));
+}
+
+.scene-horizon {
+  position: absolute;
+  inset: 30% 0 auto;
+  height: 1px;
+  background: rgba(171, 215, 214, 0.35);
+}
+
+.scene-grid {
+  position: absolute;
+  inset: auto 7% 9%;
+  height: 44%;
+  border: 1px solid rgba(143, 216, 182, 0.28);
+  background:
+    linear-gradient(rgba(143, 216, 182, 0.16) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(143, 216, 182, 0.16) 1px, transparent 1px);
+  background-size: 48px 48px;
+  transform: perspective(720px) rotateX(64deg);
+  transform-origin: center bottom;
+}
+
+.scene-empty-state {
+  position: relative;
+  z-index: 1;
+  width: min(28rem, calc(100% - 2rem));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  padding: 1rem;
+  background: rgba(17, 24, 32, 0.84);
+}
+
+.visualizer-controls {
+  display: grid;
+  align-content: start;
+  gap: 1rem;
+}
+
+.visualizer-controls fieldset {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+  margin: 0;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  padding: 0.9rem;
+}
+
+.visualizer-controls legend {
+  color: #f7fbff;
+  font-weight: 850;
+}
+
+.visualizer-controls label {
+  display: grid;
+  gap: 0.4rem;
+  color: #eff7fa;
+  font-weight: 800;
+}
+
+.segmented-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.segmented-buttons button {
+  background: rgba(255, 255, 255, 0.1);
+  color: #f7fbff;
+}
+
+.segmented-buttons .active-control {
+  background: #91d9b7;
+  color: #102018;
+}
+
 .inspector-controls {
   display: grid;
   grid-template-columns: repeat(5, minmax(150px, 1fr));
@@ -428,6 +529,7 @@ td small {
   .topbar,
   .builder-layout,
   .results-layout,
+  .visualizer-layout,
   .slice-grid,
   .control-row {
     grid-template-columns: 1fr;

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -159,8 +159,17 @@ const missingDiagnosticsCard = {
   },
 };
 
+const emptyVisualizerCard = {
+  ...resultCard,
+  result_id: "result-empty-visualizer",
+  run_id: "dry-run-empty-visualizer",
+  name: "No visual fields",
+  diagnostics_summary: "ingested result with no visualizable fields",
+  caveats: ["missing_visualization_fields"],
+};
+
 const resultsResponse = {
-  results: [resultCard, missingDiagnosticsCard],
+  results: [resultCard, missingDiagnosticsCard, emptyVisualizerCard],
 };
 
 const provenance = {
@@ -227,6 +236,14 @@ const missingFieldCatalogResponse = {
       },
     },
   ],
+};
+
+const emptyFieldCatalogResponse = {
+  ...fieldCatalogResponse,
+  result_id: "result-empty-visualizer",
+  run_id: "dry-run-empty-visualizer",
+  caveats: ["missing_visualization_fields"],
+  available_fields: [],
 };
 
 function sliceResponse({
@@ -313,6 +330,11 @@ beforeEach(() => {
       if (url === "/api/results/result-no-diagnostics/visualization/fields") {
         return Promise.resolve(
           new Response(JSON.stringify(missingFieldCatalogResponse), { status: 200 }),
+        );
+      }
+      if (url === "/api/results/result-empty-visualizer/visualization/fields") {
+        return Promise.resolve(
+          new Response(JSON.stringify(emptyFieldCatalogResponse), { status: 200 }),
         );
       }
       if (url.includes("/visualization/slice")) {
@@ -559,5 +581,57 @@ describe("App", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent("level_index=99 is outside valid range");
     });
+  });
+
+  it("opens the 3-D visualizer scene shell without rendering cloud fields", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open 3-D scene shell" }));
+
+    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
+    await screen.findByText("Scene shell ready");
+    expect(screen.getByLabelText("3-D scene container")).toBeInTheDocument();
+    expect(screen.getByText("Cloud rendering not implemented")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Orbit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pan" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reset camera" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Zoom")).toHaveValue("100");
+    expect(screen.getByLabelText("Field")).toHaveValue("qc");
+    expect(screen.getByLabelText("Time")).toBeInTheDocument();
+    expect(screen.getByText("scene_shell_no_field_rendering")).toBeInTheDocument();
+    expect(screen.getByText("Visualizer interpretation of CM1-derived output")).toBeInTheDocument();
+    expect(screen.getByText("No raw NetCDF parsing in the browser")).toBeInTheDocument();
+  });
+
+  it("updates and resets the 3-D scene shell camera controls", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open 3-D scene shell" }));
+    await screen.findByText("Scene shell ready");
+
+    fireEvent.click(screen.getByRole("button", { name: "Pan" }));
+    fireEvent.change(screen.getByLabelText("Zoom"), { target: { value: "150" } });
+
+    expect(screen.getByText("pan")).toBeInTheDocument();
+    expect(screen.getByText("150%")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset camera" }));
+
+    expect(screen.getByText("orbit")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("handles a 3-D scene shell result with no visualization-ready fields", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "No visual fields" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open 3-D scene shell" }));
+
+    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
+    await screen.findByText("No fields available");
+    expect(
+      screen.getByText("No visualization-ready fields are available for this result."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Cloud rendering not implemented")).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -305,6 +305,7 @@ export function App() {
   const [selectedResultId, setSelectedResultId] = useState<string | null>(null);
   const [resultDraft, setResultDraft] = useState({ name: "", tags: "", notes: "" });
   const [inspectedResultId, setInspectedResultId] = useState<string | null>(null);
+  const [visualizerResultId, setVisualizerResultId] = useState<string | null>(null);
   const [resultsStatus, setResultsStatus] = useState("Loading results...");
   const [status, setStatus] = useState("Loading scenarios...");
   const [error, setError] = useState<string | null>(null);
@@ -600,12 +601,19 @@ export function App() {
             onSubmit={handleResultUpdate}
             onSave={handleResultSave}
             onInspect={() => setInspectedResultId(selectedResult?.result_id ?? null)}
+            onOpenVisualizer={() => setVisualizerResultId(selectedResult?.result_id ?? null)}
           />
         </div>
 
         {inspectedResultId && selectedResult && selectedResult.result_id === inspectedResultId && (
           <FieldInspector result={selectedResult} />
         )}
+
+        {visualizerResultId &&
+          selectedResult &&
+          selectedResult.result_id === visualizerResultId && (
+            <VisualizerSceneShell result={selectedResult} />
+          )}
       </section>
     </main>
   );
@@ -718,6 +726,7 @@ function ResultNotebookCard({
   onSubmit,
   onSave,
   onInspect,
+  onOpenVisualizer,
 }: {
   result: ResultCard | undefined;
   draft: { name: string; tags: string; notes: string };
@@ -725,6 +734,7 @@ function ResultNotebookCard({
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onSave: () => void;
   onInspect: () => void;
+  onOpenVisualizer: () => void;
 }) {
   if (!result) {
     return (
@@ -837,8 +847,206 @@ function ResultNotebookCard({
           <button type="button" onClick={onInspect}>
             Inspect fields
           </button>
+          <button type="button" onClick={onOpenVisualizer}>
+            Open 3-D scene shell
+          </button>
         </div>
       </form>
+    </section>
+  );
+}
+
+function VisualizerSceneShell({ result }: { result: ResultCard }) {
+  const [catalog, setCatalog] = useState<FieldCatalogResponse | null>(null);
+  const [selectedFieldName, setSelectedFieldName] = useState("");
+  const [timeIndex, setTimeIndex] = useState(0);
+  const [cameraMode, setCameraMode] = useState<"orbit" | "pan">("orbit");
+  const [zoom, setZoom] = useState(100);
+  const [sceneStatus, setSceneStatus] = useState("Loading scene data...");
+  const [sceneError, setSceneError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setCatalog(null);
+    setSceneError(null);
+    setSelectedFieldName("");
+    setTimeIndex(0);
+    setCameraMode("orbit");
+    setZoom(100);
+    setSceneStatus("Loading scene data...");
+    fetchVisualizationFields(result.result_id)
+      .then((payload) => {
+        if (!active) return;
+        setCatalog(payload);
+        const firstPreferred =
+          payload.available_fields.find((field) => field.raw_field_name === "qc") ??
+          payload.available_fields[0];
+        setSelectedFieldName(firstPreferred?.raw_field_name ?? "");
+        setSceneStatus(
+          payload.available_fields.length > 0 ? "Scene shell ready" : "No fields available",
+        );
+      })
+      .catch((caught: unknown) => {
+        if (!active) return;
+        setSceneError(caught instanceof Error ? caught.message : "Unable to load scene data.");
+        setSceneStatus("Scene unavailable");
+      });
+    return () => {
+      active = false;
+    };
+  }, [result.result_id]);
+
+  const selectedField = useMemo(
+    () => catalog?.available_fields.find((field) => field.raw_field_name === selectedFieldName),
+    [catalog, selectedFieldName],
+  );
+
+  const timeOptions = selectedField?.time_coordinate_values ?? [];
+  const timeMax = Math.max(0, timeOptions.length - 1);
+  const provenanceLabel =
+    selectedField?.provenance.provenance_label ??
+    catalog?.provenance.provenance_label ??
+    "CM1-derived visualization-ready data; rendering not implemented";
+
+  function resetCamera() {
+    setCameraMode("orbit");
+    setZoom(100);
+  }
+
+  return (
+    <section className="visualizer-shell" aria-labelledby="visualizer-shell-title">
+      <div className="section-heading">
+        <div>
+          <p className="eyebrow">3-D visualizer</p>
+          <h2 id="visualizer-shell-title">Scene shell</h2>
+        </div>
+        <p className="state-chip">{sceneStatus}</p>
+      </div>
+
+      <p>
+        This is the 3-D interaction shell for a CM1-derived result. It does not render cloud water,
+        parse raw NetCDF in the browser, or create synthetic cloud physics.
+      </p>
+
+      {sceneError && <p role="alert">{sceneError}</p>}
+
+      {catalog && catalog.available_fields.length === 0 && (
+        <p role="status">No visualization-ready fields are available for this result.</p>
+      )}
+
+      <div className="visualizer-layout">
+        <div className="scene-container" aria-label="3-D scene container">
+          <div className="scene-horizon" />
+          <div className="scene-grid" />
+          <div className="scene-empty-state">
+            <p className="eyebrow">Rendering placeholder</p>
+            <h3>Cloud rendering not implemented</h3>
+            <p>
+              #78 will render cloud-water from visualization-ready backend data. This shell only
+              establishes the scene, camera, field, time, and provenance structure.
+            </p>
+          </div>
+        </div>
+
+        <aside className="visualizer-controls" aria-label="3-D scene controls">
+          <fieldset>
+            <legend>Camera</legend>
+            <div className="segmented-buttons">
+              <button
+                type="button"
+                className={cameraMode === "orbit" ? "active-control" : ""}
+                onClick={() => setCameraMode("orbit")}
+              >
+                Orbit
+              </button>
+              <button
+                type="button"
+                className={cameraMode === "pan" ? "active-control" : ""}
+                onClick={() => setCameraMode("pan")}
+              >
+                Pan
+              </button>
+            </div>
+            <label htmlFor="scene-zoom">
+              Zoom
+              <input
+                id="scene-zoom"
+                type="range"
+                min={50}
+                max={180}
+                value={zoom}
+                onChange={(event) => setZoom(Number(event.target.value))}
+              />
+            </label>
+            <button type="button" onClick={resetCamera}>
+              Reset camera
+            </button>
+          </fieldset>
+
+          {catalog && selectedField && (
+            <fieldset>
+              <legend>Field and time</legend>
+              <label htmlFor="scene-field">
+                Field
+                <select
+                  id="scene-field"
+                  value={selectedFieldName}
+                  onChange={(event) => {
+                    setSelectedFieldName(event.target.value);
+                    setTimeIndex(0);
+                  }}
+                >
+                  {catalog.available_fields.map((field) => (
+                    <option key={field.raw_field_name} value={field.raw_field_name}>
+                      {field.raw_field_name} - {field.display_name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label htmlFor="scene-time">
+                Time
+                <input
+                  id="scene-time"
+                  type="range"
+                  min={0}
+                  max={timeMax}
+                  value={Math.min(timeIndex, timeMax)}
+                  onChange={(event) => setTimeIndex(Number(event.target.value))}
+                />
+              </label>
+            </fieldset>
+          )}
+
+          <dl className="metric-grid">
+            <Metric label="Run ID" value={result.run_id} />
+            <Metric label="Camera mode" value={cameraMode} />
+            <Metric label="Zoom" value={`${zoom}%`} />
+            <Metric
+              label="Selected time"
+              value={formatTimeValue(timeOptions[Math.min(timeIndex, timeMax)] ?? null)}
+            />
+            <Metric
+              label="Selected field"
+              value={
+                selectedField
+                  ? `${selectedField.raw_field_name} (${selectedField.display_name})`
+                  : "Unavailable"
+              }
+            />
+            <Metric label="Rendering method" value="scene_shell_no_field_rendering" />
+          </dl>
+
+          <section aria-labelledby="visualizer-provenance-title">
+            <h3 id="visualizer-provenance-title">Provenance / rendering labels</h3>
+            <ul className="compact-list">
+              <li>{provenanceLabel}</li>
+              <li>Visualizer interpretation of CM1-derived output</li>
+              <li>No raw NetCDF parsing in the browser</li>
+              <li>No cloud-water rendering in this shell</li>
+            </ul>
+          </section>
+        </aside>
+      </div>
     </section>
   );
 }

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -296,6 +296,23 @@ NetCDF ingest (#68)
 
 The 3-D viewer should open from saved or ingested results and consume visualization-ready backend data. It should not parse raw NetCDF directly in the browser. Rendering remains a visualizer interpretation of CM1-derived output and must carry source model, run/result, field, processing, and rendering-method provenance.
 
+The first 3-D scene shell is the frontend interaction/container layer. It opens
+from a Result Card / Experiment Notebook entry, requests the visualization-ready
+field catalog, and exposes:
+
+- scene container;
+- orbit/pan camera mode shell;
+- zoom control;
+- reset camera action;
+- time slider shell;
+- field selector shell;
+- loading, empty, and error states;
+- provenance and rendering-method labels.
+
+It must not render `qc`, create isosurfaces, draw 3-D slice planes, parse raw
+NetCDF, or invent synthetic cloud physics. Until #78 lands, the scene shell's
+rendering method should remain explicitly labeled as no field rendering.
+
 ### Visualization-Ready Field Slices
 
 The backend owns NetCDF/xarray field selection. Browsers should request

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -175,6 +175,12 @@ Visualization-ready data contract (#72)
 
 Every visualizer stage must preserve provenance labels and make clear that rendered output is an interpretation of CM1-derived data.
 
+The first 3-D scene shell opens from a Result Card / Experiment Notebook entry.
+It provides the scene container, orbit/pan/zoom controls, reset camera, time
+slider shell, field selector shell, loading/empty/error states, and
+provenance/rendering labels. It does not render cloud water, slices, or
+synthetic cloud physics; those belong to later visualizer issues.
+
 ### Workflow 7 — Duplicate / Tweak / Rerun
 
 1. Duplicate previous setup.
@@ -622,6 +628,11 @@ Later:
 True fly-through or move-through should remain on the roadmap after the MVP. Orbit/pan/zoom, reset camera, time replay, slices, field selection, and cloud-water isosurface/opacity approximation are enough for the first visualizer.
 
 The browser should not parse raw CM1 NetCDF directly. Backend ingest and visualization-ready preprocessing should provide selected, provenance-labeled fields for inspection and rendering.
+
+The scene shell is intentionally a container and interaction layer first. It
+should show clearly labeled empty/loading/error states and a rendering-method
+label such as `scene_shell_no_field_rendering` until #78 adds cloud-water
+rendering from visualization-ready data.
 
 ## 2-D Field Inspection MVP
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,7 +20,7 @@ npm run build
 
 The frontend uses TypeScript, React, Vite, Vitest, ESLint, and Prettier. During local development, Vite proxies `/api` requests to `http://127.0.0.1:8000`.
 
-The current first Scenario Builder flow loads Baseline Shallow Cumulus from the backend, shows curated controls and the physical question, requests a dry-run package, and reviews generated files. Preview is explicitly not implemented and not CM1 output. Do not add heavy 3-D rendering dependencies until the visualizer work starts.
+The current first Scenario Builder flow loads Baseline Shallow Cumulus from the backend, shows curated controls and the physical question, requests a dry-run package, and reviews generated files. Preview is explicitly not implemented and not CM1 output. The first 3-D visualizer work is a scene shell only: use existing React/CSS controls, consume visualization-ready backend metadata, and do not add rendering dependencies until a concrete rendering issue requires them.
 
 ## Dev Server Helper
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -261,7 +261,7 @@ Implementation anchor:
 - #31 has been superseded by staged visualizer implementation issues. It captured the right broad goal, but was too large to implement safely as one PR.
 - #72 defines and implements the backend visualization-ready data contract. The browser should not parse raw NetCDF directly; it should consume fields and JSON slice payloads from backend endpoints. The MVP supports `qc` and `w`, native grids (`zh/yh/xh` for `qc`, `zf/yh/xh` for `w`), provenance/rendering labels, finite/non-finite stats, and vertical unit display metadata without interpolation.
 - #73 builds the 2-D field inspection MVP on top of the #72 fields/slice API before the full 3-D viewer so field orientation, time indexing, vertical coordinates, scaling, and basic cloud evolution can be checked. It opens from the Results Library detail, enables field/time selection, shows horizontal and vertical slices, and keeps the browser away from raw NetCDF parsing.
-- #77 builds the 3-D scene shell with orbit/pan/zoom, reset camera, time slider, field selector, empty/error states, and provenance/rendering labels.
+- #77 builds the 3-D scene shell from the Results Library detail: scene container, orbit/pan/zoom controls, reset camera, time slider shell, field selector shell, loading/empty/error states, and provenance/rendering labels. It does not render cloud water, slices, or raw NetCDF data in the browser.
 - #78 renders the first cloud-water field from visualization-ready data without reading raw NetCDF in the browser.
 - #79 adds horizontal and vertical slice planes using the same provenance-labeled data path and native-grid caveats.
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -72,6 +72,14 @@ slice display, units, min/max, finite/non-finite counts, provenance labels,
 missing fields, and bad slice requests. They must not add rendering
 dependencies or test a 3-D scene.
 
+3-D scene shell component tests should also mock the visualization-ready field
+catalog instead of reading NetCDF in the browser. They should cover opening from
+a Result Card, scene container rendering, orbit/pan controls, zoom/reset camera
+controls, time slider shell, field selector shell, provenance/rendering labels,
+and no-field/error states. They must not assert cloud-water rendering,
+isosurfaces, 3-D slice planes, or volumetric effects until the later visualizer
+issues implement those layers.
+
 CM1 runtime floating-point exception flags such as `IEEE_INVALID_FLAG`, `IEEE_DIVIDE_BY_ZERO`, and `IEEE_OVERFLOW_FLAG` should be preserved as caveats. Automated diagnostics should then check whether target fields contain non-finite values. If `qc`, `w`, and `qr` are finite/usable, diagnostics can complete with the runtime warning still visible. If root-cause investigation requires CM1 source-level debugging, that belongs in a separate issue rather than CI.
 
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.


### PR DESCRIPTION
Closes #77

Summary:
- Added a Results Library action to open the first 3-D visualizer scene shell from a selected Result Card / Experiment Notebook entry.
- Added a shell-only 3-D scene container with loading, empty, and error states.
- Added orbit/pan camera mode controls, zoom, reset camera, time slider shell, and field selector shell using the #72 visualization-ready field catalog.
- Added provenance and rendering-method labels that identify the view as a CM1-derived visualization interpretation.
- Added focused frontend tests for scene rendering, camera reset, time/field controls, provenance labels, and no-field state.
- Updated product, architecture, roadmap, development, and testing docs for the staged scene-shell boundary.

What was intentionally not included:
- No cloud-water rendering.
- No isosurfaces, volume ray marching, 3-D slice planes, cinematic lighting, or fly-through mode.
- No raw NetCDF parsing in the browser.
- No new rendering dependencies.
- No generated CM1 output, NetCDF files, runtime files, logs, or visualization artifacts.

Verification:
- `npm --prefix app/frontend test -- --reporter=dot` passed: 12 frontend tests.
- `scripts/check.sh` passed: frontend lint/test/build, backend ruff format/check, mypy, pytest, script syntax, forbidden artifact checks, docs/JSON/YAML sanity.
- Backend pytest result inside `scripts/check.sh`: 111 passed, 1 existing runtime warning.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, or generated visualization artifacts were committed.
