### PR TITLE
Render cloud-water point cloud

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -39,6 +39,7 @@ from cloud_chamber.visualization_data import (
     VisualizationOrientation,
     field_catalog,
     field_slice,
+    point_cloud,
 )
 
 app = FastAPI(
@@ -235,6 +236,34 @@ def get_visualization_slice(
             time_index=time_index,
             orientation=checked_orientation,
             level_index=level_index,
+            encoding="json",
+        )
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except VisualizationDataError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/results/{result_id}/visualization/point-cloud")
+def get_visualization_point_cloud(
+    result_id: str,
+    field: str = "qc",
+    time_index: int = 0,
+    threshold: float = 1e-6,
+    max_points: int = 50_000,
+    encoding: str = "json",
+) -> dict[str, object]:
+    if encoding != "json":
+        raise HTTPException(status_code=400, detail="Only encoding=json is supported.")
+    try:
+        result = point_cloud(
+            load_settings(),
+            result_id,
+            field=field,
+            time_index=time_index,
+            threshold=threshold,
+            max_points=max_points,
             encoding="json",
         )
     except ResultIngestError as exc:

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -8,6 +8,7 @@ CM1 output directly in the browser.
 from __future__ import annotations
 
 import importlib
+import itertools
 import math
 from pathlib import Path
 from typing import Any, Literal
@@ -134,6 +135,43 @@ class SliceResponse(BaseModel):
     caveats: list[str] = Field(default_factory=list)
 
 
+class PointCloudSelectionMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    time_index: int
+    time_seconds: float | None = None
+    threshold: float
+    max_points: int
+
+
+class PointCloudStats(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_count: int
+    returned_count: int
+    min_value: float | None = None
+    max_value: float | None = None
+    downsampled: bool
+    downsample_stride: int
+
+
+class PointCloudResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    run_id: str
+    scenario_id: str
+    field: VisualizableField
+    selection: PointCloudSelectionMetadata
+    coordinate_units: dict[str, str | None] = Field(default_factory=dict)
+    point_order: list[str]
+    points: list[list[float]]
+    stats: PointCloudStats
+    provenance: ProvenancePayload
+    caveats: list[str] = Field(default_factory=list)
+
+
 def field_catalog(settings: CloudChamberSettings, result_id: str) -> FieldCatalogResponse:
     """Return visualizable field metadata for an ingested result."""
     metadata = get_result_metadata(settings, result_id)
@@ -152,6 +190,104 @@ def field_catalog(settings: CloudChamberSettings, result_id: str) -> FieldCatalo
             available_fields=fields,
             provenance=_provenance(metadata),
             caveats=_dedupe(_catalog_caveats(metadata, fields)),
+        )
+    finally:
+        _close_all(close_datasets)
+
+
+def point_cloud(
+    settings: CloudChamberSettings,
+    result_id: str,
+    *,
+    field: str,
+    time_index: int,
+    threshold: float,
+    max_points: int,
+    encoding: VisualizationEncoding = "json",
+) -> PointCloudResponse:
+    """Return thresholded native-grid points for cloud-water visualization."""
+    if encoding != "json":
+        raise VisualizationDataError("Only encoding=json is supported for MVP point clouds.")
+    if field != "qc":
+        raise VisualizationDataError("Only field=qc is supported for MVP cloud-water rendering.")
+    if not math.isfinite(threshold) or threshold < 0:
+        raise VisualizationDataError("threshold must be a finite non-negative number.")
+    if max_points <= 0:
+        raise VisualizationDataError("max_points must be greater than 0.")
+
+    metadata = get_result_metadata(settings, result_id)
+    dataset, close_datasets = _open_dataset_sequence(metadata)
+    try:
+        if field not in dataset.data_vars:
+            raise VisualizationDataError("Cloud water field qc is not available for this result.")
+        data_array = dataset[field]
+        dims = _field_dimensions(data_array)
+        if not dims.time:
+            raise VisualizationDataError("Field qc has no time dimension.")
+        if not dims.vertical or not dims.y or not dims.x:
+            raise VisualizationDataError("Field qc must have native vertical/y/x dimensions.")
+        _validate_index(time_index, int(data_array.sizes[dims.time]), "time_index")
+        at_time = data_array.isel({dims.time: time_index})
+        source_points = _threshold_points(
+            at_time,
+            dims=dims,
+            dataset=dataset,
+            threshold=threshold,
+        )
+        source_count = len(source_points)
+        stride = max(1, math.ceil(source_count / max_points)) if source_count else 1
+        returned_points = source_points[::stride][:max_points]
+        values = [point[3] for point in source_points]
+        visual_field = _visualizable_field(metadata, dataset, field)
+        caveats = _dedupe(
+            [
+                *_field_caveats(field, visual_field.coordinate_names),
+                "native_grid_thresholded_point_cloud",
+                "visualizer_interpretation_of_cm1_qc",
+                *(
+                    ["deterministic_stride_downsampling_applied"]
+                    if source_count > max_points
+                    else []
+                ),
+            ]
+        )
+        return PointCloudResponse(
+            result_id=metadata.result_id,
+            run_id=metadata.run_id,
+            scenario_id=metadata.scenario_id,
+            field=visual_field,
+            selection=PointCloudSelectionMetadata(
+                field=field,
+                time_index=time_index,
+                time_seconds=_time_value_seconds(dataset, dims.time, time_index),
+                threshold=threshold,
+                max_points=max_points,
+            ),
+            coordinate_units={
+                str(dims.x): _coordinate_units(dataset, dims.x),
+                str(dims.y): _coordinate_units(dataset, dims.y),
+                str(dims.vertical): _coordinate_units(dataset, dims.vertical),
+            },
+            point_order=["x", "y", "z", "value"],
+            points=returned_points,
+            stats=PointCloudStats(
+                source_count=source_count,
+                returned_count=len(returned_points),
+                min_value=min(values) if values else None,
+                max_value=max(values) if values else None,
+                downsampled=source_count > max_points,
+                downsample_stride=stride,
+            ),
+            provenance=_provenance(
+                metadata,
+                processing_method="backend_xarray_native_grid_threshold",
+                rendering_method="thresholded_point_cloud",
+                provenance_label=(
+                    "CM1-derived cloud-water point cloud; native-grid threshold; "
+                    "visualizer interpretation"
+                ),
+            ),
+            caveats=caveats,
         )
     finally:
         _close_all(close_datasets)
@@ -351,6 +487,57 @@ def _slice_spatial_array(
     return data_array.isel({selected_dimension: level_index}), selected_dimension
 
 
+def _threshold_points(
+    data_array: Any,
+    *,
+    dims: _FieldDimensions,
+    dataset: Any,
+    threshold: float,
+) -> list[list[float]]:
+    if not dims.vertical or not dims.y or not dims.x:
+        return []
+    points: list[list[float]] = []
+    values = data_array.values
+    z_values = _coordinate_values(dataset, dims.vertical)
+    y_values = _coordinate_values(dataset, dims.y)
+    x_values = _coordinate_values(dataset, dims.x)
+    vertical_axis = data_array.dims.index(dims.vertical)
+    y_axis = data_array.dims.index(dims.y)
+    x_axis = data_array.dims.index(dims.x)
+
+    # Iterate in native array order so stride downsampling is deterministic.
+    for native_index in itertools.product(*(range(int(size)) for size in data_array.shape)):
+        raw_value = values[native_index]
+        try:
+            numeric = float(raw_value)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(numeric) or numeric < threshold:
+            continue
+        z_index = native_index[vertical_axis]
+        y_index = native_index[y_axis]
+        x_index = native_index[x_axis]
+        points.append(
+            [
+                _coordinate_number(x_values, x_index),
+                _coordinate_number(y_values, y_index),
+                _coordinate_number(z_values, z_index),
+                numeric,
+            ]
+        )
+    return points
+
+
+def _coordinate_number(values: list[float | str | None], index: int) -> float:
+    if index < len(values):
+        try:
+            value = values[index]
+            return float(value) if value is not None else float(index)
+        except (TypeError, ValueError):
+            return float(index)
+    return float(index)
+
+
 def _validate_index(index: int, size: int, label: str) -> None:
     if index < 0 or index >= size:
         raise VisualizationDataError(f"{label}={index} is outside valid range 0..{size - 1}.")
@@ -384,7 +571,15 @@ def _field_caveats(field_name: str, coordinates: FieldCoordinateMetadata) -> lis
     return caveats
 
 
-def _provenance(metadata: ResultMetadata) -> ProvenancePayload:
+def _provenance(
+    metadata: ResultMetadata,
+    *,
+    processing_method: str = "backend_xarray_native_grid_slice",
+    rendering_method: str = "json_2d_slice_for_inspection",
+    provenance_label: str = (
+        "CM1-derived visualization-ready data; native-grid view; no interpolation"
+    ),
+) -> ProvenancePayload:
     return ProvenancePayload(
         source_model=metadata.source_model,
         result_id=metadata.result_id,
@@ -392,9 +587,9 @@ def _provenance(metadata: ResultMetadata) -> ProvenancePayload:
         scenario_id=metadata.scenario_id,
         source_product_state=metadata.source_product_state,
         result_state=metadata.result_state,
-        processing_method="backend_xarray_native_grid_slice",
-        rendering_method="json_2d_slice_for_inspection",
-        provenance_label="CM1-derived visualization-ready data; native-grid view; no interpolation",
+        processing_method=processing_method,
+        rendering_method=rendering_method,
+        provenance_label=provenance_label,
     )
 
 

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -18,7 +18,12 @@ from cloud_chamber.run_manifest import (
     write_run_manifest,
 )
 from cloud_chamber.settings import CloudChamberSettings
-from cloud_chamber.visualization_data import field_catalog, field_slice
+from cloud_chamber.visualization_data import (
+    VisualizationDataError,
+    field_catalog,
+    field_slice,
+    point_cloud,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
@@ -226,6 +231,145 @@ def test_w_slice_uses_native_zf_grid(tmp_path: Path) -> None:
     assert sliced.shape == [3, 4]
     assert sliced.stats.min == 60.0
     assert sliced.stats.max == 71.0
+
+
+def test_point_cloud_returns_qc_points_above_threshold(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    cloud = point_cloud(
+        settings,
+        result_id,
+        field="qc",
+        time_index=0,
+        threshold=1e-6,
+        max_points=50_000,
+    )
+
+    assert cloud.field.raw_field_name == "qc"
+    assert cloud.field.canonical_field_name == "cloud_water"
+    assert cloud.selection.threshold == 1e-6
+    assert cloud.selection.time_seconds == 0.0
+    assert cloud.point_order == ["x", "y", "z", "value"]
+    assert cloud.coordinate_units == {"xh": "km", "yh": "km", "zh": "km"}
+    assert cloud.stats.source_count == 23
+    assert cloud.stats.returned_count == 23
+    assert cloud.stats.downsampled is False
+    assert cloud.stats.min_value == 1e-6
+    assert cloud.stats.max_value == 2.3e-05
+    assert cloud.points[0] == [1.0, 0.0, 0.4, 1e-6]
+    assert cloud.provenance.processing_method == "backend_xarray_native_grid_threshold"
+    assert cloud.provenance.rendering_method == "thresholded_point_cloud"
+    assert "native_grid_thresholded_point_cloud" in cloud.caveats
+
+
+def test_point_cloud_reports_no_points_above_threshold(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    cloud = point_cloud(
+        settings,
+        result_id,
+        field="qc",
+        time_index=0,
+        threshold=1.0,
+        max_points=50_000,
+    )
+
+    assert cloud.points == []
+    assert cloud.stats.source_count == 0
+    assert cloud.stats.returned_count == 0
+    assert cloud.stats.min_value is None
+    assert cloud.stats.max_value is None
+
+
+def test_point_cloud_missing_qc_reports_clear_error(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(
+        tmp_path,
+        include_qc=False,
+        include_w=True,
+    )
+
+    with pytest.raises(VisualizationDataError, match="qc is not available"):
+        point_cloud(
+            settings,
+            result_id,
+            field="qc",
+            time_index=0,
+            threshold=1e-6,
+            max_points=50_000,
+        )
+
+
+@pytest.mark.parametrize(
+    ("time_index", "threshold", "max_points", "message"),
+    [
+        (8, 1e-6, 50_000, "time_index"),
+        (0, -1.0, 50_000, "threshold"),
+        (0, float("nan"), 50_000, "threshold"),
+        (0, 1e-6, 0, "max_points"),
+    ],
+)
+def test_point_cloud_validates_query_values(
+    tmp_path: Path,
+    time_index: int,
+    threshold: float,
+    max_points: int,
+    message: str,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    with pytest.raises(VisualizationDataError, match=message):
+        point_cloud(
+            settings,
+            result_id,
+            field="qc",
+            time_index=time_index,
+            threshold=threshold,
+            max_points=max_points,
+        )
+
+
+def test_point_cloud_uses_deterministic_stride_downsampling(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    cloud = point_cloud(
+        settings,
+        result_id,
+        field="qc",
+        time_index=0,
+        threshold=1e-6,
+        max_points=5,
+    )
+
+    assert cloud.stats.source_count == 23
+    assert cloud.stats.returned_count == 5
+    assert cloud.stats.downsampled is True
+    assert cloud.stats.downsample_stride == 5
+    assert [point[3] for point in cloud.points] == [1e-6, 6e-6, 1.1e-05, 1.6e-05, 2.1e-05]
+    assert "deterministic_stride_downsampling_applied" in cloud.caveats
+
+
+def test_point_cloud_endpoint_returns_payload_and_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+    monkeypatch.setenv("CLOUD_CHAMBER_RUNTIME_HOME", str(settings.runtime_home))
+    client = TestClient(app)
+
+    ok = client.get(
+        f"/api/results/{result_id}/visualization/point-cloud",
+        params={"field": "qc", "time_index": 0, "threshold": 1e-6, "max_points": 5},
+    )
+    bad = client.get(
+        f"/api/results/{result_id}/visualization/point-cloud",
+        params={"field": "w", "time_index": 0, "threshold": 1e-6, "max_points": 5},
+    )
+
+    assert ok.status_code == 200
+    assert ok.json()["stats"]["downsampled"] is True
+    assert ok.json()["provenance"]["rendering_method"] == "thresholded_point_cloud"
+    assert bad.status_code == 400
+    assert "Only field=qc" in bad.json()["detail"]
 
 
 @pytest.mark.parametrize(

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -426,9 +426,24 @@ td small {
   transform-origin: center bottom;
 }
 
+.point-cloud-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.cloud-point {
+  position: absolute;
+  display: block;
+  border-radius: 999px;
+  box-shadow:
+    0 0 10px rgba(220, 250, 255, 0.72),
+    0 0 22px rgba(143, 216, 182, 0.32);
+}
+
 .scene-empty-state {
   position: relative;
-  z-index: 1;
+  z-index: 2;
   width: min(28rem, calc(100% - 2rem));
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 8px;

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -310,6 +310,59 @@ function sliceResponse({
   };
 }
 
+function pointCloudResponse({
+  threshold = 0.000001,
+  timeIndex = 0,
+  points,
+}: {
+  threshold?: number;
+  timeIndex?: number;
+  points?: Array<[number, number, number, number]>;
+} = {}) {
+  const returnedPoints =
+    points ??
+    (threshold >= 1
+      ? []
+      : [
+          [0, 0, 0.8, 0.000002],
+          [1, 1, 0.8, 0.000006],
+          [2, 1, 1.2, 0.000008],
+        ]);
+  const values = returnedPoints.map((point) => point[3]);
+  return {
+    result_id: "result-dry-run-quicklook",
+    run_id: "dry-run-quicklook",
+    scenario_id: "baseline-shallow-cumulus",
+    field: fieldCatalogResponse.available_fields[0],
+    selection: {
+      field: "qc",
+      time_index: timeIndex,
+      time_seconds: timeIndex === 0 ? 0 : 900,
+      threshold,
+      max_points: 50000,
+    },
+    coordinate_units: { xh: "km", yh: "km", zh: "km" },
+    point_order: ["x", "y", "z", "value"],
+    points: returnedPoints,
+    stats: {
+      source_count: returnedPoints.length,
+      returned_count: returnedPoints.length,
+      min_value: values.length ? Math.min(...values) : null,
+      max_value: values.length ? Math.max(...values) : null,
+      downsampled: false,
+      downsample_stride: 1,
+    },
+    provenance: {
+      ...provenance,
+      processing_method: "backend_xarray_native_grid_threshold",
+      rendering_method: "thresholded_point_cloud",
+      provenance_label:
+        "CM1-derived cloud-water point cloud; native-grid threshold; visualizer interpretation",
+    },
+    caveats: ["native_grid_thresholded_point_cloud", "visualizer_interpretation_of_cm1_qc"],
+  };
+}
+
 beforeEach(() => {
   vi.stubGlobal(
     "fetch",
@@ -335,6 +388,20 @@ beforeEach(() => {
       if (url === "/api/results/result-empty-visualizer/visualization/fields") {
         return Promise.resolve(
           new Response(JSON.stringify(emptyFieldCatalogResponse), { status: 200 }),
+        );
+      }
+      if (url.includes("/visualization/point-cloud")) {
+        const parsed = new URL(url, "http://localhost");
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              pointCloudResponse({
+                threshold: Number(parsed.searchParams.get("threshold") ?? 0.000001),
+                timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
+              }),
+            ),
+            { status: 200 },
+          ),
         );
       }
       if (url.includes("/visualization/slice")) {
@@ -428,7 +495,11 @@ describe("App", () => {
   it("requests a dry-run package and displays generated files without claiming CM1 ran", async () => {
     render(<App />);
 
-    fireEvent.change(await screen.findByLabelText("Low-level humidity"), {
+    const humidityControl = await screen.findByLabelText("Low-level humidity");
+    await waitFor(() => {
+      expect(humidityControl).toHaveValue("baseline");
+    });
+    fireEvent.change(humidityControl, {
       target: { value: "more_humid" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Create dry-run package" }));
@@ -477,7 +548,11 @@ describe("App", () => {
   it("supports name tag notes editing and save through the backend API", async () => {
     render(<App />);
 
-    fireEvent.change(await screen.findByLabelText("Name"), {
+    const nameInput = await screen.findByLabelText("Name");
+    await waitFor(() => {
+      expect(nameInput).toHaveValue("Quick-look shallow cumulus");
+    });
+    fireEvent.change(nameInput, {
       target: { value: "Saved notebook entry" },
     });
     fireEvent.change(screen.getByLabelText("Tags"), {
@@ -583,23 +658,29 @@ describe("App", () => {
     });
   });
 
-  it("opens the 3-D visualizer scene shell without rendering cloud fields", async () => {
+  it("renders cloud-water point cloud in the 3-D visualizer", async () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Open 3-D scene shell" }));
 
     expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
-    await screen.findByText("Scene shell ready");
+    await screen.findByText("Cloud-water point cloud loaded");
     expect(screen.getByLabelText("3-D scene container")).toBeInTheDocument();
-    expect(screen.getByText("Cloud rendering not implemented")).toBeInTheDocument();
+    expect(screen.getByLabelText("Cloud-water point cloud")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Orbit" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Pan" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Reset camera" })).toBeInTheDocument();
     expect(screen.getByLabelText("Zoom")).toHaveValue("100");
     expect(screen.getByLabelText("Field")).toHaveValue("qc");
     expect(screen.getByLabelText("Time")).toBeInTheDocument();
-    expect(screen.getByText("scene_shell_no_field_rendering")).toBeInTheDocument();
+    expect(screen.getByText("thresholded_point_cloud")).toBeInTheDocument();
+    expect(screen.getByText("3 of 3")).toBeInTheDocument();
+    expect(screen.getByText("2.000e-6 kg/kg to 8.000e-6 kg/kg")).toBeInTheDocument();
     expect(screen.getByText("Visualizer interpretation of CM1-derived output")).toBeInTheDocument();
+    expect(
+      screen.getByText("Processing method: native-grid thresholded point cloud"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Rendering method: thresholded point cloud")).toBeInTheDocument();
     expect(screen.getByText("No raw NetCDF parsing in the browser")).toBeInTheDocument();
   });
 
@@ -607,7 +688,7 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Open 3-D scene shell" }));
-    await screen.findByText("Scene shell ready");
+    await screen.findByText("Cloud-water point cloud loaded");
 
     fireEvent.click(screen.getByRole("button", { name: "Pan" }));
     fireEvent.change(screen.getByLabelText("Zoom"), { target: { value: "150" } });
@@ -621,6 +702,46 @@ describe("App", () => {
     expect(screen.getByText("100%")).toBeInTheDocument();
   });
 
+  it("updates cloud-water threshold opacity point size and time requests", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open 3-D scene shell" }));
+    await screen.findByText("Cloud-water point cloud loaded");
+
+    fireEvent.change(screen.getByLabelText("Threshold"), { target: { value: "1" } });
+
+    await screen.findByText("No cloud water above threshold");
+    expect(
+      screen.getByText("No cloud water above the selected threshold at this time."),
+    ).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("threshold=1"));
+
+    fireEvent.change(screen.getByLabelText("Opacity"), { target: { value: "0.8" } });
+    fireEvent.change(screen.getByLabelText("Point size"), { target: { value: "14" } });
+    fireEvent.change(screen.getByLabelText("Time"), { target: { value: "1" } });
+
+    expect(screen.getByText("0.8")).toBeInTheDocument();
+    expect(screen.getByText("14px")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining("time_index=1"));
+    });
+  });
+
+  it("handles missing qc in the 3-D point-cloud renderer", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "No diagnostics yet" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open 3-D scene shell" }));
+
+    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
+    await screen.findByText("Scene shell ready");
+    expect(
+      screen.getByText("Cloud water field qc is not available for this result."),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Field")).toHaveValue("w");
+    expect(screen.getByLabelText("Threshold")).toBeDisabled();
+  });
+
   it("handles a 3-D scene shell result with no visualization-ready fields", async () => {
     render(<App />);
 
@@ -632,6 +753,8 @@ describe("App", () => {
     expect(
       screen.getByText("No visualization-ready fields are available for this result."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Cloud rendering not implemented")).toBeInTheDocument();
+    expect(
+      screen.getByText("Cloud water field qc is not available for this result."),
+    ).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import type { FormEvent } from "react";
+import type { CSSProperties, FormEvent } from "react";
 
 import "./App.css";
 
@@ -196,6 +196,33 @@ type SliceResponse = {
   caveats: string[];
 };
 
+type PointCloudResponse = {
+  result_id: string;
+  run_id: string;
+  scenario_id: string;
+  field: VisualizableField;
+  selection: {
+    field: string;
+    time_index: number;
+    time_seconds: number | null;
+    threshold: number;
+    max_points: number;
+  };
+  coordinate_units: Record<string, string | null>;
+  point_order: string[];
+  points: Array<[number, number, number, number]>;
+  stats: {
+    source_count: number;
+    returned_count: number;
+    min_value: number | null;
+    max_value: number | null;
+    downsampled: boolean;
+    downsample_stride: number;
+  };
+  provenance: ProvenancePayload;
+  caveats: string[];
+};
+
 async function fetchScenarioCatalog(): Promise<ScenarioResponse> {
   const response = await fetch("/api/scenarios");
   if (!response.ok) {
@@ -284,6 +311,29 @@ async function fetchVisualizationSlice(
     throw new Error(await responseError(response, "Unable to load visualization slice."));
   }
   return response.json() as Promise<SliceResponse>;
+}
+
+async function fetchVisualizationPointCloud(
+  resultId: string,
+  params: {
+    field: string;
+    timeIndex: number;
+    threshold: number;
+    maxPoints: number;
+  },
+): Promise<PointCloudResponse> {
+  const search = new URLSearchParams({
+    field: params.field,
+    time_index: String(params.timeIndex),
+    threshold: String(params.threshold),
+    max_points: String(params.maxPoints),
+    encoding: "json",
+  });
+  const response = await fetch(`/api/results/${resultId}/visualization/point-cloud?${search}`);
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to load cloud-water point cloud."));
+  }
+  return response.json() as Promise<PointCloudResponse>;
 }
 
 async function responseError(response: Response, fallback: string): Promise<string> {
@@ -862,8 +912,14 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const [timeIndex, setTimeIndex] = useState(0);
   const [cameraMode, setCameraMode] = useState<"orbit" | "pan">("orbit");
   const [zoom, setZoom] = useState(100);
+  const [threshold, setThreshold] = useState(1e-6);
+  const [opacity, setOpacity] = useState(0.45);
+  const [pointSize, setPointSize] = useState(8);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [pointCloud, setPointCloud] = useState<PointCloudResponse | null>(null);
   const [sceneStatus, setSceneStatus] = useState("Loading scene data...");
   const [sceneError, setSceneError] = useState<string | null>(null);
+  const maxPoints = 50_000;
 
   useEffect(() => {
     let active = true;
@@ -873,6 +929,11 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setTimeIndex(0);
     setCameraMode("orbit");
     setZoom(100);
+    setThreshold(1e-6);
+    setOpacity(0.45);
+    setPointSize(8);
+    setIsPlaying(false);
+    setPointCloud(null);
     setSceneStatus("Loading scene data...");
     fetchVisualizationFields(result.result_id)
       .then((payload) => {
@@ -900,13 +961,63 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     () => catalog?.available_fields.find((field) => field.raw_field_name === selectedFieldName),
     [catalog, selectedFieldName],
   );
+  const qcField = useMemo(
+    () => catalog?.available_fields.find((field) => field.raw_field_name === "qc"),
+    [catalog],
+  );
 
   const timeOptions = selectedField?.time_coordinate_values ?? [];
   const timeMax = Math.max(0, timeOptions.length - 1);
+  const canRenderCloudWater = selectedFieldName === "qc" && Boolean(qcField);
   const provenanceLabel =
+    pointCloud?.provenance.provenance_label ??
     selectedField?.provenance.provenance_label ??
     catalog?.provenance.provenance_label ??
     "CM1-derived visualization-ready data; rendering not implemented";
+
+  useEffect(() => {
+    if (!selectedField || selectedField.raw_field_name !== "qc") {
+      setPointCloud(null);
+      return;
+    }
+    let active = true;
+    setSceneError(null);
+    setSceneStatus("Loading cloud-water points...");
+    fetchVisualizationPointCloud(result.result_id, {
+      field: "qc",
+      timeIndex,
+      threshold,
+      maxPoints,
+    })
+      .then((payload) => {
+        if (!active) return;
+        setPointCloud(payload);
+        setSceneStatus(
+          payload.points.length > 0
+            ? "Cloud-water point cloud loaded"
+            : "No cloud water above threshold",
+        );
+      })
+      .catch((caught: unknown) => {
+        if (!active) return;
+        setPointCloud(null);
+        setSceneError(
+          caught instanceof Error ? caught.message : "Unable to load cloud-water point cloud.",
+        );
+        setSceneStatus("Point cloud unavailable");
+      });
+    return () => {
+      active = false;
+    };
+  }, [maxPoints, result.result_id, selectedField, threshold, timeIndex]);
+
+  useEffect(() => {
+    if (!isPlaying || timeMax <= 0) return;
+    const interval = window.setInterval(() => {
+      setTimeIndex((current) => (current >= timeMax ? 0 : current + 1));
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [isPlaying, timeMax]);
 
   function resetCamera() {
     setCameraMode("orbit");
@@ -924,8 +1035,8 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
       </div>
 
       <p>
-        This is the 3-D interaction shell for a CM1-derived result. It does not render cloud water,
-        parse raw NetCDF in the browser, or create synthetic cloud physics.
+        This is a thresholded point-cloud interpretation of CM1 cloud water. The browser is not
+        parsing raw NetCDF, and the points use native-grid qc values without interpolation.
       </p>
 
       {sceneError && <p role="alert">{sceneError}</p>}
@@ -938,14 +1049,37 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
         <div className="scene-container" aria-label="3-D scene container">
           <div className="scene-horizon" />
           <div className="scene-grid" />
-          <div className="scene-empty-state">
-            <p className="eyebrow">Rendering placeholder</p>
-            <h3>Cloud rendering not implemented</h3>
-            <p>
-              #78 will render cloud-water from visualization-ready backend data. This shell only
-              establishes the scene, camera, field, time, and provenance structure.
-            </p>
-          </div>
+          {pointCloud && pointCloud.points.length > 0 && (
+            <div className="point-cloud-layer" aria-label="Cloud-water point cloud">
+              {pointCloud.points.map((point, index) => (
+                <span
+                  className="cloud-point"
+                  key={`${point.join("-")}-${index}`}
+                  style={cloudPointStyle(
+                    point,
+                    pointCloud.points,
+                    pointCloud.stats,
+                    opacity,
+                    pointSize,
+                  )}
+                />
+              ))}
+            </div>
+          )}
+          {(!pointCloud || pointCloud.points.length === 0) && (
+            <div className="scene-empty-state">
+              <p className="eyebrow">Cloud-water point cloud</p>
+              <h3>
+                {!qcField
+                  ? "Cloud water field qc is not available for this result."
+                  : "No cloud water above the selected threshold at this time."}
+              </h3>
+              <p>
+                Adjust the time or threshold after qc is available. Rendering remains an
+                interpretation of CM1-derived data.
+              </p>
+            </div>
+          )}
         </div>
 
         <aside className="visualizer-controls" aria-label="3-D scene controls">
@@ -1014,6 +1148,51 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                   onChange={(event) => setTimeIndex(Number(event.target.value))}
                 />
               </label>
+              <button type="button" onClick={() => setIsPlaying((current) => !current)}>
+                {isPlaying ? "Pause time" : "Play time"}
+              </button>
+            </fieldset>
+          )}
+
+          {catalog && selectedField && (
+            <fieldset>
+              <legend>Cloud-water rendering</legend>
+              <label htmlFor="cloud-threshold">
+                Threshold
+                <input
+                  id="cloud-threshold"
+                  type="number"
+                  min={0}
+                  step="0.000001"
+                  value={threshold}
+                  onChange={(event) => setThreshold(Number(event.target.value))}
+                  disabled={!canRenderCloudWater}
+                />
+              </label>
+              <label htmlFor="cloud-opacity">
+                Opacity
+                <input
+                  id="cloud-opacity"
+                  type="range"
+                  min={0.1}
+                  max={1}
+                  step={0.05}
+                  value={opacity}
+                  onChange={(event) => setOpacity(Number(event.target.value))}
+                />
+              </label>
+              <label htmlFor="cloud-point-size">
+                Point size
+                <input
+                  id="cloud-point-size"
+                  type="range"
+                  min={3}
+                  max={18}
+                  value={pointSize}
+                  onChange={(event) => setPointSize(Number(event.target.value))}
+                />
+              </label>
+              <p>Default max points: {maxPoints.toLocaleString()}</p>
             </fieldset>
           )}
 
@@ -1021,6 +1200,8 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
             <Metric label="Run ID" value={result.run_id} />
             <Metric label="Camera mode" value={cameraMode} />
             <Metric label="Zoom" value={`${zoom}%`} />
+            <Metric label="Opacity" value={String(opacity)} />
+            <Metric label="Point size" value={`${pointSize}px`} />
             <Metric
               label="Selected time"
               value={formatTimeValue(timeOptions[Math.min(timeIndex, timeMax)] ?? null)}
@@ -1033,16 +1214,47 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                   : "Unavailable"
               }
             />
-            <Metric label="Rendering method" value="scene_shell_no_field_rendering" />
+            <Metric label="Threshold" value={formatScientific(threshold, "kg/kg")} />
+            <Metric label="Rendering method" value="thresholded_point_cloud" />
+            <Metric
+              label="Points"
+              value={
+                pointCloud
+                  ? `${pointCloud.stats.returned_count.toLocaleString()} of ${pointCloud.stats.source_count.toLocaleString()}`
+                  : "Unavailable"
+              }
+            />
+            <Metric
+              label="Cloud-water range"
+              value={
+                pointCloud
+                  ? `${formatMaybeNumber(pointCloud.stats.min_value, selectedField?.units ?? "kg/kg")} to ${formatMaybeNumber(
+                      pointCloud.stats.max_value,
+                      selectedField?.units ?? "kg/kg",
+                    )}`
+                  : "Unavailable"
+              }
+            />
           </dl>
+
+          {pointCloud?.stats.downsampled && (
+            <p role="status">
+              Point cloud downsampled with deterministic stride {pointCloud.stats.downsample_stride}
+              .
+            </p>
+          )}
 
           <section aria-labelledby="visualizer-provenance-title">
             <h3 id="visualizer-provenance-title">Provenance / rendering labels</h3>
             <ul className="compact-list">
               <li>{provenanceLabel}</li>
               <li>Visualizer interpretation of CM1-derived output</li>
+              <li>Processing method: native-grid thresholded point cloud</li>
+              <li>Rendering method: thresholded point cloud</li>
               <li>No raw NetCDF parsing in the browser</li>
-              <li>No cloud-water rendering in this shell</li>
+              <li>
+                No interpolation, ray marching, isosurface extraction, or synthetic cloud physics
+              </li>
             </ul>
           </section>
         </aside>
@@ -1378,6 +1590,36 @@ function formatTimeValue(value: number | string | null): string {
   if (value === null) return "Time unavailable";
   if (typeof value === "number") return `${value.toLocaleString()} s`;
   return value;
+}
+
+function cloudPointStyle(
+  point: [number, number, number, number],
+  points: Array<[number, number, number, number]>,
+  stats: PointCloudResponse["stats"],
+  opacity: number,
+  pointSize: number,
+): CSSProperties {
+  const xs = points.map((candidate) => candidate[0]);
+  const ys = points.map((candidate) => candidate[1]);
+  const zs = points.map((candidate) => candidate[2]);
+  const x = normalize(point[0], Math.min(...xs), Math.max(...xs));
+  const y = normalize(point[1], Math.min(...ys), Math.max(...ys));
+  const z = normalize(point[2], Math.min(...zs), Math.max(...zs));
+  const intensity = normalize(point[3], stats.min_value ?? point[3], stats.max_value ?? point[3]);
+  return {
+    left: `${12 + x * 76}%`,
+    bottom: `${16 + y * 44}%`,
+    width: `${pointSize}px`,
+    height: `${pointSize}px`,
+    opacity,
+    transform: `translate(-50%, 50%) translateY(${-z * 92}px) scale(${0.8 + intensity * 0.75})`,
+    background: `rgba(229, 250, 255, ${0.44 + intensity * 0.46})`,
+  };
+}
+
+function normalize(value: number, min: number, max: number): number {
+  if (max <= min) return 0.5;
+  return (value - min) / (max - min);
 }
 
 function formatDate(value: string | null): string {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -309,9 +309,23 @@ field catalog, and exposes:
 - loading, empty, and error states;
 - provenance and rendering-method labels.
 
-It must not render `qc`, create isosurfaces, draw 3-D slice planes, parse raw
-NetCDF, or invent synthetic cloud physics. Until #78 lands, the scene shell's
-rendering method should remain explicitly labeled as no field rendering.
+Cloud-water rendering starts as a thresholded point cloud for `qc`, not an
+isosurface or volume renderer. The backend owns field selection and thresholding
+through:
+
+- `GET /api/results/{result_id}/visualization/point-cloud`
+
+The point-cloud endpoint reads the selected NetCDF output time, uses native
+`zh/yh/xh` coordinates for `qc`, returns `[x, y, z, value]` points where `qc`
+meets the requested threshold, and records source count, returned count,
+min/max value, downsampling status, coordinate units, and provenance. If source
+points exceed `max_points`, the backend applies deterministic stride
+downsampling and labels it. The frontend renders only the returned
+visualization-ready points and must label the result as a CM1-derived
+interpretation.
+
+It must not create isosurfaces, draw 3-D slice planes, parse raw NetCDF in the
+browser, interpolate native grids, ray march, or invent synthetic cloud physics.
 
 ### Visualization-Ready Field Slices
 
@@ -323,6 +337,7 @@ Implemented MVP endpoints:
 
 - `GET /api/results/{result_id}/visualization/fields`
 - `GET /api/results/{result_id}/visualization/slice`
+- `GET /api/results/{result_id}/visualization/point-cloud`
 
 The field catalog exposes available visualizable fields, starting with `qc`
 and `w` and including `qr` when present. It maps raw CM1 field names to product

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -613,7 +613,8 @@ MVP visualizer work should be staged:
 1. Visualization-ready backend data contract.
 2. 2-D field inspection for orientation, time indexing, scaling, and field availability.
 3. 3-D scene shell with orbit/pan/zoom, reset camera, time slider, field selector, and provenance/rendering labels.
-4. Cloud-water rendering MVP for `qc` using visualization-ready data.
+4. Cloud-water rendering MVP for `qc` using a thresholded point cloud from
+   visualization-ready data.
 5. Horizontal and vertical slice planes for `qc` and `w`.
 
 Later:
@@ -629,10 +630,14 @@ True fly-through or move-through should remain on the roadmap after the MVP. Orb
 
 The browser should not parse raw CM1 NetCDF directly. Backend ingest and visualization-ready preprocessing should provide selected, provenance-labeled fields for inspection and rendering.
 
-The scene shell is intentionally a container and interaction layer first. It
-should show clearly labeled empty/loading/error states and a rendering-method
-label such as `scene_shell_no_field_rendering` until #78 adds cloud-water
-rendering from visualization-ready data.
+The first cloud-water renderer uses a thresholded point cloud. The backend
+selects `qc` at a chosen output time, keeps native `zh/yh/xh` grid coordinates,
+returns points where `qc >= 1e-6 kg/kg` by default, and deterministically
+downsamples if needed. The browser renders those returned points only; it does
+not parse raw NetCDF, interpolate, run marching cubes, extract isosurfaces, ray
+march, or invent cloud physics. The rendering method should be labeled
+`thresholded_point_cloud`, and the processing method should identify the native
+grid threshold operation.
 
 ## 2-D Field Inspection MVP
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -262,7 +262,7 @@ Implementation anchor:
 - #72 defines and implements the backend visualization-ready data contract. The browser should not parse raw NetCDF directly; it should consume fields and JSON slice payloads from backend endpoints. The MVP supports `qc` and `w`, native grids (`zh/yh/xh` for `qc`, `zf/yh/xh` for `w`), provenance/rendering labels, finite/non-finite stats, and vertical unit display metadata without interpolation.
 - #73 builds the 2-D field inspection MVP on top of the #72 fields/slice API before the full 3-D viewer so field orientation, time indexing, vertical coordinates, scaling, and basic cloud evolution can be checked. It opens from the Results Library detail, enables field/time selection, shows horizontal and vertical slices, and keeps the browser away from raw NetCDF parsing.
 - #77 builds the 3-D scene shell from the Results Library detail: scene container, orbit/pan/zoom controls, reset camera, time slider shell, field selector shell, loading/empty/error states, and provenance/rendering labels. It does not render cloud water, slices, or raw NetCDF data in the browser.
-- #78 renders the first cloud-water field from visualization-ready data without reading raw NetCDF in the browser.
+- #78 renders the first cloud-water field from visualization-ready data as a thresholded `qc` point cloud. The backend selects native-grid points and the browser renders only that payload; no raw NetCDF parsing, interpolation, isosurface extraction, ray marching, or cinematic lighting belongs in this step.
 - #79 adds horizontal and vertical slice planes using the same provenance-labeled data path and native-grid caveats.
 
 Recommended implementation order:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -80,6 +80,17 @@ and no-field/error states. They must not assert cloud-water rendering,
 isosurfaces, 3-D slice planes, or volumetric effects until the later visualizer
 issues implement those layers.
 
+Cloud-water point-cloud tests should use tiny synthetic NetCDF fixtures on the
+backend and mocked visualization-ready point payloads on the frontend. Backend
+tests should cover `qc` points above threshold, no points above threshold,
+missing `qc`, bad time/threshold/max-point inputs, deterministic stride
+downsampling, stats, coordinate units, and provenance labels. Frontend tests
+should cover rendered point-cloud state, missing `qc`, no-cloud-above-threshold
+state, threshold/time/opacity/point-size controls, provenance/rendering labels,
+and the guarantee that the browser does not parse raw NetCDF. These tests must
+not add ray marching, isosurfaces, shadows, fly-through, export, or generated
+CM1 output.
+
 CM1 runtime floating-point exception flags such as `IEEE_INVALID_FLAG`, `IEEE_DIVIDE_BY_ZERO`, and `IEEE_OVERFLOW_FLAG` should be preserved as caveats. Automated diagnostics should then check whether target fields contain non-finite values. If `qc`, `w`, and `qr` are finite/usable, diagnostics can complete with the runtime warning still visible. If root-cause investigation requires CM1 source-level debugging, that belongs in a separate issue rather than CI.
 
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.


### PR DESCRIPTION
Closes #78

Summary:
- Added a backend visualization-ready `point-cloud` endpoint for thresholded native-grid `qc` cloud-water points.
- Returned `[x, y, z, value]` points with coordinate units, threshold, source/returned counts, min/max values, deterministic stride downsampling metadata, and provenance/rendering labels.
- Updated the 3-D visualizer scene shell to render the returned cloud-water point cloud with threshold, opacity, point-size, time, playback, and reset-camera controls.
- Added empty/error handling for missing `qc`, no points above threshold, invalid requests, and downsampled point clouds.
- Added backend tests with tiny synthetic NetCDF fixtures and frontend tests with mocked visualization-ready point payloads.
- Updated docs for the thresholded point-cloud rendering decision and non-goals.

What was intentionally not included:
- No marching cubes, isosurface extraction, voxel cube mesh, ray marching, volumetric renderer, shadows, cinematic lighting, fly-through, or export.
- No arbitrary field rendering beyond `qc` cloud water.
- No raw NetCDF parsing in the browser.
- No generated CM1 output, NetCDF files, runtime files, logs, validation reports, or visualization artifacts.

Verification:
- `npm --prefix app/frontend test -- --reporter=dot` passed: 14 frontend tests.
- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_visualization_data.py -q` passed: 18 backend visualization tests, 1 existing NumPy runtime warning.
- `scripts/check.sh` passed: frontend lint/test/build, backend ruff format/check, mypy, pytest, script syntax, forbidden artifact checks, docs/JSON/YAML sanity.
- Backend pytest result inside `scripts/check.sh`: 120 passed, 1 existing runtime warning.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, or generated visualization artifacts were committed.
