### PR TITLE
Add 3-D visualizer slice planes

### DIFF
--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -441,6 +441,48 @@ td small {
     0 0 22px rgba(143, 216, 182, 0.32);
 }
 
+.slice-plane {
+  position: absolute;
+  z-index: 1;
+  display: grid;
+  gap: 0.35rem;
+  width: min(38%, 17rem);
+  border: 1px solid rgba(216, 255, 240, 0.34);
+  border-radius: 8px;
+  padding: 0.45rem;
+  background: rgba(17, 24, 32, 0.68);
+  box-shadow: 0 0 28px rgba(78, 164, 206, 0.18);
+}
+
+.slice-plane-horizontal {
+  right: 10%;
+  bottom: 14%;
+  transform: perspective(720px) rotateX(62deg);
+}
+
+.slice-plane-vertical {
+  left: 10%;
+  top: 22%;
+  transform: perspective(720px) rotateY(-34deg);
+}
+
+.slice-plane-label {
+  color: #f7fbff;
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+.slice-plane-cells {
+  display: grid;
+  gap: 2px;
+}
+
+.slice-plane-cell {
+  aspect-ratio: 1;
+  min-width: 0.45rem;
+  border-radius: 2px;
+}
+
 .scene-empty-state {
   position: relative;
   z-index: 2;
@@ -477,6 +519,20 @@ td small {
   gap: 0.4rem;
   color: #eff7fa;
   font-weight: 800;
+}
+
+.slice-plane-summary {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.slice-plane-card {
+  display: grid;
+  gap: 0.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .segmented-buttons {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -667,13 +667,19 @@ describe("App", () => {
     await screen.findByText("Cloud-water point cloud loaded");
     expect(screen.getByLabelText("3-D scene container")).toBeInTheDocument();
     expect(screen.getByLabelText("Cloud-water point cloud")).toBeInTheDocument();
+    expect(screen.getAllByLabelText("Horizontal slice plane").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Vertical slice plane").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Orbit" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Pan" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Reset camera" })).toBeInTheDocument();
     expect(screen.getByLabelText("Zoom")).toHaveValue("100");
     expect(screen.getByLabelText("Field")).toHaveValue("qc");
+    expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
     expect(screen.getByLabelText("Time")).toBeInTheDocument();
     expect(screen.getByText("thresholded_point_cloud")).toBeInTheDocument();
+    expect(
+      screen.getByText("Slice planes: native-grid JSON slices from the backend"),
+    ).toBeInTheDocument();
     expect(screen.getByText("3 of 3")).toBeInTheDocument();
     expect(screen.getByText("2.000e-6 kg/kg to 8.000e-6 kg/kg")).toBeInTheDocument();
     expect(screen.getByText("Visualizer interpretation of CM1-derived output")).toBeInTheDocument();
@@ -682,6 +688,31 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Rendering method: thresholded point cloud")).toBeInTheDocument();
     expect(screen.getByText("No raw NetCDF parsing in the browser")).toBeInTheDocument();
+  });
+
+  it("supports qc and w slice planes synced to visualizer time", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open 3-D scene shell" }));
+    await screen.findByText("Cloud-water point cloud loaded");
+
+    expect(screen.getAllByText("Horizontal slice plane").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Vertical slice plane").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("qc (Cloud water)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("native_grid_view_no_interpolation").length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getByLabelText("Slice field"), { target: { value: "w" } });
+    fireEvent.change(screen.getByLabelText("Time"), { target: { value: "1" } });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("w (Vertical velocity)").length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText("900 s").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("6.5 m/s").length).toBeGreaterThan(0);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/results/result-dry-run-quicklook/visualization/slice?field=w"),
+    );
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("time_index=1"));
   });
 
   it("updates and resets the 3-D scene shell camera controls", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -917,8 +917,17 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const [pointSize, setPointSize] = useState(8);
   const [isPlaying, setIsPlaying] = useState(false);
   const [pointCloud, setPointCloud] = useState<PointCloudResponse | null>(null);
+  const [sliceFieldName, setSliceFieldName] = useState("qc");
+  const [sliceOrientation, setSliceOrientation] = useState<"vertical_x" | "vertical_y">(
+    "vertical_x",
+  );
+  const [horizontalSliceLevel, setHorizontalSliceLevel] = useState(0);
+  const [verticalSliceIndex, setVerticalSliceIndex] = useState(0);
+  const [sceneHorizontalSlice, setSceneHorizontalSlice] = useState<SliceResponse | null>(null);
+  const [sceneVerticalSlice, setSceneVerticalSlice] = useState<SliceResponse | null>(null);
   const [sceneStatus, setSceneStatus] = useState("Loading scene data...");
   const [sceneError, setSceneError] = useState<string | null>(null);
+  const [sliceError, setSliceError] = useState<string | null>(null);
   const maxPoints = 50_000;
 
   useEffect(() => {
@@ -934,6 +943,13 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setPointSize(8);
     setIsPlaying(false);
     setPointCloud(null);
+    setSliceFieldName("qc");
+    setSliceOrientation("vertical_x");
+    setHorizontalSliceLevel(0);
+    setVerticalSliceIndex(0);
+    setSceneHorizontalSlice(null);
+    setSceneVerticalSlice(null);
+    setSliceError(null);
     setSceneStatus("Loading scene data...");
     fetchVisualizationFields(result.result_id)
       .then((payload) => {
@@ -943,6 +959,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
           payload.available_fields.find((field) => field.raw_field_name === "qc") ??
           payload.available_fields[0];
         setSelectedFieldName(firstPreferred?.raw_field_name ?? "");
+        setSliceFieldName(firstPreferred?.raw_field_name ?? "");
         setSceneStatus(
           payload.available_fields.length > 0 ? "Scene shell ready" : "No fields available",
         );
@@ -965,10 +982,24 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     () => catalog?.available_fields.find((field) => field.raw_field_name === "qc"),
     [catalog],
   );
+  const sliceField = useMemo(
+    () => catalog?.available_fields.find((field) => field.raw_field_name === sliceFieldName),
+    [catalog, sliceFieldName],
+  );
 
   const timeOptions = selectedField?.time_coordinate_values ?? [];
   const timeMax = Math.max(0, timeOptions.length - 1);
   const canRenderCloudWater = selectedFieldName === "qc" && Boolean(qcField);
+  const sliceVerticalSize = sliceField?.coordinate_names.vertical
+    ? sliceField.shape[sliceField.dimensions.indexOf(sliceField.coordinate_names.vertical)]
+    : 1;
+  const sliceYSize = sliceField?.coordinate_names.y
+    ? sliceField.shape[sliceField.dimensions.indexOf(sliceField.coordinate_names.y)]
+    : 1;
+  const sliceXSize = sliceField?.coordinate_names.x
+    ? sliceField.shape[sliceField.dimensions.indexOf(sliceField.coordinate_names.x)]
+    : 1;
+  const verticalSliceMax = sliceOrientation === "vertical_x" ? sliceYSize : sliceXSize;
   const provenanceLabel =
     pointCloud?.provenance.provenance_label ??
     selectedField?.provenance.provenance_label ??
@@ -1012,6 +1043,51 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   }, [maxPoints, result.result_id, selectedField, threshold, timeIndex]);
 
   useEffect(() => {
+    if (!sliceField) {
+      setSceneHorizontalSlice(null);
+      setSceneVerticalSlice(null);
+      return;
+    }
+    let active = true;
+    setSliceError(null);
+    Promise.all([
+      fetchVisualizationSlice(result.result_id, {
+        field: sliceField.raw_field_name,
+        timeIndex,
+        orientation: "horizontal",
+        levelIndex: horizontalSliceLevel,
+      }),
+      fetchVisualizationSlice(result.result_id, {
+        field: sliceField.raw_field_name,
+        timeIndex,
+        orientation: sliceOrientation,
+        levelIndex: verticalSliceIndex,
+      }),
+    ])
+      .then(([horizontal, vertical]) => {
+        if (!active) return;
+        setSceneHorizontalSlice(horizontal);
+        setSceneVerticalSlice(vertical);
+      })
+      .catch((caught: unknown) => {
+        if (!active) return;
+        setSceneHorizontalSlice(null);
+        setSceneVerticalSlice(null);
+        setSliceError(caught instanceof Error ? caught.message : "Unable to load slice planes.");
+      });
+    return () => {
+      active = false;
+    };
+  }, [
+    horizontalSliceLevel,
+    result.result_id,
+    sliceField,
+    sliceOrientation,
+    timeIndex,
+    verticalSliceIndex,
+  ]);
+
+  useEffect(() => {
     if (!isPlaying || timeMax <= 0) return;
     const interval = window.setInterval(() => {
       setTimeIndex((current) => (current >= timeMax ? 0 : current + 1));
@@ -1049,6 +1125,8 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
         <div className="scene-container" aria-label="3-D scene container">
           <div className="scene-horizon" />
           <div className="scene-grid" />
+          <SlicePlane title="Horizontal slice plane" slice={sceneHorizontalSlice} />
+          <SlicePlane title="Vertical slice plane" slice={sceneVerticalSlice} />
           {pointCloud && pointCloud.points.length > 0 && (
             <div className="point-cloud-layer" aria-label="Cloud-water point cloud">
               {pointCloud.points.map((point, index) => (
@@ -1196,6 +1274,69 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
             </fieldset>
           )}
 
+          {catalog && sliceField && (
+            <fieldset>
+              <legend>Slice planes</legend>
+              <label htmlFor="slice-field">
+                Slice field
+                <select
+                  id="slice-field"
+                  value={sliceFieldName}
+                  onChange={(event) => {
+                    setSliceFieldName(event.target.value);
+                    setHorizontalSliceLevel(0);
+                    setVerticalSliceIndex(0);
+                  }}
+                >
+                  {catalog.available_fields
+                    .filter(
+                      (field) => field.raw_field_name === "qc" || field.raw_field_name === "w",
+                    )
+                    .map((field) => (
+                      <option key={field.raw_field_name} value={field.raw_field_name}>
+                        {field.raw_field_name} - {field.display_name}
+                      </option>
+                    ))}
+                </select>
+              </label>
+              <label htmlFor="scene-horizontal-level">
+                Horizontal slice level
+                <input
+                  id="scene-horizontal-level"
+                  type="number"
+                  min={0}
+                  max={Math.max(0, sliceVerticalSize - 1)}
+                  value={horizontalSliceLevel}
+                  onChange={(event) => setHorizontalSliceLevel(Number(event.target.value))}
+                />
+              </label>
+              <label htmlFor="scene-vertical-orientation">
+                Vertical orientation
+                <select
+                  id="scene-vertical-orientation"
+                  value={sliceOrientation}
+                  onChange={(event) =>
+                    setSliceOrientation(event.target.value as "vertical_x" | "vertical_y")
+                  }
+                >
+                  <option value="vertical_x">vertical_x</option>
+                  <option value="vertical_y">vertical_y</option>
+                </select>
+              </label>
+              <label htmlFor="scene-vertical-index">
+                Vertical slice index
+                <input
+                  id="scene-vertical-index"
+                  type="number"
+                  min={0}
+                  max={Math.max(0, verticalSliceMax - 1)}
+                  value={verticalSliceIndex}
+                  onChange={(event) => setVerticalSliceIndex(Number(event.target.value))}
+                />
+              </label>
+            </fieldset>
+          )}
+
           <dl className="metric-grid">
             <Metric label="Run ID" value={result.run_id} />
             <Metric label="Camera mode" value={cameraMode} />
@@ -1216,6 +1357,22 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
             />
             <Metric label="Threshold" value={formatScientific(threshold, "kg/kg")} />
             <Metric label="Rendering method" value="thresholded_point_cloud" />
+            <Metric
+              label="Slice field"
+              value={
+                sliceField
+                  ? `${sliceField.raw_field_name} (${sliceField.display_name})`
+                  : "Unavailable"
+              }
+            />
+            <Metric
+              label="Slice orientation"
+              value={
+                sceneVerticalSlice
+                  ? `${sceneVerticalSlice.selection.orientation} at ${sceneVerticalSlice.selection.selected_dimension}[${sceneVerticalSlice.selection.selected_index}]`
+                  : "Unavailable"
+              }
+            />
             <Metric
               label="Points"
               value={
@@ -1243,6 +1400,12 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
               .
             </p>
           )}
+          {sliceError && <p role="alert">{sliceError}</p>}
+
+          <div className="slice-plane-summary">
+            <SceneSliceSummary title="Horizontal slice plane" slice={sceneHorizontalSlice} />
+            <SceneSliceSummary title="Vertical slice plane" slice={sceneVerticalSlice} />
+          </div>
 
           <section aria-labelledby="visualizer-provenance-title">
             <h3 id="visualizer-provenance-title">Provenance / rendering labels</h3>
@@ -1251,6 +1414,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
               <li>Visualizer interpretation of CM1-derived output</li>
               <li>Processing method: native-grid thresholded point cloud</li>
               <li>Rendering method: thresholded point cloud</li>
+              <li>Slice planes: native-grid JSON slices from the backend</li>
               <li>No raw NetCDF parsing in the browser</li>
               <li>
                 No interpolation, ray marching, isosurface extraction, or synthetic cloud physics
@@ -1259,6 +1423,83 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
           </section>
         </aside>
       </div>
+    </section>
+  );
+}
+
+function SlicePlane({ title, slice }: { title: string; slice: SliceResponse | null }) {
+  if (!slice) return null;
+  const cells = slice.values.flat();
+  return (
+    <div
+      className={
+        slice.selection.orientation === "horizontal"
+          ? "slice-plane slice-plane-horizontal"
+          : "slice-plane slice-plane-vertical"
+      }
+      aria-label={title}
+    >
+      <span className="slice-plane-label">
+        {slice.field.raw_field_name} {slice.selection.orientation}
+      </span>
+      <div
+        className="slice-plane-cells"
+        style={{ gridTemplateColumns: `repeat(${slice.values[0]?.length ?? 1}, minmax(0, 1fr))` }}
+      >
+        {cells.map((value, index) => (
+          <span
+            className="slice-plane-cell"
+            key={`${title}-${index}`}
+            style={sliceCellStyle(value, slice.stats)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SceneSliceSummary({ title, slice }: { title: string; slice: SliceResponse | null }) {
+  if (!slice) {
+    return (
+      <section className="slice-plane-card" aria-label={title}>
+        <h3>{title}</h3>
+        <p>Slice unavailable.</p>
+      </section>
+    );
+  }
+  const selected = `${slice.selection.selected_dimension}[${slice.selection.selected_index}]`;
+  const coordinate =
+    slice.selection.level_coordinate_value !== null
+      ? ` (${slice.selection.level_coordinate_value} ${slice.selection.level_units ?? ""}${
+          slice.selection.level_meters !== null
+            ? ` / ${slice.selection.level_meters.toLocaleString()} m`
+            : ""
+        })`
+      : "";
+  return (
+    <section className="slice-plane-card" aria-label={title}>
+      <h3>{title}</h3>
+      <dl className="metric-grid">
+        <Metric
+          label="Field"
+          value={`${slice.field.raw_field_name} (${slice.field.display_name})`}
+        />
+        <Metric label="Units" value={slice.field.units ?? "Units unavailable"} />
+        <Metric label="Time" value={formatSeconds(slice.selection.time_seconds)} />
+        <Metric label="Location" value={`${selected}${coordinate}`} />
+        <Metric label="Min" value={formatMaybeNumber(slice.stats.min, slice.field.units)} />
+        <Metric label="Max" value={formatMaybeNumber(slice.stats.max, slice.field.units)} />
+        <Metric label="Dimensions" value={slice.dimension_order.join(", ")} />
+        <Metric label="Rendering method" value={slice.provenance.rendering_method} />
+      </dl>
+      <p>{slice.provenance.provenance_label}</p>
+      {slice.caveats.length > 0 && (
+        <ul className="compact-list">
+          {slice.caveats.map((caveat) => (
+            <li key={`${title}-${caveat}`}>{caveat}</li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }
@@ -1620,6 +1861,16 @@ function cloudPointStyle(
 function normalize(value: number, min: number, max: number): number {
   if (max <= min) return 0.5;
   return (value - min) / (max - min);
+}
+
+function sliceCellStyle(value: number | null, stats: SliceResponse["stats"]): CSSProperties {
+  if (value === null) {
+    return { background: "rgba(255, 255, 255, 0.12)" };
+  }
+  const intensity = normalize(value, stats.min ?? value, stats.max ?? value);
+  return {
+    background: `rgba(${78 + intensity * 110}, ${164 + intensity * 70}, ${206 + intensity * 40}, 0.72)`,
+  };
 }
 
 function formatDate(value: string | null): string {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -324,8 +324,18 @@ downsampling and labels it. The frontend renders only the returned
 visualization-ready points and must label the result as a CM1-derived
 interpretation.
 
-It must not create isosurfaces, draw 3-D slice planes, parse raw NetCDF in the
-browser, interpolate native grids, ray march, or invent synthetic cloud physics.
+3-D slice planes reuse the same backend slice endpoint as the 2-D inspector:
+
+- horizontal plane: `orientation=horizontal`;
+- vertical plane: `orientation=vertical_x` or `orientation=vertical_y`;
+- fields: `qc` and `w` first;
+- time: synced with the visualizer time state and cloud-water point cloud.
+
+The browser receives JSON slice payloads with field metadata, min/max stats,
+dimension order, selected native-grid location, caveats, and provenance labels.
+The scene may draw simple inspection planes from those payloads, but it must not
+parse raw NetCDF in the browser, interpolate native grids, ray march, or invent
+synthetic cloud physics.
 
 ### Visualization-Ready Field Slices
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -639,6 +639,13 @@ march, or invent cloud physics. The rendering method should be labeled
 `thresholded_point_cloud`, and the processing method should identify the native
 grid threshold operation.
 
+The first 3-D slice planes reuse the #72 JSON slice endpoint. The scene requests
+one horizontal and one vertical native-grid slice for the selected slice field
+(`qc` or `w`) at the same output time as the cloud-water point cloud. The UI
+must show field name, units, selected time, slice location, min/max, native-grid
+caveats, and provenance labels. These planes are inspection overlays, not
+ray-marched volumes or interpolated fields.
+
 ## 2-D Field Inspection MVP
 
 The first inspector opens from a saved or ingested Result Card / Experiment

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -263,7 +263,7 @@ Implementation anchor:
 - #73 builds the 2-D field inspection MVP on top of the #72 fields/slice API before the full 3-D viewer so field orientation, time indexing, vertical coordinates, scaling, and basic cloud evolution can be checked. It opens from the Results Library detail, enables field/time selection, shows horizontal and vertical slices, and keeps the browser away from raw NetCDF parsing.
 - #77 builds the 3-D scene shell from the Results Library detail: scene container, orbit/pan/zoom controls, reset camera, time slider shell, field selector shell, loading/empty/error states, and provenance/rendering labels. It does not render cloud water, slices, or raw NetCDF data in the browser.
 - #78 renders the first cloud-water field from visualization-ready data as a thresholded `qc` point cloud. The backend selects native-grid points and the browser renders only that payload; no raw NetCDF parsing, interpolation, isosurface extraction, ray marching, or cinematic lighting belongs in this step.
-- #79 adds horizontal and vertical slice planes using the same provenance-labeled data path and native-grid caveats.
+- #79 adds horizontal and vertical slice planes using the same provenance-labeled #72 slice API and native-grid caveats. Slice-plane time stays synced with the point cloud, supports `qc` and `w`, and remains an inspection overlay rather than raw NetCDF parsing or volumetric rendering.
 
 Recommended implementation order:
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -91,6 +91,13 @@ and the guarantee that the browser does not parse raw NetCDF. These tests must
 not add ray marching, isosurfaces, shadows, fly-through, export, or generated
 CM1 output.
 
+3-D slice-plane tests should mock the #72 visualization-ready slice API. They
+should cover horizontal and vertical slice planes, `qc` and `w` field selection,
+time synchronization with the 3-D point cloud, native-grid caveats/provenance
+labels, and clear error states for missing fields or bad slice requests. They
+must not parse raw NetCDF in the browser, add rendering dependencies, or test
+ray marching, cinematic lighting, export, fly-through, or generated CM1 output.
+
 CM1 runtime floating-point exception flags such as `IEEE_INVALID_FLAG`, `IEEE_DIVIDE_BY_ZERO`, and `IEEE_OVERFLOW_FLAG` should be preserved as caveats. Automated diagnostics should then check whether target fields contain non-finite values. If `qc`, `w`, and `qr` are finite/usable, diagnostics can complete with the runtime warning still visible. If root-cause investigation requires CM1 source-level debugging, that belongs in a separate issue rather than CI.
 
 Local validation uses `scripts/check.sh` as the canonical gate. CI mirrors it through split equivalent jobs so branch protection can require `Frontend`, `Backend`, and `Scripts and config` independently. Keep the local script and CI jobs in sync as new implemented layers add fast checks.


### PR DESCRIPTION
Closes #79

Summary:
- Added horizontal and vertical native-grid slice planes to the 3-D visualizer scene shell.
- Reused the #72 visualization-ready slice API instead of parsing raw NetCDF in the browser.
- Added `qc` and `w` slice field selection with slice time synchronized to the 3-D point-cloud time control.
- Displayed slice field, units, time, location, min/max, rendering method, native-grid caveats, and provenance labels.
- Updated docs for the 3-D slice-plane path and testing expectations.

What was intentionally not included:
- No raw NetCDF browser parsing.
- No ray marching, isosurfaces, cinematic lighting, export, or fly-through.
- No new rendering dependencies.
- No generated CM1 output or visualization artifacts.

Tests/checks run:
- `npm --prefix app/frontend test -- --reporter=dot` — 15 passed.
- `scripts/check.sh` — passed frontend lint/test/build, backend ruff format/check, mypy, pytest, script checks, forbidden artifact checks, and docs/JSON/YAML sanity.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, or large visualization artifacts were committed.
