### PR TITLE
Plan post-MVP visual polish roadmap

### DIFF
--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -337,6 +337,20 @@ The scene may draw simple inspection planes from those payloads, but it must not
 parse raw NetCDF in the browser, interpolate native grids, ray march, or invent
 synthetic cloud physics.
 
+Post-MVP visual polish is a later rendering layer, not part of the data-source
+contract. Volumetric ray marching, shadows, edge brightening, cloud-base
+darkening, fly-through/move-through camera modes, cinematic export, and
+generated thumbnails should build on the same ingested result and
+visualization-ready data contracts. They must continue to label rendered output
+as an interpretation of CM1-derived data and carry source model, run/result,
+field, processing method, rendering method, and caveats.
+
+Future export artifacts should be treated as local/generated outputs unless a
+specific policy says otherwise. Generated thumbnails, preview frames, videos,
+large processed visualization data, and browser-ready render caches should not
+be committed. If small visual fixtures are needed for tests, they should be
+intentionally tiny and documented separately from real CM1 output.
+
 ### Visualization-Ready Field Slices
 
 The backend owns NetCDF/xarray field selection. Browsers should request

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -625,6 +625,7 @@ Later:
 - cloud-base darkening
 - fly-through
 - cinematic export
+- thumbnails/previews with strict generated-artifact policy
 
 True fly-through or move-through should remain on the roadmap after the MVP. Orbit/pan/zoom, reset camera, time replay, slices, field selection, and cloud-water isosurface/opacity approximation are enough for the first visualizer.
 
@@ -645,6 +646,35 @@ one horizontal and one vertical native-grid slice for the selected slice field
 must show field name, units, selected time, slice location, min/max, native-grid
 caveats, and provenance labels. These planes are inspection overlays, not
 ray-marched volumes or interpolated fields.
+
+### Post-MVP Visual Polish, Fly-Through, and Export
+
+Visual polish is deliberately post-MVP. The first product loop should prove that
+Cloud Chamber can generate CM1 packages, run CM1 locally, ingest results,
+produce diagnostics, save/reopen result cards, inspect fields, and render a
+practical 3-D interpretation. Only after that loop is useful should the
+visualizer pursue cinematic work.
+
+Post-MVP visual work may include:
+
+- volumetric ray marching for cloud-water fields;
+- shadows and simple atmospheric lighting;
+- edge brightening to make cloud boundaries readable;
+- cloud-base darkening to emphasize vertical structure;
+- fly-through / move-through camera modes;
+- cinematic export for short videos or stills;
+- generated thumbnails or previews for saved results.
+
+These features must remain interpretations of CM1-derived data. The UI should
+continue to show the source result, field, units, processing method, rendering
+method, and any caveats. Visual polish must not imply extra model detail,
+interpolate native grids without disclosure, or turn preview imagery into a
+completed CM1 result.
+
+Generated thumbnails, videos, preview frames, and other visual artifacts are
+local/generated outputs by default. They should stay outside git unless a future
+issue defines a tiny fixture or documented artifact policy for tests. Large
+visualization artifacts must not be committed.
 
 ## 2-D Field Inspection MVP
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -264,6 +264,7 @@ Implementation anchor:
 - #77 builds the 3-D scene shell from the Results Library detail: scene container, orbit/pan/zoom controls, reset camera, time slider shell, field selector shell, loading/empty/error states, and provenance/rendering labels. It does not render cloud water, slices, or raw NetCDF data in the browser.
 - #78 renders the first cloud-water field from visualization-ready data as a thresholded `qc` point cloud. The backend selects native-grid points and the browser renders only that payload; no raw NetCDF parsing, interpolation, isosurface extraction, ray marching, or cinematic lighting belongs in this step.
 - #79 adds horizontal and vertical slice planes using the same provenance-labeled #72 slice API and native-grid caveats. Slice-plane time stays synced with the point cloud, supports `qc` and `w`, and remains an inspection overlay rather than raw NetCDF parsing or volumetric rendering.
+- #80 plans visual polish, fly-through/move-through, cinematic export, and thumbnail/preview policy after the practical 3-D MVP. It must not add rendering dependencies or implementation code.
 
 Recommended implementation order:
 
@@ -299,6 +300,10 @@ Deliverables:
 Implementation anchor:
 
 - #80 plans post-MVP visual polish, fly-through/move-through, cinematic export, and generated thumbnail/preview policy. These are later features, not prerequisites for the first inspectable CM1 result loop.
+- Rendering remains an interpretation of CM1-derived data. Future polish must preserve provenance labels for source model, run/result, field, processing method, rendering method, units, and caveats.
+- Candidate post-MVP work includes volumetric ray marching, shadows, edge brightening, cloud-base darkening, fly-through or move-through camera modes, cinematic still/video export, and generated thumbnails/previews for saved results.
+- Generated visual artifacts remain local/generated outputs by default. Do not commit thumbnails, videos, render caches, large processed visualization data, or generated previews unless a future issue defines a strict tiny-fixture policy.
+- M5 should start only after the inspectable result loop is useful: NetCDF ingest, diagnostics, result cards, Results Library UI, visualization-ready data, 2-D field inspection, 3-D scene shell, thresholded cloud-water rendering, and slice planes.
 
 ## Initial Lower-Atmosphere Scenario Set
 


### PR DESCRIPTION
Closes #80

Summary:
- Documented the post-MVP visual polish, fly-through/move-through, and export roadmap in the product spec.
- Clarified in the architecture docs that visual polish builds on ingested results and visualization-ready data contracts.
- Updated the roadmap to position #80 after the practical 3-D MVP loop and preserve provenance/interpretation labels.
- Added generated visual artifact policy language for thumbnails, videos, preview frames, render caches, and other local/generated visualization outputs.

What was intentionally not included:
- No rendering code.
- No new 3-D or export dependencies.
- No fly-through, export, ray marching, shadows, or cinematic lighting implementation.
- No generated CM1 output or generated visualization artifacts.

Tests/checks run:
- `scripts/check.sh` — passed frontend lint/test/build, backend ruff format/check, mypy, pytest, script checks, forbidden artifact checks, and docs/JSON/YAML sanity.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, thumbnails, videos, render caches, or large visualization artifacts were committed.
