### PR TITLE
Improve MVP result inspection UX

### DIFF
--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -484,13 +484,13 @@ details[open] > summary {
   position: relative;
   display: grid;
   place-items: center;
-  min-height: 420px;
+  min-height: 500px;
   overflow: hidden;
   border: 1px solid rgba(171, 215, 214, 0.28);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(116, 172, 194, 0.18), transparent 46%),
-    linear-gradient(0deg, rgba(22, 37, 50, 0.92), rgba(17, 24, 32, 0.82));
+    linear-gradient(180deg, rgba(79, 133, 154, 0.16), transparent 42%),
+    linear-gradient(0deg, rgba(9, 17, 24, 0.98), rgba(11, 18, 25, 0.94));
 }
 
 .scene-horizon {
@@ -524,8 +524,8 @@ details[open] > summary {
   display: block;
   border-radius: 999px;
   box-shadow:
-    0 0 10px rgba(220, 250, 255, 0.72),
-    0 0 22px rgba(143, 216, 182, 0.32);
+    0 0 14px rgba(232, 255, 255, 0.9),
+    0 0 32px rgba(143, 216, 182, 0.46);
 }
 
 .slice-plane {
@@ -533,13 +533,13 @@ details[open] > summary {
   z-index: 1;
   display: grid;
   gap: 0.35rem;
-  width: min(30%, 13rem);
-  border: 1px solid rgba(216, 255, 240, 0.34);
+  width: min(34%, 14rem);
+  border: 1px solid rgba(216, 255, 240, 0.52);
   border-radius: 8px;
   padding: 0.35rem;
-  background: rgba(17, 24, 32, 0.48);
-  box-shadow: 0 0 28px rgba(78, 164, 206, 0.18);
-  opacity: 0.72;
+  background: rgba(10, 18, 25, 0.62);
+  box-shadow: 0 0 30px rgba(78, 164, 206, 0.24);
+  opacity: 0.82;
 }
 
 .slice-plane-horizontal {
@@ -681,6 +681,44 @@ details[open] > summary {
   display: grid;
   gap: 0.25rem;
   overflow-x: auto;
+}
+
+.slice-heatmap {
+  display: grid;
+  gap: 0.25rem;
+  min-height: 13rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  padding: 0.45rem;
+  background: rgba(7, 13, 19, 0.48);
+}
+
+.heatmap-row {
+  display: grid;
+  grid-auto-columns: minmax(1.4rem, 1fr);
+  grid-auto-flow: column;
+  gap: 0.25rem;
+}
+
+.heatmap-cell {
+  min-height: 2rem;
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.heatmap-legend {
+  display: grid;
+  grid-template-columns: auto minmax(5rem, 1fr) auto;
+  gap: 0.55rem;
+  align-items: center;
+  color: #f7fbff;
+  font-size: 0.85rem;
+}
+
+.heatmap-scale {
+  height: 0.7rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #173047, #4ea4ce, #b4efe4);
 }
 
 .slice-row {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -533,6 +533,7 @@ describe("App", () => {
       "Quick-look shallow cumulus",
     );
     expect(screen.getAllByText("Validated quick-look baseline").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Minor caveat").length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: "Open 3-D" }).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Quick-look shallow cumulus" })).toBeInTheDocument();
     expect(screen.getAllByText("Baseline Shallow Cumulus").length).toBeGreaterThan(0);
@@ -625,8 +626,12 @@ describe("App", () => {
     expect(screen.getByText("zh/yh/xh")).toBeInTheDocument();
     expect(screen.getAllByText("Horizontal slice").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Vertical slice").length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Horizontal slice heatmap")).toBeInTheDocument();
+    expect(screen.getByLabelText("Vertical slice heatmap")).toBeInTheDocument();
+    expect(screen.getByLabelText("Horizontal slice color scale")).toBeInTheDocument();
     expect(screen.getAllByText("2.000e-5 kg/kg").length).toBeGreaterThan(0);
     expect(screen.getByText("Selected level: 0.8 km (800 m)")).toBeInTheDocument();
+    expect(screen.getAllByText("Technical slice details").length).toBeGreaterThan(0);
     expect(screen.getAllByText("native_grid_view_no_interpolation").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/CM1-derived visualization-ready data/).length).toBeGreaterThan(0);
   });

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -948,7 +948,9 @@ function ResultsTable({
                     <StatusBadge label="Validated quick-look baseline" tone="good" />
                   )}
                   <StatusBadge label={rainOutcome(result.rain_present)} tone="neutral" />
-                  {result.caveats.length > 0 && <StatusBadge label="Needs review" tone="warning" />}
+                  {result.caveats.length > 0 && (
+                    <StatusBadge label={caveatLabel(result)} tone={caveatTone(result)} />
+                  )}
                 </div>
                 <small>{result.diagnostics_summary ?? "Diagnostics unavailable"}</small>
               </td>
@@ -1008,7 +1010,9 @@ function ResultNotebookCard({
       <div className="badge-row">
         <OutcomeBadge result={result} />
         <StatusBadge label={rainOutcome(result.rain_present)} tone="neutral" />
-        {result.caveats.length > 0 && <StatusBadge label="Needs review" tone="warning" />}
+        {result.caveats.length > 0 && (
+          <StatusBadge label={caveatLabel(result)} tone={caveatTone(result)} />
+        )}
         <StatusBadge label={userFacingStatus(result)} tone={statusTone(result)} />
       </div>
 
@@ -1127,8 +1131,8 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const [cameraMode, setCameraMode] = useState<"orbit" | "pan">("orbit");
   const [zoom, setZoom] = useState(100);
   const [threshold, setThreshold] = useState(1e-6);
-  const [opacity, setOpacity] = useState(0.45);
-  const [pointSize, setPointSize] = useState(8);
+  const [opacity, setOpacity] = useState(0.68);
+  const [pointSize, setPointSize] = useState(11);
   const [isPlaying, setIsPlaying] = useState(false);
   const [pointCloud, setPointCloud] = useState<PointCloudResponse | null>(null);
   const [sliceFieldName, setSliceFieldName] = useState("qc");
@@ -1153,8 +1157,8 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setCameraMode("orbit");
     setZoom(100);
     setThreshold(1e-6);
-    setOpacity(0.45);
-    setPointSize(8);
+    setOpacity(0.68);
+    setPointSize(11);
     setIsPlaying(false);
     setPointCloud(null);
     setSliceFieldName("qc");
@@ -1332,8 +1336,8 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
       </div>
 
       <p>
-        This is a thresholded point-cloud interpretation of CM1 cloud water. The browser is not
-        parsing raw NetCDF, and the points use native-grid qc values without interpolation.
+        This view shows cloud-water points and slice planes prepared from CM1-derived fields. The
+        browser is not parsing raw NetCDF.
       </p>
 
       {sceneError && <p role="alert">{sceneError}</p>}
@@ -2020,26 +2024,58 @@ function SlicePanel({ title, slice }: { title: string; slice: SliceResponse | nu
             : ""}
         </p>
       )}
-      <div className="slice-values" role="table" aria-label={`${title} values`}>
-        {slice.values.map((row, rowIndex) => (
-          <div className="slice-row" role="row" key={`${title}-${rowIndex}`}>
-            {row.map((value, columnIndex) => (
-              <span className="slice-cell" role="cell" key={`${title}-${rowIndex}-${columnIndex}`}>
-                {value === null ? "null" : formatCompactNumber(value)}
-              </span>
-            ))}
-          </div>
-        ))}
+      <SliceHeatmap title={title} slice={slice} />
+      <div className="heatmap-legend" aria-label={`${title} color scale`}>
+        <span>{formatMaybeNumber(slice.stats.min, slice.field.units)}</span>
+        <span className="heatmap-scale" />
+        <span>{formatMaybeNumber(slice.stats.max, slice.field.units)}</span>
       </div>
-      <p>{slice.provenance.provenance_label}</p>
-      {slice.caveats.length > 0 && (
-        <ul className="compact-list">
-          {slice.caveats.map((caveat) => (
-            <li key={caveat}>{caveat}</li>
+      <details>
+        <summary>Technical slice details</summary>
+        <p>{slice.provenance.provenance_label}</p>
+        {slice.caveats.length > 0 && (
+          <ul className="compact-list">
+            {slice.caveats.map((caveat) => (
+              <li key={caveat}>{caveat}</li>
+            ))}
+          </ul>
+        )}
+        <div className="slice-values" role="table" aria-label={`${title} raw values`}>
+          {slice.values.map((row, rowIndex) => (
+            <div className="slice-row" role="row" key={`${title}-${rowIndex}`}>
+              {row.map((value, columnIndex) => (
+                <span
+                  className="slice-cell"
+                  role="cell"
+                  key={`${title}-${rowIndex}-${columnIndex}`}
+                >
+                  {value === null ? "null" : formatCompactNumber(value)}
+                </span>
+              ))}
+            </div>
           ))}
-        </ul>
-      )}
+        </div>
+      </details>
     </section>
+  );
+}
+
+function SliceHeatmap({ title, slice }: { title: string; slice: SliceResponse }) {
+  return (
+    <div className="slice-heatmap" role="img" aria-label={`${title} heatmap`}>
+      {slice.values.map((row, rowIndex) => (
+        <div className="heatmap-row" key={`${title}-heatmap-${rowIndex}`}>
+          {row.map((value, columnIndex) => (
+            <span
+              className="heatmap-cell"
+              key={`${title}-heatmap-${rowIndex}-${columnIndex}`}
+              title={value === null ? "missing" : formatMaybeNumber(value, slice.field.units)}
+              style={sliceCellStyle(value, slice.stats)}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -2205,6 +2241,14 @@ function userFacingStatus(result: ResultCard): string {
   if (result.status.includes("ingested")) return "Ingested";
   if (result.caveats.length > 0) return "Needs review";
   return humanize(result.status);
+}
+
+function caveatLabel(result: ResultCard): string {
+  return cloudOutcome(result) === "Cloud formed" ? "Minor caveat" : "Needs review";
+}
+
+function caveatTone(result: ResultCard): "good" | "warning" | "neutral" {
+  return cloudOutcome(result) === "Cloud formed" ? "neutral" : "warning";
 }
 
 function statusTone(result: ResultCard): "good" | "warning" | "neutral" {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -406,6 +406,12 @@ method, rendering method, and native-grid caveats remain available under
 technical details so scientific honesty is preserved without making the main
 workflow read like a manifest.
 
+Successful cloud-forming results can show `Minor caveat` in the primary UI when
+warnings or coordinate notes exist but the run is still inspectable. `Needs
+review` should be reserved for failed, no-cloud, missing-diagnostics, or
+incomplete states where the result needs closer attention before it is treated
+as a validated learning case.
+
 The first field inspector is a frontend consumer of the visualization-ready
 fields/slice API. It opens from a Result Card / Experiment Notebook entry and
 does not read raw NetCDF or parse CM1 files in the browser.
@@ -418,16 +424,24 @@ The inspector requests:
   `vertical_y` orientation.
 
 It displays field name, units, native grid, selected time, min/max, finite and
-non-finite counts, JSON slice values, caveats, and provenance labels. Errors
-from unavailable fields or invalid slice selections remain UI-level inspection
-errors; they do not alter the underlying result metadata or imply a failed CM1
-run.
+non-finite counts, heatmap slices, caveats, and provenance labels. The raw JSON
+numeric slice values remain available under technical details for audit and
+debugging, but the primary inspection surface should be a readable heatmap.
+Errors from unavailable fields or invalid slice selections remain UI-level
+inspection errors; they do not alter the underlying result metadata or imply a
+failed CM1 run.
 
 The 2-D inspector and 3-D visualizer both choose an initial interesting time
 from result diagnostics: first cloud time when present, otherwise time of max
 cloud water when available, otherwise the latest output time. This prevents the
 validated Baseline Shallow Cumulus quick-look result from opening at an empty
 `t=0` frame when clouds form later.
+
+The 3-D viewer keeps the same data-source contract while improving first-look
+readability: cloud-water points should be visible at the default time, slice
+planes should provide spatial context without overwhelming the point cloud, and
+long provenance/rendering labels should sit in technical details rather than in
+the main scene controls.
 
 This is not a 3-D viewer, replay engine, or rendering pipeline. It is the
 orientation/scaling check that should happen before 3-D visualizer work.

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -584,6 +584,13 @@ attempts. User-facing labels should say `Completed CM1 result`, `Ingested`,
 than leading with raw lifecycle strings. Raw lifecycle/product/provenance labels
 remain available under technical details.
 
+For completed cloud-forming results, minor runtime or coordinate caveats should
+read as caveats, not failed-run warnings. A result can be a successful,
+inspectable CM1 run while still carrying `Minor caveat` details such as
+floating-point flags or vertical-coordinate unit notes. `Needs review` remains
+appropriate for no-cloud, missing-diagnostics, failed, or otherwise incomplete
+results.
+
 The selected result is shared by the Results, Inspect, and Visualize sections.
 Inspect and Visualize should default to an interesting output time: first cloud
 time when available, otherwise time of max cloud water when available, otherwise
@@ -678,6 +685,11 @@ is more useful. Native-grid/no-interpolation caveats and rendering provenance
 must stay available, but long technical labels belong under `About this
 visualization` rather than dominating the primary view.
 
+The first 3-D impression should make the validated quick-look baseline obvious:
+opening from Results should land on the first-cloud time when available, show a
+visible cloud-water point cloud, keep slice planes visible but secondary, and
+place detailed provenance/rendering labels under `About this visualization`.
+
 ### Post-MVP Visual Polish, Fly-Through, and Export
 
 Visual polish is deliberately post-MVP. The first product loop should prove that
@@ -719,8 +731,11 @@ MVP behavior:
   when present;
 - allow field selection and output time selection;
 - request horizontal and vertical slice payloads from the backend;
-- show field units, native grid, selected time, slice shape/dimensions,
-  min/max, finite and non-finite counts, and provenance labels;
+- show heatmaps for horizontal and vertical slices, with field units, native
+  grid, selected time, slice shape/dimensions, min/max, finite and non-finite
+  counts, and provenance labels;
+- keep raw JSON numeric slice values available under technical details rather
+  than making matrix dumps the primary UI;
 - represent missing fields and bad slice requests as UI errors instead of
   crashing;
 - clearly label slices as CM1-derived inspection data, not 3-D rendering.

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -266,6 +266,7 @@ Implementation anchor:
 - #78 renders the first cloud-water field from visualization-ready data as a thresholded `qc` point cloud. The backend selects native-grid points and the browser renders only that payload; no raw NetCDF parsing, interpolation, isosurface extraction, ray marching, or cinematic lighting belongs in this step.
 - #79 adds horizontal and vertical slice planes using the same provenance-labeled #72 slice API and native-grid caveats. Slice-plane time stays synced with the point cloud, supports `qc` and `w`, and remains an inspection overlay rather than raw NetCDF parsing or volumetric rendering.
 - #98 also makes Inspect and Visualize inherit the selected result and default to an interesting time: first cloud when available, otherwise max cloud-water time if available, otherwise latest output. Technical rendering/provenance details stay available but secondary.
+- #100 sharpens the first usable inspection path: Results should surface the validated quick-look baseline, successful cloud-forming runs with caveats should read as `Minor caveat` rather than failed review states, the 2-D inspector should show slice heatmaps before raw matrix values, and the 3-D viewer should open with visible cloud-water points plus readable slice context.
 - #80 plans visual polish, fly-through/move-through, cinematic export, and thumbnail/preview policy after the practical 3-D MVP. It must not add rendering dependencies or implementation code.
 
 Recommended implementation order:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -68,9 +68,9 @@ rendering, interpolation, or large-output processing.
 2-D field inspector component tests should mock the visualization-ready API
 payloads rather than reading NetCDF in the browser. They should cover opening
 from a Result Card, field selection, time selection, horizontal and vertical
-slice display, units, min/max, finite/non-finite counts, provenance labels,
-missing fields, and bad slice requests. They must not add rendering
-dependencies or test a 3-D scene.
+slice heatmaps, units, min/max, finite/non-finite counts, provenance labels,
+raw numeric values under technical details, missing fields, and bad slice
+requests. They must not add rendering dependencies or test a 3-D scene.
 
 Guided workspace tests should cover task navigation across `Build`, `Results`,
 `Inspect`, and `Visualize`; the default `Results` landing state; selected-result
@@ -78,6 +78,8 @@ context flowing into Inspect and Visualize; prioritizing a validated
 cloud-forming quick-look baseline over historical attempts; user-facing status
 labels replacing raw internal lifecycle strings; and technical details keeping
 raw provenance available without dominating the main view.
+They should distinguish successful cloud-forming results with minor caveats
+from results that truly need review.
 
 3-D scene shell component tests should also mock the visualization-ready field
 catalog instead of reading NetCDF in the browser. They should cover opening from
@@ -104,6 +106,10 @@ time synchronization with the 3-D point cloud, native-grid caveats/provenance
 labels, and clear error states for missing fields or bad slice requests. They
 must not parse raw NetCDF in the browser, add rendering dependencies, or test
 ray marching, cinematic lighting, export, fly-through, or generated CM1 output.
+Visual first-impression tests should also keep the validated quick-look baseline
+on a cloud-bearing time, show a visible point-cloud state, show slice planes as
+secondary context, and keep technical provenance reachable without making it the
+primary reading path.
 
 CM1 runtime floating-point exception flags such as `IEEE_INVALID_FLAG`, `IEEE_DIVIDE_BY_ZERO`, and `IEEE_OVERFLOW_FLAG` should be preserved as caveats. Automated diagnostics should then check whether target fields contain non-finite values. If `qc`, `w`, and `qr` are finite/usable, diagnostics can complete with the runtime warning still visible. If root-cause investigation requires CM1 source-level debugging, that belongs in a separate issue rather than CI.
 


### PR DESCRIPTION
Closes #100

Summary:
- Added primary heatmap rendering for horizontal and vertical 2-D Inspect slices while keeping raw numeric slice values in technical details.
- Reframed successful cloud-forming results with warnings as Minor caveat instead of treating them like failed review states.
- Improved the first 3-D Visualize impression with stronger cloud-water point visibility, higher default opacity/point size, darker scene contrast, and clearer slice-plane context.
- Kept provenance, rendering labels, and native-grid caveats available under technical details without moving raw NetCDF parsing into the browser.
- Updated docs for the MVP inspection UX contract.

What was intentionally not included:
- No Results Library backend changes.
- No 2-D inspector backend changes.
- No new 3-D rendering techniques, ray marching, export, fly-through, or rendering dependencies.
- No generated CM1 output or visualization artifacts.

Verification:
- npm --prefix app/frontend test -- --reporter=dot
- scripts/check.sh

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, .dat/.ctl outputs, generated run directories, LANDUSE.TBL, local runtime files, logs, validation reports, or large visualization artifacts were committed.