### PR TITLE
Plan Dry Failed Cumulus scenario path

### DIFF
--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -109,6 +109,23 @@ Run-size presets now vary only runtime timing for this recovered baseline. The s
 
 The first quick-look validation run, `dry-run-quicklook-les-shallowcu-20260522151536`, preserved those settings, completed locally, and ingested 13 model-output time steps over 10800 seconds. Diagnostics still reported cloud formation, vertical motion, and rain, so the architecture can treat this runtime-only quick-look preset as the first validated shorter Baseline Shallow Cumulus variant.
 
+Dry Failed Cumulus should branch from this validated reference-derived family,
+not from the invalid compact quick-look derivative. Architecturally, it is a
+moisture-limited contrast case: preserve the validated grid/domain, surface
+forcing, stress/roughness path, damping, turbulence/SGS settings, boundary
+conditions, NetCDF output, runtime-file staging, and quick-look timing, then
+change only the lower-atmosphere moisture/sounding path once that path has been
+validated. The intended product control is `low-level humidity = drier`; raw
+sounding or namelist edits belong in developer implementation details.
+
+Because the current validated baseline relies on the CM1 `les_ShallowCu`
+reference behavior, the next architecture step is to prove Cloud Chamber can
+reproduce the accepted baseline through an external `input_sounding` path
+without changing the rest of the case. Only after that reproduction succeeds
+should Dry Failed reduce low-level moisture. A run with no cloud and no
+meaningful vertical motion, or no cloud with severe NaN/Infinity caveats, is
+not a valid Dry Failed Cumulus result.
+
 Cloud-scale defaults for the first lower-atmosphere contract are:
 
 ```text

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -309,6 +309,85 @@ The first quick-look Baseline Shallow Cumulus variant is derived from that valid
 
 The first quick-look validation run, `dry-run-quicklook-les-shallowcu-20260522151536`, completed with `exit_code = 0`, produced NetCDF output, and ingested 13 model-output time steps from 0 to 10800 seconds. Package size was 206 MB. First-pass diagnostics reported `cloud formed; rain detected`, first cloud time at 1800 seconds, `max_qc_kg_kg = 0.002192789688706398`, `max_w_m_s = 6.866957187652588`, and `min_w_m_s = -4.21529483795166`. This confirms the shorter runtime/cadence-only quick-look variant still produces cloud and vertical motion while preserving the reference-derived settings.
 
+### Dry Failed Cumulus Planning
+
+Dry Failed Cumulus is the next planned lower-atmosphere contrast case after
+Baseline Shallow Cumulus. It should answer:
+
+```text
+How does insufficient low-level moisture prevent shallow cumulus formation even when boundary-layer thermals and vertical motion are present?
+```
+
+This is a moisture-limited failed-cumulus case. It should not mean a dead
+simulation, a too-stable/capped atmosphere, weak surface forcing, numerical
+failure, or "no cloud" by itself. The target is thermals without meaningful
+cloud.
+
+Teaching contrast:
+
+```text
+Baseline Shallow Cumulus:
+  thermals rise
+  cloud water forms
+  rain may appear
+  qc and w are both visually/scientifically interesting
+
+Dry Failed Cumulus:
+  thermals still rise
+  parcels do not reach enough saturation
+  qc stays below cloud threshold or appears only as trace amounts
+  rain does not appear
+  w remains scientifically meaningful
+```
+
+The MVP product-facing variation should change one physical factor:
+
+```text
+low-level humidity = drier
+```
+
+Other curated controls should stay at the validated baseline for the first
+implementation:
+
+```text
+surface heating = baseline
+cap strength = baseline
+dry air aloft = baseline
+mixing / entrainment = baseline
+```
+
+The diagnostic target is:
+
+```text
+CM1 completes cleanly
+NetCDF output is produced
+full output sequence ingests
+cloud_formed = false
+rain_present = false
+max_qc_kg_kg remains below the 1e-6 kg/kg cloud threshold,
+  or fewer than 10 grid cells exceed threshold
+max_w_m_s is meaningfully nonzero
+min_w_m_s is finite and preferably negative/nonzero
+no severe NaN/Infinity caveats in qc/w/qv/thermodynamic target fields
+main limiting factor = insufficient low-level moisture / saturation deficit
+```
+
+Inspection should show `w` without meaningful `qc`: 2-D `qc` slices should be
+mostly empty/trace while `w` slices still show thermal/updraft structure. The
+3-D cloud-water point cloud should be mostly absent, while slice planes remain
+useful for explaining the failed-cloud contrast.
+
+Dry Failed must start from the validated reference-derived Baseline Shallow
+Cumulus setup, not the old compact quick-look derivative that produced no
+cloud, no vertical motion, and NaN/Infinity caveats. The planned implementation
+path is:
+
+1. #102 validates an external-sounding Baseline Shallow Cumulus reproduction while
+   preserving the validated grid/domain/runtime/surface/damping/boundary
+   settings.
+2. #103 implements the moisture-limited Dry Failed variant by drying the validated
+   external-sounding baseline and preserving vertical motion.
+
 Default cloud-scale assumptions:
 
 ```text

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -186,6 +186,47 @@ Expected local probes include `CLOUD_CHAMBER_CM1_ROOT`, `~/CloudChamber/settings
 
 The direct follow-up is #29: automate the local CM1 launcher and status/log monitor with one local run at a time, explicit failure/cancel states, and tests that use fake subprocesses rather than real CM1.
 
+### Dry Failed Cumulus Planning
+
+Dry Failed Cumulus is the first planned contrast case after the validated
+Baseline Shallow Cumulus quick-look loop. It should teach moisture limitation:
+
+```text
+How does insufficient low-level moisture prevent shallow cumulus formation even when boundary-layer thermals and vertical motion are present?
+```
+
+The target contrast is:
+
+```text
+Baseline Shallow Cumulus:
+  cloud formed
+  rain detected
+  qc and w both active
+
+Dry Failed Cumulus:
+  thermals / vertical motion remain
+  little or no qc
+  no rain
+  main limiting factor is low-level moisture / saturation deficit
+```
+
+No cloud by itself is not success. A useful Dry Failed Cumulus run must complete
+cleanly, produce NetCDF, ingest the full output sequence, keep `cloud_formed =
+false` and `rain_present = false`, retain meaningful nonzero `w`, and avoid
+severe NaN/Infinity caveats in target fields. No cloud plus no vertical motion
+is not Dry Failed Cumulus.
+
+Planning sequence:
+
+1. #102 validates external-sounding Baseline Shallow Cumulus reproduction from the
+   accepted `les_ShallowCu` reference-derived setup.
+2. #103 implements Dry Failed Cumulus as a moisture-limited variant from that
+   external-sounding baseline, changing only low-level moisture first.
+
+The old compact quick-look derivative that produced no cloud, no vertical
+motion, and NaN/Infinity caveats is invalid evidence and must not be used as a
+scenario base.
+
 ## M2 Local CM1 Run Manager
 
 Goal: make Cloud Chamber actually launch and monitor local CM1 runs.
@@ -329,6 +370,8 @@ First variations should favor one-control-at-a-time changes around baseline rath
 
 Future scenario roadmap:
 
+- Dry Failed Cumulus: moisture-limited failed cumulus with thermals and
+  meaningful vertical motion but little/no `qc`.
 - Terrain/orographic cloud.
 - Layered atmosphere.
 - Fog / near-surface cloud.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -187,6 +187,39 @@ The first quick-look variant should be validated as a runtime-only change from t
 
 The first quick-look validation run, `dry-run-quicklook-les-shallowcu-20260522151536`, completed with `exit_code = 0`, ingested 13 model-output time steps from 0 to 10800 seconds, and produced `cloud formed; rain detected`. Recorded diagnostics included first cloud time at 1800 seconds, `max_qc_kg_kg = 0.002192789688706398`, `max_w_m_s = 6.866957187652588`, `min_w_m_s = -4.21529483795166`, rain present, package size 206 MB, stderr `IEEE_UNDERFLOW_FLAG`, and the existing vertical-coordinate caveat because cloud base/top units were reported as kilometers.
 
+Dry Failed Cumulus validation should happen only after an external-sounding
+Baseline Shallow Cumulus reproduction has been accepted. The future Dry Failed
+run should be considered useful only if it is moisture-limited and numerically
+healthy: CM1 exits cleanly, NetCDF output exists, full-sequence ingest succeeds,
+`cloud_formed = false`, `rain_present = false`, `max_qc_kg_kg` stays below the
+cloud threshold or fewer than 10 grid cells exceed it, `max_w_m_s` is
+meaningfully nonzero, `min_w_m_s` is finite and preferably negative/nonzero,
+and `qc`/`w`/`qv`/thermodynamic target fields do not carry severe NaN/Infinity
+caveats. No cloud plus no vertical motion is not an accepted Dry Failed result.
+No cloud plus NaNs/Infs is not an accepted Dry Failed result.
+
+Future Dry Failed manual validation should record:
+
+```text
+run ID and package path
+validated baseline commit / package source
+external-sounding reproduction evidence
+the one intended moisture/sounding change
+CM1 command, runtime, exit code, logs, and package size
+NetCDF file count and full-sequence ingest status
+cloud_formed and first_cloud_time
+max_qc and cloud fraction summary
+rain_present
+max_w and min_w
+main limiting factor: low-level moisture / saturation deficit
+qc and w 2-D inspection notes
+3-D cloud-water point-cloud absence/presence notes
+caveats and target-field non-finite checks
+```
+
+Do not run Dry Failed CM1 cases in CI and do not commit generated output,
+NetCDF files, logs, runtime files, local reports, or copied `LANDUSE.TBL`.
+
 ### Baseline Shallow Cumulus Manual Smoke-Run Loop
 
 Use this loop after a dry-run package has been generated and before broader CM1 launcher work is trusted. This is a manual/local/offline validation path; do not run it in CI.


### PR DESCRIPTION
Closes #75

Summary:
- Documented Dry Failed Cumulus as a moisture-limited contrast case: thermals and vertical motion remain, but low-level moisture is insufficient for meaningful cloud.
- Clarified the contrast with validated Baseline Shallow Cumulus: baseline has active qc and w; Dry Failed should show w without meaningful qc or rain.
- Added diagnostic targets and manual validation expectations, including nonzero/finite vertical motion and no severe target-field NaN/Infinity caveats.
- Documented that no cloud alone is not success, and the old compact quick-look derivative must not be used as a scenario base.
- Created follow-up issues #102 and #103 for external-sounding baseline reproduction and the later moisture-limited package/smoke run.

What was intentionally not included:
- No Dry Failed package generation.
- No Baseline package-generation changes.
- No CM1 launch or generated output.
- No frontend, ingest, diagnostics, or visualizer changes.

Verification:
- scripts/check.sh

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, .dat/.ctl outputs, generated run directories, LANDUSE.TBL, local runtime files, logs, validation reports, or generated visualization artifacts were committed.