### PR TITLE
Stabilize visualizer viewport and scale markers

### DIFF
--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -521,13 +521,28 @@ details[open] > summary {
   position: relative;
   display: grid;
   place-items: center;
-  min-height: 500px;
+  min-height: 32rem;
+  aspect-ratio: 16 / 10;
   overflow: hidden;
   border: 1px solid rgba(171, 215, 214, 0.28);
   border-radius: 8px;
   background:
     linear-gradient(180deg, rgba(79, 133, 154, 0.16), transparent 42%),
     linear-gradient(0deg, rgba(9, 17, 24, 0.98), rgba(11, 18, 25, 0.94));
+}
+
+.viewport-frame {
+  position: relative;
+  width: min(96%, 62rem);
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+}
+
+.plotting-layer {
+  position: absolute;
+  inset: 0;
+  transform-origin: center center;
+  transition: transform 140ms ease;
 }
 
 .scene-horizon {
@@ -605,6 +620,77 @@ details[open] > summary {
 .scene-context-label span {
   color: #cfdae0;
   font-weight: 700;
+}
+
+.projection-description {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: 0.75rem;
+  z-index: 4;
+  margin: 0;
+  border-radius: 8px;
+  padding: 0.45rem 0.65rem;
+  background: rgba(6, 12, 18, 0.72);
+  color: #f7fbff;
+  font-size: 0.82rem;
+}
+
+.scale-markers {
+  position: absolute;
+  inset: 10% 8% 11%;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.axis-ticks {
+  position: absolute;
+  color: #f7fbff;
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.axis-ticks span {
+  position: absolute;
+  border-radius: 8px;
+  padding: 0.18rem 0.32rem;
+  background: rgba(6, 12, 18, 0.7);
+  white-space: nowrap;
+}
+
+.axis-ticks-horizontal {
+  right: 0;
+  bottom: -1.85rem;
+  left: 0;
+}
+
+.axis-ticks-horizontal span {
+  transform: translateX(-50%);
+}
+
+.axis-ticks-height,
+.axis-ticks-y {
+  top: 0;
+  bottom: 0;
+  left: -0.55rem;
+}
+
+.axis-ticks-height span,
+.axis-ticks-y span {
+  transform: translate(-100%, 50%);
+}
+
+.active-z-range {
+  position: absolute;
+  top: 0.6rem;
+  left: 0.7rem;
+  margin: 0;
+  border-radius: 8px;
+  padding: 0.28rem 0.45rem;
+  background: rgba(6, 12, 18, 0.76);
+  color: #d8fff0;
+  font-size: 0.74rem;
+  font-weight: 850;
 }
 
 .point-cloud-layer {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -969,16 +969,35 @@ describe("App", () => {
     expect(screen.getByText("height z")).toBeInTheDocument();
     expect(screen.getByLabelText("Show slice planes")).not.toBeChecked();
     const scene = screen.getByLabelText("3-D scene container");
+    const plottingGroup = within(scene).getByLabelText("Stable visualizer plotting group");
+    expect(plottingGroup).toBeInTheDocument();
+    expect(within(plottingGroup).getByLabelText("Domain bounding box")).toBeInTheDocument();
+    expect(within(plottingGroup).getByLabelText("Cloud-water point cloud")).toBeInTheDocument();
+    expect(within(plottingGroup).getByLabelText("Scale markers")).toBeInTheDocument();
+    expect(within(plottingGroup).getByLabelText("x-axis ticks")).toBeInTheDocument();
+    expect(within(plottingGroup).getByLabelText("height-axis ticks")).toBeInTheDocument();
+    expect(screen.getByText("x: -3.2 km")).toBeInTheDocument();
+    expect(screen.getByText("x: 0 km")).toBeInTheDocument();
+    expect(screen.getByText("x: 3.2 km")).toBeInTheDocument();
+    expect(screen.getByText("height: 0 km")).toBeInTheDocument();
+    expect(screen.getByText("height: 1.5 km")).toBeInTheDocument();
+    expect(screen.getByText("height: 3 km")).toBeInTheDocument();
+    expect(screen.getByText("active cloud water: 0.8-1.2 km")).toBeInTheDocument();
     expect(within(scene).queryByLabelText("Horizontal slice plane")).not.toBeInTheDocument();
     expect(within(scene).queryByLabelText("Vertical slice plane")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Orbit" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Pan" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Reset camera" })).toBeInTheDocument();
+    expect(screen.getByText("View controls")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reset view" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Orbit" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Pan" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reset camera" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Side x-z" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Side y-z" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Top-down x-y" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Oblique overview" })).toHaveClass(
       "active-control",
+    );
+    expect(screen.getByLabelText("Projection description")).toHaveTextContent(
+      "Oblique overview: interpretive overview based on CM1 coordinates, not a true perspective camera.",
     );
     expect(screen.getByLabelText("Zoom")).toHaveValue("100");
     expect(screen.getByLabelText("Field")).toHaveValue("qc");
@@ -1047,6 +1066,9 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Vertical cross-section" }));
     expect(screen.getByLabelText("Show slice planes")).toBeChecked();
     expect(screen.getByRole("button", { name: "Side x-z" })).toHaveClass("active-control");
+    expect(screen.getByLabelText("Projection description")).toHaveTextContent(
+      "Side x-z: height is vertical",
+    );
     const scene = screen.getByLabelText("3-D scene container");
     await waitFor(() => {
       expect(within(scene).getByLabelText("Vertical slice plane")).toBeInTheDocument();
@@ -1055,6 +1077,11 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Top-down slice" }));
     expect(screen.getByLabelText("Show slice planes")).toBeChecked();
     expect(screen.getByRole("button", { name: "Top-down x-y" })).toHaveClass("active-control");
+    expect(screen.getByLabelText("Projection description")).toHaveTextContent(
+      "Top-down x-y: horizontal map view; height is not shown as vertical position.",
+    );
+    expect(within(scene).getByLabelText("y-axis ticks")).toBeInTheDocument();
+    expect(within(scene).queryByLabelText("height-axis ticks")).not.toBeInTheDocument();
     await waitFor(() => {
       expect(within(scene).getByLabelText("Horizontal slice plane")).toBeInTheDocument();
     });
@@ -1068,21 +1095,27 @@ describe("App", () => {
     });
   });
 
-  it("updates and resets the 3-D scene shell camera controls", async () => {
+  it("updates and resets the 3-D scene shell view controls", async () => {
     render(<App />);
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Open 3-D" }))[0]);
     await screen.findByText("Cloud-water point cloud loaded");
 
-    fireEvent.click(screen.getByRole("button", { name: "Pan" }));
+    const plottingGroup = screen.getByLabelText("Stable visualizer plotting group");
+    fireEvent.click(screen.getByRole("button", { name: "Side x-z" }));
     fireEvent.change(screen.getByLabelText("Zoom"), { target: { value: "150" } });
 
-    expect(screen.getByText("pan")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Side x-z" })).toHaveClass("active-control");
+    expect(plottingGroup).toHaveStyle({ transform: "scale(1.5)" });
     expect(screen.getByText("150%")).toBeInTheDocument();
+    expect(screen.getByText("zoom-only CSS plotting transform")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Reset camera" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset view" }));
 
-    expect(screen.getByText("orbit")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Oblique overview" })).toHaveClass(
+      "active-control",
+    );
+    expect(plottingGroup).toHaveStyle({ transform: "scale(1)" });
     expect(screen.getByText("100%")).toBeInTheDocument();
   });
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1404,7 +1404,6 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const [selectedTimeDefaults, setSelectedTimeDefaults] = useState<ViewDefaultsResponse | null>(null);
   const [selectedFieldName, setSelectedFieldName] = useState("");
   const [timeIndex, setTimeIndex] = useState(0);
-  const [cameraMode, setCameraMode] = useState<"orbit" | "pan">("orbit");
   const [zoom, setZoom] = useState(100);
   const [threshold, setThreshold] = useState(1e-6);
   const [opacity, setOpacity] = useState(0.68);
@@ -1433,7 +1432,6 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setSceneError(null);
     setSelectedFieldName("");
     setTimeIndex(0);
-    setCameraMode("orbit");
     setZoom(100);
     setThreshold(1e-6);
     setOpacity(0.68);
@@ -1630,9 +1628,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     return () => window.clearInterval(interval);
   }, [isPlaying, timeMax]);
 
-  function resetCamera() {
-    setCameraMode("orbit");
+  function resetView() {
     setZoom(100);
+    setProjectionMode("oblique");
   }
 
   return (
@@ -1658,55 +1656,72 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
 
       <div className="visualizer-layout">
         <div className="scene-container" aria-label="3-D scene container">
-          <div className="scene-horizon" />
-          <div className="scene-grid" />
-          <div
-            className={`domain-box domain-box-${projectionMode}`}
-            aria-label="Domain bounding box"
-          >
-            <span className="axis-label axis-label-x">
-              {projectionMode === "side_yz" ? "y" : "x"}
-            </span>
-            <span className="axis-label axis-label-y">
-              {projectionMode === "side_xz" ? "depth y" : projectionMode === "top_down" ? "y" : "depth y"}
-            </span>
-            <span className="axis-label axis-label-z">
-              {projectionMode === "top_down" ? "top-down x-y" : "height z"}
-            </span>
-            <span className="ground-label">domain floor</span>
-          </div>
-          <div className="scene-context-label">
-            <strong>{selectedTimeLabel}</strong>
-            <span>Cloud-water threshold {formatScientific(threshold, "kg/kg")}</span>
-          </div>
-          {showSlicePlanes && (
-            <>
-              {viewPreset === "top-down-slice" || viewPreset === "cloud-overview" ? (
-                <SlicePlane title="Horizontal slice plane" slice={sceneHorizontalSlice} />
-              ) : null}
-              {viewPreset !== "top-down-slice" ? (
-                <SlicePlane title="Vertical slice plane" slice={sceneVerticalSlice} />
-              ) : null}
-            </>
-          )}
-          {pointCloud && pointCloud.points.length > 0 && (
-            <div className="point-cloud-layer" aria-label="Cloud-water point cloud">
-              {pointCloud.points.map((point, index) => (
-                <span
-                  className="cloud-point"
-                  key={`${point.join("-")}-${index}`}
-                  style={cloudPointStyle(
-                    point,
-                    pointCloud,
-                    projectionMode,
-                    pointCloud.stats,
-                    opacity,
-                    pointSize,
-                  )}
-                />
-              ))}
+          <div className="viewport-frame">
+            <div
+              className="plotting-layer"
+              aria-label="Stable visualizer plotting group"
+              style={{ transform: `scale(${zoom / 100})` }}
+            >
+              <div className="scene-horizon" />
+              <div className="scene-grid" />
+              <div
+                className={`domain-box domain-box-${projectionMode}`}
+                aria-label="Domain bounding box"
+              >
+                <span className="axis-label axis-label-x">
+                  {projectionMode === "side_yz" ? "y" : "x"}
+                </span>
+                <span className="axis-label axis-label-y">
+                  {projectionMode === "side_xz"
+                    ? "depth y"
+                    : projectionMode === "top_down"
+                      ? "y"
+                      : "depth y"}
+                </span>
+                <span className="axis-label axis-label-z">
+                  {projectionMode === "top_down" ? "top-down x-y" : "height z"}
+                </span>
+                <span className="ground-label">domain floor</span>
+              </div>
+              <ScaleMarkers pointCloud={pointCloud} projectionMode={projectionMode} />
+              <div className="scene-context-label">
+                <strong>{projectionLabel(projectionMode)}</strong>
+                <span>{selectedTimeLabel}</span>
+                <span>Cloud-water threshold {formatScientific(threshold, "kg/kg")}</span>
+              </div>
+              {showSlicePlanes && (
+                <>
+                  {viewPreset === "top-down-slice" || viewPreset === "cloud-overview" ? (
+                    <SlicePlane title="Horizontal slice plane" slice={sceneHorizontalSlice} />
+                  ) : null}
+                  {viewPreset !== "top-down-slice" ? (
+                    <SlicePlane title="Vertical slice plane" slice={sceneVerticalSlice} />
+                  ) : null}
+                </>
+              )}
+              {pointCloud && pointCloud.points.length > 0 && (
+                <div className="point-cloud-layer" aria-label="Cloud-water point cloud">
+                  {pointCloud.points.map((point, index) => (
+                    <span
+                      className="cloud-point"
+                      key={`${point.join("-")}-${index}`}
+                      style={cloudPointStyle(
+                        point,
+                        pointCloud,
+                        projectionMode,
+                        pointCloud.stats,
+                        opacity,
+                        pointSize,
+                      )}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
-          )}
+          </div>
+          <p className="projection-description" aria-label="Projection description">
+            {projectionDescription(projectionMode)}
+          </p>
           {(!pointCloud || pointCloud.points.length === 0) && (
             <div className="scene-empty-state">
               <p className="eyebrow">Cloud-water point cloud</p>
@@ -1725,23 +1740,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
 
         <aside className="visualizer-controls" aria-label="3-D scene controls">
           <fieldset>
-            <legend>Camera</legend>
-            <div className="segmented-buttons">
-              <button
-                type="button"
-                className={cameraMode === "orbit" ? "active-control" : ""}
-                onClick={() => setCameraMode("orbit")}
-              >
-                Orbit
-              </button>
-              <button
-                type="button"
-                className={cameraMode === "pan" ? "active-control" : ""}
-                onClick={() => setCameraMode("pan")}
-              >
-                Pan
-              </button>
-            </div>
+            <legend>View controls</legend>
             <label htmlFor="scene-zoom">
               Zoom
               <input
@@ -1753,9 +1752,14 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                 onChange={(event) => setZoom(Number(event.target.value))}
               />
             </label>
-            <button type="button" onClick={resetCamera}>
-              Reset camera
+            <p>Zoom: {zoom}%</p>
+            <button type="button" onClick={resetView}>
+              Reset view
             </button>
+            <small>
+              Zoom scales the plotting group only; it does not change CM1 coordinates or slice
+              selection.
+            </small>
           </fieldset>
 
           {catalog && selectedField && (
@@ -2119,7 +2123,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
             <summary>About this visualization</summary>
             <dl className="metric-grid">
               <Metric label="Run ID" value={result.run_id} />
-              <Metric label="Camera mode" value={cameraMode} />
+              <Metric label="View control" value="zoom-only CSS plotting transform" />
               <Metric label="Zoom" value={`${zoom}%`} />
               <Metric label="Opacity" value={String(opacity)} />
               <Metric label="Point size" value={`${pointSize}px`} />
@@ -2243,6 +2247,72 @@ function SlicePlane({ title, slice }: { title: string; slice: SliceResponse | nu
       </div>
     </div>
   );
+}
+
+function ScaleMarkers({
+  pointCloud,
+  projectionMode,
+}: {
+  pointCloud: PointCloudResponse | null;
+  projectionMode: ProjectionMode;
+}) {
+  const showHeight = projectionMode !== "top_down";
+  const horizontalCoordinate = projectionMode === "side_yz" ? "yh" : "xh";
+  const horizontalLabel = projectionMode === "side_yz" ? "y" : "x";
+  const activeRange =
+    pointCloud?.stats.active_z_min !== null && pointCloud?.stats.active_z_max !== null
+      ? `${formatCompactNumber(pointCloud?.stats.active_z_min ?? 0)}-${formatCompactNumber(
+          pointCloud?.stats.active_z_max ?? 0,
+        )} ${pointCloud?.coordinate_units.zh ?? ""}`.trim()
+      : "unavailable";
+
+  return (
+    <div className="scale-markers" aria-label="Scale markers">
+      <div className="axis-ticks axis-ticks-horizontal" aria-label={`${horizontalLabel}-axis ticks`}>
+        {extentTicks(pointCloud, horizontalCoordinate).map((tick) => (
+          <span key={`${horizontalCoordinate}-${tick.position}`} style={{ left: `${tick.position}%` }}>
+            {horizontalLabel}: {tick.label}
+          </span>
+        ))}
+      </div>
+      {projectionMode === "top_down" && (
+        <div className="axis-ticks axis-ticks-y" aria-label="y-axis ticks">
+          {extentTicks(pointCloud, "yh").map((tick) => (
+            <span key={`y-${tick.position}`} style={{ bottom: `${tick.position}%` }}>
+              y: {tick.label}
+            </span>
+          ))}
+        </div>
+      )}
+      {showHeight && (
+        <div className="axis-ticks axis-ticks-height" aria-label="height-axis ticks">
+          {extentTicks(pointCloud, "zh").map((tick) => (
+            <span key={`z-${tick.position}`} style={{ bottom: `${tick.position}%` }}>
+              height: {tick.label}
+            </span>
+          ))}
+        </div>
+      )}
+      {showHeight && (
+        <p className="active-z-range">active cloud water: {activeRange}</p>
+      )}
+    </div>
+  );
+}
+
+function extentTicks(
+  pointCloud: PointCloudResponse | null,
+  coordinate: string,
+): Array<{ position: number; label: string }> {
+  const extent = pointCloud?.coordinate_extents[coordinate];
+  if (!extent) return [];
+  const midpoint = (extent.min + extent.max) / 2;
+  const units = extent.units ? ` ${extent.units}` : "";
+  return [
+    { position: 12, label: `${formatCompactNumber(extent.min)}${units}` },
+    { position: 50, label: `${formatCompactNumber(midpoint)}${units}` },
+    { position: 88, label: `${formatCompactNumber(extent.max)}${units}` },
+  ];
 }
 
 function SceneSliceSummary({ title, slice }: { title: string; slice: SliceResponse | null }) {
@@ -2794,6 +2864,26 @@ function maxPointLocationLabel(pointCloud: PointCloudResponse | null): string {
   return `x ${formatCompactNumber(location.x)}, y ${formatCompactNumber(location.y)}, z ${formatCompactNumber(
     location.z,
   )}${units ? ` ${units}` : ""}, value ${formatCompactNumber(location.value)}`;
+}
+
+function projectionLabel(projectionMode: ProjectionMode): string {
+  const labels: Record<ProjectionMode, string> = {
+    side_xz: "Side x-z",
+    side_yz: "Side y-z",
+    top_down: "Top-down x-y",
+    oblique: "Oblique overview",
+  };
+  return labels[projectionMode];
+}
+
+function projectionDescription(projectionMode: ProjectionMode): string {
+  const descriptions: Record<ProjectionMode, string> = {
+    side_xz: "Side x-z: height is vertical; y is compressed into point opacity for cloud-base and cloud-top checks.",
+    side_yz: "Side y-z: height is vertical; x is compressed into point opacity for cloud-base and cloud-top checks.",
+    top_down: "Top-down x-y: horizontal map view; height is not shown as vertical position.",
+    oblique: "Oblique overview: interpretive overview based on CM1 coordinates, not a true perspective camera.",
+  };
+  return descriptions[projectionMode];
 }
 
 function sliceCellStyle(value: number | null, stats: SliceResponse["stats"]): CSSProperties {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -305,7 +305,7 @@ Responsibilities:
 - load processed field data
 - display volume/slices/isosurfaces
 - time playback
-- camera controls
+- projection/view controls
 - lighting controls
 - field controls
 - rendering labels/provenance
@@ -334,9 +334,9 @@ from a Result Card / Experiment Notebook entry, requests the visualization-ready
 field catalog, and exposes:
 
 - scene container;
-- orbit/pan camera mode shell;
+- projection mode controls;
 - zoom control;
-- reset camera action;
+- reset view action;
 - time slider shell;
 - field selector shell;
 - loading, empty, and error states;
@@ -364,6 +364,14 @@ projections where model height `z` is the visual vertical axis, plus top-down an
 oblique overview modes. The domain box, floor, axes, and points must share the
 same transform so horizontal `y` does not masquerade as height. Oblique overview
 is an interpretation for orientation, not a literal atmospheric photograph.
+
+The frontend viewport should use one stable internal plotting coordinate system
+for the domain box, floor/grid, slice planes, scale markers, and point cloud.
+Zoom scales that plotting group while preserving aspect ratio; it does not
+change CM1 coordinates or data selection. Until a true camera is implemented,
+controls should be described as view/projection controls rather than orbit or
+pan camera controls. Scale markers should expose horizontal distance, visible
+height, the domain floor, and active cloud-water `z` range.
 
 3-D slice planes reuse the same backend slice endpoint as the 2-D inspector:
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -149,8 +149,9 @@ For each run:
 The visualizer should support:
 
 - time slider/playback
-- orbit/pan/zoom camera
-- reset camera
+- projection/view mode controls
+- zoom
+- reset view
 - vertical slice
 - horizontal slice
 - isosurface threshold
@@ -176,8 +177,8 @@ Visualization-ready data contract (#72)
 Every visualizer stage must preserve provenance labels and make clear that rendered output is an interpretation of CM1-derived data.
 
 The first 3-D scene shell opens from a Result Card / Experiment Notebook entry.
-It provides the scene container, orbit/pan/zoom controls, reset camera, time
-slider shell, field selector shell, loading/empty/error states, and
+It provides the scene container, projection/view controls, zoom, reset view,
+time slider shell, field selector shell, loading/empty/error states, and
 provenance/rendering labels. It does not render cloud water, slices, or
 synthetic cloud physics; those belong to later visualizer issues.
 
@@ -759,7 +760,7 @@ MVP visualizer work should be staged:
 
 1. Visualization-ready backend data contract.
 2. 2-D field inspection for orientation, time indexing, scaling, and field availability.
-3. 3-D scene shell with orbit/pan/zoom, reset camera, time slider, field selector, and provenance/rendering labels.
+3. 3-D scene shell with projection/view controls, zoom, reset view, time slider, field selector, and provenance/rendering labels.
 4. Cloud-water rendering MVP for `qc` using a thresholded point cloud from
    visualization-ready data.
 5. Horizontal and vertical slice planes for `qc` and `w`.
@@ -774,7 +775,7 @@ Later:
 - cinematic export
 - thumbnails/previews with strict generated-artifact policy
 
-True fly-through or move-through should remain on the roadmap after the MVP. Orbit/pan/zoom, reset camera, time replay, slices, field selection, and cloud-water isosurface/opacity approximation are enough for the first visualizer.
+True fly-through or move-through should remain on the roadmap after the MVP. Projection/view controls, zoom, reset view, time replay, slices, field selection, and cloud-water point/opacity approximation are enough for the first visualizer.
 
 The browser should not parse raw CM1 NetCDF directly. Backend ingest and visualization-ready preprocessing should provide selected, provenance-labeled fields for inspection and rendering.
 
@@ -795,6 +796,21 @@ base/top are legible. `Top-down x-y` is for horizontal footprint, and `Oblique
 overview` is an interpretive overview. The domain box, floor, axis labels, and
 points should use the same coordinate transform, with technical details showing
 the actual coordinate units and visualized extent.
+
+The MVP viewer uses a stable plotting viewport rather than pretending to have a
+full physical camera. The primary controls are projection mode, zoom, and reset
+view. Zoom scales the rendered plotting group while preserving the underlying
+CM1 coordinate transform; it does not change the model data, slice selection, or
+diagnostic values. Projection labels should be explicit:
+
+- `Side x-z`: height is vertical; `y` is compressed or hidden.
+- `Side y-z`: height is vertical; `x` is compressed or hidden.
+- `Top-down x-y`: horizontal footprint; height is not shown vertically.
+- `Oblique overview`: interpretive overview, not a true perspective camera.
+
+Scale markers should show horizontal distance, height when visible, the domain
+floor, and the active cloud-water height range so the view remains readable at
+normal browser zoom and across common screen sizes.
 
 The first 3-D slice planes reuse the #72 JSON slice endpoint. The scene can
 request horizontal and vertical native-grid slices for the selected slice field

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -163,8 +163,8 @@ The main payoff.
 Visualize CM1 output with:
 
 - time replay
-- orbit/pan/zoom
-- pan/tilt/zoom camera controls
+- projection/view controls
+- zoom and reset view
 - fly-through / move-through later
 - sun angle
 - color temperature
@@ -209,9 +209,9 @@ Useful views:
 - Vertical slices
 - Cloud top/base diagnostics
 - Time replay
-- 3-D camera exploration
+- 3-D projection exploration
 - Appearance rendering from cloud water
-- Lighting and camera controls
+- Lighting and view controls
 
 ## Trust/Honesty Rules
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -294,7 +294,7 @@ Goal: deliver the main payoff: inspect CM1 cloud evolution in 3-D.
 Deliverables:
 
 - 3-D scene shell.
-- orbit/pan/zoom/reset camera.
+- projection/view controls, zoom, and reset view.
 - time slider/replay.
 - field selector.
 - horizontal/vertical slices.
@@ -306,13 +306,14 @@ Implementation anchor:
 - #31 has been superseded by staged visualizer implementation issues. It captured the right broad goal, but was too large to implement safely as one PR.
 - #72 defines and implements the backend visualization-ready data contract. The browser should not parse raw NetCDF directly; it should consume fields and JSON slice payloads from backend endpoints. The MVP supports `qc` and `w`, native grids (`zh/yh/xh` for `qc`, `zf/yh/xh` for `w`), provenance/rendering labels, finite/non-finite stats, and vertical unit display metadata without interpolation.
 - #73 builds the 2-D field inspection MVP on top of the #72 fields/slice API before the full 3-D viewer so field orientation, time indexing, vertical coordinates, scaling, and basic cloud evolution can be checked. It opens from the Results Library detail, enables field/time selection, shows horizontal and vertical slices, and keeps the browser away from raw NetCDF parsing.
-- #77 builds the 3-D scene shell from the Results Library detail: scene container, orbit/pan/zoom controls, reset camera, time slider shell, field selector shell, loading/empty/error states, and provenance/rendering labels. It does not render cloud water, slices, or raw NetCDF data in the browser.
+- #77 builds the 3-D scene shell from the Results Library detail: scene container, projection/view controls, zoom, reset view, time slider shell, field selector shell, loading/empty/error states, and provenance/rendering labels. It does not render cloud water, slices, or raw NetCDF data in the browser.
 - #78 renders the first cloud-water field from visualization-ready data as a thresholded `qc` point cloud. The backend selects native-grid points and the browser renders only that payload; no raw NetCDF parsing, interpolation, isosurface extraction, ray marching, or cinematic lighting belongs in this step.
 - #79 adds horizontal and vertical slice planes using the same provenance-labeled #72 slice API and native-grid caveats. Slice-plane time stays synced with the point cloud, supports `qc` and `w`, and remains an inspection overlay rather than raw NetCDF parsing or volumetric rendering.
 - #98 also makes Inspect and Visualize inherit the selected result and default to an interesting time: first cloud when available, otherwise max cloud-water time if available, otherwise latest output. Technical rendering/provenance details stay available but secondary.
 - #100 sharpens the first usable inspection path: Results should surface the validated quick-look baseline, successful cloud-forming runs with caveats should read as `Minor caveat` rather than failed review states, the 2-D inspector should show slice heatmaps before raw matrix values, and the 3-D viewer should open with visible cloud-water points plus readable slice context.
 - #105 makes Inspect and Visualize physically interpretable rather than debug-like: the backend provides native-grid default view locations for `qc` and `w`, Inspect defaults to one primary heatmap with `Horizontal` / `Vertical X` / `Vertical Y` / `Compare` modes, Visualize adds domain box/axes/height/floor/time/threshold context, slice planes are toggleable and secondary, and view presets expose Cloud overview, Vertical cross-section, Top-down slice, and Updraft view.
 - #115 fixes the 3-D visualizer coordinate projection so point placement uses full NetCDF coordinate extents rather than returned cloudy-point extents. Side x-z and y-z views make model height the visual vertical axis, top-down x-y shows footprint, oblique remains an interpretive overview, and selected-time max `qc`/`w` defaults keep slice planes centered on the current cloud or updraft location.
+- #119 stabilizes the 3-D visualizer viewport around an explicit plotting group shared by the domain box, floor/grid, scale markers, slice planes, and point cloud. The MVP controls should be view/projection mode, zoom, and reset view rather than fake orbit/pan camera controls, with projection descriptions and scale markers visible at normal browser zoom.
 - #80 plans visual polish, fly-through/move-through, cinematic export, and thumbnail/preview policy after the practical 3-D MVP. It must not add rendering dependencies or implementation code.
 
 Recommended implementation order:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -94,12 +94,13 @@ follow-up comparison issue.
 
 3-D scene shell component tests should also mock the visualization-ready field
 catalog instead of reading NetCDF in the browser. They should cover opening from
-a Result Card, scene container rendering, orbit/pan controls, zoom/reset camera
-controls, time slider shell, field selector shell, interesting-time/default
+a Result Card, scene container rendering, projection/view controls, zoom/reset
+view controls, time slider shell, field selector shell, interesting-time/default
 slice selection, first-cloud/max-cloud/max-updraft jump controls, domain box,
-axes/height/floor labels, provenance/rendering details, and no-field/error
-states. They must not assert isosurfaces or volumetric effects until the later
-visualizer issues implement those layers.
+axes/height/floor labels, scale markers, stable plotting-group transforms,
+projection descriptions, provenance/rendering details, and no-field/error
+states. They must not assert isosurfaces, true camera orbit/pan behavior, or
+volumetric effects until later visualizer issues implement those layers.
 
 Cloud-water point-cloud tests should use tiny synthetic NetCDF fixtures on the
 backend and mocked visualization-ready point payloads on the frontend. Backend
@@ -113,6 +114,14 @@ where model `z` is the visual height, domain extent/debug labels,
 provenance/rendering labels, and the guarantee that the browser does not parse
 raw NetCDF. These tests must not add ray marching, isosurfaces, shadows,
 fly-through, export, or generated CM1 output.
+
+Viewport-stability tests should verify that the domain box, floor/grid, slice
+planes, scale markers, and cloud-water point cloud live inside the same plotting
+group, that zoom scales that group without changing data selection, and that
+reset view restores zoom and projection defaults. Side views should state that
+height is vertical, top-down should state that height is not shown vertically,
+and oblique should be labeled an interpretive overview rather than a true
+perspective camera.
 
 3-D slice-plane tests should mock the #72 visualization-ready slice API. They
 should cover horizontal and vertical slice planes, `qc` and `w` field selection,


### PR DESCRIPTION
Closes #119

Summary:
- Stabilized the 3-D visualizer around a shared plotting group for the domain box, floor/grid, slice planes, scale markers, and cloud-water point cloud.
- Replaced fake orbit/pan camera controls with explicit view controls: projection mode, zoom, and reset view.
- Added projection descriptions, x/y/height scale markers, and active cloud-water height range context.
- Updated frontend tests and docs for viewport stability, projection semantics, and scale-marker behavior.

What was intentionally not included:
- No ray marching, isosurfaces, fly-through, export, new scenarios, package generation, or diagnostics changes.
- No new rendering dependencies.

Verification:
- npm test -- --run (from app/frontend) — passed, 19 tests.
- scripts/check.sh — passed; frontend lint/test/build, backend ruff/mypy/pytest, script syntax, forbidden artifact, docs/JSON/YAML checks.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, .dat/.ctl outputs, generated run directories, LANDUSE.TBL, local runtime files, logs, validation reports, or generated visualization artifacts were committed.