### PR TITLE
Fix visualizer scene containment

### DIFF
--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -512,18 +512,21 @@ details[open] > summary {
 
 .visualizer-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.6fr);
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 22rem);
   gap: 1rem;
-  align-items: stretch;
+  align-items: start;
 }
 
 .scene-container {
   position: relative;
   display: grid;
   place-items: center;
-  min-height: 32rem;
-  aspect-ratio: 16 / 10;
+  width: 100%;
+  min-width: 0;
+  min-height: clamp(26rem, 52vw, 38rem);
   overflow: hidden;
+  isolation: isolate;
+  contain: layout paint;
   border: 1px solid rgba(171, 215, 214, 0.28);
   border-radius: 8px;
   background:
@@ -533,7 +536,7 @@ details[open] > summary {
 
 .viewport-frame {
   position: relative;
-  width: min(96%, 62rem);
+  width: min(96%, 100%);
   aspect-ratio: 16 / 10;
   overflow: hidden;
 }
@@ -763,9 +766,12 @@ details[open] > summary {
 }
 
 .visualizer-controls {
+  position: relative;
+  z-index: 5;
   display: grid;
   align-content: start;
   gap: 1rem;
+  min-width: 0;
 }
 
 .visualizer-controls fieldset {


### PR DESCRIPTION
Closes #123

Summary:
- Contained the 3-D scene to its layout column so the plotting surface cannot bleed over the controls.
- Gave the control rail an explicit stacking context and fixed-width column.
- Kept the scene responsive with a contained viewport and paint/layout containment.

Verification:
- scripts/check.sh — passed.
- Browser screenshot check against local dev server — verified controls render outside the scene overlay in the app viewport.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, .dat/.ctl outputs, generated run directories, LANDUSE.TBL, local runtime files, logs, validation reports, or generated visualization artifacts were committed.