### PR TITLE
docs: add Claude Code working style section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,147 @@ If adding physics/science behavior, document:
 2. what user control it enables
 3. what diagnostics validate it
 4. what limitations must be disclosed
+
+---
+
+## Claude Code — Working Style and Expectations
+
+This section governs how Claude Code operates on this project. It extends
+the rules above; nothing here overrides the product rule, guardrails, or
+scientific-honesty requirements.
+
+### Intent First
+
+Before writing any code on a non-trivial task, Claude Code must:
+
+1. State what it understands the goal to be.
+2. Ask every question needed to fully understand intent — user workflow,
+   edge cases, acceptance criteria, what "done" looks like.
+3. Propose an approach and wait for a go-ahead before executing.
+
+For small, obviously-scoped tasks (typo fixes, single-line changes, adding
+a missing test for existing behavior) it may proceed directly.
+
+When in doubt, ask. A short clarifying exchange is cheaper than a wrong
+implementation.
+
+### Autonomy
+
+Once intent is confirmed, Claude Code should execute as fully as possible
+without interruption:
+
+- Write the code.
+- Write or update tests.
+- Run `scripts/check.sh` and fix any failures before committing.
+- Update relevant docs if architecture or workflow changed.
+- Open a PR with a clear description.
+- Create GitHub issues for anything discovered during work that is out of
+  scope for the current task (bugs, missing tests, doc gaps, a11y issues).
+  Do not silently leave TODOs for things that deserve tracking.
+
+Do not ask for permission to run the linter, run tests, fix a type error,
+or update a doc string. Those are part of the job.
+
+### Branching and PRs
+
+- Branch off `main`. Name branches `issue-NNN-short-description`.
+- One issue per branch. Keep PRs scoped.
+- PR description must include:
+  - What changed and why.
+  - How to verify it locally (specific commands or UI steps).
+  - Any known limitations or follow-up issues opened.
+- Enable auto-merge after CI passes unless the task is high-risk (see
+  Guardrails above) or the user asks for manual review.
+
+### Commit Style
+
+- Conventional commits: `feat:`, `fix:`, `test:`, `docs:`, `chore:`, `refactor:`.
+- Subject line: imperative, ≤72 chars.
+- Body: include the issue number and a sentence on why, not just what.
+- Atomic commits — one logical change per commit. Do not bundle unrelated
+  fixes.
+
+### Quality Bar
+
+Every PR must pass `scripts/check.sh` cleanly before merge:
+
+- Frontend: lint, test, build.
+- Backend: ruff format, ruff check, mypy, pytest.
+- No new warnings introduced without explanation.
+
+New behavior requires new tests. Refactors must not reduce test coverage.
+UI changes that affect user-visible text or workflow must include an update
+to the relevant doc in `docs/`.
+
+### GitHub Issues
+
+When Claude Code opens an issue it must:
+
+- Use the correct label set (see repo labels).
+- Write a description a future developer can act on without context:
+  summary, observed behavior, expected behavior, reproduction steps or
+  fix hint.
+- Tag `priority:p1` for bugs that break core workflows; `priority:p2` for
+  everything else unless the user says otherwise.
+- Reference the PR or commit that surfaced it.
+
+### What Claude Code Must Not Do Without Asking
+
+Even with full autonomy confirmed, always pause and ask before:
+
+- Changing product direction or adding a new top-level workspace/view.
+- Changing scientific interpretation, diagnostic labels, or provenance
+  language.
+- Modifying data deletion logic or storage cleanup policy.
+- Touching real CM1 execution paths.
+- Changing the run manifest schema or result card schema in a
+  backwards-incompatible way.
+- Removing or weakening a test rather than fixing the underlying issue.
+
+### Environment Assumptions
+
+Claude Code sessions assume:
+
+- `scripts/dev.sh start` has been run (frontend at `localhost:5173`,
+  backend at `127.0.0.1:8000`).
+- `~/CloudChamber/settings.json` exists with local CM1 paths if CM1
+  work is in scope.
+- `uv` or the pip fallback described in `docs/development.md` is
+  available for backend work.
+- The Playwright E2E suite lives at `~/e2e/` (separate from the repo)
+  and can be run with `npx playwright test` from that directory.
+
+### Playwright E2E
+
+When fixing a UI bug or adding a UI feature:
+
+- Check whether an existing Playwright test covers it.
+- If yes, verify the test passes after the change.
+- If no, add a test or open an issue noting the gap.
+- Never delete or skip a Playwright test to make CI pass. Fix the
+  underlying issue or open an issue and mark the test `.skip` with a
+  comment referencing it.
+
+### Documentation Standard
+
+- `docs/development.md` is the canonical dev setup reference. Keep it
+  current.
+- `docs/architecture-and-data-model.md` must reflect any schema or
+  API contract changes.
+- `docs/roadmap-and-issues.md` should be updated when milestones
+  shift significantly.
+- Inline code comments explain *why*, not *what*. Remove comments that
+  just restate the code.
+
+### Maintainability Bias
+
+Prefer:
+
+- Explicit over clever.
+- Small, testable functions over large ones.
+- Types everywhere in TypeScript and Python.
+- Clear error messages that name the problem and suggest a fix.
+- Fail loudly on bad state rather than silently degrade.
+
+When two approaches are roughly equivalent, choose the one that is easier
+to delete or replace later.


### PR DESCRIPTION
Adds working style, autonomy, branching, quality, and issue-creation guidelines for Claude Code sessions. Extends existing AGENTS.md without changing any existing rules.