### PR TITLE
Plan Capped/Suppressed Cumulus contrast scenario

### DIFF
--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -149,6 +149,24 @@ changes only the generated `input_sounding` moisture values for `drier` or
 `more_humid`. The namelist, runtime preset, NetCDF output, and runtime-file
 staging remain the same for the selected preset.
 
+Capped / Suppressed Cumulus should also branch from the accepted
+external-sounding Baseline Shallow Cumulus family, but it is not a moisture
+experiment. The first planned implementation (#140) should preserve the
+accepted baseline grid/domain, vertical spacing, domain top, runtime/cadence
+model, surface/ocean/flux settings, surface stress/roughness path, Rayleigh
+damping, turbulence/SGS settings, boundary conditions, NetCDF output,
+`LANDUSE.TBL` staging, low-level humidity, surface heating, and the baseline
+wind profile. It should change only the potential-temperature / stability
+structure near the capping layer in the generated external `input_sounding`.
+
+Architecturally, the product control is `cap_strength = stronger`. Cap height
+stays at the accepted baseline for the first implementation; lower cap height
+is later work. The scenario should not reuse the invalid compact quick-look
+derivative, should not dry the low-level moisture profile, and should not vary
+surface heating. Its result-card interpretation should be cap/stability-limited:
+moisture and thermals are present, but the stronger cap limits vertical cloud
+growth.
+
 Cloud-scale defaults for the first lower-atmosphere contract are:
 
 ```text

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -432,6 +432,103 @@ detected`, `max_qc_kg_kg = 0.0`, `max_w_m_s = 1.949130654335022`, and
 moisture-limited contrast case: thermals and vertical motion remain, but cloud
 water and rain stay absent by the MVP diagnostics.
 
+### Capped / Suppressed Cumulus Planning
+
+Capped / Suppressed Cumulus is the next planned lower-atmosphere contrast after
+Dry Failed Cumulus and the low-level humidity ladder. It should tell a distinct
+stability/inhibition story:
+
+```text
+How does a stronger cap suppress or limit shallow-cumulus growth even when moisture and boundary-layer thermals are available?
+```
+
+Dry Failed Cumulus is the moisture-limited no-cloud contrast. Capped /
+Suppressed Cumulus should not target a total no-cloud case for the first
+version. The first target is:
+
+```text
+same cloud setup, but a stronger lid
+```
+
+Moisture remains available and thermals still rise. Shallow or weak cloud may
+still form, but the stronger cap should limit cloud depth, reduce cloud water
+or cloud fraction, and suppress or reduce rain relative to the accepted Baseline
+Shallow Cumulus quick-look.
+
+Teaching contrast:
+
+```text
+Baseline Shallow Cumulus:
+  thermals rise
+  cloud water forms
+  cloud grows deeper
+  rain may appear
+  qc and w are both visually/scientifically interesting
+
+Dry Failed Cumulus:
+  thermals rise
+  lower atmosphere is too dry
+  cloud water stays absent or below threshold
+  rain does not appear
+  w remains scientifically meaningful
+
+Capped / Suppressed Cumulus:
+  thermals rise
+  moisture is available
+  cloud may still form
+  stronger cap limits vertical growth
+  cloud tops are lower
+  max qc / cloud fraction are reduced
+  rain is suppressed or absent
+```
+
+First product-facing controls:
+
+```text
+cap_strength:
+  baseline
+  stronger
+
+cap_height:
+  baseline initially
+  lower later
+
+low_level_humidity:
+  baseline for first implementation
+
+surface_heating:
+  baseline for first implementation
+```
+
+The first implementation follow-up is #140. It should use
+`cap_strength = stronger`, keep cap height at the accepted baseline, keep
+low-level humidity and surface heating at baseline, and change only the
+potential-temperature / stability structure near the capping layer in the
+generated external `input_sounding`.
+
+Expected MVP target:
+
+```text
+CM1 completes cleanly
+NetCDF output exists
+full output sequence ingests
+max w is meaningfully nonzero
+min w is finite
+cloud_formed may be true
+first_cloud_time may be delayed
+cloud_top lower than baseline
+max_qc lower than baseline
+cloud_fraction lower than baseline
+rain_present false or reduced
+main_limiting_factor = cap/stability
+```
+
+Exact morphology is not pass/fail. The key outcome is healthy thermals plus
+available moisture plus limited cloud depth because of the stronger cap. If the
+run becomes indistinguishable from Dry Failed Cumulus, or if diagnostics cannot
+separate cap limitation from moisture limitation, the scenario should be marked
+`needs_calibration` rather than overclaimed.
+
 Default cloud-scale assumptions:
 
 ```text

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -227,6 +227,64 @@ The old compact quick-look derivative that produced no cloud, no vertical
 motion, and NaN/Infinity caveats is invalid evidence and must not be used as a
 scenario base.
 
+### Capped / Suppressed Cumulus Planning
+
+Capped / Suppressed Cumulus is the next planned contrast after Dry Failed
+Cumulus. Dry Failed tests moisture limitation. Capped / Suppressed should test
+stability and inhibition:
+
+```text
+How does a stronger cap suppress or limit shallow-cumulus growth even when moisture and boundary-layer thermals are available?
+```
+
+The first target is not total no-cloud failure. The target is shallow or weak
+cloud limited by a stronger cap:
+
+```text
+Baseline:
+  moisture + thermals + normal cap -> cloud grows
+
+Dry Failed:
+  thermals + cap okay, but too dry -> no meaningful cloud
+
+Capped / Suppressed:
+  moisture + thermals okay, but stronger cap -> shallow/limited cloud
+```
+
+The first implementation follow-up is #140. It should start from the accepted
+external-sounding Baseline Shallow Cumulus path and vary only:
+
+```text
+cap_strength = stronger
+```
+
+It should keep `cap_height`, `low_level_humidity`, and `surface_heating` at the
+accepted baseline. The likely CM1-facing adjustment is a stronger stable layer
+in the generated external `input_sounding` potential-temperature profile near
+the cap. Do not use the old compact quick-look derivative, do not tune moisture,
+and do not vary cap height in the first implementation.
+
+Expected diagnostics:
+
+```text
+cloud_formed: true or weak/limited; false only if w remains healthy and moisture is not the limiting factor
+first_cloud_time: delayed relative to baseline, or null if fully suppressed
+cloud_top: lower than baseline
+max_qc: lower than baseline
+cloud_fraction: lower than baseline
+rain_present: preferably false or reduced
+max_w: meaningfully nonzero
+min_w: finite, preferably negative/nonzero
+main_limiting_factor: cap/stability
+```
+
+Potential future diagnostics include `cloud_top_time_series`,
+`max_qc_height_time_series`, cloud-fraction time-series comparison, cap-level or
+inversion metadata from the generated sounding, and `max_w_below_cap` if
+practical. If current diagnostics cannot clearly determine whether the cap
+limited vertical growth, create a follow-up diagnostics issue rather than
+overclaiming.
+
 ## M2 Local CM1 Run Manager
 
 Goal: make Cloud Chamber actually launch and monitor local CM1 runs.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -325,6 +325,58 @@ caveats and target-field non-finite checks
 Do not run Dry Failed CM1 cases in CI and do not commit generated output,
 NetCDF files, logs, runtime files, local reports, or copied `LANDUSE.TBL`.
 
+Capped / Suppressed Cumulus planning tests should remain docs/planning-only
+until #140 implements package generation. The future automated tests should use
+temporary runtime homes and assert that `cap_strength = stronger` changes only
+the generated external `input_sounding` stability structure near the cap while
+preserving the accepted external-sounding baseline's grid/domain, runtime
+preset, surface/ocean/flux settings, surface stress/roughness path, Rayleigh
+damping, turbulence/SGS settings, boundary conditions, NetCDF output,
+`LANDUSE.TBL` staging behavior, low-level humidity, and surface heating.
+
+Future Capped / Suppressed manual validation should record:
+
+```text
+run ID and package path
+accepted external-sounding baseline source
+the one intended cap/stability change
+confirmation that low-level humidity remains baseline
+confirmation that surface heating remains baseline
+confirmation that cap height remains baseline
+CM1 command, runtime, exit code, logs, and package size
+NetCDF file count and full-sequence ingest status
+cloud_formed and first_cloud_time
+cloud_top compared with accepted baseline
+max_qc and cloud fraction compared with accepted baseline
+rain_present compared with accepted baseline
+max_w and min_w
+main limiting factor: cap / stability
+qc and w 2-D inspection notes
+3-D limited-growth inspection notes
+caveats and target-field non-finite checks
+```
+
+Acceptance categories for future Capped / Suppressed validation:
+
+- `accepted`: CM1 completes, NetCDF ingests, vertical motion remains meaningful,
+  moisture remains baseline/available, cloud is shallower/weaker/delayed than
+  baseline, cloud top is lower when cloud forms, max `qc` and/or cloud fraction
+  are reduced, rain is absent or reduced, and no severe target-field caveats
+  appear.
+- `accepted_with_notes`: the run is healthy and cap effect is present but
+  subtle, or rain still occurs while cloud top / max `qc` / cloud fraction are
+  clearly reduced.
+- `needs_calibration`: the run is too similar to baseline, becomes
+  indistinguishable from Dry Failed, or current diagnostics cannot distinguish
+  cap limitation clearly.
+- `failed`: CM1 fails, NetCDF is missing, ingest fails, vertical motion is
+  absent, severe NaN/Infinity caveats appear in target fields, or more than
+  cap/stability changed unexpectedly.
+
+Do not run Capped / Suppressed CM1 cases in CI and do not commit generated
+output, NetCDF files, logs, runtime files, local reports, or copied
+`LANDUSE.TBL`.
+
 ### Baseline Shallow Cumulus Manual Smoke-Run Loop
 
 Use this loop after a dry-run package has been generated and before broader CM1 launcher work is trusted. This is a manual/local/offline validation path; do not run it in CI.


### PR DESCRIPTION
Closes #111

Summary:
- Planned Capped/Suppressed Cumulus as the next cap/stability-limited contrast after Dry Failed and the humidity ladder.
- Clarified the first target as shallow/limited cloud from a stronger cap, not a total no-cloud case.
- Documented the physical question, teaching contrast, expected diagnostics, manual validation checklist, and acceptance categories.
- Created follow-up implementation issue #140 for the stronger-cap package and smoke run.
- Confirmed this PR is docs/planning only: no package generation, CM1 tuning, UI, renderer, or generated output changes.

Verification:
- `scripts/check.sh` passed.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, `LANDUSE.TBL`, logs, local reports, or visualization artifacts were committed.