### PR TITLE
Handle Build scenario-loading failures

### DIFF
--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -172,6 +172,20 @@ small {
   padding-left: 1rem;
 }
 
+.scenario-state-panel {
+  display: grid;
+  gap: 0.65rem;
+  border: 1px solid rgba(171, 215, 214, 0.28);
+  border-radius: 8px;
+  padding: 1rem;
+  background: rgba(3, 8, 13, 0.28);
+}
+
+.scenario-state-panel h3,
+.scenario-state-panel p {
+  margin-bottom: 0;
+}
+
 .field-label,
 .control-row {
   display: grid;

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -884,6 +884,106 @@ describe("App", () => {
     expect(screen.queryByText(/namelist/i)).not.toBeInTheDocument();
   });
 
+  it("shows an explicit loading state before scenario package controls are available", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return new Promise<Response>(() => undefined);
+      }
+      if (url === "/api/results") {
+        return new Promise<Response>(() => undefined);
+      }
+      if (url === "/api/storage/inventory") {
+        return new Promise<Response>(() => undefined);
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Build" }));
+    expect(screen.getByText("Loading scenarios...")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Loading scenario catalog" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Scenario")).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Create run package" })).not.toBeInTheDocument();
+  });
+
+  it("shows a retryable scenario-loading failure state", async () => {
+    let scenarioRequestCount = 0;
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        scenarioRequestCount += 1;
+        if (scenarioRequestCount === 1) {
+          return Promise.resolve(new Response("backend unavailable", { status: 503 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(new Response(JSON.stringify(resultsResponse), { status: 200 }));
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    expect(
+      await screen.findByRole("heading", { name: "Scenario catalog unavailable" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/local backend/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Scenario")).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Create run package" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry scenarios" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Baseline Shallow Cumulus" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create run package" })).toBeEnabled();
+  });
+
+  it("shows an empty scenario state without enabling package creation", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              golden_path_scenario_id: "",
+              scenarios: [],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(new Response(JSON.stringify(resultsResponse), { status: 200 }));
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    expect(
+      await screen.findByRole("heading", { name: "No scenarios available" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/did not return any scenario templates/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Scenario")).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Create run package" })).not.toBeInTheDocument();
+  });
+
   it("labels preview as not implemented and not CM1 output", async () => {
     render(<App />);
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { CSSProperties, FormEvent } from "react";
 
 import "./App.css";
@@ -199,6 +199,7 @@ type DeleteRunResponse = {
 type WorkspaceSection = "build" | "results" | "explore";
 type ResultsTab = "notebook" | "compare" | "storage";
 type ExploreTab = "slices" | "view3d";
+type ScenarioLoadState = "loading" | "loaded" | "failed" | "empty";
 
 type ProvenancePayload = {
   source_model: string;
@@ -564,26 +565,48 @@ export function App() {
   const [deletePreview, setDeletePreview] = useState<DeleteRunResponse | null>(null);
   const [deleteMessage, setDeleteMessage] = useState<string | null>(null);
   const [status, setStatus] = useState("Loading scenarios...");
+  const [scenarioLoadState, setScenarioLoadState] = useState<ScenarioLoadState>("loading");
+  const [scenarioError, setScenarioError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [resultsError, setResultsError] = useState<string | null>(null);
 
+  const loadScenarios = useCallback(async (active: () => boolean = () => true) => {
+    setScenarioLoadState("loading");
+    setScenarioError(null);
+    setError(null);
+    setStatus("Loading scenarios...");
+    setScenarios([]);
+    setDryRun(null);
+    setRunStatus(null);
+    setRunWorkflowError(null);
+    setIngestedResultId(null);
+    try {
+      const catalog = await fetchScenarioCatalog();
+      if (!active()) return;
+      setScenarios(catalog.scenarios);
+      setSelectedScenarioId(catalog.golden_path_scenario_id);
+      if (catalog.scenarios.length === 0) {
+        setScenarioLoadState("empty");
+        setStatus("No scenarios available");
+      } else {
+        setScenarioLoadState("loaded");
+        setStatus("Scenario setup");
+      }
+    } catch (caught: unknown) {
+      if (!active()) return;
+      setScenarioLoadState("failed");
+      setScenarioError(caught instanceof Error ? caught.message : "Unable to load scenarios.");
+      setStatus("Scenario load failed");
+    }
+  }, []);
+
   useEffect(() => {
     let active = true;
-    fetchScenarioCatalog()
-      .then((catalog) => {
-        if (!active) return;
-        setScenarios(catalog.scenarios);
-        setSelectedScenarioId(catalog.golden_path_scenario_id);
-        setStatus("Scenario setup");
-      })
-      .catch((caught: unknown) => {
-        if (!active) return;
-        setError(caught instanceof Error ? caught.message : "Unable to load scenarios.");
-      });
+    loadScenarios(() => active);
     return () => {
       active = false;
     };
-  }, []);
+  }, [loadScenarios]);
 
   useEffect(() => {
     let active = true;
@@ -848,15 +871,6 @@ export function App() {
     }
   }
 
-  if (error && scenarios.length === 0) {
-    return (
-      <main className="app-shell">
-        <h1>Cloud Chamber</h1>
-        <p role="alert">{error}</p>
-      </main>
-    );
-  }
-
   return (
     <main className="app-shell">
       <header className="topbar">
@@ -883,6 +897,9 @@ export function App() {
       {activeSection === "build" && (
         <BuildWorkspace
           status={status}
+          scenarioLoadState={scenarioLoadState}
+          scenarioError={scenarioError}
+          packageError={error}
           scenarios={scenarios}
           selectedScenario={selectedScenario}
           selectedScenarioId={selectedScenarioId}
@@ -919,6 +936,9 @@ export function App() {
             if (ingestedResultId) setSelectedResultId(ingestedResultId);
             setActiveSection("explore");
             setActiveExploreTab("view3d");
+          }}
+          onRetryScenarios={() => {
+            void loadScenarios();
           }}
         />
       )}
@@ -990,6 +1010,9 @@ export function App() {
 
 function BuildWorkspace({
   status,
+  scenarioLoadState,
+  scenarioError,
+  packageError,
   scenarios,
   selectedScenario,
   selectedScenarioId,
@@ -1010,8 +1033,12 @@ function BuildWorkspace({
   onOpenInResults,
   onInspectIngested,
   onVisualizeIngested,
+  onRetryScenarios,
 }: {
   status: string;
+  scenarioLoadState: ScenarioLoadState;
+  scenarioError: string | null;
+  packageError: string | null;
   scenarios: Scenario[];
   selectedScenario: Scenario | undefined;
   selectedScenarioId: string;
@@ -1032,7 +1059,10 @@ function BuildWorkspace({
   onOpenInResults: () => void;
   onInspectIngested: () => void;
   onVisualizeIngested: () => void;
+  onRetryScenarios: () => void;
 }) {
+  const scenarioControlsReady = scenarioLoadState === "loaded" && selectedScenario !== undefined;
+
   return (
     <section className="workspace-section" aria-labelledby="build-title">
       <div className="section-heading">
@@ -1050,9 +1080,11 @@ function BuildWorkspace({
           </label>
           <select
             id="scenario"
-            value={selectedScenarioId}
+            value={scenarioControlsReady ? selectedScenarioId : ""}
+            disabled={!scenarioControlsReady}
             onChange={(event) => onSelectScenario(event.target.value)}
           >
+            {!scenarioControlsReady && <option value="">Scenario unavailable</option>}
             {scenarios.map((scenario) => (
               <option key={scenario.id} value={scenario.id}>
                 {scenario.display_name}
@@ -1060,7 +1092,34 @@ function BuildWorkspace({
             ))}
           </select>
 
-          {selectedScenario && (
+          {scenarioLoadState === "loading" && (
+            <ScenarioStatePanel
+              title="Loading scenario catalog"
+              body="Cloud Chamber is waiting for the local backend to return available CM1 scenario templates. Package controls will appear after a scenario is loaded."
+            />
+          )}
+
+          {scenarioLoadState === "failed" && (
+            <ScenarioStatePanel
+              title="Scenario catalog unavailable"
+              body={`Cloud Chamber could not load scenario templates from the local backend. ${
+                scenarioError ?? "The backend may be stopped or temporarily unavailable."
+              }`}
+              actionLabel="Retry scenarios"
+              onAction={onRetryScenarios}
+            />
+          )}
+
+          {scenarioLoadState === "empty" && (
+            <ScenarioStatePanel
+              title="No scenarios available"
+              body="The local backend responded, but it did not return any scenario templates. Package generation is unavailable until at least one scenario is configured."
+              actionLabel="Retry scenarios"
+              onAction={onRetryScenarios}
+            />
+          )}
+
+          {scenarioControlsReady && (
             <>
               <div className="hero-case">
                 <p className="eyebrow">First Golden Path hero case</p>
@@ -1121,6 +1180,12 @@ function BuildWorkspace({
                 </div>
               )}
 
+              {packageError && (
+                <div className="validation" role="alert">
+                  <p>{packageError}</p>
+                </div>
+              )}
+
               <button type="submit" disabled={validationMessages.length > 0}>
                 Create run package
               </button>
@@ -1163,6 +1228,30 @@ function BuildWorkspace({
           </section>
         </aside>
       </section>
+    </section>
+  );
+}
+
+function ScenarioStatePanel({
+  title,
+  body,
+  actionLabel,
+  onAction,
+}: {
+  title: string;
+  body: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}) {
+  return (
+    <section className="scenario-state-panel" aria-live="polite">
+      <h3>{title}</h3>
+      <p>{body}</p>
+      {actionLabel && onAction && (
+        <button type="button" onClick={onAction}>
+          {actionLabel}
+        </button>
+      )}
     </section>
   );
 }

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -47,6 +47,68 @@ Runtime storage tests must use temporary runtime homes only. They should cover t
 
 Runtime storage UI tests should mock the storage inventory and delete endpoints. They should verify the 50 GB warning state, largest-run table, completed/saved/running/missing-manifest categories, disabled cleanup for running and saved/protected runs, dry-run delete preview, explicit confirmed delete, and visible backend failure messages. Automated UI tests must not delete real local run directories.
 
+## UI Testing Standard
+
+For UI issues, do not rely only on `scripts/check.sh` and component tests. Use
+the right layer for the work:
+
+```text
+unit/component tests:
+  logic, rendering branches, API-shape handling, small component behavior
+
+Playwright/browser tests:
+  user workflows, navigation, tab behavior, form flows, save/delete flows,
+  console-error hygiene, layout regressions, occlusion/overlay bugs,
+  critical Build -> Results -> Explore paths
+
+manual QA:
+  qualitative UX and science judgment only
+```
+
+Manual QA should not be a broad checklist of objective behaviors. Objective
+checks should become automated tests. Manual review should focus on things
+automation cannot judge well: visual plausibility, scientific trust, wording
+clarity, workflow clarity, whether the page teaches the right lesson, whether a
+visualization feels physically believable, whether saved/delete/protection
+semantics feel safe, and whether the experience is enjoyable rather than
+debug-like.
+
+For any issue that changes navigation, Results, Storage, Compare, Explore,
+Build workflow, or visualizer layout:
+
+- add or update unit/component tests for logic;
+- add or update Playwright tests for user-path/browser behavior;
+- run `scripts/check.sh`;
+- run `scripts/check-e2e.sh` when the change affects user workflows or layout;
+- use manual QA only for qualitative judgment, not as a substitute for tests.
+
+When manual review is needed, keep it focused:
+
+1. What user goal is being evaluated?
+2. What screenshots or flows should be reviewed?
+3. What qualitative judgment is needed?
+4. Which objective checks should become automated tests?
+5. What follow-up issue, if any, is needed?
+
+Good manual QA asks whether the 3-D cloud geometry looks physically plausible
+in side `x-z` view, whether Baseline vs Dry Failed teaches the
+moisture-limitation story, or whether Storage makes deletion feel safe. Bad
+manual QA asks someone to click every tab, verify all standard navigation by
+hand, or manually inspect long objective checklists.
+
+Codex UI PR summaries should explicitly report:
+
+```text
+Unit/component tests added or updated:
+Playwright tests added or updated:
+Manual QA needed:
+  yes/no
+  if yes, what qualitative question should Tim review?
+Commands run:
+  scripts/check.sh
+  scripts/check-e2e.sh, if applicable
+```
+
 NetCDF ingest tests use tiny synthetic NetCDF files in temporary run directories. They should assert valid metadata extraction, result metadata serialization, missing-output failures, malformed-NetCDF failures, missing expected field warnings, and that raw `.dat/.ctl` artifacts are cataloged but not treated as NetCDF input. These tests must not use real CM1 output.
 
 Multi-file NetCDF ingest tests should use tiny generated fixtures under temporary run directories. They should cover CM1-style sequences such as `cm1out_000001.nc`, `cm1out_000002.nc`, and `cm1out_stats.nc`; verify model-field files are sorted by output index; exclude or separately classify stats NetCDF files; count total model output files and time steps; preserve first/last output time; record direct-vs-inferred time handling; tolerate corrupt individual output files with caveats when enough valid files remain; and ensure diagnostics time series span the full model-field sequence. A full-run no-cloud result is meaningful only after all usable model-output files have been evaluated.


### PR DESCRIPTION
Closes #139

Summary:
- Added explicit Build scenario catalog states for loading, loaded, failed, and empty responses.
- Kept scenario/package controls disabled or hidden until a valid scenario is loaded.
- Added a visible retry action for scenario load failures and empty catalog responses.
- Documented the UI testing standard: objective UI behavior should become unit/component or Playwright coverage, while manual QA stays qualitative.

Unit/component tests added or updated:
- Added Build workspace tests for slow/loading scenario catalog, failed load with retry, empty catalog, and unavailable package controls before scenario data loads.

Playwright tests added or updated:
- None in this PR because #138 is the in-progress Playwright harness import; #139 is covered with component tests here and should receive browser-path coverage once #138 lands.

Manual QA needed:
- No for objective acceptance. Optional qualitative glance only: does the failed/empty scenario wording make it clear that this is a local backend/catalog availability problem, not a CM1 science result?

Commands run:
- npm run test
- scripts/check.sh
- scripts/check-e2e.sh: not available on this branch yet; tracked by #138.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, logs, local runtime files, or visualization artifacts committed.