### PR TITLE
Harden Results loading and startup console hygiene

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%23111820'/%3E%3Cpath d='M18 42c-3.8 0-7-3.1-7-6.9 0-3.5 2.6-6.4 6-6.9C18.1 21.1 24.3 16 31.7 16c7.9 0 14.4 5.8 15.5 13.3 3.3.8 5.8 3.8 5.8 7.4 0 4.2-3.4 7.3-7.6 7.3H18Z' fill='%2391d9b7'/%3E%3Cpath d='M22 43h21' stroke='%23edf4f8' stroke-width='4' stroke-linecap='round' opacity='.9'/%3E%3C/svg%3E"
+    />
     <title>Cloud Chamber</title>
   </head>
   <body>

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -945,7 +945,9 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { name: "Baseline Shallow Cumulus" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Create run package" })).toBeEnabled();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Create run package" })).toBeEnabled();
+    });
   });
 
   it("shows an empty scenario state without enabling package creation", async () => {
@@ -1151,6 +1153,57 @@ describe("App", () => {
     expect(screen.getByText("Technical details")).toBeInTheDocument();
     expect(screen.getAllByText("Completed CM1 result").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Inspect fields" })).toBeEnabled();
+  });
+
+  it("accepts legacy array results responses without crashing", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(new Response(JSON.stringify([resultCard]), { status: 200 }));
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Experiment Notebook" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Quick-look shallow cumulus" })).toBeInTheDocument();
+    expect(screen.queryByText(/results is not iterable/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a clean results load failure state for malformed results payloads", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ detail: "unexpected shape" }), { status: 200 }),
+        );
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not load results");
+    expect(screen.getByText("No ingested CM1 results yet.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Refresh results" })).toBeInTheDocument();
+    expect(screen.queryByText(/results is not iterable/i)).not.toBeInTheDocument();
   });
 
   it("compares baseline and dry failed results side by side", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -398,9 +398,23 @@ async function ingestCompletedRun(manifestPath: string): Promise<IngestResponse>
 async function fetchResults(): Promise<ResultsResponse> {
   const response = await fetch("/api/results");
   if (!response.ok) {
-    throw new Error("Unable to load results.");
+    throw new Error("Could not load results.");
   }
-  return response.json() as Promise<ResultsResponse>;
+  return normalizeResultsResponse(await response.json());
+}
+
+function normalizeResultsResponse(payload: unknown): ResultsResponse {
+  if (Array.isArray(payload)) {
+    return { results: payload as ResultCard[] };
+  }
+  if (isObject(payload) && Array.isArray(payload.results)) {
+    return { results: payload.results as ResultCard[] };
+  }
+  throw new Error("Could not load results.");
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 async function patchResultCard(
@@ -620,7 +634,9 @@ export function App() {
       })
       .catch((caught: unknown) => {
         if (!active) return;
-        setResultsError(caught instanceof Error ? caught.message : "Unable to load results.");
+        setResults([]);
+        setSelectedResultId(null);
+        setResultsError(caught instanceof Error ? caught.message : "Could not load results.");
         setResultsStatus("Results unavailable");
       });
     return () => {
@@ -760,7 +776,9 @@ export function App() {
     try {
       await refreshResults();
     } catch (caught) {
-      setResultsError(caught instanceof Error ? caught.message : "Unable to refresh results.");
+      setResults([]);
+      setSelectedResultId(null);
+      setResultsError(caught instanceof Error ? caught.message : "Could not load results.");
       setResultsStatus("Results unavailable");
     }
   }


### PR DESCRIPTION
Closes #133
Closes #134

Summary:
- Normalized Results API responses so both legacy array payloads and `{ results: [...] }` payloads render safely.
- Converted malformed or failed Results payloads into a clean `Could not load results` empty/error state instead of raw JS exception text.
- Cleared stale selected-result state when Results loading fails.
- Added an inline SVG favicon to prevent the default `/favicon.ico` 404 on fresh app load.

Unit/component tests added or updated:
- Added coverage for legacy array Results payloads.
- Added coverage for malformed Results payloads and verified `results is not iterable` is not rendered.

Playwright tests added or updated:
- None in this PR; #138 is bringing in the browser harness. These cases should be covered there with console hygiene and defensive loading paths.

Manual QA needed:
- No for objective acceptance. Optional qualitative glance only: Results unavailable copy should feel clear and not alarming.

Commands run:
- npm run test
- scripts/check.sh

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, logs, local runtime files, or visualization artifacts committed.