### PR TITLE
Add stable Build selectors and ARIA tabs

### DIFF
--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1009,7 +1009,8 @@ describe("App", () => {
     fireEvent.change(humidityControl, {
       target: { value: "more_humid" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Create run package" }));
+    expect(screen.getByTestId("create-package-btn")).toBeEnabled();
+    fireEvent.click(screen.getByTestId("create-package-btn"));
 
     await waitFor(() => {
       expect(screen.getByText("/tmp/CloudChamber/runs/dry-run-001")).toBeInTheDocument();
@@ -1032,17 +1033,19 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Create run package" }));
+    fireEvent.click(await screen.findByTestId("create-package-btn"));
 
     expect(await screen.findByText("dry-run-001")).toBeInTheDocument();
+    expect(screen.getByTestId("package-review-panel")).toBeInTheDocument();
     expect(screen.getByText("Manifest path").nextElementSibling).toHaveTextContent(
       "/tmp/CloudChamber/runs/dry-run-001/run_manifest.json",
     );
     expect(screen.getByText(/Expected diagnostics/)).toHaveTextContent("first_cloud_time");
-    expect(screen.getByRole("button", { name: "Launch local CM1" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Ingest output" })).toBeDisabled();
+    expect(screen.getByTestId("launch-cm1-btn")).toBeEnabled();
+    expect(screen.getByTestId("refresh-status-btn")).toBeDisabled();
+    expect(screen.getByTestId("ingest-results-btn")).toBeDisabled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Launch local CM1" }));
+    fireEvent.click(screen.getByTestId("launch-cm1-btn"));
 
     await waitFor(() => {
       expect(screen.getAllByText("Running").length).toBeGreaterThan(0);
@@ -1050,16 +1053,16 @@ describe("App", () => {
     expect(screen.getByText("stdout log").nextElementSibling).toHaveTextContent("stdout.log");
     expect(screen.getByText("CM1 started")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh status" }));
+    fireEvent.click(screen.getByTestId("refresh-status-btn"));
 
     await waitFor(() => {
       expect(screen.getAllByText("Completed CM1 result").length).toBeGreaterThan(0);
     });
     expect(screen.getByText("Output summary").nextElementSibling).toHaveTextContent("14 NetCDF");
     expect(screen.getAllByText(/IEEE_INVALID_FLAG/).length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "Ingest output" })).toBeEnabled();
+    expect(screen.getByTestId("ingest-results-btn")).toBeEnabled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Ingest output" }));
+    fireEvent.click(screen.getByTestId("ingest-results-btn"));
 
     expect(await screen.findByText(/Result metadata created/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open in Results" })).toBeInTheDocument();
@@ -1105,11 +1108,11 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Create run package" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Launch local CM1" }));
+    fireEvent.click(await screen.findByTestId("create-package-btn"));
+    fireEvent.click(await screen.findByTestId("launch-cm1-btn"));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("CM1 executable is missing");
-    expect(screen.getByRole("button", { name: "Launch local CM1" })).toBeEnabled();
+    expect(screen.getByTestId("launch-cm1-btn")).toBeEnabled();
   });
 
   it("lists result cards in a table and shows notebook diagnostics", async () => {
@@ -1124,9 +1127,9 @@ describe("App", () => {
     expect(within(topNav).queryByRole("button", { name: "Storage" })).not.toBeInTheDocument();
     expect(within(topNav).queryByRole("button", { name: "Inspect" })).not.toBeInTheDocument();
     expect(within(topNav).queryByRole("button", { name: "Visualize" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Notebook" })).toHaveClass("active-control");
-    expect(screen.getByRole("button", { name: "Compare" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Storage" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Notebook" })).toHaveClass("active-control");
+    expect(screen.getByRole("tab", { name: "Compare" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Storage" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Experiment Notebook" })).toBeInTheDocument();
     expect(screen.getByLabelText("Selected result")).toHaveTextContent(
       "Quick-look shallow cumulus",
@@ -1209,7 +1212,7 @@ describe("App", () => {
   it("compares baseline and dry failed results side by side", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Compare" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Compare" }));
 
     expect(
       await screen.findByRole("heading", { name: "Baseline vs Dry Failed Cumulus" }),
@@ -1257,7 +1260,7 @@ describe("App", () => {
   it("switches side-by-side field comparison from qc to w", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Compare" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Compare" }));
     await screen.findByText("Comparison slices loaded");
 
     fireEvent.change(screen.getByLabelText("Comparison field"), { target: { value: "w" } });
@@ -1281,7 +1284,7 @@ describe("App", () => {
   it("opens inspect and visualize from comparison quick actions", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Compare" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Compare" }));
     fireEvent.click(await screen.findByRole("button", { name: "Open Dry Failed in Explore" }));
 
     expect(
@@ -1299,13 +1302,13 @@ describe("App", () => {
         { name: "Results" },
       ),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Compare" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Compare" }));
     fireEvent.click(screen.getByRole("button", { name: "Open Dry Failed 3-D" }));
 
     expect(
       await screen.findByRole("heading", { name: "Inspect and visualize fields" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "3-D View" })).toHaveClass("active-control");
+    expect(screen.getByRole("tab", { name: "3-D View" })).toHaveClass("active-control");
     expect(screen.getAllByText("Dry Failed Cumulus quick-look").length).toBeGreaterThan(0);
     expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(
@@ -1333,7 +1336,7 @@ describe("App", () => {
 
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Compare" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Compare" }));
 
     expect(
       await screen.findByRole("heading", {
@@ -1402,7 +1405,7 @@ describe("App", () => {
   it("shows runtime storage inventory and safe cleanup affordances", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Storage" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Storage" }));
 
     expect(
       await screen.findByRole("heading", { name: "Runtime storage cleanup" }),
@@ -1495,7 +1498,7 @@ describe("App", () => {
 
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Storage" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Storage" }));
     fireEvent.click((await screen.findAllByRole("button", { name: "Preview delete" }))[0]);
 
     expect(await screen.findByRole("alert")).toHaveTextContent(

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1204,7 +1204,11 @@ function BuildWorkspace({
                 </div>
               )}
 
-              <button type="submit" disabled={validationMessages.length > 0}>
+              <button
+                type="submit"
+                data-testid="create-package-btn"
+                disabled={validationMessages.length > 0}
+              >
                 Create run package
               </button>
             </>
@@ -1221,7 +1225,11 @@ function BuildWorkspace({
             </p>
           </section>
 
-          <section className="status-panel" aria-labelledby="review-title">
+          <section
+            className="status-panel"
+            aria-labelledby="review-title"
+            data-testid="package-review-panel"
+          >
             <p className="eyebrow">Generated package</p>
             <h3 id="review-title">Review before local CM1 run</h3>
             {dryRun ? (
@@ -1343,11 +1351,15 @@ function ResultsWorkspace({
         <p className="state-chip">{resultsStatus}</p>
       </div>
 
-      <nav className="subtab-nav" aria-label="Results workspace sections">
+      <nav className="subtab-nav" role="tablist" aria-label="Results views">
         {(["notebook", "compare", "storage"] as ResultsTab[]).map((tab) => (
           <button
             key={tab}
             type="button"
+            id={`${tab}-tab`}
+            role="tab"
+            aria-selected={activeTab === tab}
+            aria-controls={`${tab}-panel`}
             className={activeTab === tab ? "active-control" : ""}
             onClick={() => onTabChange(tab)}
           >
@@ -1464,7 +1476,12 @@ function NotebookWorkspace({
   onOpenVisualizer: () => void;
 }) {
   return (
-    <section className="workspace-section" aria-labelledby="notebook-title">
+    <section
+      className="workspace-section"
+      role="tabpanel"
+      id="notebook-panel"
+      aria-labelledby="notebook-tab notebook-title"
+    >
       <div className="section-heading">
         <div>
           <p className="eyebrow">Notebook</p>
@@ -1513,11 +1530,15 @@ function ExploreWorkspace({
         <p className="state-chip">{selectedResult ? selectedResult.name : "No result"}</p>
       </div>
 
-      <nav className="subtab-nav" aria-label="Explore workspace sections">
+      <nav className="subtab-nav" role="tablist" aria-label="Explore views">
         {(["slices", "view3d"] as ExploreTab[]).map((tab) => (
           <button
             key={tab}
             type="button"
+            id={`${tab}-tab`}
+            role="tab"
+            aria-selected={activeTab === tab}
+            aria-controls={`${tab}-panel`}
             className={activeTab === tab ? "active-control" : ""}
             onClick={() => onTabChange(tab)}
           >
@@ -1527,13 +1548,22 @@ function ExploreWorkspace({
       </nav>
 
       {!selectedResult && (
-        <section className="status-panel">
+        <section
+          className="status-panel"
+          role="tabpanel"
+          id={`${activeTab}-panel`}
+          aria-labelledby={`${activeTab}-tab`}
+        >
           <p>Select an ingested result from Results to inspect or visualize it.</p>
         </section>
       )}
 
       {selectedResult && activeTab === "slices" && (
-        <section aria-labelledby="explore-slices-title">
+        <section
+          role="tabpanel"
+          id="slices-panel"
+          aria-labelledby="slices-tab explore-slices-title"
+        >
           <p className="eyebrow">2-D Slices</p>
           <h3 id="explore-slices-title">2-D Slices</h3>
           <FieldInspector result={selectedResult} />
@@ -1541,7 +1571,7 @@ function ExploreWorkspace({
       )}
 
       {selectedResult && activeTab === "view3d" && (
-        <section aria-labelledby="explore-3d-title">
+        <section role="tabpanel" id="view3d-panel" aria-labelledby="view3d-tab explore-3d-title">
           <p className="eyebrow">3-D View</p>
           <h3 id="explore-3d-title">3-D View</h3>
           <VisualizerSceneShell result={selectedResult} />
@@ -1565,7 +1595,12 @@ function ComparisonWorkspace({
   const missing = comparisonMissingItems(pair);
 
   return (
-    <section className="comparison-workspace" aria-labelledby="comparison-title">
+    <section
+      className="comparison-workspace"
+      role="tabpanel"
+      id="compare-panel"
+      aria-labelledby="compare-tab comparison-title"
+    >
       <div className="section-heading">
         <div>
           <p className="eyebrow">Compare</p>
@@ -2074,7 +2109,12 @@ function StorageWorkspace({
   onExploreResult: (resultId: string) => void;
 }) {
   return (
-    <section className="storage-workspace" aria-labelledby="storage-title">
+    <section
+      className="storage-workspace"
+      role="tabpanel"
+      id="storage-panel"
+      aria-labelledby="storage-tab storage-title"
+    >
       <div className="section-heading">
         <div>
           <p className="eyebrow">Storage</p>
@@ -2390,13 +2430,28 @@ function GuidedRunWorkflow({
         {error && <p role="alert">{error}</p>}
 
         <div className="button-row">
-          <button type="button" onClick={onLaunchRun} disabled={Boolean(runStatus)}>
+          <button
+            type="button"
+            data-testid="launch-cm1-btn"
+            onClick={onLaunchRun}
+            disabled={Boolean(runStatus)}
+          >
             Launch local CM1
           </button>
-          <button type="button" onClick={onRefreshRunStatus} disabled={!runStatus}>
+          <button
+            type="button"
+            data-testid="refresh-status-btn"
+            onClick={onRefreshRunStatus}
+            disabled={!runStatus}
+          >
             Refresh status
           </button>
-          <button type="button" onClick={onIngestRun} disabled={!canIngest}>
+          <button
+            type="button"
+            data-testid="ingest-results-btn"
+            onClick={onIngestRun}
+            disabled={!canIngest}
+          >
             Ingest output
           </button>
         </div>


### PR DESCRIPTION
Closes #135
Closes #136

Summary:
- Added stable `data-testid` selectors for the key Build package, launch, refresh, ingest, and package-review controls.
- Converted Results sub-navigation to ARIA `tablist` / `tab` / `tabpanel` semantics.
- Applied the same ARIA tab pattern to Explore 2-D Slices and 3-D View.
- Updated component tests to use the stable Build selectors and tab roles.

Unit/component tests added or updated:
- Updated guided run workflow tests to assert and use the Build test IDs.
- Updated Results/Compare/Storage/Explore tests to query ARIA tabs.

Playwright tests added or updated:
- None in this PR; #138 is bringing in the browser harness that will consume these selectors and roles.

Manual QA needed:
- No for objective acceptance. Optional qualitative glance only: the tabs should still feel visually unchanged while being screen-reader/test friendly.

Commands run:
- npm run test
- scripts/check.sh

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, generated run directories, LANDUSE.TBL, logs, local runtime files, or visualization artifacts committed.