### PR TITLE
Add Playwright browser smoke suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ app/frontend/coverage/
 app/frontend/.vite/
 app/frontend/.eslintcache
 app/frontend/reference-indexes/
+app/frontend/playwright-report/
+app/frontend/test-results/
+app/frontend/blob-report/
+app/frontend/e2e/.auth/
 
 # CM1 runtime and generated output
 cm1.exe

--- a/app/frontend/.prettierignore
+++ b/app/frontend/.prettierignore
@@ -1,3 +1,6 @@
 dist/
 coverage/
 node_modules/
+playwright-report/
+test-results/
+blob-report/

--- a/app/frontend/e2e/README.md
+++ b/app/frontend/e2e/README.md
@@ -1,0 +1,40 @@
+# Cloud Chamber Playwright E2E
+
+These browser checks are intentionally split into three categories.
+
+## Categories
+
+- `mocked-smoke/`: deterministic browser smoke tests with mocked API routes. These are safe to run repeatedly and should pass without local CM1, local NetCDF, or `~/CloudChamber` runtime data.
+- `local-data/`: read-only checks against the local backend/runtime home. These may skip when local run/result data is absent or the backend is unavailable.
+- `visual-manual/`: partial browser checks for layout-heavy visualization behavior. They catch obvious DOM/layout regressions, but still leave some scientific/visual judgment to human inspection.
+
+## Commands
+
+From `app/frontend`:
+
+```sh
+npm run test:e2e
+npm run test:e2e:headed
+npm run test:e2e:report
+```
+
+From the repo root:
+
+```sh
+scripts/check-e2e.sh
+```
+
+`scripts/check-e2e.sh` runs only the mocked smoke tests by default. Use the npm
+scripts when you want the full local-data and visual/manual suite.
+
+## Safety Rules
+
+- Do not run real CM1 from Playwright.
+- Do not mutate real notebook data from unmocked tests.
+- Do not delete real run directories from unmocked tests.
+- Destructive/editing tests must use mocked API routes.
+- Do not commit Playwright reports, screenshots, videos, traces, NetCDF files,
+  logs, generated CM1 output, or local run folders.
+
+Known product follow-ups linked by this suite include #133, #134, #135, #136,
+and #139.

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -1,0 +1,439 @@
+import type { Page, Route } from "@playwright/test";
+
+const scenario = {
+  id: "baseline-shallow-cumulus",
+  display_name: "Baseline Shallow Cumulus",
+  description: "First Golden Path hero case for a credible idealized shallow-cumulus experiment.",
+  physical_question:
+    "How do low-level moisture, surface heating, cap strength, cap height, dry air aloft, and mixing/entrainment affect shallow-cumulus formation, timing, depth, updraft strength, and cloud-water evolution?",
+  intended_behavior: "A balanced shallow-cumulus case.",
+  expected_behavior: "Clouds may form after heating and mixing erode inhibition.",
+  learning_goals: ["Recognize first cloud time and cloud depth."],
+  warnings: ["Preview estimates are guidance only."],
+  limitations: ["Exact morphology is not pass/fail."],
+  controls: [
+    {
+      id: "low_level_humidity",
+      label: "Low-level humidity",
+      description: "Relative moisture in the lower atmosphere around the baseline profile.",
+      type: "choice",
+      default: "baseline",
+      options: [
+        { value: "drier", label: "Drier" },
+        { value: "baseline", label: "Baseline" },
+        { value: "more_humid", label: "More humid" },
+      ],
+    },
+    {
+      id: "surface_heating",
+      label: "Surface heating",
+      description: "Relative daytime heating strength for boundary-layer growth.",
+      type: "choice",
+      default: "baseline",
+      options: [
+        { value: "weaker", label: "Weaker" },
+        { value: "baseline", label: "Baseline" },
+        { value: "stronger", label: "Stronger" },
+      ],
+    },
+    {
+      id: "cap_strength",
+      label: "Cap strength",
+      description: "Relative resistance to rising thermals near the capping layer.",
+      type: "choice",
+      default: "baseline",
+      options: [
+        { value: "weaker", label: "Weaker" },
+        { value: "baseline", label: "Baseline" },
+        { value: "stronger", label: "Stronger" },
+      ],
+    },
+  ],
+  run_size_presets: [
+    {
+      id: "quick_look",
+      label: "Quick look",
+      purpose: "Sanity checks.",
+      expected_runtime: "roughly 10-20 minutes",
+      confidence: "lower confidence until locally validated",
+      output_notes: "coarser output cadence",
+    },
+  ],
+};
+
+const outputSummary = {
+  netcdf_count: 13,
+  model_output_count: 13,
+  stats_netcdf_count: 1,
+  raw_cm1_artifact_count: 0,
+  processed_artifact_count: 0,
+  visualization_ready_artifact_count: 0,
+  total_output_count: 14,
+  model_output_file_count: 13,
+  time_steps: 13,
+  first_output_time_seconds: 0,
+  last_output_time_seconds: 10800,
+};
+
+export const results = [
+  {
+    result_id: "result-baseline",
+    run_id: "dry-run-baseline",
+    name: "Baseline Shallow Cumulus — Quick Look",
+    tags: ["baseline", "quick-look"],
+    notes: "Mocked keeper result for browser smoke tests.",
+    saved: true,
+    protected: true,
+    scenario_id: "baseline-shallow-cumulus",
+    scenario_name: "Baseline Shallow Cumulus",
+    run_size_preset: "quick_look",
+    physical_question: scenario.physical_question,
+    controls: {
+      low_level_humidity: "baseline",
+      surface_heating: "baseline",
+      cap_strength: "baseline",
+    },
+    status: "ingested",
+    source_lifecycle_state: "completed",
+    source_product_state: "completed_cm1_result",
+    source_model: "CM1",
+    provenance_labels: ["CM1 result", "ingested metadata", "visualizer interpretation"],
+    diagnostics_summary: "cloud formed; rain detected",
+    first_cloud_time_seconds: 1800,
+    max_qc_kg_kg: 0.00219,
+    max_w_m_s: 6.96,
+    min_w_m_s: -3.77,
+    rain_present: true,
+    caveats: ["minor vertical-coordinate caveat"],
+    output_file_summary: outputSummary,
+    created_at: "2026-05-22T15:15:36Z",
+    completed_at: "2026-05-22T15:32:21Z",
+    ingested_at: "2026-05-22T15:35:00Z",
+    updated_at: "2026-05-22T15:35:00Z",
+  },
+  {
+    result_id: "result-dry-failed",
+    run_id: "dry-run-dry-failed",
+    name: "Dry Failed Cumulus — Quick Look",
+    tags: ["dry-failed"],
+    notes: "Mocked dry contrast.",
+    saved: true,
+    protected: true,
+    scenario_id: "dry-failed-cumulus",
+    scenario_name: "Dry Failed Cumulus",
+    run_size_preset: "quick_look",
+    physical_question:
+      "How does insufficient low-level moisture prevent shallow cumulus formation?",
+    controls: { low_level_humidity: "drier", surface_heating: "baseline" },
+    status: "ingested",
+    source_lifecycle_state: "completed",
+    source_product_state: "completed_cm1_result",
+    source_model: "CM1",
+    provenance_labels: ["CM1 result", "ingested metadata"],
+    diagnostics_summary: "no cloud formed; no rain detected",
+    first_cloud_time_seconds: null,
+    max_qc_kg_kg: 0,
+    max_w_m_s: 1.95,
+    min_w_m_s: -1.09,
+    rain_present: false,
+    caveats: ["moisture-limited"],
+    output_file_summary: outputSummary,
+    created_at: "2026-05-22T19:20:00Z",
+    completed_at: "2026-05-22T19:32:00Z",
+    ingested_at: "2026-05-22T19:35:00Z",
+    updated_at: "2026-05-22T19:35:00Z",
+  },
+];
+
+function json(route: Route, body: unknown, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+function fieldCatalog(resultId: string) {
+  const provenance = {
+    source_model: "CM1",
+    result_id: resultId,
+    run_id: "dry-run-baseline",
+    scenario_id: "baseline-shallow-cumulus",
+    source_product_state: "completed_cm1_result",
+    result_state: "ingested",
+    processing_method: "native-grid slice",
+    rendering_method: "json heatmap",
+    provenance_label: "CM1-derived visualization-ready payload",
+  };
+  return {
+    result_id: resultId,
+    run_id: "dry-run-baseline",
+    scenario_id: "baseline-shallow-cumulus",
+    source_model: "CM1",
+    available_fields: ["qc", "w"].map((name) => ({
+      raw_field_name: name,
+      canonical_field_name: name === "qc" ? "cloud_water" : "vertical_velocity",
+      display_name: name === "qc" ? "Cloud water" : "Vertical velocity",
+      units: name === "qc" ? "kg/kg" : "m/s",
+      dimensions: name === "qc" ? ["time", "zh", "yh", "xh"] : ["time", "zf", "yh", "xh"],
+      shape: [3, 4, 4, 4],
+      native_grid: name === "qc" ? "zh/yh/xh" : "zf/yh/xh",
+      coordinate_names: { time: "time", vertical: name === "qc" ? "zh" : "zf", y: "yh", x: "xh" },
+      time_coordinate_values: [0, 1800, 3600],
+      provenance,
+      caveats: ["native_grid_no_interpolation"],
+    })),
+    provenance,
+    caveats: [],
+  };
+}
+
+export async function mockCloudChamberApis(page: Page) {
+  await page.route("**/api/scenarios", (route) =>
+    json(route, { golden_path_scenario_id: "baseline-shallow-cumulus", scenarios: [scenario] }),
+  );
+
+  await page.route("**/api/dry-run-package", (route) =>
+    json(route, {
+      package_dir: "/tmp/cloud-chamber-e2e/run",
+      manifest_path: "/tmp/cloud-chamber-e2e/run/run_manifest.json",
+      report_path: "/tmp/cloud-chamber-e2e/run/dry_run_report.json",
+      generated_files: [
+        "run_manifest.json",
+        "case_manifest.json",
+        "namelist.input",
+        "input_sounding",
+      ],
+      report: {
+        scenario_id: scenario.id,
+        physical_question: scenario.physical_question,
+        controls: {
+          low_level_humidity: "baseline",
+          surface_heating: "baseline",
+          cap_strength: "baseline",
+        },
+        run_size_preset: "quick_look",
+        estimated_cost_or_size: "unknown until validated",
+        expected_diagnostics: ["first cloud time", "max qc", "max w"],
+        visualization_defaults: {},
+        generated_files: { namelist: "namelist.input" },
+        not_a_completed_cm1_result: true,
+        cm1_was_launched: false,
+        provenance: {
+          product_state: "packaged_dry_run_output",
+          source_model: "CM1",
+          preview_is_guidance_only: true,
+          visualizer_is_interpretation: true,
+        },
+      },
+    }),
+  );
+
+  await page.route("**/api/runs/launch", (route) =>
+    json(route, {
+      run_id: "dry-run-baseline",
+      lifecycle_state: "completed",
+      product_state: "completed_cm1_result",
+      validation_status: "accepted",
+      manifest_path: "/tmp/cloud-chamber-e2e/run/run_manifest.json",
+      command: ["/mock/cm1.exe"],
+      stdout_log: "/tmp/stdout.log",
+      stderr_log: "/tmp/stderr.log",
+      stdout_tail: "Program terminated normally",
+      stderr_tail: "",
+      exit_code: 0,
+      started_at: "2026-05-22T15:15:36Z",
+      finished_at: "2026-05-22T15:32:21Z",
+      output_summary: { raw_cm1_artifacts: 0, netcdf_paths: 13, processed_artifacts: 0 },
+      runtime_warnings: [],
+    }),
+  );
+
+  await page.route("**/api/runs/status**", (route) =>
+    json(route, {
+      run_id: "dry-run-baseline",
+      lifecycle_state: "completed",
+      product_state: "completed_cm1_result",
+      validation_status: "accepted",
+      manifest_path: "/tmp/cloud-chamber-e2e/run/run_manifest.json",
+      command: ["/mock/cm1.exe"],
+      stdout_log: "/tmp/stdout.log",
+      stderr_log: "/tmp/stderr.log",
+      stdout_tail: "Program terminated normally",
+      stderr_tail: "",
+      exit_code: 0,
+      started_at: "2026-05-22T15:15:36Z",
+      finished_at: "2026-05-22T15:32:21Z",
+      output_summary: { raw_cm1_artifacts: 0, netcdf_paths: 13, processed_artifacts: 0 },
+      runtime_warnings: [],
+    }),
+  );
+
+  await page.route("**/api/results/ingest", (route) =>
+    json(route, {
+      result_id: "result-baseline",
+      run_id: "dry-run-baseline",
+      diagnostics_summary: "cloud formed; rain detected",
+    }),
+  );
+
+  await page.route("**/api/results", (route) => json(route, { results }));
+
+  await page.route("**/api/results/*/save", (route) => {
+    const result = results[0];
+    return json(route, { ...result, saved: true, protected: true });
+  });
+
+  await page.route("**/api/results/*/visualization/fields", (route) =>
+    json(route, fieldCatalog("result-baseline")),
+  );
+
+  await page.route("**/api/results/*/visualization/defaults**", (route) =>
+    json(route, {
+      result_id: "result-baseline",
+      run_id: "dry-run-baseline",
+      scenario_id: "baseline-shallow-cumulus",
+      preferred_field: "qc",
+      fields: {
+        qc: {
+          field: "qc",
+          time_index: 1,
+          time_seconds: 1800,
+          horizontal_level_index: 2,
+          vertical_x_index: 1,
+          vertical_y_index: 1,
+          source: "first_cloud_time",
+          max_value: 0.00219,
+          selected_time_index: 1,
+          selected_time_seconds: 1800,
+          caveats: [],
+        },
+      },
+      provenance: fieldCatalog("result-baseline").provenance,
+      caveats: [],
+    }),
+  );
+
+  await page.route("**/api/results/*/visualization/slice**", (route) =>
+    json(route, {
+      result_id: "result-baseline",
+      run_id: "dry-run-baseline",
+      scenario_id: "baseline-shallow-cumulus",
+      field: fieldCatalog("result-baseline").available_fields[0],
+      selection: {
+        time_index: 1,
+        time_seconds: 1800,
+        orientation: "horizontal",
+        selected_dimension: "zh",
+        selected_index: 2,
+        selected_coordinate_value: 0.8,
+        level_units: "km",
+        level_coordinate_value: 0.8,
+        level_meters: 800,
+      },
+      coordinate_units: { zh: "km", yh: "km", xh: "km" },
+      shape: [4, 4],
+      dimension_order: ["yh", "xh"],
+      data_encoding: "json",
+      values: [
+        [0, 0.001, 0.002, 0],
+        [0, 0.002, 0.001, 0],
+        [0, 0.001, 0.002, 0],
+        [0, 0, 0.001, 0],
+      ],
+      stats: { min: 0, max: 0.002, mean: 0.0007, finite_count: 16, non_finite_count: 0 },
+      provenance: fieldCatalog("result-baseline").provenance,
+      caveats: ["native_grid_no_interpolation"],
+    }),
+  );
+
+  await page.route("**/api/results/*/visualization/point-cloud**", (route) =>
+    json(route, {
+      result_id: "result-baseline",
+      run_id: "dry-run-baseline",
+      scenario_id: "baseline-shallow-cumulus",
+      field: fieldCatalog("result-baseline").available_fields[0],
+      selection: {
+        field: "qc",
+        time_index: 1,
+        time_seconds: 1800,
+        threshold: 0.000001,
+        max_points: 50000,
+      },
+      coordinate_units: { xh: "km", yh: "km", zh: "km" },
+      coordinate_extents: {
+        x: { min: 0, max: 6.4, units: "km" },
+        y: { min: 0, max: 6.4, units: "km" },
+        z: { min: 0, max: 18, units: "km" },
+      },
+      point_order: ["x", "y", "z", "value"],
+      points: [
+        [2, 2, 0.8, 0.001],
+        [2.5, 2.3, 1.2, 0.002],
+        [3, 2.5, 1.8, 0.0015],
+      ],
+      stats: {
+        source_count: 3,
+        returned_count: 3,
+        min_value: 0.001,
+        max_value: 0.002,
+        active_z_min: 0.8,
+        active_z_max: 1.8,
+        max_value_location: { x: 2.5, y: 2.3, z: 1.2, value: 0.002 },
+        downsampled: false,
+        downsample_stride: 1,
+      },
+      provenance: {
+        ...fieldCatalog("result-baseline").provenance,
+        processing_method: "native-grid thresholded point cloud",
+        rendering_method: "thresholded point cloud",
+      },
+      caveats: [],
+    }),
+  );
+
+  await page.route("**/api/storage/inventory", (route) =>
+    json(route, {
+      runtime_home: "/tmp/cloud-chamber-e2e",
+      runs_directory: "/tmp/cloud-chamber-e2e/runs",
+      total_size_bytes: 4096,
+      warning_threshold_bytes: 53687091200,
+      above_warning_threshold: false,
+      warning_message: null,
+      runs: [
+        {
+          run_id: "dry-run-baseline",
+          scenario_id: "baseline-shallow-cumulus",
+          scenario_name: "Baseline Shallow Cumulus",
+          lifecycle_state: "completed",
+          validation_status: "valid",
+          product_state: "completed_cm1_result",
+          run_size_preset: "quick_look",
+          created_at: "2026-05-22T15:15:36Z",
+          updated_at: "2026-05-22T15:32:21Z",
+          saved: true,
+          protected: true,
+          output_artifact_count: 14,
+          output_summary: { raw_cm1_artifacts: 0, netcdf_paths: 13, processed_artifacts: 0 },
+          size_bytes: 4096,
+          path: "/tmp/cloud-chamber-e2e/runs/dry-run-baseline",
+          category: "saved_or_protected",
+          manifest_path: "/tmp/cloud-chamber-e2e/runs/dry-run-baseline/run_manifest.json",
+          manifest_error: null,
+        },
+      ],
+      largest_runs: [],
+    }),
+  );
+
+  await page.route("**/api/storage/delete-run", (route) =>
+    json(route, {
+      run_id: "dry-run-disposable",
+      run_directory: "/tmp/cloud-chamber-e2e/runs/dry-run-disposable",
+      dry_run: true,
+      deleted: false,
+      size_bytes: 1024,
+      message: "Preview only.",
+    }),
+  );
+}

--- a/app/frontend/e2e/helpers.ts
+++ b/app/frontend/e2e/helpers.ts
@@ -1,0 +1,45 @@
+import { expect, type Page } from "@playwright/test";
+
+export const API_GLOB = "**/api/**";
+
+export async function gotoApp(page: Page) {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Cloud Chamber" })).toBeVisible();
+}
+
+export async function gotoBuild(page: Page) {
+  await page.getByRole("button", { name: /^Build$/ }).click();
+}
+
+export async function gotoResults(page: Page) {
+  await page.getByRole("button", { name: /^Results$/ }).click();
+}
+
+export async function gotoExplore(page: Page) {
+  await page.getByRole("button", { name: /^Explore$/ }).click();
+}
+
+export async function openResultsTab(page: Page, tabName: RegExp) {
+  await page.getByRole("tab", { name: tabName }).click();
+}
+
+export async function openExploreTab(page: Page, tabName: RegExp) {
+  await page.getByRole("tab", { name: tabName }).click();
+}
+
+export function collectConsoleProblems(page: Page): string[] {
+  const problems: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") problems.push(message.text());
+  });
+  page.on("pageerror", (error) => problems.push(error.message));
+  return problems;
+}
+
+export async function skipIfBackendUnavailable(page: Page) {
+  const response = await page.request.get("http://127.0.0.1:8000/api/scenarios").catch(() => null);
+  if (!response?.ok()) {
+    return true;
+  }
+  return false;
+}

--- a/app/frontend/e2e/local-data/read-only.spec.ts
+++ b/app/frontend/e2e/local-data/read-only.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoApp, gotoResults, openResultsTab, skipIfBackendUnavailable } from "../helpers";
+
+test.describe("local data: read-only smoke", () => {
+  test("Results and Storage load against the local backend when available", async ({ page }) => {
+    if (await skipIfBackendUnavailable(page)) {
+      test.skip(true, "Local backend unavailable; start scripts/dev.sh for local-data tests.");
+    }
+
+    await gotoApp(page);
+    await gotoResults(page);
+    await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
+
+    await openResultsTab(page, /^Storage$/);
+    await expect(page.getByRole("heading", { name: "Runtime storage cleanup" })).toBeVisible();
+  });
+});

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoApp, gotoBuild, gotoResults, openExploreTab, openResultsTab } from "../helpers";
+import { mockCloudChamberApis } from "../fixtures";
+
+test.describe("mocked smoke: Build, Results, Explore path", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCloudChamberApis(page);
+    await gotoApp(page);
+  });
+
+  test("Build exposes the Golden Path scenario and creates a safe dry-run package", async ({
+    page,
+  }) => {
+    await gotoBuild(page);
+
+    await expect(page.locator("select").first()).toBeVisible();
+    await expect(page.getByText(/physical question/i).first()).toBeVisible();
+    await expect(page.getByText(/how do low-level moisture/i).first()).toBeVisible();
+    await expect(page.getByText(/preview estimate not implemented/i)).toBeVisible();
+
+    await page.getByTestId("create-package-btn").scrollIntoViewIfNeeded();
+    await page.getByTestId("create-package-btn").click();
+
+    await expect(page.getByTestId("package-review-panel")).toBeVisible();
+    await expect(page.getByText("/tmp/cloud-chamber-e2e/run/run_manifest.json")).toBeVisible();
+    await expect(page.getByText("CM1 launched").locator("..")).toContainText("No");
+    await expect(page.getByText(/not a completed|dry-run/i).first()).toBeVisible();
+    await expect(page.getByTestId("launch-cm1-btn")).toBeEnabled();
+  });
+
+  test("Results notebook, Compare, and Storage render with mocked data", async ({ page }) => {
+    await gotoResults(page);
+
+    await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
+    await expect(page.getByText("Baseline Shallow Cumulus — Quick Look").first()).toBeVisible();
+    await expect(page.getByText("cloud formed; rain detected").first()).toBeVisible();
+
+    await openResultsTab(page, /^Compare$/);
+    await expect(
+      page.getByRole("heading", { name: "Baseline vs Dry Failed Cumulus" }),
+    ).toBeVisible();
+    await expect(page.getByText("Moisture-limited", { exact: true })).toBeVisible();
+
+    await openResultsTab(page, /^Storage$/);
+    await expect(page.getByRole("heading", { name: "Runtime storage cleanup" })).toBeVisible();
+    await expect(page.getByText("/tmp/cloud-chamber-e2e").first()).toBeVisible();
+  });
+
+  test("Explore 2-D and 3-D views render from the selected result", async ({ page }) => {
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+
+    await expect(page.getByRole("heading", { name: "Inspect and visualize fields" })).toBeVisible();
+
+    await openExploreTab(page, /^2-D Slices$/);
+    await expect(page.getByText(/inspect cm1 fields/i).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/2-d field inspection/i).first()).toBeVisible();
+    await expect(page.getByText(/\[\[[\d.,\s]+\]\]/)).not.toBeVisible();
+
+    await openExploreTab(page, /^3-D View$/);
+    await expect(page.getByText(/scene shell/i).first()).toBeVisible({ timeout: 12_000 });
+    await expect(page.getByText(/oblique overview/i).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: /reset view/i })).toBeVisible();
+  });
+});

--- a/app/frontend/e2e/mocked-smoke/navigation.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/navigation.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+import { collectConsoleProblems, gotoApp, gotoBuild, gotoExplore, gotoResults } from "../helpers";
+import { mockCloudChamberApis } from "../fixtures";
+
+test.describe("mocked smoke: app shell", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCloudChamberApis(page);
+  });
+
+  test("loads without console errors and exposes Build, Results, Explore", async ({ page }) => {
+    const consoleProblems = collectConsoleProblems(page);
+
+    await gotoApp(page);
+
+    await expect(page.getByRole("button", { name: /^Build$/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Results$/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Explore$/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Compare$/ })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^Storage$/ })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^Inspect$/ })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^Visualize$/ })).toHaveCount(0);
+    expect(consoleProblems).toEqual([]);
+  });
+
+  test("navigates across primary workspaces and subtabs", async ({ page }) => {
+    await gotoApp(page);
+
+    await gotoBuild(page);
+    await expect(page.getByRole("heading", { name: "Create a CM1 run package" })).toBeVisible();
+
+    await gotoResults(page);
+    await expect(page.getByRole("tab", { name: "Notebook" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Compare" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Storage" })).toBeVisible();
+
+    await gotoExplore(page);
+    await expect(page.getByRole("tab", { name: "2-D Slices" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "3-D View" })).toBeVisible();
+  });
+});

--- a/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+import { gotoApp, gotoExplore, gotoResults } from "../helpers";
+import { mockCloudChamberApis } from "../fixtures";
+
+async function expectClickableCenter(page: Page, locator: Locator, label: string) {
+  await locator.scrollIntoViewIfNeeded();
+  await expect(locator).toBeVisible();
+  await expect(locator).toBeInViewport();
+  const box = await locator.boundingBox();
+  expect(box, `${label} should have a visible bounding box`).not.toBeNull();
+  if (!box) return;
+
+  const center = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  const receivesPointer = await locator.evaluate((element, point) => {
+    const hit = document.elementFromPoint(point.x, point.y);
+    return hit === element || element.contains(hit);
+  }, center);
+  expect(receivesPointer, `${label} center should not be covered by the visualizer`).toBe(true);
+}
+
+test.describe("mocked smoke: visualizer occlusion regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCloudChamberApis(page);
+    await gotoApp(page);
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open 3-D" }).first().click();
+    await gotoExplore(page);
+  });
+
+  test("3-D scene does not cover its primary controls", async ({ page }) => {
+    await expect(page.getByText(/scene shell/i).first()).toBeVisible({ timeout: 12_000 });
+    await expect(page.getByText(/oblique overview/i).first()).toBeVisible();
+    await expect(page.getByText(/side x-?z/i).first()).toBeVisible();
+
+    await expectClickableCenter(
+      page,
+      page.getByRole("button", { name: /reset view/i }),
+      "Reset view",
+    );
+    await expectClickableCenter(
+      page,
+      page.getByRole("tab", { name: "2-D Slices" }),
+      "2-D Slices tab",
+    );
+    await expectClickableCenter(page, page.getByRole("tab", { name: "3-D View" }), "3-D View tab");
+  });
+});

--- a/app/frontend/e2e/visual-manual/visualizer-layout.spec.ts
+++ b/app/frontend/e2e/visual-manual/visualizer-layout.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoApp, gotoResults } from "../helpers";
+import { mockCloudChamberApis } from "../fixtures";
+
+test.describe("visual/manual: 3-D workbench layout", () => {
+  test("loads the point-cloud scene with qualitative review targets visible", async ({ page }) => {
+    test.info().annotations.push({
+      type: "manual-review",
+      description:
+        "Qualitative review: does the 3-D cloud-water view feel physically readable, with slice planes secondary and controls/details reachable?",
+    });
+
+    await mockCloudChamberApis(page);
+    await gotoApp(page);
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open 3-D" }).first().click();
+
+    await expect(page.getByText(/scene shell/i).first()).toBeVisible({ timeout: 12_000 });
+    await expect(page.getByText(/cloud-water threshold/i).first()).toBeVisible();
+    await expect(page.getByText(/oblique overview/i).first()).toBeVisible();
+    await expect(page.getByText(/side x-?z/i).first()).toBeVisible();
+    await page
+      .getByText(/about this visualization/i)
+      .first()
+      .click();
+    await expect(page.getByText(/visualizer interpretation/i).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: /reset view/i })).toBeVisible();
+  });
+});

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.8.0",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.4.0",
         "@testing-library/react": "^16.0.0",
         "@types/node": "^22.0.0",
@@ -1129,6 +1130,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3705,6 +3722,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -9,17 +9,22 @@
     "lint": "eslint .",
     "format": "prettier --check .",
     "format:write": "prettier --write .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report",
+    "test:e2e:smoke": "playwright test e2e/mocked-smoke"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.0",
-    "vite": "^7.0.0",
-    "typescript": "^5.5.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^7.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^22.0.0",

--- a/app/frontend/playwright.config.ts
+++ b/app/frontend/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [["html", { open: "never" }], ["list"]],
+  outputDir: "./test-results",
+  use: {
+    baseURL: process.env.CLOUD_CHAMBER_E2E_BASE_URL ?? "http://localhost:5173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
+    exclude: ["e2e/**", "node_modules/**", "dist/**"],
     globals: true,
     setupFiles: "./src/test/setup.ts",
   },

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,6 +22,40 @@ The frontend uses TypeScript, React, Vite, Vitest, ESLint, and Prettier. During 
 
 The current first Scenario Builder flow loads Baseline Shallow Cumulus from the backend, shows curated controls and the physical question, requests a dry-run package, and reviews generated files. Preview is explicitly not implemented and not CM1 output. The first 3-D visualizer work is a scene shell only: use existing React/CSS controls, consume visualization-ready backend metadata, and do not add rendering dependencies until a concrete rendering issue requires them.
 
+### Playwright E2E
+
+Browser-level UI checks live under `app/frontend/e2e/` and are split into:
+
+- `mocked-smoke/` for deterministic, mocked API workflows that are safe to run
+  repeatedly;
+- `local-data/` for read-only checks against a local backend/runtime home, with
+  skips when prerequisites are absent;
+- `visual-manual/` for partial layout-heavy checks that support focused manual
+  review.
+
+From `app/frontend`:
+
+```sh
+npm run test:e2e
+npm run test:e2e:headed
+npm run test:e2e:report
+```
+
+From the repo root:
+
+```sh
+scripts/check-e2e.sh
+```
+
+`scripts/check-e2e.sh` requires the frontend dev server at
+`http://localhost:5173` and runs only the mocked smoke tests. It is intentionally
+separate from `scripts/check.sh` for now so the full external-style browser
+suite does not become a required gate before it has had time to settle. Use it
+for UI workflow, navigation, form-flow, and layout changes. Playwright tests
+must not launch CM1, mutate real notebook data, delete real run directories, or
+commit screenshots, videos, traces, reports, NetCDF files, logs, or generated
+run output.
+
 ## Dev Server Helper
 
 From the repo root:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -96,6 +96,21 @@ moisture-limitation story, or whether Storage makes deletion feel safe. Bad
 manual QA asks someone to click every tab, verify all standard navigation by
 hand, or manually inspect long objective checklists.
 
+The Playwright suite lives under `app/frontend/e2e/`:
+
+- `mocked-smoke/` is deterministic, uses mocked API routes, and is what
+  `scripts/check-e2e.sh` runs by default;
+- `local-data/` is read-only against a live local backend and may skip when
+  required local results or runtime data are absent;
+- `visual-manual/` performs partial browser checks for layout-heavy visualizer
+  behavior and records the qualitative question that still needs human eyes.
+
+Playwright reports, screenshots, videos, traces, NetCDF files, logs, generated
+run directories, and other runtime artifacts are not source fixtures and should
+not be committed. Known product follow-ups surfaced while stabilizing the suite
+are tracked in #133, #134, #135, #136, and #139; future skips should identify
+the missing prerequisite or linked issue rather than hiding a failure.
+
 Codex UI PR summaries should explicitly report:
 
 ```text

--- a/scripts/check-e2e.sh
+++ b/scripts/check-e2e.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRONTEND_URL="${CLOUD_CHAMBER_E2E_BASE_URL:-http://localhost:5173}"
+
+if [[ ! -d "$ROOT_DIR/app/frontend/node_modules" ]]; then
+  echo "Missing app/frontend/node_modules." >&2
+  echo "Run: cd app/frontend && npm install" >&2
+  exit 127
+fi
+
+if ! curl -fsS "$FRONTEND_URL" >/dev/null 2>&1; then
+  echo "Frontend dev server is not reachable at $FRONTEND_URL." >&2
+  echo "Start it with: scripts/dev.sh start" >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR/app/frontend"
+echo "== Playwright mocked smoke tests =="
+npm run test:e2e:smoke


### PR DESCRIPTION
Closes #138

Summary:
- Added a Playwright E2E harness under `app/frontend/e2e/` with mocked smoke, local-data, and visual/manual categories.
- Added `app/frontend/playwright.config.ts`, frontend E2E npm scripts, and `scripts/check-e2e.sh` for the stable mocked smoke subset.
- Added mocked browser coverage for Build -> Results -> Explore, ARIA tab navigation, console-error hygiene, and the prior 3-D visualizer controls-occlusion regression.
- Kept local-data tests read-only and documented skip behavior when local backend/runtime prerequisites are absent.
- Ignored Playwright reports, screenshots, videos, traces, and result artifacts in git and Prettier.
- Updated docs for when and how to run the E2E suite.

Potential issues found while running tests:
- Vitest initially picked up Playwright `*.spec.ts` files; fixed by excluding `e2e/**` from Vitest.
- Imported browser tests had brittle duplicate-text locators; fixed by scoping/narrowing selectors.
- Visual/manual test asserted hidden provenance text in collapsed details; fixed by opening the visible "About this visualization" disclosure before checking it.
- Playwright/Node emits a harmless local warning that `NO_COLOR` is ignored when `FORCE_COLOR` is set; no product issue filed.

Testing:
- `cd app/frontend && npm run format`
- `scripts/check.sh`
- `scripts/check-e2e.sh`
- `cd app/frontend && npm run test:e2e`

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, Playwright reports, screenshots, videos, traces, or large visualization artifacts were committed.
