### PR TITLE
Fix visualizer plot scale and labels

### DIFF
--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -364,7 +364,10 @@ export async function mockCloudChamberApis(page: Page) {
       coordinate_extents: {
         x: { min: 0, max: 6.4, units: "km" },
         y: { min: 0, max: 6.4, units: "km" },
-        z: { min: 0, max: 18, units: "km" },
+        z: { min: 0, max: 3, units: "km" },
+        xh: { min: 0, max: 6.4, units: "km" },
+        yh: { min: 0, max: 6.4, units: "km" },
+        zh: { min: 0, max: 3, units: "km" },
       },
       point_order: ["x", "y", "z", "value"],
       points: [

--- a/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
@@ -19,6 +19,37 @@ async function expectClickableCenter(page: Page, locator: Locator, label: string
   expect(receivesPointer, `${label} center should not be covered by the visualizer`).toBe(true);
 }
 
+async function expectNoOverlap(first: Locator, second: Locator, label: string) {
+  const firstBox = await first.boundingBox();
+  const secondBox = await second.boundingBox();
+  expect(firstBox, `${label} first element should have a bounding box`).not.toBeNull();
+  expect(secondBox, `${label} second element should have a bounding box`).not.toBeNull();
+  if (!firstBox || !secondBox) return;
+
+  const overlaps =
+    firstBox.x < secondBox.x + secondBox.width &&
+    firstBox.x + firstBox.width > secondBox.x &&
+    firstBox.y < secondBox.y + secondBox.height &&
+    firstBox.y + firstBox.height > secondBox.y;
+  expect(overlaps, `${label} should not overlap`).toBe(false);
+}
+
+async function expectInside(container: Locator, target: Locator, label: string) {
+  const containerBox = await container.boundingBox();
+  const targetBox = await target.boundingBox();
+  expect(containerBox, `${label} container should have a bounding box`).not.toBeNull();
+  expect(targetBox, `${label} target should have a bounding box`).not.toBeNull();
+  if (!containerBox || !targetBox) return;
+
+  expect(targetBox.x, `${label} should not be clipped on the left`).toBeGreaterThanOrEqual(
+    containerBox.x,
+  );
+  expect(
+    targetBox.x + targetBox.width,
+    `${label} should not be clipped on the right`,
+  ).toBeLessThanOrEqual(containerBox.x + containerBox.width);
+}
+
 test.describe("mocked smoke: visualizer occlusion regression", () => {
   test.beforeEach(async ({ page }) => {
     await mockCloudChamberApis(page);
@@ -44,5 +75,34 @@ test.describe("mocked smoke: visualizer occlusion regression", () => {
       "2-D Slices tab",
     );
     await expectClickableCenter(page, page.getByRole("tab", { name: "3-D View" }), "3-D View tab");
+  });
+
+  test("3-D plot labels stay visible and use a non-stretched scale frame", async ({ page }) => {
+    const scene = page.getByLabel("3-D scene container");
+    const description = page.getByLabel("Projection description");
+    const xAxisTicks = page.getByLabel(/x-axis ticks/).locator("span");
+    const contextLabel = page.locator(".scene-context-label").first();
+    const viewportFrame = page.locator(".viewport-frame").first();
+
+    await expect(scene).toBeVisible();
+    await expect(description).toBeVisible();
+    await expect(xAxisTicks.last()).toBeVisible();
+    await expectNoOverlap(xAxisTicks.last(), description, "Bottom x-axis label and description");
+    await expectInside(scene, contextLabel, "Scene context label");
+
+    const plotFrame = await viewportFrame.evaluate((element) => {
+      const styles = getComputedStyle(element);
+      return {
+        width: Number.parseFloat(styles.getPropertyValue("--plot-width")),
+        height: Number.parseFloat(styles.getPropertyValue("--plot-height")),
+      };
+    });
+
+    expect(plotFrame.height).toBeGreaterThan(0);
+    expect(plotFrame.width).toBeGreaterThan(0);
+    expect(
+      plotFrame.height,
+      "vertical plot scale should not stretch to match horizontal width",
+    ).toBeLessThan(plotFrame.width * 0.7);
   });
 });

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -688,10 +688,13 @@ details[open] > summary {
 .scene-container {
   position: relative;
   display: grid;
-  place-items: center;
+  place-items: stretch center;
+  align-content: center;
+  gap: 0.65rem;
   width: 100%;
   min-width: 0;
   min-height: clamp(26rem, 52vw, 38rem);
+  padding: 1rem 1rem 0.85rem;
   overflow: hidden;
   isolation: isolate;
   contain: layout paint;
@@ -707,6 +710,10 @@ details[open] > summary {
   width: min(96%, 100%);
   aspect-ratio: 16 / 10;
   overflow: hidden;
+  --plot-left: 14%;
+  --plot-bottom: 16%;
+  --plot-width: 76%;
+  --plot-height: 52%;
 }
 
 .plot-data-layer {
@@ -725,8 +732,10 @@ details[open] > summary {
 
 .scene-grid {
   position: absolute;
-  inset: auto 7% 9%;
-  height: 44%;
+  left: calc(var(--plot-left) - 1%);
+  bottom: calc(var(--plot-bottom) - 3%);
+  width: calc(var(--plot-width) + 2%);
+  height: min(44%, calc(var(--plot-height) * 0.72));
   border: 1px solid rgba(143, 216, 182, 0.28);
   background:
     linear-gradient(rgba(143, 216, 182, 0.16) 1px, transparent 1px),
@@ -738,7 +747,10 @@ details[open] > summary {
 
 .domain-box {
   position: absolute;
-  inset: 10% 8% 11%;
+  left: var(--plot-left);
+  bottom: var(--plot-bottom);
+  width: var(--plot-width);
+  height: var(--plot-height);
   border: 1px solid rgba(216, 255, 240, 0.32);
   border-radius: 8px;
   box-shadow:
@@ -781,10 +793,11 @@ details[open] > summary {
 }
 
 .scene-context-label {
-  top: 1rem;
-  right: 1rem;
+  top: 0.65rem;
+  right: 0.65rem;
   display: grid;
   gap: 0.15rem;
+  max-width: min(22rem, calc(100% - 1.3rem));
   text-align: right;
 }
 
@@ -808,11 +821,9 @@ details[open] > summary {
 }
 
 .projection-description {
-  position: absolute;
-  left: 1rem;
-  right: 1rem;
-  bottom: 0.75rem;
-  z-index: 4;
+  position: relative;
+  z-index: 1;
+  width: min(96%, 100%);
   margin: 0;
   border-radius: 8px;
   padding: 0.45rem 0.65rem;
@@ -823,7 +834,10 @@ details[open] > summary {
 
 .scale-markers {
   position: absolute;
-  inset: 10% 8% 11%;
+  left: var(--plot-left);
+  bottom: var(--plot-bottom);
+  width: var(--plot-width);
+  height: var(--plot-height);
   z-index: 3;
   pointer-events: none;
 }
@@ -1037,6 +1051,10 @@ details[open] > summary {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.65rem;
+}
+
+.visualizer-details-panel .summary-strip {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .summary-strip > div {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -3338,7 +3338,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
 
         <div className="visualizer-stage" aria-label="Fixed visualization viewport region">
           <div className="scene-container" aria-label="3-D scene container">
-            <div className="viewport-frame">
+            <div className="viewport-frame" style={plotFrameStyle(pointCloud, projectionMode)}>
               <div
                 className="plot-data-layer"
                 aria-label="Zoomable visualizer data layer"
@@ -4372,7 +4372,7 @@ function cloudPointStyle(
   const y = normalizeWithExtent(point[1], pointCloud.coordinate_extents.yh);
   const z = normalizeWithExtent(point[2], pointCloud.coordinate_extents.zh);
   const intensity = normalize(point[3], stats.min_value ?? point[3], stats.max_value ?? point[3]);
-  const projected = projectPoint(x, y, z, projectionMode);
+  const projected = projectPoint(x, y, z, projectionMode, pointCloud);
   const depthOpacity = projectionMode === "side_xz" ? 0.65 + y * 0.35 : 0.65 + x * 0.35;
   return {
     left: `${projected.left}%`,
@@ -4390,20 +4390,68 @@ function projectPoint(
   y: number,
   z: number,
   projectionMode: ProjectionMode,
+  pointCloud: PointCloudResponse,
 ): { left: number; bottom: number } {
+  const frame = plotFrame(pointCloud, projectionMode);
   if (projectionMode === "side_xz") {
-    return { left: 12 + x * 76, bottom: 14 + z * 72 };
+    return { left: frame.left + x * frame.width, bottom: frame.bottom + z * frame.height };
   }
   if (projectionMode === "side_yz") {
-    return { left: 12 + y * 76, bottom: 14 + z * 72 };
+    return { left: frame.left + y * frame.width, bottom: frame.bottom + z * frame.height };
   }
   if (projectionMode === "top_down") {
-    return { left: 12 + x * 76, bottom: 14 + y * 72 };
+    return { left: frame.left + x * frame.width, bottom: frame.bottom + y * frame.height };
   }
+  const verticalSpan = frame.height * 0.86;
+  const depthLift = frame.height * 0.14;
   return {
-    left: 18 + (x * 0.72 + y * 0.28) * 64,
-    bottom: 16 + z * 62 + y * 10,
+    left: frame.left + (x * 0.72 + y * 0.28) * frame.width,
+    bottom: frame.bottom + z * verticalSpan + y * depthLift,
   };
+}
+
+function plotFrameStyle(
+  pointCloud: PointCloudResponse | null,
+  projectionMode: ProjectionMode,
+): CSSProperties & Record<string, string> {
+  const frame = plotFrame(pointCloud, projectionMode);
+  return {
+    "--plot-left": `${frame.left}%`,
+    "--plot-bottom": `${frame.bottom}%`,
+    "--plot-width": `${frame.width}%`,
+    "--plot-height": `${frame.height}%`,
+  };
+}
+
+function plotFrame(
+  pointCloud: PointCloudResponse | null,
+  projectionMode: ProjectionMode,
+): { left: number; bottom: number; width: number; height: number } {
+  const left = 14;
+  const width = 76;
+  const horizontalCoordinate = projectionMode === "side_yz" ? "yh" : "xh";
+  const verticalCoordinate = projectionMode === "top_down" ? "yh" : "zh";
+  const horizontalRange = coordinateRange(pointCloud, horizontalCoordinate);
+  const verticalRange = coordinateRange(pointCloud, verticalCoordinate);
+  const ratio = horizontalRange > 0 ? verticalRange / horizontalRange : 0.7;
+  const height = clamp(width * ratio, 20, 64);
+  return {
+    left,
+    width,
+    height,
+    bottom: clamp((100 - height) / 2 - 3, 14, 32),
+  };
+}
+
+function coordinateRange(pointCloud: PointCloudResponse | null, coordinate: string): number {
+  const extent = pointCloud?.coordinate_extents[coordinate];
+  if (!extent) return 1;
+  const range = extent.max - extent.min;
+  return Number.isFinite(range) && range > 0 ? range : 1;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
 }
 
 function normalizeWithExtent(


### PR DESCRIPTION
Closes #146

Summary:
- Reserved scene layout space for the projection description so it no longer obscures bottom axis labels.
- Anchored the domain box, scale markers, grid, and point projection to one shared plot frame.
- Computed the plot frame from native coordinate extents so active cloud height is not stretched to match horizontal width.
- Prevented the visualizer details summary cards from clipping long values in the right panel.
- Added Playwright coverage for bottom-label/description overlap, context-label clipping, and non-stretched plot frame behavior.

Verification:
- `scripts/check.sh`
- `scripts/check-e2e.sh`
- `cd app/frontend && npm run test:e2e`
- Took a local browser screenshot of the live 3-D scene after the fix.

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, validation reports, Playwright reports, screenshots, videos, traces, or large visualization artifacts were committed.
