### PR TITLE
Align docs with Thermal Fate framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,15 @@
 
 ## Project Identity
 
-Cloud Chamber is a local-first configuration, run-management, and visualization environment for CM1 cloud experiments.
+Cloud Chamber is a local-first configuration, run-management, diagnostics, and
+visualization environment for CM1 cloud experiments.
 
-The goal is to make CM1 usable and beautiful for guided cloud-physics exploration.
+The goal is to make CM1 usable, beautiful, and explainable for guided
+cloud-physics exploration.
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local experiment builder, run manager, and visualizer.
+CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
+experiment builder, run manager, result notebook, diagnostics layer, and
+visualizer.
 
 ## Product Rule
 
@@ -99,6 +103,9 @@ Default Cloud Chamber runtime data belongs outside the repo:
 
 Use atmospheric language first:
 
+- thermal fate
+- What happened here?
+- selected region
 - lower-atmosphere humidity
 - surface moisture
 - surface heating
@@ -106,12 +113,21 @@ Use atmospheric language first:
 - cap height
 - dry air aloft
 - mixing / entrainment
+- updraft strength
+- saturation deficit
+- deep breakthrough
+- precipitation feedback
+- downdraft
+- cold pool
+- outflow boundary
 - cloud base
 - cloud top
 - first cloud time
 - rain onset
 
-Raw namelist settings belong in advanced/developer views.
+Raw namelist settings and raw CM1 variable names belong in technical,
+advanced, or developer views. Product-facing views should start with thermal
+fate, selected-region inspection, and atmospheric process language.
 
 ## Testing Notes
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,25 @@
 # Cloud Chamber
 
-Cloud Chamber is a local CM1 experiment builder, run manager, and 3-D cloud visualization lab.
+Cloud Chamber is a local CM1 experiment builder, run manager, results notebook,
+and Thermal Fate exploration workbench.
 
-It helps users configure CM1 scenarios, run them locally, ingest outputs, and explore cloud evolution through beautiful scientific and atmospheric visualizations.
+It helps users configure CM1 scenarios, run them locally, ingest outputs, save
+and compare results, inspect CM1 fields, and understand the fate of thermals
+through diagnostics and provenance-labeled visualizations.
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local experiment builder, run manager, and visualizer.
+CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
+experiment builder, run manager, result notebook, diagnostics layer, and
+visualizer.
 
 ## Core Direction
 
-Build a local-first, personal-use CM1 configuration, run-management, and 3-D visualization environment for guided cloud-physics experiments.
+Build a local-first, personal-use CM1 configuration, run-management,
+diagnostics, and visualization environment for guided cloud-physics
+experiments.
 
-The first Golden Path is **Baseline Shallow Cumulus**: a credible idealized CM1 case for learning how lower-atmosphere controls shape cloud formation.
+The first executable Golden Path is **Baseline Shallow Cumulus**: a credible
+idealized CM1 case for learning how lower-atmosphere controls shape thermal
+fate, cloud formation, vertical motion, and rain.
 
 ## Core Workflow
 
@@ -21,30 +30,40 @@ Choose experiment
 -> generate/launch a local CM1 run
 -> monitor status/logs
 -> ingest results
--> visualize cloud evolution in 3-D
+-> inspect and visualize CM1-derived fields
 -> save/name/tag useful runs
 -> replay and inspect them later
--> optionally create a new variation from the same setup
+-> compare scenario variants
+-> ask what happened to a selected thermal/region as diagnostics mature
 ```
 
-This repo is early-stage. The current app can load the first Scenario Builder flow, select Baseline Shallow Cumulus, show curated controls and the physical question, create a dry-run CM1 package for review, and label preview as not implemented. It does not launch CM1, ingest outputs, or visualize completed results yet.
+This repo is still evolving, but it is no longer only the initial scaffold. The
+current app has a guided local run loop, local CM1 launch/status handling,
+NetCDF ingest, result cards/notebook entries, Results/Compare/Storage
+workspaces, 2-D field inspection, and an initial 3-D cloud-water/slice
+visualization path. Real CM1 execution remains local/manual and outside CI.
 
 ## Docs
 
 - [Product vision](docs/product-vision.md)
 - [Product spec](docs/cloud-chamber-product-spec.md)
 - [Architecture and data model](docs/architecture-and-data-model.md)
+- [Thermal Fate process diagnostics](docs/thermal-fate-process-diagnostics.md)
 - [Roadmap and issues](docs/roadmap-and-issues.md)
 - [Codex project setup](docs/codex-project-setup.md)
 - [Development](docs/development.md)
 - [Testing and validation](docs/testing-and-validation.md)
 - [CI and branch protection](docs/ci-and-branch-protection.md)
 
-## Current Scaffold
+## Current App Shape
 
 - Frontend: TypeScript, React, Vite, Vitest, ESLint, Prettier.
 - Backend/tooling: Python 3.12+, pytest, ruff, mypy.
-- First Scenario Builder flow: Baseline Shallow Cumulus selection, curated controls, physical question, dry-run package request, and generated-file review.
+- Build workspace: scenario selection, curated controls, package generation,
+  launch/status review, and ingest action against local backend APIs.
+- Results workspace: result notebook, comparison, and runtime storage views.
+- Explore workspace: 2-D slices and initial 3-D visualization over backend
+  visualization-ready data.
 - Local checks: `scripts/check.sh`.
 - CI: GitHub Actions jobs for frontend, backend, scripts, docs, and config sanity.
 
@@ -100,4 +119,8 @@ The top-level `data/` directory is placeholder/fixture-only. It is not the runti
 
 ## Current Near-Term Scope
 
-The first Scenario Builder and dry-run review flow exists. Cloud Chamber still does not implement preview physics, the 3-D visualizer, CM1 run manager, CM1 vendoring, real NetCDF sample data, complex deployment, or heavy 3-D rendering dependencies.
+Near-term work is shifting from the first executable Baseline Shallow Cumulus
+loop toward Thermal Fate diagnostics: process summaries, selected-region
+`What happened here?` inspection, surface-heating and deep-breakthrough
+scenario families, precipitation-feedback/cold-pool reasoning, and renderer
+upgrades only after those process needs are clear.

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -4,7 +4,9 @@
 
 Cloud Chamber should be local-first.
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local experiment builder, run manager, and visualizer.
+CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
+experiment builder, run manager, result notebook, diagnostics layer, and
+visualizer.
 
 The first MVP target is a 2024 MacBook Air with 8GB RAM. Design for one local CM1 run at a time, conservative output handling, and backend-side processing/downsampling. Optional cloud compute can be researched later, but it is not part of the core architecture.
 
@@ -27,8 +29,16 @@ Output watcher / ingester
   ↓
 Local result store
   ↓
+Thermal Fate diagnostics
+  ↓
 3-D visualizer
 ```
+
+The Thermal Fate diagnostics layer sits between ingest/result metadata and
+visualization. It should distinguish global run diagnostics, local
+selected-region diagnostics, comparison diagnostics, and visualizer
+interpretation. The browser should continue to receive bounded summaries,
+visualization-ready slices/points, and provenance labels rather than raw NetCDF.
 
 ## Suggested Stack
 
@@ -337,6 +347,49 @@ Diagnostics preserve runtime warnings from the run manifest/result metadata. CM1
 
 This result metadata is not a Result Card UI and not visualization-ready data. It is the backend bridge that later result cards and inspectors can consume.
 
+### Thermal Fate Diagnostics
+
+Thermal Fate diagnostics are the process layer between ingested result metadata
+and visualization. They should answer what happened to thermals without making
+unsupported claims.
+
+The layer should distinguish:
+
+```text
+global run diagnostics
+local selected-region diagnostics
+comparison diagnostics
+visualizer interpretation
+```
+
+Global diagnostics summarize the whole completed CM1 result. Local
+selected-region diagnostics support the future `What happened here?` inspector
+for points, columns, or boxes. Comparison diagnostics explain what changed
+between saved results such as Baseline vs Dry Failed, Baseline vs Capped, and
+future surface-heating or deep-breakthrough variants.
+
+The data model should make room for process groups even before every group is
+implemented:
+
+```text
+thermal_fate
+cloud_lifecycle
+updrafts
+moisture_saturation
+cap_inversion
+buoyancy
+deep_breakthrough
+precipitation_feedback
+local_region_support
+interpretation_support
+```
+
+Deep-breakthrough and precipitation-feedback diagnostics should be represented
+as unavailable, candidate, or supported states until required fields and
+derived diagnostics exist. The browser should see bounded summaries and
+visualization-ready payloads only; backend xarray/NetCDF code owns direct field
+access, processing, and downsampling.
+
 ### Result Library
 
 Responsibilities:
@@ -376,8 +429,14 @@ NetCDF ingest (#68)
 -> 3-D scene shell (#77)
 -> cloud-water rendering (#78)
 -> slice planes (#79)
+-> Thermal Fate process contract and diagnostics (#148/#149/#151)
+-> renderer upgrade decision after process needs are clear (#112)
 -> visual polish / fly-through / export later (#80)
 ```
+
+The renderer is downstream of the process-diagnostics contract. If a rendering
+upgrade does not help expose thermal fate, selected-region evidence, or
+comparison diagnostics, it should wait.
 
 The 3-D viewer should open from saved or ingested results and consume visualization-ready backend data. It should not parse raw NetCDF directly in the browser. Rendering remains a visualizer interpretation of CM1-derived output and must carry source model, run/result, field, processing, and rendering-method provenance.
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -2,17 +2,36 @@
 
 ## Product Summary
 
-Cloud Chamber is a local-first desktop/browser application for configuring, running, managing, and visualizing CM1 cloud experiments for personal learning and exploration.
+Cloud Chamber is a local-first desktop/browser application for configuring,
+running, managing, diagnosing, comparing, and visualizing CM1 cloud experiments
+for personal learning and exploration.
 
 The product should make CM1 approachable without hiding scientific limits.
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local experiment builder, run manager, and visualizer.
+CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
+experiment builder, run manager, result notebook, diagnostics layer, and
+visualizer.
 
 Cloud Chamber's main flow should be product-shaped, not namelist-shaped. Friendly atmospheric controls come first; raw CM1 namelist settings belong in advanced/developer views.
 
 The first Golden Path case is Baseline Shallow Cumulus. Warm rain remains early, but it should not block completing that first end-to-end case.
 
 Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
+
+The organizing product concept is **Thermal Fate**: Cloud Chamber should help
+explain why air rises, why some thermals do or do not form cloud, why some
+clouds stay shallow, why others grow taller, why some break through into deep
+convection, and how precipitation feedback can reorganize or suppress
+convection. The visualizer remains important, but the product center of gravity
+is completed/saved CM1 results, process diagnostics, selected-region
+inspection, comparison across scenario variants, and visual polish later.
+
+Cloud Chamber is not a real-time slider toy. Scenario design, result browsing,
+comparison, and inspection should feel interactive; CM1 execution is a local
+simulation run with latency, logs, outputs, and caveats.
+
+See [Thermal Fate process diagnostics](thermal-fate-process-diagnostics.md) for
+the current process-diagnostics contract.
 
 ## Personas
 
@@ -179,6 +198,8 @@ Visualization-ready data contract (#72)
 -> 3-D scene shell (#77)
 -> cloud-water rendering MVP (#78)
 -> slice planes (#79)
+-> Thermal Fate diagnostics and selected-region process needs (#148/#149/#151)
+-> renderer upgrade decision (#112)
 -> later visual polish / fly-through / export (#80)
 ```
 
@@ -190,6 +211,22 @@ time slider shell, field selector shell, loading/empty/error states, and
 provenance/rendering labels. It does not render cloud water, slices, or
 synthetic cloud physics; those belong to later visualizer issues.
 
+### Workflow 6.5 — What Happened Here?
+
+The selected-region Thermal Fate workflow is a core future workflow:
+
+```text
+open a completed/saved result
+-> select a point, column, or box in Explore
+-> ask What happened here?
+-> backend computes local selected-region diagnostics
+-> UI explains the supported thermal-fate label, evidence, and caveats
+-> compare the selected region with whole-domain behavior or a scenario variant
+```
+
+This workflow must use backend diagnostics over CM1-derived fields. The browser
+must not parse raw NetCDF or invent scientific explanations.
+
 ### Workflow 7 — Duplicate / Tweak / Rerun
 
 1. Duplicate previous setup.
@@ -199,6 +236,25 @@ synthetic cloud physics; those belong to later visualizer issues.
 5. Compare results later.
 
 This workflow is useful, but it is not the core first-MVP result behavior. Replay, inspect, save, name, and tag completed CM1 results first; duplicate/tweak/rerun can mature after the Result Card / Experiment Notebook model is reliable.
+
+## Thermal Fate Diagnostic Scope
+
+Product diagnostics should be framed at three levels:
+
+- **Global run diagnostics**: cloud formed, first cloud time, cloud base/top,
+  `qc`, `w`, rain, cloud fraction, and later process summaries for the whole
+  completed CM1 result.
+- **Local selected-region diagnostics**: the `What happened here?` point,
+  column, or box story, including local `qc`, `w`, rain, saturation/cap evidence
+  where supported, and comparison to domain behavior.
+- **Comparison diagnostics**: what changed between Baseline and a variant, such
+  as Dry Failed, Capped / Suppressed, humidity-ladder, or future
+  surface-heating/deep-breakthrough cases.
+
+Deep-convection breakthrough and precipitation-feedback/cold-pool diagnostics
+are first-class product families, but they should remain unavailable,
+candidate, or insufficient-evidence states until the required CM1 fields and
+derived diagnostics exist.
 
 ## Run Size Presets
 
@@ -280,14 +336,16 @@ Validation rules should reject templates that:
 
 The schema is intentionally product-first. Raw CM1/developer controls can exist as advanced metadata, but product-facing controls remain the primary path.
 
-Initial scenario templates should include:
+Thermal Fate scenario families should include:
 
-1. Baseline shallow cumulus.
-2. Dry failed cumulus.
-3. Capped/suppressed cumulus.
-4. Humid vigorous cumulus / humid low-cloud contrast.
-5. Low stratus / low-cloud layer.
-6. Warm rain / precipitating shallow cloud.
+1. Moisture-limited thermal fate: Baseline, Dry Failed, and humidity ladder.
+2. Surface-heating-driven thermal fate: weaker/baseline/stronger heating,
+   focused warm patch, patchy heating, and gradients.
+3. Cap-limited thermal fate: Capped / Suppressed Cumulus.
+4. Dry-air-aloft / dilution-limited thermal fate.
+5. Deep-convection breakthrough: growing, towering, and cumulonimbus candidates.
+6. Precipitation feedback / cold-pool interaction.
+7. Low stratus / low-cloud layer where appropriate.
 
 Baseline shallow cumulus is the first hero case. Warm rain remains early but does not block the Golden Path.
 

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -6,17 +6,23 @@
 
 ## North Star
 
-Cloud Chamber helps users configure, run, manage, and beautifully visualize local CM1 cloud experiments.
+Cloud Chamber helps users configure, run, manage, inspect, explain, and
+beautifully visualize local CM1 cloud experiments.
 
 Short version:
 
-> A local studio for playing with CM1 and seeing cloud physics come alive.
+> A local CM1 workbench for exploring thermal fate and seeing cloud physics come alive.
 
 Internal anchor:
 
-> Cloud Chamber is a personal, scientifically honest CM1 cloud playground: curated lower-atmosphere experiments, meaningful controls, local-first CM1 runs, replayable saved results, and a beautiful 3-D viewer.
+> Cloud Chamber is a personal, scientifically honest CM1 Thermal Fate workbench:
+> curated experiments, meaningful controls, local-first CM1 runs, replayable
+> saved results, process diagnostics, selected-region inspection, and beautiful
+> visualization.
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local experiment builder, run manager, and visualizer.
+CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
+experiment builder, run manager, result notebook, diagnostics layer, and
+visualizer.
 
 The lesson from earlier Cloud Lab-style experimentation is simple: do not rebuild CM1 poorly. Cloud Chamber should wrap CM1 with a clearer product workflow, not replace the atmospheric model with hidden fake physics.
 
@@ -24,7 +30,12 @@ Cloud Lab should be treated as archived lesson/source material only. New product
 
 ## What Cloud Chamber Is
 
-Cloud Chamber is a local-first experiment and visualization environment for CM1, primarily for personal exploration and learning.
+Cloud Chamber is a local-first experiment and visualization environment for
+CM1, primarily for personal exploration and learning. Its organizing product
+concept is **Thermal Fate**: why air rises, why some thermals do or do not form
+cloud, why some clouds stay shallow, why others grow taller, why some break
+through into deep convection, and how precipitation feedback can reorganize or
+suppress convection.
 
 It should help a user:
 
@@ -35,7 +46,7 @@ Choose a cloud scenario
 → run CM1 locally
 → track the run
 → ingest and organize results
-→ visualize the 3-D cloud evolution beautifully
+→ inspect and visualize CM1-derived fields beautifully
 → replay and inspect saved results later
 → understand what happened
 ```
@@ -50,10 +61,17 @@ Cloud Chamber is not:
 - a web app that runs CM1 in the browser
 - a dashboard full of raw namelist parameters
 - a toy renderer with hidden fake physics
+- a real-time slider toy for CM1 execution
 
 ## Core Product Promise
 
-A user can choose or configure an atmospheric experiment, run CM1 locally, and explore the output in a beautiful 3-D visualizer with understandable controls and diagnostics.
+A user can choose or configure an atmospheric experiment, run CM1 locally, save
+the completed result, and explore what happened through diagnostics, comparison,
+selected-region inspection, and provenance-labeled visualization.
+
+CM1 run latency is part of the product model: scenario design, result browsing,
+comparison, and inspection are interactive; CM1 execution is a local simulation
+run, not an instant slider update.
 
 ## First Useful Workflow
 
@@ -79,9 +97,11 @@ Choose experiment
 → launch CM1 run
 → monitor status/logs
 → open result
-→ visualize in 3-D
+→ inspect diagnostics and fields
+→ visualize in 2-D/3-D
 → save/name/tag
 → replay and inspect later
+→ compare with related scenario variants
 → optionally create a new variation from the same setup
 ```
 
@@ -98,6 +118,12 @@ How do low-level moisture, surface heating, cap strength, and dry air aloft shap
 ```
 
 Warm rain remains early, but it should not block the Golden Path. Precipitating shallow cloud workflows should build on the baseline loop after the baseline case can be configured, packaged, run locally, ingested, replayed, inspected, and opened in the visualizer.
+
+Baseline Shallow Cumulus proves the first executable loop. It is not the entire
+product vision. The broader product should grow into Thermal Fate scenario
+families: moisture-limited, surface-heating-driven, cap-limited,
+dry-air-aloft/dilution-limited, deep-convection breakthrough, precipitation
+feedback/cold-pool interaction, and low-cloud/stratus cases where useful.
 
 ## User-Facing Concepts
 
@@ -116,8 +142,18 @@ The product should use atmospheric language first:
 - rain onset
 - updraft strength
 - cloud water
+- thermal fate
+- selected region
+- What happened here?
+- saturation deficit
+- deep breakthrough
+- precipitation feedback
+- downdraft
+- cold pool
+- outflow boundary
 
-Raw CM1 namelist settings belong in an advanced/developer view.
+Raw CM1 namelist settings and raw variable names belong in technical,
+advanced, or developer views.
 
 The first controls should favor relative, teachable changes around a baseline:
 
@@ -156,9 +192,21 @@ Local library of completed/failed/running CM1 experiments.
 
 Users can name, save, tag, replay, inspect, explain, and delete runs. Saved completed results should behave like experiment notebook entries. Duplicating or rerunning a saved setup is useful later, but the first MVP does not need to make rerun a central result-library feature.
 
-### 5. 3-D Visualizer
+### 5. Thermal Fate Diagnostics
 
-The main payoff.
+Backend-owned diagnostics should sit between result ingest and visualization.
+They should distinguish global run diagnostics, local selected-region
+diagnostics, comparison diagnostics, and visualizer interpretation.
+
+The selected-region product question is:
+
+```text
+What happened here?
+```
+
+### 6. 3-D Visualizer
+
+An important payoff, but not the only product center of gravity.
 
 Visualize CM1 output with:
 
@@ -176,29 +224,32 @@ Visualize CM1 output with:
 
 ## First Scenario Set
 
-Start with:
+Thermal Fate scenario families should start with:
 
-1. Baseline shallow cumulus
-2. Dry failed cumulus
-3. Capped/suppressed cumulus
-4. Humid vigorous cloud / humid low-cloud contrast
-5. Low stratus / low-cloud layer
-6. Warm rain / precipitating shallow cloud
+1. Moisture-limited thermal fate: Baseline, Dry Failed, and humidity ladder.
+2. Surface-heating-driven thermal fate.
+3. Cap-limited thermal fate: Capped / Suppressed Cumulus.
+4. Dry-air-aloft / dilution-limited thermal fate.
+5. Deep-convection breakthrough.
+6. Precipitation feedback / cold-pool interaction.
+7. Low stratus / low-cloud layer where appropriate.
 
 Baseline shallow cumulus is the first end-to-end Golden Path scenario. Warm rain remains early and important, but it should not block proving the baseline shallow-cumulus loop first.
 
 The first variation workflow should favor one-control-at-a-time changes around the baseline instead of arbitrary giant parameter sweeps. This keeps the learning path understandable and keeps CM1 as the truth source.
 
-Later:
+Later product families can include terrain/orographic cloud, layered
+atmospheres, fog / near-surface cloud, and mixed-phase / ice.
 
-7. Terrain/orographic cloud
-8. Layered atmosphere
-9. Fog / near-surface cloud
-10. Mixed-phase / ice
-
-## Visualization Philosophy
+## Thermal Fate And Visualization Philosophy
 
 CM1 output is physical source data. The visualizer may interpret it, but must label the interpretation.
+
+The visualizer should serve the Thermal Fate workbench: process overlays,
+selected-region markers, cloud base/top, cap/inversion context, updrafts,
+moisture/saturation evidence, and precipitation-feedback caveats should guide
+renderer choices. Visual polish follows process needs, not the other way
+around.
 
 Useful views:
 
@@ -247,8 +298,8 @@ The MVP should let a user:
 4. Launch CM1 locally.
 5. Track whether the run is queued/running/done/failed.
 6. Ingest NetCDF output into an app-friendly format.
-7. Open the result in a basic 3-D viewer.
-8. Replay cloud evolution over time.
+7. Open diagnostics and visualization-ready fields.
+8. Replay and inspect cloud evolution over time.
 9. Save/name/tag the run.
 10. Reopen, replay, inspect, and explain a saved result later.
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -11,14 +11,44 @@ scenario template
 -> dry-run report
 -> local CM1 launch
 -> ingest
--> 3-D visualization
+-> result diagnostics
+-> Thermal Fate inspection
+-> provenance-labeled visualization
 ```
 
 CM1 remains the source of truth. Preview estimates are guidance only, and visualization is an interpretation of CM1-derived data.
 
-Cloud Chamber is a personal, scientifically honest CM1 cloud playground: curated lower-atmosphere experiments, meaningful controls, local-first CM1 runs, replayable saved results, and a beautiful 3-D viewer.
+Cloud Chamber is a personal, scientifically honest CM1 Thermal Fate workbench:
+curated scenario families, meaningful controls, local-first CM1 runs,
+replayable saved results, process diagnostics, selected-region inspection,
+comparison across variants, and beautiful visualization.
 
 Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
+
+## Thermal Fate Roadmap
+
+Thermal Fate is the organizing product concept: Cloud Chamber should explain why
+air rises, why some thermals do or do not form cloud, why some clouds stay
+shallow, why others grow taller, why some break through into deep convection,
+and how precipitation feedback can reorganize or suppress convection.
+
+The execution sequence should be:
+
+```text
+#148 Thermal Fate Framework / process contract
+-> #149 global/process diagnostics
+-> #151 selected-region backend diagnostics
+-> #150 Thermal Fate overlays in Explore
+-> #152 Thermal Fate Inspector UI
+-> #153 surface-heating scenario family
+-> #154 deep-convection breakthrough scenario family
+-> #155 precipitation feedback / cold-pool scenario family
+-> #112 renderer upgrade after process needs are clear
+```
+
+Renderer upgrades follow process needs. They should not drive the product
+direction before Cloud Chamber can explain thermal fate with CM1-derived
+diagnostics, selected-region evidence, comparison, and caveats.
 
 ## Golden Path: Baseline Shallow Cumulus
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -1,6 +1,8 @@
 # Testing And Validation
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local experiment builder, run manager, and visualizer. Tests must preserve that distinction.
+CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
+experiment builder, run manager, result notebook, diagnostics layer, and
+visualizer. Tests must preserve that distinction.
 
 ## Fast CI Tests
 
@@ -143,6 +145,20 @@ native `zh/yh/xh` and `zf/yh/xh` grids, bad field/time/level errors,
 provenance labels, JSON array shape/order, finite and non-finite stats, and
 safe vertical kilometer-to-meter display conversion. They must not implement UI,
 rendering, interpolation, or large-output processing.
+
+Thermal Fate process-diagnostics tests should use tiny synthetic NetCDF
+fixtures and temporary runtime homes only. They should cover thermal-fate labels
+and confidence states, supported / candidate / insufficient-evidence language,
+global process diagnostics, selected-region diagnostics, comparison diagnostics,
+and unavailable/candidate/supported states for deep breakthrough and
+precipitation feedback. Surface-heating scenario tests should cover product
+metadata and package-generation contracts without exposing raw namelist fields
+as the primary UI.
+
+Thermal Fate tests must distinguish direct CM1 fields, derived diagnostics,
+proxy diagnostics, and unsupported claims. Missing fields should produce
+explicit caveats, not crashes or fabricated values. The browser must not parse
+raw NetCDF, and CI must not run real CM1.
 
 2-D field inspector component tests should mock the visualization-ready API
 payloads rather than reading NetCDF in the browser. They should cover opening

--- a/docs/thermal-fate-process-diagnostics.md
+++ b/docs/thermal-fate-process-diagnostics.md
@@ -1,0 +1,187 @@
+# Thermal Fate Process Diagnostics
+
+This document is the initial product contract for Cloud Chamber's Thermal Fate
+Framework. Issue #148 owns the deeper diagnostic specification, but current docs
+should already point future work toward this center of gravity.
+
+## Product Frame
+
+Cloud Chamber is a CM1-backed workbench for exploring the fate of thermals:
+
+```text
+why air rises
+why some thermals do or do not form cloud
+why some clouds stay shallow
+why others grow taller
+why some break through into deep convection
+how precipitation feedback can reorganize or suppress convection
+```
+
+CM1 remains the source of truth. Cloud Chamber may derive diagnostics, labels,
+overlays, and explanations from CM1 output, but it must not invent cloud
+physics or make unsupported claims.
+
+The central inspection question is:
+
+```text
+What happened here?
+```
+
+That question should eventually work at three scales:
+
+- **Global run diagnostics**: what happened across the completed CM1 result?
+- **Local selected-region diagnostics**: what happened in this point, column, or box?
+- **Comparison diagnostics**: what changed between baseline and a variant?
+
+## Thermal Fate Ladder
+
+Use conservative labels that can be marked as supported, candidate, or
+insufficient evidence:
+
+```text
+No meaningful thermal
+Thermal without cloud
+Brief / diluted cloud
+Fair-weather cumulus
+Capped / suppressed cumulus
+Growing cumulus
+Towering cumulus candidate
+Deep-convection candidate
+Precipitation-feedback candidate
+Insufficient evidence
+```
+
+The label is never just a UI mood. It must be backed by CM1 fields or derived
+diagnostics, with caveats when fields are missing.
+
+## Scenario Families
+
+Thermal Fate scenario families should be represented as curated CM1 experiments,
+not real-time sliders:
+
+- **Moisture-limited thermal fate**: Dry Failed Cumulus and the humidity ladder.
+- **Surface-heating-driven thermal fate**: weaker/baseline/stronger heating,
+  focused warm patches, patchy heating, and gradients.
+- **Cap-limited thermal fate**: Capped / Suppressed Cumulus and later cap-height
+  variants.
+- **Dry-air-aloft / dilution-limited thermal fate**: cloud edge/top weakening,
+  evaporation, and saturation-deficit stories when diagnostics support them.
+- **Deep-convection breakthrough**: growing cumulus, towering cumulus, and
+  cumulonimbus candidates when CAPE/CIN/LFC/EL and cloud-top/updraft evidence
+  exist.
+- **Precipitation feedback / cold-pool interaction**: rain onset, downdrafts,
+  evaporative cooling, cold pools, outflow, and new lifting where supported.
+- **Low stratus / low-cloud layer** where the product needs a non-thermal
+  low-cloud contrast.
+
+Baseline Shallow Cumulus remains the first executable Golden Path. It is not
+the whole product vision.
+
+## Diagnostic Layers
+
+### Direct CM1 Fields
+
+Initial direct fields include `qc`, `w`, and optional `qr`. Future thermal-fate
+work may use `qv`, `th`, pressure/temperature coordinates, and other CM1 fields
+when available.
+
+### Derived Diagnostics
+
+Current and near-term derived diagnostics include:
+
+```text
+cloud formed yes/no
+first cloud time
+cloud base/top
+cloud fraction time series
+qc max time series
+w max/min time series
+rain onset / qr summary
+cloud-top time series
+max qc height time series
+max w height time series
+cap-relative cloud top
+```
+
+Future diagnostics should include relative humidity or saturation ratio,
+saturation deficit, buoyancy or theta-v proxies, LCL/LFC/CAPE/CIN/EL metadata,
+and precipitation-feedback summaries where the source fields support them.
+
+### Proxy Diagnostics
+
+Use proxy language for inferred process evidence:
+
+```text
+consistent with dilution / evaporation
+suggests cap-limited growth
+supports moisture-limited no-cloud outcome
+candidate precipitation-feedback signal
+```
+
+Do not say a cloud died from entrainment, broke through inhibition, or formed a
+cold pool unless the required fields and diagnostics support that claim.
+
+## Selected-Region Inspection
+
+The selected-region Thermal Fate Inspector should eventually let a user choose a
+point, column, or box in Explore and ask:
+
+```text
+What happened here?
+```
+
+The backend should answer with bounded CM1-derived summaries:
+
+```text
+local max/min w over time
+local max qc over time
+first local cloud time
+local cloud fraction
+local cloud base/top if available
+local rain onset if qr exists
+local saturation deficit / RH if available
+local cap-relative cloud top if available
+comparison to whole-domain diagnostics
+thermal-fate label, confidence, and caveats
+```
+
+The browser should not parse raw NetCDF. Backend APIs own xarray/NetCDF access,
+field selection, downsampling, and diagnostic derivation.
+
+## Renderer Sequencing
+
+Renderer decisions follow process needs:
+
+```text
+NetCDF ingest
+-> global/process diagnostics
+-> selected-region diagnostics
+-> Thermal Fate overlays in Explore
+-> Thermal Fate Inspector UI
+-> renderer upgrade decision (#112)
+```
+
+Visual polish is valuable, but it should not lead the product direction. If a
+renderer upgrade does not help explain thermal fate, defer it.
+
+## Testing Contract
+
+Thermal Fate tests should use tiny synthetic fixtures and temp runtime homes.
+CI must not run real CM1 or require local output.
+
+Test coverage should include:
+
+```text
+thermal-fate labels
+supported / candidate / insufficient-evidence states
+global process diagnostics
+selected-region diagnostics
+comparison diagnostics
+deep-breakthrough unavailable/candidate/supported states
+precipitation-feedback unavailable/candidate/supported states
+surface-heating scenario metadata and package generation
+```
+
+Manual QA should focus on qualitative scientific trust: whether the explanation
+teaches the right lesson, whether caveats are clear, and whether the visual
+interpretation feels physically believable.


### PR DESCRIPTION
Closes #156

Summary:
- Reframed Cloud Chamber docs around the Thermal Fate product concept: completed/saved CM1 results, process diagnostics, selected-region inspection, scenario comparison, and visualization after process needs are clear.
- Added `docs/thermal-fate-process-diagnostics.md` as the initial master contract / handoff doc for #148 and downstream process work.
- Updated README current-state language so it no longer says the app cannot launch CM1, ingest outputs, or visualize completed results.
- Updated AGENTS product vocabulary with Thermal Fate, `What happened here?`, selected regions, saturation deficit, deep breakthrough, precipitation feedback, downdrafts, cold pools, and outflow boundaries.
- Updated product spec, architecture, roadmap, and testing docs for global/local/comparison diagnostics, selected-region inspection, deep-breakthrough and precipitation-feedback families, and #112 being downstream of process diagnostics.

Verification:
- `scripts/check.sh`

Generated-data check:
- No CM1 source, binaries, NetCDF outputs, `.dat/.ctl` outputs, generated run directories, `LANDUSE.TBL`, local runtime files, logs, screenshots, videos, Playwright artifacts, or visualization artifacts were committed.
