### PR TITLE
Implement Thermal Fate process diagnostics

### DIFF
--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -84,6 +84,9 @@ class ResultCard(BaseModel):
     source_model: str
     provenance_labels: list[str] = Field(default_factory=list)
     diagnostics_summary: str | None = None
+    thermal_fate_label: str | None = None
+    thermal_fate_confidence: str | None = None
+    main_limiting_factor: str | None = None
     first_cloud_time_seconds: float | None = None
     max_qc_kg_kg: float | None = None
     max_w_m_s: float | None = None
@@ -167,6 +170,8 @@ def _card_from_metadata(
     completed_at: datetime | None,
 ) -> ResultCard:
     diagnostics = metadata.diagnostics
+    process_diagnostics = metadata.process_diagnostics
+    interpretation = process_diagnostics.interpretation_support if process_diagnostics else None
     cloud = diagnostics.cloud if diagnostics else None
     vertical_velocity = diagnostics.vertical_velocity if diagnostics else None
     rain = diagnostics.rain if diagnostics else None
@@ -197,6 +202,9 @@ def _card_from_metadata(
             f"result_state:{metadata.result_state}",
         ],
         diagnostics_summary=metadata.diagnostics_summary,
+        thermal_fate_label=interpretation.thermal_fate_label if interpretation else None,
+        thermal_fate_confidence=interpretation.confidence if interpretation else None,
+        main_limiting_factor=interpretation.main_limiting_factor if interpretation else None,
         first_cloud_time_seconds=cloud.first_cloud_time_seconds if cloud else None,
         max_qc_kg_kg=cloud.max_qc_kg_kg if cloud else None,
         max_w_m_s=vertical_velocity.max_w_m_s if vertical_velocity else None,

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -10,9 +10,16 @@ from pydantic import BaseModel, ConfigDict, Field
 QC_CLOUD_THRESHOLD_KG_KG = 1e-6
 QR_RAIN_THRESHOLD_KG_KG = 1e-7
 MINIMUM_CLOUD_GRID_CELLS = 10
+MEANINGFUL_UPDRAFT_THRESHOLD_M_S = 0.5
 
 TIME_DIMENSION_CANDIDATES = ("time", "mtime", "t")
 VERTICAL_COORDINATE_CANDIDATES = ("z", "zh", "height", "height_m")
+THERMAL_FATE_CONFIDENCE_VALUES = (
+    "supported",
+    "candidate",
+    "insufficient_evidence",
+    "unsupported_missing_fields",
+)
 
 
 class TimeValue(BaseModel):
@@ -39,8 +46,11 @@ class CloudDiagnostics(BaseModel):
     first_cloud_time_seconds: float | None = None
     cloud_base_m: float | None = None
     cloud_top_m: float | None = None
+    cloud_base_time_series: list[TimeValue] = Field(default_factory=list)
+    cloud_top_time_series: list[TimeValue] = Field(default_factory=list)
     max_qc_kg_kg: float | None = None
     time_of_max_qc_seconds: float | None = None
+    max_qc_height_time_series: list[TimeValue] = Field(default_factory=list)
     qc_max_time_series: list[TimeValue] = Field(default_factory=list)
     cloud_fraction_time_series: list[TimeValue] = Field(default_factory=list)
     cloud_present_time_steps: list[float | None] = Field(default_factory=list)
@@ -54,6 +64,7 @@ class VerticalVelocityDiagnostics(BaseModel):
     time_of_max_w_seconds: float | None = None
     min_w_m_s: float | None = None
     time_of_min_w_seconds: float | None = None
+    max_w_height_time_series: list[TimeValue] = Field(default_factory=list)
     w_max_time_series: list[TimeValue] = Field(default_factory=list)
     w_min_time_series: list[TimeValue] = Field(default_factory=list)
     units: str | None = None
@@ -82,6 +93,222 @@ class ResultDiagnostics(BaseModel):
     rain: RainDiagnostics
     time: TimeDiagnostics
     caveats: list[str] = Field(default_factory=list)
+
+
+class ProcessDiagnosticState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    summary: str | None = None
+    direct_fields: list[str] = Field(default_factory=list)
+    derived_diagnostics: list[str] = Field(default_factory=list)
+    proxy_diagnostics: list[str] = Field(default_factory=list)
+    caveats: list[str] = Field(default_factory=list)
+
+
+class InterpretationSupport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    main_limiting_factor: str = "unknown"
+    thermal_fate_label: str = "Insufficient evidence"
+    confidence: str = "insufficient_evidence"
+    caveats: list[str] = Field(default_factory=list)
+
+
+class ProcessDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    thermal_fate: ProcessDiagnosticState
+    cloud_lifecycle: ProcessDiagnosticState
+    updrafts: ProcessDiagnosticState
+    moisture_saturation: ProcessDiagnosticState
+    cap_inversion: ProcessDiagnosticState
+    buoyancy: ProcessDiagnosticState
+    deep_breakthrough: ProcessDiagnosticState
+    precipitation_feedback: ProcessDiagnosticState
+    local_region_support: ProcessDiagnosticState
+    interpretation_support: InterpretationSupport
+
+
+def compute_process_diagnostics(
+    diagnostics: ResultDiagnostics,
+    *,
+    scenario_id: str,
+    controls: dict[str, str | float | bool],
+    variables: list[str],
+) -> ProcessDiagnostics:
+    """Compute conservative Thermal Fate process summaries from supported diagnostics."""
+
+    available_fields = set(variables)
+    caveats: list[str] = []
+    if not diagnostics.cloud.available:
+        caveats.append("thermal_fate_missing_qc")
+    if not diagnostics.vertical_velocity.available:
+        caveats.append("thermal_fate_missing_w")
+    if "qv" not in available_fields:
+        caveats.append("moisture_saturation_unsupported_missing_qv")
+    if "th" not in available_fields:
+        caveats.append("buoyancy_unsupported_missing_th")
+
+    updraft_meaningful = (
+        diagnostics.vertical_velocity.available
+        and diagnostics.vertical_velocity.max_w_m_s is not None
+        and diagnostics.vertical_velocity.max_w_m_s >= MEANINGFUL_UPDRAFT_THRESHOLD_M_S
+    )
+    has_cloud = diagnostics.cloud.available and diagnostics.cloud.formed
+    has_rain = diagnostics.rain.available and diagnostics.rain.present
+
+    label = "Insufficient evidence"
+    confidence = "insufficient_evidence"
+    main_limiting_factor = "unknown"
+    summary = "Available diagnostics are insufficient for a Thermal Fate label."
+
+    if not diagnostics.cloud.available or not diagnostics.vertical_velocity.available:
+        confidence = "unsupported_missing_fields"
+        summary = "Thermal Fate label unavailable because required qc or w fields are missing."
+    elif not updraft_meaningful and not has_cloud:
+        label = "No meaningful thermal"
+        confidence = "supported"
+        summary = "No meaningful updraft or cloud-water signal was detected."
+    elif updraft_meaningful and not has_cloud:
+        label = "Thermal without cloud"
+        confidence = "supported"
+        main_limiting_factor = "moisture"
+        summary = "Meaningful vertical motion occurred, but cloud water stayed below threshold."
+        caveats.append("moisture_limitation_inferred_without_saturation_deficit")
+    elif _is_capped_scenario(scenario_id, controls):
+        label = "Capped / suppressed cumulus"
+        confidence = "candidate"
+        main_limiting_factor = "cap/stability"
+        summary = (
+            "Cloud and vertical motion are present in a stronger-cap scenario; "
+            "cap limitation remains a candidate until baseline comparison or "
+            "cap diagnostics support it."
+        )
+        caveats.append("cap_limitation_candidate_requires_baseline_comparison")
+    elif has_cloud and _cloud_top_increases(diagnostics.cloud.cloud_top_time_series):
+        label = "Growing cumulus"
+        confidence = "candidate"
+        summary = "Cloud formed and cloud top increased over available output times."
+    elif has_cloud:
+        label = "Fair-weather cumulus"
+        confidence = "candidate"
+        summary = "Cloud formed with available updraft and cloud-water diagnostics."
+
+    thermal_fate = ProcessDiagnosticState(
+        status=confidence,
+        summary=summary,
+        direct_fields=_present(["qc", "w", "qr"], available_fields),
+        derived_diagnostics=[
+            "cloud_formed",
+            "first_cloud_time",
+            "cloud_base_top",
+            "cloud_fraction_time_series",
+            "qc_max_time_series",
+            "w_max_min_time_series",
+            "rain_summary",
+        ],
+        caveats=_dedupe(caveats),
+    )
+    cloud_lifecycle = ProcessDiagnosticState(
+        status="supported" if diagnostics.cloud.available else "unsupported_missing_fields",
+        summary="Cloud lifecycle uses qc threshold, base/top, cloud fraction, and qc series.",
+        direct_fields=_present(["qc"], available_fields),
+        derived_diagnostics=[
+            "cloud_base_time_series",
+            "cloud_top_time_series",
+            "max_qc_height_time_series",
+            "cloud_fraction_time_series",
+        ],
+        caveats=[] if diagnostics.cloud.available else ["missing_qc_field"],
+    )
+    updrafts = ProcessDiagnosticState(
+        status="supported"
+        if diagnostics.vertical_velocity.available
+        else "unsupported_missing_fields",
+        summary="Updraft diagnostics use w max/min and max-height summaries.",
+        direct_fields=_present(["w"], available_fields),
+        derived_diagnostics=["w_max_time_series", "w_min_time_series", "max_w_height_time_series"],
+        caveats=[] if diagnostics.vertical_velocity.available else ["missing_w_field"],
+    )
+    moisture_saturation = ProcessDiagnosticState(
+        status="unsupported_missing_fields",
+        summary=(
+            "Saturation deficit/RH diagnostics are not yet implemented from "
+            "qv/thermodynamic fields."
+        ),
+        direct_fields=_present(["qv"], available_fields),
+        caveats=["moisture_saturation_unsupported_missing_qv"],
+    )
+    cap_inversion = ProcessDiagnosticState(
+        status="candidate"
+        if _is_capped_scenario(scenario_id, controls)
+        else "insufficient_evidence",
+        summary=(
+            "Capped scenario metadata suggests cap/stability interpretation, but cap-relative "
+            "diagnostics are not computed yet."
+        )
+        if _is_capped_scenario(scenario_id, controls)
+        else "Cap/inversion diagnostics require cap metadata from generated soundings.",
+        proxy_diagnostics=["scenario_control:cap_strength=stronger"]
+        if _is_capped_scenario(scenario_id, controls)
+        else [],
+        caveats=["cap_inversion_metadata_not_computed"],
+    )
+    buoyancy = ProcessDiagnosticState(
+        status="unsupported_missing_fields",
+        summary=(
+            "Buoyancy/theta-v diagnostics are not implemented until required "
+            "thermodynamic fields exist."
+        ),
+        direct_fields=_present(["th", "theta_v"], available_fields),
+        caveats=["buoyancy_unsupported_missing_thermodynamic_fields"],
+    )
+    deep_breakthrough = ProcessDiagnosticState(
+        status="unsupported_missing_fields",
+        summary=(
+            "Deep-breakthrough diagnostics require CAPE/CIN/LFC/EL and sustained-updraft metadata."
+        ),
+        caveats=["deep_breakthrough_unsupported_missing_cape_cin_lfc_el"],
+    )
+    precipitation_feedback = ProcessDiagnosticState(
+        status="candidate" if has_rain else "unsupported_missing_fields",
+        summary=(
+            "Rain water is present, but downdraft/cold-pool feedback diagnostics "
+            "are not implemented."
+            if has_rain
+            else (
+                "Precipitation-feedback diagnostics require rain and near-surface "
+                "thermodynamic fields."
+            )
+        ),
+        direct_fields=_present(["qr", "w"], available_fields),
+        derived_diagnostics=["rain_onset", "min_w"] if has_rain else [],
+        caveats=["precipitation_feedback_requires_downdraft_and_cold_pool_diagnostics"],
+    )
+    local_region_support = ProcessDiagnosticState(
+        status="insufficient_evidence",
+        summary="Global process metadata is ready for future selected-region diagnostics.",
+        caveats=["selected_region_diagnostics_not_computed_in_global_ingest"],
+    )
+
+    return ProcessDiagnostics(
+        thermal_fate=thermal_fate,
+        cloud_lifecycle=cloud_lifecycle,
+        updrafts=updrafts,
+        moisture_saturation=moisture_saturation,
+        cap_inversion=cap_inversion,
+        buoyancy=buoyancy,
+        deep_breakthrough=deep_breakthrough,
+        precipitation_feedback=precipitation_feedback,
+        local_region_support=local_region_support,
+        interpretation_support=InterpretationSupport(
+            main_limiting_factor=main_limiting_factor,
+            thermal_fate_label=label,
+            confidence=confidence,
+            caveats=_dedupe(caveats),
+        ),
+    )
 
 
 def compute_baseline_diagnostics(dataset: Any, inherited_caveats: list[str]) -> ResultDiagnostics:
@@ -129,6 +356,9 @@ def _cloud_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> 
     series_arrays = _time_slices(qc, time.dimension)
     qc_max_series: list[TimeValue] = []
     cloud_fraction_series: list[TimeValue] = []
+    cloud_base_series: list[TimeValue] = []
+    cloud_top_series: list[TimeValue] = []
+    max_qc_height_series: list[TimeValue] = []
     cloud_present_steps: list[float | None] = []
     first_cloud_time: float | None = None
     max_qc: float | None = None
@@ -140,8 +370,14 @@ def _cloud_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> 
         cloudy_count = _threshold_count(array, QC_CLOUD_THRESHOLD_KG_KG)
         finite_count = _finite_count(array)
         cloud_fraction = (cloudy_count / finite_count) if finite_count else None
+        cloud_base, cloud_top = _cloud_base_top(array, caveats)
         qc_max_series.append(TimeValue(time_seconds=time_seconds, value=slice_max))
         cloud_fraction_series.append(TimeValue(time_seconds=time_seconds, value=cloud_fraction))
+        cloud_base_series.append(TimeValue(time_seconds=time_seconds, value=cloud_base))
+        cloud_top_series.append(TimeValue(time_seconds=time_seconds, value=cloud_top))
+        max_qc_height_series.append(
+            TimeValue(time_seconds=time_seconds, value=_height_of_level_max(array, caveats))
+        )
         if cloudy_count >= MINIMUM_CLOUD_GRID_CELLS:
             cloud_present_steps.append(time_seconds)
             if first_cloud_time is None:
@@ -156,8 +392,11 @@ def _cloud_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> 
         first_cloud_time_seconds=first_cloud_time,
         cloud_base_m=cloud_base,
         cloud_top_m=cloud_top,
+        cloud_base_time_series=cloud_base_series,
+        cloud_top_time_series=cloud_top_series,
         max_qc_kg_kg=max_qc,
         time_of_max_qc_seconds=time_of_max_qc,
+        max_qc_height_time_series=max_qc_height_series,
         qc_max_time_series=qc_max_series,
         cloud_fraction_time_series=cloud_fraction_series,
         cloud_present_time_steps=cloud_present_steps,
@@ -184,6 +423,7 @@ def _vertical_velocity_diagnostics(
 
     max_series: list[TimeValue] = []
     min_series: list[TimeValue] = []
+    max_height_series: list[TimeValue] = []
     max_w: float | None = None
     time_of_max_w: float | None = None
     min_w: float | None = None
@@ -195,6 +435,9 @@ def _vertical_velocity_diagnostics(
         slice_min = _finite_min(array)
         max_series.append(TimeValue(time_seconds=time_seconds, value=slice_max))
         min_series.append(TimeValue(time_seconds=time_seconds, value=slice_min))
+        max_height_series.append(
+            TimeValue(time_seconds=time_seconds, value=_height_of_level_max(array, caveats))
+        )
         if slice_max is not None and (max_w is None or slice_max > max_w):
             max_w = slice_max
             time_of_max_w = time_seconds
@@ -207,6 +450,7 @@ def _vertical_velocity_diagnostics(
         time_of_max_w_seconds=time_of_max_w,
         min_w_m_s=min_w,
         time_of_min_w_seconds=time_of_min_w,
+        max_w_height_time_series=max_height_series,
         w_max_time_series=max_series,
         w_min_time_series=min_series,
         units=units,
@@ -280,6 +524,36 @@ def _cloud_base_top(qc: Any, caveats: list[str]) -> tuple[float | None, float | 
     if not cloudy_values:
         return None, None
     return min(cloudy_values), max(cloudy_values)
+
+
+def _height_of_level_max(data_array: Any, caveats: list[str]) -> float | None:
+    vertical_name = _first_present(VERTICAL_COORDINATE_CANDIDATES, list(data_array.dims))
+    if vertical_name is None:
+        caveats.append("max_height_unavailable_missing_vertical_coordinate")
+        return None
+    vertical_values = _vertical_values(data_array, vertical_name, caveats)
+    best_value: float | None = None
+    best_height: float | None = None
+    for index in range(int(data_array.sizes[vertical_name])):
+        level_value = _finite_max(data_array.isel({vertical_name: index}))
+        if level_value is not None and (best_value is None or level_value > best_value):
+            best_value = level_value
+            best_height = vertical_values[index]
+    return best_height
+
+
+def _vertical_values(data_array: Any, vertical_name: str, caveats: list[str]) -> list[float | None]:
+    if vertical_name not in data_array.coords:
+        caveats.append("vertical_coordinate_inferred_from_index")
+        return [float(index) for index in range(int(data_array.sizes[vertical_name]))]
+    vertical_coord = data_array.coords[vertical_name]
+    vertical_values = [_to_float_or_none(value) for value in vertical_coord.values.tolist()]
+    units = _attr_string(vertical_coord, "units")
+    if units is None:
+        caveats.append("vertical_units_missing_assumed_meters")
+    elif units not in {"m", "meter", "meters"}:
+        caveats.append(f"vertical_units_not_meters:{units}")
+    return vertical_values
 
 
 def _time_context(dataset: Any, time_dimension: str | None) -> _TimeContext:
@@ -409,3 +683,19 @@ def _first_present(candidates: tuple[str, ...], names: list[str]) -> str | None:
 
 def _dedupe(values: list[str]) -> list[str]:
     return list(dict.fromkeys(values))
+
+
+def _present(names: list[str], available_fields: set[str]) -> list[str]:
+    return [name for name in names if name in available_fields]
+
+
+def _is_capped_scenario(
+    scenario_id: str,
+    controls: dict[str, str | float | bool],
+) -> bool:
+    return scenario_id == "capped-suppressed-cumulus" or controls.get("cap_strength") == "stronger"
+
+
+def _cloud_top_increases(series: list[TimeValue]) -> bool:
+    values = [point.value for point in series if point.value is not None]
+    return len(values) >= 2 and values[-1] > values[0]

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -11,7 +11,12 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from cloud_chamber.result_diagnostics import ResultDiagnostics, compute_baseline_diagnostics
+from cloud_chamber.result_diagnostics import (
+    ProcessDiagnostics,
+    ResultDiagnostics,
+    compute_baseline_diagnostics,
+    compute_process_diagnostics,
+)
 from cloud_chamber.run_manifest import LifecycleState, ProductState, RunManifest, load_run_manifest
 from cloud_chamber.settings import CloudChamberSettings
 
@@ -69,6 +74,7 @@ class ResultMetadata(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     diagnostics_summary: str | None = None
     diagnostics: ResultDiagnostics | None = None
+    process_diagnostics: ProcessDiagnostics | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -278,6 +284,12 @@ def _result_from_dataset(
             "Expected fields missing from NetCDF metadata: " + ", ".join(missing_expected)
         )
     diagnostics = compute_baseline_diagnostics(dataset, warnings)
+    process_diagnostics = compute_process_diagnostics(
+        diagnostics,
+        scenario_id=manifest.scenario.id,
+        controls=manifest.controls,
+        variables=variables,
+    )
 
     return ResultMetadata(
         result_id=f"result-{manifest.run_id}",
@@ -311,6 +323,7 @@ def _result_from_dataset(
         warnings=warnings,
         diagnostics_summary=_diagnostics_summary(diagnostics),
         diagnostics=diagnostics,
+        process_diagnostics=process_diagnostics,
         created_at=now,
         updated_at=now,
     )

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -123,6 +123,9 @@ def test_result_card_created_from_ingested_metadata(tmp_path: Path) -> None:
     assert card.run_size_preset == "quick_look"
     assert card.physical_question
     assert card.diagnostics_summary == "cloud formed; rain detected"
+    assert card.thermal_fate_label == "Fair-weather cumulus"
+    assert card.thermal_fate_confidence == "candidate"
+    assert card.main_limiting_factor == "unknown"
     assert card.first_cloud_time_seconds == 1800.0
     assert card.max_qc_kg_kg == 2e-6
     assert card.max_w_m_s == 4.0

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import xarray as xr
 
-from cloud_chamber.result_diagnostics import compute_baseline_diagnostics
+from cloud_chamber.result_diagnostics import (
+    compute_baseline_diagnostics,
+    compute_process_diagnostics,
+)
 
 
 def write_dataset(path: Path, dataset: xr.Dataset) -> xr.Dataset:
@@ -105,6 +108,16 @@ def test_cloud_formed_requires_ten_grid_cells_and_reports_base_top(tmp_path: Pat
     assert diagnostics.cloud.first_cloud_time_seconds == 300.0
     assert diagnostics.cloud.cloud_base_m == 500.0
     assert diagnostics.cloud.cloud_top_m == 1500.0
+    assert [point.value for point in diagnostics.cloud.cloud_base_time_series] == [None, 500.0]
+    assert [point.value for point in diagnostics.cloud.cloud_top_time_series] == [None, 1500.0]
+    assert [point.value for point in diagnostics.cloud.max_qc_height_time_series] == [
+        500.0,
+        1500.0,
+    ]
+    assert [point.value for point in diagnostics.vertical_velocity.max_w_height_time_series] == [
+        1500.0,
+        1500.0,
+    ]
     assert diagnostics.cloud.cloud_present_time_steps == [300.0]
 
 
@@ -265,3 +278,93 @@ def test_netcdf_time_coordinate_and_inferred_fallback(tmp_path: Path) -> None:
     assert inferred.time.source == "inferred_output_index"
     assert inferred.time.fallback_used is True
     assert inferred.cloud.first_cloud_time_seconds == 1.0
+
+
+def test_process_diagnostics_label_moisture_limited_thermal_without_cloud(
+    tmp_path: Path,
+) -> None:
+    dataset = write_dataset(
+        tmp_path / "dry_thermal.nc",
+        base_dataset(qc_values=zeros(), w_values=w_field()),
+    )
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    process = compute_process_diagnostics(
+        diagnostics,
+        scenario_id="dry-failed-cumulus",
+        controls={"low_level_humidity": "drier"},
+        variables=["qc", "w"],
+    )
+
+    assert process.interpretation_support.thermal_fate_label == "Thermal without cloud"
+    assert process.interpretation_support.confidence == "supported"
+    assert process.interpretation_support.main_limiting_factor == "moisture"
+    assert "moisture_limitation_inferred_without_saturation_deficit" in (
+        process.interpretation_support.caveats
+    )
+    assert process.deep_breakthrough.status == "unsupported_missing_fields"
+    assert process.precipitation_feedback.status == "unsupported_missing_fields"
+
+
+def test_process_diagnostics_marks_capped_result_as_candidate(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "capped.nc",
+        base_dataset(qc_values=with_cloud(12), w_values=w_field()),
+    )
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    process = compute_process_diagnostics(
+        diagnostics,
+        scenario_id="capped-suppressed-cumulus",
+        controls={"cap_strength": "stronger"},
+        variables=["qc", "w"],
+    )
+
+    assert process.interpretation_support.thermal_fate_label == "Capped / suppressed cumulus"
+    assert process.interpretation_support.confidence == "candidate"
+    assert process.interpretation_support.main_limiting_factor == "cap/stability"
+    assert process.cap_inversion.status == "candidate"
+    assert "cap_limitation_candidate_requires_baseline_comparison" in (
+        process.interpretation_support.caveats
+    )
+
+
+def test_process_diagnostics_handles_missing_required_fields(tmp_path: Path) -> None:
+    dataset = write_dataset(tmp_path / "missing.nc", base_dataset())
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    process = compute_process_diagnostics(
+        diagnostics,
+        scenario_id="baseline-shallow-cumulus",
+        controls={},
+        variables=[],
+    )
+
+    assert process.interpretation_support.thermal_fate_label == "Insufficient evidence"
+    assert process.interpretation_support.confidence == "unsupported_missing_fields"
+    assert process.thermal_fate.status == "unsupported_missing_fields"
+    assert process.cloud_lifecycle.status == "unsupported_missing_fields"
+    assert process.updrafts.status == "unsupported_missing_fields"
+
+
+def test_process_diagnostics_marks_growing_cumulus_candidate(tmp_path: Path) -> None:
+    qc = zeros()
+    for y_index in range(3):
+        for x_index in range(4):
+            qc[0][0][y_index][x_index] = 2e-6
+            qc[1][1][y_index][x_index] = 4e-6
+    dataset = write_dataset(
+        tmp_path / "growing.nc",
+        base_dataset(qc_values=qc, w_values=w_field()),
+    )
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    process = compute_process_diagnostics(
+        diagnostics,
+        scenario_id="baseline-shallow-cumulus",
+        controls={},
+        variables=["qc", "w"],
+    )
+
+    assert process.interpretation_support.thermal_fate_label == "Growing cumulus"
+    assert process.interpretation_support.confidence == "candidate"

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -185,6 +185,13 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
     assert result.diagnostics is not None
     assert result.diagnostics.cloud.formed is False
     assert result.diagnostics.rain.field_absent is True
+    assert result.process_diagnostics is not None
+    assert (
+        result.process_diagnostics.interpretation_support.thermal_fate_label
+        == "Thermal without cloud"
+    )
+    assert result.process_diagnostics.interpretation_support.confidence == "supported"
+    assert result.process_diagnostics.deep_breakthrough.status == "unsupported_missing_fields"
     assert result.warnings == [
         "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"
     ]

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -390,6 +390,25 @@ derived diagnostics exist. The browser should see bounded summaries and
 visualization-ready payloads only; backend xarray/NetCDF code owns direct field
 access, processing, and downsampling.
 
+The first implemented process-diagnostics layer attaches `process_diagnostics`
+to `result_metadata.json` during NetCDF ingest. It preserves the existing
+cloud/rain/updraft diagnostics and adds conservative Thermal Fate interpretation
+support:
+
+- moisture-limited `Thermal without cloud` when meaningful `w` exists but `qc`
+  stays below the cloud threshold;
+- `Capped / suppressed cumulus` as a candidate when the scenario/control path is
+  the stronger-cap case;
+- `Growing cumulus` as a candidate when cloud-top time series rises;
+- `Fair-weather cumulus` as a candidate for cloud-forming shallow cases without
+  stronger process evidence;
+- unavailable/caveated placeholders for buoyancy, deep breakthrough, and
+  precipitation feedback until required fields and diagnostics exist.
+
+Result cards expose the conservative `thermal_fate_label`,
+`thermal_fate_confidence`, and `main_limiting_factor` fields without replacing
+the existing cloud/rain/updraft summary.
+
 ### Result Library
 
 Responsibilities:

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -256,6 +256,14 @@ are first-class product families, but they should remain unavailable,
 candidate, or insufficient-evidence states until the required CM1 fields and
 derived diagnostics exist.
 
+The first backend process-diagnostics implementation supports a conservative
+global result summary. It can label moisture-limited thermal-without-cloud
+results when `w` is meaningful and `qc` stays below threshold, mark
+Capped / Suppressed as a candidate when the stronger-cap scenario/control path
+is selected, and expose growing/fair-weather cumulus candidate labels from
+available cloud-top and cloud-water diagnostics. It does not compute buoyancy,
+entrainment, CAPE/CIN/LFC/EL, cold pools, or selected-region explanations yet.
+
 ## Run Size Presets
 
 ### Quick look

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -50,6 +50,13 @@ Renderer upgrades follow process needs. They should not drive the product
 direction before Cloud Chamber can explain thermal fate with CM1-derived
 diagnostics, selected-region evidence, comparison, and caveats.
 
+#149 adds the first backend global/process diagnostics bridge. It attaches
+`process_diagnostics` to ingested result metadata, exposes conservative
+Thermal Fate labels/confidence/main-limiting-factor fields on result cards, and
+keeps deep-breakthrough, buoyancy, precipitation-feedback, and selected-region
+diagnostics unavailable or candidate/caveated until their required fields and
+follow-up issues exist.
+
 ## Golden Path: Baseline Shallow Cumulus
 
 Baseline Shallow Cumulus is the first complete product loop:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -155,6 +155,13 @@ precipitation feedback. Surface-heating scenario tests should cover product
 metadata and package-generation contracts without exposing raw namelist fields
 as the primary UI.
 
+The first implemented process-diagnostics tests cover global result metadata and
+result-card summaries only. They assert moisture-limited thermal-without-cloud
+support, capped-cumulus candidate support, growing-cumulus candidate support,
+missing required fields as `unsupported_missing_fields`, serialization through
+result metadata, and unavailable/caveated deep-breakthrough and
+precipitation-feedback placeholders. Selected-region diagnostics remain #151.
+
 Thermal Fate tests must distinguish direct CM1 fields, derived diagnostics,
 proxy diagnostics, and unsupported claims. Missing fields should produce
 explicit caveats, not crashes or fabricated values. The browser must not parse


### PR DESCRIPTION
Issue worked:
- Closes #149

Summary:
- Added a conservative `process_diagnostics` structure to ingested result metadata without replacing existing cloud, rain, and updraft diagnostics.
- Added Thermal Fate interpretation support for supported/candidate/insufficient/unsupported states, including conservative labels, confidence, and main limiting factor fields on result cards.
- Added cloud-base/top, max-qc-height, and max-w-height time-series support where current NetCDF fields already support it.
- Kept deep-breakthrough, buoyancy, saturation, precipitation-feedback, and selected-region process diagnostics caveated or unavailable when the required fields or region context are not present.

Tests added/updated:
- Added process-diagnostic unit coverage for moisture-limited thermals, capped candidates, missing required fields, and growing-cumulus candidates.
- Updated ingest tests to assert process diagnostics are serialized with ingested metadata.
- Updated result-card tests to assert Thermal Fate label, confidence, and limiting-factor projection.

Commands run:
- `cd app/backend && .venv/bin/python -m pytest tests/test_result_diagnostics.py tests/test_result_ingest.py tests/test_result_cards.py`
- `scripts/check.sh`

Manual QA needed:
- No. This is backend/data-model and docs work only.

Caveats / follow-up issues:
- Selected-region diagnostics remain deferred to #151.
- This PR does not implement full buoyancy, entrainment, CAPE/CIN/LFC/EL, cold-pool, or cloud-object tracking calculations; unsupported areas are represented explicitly with caveats.
- No real CM1 run was performed and no generated CM1/NetCDF/runtime artifacts were committed.
