### PR TITLE
Add Thermal Fate Inspector UI

### DIFF
--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -401,6 +401,90 @@ export async function mockCloudChamberApis(page: Page) {
     }),
   );
 
+  await page.route("**/api/results/*/diagnostics/selected-region**", (route) =>
+    json(route, {
+      result_id: "result-baseline",
+      run_id: "dry-run-baseline",
+      scenario_id: "baseline-shallow-cumulus",
+      region: {
+        region_type: "column",
+        requested: { region_type: "column", x_index: 1, y_index: 1, neighborhood: 1 },
+        x: {
+          dimension: "xh",
+          start_index: 0,
+          end_index: 2,
+          start_coordinate: 0,
+          end_coordinate: 3.2,
+          units: "km",
+        },
+        y: {
+          dimension: "yh",
+          start_index: 0,
+          end_index: 2,
+          start_coordinate: 0,
+          end_coordinate: 3.2,
+          units: "km",
+        },
+        vertical: {
+          dimension: "zh",
+          start_index: 0,
+          end_index: 3,
+          start_coordinate: 0.4,
+          end_coordinate: 1.6,
+          units: "km",
+        },
+        native_grid: "zh/yh/xh",
+        cell_count: 36,
+      },
+      diagnostics: {
+        available: true,
+        local_max_w_m_s: 4.5,
+        time_of_local_max_w_seconds: 1800,
+        local_min_w_m_s: -1.1,
+        time_of_local_min_w_seconds: 1800,
+        local_w_max_time_series: [{ time_seconds: 1800, value: 4.5 }],
+        local_w_min_time_series: [{ time_seconds: 1800, value: -1.1 }],
+        local_max_qc_kg_kg: 0.002,
+        time_of_local_max_qc_seconds: 1800,
+        first_local_cloud_time_seconds: 1800,
+        local_cloud_fraction_time_series: [{ time_seconds: 1800, value: 0.5 }],
+        local_qc_max_time_series: [{ time_seconds: 1800, value: 0.002 }],
+        local_cloud_base_time_series: [],
+        local_cloud_top_time_series: [],
+        local_max_qc_height_time_series: [],
+        local_max_w_height_time_series: [],
+        local_rain_present: true,
+        first_local_rain_time_seconds: 1800,
+        local_max_qr_kg_kg: 0.000001,
+        time_of_local_max_qr_seconds: 1800,
+        local_qr_max_time_series: [{ time_seconds: 1800, value: 0.000001 }],
+      },
+      comparison_to_domain: {
+        local_max_w_fraction_of_domain: 0.64,
+        local_max_qc_fraction_of_domain: 0.91,
+        local_first_cloud_time_delta_seconds: 0,
+        local_cloud_top_fraction_of_domain: 0.75,
+        local_first_rain_time_delta_seconds: 0,
+        caveats: [],
+      },
+      interpretation: {
+        thermal_fate_label: "Growing cumulus",
+        confidence: "candidate",
+        main_limiting_factor: "unknown",
+        summary: "Cloud water appeared locally where upward motion strengthened.",
+        caveats: ["selected_region_is_not_cloud_object_tracking"],
+      },
+      provenance: {
+        ...fieldCatalog("result-baseline").provenance,
+        processing_method: "backend_xarray_selected_region_diagnostics",
+        rendering_method: "thermal_fate_inspector_summary",
+        provenance_label:
+          "CM1-derived selected-region diagnostics; native-grid summary; browser receives bounded payload only",
+      },
+      caveats: ["native_grid_region_summary_no_interpolation"],
+    }),
+  );
+
   await page.route("**/api/storage/inventory", (route) =>
     json(route, {
       runtime_home: "/tmp/cloud-chamber-e2e",

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -58,6 +58,16 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/2-d field inspection/i).first()).toBeVisible();
     await expect(page.getByText(/thermal fate overlay/i).first()).toBeVisible();
     await expect(page.getByText(/growing cumulus/i).first()).toBeVisible();
+    await expect(page.getByText(/what happened here/i).first()).toBeVisible();
+    await page
+      .getByRole("button", { name: /inspect vertical x slice row 2, column 2/i })
+      .first()
+      .click();
+    await expect(page.getByText(/selected-region diagnostics loaded/i)).toBeVisible();
+    await expect(page.getByText(/cloud water appeared locally/i)).toBeVisible();
+    await expect(page.getByText(/local max w/i)).toBeVisible();
+    await page.getByRole("button", { name: /clear selection/i }).click();
+    await expect(page.getByText(/no region is selected/i)).toBeVisible();
     await expect(page.getByText(/\[\[[\d.,\s]+\]\]/)).not.toBeVisible();
 
     await openExploreTab(page, /^3-D View$/);

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1146,6 +1146,29 @@ details[open] > summary {
   background: rgba(3, 8, 13, 0.3);
 }
 
+.selected-region-controls,
+.selected-region-inspector {
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid rgba(143, 216, 182, 0.3);
+  border-radius: 8px;
+  padding: 0.85rem;
+  background: rgba(10, 24, 25, 0.34);
+}
+
+.selected-region-controls {
+  grid-template-columns: minmax(0, 1.6fr) minmax(16rem, 1fr) auto;
+  align-items: center;
+}
+
+.inspector-summary {
+  display: grid;
+  gap: 0.6rem;
+  align-items: start;
+  border-left: 3px solid rgba(143, 216, 182, 0.7);
+  padding-left: 0.75rem;
+}
+
 .compact-heading {
   gap: 0.65rem;
 }
@@ -1192,9 +1215,24 @@ details[open] > summary {
 }
 
 .heatmap-cell {
+  appearance: none;
   min-height: 2rem;
+  border: 0;
   border-radius: 4px;
+  cursor: crosshair;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.heatmap-cell:focus-visible,
+.heatmap-cell:hover {
+  outline: 2px solid rgba(216, 255, 240, 0.7);
+  outline-offset: 1px;
+}
+
+.heatmap-cell-selected {
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 228, 168, 0.92),
+    0 0 18px rgba(255, 206, 115, 0.34);
 }
 
 .heatmap-legend {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -661,6 +661,115 @@ function pointCloudResponse({
   };
 }
 
+function selectedRegionResponse() {
+  return {
+    result_id: "result-dry-run-quicklook",
+    run_id: "dry-run-quicklook",
+    scenario_id: "baseline-shallow-cumulus",
+    region: {
+      region_type: "column",
+      requested: {
+        region_type: "column",
+        x_index: 1,
+        y_index: 0,
+        neighborhood: 1,
+      },
+      x: {
+        dimension: "xh",
+        start_index: 0,
+        end_index: 2,
+        start_coordinate: -3.2,
+        end_coordinate: 3.2,
+        units: "km",
+      },
+      y: {
+        dimension: "yh",
+        start_index: 0,
+        end_index: 1,
+        start_coordinate: -3.2,
+        end_coordinate: 0,
+        units: "km",
+      },
+      vertical: {
+        dimension: "zh",
+        start_index: 0,
+        end_index: 1,
+        start_coordinate: 0.4,
+        end_coordinate: 0.8,
+        units: "km",
+      },
+      native_grid: "zh/yh/xh",
+      cell_count: 12,
+    },
+    diagnostics: {
+      available: true,
+      local_max_w_m_s: 4.5,
+      time_of_local_max_w_seconds: 1800,
+      local_min_w_m_s: -1.2,
+      time_of_local_min_w_seconds: 900,
+      local_w_max_time_series: [
+        { time_seconds: 0, value: 1.2 },
+        { time_seconds: 900, value: 2.4 },
+        { time_seconds: 1800, value: 4.5 },
+      ],
+      local_w_min_time_series: [
+        { time_seconds: 0, value: -0.1 },
+        { time_seconds: 900, value: -1.2 },
+        { time_seconds: 1800, value: -0.7 },
+      ],
+      local_max_qc_kg_kg: 0.00002,
+      time_of_local_max_qc_seconds: 1800,
+      first_local_cloud_time_seconds: 900,
+      local_cloud_fraction_time_series: [
+        { time_seconds: 0, value: 0 },
+        { time_seconds: 900, value: 0.25 },
+        { time_seconds: 1800, value: 0.5 },
+      ],
+      local_qc_max_time_series: [
+        { time_seconds: 0, value: 0 },
+        { time_seconds: 900, value: 0.000006 },
+        { time_seconds: 1800, value: 0.00002 },
+      ],
+      local_cloud_base_time_series: [],
+      local_cloud_top_time_series: [],
+      local_max_qc_height_time_series: [],
+      local_max_w_height_time_series: [],
+      local_rain_present: true,
+      first_local_rain_time_seconds: 1800,
+      local_max_qr_kg_kg: 0.000001,
+      time_of_local_max_qr_seconds: 1800,
+      local_qr_max_time_series: [{ time_seconds: 1800, value: 0.000001 }],
+    },
+    comparison_to_domain: {
+      local_max_w_fraction_of_domain: 0.66,
+      local_max_qc_fraction_of_domain: 0.91,
+      local_first_cloud_time_delta_seconds: -900,
+      local_cloud_top_fraction_of_domain: 0.78,
+      local_first_rain_time_delta_seconds: 0,
+      caveats: ["comparison_uses_global_result_summary"],
+    },
+    interpretation: {
+      thermal_fate_label: "Growing cumulus",
+      confidence: "candidate",
+      main_limiting_factor: "unknown",
+      summary:
+        "Cloud water appeared locally after upward motion strengthened, then remained active.",
+      caveats: ["selected_region_is_not_cloud_object_tracking"],
+    },
+    provenance: {
+      ...provenance,
+      processing_method: "backend_xarray_selected_region_diagnostics",
+      rendering_method: "thermal_fate_inspector_summary",
+      provenance_label:
+        "CM1-derived selected-region diagnostics; native-grid summary; browser receives bounded payload only",
+    },
+    caveats: [
+      "native_grid_region_summary_no_interpolation",
+      "selected_region_is_not_cloud_object_tracking",
+    ],
+  };
+}
+
 beforeEach(() => {
   vi.stubGlobal(
     "fetch",
@@ -809,6 +918,18 @@ beforeEach(() => {
             ),
             { status: 200 },
           ),
+        );
+      }
+      if (url.includes("/diagnostics/selected-region")) {
+        if (url.includes("x_index=99")) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ detail: "x_index=99 is outside valid range" }), {
+              status: 400,
+            }),
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify(selectedRegionResponse()), { status: 200 }),
         );
       }
       if (url.includes("/visualization/slice")) {
@@ -1551,6 +1672,87 @@ describe("App", () => {
     expect(screen.getAllByText("Horizontal slice").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("Horizontal slice heatmap")).toBeInTheDocument();
     expect(screen.getByText("Selected level: 0.8 km (800 m)")).toBeInTheDocument();
+  });
+
+  it("selects a slice region and renders backend Thermal Fate Inspector diagnostics", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+    await screen.findByText("Slices loaded");
+
+    const heatmap = screen.getByLabelText("Vertical X slice heatmap");
+    fireEvent.click(within(heatmap).getByRole("button", { name: /row 1, column 2/i }));
+
+    expect(await screen.findByText("Selected-region diagnostics loaded")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "What happened here?" })).toBeInTheDocument();
+    expect(screen.getAllByText("Growing cumulus").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/Cloud water appeared locally after upward motion strengthened/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("First local cloud time")).toBeInTheDocument();
+    expect(screen.getByText("Local max qc")).toBeInTheDocument();
+    expect(screen.getAllByText("2.000e-5 kg/kg").length).toBeGreaterThan(0);
+    expect(screen.getByText("Local max w")).toBeInTheDocument();
+    expect(screen.getByText("4.5 m/s")).toBeInTheDocument();
+    expect(screen.getByText("Local rain")).toBeInTheDocument();
+    expect(screen.getByText("Rain detected")).toBeInTheDocument();
+    expect(screen.getByText("Compared with whole result")).toBeInTheDocument();
+    expect(screen.getByText(/backend xarray selected-region diagnostics/i)).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "/api/results/result-dry-run-quicklook/diagnostics/selected-region?region_type=column",
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear selection" }));
+
+    expect(screen.getByText(/No region is selected/)).toBeInTheDocument();
+  });
+
+  it("shows selected-region backend failures as actionable inspector errors", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(new Response(JSON.stringify(resultsResponse), { status: 200 }));
+      }
+      if (url.includes("/visualization/fields")) {
+        return Promise.resolve(new Response(JSON.stringify(fieldCatalogResponse), { status: 200 }));
+      }
+      if (url.includes("/visualization/defaults")) {
+        return Promise.resolve(new Response(JSON.stringify(viewDefaultsResponse), { status: 200 }));
+      }
+      if (url.includes("/visualization/slice")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(sliceResponse({ orientation: "vertical_x" })), {
+            status: 200,
+          }),
+        );
+      }
+      if (url.includes("/diagnostics/selected-region")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ detail: "Unsupported selected region." }), {
+            status: 400,
+          }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+    await screen.findByText("Slices loaded");
+    fireEvent.click(
+      within(screen.getByLabelText("Vertical X slice heatmap")).getByRole("button", {
+        name: /row 1, column 1/i,
+      }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unsupported selected region.");
+    expect(screen.getByText("Selected-region request failed")).toBeInTheDocument();
   });
 
   it("supports field and time selection through visualization-ready APIs", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -308,6 +308,91 @@ type PointCloudResponse = {
   caveats: string[];
 };
 
+type RegionType = "point" | "column" | "box";
+
+type SelectedRegionRequest = {
+  regionType: RegionType;
+  xIndex?: number;
+  yIndex?: number;
+  zIndex?: number;
+  xStart?: number;
+  xEnd?: number;
+  yStart?: number;
+  yEnd?: number;
+  zStart?: number;
+  zEnd?: number;
+  neighborhood?: number;
+};
+
+type AxisSelection = {
+  dimension: string;
+  start_index: number;
+  end_index: number;
+  start_coordinate: number | string | null;
+  end_coordinate: number | string | null;
+  units: string | null;
+};
+
+type TimeValue = {
+  time_seconds: number | null;
+  value: number | null;
+};
+
+type SelectedRegionDiagnosticsResponse = {
+  result_id: string;
+  run_id: string;
+  scenario_id: string;
+  region: {
+    region_type: RegionType;
+    requested: Record<string, unknown>;
+    x: AxisSelection | null;
+    y: AxisSelection | null;
+    vertical: AxisSelection | null;
+    native_grid: string | null;
+    cell_count: number | null;
+  };
+  diagnostics: {
+    available: boolean;
+    local_max_w_m_s: number | null;
+    time_of_local_max_w_seconds: number | null;
+    local_min_w_m_s: number | null;
+    time_of_local_min_w_seconds: number | null;
+    local_w_max_time_series: TimeValue[];
+    local_w_min_time_series: TimeValue[];
+    local_max_qc_kg_kg: number | null;
+    time_of_local_max_qc_seconds: number | null;
+    first_local_cloud_time_seconds: number | null;
+    local_cloud_fraction_time_series: TimeValue[];
+    local_qc_max_time_series: TimeValue[];
+    local_cloud_base_time_series: TimeValue[];
+    local_cloud_top_time_series: TimeValue[];
+    local_max_qc_height_time_series: TimeValue[];
+    local_max_w_height_time_series: TimeValue[];
+    local_rain_present: boolean;
+    first_local_rain_time_seconds: number | null;
+    local_max_qr_kg_kg: number | null;
+    time_of_local_max_qr_seconds: number | null;
+    local_qr_max_time_series: TimeValue[];
+  };
+  comparison_to_domain: {
+    local_max_w_fraction_of_domain: number | null;
+    local_max_qc_fraction_of_domain: number | null;
+    local_first_cloud_time_delta_seconds: number | null;
+    local_cloud_top_fraction_of_domain: number | null;
+    local_first_rain_time_delta_seconds: number | null;
+    caveats: string[];
+  };
+  interpretation: {
+    thermal_fate_label: string;
+    confidence: ProcessSupport;
+    main_limiting_factor: string;
+    summary: string;
+    caveats: string[];
+  };
+  provenance: ProvenancePayload;
+  caveats: string[];
+};
+
 type FieldViewDefaults = {
   field: string;
   time_index: number;
@@ -559,6 +644,34 @@ async function fetchVisualizationPointCloud(
     throw new Error(await responseError(response, "Unable to load cloud-water point cloud."));
   }
   return response.json() as Promise<PointCloudResponse>;
+}
+
+async function fetchSelectedRegionDiagnostics(
+  resultId: string,
+  request: SelectedRegionRequest,
+): Promise<SelectedRegionDiagnosticsResponse> {
+  const search = new URLSearchParams({
+    region_type: request.regionType,
+    neighborhood: String(request.neighborhood ?? 0),
+  });
+  addOptionalIndex(search, "x_index", request.xIndex);
+  addOptionalIndex(search, "y_index", request.yIndex);
+  addOptionalIndex(search, "z_index", request.zIndex);
+  addOptionalIndex(search, "x_start", request.xStart);
+  addOptionalIndex(search, "x_end", request.xEnd);
+  addOptionalIndex(search, "y_start", request.yStart);
+  addOptionalIndex(search, "y_end", request.yEnd);
+  addOptionalIndex(search, "z_start", request.zStart);
+  addOptionalIndex(search, "z_end", request.zEnd);
+  const response = await fetch(`/api/results/${resultId}/diagnostics/selected-region?${search}`);
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to inspect the selected region."));
+  }
+  return response.json() as Promise<SelectedRegionDiagnosticsResponse>;
+}
+
+function addOptionalIndex(search: URLSearchParams, key: string, value: number | undefined) {
+  if (value !== undefined) search.set(key, String(value));
 }
 
 async function responseError(response: Response, fallback: string): Promise<string> {
@@ -3932,6 +4045,11 @@ function FieldInspector({ result }: { result: ResultCard }) {
   const [processMode, setProcessMode] = useState<ProcessMode>("thermal_fate");
   const [horizontalSlice, setHorizontalSlice] = useState<SliceResponse | null>(null);
   const [verticalSlice, setVerticalSlice] = useState<SliceResponse | null>(null);
+  const [selectedRegion, setSelectedRegion] = useState<SelectedRegionRequest | null>(null);
+  const [regionDiagnostics, setRegionDiagnostics] =
+    useState<SelectedRegionDiagnosticsResponse | null>(null);
+  const [regionStatus, setRegionStatus] = useState("Select a slice cell to inspect a region.");
+  const [regionError, setRegionError] = useState<string | null>(null);
   const [inspectorStatus, setInspectorStatus] = useState("Loading fields...");
   const [inspectorError, setInspectorError] = useState<string | null>(null);
 
@@ -3943,6 +4061,10 @@ function FieldInspector({ result }: { result: ResultCard }) {
     setViewDefaults(null);
     setHorizontalSlice(null);
     setVerticalSlice(null);
+    setSelectedRegion(null);
+    setRegionDiagnostics(null);
+    setRegionError(null);
+    setRegionStatus("Select a slice cell to inspect a region.");
     setViewMode("vertical_x");
     setProcessMode("thermal_fate");
     Promise.all([
@@ -4038,6 +4160,36 @@ function FieldInspector({ result }: { result: ResultCard }) {
     verticalOrientation,
   ]);
 
+  useEffect(() => {
+    if (!selectedRegion) {
+      setRegionDiagnostics(null);
+      setRegionError(null);
+      setRegionStatus("Select a slice cell to inspect a region.");
+      return;
+    }
+    let active = true;
+    setRegionDiagnostics(null);
+    setRegionError(null);
+    setRegionStatus("Loading selected-region diagnostics...");
+    fetchSelectedRegionDiagnostics(result.result_id, selectedRegion)
+      .then((payload) => {
+        if (!active) return;
+        setRegionDiagnostics(payload);
+        setRegionStatus("Selected-region diagnostics loaded");
+      })
+      .catch((caught: unknown) => {
+        if (!active) return;
+        setRegionDiagnostics(null);
+        setRegionError(
+          caught instanceof Error ? caught.message : "Unable to inspect the selected region.",
+        );
+        setRegionStatus("Selected-region request failed");
+      });
+    return () => {
+      active = false;
+    };
+  }, [result.result_id, selectedRegion]);
+
   const timeOptions = selectedField?.time_coordinate_values ?? [];
   const verticalSize = selectedField?.coordinate_names.vertical
     ? selectedField.shape[selectedField.dimensions.indexOf(selectedField.coordinate_names.vertical)]
@@ -4049,6 +4201,34 @@ function FieldInspector({ result }: { result: ResultCard }) {
     ? selectedField.shape[selectedField.dimensions.indexOf(selectedField.coordinate_names.x)]
     : 1;
   const verticalSliceMax = verticalOrientation === "vertical_x" ? ySize : xSize;
+  const activeSlice = viewMode === "horizontal" ? horizontalSlice : verticalSlice;
+
+  function selectRegionFromSlice(slice: SliceResponse, rowIndex: number, columnIndex: number) {
+    setSelectedRegion(selectionFromSlice(slice, rowIndex, columnIndex, "column"));
+  }
+
+  function selectPointFromActiveSlice() {
+    if (!activeSlice) return;
+    const rowIndex = Math.floor(activeSlice.values.length / 2);
+    const columnIndex = Math.floor((activeSlice.values[0]?.length ?? 1) / 2);
+    setSelectedRegion(selectionFromSlice(activeSlice, rowIndex, columnIndex, "point"));
+  }
+
+  function selectBoxFromActiveSlice() {
+    if (!activeSlice) return;
+    const rowIndex = Math.floor(activeSlice.values.length / 2);
+    const columnIndex = Math.floor((activeSlice.values[0]?.length ?? 1) / 2);
+    const center = selectionFromSlice(activeSlice, rowIndex, columnIndex, "column");
+    setSelectedRegion({
+      regionType: "box",
+      xStart: Math.max(0, (center.xIndex ?? 0) - 1),
+      xEnd: (center.xIndex ?? 0) + 1,
+      yStart: Math.max(0, (center.yIndex ?? 0) - 1),
+      yEnd: (center.yIndex ?? 0) + 1,
+      zStart: Math.max(0, (center.zIndex ?? 0) - 1),
+      zEnd: (center.zIndex ?? 0) + 1,
+    });
+  }
 
   return (
     <section className="field-inspector" aria-labelledby="field-inspector-title">
@@ -4189,17 +4369,39 @@ function FieldInspector({ result }: { result: ResultCard }) {
             slice={viewMode === "horizontal" ? horizontalSlice : verticalSlice}
           />
 
+          <SelectedRegionControls
+            selectedRegion={selectedRegion}
+            regionStatus={regionStatus}
+            onSelectPoint={selectPointFromActiveSlice}
+            onSelectBox={selectBoxFromActiveSlice}
+            onClear={() => setSelectedRegion(null)}
+          />
+
           <div className={viewMode === "compare" ? "slice-grid" : "primary-slice-grid"}>
             {(viewMode === "horizontal" || viewMode === "compare") && (
-              <SlicePanel title="Horizontal slice" slice={horizontalSlice} />
+              <SlicePanel
+                title="Horizontal slice"
+                slice={horizontalSlice}
+                selectedRegion={selectedRegion}
+                onSelectRegion={selectRegionFromSlice}
+              />
             )}
             {(viewMode === "vertical_x" || viewMode === "vertical_y" || viewMode === "compare") && (
               <SlicePanel
                 title={viewMode === "vertical_y" ? "Vertical Y slice" : "Vertical X slice"}
                 slice={verticalSlice}
+                selectedRegion={selectedRegion}
+                onSelectRegion={selectRegionFromSlice}
               />
             )}
           </div>
+
+          <SelectedRegionInspector
+            selectedRegion={selectedRegion}
+            diagnostics={regionDiagnostics}
+            status={regionStatus}
+            error={regionError}
+          />
 
           <details>
             <summary>Technical field details</summary>
@@ -4216,7 +4418,17 @@ function FieldInspector({ result }: { result: ResultCard }) {
   );
 }
 
-function SlicePanel({ title, slice }: { title: string; slice: SliceResponse | null }) {
+function SlicePanel({
+  title,
+  slice,
+  selectedRegion,
+  onSelectRegion,
+}: {
+  title: string;
+  slice: SliceResponse | null;
+  selectedRegion?: SelectedRegionRequest | null;
+  onSelectRegion?: (slice: SliceResponse, rowIndex: number, columnIndex: number) => void;
+}) {
   if (!slice) {
     return (
       <section className="slice-panel" aria-label={title}>
@@ -4248,7 +4460,12 @@ function SlicePanel({ title, slice }: { title: string; slice: SliceResponse | nu
             : ""}
         </p>
       )}
-      <SliceHeatmap title={title} slice={slice} />
+      <SliceHeatmap
+        title={title}
+        slice={slice}
+        selectedRegion={selectedRegion}
+        onSelectRegion={onSelectRegion}
+      />
       <div className="heatmap-legend" aria-label={`${title} color scale`}>
         <span>{formatMaybeNumber(slice.stats.min, slice.field.units)}</span>
         <span className="heatmap-scale" />
@@ -4363,19 +4580,208 @@ function ProcessOverlayPanel({
   );
 }
 
-function SliceHeatmap({ title, slice }: { title: string; slice: SliceResponse }) {
+function SelectedRegionControls({
+  selectedRegion,
+  regionStatus,
+  onSelectPoint,
+  onSelectBox,
+  onClear,
+}: {
+  selectedRegion: SelectedRegionRequest | null;
+  regionStatus: string;
+  onSelectPoint: () => void;
+  onSelectBox: () => void;
+  onClear: () => void;
+}) {
+  return (
+    <section className="selected-region-controls" aria-label="Selected-region controls">
+      <div>
+        <p className="eyebrow">What happened here?</p>
+        <h3>Thermal Fate Inspector</h3>
+        <p>
+          Click a slice cell to inspect the nearest column, or use the buttons below for a bounded
+          point or box around the current view center.
+        </p>
+      </div>
+      <div className="segmented-buttons">
+        <button type="button" onClick={onSelectPoint}>
+          Inspect center point
+        </button>
+        <button type="button" onClick={onSelectBox}>
+          Inspect small box
+        </button>
+        <button type="button" onClick={onClear} disabled={!selectedRegion}>
+          Clear selection
+        </button>
+      </div>
+      <p className="state-chip">{selectedRegion ? selectionLabel(selectedRegion) : regionStatus}</p>
+    </section>
+  );
+}
+
+function SelectedRegionInspector({
+  selectedRegion,
+  diagnostics,
+  status,
+  error,
+}: {
+  selectedRegion: SelectedRegionRequest | null;
+  diagnostics: SelectedRegionDiagnosticsResponse | null;
+  status: string;
+  error: string | null;
+}) {
+  return (
+    <section className="selected-region-inspector" aria-label="Thermal Fate Inspector">
+      <div className="section-heading compact-heading">
+        <div>
+          <p className="eyebrow">Selected region</p>
+          <h3>What happened here?</h3>
+        </div>
+        <p className="state-chip">{status}</p>
+      </div>
+
+      {!selectedRegion && (
+        <p>
+          No region is selected. Select a point, column, or box to request backend Thermal Fate
+          diagnostics.
+        </p>
+      )}
+
+      {error && <p role="alert">{error}</p>}
+
+      {diagnostics && (
+        <>
+          <div className="inspector-summary">
+            <StatusBadge
+              label={diagnostics.interpretation.thermal_fate_label}
+              tone={
+                diagnostics.interpretation.confidence === "supported"
+                  ? "good"
+                  : diagnostics.interpretation.confidence === "candidate"
+                    ? "neutral"
+                    : "warning"
+              }
+            />
+            <p>{diagnostics.interpretation.summary}</p>
+          </div>
+
+          <dl className="metric-grid">
+            <Metric
+              label="Confidence"
+              value={processSupportLabel(diagnostics.interpretation.confidence)}
+            />
+            <Metric
+              label="Main limiting factor"
+              value={humanize(diagnostics.interpretation.main_limiting_factor)}
+            />
+            <Metric label="Region type" value={humanize(diagnostics.region.region_type)} />
+            <Metric label="Native grid" value={diagnostics.region.native_grid ?? "Unavailable"} />
+            <Metric label="Cell count" value={String(diagnostics.region.cell_count ?? "unknown")} />
+            <Metric
+              label="First local cloud time"
+              value={formatSeconds(diagnostics.diagnostics.first_local_cloud_time_seconds)}
+            />
+            <Metric
+              label="Local max qc"
+              value={formatScientific(diagnostics.diagnostics.local_max_qc_kg_kg, "kg/kg")}
+            />
+            <Metric
+              label="Local max w"
+              value={formatNumber(diagnostics.diagnostics.local_max_w_m_s, "m/s")}
+            />
+            <Metric
+              label="Local min w"
+              value={formatNumber(diagnostics.diagnostics.local_min_w_m_s, "m/s")}
+            />
+            <Metric
+              label="Local rain"
+              value={diagnostics.diagnostics.local_rain_present ? "Rain detected" : "No rain detected"}
+            />
+          </dl>
+
+          <section aria-label="Selected-region bounds">
+            <h4>Selected-region bounds</h4>
+            <dl className="metric-grid">
+              <Metric label="x" value={axisSelectionLabel(diagnostics.region.x)} />
+              <Metric label="y" value={axisSelectionLabel(diagnostics.region.y)} />
+              <Metric label="vertical" value={axisSelectionLabel(diagnostics.region.vertical)} />
+            </dl>
+          </section>
+
+          <section aria-label="Domain comparison">
+            <h4>Compared with whole result</h4>
+            <dl className="metric-grid">
+              <Metric
+                label="Max w fraction"
+                value={formatRatio(diagnostics.comparison_to_domain.local_max_w_fraction_of_domain)}
+              />
+              <Metric
+                label="Max qc fraction"
+                value={formatRatio(diagnostics.comparison_to_domain.local_max_qc_fraction_of_domain)}
+              />
+              <Metric
+                label="First cloud delta"
+                value={formatSignedSeconds(
+                  diagnostics.comparison_to_domain.local_first_cloud_time_delta_seconds,
+                )}
+              />
+              <Metric
+                label="Cloud-top fraction"
+                value={formatRatio(diagnostics.comparison_to_domain.local_cloud_top_fraction_of_domain)}
+              />
+            </dl>
+          </section>
+
+          <details>
+            <summary>Technical selected-region details</summary>
+            <p>{diagnostics.provenance.provenance_label}</p>
+            <ul className="compact-list">
+              <li>Backend xarray selected-region diagnostics; no raw NetCDF parsing in browser.</li>
+              <li>Selected region is not cloud-object tracking.</li>
+              {_dedupeStrings([
+                ...diagnostics.caveats,
+                ...diagnostics.interpretation.caveats,
+                ...diagnostics.comparison_to_domain.caveats,
+              ]).map((caveat) => (
+                <li key={caveat}>{caveat}</li>
+              ))}
+            </ul>
+          </details>
+        </>
+      )}
+    </section>
+  );
+}
+
+function SliceHeatmap({
+  title,
+  slice,
+  selectedRegion,
+  onSelectRegion,
+}: {
+  title: string;
+  slice: SliceResponse;
+  selectedRegion?: SelectedRegionRequest | null;
+  onSelectRegion?: (slice: SliceResponse, rowIndex: number, columnIndex: number) => void;
+}) {
   return (
     <div className="slice-heatmap" role="img" aria-label={`${title} heatmap`}>
       {slice.values.map((row, rowIndex) => (
         <div className="heatmap-row" key={`${title}-heatmap-${rowIndex}`}>
-          {row.map((value, columnIndex) => (
-            <span
-              className="heatmap-cell"
-              key={`${title}-heatmap-${rowIndex}-${columnIndex}`}
-              title={value === null ? "missing" : formatMaybeNumber(value, slice.field.units)}
-              style={sliceCellStyle(value, slice.stats)}
-            />
-          ))}
+          {row.map((value, columnIndex) => {
+            const selected = isSelectedSliceCell(slice, selectedRegion, rowIndex, columnIndex);
+            return (
+              <button
+                type="button"
+                className={`heatmap-cell${selected ? " heatmap-cell-selected" : ""}`}
+                key={`${title}-heatmap-${rowIndex}-${columnIndex}`}
+                title={value === null ? "missing" : formatMaybeNumber(value, slice.field.units)}
+                aria-label={`Inspect ${title} row ${rowIndex + 1}, column ${columnIndex + 1}`}
+                style={sliceCellStyle(value, slice.stats)}
+                onClick={() => onSelectRegion?.(slice, rowIndex, columnIndex)}
+              />
+            );
+          })}
         </div>
       ))}
     </div>
@@ -4608,6 +5014,104 @@ function processSupportLabel(value: ProcessSupport): string {
     unsupported_missing_fields: "Unavailable",
   };
   return labels[value];
+}
+
+function selectionFromSlice(
+  slice: SliceResponse,
+  rowIndex: number,
+  columnIndex: number,
+  regionType: "point" | "column",
+): SelectedRegionRequest {
+  const orientation = slice.selection.orientation;
+  if (orientation === "horizontal") {
+    return {
+      regionType,
+      xIndex: columnIndex,
+      yIndex: rowIndex,
+      zIndex: slice.selection.selected_index,
+      neighborhood: regionType === "point" ? 0 : 1,
+    };
+  }
+  if (orientation === "vertical_x") {
+    return {
+      regionType,
+      xIndex: columnIndex,
+      yIndex: slice.selection.selected_index,
+      zIndex: rowIndex,
+      neighborhood: regionType === "point" ? 0 : 1,
+    };
+  }
+  return {
+    regionType,
+    xIndex: slice.selection.selected_index,
+    yIndex: columnIndex,
+    zIndex: rowIndex,
+    neighborhood: regionType === "point" ? 0 : 1,
+  };
+}
+
+function isSelectedSliceCell(
+  slice: SliceResponse,
+  selectedRegion: SelectedRegionRequest | null | undefined,
+  rowIndex: number,
+  columnIndex: number,
+): boolean {
+  if (!selectedRegion) return false;
+  const candidate = selectionFromSlice(slice, rowIndex, columnIndex, "point");
+  if (selectedRegion.regionType === "box") {
+    return (
+      candidate.xIndex !== undefined &&
+      candidate.yIndex !== undefined &&
+      candidate.zIndex !== undefined &&
+      candidate.xIndex >= (selectedRegion.xStart ?? -Infinity) &&
+      candidate.xIndex <= (selectedRegion.xEnd ?? Infinity) &&
+      candidate.yIndex >= (selectedRegion.yStart ?? -Infinity) &&
+      candidate.yIndex <= (selectedRegion.yEnd ?? Infinity) &&
+      candidate.zIndex >= (selectedRegion.zStart ?? -Infinity) &&
+      candidate.zIndex <= (selectedRegion.zEnd ?? Infinity)
+    );
+  }
+  return (
+    selectedRegion.xIndex === candidate.xIndex &&
+    selectedRegion.yIndex === candidate.yIndex &&
+    (selectedRegion.regionType === "column" || selectedRegion.zIndex === candidate.zIndex)
+  );
+}
+
+function selectionLabel(selection: SelectedRegionRequest): string {
+  if (selection.regionType === "box") {
+    return `Box x ${selection.xStart}-${selection.xEnd}, y ${selection.yStart}-${selection.yEnd}, z ${selection.zStart}-${selection.zEnd}`;
+  }
+  const z = selection.regionType === "point" ? `, z ${selection.zIndex}` : "";
+  return `${humanize(selection.regionType)} x ${selection.xIndex}, y ${selection.yIndex}${z}`;
+}
+
+function axisSelectionLabel(axis: AxisSelection | null): string {
+  if (!axis) return "Unavailable";
+  const coordinate =
+    axis.start_coordinate === axis.end_coordinate
+      ? String(axis.start_coordinate ?? "unknown")
+      : `${String(axis.start_coordinate ?? "unknown")} to ${String(axis.end_coordinate ?? "unknown")}`;
+  const index =
+    axis.start_index === axis.end_index
+      ? `${axis.dimension}[${axis.start_index}]`
+      : `${axis.dimension}[${axis.start_index}..${axis.end_index}]`;
+  return `${index}; ${coordinate}${axis.units ? ` ${axis.units}` : ""}`;
+}
+
+function formatRatio(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "Unavailable";
+  return `${formatCompactNumber(value * 100)}%`;
+}
+
+function formatSignedSeconds(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "Unavailable";
+  const prefix = value > 0 ? "+" : "";
+  return `${prefix}${formatSeconds(value)}`;
+}
+
+function _dedupeStrings(values: string[]): string[] {
+  return [...new Set(values)];
 }
 
 function parseTags(value: string): string[] {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -39,6 +39,11 @@ visualization. It should distinguish global run diagnostics, local
 selected-region diagnostics, comparison diagnostics, and visualizer
 interpretation. The browser should continue to receive bounded summaries,
 visualization-ready slices/points, and provenance labels rather than raw NetCDF.
+Explore's Thermal Fate Inspector follows that boundary: slice-cell or bounded
+region selections are sent to the backend selected-region diagnostics endpoint,
+and the frontend renders only the returned local summaries, conservative label,
+confidence, caveats, selected native-grid bounds, domain comparison, and
+provenance.
 
 ## Suggested Stack
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -223,7 +223,7 @@ synthetic cloud physics; those belong to later visualizer issues.
 
 ### Workflow 6.5 — What Happened Here?
 
-The selected-region Thermal Fate workflow is a core future workflow:
+The selected-region Thermal Fate workflow is a core Explore workflow:
 
 ```text
 open a completed/saved result
@@ -236,6 +236,14 @@ open a completed/saved result
 
 This workflow must use backend diagnostics over CM1-derived fields. The browser
 must not parse raw NetCDF or invent scientific explanations.
+
+The first UI implementation lives in Explore / 2-D Slices. Users can click a
+backend-prepared heatmap cell to inspect the nearest native-grid column, select
+a bounded center point or small box, clear the selection, and review the
+backend-returned Thermal Fate label, confidence, caveats, local `qc`/`w`/rain
+summaries, selected-region bounds, domain comparison, and provenance. The UI is
+presentation-only for scientific interpretation: labels and summaries come from
+the selected-region diagnostics API.
 
 ### Workflow 7 — Duplicate / Tweak / Rerun
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -68,6 +68,13 @@ views can show Thermal Fate process modes, direct-field evidence, candidate or
 unsupported states, and caveats while preserving the existing slice/point-cloud
 workflows. Selected-region click/brush inspection remains #152.
 
+#152 adds the first Thermal Fate Inspector UI. Explore / 2-D Slices can now turn
+a slice-cell or bounded center selection into a backend selected-region
+diagnostics request, then render `What happened here?` with the returned label,
+confidence, local `qc`/`w`/rain summaries, selected bounds, domain comparison,
+caveats, and provenance. The browser still does not parse raw NetCDF or compute
+scientific classification.
+
 ## Golden Path: Baseline Shallow Cumulus
 
 Baseline Shallow Cumulus is the first complete product loop:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -179,6 +179,14 @@ deep-breakthrough caveats, and the guarantee that frontend code displays
 backend-derived evidence instead of parsing raw NetCDF or inventing process
 classification.
 
+Thermal Fate Inspector UI tests should mock the selected-region diagnostics API.
+They should cover selecting a slice cell, selecting a bounded center point or
+small box, clearing selection, successful inspector payloads, backend failures,
+thermal-fate label/confidence/caveats, local `qc`/`w`/rain summaries,
+selected-region bounds, comparison-to-domain values, technical provenance, and
+the guarantee that the frontend presents backend scientific classification
+rather than computing it.
+
 Thermal Fate tests must distinguish direct CM1 fields, derived diagnostics,
 proxy diagnostics, and unsupported claims. Missing fields should produce
 explicit caveats, not crashes or fabricated values. The browser must not parse

--- a/docs/thermal-fate-process-diagnostics.md
+++ b/docs/thermal-fate-process-diagnostics.md
@@ -83,6 +83,13 @@ NetCDF ingest
 -> renderer upgrade decision
 ```
 
+The first Thermal Fate Inspector UI is bounded and backend-driven. In Explore /
+2-D Slices, a user can click a displayed slice cell or choose a small bounded
+point/box selection, then the frontend calls the selected-region diagnostics
+API and renders the returned `What happened here?` story. The UI may map labels
+to badges and layout, but it must not compute the fate label, confidence,
+limiting factor, or unsupported scientific explanation in browser code.
+
 ## Thermal Fate Ladder
 
 Use conservative labels that can be marked as `supported`, `candidate`,


### PR DESCRIPTION
Closes #152

Issue worked:
- #152 — Add Thermal Fate Inspector UI for selected regions

Summary:
- Added a backend-driven `What happened here?` Thermal Fate Inspector in Explore / 2-D Slices.
- Users can click a slice heatmap cell to inspect a native-grid column, select a bounded center point or small box, and clear selection.
- The frontend calls `/api/results/{result_id}/diagnostics/selected-region` and renders the returned label, confidence, caveats, local `qc`/`w`/rain summaries, selected bounds, domain comparison, and provenance.
- Kept scientific classification backend-owned; the browser still does not parse raw NetCDF or invent process labels.
- Updated Thermal Fate docs, product spec, architecture, roadmap, and testing guidance.

Tests added/updated:
- Unit/component tests added for slice-cell selection, clear selection, selected-region payload rendering, caveats/provenance, and backend failure handling.
- Playwright mocked smoke path updated to exercise the selected-region inspector workflow in Explore.

Commands run:
- `cd app/frontend && npm test -- --run src/App.test.tsx`
- `scripts/check.sh`
- `scripts/dev.sh start && scripts/dev.sh status && scripts/check-e2e.sh`
- `scripts/dev.sh stop`

Manual QA needed:
- yes
- Please qualitatively check whether clicking a cloud/updraft-looking region in Explore / 2-D Slices makes the inspector feel like a useful learning tool rather than a debug panel, and whether the caveats are visible without overwhelming the result.

Caveats / follow-up issues:
- Selection is slice-first and bounded; it is not cloud-object tracking.
- 3-D selected-region picking remains future work; this PR keeps #152 scoped to the first practical Explore inspector loop.
- No real CM1 run was performed and no generated CM1 output was committed.
