### PR TITLE
Codify guided experiment notebook UX reset

### DIFF
--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -12,19 +12,31 @@ CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
 experiment builder, run manager, result notebook, diagnostics layer, and
 visualizer.
 
-Cloud Chamber's main flow should be product-shaped, not namelist-shaped. Friendly atmospheric controls come first; raw CM1 namelist settings belong in advanced/developer views.
+Cloud Chamber's main flow should be product-shaped, not namelist-shaped.
+Friendly atmospheric controls come first; raw CM1 namelist settings belong in
+advanced/developer views.
+
+The current UX reset direction is:
+
+```text
+Cloud Chamber is a guided experiment notebook for understanding why clouds formed, failed, stayed shallow, or grew stronger.
+```
+
+See [UX Reset: Guided Experiment Notebook](ux-reset-guided-experiment-notebook.md)
+for the PM/design source of truth for future UX work.
 
 The first Golden Path case is Baseline Shallow Cumulus. Warm rain remains early, but it should not block completing that first end-to-end case.
 
 Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
 
-The organizing product concept is **Thermal Fate**: Cloud Chamber should help
-explain why air rises, why some thermals do or do not form cloud, why some
-clouds stay shallow, why others grow taller, why some break through into deep
-convection, and how precipitation feedback can reorganize or suppress
-convection. The visualizer remains important, but the product center of gravity
-is completed/saved CM1 results, process diagnostics, selected-region
-inspection, comparison across scenario variants, and visual polish later.
+The user-facing product model is guided experiments, an experiment notebook,
+focused visualization, plain-language explanation, comparison between variants,
+and technical details on demand.
+
+**Thermal Fate** remains the internal scientific diagnostic and explanation
+model. It should power explanations, confidence/caveat labels, comparison
+summaries, selected-region diagnostics, and technical provenance. It should not
+dominate the primary visible UI as a process-taxonomy cockpit.
 
 Cloud Chamber is not a real-time slider toy. Scenario design, result browsing,
 comparison, and inspection should feel interactive; CM1 execution is a local
@@ -33,15 +45,12 @@ simulation run with latency, logs, outputs, and caveats.
 See [Thermal Fate process diagnostics](thermal-fate-process-diagnostics.md) for
 the current process-diagnostics contract.
 
-Explore should now feel like a process workbench, not just a raw field viewer.
-The 2-D Slices and 3-D View workspaces expose Thermal Fate process modes for
-Thermal Fate summary, Cloud Water, Updrafts, Cloud Lifecycle, Cap / Inversion,
-Moisture / Saturation, Buoyancy, Deep Breakthrough, and Precipitation Feedback.
-Each mode must show whether the evidence is supported, candidate, insufficient,
-or unavailable. Unsupported diagnostic groups remain visible with caveats
-instead of disappearing. The browser receives only backend-prepared slices,
-point clouds, result-card process fields, and bounded summaries; it does not
-parse raw NetCDF or invent process claims.
+Explore should be a focused visualization plus explanation screen for one
+selected result. Thermal Fate process evidence remains available in secondary
+or technical layers, but the primary view should lead with the experiment
+story, outcome, visualization, and next action. The browser receives only
+backend-prepared slices, point clouds, result-card process fields, and bounded
+summaries; it does not parse raw NetCDF or invent process claims.
 
 ## Personas
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -18,21 +18,74 @@ scenario template
 
 CM1 remains the source of truth. Preview estimates are guidance only, and visualization is an interpretation of CM1-derived data.
 
-Cloud Chamber is a personal, scientifically honest CM1 Thermal Fate workbench:
+Cloud Chamber is a personal, scientifically honest guided experiment notebook:
 curated scenario families, meaningful controls, local-first CM1 runs,
 replayable saved results, process diagnostics, selected-region inspection,
 comparison across variants, and beautiful visualization.
 
+The current UX reset reframes the visible product as a guided experiment
+notebook:
+
+```text
+Cloud Chamber is a guided experiment notebook for understanding why clouds formed, failed, stayed shallow, or grew stronger.
+```
+
+See [UX Reset: Guided Experiment Notebook](ux-reset-guided-experiment-notebook.md).
+Future UX implementation should follow that reset before renderer upgrades or
+future scenario-family expansion.
+
 Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
+
+## UX Reset Track
+
+The UX reset is now the roadmap gate for future user-facing work. It keeps the
+three top-level workspaces but changes their visible contract:
+
+```text
+Build:
+  Choose/setup a guided experiment and safely create/launch a local CM1 package.
+
+Results:
+  The experiment notebook and comparison home.
+
+Explore:
+  A focused visualization plus explanation screen for one selected result.
+```
+
+Thermal Fate remains the internal scientific diagnostic/explanation model. It
+powers explanations, confidence/caveat labels, comparison summaries,
+selected-region diagnostics, and technical provenance. It should not dominate
+the primary visible UI as a process-taxonomy cockpit.
+
+Immediate UX reset sequence:
+
+```text
+#168 Codify Cloud Chamber UX reset decisions in product docs
+-> #169 Fix Explore selected-result and field-loading trust states
+-> #170 Refine Cloud Chamber navigation and layout style
+-> #171 Redesign Results as a scan-friendly experiment notebook
+-> #172 Redesign Explore around one primary visualization and one explanation panel
+-> #173 Redesign Build as guided experiment selection, not a form-first setup page
+-> #112 Revisit renderer upgrade only after the simplified Explore UX is defined
+-> #153/#154/#155 Future scenario-family expansion after the app is compelling and trustworthy
+```
+
+This track comes before renderer upgrades and before expanding the future
+scenario-family roadmap. Objective behavior should be covered by automated
+tests; manual QA for this reset is qualitative only.
 
 ## Thermal Fate Roadmap
 
-Thermal Fate is the organizing product concept: Cloud Chamber should explain why
-air rises, why some thermals do or do not form cloud, why some clouds stay
-shallow, why others grow taller, why some break through into deep convection,
-and how precipitation feedback can reorganize or suppress convection.
+Thermal Fate is the internal organizing scientific model: Cloud Chamber should
+explain why air rises, why some thermals do or do not form cloud, why some
+clouds stay shallow, why others grow taller, why some break through into deep
+convection, and how precipitation feedback can reorganize or suppress
+convection.
 
-The execution sequence should be:
+Thermal Fate remains the internal scientific model behind the guided experiment
+notebook UX. The visible app should use the UX reset track above before
+returning to renderer upgrades or future scenario-family expansion. The
+diagnostic execution sequence is:
 
 ```text
 #148 Thermal Fate Framework / process contract
@@ -40,10 +93,11 @@ The execution sequence should be:
 -> #151 selected-region backend diagnostics
 -> #150 Thermal Fate overlays in Explore
 -> #152 Thermal Fate Inspector UI
+-> #168-#173 guided experiment notebook UX reset
+-> #112 renderer upgrade after simplified Explore UX is defined
 -> #153 surface-heating scenario family
 -> #154 deep-convection breakthrough scenario family
 -> #155 precipitation feedback / cold-pool scenario family
--> #112 renderer upgrade after process needs are clear
 ```
 
 Renderer upgrades follow process needs. They should not drive the product

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -75,6 +75,24 @@ visualization feels physically believable, whether saved/delete/protection
 semantics feel safe, and whether the experience is enjoyable rather than
 debug-like.
 
+For UX reset work, use
+[UX Reset: Guided Experiment Notebook](ux-reset-guided-experiment-notebook.md)
+as the PM/design source of truth. The reset keeps objective behavior in
+automated tests and reserves manual QA for qualitative judgment only.
+
+UX reset manual QA should answer:
+
+```text
+Does this screen make the experiment understandable?
+Does the visualization feel physically plausible?
+Does the page teach the right lesson?
+Does the app feel like a tool worth reopening?
+```
+
+Do not turn the reset into a broad manual checklist of objective behaviors.
+If a requested acceptance criterion is objective and repeatable, convert it
+into a unit/component or Playwright test.
+
 For any issue that changes navigation, Results, Storage, Compare, Explore,
 Build workflow, or visualizer layout:
 

--- a/docs/ux-reset-guided-experiment-notebook.md
+++ b/docs/ux-reset-guided-experiment-notebook.md
@@ -1,0 +1,289 @@
+# UX Reset: Guided Experiment Notebook
+
+## 1. Summary
+
+Cloud Chamber's user-facing UX direction is:
+
+```text
+Cloud Chamber is a guided experiment notebook for understanding why clouds formed, failed, stayed shallow, or grew stronger.
+```
+
+This document records PM direction for future UX work. Codex does not make
+product or design decisions here; it implements documented PM direction from
+the relevant issue or doc.
+
+The reset keeps the scientific and CM1 pipeline work intact, but changes what
+the primary app surface should emphasize. The user-facing model is guided
+experiments, an experiment notebook, focused visualization, plain-language
+explanation, comparison between variants, and technical details on demand.
+
+## 2. Why The Reset Is Needed
+
+The current product surface exposes too much internal diagnostic scaffolding.
+The underlying CM1, ingest, diagnostics, selected-region, comparison, and
+visualization work remains valuable, but the visible app structure should not
+feel like a diagnostic cockpit.
+
+The product problem is not a lack of diagnostics. The product problem is that
+the internal diagnostic model is showing through as the visible app structure.
+
+Future UX work should make the first-read experience simpler, more readable,
+and more worth reopening without hiding the technical truth when the user asks
+for it.
+
+## 3. User-Facing Product Frame
+
+Use this exact top-level frame:
+
+```text
+Cloud Chamber is a guided experiment notebook for understanding why clouds formed, failed, stayed shallow, or grew stronger.
+```
+
+Primary user-facing concepts:
+
+```text
+Guided experiments
+Experiment notebook
+Focused visualization
+Plain-language explanation
+Comparison between variants
+Technical details on demand
+```
+
+Primary screens should start from the experiment story, outcome,
+visualization, and next action. They should not start from implementation
+surfaces, raw run folders, source-field tables, or process taxonomy menus.
+
+## 4. Thermal Fate Behind The Curtain
+
+Thermal Fate remains the internal scientific diagnostic and explanation model.
+
+Thermal Fate should power:
+
+```text
+explanations
+confidence/caveat labels
+comparison summaries
+selected-region diagnostics
+technical provenance
+```
+
+Thermal Fate should not dominate the primary visible UI as a process-taxonomy
+cockpit.
+
+The user should still be able to inspect technical evidence, caveats, native
+fields, and provenance. Those details belong in the technical layer, generally
+behind disclosure or other on-demand patterns.
+
+## 5. Workspace Contracts: Build / Results / Explore
+
+Keep the three top-level workspaces:
+
+```text
+Build
+Results
+Explore
+```
+
+Define them this way:
+
+```text
+Build:
+  Choose/setup a guided experiment and safely create/launch a local CM1 package.
+
+Results:
+  The experiment notebook and comparison home.
+
+Explore:
+  A focused visualization plus explanation screen for one selected result.
+```
+
+Build should feel like guided experiment setup, not a form-first namelist
+editor.
+
+Results should feel like the experiment notebook: what was run, what happened,
+what is worth saving, and how variants compare.
+
+Explore should focus on one selected result at a time: what it looks like, what
+the outcome means, and what technical evidence is available if requested.
+
+## 6. Information Hierarchy: Primary / Secondary / Technical
+
+Every primary screen should use this hierarchy:
+
+```text
+Primary layer:
+  user-facing experiment story, outcome, visualization, and next action
+
+Secondary layer:
+  controls and concise evidence needed to understand the result
+
+Technical layer:
+  raw IDs, native grids, source variables, provenance, caveats, output counts, detailed diagnostics
+```
+
+Technical-layer content must remain available. It should generally move behind
+details, disclosure, drawer, or equivalent on-demand patterns instead of
+dominating the first read.
+
+## 7. Screen-Level Direction
+
+### Build
+
+Build is for choosing and setting up a guided experiment, then safely creating
+and launching a local CM1 package.
+
+The primary read should be:
+
+```text
+What experiment am I setting up?
+What atmospheric question does it answer?
+What variant/control am I changing?
+What will happen next?
+```
+
+Raw namelist settings, run IDs, generated file lists, and low-level provenance
+belong in the technical layer.
+
+### Results
+
+Results is the experiment notebook and comparison home.
+
+The primary read should be:
+
+```text
+What experiments exist?
+What happened in each one?
+Which results are worth saving?
+How do variants compare?
+What should I open next?
+```
+
+Results should emphasize experiment names, outcomes, saved/protected status,
+plain-language diagnostics, and comparison between variants. Raw output counts,
+run IDs, lifecycle/product state values, source-field tables, and full caveat
+lists belong in the technical layer.
+
+### Explore
+
+Explore is a focused visualization plus explanation screen for one selected
+result.
+
+The primary read should be:
+
+```text
+What does this result look like?
+What field/outcome am I seeing?
+Why did this cloud form, fail, stay shallow, or grow stronger?
+What should I inspect next?
+```
+
+Explore should not start as a grid/source-field cockpit. It should make the
+visualization and plain-language explanation readable first, with concise
+evidence and technical details available on demand.
+
+## 8. What Moves Behind Disclosure
+
+The following should generally move behind details, disclosure, drawer, or an
+equivalent technical layer:
+
+```text
+raw variable names
+native grid names
+evidence tables
+source-field tables
+process taxonomy menus
+run IDs
+output file counts
+technical caveats as first-read content
+detailed diagnostics
+full provenance labels
+generated file lists
+low-level lifecycle/product state strings
+```
+
+This does not mean hiding scientific honesty. It means the first-read UI should
+lead with the experiment story and outcome, while technical evidence remains
+available for trust and debugging.
+
+## 9. Wording Guidelines
+
+Use user-facing language first:
+
+```text
+guided experiment
+experiment notebook
+cloud formed
+no cloud formed
+stayed shallow
+grew stronger
+rain detected
+no rain detected
+moisture-limited
+cap-limited
+saved / protected
+not saved
+technical details
+```
+
+Prefer plain-language explanations over process-taxonomy labels in primary UI.
+Thermal Fate, native field names, grid names, and provenance terms can appear in
+technical or advanced layers.
+
+Avoid making these primary:
+
+```text
+raw variable names
+native grid names
+evidence tables
+source-field tables
+process taxonomy menus
+run IDs
+output file counts
+technical caveats as first-read content
+```
+
+## 10. Manual QA Questions
+
+Manual QA for this reset is qualitative only. It should answer:
+
+```text
+Does this screen make the experiment understandable?
+Does the visualization feel physically plausible?
+Does the page teach the right lesson?
+Does the app feel like a tool worth reopening?
+```
+
+Objective behavior belongs in unit/component tests or Playwright, not a manual
+checklist.
+
+## 11. Implementation Sequencing
+
+The immediate UX reset sequence is:
+
+```text
+#168 Codify Cloud Chamber UX reset decisions in product docs
+-> #169 Fix Explore selected-result and field-loading trust states
+-> #170 Refine Cloud Chamber navigation and layout style
+-> #171 Redesign Results as a scan-friendly experiment notebook
+-> #172 Redesign Explore around one primary visualization and one explanation panel
+-> #173 Redesign Build as guided experiment selection, not a form-first setup page
+-> #112 Revisit renderer upgrade only after the simplified Explore UX is defined
+-> #153/#154/#155 Future scenario-family expansion after the app is compelling and trustworthy
+```
+
+Renderer upgrades and future scenario-family expansion should wait until the
+simplified guided experiment notebook UX is defined and trustworthy.
+
+## 12. Non-Goals
+
+This reset doc does not:
+
+- implement UI;
+- choose colors, typography, spacing, renderer technology, or final visual
+  design;
+- redesign Results, Explore, or Build by itself;
+- add scenario families;
+- implement renderer upgrades;
+- create broad manual QA spreadsheets or objective manual checklists;
+- weaken CM1 provenance or scientific honesty.


### PR DESCRIPTION
Closes #168

Issue worked:
- #168

Summary:
- Added `docs/ux-reset-guided-experiment-notebook.md` as the PM/design source of truth for the guided experiment notebook UX reset.
- Updated the product spec to frame Thermal Fate as the internal scientific model behind guided experiments, notebook, focused visualization, comparison, and technical details on demand.
- Updated the roadmap to place the #168-#173 UX reset track before #112 renderer upgrades and #153/#154/#155 future scenario-family expansion.
- Updated the testing doc to point UX reset work at qualitative manual QA questions while preserving automated-test-first expectations.

Tests added/updated:
- Docs-only; no automated tests added.

Commands run:
- `scripts/check.sh`

Manual QA needed:
- No. This PR encodes documented PM direction only.

Caveats / follow-up issues:
- No UI was implemented and no renderer or scenario-family decisions were made.