### PR TITLE
Center What happened here in Explore reset

### DIFF
--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -30,8 +30,9 @@ The first Golden Path case is Baseline Shallow Cumulus. Warm rain remains early,
 Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
 
 The user-facing product model is guided experiments, an experiment notebook,
-focused visualization, plain-language explanation, comparison between variants,
-and technical details on demand.
+focused visualization, `What happened here?` selected-region explanation,
+plain-language explanation, comparison between variants, and technical details
+on demand.
 
 **Thermal Fate** remains the internal scientific diagnostic and explanation
 model. It should power explanations, confidence/caveat labels, comparison
@@ -46,11 +47,14 @@ See [Thermal Fate process diagnostics](thermal-fate-process-diagnostics.md) for
 the current process-diagnostics contract.
 
 Explore should be a focused visualization plus explanation screen for one
-selected result. Thermal Fate process evidence remains available in secondary
-or technical layers, but the primary view should lead with the experiment
-story, outcome, visualization, and next action. The browser receives only
-backend-prepared slices, point clouds, result-card process fields, and bounded
-summaries; it does not parse raw NetCDF or invent process claims.
+selected result. Its core interaction is `What happened here?`: select a cloud,
+updraft, clear-air thermal, or no-cloud region and receive a CM1-backed
+explanation of what happened there and why. Thermal Fate process evidence
+remains available in secondary or technical layers, but the primary view should
+lead with the experiment story, outcome, visualization, selected-region
+explanation, and next action. The browser receives only backend-prepared
+slices, point clouds, result-card process fields, and bounded summaries; it
+does not parse raw NetCDF or invent process claims.
 
 ## Personas
 
@@ -232,27 +236,45 @@ synthetic cloud physics; those belong to later visualizer issues.
 
 ### Workflow 6.5 — What Happened Here?
 
-The selected-region Thermal Fate workflow is a core Explore workflow:
+`What happened here?` is the core Explore interaction, not a buried technical
+diagnostics panel:
 
 ```text
 open a completed/saved result
--> select a point, column, or box in Explore
--> ask What happened here?
--> backend computes local selected-region diagnostics
--> UI explains the supported thermal-fate label, evidence, and caveats
--> compare the selected region with whole-domain behavior or a scenario variant
+-> see the main 2-D or 3-D visualization
+-> click a cloud, updraft, clear-air thermal, or no-cloud region
+-> the app marks the selected spot or region
+-> the app opens an explanation panel
+-> the panel answers what happened there, what evidence supports it, and what is uncertain
 ```
 
 This workflow must use backend diagnostics over CM1-derived fields. The browser
 must not parse raw NetCDF or invent scientific explanations.
 
-The first UI implementation lives in Explore / 2-D Slices. Users can click a
-backend-prepared heatmap cell to inspect the nearest native-grid column, select
-a bounded center point or small box, clear the selection, and review the
-backend-returned Thermal Fate label, confidence, caveats, local `qc`/`w`/rain
-summaries, selected-region bounds, domain comparison, and provenance. The UI is
-presentation-only for scientific interpretation: labels and summaries come from
-the selected-region diagnostics API.
+The first implementation can start with 2-D selection if 3-D selection is too
+hard. Users can click a backend-prepared heatmap cell to inspect the nearest
+native-grid column, select a bounded center point or small box, clear the
+selection, and review the backend-returned explanation, confidence, caveats,
+local `qc`/`w`/rain summaries, selected-region bounds, domain comparison, and
+provenance. The UI is presentation-only for scientific interpretation: labels
+and summaries come from the selected-region diagnostics API.
+
+The explanation should use simple primary language such as:
+
+```text
+What happened here?
+Cloud formed here
+Thermal without cloud
+Cloud stayed shallow
+Growth was limited
+Evidence
+Still uncertain
+Technical details
+```
+
+Thermal Fate labels, native variables, source fields, confidence details, and
+provenance remain available behind details/disclosure. They should not be the
+first-read interaction model.
 
 ### Workflow 7 — Duplicate / Tweak / Rerun
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -34,6 +34,11 @@ See [UX Reset: Guided Experiment Notebook](ux-reset-guided-experiment-notebook.m
 Future UX implementation should follow that reset before renderer upgrades or
 future scenario-family expansion.
 
+Explore's key user-facing concept is `What happened here?`: click a spot or
+region in a completed cloud result, then receive a clear explanation backed by
+CM1-derived diagnostics. Thermal Fate and selected-region diagnostics remain
+the scientific model behind that answer, not the first-read UI structure.
+
 Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
 
 ## UX Reset Track
@@ -50,6 +55,9 @@ Results:
 
 Explore:
   A focused visualization plus explanation screen for one selected result.
+  The core interaction is What happened here? -- select a cloud, updraft,
+  clear-air thermal, or no-cloud region and receive a CM1-backed explanation of
+  what happened there and why.
 ```
 
 Thermal Fate remains the internal scientific diagnostic/explanation model. It
@@ -64,6 +72,7 @@ Immediate UX reset sequence:
 -> #169 Fix Explore selected-result and field-loading trust states
 -> #170 Refine Cloud Chamber navigation and layout style
 -> #171 Redesign Results as a scan-friendly experiment notebook
+-> #175 Make What happened here? the core Explore interaction
 -> #172 Redesign Explore around one primary visualization and one explanation panel
 -> #173 Redesign Build as guided experiment selection, not a form-first setup page
 -> #112 Revisit renderer upgrade only after the simplified Explore UX is defined
@@ -73,6 +82,10 @@ Immediate UX reset sequence:
 This track comes before renderer upgrades and before expanding the future
 scenario-family roadmap. Objective behavior should be covered by automated
 tests; manual QA for this reset is qualitative only.
+
+#172 depends on #175's interaction model. Explore redesign should preserve
+`What happened here?` as the central action instead of becoming a generic
+visualization-plus-panel redesign.
 
 ## Thermal Fate Roadmap
 
@@ -111,23 +124,23 @@ keeps deep-breakthrough, buoyancy, precipitation-feedback, and selected-region
 diagnostics unavailable or candidate/caveated until their required fields and
 follow-up issues exist.
 
-#151 adds the backend selected-region diagnostics bridge for the future Thermal
-Fate Inspector. It lets the app ask `What happened here?` for bounded point,
-column, and box regions, returning CM1-derived local summaries, conservative
-labels, provenance, caveats, and comparison-to-domain values without returning
-large raw arrays or moving NetCDF parsing into the browser.
+#151 adds the backend selected-region diagnostics bridge for the user-facing
+`What happened here?` interaction. It lets the app ask that question for
+bounded point, column, and box regions, returning CM1-derived local summaries,
+conservative labels, provenance, caveats, and comparison-to-domain values
+without returning large raw arrays or moving NetCDF parsing into the browser.
 
 #150 adds the first Explore process-overlay layer. The 2-D and 3-D Explore
 views can show Thermal Fate process modes, direct-field evidence, candidate or
 unsupported states, and caveats while preserving the existing slice/point-cloud
 workflows. Selected-region click/brush inspection remains #152.
 
-#152 adds the first Thermal Fate Inspector UI. Explore / 2-D Slices can now turn
-a slice-cell or bounded center selection into a backend selected-region
-diagnostics request, then render `What happened here?` with the returned label,
-confidence, local `qc`/`w`/rain summaries, selected bounds, domain comparison,
-caveats, and provenance. The browser still does not parse raw NetCDF or compute
-scientific classification.
+#152 adds the first backend-supported selected-region UI foundation. Under the
+UX reset, future Explore work should promote that capability into the primary
+`What happened here?` interaction: click a cloud, updraft, clear-air thermal, or
+no-cloud region, mark the selected spot or region, and render an explanation
+with evidence, uncertainty, caveats, and technical details on demand. The
+browser still does not parse raw NetCDF or compute scientific classification.
 
 ## Golden Path: Baseline Shallow Cumulus
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -89,6 +89,20 @@ Does the page teach the right lesson?
 Does the app feel like a tool worth reopening?
 ```
 
+For the `What happened here?` Explore interaction, manual QA remains
+qualitative:
+
+```text
+Does clicking a spot make the result easier to understand?
+Does the explanation feel like a learning moment rather than a diagnostic dump?
+Does the app preserve scientific honesty without burying the user?
+```
+
+When implementation begins, objective checks should become automated tests for
+selected-region state, clearing the selection, successful explanation payloads,
+backend failure states, missing diagnostics states, technical details
+disclosure, and selected-result flow from Results to Explore.
+
 Do not turn the reset into a broad manual checklist of objective behaviors.
 If a requested acceptance criterion is objective and repeatable, convert it
 into a unit/component or Playwright test.

--- a/docs/ux-reset-guided-experiment-notebook.md
+++ b/docs/ux-reset-guided-experiment-notebook.md
@@ -14,8 +14,9 @@ the relevant issue or doc.
 
 The reset keeps the scientific and CM1 pipeline work intact, but changes what
 the primary app surface should emphasize. The user-facing model is guided
-experiments, an experiment notebook, focused visualization, plain-language
-explanation, comparison between variants, and technical details on demand.
+experiments, an experiment notebook, focused visualization, a prominent `What
+happened here?` Explore interaction, plain-language explanation, comparison
+between variants, and technical details on demand.
 
 ## 2. Why The Reset Is Needed
 
@@ -45,6 +46,7 @@ Primary user-facing concepts:
 Guided experiments
 Experiment notebook
 Focused visualization
+What happened here?
 Plain-language explanation
 Comparison between variants
 Technical details on demand
@@ -53,6 +55,14 @@ Technical details on demand
 Primary screens should start from the experiment story, outcome,
 visualization, and next action. They should not start from implementation
 surfaces, raw run folders, source-field tables, or process taxonomy menus.
+
+Explore should make the most compelling Cloud Chamber interaction obvious:
+
+```text
+Click a spot or region in a completed cloud result
+-> ask What happened here?
+-> get a clear explanation backed by CM1-derived diagnostics
+```
 
 ## 4. Thermal Fate Behind The Curtain
 
@@ -70,6 +80,15 @@ technical provenance
 
 Thermal Fate should not dominate the primary visible UI as a process-taxonomy
 cockpit.
+
+Selected-region diagnostics are not being discarded. They power the
+user-facing `What happened here?` explanation: the user selects a cloud,
+updraft, clear-air thermal, or no-cloud region, and the app explains what
+happened there, what evidence supports it, and what is still uncertain.
+
+The frontend should present backend-supported diagnostics, confidence, and
+caveats. It should not expose the Thermal Fate taxonomy first, and it should
+not invent scientific explanations.
 
 The user should still be able to inspect technical evidence, caveats, native
 fields, and provenance. Those details belong in the technical layer, generally
@@ -96,6 +115,9 @@ Results:
 
 Explore:
   A focused visualization plus explanation screen for one selected result.
+  The core interaction is "What happened here?" -- select a cloud, updraft,
+  clear-air thermal, or no-cloud region and receive a CM1-backed explanation of
+  what happened there and why.
 ```
 
 Build should feel like guided experiment setup, not a form-first namelist
@@ -105,7 +127,8 @@ Results should feel like the experiment notebook: what was run, what happened,
 what is worth saving, and how variants compare.
 
 Explore should focus on one selected result at a time: what it looks like, what
-the outcome means, and what technical evidence is available if requested.
+the outcome means, what happened in a selected region, and what technical
+evidence is available if requested.
 
 ## 6. Information Hierarchy: Primary / Secondary / Technical
 
@@ -182,6 +205,34 @@ Explore should not start as a grid/source-field cockpit. It should make the
 visualization and plain-language explanation readable first, with concise
 evidence and technical details available on demand.
 
+Desired Explore flow:
+
+```text
+Open a result in Explore
+-> see the main 2-D or 3-D visualization
+-> click a cloud, updraft, clear-air thermal, or no-cloud region
+-> the app marks the selected spot or region
+-> the explanation panel answers what happened, what evidence supports it, and what is still uncertain
+```
+
+The explanation panel should be able to answer, when supported by backend
+diagnostics:
+
+```text
+Did air rise here?
+Did cloud water form here?
+When did cloud first appear here?
+How high did the cloud get here?
+Did it stay shallow, grow, stall, or fade?
+Was the area moisture-limited, cap-limited, or still uncertain?
+How does this spot compare with the whole result or baseline?
+What evidence supports this?
+What evidence is missing?
+```
+
+The first implementation can start with 2-D selection if 3-D selection is too
+hard. It may use existing selected-region diagnostics APIs when available.
+
 ## 8. What Moves Behind Disclosure
 
 The following should generally move behind details, disclosure, drawer, or an
@@ -215,6 +266,13 @@ guided experiment
 experiment notebook
 cloud formed
 no cloud formed
+What happened here?
+Cloud formed here
+Thermal without cloud
+Cloud stayed shallow
+Growth was limited
+Evidence
+Still uncertain
 stayed shallow
 grew stronger
 rain detected
@@ -266,11 +324,16 @@ The immediate UX reset sequence is:
 -> #169 Fix Explore selected-result and field-loading trust states
 -> #170 Refine Cloud Chamber navigation and layout style
 -> #171 Redesign Results as a scan-friendly experiment notebook
+-> #175 Make What happened here? the core Explore interaction
 -> #172 Redesign Explore around one primary visualization and one explanation panel
 -> #173 Redesign Build as guided experiment selection, not a form-first setup page
 -> #112 Revisit renderer upgrade only after the simplified Explore UX is defined
 -> #153/#154/#155 Future scenario-family expansion after the app is compelling and trustworthy
 ```
+
+#172 depends on #175's interaction model. The Explore redesign should not
+proceed as a generic visualization-plus-panel redesign without preserving
+`What happened here?` as the center of the interaction.
 
 Renderer upgrades and future scenario-family expansion should wait until the
 simplified guided experiment notebook UX is defined and trustworthy.


### PR DESCRIPTION
Closes #175

Issue worked:
- #175

Summary:
- Updated the UX reset doc to preserve `What happened here?` as a first-class Explore interaction.
- Clarified that selected-region diagnostics power the user-facing explanation while Thermal Fate remains behind the curtain.
- Updated the product spec and roadmap so #172 depends on #175 and future Explore work does not become a generic visualization-plus-panel redesign.
- Added testing-doc guidance for future objective tests and qualitative manual QA around the interaction.

Tests added/updated:
- Docs-only; no automated tests added.

Commands run:
- `scripts/check.sh`

Manual QA needed:
- No for this docs-only PR. Future UI work should ask whether clicking a spot makes the result easier to understand and whether the explanation feels like a learning moment rather than a diagnostic dump.

Caveats / follow-up issues:
- No UI was implemented. No renderer technology, CM1 run, raw NetCDF browser parsing, or process-mode cockpit was added.
- Per instruction, auto-merge is not enabled.