### PR TITLE
Fix Explore selected-result field trust states

### DIFF
--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -159,12 +159,33 @@ function json(route: Route, body: unknown, status = 200) {
   });
 }
 
-function fieldCatalog(resultId: string) {
-  const provenance = {
-    source_model: "CM1",
+function resultMeta(resultId: string) {
+  if (resultId === "result-dry-failed") {
+    return {
+      result_id: resultId,
+      run_id: "dry-run-dry-failed",
+      scenario_id: "dry-failed-cumulus",
+    };
+  }
+  return {
     result_id: resultId,
     run_id: "dry-run-baseline",
     scenario_id: "baseline-shallow-cumulus",
+  };
+}
+
+function resultIdFromUrl(url: string) {
+  const match = url.match(/\/api\/results\/([^/]+)/);
+  return match?.[1] ?? "result-baseline";
+}
+
+function fieldCatalog(resultId: string) {
+  const meta = resultMeta(resultId);
+  const provenance = {
+    source_model: "CM1",
+    result_id: meta.result_id,
+    run_id: meta.run_id,
+    scenario_id: meta.scenario_id,
     source_product_state: "completed_cm1_result",
     result_state: "ingested",
     processing_method: "native-grid slice",
@@ -172,9 +193,9 @@ function fieldCatalog(resultId: string) {
     provenance_label: "CM1-derived visualization-ready payload",
   };
   return {
-    result_id: resultId,
-    run_id: "dry-run-baseline",
-    scenario_id: "baseline-shallow-cumulus",
+    result_id: meta.result_id,
+    run_id: meta.run_id,
+    scenario_id: meta.scenario_id,
     source_model: "CM1",
     available_fields: ["qc", "w"].map((name) => ({
       raw_field_name: name,
@@ -191,6 +212,176 @@ function fieldCatalog(resultId: string) {
     })),
     provenance,
     caveats: [],
+  };
+}
+
+function viewDefaults(resultId: string, timeIndex?: number) {
+  const dryFailed = resultId === "result-dry-failed";
+  const meta = resultMeta(resultId);
+  const selectedTime = timeIndex ?? (dryFailed ? 1 : 1);
+  return {
+    result_id: meta.result_id,
+    run_id: meta.run_id,
+    scenario_id: meta.scenario_id,
+    preferred_field: dryFailed ? "w" : "qc",
+    fields: {
+      qc: {
+        field: "qc",
+        time_index: selectedTime,
+        time_seconds: [0, 1800, 3600][selectedTime] ?? 1800,
+        horizontal_level_index: dryFailed ? 0 : 2,
+        vertical_x_index: 1,
+        vertical_y_index: 1,
+        source: dryFailed ? "no_cloud_qc_zero_native_grid" : "first_cloud_time",
+        max_value: dryFailed ? 0 : 0.00219,
+        selected_time_index: timeIndex ?? null,
+        selected_time_seconds: timeIndex === undefined ? null : [0, 1800, 3600][selectedTime],
+        caveats: dryFailed ? ["qc_present_but_below_cloud_threshold"] : [],
+      },
+      w: {
+        field: "w",
+        time_index: selectedTime,
+        time_seconds: [0, 1800, 3600][selectedTime] ?? 1800,
+        horizontal_level_index: 2,
+        vertical_x_index: 1,
+        vertical_y_index: 1,
+        source: "max_w_native_grid_location",
+        max_value: dryFailed ? 1.95 : 6.96,
+        selected_time_index: timeIndex ?? null,
+        selected_time_seconds: timeIndex === undefined ? null : [0, 1800, 3600][selectedTime],
+        caveats: [],
+      },
+    },
+    provenance: fieldCatalog(resultId).provenance,
+    caveats: dryFailed ? ["no_cloud_result_qc_zero_w_available"] : [],
+  };
+}
+
+function slicePayload(resultId: string, url: string) {
+  const parsed = new URL(url);
+  const fieldName = parsed.searchParams.get("field") ?? "qc";
+  const orientation = parsed.searchParams.get("orientation") ?? "horizontal";
+  const timeIndex = Number(parsed.searchParams.get("time_index") ?? 1);
+  const dryFailed = resultId === "result-dry-failed";
+  const catalog = fieldCatalog(resultId);
+  const field =
+    catalog.available_fields.find((candidate) => candidate.raw_field_name === fieldName) ??
+    catalog.available_fields[0];
+  const qcValues = dryFailed
+    ? [
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]
+    : [
+        [0, 0.001, 0.002, 0],
+        [0, 0.002, 0.001, 0],
+        [0, 0.001, 0.002, 0],
+        [0, 0, 0.001, 0],
+      ];
+  const wValues = dryFailed
+    ? [
+        [0.2, 0.8, 1.2, 0.3],
+        [0.1, 1.95, 1.1, -0.4],
+        [0.0, 0.7, 0.5, -1.09],
+        [0.1, 0.4, 0.2, -0.2],
+      ]
+    : [
+        [0.5, 2.1, 4.8, 1.0],
+        [0.2, 6.96, 3.7, -1.4],
+        [0.1, 2.4, 1.2, -3.77],
+        [0.0, 0.8, 0.4, -0.6],
+      ];
+  const values = fieldName === "w" ? wValues : qcValues;
+  const flat = values.flat();
+  return {
+    result_id: resultId,
+    run_id: resultMeta(resultId).run_id,
+    scenario_id: resultMeta(resultId).scenario_id,
+    field,
+    selection: {
+      time_index: timeIndex,
+      time_seconds: [0, 1800, 3600][timeIndex] ?? 1800,
+      orientation,
+      selected_dimension:
+        orientation === "vertical_y" ? "xh" : orientation === "vertical_x" ? "yh" : "zh",
+      selected_index: Number(parsed.searchParams.get("level_index") ?? 1),
+      selected_coordinate_value: orientation === "horizontal" ? 0.8 : 0,
+      level_units: orientation === "horizontal" ? "km" : null,
+      level_coordinate_value: orientation === "horizontal" ? 0.8 : null,
+      level_meters: orientation === "horizontal" ? 800 : null,
+    },
+    coordinate_units: { zh: "km", yh: "km", xh: "km" },
+    shape: [4, 4],
+    dimension_order: orientation === "horizontal" ? ["yh", "xh"] : ["zh", "xh"],
+    data_encoding: "json",
+    values,
+    stats: {
+      min: Math.min(...flat),
+      max: Math.max(...flat),
+      mean: flat.reduce((sum, value) => sum + value, 0) / flat.length,
+      finite_count: flat.length,
+      non_finite_count: 0,
+    },
+    provenance: catalog.provenance,
+    caveats: ["native_grid_no_interpolation"],
+  };
+}
+
+function pointCloudPayload(resultId: string, url: string) {
+  const parsed = new URL(url);
+  const dryFailed = resultId === "result-dry-failed";
+  const points = dryFailed
+    ? []
+    : [
+        [2, 2, 0.8, 0.001],
+        [2.5, 2.3, 1.2, 0.002],
+        [3, 2.5, 1.8, 0.0015],
+      ];
+  const values = points.map((point) => point[3]);
+  return {
+    result_id: resultId,
+    run_id: resultMeta(resultId).run_id,
+    scenario_id: resultMeta(resultId).scenario_id,
+    field: fieldCatalog(resultId).available_fields[0],
+    selection: {
+      field: "qc",
+      time_index: Number(parsed.searchParams.get("time_index") ?? 1),
+      time_seconds: 1800,
+      threshold: Number(parsed.searchParams.get("threshold") ?? 0.000001),
+      max_points: Number(parsed.searchParams.get("max_points") ?? 50000),
+    },
+    coordinate_units: { xh: "km", yh: "km", zh: "km" },
+    coordinate_extents: {
+      x: { min: 0, max: 6.4, units: "km" },
+      y: { min: 0, max: 6.4, units: "km" },
+      z: { min: 0, max: 3, units: "km" },
+      xh: { min: 0, max: 6.4, units: "km" },
+      yh: { min: 0, max: 6.4, units: "km" },
+      zh: { min: 0, max: 3, units: "km" },
+    },
+    point_order: ["x", "y", "z", "value"],
+    points,
+    stats: {
+      source_count: points.length,
+      returned_count: points.length,
+      min_value: values.length ? Math.min(...values) : null,
+      max_value: values.length ? Math.max(...values) : null,
+      active_z_min: values.length ? Math.min(...points.map((point) => point[2])) : null,
+      active_z_max: values.length ? Math.max(...points.map((point) => point[2])) : null,
+      max_value_location: points.length
+        ? { x: points[1][0], y: points[1][1], z: points[1][2], value: points[1][3] }
+        : null,
+      downsampled: false,
+      downsample_stride: 1,
+    },
+    provenance: {
+      ...fieldCatalog(resultId).provenance,
+      processing_method: "native-grid thresholded point cloud",
+      rendering_method: "thresholded point cloud",
+    },
+    caveats: dryFailed ? ["qc_present_but_no_points_above_threshold"] : [],
   };
 }
 
@@ -291,115 +482,27 @@ export async function mockCloudChamberApis(page: Page) {
   });
 
   await page.route("**/api/results/*/visualization/fields", (route) =>
-    json(route, fieldCatalog("result-baseline")),
+    json(route, fieldCatalog(resultIdFromUrl(route.request().url()))),
   );
 
-  await page.route("**/api/results/*/visualization/defaults**", (route) =>
-    json(route, {
-      result_id: "result-baseline",
-      run_id: "dry-run-baseline",
-      scenario_id: "baseline-shallow-cumulus",
-      preferred_field: "qc",
-      fields: {
-        qc: {
-          field: "qc",
-          time_index: 1,
-          time_seconds: 1800,
-          horizontal_level_index: 2,
-          vertical_x_index: 1,
-          vertical_y_index: 1,
-          source: "first_cloud_time",
-          max_value: 0.00219,
-          selected_time_index: 1,
-          selected_time_seconds: 1800,
-          caveats: [],
-        },
-      },
-      provenance: fieldCatalog("result-baseline").provenance,
-      caveats: [],
-    }),
-  );
+  await page.route("**/api/results/*/visualization/defaults**", (route) => {
+    const url = route.request().url();
+    const parsed = new URL(url);
+    const timeIndex = parsed.searchParams.has("time_index")
+      ? Number(parsed.searchParams.get("time_index"))
+      : undefined;
+    return json(route, viewDefaults(resultIdFromUrl(url), timeIndex));
+  });
 
-  await page.route("**/api/results/*/visualization/slice**", (route) =>
-    json(route, {
-      result_id: "result-baseline",
-      run_id: "dry-run-baseline",
-      scenario_id: "baseline-shallow-cumulus",
-      field: fieldCatalog("result-baseline").available_fields[0],
-      selection: {
-        time_index: 1,
-        time_seconds: 1800,
-        orientation: "horizontal",
-        selected_dimension: "zh",
-        selected_index: 2,
-        selected_coordinate_value: 0.8,
-        level_units: "km",
-        level_coordinate_value: 0.8,
-        level_meters: 800,
-      },
-      coordinate_units: { zh: "km", yh: "km", xh: "km" },
-      shape: [4, 4],
-      dimension_order: ["yh", "xh"],
-      data_encoding: "json",
-      values: [
-        [0, 0.001, 0.002, 0],
-        [0, 0.002, 0.001, 0],
-        [0, 0.001, 0.002, 0],
-        [0, 0, 0.001, 0],
-      ],
-      stats: { min: 0, max: 0.002, mean: 0.0007, finite_count: 16, non_finite_count: 0 },
-      provenance: fieldCatalog("result-baseline").provenance,
-      caveats: ["native_grid_no_interpolation"],
-    }),
-  );
+  await page.route("**/api/results/*/visualization/slice**", (route) => {
+    const url = route.request().url();
+    return json(route, slicePayload(resultIdFromUrl(url), url));
+  });
 
-  await page.route("**/api/results/*/visualization/point-cloud**", (route) =>
-    json(route, {
-      result_id: "result-baseline",
-      run_id: "dry-run-baseline",
-      scenario_id: "baseline-shallow-cumulus",
-      field: fieldCatalog("result-baseline").available_fields[0],
-      selection: {
-        field: "qc",
-        time_index: 1,
-        time_seconds: 1800,
-        threshold: 0.000001,
-        max_points: 50000,
-      },
-      coordinate_units: { xh: "km", yh: "km", zh: "km" },
-      coordinate_extents: {
-        x: { min: 0, max: 6.4, units: "km" },
-        y: { min: 0, max: 6.4, units: "km" },
-        z: { min: 0, max: 3, units: "km" },
-        xh: { min: 0, max: 6.4, units: "km" },
-        yh: { min: 0, max: 6.4, units: "km" },
-        zh: { min: 0, max: 3, units: "km" },
-      },
-      point_order: ["x", "y", "z", "value"],
-      points: [
-        [2, 2, 0.8, 0.001],
-        [2.5, 2.3, 1.2, 0.002],
-        [3, 2.5, 1.8, 0.0015],
-      ],
-      stats: {
-        source_count: 3,
-        returned_count: 3,
-        min_value: 0.001,
-        max_value: 0.002,
-        active_z_min: 0.8,
-        active_z_max: 1.8,
-        max_value_location: { x: 2.5, y: 2.3, z: 1.2, value: 0.002 },
-        downsampled: false,
-        downsample_stride: 1,
-      },
-      provenance: {
-        ...fieldCatalog("result-baseline").provenance,
-        processing_method: "native-grid thresholded point cloud",
-        rendering_method: "thresholded point cloud",
-      },
-      caveats: [],
-    }),
-  );
+  await page.route("**/api/results/*/visualization/point-cloud**", (route) => {
+    const url = route.request().url();
+    return json(route, pointCloudPayload(resultIdFromUrl(url), url));
+  });
 
   await page.route("**/api/results/*/diagnostics/selected-region**", (route) =>
     json(route, {

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -76,4 +76,75 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/thermal fate overlay/i).first()).toBeVisible();
     await expect(page.getByRole("button", { name: /reset view/i })).toBeVisible();
   });
+
+  test("Results to Explore loads cloud-forming qc and w fields", async ({ page }) => {
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+
+    await openExploreTab(page, /^2-D Slices$/);
+    await expect(page.getByText(/slices loaded/i).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("#inspect-field")).toHaveValue("qc");
+    await expect(page.locator("#inspect-field option", { hasText: "qc - Cloud water" })).toHaveCount(
+      1,
+    );
+    await expect(
+      page.locator("#inspect-field option", { hasText: "w - Vertical velocity" }),
+    ).toHaveCount(1);
+    await expect(page.getByText(/loading fields/i)).not.toBeVisible();
+
+    await openExploreTab(page, /^3-D View$/);
+    await expect(page.getByText(/cloud-water point cloud loaded/i).first()).toBeVisible({
+      timeout: 12_000,
+    });
+    await expect(page.locator("#scene-field")).toHaveValue("qc");
+    await expect(page.getByText(/cloud-water point cloud/i).first()).toBeVisible();
+  });
+
+  test("Results to Explore treats Dry Failed as no-cloud with updraft inspection", async ({
+    page,
+  }) => {
+    await gotoResults(page);
+    await openResultsTab(page, /^Compare$/);
+    await page.getByRole("button", { name: "Open Dry Failed 3-D" }).click();
+
+    await expect(page.getByRole("heading", { name: "Inspect and visualize fields" })).toBeVisible();
+    await expect(page.getByText("Dry Failed Cumulus — Quick Look").first()).toBeVisible();
+    await expect(page.getByText(/scene shell ready/i).first()).toBeVisible({ timeout: 12_000 });
+    await expect(page.locator("#scene-field")).toHaveValue("w");
+    await expect(
+      page.getByText(/No cloud water formed here; vertical velocity is available/i),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/Use the vertical velocity field \(w\) to inspect the thermals/i),
+    ).toBeVisible();
+
+    await openExploreTab(page, /^2-D Slices$/);
+    await expect(page.getByText(/slices loaded/i).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("#inspect-field")).toHaveValue("w");
+    await expect(
+      page.locator("#inspect-field option", { hasText: "w - Vertical velocity" }),
+    ).toHaveCount(1);
+  });
+
+  test("Explore field loading failure shows an error and retry instead of a stuck spinner", async ({
+    page,
+  }) => {
+    await page.route("**/api/results/result-baseline/visualization/fields", (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Visualization fields temporarily failed." }),
+      }),
+    );
+
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+    await openExploreTab(page, /^2-D Slices$/);
+
+    await expect(page.getByRole("alert")).toContainText(
+      "Visualization fields temporarily failed.",
+    );
+    await expect(page.getByRole("button", { name: "Retry loading fields" })).toBeVisible();
+    await expect(page.getByText("Loading fields...", { exact: true })).not.toBeVisible();
+  });
 });

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -908,12 +908,14 @@ beforeEach(() => {
       }
       if (url.includes("/visualization/point-cloud")) {
         const parsed = new URL(url, "http://localhost");
+        const isDryFailed = parsed.pathname.includes("result-dry-failed-cumulus");
         return Promise.resolve(
           new Response(
             JSON.stringify(
               pointCloudResponse({
                 threshold: Number(parsed.searchParams.get("threshold") ?? 0.000001),
                 timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
+                points: isDryFailed ? [] : undefined,
               }),
             ),
             { status: 200 },
@@ -993,6 +995,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -1809,6 +1812,157 @@ describe("App", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent("level_index=99 is outside valid range");
     });
+  });
+
+  it("opens a cloud-forming result in Explore with qc and w available in both views", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Inspect and visualize fields" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
+    await screen.findByText("Slices loaded");
+    expect(screen.getByText("Quick-look shallow cumulus")).toBeInTheDocument();
+    expect(screen.getByLabelText("Field")).toHaveValue("qc");
+    expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("option", { name: "w - Vertical velocity" }).length).toBeGreaterThan(
+      0,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "3-D View" }));
+
+    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
+    await screen.findAllByText("Cloud-water point cloud loaded");
+    expect(screen.getByLabelText("Field")).toHaveValue("qc");
+    expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("option", { name: "w - Vertical velocity" }).length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("opens Dry Failed as a no-cloud result with a useful w/updraft path", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Compare" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open Dry Failed 3-D" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Inspect and visualize fields" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Dry Failed Cumulus quick-look").length).toBeGreaterThan(0);
+    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
+    await screen.findAllByText("Scene shell ready");
+    expect(screen.getByLabelText("Field")).toHaveValue("w");
+    expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("option", { name: "w - Vertical velocity" }).length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      screen.getByText("No cloud water formed here; vertical velocity is available."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Use the vertical velocity field \(w\) to inspect the thermals/i))
+      .toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "2-D Slices" }));
+    expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
+    await screen.findByText("Slices loaded");
+    expect(screen.getByLabelText("Field")).toHaveValue("w");
+  });
+
+  it("shows field-loading failures with retry instead of a permanent loading state", async () => {
+    let fieldsAttempts = 0;
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(new Response(JSON.stringify(resultsResponse), { status: 200 }));
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      if (url === "/api/results/result-dry-run-quicklook/visualization/fields") {
+        fieldsAttempts += 1;
+        if (fieldsAttempts === 1) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ detail: "Visualization fields temporarily failed." }), {
+              status: 503,
+            }),
+          );
+        }
+        return Promise.resolve(new Response(JSON.stringify(fieldCatalogResponse), { status: 200 }));
+      }
+      if (url.startsWith("/api/results/result-dry-run-quicklook/visualization/defaults")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(selectedTimeDefaultsResponse(url)), { status: 200 }),
+        );
+      }
+      if (url.includes("/visualization/slice")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(sliceResponse({ orientation: "vertical_x" })), {
+            status: 200,
+          }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Visualization fields temporarily failed.",
+    );
+    expect(screen.getByText("Field inspection unavailable")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry loading fields" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry loading fields" }));
+
+    expect(await screen.findByText("Slices loaded")).toBeInTheDocument();
+    expect(screen.queryByText("Loading fields...")).not.toBeInTheDocument();
+  });
+
+  it("clears 3-D field-loading errors after retry succeeds", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let fieldsAttempts = 0;
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/results/result-dry-run-quicklook/visualization/fields") {
+        fieldsAttempts += 1;
+        if (fieldsAttempts === 1) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ detail: "Visualization fields temporarily failed." }), {
+              status: 503,
+            }),
+          );
+        }
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    fireEvent.click((await screen.findAllByRole("button", { name: "Open 3-D" }))[0]);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Visualization fields temporarily failed.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry loading fields" }));
+
+    await screen.findAllByText("Cloud-water point cloud loaded");
+    await waitFor(() => {
+      expect(screen.queryByText("Visualization fields temporarily failed.")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("renders cloud-water point cloud in the 3-D visualizer", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -432,6 +432,8 @@ type SceneViewPreset = "cloud-overview" | "vertical-cross-section" | "top-down-s
 type ProjectionMode = "oblique" | "side_xz" | "side_yz" | "top_down";
 type SceneSlicePlane = "horizontal" | "vertical_x" | "vertical_y";
 
+const FIELD_LOAD_TIMEOUT_MS = 8000;
+
 async function fetchScenarioCatalog(): Promise<ScenarioResponse> {
   const response = await fetch("/api/scenarios");
   if (!response.ok) {
@@ -586,6 +588,16 @@ async function fetchVisualizationFields(resultId: string): Promise<FieldCatalogR
     throw new Error(await responseError(response, "Unable to load visualization fields."));
   }
   return response.json() as Promise<FieldCatalogResponse>;
+}
+
+function withTimeout<T>(promise: Promise<T>, message: string, timeoutMs = FIELD_LOAD_TIMEOUT_MS) {
+  let timeoutId: number | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = window.setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+  });
 }
 
 async function fetchVisualizationDefaults(
@@ -2923,6 +2935,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const [sceneStatus, setSceneStatus] = useState("Loading scene data...");
   const [sceneError, setSceneError] = useState<string | null>(null);
   const [sliceError, setSliceError] = useState<string | null>(null);
+  const [fieldLoadAttempt, setFieldLoadAttempt] = useState(0);
   const maxPoints = 50_000;
 
   useEffect(() => {
@@ -2952,12 +2965,16 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setSceneVerticalSlice(null);
     setSliceError(null);
     setSceneStatus("Loading scene data...");
-    Promise.all([
-      fetchVisualizationFields(result.result_id),
-      fetchVisualizationDefaults(result.result_id).catch(() => null),
-    ])
+    withTimeout(
+      Promise.all([
+        fetchVisualizationFields(result.result_id),
+        fetchVisualizationDefaults(result.result_id).catch(() => null),
+      ]),
+      "Timed out loading visualization fields. Check the backend and retry.",
+    )
       .then(([payload, defaults]) => {
         if (!active) return;
+        setSceneError(null);
         setCatalog(payload);
         setViewDefaults(defaults);
         const firstPreferred =
@@ -2985,7 +3002,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     return () => {
       active = false;
     };
-  }, [result]);
+  }, [fieldLoadAttempt, result]);
 
   const selectedField = useMemo(
     () => catalog?.available_fields.find((field) => field.raw_field_name === selectedFieldName),
@@ -3003,6 +3020,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const timeOptions = selectedField?.time_coordinate_values ?? [];
   const timeMax = Math.max(0, timeOptions.length - 1);
   const canRenderCloudWater = selectedFieldName === "qc" && Boolean(qcField);
+  const wField = catalog?.available_fields.find((field) => field.raw_field_name === "w");
+  const isNoCloudWithUpdraft =
+    cloudOutcome(result) === "No cloud formed" && Boolean(wField) && (result.max_w_m_s ?? 0) > 0;
   const sliceVerticalSize = sliceField?.coordinate_names.vertical
     ? sliceField.shape[sliceField.dimensions.indexOf(sliceField.coordinate_names.vertical)]
     : 1;
@@ -3162,7 +3182,14 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
         are optional native-grid inspection aids; the browser is not parsing raw NetCDF.
       </p>
 
-      {sceneError && <p role="alert">{sceneError}</p>}
+      {sceneError && (
+        <div role="alert">
+          <p>{sceneError}</p>
+          <button type="button" onClick={() => setFieldLoadAttempt((current) => current + 1)}>
+            Retry loading fields
+          </button>
+        </div>
+      )}
 
       {catalog && catalog.available_fields.length === 0 && (
         <p role="status">No visualization-ready fields are available for this result.</p>
@@ -3547,11 +3574,16 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                 <h3>
                   {!qcField
                     ? "Cloud water field qc is not available for this result."
-                    : "No cloud water above the selected threshold at this time."}
+                    : isNoCloudWithUpdraft
+                      ? "No cloud water formed here; vertical velocity is available."
+                      : "No cloud water above the selected threshold at this time."}
                 </h3>
                 <p>
-                  Adjust the time or threshold after qc is available. Rendering remains an
-                  interpretation of CM1-derived data.
+                  {!qcField
+                    ? "Use available fields such as vertical velocity when present. Rendering remains an interpretation of CM1-derived data."
+                    : isNoCloudWithUpdraft
+                      ? "This no-cloud result is still useful: use the vertical velocity field (w) to inspect the thermals."
+                      : "Adjust the time or threshold after qc is available. Rendering remains an interpretation of CM1-derived data."}
                 </p>
               </div>
             )}
@@ -4052,6 +4084,7 @@ function FieldInspector({ result }: { result: ResultCard }) {
   const [regionError, setRegionError] = useState<string | null>(null);
   const [inspectorStatus, setInspectorStatus] = useState("Loading fields...");
   const [inspectorError, setInspectorError] = useState<string | null>(null);
+  const [fieldLoadAttempt, setFieldLoadAttempt] = useState(0);
 
   useEffect(() => {
     let active = true;
@@ -4067,10 +4100,13 @@ function FieldInspector({ result }: { result: ResultCard }) {
     setRegionStatus("Select a slice cell to inspect a region.");
     setViewMode("vertical_x");
     setProcessMode("thermal_fate");
-    Promise.all([
-      fetchVisualizationFields(result.result_id),
-      fetchVisualizationDefaults(result.result_id).catch(() => null),
-    ])
+    withTimeout(
+      Promise.all([
+        fetchVisualizationFields(result.result_id),
+        fetchVisualizationDefaults(result.result_id).catch(() => null),
+      ]),
+      "Timed out loading visualization fields. Check the backend and retry.",
+    )
       .then(([payload, defaults]) => {
         if (!active) return;
         setCatalog(payload);
@@ -4098,7 +4134,7 @@ function FieldInspector({ result }: { result: ResultCard }) {
     return () => {
       active = false;
     };
-  }, [result]);
+  }, [fieldLoadAttempt, result]);
 
   const selectedField = useMemo(
     () => catalog?.available_fields.find((field) => field.raw_field_name === selectedFieldName),
@@ -4245,7 +4281,14 @@ function FieldInspector({ result }: { result: ResultCard }) {
         NetCDF, and this is not a 3-D visualization.
       </p>
 
-      {inspectorError && <p role="alert">{inspectorError}</p>}
+      {inspectorError && (
+        <div role="alert">
+          <p>{inspectorError}</p>
+          <button type="button" onClick={() => setFieldLoadAttempt((current) => current + 1)}>
+            Retry loading fields
+          </button>
+        </div>
+      )}
 
       {catalog && catalog.available_fields.length === 0 && (
         <p role="status">No qc/w/qr fields are available for this result.</p>


### PR DESCRIPTION
## Issue worked
- #169

## Summary
- Added retryable timeout/error handling for Explore field catalog loading in both 2-D Slices and 3-D View so the UI does not stay indefinitely on `Loading fields...`.
- Cleared stale 3-D scene field-loading errors when a retry/successful load completes.
- Clarified no-cloud 3-D behavior so Dry Failed Cumulus does not look like a broken/missing-qc result when vertical velocity is available.
- Made mocked browser fixtures result-aware for cloud-forming, no-cloud-with-updraft, and field-loading error states.

## Root cause found
The Explore path did not distinguish a scientifically valid no-cloud result from a missing-qc/broken field state, and field catalog failures had no retry/timeout path. The browser smoke fixtures also treated every result as cloud-forming, so the Dry Failed trust-state path was not being exercised end-to-end.

## Tests added/updated
- Component tests for cloud-forming qc/w consistency across Explore views.
- Component tests for Dry Failed no-cloud behavior with w/updraft guidance.
- Component tests for field-loading failure and retry behavior.
- Component regression for 3-D field-loading failure -> retry -> success, verifying the stale alert clears.
- Playwright mocked smoke tests for Results -> Explore cloud-forming field loading.
- Playwright mocked smoke tests for Results -> Explore Dry Failed no-cloud/updraft behavior.
- Playwright mocked smoke test for non-stuck field-loading failure state.

## 3-D retry browser coverage note
I attempted an additional Playwright test for the exact 3-D retry-success path, but the current mocked app flow makes background Results field requests consume the forced failure before the 3-D scene transition. Rather than keep a brittle request-order test, this PR uses precise component coverage for the 3-D retry-success bug and keeps Playwright coverage at the stable user-path level.

## Commands run
- `npm run test`
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Manual QA needed
Optional qualitative review only: open a saved cloud-forming result and a Dry Failed result from Results into Explore and confirm the trust-state language feels clear. The objective loading/field-state behavior is covered by component and Playwright tests.

## Caveats / follow-up issues
- No UI redesign, renderer technology, CM1 execution, or scenario behavior changes were made.

Generated-data check:
- No CM1 output, NetCDF output, logs, screenshots, videos, Playwright reports, or generated run directories were committed.

Closes #169