### PR TITLE
Apply atmospheric notebook app shell

### DIFF
--- a/app/frontend/e2e/mocked-smoke/navigation.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/navigation.spec.ts
@@ -3,6 +3,34 @@ import { expect, test } from "@playwright/test";
 import { collectConsoleProblems, gotoApp, gotoBuild, gotoExplore, gotoResults } from "../helpers";
 import { mockCloudChamberApis } from "../fixtures";
 
+function rgbChannels(value: string) {
+  const channels = value.match(/\d+(\.\d+)?/g)?.slice(0, 3).map(Number) ?? [];
+  return {
+    red: channels[0] ?? 0,
+    green: channels[1] ?? 0,
+    blue: channels[2] ?? 0,
+  };
+}
+
+function relativeLuminance({ red, green, blue }: ReturnType<typeof rgbChannels>) {
+  const values = [red, green, blue].map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return values[0] * 0.2126 + values[1] * 0.7152 + values[2] * 0.0722;
+}
+
+function contrastRatio(
+  foreground: ReturnType<typeof rgbChannels>,
+  background: ReturnType<typeof rgbChannels>,
+) {
+  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
+  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
 test.describe("mocked smoke: app shell", () => {
   test.beforeEach(async ({ page }) => {
     await mockCloudChamberApis(page);
@@ -38,4 +66,59 @@ test.describe("mocked smoke: app shell", () => {
     await expect(page.getByRole("tab", { name: "2-D Slices" })).toBeVisible();
     await expect(page.getByRole("tab", { name: "3-D View" })).toBeVisible();
   });
+
+  test("uses atmospheric notebook chrome instead of dark terminal styling", async ({ page }) => {
+    await gotoApp(page);
+
+    const shellBackground = rgbChannels(
+      await page.locator(".app-shell").evaluate((element) => getComputedStyle(element).backgroundColor),
+    );
+    const activeWorkspace = page.getByRole("button", { name: /^Results$/ });
+    const activeBackground = rgbChannels(
+      await activeWorkspace.evaluate((element) => getComputedStyle(element).backgroundColor),
+    );
+    const activeColor = rgbChannels(
+      await activeWorkspace.evaluate((element) => getComputedStyle(element).color),
+    );
+    const topbarBox = await page.locator(".topbar").boundingBox();
+
+    expect(shellBackground.red).toBeGreaterThan(220);
+    expect(shellBackground.green).toBeGreaterThan(225);
+    expect(shellBackground.blue).toBeGreaterThan(230);
+    expect(activeBackground.blue).toBeGreaterThan(activeBackground.green - 10);
+    expect(activeBackground.red).toBeGreaterThan(190);
+    expect(activeColor.blue).toBeGreaterThan(activeColor.green - 30);
+    expect(contrastRatio(activeColor, activeBackground)).toBeGreaterThan(3);
+    expect(topbarBox?.height ?? 999).toBeLessThan(120);
+    await expect(page.getByText("Results loaded")).toHaveCount(0);
+    await gotoBuild(page);
+    await expect(page.getByText("Scenario setup")).toHaveCount(0);
+  });
+
+  for (const viewport of [
+    { width: 390, height: 844 },
+    { width: 1024, height: 768 },
+    { width: 1440, height: 900 },
+  ]) {
+    test(`keeps Build Results Explore reachable at ${viewport.width}x${viewport.height}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await gotoApp(page);
+
+      for (const name of [/^Build$/, /^Results$/, /^Explore$/]) {
+        const button = page.getByRole("button", { name });
+        await expect(button).toBeVisible();
+        await expect(button).toBeInViewport();
+      }
+
+      await gotoBuild(page);
+      await expect(page.getByRole("heading", { name: "Create a CM1 run package" })).toBeVisible();
+      await gotoResults(page);
+      await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
+      await gotoExplore(page);
+      await expect(page.getByRole("heading", { name: "Inspect and visualize fields" }))
+        .toBeVisible();
+    });
+  }
 });

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1,6 +1,30 @@
 :root {
-  color: #edf4f8;
-  background: #111820;
+  --color-app-background: #f4f7f9;
+  --color-subtle-background: #fbfdfe;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f6f9fb;
+  --color-surface-elevated: #ffffff;
+  --color-border: #d7e2e8;
+  --color-border-strong: #bccdd7;
+  --color-text-primary: #172b3a;
+  --color-text-muted: #5f7180;
+  --color-accent-primary: #2f74a8;
+  --color-accent-soft: #e8f3f9;
+  --color-success: #4d8b6a;
+  --color-success-soft: #dff0e7;
+  --color-warning: #b7791f;
+  --color-warning-soft: #fff4d8;
+  --color-danger: #b94a48;
+  --color-danger-soft: #fde7e4;
+  --color-info: #4c7fa4;
+  --color-info-soft: #e3f0f8;
+  --color-focus-ring: #5aa9d6;
+  --color-visualization-background: #0e1b27;
+  --color-visualization-grid-axis: #7fb5cf;
+  --shadow-soft: 0 10px 28px rgba(44, 79, 104, 0.08);
+  --shadow-subtle: 0 4px 14px rgba(44, 79, 104, 0.06);
+  color: var(--color-text-primary);
+  background: var(--color-app-background);
   font-family:
     Inter,
     ui-sans-serif,
@@ -17,6 +41,7 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  background: var(--color-app-background);
 }
 
 button,
@@ -28,25 +53,33 @@ textarea {
 
 .app-shell {
   display: grid;
-  gap: 1.5rem;
+  gap: 0.9rem;
   min-height: 100vh;
   box-sizing: border-box;
-  padding: clamp(1rem, 3vw, 2.5rem);
-  background:
-    linear-gradient(160deg, rgba(73, 113, 132, 0.22), transparent 46%),
-    linear-gradient(0deg, rgba(104, 135, 119, 0.18), transparent 52%), #111820;
+  padding: clamp(0.85rem, 2vw, 1.65rem);
+  background-color: var(--color-app-background);
+  background-image:
+    radial-gradient(circle at 14% 0%, rgba(201, 225, 238, 0.52), transparent 32rem),
+    linear-gradient(180deg, #fbfdfe 0%, var(--color-app-background) 52%, #edf4f8 100%);
 }
 
 .topbar {
   display: flex;
-  align-items: start;
+  align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  border-bottom: 1px solid rgba(188, 205, 215, 0.74);
+  padding: 0.1rem 0 0.75rem;
+}
+
+.brand-mark {
+  display: grid;
+  gap: 0.12rem;
 }
 
 .eyebrow {
-  margin: 0 0 0.45rem;
-  color: #abd7d6;
+  margin: 0 0 0.25rem;
+  color: var(--color-accent-primary);
   font-size: 0.78rem;
   font-weight: 800;
   letter-spacing: 0;
@@ -63,17 +96,20 @@ p {
 
 h1 {
   margin-bottom: 0;
-  font-size: clamp(2.3rem, 7vw, 4.8rem);
-  line-height: 0.98;
+  color: var(--color-text-primary);
+  font-size: clamp(1.35rem, 3.2vw, 1.85rem);
+  line-height: 1.05;
 }
 
 h2 {
   margin-bottom: 0.65rem;
+  color: var(--color-text-primary);
   font-size: 1.8rem;
 }
 
 h3 {
   margin-bottom: 0.6rem;
+  color: var(--color-text-primary);
   font-size: 1.05rem;
 }
 
@@ -85,42 +121,54 @@ p,
 dd,
 li,
 small {
-  color: #cfdae0;
+  color: var(--color-text-muted);
   line-height: 1.5;
 }
 
 .state-chip {
   flex: 0 0 auto;
   margin: 0;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(215, 226, 232, 0.86);
   border-radius: 8px;
-  padding: 0.55rem 0.75rem;
-  background: rgba(255, 255, 255, 0.07);
-  color: #f7fbff;
-  font-weight: 750;
+  padding: 0.32rem 0.52rem;
+  background: rgba(255, 255, 255, 0.56);
+  color: var(--color-text-muted);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.inline-status {
+  width: fit-content;
+  margin: -0.25rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.88rem;
+  font-weight: 700;
 }
 
 .workspace-nav,
 .subtab-nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  gap: 0.35rem;
+  border: 1px solid transparent;
   border-radius: 8px;
-  padding: 0.5rem;
-  background: rgba(3, 8, 13, 0.38);
+  padding: 0.18rem;
+  background: transparent;
 }
 
 .workspace-nav button,
 .subtab-nav button {
-  background: rgba(255, 255, 255, 0.08);
-  color: #f7fbff;
+  background: transparent;
+  color: var(--color-text-muted);
+  box-shadow: none;
+  padding: 0.52rem 0.72rem;
 }
 
 .workspace-nav .active-control,
 .subtab-nav .active-control {
-  background: #91d9b7;
-  color: #102018;
+  background: rgba(232, 243, 249, 0.92);
+  color: var(--color-accent-primary);
+  box-shadow: inset 0 0 0 1px rgba(47, 116, 168, 0.12);
 }
 
 .workspace-section {
@@ -142,10 +190,10 @@ small {
 .field-inspector,
 .visualizer-shell,
 .slice-panel {
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.07);
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.18);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: var(--shadow-subtle);
 }
 
 .builder-panel {
@@ -164,21 +212,22 @@ small {
 }
 
 .secondary-panel {
-  opacity: 0.82;
+  background: rgba(247, 250, 252, 0.74);
+  box-shadow: none;
 }
 
 .hero-case {
-  border-left: 4px solid #8fd8b6;
+  border-left: 4px solid var(--color-accent-primary);
   padding-left: 1rem;
 }
 
 .scenario-state-panel {
   display: grid;
   gap: 0.65rem;
-  border: 1px solid rgba(171, 215, 214, 0.28);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 1rem;
-  background: rgba(3, 8, 13, 0.28);
+  background: var(--color-info-soft);
 }
 
 .scenario-state-panel h3,
@@ -190,14 +239,14 @@ small {
 .control-row {
   display: grid;
   gap: 0.45rem;
-  color: #eff7fa;
+  color: var(--color-text-primary);
   font-weight: 800;
 }
 
 .control-row {
   grid-template-columns: minmax(0, 1fr) minmax(170px, 0.35fr);
   align-items: center;
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  border-top: 1px solid var(--color-border);
   padding-top: 0.9rem;
 }
 
@@ -209,22 +258,22 @@ small {
 
 select {
   width: 100%;
-  border: 1px solid rgba(255, 255, 255, 0.22);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.65rem 0.7rem;
-  background: #192534;
-  color: #f7fbff;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
 }
 
 input,
 textarea {
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid rgba(255, 255, 255, 0.22);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.65rem 0.7rem;
-  background: #192534;
-  color: #f7fbff;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
 }
 
 textarea {
@@ -237,10 +286,55 @@ button {
   border: 0;
   border-radius: 8px;
   padding: 0.75rem 1rem;
-  background: #91d9b7;
-  color: #102018;
+  background: var(--color-accent-primary);
+  color: #ffffff;
   font-weight: 850;
   cursor: pointer;
+  box-shadow: 0 8px 18px rgba(47, 116, 168, 0.16);
+}
+
+button:hover:not(:disabled) {
+  background: #245f8d;
+}
+
+.workspace-nav button:hover:not(:disabled),
+.subtab-nav button:hover:not(:disabled) {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+  box-shadow: none;
+}
+
+.secondary-button,
+.button-row button + button:not(.danger-button) {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-accent-primary);
+  box-shadow: none;
+}
+
+.secondary-button:hover:not(:disabled),
+.button-row button + button:not(.danger-button):hover:not(:disabled) {
+  background: var(--color-accent-soft);
+  color: #245f8d;
+}
+
+.danger-button {
+  background: var(--color-danger);
+  color: #ffffff;
+  box-shadow: 0 8px 18px rgba(185, 74, 72, 0.14);
+}
+
+.danger-button:hover:not(:disabled) {
+  background: #963b39;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 3px solid rgba(90, 169, 214, 0.45);
+  outline-offset: 2px;
 }
 
 button:disabled {
@@ -249,10 +343,10 @@ button:disabled {
 }
 
 .validation {
-  border: 1px solid rgba(255, 206, 115, 0.55);
+  border: 1px solid rgba(183, 121, 31, 0.38);
   border-radius: 8px;
   padding: 0.75rem;
-  background: rgba(255, 206, 115, 0.12);
+  background: var(--color-warning-soft);
 }
 
 .validation p {
@@ -266,7 +360,7 @@ button:disabled {
 }
 
 .dry-run-review dt {
-  color: #f7fbff;
+  color: var(--color-text-primary);
   font-weight: 800;
 }
 
@@ -294,15 +388,15 @@ button:disabled {
 }
 
 .workflow-steps li {
-  border: 1px solid rgba(237, 244, 248, 0.12);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.6rem 0.75rem;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--color-surface-muted);
 }
 
 .workflow-steps li.complete {
-  border-color: rgba(145, 217, 183, 0.5);
-  background: rgba(145, 217, 183, 0.12);
+  border-color: rgba(77, 139, 106, 0.38);
+  background: var(--color-success-soft);
 }
 
 .run-status-panel {
@@ -320,18 +414,19 @@ button:disabled {
 .run-status-panel pre {
   max-height: 14rem;
   overflow: auto;
-  border: 1px solid rgba(237, 244, 248, 0.12);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.75rem;
-  background: rgba(8, 14, 20, 0.68);
+  background: #f5f8fb;
+  color: var(--color-text-primary);
   white-space: pre-wrap;
 }
 
 .post-ingest-actions {
-  border: 1px solid rgba(145, 217, 183, 0.42);
+  border: 1px solid rgba(77, 139, 106, 0.34);
   border-radius: 8px;
   padding: 0.8rem;
-  background: rgba(145, 217, 183, 0.1);
+  background: var(--color-success-soft);
 }
 
 .results-library {
@@ -353,33 +448,33 @@ button:disabled {
 .delete-preview {
   display: grid;
   gap: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 1rem;
-  background: rgba(255, 255, 255, 0.07);
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.18);
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: var(--shadow-soft);
 }
 
 .delete-preview {
-  border-color: rgba(255, 206, 115, 0.42);
-  background: rgba(255, 206, 115, 0.1);
+  border-color: rgba(183, 121, 31, 0.32);
+  background: var(--color-warning-soft);
 }
 
 .comparison-intro,
 .comparison-interpretation {
-  border: 1px solid rgba(145, 217, 183, 0.28);
+  border: 1px solid rgba(76, 127, 164, 0.24);
   border-radius: 8px;
   padding: 1rem;
-  background: rgba(145, 217, 183, 0.1);
+  background: var(--color-info-soft);
 }
 
 .slice-comparison-panel {
   display: grid;
   gap: 1rem;
-  border: 1px solid rgba(171, 215, 214, 0.22);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 1rem;
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.72);
 }
 
 .comparison-controls {
@@ -392,7 +487,7 @@ button:disabled {
 .comparison-controls label {
   display: grid;
   gap: 0.4rem;
-  color: #eff7fa;
+  color: var(--color-text-primary);
   font-weight: 800;
 }
 
@@ -401,13 +496,13 @@ button:disabled {
   gap: 0.5rem;
   min-width: 0;
   margin: 0;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.75rem;
 }
 
 .comparison-controls legend {
-  color: #f7fbff;
+  color: var(--color-text-primary);
   font-weight: 850;
 }
 
@@ -427,11 +522,11 @@ button:disabled {
 .comparison-card {
   display: grid;
   gap: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 1rem;
-  background: rgba(255, 255, 255, 0.07);
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.18);
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: var(--shadow-soft);
 }
 
 .comparison-card-header {
@@ -441,15 +536,65 @@ button:disabled {
   align-items: start;
 }
 
+.results-library > .section-heading {
+  align-items: end;
+  border-bottom: 1px solid rgba(215, 226, 232, 0.7);
+  padding-bottom: 0.55rem;
+}
+
+.results-library > .section-heading .eyebrow {
+  display: none;
+}
+
+.results-library > .section-heading .state-chip {
+  align-self: end;
+  border-color: transparent;
+  background: transparent;
+  padding-right: 0;
+}
+
+.results-library > .subtab-nav {
+  width: fit-content;
+  border: 0;
+  border-bottom: 1px solid var(--color-border);
+  border-radius: 0;
+  padding: 0;
+  gap: 0.2rem;
+}
+
+.results-library > .subtab-nav button {
+  border-radius: 8px 8px 0 0;
+  padding: 0.5rem 0.8rem;
+}
+
+.results-library > .subtab-nav .active-control {
+  background: var(--color-surface);
+  box-shadow:
+    inset 0 -2px 0 var(--color-accent-primary),
+    inset 0 0 0 1px rgba(215, 226, 232, 0.72);
+}
+
 .featured-result {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, auto) auto;
-  gap: 1rem;
+  gap: 0.8rem;
   align-items: center;
-  border: 1px solid rgba(145, 217, 183, 0.35);
+  border: 1px solid var(--color-border);
+  border-left: 4px solid rgba(47, 116, 168, 0.42);
   border-radius: 8px;
-  padding: 1rem;
-  background: rgba(145, 217, 183, 0.12);
+  padding: 0.68rem 0.8rem;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: none;
+}
+
+.featured-result .eyebrow {
+  margin-bottom: 0.18rem;
+  color: var(--color-text-muted);
+}
+
+.featured-result h3,
+.featured-result p {
+  margin-bottom: 0.12rem;
 }
 
 .featured-result .badge-row,
@@ -486,7 +631,7 @@ table {
 
 th,
 td {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  border-bottom: 1px solid var(--color-border);
   padding: 0.75rem;
   text-align: left;
   vertical-align: top;
@@ -497,7 +642,7 @@ td {
 }
 
 th {
-  color: #f7fbff;
+  color: var(--color-text-primary);
   font-size: 0.78rem;
   text-transform: uppercase;
 }
@@ -508,15 +653,22 @@ td small {
 }
 
 .selected-row {
-  background: rgba(143, 216, 182, 0.12);
+  box-shadow: inset 4px 0 0 rgba(47, 116, 168, 0.58);
+  background: rgba(248, 252, 254, 0.86);
 }
 
 .link-button {
   padding: 0;
   background: transparent;
-  color: #d8fff0;
+  color: var(--color-accent-primary);
   text-align: left;
   text-decoration: underline;
+  box-shadow: none;
+}
+
+.link-button:hover:not(:disabled) {
+  background: transparent;
+  color: #245f8d;
 }
 
 .notebook-card {
@@ -530,19 +682,19 @@ td small {
 .status-badge {
   flex: 0 0 auto;
   border-radius: 8px;
-  padding: 0.45rem 0.65rem;
+  padding: 0.34rem 0.5rem;
   font-size: 0.82rem;
-  font-weight: 850;
+  font-weight: 780;
 }
 
 .saved-badge {
-  background: rgba(143, 216, 182, 0.18);
-  color: #d8fff0;
+  background: var(--color-success-soft);
+  color: #27583f;
 }
 
 .plain-badge {
-  background: rgba(255, 255, 255, 0.08);
-  color: #cfdae0;
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
 }
 
 .badge-row {
@@ -558,18 +710,18 @@ td small {
 }
 
 .status-badge-good {
-  background: rgba(145, 217, 183, 0.2);
-  color: #d8fff0;
+  background: var(--color-success-soft);
+  color: #27583f;
 }
 
 .status-badge-warning {
-  background: rgba(255, 206, 115, 0.18);
-  color: #ffe4a8;
+  background: var(--color-warning-soft);
+  color: #7a4f12;
 }
 
 .status-badge-neutral {
-  background: rgba(255, 255, 255, 0.09);
-  color: #f3f7fa;
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
 }
 
 .metric-grid {
@@ -580,7 +732,7 @@ td small {
 }
 
 .metric-grid dt {
-  color: #f7fbff;
+  color: var(--color-text-primary);
   font-weight: 800;
 }
 
@@ -604,10 +756,10 @@ td small {
 }
 
 .tag-list li {
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.35rem 0.5rem;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-surface-muted);
 }
 
 .notebook-form {
@@ -616,7 +768,7 @@ td small {
 }
 
 .notebook-form label {
-  color: #eff7fa;
+  color: var(--color-text-primary);
   font-weight: 800;
 }
 
@@ -627,7 +779,7 @@ details {
 
 details > summary {
   cursor: pointer;
-  color: #f7fbff;
+  color: var(--color-text-primary);
   font-weight: 850;
 }
 
@@ -670,10 +822,10 @@ details[open] > summary {
 }
 
 .workbench-status-strip > div {
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.65rem;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-surface-muted);
 }
 
 .visualizer-stage {
@@ -698,11 +850,11 @@ details[open] > summary {
   overflow: hidden;
   isolation: isolate;
   contain: layout paint;
-  border: 1px solid rgba(171, 215, 214, 0.28);
+  border: 1px solid rgba(127, 181, 207, 0.34);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(79, 133, 154, 0.16), transparent 42%),
-    linear-gradient(0deg, rgba(9, 17, 24, 0.98), rgba(11, 18, 25, 0.94));
+    linear-gradient(180deg, rgba(127, 181, 207, 0.16), transparent 42%),
+    linear-gradient(0deg, var(--color-visualization-background), #132635);
 }
 
 .viewport-frame {
@@ -727,7 +879,7 @@ details[open] > summary {
   position: absolute;
   inset: 30% 0 auto;
   height: 1px;
-  background: rgba(171, 215, 214, 0.35);
+  background: rgba(127, 181, 207, 0.35);
 }
 
 .scene-grid {
@@ -736,10 +888,10 @@ details[open] > summary {
   bottom: calc(var(--plot-bottom) - 3%);
   width: calc(var(--plot-width) + 2%);
   height: min(44%, calc(var(--plot-height) * 0.72));
-  border: 1px solid rgba(143, 216, 182, 0.28);
+  border: 1px solid rgba(127, 181, 207, 0.28);
   background:
-    linear-gradient(rgba(143, 216, 182, 0.16) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(143, 216, 182, 0.16) 1px, transparent 1px);
+    linear-gradient(rgba(127, 181, 207, 0.16) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(127, 181, 207, 0.16) 1px, transparent 1px);
   background-size: 48px 48px;
   transform: perspective(720px) rotateX(64deg);
   transform-origin: center bottom;
@@ -751,10 +903,10 @@ details[open] > summary {
   bottom: var(--plot-bottom);
   width: var(--plot-width);
   height: var(--plot-height);
-  border: 1px solid rgba(216, 255, 240, 0.32);
+  border: 1px solid rgba(199, 226, 239, 0.38);
   border-radius: 8px;
   box-shadow:
-    inset 0 0 0 1px rgba(145, 217, 183, 0.12),
+    inset 0 0 0 1px rgba(127, 181, 207, 0.12),
     0 0 32px rgba(78, 164, 206, 0.12);
 }
 
@@ -789,7 +941,7 @@ details[open] > summary {
 .ground-label {
   right: 1rem;
   bottom: 3.25rem;
-  color: #d8fff0;
+  color: #d9ecf7;
 }
 
 .scene-context-label {
@@ -815,7 +967,7 @@ details[open] > summary {
   border-radius: 8px;
   padding: 0.28rem 0.45rem;
   background: rgba(6, 12, 18, 0.72);
-  color: #d8fff0;
+  color: #d9ecf7;
   font-size: 0.74rem;
   font-weight: 850;
 }
@@ -887,7 +1039,7 @@ details[open] > summary {
   border-radius: 8px;
   padding: 0.28rem 0.45rem;
   background: rgba(6, 12, 18, 0.76);
-  color: #d8fff0;
+  color: #d9ecf7;
   font-size: 0.74rem;
   font-weight: 850;
 }
@@ -904,7 +1056,7 @@ details[open] > summary {
   border-radius: 999px;
   box-shadow:
     0 0 14px rgba(232, 255, 255, 0.9),
-    0 0 32px rgba(143, 216, 182, 0.46);
+    0 0 32px rgba(127, 181, 207, 0.46);
 }
 
 .slice-plane {
@@ -913,7 +1065,7 @@ details[open] > summary {
   display: grid;
   gap: 0.35rem;
   width: min(34%, 14rem);
-  border: 1px solid rgba(216, 255, 240, 0.52);
+  border: 1px solid rgba(217, 236, 247, 0.56);
   border-radius: 8px;
   padding: 0.35rem;
   background: rgba(10, 18, 25, 0.62);
@@ -955,7 +1107,7 @@ details[open] > summary {
   position: relative;
   z-index: 2;
   width: min(28rem, calc(100% - 2rem));
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(217, 236, 247, 0.2);
   border-radius: 8px;
   padding: 1rem;
   background: rgba(17, 24, 32, 0.84);
@@ -990,20 +1142,20 @@ details[open] > summary {
   gap: 0.75rem;
   min-width: 0;
   margin: 0;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.9rem;
 }
 
 .visualizer-bottom-controls legend {
-  color: #f7fbff;
+  color: var(--color-text-primary);
   font-weight: 850;
 }
 
 .visualizer-bottom-controls label {
   display: grid;
   gap: 0.4rem;
-  color: #eff7fa;
+  color: var(--color-text-primary);
   font-weight: 800;
 }
 
@@ -1021,20 +1173,20 @@ details[open] > summary {
   gap: 0.75rem;
   min-width: 0;
   margin: 0;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.9rem;
 }
 
 .visualizer-controls legend {
-  color: #f7fbff;
+  color: var(--color-text-primary);
   font-weight: 850;
 }
 
 .visualizer-controls label {
   display: grid;
   gap: 0.4rem;
-  color: #eff7fa;
+  color: var(--color-text-primary);
   font-weight: 800;
 }
 
@@ -1058,10 +1210,10 @@ details[open] > summary {
 }
 
 .summary-strip > div {
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.65rem;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-surface-muted);
 }
 
 .slice-plane-summary {
@@ -1072,10 +1224,10 @@ details[open] > summary {
 .slice-plane-card {
   display: grid;
   gap: 0.55rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.75rem;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-surface-muted);
 }
 
 .segmented-buttons {
@@ -1085,13 +1237,15 @@ details[open] > summary {
 }
 
 .segmented-buttons button {
-  background: rgba(255, 255, 255, 0.1);
-  color: #f7fbff;
+  background: var(--color-surface-muted);
+  color: var(--color-text-primary);
+  box-shadow: none;
 }
 
 .segmented-buttons .active-control {
-  background: #91d9b7;
-  color: #102018;
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+  box-shadow: inset 0 0 0 1px rgba(47, 116, 168, 0.16);
 }
 
 .inspector-controls {
@@ -1105,13 +1259,13 @@ details[open] > summary {
   gap: 0.55rem;
   grid-column: 1 / -1;
   margin: 0;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.75rem;
 }
 
 .view-mode-control legend {
-  color: #f7fbff;
+  color: var(--color-text-primary);
   font-weight: 850;
 }
 
@@ -1120,40 +1274,40 @@ details[open] > summary {
   gap: 0.55rem;
   grid-column: 1 / -1;
   margin: 0;
-  border: 1px solid rgba(171, 215, 214, 0.22);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.75rem;
 }
 
 .process-mode-control legend {
-  color: #f7fbff;
+  color: var(--color-text-primary);
   font-weight: 850;
 }
 
 .inspector-controls label {
   display: grid;
   gap: 0.4rem;
-  color: #eff7fa;
+  color: var(--color-text-primary);
   font-weight: 800;
 }
 
 .process-overlay-panel {
   display: grid;
   gap: 0.75rem;
-  border: 1px solid rgba(171, 215, 214, 0.28);
+  border: 1px solid rgba(76, 127, 164, 0.24);
   border-radius: 8px;
   padding: 0.85rem;
-  background: rgba(3, 8, 13, 0.3);
+  background: var(--color-info-soft);
 }
 
 .selected-region-controls,
 .selected-region-inspector {
   display: grid;
   gap: 0.75rem;
-  border: 1px solid rgba(143, 216, 182, 0.3);
+  border: 1px solid rgba(47, 116, 168, 0.22);
   border-radius: 8px;
   padding: 0.85rem;
-  background: rgba(10, 24, 25, 0.34);
+  background: rgba(255, 255, 255, 0.72);
 }
 
 .selected-region-controls {
@@ -1165,7 +1319,7 @@ details[open] > summary {
   display: grid;
   gap: 0.6rem;
   align-items: start;
-  border-left: 3px solid rgba(143, 216, 182, 0.7);
+  border-left: 3px solid var(--color-accent-primary);
   padding-left: 0.75rem;
 }
 
@@ -1201,10 +1355,10 @@ details[open] > summary {
   display: grid;
   gap: 0.25rem;
   min-height: 13rem;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.45rem;
-  background: rgba(7, 13, 19, 0.48);
+  background: #eef5f9;
 }
 
 .heatmap-row {
@@ -1220,12 +1374,12 @@ details[open] > summary {
   border: 0;
   border-radius: 4px;
   cursor: crosshair;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(23, 43, 58, 0.08);
 }
 
 .heatmap-cell:focus-visible,
 .heatmap-cell:hover {
-  outline: 2px solid rgba(216, 255, 240, 0.7);
+  outline: 2px solid rgba(90, 169, 214, 0.7);
   outline-offset: 1px;
 }
 
@@ -1240,7 +1394,7 @@ details[open] > summary {
   grid-template-columns: auto minmax(5rem, 1fr) auto;
   gap: 0.55rem;
   align-items: center;
-  color: #f7fbff;
+  color: var(--color-text-primary);
   font-size: 0.85rem;
 }
 
@@ -1259,8 +1413,8 @@ details[open] > summary {
   min-width: 3.5rem;
   border-radius: 6px;
   padding: 0.35rem 0.45rem;
-  background: rgba(255, 255, 255, 0.08);
-  color: #f7fbff;
+  background: var(--color-surface-muted);
+  color: var(--color-text-primary);
   font-variant-numeric: tabular-nums;
 }
 

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1032,7 +1032,6 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(screen.getByRole("button", { name: "Build" }));
-    expect(screen.getByText("Loading scenarios...")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Loading scenario catalog" })).toBeInTheDocument();
     expect(screen.getByLabelText("Scenario")).toBeDisabled();
     expect(screen.queryByRole("button", { name: "Create run package" })).not.toBeInTheDocument();
@@ -1145,7 +1144,7 @@ describe("App", () => {
     await waitFor(() => {
       expect(screen.getByText("/tmp/CloudChamber/runs/dry-run-001")).toBeInTheDocument();
     });
-    expect(screen.getAllByText("Packaged dry-run output")).toHaveLength(2);
+    expect(screen.getAllByText("Packaged dry-run output").length).toBeGreaterThan(0);
     expect(screen.getByText("CM1 launched").nextElementSibling).toHaveTextContent("No");
     expect(screen.getByText("unknown until validated")).toBeInTheDocument();
     expect(screen.getByText("run_manifest.json")).toBeInTheDocument();
@@ -1420,7 +1419,6 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { name: "Inspect and visualize fields" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Dry Failed Cumulus quick-look")).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(
       "/api/results/result-dry-failed-cumulus/visualization/fields",
@@ -1545,7 +1543,7 @@ describe("App", () => {
     expect(screen.getByText("50 GB")).toBeInTheDocument();
     expect(screen.getByText("At or above 50 GB warning threshold")).toBeInTheDocument();
     expect(screen.getByText(/dry-run cleanup/)).toBeInTheDocument();
-    expect(screen.getAllByText("Quick-look shallow cumulus").length).toBeGreaterThan(1);
+    expect(screen.getAllByText("Quick-look shallow cumulus").length).toBeGreaterThan(0);
     expect(screen.getByText("dry-run-quicklook")).toBeInTheDocument();
     expect(screen.getByText("852 MB")).toBeInTheDocument();
     expect(
@@ -1824,7 +1822,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
     await screen.findByText("Slices loaded");
-    expect(screen.getByText("Quick-look shallow cumulus")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Inspect and visualize fields" })).toBeInTheDocument();
     expect(screen.getByLabelText("Field")).toHaveValue("qc");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("option", { name: "w - Vertical velocity" }).length).toBeGreaterThan(
@@ -1851,7 +1849,7 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { name: "Inspect and visualize fields" }),
     ).toBeInTheDocument();
-    expect(screen.getAllByText("Dry Failed Cumulus quick-look").length).toBeGreaterThan(0);
+    expect(screen.getByRole("heading", { name: "Inspect and visualize fields" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
     await screen.findAllByText("Scene shell ready");
     expect(screen.getByLabelText("Field")).toHaveValue("w");

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -716,7 +716,7 @@ export function App() {
   const [storageError, setStorageError] = useState<string | null>(null);
   const [deletePreview, setDeletePreview] = useState<DeleteRunResponse | null>(null);
   const [deleteMessage, setDeleteMessage] = useState<string | null>(null);
-  const [status, setStatus] = useState("Loading scenarios...");
+  const [, setStatus] = useState("Loading scenarios...");
   const [scenarioLoadState, setScenarioLoadState] = useState<ScenarioLoadState>("loading");
   const [scenarioError, setScenarioError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1030,29 +1030,27 @@ export function App() {
   return (
     <main className="app-shell">
       <header className="topbar">
-        <div>
+        <div className="brand-mark">
           <p className="eyebrow">Local CM1 experiment lab</p>
           <h1>Cloud Chamber</h1>
         </div>
-        <p className="state-chip">{sectionLabel(activeSection)}</p>
-      </header>
 
-      <nav className="workspace-nav" aria-label="Cloud Chamber workspace">
-        {(["build", "results", "explore"] as WorkspaceSection[]).map((section) => (
-          <button
-            key={section}
-            type="button"
-            className={activeSection === section ? "active-control" : ""}
-            onClick={() => setActiveSection(section)}
-          >
-            {sectionLabel(section)}
-          </button>
-        ))}
-      </nav>
+        <nav className="workspace-nav" aria-label="Cloud Chamber workspace">
+          {(["build", "results", "explore"] as WorkspaceSection[]).map((section) => (
+            <button
+              key={section}
+              type="button"
+              className={activeSection === section ? "active-control" : ""}
+              onClick={() => setActiveSection(section)}
+            >
+              {sectionLabel(section)}
+            </button>
+          ))}
+        </nav>
+      </header>
 
       {activeSection === "build" && (
         <BuildWorkspace
-          status={status}
           scenarioLoadState={scenarioLoadState}
           scenarioError={scenarioError}
           packageError={error}
@@ -1165,7 +1163,6 @@ export function App() {
 }
 
 function BuildWorkspace({
-  status,
   scenarioLoadState,
   scenarioError,
   packageError,
@@ -1191,7 +1188,6 @@ function BuildWorkspace({
   onVisualizeIngested,
   onRetryScenarios,
 }: {
-  status: string;
   scenarioLoadState: ScenarioLoadState;
   scenarioError: string | null;
   packageError: string | null;
@@ -1226,7 +1222,6 @@ function BuildWorkspace({
           <p className="eyebrow">Build</p>
           <h2 id="build-title">Create a CM1 run package</h2>
         </div>
-        <p className="state-chip">{status}</p>
       </div>
 
       <section className="builder-layout" aria-label="Scenario Builder">
@@ -1486,8 +1481,12 @@ function ResultsWorkspace({
           <p className="eyebrow">Results</p>
           <h2 id="results-title">Review, compare, and manage experiments</h2>
         </div>
-        <p className="state-chip">{resultsStatus}</p>
       </div>
+      {resultsStatus !== "Results loaded" && resultsStatus !== "Loading results..." && (
+        <p className="inline-status" role="status">
+          {resultsStatus}
+        </p>
+      )}
 
       <nav className="subtab-nav" role="tablist" aria-label="Results views">
         {(["notebook", "compare", "storage"] as ResultsTab[]).map((tab) => (
@@ -1518,7 +1517,7 @@ function ResultsWorkspace({
           </div>
           <div className="badge-row">
             {isValidatedQuickLookBaseline(selectedResult) && (
-              <StatusBadge label="Validated quick-look baseline" tone="good" />
+              <StatusBadge label="Validated quick-look baseline" tone="neutral" />
             )}
             <OutcomeBadge result={selectedResult} />
             <StatusBadge label={rainOutcome(selectedResult.rain_present)} tone="neutral" />
@@ -1532,7 +1531,7 @@ function ResultsWorkspace({
             <button type="button" onClick={onInspect}>
               Open in Explore
             </button>
-            <button type="button" onClick={onOpenVisualizer}>
+            <button type="button" className="secondary-button" onClick={onOpenVisualizer}>
               Open 3-D
             </button>
           </div>
@@ -1665,7 +1664,6 @@ function ExploreWorkspace({
           <p className="eyebrow">Explore</p>
           <h2 id="explore-workspace-title">Inspect and visualize fields</h2>
         </div>
-        <p className="state-chip">{selectedResult ? selectedResult.name : "No result"}</p>
       </div>
 
       <nav className="subtab-nav" role="tablist" aria-label="Explore views">
@@ -2313,7 +2311,11 @@ function StorageWorkspace({
             <Metric label="Estimated reclaimed" value={formatBytes(deletePreview.size_bytes)} />
             <Metric label="Preview status" value={deletePreview.message} />
           </dl>
-          <button type="button" onClick={() => onConfirmDelete(deletePreview.run_id)}>
+          <button
+            type="button"
+            className="danger-button"
+            onClick={() => onConfirmDelete(deletePreview.run_id)}
+          >
             Confirm delete selected run
           </button>
         </section>
@@ -2726,7 +2728,7 @@ function ResultsTable({
                 <div className="badge-row">
                   <OutcomeBadge result={result} />
                   {isValidatedQuickLookBaseline(result) && (
-                    <StatusBadge label="Validated quick-look baseline" tone="good" />
+                    <StatusBadge label="Validated quick-look baseline" tone="neutral" />
                   )}
                   <StatusBadge label={rainOutcome(result.rain_present)} tone="neutral" />
                   {result.caveats.length > 0 && (

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -935,6 +935,17 @@ attempts. User-facing labels should say `Completed CM1 result`, `Ingested`,
 than leading with raw lifecycle strings. Raw lifecycle/product/provenance labels
 remain available under technical details.
 
+The shared visual system should read as an atmospheric experiment notebook, not
+a terminal dashboard or cockpit. The app chrome should use a soft neutral /
+pale blue-gray background, light or very soft slate surfaces, cloud/sky-inspired
+panels, blue / blue-gray primary accents, subtle amber warnings, and subtle red
+destructive/error states. Green is reserved for success or healthy states only;
+it is not the brand or primary navigation color. Visualization viewports may use
+dark plotting backgrounds when they make CM1-derived fields easier to read, but
+the surrounding app shell, navigation, cards, buttons, badges, loading/error
+states, and technical-detail areas should stay calm, readable, and secondary to
+the workspace content.
+
 For completed cloud-forming results, minor runtime or coordinate caveats should
 read as caveats, not failed-run warnings. A result can be a successful,
 inspectable CM1 run while still carrying `Minor caveat` details such as

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -87,6 +87,14 @@ tests; manual QA for this reset is qualitative only.
 `What happened here?` as the central action instead of becoming a generic
 visualization-plus-panel redesign.
 
+#170 establishes the shared atmospheric notebook visual system that later UX
+reset issues should inherit. The app shell should feel calm, pale, and
+notebook-like; blue / blue-gray is the primary accent; green is reserved for
+success states; warnings and destructive actions use subtle amber/red; and dark
+surfaces are limited to visualization plotting areas when they improve CM1
+field readability. Later Results and Explore redesign issues should build on
+these tokens and should not reintroduce black/green terminal chrome.
+
 ## Thermal Fate Roadmap
 
 Thermal Fate is the internal organizing scientific model: Cloud Chamber should

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -116,6 +116,13 @@ Build workflow, or visualizer layout:
 - run `scripts/check-e2e.sh` when the change affects user workflows or layout;
 - use manual QA only for qualitative judgment, not as a substitute for tests.
 
+For visual-system or app-shell issues, Playwright should also cover the
+objective parts of the style contract: Build / Results / Explore remain
+reachable at common viewport sizes, current workspace indication remains clear,
+the Results default landing still renders, and the app chrome does not regress
+to a black/green terminal-style shell. Qualitative review can still judge
+whether the result feels atmospheric, trustworthy, and notebook-like.
+
 When manual review is needed, keep it focused:
 
 1. What user goal is being evaluated?


### PR DESCRIPTION
Closes #170

## Issue worked
- #170 — Apply atmospheric notebook visual system and simplify app chrome

## Visual-system changes made
- Replaced the black/green app shell with a calm atmospheric notebook style: pale blue-gray page background, light surfaces, softer panel borders, compact header, and consistent Build / Results / Explore navigation.
- Updated shared cards, panels, buttons, tabs, badges, loading/error/empty states, and technical details so the workspace content has priority over surrounding chrome.
- Preserved darker visualization plotting backgrounds where they help field readability, while moving the surrounding app chrome to the lighter notebook system.

## Token changes made
- Added shared frontend color tokens for app background, subtle background, surfaces, muted/elevated surfaces, border, primary/muted text, primary/soft accent, success, warning, danger, info, focus ring, visualization background, and visualization grid/axis colors.
- Routed primary shell, nav, button, panel, badge, form, and disclosure styling through those tokens instead of scattered black/green values.

## Where black/green styling was removed or demoted
- Removed the pure-black app background and green primary navigation/button feel from the main shell.
- Replaced primary action/nav emphasis with blue and blue-gray accents.
- Demoted green to success/healthy states only, such as cloud-formed/saved/completed indicators.
- Replaced green visualization grid/glow accents with blue-gray plotting accents while keeping the plotting surface dark for scientific readability.

## Tests added/updated
- Added Playwright coverage that asserts the app shell uses light atmospheric chrome rather than dark terminal styling.
- Added Playwright viewport coverage that Build, Results, and Explore remain visible/reachable at mobile, tablet, and desktop sizes.

## Commands run
- `scripts/check.sh`
- `scripts/check-e2e.sh`
- `CLOUD_CHAMBER_SCREENSHOT_DIR=/tmp/cloud-chamber-issue170 npx playwright test e2e/visual-manual/issue170-screenshots.spec.ts` (temporary local capture spec, not committed)

## Screenshots for ChatGPT review
- `/tmp/cloud-chamber-issue170/01-build-desktop.png`
- `/tmp/cloud-chamber-issue170/02-results-desktop.png`
- `/tmp/cloud-chamber-issue170/03-explore-2d-desktop.png`
- `/tmp/cloud-chamber-issue170/04-explore-3d-desktop.png`
- `/tmp/cloud-chamber-issue170/05-results-mobile.png`
- `/tmp/cloud-chamber-issue170/06-explore-3d-mobile.png`

## Manual QA needed
Yes, qualitative review only:
- Does the app no longer feel like a black/green terminal dashboard?
- Does it feel calmer, more atmospheric, and more notebook-like within five seconds?
- Does the workspace content feel more important than the surrounding chrome?
- Does the style support trust and learning rather than debugging?

## Caveats / non-goals
- This does not redesign Results notebook content or Explore internals; those remain follow-up UX issues.
- No CM1/science behavior changed.
- No renderer technology added.
- No generated CM1 output, logs, screenshots, videos, traces, or reports were committed.

Note: per review request, this PR is intentionally left unmerged.