### PR TITLE
Redesign Results as experiment notebook

### DIFF
--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -33,8 +33,20 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await gotoResults(page);
 
     await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
+    const resultsList = page.getByLabel("Results list");
+    await expect(resultsList).toBeVisible();
     await expect(page.getByText("Baseline Shallow Cumulus — Quick Look").first()).toBeVisible();
-    await expect(page.getByText("cloud formed; rain detected").first()).toBeVisible();
+    await expect(
+      resultsList.getByText(/Cloud water formed in the validated quick-look baseline/i),
+    ).toBeVisible();
+    await expect(page.getByText("Cloud formed").first()).toBeVisible();
+    await expect(page.getByText("Rain detected").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open in Explore" }).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open 3-D" }).first()).toBeVisible();
+    const resultDetail = page.getByLabel("Result detail");
+    await resultDetail.getByText("Technical details").click();
+    await expect(resultDetail.getByText("Run ID")).toBeVisible();
+    await expect(resultDetail.getByText("Product state")).toBeVisible();
 
     await openResultsTab(page, /^Compare$/);
     await expect(
@@ -45,6 +57,21 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await openResultsTab(page, /^Storage$/);
     await expect(page.getByRole("heading", { name: "Runtime storage cleanup" })).toBeVisible();
     await expect(page.getByText("/tmp/cloud-chamber-e2e").first()).toBeVisible();
+  });
+
+  test("Results notebook remains card-first on mobile", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await gotoResults(page);
+
+    await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
+    const resultsList = page.getByLabel("Results list");
+    await expect(resultsList).toBeVisible();
+    await expect(page.getByText("Baseline Shallow Cumulus — Quick Look").first()).toBeVisible();
+    await expect(
+      resultsList.getByText(/Cloud water formed in the validated quick-look baseline/i),
+    ).toBeVisible();
+    await expect(page.getByLabel("Result detail")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open in Explore" }).first()).toBeVisible();
   });
 
   test("Explore 2-D and 3-D views render from the selected result", async ({ page }) => {

--- a/app/frontend/e2e/mocked-smoke/navigation.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/navigation.spec.ts
@@ -41,13 +41,14 @@ test.describe("mocked smoke: app shell", () => {
 
     await gotoApp(page);
 
-    await expect(page.getByRole("button", { name: /^Build$/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^Results$/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^Explore$/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^Compare$/ })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: /^Storage$/ })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: /^Inspect$/ })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: /^Visualize$/ })).toHaveCount(0);
+    const topNav = page.getByRole("navigation", { name: "Cloud Chamber workspace" });
+    await expect(topNav.getByRole("button", { name: /^Build$/ })).toBeVisible();
+    await expect(topNav.getByRole("button", { name: /^Results$/ })).toBeVisible();
+    await expect(topNav.getByRole("button", { name: /^Explore$/ })).toBeVisible();
+    await expect(topNav.getByRole("button", { name: /^Compare$/ })).toHaveCount(0);
+    await expect(topNav.getByRole("button", { name: /^Storage$/ })).toHaveCount(0);
+    await expect(topNav.getByRole("button", { name: /^Inspect$/ })).toHaveCount(0);
+    await expect(topNav.getByRole("button", { name: /^Visualize$/ })).toHaveCount(0);
     expect(consoleProblems).toEqual([]);
   });
 

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -574,35 +574,6 @@ button:disabled {
     inset 0 0 0 1px rgba(215, 226, 232, 0.72);
 }
 
-.featured-result {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, auto) auto;
-  gap: 0.8rem;
-  align-items: center;
-  border: 1px solid var(--color-border);
-  border-left: 4px solid rgba(47, 116, 168, 0.42);
-  border-radius: 8px;
-  padding: 0.68rem 0.8rem;
-  background: rgba(255, 255, 255, 0.78);
-  box-shadow: none;
-}
-
-.featured-result .eyebrow {
-  margin-bottom: 0.18rem;
-  color: var(--color-text-muted);
-}
-
-.featured-result h3,
-.featured-result p {
-  margin-bottom: 0.12rem;
-}
-
-.featured-result .badge-row,
-.featured-result .button-row {
-  min-width: 0;
-  justify-content: end;
-}
-
 .section-heading,
 .notebook-title,
 .button-row {
@@ -614,9 +585,88 @@ button:disabled {
 
 .results-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.75fr);
+  grid-template-columns: minmax(0, 0.95fr) minmax(340px, 0.75fr);
   gap: 1rem;
   align-items: start;
+}
+
+.notebook-list-panel {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.empty-results {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1rem;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-subtle);
+}
+
+.experiment-card-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.experiment-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.8rem;
+  align-items: start;
+  border: 1px solid var(--color-border);
+  border-left: 4px solid transparent;
+  border-radius: 8px;
+  padding: 0.85rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: var(--shadow-subtle);
+}
+
+.selected-experiment-card {
+  border-left-color: var(--color-accent-primary);
+  background: var(--color-surface);
+}
+
+.experiment-card-main {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.experiment-card .link-button {
+  font-size: 1.02rem;
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.experiment-subtitle {
+  margin-bottom: 0;
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
+}
+
+.result-story {
+  margin-bottom: 0;
+  color: var(--color-text-primary);
+}
+
+.experiment-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: end;
+}
+
+.experiment-card-actions button {
+  white-space: nowrap;
+}
+
+.technical-details {
+  grid-column: 1 / -1;
+}
+
+.technical-details summary {
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-weight: 800;
 }
 
 .table-panel {
@@ -675,6 +725,24 @@ td small {
   display: grid;
   gap: 1rem;
   padding: 1rem;
+}
+
+.notebook-card > .result-story {
+  border-left: 3px solid rgba(47, 116, 168, 0.42);
+  padding-left: 0.75rem;
+}
+
+.secondary-result-note {
+  margin-bottom: 0;
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
+}
+
+.key-result-values {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.8rem;
+  background: var(--color-subtle-background);
 }
 
 .saved-badge,
@@ -1468,8 +1536,20 @@ details[open] > summary {
     grid-template-columns: 1fr;
   }
 
-  .featured-result,
-  .summary-strip {
+  .summary-strip,
+  .experiment-card {
     grid-template-columns: 1fr;
+  }
+
+  .experiment-card-actions {
+    justify-content: start;
+  }
+
+  .notebook-list-panel {
+    order: 1;
+  }
+
+  .notebook-card {
+    order: 2;
   }
 }

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1244,7 +1244,7 @@ describe("App", () => {
     expect(screen.getByTestId("launch-cm1-btn")).toBeEnabled();
   });
 
-  it("lists result cards in a table and shows notebook diagnostics", async () => {
+  it("lists result cards as notebook entries and shows diagnostics", async () => {
     render(<App />);
 
     expect(await screen.findByRole("button", { name: "Results" })).toHaveClass("active-control");
@@ -1260,31 +1260,34 @@ describe("App", () => {
     expect(screen.getByRole("tab", { name: "Compare" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Storage" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Experiment Notebook" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Selected result")).toHaveTextContent(
-      "Quick-look shallow cumulus",
-    );
-    expect(screen.getAllByText("Validated quick-look baseline").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Minor caveat").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("Review saved cloud experiments, compare variants, and open results for explanation."),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Results list")).toBeInTheDocument();
+    const resultDetail = screen.getByLabelText("Result detail");
+    expect(resultDetail).toHaveTextContent("Quick-look shallow cumulus");
+    expect(screen.getAllByText(/Validated quick-look baseline/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Minor caveat/).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: "Open 3-D" }).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Quick-look shallow cumulus" })).toBeInTheDocument();
-    expect(screen.getAllByText("Baseline Shallow Cumulus").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("quick look").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Baseline Shallow Cumulus/).length).toBeGreaterThan(0);
+    expect(resultDetail).toHaveTextContent("quick look");
     expect(screen.getAllByText("cloud formed; rain detected").length).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText("13 model files, 13 time steps, 1 stats files").length,
-    ).toBeGreaterThan(0);
     expect(screen.getAllByText("Cloud formed").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Rain detected").length).toBeGreaterThan(0);
     expect(screen.getByText("1,800 s")).toBeInTheDocument();
     expect(screen.getByText("2.193e-3 kg/kg")).toBeInTheDocument();
     expect(screen.getByText("6.867 m/s")).toBeInTheDocument();
     expect(screen.getByText("-4.215 m/s")).toBeInTheDocument();
+    fireEvent.click(within(resultDetail).getByText("Technical details"));
+    expect(
+      screen.getAllByText("13 model files, 13 time steps, 1 stats files").length,
+    ).toBeGreaterThan(0);
     expect(
       screen.getByText("CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Technical details")).toBeInTheDocument();
     expect(screen.getAllByText("Completed CM1 result").length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "Inspect fields" })).toBeEnabled();
+    expect(within(resultDetail).getByRole("button", { name: "Open in Explore" })).toBeEnabled();
   });
 
   it("accepts legacy array results responses without crashing", async () => {
@@ -1648,7 +1651,8 @@ describe("App", () => {
   it("opens the 2-D field inspector from a result and shows qc slices", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
     expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
     await screen.findByText("Slices loaded");
@@ -1678,7 +1682,8 @@ describe("App", () => {
   it("selects a slice region and renders backend Thermal Fate Inspector diagnostics", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
     await screen.findByText("Slices loaded");
 
     const heatmap = screen.getByLabelText("Vertical X slice heatmap");
@@ -1744,7 +1749,8 @@ describe("App", () => {
 
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
     await screen.findByText("Slices loaded");
     fireEvent.click(
       within(screen.getByLabelText("Vertical X slice heatmap")).getByRole("button", {
@@ -1759,7 +1765,8 @@ describe("App", () => {
   it("supports field and time selection through visualization-ready APIs", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
     fireEvent.change(await screen.findByLabelText("Field"), { target: { value: "w" } });
     fireEvent.change(screen.getByLabelText("Time"), { target: { value: "1" } });
 
@@ -1777,7 +1784,8 @@ describe("App", () => {
   it("shows process-aware 2-D overlays with unavailable diagnostic groups caveated", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
     expect(await screen.findByText("Thermal Fate overlay")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Thermal Fate summary" })).toBeInTheDocument();
@@ -1798,7 +1806,8 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "No diagnostics yet" }));
-    fireEvent.click(screen.getByRole("button", { name: "Inspect fields" }));
+    const resultDetail = screen.getByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
     expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
     await screen.findByText("Slices loaded");
@@ -1815,7 +1824,8 @@ describe("App", () => {
   it("opens a cloud-forming result in Explore with qc and w available in both views", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
     expect(
       await screen.findByRole("heading", { name: "Inspect and visualize fields" }),
@@ -1912,7 +1922,8 @@ describe("App", () => {
 
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Inspect fields" }));
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Visualization fields temporarily failed.",
@@ -2192,7 +2203,8 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "No diagnostics yet" }));
-    fireEvent.click(screen.getAllByRole("button", { name: "Open 3-D" })[0]);
+    const resultDetail = screen.getByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open 3-D" }));
 
     expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
     await screen.findAllByText("Scene shell ready");
@@ -2207,7 +2219,8 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "No visual fields" }));
-    fireEvent.click(screen.getAllByRole("button", { name: "Open 3-D" })[0]);
+    const resultDetail = screen.getByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open 3-D" }));
 
     expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
     await screen.findAllByText("No fields available");

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1478,8 +1478,8 @@ function ResultsWorkspace({
     <section className="results-library" aria-labelledby="results-title">
       <div className="section-heading">
         <div>
-          <p className="eyebrow">Results</p>
-          <h2 id="results-title">Review, compare, and manage experiments</h2>
+          <h2 id="results-title">Experiment Notebook</h2>
+          <p>Review saved cloud experiments, compare variants, and open results for explanation.</p>
         </div>
       </div>
       {resultsStatus !== "Results loaded" && resultsStatus !== "Loading results..." && (
@@ -1505,39 +1505,6 @@ function ResultsWorkspace({
         ))}
       </nav>
 
-      {selectedResult && (
-        <section className="featured-result" aria-label="Selected result">
-          <div>
-            <p className="eyebrow">Selected experiment</p>
-            <h3>{selectedResult.name}</h3>
-            <p>
-              {selectedResult.scenario_name ?? selectedResult.scenario_id} ·{" "}
-              {humanize(selectedResult.run_size_preset)}
-            </p>
-          </div>
-          <div className="badge-row">
-            {isValidatedQuickLookBaseline(selectedResult) && (
-              <StatusBadge label="Validated quick-look baseline" tone="neutral" />
-            )}
-            <OutcomeBadge result={selectedResult} />
-            <StatusBadge label={rainOutcome(selectedResult.rain_present)} tone="neutral" />
-            {selectedResult.saved || selectedResult.protected ? (
-              <StatusBadge label="Saved" tone="good" />
-            ) : (
-              <StatusBadge label="Unsaved" tone="neutral" />
-            )}
-          </div>
-          <div className="button-row">
-            <button type="button" onClick={onInspect}>
-              Open in Explore
-            </button>
-            <button type="button" className="secondary-button" onClick={onOpenVisualizer}>
-              Open 3-D
-            </button>
-          </div>
-        </section>
-      )}
-
       {resultsError && <p role="alert">{resultsError}</p>}
 
       {activeTab === "notebook" && (
@@ -1553,6 +1520,9 @@ function ResultsWorkspace({
           onRefreshResults={onRefreshResults}
           onInspect={onInspect}
           onOpenVisualizer={onOpenVisualizer}
+          onCompare={() => onTabChange("compare")}
+          onOpenResultInExplore={onCompareInspect}
+          onOpenResultVisualizer={onCompareVisualize}
         />
       )}
 
@@ -1599,6 +1569,9 @@ function NotebookWorkspace({
   onRefreshResults,
   onInspect,
   onOpenVisualizer,
+  onCompare,
+  onOpenResultInExplore,
+  onOpenResultVisualizer,
 }: {
   results: ResultCard[];
   selectedResult: ResultCard | undefined;
@@ -1611,6 +1584,9 @@ function NotebookWorkspace({
   onRefreshResults: () => void;
   onInspect: () => void;
   onOpenVisualizer: () => void;
+  onCompare: () => void;
+  onOpenResultInExplore: (resultId: string) => void;
+  onOpenResultVisualizer: (resultId: string) => void;
 }) {
   return (
     <section
@@ -1621,18 +1597,20 @@ function NotebookWorkspace({
     >
       <div className="section-heading">
         <div>
-          <p className="eyebrow">Notebook</p>
-          <h3 id="notebook-title">Experiment Notebook</h3>
+              <p className="eyebrow">Notebook</p>
+              <h3 id="notebook-title">Notebook entries</h3>
         </div>
         <button type="button" onClick={onRefreshResults}>
           Refresh results
         </button>
       </div>
       <div className="results-layout">
-        <ResultsTable
+        <ExperimentNotebookList
           results={results}
           selectedResultId={selectedResultId}
           onSelect={onSelectResult}
+          onOpenExplore={onOpenResultInExplore}
+          onOpenVisualizer={onOpenResultVisualizer}
         />
         <ResultNotebookCard
           result={selectedResult}
@@ -1642,6 +1620,7 @@ function NotebookWorkspace({
           onSave={onSave}
           onInspect={onInspect}
           onOpenVisualizer={onOpenVisualizer}
+          onCompare={onCompare}
         />
       </div>
     </section>
@@ -2672,82 +2651,90 @@ function GuidedRunWorkflow({
   );
 }
 
-function ResultsTable({
+function ExperimentNotebookList({
   results,
   selectedResultId,
   onSelect,
+  onOpenExplore,
+  onOpenVisualizer,
 }: {
   results: ResultCard[];
   selectedResultId: string | null;
   onSelect: (resultId: string) => void;
+  onOpenExplore: (resultId: string) => void;
+  onOpenVisualizer: (resultId: string) => void;
 }) {
   if (results.length === 0) {
     return (
-      <section className="status-panel" aria-label="Results list">
-        <p>No ingested CM1 results yet.</p>
+      <section className="notebook-list-panel empty-results" aria-label="Results list">
+        <p className="eyebrow">Notebook empty</p>
+        <h3>No ingested CM1 results yet.</h3>
+        <p>
+          Completed and ingested CM1 runs will appear here as experiment notebook entries.
+        </p>
       </section>
     );
   }
 
   return (
-    <section className="table-panel" aria-label="Results list">
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">Name</th>
-            <th scope="col">Scenario</th>
-            <th scope="col">Status</th>
-            <th scope="col">Run size</th>
-            <th scope="col">Outcome</th>
-            <th scope="col">Output</th>
-            <th scope="col">Saved</th>
-          </tr>
-        </thead>
-        <tbody>
-          {results.map((result) => (
-            <tr
+    <section className="notebook-list-panel" aria-label="Results list">
+      <p className="eyebrow">Experiment list</p>
+      <div className="experiment-card-list">
+        {results.map((result) => {
+          const selected = result.result_id === selectedResultId;
+          return (
+            <article
               key={result.result_id}
-              className={result.result_id === selectedResultId ? "selected-row" : ""}
+              className={`experiment-card${selected ? " selected-experiment-card" : ""}`}
+              aria-label={`${result.name} experiment`}
             >
-              <td>
+              <div className="experiment-card-main">
                 <button
                   type="button"
                   className="link-button"
                   onClick={() => onSelect(result.result_id)}
+                  aria-pressed={selected}
                 >
-                  {compactResultName(result.name)}
+                  {result.name}
                 </button>
-                <small>{formatDate(result.completed_at ?? result.created_at)}</small>
-              </td>
-              <td>{result.scenario_name ?? result.scenario_id}</td>
-              <td>
-                <StatusBadge label={userFacingStatus(result)} tone={statusTone(result)} />
-              </td>
-              <td>{humanize(result.run_size_preset)}</td>
-              <td>
+                <p className="experiment-subtitle">
+                  {result.scenario_name ?? humanize(result.scenario_id)} ·{" "}
+                  {humanize(result.run_size_preset)} · {formatDate(result.completed_at ?? result.created_at)}
+                </p>
                 <div className="badge-row">
                   <OutcomeBadge result={result} />
-                  {isValidatedQuickLookBaseline(result) && (
-                    <StatusBadge label="Validated quick-look baseline" tone="neutral" />
-                  )}
-                  <StatusBadge label={rainOutcome(result.rain_present)} tone="neutral" />
-                  {result.caveats.length > 0 && (
-                    <StatusBadge label={caveatLabel(result)} tone={caveatTone(result)} />
-                  )}
+                  <StatusBadge
+                    label={result.saved || result.protected ? "Saved" : "Unsaved"}
+                    tone={result.saved || result.protected ? "good" : "neutral"}
+                  />
                 </div>
-                <small>{result.diagnostics_summary ?? "Diagnostics unavailable"}</small>
-              </td>
-              <td>{outputSummary(result.output_file_summary)}</td>
-              <td>
-                <StatusBadge
-                  label={result.saved || result.protected ? "Saved" : "Unsaved"}
-                  tone={result.saved || result.protected ? "good" : "neutral"}
-                />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+                <p className="result-story">{resultStory(result)}</p>
+              </div>
+              <div className="experiment-card-actions">
+                <button type="button" onClick={() => onOpenExplore(result.result_id)}>
+                  Open in Explore
+                </button>
+                <button
+                  type="button"
+                  className="secondary-button"
+                  onClick={() => onOpenVisualizer(result.result_id)}
+                >
+                  Open 3-D
+                </button>
+              </div>
+              <details className="technical-details">
+                <summary>Technical details</summary>
+                <dl className="metric-grid">
+                  <Metric label="Run ID" value={result.run_id} />
+                  <Metric label="Scenario ID" value={result.scenario_id} />
+                  <Metric label="State" value={userFacingStatus(result)} />
+                  <Metric label="Output" value={outputSummary(result.output_file_summary)} />
+                </dl>
+              </details>
+            </article>
+          );
+        })}
+      </div>
     </section>
   );
 }
@@ -2760,6 +2747,7 @@ function ResultNotebookCard({
   onSave,
   onInspect,
   onOpenVisualizer,
+  onCompare,
 }: {
   result: ResultCard | undefined;
   draft: { name: string; tags: string; notes: string };
@@ -2768,6 +2756,7 @@ function ResultNotebookCard({
   onSave: () => void;
   onInspect: () => void;
   onOpenVisualizer: () => void;
+  onCompare: () => void;
 }) {
   if (!result) {
     return (
@@ -2781,8 +2770,12 @@ function ResultNotebookCard({
     <section className="notebook-card" aria-label="Result detail">
       <div className="notebook-title">
         <div>
-          <p className="eyebrow">Result detail / notebook card</p>
+          <p className="eyebrow">Notebook entry</p>
           <h3>{result.name}</h3>
+          <p>
+            {result.scenario_name ?? humanize(result.scenario_id)} ·{" "}
+            {humanize(result.run_size_preset)}
+          </p>
         </div>
         <StatusBadge
           label={result.saved || result.protected ? "Saved" : "Unsaved"}
@@ -2793,44 +2786,46 @@ function ResultNotebookCard({
       <div className="badge-row">
         <OutcomeBadge result={result} />
         <StatusBadge label={rainOutcome(result.rain_present)} tone="neutral" />
-        {result.caveats.length > 0 && (
-          <StatusBadge label={caveatLabel(result)} tone={caveatTone(result)} />
-        )}
-        <StatusBadge label={userFacingStatus(result)} tone={statusTone(result)} />
       </div>
 
-      <dl className="metric-grid">
-        <Metric label="Run ID" value={result.run_id} />
-        <Metric label="Scenario" value={result.scenario_name ?? result.scenario_id} />
-        <Metric label="Run-size preset" value={humanize(result.run_size_preset)} />
-        <Metric
-          label="Diagnostics"
-          value={result.diagnostics_summary ?? "Diagnostics unavailable"}
-        />
+      <p className="result-story">{resultStory(result)}</p>
+
+      {(isValidatedQuickLookBaseline(result) || result.caveats.length > 0) && (
+        <p className="secondary-result-note">
+          {[
+            isValidatedQuickLookBaseline(result) ? "Validated quick-look baseline" : null,
+            result.caveats.length > 0 ? caveatLabel(result) : null,
+          ]
+            .filter(Boolean)
+            .join(" · ")}
+        </p>
+      )}
+
+      <dl className="metric-grid key-result-values">
         <Metric label="Cloud" value={cloudOutcome(result)} />
         <Metric label="Rain" value={rainOutcome(result.rain_present)} />
         <Metric label="First cloud time" value={formatSeconds(result.first_cloud_time_seconds)} />
         <Metric label="Max qc" value={formatScientific(result.max_qc_kg_kg, "kg/kg")} />
         <Metric label="Max w" value={formatNumber(result.max_w_m_s, "m/s")} />
         <Metric label="Min w" value={formatNumber(result.min_w_m_s, "m/s")} />
-        <Metric label="Output" value={outputSummary(result.output_file_summary)} />
       </dl>
 
-      <section aria-labelledby="caveats-title">
-        <h4 id="caveats-title">Caveats / warnings</h4>
-        {result.caveats.length > 0 ? (
-          <ul className="compact-list">
-            {result.caveats.map((caveat) => (
-              <li key={caveat}>{caveat}</li>
-            ))}
-          </ul>
-        ) : (
-          <p>No caveats recorded.</p>
-        )}
-      </section>
-
-      <details>
+      <details className="technical-details">
         <summary>Technical details</summary>
+        <dl className="metric-grid">
+          <Metric label="Run ID" value={result.run_id} />
+          <Metric label="Scenario ID" value={result.scenario_id} />
+          <Metric label="Lifecycle" value={result.source_lifecycle_state} />
+          <Metric label="Product state" value={result.source_product_state} />
+          <Metric label="Result state" value={result.status} />
+          <Metric label="Source model" value={result.source_model} />
+          <Metric label="Output" value={outputSummary(result.output_file_summary)} />
+          <Metric
+            label="Raw diagnostics"
+            value={result.diagnostics_summary ?? "Diagnostics unavailable"}
+          />
+        </dl>
+
         <section aria-labelledby="result-question-title">
           <h4 id="result-question-title">Physical question</h4>
           <p>{result.physical_question}</p>
@@ -2858,12 +2853,19 @@ function ResultNotebookCard({
               <li key={label}>{label}</li>
             ))}
           </ul>
-          <dl className="metric-grid">
-            <Metric label="Lifecycle" value={result.source_lifecycle_state} />
-            <Metric label="Product state" value={result.source_product_state} />
-            <Metric label="Result state" value={result.status} />
-            <Metric label="Source model" value={result.source_model} />
-          </dl>
+        </section>
+
+        <section aria-labelledby="caveats-title">
+          <h4 id="caveats-title">Caveats / warnings</h4>
+          {result.caveats.length > 0 ? (
+            <ul className="compact-list">
+              {result.caveats.map((caveat) => (
+                <li key={caveat}>{caveat}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>No caveats recorded.</p>
+          )}
         </section>
       </details>
 
@@ -2891,15 +2893,20 @@ function ResultNotebookCard({
         />
 
         <div className="button-row">
-          <button type="submit">Update notebook</button>
-          <button type="button" onClick={onSave}>
-            Save result
-          </button>
           <button type="button" onClick={onInspect}>
-            Inspect fields
+            Open in Explore
           </button>
-          <button type="button" onClick={onOpenVisualizer}>
+          <button type="button" className="secondary-button" onClick={onOpenVisualizer}>
             Open 3-D
+          </button>
+          <button type="button" className="secondary-button" onClick={onCompare}>
+            Compare
+          </button>
+          <button type="submit" className="secondary-button">
+            Update notebook
+          </button>
+          <button type="button" className="secondary-button" onClick={onSave}>
+            Save result
           </button>
         </div>
       </form>
@@ -5424,10 +5431,6 @@ function exploreTabLabel(tab: ExploreTab): string {
   return labels[tab];
 }
 
-function compactResultName(value: string): string {
-  return value.length > 34 ? `${value.slice(0, 31)}...` : value;
-}
-
 function prioritizeResults(results: ResultCard[]): ResultCard[] {
   return [...results].sort((left, right) => resultPriority(right) - resultPriority(left));
 }
@@ -5506,6 +5509,22 @@ function comparisonMeaning(result: ResultCard | undefined): string {
   return result.diagnostics_summary ?? "Diagnostics unavailable";
 }
 
+function resultStory(result: ResultCard): string {
+  if (isDryFailedContrast(result)) {
+    return "Thermals rose, but low-level moisture stayed too dry for meaningful cloud water or rain.";
+  }
+  if (isValidatedQuickLookBaseline(result)) {
+    return "Cloud water formed in the validated quick-look baseline; vertical motion and rain were both detected.";
+  }
+  if (cloudOutcome(result) === "Cloud formed") {
+    return "Cloud water formed during this run. Open it in Explore to inspect the cloud and updraft structure.";
+  }
+  if (cloudOutcome(result) === "No cloud formed") {
+    return "No cloud formed by the current diagnostic threshold. The vertical velocity field may still explain the thermal behavior.";
+  }
+  return result.diagnostics_summary ?? "Diagnostics are not available yet.";
+}
+
 function userFacingStatus(result: ResultCard): string {
   if (result.saved || result.protected) return "Saved";
   if (result.source_lifecycle_state === "completed" && result.status.includes("ingested")) {
@@ -5526,18 +5545,6 @@ function caveatTone(result: ResultCard): "good" | "warning" | "neutral" {
   return cloudOutcome(result) === "Cloud formed" || isDryFailedContrast(result)
     ? "neutral"
     : "warning";
-}
-
-function statusTone(result: ResultCard): "good" | "warning" | "neutral" {
-  if (
-    result.caveats.length > 0 &&
-    cloudOutcome(result) !== "Cloud formed" &&
-    !isDryFailedContrast(result)
-  ) {
-    return "warning";
-  }
-  if (result.source_lifecycle_state === "completed") return "good";
-  return "neutral";
 }
 
 function cloudOutcome(result: ResultCard): string {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -630,6 +630,14 @@ obvious before field inspection or 3-D visualization. It contains `Notebook`,
 result display name first and raw run IDs/paths second. Saved/protected result
 cards disable normal cleanup because they are keeper notebook entries.
 
+`Notebook` renders result-card metadata as mobile-first experiment notebook
+entries rather than an admin table. The primary view should surface the result
+story, cloud/rain outcomes, first cloud time, `qc` and `w` summaries,
+caveats/warnings, saved/protected state, and open/compare actions. Technical
+metadata such as raw run IDs, lifecycle/product states, controls used,
+provenance labels, and detailed caveats remains in disclosure so it is available
+without overwhelming the first read.
+
 `Explore` contains `2-D Slices` and `3-D View` sub-tabs for one selected result.
 The selected result ID flows from Results / Notebook, Results / Compare, and
 Results / Storage into Explore; those consumers request backend-prepared

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -905,12 +905,16 @@ Editable notebook state lives beside the local run as `result_card.json`; it
 stores `name`, `tags`, `notes`, `saved`, and `protected` without modifying or
 copying CM1 output. Saving a card marks it as a saved/protected notebook entry.
 
-The first Results Library UI is intentionally table-first. It lists result
-cards from the backend, lets the user select one result, and shows a
-detail/notebook card with scenario, run-size preset, status, diagnostics
-summary, cloud/rain outcome, first cloud time, max `qc`, max/min `w`, caveats,
-output summary, provenance labels, saved/protected state, and editable
+The Results Library UI is an experiment notebook, not an admin table. It lists
+result cards from the backend as scan-friendly experiment entries, lets the user
+select one result, and shows a detail/notebook card with scenario, run-size
+preset, cloud/rain outcome, diagnostics summary, first cloud time, max `qc`,
+max/min `w`, caveats, output summary, saved/protected state, and editable
 name/tags/notes. It can save/protect a result through the backend API.
+Technical metadata such as raw lifecycle/product states, run IDs, provenance
+labels, controls, and detailed caveats remain available under disclosure rather
+than dominating the first read. The layout should be mobile-first: cards stack
+naturally on narrow screens, and desktop can use a list/detail notebook split.
 
 The library opens a 2-D field inspector from a result detail/notebook entry.
 The inspector is a CM1-output inspection surface, not a visualizer or replay
@@ -960,10 +964,11 @@ like an accepted moisture-limited outcome: `No cloud formed`, `No rain
 detected`, and `Moisture-limited`, with caveats secondary.
 
 `Results` contains `Notebook`, `Compare`, and `Storage` sub-tabs. Notebook is
-the table-first Result Card / Experiment Notebook. Compare is result-pair
-oriented and belongs with Results because it compares experiment outcomes.
-Storage is also part of Results because it manages local run directories and
-their relationship to named result cards.
+the Result Card / Experiment Notebook: a scan-friendly list of experiment cards
+plus a selected notebook detail, with technical run metadata kept secondary.
+Compare is result-pair oriented and belongs with Results because it compares
+experiment outcomes. Storage is also part of Results because it manages local
+run directories and their relationship to named result cards.
 
 `Explore` contains `2-D Slices` and `3-D View` sub-tabs. The selected result is
 shared by Results and Explore. Selecting a result in Notebook or opening a

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -95,6 +95,13 @@ surfaces are limited to visualization plotting areas when they improve CM1
 field readability. Later Results and Explore redesign issues should build on
 these tokens and should not reintroduce black/green terminal chrome.
 
+#171 redesigns Results as a mobile-first experiment notebook rather than a
+dense admin table. Notebook should use scan-friendly experiment cards and a
+selected result detail card; cloud/rain outcomes, key diagnostics, caveats,
+saved/protected state, and open/compare actions belong in the first read, while
+raw run IDs, lifecycle/product states, controls, provenance, and detailed
+warnings belong under technical details.
+
 ## Thermal Fate Roadmap
 
 Thermal Fate is the internal organizing scientific model: Cloud Chamber should
@@ -465,7 +472,7 @@ Implementation anchor:
 - #68 establishes the backend NetCDF ingest bridge: read completed-run NetCDF output with xarray, write `result_metadata.json`, preserve raw `.dat/.ctl` artifact cataloging without parsing it, and leave diagnostics/result-card UI/visualization-ready data to follow-up issues.
 - #69 adds first Baseline Shallow Cumulus diagnostics to ingested NetCDF result metadata: cloud formed yes/no with `qc >= 1e-6 kg/kg` and at least 10 cloudy grid cells, first cloud time, cloud base/top when vertical coordinates are available, `qc` summaries/time series/cloud fraction, `w` max/min summaries/time series, optional `qr` rain detection with `qr >= 1e-7 kg/kg`, and caveats for missing, inferred, or non-finite fields.
 - #70 adds the backend Result Card / Experiment Notebook API over ingested metadata: list/get cards, update name/tags/notes, save/protect results, and summarize run ID, scenario, run-size preset, physical question, diagnostics, caveats, and output files without rerunning CM1.
-- #71 adds the first frontend Results Library shell over the #70 API: a scan-friendly results table, selected result detail/notebook card, diagnostics/caveats/output summaries, saved/protected state, and editable name/tags/notes. It must not implement replay or 3-D visualization.
+- #71 adds the first frontend Results Library shell over the #70 API: result cards, selected result detail/notebook card, diagnostics/caveats/output summaries, saved/protected state, and editable name/tags/notes. It must not implement replay or 3-D visualization.
 - #98 refactors the frontend into a guided MVP workspace and #131 consolidates it into the task-based `Build`, `Results`, and `Explore` model. The default landing path should be `Results -> validated quick-look baseline -> Open in Explore/Open 3-D`, with user-facing result labels in the primary UI and raw lifecycle/provenance labels under technical details.
 - #108 makes the Build workspace a guided local run loop: create package, launch local CM1, refresh status/log tails, review output-artifact counts, ingest completed NetCDF output, and open the resulting card in Results or Explore. Automated tests must mock these API responses and never run real CM1.
 - #109 adds runtime storage management under Results / Storage over the runtime storage backend: total runtime-home usage, 50 GB warning-threshold state, largest run directories, result-card names when associated, saved/protected state, output summaries, dry-run delete preview, explicit confirmed deletion, and disabled cleanup for running or saved/protected runs.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -253,6 +253,16 @@ provenance available without dominating the main view. They should distinguish
 successful cloud-forming results with minor caveats from results that truly need
 review.
 
+Results notebook redesign tests should cover the mobile-first experiment-card
+contract rather than table mechanics. Component and Playwright tests should
+verify that Results / Notebook presents scan-friendly experiment entries,
+selected result details, cloud/rain outcomes, first cloud time, max `qc`,
+max/min `w`, caveats, saved/protected state, editable name/tags/notes, and
+actions into Explore or 3-D. They should also verify that raw run IDs,
+lifecycle/product states, controls, provenance labels, and detailed warnings
+remain available under technical-details disclosure instead of dominating the
+primary notebook view.
+
 Guided local run workflow tests should mock the backend API sequence rather
 than launching CM1: package generation, launch request, running status, completed
 status with output-artifact counts, ingest request, and post-ingest actions into


### PR DESCRIPTION
Closes #171

## Summary
- Replaced the table-first Results notebook with mobile-first experiment cards plus a focused notebook detail panel.
- Removed the redundant top selected-experiment banner; selected context now lives in the selected card and Result detail panel only.
- Reduced badge repetition: experiment cards show primary cloud outcome plus saved state; detail shows cloud/rain once, with validated baseline and caveat notes quieted below the story.
- Simplified action hierarchy around the detail panel and cards: Open in Explore stays primary, Open 3-D stays secondary, and Compare remains available from the selected notebook entry.
- Kept technical run IDs, lifecycle/product states, controls, provenance, output details, and caveats behind technical-details disclosure.
- Updated product, architecture, roadmap, and testing docs to describe the experiment-notebook contract.

## Tests added/updated
- Updated component tests for Results notebook cards, detail actions, and technical disclosure.
- Updated Playwright mocked smoke coverage for card-first Results, mobile Results layout, and scoped top-nav assertions.

## Commands run
- scripts/check.sh
- scripts/check-e2e.sh

## Manual QA needed
Yes, qualitative only:
- Can I understand the experiment notebook without decoding technical metadata?
- Can I scan the results quickly on desktop and mobile?
- Does Results make me want to open or compare a result?
- Does it feel like a notebook rather than an admin table?

## Caveats / follow-up issues
- No Explore, Build, CM1 science, renderer, or scenario behavior changed.
- No generated CM1 output, screenshots, videos, traces, logs, or reports were committed.

Note: leaving this PR unmerged for manual inspection as requested.