### PR TITLE
Redesign Explore around What happened here

### DIFF
--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -78,14 +78,31 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
-    await expect(page.getByRole("heading", { name: "Inspect and visualize fields" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "2-D Slices" })).toBeVisible();
 
     await openExploreTab(page, /^2-D Slices$/);
-    await expect(page.getByText(/inspect cm1 fields/i).first()).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText(/2-d field inspection/i).first()).toBeVisible();
-    await expect(page.getByText(/thermal fate overlay/i).first()).toBeVisible();
-    await expect(page.getByText(/growing cumulus/i).first()).toBeVisible();
+    await expect(page.getByText(/what happened in this result/i).first()).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByText(/vertical x slice at y = .*horizontal axis: x\. vertical axis: height/i),
+    ).toBeVisible();
+    await expect(page.getByLabel("Slice position")).toBeVisible();
+    await expect(page.getByRole("button", { name: /move back/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /move forward/i })).toBeVisible();
     await expect(page.getByText(/what happened here/i).first()).toBeVisible();
+    await expect(page.getByText(/select a spot or region/i).first()).toBeVisible();
+    const verticalHeatmap = page.getByLabel("Vertical X slice heatmap");
+    await expect(verticalHeatmap).toBeVisible();
+    const fieldControlsPrecedeHeatmap = await verticalHeatmap.evaluate((element) => {
+      const fieldControl = document.querySelector("#inspect-field");
+      return Boolean(
+        fieldControl &&
+          (fieldControl.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING),
+      );
+    });
+    expect(fieldControlsPrecedeHeatmap).toBe(true);
+    await page.getByText("Technical details").first().click();
+    await expect(page.getByText(/evidence/i).first()).toBeVisible();
+    await expect(page.getByText(/growing cumulus/i).first()).toBeVisible();
     await page
       .getByRole("button", { name: /inspect vertical x slice row 2, column 2/i })
       .first()
@@ -94,14 +111,20 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/cloud water appeared locally/i)).toBeVisible();
     await expect(page.getByText(/local max w/i)).toBeVisible();
     await page.getByRole("button", { name: /clear selection/i }).click();
-    await expect(page.getByText(/no region is selected/i)).toBeVisible();
+    await expect(page.getByText(/select a spot or region/i).first()).toBeVisible();
     await expect(page.getByText(/\[\[[\d.,\s]+\]\]/)).not.toBeVisible();
 
     await openExploreTab(page, /^3-D View$/);
-    await expect(page.getByText(/scene shell/i).first()).toBeVisible({ timeout: 12_000 });
-    await expect(page.getByText(/oblique overview/i).first()).toBeVisible();
-    await expect(page.getByText(/thermal fate overlay/i).first()).toBeVisible();
+    await expect(page.getByText(/what happened in this result/i).first()).toBeVisible({ timeout: 12_000 });
+    await expect(page.getByText(/what happened here/i).first()).toBeVisible();
+    await expect(page.getByText("Cloud formed in this result")).toBeVisible();
+    await expect(page.getByText("Cloud formed here")).toHaveCount(0);
     await expect(page.getByRole("button", { name: /reset view/i })).toBeVisible();
+    const visualizerControls = page.getByLabel("Primary visualizer controls");
+    await visualizerControls.getByText("Projection and rendering details").click();
+    await expect(visualizerControls.getByRole("button", { name: /oblique overview/i })).toBeVisible();
+    await page.getByText("Evidence details").click();
+    await expect(page.getByRole("heading", { name: /thermal fate summary/i })).toBeVisible();
   });
 
   test("Results to Explore loads cloud-forming qc and w fields", async ({ page }) => {
@@ -134,16 +157,18 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await openResultsTab(page, /^Compare$/);
     await page.getByRole("button", { name: "Open Dry Failed 3-D" }).click();
 
-    await expect(page.getByRole("heading", { name: "Inspect and visualize fields" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "2-D Slices" })).toBeVisible();
     await expect(page.getByText("Dry Failed Cumulus — Quick Look").first()).toBeVisible();
-    await expect(page.getByText(/scene shell ready/i).first()).toBeVisible({ timeout: 12_000 });
+    await expect(page.getByText(/cloud view ready/i).first()).toBeVisible({ timeout: 12_000 });
     await expect(page.locator("#scene-field")).toHaveValue("w");
     await expect(
-      page.getByText(/No cloud water formed here; vertical velocity is available/i),
+      page.getByText(/No cloud water formed in this result; vertical velocity is available/i),
     ).toBeVisible();
     await expect(
       page.getByText(/Use the vertical velocity field \(w\) to inspect the thermals/i),
     ).toBeVisible();
+    await expect(page.getByText("No cloud formed in this result")).toBeVisible();
+    await expect(page.getByText("No cloud formed here")).toHaveCount(0);
 
     await openExploreTab(page, /^2-D Slices$/);
     await expect(page.getByText(/slices loaded/i).first()).toBeVisible({ timeout: 10_000 });
@@ -173,5 +198,47 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     );
     await expect(page.getByRole("button", { name: "Retry loading fields" })).toBeVisible();
     await expect(page.getByText("Loading fields...", { exact: true })).not.toBeVisible();
+  });
+
+  test("Explore mobile puts visualization and explanation before technical controls", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+
+    await openExploreTab(page, /^2-D Slices$/);
+    await expect(
+      page.getByText(/vertical x slice at y = .*horizontal axis: x\. vertical axis: height/i),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel("Slice position")).toBeVisible();
+    const heatmap = page.getByLabel("Vertical X slice heatmap");
+    await expect(heatmap).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel("Selected-region controls")).toBeVisible();
+    await expect(page.getByLabel("Selected-region controls")).toContainText(/what happened here/i);
+
+    const heatmapPrecedesTechnicalDetails = await heatmap.evaluate((element) => {
+      const technicalSummary = Array.from(document.querySelectorAll("summary")).find((summary) =>
+        summary.textContent?.includes("Technical details"),
+      );
+      return Boolean(
+        technicalSummary &&
+          (element.compareDocumentPosition(technicalSummary) & Node.DOCUMENT_POSITION_FOLLOWING),
+      );
+    });
+    expect(heatmapPrecedesTechnicalDetails).toBe(true);
+
+    await openExploreTab(page, /^3-D View$/);
+    const scene = page.getByLabel("3-D scene container");
+    const explanation = page.getByLabel("Visualization details");
+    await expect(scene).toBeVisible({ timeout: 12_000 });
+    await expect(explanation).toBeVisible();
+    const scenePrecedesExplanation = await scene.evaluate((element) => {
+      const details = document.querySelector('[aria-label="Visualization details"]');
+      return Boolean(
+        details && element.compareDocumentPosition(details) & Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+    });
+    expect(scenePrecedesExplanation).toBe(true);
   });
 });

--- a/app/frontend/e2e/mocked-smoke/navigation.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/navigation.spec.ts
@@ -118,7 +118,7 @@ test.describe("mocked smoke: app shell", () => {
       await gotoResults(page);
       await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
       await gotoExplore(page);
-      await expect(page.getByRole("heading", { name: "Inspect and visualize fields" }))
+      await expect(page.getByRole("tab", { name: "2-D Slices" }))
         .toBeVisible();
     });
   }

--- a/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
@@ -60,9 +60,12 @@ test.describe("mocked smoke: visualizer occlusion regression", () => {
   });
 
   test("3-D scene does not cover its primary controls", async ({ page }) => {
-    await expect(page.getByText(/scene shell/i).first()).toBeVisible({ timeout: 12_000 });
-    await expect(page.getByText(/oblique overview/i).first()).toBeVisible();
-    await expect(page.getByText(/side x-?z/i).first()).toBeVisible();
+    await expect(page.getByText(/what happened in this result/i).first()).toBeVisible({ timeout: 12_000 });
+    await expect(page.getByText(/what happened here/i).first()).toBeVisible();
+    const visualizerControls = page.getByLabel("Primary visualizer controls");
+    await visualizerControls.getByText("Projection and rendering details").click();
+    await expect(visualizerControls.getByRole("button", { name: /oblique overview/i })).toBeVisible();
+    await expect(visualizerControls.getByRole("button", { name: /side x-?z/i })).toBeVisible();
 
     await expectClickableCenter(
       page,

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -53,6 +53,7 @@ textarea {
 
 .app-shell {
   display: grid;
+  align-content: start;
   gap: 0.9rem;
   min-height: 100vh;
   box-sizing: border-box;
@@ -173,6 +174,7 @@ small {
 
 .workspace-section {
   display: grid;
+  align-content: start;
   gap: 1rem;
 }
 
@@ -862,8 +864,34 @@ details[open] > summary {
 
 .field-inspector {
   display: grid;
-  gap: 1rem;
-  padding: 1rem;
+  gap: 0.5rem;
+  padding: 0.45rem 0 0;
+}
+
+.explore-result-view {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.explore-result-summary {
+  display: grid;
+  gap: 0.15rem;
+  border-left: 3px solid rgba(47, 116, 168, 0.24);
+  padding: 0.15rem 0 0.15rem 0.55rem;
+}
+
+.explore-result-summary h3,
+.explore-result-summary p {
+  margin: 0;
+}
+
+.explore-result-summary h3 {
+  font-size: 1rem;
+}
+
+.explore-result-summary p {
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
 }
 
 .visualizer-shell {
@@ -874,10 +902,11 @@ details[open] > summary {
 
 .visualizer-workbench {
   display: grid;
-  grid-template-columns: minmax(14rem, 16rem) minmax(0, 1fr) minmax(16rem, 18rem);
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 21rem);
   grid-template-areas:
-    "status status status"
-    "controls stage details";
+    "status status"
+    "stage controls"
+    "stage details";
   gap: 1rem;
   align-items: start;
 }
@@ -903,6 +932,7 @@ details[open] > summary {
   display: grid;
   gap: 0.75rem;
   min-width: 0;
+  overflow: hidden;
 }
 
 .scene-container {
@@ -913,7 +943,7 @@ details[open] > summary {
   gap: 0.65rem;
   width: 100%;
   min-width: 0;
-  min-height: clamp(26rem, 52vw, 38rem);
+  min-height: clamp(28rem, 56vw, 42rem);
   padding: 1rem 1rem 0.85rem;
   overflow: hidden;
   isolation: isolate;
@@ -1192,10 +1222,9 @@ details[open] > summary {
 }
 
 .visualizer-primary-controls {
-  position: sticky;
-  top: 1rem;
-  max-height: calc(100vh - 2rem);
-  overflow: auto;
+  position: relative;
+  max-height: none;
+  overflow: visible;
 }
 
 .visualizer-bottom-controls {
@@ -1215,6 +1244,15 @@ details[open] > summary {
   padding: 0.9rem;
 }
 
+.secondary-controls {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.secondary-controls > summary {
+  color: var(--color-text-primary);
+}
+
 .visualizer-bottom-controls legend {
   color: var(--color-text-primary);
   font-weight: 850;
@@ -1232,7 +1270,7 @@ details[open] > summary {
   align-content: start;
   position: sticky;
   top: 1rem;
-  max-height: calc(100vh - 2rem);
+  max-height: min(42rem, calc(100vh - 2rem));
   overflow: auto;
 }
 
@@ -1300,7 +1338,7 @@ details[open] > summary {
 
 .segmented-buttons {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.5rem;
 }
 
@@ -1320,6 +1358,58 @@ details[open] > summary {
   display: grid;
   grid-template-columns: repeat(4, minmax(150px, 1fr));
   gap: 0.75rem;
+}
+
+.inspector-controls-primary {
+  grid-template-columns: minmax(26rem, 1.25fr) minmax(9rem, 0.55fr) minmax(8rem, 0.45fr) minmax(15rem, 0.9fr) auto;
+  gap: 0.4rem;
+  align-items: end;
+  border: 1px solid rgba(47, 116, 168, 0.18);
+  border-radius: 8px;
+  padding: 0.4rem;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.inspector-controls-primary .view-mode-control {
+  grid-column: auto;
+  min-width: 0;
+  border: 0;
+  padding: 0;
+  gap: 0.25rem;
+}
+
+.inspector-controls-primary .view-mode-control legend,
+.inspector-controls-primary label {
+  min-width: 0;
+  font-size: 0.84rem;
+}
+
+.inspector-controls-primary select,
+.inspector-controls-primary input {
+  min-width: 0;
+}
+
+.inspector-controls-primary .segmented-buttons button,
+.inspector-controls-primary .button-row button {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  box-shadow: none;
+  padding: 0.4rem 0.58rem;
+  white-space: nowrap;
+}
+
+.inspector-controls-primary .segmented-buttons button:hover:not(:disabled),
+.inspector-controls-primary .button-row button:hover:not(:disabled) {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+}
+
+.inspector-controls-primary .segmented-buttons .active-control {
+  border-color: rgba(47, 116, 168, 0.34);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+  box-shadow: inset 0 0 0 1px rgba(47, 116, 168, 0.16);
 }
 
 .view-mode-control {
@@ -1364,8 +1454,34 @@ details[open] > summary {
   gap: 0.75rem;
   border: 1px solid rgba(76, 127, 164, 0.24);
   border-radius: 8px;
-  padding: 0.85rem;
-  background: var(--color-info-soft);
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(232, 242, 248, 0.72);
+}
+
+.slice-orientation-summary {
+  border-left: 3px solid rgba(47, 116, 168, 0.28);
+  padding: 0.12rem 0 0.12rem 0.55rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  font-weight: 650;
+  margin: 0;
+}
+
+.slice-view-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.slice-view-header h2 {
+  margin: 0 0 0.18rem;
+  font-size: clamp(1.08rem, 2vw, 1.35rem);
+}
+
+.slice-move-buttons {
+  align-self: end;
 }
 
 .selected-region-controls,
@@ -1409,8 +1525,8 @@ details[open] > summary {
 
 .slice-panel {
   display: grid;
-  gap: 0.75rem;
-  padding: 1rem;
+  gap: 0.42rem;
+  padding: 0.6rem;
 }
 
 .slice-values {
@@ -1421,28 +1537,30 @@ details[open] > summary {
 
 .slice-heatmap {
   display: grid;
-  gap: 0.25rem;
-  min-height: 13rem;
+  gap: 0.04rem;
+  max-height: min(34vh, 19rem);
+  overflow: hidden;
   border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.45rem;
-  background: #eef5f9;
+  background: linear-gradient(180deg, #f7fbfd, #eef5f9);
 }
 
 .heatmap-row {
   display: grid;
-  grid-auto-columns: minmax(1.4rem, 1fr);
+  grid-auto-columns: minmax(0.44rem, 1fr);
   grid-auto-flow: column;
-  gap: 0.25rem;
+  gap: 0.04rem;
 }
 
 .heatmap-cell {
   appearance: none;
-  min-height: 2rem;
+  min-height: clamp(0.44rem, 0.88vh, 0.7rem);
+  min-width: 0.44rem;
   border: 0;
-  border-radius: 4px;
+  border-radius: 1px;
   cursor: crosshair;
-  box-shadow: inset 0 0 0 1px rgba(23, 43, 58, 0.08);
+  box-shadow: none;
 }
 
 .heatmap-cell:focus-visible,
@@ -1453,8 +1571,8 @@ details[open] > summary {
 
 .heatmap-cell-selected {
   box-shadow:
-    inset 0 0 0 2px rgba(255, 228, 168, 0.92),
-    0 0 18px rgba(255, 206, 115, 0.34);
+    inset 0 0 0 2px rgba(176, 112, 0, 0.9),
+    0 0 12px rgba(255, 206, 115, 0.34);
 }
 
 .heatmap-legend {
@@ -1467,9 +1585,19 @@ details[open] > summary {
 }
 
 .heatmap-scale {
-  height: 0.7rem;
+  height: 0.9rem;
   border-radius: 999px;
-  background: linear-gradient(90deg, #173047, #4ea4ce, #b4efe4);
+  box-shadow: inset 0 0 0 1px rgba(23, 43, 58, 0.08);
+}
+
+.heatmap-scale-default,
+.heatmap-scale-cloud-water,
+.heatmap-scale-rain-water {
+  background: linear-gradient(90deg, #eaf4f8, #6bb6cf, #b4efe4);
+}
+
+.heatmap-scale-velocity {
+  background: linear-gradient(90deg, #6b8ebf, #f1f6f8, #80b87a);
 }
 
 .slice-row {
@@ -1495,7 +1623,8 @@ details[open] > summary {
   .workbench-status-strip,
   .visualizer-bottom-controls,
   .slice-grid,
-  .control-row {
+  .control-row,
+  .explore-result-summary {
     grid-template-columns: 1fr;
   }
 
@@ -1503,8 +1632,8 @@ details[open] > summary {
     grid-template-areas:
       "status"
       "stage"
-      "controls"
-      "details";
+      "details"
+      "controls";
   }
 
   .visualizer-stage,
@@ -1516,6 +1645,10 @@ details[open] > summary {
 
   .inspector-controls {
     grid-template-columns: 1fr;
+  }
+
+  .segmented-buttons {
+    flex-wrap: wrap;
   }
 
   .topbar {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1386,7 +1386,7 @@ describe("App", () => {
     expect(screen.getAllByText("Finite cells").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Non-finite cells").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/CM1-derived visualization-ready data/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/browser is not parsing raw NetCDF/)).toBeInTheDocument();
+    expect(screen.getAllByText(/CM1-derived visualization-ready data/).length).toBeGreaterThan(0);
   });
 
   it("switches side-by-side field comparison from qc to w", async () => {
@@ -1420,9 +1420,9 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Open Dry Failed in Explore" }));
 
     expect(
-      await screen.findByRole("heading", { name: "Inspect and visualize fields" }),
+      await screen.findByRole("tab", { name: "2-D Slices" }),
     ).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(
       "/api/results/result-dry-failed-cumulus/visualization/fields",
     );
@@ -1437,11 +1437,11 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open Dry Failed 3-D" }));
 
     expect(
-      await screen.findByRole("heading", { name: "Inspect and visualize fields" }),
+      await screen.findByRole("tab", { name: "2-D Slices" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "3-D View" })).toHaveClass("active-control");
     expect(screen.getAllByText("Dry Failed Cumulus quick-look").length).toBeGreaterThan(0);
-    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(
       "/api/results/result-dry-failed-cumulus/visualization/defaults",
     );
@@ -1654,9 +1654,8 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     await screen.findByText("Slices loaded");
-    expect(screen.getByText(/browser is not parsing raw NetCDF/)).toBeInTheDocument();
     expect(screen.getByLabelText("Field")).toHaveValue("qc");
     expect(screen.getByText("qc (Cloud water)")).toBeInTheDocument();
     expect(screen.getAllByText("kg/kg").length).toBeGreaterThan(0);
@@ -1665,8 +1664,29 @@ describe("App", () => {
     expect(screen.getByText("max_qc_native_grid_location")).toBeInTheDocument();
     expect(screen.getAllByText("Vertical X slice").length).toBeGreaterThan(0);
     expect(screen.queryByLabelText("Horizontal slice heatmap")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Vertical X slice heatmap")).toBeInTheDocument();
-    expect(screen.getByLabelText("Vertical X slice color scale")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Vertical X slice at y = .*Horizontal axis: x\. Vertical axis: height/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Slice position")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Move back" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Move forward" })).toBeInTheDocument();
+    const verticalHeatmap = screen.getByLabelText("Vertical X slice heatmap");
+    expect(verticalHeatmap).toBeInTheDocument();
+    const colorScale = screen.getByLabelText("Vertical X slice color scale");
+    expect(colorScale).toBeInTheDocument();
+    expect(colorScale.querySelector(".heatmap-scale-cloud-water")).not.toBeNull();
+    expect(
+      Boolean(
+        screen.getByLabelText("Field").compareDocumentPosition(verticalHeatmap) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
+    expect(
+      Boolean(
+        verticalHeatmap.compareDocumentPosition(screen.getByText("Technical details")) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
     expect(screen.getAllByText("2.000e-5 kg/kg").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Technical slice details").length).toBeGreaterThan(0);
     expect(screen.getAllByText("native_grid_view_no_interpolation").length).toBeGreaterThan(0);
@@ -1701,8 +1721,8 @@ describe("App", () => {
     expect(screen.getByText("Local max w")).toBeInTheDocument();
     expect(screen.getByText("4.5 m/s")).toBeInTheDocument();
     expect(screen.getByText("Local rain")).toBeInTheDocument();
-    expect(screen.getByText("Rain detected")).toBeInTheDocument();
-    expect(screen.getByText("Compared with whole result")).toBeInTheDocument();
+    expect(screen.getAllByText("Rain detected").length).toBeGreaterThan(0);
+    expect(screen.getByText("Technical details and provenance")).toBeInTheDocument();
     expect(screen.getByText(/backend xarray selected-region diagnostics/i)).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -1712,7 +1732,7 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Clear selection" }));
 
-    expect(screen.getByText(/No region is selected/)).toBeInTheDocument();
+    expect(screen.getByText(/Select a spot or region in the visualization/)).toBeInTheDocument();
   });
 
   it("shows selected-region backend failures as actionable inspector errors", async () => {
@@ -1787,7 +1807,7 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(await screen.findByText("Thermal Fate overlay")).toBeInTheDocument();
+    expect(await screen.findByText("Evidence")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Thermal Fate summary" })).toBeInTheDocument();
     expect(screen.getByText(/Growing cumulus/)).toBeInTheDocument();
     expect(screen.getAllByText("Candidate").length).toBeGreaterThan(0);
@@ -1809,7 +1829,7 @@ describe("App", () => {
     const resultDetail = screen.getByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     await screen.findByText("Slices loaded");
     expect(screen.getByLabelText("Field")).toHaveValue("w");
     expect(screen.queryByRole("option", { name: /qc/ })).not.toBeInTheDocument();
@@ -1828,11 +1848,11 @@ describe("App", () => {
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
     expect(
-      await screen.findByRole("heading", { name: "Inspect and visualize fields" }),
+      await screen.findByRole("tab", { name: "2-D Slices" }),
     ).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     await screen.findByText("Slices loaded");
-    expect(screen.getByRole("heading", { name: "Inspect and visualize fields" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "2-D Slices" })).toBeInTheDocument();
     expect(screen.getByLabelText("Field")).toHaveValue("qc");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("option", { name: "w - Vertical velocity" }).length).toBeGreaterThan(
@@ -1841,7 +1861,7 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "3-D View" }));
 
-    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     await screen.findAllByText("Cloud-water point cloud loaded");
     expect(screen.getByLabelText("Field")).toHaveValue("qc");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
@@ -1857,24 +1877,24 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Open Dry Failed 3-D" }));
 
     expect(
-      await screen.findByRole("heading", { name: "Inspect and visualize fields" }),
+      await screen.findByRole("tab", { name: "2-D Slices" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Inspect and visualize fields" })).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
-    await screen.findAllByText("Scene shell ready");
+    expect(screen.getByRole("tab", { name: "2-D Slices" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    await screen.findAllByText("Cloud view ready");
     expect(screen.getByLabelText("Field")).toHaveValue("w");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("option", { name: "w - Vertical velocity" }).length).toBeGreaterThan(
       0,
     );
     expect(
-      screen.getByText("No cloud water formed here; vertical velocity is available."),
+      screen.getByText("No cloud water formed in this result; vertical velocity is available."),
     ).toBeInTheDocument();
     expect(screen.getByText(/Use the vertical velocity field \(w\) to inspect the thermals/i))
       .toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("tab", { name: "2-D Slices" }));
-    expect(await screen.findByRole("heading", { name: "Inspect CM1 fields" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     await screen.findByText("Slices loaded");
     expect(screen.getByLabelText("Field")).toHaveValue("w");
   });
@@ -1979,8 +1999,10 @@ describe("App", () => {
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Open 3-D" }))[0]);
 
-    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     await screen.findAllByText("Cloud-water point cloud loaded");
+    expect(screen.getByText("Cloud formed in this result")).toBeInTheDocument();
+    expect(screen.queryByText("Cloud formed here")).not.toBeInTheDocument();
     expect(screen.getByLabelText("3-D scene container")).toBeInTheDocument();
     expect(screen.getByLabelText("Cloud-water point cloud")).toBeInTheDocument();
     expect(screen.getByLabelText("Domain bounding box")).toBeInTheDocument();
@@ -2012,8 +2034,9 @@ describe("App", () => {
     expect(screen.getByText("active cloud water: 0.8-1.2 km")).toBeInTheDocument();
     expect(within(scene).queryByLabelText("Horizontal slice plane")).not.toBeInTheDocument();
     expect(within(scene).queryByLabelText("Vertical slice plane")).not.toBeInTheDocument();
-    expect(screen.getByText("View controls")).toBeInTheDocument();
+    expect(screen.getByText("Essential controls")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Reset view" })).toBeInTheDocument();
+    fireEvent.click(screen.getByText("View and rendering controls"));
     expect(screen.queryByRole("button", { name: "Orbit" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Pan" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Reset camera" })).not.toBeInTheDocument();
@@ -2021,14 +2044,17 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "Side y-z" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Top-down x-y" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Oblique overview" })).toHaveClass("active-control");
+    fireEvent.click(screen.getByText("Projection and rendering details"));
     expect(screen.getByLabelText("Projection description")).toHaveTextContent(
       "Oblique overview: interpretive overview based on CM1 coordinates, not a true perspective camera.",
     );
     expect(screen.getByLabelText("Zoom")).toHaveValue("100");
     expect(screen.getByLabelText("Field")).toHaveValue("qc");
+    fireEvent.click(screen.getByText("Slice plane controls"));
     expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
     expect(screen.getByRole("button", { name: "Horizontal z" })).toHaveClass("active-control");
-    expect(screen.getByLabelText("Thermal Fate process overlay")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Evidence details"));
+    expect(screen.getByLabelText("Explanation evidence")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Thermal Fate summary" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Vertical x-z" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Vertical y-z" })).toBeInTheDocument();
@@ -2206,8 +2232,8 @@ describe("App", () => {
     const resultDetail = screen.getByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open 3-D" }));
 
-    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
-    await screen.findAllByText("Scene shell ready");
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    await screen.findAllByText("Cloud view ready");
     expect(
       screen.getByText("Cloud water field qc is not available for this result."),
     ).toBeInTheDocument();
@@ -2222,7 +2248,7 @@ describe("App", () => {
     const resultDetail = screen.getByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open 3-D" }));
 
-    expect(await screen.findByRole("heading", { name: "Scene shell" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     await screen.findAllByText("No fields available");
     expect(
       screen.getByText("No visualization-ready fields are available for this result."),

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -432,7 +432,7 @@ type SceneViewPreset = "cloud-overview" | "vertical-cross-section" | "top-down-s
 type ProjectionMode = "oblique" | "side_xz" | "side_yz" | "top_down";
 type SceneSlicePlane = "horizontal" | "vertical_x" | "vertical_y";
 
-const FIELD_LOAD_TIMEOUT_MS = 8000;
+const FIELD_LOAD_TIMEOUT_MS = 30000;
 
 async function fetchScenarioCatalog(): Promise<ScenarioResponse> {
   const response = await fetch("/api/scenarios");
@@ -1637,13 +1637,7 @@ function ExploreWorkspace({
   onTabChange: (tab: ExploreTab) => void;
 }) {
   return (
-    <section className="workspace-section" aria-labelledby="explore-workspace-title">
-      <div className="section-heading">
-        <div>
-          <p className="eyebrow">Explore</p>
-          <h2 id="explore-workspace-title">Inspect and visualize fields</h2>
-        </div>
-      </div>
+    <section className="workspace-section" aria-label="Explore this result">
 
       <nav className="subtab-nav" role="tablist" aria-label="Explore views">
         {(["slices", "view3d"] as ExploreTab[]).map((tab) => (
@@ -1675,23 +1669,41 @@ function ExploreWorkspace({
 
       {selectedResult && activeTab === "slices" && (
         <section
+          className="explore-result-view"
           role="tabpanel"
           id="slices-panel"
-          aria-labelledby="slices-tab explore-slices-title"
+          aria-labelledby="slices-tab"
         >
-          <p className="eyebrow">2-D Slices</p>
-          <h3 id="explore-slices-title">2-D Slices</h3>
+          <ExploreResultSummary result={selectedResult} />
           <FieldInspector result={selectedResult} />
         </section>
       )}
 
       {selectedResult && activeTab === "view3d" && (
-        <section role="tabpanel" id="view3d-panel" aria-labelledby="view3d-tab explore-3d-title">
-          <p className="eyebrow">3-D View</p>
-          <h3 id="explore-3d-title">3-D View</h3>
+        <section
+          className="explore-result-view"
+          role="tabpanel"
+          id="view3d-panel"
+          aria-labelledby="view3d-tab"
+        >
+          <ExploreResultSummary result={selectedResult} />
           <VisualizerSceneShell result={selectedResult} />
         </section>
       )}
+    </section>
+  );
+}
+
+function ExploreResultSummary({ result }: { result: ResultCard }) {
+  return (
+    <section className="explore-result-summary" aria-label="Selected Explore result">
+      <div>
+        <h3>{result.name}</h3>
+        <p>
+          {result.scenario_name ?? humanize(result.scenario_id)} ·{" "}
+          {humanize(result.run_size_preset)}
+        </p>
+      </div>
     </section>
   );
 }
@@ -3000,7 +3012,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
         setHorizontalSliceLevel(defaultHorizontalLevel(firstPreferred, initialDefaults));
         setVerticalSliceIndex(defaultVerticalIndex(firstPreferred, "vertical_x", initialDefaults));
         setSceneStatus(
-          payload.available_fields.length > 0 ? "Scene shell ready" : "No fields available",
+          payload.available_fields.length > 0 ? "Cloud view ready" : "No fields available",
         );
       })
       .catch((caught: unknown) => {
@@ -3180,8 +3192,8 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     <section className="visualizer-shell" aria-labelledby="visualizer-shell-title">
       <div className="section-heading">
         <div>
-          <p className="eyebrow">3-D visualizer</p>
-          <h2 id="visualizer-shell-title">Scene shell</h2>
+          <p className="eyebrow">Cloud view</p>
+          <h2 id="visualizer-shell-title">What happened in this result?</h2>
         </div>
         <p className="state-chip">{sceneStatus}</p>
       </div>
@@ -3216,10 +3228,36 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
           className="visualizer-controls visualizer-primary-controls"
           aria-label="Primary visualizer controls"
         >
-          <ProcessModeControl processMode={processMode} onProcessModeChange={setProcessMode} />
-
           <fieldset>
-            <legend>View controls</legend>
+            <legend>Essential controls</legend>
+            {catalog && selectedField && (
+              <label htmlFor="scene-field">
+                Field
+                <select
+                  id="scene-field"
+                  value={selectedFieldName}
+                  onChange={(event) => {
+                    const nextField = catalog.available_fields.find(
+                      (field) => field.raw_field_name === event.target.value,
+                    );
+                    setSelectedFieldName(event.target.value);
+                    setTimeIndex(
+                      defaultTimeIndex(
+                        nextField,
+                        result,
+                        defaultsForField(viewDefaults, event.target.value),
+                      ),
+                    );
+                  }}
+                >
+                  {catalog.available_fields.map((field) => (
+                    <option key={field.raw_field_name} value={field.raw_field_name}>
+                      {field.raw_field_name} - {field.display_name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
             <label htmlFor="scene-zoom">
               Zoom
               <input
@@ -3242,6 +3280,10 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
           </fieldset>
 
           {catalog && selectedField && (
+            <details className="secondary-controls">
+              <summary>View and rendering controls</summary>
+              <ProcessModeControl processMode={processMode} onProcessModeChange={setProcessMode} />
+
             <fieldset>
               <legend>View presets</legend>
               <div className="segmented-buttons">
@@ -3343,9 +3385,12 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                 domain center.
               </small>
             </fieldset>
+            </details>
           )}
 
           {catalog && selectedField && (
+            <details className="secondary-controls">
+              <summary>Projection and rendering details</summary>
             <fieldset>
               <legend>Projection</legend>
               <div className="segmented-buttons">
@@ -3382,41 +3427,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                 Side views map model height z to screen height for cloud-base and cloud-top checks.
               </small>
             </fieldset>
-          )}
 
-          {catalog && selectedField && (
-            <fieldset>
-              <legend>Field</legend>
-              <label htmlFor="scene-field">
-                Field
-                <select
-                  id="scene-field"
-                  value={selectedFieldName}
-                  onChange={(event) => {
-                    const nextField = catalog.available_fields.find(
-                      (field) => field.raw_field_name === event.target.value,
-                    );
-                    setSelectedFieldName(event.target.value);
-                    setTimeIndex(
-                      defaultTimeIndex(
-                        nextField,
-                        result,
-                        defaultsForField(viewDefaults, event.target.value),
-                      ),
-                    );
-                  }}
-                >
-                  {catalog.available_fields.map((field) => (
-                    <option key={field.raw_field_name} value={field.raw_field_name}>
-                      {field.raw_field_name} - {field.display_name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            </fieldset>
-          )}
-
-          {catalog && selectedField && (
             <fieldset>
               <legend>Cloud-water rendering</legend>
               <label htmlFor="cloud-threshold">
@@ -3456,9 +3467,12 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
               </label>
               <p>Default max points: {maxPoints.toLocaleString()}</p>
             </fieldset>
+            </details>
           )}
 
           {catalog && sliceField && (
+            <details className="secondary-controls">
+              <summary>Slice plane controls</summary>
             <fieldset>
               <legend>Slice planes</legend>
               <label htmlFor="show-slice-planes" className="checkbox-label">
@@ -3499,6 +3513,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                 </select>
               </label>
             </fieldset>
+            </details>
           )}
         </aside>
 
@@ -3584,7 +3599,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                   {!qcField
                     ? "Cloud water field qc is not available for this result."
                     : isNoCloudWithUpdraft
-                      ? "No cloud water formed here; vertical velocity is available."
+                      ? "No cloud water formed in this result; vertical velocity is available."
                       : "No cloud water above the selected threshold at this time."}
                 </h3>
                 <p>
@@ -3759,13 +3774,18 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
         </div>
 
         <aside className="visualizer-details-panel" aria-label="Visualization details">
-          <ProcessOverlayPanel
-            result={result}
-            catalog={catalog}
-            selectedField={selectedField}
-            processMode={processMode}
-            slice={activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice}
-          />
+          <ResultExplanationPanel result={result} isNoCloudWithUpdraft={isNoCloudWithUpdraft} />
+
+          <details className="technical-details">
+            <summary>Evidence details</summary>
+            <ProcessOverlayPanel
+              result={result}
+              catalog={catalog}
+              selectedField={selectedField}
+              processMode={processMode}
+              slice={activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice}
+            />
+          </details>
 
           <div className="summary-strip">
             <Metric
@@ -3894,6 +3914,63 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   );
 }
 
+function ResultExplanationPanel({
+  result,
+  isNoCloudWithUpdraft,
+}: {
+  result: ResultCard;
+  isNoCloudWithUpdraft: boolean;
+}) {
+  return (
+    <section className="selected-region-inspector" aria-label="Result-level explanation panel">
+      <div className="section-heading compact-heading">
+        <div>
+          <p className="eyebrow">Explanation</p>
+          <h3>Result explanation</h3>
+        </div>
+        <StatusBadge
+          label={
+            cloudOutcome(result) === "Cloud formed"
+              ? "Cloud formed in this result"
+              : "No cloud formed in this result"
+          }
+          tone={cloudOutcome(result) === "Cloud formed" ? "good" : "warning"}
+        />
+      </div>
+      <p>{resultStory(result)}</p>
+      <section aria-label="Evidence">
+        <h4>Evidence</h4>
+        <dl className="metric-grid">
+          <Metric label="First cloud time" value={formatSeconds(result.first_cloud_time_seconds)} />
+          <Metric label="Max qc" value={formatScientific(result.max_qc_kg_kg, "kg/kg")} />
+          <Metric label="Max w" value={formatNumber(result.max_w_m_s, "m/s")} />
+          <Metric label="Rain" value={rainOutcome(result.rain_present)} />
+        </dl>
+      </section>
+      <section aria-label="What happened here invitation">
+        <h4>What happened here?</h4>
+        <p>
+          Select a spot or region in the visualization to ask what happened there.
+          {isNoCloudWithUpdraft
+            ? " For this no-cloud result, use vertical velocity (w) to inspect the thermals."
+            : " Region-level evidence will narrow what is still uncertain."}
+        </p>
+      </section>
+      <details>
+        <summary>Technical details</summary>
+        <ul className="compact-list">
+          <li>Thermal Fate is the internal explanation model.</li>
+          <li>Evidence comes from ingested CM1 diagnostics and visualization-ready fields.</li>
+          <li>No raw NetCDF parsing in the browser.</li>
+          {result.caveats.map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      </details>
+    </section>
+  );
+}
+
 function SlicePlane({ title, slice }: { title: string; slice: SliceResponse | null }) {
   if (!slice) return null;
   const cells = slice.values.flat();
@@ -3917,7 +3994,7 @@ function SlicePlane({ title, slice }: { title: string; slice: SliceResponse | nu
           <span
             className="slice-plane-cell"
             key={`${title}-${index}`}
-            style={sliceCellStyle(value, slice.stats)}
+            style={sliceCellStyle(value, slice)}
           />
         ))}
       </div>
@@ -4246,7 +4323,29 @@ function FieldInspector({ result }: { result: ResultCard }) {
     ? selectedField.shape[selectedField.dimensions.indexOf(selectedField.coordinate_names.x)]
     : 1;
   const verticalSliceMax = verticalOrientation === "vertical_x" ? ySize : xSize;
+  const activeSliceMax = viewMode === "horizontal" ? verticalSize : verticalSliceMax;
+  const activeSliceIndex = viewMode === "horizontal" ? horizontalLevelIndex : verticalLevelIndex;
   const activeSlice = viewMode === "horizontal" ? horizontalSlice : verticalSlice;
+  const sliceVisualization = (
+    <div className={viewMode === "compare" ? "slice-grid" : "primary-slice-grid"}>
+      {(viewMode === "horizontal" || viewMode === "compare") && (
+        <SlicePanel
+          title="Horizontal slice"
+          slice={horizontalSlice}
+          selectedRegion={selectedRegion}
+          onSelectRegion={selectRegionFromSlice}
+        />
+      )}
+      {(viewMode === "vertical_x" || viewMode === "vertical_y" || viewMode === "compare") && (
+        <SlicePanel
+          title={viewMode === "vertical_y" ? "Vertical Y slice" : "Vertical X slice"}
+          slice={verticalSlice}
+          selectedRegion={selectedRegion}
+          onSelectRegion={selectRegionFromSlice}
+        />
+      )}
+    </div>
+  );
 
   function selectRegionFromSlice(slice: SliceResponse, rowIndex: number, columnIndex: number) {
     setSelectedRegion(selectionFromSlice(slice, rowIndex, columnIndex, "column"));
@@ -4277,18 +4376,15 @@ function FieldInspector({ result }: { result: ResultCard }) {
 
   return (
     <section className="field-inspector" aria-labelledby="field-inspector-title">
-      <div className="section-heading">
+      <div className="slice-view-header">
         <div>
-          <p className="eyebrow">2-D field inspection</p>
-          <h2 id="field-inspector-title">Inspect CM1 fields</h2>
+          <h2 id="field-inspector-title">What happened in this result?</h2>
+          {catalog && selectedField && (
+            <SliceOrientationSummary slice={activeSlice} viewMode={viewMode} />
+          )}
         </div>
         <p className="state-chip">{inspectorStatus}</p>
       </div>
-
-      <p>
-        These slices are backend-prepared inspections of CM1 output. The browser is not parsing raw
-        NetCDF, and this is not a 3-D visualization.
-      </p>
 
       {inspectorError && (
         <div role="alert">
@@ -4305,11 +4401,9 @@ function FieldInspector({ result }: { result: ResultCard }) {
 
       {catalog && selectedField && (
         <>
-          <div className="inspector-controls">
-            <ProcessModeControl processMode={processMode} onProcessModeChange={setProcessMode} />
-
+          <div className="inspector-controls inspector-controls-primary">
             <fieldset className="view-mode-control">
-              <legend>Slice view</legend>
+              <legend>Slice orientation</legend>
               <div className="segmented-buttons">
                 <button
                   type="button"
@@ -4372,54 +4466,66 @@ function FieldInspector({ result }: { result: ResultCard }) {
               </select>
             </label>
 
-            <label htmlFor="horizontal-level">
-              Horizontal level
+            <label htmlFor="active-slice-index">
+              Slice position
               <input
-                id="horizontal-level"
-                type="number"
+                id="active-slice-index"
+                aria-label="Slice position"
+                type="range"
                 min={0}
-                max={Math.max(0, verticalSize - 1)}
-                value={horizontalLevelIndex}
-                onChange={(event) => setHorizontalLevelIndex(Number(event.target.value))}
+                max={Math.max(0, activeSliceMax - 1)}
+                value={activeSliceIndex}
+                onChange={(event) => {
+                  const nextIndex = Number(event.target.value);
+                  if (viewMode === "horizontal") {
+                    setHorizontalLevelIndex(nextIndex);
+                  } else {
+                    setVerticalLevelIndex(nextIndex);
+                  }
+                }}
               />
+              <span>{slicePositionLabel(activeSlice, activeSliceIndex)}</span>
             </label>
 
-            <label htmlFor="vertical-index">
-              Vertical slice index
-              <input
-                id="vertical-index"
-                type="number"
-                min={0}
-                max={Math.max(0, verticalSliceMax - 1)}
-                value={verticalLevelIndex}
-                onChange={(event) => setVerticalLevelIndex(Number(event.target.value))}
-              />
-            </label>
+            <div className="button-row slice-move-buttons">
+              <button
+                type="button"
+                onClick={() => {
+                  const nextIndex = Math.max(0, activeSliceIndex - 1);
+                  if (viewMode === "horizontal") {
+                    setHorizontalLevelIndex(nextIndex);
+                  } else {
+                    setVerticalLevelIndex(nextIndex);
+                  }
+                }}
+              >
+                {viewMode === "horizontal"
+                  ? "Move down"
+                  : viewMode === "vertical_y"
+                    ? "Move left"
+                    : "Move back"}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const nextIndex = Math.min(Math.max(0, activeSliceMax - 1), activeSliceIndex + 1);
+                  if (viewMode === "horizontal") {
+                    setHorizontalLevelIndex(nextIndex);
+                  } else {
+                    setVerticalLevelIndex(nextIndex);
+                  }
+                }}
+              >
+                {viewMode === "horizontal"
+                  ? "Move up"
+                  : viewMode === "vertical_y"
+                    ? "Move right"
+                    : "Move forward"}
+              </button>
+            </div>
           </div>
 
-          <dl className="metric-grid">
-            <Metric
-              label="Field"
-              value={`${selectedField.raw_field_name} (${selectedField.display_name})`}
-            />
-            <Metric label="Units" value={selectedField.units ?? "Units unavailable"} />
-            <Metric
-              label="Selected time"
-              value={formatTimeValue(
-                timeOptions[Math.min(timeIndex, timeOptions.length - 1)] ?? null,
-              )}
-            />
-            <Metric label="Default source" value={selectedDefaults?.source ?? "domain center"} />
-            <Metric label="Native grid" value={selectedField.native_grid} />
-          </dl>
-
-          <ProcessOverlayPanel
-            result={result}
-            catalog={catalog}
-            selectedField={selectedField}
-            processMode={processMode}
-            slice={viewMode === "horizontal" ? horizontalSlice : verticalSlice}
-          />
+          {sliceVisualization}
 
           <SelectedRegionControls
             selectedRegion={selectedRegion}
@@ -4429,25 +4535,6 @@ function FieldInspector({ result }: { result: ResultCard }) {
             onClear={() => setSelectedRegion(null)}
           />
 
-          <div className={viewMode === "compare" ? "slice-grid" : "primary-slice-grid"}>
-            {(viewMode === "horizontal" || viewMode === "compare") && (
-              <SlicePanel
-                title="Horizontal slice"
-                slice={horizontalSlice}
-                selectedRegion={selectedRegion}
-                onSelectRegion={selectRegionFromSlice}
-              />
-            )}
-            {(viewMode === "vertical_x" || viewMode === "vertical_y" || viewMode === "compare") && (
-              <SlicePanel
-                title={viewMode === "vertical_y" ? "Vertical Y slice" : "Vertical X slice"}
-                slice={verticalSlice}
-                selectedRegion={selectedRegion}
-                onSelectRegion={selectRegionFromSlice}
-              />
-            )}
-          </div>
-
           <SelectedRegionInspector
             selectedRegion={selectedRegion}
             diagnostics={regionDiagnostics}
@@ -4456,7 +4543,55 @@ function FieldInspector({ result }: { result: ResultCard }) {
           />
 
           <details>
-            <summary>Technical field details</summary>
+            <summary>Technical details</summary>
+            <div className="inspector-controls">
+              <label htmlFor="horizontal-level">
+                Horizontal level
+                <input
+                  id="horizontal-level"
+                  type="number"
+                  min={0}
+                  max={Math.max(0, verticalSize - 1)}
+                  value={horizontalLevelIndex}
+                  onChange={(event) => setHorizontalLevelIndex(Number(event.target.value))}
+                />
+              </label>
+
+              <label htmlFor="vertical-index">
+                Vertical slice index
+                <input
+                  id="vertical-index"
+                  type="number"
+                  min={0}
+                  max={Math.max(0, verticalSliceMax - 1)}
+                  value={verticalLevelIndex}
+                  onChange={(event) => setVerticalLevelIndex(Number(event.target.value))}
+                />
+              </label>
+            </div>
+            <dl className="metric-grid">
+              <Metric
+                label="Field"
+                value={`${selectedField.raw_field_name} (${selectedField.display_name})`}
+              />
+              <Metric label="Units" value={selectedField.units ?? "Units unavailable"} />
+              <Metric
+                label="Selected time"
+                value={formatTimeValue(
+                  timeOptions[Math.min(timeIndex, timeOptions.length - 1)] ?? null,
+                )}
+              />
+              <Metric label="Default source" value={selectedDefaults?.source ?? "domain center"} />
+              <Metric label="Native grid" value={selectedField.native_grid} />
+            </dl>
+            <ProcessModeControl processMode={processMode} onProcessModeChange={setProcessMode} />
+            <ProcessOverlayPanel
+              result={result}
+              catalog={catalog}
+              selectedField={selectedField}
+              processMode={processMode}
+              slice={viewMode === "horizontal" ? horizontalSlice : verticalSlice}
+            />
             <p>{catalog.provenance.provenance_label}</p>
             <ul className="compact-list">
               <li>Native-grid view; no interpolation</li>
@@ -4467,6 +4602,54 @@ function FieldInspector({ result }: { result: ResultCard }) {
         </>
       )}
     </section>
+  );
+}
+
+function SliceOrientationSummary({
+  slice,
+  viewMode,
+}: {
+  slice: SliceResponse | null;
+  viewMode: InspectorViewMode;
+}) {
+  const orientation = slice?.selection.orientation;
+  const fieldLabel = slice?.field.display_name ?? "selected field";
+
+  if (!slice) {
+    return (
+      <p className="slice-orientation-summary" aria-label="Current slice explanation">
+        Current slice is loading.
+      </p>
+    );
+  }
+
+  if (viewMode === "compare") {
+    return (
+      <p className="slice-orientation-summary" aria-label="Current slice explanation">
+        Comparing a horizontal layer with a vertical slice through the cloud field.
+      </p>
+    );
+  }
+
+  if (orientation === "horizontal") {
+    return (
+      <p className="slice-orientation-summary" aria-label="Current slice explanation">
+        Horizontal layer of {fieldLabel.toLowerCase()} at{" "}
+        {slicePositionLabel(slice, slice.selection.selected_index)}. Axes: x and y.
+      </p>
+    );
+  }
+
+  const fixedAxis = orientation === "vertical_y" ? "x" : "y";
+  const movingLabel = orientation === "vertical_y" ? "left or right" : "forward or back";
+  const horizontalAxis = orientation === "vertical_y" ? "y" : "x";
+
+  return (
+    <p className="slice-orientation-summary" aria-label="Current slice explanation">
+      Vertical {orientation === "vertical_y" ? "Y" : "X"} slice at {fixedAxis} ={" "}
+      {slicePositionLabel(slice, slice.selection.selected_index)}. Horizontal axis: {horizontalAxis}.
+      Vertical axis: height. Move {movingLabel} to inspect another part of the cloud.
+    </p>
   );
 }
 
@@ -4493,25 +4676,6 @@ function SlicePanel({
   return (
     <section className="slice-panel" aria-label={title}>
       <h3>{title}</h3>
-      <dl className="metric-grid">
-        <Metric label="Orientation" value={slice.selection.orientation} />
-        <Metric label="Time" value={formatSeconds(slice.selection.time_seconds)} />
-        <Metric label="Shape" value={slice.shape.join(" x ")} />
-        <Metric label="Dimensions" value={slice.dimension_order.join(", ")} />
-        <Metric label="Min" value={formatMaybeNumber(slice.stats.min, slice.field.units)} />
-        <Metric label="Max" value={formatMaybeNumber(slice.stats.max, slice.field.units)} />
-        <Metric label="Finite values" value={String(slice.stats.finite_count)} />
-        <Metric label="Non-finite values" value={String(slice.stats.non_finite_count)} />
-      </dl>
-      {slice.selection.level_units && (
-        <p>
-          Selected level: {String(slice.selection.level_coordinate_value)}{" "}
-          {slice.selection.level_units}
-          {slice.selection.level_meters !== null
-            ? ` (${slice.selection.level_meters.toLocaleString()} m)`
-            : ""}
-        </p>
-      )}
       <SliceHeatmap
         title={title}
         slice={slice}
@@ -4520,11 +4684,30 @@ function SlicePanel({
       />
       <div className="heatmap-legend" aria-label={`${title} color scale`}>
         <span>{formatMaybeNumber(slice.stats.min, slice.field.units)}</span>
-        <span className="heatmap-scale" />
+        <span className={`heatmap-scale ${heatmapScaleClass(slice.field)}`} />
         <span>{formatMaybeNumber(slice.stats.max, slice.field.units)}</span>
       </div>
       <details>
         <summary>Technical slice details</summary>
+        <dl className="metric-grid">
+          <Metric label="Orientation" value={slice.selection.orientation} />
+          <Metric label="Time" value={formatSeconds(slice.selection.time_seconds)} />
+          <Metric label="Shape" value={slice.shape.join(" x ")} />
+          <Metric label="Dimensions" value={slice.dimension_order.join(", ")} />
+          <Metric label="Min" value={formatMaybeNumber(slice.stats.min, slice.field.units)} />
+          <Metric label="Max" value={formatMaybeNumber(slice.stats.max, slice.field.units)} />
+          <Metric label="Finite values" value={String(slice.stats.finite_count)} />
+          <Metric label="Non-finite values" value={String(slice.stats.non_finite_count)} />
+        </dl>
+        {slice.selection.level_units && (
+          <p>
+            Selected level: {String(slice.selection.level_coordinate_value)}{" "}
+            {slice.selection.level_units}
+            {slice.selection.level_meters !== null
+              ? ` (${slice.selection.level_meters.toLocaleString()} m)`
+              : ""}
+          </p>
+        )}
         <p>{slice.provenance.provenance_label}</p>
         {slice.caveats.length > 0 && (
           <ul className="compact-list">
@@ -4562,7 +4745,7 @@ function ProcessModeControl({
 }) {
   return (
     <fieldset className="process-mode-control">
-      <legend>Process mode</legend>
+      <legend>Explanation focus</legend>
       <select
         aria-label="Process mode"
         value={processMode}
@@ -4593,10 +4776,10 @@ function ProcessOverlayPanel({
 }) {
   const summary = processModeSummary(processMode, result, catalog, selectedField, slice ?? null);
   return (
-    <section className="process-overlay-panel" aria-label="Thermal Fate process overlay">
+    <section className="process-overlay-panel" aria-label="Explanation evidence">
       <div className="section-heading compact-heading">
         <div>
-          <p className="eyebrow">Thermal Fate overlay</p>
+          <p className="eyebrow">Evidence</p>
           <h3>{processModeLabel(processMode)}</h3>
         </div>
         <StatusBadge
@@ -4649,10 +4832,9 @@ function SelectedRegionControls({
     <section className="selected-region-controls" aria-label="Selected-region controls">
       <div>
         <p className="eyebrow">What happened here?</p>
-        <h3>Thermal Fate Inspector</h3>
+        <h3>Ask about a spot or region</h3>
         <p>
-          Click a slice cell to inspect the nearest column, or use the buttons below for a bounded
-          point or box around the current view center.
+          Click a slice cell, or choose the current view center, to get a CM1-backed explanation.
         </p>
       </div>
       <div className="segmented-buttons">
@@ -4683,10 +4865,10 @@ function SelectedRegionInspector({
   error: string | null;
 }) {
   return (
-    <section className="selected-region-inspector" aria-label="Thermal Fate Inspector">
+    <section className="selected-region-inspector" aria-label="What happened here panel">
       <div className="section-heading compact-heading">
         <div>
-          <p className="eyebrow">Selected region</p>
+          <p className="eyebrow">Explanation</p>
           <h3>What happened here?</h3>
         </div>
         <p className="state-chip">{status}</p>
@@ -4694,8 +4876,7 @@ function SelectedRegionInspector({
 
       {!selectedRegion && (
         <p>
-          No region is selected. Select a point, column, or box to request backend Thermal Fate
-          diagnostics.
+          Select a spot or region in the visualization to ask what happened there.
         </p>
       )}
 
@@ -4726,9 +4907,6 @@ function SelectedRegionInspector({
               label="Main limiting factor"
               value={humanize(diagnostics.interpretation.main_limiting_factor)}
             />
-            <Metric label="Region type" value={humanize(diagnostics.region.region_type)} />
-            <Metric label="Native grid" value={diagnostics.region.native_grid ?? "Unavailable"} />
-            <Metric label="Cell count" value={String(diagnostics.region.cell_count ?? "unknown")} />
             <Metric
               label="First local cloud time"
               value={formatSeconds(diagnostics.diagnostics.first_local_cloud_time_seconds)}
@@ -4751,18 +4929,15 @@ function SelectedRegionInspector({
             />
           </dl>
 
-          <section aria-label="Selected-region bounds">
-            <h4>Selected-region bounds</h4>
+          <details>
+            <summary>Technical details and provenance</summary>
             <dl className="metric-grid">
+              <Metric label="Region type" value={humanize(diagnostics.region.region_type)} />
+              <Metric label="Native grid" value={diagnostics.region.native_grid ?? "Unavailable"} />
+              <Metric label="Cell count" value={String(diagnostics.region.cell_count ?? "unknown")} />
               <Metric label="x" value={axisSelectionLabel(diagnostics.region.x)} />
               <Metric label="y" value={axisSelectionLabel(diagnostics.region.y)} />
               <Metric label="vertical" value={axisSelectionLabel(diagnostics.region.vertical)} />
-            </dl>
-          </section>
-
-          <section aria-label="Domain comparison">
-            <h4>Compared with whole result</h4>
-            <dl className="metric-grid">
               <Metric
                 label="Max w fraction"
                 value={formatRatio(diagnostics.comparison_to_domain.local_max_w_fraction_of_domain)}
@@ -4782,10 +4957,6 @@ function SelectedRegionInspector({
                 value={formatRatio(diagnostics.comparison_to_domain.local_cloud_top_fraction_of_domain)}
               />
             </dl>
-          </section>
-
-          <details>
-            <summary>Technical selected-region details</summary>
             <p>{diagnostics.provenance.provenance_label}</p>
             <ul className="compact-list">
               <li>Backend xarray selected-region diagnostics; no raw NetCDF parsing in browser.</li>
@@ -4816,21 +4987,22 @@ function SliceHeatmap({
   selectedRegion?: SelectedRegionRequest | null;
   onSelectRegion?: (slice: SliceResponse, rowIndex: number, columnIndex: number) => void;
 }) {
+  const displayRows = downsampleSliceValues(slice.values);
   return (
     <div className="slice-heatmap" role="img" aria-label={`${title} heatmap`}>
-      {slice.values.map((row, rowIndex) => (
-        <div className="heatmap-row" key={`${title}-heatmap-${rowIndex}`}>
-          {row.map((value, columnIndex) => {
-            const selected = isSelectedSliceCell(slice, selectedRegion, rowIndex, columnIndex);
+      {displayRows.map((row, displayRowIndex) => (
+        <div className="heatmap-row" key={`${title}-heatmap-${displayRowIndex}`}>
+          {row.map((cell, displayColumnIndex) => {
+            const selected = isSelectedSliceDisplayCell(slice, selectedRegion, cell);
             return (
               <button
                 type="button"
                 className={`heatmap-cell${selected ? " heatmap-cell-selected" : ""}`}
-                key={`${title}-heatmap-${rowIndex}-${columnIndex}`}
-                title={value === null ? "missing" : formatMaybeNumber(value, slice.field.units)}
-                aria-label={`Inspect ${title} row ${rowIndex + 1}, column ${columnIndex + 1}`}
-                style={sliceCellStyle(value, slice.stats)}
-                onClick={() => onSelectRegion?.(slice, rowIndex, columnIndex)}
+                key={`${title}-heatmap-${displayRowIndex}-${displayColumnIndex}`}
+                title={cell.value === null ? "missing" : formatMaybeNumber(cell.value, slice.field.units)}
+                aria-label={`Inspect ${title} row ${displayRowIndex + 1}, column ${displayColumnIndex + 1}`}
+                style={sliceCellStyle(cell.value, slice)}
+                onClick={() => onSelectRegion?.(slice, cell.sourceRowIndex, cell.sourceColumnIndex)}
               />
             );
           })}
@@ -4838,6 +5010,66 @@ function SliceHeatmap({
       ))}
     </div>
   );
+}
+
+type DisplayHeatmapCell = {
+  value: number | null;
+  sourceRowIndex: number;
+  sourceColumnIndex: number;
+  rowStart: number;
+  rowEnd: number;
+  columnStart: number;
+  columnEnd: number;
+};
+
+function downsampleSliceValues(values: Array<Array<number | null>>): DisplayHeatmapCell[][] {
+  const maxRows = 28;
+  const maxColumns = 60;
+  const rowCount = values.length;
+  const columnCount = values[0]?.length ?? 0;
+  const rowStride = Math.max(1, Math.ceil(rowCount / maxRows));
+  const columnStride = Math.max(1, Math.ceil(columnCount / maxColumns));
+
+  const rows: DisplayHeatmapCell[][] = [];
+  for (let rowStart = 0; rowStart < rowCount; rowStart += rowStride) {
+    const rowEnd = Math.min(rowCount, rowStart + rowStride);
+    const displayRow: DisplayHeatmapCell[] = [];
+    for (let columnStart = 0; columnStart < columnCount; columnStart += columnStride) {
+      const columnEnd = Math.min(columnCount, columnStart + columnStride);
+      displayRow.push({
+        value: averageSliceBlock(values, rowStart, rowEnd, columnStart, columnEnd),
+        sourceRowIndex: Math.min(rowCount - 1, Math.floor((rowStart + rowEnd - 1) / 2)),
+        sourceColumnIndex: Math.min(columnCount - 1, Math.floor((columnStart + columnEnd - 1) / 2)),
+        rowStart,
+        rowEnd: rowEnd - 1,
+        columnStart,
+        columnEnd: columnEnd - 1,
+      });
+    }
+    rows.push(displayRow);
+  }
+  return rows;
+}
+
+function averageSliceBlock(
+  values: Array<Array<number | null>>,
+  rowStart: number,
+  rowEnd: number,
+  columnStart: number,
+  columnEnd: number,
+): number | null {
+  let total = 0;
+  let count = 0;
+  for (let rowIndex = rowStart; rowIndex < rowEnd; rowIndex += 1) {
+    for (let columnIndex = columnStart; columnIndex < columnEnd; columnIndex += 1) {
+      const value = values[rowIndex]?.[columnIndex];
+      if (typeof value === "number" && Number.isFinite(value)) {
+        total += value;
+        count += 1;
+      }
+    }
+  }
+  return count > 0 ? total / count : null;
 }
 
 function OutcomeBadge({ result }: { result: ResultCard }) {
@@ -5130,6 +5362,40 @@ function isSelectedSliceCell(
   );
 }
 
+function isSelectedSliceDisplayCell(
+  slice: SliceResponse,
+  selectedRegion: SelectedRegionRequest | null | undefined,
+  cell: DisplayHeatmapCell,
+): boolean {
+  if (!selectedRegion) return false;
+  for (let rowIndex = cell.rowStart; rowIndex <= cell.rowEnd; rowIndex += 1) {
+    for (let columnIndex = cell.columnStart; columnIndex <= cell.columnEnd; columnIndex += 1) {
+      if (isSelectedSliceCell(slice, selectedRegion, rowIndex, columnIndex)) return true;
+    }
+  }
+  return false;
+}
+
+function slicePositionLabel(slice: SliceResponse | null, fallbackIndex: number): string {
+  if (!slice) return `index ${fallbackIndex}`;
+  const coordinate =
+    slice.selection.selected_coordinate_value ??
+    slice.selection.level_coordinate_value ??
+    null;
+  const units =
+    slice.coordinate_units[slice.selection.selected_dimension] ??
+    slice.selection.level_units ??
+    null;
+  const numericCoordinate = typeof coordinate === "number" ? coordinate : Number(coordinate);
+  const coordinateText =
+    coordinate === null || coordinate === undefined
+      ? "coordinate unavailable"
+      : Number.isFinite(numericCoordinate)
+        ? `${formatCompactNumber(numericCoordinate)}${units ? ` ${units}` : ""}`
+        : String(coordinate);
+  return `${coordinateText} / index ${slice.selection.selected_index}`;
+}
+
 function selectionLabel(selection: SelectedRegionRequest): string {
   if (selection.regionType === "box") {
     return `Box x ${selection.xStart}-${selection.xEnd}, y ${selection.yStart}-${selection.yEnd}, z ${selection.zStart}-${selection.zEnd}`;
@@ -5383,13 +5649,54 @@ function projectionDescription(projectionMode: ProjectionMode): string {
   return descriptions[projectionMode];
 }
 
-function sliceCellStyle(value: number | null, stats: SliceResponse["stats"]): CSSProperties {
-  if (value === null) {
-    return { background: "rgba(255, 255, 255, 0.12)" };
+function heatmapScaleClass(field: VisualizableField): string {
+  if (field.raw_field_name === "w" || field.canonical_field_name === "vertical_velocity") {
+    return "heatmap-scale-velocity";
   }
-  const intensity = normalize(value, stats.min ?? value, stats.max ?? value);
+  if (field.raw_field_name === "qc" || field.canonical_field_name === "cloud_water") {
+    return "heatmap-scale-cloud-water";
+  }
+  if (field.raw_field_name === "qr" || field.canonical_field_name === "rain_water") {
+    return "heatmap-scale-rain-water";
+  }
+  return "heatmap-scale-default";
+}
+
+function sliceCellStyle(value: number | null, slice: SliceResponse): CSSProperties {
+  if (value === null) {
+    return { background: "rgba(255, 255, 255, 0.36)" };
+  }
+
+  if (slice.field.raw_field_name === "w" || slice.field.canonical_field_name === "vertical_velocity") {
+    const maxMagnitude = Math.max(
+      Math.abs(slice.stats.min ?? value),
+      Math.abs(slice.stats.max ?? value),
+      Number.EPSILON,
+    );
+    const scaled = Math.max(-1, Math.min(1, value / maxMagnitude));
+    if (scaled >= 0) {
+      return {
+        background: `rgba(${224 - scaled * 96}, ${242 - scaled * 86}, ${236 - scaled * 132}, ${0.58 + scaled * 0.34})`,
+      };
+    }
+    const magnitude = Math.abs(scaled);
+    return {
+      background: `rgba(${229 - magnitude * 90}, ${238 - magnitude * 112}, ${247 - magnitude * 88}, ${0.58 + magnitude * 0.32})`,
+    };
+  }
+
+  const min = slice.stats.min ?? value;
+  const max = slice.stats.max ?? value;
+  const normalized = normalize(value, min, max);
+  const intensity =
+    slice.field.raw_field_name === "qc" || slice.field.canonical_field_name === "cloud_water"
+      ? Math.sqrt(Math.max(0, normalized))
+      : normalized;
+  if (intensity < 0.015) {
+    return { background: "rgba(234, 244, 248, 0.72)" };
+  }
   return {
-    background: `rgba(${78 + intensity * 110}, ${164 + intensity * 70}, ${206 + intensity * 40}, 0.72)`,
+    background: `rgba(${38 + intensity * 155}, ${98 + intensity * 130}, ${128 + intensity * 108}, ${0.62 + intensity * 0.28})`,
   };
 }
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -643,6 +643,13 @@ The selected result ID flows from Results / Notebook, Results / Compare, and
 Results / Storage into Explore; those consumers request backend-prepared
 payloads for that result rather than opening files directly.
 
+Explore's UI contract is explanation-first. The selected result summary,
+cloud/no-cloud state, field-loading state, and `What happened here?` panel are
+primary state. Technical Thermal Fate process modes, native-grid caveats,
+rendering/projection details, and provenance stay available in disclosure so the
+browser remains a presentation layer over backend diagnostics instead of a
+scientific classifier.
+
 User-facing state labels are separate from technical provenance. The primary UI
 may translate raw states like `ingested_result_metadata` or
 `completed_cm1_result` into `Ingested`, `Completed CM1 result`, `Saved`, or

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -974,7 +974,17 @@ run directories and their relationship to named result cards.
 shared by Results and Explore. Selecting a result in Notebook or opening a
 comparison/storage row in Explore should preserve that context. If no selected
 result is available, Explore should tell the user to select an ingested result
-from Results. The 2-D and 3-D views should default to physically interesting output views, not
+from Results.
+
+The first-read Explore screen should be an explanation workspace, not a
+process-mode cockpit. Both `2-D Slices` and `3-D View` should show a selected
+result summary, a dominant CM1-derived visual surface, and a visible `What
+happened here?` explanation panel. Core field/time/view controls stay visible;
+process focus, projection/rendering details, slice-plane controls, and long
+provenance labels belong behind details/disclosure until the user asks for
+them.
+
+The 2-D and 3-D views should default to physically interesting output views, not
 arbitrary zero-index slices. The backend should provide default field/time/slice
 locations from native-grid data when possible: for `qc`, first cloud time or the
 max cloud-water location; for `w`, the max-updraft location. If those locations

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -87,6 +87,13 @@ tests; manual QA for this reset is qualitative only.
 `What happened here?` as the central action instead of becoming a generic
 visualization-plus-panel redesign.
 
+#172 applies that model to the current Explore shell: the page should read as
+`Explore this result`, keep the selected result and cloud/no-cloud trust state
+obvious, make the primary CM1-derived visual surface dominant, and keep a
+visible `What happened here?` explanation panel beside the view. Process modes,
+projection/rendering controls, slice-plane controls, and detailed provenance
+remain available but secondary behind disclosure.
+
 #170 establishes the shared atmospheric notebook visual system that later UX
 reset issues should inherit. The app shell should feel calm, pale, and
 notebook-like; blue / blue-gray is the primary accent; green is reserved for
@@ -516,6 +523,7 @@ Implementation anchor:
 - #119 stabilizes the 3-D visualizer viewport around an explicit plotting group shared by the domain box, floor/grid, scale markers, slice planes, and point cloud. The MVP controls should be view/projection mode, zoom, and reset view rather than fake orbit/pan camera controls, with projection descriptions and scale markers visible at normal browser zoom.
 - #121 adds explicit 3-D slice-plane controls: horizontal `z` slices can move up/down, vertical `x-z` slices can move through `y`, and vertical `y-z` slices can move through `x`. These controls reuse the backend slice API and remain native-grid selectors, not interpolation or true camera rotation.
 - #125 refactors the visualizer into a fixed scientific workbench: primary visual controls sit beside the viewport, timeline and slice-position controls sit below the render, technical details move to a secondary panel, and axes/scale/annotation labels stay readable outside the zoomed data layer. Browser visual checks are required for layout changes so the scene cannot cover controls again.
+- #172 redesigns Explore around one primary visualization plus one explanation panel. The visible interaction should be `What happened here?`; technical Thermal Fate/process controls, rendering details, and provenance stay accessible without dominating the first read.
 - #80 plans visual polish, fly-through/move-through, cinematic export, and thumbnail/preview policy after the practical 3-D MVP. It must not add rendering dependencies or implementation code.
 
 Recommended implementation order:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -103,6 +103,13 @@ selected-region state, clearing the selection, successful explanation payloads,
 backend failure states, missing diagnostics states, technical details
 disclosure, and selected-result flow from Results to Explore.
 
+Explore redesign tests should also cover the current #172 contract: the page
+uses `Explore this result` / `What happened here?` language, opens cloud-forming
+results with `qc` and `w` available, opens no-cloud Dry Failed results as useful
+`w`/updraft inspection cases rather than broken visualizations, shows retryable
+field-loading failures, and keeps advanced process/rendering/provenance controls
+behind disclosure instead of replacing the primary explanation flow.
+
 Do not turn the reset into a broad manual checklist of objective behaviors.
 If a requested acceptance criterion is objective and repeatable, convert it
 into a unit/component or Playwright test.


### PR DESCRIPTION
Closes #172

Issue worked:
- #172

Summary:
- Renamed Explore from field-inspection language to an explanation-first `Explore this result` flow.
- Promoted `What happened here?` as the visible explanation panel in both 2-D and 3-D Explore views.
- Added selected-result context at the top of each Explore view so cloud/no-cloud and rain state stay obvious.
- Made the 3-D cloud view more dominant by simplifying visible controls to field, zoom, and reset while moving process focus, view presets, projection/rendering settings, slice-plane controls, and provenance/evidence detail behind disclosures.
- Kept #169 trust states intact: cloud-forming results load qc/w, Dry Failed stays a useful no-cloud/updraft path, and field-loading failures remain retryable.
- Updated docs so future Explore work keeps the explanation panel and disclosure hierarchy as the intended direction.

Tests added/updated:
- Updated component coverage for Explore labels, explanation panel behavior, hidden/secondary process controls, 3-D retry trust state, Dry Failed no-cloud copy, and visualizer controls.
- Updated Playwright mocked-smoke coverage for Results -> Explore, Dry Failed no-cloud/updraft path, field-loading failure, nav reachability, and visualizer occlusion/layout checks under the new disclosure model.

Commands run:
- `scripts/check.sh`
- `scripts/check-e2e.sh`

Manual QA needed:
- Yes, qualitative only.
- Does Explore immediately feel centered on “What happened here?” rather than debug controls?
- Does the main 2-D/3-D visualization feel dominant enough?
- Are the hidden technical controls still discoverable without dominating the page?
- Does Dry Failed read as a useful no-cloud/updraft case rather than broken?

Caveats / follow-up issues:
- No renderer technology, CM1 science, raw NetCDF browser parsing, Build redesign, or Results redesign changes were included.
- This PR is intentionally left unmerged for review.