### PR TITLE
Clean up unified Explore tests and roadmap language

### DIFF
--- a/app/frontend/e2e/helpers.ts
+++ b/app/frontend/e2e/helpers.ts
@@ -23,10 +23,6 @@ export async function openResultsTab(page: Page, tabName: RegExp) {
   await page.getByRole("tab", { name: tabName }).click();
 }
 
-export async function openExploreTab(page: Page, tabName: RegExp) {
-  await page.getByRole("tab", { name: tabName }).click();
-}
-
 export function collectConsoleProblems(page: Page): string[] {
   const problems: string[] = [];
   page.on("console", (message) => {

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -42,7 +42,6 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("Cloud formed").first()).toBeVisible();
     await expect(page.getByText("Rain detected").first()).toBeVisible();
     await expect(page.getByRole("button", { name: "Open in Explore" }).first()).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open in Explore" }).first()).toBeVisible();
     const resultDetail = page.getByLabel("Result detail");
     await resultDetail.getByText("Technical details").click();
     await expect(resultDetail.getByText("Run ID")).toBeVisible();
@@ -74,7 +73,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("button", { name: "Open in Explore" }).first()).toBeVisible();
   });
 
-  test("Explore 2-D and 3-D views render from the selected result", async ({ page }) => {
+  test("Unified Explore renders cloud context, slice inspector, and explanation", async ({ page }) => {
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1545,7 +1545,7 @@ describe("App", () => {
     );
   });
 
-  it("shows missing diagnostics and warnings without field inspection UI", async () => {
+  it("shows missing diagnostics and warnings without exposing Explore slice controls in Results", async () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "No diagnostics yet" }));
@@ -2075,7 +2075,7 @@ describe("App", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
-  it("renders cloud-water point cloud in the 3-D visualizer", async () => {
+  it("renders cloud-water context in unified Explore", async () => {
     render(<App />);
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Open in Explore" }))[0]);
@@ -2162,7 +2162,7 @@ describe("App", () => {
     );
   });
 
-  it("supports qc and w slice planes synced to visualizer time", async () => {
+  it("supports qc and w slice planes synced to Explore time", async () => {
     render(<App />);
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Open in Explore" }))[0]);
@@ -2249,7 +2249,7 @@ describe("App", () => {
     });
   });
 
-  it("updates and resets the 3-D scene shell view controls", async () => {
+  it("updates and resets unified Explore view controls", async () => {
     render(<App />);
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Open in Explore" }))[0]);
@@ -2298,7 +2298,7 @@ describe("App", () => {
     });
   });
 
-  it("handles missing qc in the 3-D point-cloud renderer", async () => {
+  it("handles missing qc in the unified Explore cloud context", async () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "No diagnostics yet" }));
@@ -2315,7 +2315,7 @@ describe("App", () => {
     expect(screen.getByLabelText("Cloud-water threshold")).toBeDisabled();
   });
 
-  it("handles a 3-D scene shell result with no visualization-ready fields", async () => {
+  it("handles an Explore result with no visualization-ready fields", async () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "No visual fields" }));

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -85,7 +85,7 @@ Pick Baseline Shallow Cumulus
 -> ingest NetCDF output
 -> create result card / experiment notebook entry
 -> replay cloud evolution
--> open 3-D visualizer
+-> open Explore
 -> save/name/tag result
 ```
 
@@ -190,49 +190,36 @@ Deletion is always explicit. The UI first requests a dry-run delete preview for 
 
 1. Select completed run.
 2. App ingests or loads processed data.
-3. App shows diagnostics and visualizer.
+3. App shows diagnostics and a unified Explore workspace.
 4. User can save/name/tag result.
-5. User can replay and inspect the saved result later.
+5. User can reopen, inspect, explain, and compare the saved result later.
 
-### Workflow 6 — 3-D Visualization
+### Workflow 6 — Unified Explore
 
-The visualizer should support:
-
-- time slider/playback
-- projection/view mode controls
-- zoom
-- reset view
-- vertical slice
-- horizontal slice
-- isosurface threshold
-- volume opacity controls
-- sun angle
-- color temperature
-- brightness/contrast
-- cloud appearance presets
-
-The broad original visualizer goal in #31 has been superseded by staged implementation issues. The visualizer should build from saved/ingested results and backend visualization-ready data, not from raw NetCDF parsing in the browser.
-
-Staged visualizer path:
+Explore is now the single selected-result inspection and explanation workspace.
+It should keep the current product loop focused on:
 
 ```text
-Visualization-ready data contract (#72)
--> 2-D field inspection MVP (#73)
--> 3-D scene shell (#77)
--> cloud-water rendering MVP (#78)
--> slice planes (#79)
--> Thermal Fate diagnostics and selected-region process needs (#148/#149/#151)
--> renderer upgrade decision (#112)
--> later visual polish / fly-through / export (#80)
+selected-result trust
+-> 3-D cloud-water context
+-> shared time / field / slice controls
+-> visible native-grid slice plane
+-> matching 2-D slice inspector
+-> click-cell "What happened here?" explanation
+-> technical details on demand
 ```
 
-Every visualizer stage must preserve provenance labels and make clear that rendered output is an interpretation of CM1-derived data.
+The broad original visualizer goal in #31 has been superseded by staged
+implementation issues and the UX reset. Explore should build from saved/ingested
+results and backend visualization-ready data, not from raw NetCDF parsing in the
+browser. Every stage must preserve provenance labels and make clear that rendered
+output is an interpretation of CM1-derived data.
 
-The first 3-D scene shell opens from a Result Card / Experiment Notebook entry.
-It provides the scene container, projection/view controls, zoom, reset view,
-time slider shell, field selector shell, loading/empty/error states, and
-provenance/rendering labels. It does not render cloud water, slices, or
-synthetic cloud physics; those belong to later visualizer issues.
+Renderer upgrades such as isosurfaces, volumetric opacity, cinematic lighting,
+appearance presets, fly-through, and export are not near-term payoff work. They
+remain deferred to the renderer-upgrade decision (#112) and later visual polish
+planning (#80) after the guided experiment notebook and `What happened here?`
+loop are stable.
 
 ### Workflow 6.5 — What Happened Here?
 
@@ -990,13 +977,14 @@ and slice inspector. Process focus, projection/rendering details, raw
 coordinate metadata, and long provenance labels belong behind
 details/disclosure until the user asks for them.
 
-The 2-D and 3-D views should default to physically interesting output views, not
-arbitrary zero-index slices. The backend should provide default field/time/slice
-locations from native-grid data when possible: for `qc`, first cloud time or the
-max cloud-water location; for `w`, the max-updraft location. If those locations
-are unavailable, the UI may fall back to domain-center slices and clearly keep
-the native-grid/provenance caveats available. The 3-D view should not open at
-`t=0` when diagnostics show clouds appear later.
+Explore's cloud context and slice inspector should default to physically
+interesting output views, not arbitrary zero-index slices. The backend should
+provide default field/time/slice locations from native-grid data when possible:
+for `qc`, first cloud time or the max cloud-water location; for `w`, the
+max-updraft location. If those locations are unavailable, the UI may fall back
+to domain-center slices and clearly keep the native-grid/provenance caveats
+available. Explore should not open at `t=0` when diagnostics show clouds appear
+later.
 
 The first comparison workflow is Baseline Shallow Cumulus vs Dry Failed
 Cumulus. It should start as a side-by-side result-card comparison, not a new
@@ -1028,7 +1016,7 @@ Completed results should be replayable and inspectable without rerunning CM1. Du
 - Launch CM1 through local command
 - Track process/log status
 - Ingest NetCDF output or create intermediate artifacts
-- Basic 3-D visualizer MVP
+- Unified Explore cloud context, slice inspector, and explanation workflow
 - Result library
 - Save/name/tag runs
 - Replay and inspect saved results
@@ -1053,30 +1041,27 @@ Completed results should be replayable and inspectable without rerunning CM1. Du
 - Commit generated CM1 output or real NetCDF outputs.
 - Overbuild deployment.
 
-## 3-D Visualizer MVP
+## Unified Explore MVP
 
-Start with a practical visualizer, not a cinematic renderer.
+Start with a practical, trustworthy Explore instrument, not a cinematic
+renderer. The near-term MVP is the product loop: select a saved result, see the
+cloud-water context, inspect the synchronized native-grid slice, click a cell,
+and get a CM1-backed `What happened here?` explanation.
 
-MVP visualizer work should be staged:
+The implemented/near-term Explore layers are:
 
 1. Visualization-ready backend data contract.
-2. 2-D field inspection for orientation, time indexing, scaling, and field availability.
-3. 3-D scene shell with projection/view controls, zoom, reset view, time slider, field selector, and provenance/rendering labels.
-4. Cloud-water rendering MVP for `qc` using a thresholded point cloud from
+2. Native-grid slice inspection for orientation, time indexing, scaling, and
+   field availability.
+3. Cloud-water context for `qc` using a thresholded point cloud from
    visualization-ready data.
-5. Horizontal and vertical slice planes for `qc` and `w`.
+4. Horizontal and vertical slice planes for `qc` and `w`.
+5. Selected-cell / selected-region explanation backed by Thermal Fate
+   diagnostics.
 
-Later:
-
-- volumetric ray marching
-- shadows
-- edge brightening
-- cloud-base darkening
-- fly-through
-- cinematic export
-- thumbnails/previews with strict generated-artifact policy
-
-True fly-through or move-through should remain on the roadmap after the MVP. Projection/view controls, zoom, reset view, time replay, slices, field selection, and cloud-water point/opacity approximation are enough for the first visualizer.
+Later renderer decisions live in #112 and #80, not in the near-term Explore MVP:
+volumetric ray marching, isosurfaces, lighting, appearance controls,
+fly-through/move-through, cinematic export, and thumbnail/preview generation.
 
 The browser should not parse raw CM1 NetCDF directly. Backend ingest and visualization-ready preprocessing should provide selected, provenance-labeled fields for inspection and rendering.
 
@@ -1217,8 +1202,9 @@ MVP behavior:
 - clearly label slices as CM1-derived inspection data, not 3-D rendering.
 
 The 2-D inspector is deliberately practical and small. It helps verify field
-orientation, time indexing, vertical coordinates, units, and scaling before the
-3-D scene shell and cloud rendering work begin.
+orientation, time indexing, vertical coordinates, units, and scaling inside the
+unified Explore workflow before any later renderer upgrade changes the visual
+representation.
 
 ## Visualization-Ready Data Contract
 

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -204,23 +204,23 @@ The selected-region product question is:
 What happened here?
 ```
 
-### 6. 3-D Visualizer
+### 6. Unified Explore
 
-An important payoff, but not the only product center of gravity.
+An important payoff, but not the only product center of gravity. Explore should
+first feel like one trustworthy instrument for understanding a selected result:
+cloud context, synchronized slices, `What happened here?`, and technical
+evidence on demand.
 
-Visualize CM1 output with:
+Near-term Explore should support:
 
 - time replay
 - projection/view controls
 - zoom and reset view
-- fly-through / move-through later
-- sun angle
-- color temperature
-- opacity/brightness controls
 - slices
 - projections
-- isosurfaces
-- volume rendering eventually
+- selected-region markers
+- plain-language explanations
+- provenance and caveats
 
 ## First Scenario Set
 
@@ -251,18 +251,22 @@ moisture/saturation evidence, and precipitation-feedback caveats should guide
 renderer choices. Visual polish follows process needs, not the other way
 around.
 
-Useful views:
+Useful views for the current Explore loop:
 
-- Cloud-water volume / isosurface
+- Cloud-water context
 - Rain-water field
 - Vertical velocity field
 - Horizontal slices
 - Vertical slices
 - Cloud top/base diagnostics
 - Time replay
-- 3-D projection exploration
-- Appearance rendering from cloud water
-- Lighting and view controls
+- 3-D projection context
+- Selected-region explanation
+- Technical evidence and caveats
+
+Renderer upgrades such as isosurfaces, volumetric rendering, cinematic lighting,
+fly-through, export, and appearance polish should wait until the notebook,
+comparison, and `What happened here?` loop are stable.
 
 ## Trust/Honesty Rules
 

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -179,7 +179,7 @@ Pick Baseline Shallow Cumulus
 -> ingest NetCDF output
 -> create result card / experiment notebook entry
 -> replay cloud evolution
--> open 3-D visualizer
+-> open Explore
 -> save/name/tag result
 ```
 
@@ -494,19 +494,21 @@ Implementation anchor:
 - #110 adds the disciplined Baseline Shallow Cumulus low-level humidity ladder. `drier`, `baseline`, and `more_humid` preserve the accepted external-sounding namelist family and change only the generated `input_sounding` moisture profile for one-control-at-a-time learning. Initial local quick-look validation completed and ingested: `drier` produced no cloud/rain with meaningful vertical motion, while `more_humid` produced earlier cloud, rain, stronger `qc`, and stronger updrafts.
 - #140 implements the first Capped / Suppressed Cumulus stronger-cap package from the accepted external-sounding baseline. The package preserves the namelist family and changes only potential-temperature / stability near the cap for `cap_strength = stronger`. Validation run `dry-run-capped-suppressed-20260526015634` completed and ingested 13 model-output time steps with `cloud formed; rain detected`, but cloud top, max `qc`, cloud fraction, max/min `w`, and max rain water were all reduced relative to the accepted baseline. Treat it as `accepted_with_notes` / cap-limited candidate until process diagnostics can directly explain the cap limitation.
 
-## M4 3-D Visualizer MVP
+## M4 Unified Explore MVP
 
-Goal: deliver the main payoff: inspect CM1 cloud evolution in 3-D.
+Goal: deliver the main payoff as a stable selected-result Explore loop: see the
+cloud context, inspect synchronized slices, click a cell/region, and ask `What
+happened here?`
 
 Deliverables:
 
-- 3-D scene shell.
-- projection/view controls, zoom, and reset view.
-- time slider/replay.
-- field selector.
-- horizontal/vertical slices.
-- cloud-water isosurface or opacity approximation.
-- simple lighting.
+- selected-result trust and field-loading states.
+- unified desktop Explore workflow.
+- 3-D `qc` cloud-water context as an interpretation of CM1 output.
+- shared time / field / slice controls.
+- horizontal/vertical native-grid slices.
+- selected-cell `What happened here?` explanation.
+- technical details and provenance on demand.
 
 Implementation anchor:
 
@@ -525,7 +527,10 @@ Implementation anchor:
 - #125 refactors the visualizer into a fixed scientific workbench: primary visual controls sit beside the viewport, timeline and slice-position controls sit below the render, technical details move to a secondary panel, and axes/scale/annotation labels stay readable outside the zoomed data layer. Browser visual checks are required for layout changes so the scene cannot cover controls again.
 - #172 redesigns Explore around one primary visualization plus one explanation panel. The visible interaction should be `What happened here?`; technical Thermal Fate/process controls, rendering details, and provenance stay accessible without dominating the first read.
 - #184 consolidates the former `2-D Slices` / `3-D View` scaffold into one desktop Explore workflow. The current target is compact selected-result context, shared field/time/slice controls, 3-D `qc` cloud-water context, a visible native-grid slice plane, the matching 2-D slice inspector, and selected-cell `What happened here?` diagnostics. `w` and other broader fields are inspected through slices, not through fake 3-D point rendering.
-- #80 plans visual polish, fly-through/move-through, cinematic export, and thumbnail/preview policy after the practical 3-D MVP. It must not add rendering dependencies or implementation code.
+- #185 cleans the Explore test suite after #184 so tests protect the unified workflow rather than the old separate `2-D Slices` / `3-D View` scaffold.
+- #177 keeps older visualizer-roadmap language from pulling near-term work back toward renderer polish before the UX/product loop is stable.
+- #112 is the renderer-upgrade decision point after the simplified Explore loop is stable.
+- #80 plans visual polish, fly-through/move-through, cinematic export, and thumbnail/preview policy later. It must not add rendering dependencies or implementation code.
 
 Recommended implementation order:
 
@@ -539,10 +544,16 @@ Recommended implementation order:
 -> #77 3-D scene shell
 -> #78 cloud-water rendering
 -> #79 slice planes
+-> #169 selected-result trust states
+-> #170/#171 notebook visual system and Results
+-> #175 What happened here? interaction model
+-> #172/#184 unified Explore explanation workflow
+-> #185 Explore test cleanup
+-> #112 renderer upgrade decision later
 -> #80 visual polish / fly-through / export later
 ```
 
-The 3-D visualizer should open from saved or ingested results, should not require rerunning CM1, and should label visual output as an interpretation of CM1-derived data with clear provenance and rendering-method labels.
+Explore should open from saved or ingested results, should not require rerunning CM1, and should label visual output as an interpretation of CM1-derived data with clear provenance and rendering-method labels.
 
 ## M5 Visual Polish + Export
 
@@ -564,7 +575,7 @@ Implementation anchor:
 - Rendering remains an interpretation of CM1-derived data. Future polish must preserve provenance labels for source model, run/result, field, processing method, rendering method, units, and caveats.
 - Candidate post-MVP work includes volumetric ray marching, shadows, edge brightening, cloud-base darkening, fly-through or move-through camera modes, cinematic still/video export, and generated thumbnails/previews for saved results.
 - Generated visual artifacts remain local/generated outputs by default. Do not commit thumbnails, videos, render caches, large processed visualization data, or generated previews unless a future issue defines a strict tiny-fixture policy.
-- M5 should start only after the inspectable result loop is useful: NetCDF ingest, diagnostics, result cards, Results Library UI, visualization-ready data, 2-D field inspection, 3-D scene shell, thresholded cloud-water rendering, and slice planes.
+- M5 should start only after the inspectable result loop is useful and stable: NetCDF ingest, diagnostics, result cards, Results, unified Explore, selected-region explanation, and test coverage for the current product loop.
 
 ## Initial Lower-Atmosphere Scenario Set
 
@@ -604,7 +615,7 @@ The canonical startup backlog now lives in GitHub issues and milestones:
 - M1.5 Golden Path Manual CM1 Validation
 - M2 Local CM1 Run Manager
 - M3 Results Library + Experiment Notebook
-- M4 3-D Visualizer MVP
+- M4 Unified Explore MVP
 - M5 Visual Polish + Export
 
 Issue work should remain scoped, testable, and honest about whether it is preview guidance, generated CM1 configuration, running/completed CM1 result, or visualization interpretation.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -266,7 +266,7 @@ contract rather than table mechanics. Component and Playwright tests should
 verify that Results / Notebook presents scan-friendly experiment entries,
 selected result details, cloud/rain outcomes, first cloud time, max `qc`,
 max/min `w`, caveats, saved/protected state, editable name/tags/notes, and
-actions into Explore or 3-D. They should also verify that raw run IDs,
+actions into the unified Explore workflow. They should also verify that raw run IDs,
 lifecycle/product states, controls, provenance labels, and detailed warnings
 remain available under technical-details disclosure instead of dominating the
 primary notebook view.
@@ -293,16 +293,16 @@ time-index mismatch labeling where practical, units, min/max, finite/non-finite
 counts, provenance labels, and the guarantee that raw NetCDF is not parsed in
 the browser.
 
-3-D scene shell component tests should also mock the visualization-ready field
-catalog instead of reading NetCDF in the browser. They should cover opening from
-a Result Card, scene container rendering, projection/view controls, zoom/reset
-view controls, time slider shell, field selector shell, interesting-time/default
-slice selection, first-cloud/max-cloud/max-updraft jump controls, domain box,
-axes/height/floor labels, scale markers, fixed workbench regions, stable
-data-layer transforms, projection descriptions, provenance/rendering details,
-and no-field/error states. They must not assert isosurfaces, true camera
-orbit/pan behavior, or volumetric effects until later visualizer issues
-implement those layers.
+Unified Explore cloud-context component tests should mock the visualization-ready
+field catalog instead of reading NetCDF in the browser. They should cover
+opening from a Result Card, selected-result header rendering, shared
+field/time/slice controls, cloud-context rendering, projection/view controls,
+zoom/reset view controls, interesting-time/default slice selection,
+first-cloud/max-cloud/max-updraft jump controls, domain axes/height/floor
+labels, scale markers, fixed workbench regions, stable data-layer transforms,
+projection descriptions, provenance/rendering details, and no-field/error
+states. They must not assert isosurfaces, true camera orbit/pan behavior, or
+volumetric effects until later renderer issues implement those layers.
 
 Cloud-water point-cloud tests should use tiny synthetic NetCDF fixtures on the
 backend and mocked visualization-ready point payloads on the frontend. Backend
@@ -328,29 +328,30 @@ that height is vertical, top-down should state that height is not shown
 vertically, and oblique should be labeled an interpretive overview rather than a
 true perspective camera.
 
-The consolidated Results/Explore shell and fixed visualizer workbench should
-also get a real browser smoke check after
-layout changes, not only component tests. Open the app, navigate to Results,
-open the validated quick-look baseline in Explore, and confirm by screenshot or
-direct browser inspection that the 3-D cloud-water context, visible slice plane,
-shared controls, 2-D slice inspector, and selected-point explanation are all
-reachable without the render viewport covering controls or details. At minimum
-verify desktop viewports around 1470x956 and 1720x1440, because #184's
-acceptance target is desktop; mobile checks are smoke coverage, not a separate
-mobile redesign acceptance gate.
+The consolidated Results/Explore shell and fixed Explore workbench should also
+get a real browser smoke check after layout changes, not only component tests.
+Open the app, navigate to Results, open the validated quick-look baseline in
+Explore, and confirm by screenshot or direct browser inspection that the 3-D
+cloud-water context, visible slice plane, shared controls, matching slice
+inspector, and selected-point explanation are all reachable without the render
+viewport covering controls or details. At minimum verify desktop viewports
+around 1470x956 and 1720x1440, because #184's acceptance target is desktop;
+mobile checks are smoke coverage, not a separate mobile redesign acceptance
+gate.
 
-3-D slice-plane tests should mock the #72 visualization-ready slice API. They
-should cover horizontal and vertical slice planes, `qc` and `w` field selection,
-time synchronization with the 3-D point cloud, native-grid caveats/provenance
-labels, selected-time max `qc`/`w` default locations, visible slice-plane
-orientation changes, view presets, explicit horizontal `z`, vertical `x-z`, and
-vertical `y-z` controls, up/down or forward/back level-index movement, selected
-slice-cell point diagnostics, and clear error states for missing fields or bad
-slice requests. They must not parse raw NetCDF in the browser, add rendering
-dependencies, or test ray marching, cinematic lighting, export, fly-through, or
-generated CM1 output. The 3-D point context remains `qc` cloud water only; `w`
-and broader variable inspection should be tested through the synchronized slice
-path unless a future issue adds a scientifically honest 3-D representation.
+Unified Explore slice-plane tests should mock the #72 visualization-ready slice
+API. They should cover horizontal and vertical slice planes, `qc` and `w` field
+selection, time synchronization with the cloud-water context, native-grid
+caveats/provenance labels, selected-time max `qc`/`w` default locations, visible
+slice-plane orientation changes, projection controls, explicit horizontal `z`,
+vertical `x-z`, and vertical `y-z` controls, up/down or forward/back
+level-index movement, selected slice-cell point diagnostics, and clear error
+states for missing fields or bad slice requests. They must not parse raw NetCDF
+in the browser, add rendering dependencies, or test ray marching, cinematic
+lighting, export, fly-through, or generated CM1 output. The 3-D point context
+remains `qc` cloud water only; `w` and broader variable inspection should be
+tested through the synchronized slice path unless a future issue adds a
+scientifically honest 3-D representation.
 Visual first-impression tests should also keep the validated quick-look baseline
 on a cloud-bearing time, show a visible point-cloud state, keep slice planes
 optional and secondary, and keep technical provenance reachable without making


### PR DESCRIPTION
Closes #185
Closes #177

## Issue worked
- #185
- #177

## Summary
- Removed stale Explore test helper/code assumptions around separate `2-D Slices` / `3-D View` destinations and renamed the mocked smoke flow around the unified Explore workflow.
- Renamed component test descriptions so they describe unified Explore behavior while preserving the existing selected-result, field-loading, missing-field, and Dry Failed/no-cloud coverage.
- Updated product vision, product spec, roadmap, and testing docs to keep Build -> Results -> unified Explore as the current product model.
- Demoted old renderer-first roadmap language so isosurfaces, volume rendering, lighting, fly-through/export, and visual polish remain later decisions after the UX/product loop is stable.

## Tests added/updated
- Updated Playwright mocked-smoke wording for the unified Explore cloud-context/slice/explanation flow.
- Updated frontend component test descriptions only; existing #169 trust-state coverage remains intact.
- Preserved Dry Failed / no-cloud vertical-motion coverage in the mocked Results -> Explore path.

## Commands run
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Manual QA needed
No. This is a tests/docs cleanup PR with no UI behavior, renderer, CM1, or science changes.

## Generated-data check
No screenshots, videos, traces, reports, generated outputs, logs, NetCDF files, CM1 runtime files, or large artifacts were committed.