### PR TITLE
Gate Explore process evidence modes

### DIFF
--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -177,6 +177,37 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/selected point: x/i)).toBeVisible();
   });
 
+  test("Explore process evidence offers useful modes and moves unsupported modes secondary", async ({
+    page,
+  }) => {
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+
+    await expect(page.getByText(/what happened in this result/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByText("Process evidence details").click();
+
+    const processMode = page.getByLabel("Process mode");
+    await expect(processMode).toBeVisible();
+    await expect(processMode.locator("option", { hasText: "Thermal Fate summary" })).toHaveCount(
+      1,
+    );
+    await expect(processMode.locator("option", { hasText: "Cloud Water" })).toHaveCount(1);
+    await expect(processMode.locator("option", { hasText: "Updrafts" })).toHaveCount(1);
+    await expect(processMode.locator("option", { hasText: "Moisture" })).toHaveCount(0);
+    await expect(processMode.locator("option", { hasText: "Buoyancy" })).toHaveCount(0);
+    await expect(processMode.locator("option", { hasText: "Deep Breakthrough" })).toHaveCount(0);
+    await expect(processMode.locator("option", { hasText: "Precipitation Feedback" })).toHaveCount(
+      0,
+    );
+
+    await page.getByText("Not available for this result").click();
+    await expect(page.getByText("Moisture / Saturation", { exact: true })).toBeVisible();
+    await expect(page.getByText("Deep Breakthrough", { exact: true })).toBeVisible();
+    await expect(page.getByText(/missing required CM1 fields/i)).toBeVisible();
+  });
+
   test("Results to Explore loads cloud-forming qc and w fields", async ({ page }) => {
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1853,6 +1853,31 @@ details[open] > summary {
   font-weight: 850;
 }
 
+.process-mode-helper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.unavailable-diagnostics {
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.55rem;
+}
+
+.unavailable-diagnostics summary {
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
+  font-weight: 800;
+}
+
+.muted-text {
+  color: var(--color-text-muted);
+}
+
 .inspector-controls label {
   display: grid;
   gap: 0.4rem;

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -220,6 +220,42 @@ const dryFailedCard = {
   updated_at: "2026-05-22T19:52:00Z",
 };
 
+const cappedCard = {
+  ...resultCard,
+  result_id: "result-capped-cumulus",
+  run_id: "dry-run-capped-suppressed-20260526015634",
+  name: "Capped / Suppressed Cumulus quick-look",
+  tags: ["capped", "quick-look"],
+  notes: "Stronger-cap contrast candidate.",
+  scenario_id: "capped-suppressed-cumulus",
+  scenario_name: "Capped / Suppressed Cumulus",
+  physical_question:
+    "How does a stronger cap suppress or limit shallow-cumulus growth even when moisture and boundary-layer thermals are available?",
+  controls: {
+    low_level_humidity: "baseline",
+    surface_heating: "baseline",
+    cap_strength: "stronger",
+  },
+  diagnostics_summary: "cloud formed; rain detected",
+  thermal_fate_label: "Capped / suppressed cumulus candidate",
+  thermal_fate_confidence: "candidate",
+  main_limiting_factor: "cap/stability",
+  first_cloud_time_seconds: 2700,
+  max_qc_kg_kg: 0.0004778,
+  time_of_max_qc_seconds: 3600,
+  max_w_m_s: 3.1,
+  time_of_max_w_seconds: 3600,
+  min_w_m_s: -1.8,
+  time_of_min_w_seconds: 4500,
+  rain_present: true,
+  first_rain_time_seconds: 7200,
+  caveats: ["cap_layer_annotation_is_proxy_without_full_cap_diagnostics"],
+  created_at: "2026-05-26T01:56:34Z",
+  completed_at: "2026-05-26T02:15:00Z",
+  ingested_at: "2026-05-26T02:20:00Z",
+  updated_at: "2026-05-26T02:20:00Z",
+};
+
 const missingDiagnosticsCard = {
   ...resultCard,
   result_id: "result-no-diagnostics",
@@ -253,7 +289,7 @@ const emptyVisualizerCard = {
 };
 
 const resultsResponse = {
-  results: [resultCard, dryFailedCard, missingDiagnosticsCard, emptyVisualizerCard],
+  results: [resultCard, dryFailedCard, cappedCard, missingDiagnosticsCard, emptyVisualizerCard],
 };
 
 const storageRuns = [
@@ -628,6 +664,23 @@ const dryFailedFieldCatalogResponse = {
     },
   })),
 };
+
+const cappedFieldCatalogResponse = {
+  ...fieldCatalogResponse,
+  result_id: "result-capped-cumulus",
+  run_id: "dry-run-capped-suppressed-20260526015634",
+  scenario_id: "capped-suppressed-cumulus",
+  available_fields: fieldCatalogResponse.available_fields.map((field) => ({
+    ...field,
+    provenance: {
+      ...field.provenance,
+      result_id: "result-capped-cumulus",
+      run_id: "dry-run-capped-suppressed-20260526015634",
+      scenario_id: "capped-suppressed-cumulus",
+    },
+  })),
+};
+
 
 function sliceResponse({
   field = "qc",
@@ -1028,6 +1081,25 @@ beforeEach(() => {
               scenario_id: "dry-failed-cumulus",
               preferred_field: "w",
               fields: { w: viewDefaultsResponse.fields.w },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/results/result-capped-cumulus/visualization/fields") {
+        return Promise.resolve(
+          new Response(JSON.stringify(cappedFieldCatalogResponse), { status: 200 }),
+        );
+      }
+      if (url.startsWith("/api/results/result-capped-cumulus/visualization/defaults")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ...viewDefaultsResponse,
+              result_id: "result-capped-cumulus",
+              run_id: "dry-run-capped-suppressed-20260526015634",
+              scenario_id: "capped-suppressed-cumulus",
+              preferred_field: "qc",
             }),
             { status: 200 },
           ),
@@ -2159,7 +2231,7 @@ describe("App", () => {
     );
   });
 
-  it("keeps process-aware evidence available behind technical controls", async () => {
+  it("keeps only supported process evidence modes in the Baseline primary focus control", async () => {
     render(<App />);
 
     const resultDetail = await screen.findByLabelText("Result detail");
@@ -2172,11 +2244,76 @@ describe("App", () => {
       .toBeGreaterThan(0);
 
     fireEvent.click(screen.getByText("Process evidence details"));
-    fireEvent.change(screen.getByLabelText("Process mode"), {
-      target: { value: "moisture" },
-    });
+    const processMode = screen.getByLabelText("Process mode");
+    expect(processMode).toHaveValue("thermal_fate");
+    expect(within(processMode).getByRole("option", { name: /Thermal Fate summary/ }))
+      .toBeInTheDocument();
+    expect(within(processMode).getByRole("option", { name: "Cloud Water" })).toBeInTheDocument();
+    expect(within(processMode).getByRole("option", { name: "Updrafts" })).toBeInTheDocument();
+    expect(within(processMode).getByRole("option", { name: /Cloud Lifecycle/ })).toBeInTheDocument();
+    expect(within(processMode).queryByRole("option", { name: /Moisture/ })).not.toBeInTheDocument();
+    expect(within(processMode).queryByRole("option", { name: /Buoyancy/ })).not.toBeInTheDocument();
+    expect(within(processMode).queryByRole("option", { name: /Deep Breakthrough/ })).not
+      .toBeInTheDocument();
+    expect(within(processMode).queryByRole("option", { name: /Precipitation Feedback/ })).not
+      .toBeInTheDocument();
 
-    expect(screen.getByLabelText("Process mode")).toHaveValue("moisture");
+    fireEvent.change(processMode, { target: { value: "cloud_water" } });
+
+    expect(processMode).toHaveValue("cloud_water");
+    expect(screen.getByRole("heading", { name: "Cloud Water" })).toBeInTheDocument();
+
+    expect(screen.getByText("Not available for this result")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Not available for this result"));
+    expect(screen.getByText(/Moisture \/ Saturation/)).toBeInTheDocument();
+    expect(screen.getByText(/missing required CM1 fields/i)).toBeInTheDocument();
+    expect(screen.getByText(/Deep Breakthrough/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Future diagnostic/i).length).toBeGreaterThan(0);
+  });
+
+  it("shows Dry Failed moisture limitation as a candidate focus instead of a dead-end", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dry Failed Cumulus quick-look" }));
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    await screen.findByText("Slice synced");
+    fireEvent.click(screen.getByText("Process evidence details"));
+    const processMode = screen.getByLabelText("Process mode");
+    expect(within(processMode).getByRole("option", { name: /Moisture \/ Saturation \(candidate\)/ }))
+      .toBeInTheDocument();
+    expect(within(processMode).queryByRole("option", { name: /Buoyancy/ })).not.toBeInTheDocument();
+
+    fireEvent.change(processMode, { target: { value: "moisture" } });
+
+    expect(processMode).toHaveValue("moisture");
+    expect(screen.getByRole("heading", { name: "Moisture / Saturation" })).toBeInTheDocument();
+    expect(screen.getAllByText("Candidate").length).toBeGreaterThan(0);
+    expect(screen.getByText(/thermals are present while cloud water and rain stay below threshold/i))
+      .toBeInTheDocument();
+  });
+
+  it("shows capped-style results with cap inversion as a candidate focus", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Capped / Suppressed Cumulus quick-look" }));
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+
+    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    await screen.findByText("Slice synced");
+    fireEvent.click(screen.getByText("Process evidence details"));
+    const processMode = screen.getByLabelText("Process mode");
+    expect(within(processMode).getByRole("option", { name: /Cap \/ Inversion \(candidate\)/ }))
+      .toBeInTheDocument();
+
+    fireEvent.change(processMode, { target: { value: "cap" } });
+
+    expect(processMode).toHaveValue("cap");
+    expect(screen.getByRole("heading", { name: "Cap / Inversion" })).toBeInTheDocument();
+    expect(screen.getByText(/candidate process view/i)).toBeInTheDocument();
   });
 
   it("handles missing qc fields without treating no-qc as a broken Explore state", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -3514,6 +3514,18 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const activeSlice = activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice;
   const activeSliceLabel = slicePlainLabel(activeSlice, activeSlicePlane, activeSliceIndex);
   const selectedSliceValue = selectedSliceCellValue(activeSlice, selectedRegion);
+  const processModeStates = useMemo(
+    () => processModeClassifications(result, catalog, sliceField, activeSlice),
+    [activeSlice, catalog, result, sliceField],
+  );
+  const primaryProcessModes = processModeStates.filter((state) => state.primary);
+  const unavailableProcessModes = processModeStates.filter((state) => !state.primary);
+  const activeProcessMode = primaryProcessModes.some((state) => state.mode === processMode)
+    ? processMode
+    : (primaryProcessModes[0]?.mode ?? "thermal_fate");
+  const activeProcessModeState =
+    primaryProcessModes.find((state) => state.mode === activeProcessMode) ??
+    processModeStates.find((state) => state.mode === activeProcessMode);
   const timePresets = [
     result.time_of_max_qc_seconds !== null && result.time_of_max_qc_seconds !== undefined
       ? { label: "Max cloud water", seconds: result.time_of_max_qc_seconds }
@@ -3528,6 +3540,12 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
       ? { label: "Rain onset", seconds: result.first_rain_time_seconds }
       : null,
   ].filter((preset): preset is { label: string; seconds: number } => preset !== null);
+
+  useEffect(() => {
+    if (processMode !== activeProcessMode) {
+      setProcessMode(activeProcessMode);
+    }
+  }, [activeProcessMode, processMode]);
 
   useEffect(() => {
     if (!selectedField || selectedField.raw_field_name !== "qc") {
@@ -3942,12 +3960,18 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
 
           <details className="technical-details">
             <summary>Process evidence details</summary>
-            <ProcessModeControl processMode={processMode} onProcessModeChange={setProcessMode} />
+            <ProcessModeControl
+              processMode={activeProcessMode}
+              processModeStates={primaryProcessModes}
+              activeProcessModeState={activeProcessModeState}
+              unavailableProcessModes={unavailableProcessModes}
+              onProcessModeChange={setProcessMode}
+            />
             <ProcessOverlayPanel
               result={result}
               catalog={catalog}
               selectedField={sliceField}
-              processMode={processMode}
+              processMode={activeProcessMode}
               slice={activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice}
             />
           </details>
@@ -4399,25 +4423,68 @@ function axisSize(slice: SliceResponse, dimension: string | null): number {
 
 function ProcessModeControl({
   processMode,
+  processModeStates,
+  activeProcessModeState,
+  unavailableProcessModes,
   onProcessModeChange,
 }: {
   processMode: ProcessMode;
+  processModeStates: ProcessModeClassification[];
+  activeProcessModeState: ProcessModeClassification | undefined;
+  unavailableProcessModes: ProcessModeClassification[];
   onProcessModeChange: (mode: ProcessMode) => void;
 }) {
   return (
     <fieldset className="process-mode-control">
       <legend>Explanation focus</legend>
-      <select
-        aria-label="Process mode"
-        value={processMode}
-        onChange={(event) => onProcessModeChange(event.target.value as ProcessMode)}
-      >
-        {PROCESS_MODES.map((mode) => (
-          <option key={mode} value={mode}>
-            {processModeLabel(mode)}
-          </option>
-        ))}
-      </select>
+      {processModeStates.length > 0 ? (
+        <>
+          <select
+            aria-label="Process mode"
+            value={processMode}
+            onChange={(event) => onProcessModeChange(event.target.value as ProcessMode)}
+          >
+            {processModeStates.map((state) => (
+              <option key={state.mode} value={state.mode}>
+                {processModeLabel(state.mode)}
+                {state.support === "candidate" ? " (candidate)" : ""}
+              </option>
+            ))}
+          </select>
+          {activeProcessModeState && (
+            <p className="process-mode-helper">
+              <StatusBadge
+                label={processSupportLabel(activeProcessModeState.support)}
+                tone={
+                  activeProcessModeState.support === "supported"
+                    ? "good"
+                    : activeProcessModeState.support === "candidate"
+                      ? "neutral"
+                      : "warning"
+                }
+              />
+              <span>{activeProcessModeState.primaryReason}</span>
+            </p>
+          )}
+        </>
+      ) : (
+        <p>No supported process evidence focus is available for this result yet.</p>
+      )}
+      {unavailableProcessModes.length > 0 && (
+        <details className="unavailable-diagnostics">
+          <summary>Not available for this result</summary>
+          <ul className="compact-list">
+            {unavailableProcessModes.map((state) => (
+              <li key={state.mode}>
+                <strong>{processModeLabel(state.mode)}</strong>{" "}
+                <span className="muted-text">
+                  {processSupportLabel(state.support)}. {state.primaryReason} {state.description}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
     </fieldset>
   );
 }
@@ -4466,7 +4533,7 @@ function ProcessOverlayPanel({
         <details>
           <summary>Process caveats</summary>
           <ul className="compact-list">
-            {summary.caveats.map((caveat) => (
+            {_dedupeStrings(summary.caveats).map((caveat) => (
               <li key={caveat}>{caveat}</li>
             ))}
           </ul>
@@ -4839,7 +4906,12 @@ const PROCESS_MODES: ProcessMode[] = [
   "precipitation_feedback",
 ];
 
-type ProcessSupport = "supported" | "candidate" | "insufficient_evidence" | "unsupported_missing_fields";
+type ProcessSupport =
+  | "supported"
+  | "candidate"
+  | "insufficient_evidence"
+  | "unsupported_missing_fields"
+  | "future";
 
 type ProcessModeSummary = {
   support: ProcessSupport;
@@ -4848,6 +4920,12 @@ type ProcessModeSummary = {
   description: string;
   annotations: string[];
   caveats: string[];
+};
+
+type ProcessModeClassification = ProcessModeSummary & {
+  mode: ProcessMode;
+  primary: boolean;
+  primaryReason: string;
 };
 
 function processModeSummary(
@@ -4872,8 +4950,11 @@ function processModeSummary(
     : "No active slice summary is available yet.";
 
   if (mode === "thermal_fate") {
+    const hasResultSummary = Boolean(result.thermal_fate_label || result.diagnostics_summary);
+    const summarySupport =
+      confidence === "insufficient_evidence" && hasResultSummary ? "candidate" : confidence;
     return {
-      support: confidence,
+      support: summarySupport,
       evidenceType: "backend process diagnostics",
       source: "Result Card process fields from ingested CM1 output",
       description: `${thermalLabel}. ${
@@ -4958,14 +5039,42 @@ function processModeSummary(
     };
   }
 
+  if (mode === "moisture") {
+    const moistureLimited =
+      result.main_limiting_factor === "moisture" ||
+      result.scenario_id.includes("dry-failed") ||
+      result.caveats.some((caveat) => caveat.includes("moisture"));
+    return {
+      support: moistureLimited ? "candidate" : "unsupported_missing_fields",
+      evidenceType: moistureLimited
+        ? "scenario/control proxy plus cloud-water and updraft diagnostics"
+        : "unavailable moisture diagnostic group",
+      source: moistureLimited
+        ? "Dry Failed / moisture-limited result metadata and derived diagnostics"
+        : "Required humidity, qv, RH, or saturation-deficit fields were not ingested",
+      description: moistureLimited
+        ? "Moisture limitation is a candidate explanation for this contrast case because thermals are present while cloud water and rain stay below threshold."
+        : "Moisture / saturation diagnostics need qv, RH, or saturation-deficit fields before they can be selected as a focus.",
+      annotations: [
+        `Main limiting factor: ${String(result.main_limiting_factor ?? "not recorded")}`,
+        `Cloud: ${cloudOutcome(result)}; max w: ${formatNumber(result.max_w_m_s, "m/s")}`,
+      ],
+      caveats: moistureLimited
+        ? [...caveats, "moisture_limitation_is_candidate_without_direct_qv_or_rh_diagnostics"]
+        : [...caveats, "moisture_unsupported_missing_fields"],
+    };
+  }
+
   if (mode === "precipitation_feedback") {
     return {
-      support: result.rain_present ? "candidate" : "unsupported_missing_fields",
+      support: "future",
       evidenceType: "qr/rain and downdraft proxy diagnostics",
-      source: "Rain summary and w min diagnostics",
+      source: result.rain_present
+        ? "Rain summary exists, but cold-pool/outflow evidence is not available"
+        : "Required rain, downdraft, cold-pool, and outflow evidence is not available",
       description: result.rain_present
-        ? "Rain is present, but precipitation-feedback needs downdraft/cold-pool evidence before a stronger claim."
-        : "Precipitation-feedback overlay is unavailable because rain/qr was not detected or not output.",
+        ? "Rain is present, but precipitation-feedback needs downdraft/cold-pool evidence before it can be selected as a normal focus."
+        : "Precipitation feedback is future work for this result because rain/cold-pool/outflow diagnostics are not available.",
       annotations: [
         `Rain: ${rainOutcome(result.rain_present)}`,
         `Min w: ${formatNumber(result.min_w_m_s, "m/s")}`,
@@ -4980,19 +5089,77 @@ function processModeSummary(
     updrafts: "",
     cloud_lifecycle: "",
     cap: "",
-    precipitation_feedback: "",
     moisture: "Moisture / saturation diagnostics need qv/RH or saturation-deficit fields.",
     buoyancy: "Buoyancy diagnostics need thermodynamic fields and a documented buoyancy method.",
     deep_breakthrough: "Deep-breakthrough diagnostics need CAPE/CIN/LFC/EL and sustained-updraft context.",
+    precipitation_feedback:
+      "Precipitation-feedback diagnostics need rain, downdraft, cold-pool, and outflow evidence.",
   };
   return {
-    support: "unsupported_missing_fields",
+    support: mode === "buoyancy" || mode === "deep_breakthrough" ? "future" : "unsupported_missing_fields",
     evidenceType: "unavailable diagnostic group",
     source: "Required source fields were not ingested",
     description: unavailableLabels[mode],
     annotations: ["Unavailable diagnostics are shown explicitly rather than hidden."],
     caveats: [...caveats, `${mode}_unsupported_missing_fields`],
   };
+}
+
+function processModeClassifications(
+  result: ResultCard,
+  catalog: FieldCatalogResponse | null,
+  selectedField: VisualizableField | undefined,
+  slice: SliceResponse | null,
+): ProcessModeClassification[] {
+  return PROCESS_MODES.map((mode) => {
+    const summary = processModeSummary(mode, result, catalog, selectedField, slice);
+    const primary = processModeIsPrimary(mode, summary, result);
+    return {
+      mode,
+      ...summary,
+      primary,
+      primaryReason: primary
+        ? "Supported or useful candidate for this result."
+        : unavailableProcessReason(mode, summary),
+    };
+  });
+}
+
+function processModeIsPrimary(
+  mode: ProcessMode,
+  summary: ProcessModeSummary,
+  result: ResultCard,
+): boolean {
+  if (summary.support === "supported") return true;
+  if (summary.support !== "candidate") return false;
+  if (mode === "precipitation_feedback") return false;
+  if (mode === "cap") {
+    return result.scenario_id.includes("capped") || result.controls.cap_strength === "stronger";
+  }
+  if (mode === "moisture") {
+    return (
+      result.main_limiting_factor === "moisture" ||
+      result.scenario_id.includes("dry-failed") ||
+      result.caveats.some((caveat) => caveat.includes("moisture"))
+    );
+  }
+  return true;
+}
+
+function unavailableProcessReason(mode: ProcessMode, summary: ProcessModeSummary): string {
+  if (summary.support === "future") {
+    return "Future diagnostic: required backend evidence is not implemented for this result family.";
+  }
+  if (summary.support === "unsupported_missing_fields") {
+    return "Missing required CM1 fields or derived diagnostics for this selected result.";
+  }
+  if (summary.support === "insufficient_evidence") {
+    return "Evidence is present but not enough to make this a useful primary focus.";
+  }
+  if (summary.support === "candidate" && mode === "precipitation_feedback") {
+    return "Rain alone is not enough to select precipitation feedback without downdraft/cold-pool evidence.";
+  }
+  return "Not useful as a primary focus for this selected result.";
 }
 
 function processModeLabel(mode: ProcessMode): string {
@@ -5015,7 +5182,8 @@ function normalizeProcessSupport(value: string | null | undefined): ProcessSuppo
     value === "supported" ||
     value === "candidate" ||
     value === "insufficient_evidence" ||
-    value === "unsupported_missing_fields"
+    value === "unsupported_missing_fields" ||
+    value === "future"
   ) {
     return value;
   }
@@ -5028,6 +5196,7 @@ function processSupportLabel(value: ProcessSupport): string {
     candidate: "Candidate",
     insufficient_evidence: "Insufficient evidence",
     unsupported_missing_fields: "Unavailable",
+    future: "Future",
   };
   return labels[value];
 }

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -288,6 +288,19 @@ Thermal Fate labels, native variables, source fields, confidence details, and
 provenance remain available behind details/disclosure. They should not be the
 first-read interaction model.
 
+Process evidence controls in Explore should be result-aware. The primary
+`Explanation focus` control should show only supported modes and caveated modes
+that are still useful for the selected result. For example, direct `qc` cloud
+water and `w` updraft evidence can be normal focus choices when those fields are
+available, moisture limitation can be a candidate focus for Dry Failed-style
+results, and cap/inversion can be a candidate focus for stronger-cap results.
+Modes that need missing fields or future backend diagnostics, such as buoyancy,
+deep breakthrough, or precipitation feedback without cold-pool/outflow evidence,
+belong under a collapsed `Not available for this result` disclosure with plain
+reasons. The browser may gate presentation from existing result metadata,
+support/confidence labels, caveats, and available visualization fields, but it
+must not invent unsupported scientific classifications.
+
 ### Workflow 7 — Duplicate / Tweak / Rerun
 
 1. Duplicate previous setup.

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -531,6 +531,7 @@ Implementation anchor:
 - #184 consolidates the former `2-D Slices` / `3-D View` scaffold into one desktop Explore workflow. The current target is compact selected-result context, shared field/time/slice controls, 3-D `qc` cloud-water context, a visible native-grid slice plane, the matching 2-D slice inspector, and selected-cell `What happened here?` diagnostics. `w` and other broader fields are inspected through slices, not through fake 3-D point rendering.
 - #185 cleans the Explore test suite after #184 so tests protect the unified workflow rather than the old separate `2-D Slices` / `3-D View` scaffold.
 - #177 keeps older visualizer-roadmap language from pulling near-term work back toward renderer polish before the UX/product loop is stable.
+- #196 cleans up process evidence focus states in Explore. The primary `Explanation focus` control should be result-aware and show only supported or useful candidate modes; missing/future diagnostics remain visible under a collapsed `Not available for this result` section with evidence requirements and caveats.
 - #112 is the renderer-upgrade decision point after the simplified Explore loop is stable.
 - #80 plans visual polish, fly-through/move-through, cinematic export, and thumbnail/preview policy later. It must not add rendering dependencies or implementation code.
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -219,11 +219,14 @@ raw-NetCDF parsing or real CM1 output.
 
 Thermal Fate overlay UI tests should mock result cards and visualization-ready
 API payloads. They should cover process mode selection, supported and candidate
-labels, unsupported/unavailable diagnostic groups, cloud base/top or slice
-annotations, cap/inversion proxy caveats, precipitation-feedback and
-deep-breakthrough caveats, and the guarantee that frontend code displays
-backend-derived evidence instead of parsing raw NetCDF or inventing process
-classification.
+labels, result-aware filtering of the primary `Explanation focus` control,
+unsupported/unavailable diagnostic groups under a collapsed `Not available for
+this result` disclosure, cloud base/top or slice annotations, cap/inversion
+proxy caveats, precipitation-feedback and deep-breakthrough caveats, and the
+guarantee that frontend code displays backend-derived evidence instead of
+parsing raw NetCDF or inventing process classification. Baseline, Dry Failed,
+and capped-style mocked result states should remain covered so candidate modes
+appear only when the selected result has useful evidence or metadata.
 
 Thermal Fate Inspector UI tests should mock the selected-region diagnostics API.
 They should cover selecting a slice cell, selecting a bounded center point or


### PR DESCRIPTION
Closes #196

Summary:
- Made the Explore `Explanation focus` control result-aware so the primary dropdown only shows supported modes and useful candidate modes for the selected result.
- Moved missing, insufficient, or future diagnostics into a collapsed `Not available for this result` section with plain evidence requirements.
- Kept Dry Failed moisture limitation and capped/inversion evidence available as candidate focuses only when result metadata supports those stories.
- Documented the supported/candidate/unavailable process-evidence model in the product spec, testing docs, and roadmap.

Tests added/updated:
- Added component coverage for Baseline primary modes, Dry Failed moisture candidate behavior, and capped cap/inversion candidate behavior.
- Added Playwright mocked-smoke coverage that verifies unsupported/future modes are not offered as primary process focuses.

Commands run:
- `scripts/check.sh`
- `scripts/check-e2e.sh`

Browser check:
- Verified a real local More Humid result in Explore after field loading. The primary process-focus options were `Thermal Fate summary (candidate)`, `Cloud Water`, `Updrafts`, and `Cloud Lifecycle (candidate)`; unsupported/future modes were not primary.

Manual QA needed:
- No broad manual QA needed. If reviewing visually, just confirm the Process evidence details section feels like useful result-specific explanation choices rather than a list of dead-end scientific categories.

Generated-data check:
- No CM1 output, NetCDF, logs, screenshots, videos, traces, runtime folders, or generated artifacts committed.