### PR TITLE
Expand Explore scalar field views

### DIFF
--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -28,12 +28,23 @@ FIELD_DEFINITIONS: dict[str, tuple[str, str]] = {
     "qc": ("cloud_water", "Cloud water"),
     "w": ("vertical_velocity", "Vertical velocity"),
     "qr": ("rain_water", "Rain water"),
+    "qv": ("water_vapor", "Water vapor"),
+    "t": ("temperature", "Temperature"),
+    "temp": ("temperature", "Temperature"),
+    "temperature": ("temperature", "Temperature"),
+    "th": ("potential_temperature", "Potential temperature"),
+    "theta": ("potential_temperature", "Potential temperature"),
     "rain": ("accumulated_surface_rain", "Accumulated surface rain"),
     "dbz": ("reflectivity", "Reflectivity"),
 }
 
+SIGNED_FLOW_FIELDS = {"w"}
+SURFACE_POINT_FIELDS = {"rain"}
+POINT_CLOUD_FIELDS = {"qc", "qr", "qv", "dbz", *SURFACE_POINT_FIELDS}
+
 TIME_DIMENSION_CANDIDATES = ("time", "mtime", "t")
 VERTICAL_DIMENSION_CANDIDATES = ("zh", "zf", "z", "height", "height_m", "height_km")
+SURFACE_VERTICAL_CANDIDATES = ("zf", "zh", "z", "height", "height_m", "height_km")
 Y_DIMENSION_CANDIDATES = ("yh", "y")
 X_DIMENSION_CANDIDATES = ("xh", "x")
 
@@ -150,6 +161,11 @@ class PointCloudStats(BaseModel):
 
     source_count: int
     returned_count: int
+    field_min_value: float | None = None
+    field_max_value: float | None = None
+    field_mean_value: float | None = None
+    field_finite_count: int
+    field_non_finite_count: int
     min_value: float | None = None
     max_value: float | None = None
     active_z_min: float | None = None
@@ -246,7 +262,7 @@ def view_defaults(
     dataset, close_datasets = _open_dataset_sequence(metadata)
     try:
         fields: dict[str, FieldViewDefaults] = {}
-        for field_name in ("qc", "w"):
+        for field_name in FIELD_DEFINITIONS:
             if field_name in dataset.data_vars:
                 fields[field_name] = _field_view_defaults(
                     metadata,
@@ -298,11 +314,19 @@ def point_cloud(
     max_points: int,
     encoding: VisualizationEncoding = "json",
 ) -> PointCloudResponse:
-    """Return thresholded native-grid points for cloud-water visualization."""
+    """Return thresholded native-grid points for supported 3-D scalar visualization."""
     if encoding != "json":
         raise VisualizationDataError("Only encoding=json is supported for MVP point clouds.")
-    if field != "qc":
-        raise VisualizationDataError("Only field=qc is supported for MVP cloud-water rendering.")
+    if field not in FIELD_DEFINITIONS:
+        raise VisualizationDataError(f"Unsupported visualization field: {field}")
+    if field in SIGNED_FLOW_FIELDS:
+        raise VisualizationDataError(
+            f"Field {field} requires signed-flow 3-D rendering and is slice-only for now."
+        )
+    if field not in POINT_CLOUD_FIELDS:
+        raise VisualizationDataError(
+            f"Field {field} is available for 2-D slices but not 3-D point-cloud rendering."
+        )
     if not math.isfinite(threshold) or threshold < 0:
         raise VisualizationDataError("threshold must be a finite non-negative number.")
     if max_points <= 0:
@@ -312,29 +336,41 @@ def point_cloud(
     dataset, close_datasets = _open_dataset_sequence(metadata)
     try:
         if field not in dataset.data_vars:
-            raise VisualizationDataError("Cloud water field qc is not available for this result.")
+            raise VisualizationDataError(f"Field is not available for this result: {field}")
         data_array = dataset[field]
         dims = _field_dimensions(data_array)
         if not dims.time:
-            raise VisualizationDataError("Field qc has no time dimension.")
-        if not dims.vertical or not dims.y or not dims.x:
-            raise VisualizationDataError("Field qc must have native vertical/y/x dimensions.")
+            raise VisualizationDataError(f"Field {field} has no time dimension.")
+        is_surface_field = field in SURFACE_POINT_FIELDS and not dims.vertical and dims.y and dims.x
+        if not is_surface_field and (not dims.vertical or not dims.y or not dims.x):
+            raise VisualizationDataError(f"Field {field} must have native vertical/y/x dimensions.")
         _validate_index(time_index, int(data_array.sizes[dims.time]), "time_index")
         at_time = data_array.isel({dims.time: time_index})
-        source_points = _threshold_points(
-            at_time,
-            dims=dims,
-            dataset=dataset,
-            threshold=threshold,
+        source_points = (
+            _threshold_surface_points(at_time, dims=dims, dataset=dataset, threshold=threshold)
+            if is_surface_field
+            else _threshold_points(
+                at_time,
+                dims=dims,
+                dataset=dataset,
+                threshold=threshold,
+            )
         )
         source_count = len(source_points)
+        selected_field_stats = _slice_stats(at_time)
         stride = max(1, math.ceil(source_count / max_points)) if source_count else 1
         returned_points = source_points[::stride][:max_points]
         values = [point[3] for point in source_points]
+        vertical_extent = (
+            _surface_vertical_extent(dataset)
+            if is_surface_field
+            else _coordinate_extent(dataset, dims.vertical)
+        )
+        vertical_extent_name = "z" if is_surface_field else str(dims.vertical)
         coordinate_extents = {
             str(dims.x): _coordinate_extent(dataset, dims.x),
             str(dims.y): _coordinate_extent(dataset, dims.y),
-            str(dims.vertical): _coordinate_extent(dataset, dims.vertical),
+            vertical_extent_name: vertical_extent,
         }
         finite_extents = {
             name: extent for name, extent in coordinate_extents.items() if extent is not None
@@ -346,7 +382,8 @@ def point_cloud(
             [
                 *_field_caveats(field, visual_field.coordinate_names),
                 "native_grid_thresholded_point_cloud",
-                "visualizer_interpretation_of_cm1_qc",
+                f"visualizer_interpretation_of_cm1_{field}",
+                *(["surface_field_rendered_on_domain_floor"] if is_surface_field else []),
                 *(
                     ["deterministic_stride_downsampling_applied"]
                     if source_count > max_points
@@ -369,7 +406,9 @@ def point_cloud(
             coordinate_units={
                 str(dims.x): _coordinate_units(dataset, dims.x),
                 str(dims.y): _coordinate_units(dataset, dims.y),
-                str(dims.vertical): _coordinate_units(dataset, dims.vertical),
+                vertical_extent_name: vertical_extent.units
+                if vertical_extent
+                else _coordinate_units(dataset, dims.vertical),
             },
             coordinate_extents=finite_extents,
             point_order=["x", "y", "z", "value"],
@@ -377,6 +416,11 @@ def point_cloud(
             stats=PointCloudStats(
                 source_count=source_count,
                 returned_count=len(returned_points),
+                field_min_value=selected_field_stats.min,
+                field_max_value=selected_field_stats.max,
+                field_mean_value=selected_field_stats.mean,
+                field_finite_count=selected_field_stats.finite_count,
+                field_non_finite_count=selected_field_stats.non_finite_count,
                 min_value=min(values) if values else None,
                 max_value=max(values) if values else None,
                 active_z_min=min(active_z_values) if active_z_values else None,
@@ -390,8 +434,9 @@ def point_cloud(
                 processing_method="backend_xarray_native_grid_threshold",
                 rendering_method="thresholded_point_cloud",
                 provenance_label=(
-                    "CM1-derived cloud-water point cloud; native-grid threshold; "
-                    "visualizer interpretation"
+                    f"CM1-derived {visual_field.display_name.lower()} "
+                    f"{'floor layer' if is_surface_field else 'point cloud'}; "
+                    "native-grid threshold; visualizer interpretation"
                 ),
             ),
             caveats=caveats,
@@ -552,6 +597,55 @@ def field_slice(
         _validate_index(time_index, int(data_array.sizes[dims.time]), "time_index")
         at_time = data_array.isel({dims.time: time_index})
         spatial_dims = [dimension for dimension in at_time.dims]
+        if len(spatial_dims) == 2 and dims.y and dims.x and not dims.vertical:
+            if orientation != "horizontal":
+                raise VisualizationDataError(
+                    f"Field {field} is a surface field and only supports horizontal slices."
+                )
+            _validate_index(level_index, 1, "level_index")
+            sliced = at_time.transpose(dims.y, dims.x)
+            values = _json_values(sliced)
+            stats = _slice_stats(sliced)
+            visual_field = _visualizable_field(metadata, dataset, field)
+            surface_extent = _surface_vertical_extent(dataset)
+            selected_value = surface_extent.min if surface_extent else 0.0
+            level_units = surface_extent.units if surface_extent else None
+            caveats = _dedupe(
+                [
+                    *_field_caveats(field, visual_field.coordinate_names),
+                    "surface_field_no_vertical_dimension",
+                    "surface_field_rendered_on_domain_floor",
+                    "native_grid_view_no_interpolation",
+                    "json_numeric_slice_mvp",
+                ]
+            )
+            return SliceResponse(
+                result_id=metadata.result_id,
+                run_id=metadata.run_id,
+                scenario_id=metadata.scenario_id,
+                field=visual_field,
+                selection=SliceSelectionMetadata(
+                    time_index=time_index,
+                    time_seconds=_time_value_seconds(dataset, dims.time, time_index),
+                    orientation=orientation,
+                    selected_dimension="surface",
+                    selected_index=0,
+                    selected_coordinate_value=selected_value,
+                    level_units=level_units,
+                    level_coordinate_value=selected_value,
+                    level_meters=_meters_if_safe(selected_value, level_units),
+                ),
+                coordinate_units={
+                    dimension: _coordinate_units(dataset, dimension) for dimension in sliced.dims
+                },
+                shape=[int(size) for size in sliced.shape],
+                dimension_order=[str(dimension) for dimension in sliced.dims],
+                data_encoding=encoding,
+                values=values,
+                stats=stats,
+                provenance=_provenance(metadata),
+                caveats=caveats,
+            )
         if len(spatial_dims) != 3:
             raise VisualizationDataError(
                 f"Field {field} must have three native spatial dimensions after time selection."
@@ -566,7 +660,7 @@ def field_slice(
         values = _json_values(sliced)
         stats = _slice_stats(sliced)
         visual_field = _visualizable_field(metadata, dataset, field)
-        selected_value = _coordinate_value(dataset, selected_dimension, level_index)
+        selected_coordinate_value = _coordinate_value(dataset, selected_dimension, level_index)
         vertical_dim = dims.vertical
         vertical_units = _coordinate_units(dataset, vertical_dim)
         level_units = _coordinate_units(dataset, selected_dimension)
@@ -583,10 +677,12 @@ def field_slice(
             orientation=orientation,
             selected_dimension=selected_dimension,
             selected_index=level_index,
-            selected_coordinate_value=selected_value,
+            selected_coordinate_value=selected_coordinate_value,
             level_units=level_units,
-            level_coordinate_value=selected_value if selected_dimension == vertical_dim else None,
-            level_meters=_meters_if_safe(selected_value, level_units)
+            level_coordinate_value=selected_coordinate_value
+            if selected_dimension == vertical_dim
+            else None,
+            level_meters=_meters_if_safe(selected_coordinate_value, level_units)
             if selected_dimension == vertical_dim
             else None,
         )
@@ -759,6 +855,45 @@ def _threshold_points(
     return points
 
 
+def _threshold_surface_points(
+    data_array: Any,
+    *,
+    dims: _FieldDimensions,
+    dataset: Any,
+    threshold: float,
+) -> list[list[float]]:
+    if not dims.y or not dims.x:
+        return []
+    points: list[list[float]] = []
+    values = data_array.values
+    y_values = _coordinate_values(dataset, dims.y)
+    x_values = _coordinate_values(dataset, dims.x)
+    y_axis = data_array.dims.index(dims.y)
+    x_axis = data_array.dims.index(dims.x)
+    z_value = _surface_vertical_extent(dataset).min
+
+    # Iterate in native array order so stride downsampling is deterministic.
+    for native_index in itertools.product(*(range(int(size)) for size in data_array.shape)):
+        raw_value = values[native_index]
+        try:
+            numeric = float(raw_value)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(numeric) or numeric < threshold:
+            continue
+        y_index = native_index[y_axis]
+        x_index = native_index[x_axis]
+        points.append(
+            [
+                _coordinate_number(x_values, x_index),
+                _coordinate_number(y_values, y_index),
+                z_value,
+                numeric,
+            ]
+        )
+    return points
+
+
 def _coordinate_number(values: list[float | str | None], index: int) -> float:
     if index < len(values):
         try:
@@ -782,6 +917,14 @@ def _coordinate_extent(dataset: Any, coordinate_name: str | None) -> CoordinateE
         max=max(values),
         units=_coordinate_units(dataset, coordinate_name),
     )
+
+
+def _surface_vertical_extent(dataset: Any) -> CoordinateExtent:
+    for coordinate_name in SURFACE_VERTICAL_CANDIDATES:
+        extent = _coordinate_extent(dataset, coordinate_name)
+        if extent is not None:
+            return extent
+    return CoordinateExtent(min=0.0, max=1.0, units=None)
 
 
 def _coordinate_number_values(dataset: Any, coordinate_name: str | None) -> list[float]:
@@ -809,6 +952,8 @@ def _native_grid_label(coordinates: FieldCoordinateMetadata) -> str:
     spatial = [coordinates.vertical, coordinates.y, coordinates.x]
     if all(spatial):
         return "/".join(str(dimension) for dimension in spatial)
+    if not coordinates.vertical and coordinates.y and coordinates.x:
+        return f"surface/{coordinates.y}/{coordinates.x}"
     return "unknown_native_grid"
 
 
@@ -830,6 +975,8 @@ def _field_caveats(field_name: str, coordinates: FieldCoordinateMetadata) -> lis
         caveats.append("qc_native_vertical_grid_not_zh")
     if field_name == "w" and coordinates.vertical != "zf":
         caveats.append("w_native_vertical_grid_not_zf")
+    if field_name in SURFACE_POINT_FIELDS and not coordinates.vertical:
+        caveats.append("surface_field_no_vertical_dimension")
     return caveats
 
 

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -46,6 +47,9 @@ def create_visualization_result(
     *,
     include_qc: bool = True,
     include_w: bool = True,
+    include_qr: bool = False,
+    include_qv: bool = True,
+    include_dbz: bool = True,
     run_id: str = "run-visualization",
 ) -> tuple[CloudChamberSettings, str, Path]:
     settings = fake_settings(tmp_path)
@@ -56,7 +60,14 @@ def create_visualization_result(
         run_size_preset="quick_look",
     )
     netcdf_path = package.package_dir / "cm1out_000001.nc"
-    write_visualization_netcdf(netcdf_path, include_qc=include_qc, include_w=include_w)
+    write_visualization_netcdf(
+        netcdf_path,
+        include_qc=include_qc,
+        include_w=include_w,
+        include_qr=include_qr,
+        include_qv=include_qv,
+        include_dbz=include_dbz,
+    )
     manifest = load_run_manifest(package.manifest_path)
     write_run_manifest(
         package.manifest_path,
@@ -77,8 +88,11 @@ def write_visualization_netcdf(
     *,
     include_qc: bool,
     include_w: bool,
+    include_qr: bool,
+    include_qv: bool,
+    include_dbz: bool,
 ) -> None:
-    data_vars = {}
+    data_vars: dict[str, Any] = {}
     if include_qc:
         qc = np.arange(2 * 2 * 3 * 4, dtype=float).reshape(2, 2, 3, 4) * 1e-6
         qc[0, 0, 0, 0] = np.nan
@@ -95,10 +109,42 @@ def write_visualization_netcdf(
             w,
             {"units": "m/s"},
         )
+    if include_qr:
+        qr = np.arange(2 * 2 * 3 * 4, dtype=float).reshape(2, 2, 3, 4) * 1e-7
+        data_vars["qr"] = (
+            ("time", "zh", "yh", "xh"),
+            qr,
+            {"units": "kg/kg"},
+        )
     data_vars["theta"] = (
         ("time", "zh", "yh", "xh"),
-        np.zeros((2, 2, 3, 4), dtype=float),
+        300.0 + np.arange(2 * 2 * 3 * 4, dtype=float).reshape(2, 2, 3, 4) * 0.1,
         {"units": "K"},
+    )
+    data_vars["temperature"] = (
+        ("time", "zh", "yh", "xh"),
+        285.0 + np.arange(2 * 2 * 3 * 4, dtype=float).reshape(2, 2, 3, 4) * 0.2,
+        {"units": "K"},
+    )
+    if include_qv:
+        qv = 0.010 + np.arange(2 * 2 * 3 * 4, dtype=float).reshape(2, 2, 3, 4) * 1e-5
+        data_vars["qv"] = (
+            ("time", "zh", "yh", "xh"),
+            qv,
+            {"units": "kg/kg"},
+        )
+    if include_dbz:
+        dbz = np.arange(2 * 2 * 3 * 4, dtype=float).reshape(2, 2, 3, 4) - 10.0
+        data_vars["dbz"] = (
+            ("time", "zh", "yh", "xh"),
+            dbz,
+            {"units": "dBZ"},
+        )
+    rain = np.arange(2 * 3 * 4, dtype=float).reshape(2, 3, 4) * 0.25
+    data_vars["rain"] = (
+        ("time", "yh", "xh"),
+        rain,
+        {"units": "mm"},
     )
     xr.Dataset(
         data_vars=data_vars,
@@ -126,6 +172,14 @@ def test_field_catalog_includes_qc_and_w_with_provenance(tmp_path: Path) -> None
     assert fields["w"].canonical_field_name == "vertical_velocity"
     assert fields["w"].native_grid == "zf/yh/xh"
     assert fields["w"].coordinate_names.vertical == "zf"
+    assert fields["theta"].canonical_field_name == "potential_temperature"
+    assert fields["theta"].units == "K"
+    assert fields["temperature"].canonical_field_name == "temperature"
+    assert fields["temperature"].units == "K"
+    assert fields["qv"].canonical_field_name == "water_vapor"
+    assert fields["dbz"].canonical_field_name == "reflectivity"
+    assert fields["rain"].canonical_field_name == "accumulated_surface_rain"
+    assert fields["rain"].native_grid == "surface/yh/xh"
     assert catalog.provenance.source_model == "CM1"
     assert "native-grid view" in catalog.provenance.provenance_label
 
@@ -211,6 +265,64 @@ def test_vertical_qc_slices_have_stable_shape_and_order(tmp_path: Path) -> None:
     assert vertical_y.dimension_order == ["zh", "yh"]
 
 
+def test_temperature_slice_is_available_when_direct_temperature_exists(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    sliced = field_slice(
+        settings,
+        result_id,
+        field="temperature",
+        time_index=0,
+        orientation="horizontal",
+        level_index=1,
+    )
+
+    assert sliced.field.raw_field_name == "temperature"
+    assert sliced.field.canonical_field_name == "temperature"
+    assert sliced.field.units == "K"
+    assert sliced.selection.selected_dimension == "zh"
+    assert sliced.dimension_order == ["yh", "xh"]
+    assert sliced.stats.min == 287.4
+    assert sliced.stats.max == 289.6
+
+
+def test_surface_rain_slice_is_horizontal_floor_map(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    sliced = field_slice(
+        settings,
+        result_id,
+        field="rain",
+        time_index=1,
+        orientation="horizontal",
+        level_index=0,
+    )
+
+    assert sliced.field.raw_field_name == "rain"
+    assert sliced.field.native_grid == "surface/yh/xh"
+    assert sliced.selection.selected_dimension == "surface"
+    assert sliced.selection.level_coordinate_value == 0.0
+    assert sliced.selection.level_units == "km"
+    assert sliced.dimension_order == ["yh", "xh"]
+    assert sliced.shape == [3, 4]
+    assert sliced.stats.max == 5.75
+    assert "surface_field_rendered_on_domain_floor" in sliced.caveats
+
+
+def test_surface_rain_rejects_vertical_slice_orientation(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    with pytest.raises(VisualizationDataError, match="surface field.*horizontal slices"):
+        field_slice(
+            settings,
+            result_id,
+            field="rain",
+            time_index=0,
+            orientation="vertical_x",
+            level_index=0,
+        )
+
+
 def test_w_slice_uses_native_zf_grid(tmp_path: Path) -> None:
     settings, result_id, _run_dir = create_visualization_result(tmp_path)
 
@@ -260,6 +372,10 @@ def test_point_cloud_returns_qc_points_above_threshold(tmp_path: Path) -> None:
     assert cloud.coordinate_extents["zh"].max == 0.8
     assert cloud.stats.source_count == 23
     assert cloud.stats.returned_count == 23
+    assert cloud.stats.field_finite_count == 23
+    assert cloud.stats.field_non_finite_count == 1
+    assert cloud.stats.field_min_value == 1e-6
+    assert cloud.stats.field_max_value == 2.3e-05
     assert cloud.stats.downsampled is False
     assert cloud.stats.min_value == 1e-6
     assert cloud.stats.max_value == 2.3e-05
@@ -270,6 +386,85 @@ def test_point_cloud_returns_qc_points_above_threshold(tmp_path: Path) -> None:
     assert cloud.provenance.processing_method == "backend_xarray_native_grid_threshold"
     assert cloud.provenance.rendering_method == "thresholded_point_cloud"
     assert "native_grid_thresholded_point_cloud" in cloud.caveats
+
+
+def test_point_cloud_returns_qr_points_when_rain_water_is_available(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path, include_qr=True)
+
+    rain = point_cloud(
+        settings,
+        result_id,
+        field="qr",
+        time_index=0,
+        threshold=5e-7,
+        max_points=50_000,
+    )
+
+    assert rain.field.raw_field_name == "qr"
+    assert rain.field.canonical_field_name == "rain_water"
+    assert rain.selection.threshold == 5e-7
+    assert rain.stats.source_count == 19
+    assert rain.stats.returned_count == 19
+    assert rain.stats.min_value == 5e-7
+    assert rain.stats.max_value == 2.3e-06
+    assert rain.provenance.provenance_label.startswith("CM1-derived rain water point cloud")
+    assert "visualizer_interpretation_of_cm1_qr" in rain.caveats
+
+
+def test_point_cloud_rejects_potential_temperature_for_now(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    with pytest.raises(VisualizationDataError, match="2-D slices but not 3-D point-cloud"):
+        point_cloud(
+            settings,
+            result_id,
+            field="theta",
+            time_index=0,
+            threshold=0,
+            max_points=50_000,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "canonical_name", "threshold", "expected_count"),
+    [
+        ("qv", "water_vapor", 0.0, 24),
+        ("dbz", "reflectivity", 0.0, 14),
+        ("rain", "accumulated_surface_rain", 0.0, 12),
+    ],
+)
+def test_point_cloud_returns_additional_scalar_fields(
+    tmp_path: Path,
+    field_name: str,
+    canonical_name: str,
+    threshold: float,
+    expected_count: int,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    scalar = point_cloud(
+        settings,
+        result_id,
+        field=field_name,
+        time_index=0,
+        threshold=threshold,
+        max_points=50_000,
+    )
+
+    assert scalar.field.raw_field_name == field_name
+    assert scalar.field.canonical_field_name == canonical_name
+    assert scalar.stats.source_count == expected_count
+    assert scalar.stats.returned_count == expected_count
+    assert scalar.stats.field_finite_count > 0
+    assert scalar.stats.field_max_value is not None
+    assert f"visualizer_interpretation_of_cm1_{field_name}" in scalar.caveats
+    if field_name == "dbz":
+        assert scalar.stats.field_min_value == -10.0
+        assert scalar.stats.field_max_value == 13.0
+    if field_name == "rain":
+        assert scalar.stats.active_z_min == 0.0
+        assert scalar.stats.active_z_max == 0.0
+        assert "surface_field_rendered_on_domain_floor" in scalar.caveats
 
 
 def test_view_defaults_choose_native_grid_max_locations(tmp_path: Path) -> None:
@@ -290,6 +485,12 @@ def test_view_defaults_choose_native_grid_max_locations(tmp_path: Path) -> None:
     assert defaults.fields["w"].horizontal_level_index == 2
     assert defaults.fields["w"].vertical_x_index == 2
     assert defaults.fields["w"].vertical_y_index == 3
+    assert defaults.fields["theta"].source == "max_theta_native_grid_location"
+    assert defaults.fields["theta"].horizontal_level_index == 1
+    assert defaults.fields["temperature"].source == "max_temperature_native_grid_location"
+    assert defaults.fields["qv"].source == "max_qv_native_grid_location"
+    assert defaults.fields["dbz"].source == "max_dbz_native_grid_location"
+    assert defaults.fields["rain"].source == "domain_center_missing_required_dimensions"
     assert "default_locations_are_native_grid_indices" in defaults.caveats
     assert defaults.provenance.processing_method == "backend_xarray_interesting_view_defaults"
 
@@ -332,24 +533,40 @@ def test_point_cloud_reports_no_points_above_threshold(tmp_path: Path) -> None:
     assert cloud.points == []
     assert cloud.stats.source_count == 0
     assert cloud.stats.returned_count == 0
+    assert cloud.stats.field_finite_count == 23
+    assert cloud.stats.field_max_value == 2.3e-05
     assert cloud.stats.min_value is None
     assert cloud.stats.max_value is None
 
 
-def test_point_cloud_missing_qc_reports_clear_error(tmp_path: Path) -> None:
+def test_point_cloud_missing_field_reports_clear_error(tmp_path: Path) -> None:
     settings, result_id, _run_dir = create_visualization_result(
         tmp_path,
         include_qc=False,
         include_w=True,
     )
 
-    with pytest.raises(VisualizationDataError, match="qc is not available"):
+    with pytest.raises(VisualizationDataError, match="Field is not available.*qc"):
         point_cloud(
             settings,
             result_id,
             field="qc",
             time_index=0,
             threshold=1e-6,
+            max_points=50_000,
+        )
+
+
+def test_point_cloud_rejects_signed_flow_fields_for_now(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    with pytest.raises(VisualizationDataError, match="signed-flow 3-D rendering"):
+        point_cloud(
+            settings,
+            result_id,
+            field="w",
+            time_index=0,
+            threshold=0,
             max_points=50_000,
         )
 
@@ -424,7 +641,7 @@ def test_point_cloud_endpoint_returns_payload_and_errors(
     assert ok.json()["stats"]["downsampled"] is True
     assert ok.json()["provenance"]["rendering_method"] == "thresholded_point_cloud"
     assert bad.status_code == 400
-    assert "Only field=qc" in bad.json()["detail"]
+    assert "signed-flow 3-D rendering" in bad.json()["detail"]
 
 
 @pytest.mark.parametrize(

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -200,23 +200,108 @@ function fieldCatalog(resultId: string) {
     rendering_method: "json heatmap",
     provenance_label: "CM1-derived visualization-ready payload",
   };
+  const fields = [
+    {
+      raw: "qc",
+      canonical: "cloud_water",
+      display: "Cloud water",
+      units: "kg/kg",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 4, 4, 4],
+      nativeGrid: "zh/yh/xh",
+      vertical: "zh",
+    },
+    {
+      raw: "w",
+      canonical: "vertical_velocity",
+      display: "Vertical velocity",
+      units: "m/s",
+      dimensions: ["time", "zf", "yh", "xh"],
+      shape: [3, 4, 4, 4],
+      nativeGrid: "zf/yh/xh",
+      vertical: "zf",
+    },
+    {
+      raw: "qr",
+      canonical: "rain_water",
+      display: "Rain water",
+      units: "kg/kg",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 4, 4, 4],
+      nativeGrid: "zh/yh/xh",
+      vertical: "zh",
+    },
+    {
+      raw: "theta",
+      canonical: "potential_temperature",
+      display: "Potential temperature",
+      units: "K",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 4, 4, 4],
+      nativeGrid: "zh/yh/xh",
+      vertical: "zh",
+    },
+    {
+      raw: "temperature",
+      canonical: "temperature",
+      display: "Temperature",
+      units: "K",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 4, 4, 4],
+      nativeGrid: "zh/yh/xh",
+      vertical: "zh",
+    },
+    {
+      raw: "qv",
+      canonical: "water_vapor",
+      display: "Water vapor",
+      units: "kg/kg",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 4, 4, 4],
+      nativeGrid: "zh/yh/xh",
+      vertical: "zh",
+    },
+    {
+      raw: "dbz",
+      canonical: "reflectivity",
+      display: "Reflectivity",
+      units: "dBZ",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 4, 4, 4],
+      nativeGrid: "zh/yh/xh",
+      vertical: "zh",
+    },
+    {
+      raw: "rain",
+      canonical: "accumulated_surface_rain",
+      display: "Accumulated surface rain",
+      units: "mm",
+      dimensions: ["time", "yh", "xh"],
+      shape: [3, 4, 4],
+      nativeGrid: "surface/yh/xh",
+      vertical: null,
+    },
+  ];
   return {
     result_id: meta.result_id,
     run_id: meta.run_id,
     scenario_id: meta.scenario_id,
     source_model: "CM1",
-    available_fields: ["qc", "w"].map((name) => ({
-      raw_field_name: name,
-      canonical_field_name: name === "qc" ? "cloud_water" : "vertical_velocity",
-      display_name: name === "qc" ? "Cloud water" : "Vertical velocity",
-      units: name === "qc" ? "kg/kg" : "m/s",
-      dimensions: name === "qc" ? ["time", "zh", "yh", "xh"] : ["time", "zf", "yh", "xh"],
-      shape: [3, 4, 4, 4],
-      native_grid: name === "qc" ? "zh/yh/xh" : "zf/yh/xh",
-      coordinate_names: { time: "time", vertical: name === "qc" ? "zh" : "zf", y: "yh", x: "xh" },
+    available_fields: fields.map((field) => ({
+      raw_field_name: field.raw,
+      canonical_field_name: field.canonical,
+      display_name: field.display,
+      units: field.units,
+      dimensions: field.dimensions,
+      shape: field.shape,
+      native_grid: field.nativeGrid,
+      coordinate_names: { time: "time", vertical: field.vertical, y: "yh", x: "xh" },
       time_coordinate_values: [0, 1800, 3600],
       provenance,
-      caveats: ["native_grid_no_interpolation"],
+      caveats:
+        field.raw === "rain"
+          ? ["native_grid_no_interpolation", "surface_field_no_vertical_dimension"]
+          : ["native_grid_no_interpolation"],
     })),
     provenance,
     caveats: [],
@@ -259,6 +344,84 @@ function viewDefaults(resultId: string, timeIndex?: number) {
         selected_time_seconds: timeIndex === undefined ? null : [0, 1800, 3600][selectedTime],
         caveats: [],
       },
+      qr: {
+        field: "qr",
+        time_index: selectedTime,
+        time_seconds: [0, 1800, 3600][selectedTime] ?? 1800,
+        horizontal_level_index: 1,
+        vertical_x_index: 1,
+        vertical_y_index: 2,
+        source: "max_qr_native_grid_location",
+        max_value: dryFailed ? 0 : 0.000001,
+        selected_time_index: timeIndex ?? null,
+        selected_time_seconds: timeIndex === undefined ? null : [0, 1800, 3600][selectedTime],
+        caveats: [],
+      },
+      theta: {
+        field: "theta",
+        time_index: selectedTime,
+        time_seconds: [0, 1800, 3600][selectedTime] ?? 1800,
+        horizontal_level_index: 2,
+        vertical_x_index: 1,
+        vertical_y_index: 2,
+        source: "max_theta_native_grid_location",
+        max_value: 304,
+        selected_time_index: timeIndex ?? null,
+        selected_time_seconds: timeIndex === undefined ? null : [0, 1800, 3600][selectedTime],
+        caveats: [],
+      },
+      temperature: {
+        field: "temperature",
+        time_index: selectedTime,
+        time_seconds: [0, 1800, 3600][selectedTime] ?? 1800,
+        horizontal_level_index: 2,
+        vertical_x_index: 1,
+        vertical_y_index: 2,
+        source: "max_temperature_native_grid_location",
+        max_value: 292,
+        selected_time_index: timeIndex ?? null,
+        selected_time_seconds: timeIndex === undefined ? null : [0, 1800, 3600][selectedTime],
+        caveats: [],
+      },
+      qv: {
+        field: "qv",
+        time_index: selectedTime,
+        time_seconds: [0, 1800, 3600][selectedTime] ?? 1800,
+        horizontal_level_index: 1,
+        vertical_x_index: 1,
+        vertical_y_index: 2,
+        source: "max_qv_native_grid_location",
+        max_value: 0.012,
+        selected_time_index: timeIndex ?? null,
+        selected_time_seconds: timeIndex === undefined ? null : [0, 1800, 3600][selectedTime],
+        caveats: [],
+      },
+      dbz: {
+        field: "dbz",
+        time_index: selectedTime,
+        time_seconds: [0, 1800, 3600][selectedTime] ?? 1800,
+        horizontal_level_index: 1,
+        vertical_x_index: 1,
+        vertical_y_index: 2,
+        source: "max_dbz_native_grid_location",
+        max_value: dryFailed ? 0 : 32,
+        selected_time_index: timeIndex ?? null,
+        selected_time_seconds: timeIndex === undefined ? null : [0, 1800, 3600][selectedTime],
+        caveats: [],
+      },
+      rain: {
+        field: "rain",
+        time_index: selectedTime,
+        time_seconds: [0, 1800, 3600][selectedTime] ?? 1800,
+        horizontal_level_index: 0,
+        vertical_x_index: 0,
+        vertical_y_index: 0,
+        source: "surface_rain_domain_floor",
+        max_value: dryFailed ? 0 : 4.5,
+        selected_time_index: timeIndex ?? null,
+        selected_time_seconds: timeIndex === undefined ? null : [0, 1800, 3600][selectedTime],
+        caveats: ["surface_field_rendered_on_domain_floor"],
+      },
     },
     provenance: fieldCatalog(resultId).provenance,
     caveats: dryFailed ? ["no_cloud_result_qc_zero_w_available"] : [],
@@ -275,34 +438,10 @@ function slicePayload(resultId: string, url: string) {
   const field =
     catalog.available_fields.find((candidate) => candidate.raw_field_name === fieldName) ??
     catalog.available_fields[0];
-  const qcValues = dryFailed
-    ? [
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-      ]
-    : [
-        [0, 0.001, 0.002, 0],
-        [0, 0.002, 0.001, 0],
-        [0, 0.001, 0.002, 0],
-        [0, 0, 0.001, 0],
-      ];
-  const wValues = dryFailed
-    ? [
-        [0.2, 0.8, 1.2, 0.3],
-        [0.1, 1.95, 1.1, -0.4],
-        [0.0, 0.7, 0.5, -1.09],
-        [0.1, 0.4, 0.2, -0.2],
-      ]
-    : [
-        [0.5, 2.1, 4.8, 1.0],
-        [0.2, 6.96, 3.7, -1.4],
-        [0.1, 2.4, 1.2, -3.77],
-        [0.0, 0.8, 0.4, -0.6],
-      ];
-  const values = fieldName === "w" ? wValues : qcValues;
+  const values = mockSliceValues(fieldName, dryFailed);
   const flat = values.flat();
+  const isSurface = fieldName === "rain";
+  const isVertical = orientation !== "horizontal" && !isSurface;
   return {
     result_id: resultId,
     run_id: resultMeta(resultId).run_id,
@@ -313,14 +452,20 @@ function slicePayload(resultId: string, url: string) {
       time_seconds: [0, 1800, 3600][timeIndex] ?? 1800,
       orientation,
       selected_dimension:
-        orientation === "vertical_y" ? "xh" : orientation === "vertical_x" ? "yh" : "zh",
+        isSurface
+          ? "surface"
+          : orientation === "vertical_y"
+            ? "xh"
+            : orientation === "vertical_x"
+              ? "yh"
+              : (field.coordinate_names.vertical ?? "zh"),
       selected_index: Number(parsed.searchParams.get("level_index") ?? 1),
-      selected_coordinate_value: orientation === "horizontal" ? 0.8 : 0,
+      selected_coordinate_value: isSurface ? 0 : orientation === "horizontal" ? 0.8 : 0,
       level_units: orientation === "horizontal" ? "km" : null,
-      level_coordinate_value: orientation === "horizontal" ? 0.8 : null,
-      level_meters: orientation === "horizontal" ? 800 : null,
+      level_coordinate_value: orientation === "horizontal" ? (isSurface ? 0 : 0.8) : null,
+      level_meters: orientation === "horizontal" ? (isSurface ? 0 : 800) : null,
     },
-    coordinate_units: { zh: "km", yh: "km", xh: "km" },
+    coordinate_units: isVertical ? { zh: "km", xh: "km" } : { yh: "km", xh: "km" },
     shape: [4, 4],
     dimension_order: orientation === "horizontal" ? ["yh", "xh"] : ["zh", "xh"],
     data_encoding: "json",
@@ -333,47 +478,137 @@ function slicePayload(resultId: string, url: string) {
       non_finite_count: 0,
     },
     provenance: catalog.provenance,
-    caveats: ["native_grid_no_interpolation"],
+    caveats: isSurface
+      ? ["native_grid_no_interpolation", "surface_field_no_vertical_dimension", "surface_field_rendered_on_domain_floor"]
+      : ["native_grid_no_interpolation"],
   };
+}
+
+function mockSliceValues(fieldName: string, dryFailed: boolean) {
+  if (fieldName === "w") {
+    return dryFailed
+      ? [
+          [0.2, 0.8, 1.2, 0.3],
+          [0.1, 1.95, 1.1, -0.4],
+          [0.0, 0.7, 0.5, -1.09],
+          [0.1, 0.4, 0.2, -0.2],
+        ]
+      : [
+          [0.5, 2.1, 4.8, 1.0],
+          [0.2, 6.96, 3.7, -1.4],
+          [0.1, 2.4, 1.2, -3.77],
+          [0.0, 0.8, 0.4, -0.6],
+        ];
+  }
+  if (fieldName === "qr") {
+    return dryFailed ? zeroGrid() : scaleGrid(0.000001);
+  }
+  if (fieldName === "qv") {
+    return [
+      [0.0101, 0.0104, 0.0108, 0.0103],
+      [0.0105, 0.0112, 0.0118, 0.0109],
+      [0.0107, 0.0114, 0.0124, 0.0111],
+      [0.0102, 0.0107, 0.0112, 0.0105],
+    ];
+  }
+  if (fieldName === "dbz") {
+    return dryFailed
+      ? [
+          [-10, -5, 0, -8],
+          [-4, 0, 4, -2],
+          [-6, 0, 2, -3],
+          [-10, -5, 0, -8],
+        ]
+      : [
+          [0, 8, 18, 3],
+          [12, 24, 32, 16],
+          [8, 20, 28, 10],
+          [0, 6, 14, 2],
+        ];
+  }
+  if (fieldName === "temperature") {
+    return [
+      [287, 288, 289, 287.5],
+      [286, 289, 292, 288],
+      [285.5, 288, 291, 287],
+      [285, 286, 287, 286],
+    ];
+  }
+  if (fieldName === "theta") {
+    return [
+      [300, 301, 302, 301],
+      [300.5, 302, 304, 302],
+      [301, 302.5, 303.5, 302],
+      [300, 301, 302, 301],
+    ];
+  }
+  if (fieldName === "rain") {
+    return dryFailed ? zeroGrid() : scaleGrid(4.2);
+  }
+  return dryFailed ? zeroGrid() : scaleGrid(0.002);
+}
+
+function zeroGrid() {
+  return [
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+  ];
+}
+
+function scaleGrid(maximum: number) {
+  return [
+    [0, maximum * 0.35, maximum * 0.7, 0],
+    [maximum * 0.2, maximum, maximum * 0.6, maximum * 0.1],
+    [maximum * 0.1, maximum * 0.5, maximum * 0.85, maximum * 0.2],
+    [0, maximum * 0.2, maximum * 0.45, 0],
+  ];
 }
 
 function pointCloudPayload(resultId: string, url: string) {
   const parsed = new URL(url);
   const dryFailed = resultId === "result-dry-failed";
-  const points = dryFailed
-    ? []
-    : [
-        [2, 2, 0.8, 0.001],
-        [2.5, 2.3, 1.2, 0.002],
-        [3, 2.5, 1.8, 0.0015],
-      ];
+  const fieldName = parsed.searchParams.get("field") ?? "qc";
+  const threshold = Number(parsed.searchParams.get("threshold") ?? (fieldName === "qr" ? 0.0000001 : 0.000001));
+  const points = mockPointCloudPoints(fieldName, dryFailed, threshold);
   const values = points.map((point) => point[3]);
+  const catalog = fieldCatalog(resultId);
+  const field =
+    catalog.available_fields.find((candidate) => candidate.raw_field_name === fieldName) ??
+    catalog.available_fields[0];
+  const isSurface = fieldName === "rain";
   return {
     result_id: resultId,
     run_id: resultMeta(resultId).run_id,
     scenario_id: resultMeta(resultId).scenario_id,
-    field: fieldCatalog(resultId).available_fields[0],
+    field,
     selection: {
-      field: "qc",
+      field: field.raw_field_name,
       time_index: Number(parsed.searchParams.get("time_index") ?? 1),
       time_seconds: 1800,
-      threshold: Number(parsed.searchParams.get("threshold") ?? 0.000001),
+      threshold,
       max_points: Number(parsed.searchParams.get("max_points") ?? 50000),
     },
-    coordinate_units: { xh: "km", yh: "km", zh: "km" },
+    coordinate_units: isSurface ? { xh: "km", yh: "km", z: "km" } : { xh: "km", yh: "km", zh: "km" },
     coordinate_extents: {
       x: { min: 0, max: 6.4, units: "km" },
       y: { min: 0, max: 6.4, units: "km" },
       z: { min: 0, max: 3, units: "km" },
       xh: { min: 0, max: 6.4, units: "km" },
       yh: { min: 0, max: 6.4, units: "km" },
-      zh: { min: 0, max: 3, units: "km" },
+      ...(isSurface ? {} : { zh: { min: 0, max: 3, units: "km" } }),
     },
     point_order: ["x", "y", "z", "value"],
     points,
     stats: {
       source_count: points.length,
       returned_count: points.length,
+      field_min_value: mockPointFieldRange(fieldName, dryFailed).min,
+      field_max_value: mockPointFieldRange(fieldName, dryFailed).max,
+      field_mean_value: mockPointFieldRange(fieldName, dryFailed).mean,
+      field_finite_count: 64,
+      field_non_finite_count: 0,
       min_value: values.length ? Math.min(...values) : null,
       max_value: values.length ? Math.max(...values) : null,
       active_z_min: values.length ? Math.min(...points.map((point) => point[2])) : null,
@@ -385,12 +620,58 @@ function pointCloudPayload(resultId: string, url: string) {
       downsample_stride: 1,
     },
     provenance: {
-      ...fieldCatalog(resultId).provenance,
+      ...catalog.provenance,
       processing_method: "native-grid thresholded point cloud",
-      rendering_method: "thresholded point cloud",
+      rendering_method: isSurface ? "surface floor layer" : "thresholded point cloud",
     },
-    caveats: dryFailed ? ["qc_present_but_no_points_above_threshold"] : [],
+    caveats: [
+      ...(dryFailed ? [`${fieldName}_present_but_no_points_above_threshold`] : []),
+      ...(isSurface ? ["surface_field_rendered_on_domain_floor"] : []),
+    ],
   };
+}
+
+function mockPointFieldRange(fieldName: string, dryFailed: boolean) {
+  if (dryFailed && fieldName === "qc") return { min: 0, max: 0, mean: 0 };
+  if (fieldName === "qr") return dryFailed ? { min: 0, max: 0, mean: 0 } : { min: 0, max: 0.000001, mean: 0.0000003 };
+  if (fieldName === "qv") return { min: 0.0101, max: 0.0124, mean: 0.0111 };
+  if (fieldName === "dbz") {
+    return dryFailed ? { min: -10, max: 4, mean: -3 } : { min: 0, max: 32, mean: 14 };
+  }
+  if (fieldName === "rain") return dryFailed ? { min: 0, max: 0, mean: 0 } : { min: 0, max: 4.2, mean: 1.3 };
+  return dryFailed ? { min: 0, max: 0, mean: 0 } : { min: 0, max: 0.002, mean: 0.0006 };
+}
+
+function mockPointCloudPoints(fieldName: string, dryFailed: boolean, threshold: number) {
+  if (dryFailed && fieldName === "qc") return [];
+  const pointValues: Record<string, Array<[number, number, number, number]>> = {
+    qc: [
+      [2, 2, 0.8, 0.001],
+      [2.5, 2.3, 1.2, 0.002],
+      [3, 2.5, 1.8, 0.0015],
+    ],
+    qr: [
+      [2, 2, 0.8, 0.0000002],
+      [2.5, 2.3, 1.2, 0.0000006],
+      [3, 2.5, 1.8, 0.0000009],
+    ],
+    qv: [
+      [1.5, 1.2, 0.6, 0.0104],
+      [2.5, 2.3, 1.2, 0.0113],
+      [3.4, 2.5, 1.8, 0.0124],
+    ],
+    dbz: [
+      [1.5, 1.2, 0.6, 8],
+      [2.5, 2.3, 1.2, 22],
+      [3.4, 2.5, 1.8, 38],
+    ],
+    rain: [
+      [1.5, 1.2, 0, 0.8],
+      [2.5, 2.3, 0, 2.4],
+      [3.4, 2.5, 0, 4.2],
+    ],
+  };
+  return (pointValues[fieldName] ?? pointValues.qc).filter((point) => point[3] >= threshold);
 }
 
 export async function mockCloudChamberApis(page: Page) {

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -135,12 +135,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       timeout: 10_000,
     });
     await expect(page.getByLabel("Explore viewer controls")).toBeVisible();
-    await expect(page.getByLabel("True 3-D cloud-water viewer")).toBeVisible({
+    await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible({
       timeout: 12_000,
     });
     await expect(
       page.getByLabel(
-        "Interactive Three.js scene showing CM1 cloud water, domain bounds, slice plane, and selected point",
+        "Interactive Three.js scene showing a CM1 scalar field, domain bounds, slice plane, and selected point",
       ),
     ).toBeVisible();
     await expect(page.getByLabel("3-D camera controls")).toBeVisible();
@@ -218,14 +218,57 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       1,
     );
     await expect(
-      page.locator("#explore-slice-field option", { hasText: "w - Vertical velocity" }),
+      page.locator("#explore-slice-field option", { hasText: "w - Vertical velocity (slice only)" }),
     ).toHaveCount(1);
     await expect(page.getByText(/loading fields/i)).not.toBeVisible();
 
-    await expect(page.getByText(/cloud-water point cloud loaded/i).first()).toBeVisible({
+    await expect(page.getByText(/cloud-water point layer loaded/i).first()).toBeVisible({
       timeout: 12_000,
     });
-    await expect(page.getByText(/cloud-water point cloud/i).first()).toBeVisible();
+    await expect(page.getByText(/cloud-water point layer/i).first()).toBeVisible();
+  });
+
+  test("Explore exposes expanded 3-D scalar fields without promoting slice-only fields", async ({
+    page,
+  }) => {
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+
+    await expect(page.getByText(/cloud-water point layer loaded/i).first()).toBeVisible({
+      timeout: 12_000,
+    });
+    const threeDField = page.locator("#explore-3d-field");
+    await expect(threeDField).toBeVisible();
+    await expect(threeDField.locator("option", { hasText: "qc - Cloud water" })).toHaveCount(1);
+    await expect(threeDField.locator("option", { hasText: "qr - Rain water" })).toHaveCount(1);
+    await expect(threeDField.locator("option", { hasText: "qv - Water vapor" })).toHaveCount(1);
+    await expect(threeDField.locator("option", { hasText: "dbz - Reflectivity" })).toHaveCount(1);
+    await expect(
+      threeDField.locator("option", { hasText: "rain - Accumulated surface rain" }),
+    ).toHaveCount(1);
+    await expect(threeDField.locator("option", { hasText: "temperature" })).toHaveCount(0);
+    await expect(threeDField.locator("option", { hasText: "theta" })).toHaveCount(0);
+    await expect(threeDField.locator("option", { hasText: "Vertical velocity" })).toHaveCount(0);
+
+    await threeDField.selectOption("qr");
+    await expect(page.getByText("Rain-water point layer loaded").first()).toBeVisible();
+    await expect(page.locator("#explore-slice-field")).toHaveValue("qr");
+
+    await threeDField.selectOption("qv");
+    await expect(page.getByText("Water-vapor point layer loaded").first()).toBeVisible();
+    await expect(page.locator("#explore-slice-field")).toHaveValue("qv");
+
+    await threeDField.selectOption("dbz");
+    await expect(page.getByText("Reflectivity point layer loaded").first()).toBeVisible();
+    const threeDLegend = page.getByLabel("3-D field color legend");
+    await expect(threeDLegend.getByText("0 dBZ")).toBeVisible();
+    await expect(threeDLegend.getByText("60+ dBZ")).toBeVisible();
+
+    await threeDField.selectOption("rain");
+    await expect(page.getByText("Surface-rain floor layer loaded").first()).toBeVisible();
+    await expect(page.locator("#explore-slice-field")).toHaveValue("rain");
+    await expect(page.getByRole("button", { name: "Vertical x-z slice" })).toBeDisabled();
+    await expect(page.getByRole("button", { name: "Vertical y-z slice" })).toBeDisabled();
   });
 
   test("Results to Explore treats Dry Failed as no-cloud with updraft inspection", async ({
@@ -249,7 +292,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/slice synced/i).first()).toBeVisible({ timeout: 10_000 });
     await expect(page.locator("#explore-slice-field")).toHaveValue("w");
     await expect(
-      page.locator("#explore-slice-field option", { hasText: "w - Vertical velocity" }),
+      page.locator("#explore-slice-field option", { hasText: "w - Vertical velocity (slice only)" }),
     ).toHaveCount(1);
   });
 
@@ -299,7 +342,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     });
     expect(heatmapPrecedesTechnicalDetails).toBe(true);
 
-    const scene = page.getByLabel("True 3-D cloud-water viewer");
+    const scene = page.getByLabel("True 3-D scalar field viewer");
     const explanation = page.getByLabel("Visualization details");
     await expect(scene).toBeVisible({ timeout: 12_000 });
     await expect(explanation).toBeVisible();

--- a/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
@@ -61,7 +61,7 @@ test.describe("mocked smoke: visualizer occlusion regression", () => {
 
   test("3-D scene does not cover its primary controls", async ({ page }) => {
     await expect(page.getByText(/what happened in this result/i).first()).toBeVisible({ timeout: 12_000 });
-    await expect(page.getByLabel("True 3-D cloud-water viewer")).toBeVisible({
+    await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible({
       timeout: 12_000,
     });
     await expect(page.getByLabel("3-D camera controls")).toBeVisible();
@@ -87,9 +87,9 @@ test.describe("mocked smoke: visualizer occlusion regression", () => {
   });
 
   test("true 3-D scene labels stay inside the viewer frame", async ({ page }) => {
-    const scene = page.getByLabel("True 3-D cloud-water viewer");
+    const scene = page.getByLabel("True 3-D scalar field viewer");
     const canvasMount = page.getByLabel(
-      "Interactive Three.js scene showing CM1 cloud water, domain bounds, slice plane, and selected point",
+      "Interactive Three.js scene showing a CM1 scalar field, domain bounds, slice plane, and selected point",
     );
     const contextLabel = page.locator(".true3d-scene-label").first();
     const sliceLabel = page.locator(".true3d-slice-label").first();

--- a/app/frontend/e2e/visual-manual/visualizer-layout.spec.ts
+++ b/app/frontend/e2e/visual-manual/visualizer-layout.spec.ts
@@ -17,12 +17,12 @@ test.describe("visual/manual: 3-D workbench layout", () => {
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
     await expect(page.getByText(/what happened in this result/i).first()).toBeVisible({ timeout: 12_000 });
-    await expect(page.getByText(/cloud-water point cloud loaded/i).first()).toBeVisible({
+    await expect(page.getByText(/cloud-water point layer loaded/i).first()).toBeVisible({
       timeout: 12_000,
     });
     await expect(page.getByText("Cloud-water rendering").first()).toBeVisible();
     await expect(page.getByLabel("Cloud-water threshold")).toBeVisible();
-    await expect(page.getByLabel("True 3-D cloud-water viewer")).toBeVisible();
+    await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible();
     await expect(page.getByRole("button", { name: /reset camera/i })).toBeVisible();
     await expect(page.getByLabel("3-D axis tick labels")).toBeVisible();
     await page.getByText(/technical visualization details/i).first().click();

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1201,6 +1201,73 @@ details[open] > summary {
   font-weight: 700;
 }
 
+.true3d-field-legend {
+  position: absolute;
+  z-index: 2;
+  left: 0.75rem;
+  bottom: 0.75rem;
+  display: grid;
+  gap: 0.32rem;
+  min-width: min(26rem, calc(100% - 1.5rem));
+  max-width: 34rem;
+  border-radius: 8px;
+  padding: 0.45rem 0.55rem;
+  background: rgba(255, 255, 255, 0.72);
+  color: #244457;
+  box-shadow: 0 8px 22px rgba(40, 80, 110, 0.08);
+  pointer-events: none;
+}
+
+.true3d-field-legend > span {
+  font-size: 0.78rem;
+  font-weight: 850;
+}
+
+.true3d-field-legend-row {
+  display: grid;
+  grid-template-columns: auto minmax(7rem, 1fr) auto;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.true3d-field-legend small {
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.true3d-field-ramp {
+  height: 0.52rem;
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(23, 43, 58, 0.1);
+}
+
+.true3d-field-ramp-qc {
+  background: linear-gradient(90deg, rgba(61, 169, 199, 0.42), #c7fbff);
+}
+
+.true3d-field-ramp-rain {
+  background: linear-gradient(90deg, #7195e6, #a78bfa);
+}
+
+.true3d-field-ramp-qv {
+  background: linear-gradient(90deg, #5aa9bf, #8be0c8);
+}
+
+.true3d-field-ramp-dbz {
+  background: linear-gradient(
+    90deg,
+    #2561c7 0%,
+    #2eb8d0 17%,
+    #38a941 34%,
+    #f5dc33 52%,
+    #ed5c1f 68%,
+    #c21b2a 84%,
+    #a52dbc 100%
+  );
+}
+
 .true3d-axis-label-layer {
   position: absolute;
   inset: 0;
@@ -2066,9 +2133,38 @@ details[open] > summary {
 }
 
 .heatmap-scale-default,
-.heatmap-scale-cloud-water,
-.heatmap-scale-rain-water {
+.heatmap-scale-cloud-water {
   background: linear-gradient(90deg, #eaf4f8, #6bb6cf, #b4efe4);
+}
+
+.heatmap-scale-rain-water {
+  background: linear-gradient(90deg, #e7efff, #7fa0e9, #8674d9);
+}
+
+.heatmap-scale-water-vapor {
+  background: linear-gradient(90deg, #e8f8f5, #8be0c8, #4daa92);
+}
+
+.heatmap-scale-surface-rain {
+  background: linear-gradient(90deg, #e5f2ff, #74b9e3, #2e74be);
+}
+
+.heatmap-scale-temperature,
+.heatmap-scale-potential-temperature {
+  background: linear-gradient(90deg, #4f8fe8, #d6bd69, #f08f4e);
+}
+
+.heatmap-scale-reflectivity {
+  background: linear-gradient(
+    90deg,
+    #2561c7 0%,
+    #2eb8d0 17%,
+    #38a941 34%,
+    #f5dc33 52%,
+    #ed5c1f 68%,
+    #c21b2a 84%,
+    #a52dbc 100%
+  );
 }
 
 .heatmap-scale-velocity {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -507,6 +507,9 @@ const provenance = {
   provenance_label: "CM1-derived visualization-ready data; native-grid view; no interpolation",
 };
 
+type MockVisualFieldName = "qc" | "w" | "qr" | "theta" | "temperature" | "qv" | "dbz" | "rain";
+type MockPointFieldName = "qc" | "qr" | "qv" | "dbz" | "rain";
+
 const fieldCatalogResponse = {
   result_id: "result-dry-run-quicklook",
   run_id: "dry-run-quicklook",
@@ -540,6 +543,84 @@ const fieldCatalogResponse = {
       time_coordinate_values: [0, 900, 1800],
       provenance,
       caveats: ["native_grid_view_no_interpolation"],
+    },
+    {
+      raw_field_name: "qr",
+      canonical_field_name: "rain_water",
+      display_name: "Rain water",
+      units: "kg/kg",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 2, 2, 3],
+      native_grid: "zh/yh/xh",
+      coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
+      time_coordinate_values: [0, 900, 1800],
+      provenance,
+      caveats: ["native_grid_view_no_interpolation"],
+    },
+    {
+      raw_field_name: "theta",
+      canonical_field_name: "potential_temperature",
+      display_name: "Potential temperature",
+      units: "K",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 2, 2, 3],
+      native_grid: "zh/yh/xh",
+      coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
+      time_coordinate_values: [0, 900, 1800],
+      provenance,
+      caveats: ["native_grid_view_no_interpolation"],
+    },
+    {
+      raw_field_name: "temperature",
+      canonical_field_name: "temperature",
+      display_name: "Temperature",
+      units: "K",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 2, 2, 3],
+      native_grid: "zh/yh/xh",
+      coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
+      time_coordinate_values: [0, 900, 1800],
+      provenance,
+      caveats: ["native_grid_view_no_interpolation"],
+    },
+    {
+      raw_field_name: "qv",
+      canonical_field_name: "water_vapor",
+      display_name: "Water vapor",
+      units: "kg/kg",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 2, 2, 3],
+      native_grid: "zh/yh/xh",
+      coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
+      time_coordinate_values: [0, 900, 1800],
+      provenance,
+      caveats: ["native_grid_view_no_interpolation"],
+    },
+    {
+      raw_field_name: "dbz",
+      canonical_field_name: "reflectivity",
+      display_name: "Reflectivity",
+      units: "dBZ",
+      dimensions: ["time", "zh", "yh", "xh"],
+      shape: [3, 2, 2, 3],
+      native_grid: "zh/yh/xh",
+      coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
+      time_coordinate_values: [0, 900, 1800],
+      provenance,
+      caveats: ["native_grid_view_no_interpolation"],
+    },
+    {
+      raw_field_name: "rain",
+      canonical_field_name: "accumulated_surface_rain",
+      display_name: "Accumulated surface rain",
+      units: "mm",
+      dimensions: ["time", "yh", "xh"],
+      shape: [3, 2, 3],
+      native_grid: "surface/yh/xh",
+      coordinate_names: { time: "time", vertical: null, y: "yh", x: "xh" },
+      time_coordinate_values: [0, 900, 1800],
+      provenance,
+      caveats: ["native_grid_view_no_interpolation", "surface_field_no_vertical_dimension"],
     },
   ],
 };
@@ -576,6 +657,84 @@ const viewDefaultsResponse = {
       selected_time_seconds: null,
       caveats: ["default_location_uses_field_maximum"],
     },
+    qr: {
+      field: "qr",
+      time_index: 2,
+      time_seconds: 1800,
+      horizontal_level_index: 1,
+      vertical_x_index: 1,
+      vertical_y_index: 2,
+      source: "max_qr_native_grid_location",
+      max_value: 0.000002,
+      selected_time_index: null,
+      selected_time_seconds: null,
+      caveats: ["default_location_uses_field_maximum"],
+    },
+    theta: {
+      field: "theta",
+      time_index: 0,
+      time_seconds: 0,
+      horizontal_level_index: 1,
+      vertical_x_index: 1,
+      vertical_y_index: 2,
+      source: "max_theta_native_grid_location",
+      max_value: 302,
+      selected_time_index: null,
+      selected_time_seconds: null,
+      caveats: ["default_location_uses_field_maximum"],
+    },
+    temperature: {
+      field: "temperature",
+      time_index: 0,
+      time_seconds: 0,
+      horizontal_level_index: 1,
+      vertical_x_index: 1,
+      vertical_y_index: 2,
+      source: "max_temperature_native_grid_location",
+      max_value: 289,
+      selected_time_index: null,
+      selected_time_seconds: null,
+      caveats: ["default_location_uses_field_maximum"],
+    },
+    qv: {
+      field: "qv",
+      time_index: 1,
+      time_seconds: 900,
+      horizontal_level_index: 1,
+      vertical_x_index: 1,
+      vertical_y_index: 2,
+      source: "max_qv_native_grid_location",
+      max_value: 0.012,
+      selected_time_index: null,
+      selected_time_seconds: null,
+      caveats: ["default_location_uses_field_maximum"],
+    },
+    dbz: {
+      field: "dbz",
+      time_index: 2,
+      time_seconds: 1800,
+      horizontal_level_index: 1,
+      vertical_x_index: 1,
+      vertical_y_index: 2,
+      source: "max_dbz_native_grid_location",
+      max_value: 28,
+      selected_time_index: null,
+      selected_time_seconds: null,
+      caveats: ["default_location_uses_field_maximum"],
+    },
+    rain: {
+      field: "rain",
+      time_index: 2,
+      time_seconds: 1800,
+      horizontal_level_index: 0,
+      vertical_x_index: 0,
+      vertical_y_index: 0,
+      source: "surface_rain_domain_floor",
+      max_value: 4.2,
+      selected_time_index: null,
+      selected_time_seconds: null,
+      caveats: ["surface_field_rendered_on_domain_floor"],
+    },
   },
   provenance: {
     ...provenance,
@@ -594,6 +753,7 @@ function selectedTimeDefaultsResponse(url: string) {
   return {
     ...viewDefaultsResponse,
     fields: {
+      ...viewDefaultsResponse.fields,
       qc: {
         ...viewDefaultsResponse.fields.qc,
         time_index: Number(timeIndex),
@@ -613,6 +773,48 @@ function selectedTimeDefaultsResponse(url: string) {
         vertical_x_index: 1,
         vertical_y_index: 2,
         source: "selected_time_max_w_native_grid_location",
+        selected_time_index: Number(timeIndex),
+        selected_time_seconds: Number(timeIndex) * 900,
+      },
+      qr: {
+        ...viewDefaultsResponse.fields.qr,
+        time_index: Number(timeIndex),
+        time_seconds: Number(timeIndex) * 900,
+        selected_time_index: Number(timeIndex),
+        selected_time_seconds: Number(timeIndex) * 900,
+      },
+      theta: {
+        ...viewDefaultsResponse.fields.theta,
+        time_index: Number(timeIndex),
+        time_seconds: Number(timeIndex) * 900,
+        selected_time_index: Number(timeIndex),
+        selected_time_seconds: Number(timeIndex) * 900,
+      },
+      temperature: {
+        ...viewDefaultsResponse.fields.temperature,
+        time_index: Number(timeIndex),
+        time_seconds: Number(timeIndex) * 900,
+        selected_time_index: Number(timeIndex),
+        selected_time_seconds: Number(timeIndex) * 900,
+      },
+      qv: {
+        ...viewDefaultsResponse.fields.qv,
+        time_index: Number(timeIndex),
+        time_seconds: Number(timeIndex) * 900,
+        selected_time_index: Number(timeIndex),
+        selected_time_seconds: Number(timeIndex) * 900,
+      },
+      dbz: {
+        ...viewDefaultsResponse.fields.dbz,
+        time_index: Number(timeIndex),
+        time_seconds: Number(timeIndex) * 900,
+        selected_time_index: Number(timeIndex),
+        selected_time_seconds: Number(timeIndex) * 900,
+      },
+      rain: {
+        ...viewDefaultsResponse.fields.rain,
+        time_index: Number(timeIndex),
+        time_seconds: Number(timeIndex) * 900,
         selected_time_index: Number(timeIndex),
         selected_time_seconds: Number(timeIndex) * 900,
       },
@@ -688,7 +890,7 @@ function sliceResponse({
   timeIndex = 0,
   levelIndex = 0,
 }: {
-  field?: "qc" | "w";
+  field?: MockVisualFieldName;
   orientation?: "horizontal" | "vertical_x" | "vertical_y";
   timeIndex?: number;
   levelIndex?: number;
@@ -697,22 +899,18 @@ function sliceResponse({
     fieldCatalogResponse.available_fields.find((candidate) => candidate.raw_field_name === field) ??
     fieldCatalogResponse.available_fields[0];
   const units = fieldMetadata.units;
-  const isVertical = orientation !== "horizontal";
+  const isSurface = field === "rain";
+  const isVertical = orientation !== "horizontal" && !isSurface;
   const values =
-    field === "qc"
-      ? timeIndex < 2
-        ? [
-            [0, 0.000002, null],
-            [0.000004, 0.000006, 0.000008],
-          ]
-        : [
-            [0.00001, 0.000012, 0.000014],
-            [0.000016, 0.000018, 0.00002],
-          ]
-      : [
+    field === "w"
+      ? [
           [1.5, 2.5, 3.5],
           [4.5, 5.5, 6.5],
-        ];
+        ]
+      : mockSliceValues(field, timeIndex);
+  const finiteValues = values
+    .flat()
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
   return {
     result_id: "result-dry-run-quicklook",
     run_id: "dry-run-quicklook",
@@ -722,18 +920,24 @@ function sliceResponse({
       time_index: timeIndex,
       time_seconds: [0, 900, 1800][timeIndex] ?? 1800,
       orientation,
-      selected_dimension:
-        orientation === "vertical_y" ? "xh" : orientation === "vertical_x" ? "yh" : "zh",
-      selected_index: levelIndex,
-      selected_coordinate_value:
-        orientation === "horizontal"
+      selected_dimension: isSurface
+        ? "surface"
+        : orientation === "vertical_y"
+          ? "xh"
+          : orientation === "vertical_x"
+            ? "yh"
+            : "zh",
+      selected_index: isSurface ? 0 : levelIndex,
+      selected_coordinate_value: isSurface
+        ? 0
+        : orientation === "horizontal"
           ? ([0.4, 0.8, 1.2][levelIndex] ?? 0.8)
           : ([-3.2, 0, 3.2][levelIndex] ?? 0),
       level_units: orientation === "horizontal" ? "km" : null,
       level_coordinate_value:
-        orientation === "horizontal" ? ([0.4, 0.8, 1.2][levelIndex] ?? 0.8) : null,
+        orientation === "horizontal" ? (isSurface ? 0 : ([0.4, 0.8, 1.2][levelIndex] ?? 0.8)) : null,
       level_meters:
-        orientation === "horizontal" ? ([0.4, 0.8, 1.2][levelIndex] ?? 0.8) * 1000 : null,
+        orientation === "horizontal" ? (isSurface ? 0 : ([0.4, 0.8, 1.2][levelIndex] ?? 0.8) * 1000) : null,
     },
     coordinate_units: isVertical ? { zh: "km", xh: "km" } : { yh: "km", xh: "km" },
     shape: [2, 3],
@@ -741,11 +945,11 @@ function sliceResponse({
     data_encoding: "json",
     values,
     stats: {
-      min: field === "qc" ? 0 : 1.5,
-      max: field === "qc" ? (timeIndex < 2 ? 0.000008 : 0.00002) : 6.5,
-      mean: field === "qc" ? 0.000004 : 4,
-      finite_count: 5,
-      non_finite_count: field === "qc" && timeIndex < 2 ? 1 : 0,
+      min: Math.min(...finiteValues),
+      max: Math.max(...finiteValues),
+      mean: finiteValues.reduce((sum, value) => sum + value, 0) / finiteValues.length,
+      finite_count: finiteValues.length,
+      non_finite_count: values.flat().length - finiteValues.length,
     },
     provenance,
     caveats: ["native_grid_view_no_interpolation", "json_numeric_slice_mvp"],
@@ -753,48 +957,142 @@ function sliceResponse({
   };
 }
 
+function mockSliceValues(field: MockVisualFieldName, timeIndex: number): Array<Array<number | null>> {
+  if (field === "theta") {
+    return timeIndex < 2
+      ? [
+          [300, 301, null],
+          [302, 303, 304],
+        ]
+      : [
+          [305, 306, 307],
+          [308, 309, 310],
+        ];
+  }
+  if (field === "temperature") {
+    return timeIndex < 2
+      ? [
+          [285, 286, null],
+          [287, 288, 289],
+        ]
+      : [
+          [289, 290, 291],
+          [292, 293, 294],
+        ];
+  }
+  if (field === "qv") {
+    return timeIndex < 2
+      ? [
+          [0.0101, 0.0104, null],
+          [0.0107, 0.0109, 0.0112],
+        ]
+      : [
+          [0.0113, 0.0115, 0.0118],
+          [0.012, 0.0122, 0.0124],
+        ];
+  }
+  if (field === "dbz") {
+    return timeIndex < 2
+      ? [
+          [-8, 2, null],
+          [8, 14, 20],
+        ]
+      : [
+          [6, 12, 18],
+          [22, 26, 30],
+        ];
+  }
+  if (field === "rain") {
+    return timeIndex < 2
+      ? [
+          [0, 0.2, null],
+          [0.6, 0.8, 1.1],
+        ]
+      : [
+          [1.3, 1.8, 2.1],
+          [2.6, 3.4, 4.2],
+        ];
+  }
+  return timeIndex < 2
+    ? [
+        [0, field === "qr" ? 2e-7 : 0.000002, null],
+        [
+          field === "qr" ? 4e-7 : 0.000004,
+          field === "qr" ? 6e-7 : 0.000006,
+          field === "qr" ? 8e-7 : 0.000008,
+        ],
+      ]
+    : [
+        [
+          field === "qr" ? 1e-6 : 0.00001,
+          field === "qr" ? 1.2e-6 : 0.000012,
+          field === "qr" ? 1.4e-6 : 0.000014,
+        ],
+        [
+          field === "qr" ? 1.6e-6 : 0.000016,
+          field === "qr" ? 1.8e-6 : 0.000018,
+          field === "qr" ? 2e-6 : 0.00002,
+        ],
+      ];
+}
+
 function pointCloudResponse({
+  field = "qc",
   threshold = 0.000001,
   timeIndex = 2,
   points,
+  fieldRange,
 }: {
+  field?: MockPointFieldName;
   threshold?: number;
   timeIndex?: number;
   points?: Array<[number, number, number, number]>;
+  fieldRange?: { min: number; max: number; mean: number };
 } = {}) {
+  const fieldMetadata =
+    fieldCatalogResponse.available_fields.find((candidate) => candidate.raw_field_name === field) ??
+    fieldCatalogResponse.available_fields[0];
+  const isSurface = field === "rain";
   const returnedPoints =
     points ??
     (threshold >= 1 || timeIndex === 0
       ? []
       : [
-          [0, 0, 0.8, 0.000002],
-          [1, 1, 0.8, 0.000006],
-          [2, 1, 1.2, 0.000008],
+          [0, 0, field === "rain" ? 0 : 0.8, mockPointValue(field, 0)],
+          [1, 1, field === "rain" ? 0 : 0.8, mockPointValue(field, 1)],
+          [2, 1, field === "rain" ? 0 : 1.2, mockPointValue(field, 2)],
         ]);
   const values = returnedPoints.map((point) => point[3]);
   return {
     result_id: "result-dry-run-quicklook",
     run_id: "dry-run-quicklook",
     scenario_id: "baseline-shallow-cumulus",
-    field: fieldCatalogResponse.available_fields[0],
+    field: fieldMetadata,
     selection: {
-      field: "qc",
+      field,
       time_index: timeIndex,
       time_seconds: [0, 900, 1800][timeIndex] ?? 1800,
       threshold,
       max_points: 50000,
     },
-    coordinate_units: { xh: "km", yh: "km", zh: "km" },
+    coordinate_units: isSurface ? { xh: "km", yh: "km", z: "km" } : { xh: "km", yh: "km", zh: "km" },
     coordinate_extents: {
       xh: { min: -3.2, max: 3.2, units: "km" },
       yh: { min: -3.2, max: 3.2, units: "km" },
-      zh: { min: 0.0, max: 3.0, units: "km" },
+      ...(isSurface
+        ? { z: { min: 0.0, max: 3.0, units: "km" } }
+        : { zh: { min: 0.0, max: 3.0, units: "km" } }),
     },
     point_order: ["x", "y", "z", "value"],
     points: returnedPoints,
     stats: {
       source_count: returnedPoints.length,
       returned_count: returnedPoints.length,
+      field_min_value: (fieldRange ?? mockFieldRange(field)).min,
+      field_max_value: (fieldRange ?? mockFieldRange(field)).max,
+      field_mean_value: (fieldRange ?? mockFieldRange(field)).mean,
+      field_finite_count: 24,
+      field_non_finite_count: 0,
       min_value: values.length ? Math.min(...values) : null,
       max_value: values.length ? Math.max(...values) : null,
       active_z_min: values.length ? Math.min(...returnedPoints.map((point) => point[2])) : null,
@@ -815,10 +1113,54 @@ function pointCloudResponse({
       processing_method: "backend_xarray_native_grid_threshold",
       rendering_method: "thresholded_point_cloud",
       provenance_label:
-        "CM1-derived cloud-water point cloud; native-grid threshold; visualizer interpretation",
+        `CM1-derived ${fieldMetadata.display_name.toLowerCase()} point cloud; native-grid threshold; visualizer interpretation`,
     },
-    caveats: ["native_grid_thresholded_point_cloud", "visualizer_interpretation_of_cm1_qc"],
+    caveats: ["native_grid_thresholded_point_cloud", `visualizer_interpretation_of_cm1_${field}`],
   };
+}
+
+function mockFieldRange(field: MockPointFieldName): { min: number; max: number; mean: number } {
+  const ranges: Record<MockPointFieldName, { min: number; max: number; mean: number }> = {
+    qc: { min: 0, max: 0.000008, mean: 0.000002 },
+    qr: { min: 0, max: 0.0000008, mean: 0.0000002 },
+    qv: { min: 0.0098, max: 0.0124, mean: 0.0111 },
+    dbz: { min: -8, max: 30, mean: 9.5 },
+    rain: { min: 0, max: 4.2, mean: 1.4 },
+  };
+  return ranges[field];
+}
+
+function mockPointValue(field: MockPointFieldName, index: number): number {
+  const values: Record<MockPointFieldName, number[]> = {
+    qc: [0.000002, 0.000006, 0.000008],
+    qr: [0.0000002, 0.0000006, 0.0000008],
+    qv: [0.0104, 0.0112, 0.0124],
+    dbz: [8, 18, 30],
+    rain: [0.8, 2.2, 4.2],
+  };
+  return values[field][index] ?? values[field][0];
+}
+
+function mockFieldFromParam(value: string | null): MockVisualFieldName {
+  if (
+    value === "w" ||
+    value === "qr" ||
+    value === "theta" ||
+    value === "temperature" ||
+    value === "qv" ||
+    value === "dbz" ||
+    value === "rain"
+  ) {
+    return value;
+  }
+  return "qc";
+}
+
+function mockPointFieldFromParam(value: string | null): MockPointFieldName {
+  if (value === "qr" || value === "qv" || value === "dbz" || value === "rain") {
+    return value;
+  }
+  return "qc";
 }
 
 function selectedRegionResponse() {
@@ -1108,13 +1450,16 @@ beforeEach(() => {
       if (url.includes("/visualization/point-cloud")) {
         const parsed = new URL(url, "http://localhost");
         const isDryFailed = parsed.pathname.includes("result-dry-failed-cumulus");
+        const requestedField = mockPointFieldFromParam(parsed.searchParams.get("field"));
         return Promise.resolve(
           new Response(
             JSON.stringify(
               pointCloudResponse({
+                field: requestedField,
                 threshold: Number(parsed.searchParams.get("threshold") ?? 0.000001),
                 timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
                 points: isDryFailed ? [] : undefined,
+                fieldRange: isDryFailed && requestedField === "qc" ? { min: 0, max: 0, mean: 0 } : undefined,
               }),
             ),
             { status: 200 },
@@ -1147,7 +1492,7 @@ beforeEach(() => {
           new Response(
             JSON.stringify(
               sliceResponse({
-                field: parsed.searchParams.get("field") === "w" ? "w" : "qc",
+                field: mockFieldFromParam(parsed.searchParams.get("field")),
                 orientation:
                   parsed.searchParams.get("orientation") === "vertical_y"
                     ? "vertical_y"
@@ -1722,7 +2067,7 @@ describe("App", () => {
 
     expect(screen.getAllByText("Dry Failed Cumulus quick-look").length).toBeGreaterThan(0);
     expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
-    expect(screen.getByLabelText("True 3-D cloud-water viewer")).toBeInTheDocument();
+    expect(screen.getByLabelText("True 3-D scalar field viewer")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Inspect the current slice" })).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(
       "/api/results/result-dry-failed-cumulus/visualization/defaults",
@@ -2155,10 +2500,12 @@ describe("App", () => {
       }
       if (url.includes("/visualization/point-cloud")) {
         const parsed = new URL(url, "http://localhost");
+        const requestedField = mockPointFieldFromParam(parsed.searchParams.get("field"));
         return Promise.resolve(
           new Response(
             JSON.stringify(
               pointCloudResponse({
+                field: requestedField,
                 threshold: Number(parsed.searchParams.get("threshold") ?? 0.000001),
                 timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
               }),
@@ -2173,7 +2520,7 @@ describe("App", () => {
           new Response(
             JSON.stringify(
               sliceResponse({
-                field: parsed.searchParams.get("field") === "w" ? "w" : "qc",
+                field: mockFieldFromParam(parsed.searchParams.get("field")),
                 orientation:
                   parsed.searchParams.get("orientation") === "vertical_y"
                     ? "vertical_y"
@@ -2238,7 +2585,7 @@ describe("App", () => {
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
     expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
-    await screen.findAllByText("Cloud-water point cloud loaded");
+    await screen.findAllByText("Cloud-water point layer loaded");
     expect(screen.getByText("Result explanation")).toBeInTheDocument();
     expect(screen.getAllByText(/Cloud water formed in the validated quick-look baseline/).length)
       .toBeGreaterThan(0);
@@ -2327,7 +2674,7 @@ describe("App", () => {
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.queryByRole("option", { name: /qc/ })).not.toBeInTheDocument();
-    expect(screen.getByLabelText("True 3-D cloud-water viewer")).toBeInTheDocument();
+    expect(screen.getByLabelText("True 3-D scalar field viewer")).toBeInTheDocument();
     expect(screen.getByLabelText("Slice position")).toBeInTheDocument();
   });
 
@@ -2339,20 +2686,96 @@ describe("App", () => {
 
     expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     await screen.findByText("Slice synced");
-    expect(screen.getByLabelText("True 3-D cloud-water viewer")).toBeInTheDocument();
+    expect(screen.getByLabelText("True 3-D scalar field viewer")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Inspect the current slice" })).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("option", { name: "w - Vertical velocity" }).length).toBeGreaterThan(
+    expect(screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length).toBeGreaterThan(
       0,
     );
 
-    await screen.findAllByText("Cloud-water point cloud loaded");
+    await screen.findAllByText("Cloud-water point layer loaded");
     expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("option", { name: "w - Vertical velocity" }).length).toBeGreaterThan(
+    expect(screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length).toBeGreaterThan(
       0,
     );
+  });
+
+  it("separates 3-D scalar fields from slice-only fields", async () => {
+    render(<App />);
+
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+    await screen.findAllByText("Cloud-water point layer loaded");
+
+    const threeDField = screen.getByLabelText("3-D scalar field") as HTMLSelectElement;
+    const threeDOptions = Array.from(threeDField.options).map((option) => option.textContent);
+    expect(threeDOptions).toEqual(
+      expect.arrayContaining([
+        "qc - Cloud water",
+        "qr - Rain water",
+        "qv - Water vapor",
+        "dbz - Reflectivity",
+        "rain - Accumulated surface rain",
+      ]),
+    );
+    expect(threeDOptions.join(" ")).not.toContain("theta");
+    expect(threeDOptions.join(" ")).not.toContain("temperature");
+    expect(threeDOptions.join(" ")).not.toContain("Vertical velocity");
+
+    const sliceField = screen.getByLabelText("Slice field") as HTMLSelectElement;
+    const sliceOptions = Array.from(sliceField.options).map((option) => option.textContent);
+    expect(sliceOptions).toEqual(
+      expect.arrayContaining([
+        "w - Vertical velocity (slice only)",
+        "theta - Potential temperature (slice only)",
+        "temperature - Temperature (slice only)",
+      ]),
+    );
+
+    fireEvent.change(sliceField, { target: { value: "temperature" } });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Slice field")).toHaveValue("temperature");
+    });
+    expect(screen.getByLabelText("3-D scalar field")).toHaveValue("qc");
+  });
+
+  it("renders expanded 3-D scalar fields with honest legends and floor-layer rain", async () => {
+    render(<App />);
+
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+    await screen.findAllByText("Cloud-water point layer loaded");
+
+    const threeDField = screen.getByLabelText("3-D scalar field");
+    fireEvent.change(threeDField, { target: { value: "qr" } });
+    expect((await screen.findAllByText("Rain-water point layer loaded")).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Slice field")).toHaveValue("qr");
+    expect(screen.getAllByText("Rain water").length).toBeGreaterThan(0);
+
+    fireEvent.change(threeDField, { target: { value: "qv" } });
+    expect((await screen.findAllByText("Water-vapor point layer loaded")).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByLabelText("Slice field")).toHaveValue("qv");
+    expect(screen.getAllByText("Water vapor").length).toBeGreaterThan(0);
+
+    fireEvent.change(threeDField, { target: { value: "dbz" } });
+    expect((await screen.findAllByText("Reflectivity point layer loaded")).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByLabelText("Slice field")).toHaveValue("dbz");
+    expect(screen.getAllByText("0 dBZ").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("60+ dBZ").length).toBeGreaterThan(0);
+
+    fireEvent.change(threeDField, { target: { value: "rain" } });
+    expect((await screen.findAllByText("Surface-rain floor layer loaded")).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByLabelText("Slice field")).toHaveValue("rain");
+    expect(screen.getByRole("button", { name: "Vertical x-z slice" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Vertical y-z slice" })).toBeDisabled();
   });
 
   it("opens Dry Failed as a no-cloud result with a useful w/updraft path", async () => {
@@ -2362,19 +2785,18 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Open Dry Failed in Explore" }));
 
     expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
-    await screen.findAllByText("Cloud view ready");
+    await screen.findAllByText("Cloud water max is 0 kg/kg; no points are above 1.000e-6 kg/kg");
     expect(screen.getByRole("heading", { name: "Inspect the current slice" })).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("option", { name: "w - Vertical velocity" }).length).toBeGreaterThan(
+    expect(screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length).toBeGreaterThan(
       0,
     );
     expect(
-      screen.getByText("No cloud water formed in this result; vertical velocity is available."),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/use vertical velocity \(w\) slices to inspect the thermals/i))
-      .toBeInTheDocument();
-
+      screen.getAllByText(
+        "Thermals rose, but low-level moisture stayed too dry for meaningful cloud water or rain.",
+      ).length,
+    ).toBeGreaterThan(0);
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
   });
@@ -2467,7 +2889,7 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Retry loading fields" }));
 
-    await screen.findAllByText("Cloud-water point cloud loaded");
+    await screen.findAllByText("Cloud-water point layer loaded");
     await waitFor(() => {
       expect(screen.queryByText("Visualization fields temporarily failed.")).not.toBeInTheDocument();
     });
@@ -2480,14 +2902,14 @@ describe("App", () => {
     fireEvent.click((await screen.findAllByRole("button", { name: "Open in Explore" }))[0]);
 
     expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
-    await screen.findAllByText("Cloud-water point cloud loaded");
+    await screen.findAllByText("Cloud-water point layer loaded");
     expect(screen.getByText("Cloud formed in this result")).toBeInTheDocument();
     expect(screen.queryByText("Cloud formed here")).not.toBeInTheDocument();
-    const viewer = screen.getByLabelText("True 3-D cloud-water viewer");
+    const viewer = screen.getByLabelText("True 3-D scalar field viewer");
     expect(viewer).toBeInTheDocument();
     expect(
       screen.getByLabelText(
-        "Interactive Three.js scene showing CM1 cloud water, domain bounds, slice plane, and selected point",
+        "Interactive Three.js scene showing a CM1 scalar field, domain bounds, slice plane, and selected point",
       ),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Scientific visualization workbench")).toBeInTheDocument();
@@ -2522,9 +2944,7 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "Vertical y-z slice" })).toBeInTheDocument();
     expect(screen.getByLabelText("Time")).toBeInTheDocument();
     expect(screen.getByLabelText("Show slice plane")).toBeChecked();
-    expect(screen.getAllByText("selected_time_max_qc_native_grid_location").length).toBeGreaterThan(
-      0,
-    );
+    expect(screen.getAllByText("Current field max: 8.000e-6 kg/kg. Visible points above 1.000e-6 kg/kg: 3.").length).toBeGreaterThan(0);
     expect(screen.getByText("0 to 3 km")).toBeInTheDocument();
     expect(screen.getByText("0.8 km to 1.2 km")).toBeInTheDocument();
     expect(screen.getByText("x 2, y 1, z 1.2 km, value 8.000e-6")).toBeInTheDocument();
@@ -2536,9 +2956,11 @@ describe("App", () => {
     expect(screen.getByText("2.000e-6 kg/kg to 8.000e-6 kg/kg")).toBeInTheDocument();
     expect(screen.getByText("Visualizer interpretation of CM1-derived output")).toBeInTheDocument();
     expect(
-      screen.getByText("Processing method: native-grid thresholded point cloud"),
+      screen.getByText(
+        "Processing method: backend native-grid thresholded point cloud for supported scalar fields",
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Rendering method: direct Three.js thresholded point cloud"))
+    expect(screen.getByText("Rendering method: direct Three.js scalar point cloud"))
       .toBeInTheDocument();
     expect(screen.getByText("No raw NetCDF parsing in the browser")).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining("time_index=2"));
@@ -2551,9 +2973,9 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Open in Explore" }))[0]);
-    await screen.findAllByText("Cloud-water point cloud loaded");
+    await screen.findAllByText("Cloud-water point layer loaded");
 
-    const viewer = screen.getByLabelText("True 3-D cloud-water viewer");
+    const viewer = screen.getByLabelText("True 3-D scalar field viewer");
     expect(within(viewer).getByText(/Slice plane: Horizontal layer at z = /)).toBeInTheDocument();
     expect(within(viewer).queryByText(/Slice plane: Vertical x-z slice at y = /))
       .not.toBeInTheDocument();
@@ -2605,10 +3027,10 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Open in Explore" }))[0]);
-    await screen.findAllByText("Cloud-water point cloud loaded");
+    await screen.findAllByText("Cloud-water point layer loaded");
 
     fireEvent.click(screen.getByRole("button", { name: "Vertical x-z slice" }));
-    const viewer = screen.getByLabelText("True 3-D cloud-water viewer");
+    const viewer = screen.getByLabelText("True 3-D scalar field viewer");
     await waitFor(() => {
       expect(within(viewer).getByText(/Slice plane: Vertical x-z slice at y = /))
         .toBeInTheDocument();
@@ -2632,7 +3054,7 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Open in Explore" }))[0]);
-    await screen.findAllByText("Cloud-water point cloud loaded");
+    await screen.findAllByText("Cloud-water point layer loaded");
 
     const cameraControls = screen.getByLabelText("3-D camera controls");
     expect(within(cameraControls).getByText(/Camera ready/)).toBeInTheDocument();
@@ -2660,17 +3082,17 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click((await screen.findAllByRole("button", { name: "Open in Explore" }))[0]);
-    await screen.findAllByText("Cloud-water point cloud loaded");
+    await screen.findAllByText("Cloud-water point layer loaded");
 
     fireEvent.change(screen.getByLabelText("Cloud-water threshold"), { target: { value: "1" } });
 
-    await screen.findAllByText("No cloud water above threshold");
+    await screen.findAllByText("Cloud water max is 8.000e-6 kg/kg; no points are above 1.000e+0 kg/kg");
     expect(
       screen.getByText("No cloud water above the selected threshold at this time."),
     ).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining("threshold=1"));
 
-    fireEvent.change(screen.getByLabelText("Cloud opacity"), { target: { value: "0.8" } });
+    fireEvent.change(screen.getByLabelText("Layer opacity"), { target: { value: "0.8" } });
     fireEvent.change(screen.getByLabelText("Point size"), { target: { value: "14" } });
     fireEvent.change(screen.getByLabelText("Time"), { target: { value: "1" } });
 
@@ -2689,12 +3111,10 @@ describe("App", () => {
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
     expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
-    await screen.findAllByText("Cloud view ready");
-    expect(
-      screen.getByText("Cloud water field qc is not available for this result."),
-    ).toBeInTheDocument();
+    await screen.findAllByText("Slice fields ready; no 3-D scalar field available");
+    expect(screen.getByText("No supported 3-D scalar field")).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
-    expect(screen.getByLabelText("Cloud-water threshold")).toBeDisabled();
+    expect(screen.getByLabelText("3-D scalar field")).toBeDisabled();
   });
 
   it("handles an Explore result with no visualization-ready fields", async () => {
@@ -2709,8 +3129,6 @@ describe("App", () => {
     expect(
       screen.getByText("No visualization-ready fields are available for this result."),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText("Cloud water field qc is not available for this result."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("No supported 3-D scalar field")).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -308,6 +308,11 @@ type PointCloudResponse = {
   stats: {
     source_count: number;
     returned_count: number;
+    field_min_value: number | null;
+    field_max_value: number | null;
+    field_mean_value: number | null;
+    field_finite_count: number;
+    field_non_finite_count: number;
     min_value: number | null;
     max_value: number | null;
     active_z_min: number | null;
@@ -318,6 +323,18 @@ type PointCloudResponse = {
   };
   provenance: ProvenancePayload;
   caveats: string[];
+};
+
+type ThreeDScalarEncoding = {
+  field: VisualizableField;
+  defaultThreshold: number;
+  thresholdStep: number;
+  statusLabel: string;
+  emptyStateTitle: string;
+  thresholdAriaLabel: string;
+  thresholdLabel: string;
+  rangeLabel: string;
+  valueChannel: string;
 };
 
 type RegionType = "point" | "column" | "box";
@@ -662,7 +679,7 @@ async function fetchVisualizationPointCloud(
   });
   const response = await fetch(`/api/results/${resultId}/visualization/point-cloud?${search}`);
   if (!response.ok) {
-    throw new Error(await responseError(response, "Unable to load cloud-water point cloud."));
+    throw new Error(await responseError(response, "Unable to load 3-D scalar point layer."));
   }
   return response.json() as Promise<PointCloudResponse>;
 }
@@ -3356,6 +3373,124 @@ function ResultNotebookCard({
   );
 }
 
+function threeDScalarEncoding(field: VisualizableField | undefined): ThreeDScalarEncoding | null {
+  if (!field || !field.coordinate_names.time || !field.coordinate_names.y || !field.coordinate_names.x) {
+    return null;
+  }
+  if (field.raw_field_name === "w" || field.canonical_field_name === "vertical_velocity") {
+    return null;
+  }
+  if (isSliceOnlyTemperatureField(field)) return null;
+  const hasVerticalGrid = Boolean(field.coordinate_names.vertical);
+
+  if (field.canonical_field_name === "cloud_water" || field.raw_field_name === "qc") {
+    if (!hasVerticalGrid) return null;
+    return {
+      field,
+      defaultThreshold: 1e-6,
+      thresholdStep: 1e-6,
+      statusLabel: "Cloud-water point layer loaded",
+      emptyStateTitle: "No cloud water above the selected threshold at this time.",
+      thresholdAriaLabel: "Cloud-water threshold",
+      thresholdLabel: "Cloud-water threshold",
+      rangeLabel: "Cloud-water range",
+      valueChannel:
+        "Color intensity shows cloud-water magnitude above threshold; opacity and point size are rendering controls.",
+    };
+  }
+
+  if (field.canonical_field_name === "rain_water" || field.raw_field_name === "qr") {
+    if (!hasVerticalGrid) return null;
+    return {
+      field,
+      defaultThreshold: 1e-7,
+      thresholdStep: 1e-7,
+      statusLabel: "Rain-water point layer loaded",
+      emptyStateTitle: "No rain water above the selected threshold at this time.",
+      thresholdAriaLabel: "Rain-water threshold",
+      thresholdLabel: "Rain-water threshold",
+      rangeLabel: "Rain-water range",
+      valueChannel:
+        "Color intensity shows rain-water magnitude above threshold; opacity and point size are rendering controls.",
+    };
+  }
+
+  if (field.canonical_field_name === "reflectivity" || field.raw_field_name === "dbz") {
+    if (!hasVerticalGrid) return null;
+    return {
+      field,
+      defaultThreshold: 0,
+      thresholdStep: 1,
+      statusLabel: "Reflectivity point layer loaded",
+      emptyStateTitle: "No reflectivity values above the selected threshold at this time.",
+      thresholdAriaLabel: "Reflectivity threshold",
+      thresholdLabel: "Reflectivity threshold",
+      rangeLabel: "Reflectivity range",
+      valueChannel:
+        "Color intensity shows reflectivity value; point size stays globally controlled and does not imply mass.",
+    };
+  }
+
+  if (field.canonical_field_name === "water_vapor" || field.raw_field_name === "qv") {
+    if (!hasVerticalGrid) return null;
+    return {
+      field,
+      defaultThreshold: 0.01,
+      thresholdStep: 1e-6,
+      statusLabel: "Water-vapor point layer loaded",
+      emptyStateTitle: "No water-vapor values above the selected threshold at this time.",
+      thresholdAriaLabel: "Water-vapor visible minimum",
+      thresholdLabel: "Water-vapor visible minimum",
+      rangeLabel: "Water-vapor range",
+      valueChannel:
+        "Color intensity shows water-vapor magnitude above threshold; opacity and point size are rendering controls.",
+    };
+  }
+
+  if (isSurfaceRainField(field)) {
+    return {
+      field,
+      defaultThreshold: 0,
+      thresholdStep: 0.1,
+      statusLabel: "Surface-rain floor layer loaded",
+      emptyStateTitle: "No accumulated surface rain above the selected threshold at this time.",
+      thresholdAriaLabel: "Surface-rain threshold",
+      thresholdLabel: "Surface-rain threshold",
+      rangeLabel: "Surface-rain range",
+      valueChannel:
+        "Color intensity shows accumulated surface rain on the domain floor; opacity and point size are rendering controls.",
+    };
+  }
+
+  return null;
+}
+
+function isSurfaceRainField(field: VisualizableField | undefined): boolean {
+  if (!field) return false;
+  return (
+    field.raw_field_name === "rain" ||
+    field.canonical_field_name === "accumulated_surface_rain"
+  );
+}
+
+function isSliceOnlyTemperatureField(field: VisualizableField | undefined): boolean {
+  if (!field) return false;
+  return (
+    field.canonical_field_name === "potential_temperature" ||
+    field.canonical_field_name === "temperature" ||
+    field.raw_field_name === "th" ||
+    field.raw_field_name === "theta" ||
+    field.raw_field_name === "t" ||
+    field.raw_field_name === "temp" ||
+    field.raw_field_name === "temperature"
+  );
+}
+
+function sliceFieldOptionLabel(field: VisualizableField): string {
+  const suffix = threeDScalarEncoding(field) ? "" : " (slice only)";
+  return `${field.raw_field_name} - ${field.display_name}${suffix}`;
+}
+
 function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const [catalog, setCatalog] = useState<FieldCatalogResponse | null>(null);
   const [viewDefaults, setViewDefaults] = useState<ViewDefaultsResponse | null>(null);
@@ -3431,24 +3566,37 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
         setSceneError(null);
         setCatalog(payload);
         setViewDefaults(defaults);
+        const renderableEncodings = payload.available_fields
+          .map(threeDScalarEncoding)
+          .filter((encoding): encoding is ThreeDScalarEncoding => encoding !== null);
         const firstPreferred =
           payload.available_fields.find(
             (field) => field.raw_field_name === (defaults?.preferred_field ?? "qc"),
           ) ??
           payload.available_fields.find((field) => field.raw_field_name === "qc") ??
           payload.available_fields[0];
-        const cloudContextField =
-          payload.available_fields.find((field) => field.raw_field_name === "qc") ??
-          firstPreferred;
-        const initialDefaults = defaultsForField(defaults, firstPreferred?.raw_field_name);
-        const initialTimeIndex = defaultTimeIndex(firstPreferred, result, initialDefaults);
-        setSelectedFieldName(cloudContextField?.raw_field_name ?? "");
-        setSliceFieldName(firstPreferred?.raw_field_name ?? "");
+        const firstRenderable =
+          renderableEncodings.find(
+            (encoding) => encoding.field.raw_field_name === (defaults?.preferred_field ?? "qc"),
+          ) ??
+          renderableEncodings.find((encoding) => encoding.field.raw_field_name === "qc") ??
+          renderableEncodings[0] ??
+          null;
+        const initialSliceField = firstPreferred ?? firstRenderable?.field ?? payload.available_fields[0];
+        const initialDefaults = defaultsForField(defaults, initialSliceField?.raw_field_name);
+        const initialTimeIndex = defaultTimeIndex(initialSliceField, result, initialDefaults);
+        setSelectedFieldName(firstRenderable?.field.raw_field_name ?? "");
+        setSliceFieldName(initialSliceField?.raw_field_name ?? "");
         setTimeIndex(initialTimeIndex);
-        setHorizontalSliceLevel(defaultHorizontalLevel(firstPreferred, initialDefaults));
-        setVerticalSliceIndex(defaultVerticalIndex(firstPreferred, "vertical_x", initialDefaults));
+        setThreshold(firstRenderable?.defaultThreshold ?? 1e-6);
+        setHorizontalSliceLevel(defaultHorizontalLevel(initialSliceField, initialDefaults));
+        setVerticalSliceIndex(defaultVerticalIndex(initialSliceField, "vertical_x", initialDefaults));
         setSceneStatus(
-          payload.available_fields.length > 0 ? "Cloud view ready" : "No fields available",
+          payload.available_fields.length === 0
+            ? "No fields available"
+            : firstRenderable
+              ? "Field view ready"
+              : "Slice fields ready; no 3-D scalar field available",
         );
       })
       .catch((caught: unknown) => {
@@ -3465,23 +3613,36 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     () => catalog?.available_fields.find((field) => field.raw_field_name === selectedFieldName),
     [catalog, selectedFieldName],
   );
-  const qcField = useMemo(
-    () => catalog?.available_fields.find((field) => field.raw_field_name === "qc"),
-    [catalog],
-  );
   const sliceField = useMemo(
     () => catalog?.available_fields.find((field) => field.raw_field_name === sliceFieldName),
     [catalog, sliceFieldName],
   );
+  const threeDScalarEncodings = useMemo(
+    () =>
+      (catalog?.available_fields ?? [])
+        .map(threeDScalarEncoding)
+        .filter((encoding): encoding is ThreeDScalarEncoding => encoding !== null),
+    [catalog],
+  );
+  const selectedEncoding = useMemo(
+    () =>
+      threeDScalarEncodings.find(
+        (encoding) => encoding.field.raw_field_name === selectedFieldName,
+      ) ?? null,
+    [selectedFieldName, threeDScalarEncodings],
+  );
+  const controlField = selectedField ?? sliceField;
 
-  const timeOptions = selectedField?.time_coordinate_values ?? [];
+  const timeOptions = controlField?.time_coordinate_values ?? [];
   const timeMax = Math.max(0, timeOptions.length - 1);
+  const resolvedTimeIndex = Math.min(timeIndex, timeMax);
   const wField = catalog?.available_fields.find((field) => field.raw_field_name === "w");
   const isNoCloudWithUpdraft =
     cloudOutcome(result) === "No cloud formed" && Boolean(wField) && (result.max_w_m_s ?? 0) > 0;
   const sliceVerticalSize = sliceField?.coordinate_names.vertical
     ? sliceField.shape[sliceField.dimensions.indexOf(sliceField.coordinate_names.vertical)]
     : 1;
+  const sliceSupportsVertical = Boolean(sliceField?.coordinate_names.vertical);
   const sliceYSize = sliceField?.coordinate_names.y
     ? sliceField.shape[sliceField.dimensions.indexOf(sliceField.coordinate_names.y)]
     : 1;
@@ -3509,7 +3670,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const selectedDefaults = defaultsForField(viewDefaults, selectedFieldName);
   const selectedTimeFieldDefaults = defaultsForField(selectedTimeDefaults, selectedFieldName);
   const selectedTimeSliceDefaults = defaultsForField(selectedTimeDefaults, sliceFieldName);
-  const selectedTimeValue = timeOptions[Math.min(timeIndex, timeMax)] ?? null;
+  const selectedTimeValue = timeOptions[resolvedTimeIndex] ?? null;
   const selectedTimeLabel = formatTimeValue(selectedTimeValue);
   const activeSlice = activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice;
   const activeSliceLabel = slicePlainLabel(activeSlice, activeSlicePlane, activeSliceIndex);
@@ -3548,16 +3709,23 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   }, [activeProcessMode, processMode]);
 
   useEffect(() => {
-    if (!selectedField || selectedField.raw_field_name !== "qc") {
+    if (!sliceSupportsVertical && activeSlicePlane !== "horizontal") {
+      setActiveSlicePlane("horizontal");
+      setSelectedRegion(null);
+    }
+  }, [activeSlicePlane, sliceSupportsVertical]);
+
+  useEffect(() => {
+    if (!selectedEncoding) {
       setPointCloud(null);
       return;
     }
     let active = true;
     setSceneError(null);
-    setSceneStatus("Loading cloud-water points...");
+    setSceneStatus(`Loading ${selectedEncoding.field.display_name.toLowerCase()} points...`);
     fetchVisualizationPointCloud(result.result_id, {
-      field: "qc",
-      timeIndex,
+      field: selectedEncoding.field.raw_field_name,
+      timeIndex: resolvedTimeIndex,
       threshold,
       maxPoints,
     })
@@ -3566,16 +3734,16 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
         setPointCloud(payload);
         setSceneStatus(
           payload.points.length > 0
-            ? "Cloud-water point cloud loaded"
-            : "No cloud water above threshold",
+            ? selectedEncoding.statusLabel
+            : emptyPointCloudStatus(payload, selectedEncoding),
         );
-        return fetchVisualizationDefaults(result.result_id, timeIndex)
+        return fetchVisualizationDefaults(result.result_id, resolvedTimeIndex)
           .then((defaults) => {
             if (!active) return;
             setSelectedTimeDefaults(defaults);
             const fieldDefaults =
               defaultsForField(defaults, sliceFieldName) ??
-              defaultsForField(defaults, selectedField.raw_field_name);
+              defaultsForField(defaults, selectedEncoding.field.raw_field_name);
             if (fieldDefaults) {
               setHorizontalSliceLevel(fieldDefaults.horizontal_level_index);
               setVerticalSliceIndex(
@@ -3593,9 +3761,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
         if (!active) return;
         setPointCloud(null);
         setSceneError(
-          caught instanceof Error ? caught.message : "Unable to load cloud-water point cloud.",
+          caught instanceof Error ? caught.message : "Unable to load 3-D scalar point layer.",
         );
-        setSceneStatus("Point cloud unavailable");
+        setSceneStatus("3-D scalar layer unavailable");
       });
     return () => {
       active = false;
@@ -3603,11 +3771,11 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   }, [
     maxPoints,
     result.result_id,
-    selectedField,
+    resolvedTimeIndex,
+    selectedEncoding,
     sliceFieldName,
     sliceOrientation,
     threshold,
-    timeIndex,
   ]);
 
   useEffect(() => {
@@ -3620,20 +3788,21 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     let active = true;
     setSliceLoading(true);
     setSliceError(null);
-    Promise.all([
-      fetchVisualizationSlice(result.result_id, {
-        field: sliceField.raw_field_name,
-        timeIndex,
-        orientation: "horizontal",
-        levelIndex: horizontalSliceLevel,
-      }),
-      fetchVisualizationSlice(result.result_id, {
-        field: sliceField.raw_field_name,
-        timeIndex,
-        orientation: sliceOrientation,
-        levelIndex: verticalSliceIndex,
-      }),
-    ])
+    const horizontalPromise = fetchVisualizationSlice(result.result_id, {
+      field: sliceField.raw_field_name,
+      timeIndex: resolvedTimeIndex,
+      orientation: "horizontal",
+      levelIndex: horizontalSliceLevel,
+    });
+    const verticalPromise = sliceSupportsVertical
+      ? fetchVisualizationSlice(result.result_id, {
+          field: sliceField.raw_field_name,
+          timeIndex: resolvedTimeIndex,
+          orientation: sliceOrientation,
+          levelIndex: verticalSliceIndex,
+        })
+      : Promise.resolve(null);
+    Promise.all([horizontalPromise, verticalPromise])
       .then(([horizontal, vertical]) => {
         if (!active) return;
         setSceneHorizontalSlice(horizontal);
@@ -3653,9 +3822,10 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   }, [
     horizontalSliceLevel,
     result.result_id,
+    resolvedTimeIndex,
     sliceField,
+    sliceSupportsVertical,
     sliceOrientation,
-    timeIndex,
     verticalSliceIndex,
   ]);
 
@@ -3697,7 +3867,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     <section className="visualizer-shell" aria-labelledby="visualizer-shell-title">
       <div className="section-heading">
         <div>
-          <p className="eyebrow">Cloud view</p>
+          <p className="eyebrow">Field view</p>
           <h2 id="visualizer-shell-title">What happened in this result?</h2>
         </div>
         <p className="state-chip">{sceneStatus}</p>
@@ -3721,6 +3891,12 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
           <True3DViewer
             resultName={result.name}
             pointCloud={pointCloud}
+            fieldLabel={
+              selectedEncoding
+                ? `${selectedEncoding.field.raw_field_name} — ${selectedEncoding.field.display_name}`
+                : "No supported 3-D scalar field"
+            }
+            valueChannelLabel={selectedEncoding?.valueChannel ?? "3-D scalar rendering unavailable."}
             activeSlice={
               activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice
             }
@@ -3729,20 +3905,20 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
             selectedRegion={selectedRegion}
             coordinateSizes={{ x: sliceXSize, y: sliceYSize, z: sliceVerticalSize }}
             selectedTimeLabel={selectedTimeLabel}
-            thresholdLabel={formatScientific(threshold, "kg/kg")}
+            thresholdLabel={formatScientific(threshold, selectedEncoding?.field.units ?? "")}
             opacity={opacity}
             pointSize={pointSize}
             status={sceneStatus}
             provenanceLabel={provenanceLabel}
             noCloudMessage={
-              !qcField
-                ? "Cloud water field qc is not available for this result."
-                : isNoCloudWithUpdraft
-                  ? "No cloud water formed in this result; vertical velocity is available."
-                  : "No cloud water above the selected threshold at this time."
+              !selectedEncoding
+                ? "No supported 3-D scalar field is available for this result. Use the 2-D slice inspector for available fields."
+                : selectedEncoding.field.raw_field_name === "qc" && isNoCloudWithUpdraft
+                  ? "No cloud water formed in this result; vertical velocity is available in the 2-D slice inspector."
+                  : selectedEncoding.emptyStateTitle
             }
           />
-          {catalog && sliceField && selectedField && (
+          {catalog && sliceField && (
             <section className="explore-control-deck" aria-label="Explore viewer controls">
               <fieldset className="explore-control-card explore-control-card-time">
                 <legend>Time</legend>
@@ -3751,7 +3927,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                   <select
                     id="explore-time"
                     aria-label="Time"
-                    value={Math.min(timeIndex, timeMax)}
+                    value={resolvedTimeIndex}
                     onChange={(event) => setTimeIndex(Number(event.target.value))}
                   >
                     {timeOptions.map((value, index) => (
@@ -3779,7 +3955,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
               <fieldset className="explore-control-card explore-control-card-slice">
                 <legend>Slice</legend>
                 <label htmlFor="explore-slice-field">
-                  Field
+                  2-D slice field
                   <select
                     id="explore-slice-field"
                     aria-label="Slice field"
@@ -3792,12 +3968,15 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                       const nextDefaults = defaultsForField(viewDefaults, event.target.value);
                       setHorizontalSliceLevel(defaultHorizontalLevel(nextField, nextDefaults));
                       setVerticalSliceIndex(defaultVerticalIndex(nextField, sliceOrientation, nextDefaults));
+                      if (!nextField?.coordinate_names.vertical) {
+                        setActiveSlicePlane("horizontal");
+                      }
                       setSelectedRegion(null);
                     }}
                   >
                     {catalog.available_fields.map((field) => (
                       <option key={field.raw_field_name} value={field.raw_field_name}>
-                        {field.raw_field_name} - {field.display_name}
+                        {sliceFieldOptionLabel(field)}
                       </option>
                     ))}
                   </select>
@@ -3817,6 +3996,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                   <button
                     type="button"
                     className={activeSlicePlane === "vertical_x" ? "active-control" : ""}
+                    disabled={!sliceSupportsVertical}
                     onClick={() => {
                       setActiveSlicePlane("vertical_x");
                       setSliceOrientation("vertical_x");
@@ -3828,6 +4008,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                   <button
                     type="button"
                     className={activeSlicePlane === "vertical_y" ? "active-control" : ""}
+                    disabled={!sliceSupportsVertical}
                     onClick={() => {
                       setActiveSlicePlane("vertical_y");
                       setSliceOrientation("vertical_y");
@@ -3909,25 +4090,83 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
               </fieldset>
 
               <fieldset className="explore-control-card explore-control-card-rendering">
-                <legend>Cloud-water rendering</legend>
+                <legend>3-D scalar layer</legend>
+                <label htmlFor="explore-3d-field">
+                  3-D field
+                  <select
+                    id="explore-3d-field"
+                    aria-label="3-D scalar field"
+                    value={selectedFieldName}
+                    disabled={threeDScalarEncodings.length === 0}
+                    onChange={(event) => {
+                      const nextEncoding =
+                        threeDScalarEncodings.find(
+                          (encoding) => encoding.field.raw_field_name === event.target.value,
+                        ) ?? null;
+                      setSelectedFieldName(event.target.value);
+                      if (nextEncoding) {
+                        setSliceFieldName(nextEncoding.field.raw_field_name);
+                        setThreshold(nextEncoding.defaultThreshold);
+                        if (!nextEncoding.field.coordinate_names.vertical) {
+                          setActiveSlicePlane("horizontal");
+                        }
+                        const nextDefaults =
+                          defaultsForField(selectedTimeDefaults, nextEncoding.field.raw_field_name) ??
+                          defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
+                        setHorizontalSliceLevel(
+                          defaultHorizontalLevel(nextEncoding.field, nextDefaults),
+                        );
+                        setVerticalSliceIndex(
+                          defaultVerticalIndex(nextEncoding.field, sliceOrientation, nextDefaults),
+                        );
+                      }
+                      setSelectedRegion(null);
+                    }}
+                  >
+                    {threeDScalarEncodings.length === 0 && (
+                      <option value="">No 3-D scalar fields</option>
+                    )}
+                    {threeDScalarEncodings.map((encoding) => (
+                      <option
+                        key={encoding.field.raw_field_name}
+                        value={encoding.field.raw_field_name}
+                      >
+                        {encoding.field.raw_field_name} - {encoding.field.display_name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <p className="control-help">
+                  {selectedEncoding
+                    ? selectedEncoding.valueChannel
+                    : "Only fields with a defined 3-D scalar encoding appear here; vertical velocity remains slice-only."}
+                </p>
+                {pointCloud && selectedEncoding && (
+                  <p className="control-help">
+                    {pointCloudFieldSummary(pointCloud)}
+                    {selectedEncoding.field.raw_field_name === "dbz"
+                      ? " Weather-radar colors use a fixed 0 to 60+ dBZ scale."
+                      : ""}
+                  </p>
+                )}
                 <label htmlFor="cloud-threshold">
-                  Threshold
+                  {selectedEncoding?.thresholdLabel ?? "Visible minimum"}
                   <input
                     id="cloud-threshold"
-                    aria-label="Cloud-water threshold"
+                    aria-label={selectedEncoding?.thresholdAriaLabel ?? "3-D scalar threshold"}
                     type="number"
                     min={0}
-                    step="0.000001"
+                    step={selectedEncoding?.thresholdStep ?? 0.000001}
                     value={threshold}
                     onChange={(event) => setThreshold(Number(event.target.value))}
-                    disabled={!qcField}
+                    disabled={!selectedEncoding}
                   />
                 </label>
                 <label htmlFor="cloud-opacity">
                   Opacity
                   <input
                     id="cloud-opacity"
-                    aria-label="Cloud opacity"
+                    aria-label="Layer opacity"
                     type="range"
                     min={0.1}
                     max={1}
@@ -3987,7 +4226,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                 value="Direct Three.js point cloud"
               />
               <Metric
-                label="Source field"
+                label="3-D field"
                 value={
                   selectedField
                     ? `${selectedField.raw_field_name} (${selectedField.display_name})`
@@ -3997,7 +4236,10 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
               <Metric label="Selected time" value={selectedTimeLabel} />
               <Metric label="Slice plane" value={activeSliceLabel} />
               <Metric label="Slice plane visible" value={showSlicePlanes ? "Yes" : "No"} />
-              <Metric label="Threshold" value={formatScientific(threshold, "kg/kg")} />
+              <Metric
+                label={selectedEncoding?.thresholdLabel ?? "Visible threshold"}
+                value={formatScientific(threshold, selectedField?.units ?? "")}
+              />
               <Metric label="Opacity" value={String(opacity)} />
               <Metric label="Point size" value={`${pointSize}px`} />
               <Metric
@@ -4009,11 +4251,25 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                 }
               />
               <Metric
-                label="Cloud-water range"
+                label={selectedEncoding?.rangeLabel ?? "3-D field range"}
                 value={
                   pointCloud
                     ? `${formatMaybeNumber(pointCloud.stats.min_value, selectedField?.units ?? "kg/kg")} to ${formatMaybeNumber(
                         pointCloud.stats.max_value,
+                        selectedField?.units ?? "kg/kg",
+                      )}`
+                    : "Unavailable"
+                }
+              />
+              <Metric
+                label="Selected-field range"
+                value={
+                  pointCloud
+                    ? `${formatMaybeNumber(
+                        pointCloud.stats.field_min_value,
+                        selectedField?.units ?? "kg/kg",
+                      )} to ${formatMaybeNumber(
+                        pointCloud.stats.field_max_value,
                         selectedField?.units ?? "kg/kg",
                       )}`
                     : "Unavailable"
@@ -4055,19 +4311,19 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
               />
               <Metric label="Domain x extent" value={extentLabel(pointCloud, "xh")} />
               <Metric label="Domain y extent" value={extentLabel(pointCloud, "yh")} />
-              <Metric label="Domain z extent" value={extentLabel(pointCloud, "zh")} />
+              <Metric label="Domain z extent" value={verticalExtentLabel(pointCloud)} />
               <Metric
                 label="Active cloud z range"
                 value={
                   pointCloud
-                    ? `${formatMaybeNumber(pointCloud.stats.active_z_min, pointCloud.coordinate_units.zh ?? null)} to ${formatMaybeNumber(
+                    ? `${formatMaybeNumber(pointCloud.stats.active_z_min, verticalCoordinateUnit(pointCloud))} to ${formatMaybeNumber(
                         pointCloud.stats.active_z_max,
-                        pointCloud.coordinate_units.zh ?? null,
+                        verticalCoordinateUnit(pointCloud),
                       )}`
                     : "Unavailable"
                 }
               />
-              <Metric label="Max cloud-water location" value={maxPointLocationLabel(pointCloud)} />
+              <Metric label="Max 3-D field location" value={maxPointLocationLabel(pointCloud)} />
               <Metric
                 label="Selected-time slice default"
                 value={selectedTimeSliceDefaults?.source ?? "Unavailable"}
@@ -4079,8 +4335,15 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
               <ul className="compact-list">
                 <li>{provenanceLabel}</li>
                 <li>Visualizer interpretation of CM1-derived output</li>
-                <li>Processing method: native-grid thresholded point cloud</li>
-                <li>Rendering method: direct Three.js thresholded point cloud</li>
+                <li>
+                  Value channel:{" "}
+                  {selectedEncoding?.valueChannel ?? "3-D scalar rendering unavailable"}
+                </li>
+                <li>
+                  Processing method: backend native-grid thresholded point cloud for supported
+                  scalar fields
+                </li>
+                <li>Rendering method: direct Three.js scalar point cloud</li>
                 <li>Slice planes: native-grid JSON slices from the backend</li>
                 <li>No raw NetCDF parsing in the browser</li>
                 <li>
@@ -4309,9 +4572,9 @@ function SlicePanel({
         <span className="slice-map-anchor slice-map-anchor-bottom">{anchors.bottom}</span>
       </div>
       <div className="heatmap-legend" aria-label={`${title} color scale`}>
-        <span>{formatMaybeNumber(slice.stats.min, slice.field.units)}</span>
+        <span>{sliceLegendMinimum(slice)}</span>
         <span className={`heatmap-scale ${heatmapScaleClass(slice.field)}`} />
-        <span>{formatMaybeNumber(slice.stats.max, slice.field.units)}</span>
+        <span>{sliceLegendMaximum(slice)}</span>
       </div>
       <details>
         <summary>Technical slice details</summary>
@@ -5329,7 +5592,7 @@ function formatSeconds(value: number | null): string {
 
 function formatScientific(value: number | null, units: string): string {
   if (value === null) return "Unavailable";
-  return `${value.toExponential(3)} ${units}`;
+  return `${value.toExponential(3)}${units ? ` ${units}` : ""}`;
 }
 
 function formatNumber(value: number | null, units: string): string {
@@ -5398,10 +5661,51 @@ function extentLabel(pointCloud: PointCloudResponse | null, coordinate: string):
   return `${formatCompactNumber(extent.min)} to ${formatCompactNumber(extent.max)}${suffix}`;
 }
 
+function verticalExtentLabel(pointCloud: PointCloudResponse | null): string {
+  const extent =
+    pointCloud?.coordinate_extents.zh ??
+    pointCloud?.coordinate_extents.zf ??
+    pointCloud?.coordinate_extents.z;
+  if (!extent) return "Unavailable";
+  const suffix = extent.units ? ` ${extent.units}` : "";
+  return `${formatCompactNumber(extent.min)} to ${formatCompactNumber(extent.max)}${suffix}`;
+}
+
+function verticalCoordinateUnit(pointCloud: PointCloudResponse | null): string | null {
+  return (
+    pointCloud?.coordinate_units.zh ??
+    pointCloud?.coordinate_units.zf ??
+    pointCloud?.coordinate_units.z ??
+    null
+  );
+}
+
+function pointCloudFieldSummary(pointCloud: PointCloudResponse): string {
+  const units = pointCloud.field.units ?? "";
+  const maxValue = formatMaybeNumber(pointCloud.stats.field_max_value, units);
+  const threshold = formatScientific(pointCloud.selection.threshold, units);
+  return `Current field max: ${maxValue}. Visible points above ${threshold}: ${pointCloud.stats.source_count.toLocaleString()}.`;
+}
+
+function emptyPointCloudStatus(
+  pointCloud: PointCloudResponse,
+  selectedEncoding: ThreeDScalarEncoding,
+): string {
+  const maxValue = formatMaybeNumber(
+    pointCloud.stats.field_max_value,
+    selectedEncoding.field.units ?? "",
+  );
+  const threshold = formatScientific(
+    pointCloud.selection.threshold,
+    selectedEncoding.field.units ?? "",
+  );
+  return `${selectedEncoding.field.display_name} max is ${maxValue}; no points are above ${threshold}`;
+}
+
 function maxPointLocationLabel(pointCloud: PointCloudResponse | null): string {
   const location = pointCloud?.stats.max_value_location;
   if (!location) return "Unavailable";
-  const units = pointCloud?.coordinate_units.zh ?? "";
+  const units = verticalCoordinateUnit(pointCloud) ?? "";
   return `x ${formatCompactNumber(location.x)}, y ${formatCompactNumber(location.y)}, z ${formatCompactNumber(
     location.z,
   )}${units ? ` ${units}` : ""}, value ${formatCompactNumber(location.value)}`;
@@ -5410,6 +5714,21 @@ function maxPointLocationLabel(pointCloud: PointCloudResponse | null): string {
 function heatmapScaleClass(field: VisualizableField): string {
   if (field.raw_field_name === "w" || field.canonical_field_name === "vertical_velocity") {
     return "heatmap-scale-velocity";
+  }
+  if (field.raw_field_name === "dbz" || field.canonical_field_name === "reflectivity") {
+    return "heatmap-scale-reflectivity";
+  }
+  if (field.canonical_field_name === "temperature") {
+    return "heatmap-scale-temperature";
+  }
+  if (field.canonical_field_name === "potential_temperature") {
+    return "heatmap-scale-potential-temperature";
+  }
+  if (field.raw_field_name === "qv" || field.canonical_field_name === "water_vapor") {
+    return "heatmap-scale-water-vapor";
+  }
+  if (isSurfaceRainField(field)) {
+    return "heatmap-scale-surface-rain";
   }
   if (field.raw_field_name === "qc" || field.canonical_field_name === "cloud_water") {
     return "heatmap-scale-cloud-water";
@@ -5443,19 +5762,100 @@ function sliceCellStyle(value: number | null, slice: SliceResponse): CSSProperti
     };
   }
 
+  if (slice.field.raw_field_name === "dbz" || slice.field.canonical_field_name === "reflectivity") {
+    return { background: radarReflectivityBackground(value) };
+  }
+
   const min = slice.stats.min ?? value;
   const max = slice.stats.max ?? value;
   const normalized = normalize(value, min, max);
-  const intensity =
-    slice.field.raw_field_name === "qc" || slice.field.canonical_field_name === "cloud_water"
-      ? Math.sqrt(Math.max(0, normalized))
-      : normalized;
+  if (
+    slice.field.canonical_field_name === "temperature" ||
+    slice.field.canonical_field_name === "potential_temperature"
+  ) {
+    return { background: temperatureBackground(normalized) };
+  }
+
+  const intensity = Math.sqrt(Math.max(0, normalized));
   if (intensity < 0.015) {
     return { background: "rgba(234, 244, 248, 0.72)" };
   }
-  return {
-    background: `rgba(${38 + intensity * 155}, ${98 + intensity * 130}, ${128 + intensity * 108}, ${0.62 + intensity * 0.28})`,
-  };
+  return { background: scalarMagnitudeBackground(slice.field, intensity) };
+}
+
+function sliceLegendMinimum(slice: SliceResponse): string {
+  if (slice.field.raw_field_name === "dbz" || slice.field.canonical_field_name === "reflectivity") {
+    return "0 dBZ";
+  }
+  return formatMaybeNumber(slice.stats.min, slice.field.units);
+}
+
+function sliceLegendMaximum(slice: SliceResponse): string {
+  if (slice.field.raw_field_name === "dbz" || slice.field.canonical_field_name === "reflectivity") {
+    return "60+ dBZ";
+  }
+  return formatMaybeNumber(slice.stats.max, slice.field.units);
+}
+
+function radarReflectivityBackground(dbz: number): string {
+  const stops = [
+    { value: 0, color: [37, 97, 199] },
+    { value: 10, color: [46, 184, 208] },
+    { value: 20, color: [56, 169, 65] },
+    { value: 30, color: [245, 220, 51] },
+    { value: 40, color: [237, 92, 31] },
+    { value: 50, color: [194, 27, 42] },
+    { value: 60, color: [165, 45, 188] },
+  ];
+  const alpha = 0.72;
+  if (!Number.isFinite(dbz)) return "rgba(255, 255, 255, 0.36)";
+  if (dbz <= stops[0].value) return `rgba(${stops[0].color.join(", ")}, ${alpha})`;
+  for (let index = 1; index < stops.length; index += 1) {
+    const lower = stops[index - 1];
+    const upper = stops[index];
+    if (dbz <= upper.value) {
+      const amount = (dbz - lower.value) / (upper.value - lower.value);
+      const color = lower.color.map((component, componentIndex) =>
+        Math.round(component + (upper.color[componentIndex] - component) * amount),
+      );
+      return `rgba(${color.join(", ")}, ${alpha})`;
+    }
+  }
+  return `rgba(${stops[stops.length - 1].color.join(", ")}, ${alpha})`;
+}
+
+function scalarMagnitudeBackground(field: VisualizableField, intensity: number): string {
+  const alpha = 0.58 + intensity * 0.34;
+  let start = [234, 244, 248];
+  let end = [180, 239, 228];
+  if (field.raw_field_name === "qr" || field.canonical_field_name === "rain_water") {
+    start = [231, 239, 255];
+    end = [134, 116, 217];
+  } else if (field.raw_field_name === "qv" || field.canonical_field_name === "water_vapor") {
+    start = [232, 248, 245];
+    end = [77, 170, 146];
+  } else if (isSurfaceRainField(field)) {
+    start = [229, 242, 255];
+    end = [46, 116, 190];
+  }
+  const color = start.map((component, index) =>
+    Math.round(component + (end[index] - component) * intensity),
+  );
+  return `rgba(${color.join(", ")}, ${alpha})`;
+}
+
+function temperatureBackground(intensity: number): string {
+  const clamped = Math.max(0, Math.min(1, intensity));
+  const cold = [74, 143, 232];
+  const middle = [214, 189, 105];
+  const warm = [240, 143, 78];
+  const lower = clamped < 0.5 ? cold : middle;
+  const upper = clamped < 0.5 ? middle : warm;
+  const amount = clamped < 0.5 ? clamped * 2 : (clamped - 0.5) * 2;
+  const color = lower.map((component, index) =>
+    Math.round(component + (upper[index] - component) * amount),
+  );
+  return `rgba(${color.join(", ")}, ${0.52 + clamped * 0.34})`;
 }
 
 function formatDate(value: string | null): string {

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -28,6 +28,11 @@ type PointCloudResponse = {
   stats: {
     source_count: number;
     returned_count: number;
+    field_min_value: number | null;
+    field_max_value: number | null;
+    field_mean_value: number | null;
+    field_finite_count: number;
+    field_non_finite_count: number;
     min_value: number | null;
     max_value: number | null;
     active_z_min: number | null;
@@ -61,6 +66,8 @@ type SelectedRegionRequest = {
 type True3DViewerProps = {
   resultName: string;
   pointCloud: PointCloudResponse | null;
+  fieldLabel: string;
+  valueChannelLabel: string;
   activeSlice: SliceResponse | null;
   activeSliceLabel: string;
   showSlicePlane: boolean;
@@ -115,6 +122,8 @@ const DEFAULT_BOUNDS: SceneBounds = {
 export function True3DViewer({
   resultName,
   pointCloud,
+  fieldLabel,
+  valueChannelLabel,
   activeSlice,
   activeSliceLabel,
   showSlicePlane,
@@ -134,7 +143,8 @@ export function True3DViewer({
   const [renderError, setRenderError] = useState<string | null>(null);
   const [cameraStatus, setCameraStatus] = useState("Camera ready");
 
-  const bounds = useMemo(() => sceneBounds(pointCloud), [pointCloud]);
+  const boundsKey = boundsSignature(pointCloud);
+  const bounds = useMemo(() => sceneBoundsFromSignature(boundsKey), [boundsKey]);
   const axisLabels = useMemo(() => axisLabelDefinitions(bounds), [bounds]);
   const selectedPoint = useMemo(
     () => selectedRegionPoint(selectedRegion, coordinateSizes, bounds),
@@ -271,7 +281,7 @@ export function True3DViewer({
   ]);
 
   return (
-    <section className="true3d-viewer" aria-label="True 3-D cloud-water viewer">
+    <section className="true3d-viewer" aria-label="True 3-D scalar field viewer">
       <div className="true3d-scene-header">
         <div>
           <p className="eyebrow">True 3-D scene</p>
@@ -285,13 +295,27 @@ export function True3DViewer({
           ref={mountRef}
           className="true3d-canvas-mount"
           role="img"
-          aria-label="Interactive Three.js scene showing CM1 cloud water, domain bounds, slice plane, and selected point"
+          aria-label="Interactive Three.js scene showing a CM1 scalar field, domain bounds, slice plane, and selected point"
         />
         <div className="true3d-scene-label true3d-scene-label-context">
-          <strong>Cloud water</strong>
+          <strong>{fieldLabel}</strong>
           <span>{selectedTimeLabel}</span>
           <span>Threshold {thresholdLabel}</span>
         </div>
+        {pointCloud && (
+          <div className="true3d-field-legend" aria-label="3-D field color legend">
+            <span>{pointCloud.field.display_name}</span>
+            <div className="true3d-field-legend-row">
+              <small>{fieldLegendMinimum(pointCloud)}</small>
+              <span
+                className={`true3d-field-ramp true3d-field-ramp-${scalarRampKey(
+                  pointCloud.field.raw_field_name,
+                )}`}
+              />
+              <small>{fieldLegendMaximum(pointCloud)}</small>
+            </div>
+          </div>
+        )}
         <div
           ref={axisLabelLayerRef}
           className="true3d-axis-label-layer"
@@ -324,7 +348,7 @@ export function True3DViewer({
         )}
         {(!pointCloud || pointCloud.points.length === 0) && (
           <div className="true3d-empty-state">
-            <p className="eyebrow">Cloud-water layer</p>
+            <p className="eyebrow">3-D scalar layer</p>
             <h4>{noCloudMessage}</h4>
             <p>The domain and slice plane remain visible so the result does not look broken.</p>
           </div>
@@ -366,8 +390,8 @@ export function True3DViewer({
         <p>{cameraStatus}. Drag to orbit, right-drag to pan, scroll to zoom.</p>
       </div>
       <p className="true3d-provenance" aria-label="3-D provenance labels">
-        CM1-derived visualization-ready cloud-water points and native-grid slice plane; rendered
-        with direct Three.js. {provenanceLabel}
+        {valueChannelLabel} CM1-derived visualization-ready scalar points and native-grid slice
+        plane; rendered with direct Three.js. {provenanceLabel}
       </p>
     </section>
   );
@@ -423,10 +447,29 @@ function rebuildScene(
   }
 }
 
-function sceneBounds(pointCloud: PointCloudResponse | null): SceneBounds {
-  const x = pointCloud?.coordinate_extents.xh ?? pointCloud?.coordinate_extents.x ?? DEFAULT_BOUNDS.x;
-  const y = pointCloud?.coordinate_extents.yh ?? pointCloud?.coordinate_extents.y ?? DEFAULT_BOUNDS.y;
-  const z = pointCloud?.coordinate_extents.zh ?? pointCloud?.coordinate_extents.z ?? DEFAULT_BOUNDS.z;
+function boundsSignature(pointCloud: PointCloudResponse | null): string {
+  const extents = pointCloud?.coordinate_extents;
+  const x = extents?.xh ?? extents?.x ?? DEFAULT_BOUNDS.x;
+  const y = extents?.yh ?? extents?.y ?? DEFAULT_BOUNDS.y;
+  const z = extents?.zh ?? extents?.z ?? DEFAULT_BOUNDS.z;
+  return [
+    x.min,
+    x.max,
+    x.units ?? "",
+    y.min,
+    y.max,
+    y.units ?? "",
+    z.min,
+    z.max,
+    z.units ?? "",
+  ].join("|");
+}
+
+function sceneBoundsFromSignature(signature: string): SceneBounds {
+  const [xMin, xMax, xUnits, yMin, yMax, yUnits, zMin, zMax, zUnits] = signature.split("|");
+  const x = { min: Number(xMin), max: Number(xMax), units: xUnits || null };
+  const y = { min: Number(yMin), max: Number(yMax), units: yUnits || null };
+  const z = { min: Number(zMin), max: Number(zMax), units: zUnits || null };
   const xRange = range(x);
   const yRange = range(y);
   const zRange = range(z);
@@ -604,9 +647,10 @@ function cloudPointLayer(
     positions[index * 3 + 1] = mapped.y;
     positions[index * 3 + 2] = mapped.z;
     const intensity = normalize(point[3], min, max);
-    colors[index * 3] = 0.24 + intensity * 0.55;
-    colors[index * 3 + 1] = 0.66 + intensity * 0.3;
-    colors[index * 3 + 2] = 0.78 + intensity * 0.18;
+    const color = scalarPointColor(pointCloud.field.raw_field_name, intensity, point[3]);
+    colors[index * 3] = color.r;
+    colors[index * 3 + 1] = color.g;
+    colors[index * 3 + 2] = color.b;
   });
 
   const geometry = new THREE.BufferGeometry();
@@ -621,6 +665,86 @@ function cloudPointLayer(
     sizeAttenuation: true,
   });
   return new THREE.Points(geometry, material);
+}
+
+function scalarPointColor(
+  fieldName: string,
+  intensity: number,
+  value: number,
+): { r: number; g: number; b: number } {
+  if (fieldName === "rain") {
+    return {
+      r: 0.18 + intensity * 0.2,
+      g: 0.45 + intensity * 0.28,
+      b: 0.74 + intensity * 0.18,
+    };
+  }
+  if (fieldName === "qr") {
+    return {
+      r: 0.28 + intensity * 0.38,
+      g: 0.44 + intensity * 0.32,
+      b: 0.86 + intensity * 0.1,
+    };
+  }
+  if (fieldName === "qv") {
+    return {
+      r: 0.24 + intensity * 0.22,
+      g: 0.58 + intensity * 0.34,
+      b: 0.76 + intensity * 0.1,
+    };
+  }
+  if (fieldName === "dbz") {
+    return radarReflectivityColor(value);
+  }
+  return {
+    r: 0.24 + intensity * 0.55,
+    g: 0.66 + intensity * 0.3,
+    b: 0.78 + intensity * 0.18,
+  };
+}
+
+function radarReflectivityColor(dbz: number): { r: number; g: number; b: number } {
+  const stops = [
+    { value: 0, color: { r: 0.15, g: 0.38, b: 0.78 } },
+    { value: 10, color: { r: 0.18, g: 0.72, b: 0.82 } },
+    { value: 20, color: { r: 0.22, g: 0.66, b: 0.26 } },
+    { value: 30, color: { r: 0.96, g: 0.86, b: 0.2 } },
+    { value: 40, color: { r: 0.93, g: 0.36, b: 0.12 } },
+    { value: 50, color: { r: 0.76, g: 0.1, b: 0.12 } },
+    { value: 60, color: { r: 0.66, g: 0.18, b: 0.74 } },
+  ];
+  if (!Number.isFinite(dbz)) return stops[0].color;
+  if (dbz <= stops[0].value) return stops[0].color;
+  for (let index = 1; index < stops.length; index += 1) {
+    const lower = stops[index - 1];
+    const upper = stops[index];
+    if (dbz <= upper.value) {
+      const amount = (dbz - lower.value) / (upper.value - lower.value);
+      return {
+        r: lower.color.r + (upper.color.r - lower.color.r) * amount,
+        g: lower.color.g + (upper.color.g - lower.color.g) * amount,
+        b: lower.color.b + (upper.color.b - lower.color.b) * amount,
+      };
+    }
+  }
+  return stops[stops.length - 1].color;
+}
+
+function scalarRampKey(fieldName: string): string {
+  if (fieldName === "qr" || fieldName === "rain") return "rain";
+  if (fieldName === "qv") return "qv";
+  if (fieldName === "dbz") return "dbz";
+  return "qc";
+}
+
+function fieldLegendMinimum(pointCloud: PointCloudResponse): string {
+  if (pointCloud.field.raw_field_name === "dbz") return "0 dBZ";
+  return formatValue(pointCloud.stats.min_value, pointCloud.field.units);
+}
+
+function fieldLegendMaximum(pointCloud: PointCloudResponse): string {
+  if (pointCloud.field.raw_field_name === "dbz") return "60+ dBZ";
+  return formatValue(pointCloud.stats.max_value, pointCloud.field.units);
 }
 
 function slicePlane(slice: SliceResponse, label: string, bounds: SceneBounds): THREE.Group {
@@ -852,6 +976,14 @@ function normalize(value: number, min: number, max: number): number {
 }
 
 function formatCoordinate(value: number, units: string | null): string {
+  return `${formatCompactNumber(value)}${units ? ` ${units}` : ""}`;
+}
+
+function formatValue(value: number | null, units: string | null): string {
+  if (value === null) return "Unavailable";
+  if (Math.abs(value) > 0 && Math.abs(value) < 0.001) {
+    return `${value.toExponential(3)}${units ? ` ${units}` : ""}`;
+  }
   return `${formatCompactNumber(value)}${units ? ` ${units}` : ""}`;
 }
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -535,21 +535,31 @@ field catalog, and exposes:
 - loading, empty, and error states;
 - provenance and rendering-method labels.
 
-Cloud-water rendering starts as a thresholded point cloud for `qc`, not an
-isosurface or volume renderer. The backend owns field selection and thresholding
-through:
+3-D scalar rendering starts as backend-prepared thresholded point clouds for
+selected native-grid fields, not isosurfaces or a volume renderer. The backend
+owns field selection and thresholding through:
 
 - `GET /api/results/{result_id}/visualization/point-cloud`
 
 The point-cloud endpoint reads the selected NetCDF output time, uses native
-`zh/yh/xh` coordinates for `qc`, returns `[x, y, z, value]` points where `qc`
-meets the requested threshold, and records source count, returned count,
-min/max value, active `z` range, max-value location, full coordinate extents,
+coordinates for the selected field, returns `[x, y, z, value]` points where the
+field meets the requested threshold, and records source count, returned count,
+thresholded-value range, full selected-field min/max/mean stats, active `z`
+range where applicable, max-value location, full coordinate extents,
 downsampling status, coordinate units, and provenance. If source points exceed
 `max_points`, the backend applies deterministic stride downsampling and labels
-it. The frontend renders only the returned
-visualization-ready points and must label the result as a CM1-derived
-interpretation.
+it. Surface `rain` is represented as a floor layer rather than a vertical cloud
+volume. The frontend renders only returned visualization-ready points and must
+label the result as a CM1-derived interpretation.
+
+The first supported 3-D fields are `qc` cloud water, `qr` rain water, `qv` water
+vapor, `dbz` reflectivity, and surface `rain` when present. Potential
+temperature, direct temperature, and `w` vertical velocity remain slice-first
+inspection fields until future issues define field-specific 3-D rendering that
+does not overclaim physical meaning. Reflectivity uses a fixed weather-radar
+dBZ scale from 0 to 60+ dBZ rather than a dynamic per-run color range; shallow
+cumulus may legitimately show weak or sparse reflectivity even when rain water
+is present.
 
 The frontend point projection uses those full coordinate extents, not the
 min/max of returned cloudy points. Scientific views should include side/elevation
@@ -573,8 +583,10 @@ height, the domain floor, and active cloud-water `z` range.
 
 - horizontal plane: `orientation=horizontal`;
 - vertical plane: `orientation=vertical_x` or `orientation=vertical_y`;
-- fields: `qc` and `w` first;
-- time: synced with the visualizer time state and cloud-water point cloud.
+- fields: native-grid slice-capable fields from the catalog, including `qc`,
+  `w`, `qr`, `qv`, `dbz`, direct temperature, potential temperature, and
+  surface `rain` where supported;
+- time: synced with the visualizer time state and the 3-D scalar layer.
 
 The browser receives JSON slice payloads with field metadata, min/max stats,
 dimension order, selected native-grid location, caveats, and provenance labels.
@@ -616,16 +628,21 @@ Implemented MVP endpoints:
 - `GET /api/results/{result_id}/visualization/point-cloud`
 
 The field catalog exposes available visualizable fields, starting with `qc`
-and `w` and including `qr` when present. It maps raw CM1 field names to product
-canonical names such as `cloud_water` and `vertical_velocity`, includes native
-dimensions, coordinate names, units, time values, source model/run/result
-provenance, processing method, and rendering method labels.
+and `w` and expanding to supported fields such as `qr`, `qv`, `dbz`, surface
+`rain`, potential temperature, and direct temperature when present. It maps raw
+CM1 field names to product canonical names such as `cloud_water`,
+`vertical_velocity`, `rain_water`, `water_vapor`, and `reflectivity`, includes
+native dimensions, coordinate names, units, time values, source
+model/run/result provenance, processing method, and rendering method labels.
 
 The slice endpoint returns JSON numeric arrays for the slice-first MVP. It
 supports horizontal slices and vertical `x`/`y` slices on native grids:
 
 - `qc`: `time, zh, yh, xh`
 - `w`: `time, zf, yh, xh`
+- `qr`, `qv`, `dbz`, direct temperature, and potential temperature: native
+  `time, z, y, x` style grids when those fields are present
+- surface `rain`: horizontal floor map only
 
 It does not interpolate staggered fields. Payloads include the selected time,
 orientation, level/index, dimension order, shape, min/max/mean, finite and
@@ -684,11 +701,12 @@ open NetCDF files or classify the physics itself.
 
 Explore's UI contract is explanation-first. The selected result summary,
 cloud/no-cloud state, field-loading state, shared field/time/slice controls,
-3-D cloud-water context, visible slice plane, 2-D slice inspector, and `What
+3-D scalar-field context, visible slice plane, 2-D slice inspector, and `What
 happened here?` selected-point panel are primary state. The 3-D context renders
-`qc` as a thresholded cloud-water point cloud; broader variables such as `w`
-are inspected through synchronized native-grid slices. Technical Thermal Fate
-process modes, native-grid caveats, rendering/projection details, and
+only supported scalar/floor layers such as `qc`, `qr`, `qv`, `dbz`, and surface
+`rain`; motion and thermodynamic fields such as `w`, potential temperature, and
+temperature are inspected through synchronized native-grid slices. Technical
+Thermal Fate process modes, native-grid caveats, rendering/projection details, and
 provenance stay available in disclosure so the browser remains a presentation
 layer over backend diagnostics instead of a scientific classifier.
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -226,7 +226,7 @@ It should keep the current product loop focused on:
 
 ```text
 selected-result trust
--> 3-D cloud-water context
+-> 3-D scalar-field context
 -> shared time / field / slice controls
 -> visible native-grid slice plane
 -> matching 2-D slice inspector
@@ -1001,7 +1001,7 @@ table keyed by run ID.
 single selected result. The old `2-D Slices` / `3-D View` split was useful
 scaffolding while capabilities were built separately, but the product workflow
 is now a unified instrument: compact selected-result context, shared
-field/time/slice controls, a 3-D cloud-water context, a visible native-grid
+field/time/slice controls, a 3-D scalar-field context, a visible native-grid
 slice plane, the matching 2-D slice inspector, and a `What happened here?`
 selected-point explanation panel. Selecting a result in Notebook or opening a
 comparison/storage row in Explore should preserve that context. If no selected
@@ -1009,13 +1009,16 @@ result is available, Explore should tell the user to select an ingested result
 from Results.
 
 The first-read Explore screen should be an explanation workspace, not a
-process-mode cockpit. The 3-D context renders `qc` cloud-water points only; it
-does not pretend that every field has a 3-D cloud rendering. Broader field
-inspection, including `w`, happens through synchronized native-grid slices.
-Core field/time/slice controls stay visible and shared across the 3-D context
-and slice inspector. Process focus, projection/rendering details, raw
-coordinate metadata, and long provenance labels belong behind
-details/disclosure until the user asks for them.
+process-mode cockpit. The 3-D context renders only backend-supported scalar
+layers: `qc` cloud water, `qr` rain water, `qv` water vapor, `dbz`
+reflectivity, and surface `rain` when those fields exist in the ingested result.
+It does not pretend that every CM1 output field has a trustworthy 3-D rendering.
+`w`, potential temperature, and direct temperature remain native-grid slice
+inspection fields until a later issue defines scientifically honest 3-D
+rendering for them. Core field/time/slice controls stay visible and shared
+across the 3-D context and slice inspector. Process focus,
+projection/rendering details, raw coordinate metadata, and long provenance
+labels belong behind details/disclosure until the user asks for them.
 
 Explore's cloud context and slice inspector should default to physically
 interesting output views, not arbitrary zero-index slices. The backend should
@@ -1085,7 +1088,7 @@ Completed results should be replayable and inspectable without rerunning CM1. Du
 
 Start with a practical, trustworthy Explore instrument, not a cinematic
 renderer. The near-term MVP is the product loop: select a saved result, see the
-cloud-water context, inspect the synchronized native-grid slice, click a cell,
+scalar-field context, inspect the synchronized native-grid slice, click a cell,
 and get a CM1-backed `What happened here?` explanation.
 
 The implemented/near-term Explore layers are:
@@ -1093,9 +1096,11 @@ The implemented/near-term Explore layers are:
 1. Visualization-ready backend data contract.
 2. Native-grid slice inspection for orientation, time indexing, scaling, and
    field availability.
-3. Cloud-water context for `qc` using a thresholded point cloud from
-   visualization-ready data.
-4. Horizontal and vertical slice planes for `qc` and `w`.
+3. Scalar 3-D context for supported fields using thresholded backend-prepared
+   point payloads (`qc`, `qr`, `qv`, `dbz`) and a surface-floor layer for
+   surface `rain`.
+4. Horizontal and vertical slice planes for native-grid fields such as `qc`,
+   `w`, `qr`, `qv`, `dbz`, temperature, and potential temperature when present.
 5. Selected-cell / selected-region explanation backed by Thermal Fate
    diagnostics.
 
@@ -1105,15 +1110,23 @@ fly-through/move-through, cinematic export, and thumbnail/preview generation.
 
 The browser should not parse raw CM1 NetCDF directly. Backend ingest and visualization-ready preprocessing should provide selected, provenance-labeled fields for inspection and rendering.
 
-The first cloud-water renderer uses a thresholded point cloud. The backend
-selects `qc` at a chosen output time, keeps native `zh/yh/xh` grid coordinates,
-returns points where `qc >= 1e-6 kg/kg` by default, reports full NetCDF
-coordinate extents, active cloud-water height range, point count, max value, and
-max-value location, and deterministically downsamples if needed. The browser
-renders those returned points only; it does not parse raw NetCDF, interpolate,
-run marching cubes, extract isosurfaces, ray march, or invent cloud physics. The
-rendering method should be labeled `thresholded_point_cloud`, and the processing
-method should identify the native grid threshold operation.
+The first 3-D scalar renderer uses thresholded point clouds and a surface-floor
+layer, not volumes or isosurfaces. The backend selects a supported field at a
+chosen output time, keeps native coordinates, returns points that pass the
+field-specific threshold, reports full NetCDF coordinate extents, active height
+range where applicable, thresholded point count, full selected-field
+min/max/mean stats, max-value location, and deterministic downsampling if
+needed. The browser renders those returned points only; it does not parse raw
+NetCDF, interpolate, run marching cubes, extract isosurfaces, ray march, or
+invent cloud physics. The rendering method should be labeled as a direct scalar
+point cloud or surface-floor layer, and the processing method should identify
+the backend native-grid threshold operation.
+
+Reflectivity uses weather-radar-style fixed dBZ colors rather than a dynamic
+per-run scale. The legend should cover 0 to 60+ dBZ even when a shallow-cumulus
+result only contains weak or sparse reflectivity. The UI should show the current
+field max and the visible-point threshold so a low-reflectivity case is
+understandable without presenting it as a rendering failure.
 
 Point placement must use full coordinate extents from the payload, not the
 min/max of returned cloudy points. Side/elevation views are the first scientific
@@ -1143,7 +1156,7 @@ normal browser zoom and across common screen sizes.
 
 The first 3-D slice planes reuse the #72 JSON slice endpoint. The scene can
 request horizontal and vertical native-grid slices for the selected slice field
-(`qc` or `w`) at the same output time as the cloud-water point cloud. Slice
+at the same output time as the 3-D scalar layer. Slice
 planes are optional inspection aids, not the cloud itself: they should be
 toggleable, visually secondary, semi-transparent, and tied to the same
 interesting native-grid locations used by Inspect. The UI must show field name,

--- a/docs/roadmap-and-issues.md
+++ b/docs/roadmap-and-issues.md
@@ -506,7 +506,7 @@ Deliverables:
 
 - selected-result trust and field-loading states.
 - unified desktop Explore workflow.
-- 3-D `qc` cloud-water context as an interpretation of CM1 output.
+- 3-D scalar-field context as an interpretation of CM1 output.
 - shared time / field / slice controls.
 - horizontal/vertical native-grid slices.
 - selected-cell `What happened here?` explanation.
@@ -528,10 +528,11 @@ Implementation anchor:
 - #121 adds explicit 3-D slice-plane controls: horizontal `z` slices can move up/down, vertical `x-z` slices can move through `y`, and vertical `y-z` slices can move through `x`. These controls reuse the backend slice API and remain native-grid selectors, not interpolation or true camera rotation.
 - #125 refactors the visualizer into a fixed scientific workbench: primary visual controls sit beside the viewport, timeline and slice-position controls sit below the render, technical details move to a secondary panel, and axes/scale/annotation labels stay readable outside the zoomed data layer. Browser visual checks are required for layout changes so the scene cannot cover controls again.
 - #172 redesigns Explore around one primary visualization plus one explanation panel. The visible interaction should be `What happened here?`; technical Thermal Fate/process controls, rendering details, and provenance stay accessible without dominating the first read.
-- #184 consolidates the former `2-D Slices` / `3-D View` scaffold into one desktop Explore workflow. The current target is compact selected-result context, shared field/time/slice controls, 3-D `qc` cloud-water context, a visible native-grid slice plane, the matching 2-D slice inspector, and selected-cell `What happened here?` diagnostics. `w` and other broader fields are inspected through slices, not through fake 3-D point rendering.
+- #184 consolidates the former `2-D Slices` / `3-D View` scaffold into one desktop Explore workflow. The current target is compact selected-result context, shared field/time/slice controls, a supported 3-D scalar context, a visible native-grid slice plane, the matching 2-D slice inspector, and selected-cell `What happened here?` diagnostics.
 - #185 cleans the Explore test suite after #184 so tests protect the unified workflow rather than the old separate `2-D Slices` / `3-D View` scaffold.
 - #177 keeps older visualizer-roadmap language from pulling near-term work back toward renderer polish before the UX/product loop is stable.
 - #196 cleans up process evidence focus states in Explore. The primary `Explanation focus` control should be result-aware and show only supported or useful candidate modes; missing/future diagnostics remain visible under a collapsed `Not available for this result` section with evidence requirements and caveats.
+- #199 expands the Explore field-view contract without pretending every field has the same rendering semantics. The 3-D scalar layer supports backend-prepared `qc`, `qr`, `qv`, `dbz`, and surface `rain` payloads when present; `w`, potential temperature, and direct temperature remain slice-first inspection fields. Reflectivity uses a fixed 0 to 60+ dBZ radar-style scale, while the UI reports the current field max so weak shallow-cumulus echoes are understandable.
 - #112 is the renderer-upgrade decision point after the simplified Explore loop is stable.
 - #80 plans visual polish, fly-through/move-through, cinematic export, and thumbnail/preview policy later. It must not add rendering dependencies or implementation code.
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -329,15 +329,18 @@ projection descriptions, provenance/rendering details, and no-field/error
 states. They must not assert isosurfaces, true camera orbit/pan behavior, or
 volumetric effects until later renderer issues implement those layers.
 
-Cloud-water point-cloud tests should use tiny synthetic NetCDF fixtures on the
+Scalar point-cloud tests should use tiny synthetic NetCDF fixtures on the
 backend and mocked visualization-ready point payloads on the frontend. Backend
-tests should cover `qc` points above threshold, no points above threshold,
-missing `qc`, bad time/threshold/max-point inputs, deterministic stride
-downsampling, stats, full coordinate extents, active `z` range, max-value
-location, coordinate units, and provenance labels. Frontend tests should cover
-rendered point-cloud state, missing `qc`, no-cloud-above-threshold state,
-threshold/time/opacity/point-size controls, side/elevation projection controls
-where model `z` is the visual height, domain extent/debug labels,
+tests should cover supported 3-D fields (`qc`, `qr`, `qv`, `dbz`, and surface
+`rain`), no points above threshold, missing fields, slice-only fields rejected
+from the 3-D endpoint, bad time/threshold/max-point inputs, deterministic stride
+downsampling, thresholded stats, full selected-field min/max/mean stats, full
+coordinate extents, active `z` range where applicable, max-value location,
+coordinate units, and provenance labels. Frontend tests should cover rendered
+scalar point-cloud states, fixed weather-radar dBZ legend scaling, surface-rain
+floor rendering, no-points-above-threshold states that still show the current
+field max, threshold/time/opacity/point-size controls, side/elevation projection
+controls where model `z` is the visual height, domain extent labels,
 provenance/rendering labels, and the guarantee that the browser does not parse
 raw NetCDF. These tests must not add ray marching, isosurfaces, shadows,
 fly-through, export, or generated CM1 output.
@@ -353,11 +356,16 @@ that height is vertical, top-down should state that height is not shown
 vertically, and oblique should be labeled an interpretive overview rather than a
 true perspective camera.
 
+Browser checks for field-view changes should inspect `qc`, `qr`, `qv`, `dbz`,
+and surface `rain` when mocked or local data exposes them. Reflectivity checks
+should confirm the fixed 0 to 60+ dBZ legend and current-field-max copy rather
+than expecting shallow-cumulus runs to contain strong radar echoes.
+
 The consolidated Results/Explore shell and fixed Explore workbench should also
 get a real browser smoke check after layout changes, not only component tests.
 Open the app, navigate to Results, open the validated quick-look baseline in
 Explore, and confirm by screenshot or direct browser inspection that the 3-D
-cloud-water context, visible slice plane, shared controls, matching slice
+scalar-field context, visible slice plane, shared controls, matching slice
 inspector, and selected-point explanation are all reachable without the render
 viewport covering controls or details. At minimum verify desktop viewports
 around 1470x956 and 1720x1440, because #184's acceptance target is desktop;
@@ -366,17 +374,17 @@ gate.
 
 Unified Explore slice-plane tests should mock the #72 visualization-ready slice
 API. They should cover horizontal and vertical slice planes, `qc` and `w` field
-selection, time synchronization with the cloud-water context, native-grid
+selection, time synchronization with the 3-D scalar context, native-grid
 caveats/provenance labels, selected-time max `qc`/`w` default locations, visible
 slice-plane orientation changes, projection controls, explicit horizontal `z`,
 vertical `x-z`, and vertical `y-z` controls, up/down or forward/back
 level-index movement, selected slice-cell point diagnostics, and clear error
 states for missing fields or bad slice requests. They must not parse raw NetCDF
 in the browser, add rendering dependencies, or test ray marching, cinematic
-lighting, export, fly-through, or generated CM1 output. The 3-D point context
-remains `qc` cloud water only; `w` and broader variable inspection should be
-tested through the synchronized slice path unless a future issue adds a
-scientifically honest 3-D representation.
+lighting, export, fly-through, or generated CM1 output. The 3-D point context is
+limited to explicitly supported scalar/floor layers; `w`, potential
+temperature, and direct temperature should be tested through synchronized slices
+unless a future issue adds a scientifically honest 3-D representation for them.
 Visual first-impression tests should also keep the validated quick-look baseline
 on a cloud-bearing time, show a visible point-cloud state, keep slice planes
 optional and secondary, and keep technical provenance reachable without making

--- a/docs/true-3d-viewer-architecture-decision.md
+++ b/docs/true-3d-viewer-architecture-decision.md
@@ -179,19 +179,28 @@ The browser must not parse raw NetCDF.
 For the first implementation, prefer reusing current backend visualization-ready payloads:
 
 - field catalog;
-- `qc` point-cloud payload;
+- scalar point-cloud payloads;
 - slice payloads;
 - selected-region diagnostics payloads.
 
 Only add or change backend endpoints if the current payloads are missing essential scene information such as domain extents or stable coordinate metadata.
 
-The first `qc` layer can remain thresholded point rendering. It does not need isosurfaces, opacity approximation, or volume rendering. Coordinate extents, units, thresholds, max point counts, downsampling notes, and provenance/caveats should remain visible or available on demand.
+The first scalar layers can remain thresholded point rendering or a surface-floor
+layer for surface rain. They do not need isosurfaces, opacity approximation, or
+volume rendering. Coordinate extents, units, thresholds, max point counts,
+selected-field min/max/mean stats, downsampling notes, and provenance/caveats
+should remain visible or available on demand.
 
 ## Relationship to vertical velocity
 
 Do not fold #183 into #187 by default.
 
-#187 should establish the scene, camera, labels, slice plane, and cloud-water layer. #183 should then add the first additional 3-D science layer: signed `w` for updrafts and downdrafts.
+#187 should establish the scene, camera, labels, slice plane, and initial scalar
+field layer. Later field-layer work can add supported scalar views such as
+`qc`, `qr`, `qv`, `dbz`, and surface `rain` when the backend can provide
+trustworthy visualization-ready payloads. #183 should still remain separate for
+signed `w` updrafts and downdrafts, because vector/signed-motion fields need
+their own representation and should not be hidden inside a generic scalar layer.
 
 This sequencing matters because vertical velocity needs its own data contract and visual defaults. It should not be hidden inside the base viewer PR.
 


### PR DESCRIPTION
Closes #199

Summary:
- Expanded backend visualization-ready point-cloud support from qc-only to supported scalar/floor fields: qc, qr, qv, dbz, and surface rain, while keeping w/theta/direct temperature slice-first.
- Added full selected-field min/max/mean stats to point-cloud payloads so low-visibility cases, especially weak reflectivity, can be trusted instead of looking broken.
- Updated Explore field controls, legends, empty-state copy, and rendering modes for cloud water, rain water, water vapor, reflectivity, and surface rain.
- Kept reflectivity on a fixed weather-radar-style 0 to 60+ dBZ scale and surfaced current field max / visible point count.
- Updated component, backend, and Playwright coverage plus docs for the expanded field-view contract.

Tests added/updated:
- Backend visualization-data tests for expanded point-cloud/surface-field behavior and full-field stats.
- Frontend component tests for 3-D scalar fields, slice-only fields, dBZ legend, surface rain, empty states, and field sync.
- Playwright mocked smoke tests for expanded 3-D scalar field availability without promoting slice-only fields.

Commands run:
- app/backend/.venv/bin/python -m pytest app/backend/tests/test_visualization_data.py
- npm run test -- App.test.tsx
- scripts/check.sh
- scripts/check-e2e.sh

Screenshots reviewed, not committed:
- /tmp/cloud-chamber-issue199-field-screens/01-qc-cloud-water.png
- /tmp/cloud-chamber-issue199-field-screens/02-qr-rain-water.png
- /tmp/cloud-chamber-issue199-field-screens/03-qv-water-vapor.png
- /tmp/cloud-chamber-issue199-field-screens/04-dbz-reflectivity.png
- /tmp/cloud-chamber-issue199-field-screens/05-surface-rain-floor.png
- /tmp/cloud-chamber-issue199-field-screens-1720/01-qc-cloud-water.png
- /tmp/cloud-chamber-issue199-field-screens-1720/02-qr-rain-water.png
- /tmp/cloud-chamber-issue199-field-screens-1720/03-qv-water-vapor.png
- /tmp/cloud-chamber-issue199-field-screens-1720/04-dbz-reflectivity.png
- /tmp/cloud-chamber-issue199-field-screens-1720/05-surface-rain-floor.png

Manual QA needed:
- Optional: review whether the field colors/legends feel physically intuitive across qc, qr, qv, dbz, and surface rain.

Generated-data check:
- No generated CM1 output, NetCDF files, logs, screenshots, videos, traces, reports, runtime folders, or CM1 artifacts were committed.