### PR TITLE
Add output product manifest time index

### DIFF
--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -1,0 +1,504 @@
+"""Runtime-local output product manifest contracts.
+
+The output product manifest indexes CM1 output without making the browser infer
+file/time relationships or parse raw NetCDF. It is a small, rebuildable runtime
+artifact that points back to CM1-owned source files.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+OUTPUT_PRODUCT_MANIFEST_VERSION = 1
+DERIVED_PRODUCTS_DIRNAME = "derived-products"
+OUTPUT_PRODUCT_MANIFEST_FILENAME = "output_product_manifest.json"
+
+MODEL_OUTPUT_PATTERN = re.compile(r"^cm1out_\d+\.nc(?:4)?$")
+STATS_OUTPUT_NAMES = {"cm1out_stats.nc", "cm1out_stats.nc4"}
+TIME_COORDINATE_CANDIDATES = ("time", "mtime", "t")
+
+SourceFileKind = Literal["model_output_netcdf", "stats_netcdf", "raw_cm1_artifact"]
+TimeSource = Literal["netcdf_time_coordinate", "inferred_filename_order"]
+
+
+class OutputProductManifestError(RuntimeError):
+    """Raised when an output product manifest cannot be built or resolved."""
+
+
+class OutputTimeIndexEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time_index: int
+    time_seconds: float | None = None
+    source_time_value: float | str | None = None
+    source_file: str
+    source_file_kind: SourceFileKind
+    local_time_index: int
+    time_source: TimeSource
+    time_caveats: list[str] = Field(default_factory=list)
+
+
+class SourceRawOutputs(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    model_output_files: list[str] = Field(default_factory=list)
+    stats_files: list[str] = Field(default_factory=list)
+    raw_cm1_artifacts: list[str] = Field(default_factory=list)
+
+
+class OutputProductCache(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product_root: str
+    cache_key: str | None = None
+    invalidated: bool = False
+
+
+class OutputProductProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_model: str = "CM1"
+    processing_method: str = "backend_output_product_manifest_time_index"
+    provenance_label: str = (
+        "CM1 output product manifest; backend-resolved file/time mapping; "
+        "raw NetCDF stays local and backend-owned"
+    )
+
+
+class OutputProductManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    manifest_version: int = OUTPUT_PRODUCT_MANIFEST_VERSION
+    product_manifest_id: str
+    result_id: str
+    run_id: str
+    scenario_id: str | None = None
+    source_model: str = "CM1"
+    source_result_metadata_path: str | None = None
+    source_run_manifest_path: str | None = None
+    source_raw_outputs: SourceRawOutputs
+    time_index: list[OutputTimeIndexEntry]
+    cache: OutputProductCache
+    provenance: OutputProductProvenance = Field(default_factory=OutputProductProvenance)
+    caveats: list[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+    def to_json_text(self) -> str:
+        return self.model_dump_json(indent=2) + "\n"
+
+
+class ClassifiedOutputPaths(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    model_output_paths: list[Path]
+    stats_netcdf_paths: list[Path]
+    other_paths: list[Path]
+
+
+class ResolvedTimeIndex(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time_index: int
+    time_seconds: float | None = None
+    source_file: str
+    source_file_kind: SourceFileKind
+    local_time_index: int
+    time_source: TimeSource
+    time_caveats: list[str] = Field(default_factory=list)
+
+
+def default_output_product_root(run_dir: Path) -> Path:
+    """Return the runtime-local derived product root for a run directory."""
+    return run_dir / DERIVED_PRODUCTS_DIRNAME
+
+
+def default_output_product_manifest_path(run_dir: Path) -> Path:
+    """Return the runtime-local output product manifest path for a run."""
+    return default_output_product_root(run_dir) / OUTPUT_PRODUCT_MANIFEST_FILENAME
+
+
+def output_product_manifest_from_json(text: str) -> OutputProductManifest:
+    """Parse an output product manifest JSON string."""
+    return OutputProductManifest.model_validate(json.loads(text))
+
+
+def write_output_product_manifest(path: Path, manifest: OutputProductManifest) -> None:
+    """Write an output product manifest, creating the runtime product directory."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(manifest.to_json_text())
+
+
+def classify_output_paths(paths: list[Path]) -> ClassifiedOutputPaths:
+    """Classify CM1 output paths without treating stats files as model fields."""
+    model_output_paths: list[Path] = []
+    stats_netcdf_paths: list[Path] = []
+    other_paths: list[Path] = []
+    for path in sorted(paths, key=_output_sort_key):
+        if MODEL_OUTPUT_PATTERN.match(path.name):
+            model_output_paths.append(path)
+        elif path.name in STATS_OUTPUT_NAMES:
+            stats_netcdf_paths.append(path)
+        else:
+            other_paths.append(path)
+    return ClassifiedOutputPaths(
+        model_output_paths=model_output_paths,
+        stats_netcdf_paths=stats_netcdf_paths,
+        other_paths=other_paths,
+    )
+
+
+def build_output_product_manifest_for_result(
+    result_metadata: Any,
+    *,
+    result_metadata_path: Path | None = None,
+    run_manifest_path: Path | None = None,
+    product_root: Path | None = None,
+) -> OutputProductManifest:
+    """Build an output product manifest from an existing result metadata object."""
+    model_output_paths = [Path(path).expanduser() for path in result_metadata.model_output_paths]
+    stats_paths = [Path(path).expanduser() for path in result_metadata.stats_netcdf_paths]
+    raw_paths = [Path(path).expanduser() for path in result_metadata.raw_cm1_artifacts]
+    if product_root is None:
+        inferred_run_dir = (
+            result_metadata_path.parent
+            if result_metadata_path is not None
+            else _common_parent(model_output_paths + stats_paths + raw_paths)
+        )
+        product_root = default_output_product_root(inferred_run_dir)
+    return build_output_product_manifest(
+        result_id=str(result_metadata.result_id),
+        run_id=str(result_metadata.run_id),
+        scenario_id=getattr(result_metadata, "scenario_id", None),
+        source_model=str(getattr(result_metadata, "source_model", "CM1")),
+        model_output_paths=model_output_paths,
+        stats_netcdf_paths=stats_paths,
+        raw_cm1_artifacts=raw_paths,
+        source_result_metadata_path=result_metadata_path,
+        source_run_manifest_path=run_manifest_path,
+        product_root=product_root,
+        inherited_caveats=[
+            *[str(warning) for warning in getattr(result_metadata, "warnings", [])],
+            *[
+                f"skipped_netcdf_output:{path}"
+                for path in getattr(result_metadata, "skipped_netcdf_paths", [])
+            ],
+        ],
+    )
+
+
+def build_output_product_manifest(
+    *,
+    result_id: str,
+    run_id: str,
+    model_output_paths: list[Path],
+    stats_netcdf_paths: list[Path] | None = None,
+    raw_cm1_artifacts: list[Path] | None = None,
+    scenario_id: str | None = None,
+    source_model: str = "CM1",
+    source_result_metadata_path: Path | None = None,
+    source_run_manifest_path: Path | None = None,
+    product_root: Path,
+    inherited_caveats: list[str] | None = None,
+) -> OutputProductManifest:
+    """Build an output product manifest and global time index.
+
+    Each model-output file is opened independently to inspect only time
+    coordinates. The files are never concatenated here.
+    """
+    stats_netcdf_paths = stats_netcdf_paths or []
+    raw_cm1_artifacts = raw_cm1_artifacts or []
+    now = datetime.now(UTC)
+    time_entries, time_caveats = build_time_index(model_output_paths)
+    caveats = _dedupe([*(inherited_caveats or []), *time_caveats])
+    if not time_entries:
+        raise OutputProductManifestError("No model-output timesteps could be indexed.")
+    return OutputProductManifest(
+        product_manifest_id=f"output-products-{result_id}",
+        result_id=result_id,
+        run_id=run_id,
+        scenario_id=scenario_id,
+        source_model=source_model,
+        source_result_metadata_path=str(source_result_metadata_path)
+        if source_result_metadata_path
+        else None,
+        source_run_manifest_path=str(source_run_manifest_path)
+        if source_run_manifest_path
+        else None,
+        source_raw_outputs=SourceRawOutputs(
+            model_output_files=[
+                str(path) for path in sorted(model_output_paths, key=_output_sort_key)
+            ],
+            stats_files=[str(path) for path in sorted(stats_netcdf_paths, key=_output_sort_key)],
+            raw_cm1_artifacts=[
+                str(path) for path in sorted(raw_cm1_artifacts, key=_output_sort_key)
+            ],
+        ),
+        time_index=time_entries,
+        cache=OutputProductCache(
+            product_root=str(product_root),
+            cache_key=_cache_key(model_output_paths, stats_netcdf_paths, raw_cm1_artifacts),
+        ),
+        provenance=OutputProductProvenance(source_model=source_model),
+        caveats=caveats,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def build_time_index(
+    model_output_paths: list[Path],
+) -> tuple[list[OutputTimeIndexEntry], list[str]]:
+    """Build a global time index from model-output NetCDF files."""
+    entries: list[OutputTimeIndexEntry] = []
+    caveats: list[str] = []
+    original_numeric_times: list[float | None] = []
+    sorted_paths = sorted(model_output_paths, key=_output_sort_key)
+    for file_order, path in enumerate(sorted_paths):
+        if path.name in STATS_OUTPUT_NAMES:
+            caveats.append(f"stats_file_excluded_from_model_time_index:{path}")
+            continue
+        if not MODEL_OUTPUT_PATTERN.match(path.name):
+            caveats.append(f"non_model_netcdf_excluded_from_time_index:{path}")
+            continue
+        if not path.exists():
+            caveats.append(f"missing_model_output_file:{path}")
+            continue
+        try:
+            file_entries = _time_entries_for_file(path, file_order)
+        except OutputProductManifestError as exc:
+            caveats.append(f"skipped_model_output_file:{path}:{exc}")
+            continue
+        entries.extend(file_entries)
+        original_numeric_times.extend(entry.time_seconds for entry in file_entries)
+
+    if not entries:
+        return [], _dedupe([*caveats, "no_model_output_files_indexed"])
+
+    all_direct_numeric = all(
+        entry.time_source == "netcdf_time_coordinate" and entry.time_seconds is not None
+        for entry in entries
+    )
+    if all_direct_numeric:
+        entries = sorted(
+            entries,
+            key=lambda entry: (
+                float(entry.time_seconds) if entry.time_seconds is not None else math.inf,
+                entry.source_file,
+                entry.local_time_index,
+            ),
+        )
+    else:
+        caveats.append("global_time_index_preserves_filename_order_due_to_inferred_times")
+
+    caveats.extend(_time_order_caveats(original_numeric_times, entries))
+    entries = _flag_duplicate_entry_times(entries)
+    return [
+        entry.model_copy(update={"time_index": time_index})
+        for time_index, entry in enumerate(entries)
+    ], _dedupe(caveats)
+
+
+def resolve_time_index(manifest: OutputProductManifest, time_index: int) -> ResolvedTimeIndex:
+    """Resolve a global time index to the source file and local file index."""
+    if time_index < 0:
+        raise OutputProductManifestError("time_index must be non-negative.")
+    for entry in manifest.time_index:
+        if entry.time_index == time_index:
+            return ResolvedTimeIndex(
+                time_index=entry.time_index,
+                time_seconds=entry.time_seconds,
+                source_file=entry.source_file,
+                source_file_kind=entry.source_file_kind,
+                local_time_index=entry.local_time_index,
+                time_source=entry.time_source,
+                time_caveats=entry.time_caveats,
+            )
+    raise OutputProductManifestError(f"time_index is not available: {time_index}")
+
+
+def _time_entries_for_file(path: Path, file_order: int) -> list[OutputTimeIndexEntry]:
+    xarray = importlib.import_module("xarray")
+    try:
+        dataset = xarray.open_dataset(path)
+    except Exception as exc:
+        raise OutputProductManifestError(f"could_not_open_netcdf:{exc}") from exc
+    try:
+        return _time_entries_from_dataset(dataset, path, file_order)
+    finally:
+        close = getattr(dataset, "close", None)
+        if callable(close):
+            close()
+
+
+def _time_entries_from_dataset(
+    dataset: Any, path: Path, file_order: int
+) -> list[OutputTimeIndexEntry]:
+    time_coordinate = _first_present(
+        TIME_COORDINATE_CANDIDATES, [str(name) for name in dataset.coords]
+    )
+    if time_coordinate is not None:
+        values = _coordinate_values(dataset, time_coordinate)
+        return [
+            OutputTimeIndexEntry(
+                time_index=-1,
+                time_seconds=_float_or_none(value),
+                source_time_value=_source_time_value(value),
+                source_file=str(path),
+                source_file_kind="model_output_netcdf",
+                local_time_index=local_index,
+                time_source="netcdf_time_coordinate",
+                time_caveats=_direct_time_caveats(value),
+            )
+            for local_index, value in enumerate(values)
+        ]
+
+    time_dimension = _first_present(
+        TIME_COORDINATE_CANDIDATES, [str(name) for name in dataset.sizes]
+    )
+    time_size = int(dataset.sizes[time_dimension]) if time_dimension is not None else 1
+    return [
+        OutputTimeIndexEntry(
+            time_index=-1,
+            time_seconds=float(file_order + local_index),
+            source_time_value=float(file_order + local_index),
+            source_file=str(path),
+            source_file_kind="model_output_netcdf",
+            local_time_index=local_index,
+            time_source="inferred_filename_order",
+            time_caveats=[
+                "time_coordinate_missing",
+                "time_inferred_from_filename_order",
+            ],
+        )
+        for local_index in range(time_size)
+    ]
+
+
+def _coordinate_values(dataset: Any, coordinate: str) -> list[Any]:
+    values = dataset.coords[coordinate].values
+    reshaped = values.reshape(-1)
+    return list(reshaped.tolist())
+
+
+def _direct_time_caveats(value: Any) -> list[str]:
+    if _float_or_none(value) is None:
+        return ["time_coordinate_not_numeric_seconds"]
+    return []
+
+
+def _time_order_caveats(
+    original_numeric_times: list[float | None],
+    entries: list[OutputTimeIndexEntry],
+) -> list[str]:
+    caveats: list[str] = []
+    direct_numeric = [time for time in original_numeric_times if time is not None]
+    if len(direct_numeric) >= 2 and any(
+        later < earlier for earlier, later in zip(direct_numeric, direct_numeric[1:], strict=False)
+    ):
+        caveats.append("non_monotonic_time_coordinates_detected")
+    seen: set[float] = set()
+    duplicates: set[float] = set()
+    for entry in entries:
+        if entry.time_seconds is None:
+            continue
+        if entry.time_seconds in seen:
+            duplicates.add(entry.time_seconds)
+        seen.add(entry.time_seconds)
+    for value in sorted(duplicates):
+        caveats.append(f"duplicate_time_coordinate_detected:{value:g}")
+    if any(entry.time_source == "inferred_filename_order" for entry in entries):
+        caveats.append("inferred_time_indices_present")
+    return caveats
+
+
+def _flag_duplicate_entry_times(
+    entries: list[OutputTimeIndexEntry],
+) -> list[OutputTimeIndexEntry]:
+    counts: dict[float, int] = {}
+    for entry in entries:
+        if entry.time_seconds is None:
+            continue
+        counts[entry.time_seconds] = counts.get(entry.time_seconds, 0) + 1
+    flagged: list[OutputTimeIndexEntry] = []
+    for entry in entries:
+        if entry.time_seconds is None or counts.get(entry.time_seconds, 0) <= 1:
+            flagged.append(entry)
+            continue
+        flagged.append(
+            entry.model_copy(
+                update={"time_caveats": _dedupe([*entry.time_caveats, "duplicate_time_coordinate"])}
+            )
+        )
+    return flagged
+
+
+def _first_present(candidates: tuple[str, ...], names: list[str]) -> str | None:
+    for candidate in candidates:
+        if candidate in names:
+            return candidate
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric):
+        return None
+    return numeric
+
+
+def _source_time_value(value: Any) -> float | str | None:
+    numeric = _float_or_none(value)
+    if numeric is not None:
+        return numeric
+    if value is None:
+        return None
+    return str(value)
+
+
+def _cache_key(*path_groups: list[Path]) -> str:
+    parts: list[str] = []
+    for paths in path_groups:
+        for path in sorted(paths, key=_output_sort_key):
+            try:
+                stat = path.stat()
+            except OSError:
+                parts.append(f"{path}:missing")
+                continue
+            parts.append(f"{path}:{stat.st_size}:{stat.st_mtime_ns}")
+    return "|".join(parts)
+
+
+def _output_sort_key(path: Path) -> tuple[int, str]:
+    match = re.search(r"cm1out_(\d+)", path.name)
+    if match:
+        return int(match.group(1)), path.name
+    return 10**9, path.name
+
+
+def _common_parent(paths: list[Path]) -> Path:
+    if not paths:
+        return Path(".")
+    return paths[0].parent
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        deduped.append(item)
+    return deduped

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -11,6 +11,11 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from cloud_chamber.output_products import (
+    build_output_product_manifest_for_result,
+    default_output_product_manifest_path,
+    write_output_product_manifest,
+)
 from cloud_chamber.result_diagnostics import (
     ProcessDiagnostics,
     ResultDiagnostics,
@@ -128,7 +133,18 @@ def ingest_completed_run(manifest_path: Path) -> ResultMetadata:
                 close()
 
     result_path = run_dir / RESULT_METADATA_FILENAME
+    product_manifest_path = default_output_product_manifest_path(run_dir)
+    result = result.model_copy(
+        update={"processed_artifacts": [*result.processed_artifacts, str(product_manifest_path)]}
+    )
+    product_manifest = build_output_product_manifest_for_result(
+        result,
+        result_metadata_path=result_path,
+        run_manifest_path=manifest_path.expanduser(),
+        product_root=product_manifest_path.parent,
+    )
     result_path.write_text(result.to_json_text())
+    write_output_product_manifest(product_manifest_path, product_manifest)
     return result
 
 

--- a/app/backend/tests/test_output_products.py
+++ b/app/backend/tests/test_output_products.py
@@ -1,0 +1,224 @@
+from pathlib import Path
+
+import pytest
+import xarray as xr
+
+from cloud_chamber.output_products import (
+    OutputProductManifest,
+    OutputProductManifestError,
+    build_output_product_manifest,
+    classify_output_paths,
+    default_output_product_manifest_path,
+    output_product_manifest_from_json,
+    resolve_time_index,
+    write_output_product_manifest,
+)
+
+
+def write_model_netcdf(
+    path: Path,
+    *,
+    times: list[float] | None,
+    values: list[float],
+) -> None:
+    coords = {"z": [0.0], "y": [0.0], "x": [0.0]}
+    if times is not None:
+        coords["time"] = times
+    xr.Dataset(
+        data_vars={
+            "qc": (
+                ("time", "z", "y", "x"),
+                [[[[value]]] for value in values],
+                {"units": "kg/kg"},
+            )
+        },
+        coords=coords,
+    ).to_netcdf(path, engine="scipy")
+
+
+def write_no_time_dimension_netcdf(path: Path) -> None:
+    xr.Dataset(
+        data_vars={
+            "qc": (
+                ("z", "y", "x"),
+                [[[0.0]]],
+                {"units": "kg/kg"},
+            )
+        },
+        coords={"z": [0.0], "y": [0.0], "x": [0.0]},
+    ).to_netcdf(path, engine="scipy")
+
+
+def write_stats_netcdf(path: Path) -> None:
+    xr.Dataset(
+        data_vars={"mass": (("time",), [1.0])},
+        coords={"time": [0.0]},
+    ).to_netcdf(path, engine="scipy")
+
+
+def build_manifest(tmp_path: Path, paths: list[Path]) -> OutputProductManifest:
+    classified = classify_output_paths(paths)
+    return build_output_product_manifest(
+        result_id="result-run-output-products",
+        run_id="run-output-products",
+        scenario_id="baseline-shallow-cumulus",
+        model_output_paths=classified.model_output_paths,
+        stats_netcdf_paths=classified.stats_netcdf_paths,
+        raw_cm1_artifacts=classified.other_paths,
+        source_result_metadata_path=tmp_path / "result_metadata.json",
+        source_run_manifest_path=tmp_path / "run_manifest.json",
+        product_root=tmp_path / "derived-products",
+    )
+
+
+def test_single_model_output_file_with_one_timestep(tmp_path: Path) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=[300.0], values=[0.0])
+
+    manifest = build_manifest(tmp_path, [model])
+
+    assert manifest.manifest_version == 1
+    assert manifest.source_raw_outputs.model_output_files == [str(model)]
+    assert manifest.source_raw_outputs.stats_files == []
+    assert len(manifest.time_index) == 1
+    entry = manifest.time_index[0]
+    assert entry.time_index == 0
+    assert entry.time_seconds == 300.0
+    assert entry.source_file == str(model)
+    assert entry.source_file_kind == "model_output_netcdf"
+    assert entry.local_time_index == 0
+    assert entry.time_source == "netcdf_time_coordinate"
+    assert entry.time_caveats == []
+
+
+def test_single_model_output_file_with_multiple_timesteps(tmp_path: Path) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=[0.0, 600.0, 1200.0], values=[0.0, 1.0, 2.0])
+
+    manifest = build_manifest(tmp_path, [model])
+
+    assert [
+        (entry.time_index, entry.time_seconds, entry.local_time_index)
+        for entry in manifest.time_index
+    ] == [
+        (0, 0.0, 0),
+        (1, 600.0, 1),
+        (2, 1200.0, 2),
+    ]
+    resolved = resolve_time_index(manifest, 2)
+    assert resolved.source_file == str(model)
+    assert resolved.local_time_index == 2
+
+
+def test_multi_file_sequence_with_one_timestep_per_file_excludes_stats(tmp_path: Path) -> None:
+    first = tmp_path / "cm1out_000001.nc"
+    second = tmp_path / "cm1out_000002.nc"
+    stats = tmp_path / "cm1out_stats.nc"
+    write_model_netcdf(first, times=[900.0], values=[1.0])
+    write_model_netcdf(second, times=[1800.0], values=[2.0])
+    write_stats_netcdf(stats)
+
+    manifest = build_manifest(tmp_path, [second, stats, first])
+
+    assert manifest.source_raw_outputs.model_output_files == [str(first), str(second)]
+    assert manifest.source_raw_outputs.stats_files == [str(stats)]
+    assert [entry.time_seconds for entry in manifest.time_index] == [900.0, 1800.0]
+    assert resolve_time_index(manifest, 0).source_file == str(first)
+    assert resolve_time_index(manifest, 1).source_file == str(second)
+    assert all(entry.source_file != str(stats) for entry in manifest.time_index)
+
+
+def test_inferred_order_based_time_mapping_records_caveats(tmp_path: Path) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=None, values=[0.0, 1.0])
+
+    manifest = build_manifest(tmp_path, [model])
+
+    assert [entry.time_seconds for entry in manifest.time_index] == [0.0, 1.0]
+    assert [entry.local_time_index for entry in manifest.time_index] == [0, 1]
+    assert {entry.time_source for entry in manifest.time_index} == {"inferred_filename_order"}
+    assert "inferred_time_indices_present" in manifest.caveats
+    assert "global_time_index_preserves_filename_order_due_to_inferred_times" in manifest.caveats
+    assert all("time_coordinate_missing" in entry.time_caveats for entry in manifest.time_index)
+
+
+def test_no_time_dimension_records_single_inferred_timestep(tmp_path: Path) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_no_time_dimension_netcdf(model)
+
+    manifest = build_manifest(tmp_path, [model])
+
+    assert len(manifest.time_index) == 1
+    assert manifest.time_index[0].local_time_index == 0
+    assert manifest.time_index[0].time_source == "inferred_filename_order"
+    assert "time_coordinate_missing" in manifest.time_index[0].time_caveats
+
+
+def test_duplicate_and_non_monotonic_direct_times_are_caveated(tmp_path: Path) -> None:
+    first = tmp_path / "cm1out_000001.nc"
+    second = tmp_path / "cm1out_000002.nc"
+    write_model_netcdf(first, times=[600.0], values=[1.0])
+    write_model_netcdf(second, times=[300.0, 600.0], values=[2.0, 3.0])
+
+    manifest = build_manifest(tmp_path, [first, second])
+
+    assert [entry.time_seconds for entry in manifest.time_index] == [300.0, 600.0, 600.0]
+    assert "non_monotonic_time_coordinates_detected" in manifest.caveats
+    assert "duplicate_time_coordinate_detected:600" in manifest.caveats
+    duplicate_entries = [entry for entry in manifest.time_index if entry.time_seconds == 600.0]
+    assert all("duplicate_time_coordinate" in entry.time_caveats for entry in duplicate_entries)
+
+
+def test_missing_or_corrupt_file_is_caveated_when_other_outputs_remain(tmp_path: Path) -> None:
+    valid = tmp_path / "cm1out_000001.nc"
+    corrupt = tmp_path / "cm1out_000002.nc"
+    missing = tmp_path / "cm1out_000003.nc"
+    write_model_netcdf(valid, times=[300.0], values=[1.0])
+    corrupt.write_text("not netcdf")
+
+    manifest = build_output_product_manifest(
+        result_id="result-run-output-products",
+        run_id="run-output-products",
+        model_output_paths=[valid, corrupt, missing],
+        product_root=tmp_path / "derived-products",
+    )
+
+    assert [entry.source_file for entry in manifest.time_index] == [str(valid)]
+    assert any(str(corrupt) in caveat for caveat in manifest.caveats)
+    assert f"missing_model_output_file:{missing}" in manifest.caveats
+
+
+def test_all_unreadable_model_files_fail_cleanly(tmp_path: Path) -> None:
+    corrupt = tmp_path / "cm1out_000001.nc"
+    corrupt.write_text("not netcdf")
+
+    with pytest.raises(OutputProductManifestError, match="No model-output timesteps"):
+        build_output_product_manifest(
+            result_id="result-run-output-products",
+            run_id="run-output-products",
+            model_output_paths=[corrupt],
+            product_root=tmp_path / "derived-products",
+        )
+
+
+def test_manifest_can_be_written_and_read_from_runtime_product_path(tmp_path: Path) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=[300.0], values=[0.0])
+    manifest = build_manifest(tmp_path, [model])
+    path = default_output_product_manifest_path(tmp_path)
+
+    write_output_product_manifest(path, manifest)
+    round_tripped = output_product_manifest_from_json(path.read_text())
+
+    assert round_tripped == manifest
+    assert path == tmp_path / "derived-products" / "output_product_manifest.json"
+    assert not any(".git" in part for part in path.parts)
+
+
+def test_resolve_time_index_rejects_unavailable_index(tmp_path: Path) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=[300.0], values=[0.0])
+    manifest = build_manifest(tmp_path, [model])
+
+    with pytest.raises(OutputProductManifestError, match="time_index is not available"):
+        resolve_time_index(manifest, 2)

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -5,6 +5,10 @@ import pytest
 import xarray as xr
 
 from cloud_chamber.dry_run_package import generate_dry_run_package
+from cloud_chamber.output_products import (
+    default_output_product_manifest_path,
+    output_product_manifest_from_json,
+)
 from cloud_chamber.result_ingest import (
     RESULT_METADATA_FILENAME,
     ResultIngestError,
@@ -169,7 +173,8 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
     assert result.source_model == "CM1"
     assert result.netcdf_paths == [str(netcdf_path)]
     assert result.raw_cm1_artifacts == [str(raw_path)]
-    assert result.processed_artifacts == []
+    product_manifest_path = default_output_product_manifest_path(run_dir)
+    assert result.processed_artifacts == [str(product_manifest_path)]
     assert result.visualization_ready_artifacts == []
     assert result.dimensions == {"time": 1, "z": 2, "y": 2, "x": 2}
     assert result.coordinates == ["time", "z", "y", "x"]
@@ -196,6 +201,15 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
         "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"
     ]
     assert (run_dir / RESULT_METADATA_FILENAME).exists()
+    assert product_manifest_path.exists()
+    product_manifest = output_product_manifest_from_json(product_manifest_path.read_text())
+    assert product_manifest.result_id == result.result_id
+    assert product_manifest.run_id == result.run_id
+    assert product_manifest.source_result_metadata_path == str(run_dir / RESULT_METADATA_FILENAME)
+    assert product_manifest.source_run_manifest_path == str(manifest_path)
+    assert [entry.time_index for entry in product_manifest.time_index] == [0]
+    assert product_manifest.time_index[0].source_file == str(netcdf_path)
+    assert product_manifest.time_index[0].local_time_index == 0
 
 
 def test_result_metadata_serializes_and_lists_from_runtime_home(tmp_path: Path) -> None:

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -190,6 +190,13 @@ files they depend on, and how to invalidate or delete them. It should not copy
 large raw NetCDF files into the repository or make derived products appear more
 authoritative than CM1 output.
 
+Implementation note: the first backend foundation for this contract lives in
+`cloud_chamber.output_products`. Ingested results now write a runtime-local
+`derived-products/output_product_manifest.json` beside the run directory's
+result metadata. That manifest currently focuses on source output references
+and global file/time index mapping; later product records should build on it
+rather than inventing separate time addressing.
+
 ## Product Type Decisions
 
 | Product type | When computed | Format now | Future format | Size class | API owner | Frontend consumer |

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -57,7 +57,10 @@ Output product tests should follow the
 raw CM1 NetCDF remains backend-only source data, product manifests and derived
 payloads use tiny fixtures, field catalogs/defaults should be metadata-backed
 when possible, selected timestep requests should resolve through explicit
-file/time mapping, and browser/UI tests should never parse raw NetCDF.
+file/time mapping, and browser/UI tests should never parse raw NetCDF. The
+output product manifest tests should cover single-file, multi-time,
+multi-file, stats-exclusion, inferred-time, duplicate/non-monotonic-time, and
+missing/corrupt-file cases using temp runtime homes only.
 
 Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
 They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, `.dat/.ctl` and NetCDF output artifacts are cataloged separately in the manifest, stderr floating-point flags are surfaced as runtime warnings, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.


### PR DESCRIPTION
Closes #220

## Issue worked

#220 — Implement output product manifest and time index

## Summary

- Added a backend output product manifest foundation in `cloud_chamber.output_products`.
- Builds a runtime-local `derived-products/output_product_manifest.json` for ingested CM1 results.
- Records source result metadata/run manifest paths, model-output NetCDF files, stats NetCDF files, raw CM1 artifacts, product cache root, provenance, and caveats.
- Adds a global time index that maps each output `time_index` to source file + local time index.
- Adds a reusable `resolve_time_index` helper for future bounded slice/point/profile requests.

## Manifest / helper location

- Module: `app/backend/cloud_chamber/output_products.py`
- Runtime path: `<run-dir>/derived-products/output_product_manifest.json`
- Ingest integration: `ingest_completed_run` now writes the product manifest and records its path in `processed_artifacts`.

## Model-output vs stats distinction

- `cm1out_*.nc` numeric output files are classified as model-output files.
- `cm1out_stats.nc` / `.nc4` are classified as stats files and excluded from model-field time mapping.
- Other paths remain raw/other artifacts and are not used for model timestep resolution.

## Caveat behavior

- Direct NetCDF time coordinates are preferred.
- Missing time coordinates fall back to filename/order-based inferred indices with caveats.
- Missing, corrupt, skipped, duplicate, non-monotonic, inferred, and non-numeric time cases become explicit caveats.
- If no model-output timesteps can be indexed, manifest building fails cleanly.

## Tests added/updated

- Added `app/backend/tests/test_output_products.py`.
- Updated result ingest tests to assert product manifest persistence.
- Covered single-file one timestep, single-file multiple timesteps, multi-file one timestep per file, stats exclusion, resolver behavior, direct time preservation, inferred time caveats, duplicate/non-monotonic caveats, missing/corrupt files, manifest serialization, and temp-runtime-only generated artifacts.

## Commands run

- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_output_products.py app/backend/tests/test_result_ingest.py`
- `scripts/check.sh`

## Generated-artifact check

No generated CM1 output, NetCDF files, runtime folders, logs, screenshots, videos, traces, or large artifacts are committed. Tests write tiny synthetic NetCDF fixtures only under temporary runtime homes.

## Merge posture

Opened for Tim review. Do not merge automatically.
