### PR TITLE
Add Build UI action for LAN worker runs

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -11,6 +11,14 @@ from pydantic import BaseModel, Field
 
 from cloud_chamber.cli import ENGINE_NOTE
 from cloud_chamber.dry_run_package import generate_dry_run_package, read_dry_run_report
+from cloud_chamber.lan_worker import (
+    LanWorkerApiError,
+    cleanup_lan_worker_run,
+    collect_lan_worker_run,
+    lan_worker_config_status,
+    lan_worker_run_status,
+    start_lan_worker_run,
+)
 from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError, RunStatus
 from cloud_chamber.result_cards import (
     ResultCardUpdate,
@@ -90,6 +98,10 @@ class IngestResultRequest(BaseModel):
     manifest_path: str
 
 
+class LanWorkerRunRequest(BaseModel):
+    manifest_path: str
+
+
 @app.get("/api/scenarios")
 def list_scenarios() -> dict[str, object]:
     scenarios = [scenario_summary(scenario) for scenario in load_scenario_templates()]
@@ -145,6 +157,43 @@ def cancel_run() -> dict[str, object]:
     except LocalRunManagerError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return _run_status_payload(status)
+
+
+@app.get("/api/lan-worker/config")
+def get_lan_worker_config() -> dict[str, object]:
+    return lan_worker_config_status()
+
+
+@app.post("/api/lan-worker/start")
+def start_lan_worker(request: LanWorkerRunRequest) -> dict[str, object]:
+    try:
+        return start_lan_worker_run(load_settings(), Path(request.manifest_path).expanduser())
+    except LanWorkerApiError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/api/lan-worker/status")
+def get_lan_worker_status(manifest_path: str) -> dict[str, object]:
+    try:
+        return lan_worker_run_status(load_settings(), Path(manifest_path).expanduser())
+    except LanWorkerApiError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/api/lan-worker/collect")
+def collect_lan_worker(request: LanWorkerRunRequest) -> dict[str, object]:
+    try:
+        return collect_lan_worker_run(load_settings(), Path(request.manifest_path).expanduser())
+    except LanWorkerApiError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/api/lan-worker/cleanup")
+def cleanup_lan_worker(request: LanWorkerRunRequest) -> dict[str, object]:
+    try:
+        return cleanup_lan_worker_run(load_settings(), Path(request.manifest_path).expanduser())
+    except LanWorkerApiError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @app.get("/api/storage/inventory")

--- a/app/backend/cloud_chamber/lan_worker.py
+++ b/app/backend/cloud_chamber/lan_worker.py
@@ -1,0 +1,171 @@
+"""Backend wrapper for trusted LAN worker CM1 runs.
+
+The script in ``scripts/lan_worker_run.py`` owns SSH/rsync execution and the
+worker cleanup safety checks.  This module gives the FastAPI app a small,
+bounded JSON surface without teaching the browser anything about SSH.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from cloud_chamber.run_manifest import RunManifestError, load_run_manifest
+from cloud_chamber.settings import CloudChamberSettings
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "lan_worker_run.py"
+SCRIPT_WRAPPER_PATH = REPO_ROOT / "scripts" / "lan-worker-run.sh"
+
+
+class LanWorkerApiError(RuntimeError):
+    """Raised when a LAN worker operation cannot be completed safely."""
+
+
+def lan_worker_config_status() -> dict[str, object]:
+    """Return a sanitized worker configuration status for Build UI gating."""
+    try:
+        script = _load_script_module()
+        config = script.load_worker_config()
+    except Exception as exc:  # noqa: BLE001 - script reports setup problems as runtime errors.
+        return {
+            "configured": False,
+            "available": False,
+            "message": str(exc),
+            "cm1_env_keys": [],
+            "cm1_env_settings": [],
+            "custom_launch_command": False,
+        }
+    cm1_env = config.cm1_env or {}
+    return {
+        "configured": True,
+        "available": True,
+        "message": "Trusted LAN worker is configured.",
+        "cm1_env_keys": sorted(cm1_env.keys()),
+        "cm1_env_settings": _safe_cm1_env_settings(cm1_env),
+        "custom_launch_command": bool(config.cm1_command),
+    }
+
+
+def _safe_cm1_env_settings(cm1_env: dict[str, str]) -> list[str]:
+    """Return non-secret CM1 runtime environment settings for the UI."""
+    blocked_fragments = ("KEY", "TOKEN", "SECRET", "PASSWORD", "PASS")
+    settings: list[str] = []
+    for key in sorted(cm1_env):
+        if any(fragment in key.upper() for fragment in blocked_fragments):
+            continue
+        settings.append(f"{key}={cm1_env[key]}")
+    return settings
+
+
+def start_lan_worker_run(settings: CloudChamberSettings, manifest_path: Path) -> dict[str, object]:
+    package_dir = _package_dir_from_manifest(manifest_path)
+    payload = _run_lan_worker_script(settings, "start", package_dir)
+    payload["state"] = "running"
+    payload["message"] = "Package copied to the LAN worker and CM1 launch was requested."
+    return payload
+
+
+def lan_worker_run_status(settings: CloudChamberSettings, manifest_path: Path) -> dict[str, object]:
+    package_dir = _package_dir_from_manifest(manifest_path)
+    return _run_lan_worker_script(settings, "status", package_dir)
+
+
+def collect_lan_worker_run(
+    settings: CloudChamberSettings, manifest_path: Path
+) -> dict[str, object]:
+    package_dir = _package_dir_from_manifest(manifest_path)
+    payload = _run_lan_worker_script(
+        settings,
+        "collect",
+        package_dir,
+        extra_args=("--replace-incoming",),
+    )
+    if payload.get("ready_for_ingest"):
+        payload["state"] = "ready_for_local_ingest"
+        payload["message"] = (
+            "Completed LAN worker output was copied back, verified, and is ready for local ingest."
+        )
+    else:
+        payload["state"] = payload.get("state") or "copied_back_to_mac"
+        payload["message"] = (
+            "LAN worker output was copied back, but it is not a successful output-producing run."
+        )
+    return payload
+
+
+def cleanup_lan_worker_run(
+    settings: CloudChamberSettings, manifest_path: Path
+) -> dict[str, object]:
+    package_dir = _package_dir_from_manifest(manifest_path)
+    return _run_lan_worker_script(settings, "cleanup", package_dir)
+
+
+def _run_lan_worker_script(
+    settings: CloudChamberSettings,
+    command: str,
+    package_dir: Path,
+    *,
+    extra_args: tuple[str, ...] = (),
+) -> dict[str, object]:
+    args = (
+        str(SCRIPT_WRAPPER_PATH),
+        "--runtime-home",
+        str(settings.runtime_home),
+        command,
+        "--package-dir",
+        str(package_dir),
+        *extra_args,
+    )
+    try:
+        completed = subprocess.run(
+            args,
+            check=True,
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+        )
+    except FileNotFoundError as exc:
+        raise LanWorkerApiError(
+            f"LAN worker helper script was not found: {SCRIPT_WRAPPER_PATH}"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or str(exc)).strip()
+        raise LanWorkerApiError(detail or "LAN worker command failed.") from exc
+    return _parse_json_payload(completed.stdout)
+
+
+def _package_dir_from_manifest(manifest_path: Path) -> Path:
+    expanded = manifest_path.expanduser()
+    try:
+        load_run_manifest(expanded)
+    except RunManifestError as exc:
+        raise LanWorkerApiError(str(exc)) from exc
+    return expanded.parent
+
+
+def _parse_json_payload(stdout: str) -> dict[str, object]:
+    start = stdout.find("{")
+    if start < 0:
+        raise LanWorkerApiError("LAN worker command did not return a JSON payload.")
+    try:
+        payload = json.loads(stdout[start:])
+    except json.JSONDecodeError as exc:
+        raise LanWorkerApiError(f"LAN worker command returned invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise LanWorkerApiError("LAN worker command returned a non-object JSON payload.")
+    return dict(payload)
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("cloud_chamber_lan_worker_script", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise LanWorkerApiError(f"Unable to load LAN worker helper: {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/app/backend/cloud_chamber/runtime_storage.py
+++ b/app/backend/cloud_chamber/runtime_storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -44,6 +45,14 @@ class RunStorageEntry(BaseModel):
     category: str
     manifest_path: str | None = None
     manifest_error: str | None = None
+    worker_state: str | None = None
+    worker_message: str | None = None
+    worker_started_at: str | None = None
+    worker_finished_at: str | None = None
+    worker_status_updated_at: str | None = None
+    worker_remote_dir: str | None = None
+    worker_netcdf_count: int | None = None
+    worker_raw_artifact_count: int | None = None
 
 
 class RuntimeStorageInventory(BaseModel):
@@ -191,6 +200,7 @@ def _entry_from_manifest(
         "netcdf_paths": len(manifest.outputs.netcdf_paths),
         "processed_artifacts": len(manifest.outputs.processed_artifacts),
     }
+    worker_status = _read_worker_status(run_dir / "worker_status.json")
     return RunStorageEntry(
         run_id=manifest.run_id,
         scenario_id=manifest.scenario.id,
@@ -206,12 +216,22 @@ def _entry_from_manifest(
         output_summary=output_summary,
         size_bytes=size_bytes,
         path=str(run_dir),
-        category=_classify_run(manifest),
+        category=_classify_run(manifest, worker_status),
         manifest_path=str(manifest_path),
+        worker_state=_string_or_none(worker_status.get("state")),
+        worker_message=_string_or_none(worker_status.get("message")),
+        worker_started_at=_string_or_none(worker_status.get("started_at")),
+        worker_finished_at=_string_or_none(worker_status.get("finished_at")),
+        worker_status_updated_at=_string_or_none(worker_status.get("local_status_updated_at")),
+        worker_remote_dir=_string_or_none(worker_status.get("remote_dir")),
+        worker_netcdf_count=_int_or_none(worker_status.get("netcdf_count")),
+        worker_raw_artifact_count=_int_or_none(worker_status.get("raw_artifact_count")),
     )
 
 
-def _classify_run(manifest: RunManifest) -> str:
+def _classify_run(manifest: RunManifest, worker_status: dict[str, object] | None = None) -> str:
+    if worker_status and worker_status.get("state") == "running":
+        return "running"
     if manifest.user.saved:
         return "saved_or_protected"
     if manifest.lifecycle_state in {LifecycleState.QUEUED, LifecycleState.RUNNING}:
@@ -232,6 +252,24 @@ def _classify_run(manifest: RunManifest) -> str:
     if manifest.lifecycle_state == LifecycleState.CANCELED:
         return "canceled"
     return "unknown"
+
+
+def _read_worker_status(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {}
+    try:
+        loaded = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _string_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _int_or_none(value: object) -> int | None:
+    return value if isinstance(value, int) else None
 
 
 def _safe_run_directory(runtime_home: Path, run_id: str) -> Path:

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -138,6 +138,128 @@ def test_launch_run_api_reports_clear_failure(monkeypatch: pytest.MonkeyPatch) -
     assert response.json()["detail"] == "CM1 is not ready"
 
 
+def test_lan_worker_config_endpoint_returns_sanitized_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "cloud_chamber.app.lan_worker_config_status",
+        lambda: {
+            "configured": True,
+            "available": True,
+            "message": "Trusted LAN worker is configured.",
+            "cm1_env_keys": ["OMP_NUM_THREADS"],
+            "cm1_env_settings": ["OMP_NUM_THREADS=16"],
+            "custom_launch_command": False,
+        },
+    )
+
+    response = TestClient(app).get("/api/lan-worker/config")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "configured": True,
+        "available": True,
+        "message": "Trusted LAN worker is configured.",
+        "cm1_env_keys": ["OMP_NUM_THREADS"],
+        "cm1_env_settings": ["OMP_NUM_THREADS=16"],
+        "custom_launch_command": False,
+    }
+
+
+def test_lan_worker_run_endpoints_surface_worker_states(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, Path]] = []
+
+    def fake_start(_settings: object, manifest_path: Path) -> dict[str, object]:
+        calls.append(("start", manifest_path))
+        return {
+            "run_id": "dry-run-worker",
+            "state": "running",
+            "message": "Package copied to the LAN worker and CM1 launch was requested.",
+        }
+
+    def fake_status(_settings: object, manifest_path: Path) -> dict[str, object]:
+        calls.append(("status", manifest_path))
+        return {
+            "run_id": "dry-run-worker",
+            "state": "completed",
+            "exit_code": 0,
+            "netcdf_count": 13,
+            "raw_artifact_count": 0,
+            "message": "CM1 completed with output artifacts.",
+        }
+
+    def fake_collect(_settings: object, manifest_path: Path) -> dict[str, object]:
+        calls.append(("collect", manifest_path))
+        return {
+            "run_id": "dry-run-worker",
+            "state": "ready_for_local_ingest",
+            "ready_for_ingest": True,
+            "local_package_dir": "/tmp/CloudChamber/runs/dry-run-worker",
+            "message": "Completed LAN worker output was copied back.",
+        }
+
+    def fake_cleanup(_settings: object, manifest_path: Path) -> dict[str, object]:
+        calls.append(("cleanup", manifest_path))
+        return {
+            "run_id": "dry-run-worker",
+            "state": "worker_cleanup_complete",
+            "message": "LAN worker run directory was removed.",
+        }
+
+    monkeypatch.setattr("cloud_chamber.app.start_lan_worker_run", fake_start)
+    monkeypatch.setattr("cloud_chamber.app.lan_worker_run_status", fake_status)
+    monkeypatch.setattr("cloud_chamber.app.collect_lan_worker_run", fake_collect)
+    monkeypatch.setattr("cloud_chamber.app.cleanup_lan_worker_run", fake_cleanup)
+    client = TestClient(app)
+
+    start = client.post(
+        "/api/lan-worker/start",
+        json={"manifest_path": "/tmp/CloudChamber/runs/dry-run-worker/run_manifest.json"},
+    )
+    status = client.get(
+        "/api/lan-worker/status",
+        params={"manifest_path": "/tmp/CloudChamber/runs/dry-run-worker/run_manifest.json"},
+    )
+    collect = client.post(
+        "/api/lan-worker/collect",
+        json={"manifest_path": "/tmp/CloudChamber/runs/dry-run-worker/run_manifest.json"},
+    )
+    cleanup = client.post(
+        "/api/lan-worker/cleanup",
+        json={"manifest_path": "/tmp/CloudChamber/runs/dry-run-worker/run_manifest.json"},
+    )
+
+    assert start.status_code == 200
+    assert start.json()["state"] == "running"
+    assert status.status_code == 200
+    assert status.json()["state"] == "completed"
+    assert status.json()["netcdf_count"] == 13
+    assert collect.status_code == 200
+    assert collect.json()["state"] == "ready_for_local_ingest"
+    assert cleanup.status_code == 200
+    assert cleanup.json()["state"] == "worker_cleanup_complete"
+    assert [call[0] for call in calls] == ["start", "status", "collect", "cleanup"]
+
+
+def test_lan_worker_endpoint_reports_clear_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cloud_chamber.lan_worker import LanWorkerApiError
+
+    def fake_start(_settings: object, _manifest_path: Path) -> dict[str, object]:
+        raise LanWorkerApiError("LAN worker SSH failed")
+
+    monkeypatch.setattr("cloud_chamber.app.start_lan_worker_run", fake_start)
+
+    response = TestClient(app).post(
+        "/api/lan-worker/start",
+        json={"manifest_path": "/tmp/CloudChamber/runs/dry-run-worker/run_manifest.json"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "LAN worker SSH failed"
+
+
 def test_storage_inventory_api_uses_runtime_home_override(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1374,6 +1374,21 @@ beforeEach(() => {
       if (url === "/api/runs/launch") {
         return Promise.resolve(new Response(JSON.stringify(runningRunStatus), { status: 200 }));
       }
+      if (url === "/api/lan-worker/config") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              configured: false,
+              available: false,
+              message: "LAN worker is not configured.",
+              cm1_env_keys: [],
+              cm1_env_settings: [],
+              custom_launch_command: false,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
       if (url.startsWith("/api/runs/status")) {
         return Promise.resolve(new Response(JSON.stringify(completedRunStatus), { status: 200 }));
       }
@@ -1795,7 +1810,8 @@ describe("App", () => {
     expect(screen.queryByText("Ready to review")).not.toBeInTheDocument();
     expect(screen.queryByText("Quick-look shallow cumulus")).not.toBeInTheDocument();
     expect(screen.queryByText("Ingested result")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Run with local CM1" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run with local CM1" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run on LAN worker" })).not.toBeInTheDocument();
     expect(screen.getByTestId("create-package-btn")).toBeEnabled();
     expect(screen.getAllByRole("button", { name: "Create run package" })).toHaveLength(1);
     expect(screen.getByRole("button", { name: "Open Storage cleanup" })).toBeInTheDocument();
@@ -1821,6 +1837,154 @@ describe("App", () => {
       );
     });
     expect(await screen.findByText(/Result metadata created/)).toBeInTheDocument();
+  });
+
+  it("automatically copies back, ingests, and cleans LAN worker output after completion", async () => {
+    let ingested = false;
+    const workerRun = {
+      ...storageRuns[0],
+      run_id: "dry-run-worker-completed",
+      scenario_id: "humid-vigorous-cumulus",
+      scenario_name: "Humid Vigorous Cumulus",
+      run_size_preset: "quick_look",
+      category: "running",
+      manifest_path: "/tmp/CloudChamber/runs/dry-run-worker-completed/run_manifest.json",
+      path: "/tmp/CloudChamber/runs/dry-run-worker-completed",
+      worker_state: "completed",
+      worker_message: "CM1 completed with output artifacts.",
+      worker_netcdf_count: 14,
+      worker_raw_artifact_count: 0,
+      worker_remote_dir: "/worker/runs/dry-run-worker-completed",
+      worker_started_at: "2026-07-01T04:30:07Z",
+      worker_finished_at: "2026-07-01T04:39:23Z",
+    };
+    const workerResult = {
+      ...resultCard,
+      result_id: "result-dry-run-worker-completed",
+      run_id: "dry-run-worker-completed",
+      name: "Humid Vigorous Cumulus quick-look",
+      scenario_id: "humid-vigorous-cumulus",
+      scenario_name: "Humid Vigorous Cumulus",
+    };
+
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/lan-worker/config") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              configured: true,
+              available: true,
+              message: "LAN worker configured.",
+              cm1_env_keys: ["OMP_NUM_THREADS"],
+              cm1_env_settings: ["OMP_NUM_THREADS=16"],
+              custom_launch_command: false,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ...storageInventoryResponse,
+              runs: [workerRun],
+              largest_runs: [workerRun],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ results: ingested ? [workerResult] : [] }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/lan-worker/collect") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              run_id: "dry-run-worker-completed",
+              state: "ready_for_local_ingest",
+              message: "LAN worker output copied back to this MacBook.",
+              netcdf_count: 14,
+              raw_artifact_count: 0,
+              ready_for_ingest: true,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/results/ingest") {
+        ingested = true;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              result_id: "result-dry-run-worker-completed",
+              run_id: "dry-run-worker-completed",
+              diagnostics_summary: "cloud formed; rain detected",
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/lan-worker/cleanup") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              run_id: "dry-run-worker-completed",
+              state: "worker_cleanup_complete",
+              message: "LAN worker run directory was removed.",
+              netcdf_count: 0,
+              raw_artifact_count: 0,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/lan-worker/collect",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            manifest_path: "/tmp/CloudChamber/runs/dry-run-worker-completed/run_manifest.json",
+          }),
+        }),
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/results/ingest",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            manifest_path: "/tmp/CloudChamber/runs/dry-run-worker-completed/run_manifest.json",
+          }),
+        }),
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/lan-worker/cleanup",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            manifest_path: "/tmp/CloudChamber/runs/dry-run-worker-completed/run_manifest.json",
+          }),
+        }),
+      );
+    });
+    expect(screen.queryByRole("button", { name: "Copy back and ingest" })).not.toBeInTheDocument();
   });
 
   it("requests a dry-run package and displays generated files without claiming CM1 ran", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -122,6 +122,28 @@ type RunStatusResponse = {
   runtime_warnings: string[];
 };
 
+type LanWorkerConfigResponse = {
+  configured: boolean;
+  available: boolean;
+  message: string;
+  cm1_env_keys: string[];
+  cm1_env_settings: string[];
+  custom_launch_command: boolean;
+};
+
+type LanWorkerRunResponse = {
+  run_id: string;
+  state: string;
+  message?: string | null;
+  exit_code?: number | null;
+  netcdf_count?: number;
+  raw_artifact_count?: number;
+  started_at?: string | null;
+  finished_at?: string | null;
+  local_package_dir?: string | null;
+  ready_for_ingest?: boolean;
+};
+
 type IngestResponse = {
   result_id: string;
   run_id: string;
@@ -131,10 +153,16 @@ type IngestResponse = {
 type BuildRunStage =
   | "not_packaged"
   | "package_ready"
+  | "lan_worker_running"
+  | "lan_worker_completed"
+  | "ready_for_local_ingest"
   | "running"
   | "completed"
   | "failed"
-  | "ingested";
+  | "ingested"
+  | "worker_cleanup_pending"
+  | "worker_cleanup_complete"
+  | "worker_cleanup_failed";
 
 type OutputFileSummary = {
   netcdf_count: number;
@@ -216,6 +244,14 @@ type RunStorageEntry = {
   category: string;
   manifest_path: string | null;
   manifest_error: string | null;
+  worker_state: string | null;
+  worker_message: string | null;
+  worker_started_at: string | null;
+  worker_finished_at: string | null;
+  worker_status_updated_at: string | null;
+  worker_remote_dir: string | null;
+  worker_netcdf_count: number | null;
+  worker_raw_artifact_count: number | null;
 };
 
 type StorageInventoryResponse = {
@@ -535,6 +571,59 @@ async function fetchRunStatus(manifestPath: string): Promise<RunStatusResponse> 
   return response.json() as Promise<RunStatusResponse>;
 }
 
+async function fetchLanWorkerConfig(): Promise<LanWorkerConfigResponse> {
+  const response = await fetch("/api/lan-worker/config");
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to load LAN worker configuration."));
+  }
+  return response.json() as Promise<LanWorkerConfigResponse>;
+}
+
+async function startLanWorkerRun(manifestPath: string): Promise<LanWorkerRunResponse> {
+  const response = await fetch("/api/lan-worker/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ manifest_path: manifestPath }),
+  });
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to start LAN worker run."));
+  }
+  return response.json() as Promise<LanWorkerRunResponse>;
+}
+
+async function fetchLanWorkerStatus(manifestPath: string): Promise<LanWorkerRunResponse> {
+  const search = new URLSearchParams({ manifest_path: manifestPath });
+  const response = await fetch(`/api/lan-worker/status?${search}`);
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to refresh LAN worker status."));
+  }
+  return response.json() as Promise<LanWorkerRunResponse>;
+}
+
+async function collectLanWorkerRun(manifestPath: string): Promise<LanWorkerRunResponse> {
+  const response = await fetch("/api/lan-worker/collect", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ manifest_path: manifestPath }),
+  });
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to copy LAN worker output back."));
+  }
+  return response.json() as Promise<LanWorkerRunResponse>;
+}
+
+async function cleanupLanWorkerRun(manifestPath: string): Promise<LanWorkerRunResponse> {
+  const response = await fetch("/api/lan-worker/cleanup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ manifest_path: manifestPath }),
+  });
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to clean up LAN worker copy."));
+  }
+  return response.json() as Promise<LanWorkerRunResponse>;
+}
+
 async function ingestCompletedRun(manifestPath: string): Promise<IngestResponse> {
   const response = await fetch("/api/results/ingest", {
     method: "POST",
@@ -749,6 +838,14 @@ export function App() {
   const [dryRun, setDryRun] = useState<DryRunResponse | null>(null);
   const [runStatus, setRunStatus] = useState<RunStatusResponse | null>(null);
   const [runWorkflowError, setRunWorkflowError] = useState<string | null>(null);
+  const [lanWorkerConfig, setLanWorkerConfig] = useState<LanWorkerConfigResponse | null>(null);
+  const [lanWorkerStatus, setLanWorkerStatus] = useState<LanWorkerRunResponse | null>(null);
+  const [lanWorkerError, setLanWorkerError] = useState<string | null>(null);
+  const [lanWorkerActionStatus, setLanWorkerActionStatus] = useState<string | null>(null);
+  const [autoFinalizingWorkerRunIds, setAutoFinalizingWorkerRunIds] = useState<string[]>([]);
+  const [failedAutoFinalizingWorkerRunIds, setFailedAutoFinalizingWorkerRunIds] = useState<
+    string[]
+  >([]);
   const [ingestedResultId, setIngestedResultId] = useState<string | null>(null);
   const [results, setResults] = useState<ResultCard[]>([]);
   const [selectedResultId, setSelectedResultId] = useState<string | null>(null);
@@ -775,6 +872,9 @@ export function App() {
     setDryRun(null);
     setRunStatus(null);
     setRunWorkflowError(null);
+    setLanWorkerStatus(null);
+    setLanWorkerError(null);
+    setLanWorkerActionStatus(null);
     setIngestedResultId(null);
     try {
       const catalog = await fetchScenarioCatalog();
@@ -828,6 +928,29 @@ export function App() {
 
   useEffect(() => {
     let active = true;
+    fetchLanWorkerConfig()
+      .then((payload) => {
+        if (!active) return;
+        setLanWorkerConfig(payload);
+      })
+      .catch((caught: unknown) => {
+        if (!active) return;
+        setLanWorkerConfig({
+          configured: false,
+          available: false,
+          message: caught instanceof Error ? caught.message : "Unable to load LAN worker setup.",
+          cm1_env_keys: [],
+          cm1_env_settings: [],
+          custom_launch_command: false,
+        });
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
     refreshStorageInventory().catch(() => undefined);
     return () => {
       active = false;
@@ -859,6 +982,14 @@ export function App() {
     [results, selectedResultId],
   );
   const comparisonPair = useMemo(() => defaultComparisonPair(results), [results]);
+  const autoFinalizingWorkerRunIdSet = useMemo(
+    () => new Set(autoFinalizingWorkerRunIds),
+    [autoFinalizingWorkerRunIds],
+  );
+  const failedAutoFinalizingWorkerRunIdSet = useMemo(
+    () => new Set(failedAutoFinalizingWorkerRunIds),
+    [failedAutoFinalizingWorkerRunIds],
+  );
 
   useEffect(() => {
     if (!selectedScenario) return;
@@ -870,6 +1001,9 @@ export function App() {
     setDryRun(null);
     setRunStatus(null);
     setRunWorkflowError(null);
+    setLanWorkerStatus(null);
+    setLanWorkerError(null);
+    setLanWorkerActionStatus(null);
     setIngestedResultId(null);
   }, [selectedScenario]);
 
@@ -881,6 +1015,23 @@ export function App() {
       notes: selectedResult.notes ?? "",
     });
   }, [selectedResult]);
+
+  useEffect(() => {
+    if (!storageInventory) return;
+    const nextRun = storageInventory.runs.find(
+      (run) =>
+        run.worker_state === "completed" &&
+        run.manifest_path &&
+        !resultForRun(results, run.run_id) &&
+        !autoFinalizingWorkerRunIdSet.has(run.run_id) &&
+        !failedAutoFinalizingWorkerRunIdSet.has(run.run_id),
+    );
+    if (!nextRun?.manifest_path) return;
+    void autoFinalizeStoredLanWorkerRun(nextRun.manifest_path, nextRun.run_id);
+    // autoFinalizeStoredLanWorkerRun is intentionally omitted because it mutates the
+    // same worker-finalization state that gates this effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoFinalizingWorkerRunIdSet, failedAutoFinalizingWorkerRunIdSet, results, storageInventory]);
 
   const validationMessages = useMemo(() => {
     if (!selectedScenario) return [];
@@ -916,6 +1067,9 @@ export function App() {
     setDryRun(null);
     setRunStatus(null);
     setRunWorkflowError(null);
+    setLanWorkerStatus(null);
+    setLanWorkerError(null);
+    setLanWorkerActionStatus(null);
     setIngestedResultId(null);
     try {
       const result = await requestDryRunPackage(selectedScenario.id, controls, runSizePreset);
@@ -958,6 +1112,128 @@ export function App() {
     }
   }
 
+  async function handleLaunchLanWorkerRun(manifestPath?: string) {
+    const targetManifestPath = manifestPath ?? dryRun?.manifest_path;
+    if (!targetManifestPath) return;
+    setRunWorkflowError(null);
+    setLanWorkerError(null);
+    setLanWorkerActionStatus("Copying package to LAN worker");
+    setStatus("Copying package to LAN worker");
+    try {
+      const launched = await startLanWorkerRun(targetManifestPath);
+      setLanWorkerStatus(launched);
+      setLanWorkerActionStatus("Running CM1 on LAN worker");
+      setStatus("Running CM1 on LAN worker");
+      await refreshStorageAfterWorkflow("Local pipeline updated");
+    } catch (caught) {
+      const message =
+        caught instanceof Error ? caught.message : "Unable to start LAN worker run.";
+      setLanWorkerError(message);
+      setRunWorkflowError(message);
+      setLanWorkerActionStatus("LAN worker launch blocked");
+      setStatus("LAN worker launch blocked");
+    }
+  }
+
+  async function handleRefreshLanWorkerStatus() {
+    if (!dryRun) return;
+    setLanWorkerError(null);
+    setLanWorkerActionStatus("Refreshing LAN worker status");
+    try {
+      const refreshed = await fetchLanWorkerStatus(dryRun.manifest_path);
+      setLanWorkerStatus(refreshed);
+      setLanWorkerActionStatus(lanWorkerStatusLabel(refreshed));
+      await refreshStorageAfterWorkflow("Local pipeline updated");
+      if (refreshed.state === "completed" && !ingestedResultId) {
+        await collectAndIngestLanWorkerRun(dryRun.manifest_path);
+      }
+    } catch (caught) {
+      const message =
+        caught instanceof Error ? caught.message : "Unable to refresh LAN worker status.";
+      setLanWorkerError(message);
+      setLanWorkerActionStatus("LAN worker status unavailable");
+    }
+  }
+
+  async function handleCollectLanWorkerRun() {
+    if (!dryRun) return;
+    await collectAndIngestLanWorkerRun(dryRun.manifest_path);
+  }
+
+  async function collectAndIngestLanWorkerRun(manifestPath: string): Promise<boolean> {
+    setLanWorkerError(null);
+    setLanWorkerActionStatus("Copying completed output back");
+    setStatus("Copying completed output back");
+    try {
+      const collected = await collectLanWorkerRun(manifestPath);
+      setLanWorkerStatus(collected);
+      setLanWorkerActionStatus(lanWorkerStatusLabel(collected));
+      await refreshStorageAfterWorkflow("Completed LAN worker output returned");
+      if (collected.ready_for_ingest || collected.state === "ready_for_local_ingest") {
+        setLanWorkerActionStatus("Ingesting copied LAN worker output");
+        setStatus("Ingesting copied LAN worker output");
+        const ingested = await ingestCompletedRun(manifestPath);
+        setIngestedResultId(ingested.result_id);
+        await refreshResults(ingested.result_id);
+        await refreshStorageAfterWorkflow("LAN worker output ingested locally");
+        setLanWorkerActionStatus("Cleaning LAN worker copy");
+        setStatus("Cleaning LAN worker copy");
+        try {
+          const cleaned = await cleanupLanWorkerRun(manifestPath);
+          setLanWorkerStatus(cleaned);
+          setLanWorkerActionStatus(lanWorkerStatusLabel(cleaned));
+          await refreshStorageAfterWorkflow("LAN worker cleanup complete");
+          setStatus("Ingested result metadata and cleaned worker copy");
+        } catch (cleanupError) {
+          const cleanupMessage =
+            cleanupError instanceof Error
+              ? cleanupError.message
+              : "Unable to clean up LAN worker copy.";
+          setLanWorkerError(cleanupMessage);
+          setLanWorkerActionStatus("LAN worker cleanup failed");
+          setStatus("Ingested result metadata; worker cleanup needs retry");
+        }
+        return true;
+      } else {
+        setStatus("Copied output needs review before ingest");
+        return false;
+      }
+    } catch (caught) {
+      const message =
+        caught instanceof Error ? caught.message : "Unable to copy and ingest LAN worker output.";
+      setLanWorkerError(message);
+      setLanWorkerActionStatus("LAN worker copy-back or ingest failed");
+      setStatus("LAN worker copy-back or ingest failed");
+      return false;
+    }
+  }
+
+  async function handleCleanupLanWorkerRun() {
+    if (!dryRun) return;
+    setLanWorkerError(null);
+    setLanWorkerActionStatus("Cleaning LAN worker copy");
+    try {
+      const cleaned = await cleanupLanWorkerRun(dryRun.manifest_path);
+      setLanWorkerStatus(cleaned);
+      setLanWorkerActionStatus(lanWorkerStatusLabel(cleaned));
+      await refreshStorageAfterWorkflow("LAN worker cleanup complete");
+    } catch (caught) {
+      const message =
+        caught instanceof Error ? caught.message : "Unable to clean up LAN worker copy.";
+      setLanWorkerError(message);
+      setLanWorkerStatus((current) =>
+        current
+          ? {
+              ...current,
+              state: "worker_cleanup_failed",
+              message,
+            }
+          : current,
+      );
+      setLanWorkerActionStatus("LAN worker cleanup failed");
+    }
+  }
+
   async function refreshResults(selectResultId?: string) {
     const payload = await fetchResults();
     const prioritized = prioritizeResults(payload.results);
@@ -993,6 +1269,9 @@ export function App() {
       setIngestedResultId(ingested.result_id);
       await refreshResults(ingested.result_id);
       await refreshStorageAfterWorkflow("Local pipeline updated");
+      if (lanWorkerStatus && lanWorkerStatus.state !== "worker_cleanup_complete") {
+        setLanWorkerActionStatus("Worker cleanup pending");
+      }
       setStatus("Ingested result metadata");
     } catch (caught) {
       setRunWorkflowError(
@@ -1013,6 +1292,49 @@ export function App() {
     } catch (caught) {
       setRunWorkflowError(caught instanceof Error ? caught.message : "Unable to launch local CM1.");
       setStatus("Launch blocked");
+    }
+  }
+
+  async function handleFinalizeStoredLanWorkerRun(manifestPath: string) {
+    await collectAndIngestLanWorkerRun(manifestPath);
+  }
+
+  async function autoFinalizeStoredLanWorkerRun(manifestPath: string, runId: string) {
+    setAutoFinalizingWorkerRunIds((current) =>
+      current.includes(runId) ? current : [...current, runId],
+    );
+    setFailedAutoFinalizingWorkerRunIds((current) => current.filter((id) => id !== runId));
+    const succeeded = await collectAndIngestLanWorkerRun(manifestPath);
+    setAutoFinalizingWorkerRunIds((current) => current.filter((id) => id !== runId));
+    if (!succeeded) {
+      setFailedAutoFinalizingWorkerRunIds((current) =>
+        current.includes(runId) ? current : [...current, runId],
+      );
+    }
+  }
+
+  async function handleRefreshStoredLanWorkerStatus(manifestPath: string) {
+    setRunWorkflowError(null);
+    setLanWorkerError(null);
+    setLanWorkerActionStatus("Refreshing LAN worker status");
+    setStatus("Refreshing LAN worker status");
+    try {
+      const refreshed = await fetchLanWorkerStatus(manifestPath);
+      if (dryRun?.manifest_path === manifestPath) {
+        setLanWorkerStatus(refreshed);
+      }
+      setLanWorkerActionStatus(lanWorkerStatusLabel(refreshed));
+      await refreshStorageAfterWorkflow(`LAN worker status refreshed at ${new Date().toLocaleTimeString()}`);
+      if (refreshed.state === "completed") {
+        await collectAndIngestLanWorkerRun(manifestPath);
+      }
+    } catch (caught) {
+      const message =
+        caught instanceof Error ? caught.message : "Unable to refresh LAN worker status.";
+      setLanWorkerError(message);
+      setRunWorkflowError(message);
+      setLanWorkerActionStatus("LAN worker status unavailable");
+      setStatus("LAN worker status unavailable");
     }
   }
 
@@ -1151,11 +1473,17 @@ export function App() {
           dryRun={dryRun}
           runStatus={runStatus}
           runWorkflowError={runWorkflowError}
+          lanWorkerConfig={lanWorkerConfig}
+          lanWorkerStatus={lanWorkerStatus}
+          lanWorkerError={lanWorkerError}
+          lanWorkerActionStatus={lanWorkerActionStatus}
           ingestedResultId={ingestedResultId}
           storageInventory={storageInventory}
           storageStatus={storageStatus}
           storageError={storageError}
           results={results}
+          autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIdSet}
+          failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIdSet}
           onSelectScenario={setSelectedScenarioId}
           onControlChange={(id, value) =>
             setControls((current) => ({
@@ -1167,8 +1495,15 @@ export function App() {
           onDryRun={handleDryRun}
           onLaunchRun={handleLaunchRun}
           onRefreshRunStatus={handleRefreshRunStatus}
+          onLaunchLanWorkerRun={() => void handleLaunchLanWorkerRun()}
+          onRefreshLanWorkerStatus={handleRefreshLanWorkerStatus}
+          onCollectLanWorkerRun={handleCollectLanWorkerRun}
+          onCleanupLanWorkerRun={handleCleanupLanWorkerRun}
           onIngestRun={handleIngestRun}
           onLaunchStoredRun={handleLaunchStoredRun}
+          onLaunchStoredLanWorkerRun={(manifestPath) => void handleLaunchLanWorkerRun(manifestPath)}
+          onRefreshStoredLanWorkerStatus={handleRefreshStoredLanWorkerStatus}
+          onFinalizeStoredLanWorkerRun={handleFinalizeStoredLanWorkerRun}
           onIngestStoredRun={handleIngestStoredRun}
           onOpenInResults={() => {
             if (ingestedResultId) setSelectedResultId(ingestedResultId);
@@ -1268,19 +1603,32 @@ function BuildWorkspace({
   dryRun,
   runStatus,
   runWorkflowError,
+  lanWorkerConfig,
+  lanWorkerStatus,
+  lanWorkerError,
+  lanWorkerActionStatus,
   ingestedResultId,
   storageInventory,
   storageStatus,
   storageError,
   results,
+  autoFinalizingWorkerRunIds,
+  failedAutoFinalizingWorkerRunIds,
   onSelectScenario,
   onControlChange,
   onRunSizeChange,
   onDryRun,
   onLaunchRun,
   onRefreshRunStatus,
+  onLaunchLanWorkerRun,
+  onRefreshLanWorkerStatus,
+  onCollectLanWorkerRun,
+  onCleanupLanWorkerRun,
   onIngestRun,
   onLaunchStoredRun,
+  onLaunchStoredLanWorkerRun,
+  onRefreshStoredLanWorkerStatus,
+  onFinalizeStoredLanWorkerRun,
   onIngestStoredRun,
   onOpenInResults,
   onInspectIngested,
@@ -1302,19 +1650,32 @@ function BuildWorkspace({
   dryRun: DryRunResponse | null;
   runStatus: RunStatusResponse | null;
   runWorkflowError: string | null;
+  lanWorkerConfig: LanWorkerConfigResponse | null;
+  lanWorkerStatus: LanWorkerRunResponse | null;
+  lanWorkerError: string | null;
+  lanWorkerActionStatus: string | null;
   ingestedResultId: string | null;
   storageInventory: StorageInventoryResponse | null;
   storageStatus: string;
   storageError: string | null;
   results: ResultCard[];
+  autoFinalizingWorkerRunIds: Set<string>;
+  failedAutoFinalizingWorkerRunIds: Set<string>;
   onSelectScenario: (scenarioId: string) => void;
   onControlChange: (controlId: string, value: string) => void;
   onRunSizeChange: (presetId: string) => void;
   onDryRun: (event: FormEvent<HTMLFormElement>) => void;
   onLaunchRun: () => void;
   onRefreshRunStatus: () => void;
+  onLaunchLanWorkerRun: () => void;
+  onRefreshLanWorkerStatus: () => void;
+  onCollectLanWorkerRun: () => void;
+  onCleanupLanWorkerRun: () => void;
   onIngestRun: () => void;
   onLaunchStoredRun: (manifestPath: string) => void;
+  onLaunchStoredLanWorkerRun: (manifestPath: string) => void;
+  onRefreshStoredLanWorkerStatus: (manifestPath: string) => void;
+  onFinalizeStoredLanWorkerRun: (manifestPath: string) => void;
   onIngestStoredRun: (manifestPath: string) => void;
   onOpenInResults: () => void;
   onInspectIngested: () => void;
@@ -1500,17 +1861,30 @@ function BuildWorkspace({
             dryRun={dryRun}
             runStatus={runStatus}
             error={runWorkflowError}
+            lanWorkerConfig={lanWorkerConfig}
+            lanWorkerStatus={lanWorkerStatus}
+            lanWorkerError={lanWorkerError}
+            lanWorkerActionStatus={lanWorkerActionStatus}
             ingestedResultId={ingestedResultId}
             showCreatePackageAction={scenarioControlsReady}
             canCreatePackage={validationMessages.length === 0}
             onLaunchRun={onLaunchRun}
             onRefreshRunStatus={onRefreshRunStatus}
+            onLaunchLanWorkerRun={onLaunchLanWorkerRun}
+            onRefreshLanWorkerStatus={onRefreshLanWorkerStatus}
+            onCollectLanWorkerRun={onCollectLanWorkerRun}
+            onCleanupLanWorkerRun={onCleanupLanWorkerRun}
             onIngestRun={onIngestRun}
             storageInventory={storageInventory}
             storageStatus={storageStatus}
             storageError={storageError}
             results={results}
+            autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIds}
+            failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIds}
             onLaunchStoredRun={onLaunchStoredRun}
+            onLaunchStoredLanWorkerRun={onLaunchStoredLanWorkerRun}
+            onRefreshStoredLanWorkerStatus={onRefreshStoredLanWorkerStatus}
+            onFinalizeStoredLanWorkerRun={onFinalizeStoredLanWorkerRun}
             onIngestStoredRun={onIngestStoredRun}
             onOpenInResults={onOpenInResults}
             onInspectIngested={onInspectIngested}
@@ -2549,17 +2923,30 @@ function LocalRunWorkflowPanel({
   dryRun,
   runStatus,
   error,
+  lanWorkerConfig,
+  lanWorkerStatus,
+  lanWorkerError,
+  lanWorkerActionStatus,
   ingestedResultId,
   storageInventory,
   storageStatus,
   storageError,
   results,
+  autoFinalizingWorkerRunIds,
+  failedAutoFinalizingWorkerRunIds,
   showCreatePackageAction,
   canCreatePackage,
   onLaunchRun,
   onRefreshRunStatus,
+  onLaunchLanWorkerRun,
+  onRefreshLanWorkerStatus,
+  onCollectLanWorkerRun,
+  onCleanupLanWorkerRun,
   onIngestRun,
   onLaunchStoredRun,
+  onLaunchStoredLanWorkerRun,
+  onRefreshStoredLanWorkerStatus,
+  onFinalizeStoredLanWorkerRun,
   onIngestStoredRun,
   onOpenInResults,
   onInspectIngested,
@@ -2571,17 +2958,30 @@ function LocalRunWorkflowPanel({
   dryRun: DryRunResponse | null;
   runStatus: RunStatusResponse | null;
   error: string | null;
+  lanWorkerConfig: LanWorkerConfigResponse | null;
+  lanWorkerStatus: LanWorkerRunResponse | null;
+  lanWorkerError: string | null;
+  lanWorkerActionStatus: string | null;
   ingestedResultId: string | null;
   storageInventory: StorageInventoryResponse | null;
   storageStatus: string;
   storageError: string | null;
   results: ResultCard[];
+  autoFinalizingWorkerRunIds: Set<string>;
+  failedAutoFinalizingWorkerRunIds: Set<string>;
   showCreatePackageAction: boolean;
   canCreatePackage: boolean;
   onLaunchRun: () => void;
   onRefreshRunStatus: () => void;
+  onLaunchLanWorkerRun: () => void;
+  onRefreshLanWorkerStatus: () => void;
+  onCollectLanWorkerRun: () => void;
+  onCleanupLanWorkerRun: () => void;
   onIngestRun: () => void;
   onLaunchStoredRun: (manifestPath: string) => void;
+  onLaunchStoredLanWorkerRun: (manifestPath: string) => void;
+  onRefreshStoredLanWorkerStatus: (manifestPath: string) => void;
+  onFinalizeStoredLanWorkerRun: (manifestPath: string) => void;
   onIngestStoredRun: (manifestPath: string) => void;
   onOpenInResults: () => void;
   onInspectIngested: () => void;
@@ -2590,18 +2990,21 @@ function LocalRunWorkflowPanel({
   onOpenStorage: (runId?: string | null) => void;
   onRefreshStorage: () => void;
 }) {
-  const stage = buildRunStage(dryRun, runStatus, ingestedResultId);
-  const canIngest =
+  const stage = buildRunStage(dryRun, runStatus, ingestedResultId, lanWorkerStatus);
+  const canIngestLocal =
     runStatus?.lifecycle_state === "completed" &&
     runStatus.product_state === "completed_cm1_result" &&
     !ingestedResultId;
+  const canIngestLanWorker =
+    lanWorkerStatus?.state === "ready_for_local_ingest" && !ingestedResultId;
+  const canIngest = canIngestLocal || canIngestLanWorker;
   const outputCount = runStatus
     ? Object.values(runStatus.output_summary).reduce((total, value) => total + value, 0)
     : 0;
   const generatedInputNames = dryRun ? generatedInputSummary(dryRun) : [];
   const currentRunId = dryRun ? runIdFromPackage(dryRun) : null;
   const showCreatePackageButton = showCreatePackageAction;
-  const showLaunchButton = Boolean(dryRun && stage === "package_ready");
+  const showLaunchButton = Boolean(dryRun && !runStatus && !lanWorkerStatus);
   const showRefreshButton = Boolean(dryRun && runStatus);
   const showIngestButton = Boolean(dryRun && canIngest);
   const showActionRow =
@@ -2738,6 +3141,24 @@ function LocalRunWorkflowPanel({
           </div>
         )}
 
+        {dryRun && (
+          <LanWorkerRunPanel
+            configured={lanWorkerConfig?.configured ?? false}
+            configMessage={lanWorkerConfig?.message ?? "Checking LAN worker setup."}
+            cm1EnvKeys={lanWorkerConfig?.cm1_env_keys ?? []}
+            cm1EnvSettings={lanWorkerConfig?.cm1_env_settings ?? []}
+            status={lanWorkerStatus}
+            actionStatus={lanWorkerActionStatus}
+            error={lanWorkerError}
+            ingestedResultId={ingestedResultId}
+            canStart={showLaunchButton}
+            onLaunch={onLaunchLanWorkerRun}
+            onRefresh={onRefreshLanWorkerStatus}
+            onCollect={onCollectLanWorkerRun}
+            onCleanup={onCleanupLanWorkerRun}
+          />
+        )}
+
         {runStatus ? (
           <div className="run-status-panel" aria-label="Local run status">
             <dl>
@@ -2862,7 +3283,13 @@ function LocalRunWorkflowPanel({
         error={storageError}
         results={results}
         currentRunId={currentRunId}
+        lanWorkerConfigured={lanWorkerConfig?.configured ?? false}
+        autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIds}
+        failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIds}
         onLaunchStoredRun={onLaunchStoredRun}
+        onLaunchStoredLanWorkerRun={onLaunchStoredLanWorkerRun}
+        onRefreshStoredLanWorkerStatus={onRefreshStoredLanWorkerStatus}
+        onFinalizeStoredLanWorkerRun={onFinalizeStoredLanWorkerRun}
         onIngestStoredRun={onIngestStoredRun}
         onOpenStoredResult={onOpenStoredResult}
         onExploreStoredResult={onExploreStoredResult}
@@ -2874,13 +3301,141 @@ function LocalRunWorkflowPanel({
   );
 }
 
+function LanWorkerRunPanel({
+  configured,
+  configMessage,
+  cm1EnvKeys,
+  cm1EnvSettings,
+  status,
+  actionStatus,
+  error,
+  ingestedResultId,
+  canStart,
+  onLaunch,
+  onRefresh,
+  onCollect,
+  onCleanup,
+}: {
+  configured: boolean;
+  configMessage: string;
+  cm1EnvKeys: string[];
+  cm1EnvSettings: string[];
+  status: LanWorkerRunResponse | null;
+  actionStatus: string | null;
+  error: string | null;
+  ingestedResultId: string | null;
+  canStart: boolean;
+  onLaunch: () => void;
+  onRefresh: () => void;
+  onCollect: () => void;
+  onCleanup: () => void;
+}) {
+  const canCollect = status?.state === "completed" && Boolean(error);
+  const cleanupComplete = status?.state === "worker_cleanup_complete";
+  const cleanupFailed = status?.state === "worker_cleanup_failed";
+  const cleanupAvailable =
+    Boolean(ingestedResultId) &&
+    Boolean(status) &&
+    !cleanupComplete &&
+    status?.state !== "running" &&
+    status?.state !== "completed";
+
+  return (
+    <section className="run-status-panel lan-worker-panel" aria-label="LAN worker run status">
+      <div className="panel-heading-row">
+        <div>
+          <p className="eyebrow">Trusted LAN worker</p>
+          <h5>Run CM1 on LAN worker</h5>
+        </div>
+        <StatusBadge
+          label={status ? lanWorkerStatusLabel(status) : configured ? "Configured" : "Not configured"}
+          tone={lanWorkerTone(status, configured)}
+        />
+      </div>
+
+      <p className="state-note">
+        {configured
+          ? "Use the LAN worker as a compute appliance. Copy completed output back, ingest locally, then clean up the worker copy."
+          : "LAN worker execution is unavailable until an ignored local worker config is present."}
+      </p>
+      {!configured && <p className="state-note">{configMessage}</p>}
+      {error && <p role="alert">{error}</p>}
+      {actionStatus && <p role="status">{actionStatus}</p>}
+
+      {configured && (
+        <>
+          <dl className="compact-metrics">
+            <Metric label="Worker state" value={status ? lanWorkerStatusLabel(status) : "Ready"} />
+            <Metric
+              label="Worker output"
+              value={
+                status
+                  ? `${status.netcdf_count ?? 0} NetCDF, ${status.raw_artifact_count ?? 0} raw CM1`
+                  : "Not started"
+              }
+            />
+            <Metric
+              label="Worker runtime settings"
+              value={
+                cm1EnvSettings.length > 0
+                  ? cm1EnvSettings.join(", ")
+                  : cm1EnvKeys.length > 0
+                    ? cm1EnvKeys.join(", ")
+                    : "Default worker environment"
+              }
+            />
+            {status?.message && <Metric label="Worker message" value={status.message} />}
+          </dl>
+          <div className="button-row">
+            {!status && canStart && (
+              <button type="button" className="secondary-button" onClick={onLaunch}>
+                Run on LAN worker
+              </button>
+            )}
+            {status && status.state !== "worker_cleanup_complete" && (
+              <button type="button" className="secondary-button" onClick={onRefresh}>
+                Refresh LAN worker status
+              </button>
+            )}
+            {canCollect && (
+              <button type="button" onClick={onCollect}>
+                Retry copy-back and ingest
+              </button>
+            )}
+            {cleanupAvailable && (
+              <button type="button" onClick={onCleanup}>
+                {cleanupFailed ? "Retry LAN worker cleanup" : "Clean up LAN worker copy"}
+              </button>
+            )}
+          </div>
+          {status?.state === "ready_for_local_ingest" && !ingestedResultId && (
+            <p className="state-note">
+              Worker output is now on this MacBook. Cloud Chamber will ingest it locally and clean up
+              the worker copy after ingest succeeds.
+            </p>
+          )}
+          {cleanupComplete && (
+            <p className="state-note">LAN worker cleanup complete. Results and Explore use the MacBook-local copy.</p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
 function LocalPipelinePanel({
   inventory,
   status,
   error,
   results,
   currentRunId,
+  lanWorkerConfigured,
+  autoFinalizingWorkerRunIds,
+  failedAutoFinalizingWorkerRunIds,
   onLaunchStoredRun,
+  onLaunchStoredLanWorkerRun,
+  onRefreshStoredLanWorkerStatus,
+  onFinalizeStoredLanWorkerRun,
   onIngestStoredRun,
   onOpenStoredResult,
   onExploreStoredResult,
@@ -2892,7 +3447,13 @@ function LocalPipelinePanel({
   error: string | null;
   results: ResultCard[];
   currentRunId: string | null;
+  lanWorkerConfigured: boolean;
+  autoFinalizingWorkerRunIds: Set<string>;
+  failedAutoFinalizingWorkerRunIds: Set<string>;
   onLaunchStoredRun: (manifestPath: string) => void;
+  onLaunchStoredLanWorkerRun: (manifestPath: string) => void;
+  onRefreshStoredLanWorkerStatus: (manifestPath: string) => void;
+  onFinalizeStoredLanWorkerRun: (manifestPath: string) => void;
   onIngestStoredRun: (manifestPath: string) => void;
   onOpenStoredResult: (resultId: string) => void;
   onExploreStoredResult: (resultId: string) => void;
@@ -2934,7 +3495,13 @@ function LocalPipelinePanel({
               run={run}
               result={resultForRun(results, run.run_id)}
               current={run.run_id === currentRunId}
+              lanWorkerConfigured={lanWorkerConfigured}
+              autoFinalizing={autoFinalizingWorkerRunIds.has(run.run_id)}
+              autoFinalizeFailed={failedAutoFinalizingWorkerRunIds.has(run.run_id)}
               onLaunchStoredRun={onLaunchStoredRun}
+              onLaunchStoredLanWorkerRun={onLaunchStoredLanWorkerRun}
+              onRefreshStoredLanWorkerStatus={onRefreshStoredLanWorkerStatus}
+              onFinalizeStoredLanWorkerRun={onFinalizeStoredLanWorkerRun}
               onIngestStoredRun={onIngestStoredRun}
               onOpenStoredResult={onOpenStoredResult}
               onExploreStoredResult={onExploreStoredResult}
@@ -2951,7 +3518,13 @@ function PipelineRunCard({
   run,
   result,
   current,
+  lanWorkerConfigured,
+  autoFinalizing,
+  autoFinalizeFailed,
   onLaunchStoredRun,
+  onLaunchStoredLanWorkerRun,
+  onRefreshStoredLanWorkerStatus,
+  onFinalizeStoredLanWorkerRun,
   onIngestStoredRun,
   onOpenStoredResult,
   onExploreStoredResult,
@@ -2960,16 +3533,33 @@ function PipelineRunCard({
   run: RunStorageEntry;
   result: ResultCard | undefined;
   current: boolean;
+  lanWorkerConfigured: boolean;
+  autoFinalizing: boolean;
+  autoFinalizeFailed: boolean;
   onLaunchStoredRun: (manifestPath: string) => void;
+  onLaunchStoredLanWorkerRun: (manifestPath: string) => void;
+  onRefreshStoredLanWorkerStatus: (manifestPath: string) => void;
+  onFinalizeStoredLanWorkerRun: (manifestPath: string) => void;
   onIngestStoredRun: (manifestPath: string) => void;
   onOpenStoredResult: (resultId: string) => void;
   onExploreStoredResult: (resultId: string) => void;
   onOpenStorage: (runId?: string | null) => void;
 }) {
   const displayName = result?.name ?? run.scenario_name ?? run.scenario_id ?? run.run_id;
-  const canLaunch = Boolean(run.manifest_path && run.category === "dry_run_only");
-  const canIngest = Boolean(run.manifest_path && run.category === "completed_with_output" && !result);
+  const canLaunch = Boolean(run.manifest_path && run.category === "dry_run_only" && !run.worker_state);
+  const canRefreshWorker = Boolean(run.manifest_path && run.worker_state === "running");
+  const canFinalizeWorker = Boolean(
+    run.manifest_path && run.worker_state === "completed" && !result && autoFinalizeFailed,
+  );
+  const canIngest = Boolean(
+    run.manifest_path &&
+      !result &&
+      (run.category === "completed_with_output" || run.worker_state === "ready_for_local_ingest"),
+  );
   const stateLabel = pipelineRunStateLabel(run, result);
+  const nextStep = pipelineRunNextStep(run, result);
+  const showWorkerMessage = Boolean(run.worker_message && !run.worker_state);
+  const workerProgress = workerProgressSummary(run);
 
   return (
     <article className={current ? "pipeline-run-card current" : "pipeline-run-card"}>
@@ -2989,17 +3579,56 @@ function PipelineRunCard({
         {humanize(result?.run_size_preset ?? run.run_size_preset ?? "preset unknown")}
       </p>
       <p className="state-note">
-        {storageResultOutputSummary(run, result)} · {formatBytes(run.size_bytes)}
+        {pipelineRunOutputSummary(run, result)} · Local package {formatBytes(run.size_bytes)}
       </p>
-      <p className="state-note">{pipelineRunNextStep(run, result)}</p>
+      {workerProgress && <p className="state-note">{workerProgress}</p>}
+      {showWorkerMessage && <p className="state-note">{run.worker_message}</p>}
+      {autoFinalizing && (
+        <p className="state-note" role="status">
+          Copying worker output back and ingesting locally.
+        </p>
+      )}
+      {autoFinalizeFailed && (
+        <p className="state-note" role="alert">
+          Automatic copy-back or ingest failed. Retry when the backend and worker are reachable.
+        </p>
+      )}
+      <p className="state-note">{nextStep}</p>
       <div className="button-row">
-        {canLaunch && run.manifest_path && (
+        {canLaunch && current && run.manifest_path && (
           <button
             type="button"
             className="secondary-button"
             onClick={() => onLaunchStoredRun(run.manifest_path!)}
           >
             Run with local CM1
+          </button>
+        )}
+        {canLaunch && lanWorkerConfigured && run.manifest_path && (
+          <button
+            type="button"
+            className="secondary-button"
+            onClick={() => onLaunchStoredLanWorkerRun(run.manifest_path!)}
+          >
+            Run on LAN worker
+          </button>
+        )}
+        {canRefreshWorker && run.manifest_path && (
+          <button
+            type="button"
+            className="secondary-button"
+            onClick={() => onRefreshStoredLanWorkerStatus(run.manifest_path!)}
+          >
+            Refresh LAN worker status
+          </button>
+        )}
+        {canFinalizeWorker && run.manifest_path && (
+          <button
+            type="button"
+            className="secondary-button"
+            onClick={() => onFinalizeStoredLanWorkerRun(run.manifest_path!)}
+          >
+            Retry copy-back and ingest
           </button>
         )}
         {canIngest && run.manifest_path && (
@@ -3045,9 +3674,23 @@ function buildRunStage(
   dryRun: DryRunResponse | null,
   runStatus: RunStatusResponse | null,
   ingestedResultId: string | null,
+  lanWorkerStatus: LanWorkerRunResponse | null,
 ): BuildRunStage {
+  if (ingestedResultId && lanWorkerStatus?.state === "worker_cleanup_complete") {
+    return "worker_cleanup_complete";
+  }
+  if (ingestedResultId && lanWorkerStatus?.state === "worker_cleanup_failed") {
+    return "worker_cleanup_failed";
+  }
+  if (ingestedResultId && lanWorkerStatus) return "worker_cleanup_pending";
   if (ingestedResultId) return "ingested";
   if (!dryRun) return "not_packaged";
+  if (lanWorkerStatus?.state === "running") return "lan_worker_running";
+  if (lanWorkerStatus?.state === "completed") return "lan_worker_completed";
+  if (lanWorkerStatus?.state === "ready_for_local_ingest") return "ready_for_local_ingest";
+  if (lanWorkerStatus?.state === "failed" || lanWorkerStatus?.state === "completed_no_output") {
+    return "failed";
+  }
   if (!runStatus) return "package_ready";
   if (runStatus.lifecycle_state === "queued" || runStatus.lifecycle_state === "running") {
     return "running";
@@ -3063,17 +3706,62 @@ function buildStageLabel(stage: BuildRunStage): string {
   const labels: Record<BuildRunStage, string> = {
     not_packaged: "Not packaged yet",
     package_ready: "Package ready",
+    lan_worker_running: "Running on LAN worker",
+    lan_worker_completed: "Ready to copy back",
+    ready_for_local_ingest: "Ready to ingest",
     running: "Running",
     completed: "Completed",
     failed: "Failed",
     ingested: "Ingested",
+    worker_cleanup_pending: "Cleanup pending",
+    worker_cleanup_complete: "Worker cleanup complete",
+    worker_cleanup_failed: "Cleanup retry needed",
   };
   return labels[stage];
 }
 
 function buildStageTone(stage: BuildRunStage): "good" | "warning" | "neutral" {
   if (stage === "completed" || stage === "ingested") return "good";
-  if (stage === "failed") return "warning";
+  if (stage === "ready_for_local_ingest" || stage === "worker_cleanup_complete") return "good";
+  if (stage === "failed" || stage === "worker_cleanup_failed") return "warning";
+  return "neutral";
+}
+
+function lanWorkerStatusLabel(status: LanWorkerRunResponse): string {
+  const labels: Record<string, string> = {
+    running: "Running CM1 on LAN worker",
+    completed: "Worker completed with output",
+    completed_no_output: "Worker completed with no output",
+    failed: "LAN worker failed",
+    copied_back_to_mac: "Copied back to MacBook",
+    ready_for_local_ingest: "Completed output ready to ingest",
+    worker_cleanup_pending: "Worker cleanup pending",
+    worker_cleanup_complete: "LAN worker cleanup complete",
+    worker_cleanup_failed: "LAN worker cleanup failed",
+  };
+  return labels[status.state] ?? humanize(status.state);
+}
+
+function lanWorkerTone(
+  status: LanWorkerRunResponse | null,
+  configured: boolean,
+): "good" | "warning" | "neutral" {
+  if (!configured) return "neutral";
+  if (!status) return "neutral";
+  if (
+    status.state === "completed" ||
+    status.state === "ready_for_local_ingest" ||
+    status.state === "worker_cleanup_complete"
+  ) {
+    return "good";
+  }
+  if (
+    status.state === "failed" ||
+    status.state === "completed_no_output" ||
+    status.state === "worker_cleanup_failed"
+  ) {
+    return "warning";
+  }
   return "neutral";
 }
 
@@ -3117,6 +3805,17 @@ function selectPipelineRuns(
 
 function pipelineRunStateLabel(run: RunStorageEntry, result: ResultCard | undefined): string {
   if (result) return "Ready to review";
+  if (run.worker_state) {
+    return lanWorkerStatusLabel({
+      run_id: run.run_id,
+      state: run.worker_state,
+      message: run.worker_message,
+      started_at: run.worker_started_at,
+      finished_at: run.worker_finished_at,
+      netcdf_count: run.worker_netcdf_count ?? 0,
+      raw_artifact_count: run.worker_raw_artifact_count ?? 0,
+    });
+  }
   const labels: Record<string, string> = {
     dry_run_only: "Ready to run",
     running: "Running",
@@ -3137,6 +3836,20 @@ function pipelineRunTone(
   result: ResultCard | undefined,
 ): "good" | "warning" | "neutral" {
   if (result?.saved || result?.protected || result) return "good";
+  if (run.worker_state) {
+    return lanWorkerTone(
+      {
+        run_id: run.run_id,
+        state: run.worker_state,
+        message: run.worker_message,
+        started_at: run.worker_started_at,
+        finished_at: run.worker_finished_at,
+        netcdf_count: run.worker_netcdf_count ?? 0,
+        raw_artifact_count: run.worker_raw_artifact_count ?? 0,
+      },
+      true,
+    );
+  }
   if (run.category === "completed_with_output") return "good";
   if (
     run.category === "failed" ||
@@ -3152,6 +3865,14 @@ function pipelineRunTone(
 
 function pipelineRunNextStep(run: RunStorageEntry, result: ResultCard | undefined): string {
   if (result) return "Review in Results or Explore fields; cleanup remains available in Storage.";
+  if (run.worker_state === "running") return "CM1 is running on the LAN worker; refresh runs for status.";
+  if (run.worker_state === "completed") {
+    return "LAN worker output is complete; Cloud Chamber will copy it back, ingest locally, and clean up the worker copy.";
+  }
+  if (run.worker_state === "ready_for_local_ingest") {
+    return "Worker output is on this MacBook; ingest it locally before worker cleanup.";
+  }
+  if (run.worker_message) return run.worker_message;
   if (run.category === "dry_run_only") return "Ready to run after CM1 checks.";
   if (run.category === "running") return "CM1 is active or queued; refresh runs for status.";
   if (run.category === "completed_with_output") {
@@ -3167,6 +3888,58 @@ function pipelineRunNextStep(run: RunStorageEntry, result: ResultCard | undefine
     return "Run directory needs cleanup review before trusting it.";
   }
   return "Review in Storage for the safest next action.";
+}
+
+function workerProgressSummary(run: RunStorageEntry): string | null {
+  if (!run.worker_state) return null;
+  const parts: string[] = [];
+  if (run.worker_status_updated_at) {
+    parts.push(`Last checked ${formatShortTime(run.worker_status_updated_at)}`);
+  }
+  if (run.worker_state === "running") {
+    const estimate = workerEstimatedFinish(run);
+    if (estimate) parts.push(estimate);
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+function workerEstimatedFinish(run: RunStorageEntry): string | null {
+  if (!run.worker_started_at) return null;
+  const expectedFrames = expectedOutputFramesForPreset(run.run_size_preset);
+  if (!expectedFrames) return null;
+  const netcdfCount = run.worker_netcdf_count ?? 0;
+  const observedModelFrames = Math.max(0, netcdfCount - 1);
+  if (observedModelFrames < 2 || observedModelFrames >= expectedFrames) return null;
+  const startedAt = Date.parse(run.worker_started_at);
+  if (!Number.isFinite(startedAt)) return null;
+  const elapsedMs = Date.now() - startedAt;
+  if (elapsedMs <= 0) return null;
+  const totalMs = (elapsedMs / observedModelFrames) * expectedFrames;
+  const remainingMs = totalMs - elapsedMs;
+  if (!Number.isFinite(remainingMs) || remainingMs <= 0) return null;
+  return `Approx finish ${formatDurationFromNow(remainingMs)} (${observedModelFrames}/${expectedFrames} output frames)`;
+}
+
+function expectedOutputFramesForPreset(preset: string | null): number | null {
+  if (preset === "quick_look") return 13;
+  if (preset === "standard") return 7;
+  if (preset === "deep_overnight") return 73;
+  return null;
+}
+
+function formatShortTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit", second: "2-digit" });
+}
+
+function formatDurationFromNow(durationMs: number): string {
+  const totalMinutes = Math.max(1, Math.round(durationMs / 60000));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours <= 0) return `in about ${minutes} min`;
+  if (minutes === 0) return `in about ${hours} hr`;
+  return `in about ${hours} hr ${minutes} min`;
 }
 
 function selectedControlOption(
@@ -6191,6 +6964,18 @@ function storageOutputSummary(run: RunStorageEntry): string {
 function storageResultOutputSummary(run: RunStorageEntry, result: ResultCard | undefined): string {
   if (result) return outputSummary(result.output_file_summary);
   return storageOutputSummary(run);
+}
+
+function pipelineRunOutputSummary(run: RunStorageEntry, result: ResultCard | undefined): string {
+  if (result) return outputSummary(result.output_file_summary);
+  if (!run.worker_state) return storageOutputSummary(run);
+  const netcdf = run.worker_netcdf_count ?? 0;
+  const raw = run.worker_raw_artifact_count ?? 0;
+  if (netcdf === 0 && raw === 0) return "Worker output not detected yet";
+  const parts = [];
+  if (netcdf > 0) parts.push(`${netcdf} remote NetCDF files`);
+  if (raw > 0) parts.push(`${raw} remote raw CM1 files`);
+  return parts.join(", ");
 }
 
 function resultForRun(results: ResultCard[], runId: string): ResultCard | undefined {

--- a/scripts/lan_worker_run.py
+++ b/scripts/lan_worker_run.py
@@ -332,6 +332,20 @@ def start_worker_run(args: argparse.Namespace) -> None:
         "printf '%s\\n' worker_run_started"
     )
     run_command((*config.ssh_command, config.host, remote_start))
+    mark_local_worker_status(
+        package.package_dir,
+        "running",
+        "Package copied to the LAN worker and CM1 launch was requested.",
+        {
+            "run_id": package.run_id,
+            "remote_dir": remote_dir,
+            "cm1_exe": config.cm1_exe,
+            "cm1_command": config.cm1_command or config.cm1_exe,
+            "cm1_env": config.cm1_env or {},
+            "netcdf_count": 0,
+            "raw_artifact_count": 0,
+        },
+    )
     print(json.dumps({"run_id": package.run_id, "remote_dir": remote_dir, "state": "started"}))
 
 
@@ -339,7 +353,36 @@ def print_worker_status(args: argparse.Namespace) -> None:
     config = load_worker_config(config_path=args.worker_config)
     package = validate_package(args.package_dir, args.runtime_home)
     status = fetch_worker_status(config, package.run_id)
+    status_path = package.package_dir / "worker_status.json"
+    local_status = _read_json(status_path) if status_path.exists() else {}
+    local_state = str(local_status.get("state") or "")
+    if _preserve_local_worker_state(local_state, status.state):
+        print(json.dumps(local_status, indent=2, sort_keys=True))
+        return
+
+    mark_local_worker_status(
+        package.package_dir,
+        status.state,
+        status.message or "LAN worker status refreshed.",
+        status.__dict__,
+    )
     print(json.dumps(status.__dict__, indent=2, sort_keys=True))
+
+
+def _preserve_local_worker_state(local_state: str, remote_state: str) -> bool:
+    local_states_after_copy_back = {
+        "copied_back_to_mac",
+        "ready_for_local_ingest",
+        "local_ingest_confirmed",
+        "worker_cleanup_pending",
+        "worker_cleanup_complete",
+        "worker_cleanup_failed",
+    }
+    return local_state in local_states_after_copy_back and remote_state in {
+        "completed",
+        "completed_no_output",
+        "failed",
+    }
 
 
 def collect_worker_run(args: argparse.Namespace) -> None:
@@ -645,8 +688,34 @@ exit "$exit_code"
 
 def fetch_worker_status(config: WorkerConfig, run_id: str) -> WorkerStatus:
     remote_dir = remote_run_dir(config, run_id)
+    remote_dir_q = shlex.quote(remote_dir)
+    command = f"""python3 - {remote_dir_q} <<'PY'
+import glob
+import json
+import sys
+from pathlib import Path
+
+run_dir = Path(sys.argv[1])
+status_path = run_dir / "worker_status.json"
+data = json.loads(status_path.read_text())
+data["netcdf_count"] = len(
+    set(
+        str(path)
+        for pattern in ("*.nc", "*.nc4", "*.cdf", "*.netcdf")
+        for path in run_dir.glob(pattern)
+    )
+)
+data["raw_artifact_count"] = len(
+    set(
+        str(path)
+        for pattern in ("cm1out_*.dat", "cm1out_*.ctl")
+        for path in run_dir.glob(pattern)
+    )
+)
+print(json.dumps(data, sort_keys=True))
+PY"""
     result = run_command(
-        (*config.ssh_command, config.host, f"cat {shlex.quote(remote_dir)}/worker_status.json"),
+        (*config.ssh_command, config.host, command),
         capture=True,
     )
     data = json.loads(result.stdout)
@@ -699,12 +768,19 @@ def verify_returned_run(returned_dir: Path, expected_run_id: str) -> None:
         )
 
 
-def mark_local_worker_status(package_dir: Path, state: str, message: str) -> None:
+def mark_local_worker_status(
+    package_dir: Path,
+    state: str,
+    message: str,
+    extra: dict[str, Any] | None = None,
+) -> None:
     status_path = package_dir / "worker_status.json"
     data = _read_json(status_path) if status_path.exists() else {}
     previous_state = data.get("state")
     if previous_state and previous_state != state:
         data["previous_state"] = previous_state
+    if extra:
+        data.update(extra)
     data.update(
         {
             "state": state,
@@ -748,8 +824,6 @@ def update_local_manifest_after_return(package: PackageInfo, status: WorkerStatu
     execution.update(
         {
             "command": command,
-            "lan_worker_cm1_exe": status.cm1_exe,
-            "lan_worker_cm1_env": status.cm1_env or {},
             "started_at": _normalize_datetime(status.started_at),
             "finished_at": _normalize_datetime(status.finished_at) or now,
             "exit_code": exit_code,


### PR DESCRIPTION
## Issue worked
Closes #228

## Summary
- Add backend LAN worker API endpoints for config, start, status, collect, and cleanup.
- Surface LAN worker state in runtime storage inventory, including remote output counts and last status refresh.
- Update Build's local pipeline to launch LAN worker runs, refresh worker status, auto copy back completed output, ingest locally, and clean up the worker copy after ingest succeeds.
- Keep cleanup/destructive behavior routed through safe worker cleanup logic and preserve MacBook-local ingest as the system of record.
- Show LAN worker runtime settings, remote output counts, last checked time, and an approximate finish estimate for active worker runs.

## Tests added/updated
- Backend API coverage for LAN worker config/status/start/collect/cleanup behavior and sanitized worker settings.
- Frontend coverage for Build pipeline worker states and automatic collect -> ingest -> cleanup behavior.
- Existing Playwright mocked smoke suite covers Build/Results/Explore reachability and lifecycle workflows.

## Commands run
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Manual QA needed
No broad manual checklist. Qualitative question: does the Build pipeline make the worker run state understandable while keeping cleanup/destructive action boundaries clear?

## Caveats / follow-up
- A real Deep Overnight LAN worker run is still running separately (`dry-run-accbd2122ff6`). If real collect/ingest/cleanup exposes a gap after completion, patch it in a focused follow-up.
- Approximate finish time is derived from observed remote NetCDF output-frame progress and is intentionally labeled approximate.

## Generated-artifact check
No generated CM1 output, NetCDF files, runtime folders, logs, screenshots, videos, traces, SSH keys, hostnames, IPs, or secrets are committed.
