### PR TITLE
Add interesting-time output products and Results science summary

### DIFF
--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -17,6 +17,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from cloud_chamber.result_diagnostics import ResultDiagnostics, TimeValue
+
 OUTPUT_PRODUCT_MANIFEST_VERSION = 1
 DERIVED_PRODUCTS_DIRNAME = "derived-products"
 OUTPUT_PRODUCT_MANIFEST_FILENAME = "output_product_manifest.json"
@@ -27,6 +29,13 @@ TIME_COORDINATE_CANDIDATES = ("time", "mtime", "t")
 
 SourceFileKind = Literal["model_output_netcdf", "stats_netcdf", "raw_cm1_artifact"]
 TimeSource = Literal["netcdf_time_coordinate", "inferred_filename_order"]
+InterestingTimeSupportState = Literal[
+    "supported",
+    "fallback",
+    "unavailable",
+    "unsupported_missing_fields",
+    "unsupported_missing_diagnostic",
+]
 
 
 class OutputProductManifestError(RuntimeError):
@@ -73,6 +82,79 @@ class OutputProductProvenance(BaseModel):
     )
 
 
+class InterestingTimeProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_model: str = "CM1"
+    processing_method: str = "backend_output_product_interesting_times"
+    provenance_label: str = (
+        "CM1-derived interesting-time product; backend diagnostics plus output "
+        "manifest time-index mapping; raw NetCDF stays backend-owned"
+    )
+
+
+class InterestingTimeRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    label: str
+    time_index: int | None = None
+    time_seconds: float | None = None
+    source_time_value: float | str | None = None
+    source_field: str | None = None
+    source_diagnostic: str | None = None
+    value: float | bool | None = None
+    units: str | None = None
+    support_state: InterestingTimeSupportState
+    provenance: InterestingTimeProvenance = Field(default_factory=InterestingTimeProvenance)
+    caveats: list[str] = Field(default_factory=list)
+    fallback_reason: str | None = None
+
+
+class FieldDefaultTime(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    time_index: int | None = None
+    time_seconds: float | None = None
+    source_interesting_time_key: str
+    support_state: InterestingTimeSupportState
+    fallback_reason: str | None = None
+    caveats: list[str] = Field(default_factory=list)
+
+
+class ScienceSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    first_cloud_time_seconds: float | None = None
+    first_cloud_time_label: str | None = None
+    max_qc_kg_kg: float | None = None
+    max_qc_time_seconds: float | None = None
+    max_updraft_w_m_s: float | None = None
+    max_updraft_time_seconds: float | None = None
+    min_downdraft_w_m_s: float | None = None
+    min_downdraft_time_seconds: float | None = None
+    highest_cloud_top_m: float | None = None
+    rain_onset_time_seconds: float | None = None
+    max_qr_kg_kg: float | None = None
+    latest_output_time_seconds: float | None = None
+    default_explore_time_index: int | None = None
+    default_explore_time_seconds: float | None = None
+    interesting_time_caveats: list[str] = Field(default_factory=list)
+    interesting_time_support_state: str = "unavailable"
+
+
+class InterestingTimeProduct(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    available_interesting_times: list[InterestingTimeRecord]
+    default_time_by_field: dict[str, FieldDefaultTime] = Field(default_factory=dict)
+    science_summary: ScienceSummary
+    caveats: list[str] = Field(default_factory=list)
+    provenance: InterestingTimeProvenance = Field(default_factory=InterestingTimeProvenance)
+
+
 class OutputProductManifest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -86,6 +168,7 @@ class OutputProductManifest(BaseModel):
     source_run_manifest_path: str | None = None
     source_raw_outputs: SourceRawOutputs
     time_index: list[OutputTimeIndexEntry]
+    interesting_time_product: InterestingTimeProduct | None = None
     cache: OutputProductCache
     provenance: OutputProductProvenance = Field(default_factory=OutputProductProvenance)
     caveats: list[str] = Field(default_factory=list)
@@ -323,6 +406,521 @@ def resolve_time_index(manifest: OutputProductManifest, time_index: int) -> Reso
                 time_caveats=entry.time_caveats,
             )
     raise OutputProductManifestError(f"time_index is not available: {time_index}")
+
+
+def build_interesting_time_product(
+    *,
+    result_id: str,
+    diagnostics: ResultDiagnostics | None,
+    output_manifest: OutputProductManifest,
+    variables: list[str],
+) -> InterestingTimeProduct:
+    """Build small science time landmarks from diagnostics and manifest time mapping."""
+    records = _interesting_time_records(
+        diagnostics=diagnostics,
+        output_manifest=output_manifest,
+        variables=set(variables),
+    )
+    defaults = _field_defaults(records)
+    summary = _science_summary(diagnostics, output_manifest, records, defaults)
+    caveats = _dedupe(
+        [
+            *(output_manifest.caveats or []),
+            *(diagnostics.caveats if diagnostics else []),
+            *(caveat for record in records for caveat in record.caveats),
+            *(caveat for default in defaults.values() for caveat in default.caveats),
+        ]
+    )
+    return InterestingTimeProduct(
+        result_id=result_id,
+        available_interesting_times=records,
+        default_time_by_field=defaults,
+        science_summary=summary.model_copy(update={"interesting_time_caveats": caveats}),
+        caveats=caveats,
+    )
+
+
+def _interesting_time_records(
+    *,
+    diagnostics: ResultDiagnostics | None,
+    output_manifest: OutputProductManifest,
+    variables: set[str],
+) -> list[InterestingTimeRecord]:
+    latest = _latest_time_record(output_manifest)
+    if diagnostics is None:
+        return [
+            _unavailable_record(
+                key="first_cloud",
+                label="First cloud",
+                source_field="qc",
+                source_diagnostic="diagnostics.cloud.first_cloud_time_seconds",
+                support_state="unsupported_missing_diagnostic",
+                caveat="diagnostics_unavailable",
+            ),
+            latest,
+            _field_default_record(latest, fallback_reason="diagnostics_unavailable"),
+        ]
+
+    cloud = diagnostics.cloud
+    vertical = diagnostics.vertical_velocity
+    rain = diagnostics.rain
+    records = [
+        _event_record(
+            key="first_cloud",
+            label="First cloud",
+            time_seconds=cloud.first_cloud_time_seconds
+            if cloud.available and cloud.formed
+            else None,
+            source_field="qc",
+            source_diagnostic="diagnostics.cloud.first_cloud_time_seconds",
+            value=cloud.formed if cloud.available else None,
+            units=None,
+            output_manifest=output_manifest,
+            unavailable_caveat="no_cloud_formed" if cloud.available else "missing_qc_field",
+            support_state="unavailable" if cloud.available else "unsupported_missing_fields",
+        ),
+        _event_record(
+            key="max_qc",
+            label="Max cloud water",
+            time_seconds=cloud.time_of_max_qc_seconds
+            if cloud.available and _positive(cloud.max_qc_kg_kg)
+            else None,
+            source_field="qc",
+            source_diagnostic="diagnostics.cloud.max_qc_kg_kg",
+            value=cloud.max_qc_kg_kg if cloud.available else None,
+            units="kg/kg",
+            output_manifest=output_manifest,
+            unavailable_caveat="no_positive_cloud_water_detected"
+            if cloud.available
+            else "missing_qc_field",
+            support_state="unavailable" if cloud.available else "unsupported_missing_fields",
+        ),
+        _series_max_record(
+            key="highest_cloud_top",
+            label="Highest cloud top",
+            series=cloud.cloud_top_time_series if cloud.available else [],
+            source_field="qc",
+            source_diagnostic="diagnostics.cloud.cloud_top_time_series",
+            units="m",
+            output_manifest=output_manifest,
+            unavailable_caveat="no_cloud_top_detected" if cloud.available else "missing_qc_field",
+            support_state="unavailable" if cloud.available else "unsupported_missing_fields",
+        ),
+        _event_record(
+            key="max_updraft_w",
+            label="Max updraft",
+            time_seconds=vertical.time_of_max_w_seconds if vertical.available else None,
+            source_field="w",
+            source_diagnostic="diagnostics.vertical_velocity.max_w_m_s",
+            value=vertical.max_w_m_s if vertical.available else None,
+            units=vertical.units or "m/s",
+            output_manifest=output_manifest,
+            unavailable_caveat="missing_w_field",
+            support_state="unsupported_missing_fields",
+        ),
+        _event_record(
+            key="min_downdraft_w",
+            label="Min downdraft",
+            time_seconds=vertical.time_of_min_w_seconds if vertical.available else None,
+            source_field="w",
+            source_diagnostic="diagnostics.vertical_velocity.min_w_m_s",
+            value=vertical.min_w_m_s if vertical.available else None,
+            units=vertical.units or "m/s",
+            output_manifest=output_manifest,
+            unavailable_caveat="missing_w_field",
+            support_state="unsupported_missing_fields",
+        ),
+        _event_record(
+            key="rain_onset",
+            label="Rain onset",
+            time_seconds=rain.first_rain_time_seconds if rain.available and rain.present else None,
+            source_field="qr",
+            source_diagnostic="diagnostics.rain.first_rain_time_seconds",
+            value=rain.present if rain.available else None,
+            units=None,
+            output_manifest=output_manifest,
+            unavailable_caveat="no_rain_detected"
+            if rain.available
+            else ("missing_qr_field" if rain.field_absent else "rain_diagnostics_unavailable"),
+            support_state="unavailable" if rain.available else "unsupported_missing_fields",
+        ),
+        _event_record(
+            key="max_qr",
+            label="Max rain water",
+            time_seconds=rain.time_of_max_qr_seconds
+            if rain.available and _positive(rain.max_qr_kg_kg)
+            else None,
+            source_field="qr",
+            source_diagnostic="diagnostics.rain.max_qr_kg_kg",
+            value=rain.max_qr_kg_kg if rain.available else None,
+            units="kg/kg",
+            output_manifest=output_manifest,
+            unavailable_caveat="no_rain_water_detected"
+            if rain.available
+            else ("missing_qr_field" if rain.field_absent else "rain_diagnostics_unavailable"),
+            support_state="unavailable" if rain.available else "unsupported_missing_fields",
+        ),
+        _unsupported_field_record(
+            key="max_dbz",
+            label="Max reflectivity",
+            source_field="dbz",
+            source_diagnostic="diagnostics.reflectivity.max_dbz",
+            field_present="dbz" in variables,
+        ),
+        _unsupported_field_record(
+            key="max_surface_rain",
+            label="Max surface rain",
+            source_field="rain",
+            source_diagnostic="diagnostics.surface_rain.max_surface_rain",
+            field_present="rain" in variables,
+        ),
+        latest,
+    ]
+    records.append(_field_default_record(_default_source_record(records), fallback_reason=None))
+    return records
+
+
+def _event_record(
+    *,
+    key: str,
+    label: str,
+    time_seconds: float | None,
+    source_field: str,
+    source_diagnostic: str,
+    value: float | bool | None,
+    units: str | None,
+    output_manifest: OutputProductManifest,
+    unavailable_caveat: str,
+    support_state: InterestingTimeSupportState,
+) -> InterestingTimeRecord:
+    if time_seconds is None:
+        return _unavailable_record(
+            key=key,
+            label=label,
+            source_field=source_field,
+            source_diagnostic=source_diagnostic,
+            support_state=support_state,
+            caveat=unavailable_caveat,
+            value=value,
+            units=units,
+        )
+    resolved, caveats = _resolve_time_seconds(output_manifest, time_seconds)
+    if resolved is None:
+        return _unavailable_record(
+            key=key,
+            label=label,
+            source_field=source_field,
+            source_diagnostic=source_diagnostic,
+            support_state="unavailable",
+            caveat=f"time_not_found_in_output_manifest:{time_seconds:g}",
+            value=value,
+            units=units,
+        )
+    return InterestingTimeRecord(
+        key=key,
+        label=label,
+        time_index=resolved.time_index,
+        time_seconds=resolved.time_seconds,
+        source_time_value=resolved.source_time_value,
+        source_field=source_field,
+        source_diagnostic=source_diagnostic,
+        value=value,
+        units=units,
+        support_state="supported",
+        caveats=_dedupe([*resolved.time_caveats, *caveats]),
+    )
+
+
+def _series_max_record(
+    *,
+    key: str,
+    label: str,
+    series: list[TimeValue],
+    source_field: str,
+    source_diagnostic: str,
+    units: str,
+    output_manifest: OutputProductManifest,
+    unavailable_caveat: str,
+    support_state: InterestingTimeSupportState,
+) -> InterestingTimeRecord:
+    candidates = [point for point in series if point.value is not None]
+    if not candidates:
+        return _unavailable_record(
+            key=key,
+            label=label,
+            source_field=source_field,
+            source_diagnostic=source_diagnostic,
+            support_state=support_state,
+            caveat=unavailable_caveat,
+            units=units,
+        )
+    highest = max(
+        candidates, key=lambda point: point.value if point.value is not None else -math.inf
+    )
+    return _event_record(
+        key=key,
+        label=label,
+        time_seconds=highest.time_seconds,
+        source_field=source_field,
+        source_diagnostic=source_diagnostic,
+        value=highest.value,
+        units=units,
+        output_manifest=output_manifest,
+        unavailable_caveat=unavailable_caveat,
+        support_state=support_state,
+    )
+
+
+def _latest_time_record(output_manifest: OutputProductManifest) -> InterestingTimeRecord:
+    if not output_manifest.time_index:
+        return _unavailable_record(
+            key="latest_output",
+            label="Latest output",
+            source_diagnostic="output_manifest.time_index",
+            support_state="unavailable",
+            caveat="time_index_unavailable",
+        )
+    latest = output_manifest.time_index[-1]
+    return InterestingTimeRecord(
+        key="latest_output",
+        label="Latest output",
+        time_index=latest.time_index,
+        time_seconds=latest.time_seconds,
+        source_time_value=latest.source_time_value,
+        source_diagnostic="output_manifest.time_index",
+        support_state="supported",
+        caveats=list(latest.time_caveats),
+    )
+
+
+def _field_default_record(
+    source_record: InterestingTimeRecord,
+    *,
+    fallback_reason: str | None,
+) -> InterestingTimeRecord:
+    fallback = fallback_reason or (
+        None if source_record.support_state == "supported" else "no_supported_science_landmark"
+    )
+    return InterestingTimeRecord(
+        key="field_default_time",
+        label="Default Explore time",
+        time_index=source_record.time_index,
+        time_seconds=source_record.time_seconds,
+        source_time_value=source_record.source_time_value,
+        source_field=source_record.source_field,
+        source_diagnostic=source_record.source_diagnostic,
+        value=source_record.value,
+        units=source_record.units,
+        support_state="supported" if fallback is None else "fallback",
+        caveats=list(source_record.caveats),
+        fallback_reason=fallback,
+    )
+
+
+def _unsupported_field_record(
+    *,
+    key: str,
+    label: str,
+    source_field: str,
+    source_diagnostic: str,
+    field_present: bool,
+) -> InterestingTimeRecord:
+    return _unavailable_record(
+        key=key,
+        label=label,
+        source_field=source_field,
+        source_diagnostic=source_diagnostic,
+        support_state="unsupported_missing_diagnostic"
+        if field_present
+        else "unsupported_missing_fields",
+        caveat=(
+            f"{source_field}_interesting_time_diagnostic_not_implemented"
+            if field_present
+            else f"missing_{source_field}_field"
+        ),
+    )
+
+
+def _unavailable_record(
+    *,
+    key: str,
+    label: str,
+    source_field: str | None = None,
+    source_diagnostic: str | None = None,
+    support_state: InterestingTimeSupportState,
+    caveat: str,
+    value: float | bool | None = None,
+    units: str | None = None,
+) -> InterestingTimeRecord:
+    return InterestingTimeRecord(
+        key=key,
+        label=label,
+        source_field=source_field,
+        source_diagnostic=source_diagnostic,
+        value=value,
+        units=units,
+        support_state=support_state,
+        caveats=[caveat],
+    )
+
+
+def _field_defaults(
+    records: list[InterestingTimeRecord],
+) -> dict[str, FieldDefaultTime]:
+    by_key = {record.key: record for record in records}
+    latest = by_key.get("latest_output")
+    defaults: dict[str, FieldDefaultTime] = {}
+    choices = {
+        "qc": ("max_qc", "first_cloud"),
+        "w": ("max_updraft_w",),
+        "qr": ("rain_onset", "max_qr"),
+        "dbz": ("max_dbz",),
+    }
+    for field, keys in choices.items():
+        source = next(
+            (
+                by_key[key]
+                for key in keys
+                if by_key.get(key) and by_key[key].support_state == "supported"
+            ),
+            None,
+        )
+        fallback_reason = None
+        if source is None:
+            source = latest
+            fallback_reason = f"no_supported_{field}_interesting_time"
+        if source is None:
+            continue
+        defaults[field] = FieldDefaultTime(
+            field=field,
+            time_index=source.time_index,
+            time_seconds=source.time_seconds,
+            source_interesting_time_key=source.key,
+            support_state="supported" if fallback_reason is None else "fallback",
+            fallback_reason=fallback_reason,
+            caveats=list(source.caveats),
+        )
+    return defaults
+
+
+def _science_summary(
+    diagnostics: ResultDiagnostics | None,
+    output_manifest: OutputProductManifest,
+    records: list[InterestingTimeRecord],
+    defaults: dict[str, FieldDefaultTime],
+) -> ScienceSummary:
+    record_by_key = {record.key: record for record in records}
+    default_record = record_by_key.get("field_default_time")
+    latest = record_by_key.get("latest_output")
+    qc_default = defaults.get("qc")
+    if diagnostics is None:
+        return ScienceSummary(
+            latest_output_time_seconds=latest.time_seconds if latest else None,
+            default_explore_time_index=default_record.time_index if default_record else None,
+            default_explore_time_seconds=default_record.time_seconds if default_record else None,
+            interesting_time_support_state="fallback",
+        )
+    supported_science_keys = {
+        "first_cloud",
+        "max_qc",
+        "highest_cloud_top",
+        "max_updraft_w",
+        "min_downdraft_w",
+        "rain_onset",
+        "max_qr",
+        "max_dbz",
+        "max_surface_rain",
+    }
+    supported_count = sum(
+        1
+        for record in records
+        if record.key in supported_science_keys and record.support_state == "supported"
+    )
+    support_state = "supported" if supported_count > 0 else "fallback"
+    return ScienceSummary(
+        first_cloud_time_seconds=diagnostics.cloud.first_cloud_time_seconds,
+        first_cloud_time_label=_format_time_label(diagnostics.cloud.first_cloud_time_seconds),
+        max_qc_kg_kg=diagnostics.cloud.max_qc_kg_kg if diagnostics.cloud.available else None,
+        max_qc_time_seconds=diagnostics.cloud.time_of_max_qc_seconds
+        if record_by_key.get("max_qc", None)
+        and record_by_key["max_qc"].support_state == "supported"
+        else None,
+        max_updraft_w_m_s=diagnostics.vertical_velocity.max_w_m_s
+        if diagnostics.vertical_velocity.available
+        else None,
+        max_updraft_time_seconds=diagnostics.vertical_velocity.time_of_max_w_seconds,
+        min_downdraft_w_m_s=diagnostics.vertical_velocity.min_w_m_s
+        if diagnostics.vertical_velocity.available
+        else None,
+        min_downdraft_time_seconds=diagnostics.vertical_velocity.time_of_min_w_seconds,
+        highest_cloud_top_m=_record_value(record_by_key.get("highest_cloud_top")),
+        rain_onset_time_seconds=diagnostics.rain.first_rain_time_seconds,
+        max_qr_kg_kg=diagnostics.rain.max_qr_kg_kg if diagnostics.rain.available else None,
+        latest_output_time_seconds=latest.time_seconds
+        if latest
+        else _latest_manifest_time(output_manifest),
+        default_explore_time_index=qc_default.time_index
+        if qc_default is not None
+        else (default_record.time_index if default_record else None),
+        default_explore_time_seconds=qc_default.time_seconds
+        if qc_default is not None
+        else (default_record.time_seconds if default_record else None),
+        interesting_time_support_state=support_state,
+    )
+
+
+def _default_source_record(records: list[InterestingTimeRecord]) -> InterestingTimeRecord:
+    by_key = {record.key: record for record in records}
+    for key in ("first_cloud", "max_qc", "max_updraft_w"):
+        record = by_key.get(key)
+        if record and record.support_state == "supported":
+            return record
+    return by_key["latest_output"]
+
+
+def _resolve_time_seconds(
+    manifest: OutputProductManifest, time_seconds: float
+) -> tuple[OutputTimeIndexEntry | None, list[str]]:
+    if not manifest.time_index:
+        return None, ["time_index_unavailable"]
+    direct = [entry for entry in manifest.time_index if entry.time_seconds == time_seconds]
+    if direct:
+        caveats: list[str] = []
+        if len(direct) > 1:
+            caveats.append(f"duplicate_interesting_time_seconds:{time_seconds:g}")
+        return direct[0], caveats
+    nearest = min(
+        (entry for entry in manifest.time_index if entry.time_seconds is not None),
+        key=lambda entry: abs((entry.time_seconds or 0.0) - time_seconds),
+        default=None,
+    )
+    if nearest is None:
+        return None, ["time_index_has_no_numeric_times"]
+    if abs((nearest.time_seconds or 0.0) - time_seconds) <= 1e-6:
+        return nearest, []
+    return None, [f"time_not_found_in_output_manifest:{time_seconds:g}"]
+
+
+def _latest_manifest_time(manifest: OutputProductManifest) -> float | None:
+    if not manifest.time_index:
+        return None
+    return manifest.time_index[-1].time_seconds
+
+
+def _record_value(record: InterestingTimeRecord | None) -> float | None:
+    if record is None or record.support_state != "supported":
+        return None
+    return float(record.value) if isinstance(record.value, (int, float)) else None
+
+
+def _positive(value: float | None) -> bool:
+    return value is not None and math.isfinite(value) and value > 0.0
+
+
+def _format_time_label(time_seconds: float | None) -> str | None:
+    if time_seconds is None:
+        return None
+    return f"{time_seconds:g} s"
 
 
 def _time_entries_for_file(path: Path, file_order: int) -> list[OutputTimeIndexEntry]:

--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from cloud_chamber.output_products import FieldDefaultTime, InterestingTimeRecord, ScienceSummary
 from cloud_chamber.result_ingest import (
     RESULT_METADATA_FILENAME,
     ResultIngestError,
@@ -97,6 +98,10 @@ class ResultCard(BaseModel):
     time_of_min_w_seconds: float | None = None
     rain_present: bool | None = None
     first_rain_time_seconds: float | None = None
+    interesting_times: list[InterestingTimeRecord] = Field(default_factory=list)
+    default_time_by_field: dict[str, FieldDefaultTime] = Field(default_factory=dict)
+    science_summary: ScienceSummary | None = None
+    interesting_time_caveats: list[str] = Field(default_factory=list)
     caveats: list[str] = Field(default_factory=list)
     output_file_summary: OutputFileSummary
     created_at: datetime
@@ -223,6 +228,10 @@ def _card_from_metadata(
         else None,
         rain_present=rain.present if rain else None,
         first_rain_time_seconds=rain.first_rain_time_seconds if rain else None,
+        interesting_times=metadata.interesting_times,
+        default_time_by_field=metadata.default_time_by_field,
+        science_summary=metadata.science_summary,
+        interesting_time_caveats=metadata.interesting_time_caveats,
         caveats=_dedupe(caveats),
         output_file_summary=_output_file_summary(metadata),
         created_at=metadata.created_at,

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -12,6 +12,10 @@ from typing import Any, cast
 from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.output_products import (
+    FieldDefaultTime,
+    InterestingTimeRecord,
+    ScienceSummary,
+    build_interesting_time_product,
     build_output_product_manifest_for_result,
     default_output_product_manifest_path,
     write_output_product_manifest,
@@ -85,6 +89,10 @@ class ResultMetadata(BaseModel):
     diagnostics_summary: str | None = None
     diagnostics: ResultDiagnostics | None = None
     process_diagnostics: ProcessDiagnostics | None = None
+    interesting_times: list[InterestingTimeRecord] = Field(default_factory=list)
+    default_time_by_field: dict[str, FieldDefaultTime] = Field(default_factory=dict)
+    science_summary: ScienceSummary | None = None
+    interesting_time_caveats: list[str] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
 
@@ -131,6 +139,23 @@ def ingest_completed_run(manifest_path: Path) -> ResultMetadata:
         result_metadata_path=result_path,
         run_manifest_path=manifest_path.expanduser(),
         product_root=product_manifest_path.parent,
+    )
+    interesting_time_product = build_interesting_time_product(
+        result_id=result.result_id,
+        diagnostics=result.diagnostics,
+        output_manifest=product_manifest,
+        variables=result.variables,
+    )
+    product_manifest = product_manifest.model_copy(
+        update={"interesting_time_product": interesting_time_product}
+    )
+    result = result.model_copy(
+        update={
+            "interesting_times": interesting_time_product.available_interesting_times,
+            "default_time_by_field": interesting_time_product.default_time_by_field,
+            "science_summary": interesting_time_product.science_summary,
+            "interesting_time_caveats": interesting_time_product.caveats,
+        }
     )
     result_path.write_text(result.to_json_text())
     write_output_product_manifest(product_manifest_path, product_manifest)

--- a/app/backend/tests/test_output_products.py
+++ b/app/backend/tests/test_output_products.py
@@ -6,12 +6,20 @@ import xarray as xr
 from cloud_chamber.output_products import (
     OutputProductManifest,
     OutputProductManifestError,
+    build_interesting_time_product,
     build_output_product_manifest,
     classify_output_paths,
     default_output_product_manifest_path,
     output_product_manifest_from_json,
     resolve_time_index,
     write_output_product_manifest,
+)
+from cloud_chamber.result_diagnostics import (
+    CloudDiagnostics,
+    RainDiagnostics,
+    ResultDiagnostics,
+    TimeDiagnostics,
+    VerticalVelocityDiagnostics,
 )
 
 
@@ -222,3 +230,42 @@ def test_resolve_time_index_rejects_unavailable_index(tmp_path: Path) -> None:
 
     with pytest.raises(OutputProductManifestError, match="time_index is not available"):
         resolve_time_index(manifest, 2)
+
+
+def test_interesting_times_preserve_inferred_time_caveats(tmp_path: Path) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=None, values=[0.0, 2e-6])
+    manifest = build_manifest(tmp_path, [model])
+    diagnostics = ResultDiagnostics(
+        cloud=CloudDiagnostics(
+            formed=True,
+            first_cloud_time_seconds=1.0,
+            max_qc_kg_kg=2e-6,
+            time_of_max_qc_seconds=1.0,
+        ),
+        vertical_velocity=VerticalVelocityDiagnostics(
+            max_w_m_s=1.5,
+            time_of_max_w_seconds=1.0,
+            min_w_m_s=-0.5,
+            time_of_min_w_seconds=0.0,
+            units="m/s",
+        ),
+        rain=RainDiagnostics(available=False, field_absent=True),
+        time=TimeDiagnostics(source="inferred_output_index", fallback_used=True),
+        caveats=["diagnostics_used_inferred_time"],
+    )
+
+    product = build_interesting_time_product(
+        result_id="result-run-output-products",
+        diagnostics=diagnostics,
+        output_manifest=manifest,
+        variables=["qc", "w"],
+    )
+
+    records = {record.key: record for record in product.available_interesting_times}
+    assert records["first_cloud"].time_index == 1
+    assert records["first_cloud"].support_state == "supported"
+    assert "time_coordinate_missing" in records["first_cloud"].caveats
+    assert "diagnostics_used_inferred_time" in product.caveats
+    assert product.default_time_by_field["qc"].time_index == 1
+    assert product.science_summary.default_explore_time_index == 1

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -135,6 +135,22 @@ def test_result_card_created_from_ingested_metadata(tmp_path: Path) -> None:
     assert card.time_of_min_w_seconds == 1800.0
     assert card.rain_present is True
     assert card.first_rain_time_seconds == 1800.0
+    assert card.science_summary is not None
+    assert card.science_summary.first_cloud_time_seconds == 1800.0
+    assert card.science_summary.max_qc_kg_kg == 2e-6
+    assert card.science_summary.max_updraft_w_m_s == 4.0
+    assert card.science_summary.rain_onset_time_seconds == 1800.0
+    assert card.science_summary.default_explore_time_index == 0
+    assert card.interesting_times
+    assert {record.key for record in card.interesting_times} >= {
+        "first_cloud",
+        "max_qc",
+        "max_updraft_w",
+        "rain_onset",
+        "latest_output",
+        "field_default_time",
+    }
+    assert card.default_time_by_field["qc"].time_index == 0
     assert card.output_file_summary.netcdf_count == 1
     assert card.output_file_summary.model_output_count == 1
     assert card.output_file_summary.time_steps == 1
@@ -210,5 +226,12 @@ def test_result_card_handles_missing_diagnostics_gracefully(tmp_path: Path) -> N
     assert card.time_of_min_w_seconds is None
     assert card.rain_present is False
     assert card.first_rain_time_seconds is None
+    assert card.science_summary is not None
+    assert card.science_summary.interesting_time_support_state == "fallback"
+    assert card.default_time_by_field["qc"].support_state == "fallback"
+    assert any(
+        record.key == "first_cloud" and record.support_state == "unsupported_missing_fields"
+        for record in card.interesting_times
+    )
     assert "missing_qc_field" in card.caveats
     assert "missing_w_field" in card.caveats

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -261,6 +261,69 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     assert result.diagnostics.cloud.time_of_max_qc_seconds == 600.0
     assert result.diagnostics.vertical_velocity.min_w_m_s == -5.0
     assert result.diagnostics.vertical_velocity.max_w_m_s == 7.0
+    interesting = {record.key: record for record in result.interesting_times}
+    assert interesting["first_cloud"].support_state == "supported"
+    assert interesting["first_cloud"].time_index == 1
+    assert interesting["first_cloud"].time_seconds == 600.0
+    assert interesting["max_qc"].support_state == "supported"
+    assert interesting["max_qc"].time_index == 1
+    assert interesting["max_updraft_w"].time_index == 1
+    assert interesting["min_downdraft_w"].time_index == 0
+    assert interesting["rain_onset"].support_state == "unsupported_missing_fields"
+    assert interesting["max_dbz"].support_state == "unsupported_missing_fields"
+    assert interesting["latest_output"].time_index == 1
+    assert interesting["field_default_time"].time_index == 1
+    assert result.default_time_by_field["qc"].time_index == 1
+    assert result.default_time_by_field["w"].time_index == 1
+    assert result.default_time_by_field["qr"].support_state == "fallback"
+    assert result.science_summary is not None
+    assert result.science_summary.first_cloud_time_seconds == 600.0
+    assert result.science_summary.max_qc_kg_kg == 2e-6
+    assert result.science_summary.max_qc_time_seconds == 600.0
+    assert result.science_summary.max_updraft_w_m_s == 7.0
+    assert result.science_summary.min_downdraft_w_m_s == -5.0
+    assert result.science_summary.latest_output_time_seconds == 600.0
+    assert result.science_summary.default_explore_time_index == 1
+    assert result.science_summary.interesting_time_support_state == "supported"
+    product_manifest = output_product_manifest_from_json(
+        default_output_product_manifest_path(run_dir).read_text()
+    )
+    assert product_manifest.interesting_time_product is not None
+    assert product_manifest.interesting_time_product.science_summary == result.science_summary
+
+
+def test_no_cloud_result_keeps_interesting_times_honest(tmp_path: Path) -> None:
+    manifest_path = create_manifest(tmp_path, run_id="run-no-cloud-interesting-times")
+    run_dir = manifest_path.parent
+    first = run_dir / "cm1out_000001.nc"
+    second = run_dir / "cm1out_000002.nc"
+    write_model_netcdf(first, times=[0.0], qc_values=[0.0], w_values=[1.0])
+    write_model_netcdf(second, times=[900.0], qc_values=[0.0], w_values=[2.0])
+    complete_manifest(manifest_path, OutputMetadata(netcdf_paths=[str(first), str(second)]))
+
+    result = ingest_completed_run(manifest_path)
+
+    interesting = {record.key: record for record in result.interesting_times}
+    assert result.diagnostics is not None
+    assert result.diagnostics.cloud.formed is False
+    assert interesting["first_cloud"].support_state == "unavailable"
+    assert interesting["first_cloud"].time_index is None
+    assert interesting["first_cloud"].caveats == ["no_cloud_formed"]
+    assert interesting["max_qc"].support_state == "unavailable"
+    assert interesting["max_qc"].time_index is None
+    assert interesting["max_qc"].caveats == ["no_positive_cloud_water_detected"]
+    assert interesting["max_updraft_w"].support_state == "supported"
+    assert interesting["max_updraft_w"].time_index == 1
+    assert interesting["latest_output"].time_index == 1
+    assert result.default_time_by_field["qc"].support_state == "fallback"
+    assert result.default_time_by_field["qc"].source_interesting_time_key == "latest_output"
+    assert result.default_time_by_field["w"].support_state == "supported"
+    assert result.science_summary is not None
+    assert result.science_summary.first_cloud_time_seconds is None
+    assert result.science_summary.max_qc_kg_kg == 0.0
+    assert result.science_summary.max_qc_time_seconds is None
+    assert result.science_summary.default_explore_time_index == 1
+    assert "no_cloud_formed" in result.interesting_time_caveats
 
 
 def test_multifile_ingest_does_not_concatenate_full_sequence(

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -400,6 +400,13 @@ CM1 may write a completed run as a sequence of NetCDF model-output files such as
 
 Result metadata records model-output paths separately from stats NetCDF paths, skipped/corrupt files, contributing model-output file count, total time steps, first/last output time, and whether time came directly from a NetCDF coordinate or an inferred fallback.
 
+Ingest also writes the first output-product summary fields into result
+metadata: interesting-time records, per-field default time choices, a compact
+science summary for Results filtering/sorting, and caveats from interesting-time
+resolution. These fields are derived from CM1 diagnostics and the output-product
+manifest time index. They do not replace raw NetCDF output, and they do not give
+the browser permission to infer file/time mapping or parse NetCDF directly.
+
 ### Result Cards / Experiment Notebook Entries
 
 The backend result-card layer is the product-facing view over ingested metadata.
@@ -810,6 +817,14 @@ from result diagnostics: first cloud time when present, otherwise time of max
 cloud water when available, otherwise the latest output time. This prevents the
 validated Baseline Shallow Cumulus quick-look result from opening at an empty
 `t=0` frame when clouds form later.
+
+When present, `science_summary` and `default_time_by_field` provide the
+metadata-backed version of that startup choice. Cloud-forming fields can open at
+their supported diagnostic landmark, while no-cloud or missing-field cases
+declare an explicit fallback or unavailable state. Explore can still request
+bounded field/slice/point-cloud payloads for rendering, but it should not reopen
+or concatenate the full raw NetCDF sequence just to decide which timestep is
+interesting.
 
 The 3-D viewer keeps the same data-source contract while improving first-look
 readability: cloud-water points should be visible at the default time, slice

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -250,6 +250,17 @@ Interesting-time products should not require opening the full NetCDF sequence
 when a user merely opens Explore. They should be computed from existing
 diagnostics, stored product summaries, or a bounded product-build pass.
 
+The first implementation stores an `interesting_time_product` in the runtime
+output product manifest and mirrors compact fields into `result_metadata.json`:
+`interesting_times`, `default_time_by_field`, `science_summary`, and
+`interesting_time_caveats`. It uses the output-product manifest time index plus
+existing CM1-derived diagnostics; it does not build a second time index and it
+does not ask the browser to parse NetCDF. Missing fields, no-event outcomes,
+and diagnostics that are not implemented yet are represented explicitly with
+support states such as `unavailable`, `unsupported_missing_fields`, and
+`unsupported_missing_diagnostic` rather than silently falling back to a
+misleading cloud/rain landmark.
+
 ## Field Catalog Products
 
 The field catalog answers:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -375,6 +375,13 @@ provenance/rendering labels, and the guarantee that the browser does not parse
 raw NetCDF. These tests must not add ray marching, isosurfaces, shadows,
 fly-through, export, or generated CM1 output.
 
+Output-product tests should cover interesting-time metadata without using real
+CM1 output. Tiny synthetic NetCDF fixtures and fake diagnostics should verify
+supported landmarks such as first cloud, max `qc`, max/min `w`, rain onset, and
+latest output; honest no-event behavior for no-cloud results; missing-field and
+missing-diagnostic support states; inferred-time caveats; per-field default
+time choices; and Result Card propagation of the compact `science_summary`.
+
 Viewport-stability tests should verify that the domain box, floor/grid, active
 slice plane, and cloud-water point cloud live inside the same zoomable data
 layer, that axes/scale markers remain outside that zoomed layer and readable,


### PR DESCRIPTION
## Issue worked
#221 — Add interesting-time products and Results summary metadata

## Summary
- Added backend interesting-time product models and builder logic in `output_products.py`.
- Derives supported/fallback/unavailable interesting-time records from CM1 diagnostics plus the output-product manifest time index, without creating a separate time index.
- Persists the product into the runtime output product manifest and mirrors compact fields into `result_metadata.json`:
  - `interesting_times`
  - `default_time_by_field`
  - `science_summary`
  - `interesting_time_caveats`
- Propagates the compact metadata through Result Cards for future Results sorting/filtering and Explore startup.
- Documents the contract in the output product spec, architecture notes, and testing guidance.

## Behavior notes
- Cloud-forming results expose supported records for first cloud, max `qc`, max/min `w`, rain onset/max `qr` when available, highest cloud top, latest output, and field defaults.
- No-cloud results remain honest: no-event landmarks are `unavailable`, while fields with useful motion can still provide supported defaults.
- Missing fields and not-yet-implemented diagnostics use explicit support states such as `unsupported_missing_fields` and `unsupported_missing_diagnostic`.
- Inferred/missing time-coordinate caveats are preserved in interesting-time records and summary metadata.

## Tests added/updated
- Backend output-product tests for inferred-time caveats and interesting-time products.
- Ingest tests for multifile interesting-time metadata and no-cloud honesty.
- Result Card tests for compact science summary and interesting-time propagation.

## Commands run
- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_output_products.py app/backend/tests/test_result_ingest.py app/backend/tests/test_result_cards.py -q`
- `app/backend/.venv/bin/python -m ruff format --check app/backend/cloud_chamber/output_products.py app/backend/cloud_chamber/result_ingest.py app/backend/cloud_chamber/result_cards.py app/backend/tests/test_output_products.py app/backend/tests/test_result_ingest.py app/backend/tests/test_result_cards.py`
- `app/backend/.venv/bin/python -m ruff check app/backend/cloud_chamber/output_products.py app/backend/cloud_chamber/result_ingest.py app/backend/cloud_chamber/result_cards.py app/backend/tests/test_output_products.py app/backend/tests/test_result_ingest.py app/backend/tests/test_result_cards.py`
- `app/backend/.venv/bin/python -m mypy app/backend/cloud_chamber/output_products.py app/backend/cloud_chamber/result_ingest.py app/backend/cloud_chamber/result_cards.py`
- `scripts/check.sh`

## Manual QA needed
No. This is backend/data-product contract work using tiny synthetic fixtures. UI/manual validation can happen in follow-up Results/Explore issues that consume the metadata.

## Caveats / follow-up
- `max_dbz` and `max_surface_rain` are represented as explicit unsupported records until those diagnostics are implemented.
- This does not implement #206 filtering/sorting UI; it only provides the compact metadata that future UI can consume.

## Generated-artifact check
No generated CM1 output, NetCDF files, runtime folders, logs, screenshots, videos, or traces are included.
