### PR TITLE
Add IGRA recent catalog cache

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -12,6 +12,13 @@ from pydantic import BaseModel, Field
 
 from cloud_chamber.cli import ENGINE_NOTE
 from cloud_chamber.dry_run_package import generate_dry_run_package, read_dry_run_report
+from cloud_chamber.igra_catalog import (
+    IGRACatalogError,
+    cache_station_zip_from_catalog,
+    read_igra_cache_manifest,
+    read_igra_recent_catalog,
+    refresh_recent_catalog,
+)
 from cloud_chamber.lan_worker import (
     LanWorkerApiError,
     cleanup_lan_worker_run,
@@ -111,6 +118,11 @@ class LanWorkerRunRequest(BaseModel):
     manifest_path: str
 
 
+class IGRACacheRequest(BaseModel):
+    station_id: str
+    filename: str | None = None
+
+
 @app.get("/api/scenarios")
 def list_scenarios() -> dict[str, object]:
     scenarios = [scenario_summary(scenario) for scenario in load_scenario_templates()]
@@ -158,6 +170,40 @@ def parse_observed_sounding(request: ObservedSoundingParseRequest) -> dict[str, 
     except ObservedSoundingError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return result.model_dump(mode="json")
+
+
+@app.get("/api/igra/recent/catalog")
+def get_igra_recent_catalog() -> dict[str, object]:
+    catalog = read_igra_recent_catalog(load_settings())
+    return {"catalog": catalog.model_dump(mode="json") if catalog else None}
+
+
+@app.post("/api/igra/recent/refresh-catalog")
+def refresh_igra_recent_catalog() -> dict[str, object]:
+    try:
+        catalog = refresh_recent_catalog(load_settings())
+    except IGRACatalogError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return catalog.model_dump(mode="json")
+
+
+@app.get("/api/igra/recent/cache")
+def get_igra_recent_cache() -> dict[str, object]:
+    manifest = read_igra_cache_manifest(load_settings())
+    return manifest.model_dump(mode="json")
+
+
+@app.post("/api/igra/recent/cache")
+def cache_igra_recent_file(request: IGRACacheRequest) -> dict[str, object]:
+    try:
+        entry = cache_station_zip_from_catalog(
+            load_settings(),
+            station_id=request.station_id,
+            filename=request.filename,
+        )
+    except IGRACatalogError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return entry.model_dump(mode="json")
 
 
 @app.post("/api/runs/launch")

--- a/app/backend/cloud_chamber/igra_catalog.py
+++ b/app/backend/cloud_chamber/igra_catalog.py
@@ -1,0 +1,538 @@
+"""NOAA/NCEI IGRA recent station-period catalog and cache helpers."""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from datetime import UTC, datetime
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.settings import CloudChamberSettings
+
+IGRA_RECENT_CATALOG_VERSION = 1
+IGRA_CACHE_MANIFEST_VERSION = 1
+IGRA_RECENT_DATA_URL = (
+    "https://www.ncei.noaa.gov/data/integrated-global-radiosonde-archive/access/data-y2d/"
+)
+IGRA_STATION_LIST_URL = "https://www.ncei.noaa.gov/pub/data/igra/igra2-station-list.txt"
+
+CATALOG_FILENAME = "catalog.json"
+CACHE_MANIFEST_FILENAME = "cache_manifest.json"
+
+STATION_ID_PATTERN = re.compile(r"^[A-Z0-9]{11}$")
+RECENT_ZIP_FILENAME_PATTERN = re.compile(r"^([A-Z0-9]{11})-data-beg(\d{4})\.txt\.zip$")
+MAX_DIRECTORY_LISTING_BYTES = 5_000_000
+MAX_STATION_METADATA_BYTES = 20_000_000
+MAX_STATION_ZIP_BYTES = 250_000_000
+
+RegionTag = Literal["great_plains_midwest"]
+CachedStatus = Literal["not_cached", "cached_zip", "cached_extracted"]
+
+
+class IGRACatalogError(RuntimeError):
+    """Raised when IGRA catalog/cache data cannot be parsed or managed safely."""
+
+
+class IGRARegionDefinition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tag: RegionTag
+    label: str
+    min_latitude: float
+    max_latitude: float
+    min_longitude: float
+    max_longitude: float
+    caveats: list[str] = Field(default_factory=list)
+
+    def contains(self, station: IGRAStationMetadata) -> bool:
+        if station.latitude is None or station.longitude is None:
+            return False
+        return (
+            self.min_latitude <= station.latitude <= self.max_latitude
+            and self.min_longitude <= station.longitude <= self.max_longitude
+        )
+
+
+class IGRAStationMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    station_id: str
+    station_name: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    elevation_m_msl: float | None = None
+    state: str | None = None
+    first_year: int | None = None
+    last_year: int | None = None
+    record_count: int | None = None
+    region_tags: list[RegionTag] = Field(default_factory=list)
+    source: str = IGRA_STATION_LIST_URL
+    caveats: list[str] = Field(default_factory=list)
+
+
+class IGRAStationZipReference(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    station_id: str
+    station_name: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    elevation_m_msl: float | None = None
+    filename: str
+    begin_year: int
+    source_url: str
+    last_modified: str | None = None
+    compressed_size_bytes: int | None = None
+    region_tags: list[RegionTag] = Field(default_factory=list)
+    cached_status: CachedStatus = "not_cached"
+    cached_zip_path: str | None = None
+    cached_text_path: str | None = None
+    source_etag_or_last_modified: str | None = None
+    caveats: list[str] = Field(default_factory=list)
+
+
+class IGRACacheEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    station_id: str
+    station_name: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    elevation_m_msl: float | None = None
+    filename: str
+    source_url: str
+    region_tags: list[RegionTag] = Field(default_factory=list)
+    cached_status: CachedStatus
+    cached_zip_path: str
+    cached_text_path: str | None = None
+    downloaded_at: datetime
+    extracted_at: datetime | None = None
+    source_etag_or_last_modified: str | None = None
+    caveats: list[str] = Field(default_factory=list)
+
+
+class IGRACacheManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    manifest_version: int = IGRA_CACHE_MANIFEST_VERSION
+    cache_root: str
+    entries: list[IGRACacheEntry] = Field(default_factory=list)
+    updated_at: datetime
+    caveats: list[str] = Field(default_factory=list)
+
+
+class IGRARecentCatalog(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    catalog_version: int = IGRA_RECENT_CATALOG_VERSION
+    source_url: str
+    station_metadata_source: str
+    region: IGRARegionDefinition
+    refreshed_at: datetime
+    stations: list[IGRAStationMetadata]
+    zip_references: list[IGRAStationZipReference]
+    cache_manifest_path: str
+    caveats: list[str] = Field(default_factory=list)
+
+
+GREAT_PLAINS_MIDWEST_REGION = IGRARegionDefinition(
+    tag="great_plains_midwest",
+    label="Great Plains / Midwest",
+    min_latitude=30.0,
+    max_latitude=50.0,
+    min_longitude=-106.0,
+    max_longitude=-80.0,
+    caveats=[
+        "Broad v1 lat/lon bounding box; not a GIS boundary.",
+        "Bounds are intentionally conservative for recent IGRA sounding discovery.",
+    ],
+)
+
+
+class _HrefParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "a":
+            return
+        for name, value in attrs:
+            if name.lower() == "href" and value:
+                self.hrefs.append(value)
+
+
+def igra_recent_cache_root(settings: CloudChamberSettings) -> Path:
+    """Return the runtime-local IGRA recent cache root."""
+    return settings.cache_dir.expanduser() / "igra" / "recent"
+
+
+def igra_recent_catalog_path(settings: CloudChamberSettings) -> Path:
+    return igra_recent_cache_root(settings) / CATALOG_FILENAME
+
+
+def igra_cache_manifest_path(settings: CloudChamberSettings) -> Path:
+    return igra_recent_cache_root(settings) / CACHE_MANIFEST_FILENAME
+
+
+def parse_recent_directory_listing(
+    html: str,
+    *,
+    base_url: str = IGRA_RECENT_DATA_URL,
+) -> list[IGRAStationZipReference]:
+    """Parse the IGRA recent directory listing for station-period ZIP links."""
+    parser = _HrefParser()
+    parser.feed(html)
+    references: list[IGRAStationZipReference] = []
+    seen: set[str] = set()
+    for href in parser.hrefs:
+        filename = Path(urllib.parse.urlparse(href).path).name
+        match = RECENT_ZIP_FILENAME_PATTERN.match(filename)
+        if match is None or filename in seen:
+            continue
+        seen.add(filename)
+        station_id = match.group(1)
+        references.append(
+            IGRAStationZipReference(
+                station_id=station_id,
+                filename=filename,
+                begin_year=int(match.group(2)),
+                source_url=urllib.parse.urljoin(base_url, href),
+            )
+        )
+    return sorted(references, key=lambda reference: (reference.station_id, reference.filename))
+
+
+def parse_station_metadata(
+    text: str, *, source: str = IGRA_STATION_LIST_URL
+) -> dict[str, IGRAStationMetadata]:
+    """Parse IGRA station-list fixed-width metadata."""
+    stations: dict[str, IGRAStationMetadata] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\n")
+        if not line or line.startswith("ID") or line.startswith("-"):
+            continue
+        station_id = line[0:11].strip() if len(line) >= 11 else ""
+        if not STATION_ID_PATTERN.match(station_id):
+            continue
+        station = IGRAStationMetadata(
+            station_id=station_id,
+            latitude=_parse_optional_float(line[12:20] if len(line) >= 20 else ""),
+            longitude=_parse_optional_float(line[21:30] if len(line) >= 30 else ""),
+            elevation_m_msl=_parse_optional_float(line[31:37] if len(line) >= 37 else ""),
+            state=_parse_optional_text(line[38:40] if len(line) >= 40 else ""),
+            station_name=_parse_optional_text(line[41:71] if len(line) >= 71 else ""),
+            first_year=_parse_optional_int(line[72:76] if len(line) >= 76 else ""),
+            last_year=_parse_optional_int(line[77:81] if len(line) >= 81 else ""),
+            record_count=_parse_optional_int(line[82:88] if len(line) >= 88 else ""),
+            source=source,
+        )
+        stations[station_id] = station.model_copy(
+            update={"region_tags": _region_tags_for_station(station)}
+        )
+    return stations
+
+
+def build_recent_catalog(
+    *,
+    directory_html: str,
+    station_metadata_text: str,
+    cache_manifest: IGRACacheManifest | None = None,
+    source_url: str = IGRA_RECENT_DATA_URL,
+    station_metadata_source: str = IGRA_STATION_LIST_URL,
+    region: IGRARegionDefinition = GREAT_PLAINS_MIDWEST_REGION,
+    refreshed_at: datetime | None = None,
+) -> IGRARecentCatalog:
+    """Build a Great Plains / Midwest recent IGRA catalog from source text."""
+    station_by_id = parse_station_metadata(station_metadata_text, source=station_metadata_source)
+    cache_by_filename = {
+        entry.filename: entry for entry in (cache_manifest.entries if cache_manifest else [])
+    }
+    caveats: list[str] = []
+    stations_in_region = [
+        station for station in station_by_id.values() if region.tag in station.region_tags
+    ]
+    references: list[IGRAStationZipReference] = []
+    for reference in parse_recent_directory_listing(directory_html, base_url=source_url):
+        station = station_by_id.get(reference.station_id)
+        if station is None:
+            caveats.append(f"station_metadata_missing:{reference.station_id}")
+            continue
+        if region.tag not in station.region_tags:
+            continue
+        cache_entry = cache_by_filename.get(reference.filename)
+        references.append(
+            reference.model_copy(
+                update={
+                    "station_name": station.station_name,
+                    "latitude": station.latitude,
+                    "longitude": station.longitude,
+                    "elevation_m_msl": station.elevation_m_msl,
+                    "region_tags": station.region_tags,
+                    "cached_status": cache_entry.cached_status if cache_entry else "not_cached",
+                    "cached_zip_path": cache_entry.cached_zip_path if cache_entry else None,
+                    "cached_text_path": cache_entry.cached_text_path if cache_entry else None,
+                    "source_etag_or_last_modified": (
+                        cache_entry.source_etag_or_last_modified if cache_entry else None
+                    ),
+                }
+            )
+        )
+    return IGRARecentCatalog(
+        source_url=source_url,
+        station_metadata_source=station_metadata_source,
+        region=region,
+        refreshed_at=refreshed_at or datetime.now(UTC),
+        stations=sorted(stations_in_region, key=lambda station: station.station_id),
+        zip_references=references,
+        cache_manifest_path=str(Path("cache") / "igra" / "recent" / CACHE_MANIFEST_FILENAME),
+        caveats=sorted(set(caveats)),
+    )
+
+
+def read_igra_recent_catalog(settings: CloudChamberSettings) -> IGRARecentCatalog | None:
+    path = igra_recent_catalog_path(settings)
+    if not path.exists():
+        return None
+    return IGRARecentCatalog.model_validate(json.loads(path.read_text()))
+
+
+def write_igra_recent_catalog(settings: CloudChamberSettings, catalog: IGRARecentCatalog) -> None:
+    path = igra_recent_catalog_path(settings)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(catalog.model_dump_json(indent=2) + "\n")
+
+
+def read_igra_cache_manifest(settings: CloudChamberSettings) -> IGRACacheManifest:
+    path = igra_cache_manifest_path(settings)
+    if not path.exists():
+        return IGRACacheManifest(
+            cache_root=str(igra_recent_cache_root(settings)),
+            updated_at=datetime.now(UTC),
+        )
+    return IGRACacheManifest.model_validate(json.loads(path.read_text()))
+
+
+def write_igra_cache_manifest(settings: CloudChamberSettings, manifest: IGRACacheManifest) -> None:
+    path = igra_cache_manifest_path(settings)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(manifest.model_dump_json(indent=2) + "\n")
+
+
+def refresh_recent_catalog(settings: CloudChamberSettings) -> IGRARecentCatalog:
+    """Fetch and persist the bounded recent IGRA catalog."""
+    directory_html = _fetch_url_text(IGRA_RECENT_DATA_URL, max_bytes=MAX_DIRECTORY_LISTING_BYTES)
+    station_metadata_text = _fetch_url_text(
+        IGRA_STATION_LIST_URL,
+        max_bytes=MAX_STATION_METADATA_BYTES,
+    )
+    catalog = build_recent_catalog(
+        directory_html=directory_html,
+        station_metadata_text=station_metadata_text,
+        cache_manifest=read_igra_cache_manifest(settings),
+    )
+    catalog = catalog.model_copy(
+        update={"cache_manifest_path": str(igra_cache_manifest_path(settings))}
+    )
+    write_igra_recent_catalog(settings, catalog)
+    return catalog
+
+
+def cache_station_zip(
+    settings: CloudChamberSettings,
+    reference: IGRAStationZipReference,
+    *,
+    zip_bytes: bytes | None = None,
+) -> IGRACacheEntry:
+    """Cache and safely extract a selected IGRA station-period ZIP."""
+    _validate_station_id(reference.station_id)
+    _validate_recent_zip_filename(reference.filename, expected_station_id=reference.station_id)
+    payload = zip_bytes
+    if payload is None:
+        payload = _fetch_url_bytes(reference.source_url, max_bytes=MAX_STATION_ZIP_BYTES)
+    station_dir = _station_cache_dir(settings, reference.station_id)
+    station_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = station_dir / reference.filename
+    zip_path.write_bytes(payload)
+    extracted_text_path, caveats = _safe_extract_station_zip(
+        zip_bytes=payload,
+        target_dir=station_dir,
+        expected_station_id=reference.station_id,
+    )
+    now = datetime.now(UTC)
+    entry = IGRACacheEntry(
+        station_id=reference.station_id,
+        station_name=reference.station_name,
+        latitude=reference.latitude,
+        longitude=reference.longitude,
+        elevation_m_msl=reference.elevation_m_msl,
+        filename=reference.filename,
+        source_url=reference.source_url,
+        region_tags=reference.region_tags,
+        cached_status="cached_extracted" if extracted_text_path else "cached_zip",
+        cached_zip_path=str(zip_path),
+        cached_text_path=str(extracted_text_path) if extracted_text_path else None,
+        downloaded_at=now,
+        extracted_at=now if extracted_text_path else None,
+        source_etag_or_last_modified=reference.source_etag_or_last_modified,
+        caveats=caveats,
+    )
+    manifest = read_igra_cache_manifest(settings)
+    updated_entries = [
+        existing for existing in manifest.entries if existing.filename != entry.filename
+    ]
+    updated_entries.append(entry)
+    write_igra_cache_manifest(
+        settings,
+        manifest.model_copy(
+            update={
+                "cache_root": str(igra_recent_cache_root(settings)),
+                "entries": sorted(
+                    updated_entries, key=lambda item: (item.station_id, item.filename)
+                ),
+                "updated_at": now,
+            }
+        ),
+    )
+    return entry
+
+
+def cache_station_zip_from_catalog(
+    settings: CloudChamberSettings,
+    *,
+    station_id: str,
+    filename: str | None = None,
+) -> IGRACacheEntry:
+    catalog = read_igra_recent_catalog(settings)
+    if catalog is None:
+        raise IGRACatalogError("Refresh IGRA recent catalog before caching station files.")
+    matches = [
+        reference
+        for reference in catalog.zip_references
+        if reference.station_id == station_id
+        and (filename is None or reference.filename == filename)
+    ]
+    if not matches:
+        raise IGRACatalogError("Requested IGRA station-period file is not in the recent catalog.")
+    return cache_station_zip(settings, matches[0])
+
+
+def _region_tags_for_station(station: IGRAStationMetadata) -> list[RegionTag]:
+    return ["great_plains_midwest"] if GREAT_PLAINS_MIDWEST_REGION.contains(station) else []
+
+
+def _safe_extract_station_zip(
+    *,
+    zip_bytes: bytes,
+    target_dir: Path,
+    expected_station_id: str,
+) -> tuple[Path | None, list[str]]:
+    caveats: list[str] = []
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as exc:
+        raise IGRACatalogError("IGRA station ZIP is not a readable ZIP archive.") from exc
+    safe_text_members: list[zipfile.ZipInfo] = []
+    target_root = target_dir.resolve()
+    with archive:
+        for member in archive.infolist():
+            if member.is_dir():
+                continue
+            member_path = Path(member.filename)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise IGRACatalogError(f"Unsafe path in IGRA ZIP entry: {member.filename}")
+            output_path = (target_dir / member_path.name).resolve()
+            if not output_path.is_relative_to(target_root):
+                raise IGRACatalogError(
+                    f"Unsafe extraction target for IGRA ZIP entry: {member.filename}"
+                )
+            if output_path.suffix != ".txt":
+                caveats.append(f"unexpected_zip_member_ignored:{member.filename}")
+                continue
+            if not member_path.name.startswith(expected_station_id):
+                caveats.append(f"unexpected_station_text_filename:{member_path.name}")
+            safe_text_members.append(member)
+        if not safe_text_members:
+            raise IGRACatalogError("IGRA station ZIP did not contain a station text file.")
+        if len(safe_text_members) > 1:
+            caveats.append(f"multiple_station_text_files:{len(safe_text_members)}")
+        selected = sorted(safe_text_members, key=lambda item: item.filename)[0]
+        output_path = (target_dir / Path(selected.filename).name).resolve()
+        output_path.write_bytes(archive.read(selected))
+        return output_path, caveats
+
+
+def _station_cache_dir(settings: CloudChamberSettings, station_id: str) -> Path:
+    _validate_station_id(station_id)
+    return igra_recent_cache_root(settings) / "stations" / station_id
+
+
+def _validate_station_id(station_id: str) -> None:
+    if not STATION_ID_PATTERN.match(station_id):
+        raise IGRACatalogError(f"Unsafe or unsupported IGRA station id: {station_id!r}")
+
+
+def _validate_recent_zip_filename(filename: str, *, expected_station_id: str) -> None:
+    basename = Path(filename).name
+    if basename != filename:
+        raise IGRACatalogError("IGRA ZIP filename must not include a directory path.")
+    match = RECENT_ZIP_FILENAME_PATTERN.match(filename)
+    if match is None:
+        raise IGRACatalogError(f"Unsupported IGRA recent ZIP filename: {filename!r}")
+    if match.group(1) != expected_station_id:
+        raise IGRACatalogError("IGRA ZIP filename station id does not match requested station.")
+
+
+def _fetch_url_text(url: str, *, max_bytes: int) -> str:
+    return _fetch_url_bytes(url, max_bytes=max_bytes).decode("utf-8", errors="replace")
+
+
+def _fetch_url_bytes(url: str, *, max_bytes: int) -> bytes:
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            payload = cast(bytes, response.read(max_bytes + 1))
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise IGRACatalogError(f"Unable to fetch IGRA source URL: {url}") from exc
+    if len(payload) > max_bytes:
+        raise IGRACatalogError(f"IGRA source URL exceeded maximum size: {url}")
+    return payload
+
+
+def _parse_optional_text(text: str) -> str | None:
+    stripped = text.strip()
+    return stripped or None
+
+
+def _parse_optional_float(text: str) -> float | None:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    try:
+        value = float(stripped)
+    except ValueError:
+        return None
+    if value in {-98_888.0, -99_999.0, -999.9, -998.8}:
+        return None
+    return value
+
+
+def _parse_optional_int(text: str) -> int | None:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    try:
+        value = int(stripped)
+    except ValueError:
+        return None
+    if value in {-8888, -9999}:
+        return None
+    return value

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,12 @@ from igra_fixtures import IGRA_FIXTURE
 
 from cloud_chamber.app import app
 from cloud_chamber.dry_run_package import generate_dry_run_package
+from cloud_chamber.igra_catalog import (
+    IGRACatalogError,
+    IGRARecentCatalog,
+    IGRARegionDefinition,
+    IGRAStationZipReference,
+)
 from cloud_chamber.local_run_manager import LocalRunManagerError, RunStatus
 from cloud_chamber.run_manifest import (
     LifecycleState,
@@ -138,6 +145,60 @@ def test_parse_observed_sounding_api_blocks_malformed_upload() -> None:
 
     assert response.status_code == 400
     assert "No IGRA sounding headers" in response.json()["detail"]
+
+
+def test_igra_recent_catalog_endpoint_returns_cached_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = IGRARecentCatalog(
+        source_url="https://example.test/igra/",
+        station_metadata_source="https://example.test/stations.txt",
+        region=IGRARegionDefinition(
+            tag="great_plains_midwest",
+            label="Great Plains / Midwest",
+            min_latitude=30,
+            max_latitude=50,
+            min_longitude=-106,
+            max_longitude=-80,
+        ),
+        refreshed_at=datetime(2026, 7, 1, tzinfo=UTC),
+        stations=[],
+        zip_references=[
+            IGRAStationZipReference(
+                station_id="USM00072558",
+                filename="USM00072558-data-beg2025.txt.zip",
+                begin_year=2025,
+                source_url="https://example.test/USM00072558-data-beg2025.txt.zip",
+                region_tags=["great_plains_midwest"],
+            )
+        ],
+        cache_manifest_path="/tmp/cache/igra/recent/cache_manifest.json",
+    )
+    monkeypatch.setattr("cloud_chamber.app.read_igra_recent_catalog", lambda _settings: catalog)
+
+    response = TestClient(app).get("/api/igra/recent/catalog")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["catalog"]["zip_references"][0]["station_id"] == "USM00072558"
+    assert payload["catalog"]["zip_references"][0]["cached_status"] == "not_cached"
+
+
+def test_igra_recent_cache_endpoint_reports_clear_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def blocked_cache(_settings: object, *, station_id: str, filename: str | None) -> object:
+        raise IGRACatalogError(f"Requested file is not cached: {station_id} {filename}")
+
+    monkeypatch.setattr("cloud_chamber.app.cache_station_zip_from_catalog", blocked_cache)
+
+    response = TestClient(app).post(
+        "/api/igra/recent/cache",
+        json={"station_id": "USM00072558", "filename": "USM00072558-data-beg2025.txt.zip"},
+    )
+
+    assert response.status_code == 400
+    assert "Requested file is not cached" in response.json()["detail"]
 
 
 def test_launch_run_api_returns_status(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/app/backend/tests/test_igra_catalog.py
+++ b/app/backend/tests/test_igra_catalog.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from cloud_chamber.igra_catalog import (
+    IGRACacheManifest,
+    IGRACatalogError,
+    IGRAStationZipReference,
+    build_recent_catalog,
+    cache_station_zip,
+    cache_station_zip_from_catalog,
+    igra_cache_manifest_path,
+    parse_recent_directory_listing,
+    parse_station_metadata,
+    read_igra_cache_manifest,
+    read_igra_recent_catalog,
+    write_igra_recent_catalog,
+)
+from cloud_chamber.settings import CloudChamberSettings
+
+DIRECTORY_HTML = """
+<html>
+  <body>
+    <a href="USM00072558-data-beg2025.txt.zip">Valley</a>
+    <a href="USM00072469-data-beg2025.txt.zip">Denver</a>
+    <a href="USM00099999-data-beg2025.txt.zip">Missing station</a>
+    <a href="README.txt">README</a>
+    <a href="../">Parent</a>
+  </body>
+</html>
+"""
+
+
+def station_line(
+    station_id: str,
+    latitude: float,
+    longitude: float,
+    elevation: float,
+    state: str,
+    name: str,
+) -> str:
+    return (
+        f"{station_id:<11} {latitude:8.4f} {longitude:9.4f} {elevation:6.1f} "
+        f"{state:<2} {name:<30} {1948:4d} {2026:4d} {50000:6d}"
+    )
+
+
+STATION_LIST = "\n".join(
+    [
+        station_line("USM00072558", 41.32, -96.3669, 351.5, "NE", "VALLEY"),
+        station_line("USM00072469", 39.8328, -104.6575, 1650.0, "CO", "DENVER INTL AIRPORT"),
+        station_line("USM00072295", 33.4255, -112.0130, 337.0, "AZ", "PHOENIX"),
+    ]
+)
+
+
+def fake_settings(tmp_path: Path) -> CloudChamberSettings:
+    runtime_home = tmp_path / "CloudChamber"
+    return CloudChamberSettings(
+        runtime_home=runtime_home,
+        cm1_root=None,
+        cm1_run_dir=None,
+        cache_dir=runtime_home / "cache",
+        log_dir=runtime_home / "logs",
+    )
+
+
+def station_zip(filename: str = "USM00072558-data-beg2025.txt") -> bytes:
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as archive:
+        archive.writestr(filename, "#USM00072558 2025 01 01 00\n")
+    return payload.getvalue()
+
+
+def test_recent_directory_parser_finds_station_period_zip_links() -> None:
+    references = parse_recent_directory_listing(
+        DIRECTORY_HTML,
+        base_url="https://example.test/igra/",
+    )
+
+    assert [reference.filename for reference in references] == [
+        "USM00072469-data-beg2025.txt.zip",
+        "USM00072558-data-beg2025.txt.zip",
+        "USM00099999-data-beg2025.txt.zip",
+    ]
+    assert references[1].station_id == "USM00072558"
+    assert references[1].begin_year == 2025
+    assert references[1].source_url == (
+        "https://example.test/igra/USM00072558-data-beg2025.txt.zip"
+    )
+
+
+def test_station_metadata_join_and_great_plains_midwest_filter() -> None:
+    catalog = build_recent_catalog(
+        directory_html=DIRECTORY_HTML,
+        station_metadata_text=STATION_LIST,
+        source_url="https://example.test/igra/",
+        refreshed_at=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+
+    assert [station.station_id for station in catalog.stations] == ["USM00072469", "USM00072558"]
+    assert [reference.station_id for reference in catalog.zip_references] == [
+        "USM00072469",
+        "USM00072558",
+    ]
+    valley = catalog.zip_references[1]
+    assert valley.station_name == "VALLEY"
+    assert valley.latitude == pytest.approx(41.32)
+    assert valley.longitude == pytest.approx(-96.3669)
+    assert valley.region_tags == ["great_plains_midwest"]
+    assert valley.cached_status == "not_cached"
+    assert "station_metadata_missing:USM00099999" in catalog.caveats
+
+
+def test_parse_station_metadata_handles_fixed_width_station_list() -> None:
+    stations = parse_station_metadata(STATION_LIST)
+
+    valley = stations["USM00072558"]
+    assert valley.station_name == "VALLEY"
+    assert valley.elevation_m_msl == pytest.approx(351.5)
+    assert valley.first_year == 1948
+    assert valley.last_year == 2026
+    assert valley.record_count == 50000
+    assert valley.region_tags == ["great_plains_midwest"]
+    assert stations["USM00072295"].region_tags == []
+
+
+def test_cache_manifest_marks_already_cached_references(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    reference = IGRAStationZipReference(
+        station_id="USM00072558",
+        filename="USM00072558-data-beg2025.txt.zip",
+        begin_year=2025,
+        source_url="https://example.test/USM00072558-data-beg2025.txt.zip",
+        region_tags=["great_plains_midwest"],
+    )
+    entry = cache_station_zip(settings, reference, zip_bytes=station_zip())
+    manifest = read_igra_cache_manifest(settings)
+
+    catalog = build_recent_catalog(
+        directory_html=DIRECTORY_HTML,
+        station_metadata_text=STATION_LIST,
+        cache_manifest=manifest,
+        source_url="https://example.test/igra/",
+    )
+
+    cached = next(item for item in catalog.zip_references if item.filename == entry.filename)
+    assert cached.cached_status == "cached_extracted"
+    assert cached.cached_zip_path == entry.cached_zip_path
+    assert cached.cached_text_path == entry.cached_text_path
+
+
+def test_cache_station_zip_writes_under_runtime_cache_only(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    reference = IGRAStationZipReference(
+        station_id="USM00072558",
+        station_name="Valley",
+        latitude=41.32,
+        longitude=-96.3669,
+        elevation_m_msl=351.5,
+        filename="USM00072558-data-beg2025.txt.zip",
+        begin_year=2025,
+        source_url="https://example.test/USM00072558-data-beg2025.txt.zip",
+        region_tags=["great_plains_midwest"],
+    )
+
+    entry = cache_station_zip(settings, reference, zip_bytes=station_zip())
+
+    assert Path(entry.cached_zip_path).is_relative_to(settings.cache_dir)
+    assert entry.cached_text_path is not None
+    assert Path(entry.cached_text_path).is_relative_to(settings.cache_dir)
+    assert Path(entry.cached_zip_path).exists()
+    assert Path(entry.cached_text_path).exists()
+    manifest = read_igra_cache_manifest(settings)
+    assert manifest.entries == [entry]
+    assert igra_cache_manifest_path(settings).exists()
+
+
+def test_cache_station_zip_rejects_zip_slip_entries(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    reference = IGRAStationZipReference(
+        station_id="USM00072558",
+        filename="USM00072558-data-beg2025.txt.zip",
+        begin_year=2025,
+        source_url="https://example.test/USM00072558-data-beg2025.txt.zip",
+    )
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as archive:
+        archive.writestr("../USM00072558-data-beg2025.txt", "unsafe")
+
+    with pytest.raises(IGRACatalogError, match="Unsafe path"):
+        cache_station_zip(settings, reference, zip_bytes=payload.getvalue())
+
+    assert not (tmp_path / "USM00072558-data-beg2025.txt").exists()
+
+
+def test_cache_station_zip_rejects_absolute_entries(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    reference = IGRAStationZipReference(
+        station_id="USM00072558",
+        filename="USM00072558-data-beg2025.txt.zip",
+        begin_year=2025,
+        source_url="https://example.test/USM00072558-data-beg2025.txt.zip",
+    )
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as archive:
+        archive.writestr("/tmp/USM00072558-data-beg2025.txt", "unsafe")
+
+    with pytest.raises(IGRACatalogError, match="Unsafe path"):
+        cache_station_zip(settings, reference, zip_bytes=payload.getvalue())
+
+
+def test_cache_station_zip_from_catalog_uses_cached_catalog(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = fake_settings(tmp_path)
+    catalog = build_recent_catalog(
+        directory_html=DIRECTORY_HTML,
+        station_metadata_text=STATION_LIST,
+        source_url="https://example.test/igra/",
+    )
+    write_igra_recent_catalog(settings, catalog)
+    monkeypatch.setattr(
+        "cloud_chamber.igra_catalog._fetch_url_bytes",
+        lambda _url, *, max_bytes: station_zip(),
+    )
+
+    entry = cache_station_zip_from_catalog(settings, station_id="USM00072558")
+
+    assert entry.station_id == "USM00072558"
+    assert entry.cached_status == "cached_extracted"
+    assert read_igra_recent_catalog(settings) == catalog
+
+
+def test_cache_station_zip_rejects_unsafe_station_id_and_filename(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    bad_station = IGRAStationZipReference(
+        station_id="BAD/ID",
+        filename="BAD00000000-data-beg2025.txt.zip",
+        begin_year=2025,
+        source_url="https://example.test/BAD00000000-data-beg2025.txt.zip",
+    )
+    with pytest.raises(IGRACatalogError, match="station id"):
+        cache_station_zip(settings, bad_station, zip_bytes=station_zip())
+
+    bad_filename = IGRAStationZipReference(
+        station_id="USM00072558",
+        filename="../USM00072558-data-beg2025.txt.zip",
+        begin_year=2025,
+        source_url="https://example.test/USM00072558-data-beg2025.txt.zip",
+    )
+    with pytest.raises(IGRACatalogError, match="filename"):
+        cache_station_zip(settings, bad_filename, zip_bytes=station_zip())
+
+
+def test_cache_manifest_default_is_runtime_local(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+
+    manifest = read_igra_cache_manifest(settings)
+
+    assert isinstance(manifest, IGRACacheManifest)
+    assert manifest.cache_root == str(settings.cache_dir / "igra" / "recent")
+    assert manifest.entries == []

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -71,6 +71,16 @@ rendering. The frontend sends uploaded text to the backend, receives a bounded
 review payload, and passes the selected sounding record into dry-run package
 generation; it does not parse sounding files into CM1-ready data itself.
 
+The IGRA recent catalog/cache layer is separate from package generation. The
+backend can refresh the NOAA/NCEI IGRA recent station-period directory, parse
+station metadata, filter to the v1 Great Plains / Midwest region bounds
+(`30.0` to `50.0` latitude, `-106.0` to `-80.0` longitude), and cache selected
+station-period ZIP/text files under `<runtime-home>/cache/igra/recent/`.
+Runtime cache metadata is stored in `catalog.json` and `cache_manifest.json`;
+downloaded ZIPs and extracted station text stay under per-station cache
+directories. The browser does not parse remote HTML, station archives, or
+station text files.
+
 ## Suggested Stack
 
 This is not final, but a reasonable starting point:

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -78,6 +78,15 @@ preserved as metadata only; the generated CM1 namelist keeps the validated
 external-sounding wind-handling path until a separate validation accepts
 observed-wind forcing.
 
+Cloud Chamber also owns a backend-only local cache foundation for recent IGRA
+station-period source files. V1 can refresh the NOAA/NCEI IGRA recent catalog,
+join station metadata, filter to a broad Great Plains / Midwest bounding box
+(`30.0` to `50.0` latitude, `-106.0` to `-80.0` longitude), and cache selected
+station ZIP/text files under `<runtime-home>/cache/igra/recent/`. This is source
+data for future “Find Interesting Soundings” work only: it does not score
+soundings, choose LES stories, generate packages, or run CM1. The browser never
+parses remote directory listings, ZIP files, or station text files.
+
 Explore should be a focused visualization plus explanation screen for one
 selected result. Its core interaction is `What happened here?`: select a cloud,
 updraft, clear-air thermal, or no-cloud region and receive a CM1-backed

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,6 +142,15 @@ separate validation changes wind forcing. Use tiny synthetic IGRA fixtures in
 tests. Large local station files, for example files in `~/Downloads`, are manual
 validation inputs and must not be copied into the repo.
 
+Recent IGRA source-file discovery is backend-owned. The backend endpoints under
+`/api/igra/recent/*` can refresh a bounded NOAA/NCEI recent catalog, join station
+metadata, filter to the v1 Great Plains / Midwest bounds, and cache selected
+station ZIP/text files under `<runtime-home>/cache/igra/recent/`. The cache
+contains `catalog.json`, `cache_manifest.json`, and per-station cached ZIP/text
+files. These are runtime-local generated/source-data artifacts; do not commit
+them. Automated tests use tiny fixture HTML, station-list text, and ZIP payloads
+only. No CI test should fetch live NOAA/NCEI data.
+
 Baseline Shallow Cumulus currently uses `zd = 4500.0` for Rayleigh damping in the 6 km quick-look domain. Preflight rejects namelists where Rayleigh damping would begin at or below half the configured domain top. A CM1 process that exits `0` without NetCDF or raw CM1 `.dat/.ctl` artifacts is recorded as `validation_status: needs_review` and `product_state: process_completed_no_output`, not as a completed usable CM1 result.
 
 Generated Baseline Shallow Cumulus packages prefer CM1 NetCDF output with `output_format = 2` and `output_filetype = 2`. CM1 documents `output_format = 1` as GrADS/direct-access output and `output_format = 2` as NetCDF. The first successful smoke run produced `.dat/.ctl` files, so those are cataloged as raw CM1 artifacts while the next manual run should verify the NetCDF path.
@@ -238,6 +247,8 @@ Runtime data belongs outside the repo by default:
   settings.json
   runs/
   cache/
+    igra/
+      recent/
   logs/
 ```
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -59,6 +59,14 @@ metadata-only observed-wind limitation. Large real station downloads, such as a
 full local IGRA file from `~/Downloads`, are manual validation inputs only and
 must not be committed.
 
+Recent IGRA catalog/cache tests must also use tiny fixtures only. They should
+cover directory-listing parsing for `*-data-beg*.txt.zip`, station-id extraction,
+station metadata joins, the documented Great Plains / Midwest lat/lon filter,
+runtime-local cache manifest writes, already-cached status, safe ZIP extraction,
+zip-slip/absolute-path rejection, and deterministic refresh/update behavior.
+CI must not fetch live NOAA/NCEI data, parse remote archives in the browser, or
+write downloaded ZIP/text/cache manifests outside temp runtime homes.
+
 Dry-run package tests should use temporary runtime homes and assert overwrite protection, manifest/report content, CM1-facing input readiness, and absence of NetCDF output. A dry-run package is packaged configuration and metadata only; it is not a launched process or completed CM1 result.
 
 Output product tests should follow the


### PR DESCRIPTION
## Issue worked
- Closes #238

## Summary
- Added backend IGRA recent catalog/cache helpers for NOAA/NCEI station-period ZIP references.
- Parses recent directory listings, extracts station IDs from `*-data-beg*.txt.zip`, joins IGRA station metadata, and filters to the documented Great Plains / Midwest v1 bounds.
- Caches selected station ZIP/text files under the configured runtime cache at `<runtime-home>/cache/igra/recent/` with `catalog.json` and `cache_manifest.json` metadata.
- Adds safe ZIP extraction protections for path traversal, absolute paths, unexpected members, and station/filename validation.
- Adds minimal bounded API hooks: catalog read/refresh, cache manifest read, and cache selected station-period file.
- Updates product, architecture, development, and testing docs for the backend/browser boundary and fixture-only CI rule.

## Model-output vs stats / data boundary
- This PR does not touch CM1 output ingest or NetCDF behavior.
- Browser code does not parse IGRA remote HTML, ZIPs, or station text files; backend owns fetch/cache/extract/metadata.

## Caveat behavior
- Missing station metadata is recorded as catalog caveats.
- The v1 Great Plains / Midwest region is a broad documented lat/lon bounding box, not a GIS boundary.
- Live NOAA/NCEI fetch is available through backend helpers/endpoints, but automated tests use fixtures only.

## Tests added/updated
- Added backend tests for recent directory parsing, station metadata parsing/join, region filtering, cached-state reporting, runtime-local manifest writes, safe ZIP extraction, zip-slip/absolute path rejection, and cached-catalog caching.
- Added API tests for the catalog endpoint and IGRA cache error mapping.

## Commands run
- `app/backend/.venv/bin/pytest app/backend/tests/test_igra_catalog.py app/backend/tests/test_app.py -q`
- `app/backend/.venv/bin/ruff check app/backend/cloud_chamber/igra_catalog.py app/backend/cloud_chamber/app.py app/backend/tests/test_igra_catalog.py app/backend/tests/test_app.py`
- `app/backend/.venv/bin/mypy app/backend/cloud_chamber/igra_catalog.py app/backend/cloud_chamber/app.py`
- `scripts/check.sh`

## Manual QA needed
- No UI manual QA needed; this is backend/data-contract foundation work.

## Generated-artifact check
- No IGRA ZIPs, extracted station text files, cache manifests, CM1 output, NetCDF files, runtime folders, logs, screenshots, videos, or traces were committed.
- Local artifact scan only found ignored dependency/dev files under `node_modules`, `.venv`, and `.dev`.
