### PR TITLE
Add IGRA recent cache script

### DIFF
--- a/app/backend/cloud_chamber/igra_catalog.py
+++ b/app/backend/cloud_chamber/igra_catalog.py
@@ -147,10 +147,10 @@ class IGRARecentCatalog(BaseModel):
 GREAT_PLAINS_MIDWEST_REGION = IGRARegionDefinition(
     tag="great_plains_midwest",
     label="Great Plains / Midwest",
-    min_latitude=30.0,
+    min_latitude=35.0,
     max_latitude=50.0,
     min_longitude=-106.0,
-    max_longitude=-80.0,
+    max_longitude=-82.0,
     caveats=[
         "Broad v1 lat/lon bounding box; not a GIS boundary.",
         "Bounds are intentionally conservative for recent IGRA sounding discovery.",
@@ -257,7 +257,7 @@ def build_recent_catalog(
     cache_by_filename = {
         entry.filename: entry for entry in (cache_manifest.entries if cache_manifest else [])
     }
-    caveats: list[str] = []
+    missing_station_metadata_count = 0
     stations_in_region = [
         station for station in station_by_id.values() if region.tag in station.region_tags
     ]
@@ -265,7 +265,7 @@ def build_recent_catalog(
     for reference in parse_recent_directory_listing(directory_html, base_url=source_url):
         station = station_by_id.get(reference.station_id)
         if station is None:
-            caveats.append(f"station_metadata_missing:{reference.station_id}")
+            missing_station_metadata_count += 1
             continue
         if region.tag not in station.region_tags:
             continue
@@ -286,6 +286,11 @@ def build_recent_catalog(
                     ),
                 }
             )
+        )
+    caveats: list[str] = []
+    if missing_station_metadata_count:
+        caveats.append(
+            f"station_metadata_missing_for_recent_links:{missing_station_metadata_count}"
         )
     return IGRARecentCatalog(
         source_url=source_url,
@@ -423,7 +428,37 @@ def cache_station_zip_from_catalog(
     ]
     if not matches:
         raise IGRACatalogError("Requested IGRA station-period file is not in the recent catalog.")
-    return cache_station_zip(settings, matches[0])
+    entry = cache_station_zip(settings, matches[0])
+    updated_references = [
+        _reference_with_cache_entry(reference, entry)
+        if reference.filename == entry.filename
+        else reference
+        for reference in catalog.zip_references
+    ]
+    write_igra_recent_catalog(
+        settings,
+        catalog.model_copy(
+            update={
+                "zip_references": updated_references,
+                "cache_manifest_path": str(igra_cache_manifest_path(settings)),
+            }
+        ),
+    )
+    return entry
+
+
+def _reference_with_cache_entry(
+    reference: IGRAStationZipReference,
+    entry: IGRACacheEntry,
+) -> IGRAStationZipReference:
+    return reference.model_copy(
+        update={
+            "cached_status": entry.cached_status,
+            "cached_zip_path": entry.cached_zip_path,
+            "cached_text_path": entry.cached_text_path,
+            "source_etag_or_last_modified": entry.source_etag_or_last_modified,
+        }
+    )
 
 
 def _region_tags_for_station(station: IGRAStationMetadata) -> list[RegionTag]:

--- a/app/backend/cloud_chamber/igra_recent_cli.py
+++ b/app/backend/cloud_chamber/igra_recent_cli.py
@@ -1,0 +1,428 @@
+"""Small command-line surface for the runtime-local IGRA recent cache."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from collections.abc import Sequence
+from pathlib import Path
+
+from cloud_chamber.igra_catalog import (
+    IGRACacheEntry,
+    IGRACacheManifest,
+    IGRACatalogError,
+    IGRARecentCatalog,
+    IGRAStationZipReference,
+    cache_station_zip,
+    cache_station_zip_from_catalog,
+    igra_cache_manifest_path,
+    igra_recent_catalog_path,
+    read_igra_cache_manifest,
+    read_igra_recent_catalog,
+    refresh_recent_catalog,
+    write_igra_recent_catalog,
+)
+from cloud_chamber.observed_sounding import ObservedSoundingError, summarize_igra_station_text
+from cloud_chamber.settings import CloudChamberSettings, load_settings
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    settings = load_settings()
+    try:
+        return int(args.func(args, settings))
+    except IGRACatalogError as exc:
+        print(f"IGRA recent cache error: {exc}")
+        return 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="scripts/igra-recent.sh",
+        description="Manage Cloud Chamber's runtime-local NOAA/NCEI IGRA recent cache.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    refresh = subparsers.add_parser(
+        "refresh",
+        help="Fetch the recent IGRA catalog and station metadata, then cache catalog metadata.",
+    )
+    refresh.set_defaults(func=_cmd_refresh)
+
+    cleanup = subparsers.add_parser(
+        "cleanup",
+        help="Delete the runtime-local recent IGRA cache so discovery can start clean.",
+    )
+    cleanup.set_defaults(func=_cmd_cleanup)
+
+    status = subparsers.add_parser(
+        "status",
+        help="Show the current local IGRA recent catalog/cache status.",
+    )
+    status.set_defaults(func=_cmd_status)
+
+    list_parser = subparsers.add_parser(
+        "list",
+        help="List Great Plains / Midwest station-period files from the cached catalog.",
+    )
+    list_parser.add_argument("--cached", action="store_true", help="Show only cached files.")
+    list_parser.add_argument("--station", help="Show only one station id.")
+    list_parser.add_argument("--limit", type=int, default=25, help="Maximum rows to print.")
+    list_parser.set_defaults(func=_cmd_list)
+
+    cache = subparsers.add_parser(
+        "cache",
+        help="Download/cache one selected station-period file from the cached catalog.",
+    )
+    cache.add_argument("station_id", help="IGRA station id, for example USM00072558.")
+    cache.add_argument(
+        "filename",
+        nargs="?",
+        help="Optional exact station-period ZIP filename. Usually not needed.",
+    )
+    cache.set_defaults(func=_cmd_cache)
+
+    cache_all = subparsers.add_parser(
+        "cache-all",
+        help="Download/cache many uncached station-period files from the cached catalog.",
+    )
+    cache_all.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum uncached station-period files to download. Default: 10.",
+    )
+    cache_all.add_argument(
+        "--station",
+        help="Optionally restrict batch caching to one station id.",
+    )
+    cache_all.set_defaults(func=_cmd_cache_all)
+
+    soundings = subparsers.add_parser(
+        "soundings",
+        help="List available sounding times from locally cached station text files.",
+    )
+    soundings.add_argument("--station", help="Show only one station id.")
+    soundings.add_argument("--limit", type=int, default=50, help="Maximum rows to print.")
+    soundings.add_argument(
+        "--latest-per-station",
+        type=int,
+        default=5,
+        help="Show only the latest N sounding times per station. Default: 5.",
+    )
+    soundings.add_argument(
+        "--all",
+        action="store_true",
+        help="Show all cached sounding times instead of the latest N per station.",
+    )
+    soundings.set_defaults(func=_cmd_soundings)
+
+    return parser
+
+
+def _cmd_refresh(_args: argparse.Namespace, settings: CloudChamberSettings) -> int:
+    catalog = refresh_recent_catalog(settings)
+    _print_catalog_summary(catalog, settings)
+    print("")
+    print("Next:")
+    print("  scripts/igra-recent.sh list --limit 20")
+    print("  scripts/igra-recent.sh cache-all --limit 10")
+    print("  scripts/igra-recent.sh soundings")
+    return 0
+
+
+def _cmd_cleanup(_args: argparse.Namespace, settings: CloudChamberSettings) -> int:
+    cache_root = igra_recent_catalog_path(settings).parent.expanduser()
+    expected_root = (settings.cache_dir.expanduser() / "igra" / "recent").resolve()
+    resolved = cache_root.resolve()
+    if resolved != expected_root:
+        raise IGRACatalogError(
+            "Refusing to clean IGRA cache because the resolved path did not match "
+            f"the expected runtime cache path: {resolved}"
+        )
+    if resolved in {
+        settings.runtime_home.expanduser().resolve(),
+        settings.cache_dir.expanduser().resolve(),
+        Path.home().resolve(),
+        Path("/").resolve(),
+    }:
+        raise IGRACatalogError(f"Refusing to clean unsafe IGRA cache path: {resolved}")
+    if not resolved.exists():
+        print("IGRA recent cache is already clean")
+        print(f"  Cache root: {resolved}")
+        return 0
+    if not resolved.is_dir():
+        raise IGRACatalogError(f"Refusing to clean non-directory IGRA cache path: {resolved}")
+    shutil.rmtree(resolved)
+    print("Deleted IGRA recent cache")
+    print(f"  Cache root: {resolved}")
+    print("")
+    print("Next:")
+    print("  scripts/igra-recent.sh status")
+    print("  scripts/igra-recent.sh refresh")
+    return 0
+
+
+def _cmd_status(_args: argparse.Namespace, settings: CloudChamberSettings) -> int:
+    catalog = read_igra_recent_catalog(settings)
+    manifest = read_igra_cache_manifest(settings)
+    if catalog is None:
+        print("IGRA recent catalog: not refreshed yet")
+        print(f"Expected catalog path: {igra_recent_catalog_path(settings)}")
+        print("")
+        print("Run: scripts/igra-recent.sh refresh")
+    else:
+        _print_catalog_summary(catalog, settings)
+    print("")
+    _print_cache_summary(manifest, settings)
+    return 0
+
+
+def _cmd_list(args: argparse.Namespace, settings: CloudChamberSettings) -> int:
+    catalog = read_igra_recent_catalog(settings)
+    if catalog is None:
+        raise IGRACatalogError("No local catalog yet. Run: scripts/igra-recent.sh refresh")
+    references = catalog.zip_references
+    if args.cached:
+        references = [
+            reference for reference in references if reference.cached_status != "not_cached"
+        ]
+    if args.station:
+        references = [reference for reference in references if reference.station_id == args.station]
+    if args.limit < 1:
+        raise IGRACatalogError("--limit must be at least 1.")
+    _print_references(references[: args.limit])
+    if len(references) > args.limit:
+        print(
+            f"... {len(references) - args.limit} more. Use --limit {len(references)} to show all."
+        )
+    return 0
+
+
+def _cmd_cache(args: argparse.Namespace, settings: CloudChamberSettings) -> int:
+    entry = cache_station_zip_from_catalog(
+        settings,
+        station_id=args.station_id,
+        filename=args.filename,
+    )
+    _print_cache_entry(entry)
+    return 0
+
+
+def _cmd_cache_all(args: argparse.Namespace, settings: CloudChamberSettings) -> int:
+    catalog = read_igra_recent_catalog(settings)
+    if catalog is None:
+        raise IGRACatalogError("No local catalog yet. Run: scripts/igra-recent.sh refresh")
+    if args.limit < 1:
+        raise IGRACatalogError("--limit must be at least 1.")
+    references = [
+        reference
+        for reference in catalog.zip_references
+        if reference.cached_status == "not_cached"
+        and (args.station is None or reference.station_id == args.station)
+    ]
+    selected = references[: args.limit]
+    if not selected:
+        print("No uncached IGRA station-period files matched.")
+        return 0
+    entries: list[IGRACacheEntry] = []
+    updated_references = list(catalog.zip_references)
+    print(f"Caching {len(selected)} IGRA station-period file(s)")
+    for index, reference in enumerate(selected, start=1):
+        name = reference.station_name or reference.station_id
+        print(f"  [{index}/{len(selected)}] {reference.station_id} {name}")
+        entry = cache_station_zip(settings, reference)
+        entries.append(entry)
+        updated_references = [
+            _reference_with_cache_entry_for_cli(existing, entry)
+            if existing.filename == entry.filename
+            else existing
+            for existing in updated_references
+        ]
+    write_igra_recent_catalog(
+        settings,
+        catalog.model_copy(
+            update={
+                "zip_references": updated_references,
+                "cache_manifest_path": str(igra_cache_manifest_path(settings)),
+            }
+        ),
+    )
+    print("")
+    print(f"Cached {len(entries)} station-period file(s).")
+    print("Next:")
+    print("  scripts/igra-recent.sh soundings")
+    return 0
+
+
+def _cmd_soundings(args: argparse.Namespace, settings: CloudChamberSettings) -> int:
+    manifest = read_igra_cache_manifest(settings)
+    entries = [
+        entry
+        for entry in manifest.entries
+        if entry.cached_text_path and (args.station is None or entry.station_id == args.station)
+    ]
+    if args.limit < 1:
+        raise IGRACatalogError("--limit must be at least 1.")
+    if args.latest_per_station < 1:
+        raise IGRACatalogError("--latest-per-station must be at least 1.")
+    if not entries:
+        print("No cached IGRA station text files matched.")
+        print("Run: scripts/igra-recent.sh cache-all --limit 10")
+        return 0
+    rows: list[tuple[str, str, str, int, str]] = []
+    caveats: list[str] = []
+    for entry in entries:
+        assert entry.cached_text_path is not None
+        path = Path(entry.cached_text_path)
+        try:
+            soundings = summarize_igra_station_text(path.read_text())
+        except (OSError, ObservedSoundingError) as exc:
+            caveats.append(f"{entry.station_id}:{path.name}:{exc}")
+            continue
+        for sounding in soundings:
+            rows.append(
+                (
+                    sounding.station_id,
+                    entry.station_name or "",
+                    sounding.valid_time_utc.isoformat().replace("+00:00", "Z"),
+                    sounding.num_levels,
+                    path.name,
+                )
+            )
+    rows.sort(key=lambda row: (row[2], row[0]), reverse=True)
+    total_rows = len(rows)
+    if not args.all:
+        rows = _latest_rows_per_station(rows, latest_per_station=args.latest_per_station)
+    _print_soundings(rows[: args.limit])
+    if len(rows) > args.limit:
+        print(f"... {len(rows) - args.limit} more. Use --limit {len(rows)} to show all.")
+    if not args.all and total_rows > len(rows):
+        print(
+            f"Showing latest {args.latest_per_station} sounding(s) per station "
+            f"({len(rows)} of {total_rows} cached sounding times). Use --all to list every time."
+        )
+    if caveats:
+        print("")
+        print("Caveats:")
+        for caveat in caveats[:8]:
+            print(f"  - {caveat}")
+    return 0
+
+
+def _latest_rows_per_station(
+    rows: list[tuple[str, str, str, int, str]], *, latest_per_station: int
+) -> list[tuple[str, str, str, int, str]]:
+    kept: list[tuple[str, str, str, int, str]] = []
+    counts_by_station: dict[str, int] = {}
+    for row in rows:
+        station_id = row[0]
+        count = counts_by_station.get(station_id, 0)
+        if count >= latest_per_station:
+            continue
+        kept.append(row)
+        counts_by_station[station_id] = count + 1
+    return kept
+
+
+def _print_catalog_summary(catalog: IGRARecentCatalog, settings: CloudChamberSettings) -> None:
+    cached = [
+        reference for reference in catalog.zip_references if reference.cached_status != "not_cached"
+    ]
+    print("IGRA recent catalog")
+    print(f"  Region: {catalog.region.label} ({catalog.region.tag})")
+    print(
+        "  Bounds: "
+        f"lat {catalog.region.min_latitude:g} to {catalog.region.max_latitude:g}, "
+        f"lon {catalog.region.min_longitude:g} to {catalog.region.max_longitude:g}"
+    )
+    print(f"  Refreshed: {catalog.refreshed_at.isoformat()}")
+    print(f"  Region stations: {len(catalog.stations)}")
+    print(f"  Region station-period files: {len(catalog.zip_references)}")
+    print(f"  Cached station-period files: {len(cached)}")
+    print(f"  Catalog path: {igra_recent_catalog_path(settings)}")
+    if catalog.caveats:
+        print("  Caveats:")
+        for caveat in catalog.caveats[:8]:
+            print(f"    - {caveat}")
+
+
+def _print_cache_summary(manifest: IGRACacheManifest, settings: CloudChamberSettings) -> None:
+    print("IGRA recent cache")
+    print(f"  Cache root: {manifest.cache_root}")
+    print(f"  Cache manifest: {igra_cache_manifest_path(settings)}")
+    print(f"  Cached entries: {len(manifest.entries)}")
+    if manifest.entries:
+        print("  Recent cached files:")
+        for entry in manifest.entries[-5:]:
+            name = entry.station_name or entry.station_id
+            cached_path = Path(entry.cached_text_path or entry.cached_zip_path).name
+            print(f"    - {entry.station_id} {name}: {cached_path}")
+
+
+def _print_references(references: list[IGRAStationZipReference]) -> None:
+    if not references:
+        print("No IGRA recent station-period files matched.")
+        return
+    print("Station ID   Status            Station                         File")
+    print("-" * 92)
+    for reference in references:
+        name = (reference.station_name or "").strip()[:30]
+        print(
+            f"{reference.station_id:<11}  "
+            f"{reference.cached_status:<16}  "
+            f"{name:<30}  "
+            f"{reference.filename}"
+        )
+
+
+def _print_soundings(rows: list[tuple[str, str, str, int, str]]) -> None:
+    if not rows:
+        print("No cached IGRA sounding times could be parsed.")
+        return
+    print("Station ID   Valid time UTC        Levels  Station                         File")
+    print("-" * 102)
+    for station_id, station_name, valid_time, levels, filename in rows:
+        print(
+            f"{station_id:<11}  "
+            f"{valid_time:<20}  "
+            f"{levels:<6}  "
+            f"{station_name.strip()[:30]:<30}  "
+            f"{filename}"
+        )
+
+
+def _reference_with_cache_entry_for_cli(
+    reference: IGRAStationZipReference,
+    entry: IGRACacheEntry,
+) -> IGRAStationZipReference:
+    return reference.model_copy(
+        update={
+            "cached_status": entry.cached_status,
+            "cached_zip_path": entry.cached_zip_path,
+            "cached_text_path": entry.cached_text_path,
+            "source_etag_or_last_modified": entry.source_etag_or_last_modified,
+        }
+    )
+
+
+def _print_cache_entry(entry: IGRACacheEntry) -> None:
+    print("Cached IGRA station-period file")
+    print(f"  Station: {entry.station_id} {entry.station_name or ''}".rstrip())
+    print(f"  Status: {entry.cached_status}")
+    print(f"  ZIP: {entry.cached_zip_path}")
+    if entry.cached_text_path:
+        print(f"  Text: {entry.cached_text_path}")
+    print(f"  Source: {entry.source_url}")
+    print(f"  Downloaded: {entry.downloaded_at.isoformat()}")
+    if entry.extracted_at:
+        print(f"  Extracted: {entry.extracted_at.isoformat()}")
+    if entry.caveats:
+        print("  Caveats:")
+        for caveat in entry.caveats:
+            print(f"    - {caveat}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/backend/cloud_chamber/observed_sounding.py
+++ b/app/backend/cloud_chamber/observed_sounding.py
@@ -133,6 +133,7 @@ def parse_igra_station_text(
     *,
     uploaded_filename: str,
     selected_time_utc: datetime | None = None,
+    station_metadata: StationMetadata | None = None,
 ) -> ObservedSoundingUploadResponse:
     """Parse NOAA/NCEI IGRA station sounding-data text.
 
@@ -164,6 +165,7 @@ def parse_igra_station_text(
         header=selected,
         raw_levels=raw_levels,
         uploaded_filename=uploaded_filename,
+        station_metadata=station_metadata,
     )
     return ObservedSoundingUploadResponse(
         source_provider="NOAA/NCEI IGRA",
@@ -172,6 +174,26 @@ def parse_igra_station_text(
         available_soundings=available,
         selected_sounding=record,
     )
+
+
+def summarize_igra_station_text(text: str) -> list[SoundingTimeSummary]:
+    """Return available IGRA sounding times without package-readiness validation."""
+
+    lines = text.splitlines()
+    headers = _scan_headers(lines)
+    if not headers:
+        raise ObservedSoundingError("No IGRA sounding headers were found in the station file.")
+    return [
+        SoundingTimeSummary(
+            station_id=header["station_id"],
+            valid_time_utc=header["valid_time_utc"],
+            source_time_text=header["source_time_text"],
+            num_levels=header["num_levels"],
+            pressure_source=header["pressure_source"],
+            non_pressure_source=header["non_pressure_source"],
+        )
+        for header in headers
+    ]
 
 
 def observed_sounding_from_payload(payload: object) -> ObservedSoundingRecord:
@@ -258,9 +280,14 @@ def _normalize_sounding(
     header: _IgraHeader,
     raw_levels: list[str],
     uploaded_filename: str,
+    station_metadata: StationMetadata | None = None,
 ) -> ObservedSoundingRecord:
     station_id = str(header["station_id"])
-    station = _STATION_METADATA.get(station_id)
+    station = (
+        station_metadata
+        if station_metadata is not None and station_metadata.station_id == station_id
+        else _STATION_METADATA.get(station_id)
+    )
     errors: list[str] = []
     caveats: list[str] = [
         "Observed IGRA sounding winds preserved as metadata; current CM1 "
@@ -273,7 +300,7 @@ def _normalize_sounding(
         errors.append("station_site_elevation_missing")
         station = StationMetadata(station_id=station_id)
     else:
-        caveats.append("station elevation joined from IGRA station metadata fixture")
+        caveats.append(f"station elevation joined from {station.source}")
 
     source_latitude = _coalesce_float(header.get("latitude"), station.latitude)
     source_longitude = _coalesce_float(header.get("longitude"), station.longitude)

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -156,10 +156,10 @@ def test_igra_recent_catalog_endpoint_returns_cached_catalog(
         region=IGRARegionDefinition(
             tag="great_plains_midwest",
             label="Great Plains / Midwest",
-            min_latitude=30,
+            min_latitude=35,
             max_latitude=50,
             min_longitude=-106,
-            max_longitude=-80,
+            max_longitude=-82,
         ),
         refreshed_at=datetime(2026, 7, 1, tzinfo=UTC),
         stations=[],

--- a/app/backend/tests/test_igra_catalog.py
+++ b/app/backend/tests/test_igra_catalog.py
@@ -114,7 +114,7 @@ def test_station_metadata_join_and_great_plains_midwest_filter() -> None:
     assert valley.longitude == pytest.approx(-96.3669)
     assert valley.region_tags == ["great_plains_midwest"]
     assert valley.cached_status == "not_cached"
-    assert "station_metadata_missing:USM00099999" in catalog.caveats
+    assert "station_metadata_missing_for_recent_links:1" in catalog.caveats
 
 
 def test_parse_station_metadata_handles_fixed_width_station_list() -> None:
@@ -234,7 +234,15 @@ def test_cache_station_zip_from_catalog_uses_cached_catalog(
 
     assert entry.station_id == "USM00072558"
     assert entry.cached_status == "cached_extracted"
-    assert read_igra_recent_catalog(settings) == catalog
+    updated_catalog = read_igra_recent_catalog(settings)
+    assert updated_catalog is not None
+    cached_reference = next(
+        reference
+        for reference in updated_catalog.zip_references
+        if reference.station_id == "USM00072558"
+    )
+    assert cached_reference.cached_status == "cached_extracted"
+    assert cached_reference.cached_text_path == entry.cached_text_path
 
 
 def test_cache_station_zip_rejects_unsafe_station_id_and_filename(tmp_path: Path) -> None:

--- a/app/backend/tests/test_igra_recent_cli.py
+++ b/app/backend/tests/test_igra_recent_cli.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from igra_fixtures import IGRA_FIXTURE
+
+from cloud_chamber.igra_catalog import (
+    GREAT_PLAINS_MIDWEST_REGION,
+    IGRACacheEntry,
+    IGRACacheManifest,
+    IGRARecentCatalog,
+    IGRAStationMetadata,
+    IGRAStationZipReference,
+)
+from cloud_chamber.igra_recent_cli import main
+from cloud_chamber.settings import CloudChamberSettings
+
+
+def catalog() -> IGRARecentCatalog:
+    return IGRARecentCatalog(
+        source_url="https://example.test/igra/",
+        station_metadata_source="https://example.test/stations.txt",
+        region=GREAT_PLAINS_MIDWEST_REGION,
+        refreshed_at=datetime(2026, 7, 1, tzinfo=UTC),
+        stations=[
+            IGRAStationMetadata(
+                station_id="USM00072558",
+                station_name="VALLEY",
+                latitude=41.32,
+                longitude=-96.3669,
+                elevation_m_msl=351.5,
+                region_tags=["great_plains_midwest"],
+            )
+        ],
+        zip_references=[
+            IGRAStationZipReference(
+                station_id="USM00072558",
+                station_name="VALLEY",
+                latitude=41.32,
+                longitude=-96.3669,
+                elevation_m_msl=351.5,
+                filename="USM00072558-data-beg2025.txt.zip",
+                begin_year=2025,
+                source_url="https://example.test/USM00072558-data-beg2025.txt.zip",
+                region_tags=["great_plains_midwest"],
+                cached_status="not_cached",
+            )
+        ],
+        cache_manifest_path="/tmp/cache/igra/recent/cache_manifest.json",
+    )
+
+
+def cache_manifest() -> IGRACacheManifest:
+    return IGRACacheManifest(
+        cache_root="/tmp/CloudChamber/cache/igra/recent",
+        entries=[],
+        updated_at=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+
+
+def cache_entry(tmp_path: Path) -> IGRACacheEntry:
+    return IGRACacheEntry(
+        station_id="USM00072558",
+        station_name="VALLEY",
+        latitude=41.32,
+        longitude=-96.3669,
+        elevation_m_msl=351.5,
+        filename="USM00072558-data-beg2025.txt.zip",
+        source_url="https://example.test/USM00072558-data-beg2025.txt.zip",
+        region_tags=["great_plains_midwest"],
+        cached_status="cached_extracted",
+        cached_zip_path=str(tmp_path / "USM00072558-data-beg2025.txt.zip"),
+        cached_text_path=str(tmp_path / "USM00072558-data-beg2025.txt"),
+        downloaded_at=datetime(2026, 7, 1, tzinfo=UTC),
+        extracted_at=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+
+
+def test_cleanup_deletes_runtime_recent_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    settings = CloudChamberSettings(
+        runtime_home=tmp_path / "CloudChamber",
+        cm1_root=None,
+        cm1_run_dir=None,
+        cache_dir=tmp_path / "CloudChamber" / "cache",
+        log_dir=tmp_path / "CloudChamber" / "logs",
+    )
+    recent_cache = settings.cache_dir / "igra" / "recent"
+    recent_cache.mkdir(parents=True)
+    (recent_cache / "catalog.json").write_text("{}")
+    monkeypatch.setattr("cloud_chamber.igra_recent_cli.load_settings", lambda: settings)
+
+    assert main(["cleanup"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Deleted IGRA recent cache" in output
+    assert not recent_cache.exists()
+
+
+def test_cleanup_is_idempotent_when_cache_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    settings = CloudChamberSettings(
+        runtime_home=tmp_path / "CloudChamber",
+        cm1_root=None,
+        cm1_run_dir=None,
+        cache_dir=tmp_path / "CloudChamber" / "cache",
+        log_dir=tmp_path / "CloudChamber" / "logs",
+    )
+    monkeypatch.setattr("cloud_chamber.igra_recent_cli.load_settings", lambda: settings)
+
+    assert main(["cleanup"]) == 0
+
+    output = capsys.readouterr().out
+    assert "already clean" in output
+
+
+def test_cleanup_refuses_unexpected_cache_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    settings = CloudChamberSettings(
+        runtime_home=tmp_path / "CloudChamber",
+        cm1_root=None,
+        cm1_run_dir=None,
+        cache_dir=tmp_path / "CloudChamber" / "cache",
+        log_dir=tmp_path / "CloudChamber" / "logs",
+    )
+    monkeypatch.setattr("cloud_chamber.igra_recent_cli.load_settings", lambda: settings)
+    monkeypatch.setattr(
+        "cloud_chamber.igra_recent_cli.igra_recent_catalog_path",
+        lambda _settings: settings.cache_dir / "catalog.json",
+    )
+
+    assert main(["cleanup"]) == 2
+
+    output = capsys.readouterr().out
+    assert "Refusing to clean IGRA cache" in output
+
+
+def test_status_points_to_refresh_when_catalog_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("cloud_chamber.igra_recent_cli.read_igra_recent_catalog", lambda _s: None)
+    monkeypatch.setattr(
+        "cloud_chamber.igra_recent_cli.read_igra_cache_manifest",
+        lambda _s: cache_manifest(),
+    )
+
+    assert main(["status"]) == 0
+
+    output = capsys.readouterr().out
+    assert "IGRA recent catalog: not refreshed yet" in output
+    assert "Run: scripts/igra-recent.sh refresh" in output
+    assert "Cached entries: 0" in output
+
+
+def test_list_prints_station_period_files(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        "cloud_chamber.igra_recent_cli.read_igra_recent_catalog", lambda _s: catalog()
+    )
+
+    assert main(["list"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Station ID" in output
+    assert "USM00072558" in output
+    assert "USM00072558-data-beg2025.txt.zip" in output
+
+
+def test_cache_prints_local_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    entry = cache_entry(tmp_path)
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_cache(
+        _settings: object,
+        *,
+        station_id: str,
+        filename: str | None,
+    ) -> IGRACacheEntry:
+        calls.append((station_id, filename))
+        return entry
+
+    monkeypatch.setattr("cloud_chamber.igra_recent_cli.cache_station_zip_from_catalog", fake_cache)
+
+    assert main(["cache", "USM00072558"]) == 0
+
+    output = capsys.readouterr().out
+    assert calls == [("USM00072558", None)]
+    assert "Cached IGRA station-period file" in output
+    assert str(tmp_path / "USM00072558-data-beg2025.txt") in output
+
+
+def test_cache_all_downloads_multiple_uncached_references(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    second_reference = IGRAStationZipReference(
+        station_id="USM00072558",
+        station_name="VALLEY",
+        latitude=41.32,
+        longitude=-96.3669,
+        elevation_m_msl=351.5,
+        filename="USM00072558-data-beg2026.txt.zip",
+        begin_year=2026,
+        source_url="https://example.test/USM00072558-data-beg2026.txt.zip",
+        region_tags=["great_plains_midwest"],
+        cached_status="not_cached",
+    )
+    test_catalog = catalog().model_copy(
+        update={"zip_references": [*catalog().zip_references, second_reference]}
+    )
+    entries = [
+        cache_entry(tmp_path).model_copy(update={"filename": "USM00072558-data-beg2025.txt.zip"}),
+        cache_entry(tmp_path).model_copy(update={"filename": "USM00072558-data-beg2026.txt.zip"}),
+    ]
+    calls: list[str] = []
+    written_catalogs: list[IGRARecentCatalog] = []
+
+    def fake_cache(_settings: object, reference: IGRAStationZipReference) -> IGRACacheEntry:
+        calls.append(reference.filename)
+        return entries[len(calls) - 1]
+
+    monkeypatch.setattr(
+        "cloud_chamber.igra_recent_cli.read_igra_recent_catalog", lambda _s: test_catalog
+    )
+    monkeypatch.setattr("cloud_chamber.igra_recent_cli.cache_station_zip", fake_cache)
+    monkeypatch.setattr(
+        "cloud_chamber.igra_recent_cli.write_igra_recent_catalog",
+        lambda _s, item: written_catalogs.append(item),
+    )
+
+    assert main(["cache-all", "--limit", "2"]) == 0
+
+    output = capsys.readouterr().out
+    assert calls == ["USM00072558-data-beg2025.txt.zip", "USM00072558-data-beg2026.txt.zip"]
+    assert "Caching 2 IGRA station-period file(s)" in output
+    assert "scripts/igra-recent.sh soundings" in output
+    assert len(written_catalogs) == 1
+    assert all(
+        reference.cached_status == "cached_extracted"
+        for reference in written_catalogs[0].zip_references
+    )
+
+
+def test_soundings_lists_cached_sounding_times(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    text_path = tmp_path / "USM00072558-data-beg2025.txt"
+    text_path.write_text(IGRA_FIXTURE)
+    entry = cache_entry(tmp_path).model_copy(update={"cached_text_path": str(text_path)})
+    manifest = cache_manifest().model_copy(update={"entries": [entry]})
+    monkeypatch.setattr(
+        "cloud_chamber.igra_recent_cli.read_igra_cache_manifest",
+        lambda _s: manifest,
+    )
+
+    assert main(["soundings", "--limit", "5"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Station ID" in output
+    assert "Valid time UTC" in output
+    assert "USM00072558" in output
+    assert "2025-01-01T00:00:00Z" in output
+
+
+def test_soundings_defaults_to_latest_per_station(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    text_path = tmp_path / "USM00072558-data-beg2025.txt"
+    text_path.write_text(IGRA_FIXTURE)
+    entry = cache_entry(tmp_path).model_copy(update={"cached_text_path": str(text_path)})
+    manifest = cache_manifest().model_copy(update={"entries": [entry]})
+    monkeypatch.setattr(
+        "cloud_chamber.igra_recent_cli.read_igra_cache_manifest",
+        lambda _s: manifest,
+    )
+
+    assert main(["soundings", "--latest-per-station", "1"]) == 0
+
+    output = capsys.readouterr().out
+    assert "2025-01-02T00:00:00Z" in output
+    assert "2025-01-01T00:00:00Z" not in output
+    assert "Use --all to list every time" in output
+
+
+def test_soundings_all_lists_every_cached_time(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    text_path = tmp_path / "USM00072558-data-beg2025.txt"
+    text_path.write_text(IGRA_FIXTURE)
+    entry = cache_entry(tmp_path).model_copy(update={"cached_text_path": str(text_path)})
+    manifest = cache_manifest().model_copy(update={"entries": [entry]})
+    monkeypatch.setattr(
+        "cloud_chamber.igra_recent_cli.read_igra_cache_manifest",
+        lambda _s: manifest,
+    )
+
+    assert main(["soundings", "--latest-per-station", "1", "--all"]) == 0
+
+    output = capsys.readouterr().out
+    assert "2025-01-02T00:00:00Z" in output
+    assert "2025-01-01T00:00:00Z" in output
+    assert "Use --all to list every time" not in output
+
+
+def test_soundings_lists_multiple_cached_stations(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    valley_path = tmp_path / "USM00072558-data-beg2025.txt"
+    norman_path = tmp_path / "USM00072357-data-beg2025.txt"
+    valley_path.write_text(IGRA_FIXTURE)
+    norman_path.write_text(IGRA_FIXTURE.replace("USM00072558", "USM00072357"))
+    valley = cache_entry(tmp_path).model_copy(update={"cached_text_path": str(valley_path)})
+    norman = cache_entry(tmp_path).model_copy(
+        update={
+            "station_id": "USM00072357",
+            "station_name": "NORMAN/MAX WESTHEIMER A; OK.",
+            "filename": "USM00072357-data-beg2025.txt.zip",
+            "cached_zip_path": str(tmp_path / "USM00072357-data-beg2025.txt.zip"),
+            "cached_text_path": str(norman_path),
+        }
+    )
+    manifest = cache_manifest().model_copy(update={"entries": [valley, norman]})
+    monkeypatch.setattr(
+        "cloud_chamber.igra_recent_cli.read_igra_cache_manifest",
+        lambda _s: manifest,
+    )
+
+    assert main(["soundings", "--limit", "10"]) == 0
+
+    output = capsys.readouterr().out
+    assert "USM00072558" in output
+    assert "USM00072357" in output
+    assert "NORMAN/MAX WESTHEIMER A; OK." in output
+
+
+def test_refresh_prints_next_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        "cloud_chamber.igra_recent_cli.refresh_recent_catalog", lambda _s: catalog()
+    )
+
+    assert main(["refresh"]) == 0
+
+    output = capsys.readouterr().out
+    assert "IGRA recent catalog" in output
+    assert "scripts/igra-recent.sh list" in output
+    assert "scripts/igra-recent.sh cache-all --limit 10" in output
+    assert "scripts/igra-recent.sh soundings" in output

--- a/app/backend/tests/test_observed_sounding.py
+++ b/app/backend/tests/test_observed_sounding.py
@@ -7,8 +7,10 @@ from igra_fixtures import IGRA_FIXTURE
 
 from cloud_chamber.observed_sounding import (
     ObservedSoundingError,
+    StationMetadata,
     parse_igra_station_text,
     render_observed_input_sounding,
+    summarize_igra_station_text,
 )
 
 
@@ -34,6 +36,38 @@ def test_parse_igra_station_text_defaults_to_latest_sounding() -> None:
     assert record.validation.status == "needs_review"
     assert "station elevation joined" in " ".join(record.validation.caveats)
     assert "metadata_only" in record.wind_handling
+
+
+def test_summarize_igra_station_text_lists_times_without_package_validation() -> None:
+    summaries = summarize_igra_station_text(IGRA_FIXTURE)
+
+    assert len(summaries) == 2
+    assert summaries[0].station_id == "USM00072558"
+    assert summaries[0].valid_time_utc == datetime(2025, 1, 1, tzinfo=UTC)
+    assert summaries[0].num_levels > 0
+
+
+def test_parse_igra_station_text_accepts_supplied_station_metadata() -> None:
+    alternate_station_text = IGRA_FIXTURE.replace("USM00072558", "USM00072357")
+    parsed = parse_igra_station_text(
+        alternate_station_text,
+        uploaded_filename="USM00072357-data-beg2025.txt",
+        station_metadata=StationMetadata(
+            station_id="USM00072357",
+            station_name="Norman, Oklahoma",
+            latitude=35.2456,
+            longitude=-97.4721,
+            elevation_m_msl=357.0,
+            source="IGRA recent cache station metadata",
+        ),
+    )
+
+    record = parsed.selected_sounding
+    assert record.station_id == "USM00072357"
+    assert record.station_name == "Norman, Oklahoma"
+    assert record.station_elevation_m_msl == pytest.approx(357.0)
+    assert record.model_bottom_elevation_m_msl == pytest.approx(357.0)
+    assert "station elevation joined from IGRA recent cache" in " ".join(record.validation.caveats)
 
 
 def test_parse_igra_station_text_selects_requested_sounding_time() -> None:

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -74,12 +74,16 @@ generation; it does not parse sounding files into CM1-ready data itself.
 The IGRA recent catalog/cache layer is separate from package generation. The
 backend can refresh the NOAA/NCEI IGRA recent station-period directory, parse
 station metadata, filter to the v1 Great Plains / Midwest region bounds
-(`30.0` to `50.0` latitude, `-106.0` to `-80.0` longitude), and cache selected
-station-period ZIP/text files under `<runtime-home>/cache/igra/recent/`.
-Runtime cache metadata is stored in `catalog.json` and `cache_manifest.json`;
-downloaded ZIPs and extracted station text stay under per-station cache
-directories. The browser does not parse remote HTML, station archives, or
-station text files.
+(`35.0` to `50.0` latitude, `-106.0` to `-82.0` longitude), and cache selected
+or batched station-period ZIP/text files under
+`<runtime-home>/cache/igra/recent/`. Runtime cache metadata is stored in
+`catalog.json` and `cache_manifest.json`; downloaded ZIPs and extracted station
+text stay under per-station cache directories. The command-line cache surface
+can also summarize available sounding times from cached station text. The browser
+does not parse remote HTML, station archives, or station text files.
+When cached station metadata is available, the observed-sounding parser can use
+it for station name, location, and elevation instead of relying only on built-in
+fixture metadata.
 
 ## Suggested Stack
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -81,8 +81,10 @@ observed-wind forcing.
 Cloud Chamber also owns a backend-only local cache foundation for recent IGRA
 station-period source files. V1 can refresh the NOAA/NCEI IGRA recent catalog,
 join station metadata, filter to a broad Great Plains / Midwest bounding box
-(`30.0` to `50.0` latitude, `-106.0` to `-80.0` longitude), and cache selected
-station ZIP/text files under `<runtime-home>/cache/igra/recent/`. This is source
+(`35.0` to `50.0` latitude, `-106.0` to `-82.0` longitude), and cache selected
+or batched station ZIP/text files under `<runtime-home>/cache/igra/recent/`.
+The local script surface can list cached sounding times so Tim can inspect a
+batch of recent soundings without hand-written HTTP requests. This is source
 data for future “Find Interesting Soundings” work only: it does not score
 soundings, choose LES stories, generate packages, or run CM1. The browser never
 parses remote directory listings, ZIP files, or station text files.

--- a/docs/development.md
+++ b/docs/development.md
@@ -151,6 +151,42 @@ files. These are runtime-local generated/source-data artifacts; do not commit
 them. Automated tests use tiny fixture HTML, station-list text, and ZIP payloads
 only. No CI test should fetch live NOAA/NCEI data.
 
+Use the script surface for manual/local IGRA cache work; do not hand-write curl
+commands for normal use:
+
+```bash
+scripts/igra-recent.sh status
+scripts/igra-recent.sh refresh
+scripts/igra-recent.sh list --limit 20
+scripts/igra-recent.sh cache-all --limit 10
+scripts/igra-recent.sh soundings
+scripts/igra-recent.sh cache USM00072558
+```
+
+`refresh` contacts NOAA/NCEI catalog sources and writes local catalog metadata.
+`cache-all` downloads a batch of station-period ZIP/text files from the
+already-refreshed local catalog. `soundings` inspects cached station text files
+and lists available sounding times. `cache` remains available when a single
+known station is desired. These commands write only under the configured runtime
+cache.
+
+By default, `soundings` shows only the latest few times for each cached station.
+Use `--all` only when you intentionally want every cached sounding time:
+
+```bash
+scripts/igra-recent.sh soundings --latest-per-station 3
+scripts/igra-recent.sh soundings --all --limit 200
+```
+
+To reset the recent IGRA cache and test from a clean state, use the script
+cleanup command, then rerun `status` / `refresh`:
+
+```bash
+scripts/igra-recent.sh cleanup
+scripts/igra-recent.sh status
+scripts/igra-recent.sh refresh
+```
+
 Baseline Shallow Cumulus currently uses `zd = 4500.0` for Rayleigh damping in the 6 km quick-look domain. Preflight rejects namelists where Rayleigh damping would begin at or below half the configured domain top. A CM1 process that exits `0` without NetCDF or raw CM1 `.dat/.ctl` artifacts is recorded as `validation_status: needs_review` and `product_state: process_completed_no_output`, not as a completed usable CM1 result.
 
 Generated Baseline Shallow Cumulus packages prefer CM1 NetCDF output with `output_format = 2` and `output_filetype = 2`. CM1 documents `output_format = 1` as GrADS/direct-access output and `output_format = 2` as NetCDF. The first successful smoke run produced `.dat/.ctl` files, so those are cataloged as raw CM1 artifacts while the next manual run should verify the NetCDF path.

--- a/scripts/igra-recent.sh
+++ b/scripts/igra-recent.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_PYTHON="${BACKEND_PYTHON:-python}"
+
+if [[ -x "$ROOT_DIR/app/backend/.venv/bin/python" && "$BACKEND_PYTHON" == "python" ]]; then
+  BACKEND_PYTHON="$ROOT_DIR/app/backend/.venv/bin/python"
+fi
+
+if ! command -v "$BACKEND_PYTHON" >/dev/null 2>&1; then
+  echo "Missing backend Python: $BACKEND_PYTHON" >&2
+  echo "Run backend setup from docs/development.md, or set BACKEND_PYTHON." >&2
+  exit 127
+fi
+
+cd "$ROOT_DIR/app/backend"
+exec "$BACKEND_PYTHON" -m cloud_chamber.igra_recent_cli "$@"


### PR DESCRIPTION
## Issue worked

Follow-up to #238 / PR #243.

## Summary

This PR adds a repo-native script flow for the recent IGRA station catalog/cache so Tim does not need to run hand-written curl commands.

New commands:

```bash
scripts/igra-recent.sh status
scripts/igra-recent.sh refresh
scripts/igra-recent.sh list --limit 20
scripts/igra-recent.sh cache-all --limit 10
scripts/igra-recent.sh soundings
scripts/igra-recent.sh soundings --latest-per-station 3
scripts/igra-recent.sh soundings --all --limit 200
scripts/igra-recent.sh cache USM00072558
scripts/igra-recent.sh cleanup
```

What changed:

- Added `scripts/igra-recent.sh` as the user-facing command wrapper.
- Added `cloud_chamber.igra_recent_cli` with `status`, `refresh`, `list`, `cache-all`, `soundings`, `cache`, and `cleanup` subcommands.
- Added batch caching so a user can pull down multiple recent station-period files at once.
- Added cached-sounding inspection so a user can list available sounding times across cached station text files.
- Made `soundings` default to the latest 5 sounding times per station, with `--all` required to intentionally list every cached time.
- Added `cleanup` to delete only the runtime-local recent IGRA cache and start over cleanly.
- Documented the script in `docs/development.md`.
- Tightened the V1 Great Plains/Midwest station bounds to avoid obviously out-of-region stations.
- Fixed catalog/cache status consistency so caching stations updates the local catalog state.
- Collapsed missing station metadata caveats into a count instead of dumping unrelated station IDs.
- Separated IGRA header/time discovery from full CM1 package-readiness validation.
- Allowed observed-sounding parsing to use supplied station metadata from the IGRA catalog/cache, instead of only built-in fixture metadata.

## Live smoke

Ran the script flow locally against the runtime cache:

```bash
scripts/igra-recent.sh status
scripts/igra-recent.sh list --limit 5
scripts/igra-recent.sh soundings
```

Observed after caching the current local batch:

- Region bounds: lat 35 to 50, lon -106 to -82
- Region stations: 137
- Region station-period files: 22
- Cached station-period files: 22
- `soundings` lists multiple cached stations, including Topeka, Springfield, Wilmington, Norman, Nashville, North Platte, Valley, Dodge City, Amarillo, Kapuskasing, and Winnipeg.
- `soundings` reports when it is showing a bounded latest-per-station subset, for example 110 of 22029 cached sounding times.
- Catalog path: `<runtime-home>/cache/igra/recent/catalog.json`

Runtime cache files were written under `/Users/timpeterson/CloudChamber/cache/igra/recent/`, outside the repo.

## How to verify locally

No dev server is required.

```bash
cd /Users/timpeterson/Documents/Codex/cloud-chamber
scripts/igra-recent.sh cleanup
scripts/igra-recent.sh status
scripts/igra-recent.sh refresh
scripts/igra-recent.sh list --limit 20
scripts/igra-recent.sh cache-all --limit 10
scripts/igra-recent.sh soundings
scripts/igra-recent.sh soundings --latest-per-station 3
scripts/igra-recent.sh list --cached --limit 20
```

For one known station:

```bash
scripts/igra-recent.sh cache USM00072558
scripts/igra-recent.sh soundings --station USM00072558 --latest-per-station 10
```

For every cached sounding time, opt in explicitly:

```bash
scripts/igra-recent.sh soundings --all --limit 200
```

## Tests run

```bash
app/backend/.venv/bin/pytest app/backend/tests/test_igra_recent_cli.py app/backend/tests/test_observed_sounding.py -q
scripts/igra-recent.sh soundings
scripts/check.sh
```

## Generated artifact check

No generated runtime/cache files are committed. The live-smoke cache files are local runtime data under `/Users/timpeterson/CloudChamber/cache/igra/recent/`.

## Merge posture

Tim approved adding cleanup and merging when done. Merge after checks pass.
