### PR TITLE
Add Build UI for observed sounding candidates

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -133,6 +133,11 @@ class IGRACacheRequest(BaseModel):
     filename: str | None = None
 
 
+class IGRABatchCacheRequest(BaseModel):
+    station_id: str | None = None
+    limit: int = 10
+
+
 class SoundingCandidateScreenRequest(BaseModel):
     station_id: str | None = None
     latest_per_station: int = 5
@@ -222,6 +227,51 @@ def cache_igra_recent_file(request: IGRACacheRequest) -> dict[str, object]:
     except IGRACatalogError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return entry.model_dump(mode="json")
+
+
+@app.post("/api/igra/recent/cache-batch")
+def cache_igra_recent_files(request: IGRABatchCacheRequest) -> dict[str, object]:
+    if request.limit < 1:
+        raise HTTPException(status_code=400, detail="limit must be at least 1")
+    settings = load_settings()
+    catalog = read_igra_recent_catalog(settings)
+    if catalog is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Refresh IGRA recent catalog before caching station files.",
+        )
+    uncached = [
+        reference
+        for reference in catalog.zip_references
+        if reference.cached_status == "not_cached"
+        and (request.station_id is None or reference.station_id == request.station_id)
+    ]
+    selected = uncached[: request.limit]
+    cached_entries: list[dict[str, object]] = []
+    failed: list[dict[str, str]] = []
+    for reference in selected:
+        try:
+            entry = cache_station_zip_from_catalog(
+                settings,
+                station_id=reference.station_id,
+                filename=reference.filename,
+            )
+            cached_entries.append(entry.model_dump(mode="json"))
+        except IGRACatalogError as exc:
+            failed.append(
+                {
+                    "station_id": reference.station_id,
+                    "filename": reference.filename,
+                    "error": str(exc),
+                }
+            )
+    return {
+        "requested_limit": request.limit,
+        "selected_count": len(selected),
+        "cached_entries": cached_entries,
+        "failed": failed,
+        "remaining_uncached_count": max(0, len(uncached) - len(cached_entries)),
+    }
 
 
 @app.get("/api/sounding-candidates/screening-inputs")

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -116,6 +116,9 @@ class ScreeningInput(BaseModel):
     cached_text_path: str
     source_file_name: str
     cached_status: str
+    sounding_count: int | None = None
+    latest_valid_time_utc: datetime | None = None
+    caveats: list[str] = Field(default_factory=list)
 
 
 class ScreeningResult(BaseModel):
@@ -158,17 +161,34 @@ class SaveCandidateRequest(BaseModel):
 def list_screening_inputs(settings: CloudChamberSettings) -> list[ScreeningInput]:
     """List cached station text files available for screening."""
 
-    return [
-        ScreeningInput(
-            station_id=entry.station_id,
-            station_name=entry.station_name,
-            cached_text_path=entry.cached_text_path,
-            source_file_name=Path(entry.cached_text_path).name,
-            cached_status=entry.cached_status,
+    inputs: list[ScreeningInput] = []
+    for entry in _cached_text_entries(settings):
+        if entry.cached_text_path is None:
+            continue
+        text_path = Path(entry.cached_text_path)
+        sounding_count: int | None = None
+        latest_valid_time_utc: datetime | None = None
+        caveats: list[str] = []
+        try:
+            summaries = summarize_igra_station_text(text_path.read_text())
+            sounding_count = len(summaries)
+            if summaries:
+                latest_valid_time_utc = max(summary.valid_time_utc for summary in summaries)
+        except (OSError, ObservedSoundingError) as exc:
+            caveats.append(str(exc))
+        inputs.append(
+            ScreeningInput(
+                station_id=entry.station_id,
+                station_name=entry.station_name,
+                cached_text_path=entry.cached_text_path,
+                source_file_name=text_path.name,
+                cached_status=entry.cached_status,
+                sounding_count=sounding_count,
+                latest_valid_time_utc=latest_valid_time_utc,
+                caveats=caveats,
+            )
         )
-        for entry in _cached_text_entries(settings)
-        if entry.cached_text_path is not None
-    ]
+    return inputs
 
 
 def screen_cached_soundings(

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -10,6 +10,7 @@ from igra_fixtures import IGRA_FIXTURE
 from cloud_chamber.app import app
 from cloud_chamber.dry_run_package import generate_dry_run_package
 from cloud_chamber.igra_catalog import (
+    IGRACacheEntry,
     IGRACatalogError,
     IGRARecentCatalog,
     IGRARegionDefinition,
@@ -199,6 +200,82 @@ def test_igra_recent_cache_endpoint_reports_clear_failure(
 
     assert response.status_code == 400
     assert "Requested file is not cached" in response.json()["detail"]
+
+
+def test_igra_recent_batch_cache_endpoint_caches_bounded_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    catalog = IGRARecentCatalog(
+        source_url="https://example.test/igra/",
+        station_metadata_source="https://example.test/stations.txt",
+        region=IGRARegionDefinition(
+            tag="great_plains_midwest",
+            label="Great Plains / Midwest",
+            min_latitude=35,
+            max_latitude=50,
+            min_longitude=-106,
+            max_longitude=-82,
+        ),
+        refreshed_at=datetime(2026, 7, 1, tzinfo=UTC),
+        stations=[],
+        zip_references=[
+            IGRAStationZipReference(
+                station_id="USM00072558",
+                filename="USM00072558-data-beg2025.txt.zip",
+                begin_year=2025,
+                source_url="https://example.test/USM00072558-data-beg2025.txt.zip",
+                region_tags=["great_plains_midwest"],
+            ),
+            IGRAStationZipReference(
+                station_id="USM00072426",
+                filename="USM00072426-data-beg2025.txt.zip",
+                begin_year=2025,
+                source_url="https://example.test/USM00072426-data-beg2025.txt.zip",
+                region_tags=["great_plains_midwest"],
+            ),
+        ],
+        cache_manifest_path=str(tmp_path / "cache_manifest.json"),
+    )
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_cache(
+        _settings: object,
+        *,
+        station_id: str,
+        filename: str | None,
+    ) -> IGRACacheEntry:
+        calls.append((station_id, filename))
+        return IGRACacheEntry(
+            station_id=station_id,
+            filename=filename or f"{station_id}-data-beg2025.txt.zip",
+            source_url=f"https://example.test/{filename}",
+            region_tags=["great_plains_midwest"],
+            cached_status="cached_extracted",
+            cached_zip_path=str(tmp_path / (filename or f"{station_id}.zip")),
+            cached_text_path=str(tmp_path / station_id / f"{station_id}-data.txt"),
+            downloaded_at=datetime(2026, 7, 1, tzinfo=UTC),
+            extracted_at=datetime(2026, 7, 1, tzinfo=UTC),
+        )
+
+    monkeypatch.setattr("cloud_chamber.app.read_igra_recent_catalog", lambda _settings: catalog)
+    monkeypatch.setattr("cloud_chamber.app.cache_station_zip_from_catalog", fake_cache)
+
+    response = TestClient(app).post("/api/igra/recent/cache-batch", json={"limit": 1})
+
+    assert response.status_code == 200
+    assert calls == [("USM00072558", "USM00072558-data-beg2025.txt.zip")]
+    payload = response.json()
+    assert payload["selected_count"] == 1
+    assert payload["cached_entries"][0]["station_id"] == "USM00072558"
+    assert payload["remaining_uncached_count"] == 1
+
+
+def test_igra_recent_batch_cache_endpoint_rejects_invalid_limit() -> None:
+    response = TestClient(app).post("/api/igra/recent/cache-batch", json={"limit": 0})
+
+    assert response.status_code == 400
+    assert "limit" in response.json()["detail"]
 
 
 def test_launch_run_api_returns_status(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -175,6 +175,108 @@ const observedSoundingParseResponse = {
   },
 };
 
+const shallowSoundingCandidate = {
+  candidate_id: "USM00072558-2025010200-shallow",
+  station_id: "USM00072558",
+  station_name: "Valley, Nebraska",
+  station_latitude: 41.32,
+  station_longitude: -96.3669,
+  station_elevation_m_msl: 351.5,
+  valid_time_utc: "2025-01-02T00:00:00Z",
+  source_time_text: "2025 01 02 00",
+  source_file_name: "USM00072558-data.txt",
+  source_file_hash: "mock-hash",
+  source_format: "igra_station_text",
+  source_provider: "NOAA/NCEI IGRA",
+  primary_story: "shallow_cumulus_candidate",
+  primary_story_label: "Cloud-forming shallow cumulus",
+  rank_score: 82,
+  confidence: "medium",
+  package_ready: true,
+  selected_sounding_payload: observedSoundingParseResponse.selected_sounding,
+  story_scores: [
+    {
+      story: "shallow_cumulus_candidate",
+      label: "Cloud-forming shallow cumulus",
+      score_0_to_100: 82,
+      support: "candidate",
+      reasons: ["moist boundary layer", "reasonable LCL"],
+      caveats: [],
+    },
+    {
+      story: "dry_failed_candidate",
+      label: "Dry failed cumulus",
+      score_0_to_100: 24,
+      support: "insufficient_evidence",
+      reasons: [],
+      caveats: [],
+    },
+  ],
+  features: {
+    mean_qv_0_1000m_g_kg: 10.2,
+    estimated_lcl_height_m_agl: 820,
+    lapse_rate_0_1000m_c_per_km: 7.1,
+    cap_strength_proxy: 0.6,
+    moisture_depth_m: 2100,
+    profile_top_m_agl: 18468.5,
+    data_completeness_score: 94,
+  },
+  evidence: [
+    {
+      label: "Low-level moisture",
+      value: 10.2,
+      units: "g/kg",
+      interpretation: "Enough low-level water vapor for a cloud-forming trial.",
+      supports_story: ["shallow_cumulus_candidate"],
+      caveats: [],
+    },
+    {
+      label: "Estimated LCL",
+      value: 820,
+      units: "m AGL",
+      interpretation: "Cloud base is plausible inside the lower domain.",
+      supports_story: ["shallow_cumulus_candidate"],
+      caveats: [],
+    },
+    {
+      label: "Cap proxy",
+      value: 0.6,
+      units: "",
+      interpretation: "The cap proxy is not extreme for a shallow-cumulus screen.",
+      supports_story: ["shallow_cumulus_candidate"],
+      caveats: [],
+    },
+  ],
+  caveats: ["screening_is_not_cm1_outcome_prediction"],
+  screening_version: "test-screening-v1",
+  created_at: "2026-07-01T12:00:00Z",
+};
+
+const blockedSoundingCandidate = {
+  ...shallowSoundingCandidate,
+  candidate_id: "USM00072357-2025010100-blocked",
+  station_id: "USM00072357",
+  station_name: "Norman, Oklahoma",
+  valid_time_utc: "2025-01-01T00:00:00Z",
+  primary_story: "needs_review",
+  primary_story_label: "Needs review",
+  rank_score: 40,
+  confidence: "low",
+  package_ready: false,
+  selected_sounding_payload: null,
+  story_scores: [
+    {
+      story: "needs_review",
+      label: "Needs review",
+      score_0_to_100: 40,
+      support: "insufficient_evidence",
+      reasons: ["missing surface level"],
+      caveats: ["missing_surface_level"],
+    },
+  ],
+  caveats: ["missing_surface_level"],
+};
+
 export const results = [
   {
     result_id: "result-baseline",
@@ -989,6 +1091,17 @@ function mockPointCloudPoints(fieldName: string, dryFailed: boolean, threshold: 
 }
 
 export async function mockCloudChamberApis(page: Page) {
+  let savedSoundingCandidates: Array<{
+    saved_candidate_id: string;
+    candidate: typeof shallowSoundingCandidate;
+    primary_story: string;
+    tags: string[];
+    notes: string;
+    linked_run_ids: string[];
+    created_at: string;
+    updated_at: string;
+  }> = [];
+
   await page.route("**/api/scenarios", (route) =>
     json(route, { golden_path_scenario_id: "baseline-shallow-cumulus", scenarios: [scenario] }),
   );
@@ -996,6 +1109,102 @@ export async function mockCloudChamberApis(page: Page) {
   await page.route("**/api/observed-soundings/parse", (route) =>
     json(route, observedSoundingParseResponse),
   );
+
+  await page.route("**/api/igra/recent/catalog", (route) =>
+    json(route, {
+      catalog: {
+        generated_at: "2026-07-01T12:00:00Z",
+        refreshed_at: "2026-07-01T12:00:00Z",
+        region: { id: "great_plains_midwest", label: "Great Plains / Midwest" },
+        zip_references: [
+          {
+            station_id: "USM00072558",
+            station_name: "VALLEY",
+            cached_status: "cached",
+            url: "https://example.test/USM00072558-data-beg2025.txt.zip",
+          },
+        ],
+      },
+    }),
+  );
+
+  await page.route("**/api/igra/recent/refresh-catalog", (route) =>
+    json(route, {
+      generated_at: "2026-07-01T12:00:00Z",
+      refreshed_at: "2026-07-01T12:00:00Z",
+      region: { id: "great_plains_midwest", label: "Great Plains / Midwest" },
+      zip_references: [
+        {
+          station_id: "USM00072558",
+          station_name: "VALLEY",
+          cached_status: "cached",
+          url: "https://example.test/USM00072558-data-beg2025.txt.zip",
+        },
+      ],
+    }),
+  );
+
+  await page.route("**/api/igra/recent/cache", (route) =>
+    json(route, {
+      entries: [
+        {
+          station_id: "USM00072558",
+          station_name: "VALLEY",
+          data_txt_path: "/tmp/cloud-chamber-e2e/cache/USM00072558-data.txt",
+          zip_path: "/tmp/cloud-chamber-e2e/cache/USM00072558-data-beg2025.txt.zip",
+          sounding_count: 2,
+          latest_valid_time_utc: "2025-01-02T00:00:00Z",
+          size_bytes: 1234,
+        },
+      ],
+    }),
+  );
+
+  await page.route("**/api/sounding-candidates/screening-inputs", (route) =>
+    json(route, {
+      inputs: [
+        {
+          station_id: "USM00072558",
+          station_name: "VALLEY",
+          cached_text_path: "/tmp/cloud-chamber-e2e/cache/USM00072558-data.txt",
+          source_file_name: "USM00072558-data.txt",
+          cached_status: "cached",
+        },
+      ],
+    }),
+  );
+
+  await page.route("**/api/sounding-candidates/screen", (route) =>
+    json(route, {
+      screening_version: "test-screening-v1",
+      generated_at: "2026-07-01T12:00:00Z",
+      candidates: [shallowSoundingCandidate, blockedSoundingCandidate],
+      caveats: ["screening_guidance_only"],
+    }),
+  );
+
+  await page.route("**/api/sounding-candidates/saved", (route) => {
+    if (route.request().method() === "POST") {
+      const saved = {
+        saved_candidate_id: "saved-USM00072558-2025010200",
+        candidate: shallowSoundingCandidate,
+        primary_story: "shallow_cumulus_candidate",
+        tags: ["interesting-sounding"],
+        notes: "",
+        linked_run_ids: [],
+        created_at: "2026-07-01T12:05:00Z",
+        updated_at: "2026-07-01T12:05:00Z",
+      };
+      savedSoundingCandidates = [saved];
+      return json(route, saved);
+    }
+    return json(route, { saved_candidates: savedSoundingCandidates });
+  });
+
+  await page.route("**/api/sounding-candidates/saved/*", (route) => {
+    savedSoundingCandidates = [];
+    return json(route, { removed: true });
+  });
 
   await page.route("**/api/dry-run-package", (route) =>
     json(route, {

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -199,7 +199,7 @@ const shallowSoundingCandidate = {
       story: "shallow_cumulus_candidate",
       label: "Cloud-forming shallow cumulus",
       score_0_to_100: 82,
-      support: "candidate",
+      support: "supported",
       reasons: ["moist boundary layer", "reasonable LCL"],
       caveats: [],
     },
@@ -207,7 +207,7 @@ const shallowSoundingCandidate = {
       story: "dry_failed_candidate",
       label: "Dry failed cumulus",
       score_0_to_100: 24,
-      support: "insufficient_evidence",
+      support: "unavailable",
       reasons: [],
       caveats: [],
     },
@@ -269,7 +269,7 @@ const blockedSoundingCandidate = {
       story: "needs_review",
       label: "Needs review",
       score_0_to_100: 40,
-      support: "insufficient_evidence",
+      support: "weak",
       reasons: ["missing surface level"],
       caveats: ["missing_surface_level"],
     },
@@ -1160,6 +1160,22 @@ export async function mockCloudChamberApis(page: Page) {
     }),
   );
 
+  await page.route("**/api/igra/recent/cache-batch", (route) =>
+    json(route, {
+      requested_limit: 10,
+      selected_count: 1,
+      cached_entries: [
+        {
+          station_id: "USM00072558",
+          station_name: "VALLEY",
+          cached_text_path: "/tmp/cloud-chamber-e2e/cache/USM00072558-data.txt",
+        },
+      ],
+      failed: [],
+      remaining_uncached_count: 0,
+    }),
+  );
+
   await page.route("**/api/sounding-candidates/screening-inputs", (route) =>
     json(route, {
       inputs: [
@@ -1169,6 +1185,9 @@ export async function mockCloudChamberApis(page: Page) {
           cached_text_path: "/tmp/cloud-chamber-e2e/cache/USM00072558-data.txt",
           source_file_name: "USM00072558-data.txt",
           cached_status: "cached",
+          sounding_count: 2,
+          latest_valid_time_utc: "2025-01-02T00:00:00Z",
+          caveats: [],
         },
       ],
     }),

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -87,6 +87,55 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("/tmp/cloud-chamber-e2e/run/run_manifest.json")).toBeVisible();
   });
 
+  test("Build can screen, save, and use observed sounding candidates", async ({ page }) => {
+    await gotoBuild(page);
+
+    await page.getByLabel("Experiment", { exact: true }).selectOption("__observed_sounding_upload__");
+    await expect(page.getByRole("heading", { name: "Find interesting soundings" })).toBeVisible();
+    await expect(page.getByText(/Screening guidance only/i).first()).toBeVisible();
+    await expect(page.getByText("IGRA cache not checked yet")).toBeVisible();
+
+    await page.getByRole("button", { name: "Refresh recent IGRA data" }).click();
+    await expect(page.getByText("Recent IGRA catalog refreshed")).toBeVisible();
+    await expect(page.getByText("Screenable soundings").locator("..")).toContainText("1");
+
+    await page.getByLabel("Story filter").selectOption("shallow_cumulus_candidate");
+    await page.getByRole("button", { name: "Screen cached soundings" }).click();
+
+    await expect(page.getByText("Screening guidance loaded")).toBeVisible();
+    const valleyCard = page.getByLabel("Sounding candidate Valley, Nebraska (USM00072558)");
+    await expect(valleyCard).toBeVisible();
+    await expect(valleyCard).toContainText("Cloud-forming shallow cumulus");
+    await expect(valleyCard).toContainText("Package-ready");
+    await expect(valleyCard).toContainText("Low-level moisture: 10.2 g/kg");
+    await expect(page.getByLabel("Candidate details")).toContainText(
+      "Candidate match score is screening guidance only",
+    );
+
+    await page.getByLabel("Story filter").selectOption("needs_review");
+    const blockedCard = page.getByLabel("Sounding candidate Norman, Oklahoma (USM00072357)");
+    await expect(blockedCard).toBeVisible();
+    await expect(blockedCard).toContainText("Blocked");
+    await expect(blockedCard.getByRole("button", { name: "Use this sounding" })).toBeDisabled();
+
+    await page.getByLabel("Story filter").selectOption("all");
+    await valleyCard.getByRole("button", { name: "Save candidate" }).click();
+    await expect(page.getByText("Sounding candidate saved")).toBeVisible();
+    await expect(
+      page.getByLabel("Saved sounding candidate Valley, Nebraska (USM00072558)"),
+    ).toBeVisible();
+
+    await valleyCard.getByRole("button", { name: "Use this sounding" }).click();
+    await expect(page.getByText("Candidate selected for package review")).toBeVisible();
+    await expect(page.getByText("Candidate loaded into observed-sounding package review")).toBeVisible();
+    await expect(page.getByText("USM00072558 · Valley, Nebraska")).toBeVisible();
+    await expect(page.getByText(/Screened as Cloud-forming shallow cumulus/i)).toBeVisible();
+
+    await page.getByTestId("create-package-btn").scrollIntoViewIfNeeded();
+    await page.getByTestId("create-package-btn").click();
+    await expect(page.getByText("Package ready").first()).toBeVisible();
+  });
+
   test("Results notebook, Compare, and Storage render with mocked data", async ({ page }) => {
     await gotoResults(page);
 

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -95,9 +95,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/Screening guidance only/i).first()).toBeVisible();
     await expect(page.getByText("IGRA cache not checked yet")).toBeVisible();
 
-    await page.getByRole("button", { name: "Refresh recent IGRA data" }).click();
-    await expect(page.getByText("Recent IGRA catalog refreshed")).toBeVisible();
-    await expect(page.getByText("Screenable soundings").locator("..")).toContainText("1");
+    await page.getByRole("button", { name: "Refresh IGRA catalog" }).click();
+    await expect(page.getByText("IGRA station catalog refreshed")).toBeVisible();
+    await expect(page.getByText("Screenable soundings").locator("..")).toContainText("2 soundings");
+
+    await page.getByRole("button", { name: "Cache station files" }).click();
+    await expect(page.getByText("Cached 1 station file")).toBeVisible();
 
     await page.getByLabel("Story filter").selectOption("shallow_cumulus_candidate");
     await page.getByRole("button", { name: "Screen cached soundings" }).click();

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -287,6 +287,138 @@ small {
   margin-bottom: 0.65rem;
 }
 
+.sounding-candidate-workbench {
+  display: grid;
+  gap: 1rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(247, 251, 253, 0.86));
+}
+
+.candidate-cache-summary {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.candidate-cache-summary > div,
+.candidate-detail-panel,
+.saved-candidate-card {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.76);
+}
+
+.candidate-toolbar {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.candidate-toolbar label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.candidate-toolbar-actions {
+  grid-column: 1 / -1;
+  justify-content: start;
+}
+
+.candidate-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.85rem;
+  align-items: start;
+}
+
+.candidate-list,
+.saved-candidate-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.candidate-card {
+  display: grid;
+  gap: 0.65rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: var(--color-surface);
+}
+
+.selected-candidate-card {
+  border-color: rgba(47, 116, 168, 0.58);
+  box-shadow: inset 4px 0 0 rgba(47, 116, 168, 0.22);
+}
+
+.candidate-card-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  align-items: start;
+  width: 100%;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--color-text-primary);
+  box-shadow: none;
+  text-align: left;
+}
+
+.candidate-card-select:hover,
+.candidate-card-select:focus-visible {
+  color: var(--color-text-primary);
+  background: transparent;
+  box-shadow: none;
+}
+
+.candidate-card-select strong {
+  color: var(--color-text-primary);
+}
+
+.candidate-card-main small,
+.saved-candidate-card small {
+  display: block;
+}
+
+.candidate-detail-panel {
+  display: grid;
+  gap: 0.75rem;
+  position: sticky;
+  top: 0.75rem;
+}
+
+.candidate-detail-panel h5 {
+  margin: 0 0 0.3rem;
+}
+
+.saved-candidates-panel {
+  display: grid;
+  gap: 0.7rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.9rem;
+}
+
+.saved-candidate-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.screening-guidance-note {
+  display: grid;
+  gap: 0.2rem;
+  border-left: 4px solid var(--color-warning);
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  background: var(--color-warning-soft);
+}
+
 .field-help {
   margin-top: -0.35rem;
   color: var(--color-text-muted);
@@ -2236,10 +2368,12 @@ details[open] > summary {
   .workbench-status-strip,
   .visualizer-bottom-controls,
   .slice-grid,
-  .control-row,
-  .explore-result-summary {
-    grid-template-columns: 1fr;
-  }
+	  .control-row,
+	  .candidate-toolbar,
+	  .candidate-workspace,
+	  .explore-result-summary {
+	    grid-template-columns: 1fr;
+	  }
 
   .visualizer-workbench {
     grid-template-areas:
@@ -2277,9 +2411,27 @@ details[open] > summary {
     display: grid;
   }
 
-  .metric-grid {
-    grid-template-columns: 1fr;
-  }
+	  .metric-grid {
+	    grid-template-columns: 1fr;
+	  }
+
+	  .candidate-cache-summary {
+	    grid-template-columns: repeat(2, minmax(0, 1fr));
+	  }
+
+	  .candidate-toolbar-actions,
+	  .saved-candidate-card {
+	    justify-content: start;
+	  }
+
+	  .candidate-detail-panel {
+	    position: static;
+	  }
+
+	  .candidate-card-main,
+	  .saved-candidate-card {
+	    grid-template-columns: 1fr;
+	  }
 
   .experiment-card {
     grid-template-columns: 1fr;

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -311,7 +311,7 @@ small {
 
 .candidate-toolbar {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.75rem;
   align-items: end;
 }
@@ -330,7 +330,7 @@ small {
 
 .candidate-workspace {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1.08fr) minmax(300px, 0.72fr);
   gap: 0.85rem;
   align-items: start;
 }
@@ -339,6 +339,12 @@ small {
 .saved-candidate-list {
   display: grid;
   gap: 0.75rem;
+}
+
+.candidate-list {
+  max-height: min(44rem, 72vh);
+  overflow: auto;
+  padding-right: 0.25rem;
 }
 
 .candidate-card {
@@ -357,7 +363,7 @@ small {
 
 .candidate-card-main {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr);
   gap: 0.65rem;
   align-items: start;
   width: 100%;
@@ -367,6 +373,10 @@ small {
   color: var(--color-text-primary);
   box-shadow: none;
   text-align: left;
+}
+
+.candidate-card-main .badge-row {
+  margin-top: -0.15rem;
 }
 
 .candidate-card-select:hover,

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -263,13 +263,13 @@ const shallowCandidate = {
       story: "shallow_cumulus_candidate",
       label: "Cloud-forming shallow cumulus",
       score_0_to_100: 82,
-      support: "candidate",
+      support: "supported",
     },
     {
       story: "dry_failed_candidate",
       label: "Dry failed cumulus",
       score_0_to_100: 24,
-      support: "insufficient_evidence",
+      support: "unavailable",
     },
   ],
   evidence: [
@@ -329,10 +329,54 @@ const blockedCandidate = {
       story: "needs_review",
       label: "Needs review",
       score_0_to_100: 40,
-      support: "insufficient_evidence",
+      support: "weak",
     },
   ],
   caveats: ["missing_surface_level"],
+};
+
+const secondaryShallowCandidate = {
+  ...shallowCandidate,
+  candidate_id: "USM00072426-2025010300-humid-secondary-shallow",
+  station_id: "USM00072426",
+  station_name: "Wilmington, Ohio",
+  valid_time_utc: "2025-01-03T00:00:00Z",
+  primary_story: "humid_rainy_candidate",
+  primary_story_label: "Humid / rainy",
+  rank_score: 86,
+  story_scores: [
+    {
+      story: "humid_rainy_candidate",
+      label: "Humid / rainy",
+      score_0_to_100: 86,
+      support: "supported",
+    },
+    {
+      story: "shallow_cumulus_candidate",
+      label: "Cloud-forming shallow cumulus",
+      score_0_to_100: 61,
+      support: "weak",
+    },
+  ],
+  features: {
+    ...shallowCandidate.features,
+    mean_qv_0_1000m_g_kg: 13.6,
+    estimated_lcl_height_m_agl: 640,
+  },
+};
+
+const missingLclCandidate = {
+  ...shallowCandidate,
+  candidate_id: "USM00072440-2025010400-missing-lcl",
+  station_id: "USM00072440",
+  station_name: "Springfield, Missouri",
+  valid_time_utc: "2025-01-04T00:00:00Z",
+  rank_score: 78,
+  features: {
+    ...shallowCandidate.features,
+    estimated_lcl_height_m_agl: null,
+  },
+  evidence: shallowCandidate.evidence.filter((item) => item.label !== "Estimated LCL"),
 };
 
 const screeningInputsResponse = {
@@ -352,7 +396,12 @@ const screeningInputsResponse = {
 const screeningResponse = {
   story: "all",
   generated_at: "2026-07-01T12:00:00Z",
-  candidates: [shallowCandidate, blockedCandidate],
+  candidates: [
+    shallowCandidate,
+    blockedCandidate,
+    secondaryShallowCandidate,
+    missingLclCandidate,
+  ],
   caveats: ["screening_guidance_only"],
 };
 
@@ -1761,6 +1810,20 @@ beforeEach(() => {
       if (url === "/api/igra/recent/cache") {
         return Promise.resolve(new Response(JSON.stringify(igraCacheResponse), { status: 200 }));
       }
+      if (url === "/api/igra/recent/cache-batch" && init?.method === "POST") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              requested_limit: 10,
+              selected_count: 1,
+              cached_entries: [igraCacheResponse.entries[0]],
+              failed: [],
+              remaining_uncached_count: 0,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
       if (url === "/api/sounding-candidates/screening-inputs") {
         return Promise.resolve(
           new Response(JSON.stringify(screeningInputsResponse), { status: 200 }),
@@ -2163,10 +2226,15 @@ describe("App", () => {
     expect(screen.getByText(/Screening guidance only/)).toBeInTheDocument();
     expect(screen.getByText("IGRA cache not checked yet")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Refresh recent IGRA data" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh IGRA catalog" }));
 
-    expect(await screen.findByText("Recent IGRA catalog refreshed")).toBeInTheDocument();
-    expect(screen.getByText("Screenable soundings").nextElementSibling).toHaveTextContent("1");
+    expect(await screen.findByText("IGRA station catalog refreshed")).toBeInTheDocument();
+    expect(screen.getByText("Screenable soundings").nextElementSibling).toHaveTextContent(
+      "2 soundings",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cache station files" }));
+    expect(await screen.findByText("Cached 1 station file")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Story filter"), {
       target: { value: "shallow_cumulus_candidate" },
@@ -2179,6 +2247,9 @@ describe("App", () => {
     expect(valleyCard).toHaveTextContent("Cloud-forming shallow cumulus");
     expect(valleyCard).toHaveTextContent("Package-ready");
     expect(valleyCard).toHaveTextContent("Low-level moisture: 10.2 g/kg");
+    expect(
+      screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
+    ).toHaveTextContent("Cloud-forming shallow cumulus");
     expect(
       screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
     ).not.toBeInTheDocument();
@@ -2230,6 +2301,37 @@ describe("App", () => {
       expect(dryRunBody).toContain('"primary_story":"shallow_cumulus_candidate"');
       expect(dryRunBody).toContain('"candidate_id":"USM00072558-2025010200-shallow"');
     });
+  });
+
+  it("keeps secondary story matches visible and sorts missing LCL last", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Screen cached soundings" }));
+    expect(await screen.findByText("Screening guidance loaded")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Story filter"), {
+      target: { value: "shallow_cumulus_candidate" },
+    });
+    expect(
+      screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Sort"), {
+      target: { value: "lowest_lcl" },
+    });
+    const candidateCards = screen.getAllByLabelText(/^Sounding candidate /);
+    const visibleOrder = candidateCards.map((card) => card.textContent ?? "");
+    const validLclIndex = visibleOrder.findIndex((text) => text.includes("Wilmington, Ohio"));
+    const missingLclIndex = visibleOrder.findIndex((text) =>
+      text.includes("Springfield, Missouri"),
+    );
+    expect(validLclIndex).toBeGreaterThanOrEqual(0);
+    expect(missingLclIndex).toBeGreaterThan(validLclIndex);
   });
 
   it("shows Deep Overnight as an expensive distinct generated package", async () => {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -239,6 +239,170 @@ const observedSoundingParseResponse = {
   },
 };
 
+const shallowCandidate = {
+  candidate_id: "USM00072558-2025010200-shallow",
+  station_id: "USM00072558",
+  station_name: "Valley, Nebraska",
+  station_latitude: 41.32,
+  station_longitude: -96.3669,
+  valid_time_utc: "2025-01-02T00:00:00Z",
+  source_time_text: "2025-01-02 00 UTC",
+  source_file_name: "USM00072558-data.txt",
+  source_file_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072558-data.txt",
+  source_file_hash: "mock-hash",
+  source_format: "igra_station_text",
+  source_provider: "NOAA/NCEI IGRA",
+  primary_story: "shallow_cumulus_candidate",
+  primary_story_label: "Cloud-forming shallow cumulus",
+  rank_score: 82,
+  confidence: "medium",
+  package_ready: true,
+  selected_sounding_payload: observedSoundingParseResponse.selected_sounding,
+  story_scores: [
+    {
+      story: "shallow_cumulus_candidate",
+      label: "Cloud-forming shallow cumulus",
+      score_0_to_100: 82,
+      support: "candidate",
+    },
+    {
+      story: "dry_failed_candidate",
+      label: "Dry failed cumulus",
+      score_0_to_100: 24,
+      support: "insufficient_evidence",
+    },
+  ],
+  evidence: [
+    {
+      label: "Low-level moisture",
+      value: 10.2,
+      units: "g/kg",
+      interpretation: "Enough low-level water vapor for a cloud-forming trial.",
+      supports_story: ["shallow_cumulus_candidate"],
+      caveats: [],
+    },
+    {
+      label: "Estimated LCL",
+      value: 820,
+      units: "m AGL",
+      interpretation: "Cloud base is plausible inside the lower domain.",
+      supports_story: ["shallow_cumulus_candidate"],
+      caveats: [],
+    },
+    {
+      label: "Cap proxy",
+      value: 0.6,
+      units: "",
+      interpretation: "The cap proxy is not extreme for a shallow-cumulus screen.",
+      supports_story: ["shallow_cumulus_candidate"],
+      caveats: [],
+    },
+  ],
+  features: {
+    mean_qv_0_1000m_g_kg: 10.2,
+    estimated_lcl_height_m_agl: 820,
+    lapse_rate_0_1000m_c_per_km: 7.1,
+    cap_strength_proxy: 0.6,
+    moisture_depth_m: 2100,
+    profile_top_m_agl: 18816.5,
+    data_completeness_score: 94,
+  },
+  caveats: ["screening_is_not_cm1_outcome_prediction"],
+  screening_version: "test-screening-v1",
+  created_at: "2026-07-01T12:00:00Z",
+};
+
+const blockedCandidate = {
+  ...shallowCandidate,
+  candidate_id: "USM00072357-2025010100-blocked",
+  station_id: "USM00072357",
+  station_name: "Norman, Oklahoma",
+  valid_time_utc: "2025-01-01T00:00:00Z",
+  primary_story: "needs_review",
+  primary_story_label: "Needs review",
+  rank_score: 40,
+  confidence: "low",
+  package_ready: false,
+  selected_sounding_payload: null,
+  story_scores: [
+    {
+      story: "needs_review",
+      label: "Needs review",
+      score_0_to_100: 40,
+      support: "insufficient_evidence",
+    },
+  ],
+  caveats: ["missing_surface_level"],
+};
+
+const screeningInputsResponse = {
+  inputs: [
+    {
+      station_id: "USM00072558",
+      source_file_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072558-data.txt",
+      source_file_name: "USM00072558-data.txt",
+      sounding_count: 2,
+      package_ready_count: 1,
+      blocked_count: 1,
+      latest_valid_time_utc: "2025-01-02T00:00:00Z",
+    },
+  ],
+};
+
+const screeningResponse = {
+  story: "all",
+  generated_at: "2026-07-01T12:00:00Z",
+  candidates: [shallowCandidate, blockedCandidate],
+  caveats: ["screening_guidance_only"],
+};
+
+const savedCandidatesResponse = {
+  saved_candidates: [
+    {
+      saved_candidate_id: "saved-USM00072558-2025010200",
+      candidate: shallowCandidate,
+      primary_story: "shallow_cumulus_candidate",
+      tags: ["interesting-sounding"],
+      notes: "",
+      linked_run_ids: [],
+      created_at: "2026-07-01T12:05:00Z",
+      updated_at: "2026-07-01T12:05:00Z",
+    },
+  ],
+};
+
+const emptySavedCandidatesResponse = { saved_candidates: [] };
+
+const igraCatalogResponse = {
+  catalog: {
+    generated_at: "2026-07-01T12:00:00Z",
+    refreshed_at: "2026-07-01T12:00:00Z",
+    region: { id: "great_plains_midwest", label: "Great Plains / Midwest" },
+    zip_references: [
+      {
+        station_id: "USM00072558",
+        station_name: "VALLEY",
+        cached_status: "cached",
+        url: "https://example.test/USM00072558-data-beg2025.txt.zip",
+      },
+    ],
+  },
+};
+
+const igraCacheResponse = {
+  entries: [
+    {
+      station_id: "USM00072558",
+      station_name: "VALLEY",
+      data_txt_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072558-data.txt",
+      zip_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072558-data-beg2025.txt.zip",
+      sounding_count: 2,
+      latest_valid_time_utc: "2025-01-02T00:00:00Z",
+      size_bytes: 1234,
+    },
+  ],
+};
+
 const runningRunStatus = {
   run_id: "dry-run-001",
   lifecycle_state: "running",
@@ -1581,6 +1745,45 @@ beforeEach(() => {
       if (url === "/api/scenarios") {
         return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
       }
+      if (url === "/api/observed-soundings/parse") {
+        return Promise.resolve(
+          new Response(JSON.stringify(observedSoundingParseResponse), { status: 200 }),
+        );
+      }
+      if (url === "/api/igra/recent/catalog") {
+        return Promise.resolve(new Response(JSON.stringify(igraCatalogResponse), { status: 200 }));
+      }
+      if (url === "/api/igra/recent/refresh-catalog" && init?.method === "POST") {
+        return Promise.resolve(
+          new Response(JSON.stringify(igraCatalogResponse.catalog), { status: 200 }),
+        );
+      }
+      if (url === "/api/igra/recent/cache") {
+        return Promise.resolve(new Response(JSON.stringify(igraCacheResponse), { status: 200 }));
+      }
+      if (url === "/api/sounding-candidates/screening-inputs") {
+        return Promise.resolve(
+          new Response(JSON.stringify(screeningInputsResponse), { status: 200 }),
+        );
+      }
+      if (url === "/api/sounding-candidates/screen") {
+        return Promise.resolve(new Response(JSON.stringify(screeningResponse), { status: 200 }));
+      }
+      if (url === "/api/sounding-candidates/saved" && init?.method === "POST") {
+        return Promise.resolve(
+          new Response(JSON.stringify(savedCandidatesResponse.saved_candidates[0]), {
+            status: 200,
+          }),
+        );
+      }
+      if (url === "/api/sounding-candidates/saved") {
+        return Promise.resolve(
+          new Response(JSON.stringify(emptySavedCandidatesResponse), { status: 200 }),
+        );
+      }
+      if (url.startsWith("/api/sounding-candidates/saved/") && init?.method === "DELETE") {
+        return Promise.resolve(new Response(JSON.stringify({ removed: true }), { status: 200 }));
+      }
       if (url === "/api/dry-run-package") {
         return Promise.resolve(new Response(JSON.stringify(dryRunResponse), { status: 200 }));
       }
@@ -1929,6 +2132,103 @@ describe("App", () => {
       expect(dryRunBody).toContain('"observed_sounding"');
       expect(dryRunBody).toContain('"station_id":"USM00072558"');
       expect(dryRunBody).toContain('"model_bottom_elevation_m_msl":351.5');
+    });
+  });
+
+  it("screens, saves, and uses observed-atmosphere candidates as package-review guidance", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let dryRunBody = "";
+    let screenBody = "";
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/sounding-candidates/screen") {
+        screenBody = String(init?.body ?? "");
+      }
+      if (url === "/api/dry-run-package") {
+        dryRunBody = String(init?.body ?? "");
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+
+    expect(await screen.findByRole("heading", { name: "Find interesting soundings" })).toBeInTheDocument();
+    expect(screen.getByText(/Screening guidance only/)).toBeInTheDocument();
+    expect(screen.getByText("IGRA cache not checked yet")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh recent IGRA data" }));
+
+    expect(await screen.findByText("Recent IGRA catalog refreshed")).toBeInTheDocument();
+    expect(screen.getByText("Screenable soundings").nextElementSibling).toHaveTextContent("1");
+
+    fireEvent.change(screen.getByLabelText("Story filter"), {
+      target: { value: "shallow_cumulus_candidate" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Screen cached soundings" }));
+
+    expect(await screen.findByText("Screening guidance loaded")).toBeInTheDocument();
+    expect(screenBody).toContain('"target_story":"shallow_cumulus_candidate"');
+    const valleyCard = screen.getByLabelText("Sounding candidate Valley, Nebraska (USM00072558)");
+    expect(valleyCard).toHaveTextContent("Cloud-forming shallow cumulus");
+    expect(valleyCard).toHaveTextContent("Package-ready");
+    expect(valleyCard).toHaveTextContent("Low-level moisture: 10.2 g/kg");
+    expect(
+      screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Candidate details")).toHaveTextContent(
+      "Candidate match score is screening guidance only",
+    );
+
+    fireEvent.change(screen.getByLabelText("Story filter"), {
+      target: { value: "needs_review" },
+    });
+    const normanCard = await screen.findByLabelText(
+      "Sounding candidate Norman, Oklahoma (USM00072357)",
+    );
+    expect(normanCard).toHaveTextContent("Blocked");
+    expect(within(normanCard).getByRole("button", { name: "Use this sounding" })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Story filter"), {
+      target: { value: "all" },
+    });
+    const selectedValleyCard = await screen.findByLabelText(
+      "Sounding candidate Valley, Nebraska (USM00072558)",
+    );
+    fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Save candidate" }));
+
+    expect(await screen.findByText("Sounding candidate saved")).toBeInTheDocument();
+    const savedCard = screen.getByLabelText(
+      "Saved sounding candidate Valley, Nebraska (USM00072558)",
+    );
+    expect(savedCard).toHaveTextContent("Cloud-forming shallow cumulus");
+
+    fireEvent.click(within(savedCard).getByRole("button", { name: "Remove saved" }));
+    expect(await screen.findByText("Saved sounding candidate removed")).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Saved sounding candidate Valley, Nebraska (USM00072558)"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Use this sounding" }));
+
+    expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
+    expect(screen.getByText("Candidate loaded into observed-sounding package review")).toBeInTheDocument();
+    expect(screen.getByText("USM00072558 · Valley, Nebraska")).toBeInTheDocument();
+    expect(screen.getByText(/Screened as Cloud-forming shallow cumulus/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("create-package-btn"));
+
+    await waitFor(() => {
+      expect(dryRunBody).toContain('"observed_sounding"');
+      expect(dryRunBody).toContain('"candidate_screening"');
+      expect(dryRunBody).toContain('"primary_story":"shallow_cumulus_candidate"');
+      expect(dryRunBody).toContain('"candidate_id":"USM00072558-2025010200-shallow"');
     });
   });
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -158,6 +158,134 @@ type ObservedSoundingParseResponse = {
   selected_sounding: ObservedSoundingRecord;
 };
 
+type CandidateStoryId =
+  | "shallow_cumulus_candidate"
+  | "dry_failed_candidate"
+  | "capped_suppressed_candidate"
+  | "humid_rainy_candidate"
+  | "needs_review"
+  | "poor_or_incomplete_candidate";
+
+type CandidateStoryFilter =
+  | "all"
+  | "shallow_cumulus_candidate"
+  | "dry_failed_candidate"
+  | "capped_suppressed_candidate"
+  | "humid_rainy_candidate"
+  | "needs_review";
+
+type CandidateSort =
+  | "best"
+  | "latest"
+  | "data_quality"
+  | "lowest_lcl"
+  | "highest_moisture"
+  | "strongest_cap";
+
+type StoryScore = {
+  story: CandidateStoryId;
+  label: string;
+  score_0_to_100: number;
+  support: string;
+  reasons: string[];
+  caveats: string[];
+};
+
+type EvidenceItem = {
+  label: string;
+  value: string | number | boolean | null;
+  units?: string | null;
+  interpretation: string;
+  supports_story: CandidateStoryId[];
+  caveats: string[];
+};
+
+type SoundingCandidate = {
+  candidate_id: string;
+  station_id: string;
+  station_name?: string | null;
+  station_latitude?: number | null;
+  station_longitude?: number | null;
+  station_elevation_m_msl?: number | null;
+  valid_time_utc: string;
+  source_time_text: string;
+  source_file_name: string;
+  source_file_hash: string;
+  source_format: string;
+  source_provider: string;
+  primary_story: CandidateStoryId;
+  primary_story_label: string;
+  story_scores: StoryScore[];
+  rank_score: number;
+  confidence: "low" | "medium" | "high";
+  package_ready: boolean;
+  features: Record<string, string | number | boolean | null>;
+  evidence: EvidenceItem[];
+  caveats: string[];
+  selected_sounding_payload?: ObservedSoundingRecord | null;
+  screening_version: string;
+  created_at: string;
+};
+
+type ScreeningInput = {
+  station_id: string;
+  station_name?: string | null;
+  cached_text_path: string;
+  source_file_name: string;
+  cached_status: string;
+};
+
+type ScreeningInputsResponse = {
+  inputs: ScreeningInput[];
+};
+
+type ScreeningResult = {
+  screening_version: string;
+  generated_at: string;
+  candidates: SoundingCandidate[];
+  caveats: string[];
+};
+
+type SavedSoundingCandidate = {
+  saved_candidate_id: string;
+  candidate: SoundingCandidate;
+  selected_sounding_payload?: ObservedSoundingRecord | null;
+  screening_version: string;
+  primary_story: CandidateStoryId;
+  story_scores: StoryScore[];
+  features: Record<string, string | number | boolean | null>;
+  evidence: EvidenceItem[];
+  caveats: string[];
+  tags: string[];
+  notes?: string | null;
+  created_at: string;
+  last_used_at?: string | null;
+  linked_run_ids: string[];
+  linked_result_ids: string[];
+};
+
+type SavedCandidatesResponse = {
+  saved_candidates: SavedSoundingCandidate[];
+};
+
+type IGRACatalogResponse = {
+  catalog: {
+    refreshed_at: string;
+    region: { label: string; tag: string };
+    stations: unknown[];
+    zip_references: { cached_status: string }[];
+  } | null;
+};
+
+type IGRACacheResponse = {
+  entries: {
+    station_id: string;
+    station_name?: string | null;
+    cached_text_path?: string | null;
+  }[];
+  updated_at: string;
+};
+
 type ObservedSoundingSummary = {
   source_provider: string;
   source_format: string;
@@ -697,6 +825,7 @@ async function requestDryRunPackage(
   controls: Record<string, string | number | boolean>,
   runSizePreset: string,
   observedSounding?: ObservedSoundingRecord | null,
+  candidateScreening?: Record<string, unknown> | null,
 ): Promise<DryRunResponse> {
   const response = await fetch("/api/dry-run-package", {
     method: "POST",
@@ -706,6 +835,7 @@ async function requestDryRunPackage(
       controls,
       run_size_preset: runSizePreset,
       observed_sounding: observedSounding ?? null,
+      candidate_screening: candidateScreening ?? null,
     }),
   });
   if (!response.ok) {
@@ -732,6 +862,85 @@ async function parseObservedSoundingUpload(
     throw new Error(await responseError(response, "Unable to parse observed sounding."));
   }
   return response.json() as Promise<ObservedSoundingParseResponse>;
+}
+
+async function fetchIGRARecentCatalog(): Promise<IGRACatalogResponse> {
+  const response = await fetch("/api/igra/recent/catalog");
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to load IGRA recent catalog."));
+  }
+  return response.json() as Promise<IGRACatalogResponse>;
+}
+
+async function refreshIGRARecentCatalog(): Promise<IGRACatalogResponse["catalog"]> {
+  const response = await fetch("/api/igra/recent/refresh-catalog", { method: "POST" });
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to refresh IGRA recent catalog."));
+  }
+  return response.json() as Promise<IGRACatalogResponse["catalog"]>;
+}
+
+async function fetchIGRARecentCache(): Promise<IGRACacheResponse> {
+  const response = await fetch("/api/igra/recent/cache");
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to load IGRA recent cache."));
+  }
+  return response.json() as Promise<IGRACacheResponse>;
+}
+
+async function fetchScreeningInputs(): Promise<ScreeningInputsResponse> {
+  const response = await fetch("/api/sounding-candidates/screening-inputs");
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to load screenable soundings."));
+  }
+  return response.json() as Promise<ScreeningInputsResponse>;
+}
+
+async function screenSoundingCandidates(
+  story: CandidateStoryFilter,
+): Promise<ScreeningResult> {
+  const response = await fetch("/api/sounding-candidates/screen", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      latest_per_station: 5,
+      limit: 50,
+      target_story: story === "all" ? null : story,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to screen cached soundings."));
+  }
+  return response.json() as Promise<ScreeningResult>;
+}
+
+async function fetchSavedSoundingCandidates(): Promise<SavedCandidatesResponse> {
+  const response = await fetch("/api/sounding-candidates/saved");
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to load saved sounding candidates."));
+  }
+  return response.json() as Promise<SavedCandidatesResponse>;
+}
+
+async function saveSoundingCandidate(candidate: SoundingCandidate): Promise<SavedSoundingCandidate> {
+  const response = await fetch("/api/sounding-candidates/saved", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ candidate, tags: ["build-candidate"] }),
+  });
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to save sounding candidate."));
+  }
+  return response.json() as Promise<SavedSoundingCandidate>;
+}
+
+async function deleteSavedSoundingCandidate(savedCandidateId: string): Promise<void> {
+  const response = await fetch(`/api/sounding-candidates/saved/${savedCandidateId}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to remove saved candidate."));
+  }
 }
 
 async function readUploadedTextFile(file: File): Promise<string> {
@@ -1044,6 +1253,19 @@ export function App() {
     useState<ObservedSoundingParseResponse | null>(null);
   const [observedSoundingStatus, setObservedSoundingStatus] = useState<string | null>(null);
   const [observedSoundingError, setObservedSoundingError] = useState<string | null>(null);
+  const [selectedCandidateScreening, setSelectedCandidateScreening] =
+    useState<Record<string, unknown> | null>(null);
+  const [igraCatalog, setIgraCatalog] = useState<IGRACatalogResponse["catalog"] | null>(null);
+  const [igraCache, setIgraCache] = useState<IGRACacheResponse | null>(null);
+  const [screeningInputs, setScreeningInputs] = useState<ScreeningInput[]>([]);
+  const [candidateStoryFilter, setCandidateStoryFilter] =
+    useState<CandidateStoryFilter>("all");
+  const [candidateSort, setCandidateSort] = useState<CandidateSort>("best");
+  const [candidateStatus, setCandidateStatus] = useState("IGRA cache not checked yet");
+  const [candidateError, setCandidateError] = useState<string | null>(null);
+  const [candidateScreening, setCandidateScreening] = useState<ScreeningResult | null>(null);
+  const [savedCandidates, setSavedCandidates] = useState<SavedSoundingCandidate[]>([]);
+  const [candidateDetailId, setCandidateDetailId] = useState<string | null>(null);
   const [dryRun, setDryRun] = useState<DryRunResponse | null>(null);
   const [runStatus, setRunStatus] = useState<RunStatusResponse | null>(null);
   const [runWorkflowError, setRunWorkflowError] = useState<string | null>(null);
@@ -1226,7 +1448,7 @@ export function App() {
     setLanWorkerError(null);
     setLanWorkerActionStatus(null);
     setIngestedResultId(null);
-  }, [observedSoundingExperimentSelected, selectedScenario]);
+  }, [selectedScenario]);
 
   useEffect(() => {
     if (!selectedResult) return;
@@ -1280,6 +1502,151 @@ export function App() {
     }
   }
 
+  function handleSelectScenario(scenarioId: string) {
+    setSelectedScenarioId(scenarioId);
+    setObservedSoundingFilename(null);
+    setObservedSoundingText(null);
+    setObservedSoundingParse(null);
+    setObservedSoundingStatus(null);
+    setObservedSoundingError(null);
+    setSelectedCandidateScreening(null);
+    setDryRun(null);
+    setRunStatus(null);
+    setRunWorkflowError(null);
+    setLanWorkerStatus(null);
+    setLanWorkerError(null);
+    setLanWorkerActionStatus(null);
+    setIngestedResultId(null);
+  }
+
+  async function refreshSoundingCandidateState(statusWhenLoaded?: string) {
+    setCandidateError(null);
+    setCandidateStatus("Checking local IGRA cache");
+    try {
+      const [catalogPayload, cachePayload, inputsPayload, savedPayload] = await Promise.all([
+        fetchIGRARecentCatalog(),
+        fetchIGRARecentCache(),
+        fetchScreeningInputs(),
+        fetchSavedSoundingCandidates(),
+      ]);
+      setIgraCatalog(catalogPayload.catalog);
+      setIgraCache(cachePayload);
+      setScreeningInputs(inputsPayload.inputs);
+      setSavedCandidates(savedPayload.saved_candidates);
+      setCandidateStatus(
+        statusWhenLoaded ??
+          (inputsPayload.inputs.length > 0
+            ? "Cached soundings ready to screen"
+            : "No cached sounding files ready to screen"),
+      );
+    } catch (caught) {
+      setCandidateError(
+        caught instanceof Error ? caught.message : "Unable to load sounding candidate state.",
+      );
+      setCandidateStatus("Sounding candidate state unavailable");
+    }
+  }
+
+  async function handleRefreshIGRAData() {
+    setCandidateError(null);
+    setCandidateStatus("Refreshing recent IGRA catalog");
+    try {
+      const catalog = await refreshIGRARecentCatalog();
+      setIgraCatalog(catalog);
+      await refreshSoundingCandidateState("Recent IGRA catalog refreshed");
+    } catch (caught) {
+      setCandidateError(
+        caught instanceof Error ? caught.message : "Unable to refresh recent IGRA data.",
+      );
+      setCandidateStatus("IGRA refresh blocked");
+    }
+  }
+
+  async function handleScreenSoundingCandidates() {
+    setCandidateError(null);
+    setCandidateStatus("Screening cached soundings");
+    try {
+      const result = await screenSoundingCandidates(candidateStoryFilter);
+      setCandidateScreening(result);
+      setCandidateDetailId(result.candidates[0]?.candidate_id ?? null);
+      setCandidateStatus(
+        result.candidates.length > 0
+          ? "Screening guidance loaded"
+          : "No candidate matches found in cached soundings",
+      );
+      const savedPayload = await fetchSavedSoundingCandidates();
+      setSavedCandidates(savedPayload.saved_candidates);
+    } catch (caught) {
+      setCandidateError(
+        caught instanceof Error ? caught.message : "Unable to screen cached soundings.",
+      );
+      setCandidateStatus("Candidate screening failed");
+    }
+  }
+
+  async function handleSaveSoundingCandidate(candidate: SoundingCandidate) {
+    setCandidateError(null);
+    setCandidateStatus("Saving sounding candidate");
+    try {
+      const saved = await saveSoundingCandidate(candidate);
+      setSavedCandidates((current) => [
+        saved,
+        ...current.filter((item) => item.saved_candidate_id !== saved.saved_candidate_id),
+      ]);
+      setCandidateStatus("Sounding candidate saved");
+    } catch (caught) {
+      setCandidateError(
+        caught instanceof Error ? caught.message : "Unable to save sounding candidate.",
+      );
+      setCandidateStatus("Save candidate failed");
+    }
+  }
+
+  async function handleRemoveSavedSoundingCandidate(savedCandidateId: string) {
+    setCandidateError(null);
+    setCandidateStatus("Removing saved sounding candidate");
+    try {
+      await deleteSavedSoundingCandidate(savedCandidateId);
+      setSavedCandidates((current) =>
+        current.filter((item) => item.saved_candidate_id !== savedCandidateId),
+      );
+      setCandidateStatus("Saved sounding candidate removed");
+    } catch (caught) {
+      setCandidateError(
+        caught instanceof Error ? caught.message : "Unable to remove saved candidate.",
+      );
+      setCandidateStatus("Remove candidate failed");
+    }
+  }
+
+  function handleUseSoundingCandidate(
+    candidate: SoundingCandidate,
+    savedCandidate?: SavedSoundingCandidate,
+  ) {
+    if (!candidate.package_ready || !candidate.selected_sounding_payload) {
+      setCandidateError(
+        "This candidate is not package-ready. Review its caveats before trying another sounding.",
+      );
+      return;
+    }
+    const selectedSounding = candidate.selected_sounding_payload;
+    setSelectedScenarioId(OBSERVED_SOUNDING_EXPERIMENT_ID);
+    setObservedSoundingFilename(candidate.source_file_name);
+    setObservedSoundingText(null);
+    setObservedSoundingParse(observedSoundingParseFromCandidate(candidate, selectedSounding));
+    setObservedSoundingStatus("Candidate loaded into observed-sounding package review");
+    setObservedSoundingError(null);
+    setSelectedCandidateScreening(candidateScreeningMetadata(candidate, savedCandidate));
+    setDryRun(null);
+    setRunStatus(null);
+    setRunWorkflowError(null);
+    setLanWorkerStatus(null);
+    setLanWorkerError(null);
+    setLanWorkerActionStatus(null);
+    setIngestedResultId(null);
+    setCandidateStatus("Candidate selected for package review");
+  }
+
   async function handleDryRun(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!selectedScenario || validationMessages.length > 0) return;
@@ -1302,6 +1669,7 @@ export function App() {
         controls,
         runSizePreset,
         observedSoundingExperimentSelected ? observedSoundingParse?.selected_sounding : null,
+        observedSoundingExperimentSelected ? selectedCandidateScreening : null,
       );
       setDryRun(result);
       setStatus("Packaged dry-run output");
@@ -1317,6 +1685,7 @@ export function App() {
     setObservedSoundingStatus("Reading observed sounding file...");
     setObservedSoundingError(null);
     setObservedSoundingParse(null);
+    setSelectedCandidateScreening(null);
     setDryRun(null);
     setRunStatus(null);
     setLanWorkerStatus(null);
@@ -1326,6 +1695,7 @@ export function App() {
       setObservedSoundingStatus("Parsing observed sounding...");
       const parsed = await parseObservedSoundingUpload(file.name, text);
       setObservedSoundingParse(parsed);
+      setSelectedCandidateScreening(null);
       setObservedSoundingStatus("Observed sounding validated for package review");
     } catch (caught) {
       setObservedSoundingText(null);
@@ -1350,6 +1720,7 @@ export function App() {
         validTimeUtc,
       );
       setObservedSoundingParse(parsed);
+      setSelectedCandidateScreening(null);
       setObservedSoundingStatus("Observed sounding validated for package review");
     } catch (caught) {
       setObservedSoundingError(
@@ -1750,6 +2121,17 @@ export function App() {
           observedSoundingParse={observedSoundingParse}
           observedSoundingStatus={observedSoundingStatus}
           observedSoundingError={observedSoundingError}
+          selectedCandidateScreening={selectedCandidateScreening}
+          igraCatalog={igraCatalog}
+          igraCache={igraCache}
+          screeningInputs={screeningInputs}
+          candidateStoryFilter={candidateStoryFilter}
+          candidateSort={candidateSort}
+          candidateStatus={candidateStatus}
+          candidateError={candidateError}
+          candidateScreening={candidateScreening}
+          savedCandidates={savedCandidates}
+          candidateDetailId={candidateDetailId}
           validationMessages={validationMessages}
           dryRun={dryRun}
           runStatus={runStatus}
@@ -1765,7 +2147,7 @@ export function App() {
           results={results}
           autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIdSet}
           failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIdSet}
-          onSelectScenario={setSelectedScenarioId}
+          onSelectScenario={handleSelectScenario}
           onControlChange={(id, value) =>
             setControls((current) => ({
               ...current,
@@ -1775,6 +2157,14 @@ export function App() {
           onRunSizeChange={setRunSizePreset}
           onObservedSoundingFile={handleObservedSoundingFile}
           onObservedSoundingTimeChange={handleObservedSoundingTimeChange}
+          onCandidateStoryFilterChange={setCandidateStoryFilter}
+          onCandidateSortChange={setCandidateSort}
+          onCandidateDetailChange={setCandidateDetailId}
+          onRefreshIGRAData={handleRefreshIGRAData}
+          onScreenSoundingCandidates={handleScreenSoundingCandidates}
+          onSaveSoundingCandidate={handleSaveSoundingCandidate}
+          onRemoveSavedSoundingCandidate={handleRemoveSavedSoundingCandidate}
+          onUseSoundingCandidate={handleUseSoundingCandidate}
           onDryRun={handleDryRun}
           onLaunchRun={handleLaunchRun}
           onRefreshRunStatus={handleRefreshRunStatus}
@@ -1886,6 +2276,17 @@ function BuildWorkspace({
   observedSoundingParse,
   observedSoundingStatus,
   observedSoundingError,
+  selectedCandidateScreening,
+  igraCatalog,
+  igraCache,
+  screeningInputs,
+  candidateStoryFilter,
+  candidateSort,
+  candidateStatus,
+  candidateError,
+  candidateScreening,
+  savedCandidates,
+  candidateDetailId,
   validationMessages,
   dryRun,
   runStatus,
@@ -1906,6 +2307,14 @@ function BuildWorkspace({
   onRunSizeChange,
   onObservedSoundingFile,
   onObservedSoundingTimeChange,
+  onCandidateStoryFilterChange,
+  onCandidateSortChange,
+  onCandidateDetailChange,
+  onRefreshIGRAData,
+  onScreenSoundingCandidates,
+  onSaveSoundingCandidate,
+  onRemoveSavedSoundingCandidate,
+  onUseSoundingCandidate,
   onDryRun,
   onLaunchRun,
   onRefreshRunStatus,
@@ -1939,6 +2348,17 @@ function BuildWorkspace({
   observedSoundingParse: ObservedSoundingParseResponse | null;
   observedSoundingStatus: string | null;
   observedSoundingError: string | null;
+  selectedCandidateScreening: Record<string, unknown> | null;
+  igraCatalog: IGRACatalogResponse["catalog"] | null;
+  igraCache: IGRACacheResponse | null;
+  screeningInputs: ScreeningInput[];
+  candidateStoryFilter: CandidateStoryFilter;
+  candidateSort: CandidateSort;
+  candidateStatus: string;
+  candidateError: string | null;
+  candidateScreening: ScreeningResult | null;
+  savedCandidates: SavedSoundingCandidate[];
+  candidateDetailId: string | null;
   validationMessages: string[];
   dryRun: DryRunResponse | null;
   runStatus: RunStatusResponse | null;
@@ -1959,6 +2379,17 @@ function BuildWorkspace({
   onRunSizeChange: (presetId: string) => void;
   onObservedSoundingFile: (file: File) => void;
   onObservedSoundingTimeChange: (validTimeUtc: string) => void;
+  onCandidateStoryFilterChange: (filter: CandidateStoryFilter) => void;
+  onCandidateSortChange: (sort: CandidateSort) => void;
+  onCandidateDetailChange: (candidateId: string) => void;
+  onRefreshIGRAData: () => void;
+  onScreenSoundingCandidates: () => void;
+  onSaveSoundingCandidate: (candidate: SoundingCandidate) => void;
+  onRemoveSavedSoundingCandidate: (savedCandidateId: string) => void;
+  onUseSoundingCandidate: (
+    candidate: SoundingCandidate,
+    savedCandidate?: SavedSoundingCandidate,
+  ) => void;
   onDryRun: (event: FormEvent<HTMLFormElement>) => void;
   onLaunchRun: () => void;
   onRefreshRunStatus: () => void;
@@ -2121,13 +2552,36 @@ function BuildWorkspace({
               </section>
 
               {observedSoundingExperimentSelected && (
-                <ObservedSoundingInputPanel
-                  parsed={observedSoundingParse}
-                  status={observedSoundingStatus}
-                  error={observedSoundingError}
-                  onFile={onObservedSoundingFile}
-                  onTimeChange={onObservedSoundingTimeChange}
-                />
+                <>
+                  <ObservedAtmosphereCandidatesPanel
+                    catalog={igraCatalog}
+                    cache={igraCache}
+                    screeningInputs={screeningInputs}
+                    storyFilter={candidateStoryFilter}
+                    sort={candidateSort}
+                    status={candidateStatus}
+                    error={candidateError}
+                    screening={candidateScreening}
+                    savedCandidates={savedCandidates}
+                    selectedCandidateId={candidateDetailId}
+                    onStoryFilterChange={onCandidateStoryFilterChange}
+                    onSortChange={onCandidateSortChange}
+                    onCandidateDetailChange={onCandidateDetailChange}
+                    onRefreshIGRAData={onRefreshIGRAData}
+                    onScreen={onScreenSoundingCandidates}
+                    onSave={onSaveSoundingCandidate}
+                    onRemoveSaved={onRemoveSavedSoundingCandidate}
+                    onUse={onUseSoundingCandidate}
+                  />
+                  <ObservedSoundingInputPanel
+                    parsed={observedSoundingParse}
+                    status={observedSoundingStatus}
+                    error={observedSoundingError}
+                    selectedCandidateScreening={selectedCandidateScreening}
+                    onFile={onObservedSoundingFile}
+                    onTimeChange={onObservedSoundingTimeChange}
+                  />
+                </>
               )}
 
               <label className="field-label" htmlFor="run-size">
@@ -2285,16 +2739,401 @@ function ScenarioStatePanel({
   );
 }
 
+function ObservedAtmosphereCandidatesPanel({
+  catalog,
+  cache,
+  screeningInputs,
+  storyFilter,
+  sort,
+  status,
+  error,
+  screening,
+  savedCandidates,
+  selectedCandidateId,
+  onStoryFilterChange,
+  onSortChange,
+  onCandidateDetailChange,
+  onRefreshIGRAData,
+  onScreen,
+  onSave,
+  onRemoveSaved,
+  onUse,
+}: {
+  catalog: IGRACatalogResponse["catalog"] | null;
+  cache: IGRACacheResponse | null;
+  screeningInputs: ScreeningInput[];
+  storyFilter: CandidateStoryFilter;
+  sort: CandidateSort;
+  status: string;
+  error: string | null;
+  screening: ScreeningResult | null;
+  savedCandidates: SavedSoundingCandidate[];
+  selectedCandidateId: string | null;
+  onStoryFilterChange: (filter: CandidateStoryFilter) => void;
+  onSortChange: (sort: CandidateSort) => void;
+  onCandidateDetailChange: (candidateId: string) => void;
+  onRefreshIGRAData: () => void;
+  onScreen: () => void;
+  onSave: (candidate: SoundingCandidate) => void;
+  onRemoveSaved: (savedCandidateId: string) => void;
+  onUse: (candidate: SoundingCandidate, savedCandidate?: SavedSoundingCandidate) => void;
+}) {
+  const visibleCandidates = useMemo(
+    () => sortSoundingCandidates(screening?.candidates ?? [], storyFilter, sort),
+    [screening?.candidates, sort, storyFilter],
+  );
+  const selectedCandidate =
+    visibleCandidates.find((candidate) => candidate.candidate_id === selectedCandidateId) ??
+    visibleCandidates[0] ??
+    null;
+  const savedCandidateIds = useMemo(
+    () => new Set(savedCandidates.map((saved) => saved.candidate.candidate_id)),
+    [savedCandidates],
+  );
+  const cachedStations = new Set(
+    (cache?.entries ?? []).map((entry) => entry.station_id),
+  ).size;
+  const cachedStationFiles = cache?.entries.length ?? 0;
+  const cachedCatalogFiles =
+    catalog?.zip_references.filter((reference) => reference.cached_status !== "not_cached")
+      .length ?? cachedStationFiles;
+
+  return (
+    <section
+      className="experiment-summary sounding-candidate-workbench"
+      aria-labelledby="sounding-candidates-title"
+    >
+      <div className="panel-heading-row">
+        <div>
+          <p className="eyebrow">Observed atmosphere</p>
+          <h3 id="sounding-candidates-title">Find interesting soundings</h3>
+          <p className="field-help">
+            Screening guidance only. Use this to choose an observed atmosphere to try; CM1
+            decides what actually happens.
+          </p>
+        </div>
+        <p className="state-chip" role="status">
+          {status}
+        </p>
+      </div>
+
+      <dl className="candidate-cache-summary">
+        <Metric label="Region" value={catalog?.region.label ?? "Great Plains / Midwest"} />
+        <Metric
+          label="Last refreshed"
+          value={catalog?.refreshed_at ? formatDate(catalog.refreshed_at) : "Not refreshed here"}
+        />
+        <Metric label="Cached stations" value={cachedStations.toString()} />
+        <Metric label="Cached station files" value={cachedCatalogFiles.toString()} />
+        <Metric label="Screenable soundings" value={screeningInputs.length.toString()} />
+      </dl>
+
+      {error && (
+        <div className="validation" role="alert">
+          <p>{error}</p>
+        </div>
+      )}
+
+      <div className="candidate-toolbar" aria-label="Sounding candidate controls">
+        <label>
+          Story filter
+          <select
+            value={storyFilter}
+            onChange={(event) => onStoryFilterChange(event.target.value as CandidateStoryFilter)}
+          >
+            <option value="all">All screening stories</option>
+            <option value="shallow_cumulus_candidate">Cloud-forming shallow cumulus</option>
+            <option value="dry_failed_candidate">Dry failed cumulus</option>
+            <option value="capped_suppressed_candidate">Capped / suppressed</option>
+            <option value="humid_rainy_candidate">Humid / rainy</option>
+            <option value="needs_review">Needs review</option>
+          </select>
+        </label>
+        <label>
+          Sort
+          <select value={sort} onChange={(event) => onSortChange(event.target.value as CandidateSort)}>
+            <option value="best">Best match for story</option>
+            <option value="latest">Latest</option>
+            <option value="data_quality">Best data quality</option>
+            <option value="lowest_lcl">Lowest LCL</option>
+            <option value="highest_moisture">Highest low-level moisture</option>
+            <option value="strongest_cap">Strongest cap</option>
+          </select>
+        </label>
+        <div className="button-row candidate-toolbar-actions">
+          <button type="button" onClick={onRefreshIGRAData}>
+            Refresh recent IGRA data
+          </button>
+          <button type="button" onClick={onScreen}>
+            Screen cached soundings
+          </button>
+        </div>
+      </div>
+
+      <div className="candidate-workspace">
+        <section aria-label="Screened sounding candidates">
+          {visibleCandidates.length === 0 ? (
+            <div className="scenario-state-panel">
+              <h4>No screened candidates loaded</h4>
+              <p>
+                Refresh recent IGRA data to check cached stations, then screen cached soundings by
+                atmospheric story. If nothing is ready, cache station files with the IGRA recent
+                script first.
+              </p>
+            </div>
+          ) : (
+            <div className="candidate-list">
+              {visibleCandidates.map((candidate) => (
+                <SoundingCandidateCard
+                  key={candidate.candidate_id}
+                  candidate={candidate}
+                  storyFilter={storyFilter}
+                  selected={selectedCandidate?.candidate_id === candidate.candidate_id}
+                  saved={savedCandidateIds.has(candidate.candidate_id)}
+                  onSelect={() => onCandidateDetailChange(candidate.candidate_id)}
+                  onSave={() => onSave(candidate)}
+                  onUse={() => onUse(candidate)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <SoundingCandidateDetail candidate={selectedCandidate} storyFilter={storyFilter} />
+      </div>
+
+      <section className="saved-candidates-panel" aria-labelledby="saved-candidates-title">
+        <div className="panel-heading-row">
+          <div>
+            <h4 id="saved-candidates-title">Saved sounding candidates</h4>
+            <p>
+              Saved candidates are pre-run hypotheses. They are not Results and they do not prove
+              an atmospheric outcome.
+            </p>
+          </div>
+        </div>
+        {savedCandidates.length === 0 ? (
+          <p className="field-help">No saved candidates yet.</p>
+        ) : (
+          <div className="saved-candidate-list">
+            {savedCandidates.map((saved) => (
+              <article
+                className="saved-candidate-card"
+                key={saved.saved_candidate_id}
+                aria-label={`Saved sounding candidate ${candidateStationLabel(saved.candidate)}`}
+              >
+                <div>
+                  <strong>{candidateStationLabel(saved.candidate)}</strong>
+                  <small>
+                    {formatDate(saved.candidate.valid_time_utc)} ·{" "}
+                    {candidateStoryLabel(saved.primary_story)}
+                  </small>
+                  {saved.linked_run_ids.length > 0 && (
+                    <small>Used in {saved.linked_run_ids.join(", ")}</small>
+                  )}
+                </div>
+                <div className="button-row">
+                  <button type="button" onClick={() => onUse(saved.candidate, saved)}>
+                    Use to create package
+                  </button>
+                  <button
+                    type="button"
+                    className="secondary-button"
+                    onClick={() => onRemoveSaved(saved.saved_candidate_id)}
+                  >
+                    Remove saved
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+    </section>
+  );
+}
+
+function SoundingCandidateCard({
+  candidate,
+  storyFilter,
+  selected,
+  saved,
+  onSelect,
+  onSave,
+  onUse,
+}: {
+  candidate: SoundingCandidate;
+  storyFilter: CandidateStoryFilter;
+  selected: boolean;
+  saved: boolean;
+  onSelect: () => void;
+  onSave: () => void;
+  onUse: () => void;
+}) {
+  const story = storyFilter === "all" ? candidate.primary_story : storyFilter;
+  const matchScore = candidateMatchScore(candidate, story);
+  return (
+    <article
+      className={`candidate-card${selected ? " selected-candidate-card" : ""}`}
+      aria-label={`Sounding candidate ${candidateStationLabel(candidate)}`}
+    >
+      <button type="button" className="candidate-card-main candidate-card-select" onClick={onSelect}>
+        <span>
+          <strong>{candidateStationLabel(candidate)}</strong>
+          <small>{formatDate(candidate.valid_time_utc)}</small>
+        </span>
+        <span className="badge-row">
+          <StatusBadge label={candidateStoryLabel(story)} tone="neutral" />
+          <StatusBadge label={`${formatNumber(matchScore, "%")} match`} tone="neutral" />
+          <StatusBadge
+            label={candidate.package_ready ? "Package-ready" : "Blocked"}
+            tone={candidate.package_ready ? "good" : "warning"}
+          />
+        </span>
+      </button>
+      <ul className="compact-list">
+        {candidate.evidence.slice(0, 3).map((item) => (
+          <li key={`${candidate.candidate_id}-${item.label}`}>
+            {item.label}: {candidateEvidenceValue(item)}
+          </li>
+        ))}
+      </ul>
+      {candidate.caveats.length > 0 && (
+        <p className="field-help">
+          {candidate.caveats.length} caveat{candidate.caveats.length === 1 ? "" : "s"}
+        </p>
+      )}
+      <div className="button-row">
+        <button type="button" disabled={!candidate.package_ready} onClick={onUse}>
+          Use this sounding
+        </button>
+        <button type="button" className="secondary-button" disabled={saved} onClick={onSave}>
+          {saved ? "Saved" : "Save candidate"}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function SoundingCandidateDetail({
+  candidate,
+  storyFilter,
+}: {
+  candidate: SoundingCandidate | null;
+  storyFilter: CandidateStoryFilter;
+}) {
+  if (!candidate) {
+    return (
+      <aside className="candidate-detail-panel">
+        <h4>Candidate details</h4>
+        <p>Select or screen a sounding candidate to inspect evidence, caveats, and readiness.</p>
+      </aside>
+    );
+  }
+  const story = storyFilter === "all" ? candidate.primary_story : storyFilter;
+  const featureRows = [
+    ["Low-level moisture", "mean_qv_0_1000m_g_kg", "g/kg"],
+    ["Estimated LCL", "estimated_lcl_height_m_agl", "m AGL"],
+    ["Low-level lapse rate", "lapse_rate_0_1000m_c_per_km", "C/km"],
+    ["Cap proxy", "cap_strength_proxy", ""],
+    ["Moisture depth", "moisture_depth_m", "m"],
+    ["Profile top", "profile_top_m_agl", "m AGL"],
+    ["Data completeness", "data_completeness_score", "%"],
+  ] as const;
+  return (
+    <aside className="candidate-detail-panel" aria-label="Candidate details">
+      <div className="panel-heading-row">
+        <div>
+          <h4>{candidateStationLabel(candidate)}</h4>
+          <p>
+            {formatDate(candidate.valid_time_utc)} · {candidateStoryLabel(story)}
+          </p>
+        </div>
+        <StatusBadge
+          label={candidate.package_ready ? "Ready for review" : "Blocked"}
+          tone={candidate.package_ready ? "good" : "warning"}
+        />
+      </div>
+      <p>
+        Candidate match score is screening guidance only. CM1 decides whether clouds, rain, or
+        suppression actually happen.
+      </p>
+      <dl className="compact-metrics">
+        <Metric label="Match score" value={formatNumber(candidateMatchScore(candidate, story), "%")} />
+        <Metric label="Evidence level" value={humanize(candidate.confidence)} />
+        <Metric label="Station ID" value={candidate.station_id} />
+        <Metric
+          label="Location"
+          value={
+            candidate.station_latitude !== null &&
+            candidate.station_latitude !== undefined &&
+            candidate.station_longitude !== null &&
+            candidate.station_longitude !== undefined
+              ? `${formatNumber(candidate.station_latitude, "deg")}, ${formatNumber(candidate.station_longitude, "deg")}`
+              : "Not available"
+          }
+        />
+      </dl>
+      <section>
+        <h5>Evidence</h5>
+        <ul className="compact-list">
+          {candidate.evidence.map((item) => (
+            <li key={`${candidate.candidate_id}-detail-${item.label}`}>
+              <strong>{item.label}:</strong> {candidateEvidenceValue(item)}. {item.interpretation}
+            </li>
+          ))}
+        </ul>
+      </section>
+      <details>
+        <summary>All story scores</summary>
+        <dl className="compact-metrics">
+          {candidate.story_scores.map((score) => (
+            <Metric
+              key={score.story}
+              label={score.label}
+              value={`${formatNumber(score.score_0_to_100, "%")} · ${humanize(score.support)}`}
+            />
+          ))}
+        </dl>
+      </details>
+      <details>
+        <summary>Feature values</summary>
+        <dl className="compact-metrics">
+          {featureRows.map(([label, key, units]) => (
+            <Metric
+              key={key}
+              label={label}
+              value={candidateFeatureValue(candidate, key, units)}
+            />
+          ))}
+        </dl>
+      </details>
+      {candidate.caveats.length > 0 && (
+        <details open={!candidate.package_ready}>
+          <summary>Screening caveats</summary>
+          <ul className="compact-list">
+            {candidate.caveats.map((caveat) => (
+              <li key={caveat}>{humanize(caveat)}</li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </aside>
+  );
+}
+
 function ObservedSoundingInputPanel({
   parsed,
   status,
   error,
+  selectedCandidateScreening,
   onFile,
   onTimeChange,
 }: {
   parsed: ObservedSoundingParseResponse | null;
   status: string | null;
   error: string | null;
+  selectedCandidateScreening: Record<string, unknown> | null;
   onFile: (file: File) => void;
   onTimeChange: (validTimeUtc: string) => void;
 }) {
@@ -2336,6 +3175,18 @@ function ObservedSoundingInputPanel({
 
       {parsed && selected && (
         <section className="observed-sounding-review" aria-label="Observed sounding review">
+              {selectedCandidateScreening && (
+                <div className="screening-guidance-note">
+                  <strong>Screening guidance only</strong>
+                  <span>
+                    Screened as{" "}
+                    {candidateStoryLabel(
+                      String(selectedCandidateScreening.primary_story ?? "needs_review") as CandidateStoryId,
+                    )}
+                    . CM1 decides what actually happens.
+                  </span>
+                </div>
+              )}
               <div className="control-row">
                 <span>
                   <label htmlFor="observed-sounding-time">
@@ -6611,6 +7462,134 @@ function OutcomeBadge({ result }: { result: ResultCard }) {
   );
 }
 
+function candidateStoryLabel(story: CandidateStoryId | CandidateStoryFilter): string {
+  switch (story) {
+    case "shallow_cumulus_candidate":
+      return "Cloud-forming shallow cumulus";
+    case "dry_failed_candidate":
+      return "Dry failed cumulus";
+    case "capped_suppressed_candidate":
+      return "Capped / suppressed";
+    case "humid_rainy_candidate":
+      return "Humid / rainy";
+    case "poor_or_incomplete_candidate":
+      return "Poor or incomplete";
+    case "needs_review":
+      return "Needs review";
+    case "all":
+      return "All screening stories";
+  }
+}
+
+function candidateStationLabel(candidate: SoundingCandidate): string {
+  return `${candidate.station_name ?? "Observed sounding"} (${candidate.station_id})`;
+}
+
+function candidateMatchScore(
+  candidate: SoundingCandidate,
+  story: CandidateStoryId | CandidateStoryFilter,
+): number {
+  if (story === "all") return candidate.rank_score;
+  return (
+    candidate.story_scores.find((score) => score.story === story)?.score_0_to_100 ??
+    candidate.rank_score
+  );
+}
+
+function sortSoundingCandidates(
+  candidates: SoundingCandidate[],
+  story: CandidateStoryFilter,
+  sort: CandidateSort,
+): SoundingCandidate[] {
+  const valueForSort = (candidate: SoundingCandidate): number => {
+    switch (sort) {
+      case "latest":
+        return new Date(candidate.valid_time_utc).getTime();
+      case "data_quality":
+        return numberFeature(candidate, "data_completeness_score");
+      case "lowest_lcl":
+        return -numberFeature(candidate, "estimated_lcl_height_m_agl");
+      case "highest_moisture":
+        return numberFeature(candidate, "mean_qv_0_1000m_g_kg");
+      case "strongest_cap":
+        return numberFeature(candidate, "cap_strength_proxy");
+      case "best":
+        return candidateMatchScore(candidate, story);
+    }
+  };
+  const filtered =
+    story === "all"
+      ? candidates
+      : candidates.filter((candidate) => candidate.primary_story === story);
+  return [...filtered].sort((a, b) => {
+    const readiness = Number(b.package_ready) - Number(a.package_ready);
+    if (readiness !== 0) return readiness;
+    const score = valueForSort(b) - valueForSort(a);
+    if (score !== 0) return score;
+    return new Date(b.valid_time_utc).getTime() - new Date(a.valid_time_utc).getTime();
+  });
+}
+
+function numberFeature(candidate: SoundingCandidate, key: string): number {
+  const value = candidate.features[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
+}
+
+function candidateEvidenceValue(item: EvidenceItem): string {
+  if (item.value === null || item.value === undefined || item.value === "") return "not available";
+  return `${String(item.value)}${item.units ? ` ${item.units}` : ""}`;
+}
+
+function candidateFeatureValue(candidate: SoundingCandidate, key: string, units: string): string {
+  const value = candidate.features[key];
+  if (typeof value === "number") return formatNumber(value, units);
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "string" && value.length > 0) return value;
+  return "Not available";
+}
+
+function observedSoundingParseFromCandidate(
+  candidate: SoundingCandidate,
+  selectedSounding: ObservedSoundingRecord,
+): ObservedSoundingParseResponse {
+  return {
+    source_provider: candidate.source_provider,
+    source_format: candidate.source_format,
+    uploaded_filename: candidate.source_file_name,
+    available_soundings: [
+      {
+        station_id: selectedSounding.station_id,
+        valid_time_utc: selectedSounding.valid_time_utc,
+        source_time_text: selectedSounding.source_time_text,
+        num_levels: selectedSounding.levels.length,
+        pressure_source: "observed_sounding_candidate",
+        non_pressure_source: "observed_sounding_candidate",
+      },
+    ],
+    selected_sounding: selectedSounding,
+  };
+}
+
+function candidateScreeningMetadata(
+  candidate: SoundingCandidate,
+  savedCandidate?: SavedSoundingCandidate,
+): Record<string, unknown> {
+  return {
+    candidate_id: candidate.candidate_id,
+    saved_candidate_id: savedCandidate?.saved_candidate_id ?? null,
+    screening_version: candidate.screening_version,
+    primary_story: candidate.primary_story,
+    story_scores: candidate.story_scores,
+    rank_score: candidate.rank_score,
+    confidence: candidate.confidence,
+    features: candidate.features,
+    evidence: candidate.evidence,
+    caveats: candidate.caveats,
+    source_file_name: candidate.source_file_name,
+    source_file_hash: candidate.source_file_hash,
+  };
+}
+
 function StatusBadge({ label, tone }: { label: string; tone: "good" | "warning" | "neutral" }) {
   return <span className={`status-badge status-badge-${tone}`}>{label}</span>;
 }
@@ -7081,7 +8060,8 @@ function formatScientific(value: number | null, units: string): string {
 
 function formatNumber(value: number | null, units: string): string {
   if (value === null) return "Unavailable";
-  return `${Number(value.toFixed(3)).toLocaleString()} ${units}`;
+  const formatted = Number(value.toFixed(3)).toLocaleString();
+  return units ? `${formatted} ${units}` : formatted;
 }
 
 function formatMaybeNumber(value: number | null, units: string | null): string {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -233,6 +233,9 @@ type ScreeningInput = {
   cached_text_path: string;
   source_file_name: string;
   cached_status: string;
+  sounding_count?: number | null;
+  latest_valid_time_utc?: string | null;
+  caveats?: string[];
 };
 
 type ScreeningInputsResponse = {
@@ -284,6 +287,14 @@ type IGRACacheResponse = {
     cached_text_path?: string | null;
   }[];
   updated_at: string;
+};
+
+type IGRABatchCacheResponse = {
+  requested_limit: number;
+  selected_count: number;
+  cached_entries: unknown[];
+  failed: Array<{ station_id: string; filename: string; error: string }>;
+  remaining_uncached_count: number;
 };
 
 type ObservedSoundingSummary = {
@@ -888,6 +899,18 @@ async function fetchIGRARecentCache(): Promise<IGRACacheResponse> {
   return response.json() as Promise<IGRACacheResponse>;
 }
 
+async function cacheIGRARecentBatch(limit: number): Promise<IGRABatchCacheResponse> {
+  const response = await fetch("/api/igra/recent/cache-batch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ limit }),
+  });
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to cache IGRA station files."));
+  }
+  return response.json() as Promise<IGRABatchCacheResponse>;
+}
+
 async function fetchScreeningInputs(): Promise<ScreeningInputsResponse> {
   const response = await fetch("/api/sounding-candidates/screening-inputs");
   if (!response.ok) {
@@ -898,13 +921,14 @@ async function fetchScreeningInputs(): Promise<ScreeningInputsResponse> {
 
 async function screenSoundingCandidates(
   story: CandidateStoryFilter,
+  options: { latestPerStation: number; limit: number },
 ): Promise<ScreeningResult> {
   const response = await fetch("/api/sounding-candidates/screen", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      latest_per_station: 5,
-      limit: 50,
+      latest_per_station: options.latestPerStation,
+      limit: options.limit,
       target_story: story === "all" ? null : story,
     }),
   });
@@ -1261,6 +1285,12 @@ export function App() {
   const [candidateStoryFilter, setCandidateStoryFilter] =
     useState<CandidateStoryFilter>("all");
   const [candidateSort, setCandidateSort] = useState<CandidateSort>("best");
+  const [candidateStationSearch, setCandidateStationSearch] = useState("");
+  const [candidateReadinessFilter, setCandidateReadinessFilter] =
+    useState<"all" | "package_ready" | "blocked">("all");
+  const [candidateCacheLimit, setCandidateCacheLimit] = useState("10");
+  const [candidateLatestPerStation, setCandidateLatestPerStation] = useState("5");
+  const [candidateResultLimit, setCandidateResultLimit] = useState("50");
   const [candidateStatus, setCandidateStatus] = useState("IGRA cache not checked yet");
   const [candidateError, setCandidateError] = useState<string | null>(null);
   const [candidateScreening, setCandidateScreening] = useState<ScreeningResult | null>(null);
@@ -1549,16 +1579,44 @@ export function App() {
 
   async function handleRefreshIGRAData() {
     setCandidateError(null);
-    setCandidateStatus("Refreshing recent IGRA catalog");
+    setCandidateStatus("Refreshing IGRA station catalog");
     try {
       const catalog = await refreshIGRARecentCatalog();
       setIgraCatalog(catalog);
-      await refreshSoundingCandidateState("Recent IGRA catalog refreshed");
+      await refreshSoundingCandidateState("IGRA station catalog refreshed");
     } catch (caught) {
       setCandidateError(
-        caught instanceof Error ? caught.message : "Unable to refresh recent IGRA data.",
+        caught instanceof Error ? caught.message : "Unable to refresh IGRA station catalog.",
       );
-      setCandidateStatus("IGRA refresh blocked");
+      setCandidateStatus("IGRA catalog refresh blocked");
+    }
+  }
+
+  async function handleCacheIGRAStationFiles() {
+    const limit = boundedInteger(candidateCacheLimit, 1, 100, 10);
+    setCandidateError(null);
+    setCandidateStatus(`Caching up to ${limit} IGRA station file${limit === 1 ? "" : "s"}`);
+    try {
+      const result = await cacheIGRARecentBatch(limit);
+      await refreshSoundingCandidateState(
+        result.cached_entries.length > 0
+          ? `Cached ${result.cached_entries.length} station file${
+              result.cached_entries.length === 1 ? "" : "s"
+            }`
+          : result.failed.length > 0
+            ? "Station-file caching had errors"
+            : "No uncached station files found",
+      );
+      if (result.failed.length > 0) {
+        setCandidateError(
+          `${result.failed.length} station file${result.failed.length === 1 ? "" : "s"} could not be cached. Check the IGRA cache details or try a smaller batch.`,
+        );
+      }
+    } catch (caught) {
+      setCandidateError(
+        caught instanceof Error ? caught.message : "Unable to cache IGRA station files.",
+      );
+      setCandidateStatus("Station-file caching blocked");
     }
   }
 
@@ -1566,7 +1624,10 @@ export function App() {
     setCandidateError(null);
     setCandidateStatus("Screening cached soundings");
     try {
-      const result = await screenSoundingCandidates(candidateStoryFilter);
+      const result = await screenSoundingCandidates(candidateStoryFilter, {
+        latestPerStation: boundedInteger(candidateLatestPerStation, 1, 50, 5),
+        limit: boundedInteger(candidateResultLimit, 1, 200, 50),
+      });
       setCandidateScreening(result);
       setCandidateDetailId(result.candidates[0]?.candidate_id ?? null);
       setCandidateStatus(
@@ -2127,6 +2188,11 @@ export function App() {
           screeningInputs={screeningInputs}
           candidateStoryFilter={candidateStoryFilter}
           candidateSort={candidateSort}
+          candidateStationSearch={candidateStationSearch}
+          candidateReadinessFilter={candidateReadinessFilter}
+          candidateCacheLimit={candidateCacheLimit}
+          candidateLatestPerStation={candidateLatestPerStation}
+          candidateResultLimit={candidateResultLimit}
           candidateStatus={candidateStatus}
           candidateError={candidateError}
           candidateScreening={candidateScreening}
@@ -2159,8 +2225,14 @@ export function App() {
           onObservedSoundingTimeChange={handleObservedSoundingTimeChange}
           onCandidateStoryFilterChange={setCandidateStoryFilter}
           onCandidateSortChange={setCandidateSort}
+          onCandidateStationSearchChange={setCandidateStationSearch}
+          onCandidateReadinessFilterChange={setCandidateReadinessFilter}
+          onCandidateCacheLimitChange={setCandidateCacheLimit}
+          onCandidateLatestPerStationChange={setCandidateLatestPerStation}
+          onCandidateResultLimitChange={setCandidateResultLimit}
           onCandidateDetailChange={setCandidateDetailId}
           onRefreshIGRAData={handleRefreshIGRAData}
+          onCacheIGRAStationFiles={handleCacheIGRAStationFiles}
           onScreenSoundingCandidates={handleScreenSoundingCandidates}
           onSaveSoundingCandidate={handleSaveSoundingCandidate}
           onRemoveSavedSoundingCandidate={handleRemoveSavedSoundingCandidate}
@@ -2282,6 +2354,11 @@ function BuildWorkspace({
   screeningInputs,
   candidateStoryFilter,
   candidateSort,
+  candidateStationSearch,
+  candidateReadinessFilter,
+  candidateCacheLimit,
+  candidateLatestPerStation,
+  candidateResultLimit,
   candidateStatus,
   candidateError,
   candidateScreening,
@@ -2309,8 +2386,14 @@ function BuildWorkspace({
   onObservedSoundingTimeChange,
   onCandidateStoryFilterChange,
   onCandidateSortChange,
+  onCandidateStationSearchChange,
+  onCandidateReadinessFilterChange,
+  onCandidateCacheLimitChange,
+  onCandidateLatestPerStationChange,
+  onCandidateResultLimitChange,
   onCandidateDetailChange,
   onRefreshIGRAData,
+  onCacheIGRAStationFiles,
   onScreenSoundingCandidates,
   onSaveSoundingCandidate,
   onRemoveSavedSoundingCandidate,
@@ -2354,6 +2437,11 @@ function BuildWorkspace({
   screeningInputs: ScreeningInput[];
   candidateStoryFilter: CandidateStoryFilter;
   candidateSort: CandidateSort;
+  candidateStationSearch: string;
+  candidateReadinessFilter: "all" | "package_ready" | "blocked";
+  candidateCacheLimit: string;
+  candidateLatestPerStation: string;
+  candidateResultLimit: string;
   candidateStatus: string;
   candidateError: string | null;
   candidateScreening: ScreeningResult | null;
@@ -2381,8 +2469,14 @@ function BuildWorkspace({
   onObservedSoundingTimeChange: (validTimeUtc: string) => void;
   onCandidateStoryFilterChange: (filter: CandidateStoryFilter) => void;
   onCandidateSortChange: (sort: CandidateSort) => void;
+  onCandidateStationSearchChange: (value: string) => void;
+  onCandidateReadinessFilterChange: (filter: "all" | "package_ready" | "blocked") => void;
+  onCandidateCacheLimitChange: (value: string) => void;
+  onCandidateLatestPerStationChange: (value: string) => void;
+  onCandidateResultLimitChange: (value: string) => void;
   onCandidateDetailChange: (candidateId: string) => void;
   onRefreshIGRAData: () => void;
+  onCacheIGRAStationFiles: () => void;
   onScreenSoundingCandidates: () => void;
   onSaveSoundingCandidate: (candidate: SoundingCandidate) => void;
   onRemoveSavedSoundingCandidate: (savedCandidateId: string) => void;
@@ -2559,6 +2653,11 @@ function BuildWorkspace({
                     screeningInputs={screeningInputs}
                     storyFilter={candidateStoryFilter}
                     sort={candidateSort}
+                    stationSearch={candidateStationSearch}
+                    readinessFilter={candidateReadinessFilter}
+                    cacheLimit={candidateCacheLimit}
+                    latestPerStation={candidateLatestPerStation}
+                    resultLimit={candidateResultLimit}
                     status={candidateStatus}
                     error={candidateError}
                     screening={candidateScreening}
@@ -2566,8 +2665,14 @@ function BuildWorkspace({
                     selectedCandidateId={candidateDetailId}
                     onStoryFilterChange={onCandidateStoryFilterChange}
                     onSortChange={onCandidateSortChange}
+                    onStationSearchChange={onCandidateStationSearchChange}
+                    onReadinessFilterChange={onCandidateReadinessFilterChange}
+                    onCacheLimitChange={onCandidateCacheLimitChange}
+                    onLatestPerStationChange={onCandidateLatestPerStationChange}
+                    onResultLimitChange={onCandidateResultLimitChange}
                     onCandidateDetailChange={onCandidateDetailChange}
                     onRefreshIGRAData={onRefreshIGRAData}
+                    onCacheStationFiles={onCacheIGRAStationFiles}
                     onScreen={onScreenSoundingCandidates}
                     onSave={onSaveSoundingCandidate}
                     onRemoveSaved={onRemoveSavedSoundingCandidate}
@@ -2745,6 +2850,11 @@ function ObservedAtmosphereCandidatesPanel({
   screeningInputs,
   storyFilter,
   sort,
+  stationSearch,
+  readinessFilter,
+  cacheLimit,
+  latestPerStation,
+  resultLimit,
   status,
   error,
   screening,
@@ -2752,8 +2862,14 @@ function ObservedAtmosphereCandidatesPanel({
   selectedCandidateId,
   onStoryFilterChange,
   onSortChange,
+  onStationSearchChange,
+  onReadinessFilterChange,
+  onCacheLimitChange,
+  onLatestPerStationChange,
+  onResultLimitChange,
   onCandidateDetailChange,
   onRefreshIGRAData,
+  onCacheStationFiles,
   onScreen,
   onSave,
   onRemoveSaved,
@@ -2764,6 +2880,11 @@ function ObservedAtmosphereCandidatesPanel({
   screeningInputs: ScreeningInput[];
   storyFilter: CandidateStoryFilter;
   sort: CandidateSort;
+  stationSearch: string;
+  readinessFilter: "all" | "package_ready" | "blocked";
+  cacheLimit: string;
+  latestPerStation: string;
+  resultLimit: string;
   status: string;
   error: string | null;
   screening: ScreeningResult | null;
@@ -2771,16 +2892,28 @@ function ObservedAtmosphereCandidatesPanel({
   selectedCandidateId: string | null;
   onStoryFilterChange: (filter: CandidateStoryFilter) => void;
   onSortChange: (sort: CandidateSort) => void;
+  onStationSearchChange: (value: string) => void;
+  onReadinessFilterChange: (filter: "all" | "package_ready" | "blocked") => void;
+  onCacheLimitChange: (value: string) => void;
+  onLatestPerStationChange: (value: string) => void;
+  onResultLimitChange: (value: string) => void;
   onCandidateDetailChange: (candidateId: string) => void;
   onRefreshIGRAData: () => void;
+  onCacheStationFiles: () => void;
   onScreen: () => void;
   onSave: (candidate: SoundingCandidate) => void;
   onRemoveSaved: (savedCandidateId: string) => void;
   onUse: (candidate: SoundingCandidate, savedCandidate?: SavedSoundingCandidate) => void;
 }) {
   const visibleCandidates = useMemo(
-    () => sortSoundingCandidates(screening?.candidates ?? [], storyFilter, sort),
-    [screening?.candidates, sort, storyFilter],
+    () =>
+      sortSoundingCandidates(screening?.candidates ?? [], {
+        story: storyFilter,
+        sort,
+        stationSearch,
+        readiness: readinessFilter,
+      }),
+    [readinessFilter, screening?.candidates, sort, stationSearch, storyFilter],
   );
   const selectedCandidate =
     visibleCandidates.find((candidate) => candidate.candidate_id === selectedCandidateId) ??
@@ -2797,6 +2930,14 @@ function ObservedAtmosphereCandidatesPanel({
   const cachedCatalogFiles =
     catalog?.zip_references.filter((reference) => reference.cached_status !== "not_cached")
       .length ?? cachedStationFiles;
+  const screenableSoundingCount = screeningInputs.reduce(
+    (total, input) => total + (input.sounding_count ?? 0),
+    0,
+  );
+  const screenableSummary =
+    screenableSoundingCount > 0
+      ? `${screenableSoundingCount.toLocaleString()} soundings`
+      : `${screeningInputs.length.toLocaleString()} cached files`;
 
   return (
     <section
@@ -2825,7 +2966,7 @@ function ObservedAtmosphereCandidatesPanel({
         />
         <Metric label="Cached stations" value={cachedStations.toString()} />
         <Metric label="Cached station files" value={cachedCatalogFiles.toString()} />
-        <Metric label="Screenable soundings" value={screeningInputs.length.toString()} />
+        <Metric label="Screenable soundings" value={screenableSummary} />
       </dl>
 
       {error && (
@@ -2860,9 +3001,64 @@ function ObservedAtmosphereCandidatesPanel({
             <option value="strongest_cap">Strongest cap</option>
           </select>
         </label>
+        <label>
+          Station search
+          <input
+            type="search"
+            value={stationSearch}
+            placeholder="Station name, ID, or state"
+            onChange={(event) => onStationSearchChange(event.target.value)}
+          />
+        </label>
+        <label>
+          Readiness
+          <select
+            value={readinessFilter}
+            onChange={(event) =>
+              onReadinessFilterChange(event.target.value as "all" | "package_ready" | "blocked")
+            }
+          >
+            <option value="all">All readiness states</option>
+            <option value="package_ready">Package-ready only</option>
+            <option value="blocked">Blocked / needs review</option>
+          </select>
+        </label>
+        <label>
+          Cache up to
+          <input
+            type="number"
+            min="1"
+            max="100"
+            value={cacheLimit}
+            onChange={(event) => onCacheLimitChange(event.target.value)}
+          />
+        </label>
+        <label>
+          Latest per station
+          <input
+            type="number"
+            min="1"
+            max="50"
+            value={latestPerStation}
+            onChange={(event) => onLatestPerStationChange(event.target.value)}
+          />
+        </label>
+        <label>
+          Candidate limit
+          <input
+            type="number"
+            min="1"
+            max="200"
+            value={resultLimit}
+            onChange={(event) => onResultLimitChange(event.target.value)}
+          />
+        </label>
         <div className="button-row candidate-toolbar-actions">
           <button type="button" onClick={onRefreshIGRAData}>
-            Refresh recent IGRA data
+            Refresh IGRA catalog
+          </button>
+          <button type="button" className="secondary-button" onClick={onCacheStationFiles}>
+            Cache station files
           </button>
           <button type="button" onClick={onScreen}>
             Screen cached soundings
@@ -2872,13 +3068,18 @@ function ObservedAtmosphereCandidatesPanel({
 
       <div className="candidate-workspace">
         <section aria-label="Screened sounding candidates">
+          {screening && (
+            <p className="field-help">
+              Showing {visibleCandidates.length.toLocaleString()} of{" "}
+              {screening.candidates.length.toLocaleString()} screened candidates.
+            </p>
+          )}
           {visibleCandidates.length === 0 ? (
             <div className="scenario-state-panel">
               <h4>No screened candidates loaded</h4>
               <p>
-                Refresh recent IGRA data to check cached stations, then screen cached soundings by
-                atmospheric story. If nothing is ready, cache station files with the IGRA recent
-                script first.
+                Refresh the IGRA catalog to check available stations, cache a bounded batch of
+                station files, then screen cached soundings by atmospheric story.
               </p>
             </div>
           ) : (
@@ -7496,31 +7697,74 @@ function candidateMatchScore(
   );
 }
 
+function candidateStoryScore(
+  candidate: SoundingCandidate,
+  story: CandidateStoryId | CandidateStoryFilter,
+): StoryScore | null {
+  if (story === "all") return null;
+  return candidate.story_scores.find((score) => score.story === story) ?? null;
+}
+
+function candidateSupportsStory(
+  candidate: SoundingCandidate,
+  story: CandidateStoryFilter,
+): boolean {
+  if (story === "all") return true;
+  const score = candidateStoryScore(candidate, story);
+  if (!score) return false;
+  if (score.score_0_to_100 <= 0) return false;
+  return !["unavailable", "unsupported", "insufficient_evidence"].includes(score.support);
+}
+
 function sortSoundingCandidates(
   candidates: SoundingCandidate[],
-  story: CandidateStoryFilter,
-  sort: CandidateSort,
+  options: {
+    story: CandidateStoryFilter;
+    sort: CandidateSort;
+    stationSearch: string;
+    readiness: "all" | "package_ready" | "blocked";
+  },
 ): SoundingCandidate[] {
+  const { story, sort, stationSearch, readiness } = options;
   const valueForSort = (candidate: SoundingCandidate): number => {
     switch (sort) {
       case "latest":
         return new Date(candidate.valid_time_utc).getTime();
       case "data_quality":
-        return numberFeature(candidate, "data_completeness_score");
+        return numberFeature(candidate, "data_completeness_score", Number.NEGATIVE_INFINITY);
       case "lowest_lcl":
-        return -numberFeature(candidate, "estimated_lcl_height_m_agl");
+        return -numberFeature(candidate, "estimated_lcl_height_m_agl", Number.POSITIVE_INFINITY);
       case "highest_moisture":
-        return numberFeature(candidate, "mean_qv_0_1000m_g_kg");
+        return numberFeature(candidate, "mean_qv_0_1000m_g_kg", Number.NEGATIVE_INFINITY);
       case "strongest_cap":
-        return numberFeature(candidate, "cap_strength_proxy");
+        return numberFeature(candidate, "cap_strength_proxy", Number.NEGATIVE_INFINITY);
       case "best":
         return candidateMatchScore(candidate, story);
     }
   };
-  const filtered =
-    story === "all"
-      ? candidates
-      : candidates.filter((candidate) => candidate.primary_story === story);
+  const normalizedSearch = stationSearch.trim().toLowerCase();
+  const filtered = candidates
+    .filter((candidate) => candidateSupportsStory(candidate, story))
+    .filter((candidate) =>
+      readiness === "all"
+        ? true
+        : readiness === "package_ready"
+          ? candidate.package_ready
+          : !candidate.package_ready,
+    )
+    .filter((candidate) => {
+      if (!normalizedSearch) return true;
+      return [
+        candidate.station_id,
+        candidate.station_name,
+        candidate.source_file_name,
+        candidate.primary_story_label,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(normalizedSearch);
+    });
   return [...filtered].sort((a, b) => {
     const readiness = Number(b.package_ready) - Number(a.package_ready);
     if (readiness !== 0) return readiness;
@@ -7530,9 +7774,19 @@ function sortSoundingCandidates(
   });
 }
 
-function numberFeature(candidate: SoundingCandidate, key: string): number {
+function numberFeature(
+  candidate: SoundingCandidate,
+  key: string,
+  missingValue = Number.NEGATIVE_INFINITY,
+): number {
   const value = candidate.features[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
+  return typeof value === "number" && Number.isFinite(value) ? value : missingValue;
+}
+
+function boundedInteger(value: string, min: number, max: number, fallback: number): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
 }
 
 function candidateEvidenceValue(item: EvidenceItem): string {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -102,6 +102,15 @@ to generate a package, its screening summary may be copied into
 provenance. The screening score remains a candidate-selection aid; CM1 output
 remains the source of truth.
 
+The Build UI consumes this layer through bounded JSON only. `Upload a Sounding`
+can call the recent-catalog/cache and candidate-screening endpoints, display the
+candidate list and saved candidates, and pass a selected candidate's
+`selected_sounding_payload` into the existing observed-sounding package review.
+The frontend does not read cached station text directly and does not compute the
+story scores. Candidate status is separate from run/result status: saved
+candidates are pre-run hypotheses, while generated packages, launched runs, and
+ingested results remain separate lifecycle objects.
+
 ## Suggested Stack
 
 This is not final, but a reasonable starting point:

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -94,6 +94,18 @@ the runtime cache and may be handed into package metadata as provenance for why
 a sounding was tried. The browser never parses remote directory listings, ZIP
 files, or station text files.
 
+In Build, `Upload a Sounding` is the product-facing entry point for this
+candidate workflow. It should show a `Find interesting soundings` workbench
+beside the observed-sounding upload path. The workbench can refresh the bounded
+IGRA cache, screen cached soundings by experiment story, show package-ready and
+blocked candidates with evidence and caveats, save candidates for later review,
+and load a selected package-ready candidate into the observed-sounding package
+review. It must keep the language pre-run and provisional: a candidate is an
+observed atmosphere worth trying, not a prediction that clouds, rain, or
+suppression will occur. When a candidate is used, its screening story, score,
+evidence, feature summary, and caveats should be copied into package metadata as
+provenance.
+
 Explore should be a focused visualization plus explanation screen for one
 selected result. Its core interaction is `What happened here?`: select a cloud,
 updraft, clear-air thermal, or no-cloud region and receive a CM1-backed

--- a/docs/development.md
+++ b/docs/development.md
@@ -197,8 +197,9 @@ sounding independent of the experiment story: use `--story shallow-cumulus`,
 depending on what you want to test. CM1 output remains the source of truth.
 
 The same workflow is available in the app from Build -> `Upload a Sounding` ->
-`Find interesting soundings`. Use `Refresh recent IGRA data` to update the
-bounded recent cache, choose a story filter, then `Screen cached soundings`.
+`Find interesting soundings`. Use `Refresh IGRA catalog` to update station
+metadata, `Cache station files` to download a bounded batch of station-period
+files, choose a story filter, then `Screen cached soundings`.
 `Use this sounding` loads a package-ready candidate into the observed-sounding
 package review; it does not launch CM1 and it does not claim the candidate will
 produce the screened outcome. Blocked candidates remain reviewable but cannot be

--- a/docs/development.md
+++ b/docs/development.md
@@ -196,6 +196,14 @@ sounding independent of the experiment story: use `--story shallow-cumulus`,
 `--story dry-failed`, `--story capped-suppressed`, or `--story humid-rainy`
 depending on what you want to test. CM1 output remains the source of truth.
 
+The same workflow is available in the app from Build -> `Upload a Sounding` ->
+`Find interesting soundings`. Use `Refresh recent IGRA data` to update the
+bounded recent cache, choose a story filter, then `Screen cached soundings`.
+`Use this sounding` loads a package-ready candidate into the observed-sounding
+package review; it does not launch CM1 and it does not claim the candidate will
+produce the screened outcome. Blocked candidates remain reviewable but cannot be
+used for package generation until their caveats are resolved.
+
 To reset the recent IGRA cache and test from a clean state, use the script
 cleanup command, then rerun `status` / `refresh`:
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -77,6 +77,15 @@ and candidate-screening metadata is copied into generated package manifests
 when provided. These tests validate pre-run hypothesis plumbing only; they must
 not claim a scored candidate will produce a specific CM1 outcome.
 
+Frontend tests for the `Upload a Sounding` Build workflow should cover the same
+boundary. Component tests and mocked Playwright smoke tests should verify that
+the candidate workbench can refresh IGRA cache state, screen cached soundings by
+story, show blocked candidates as unusable, save candidates, load a
+package-ready candidate into the observed-sounding package review, and include
+candidate-screening provenance in the generated package request. Browser tests
+must mock the backend APIs and must not fetch NOAA/NCEI, parse raw station text,
+or imply that a candidate score predicts the CM1 outcome.
+
 Dry-run package tests should use temporary runtime homes and assert overwrite protection, manifest/report content, CM1-facing input readiness, and absence of NetCDF output. A dry-run package is packaged configuration and metadata only; it is not a launched process or completed CM1 result.
 
 Output product tests should follow the

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -79,9 +79,11 @@ not claim a scored candidate will produce a specific CM1 outcome.
 
 Frontend tests for the `Upload a Sounding` Build workflow should cover the same
 boundary. Component tests and mocked Playwright smoke tests should verify that
-the candidate workbench can refresh IGRA cache state, screen cached soundings by
-story, show blocked candidates as unusable, save candidates, load a
-package-ready candidate into the observed-sounding package review, and include
+the candidate workbench can refresh IGRA catalog metadata, cache a bounded batch
+of station files through mocked APIs, screen cached soundings by story, include
+secondary story-score matches in filtered results, sort missing metrics last,
+show blocked candidates as unusable, save candidates, load a package-ready
+candidate into the observed-sounding package review, and include
 candidate-screening provenance in the generated package request. Browser tests
 must mock the backend APIs and must not fetch NOAA/NCEI, parse raw station text,
 or imply that a candidate score predicts the CM1 outcome.


### PR DESCRIPTION
Issue worked: #240

## Summary
- Added the Build -> Upload a Sounding "Find interesting soundings" workflow for cached IGRA sounding candidates.
- Split candidate discovery into honest steps: refresh IGRA catalog metadata, cache a bounded batch of station files, then screen cached soundings.
- Added story filtering, sorting, station search, readiness filtering, package-ready/blocked candidate cards, side-by-side candidate detail, saved candidate actions, and candidate use through the existing observed-sounding package review.
- Fixed story filtering so secondary story-score matches appear under the selected story when they have meaningful support.
- Fixed lowest-LCL sorting so missing/unavailable LCL sorts after valid LCL values.
- Included candidate-screening provenance in dry-run package requests when a candidate is used.
- Updated docs to state that candidate scores are screening guidance only, not CM1 outcome predictions.

## Tests added/updated
- Added backend coverage for bounded batch IGRA station-file caching and invalid cache limits.
- Added component coverage for catalog refresh copy, bounded cache action, candidate screening, secondary story-score filtering, missing-LCL sorting, blocked candidate disabling, save/remove saved candidate, use candidate, and dry-run package metadata handoff.
- Updated Playwright mocked-smoke coverage for catalog refresh, station-file caching, screening, saving, using, and package creation with candidate provenance.

## Playwright / visual review
- Ran mocked browser suite with the new candidate flow.
- Captured and inspected a targeted Playwright screenshot of Build -> Upload a Sounding -> candidate workbench.
- Visual review caught overly narrow candidate-card title wrapping; fixed card header layout before final checks.
- Review screenshot: /tmp/cloud-chamber-issue-240-candidate-workbench-tightened.png

## Commands run
- scripts/check.sh
- scripts/check-e2e.sh
- npm run test:e2e -- e2e/tmp-candidate-workbench-screenshot.spec.ts (temporary screenshot spec, removed before commit)

## Manual QA needed
Yes. Please review whether Build -> Upload a Sounding feels like a useful pre-run discovery workbench rather than a fake universal ranking. In particular, check whether the candidate cards/details make it clear that CM1 decides what actually happens.

## Caveats / follow-up issues
- Uses mocked API payloads in browser tests; no live NOAA/NCEI calls or real CM1 runs are part of automated verification.
- This PR should not be merged until Tim reviews the UI.

## Generated-artifact check
No generated IGRA cache files, CM1 outputs, NetCDF files, logs, screenshots, videos, traces, reports, or runtime folders were committed.