### PR TITLE
Use observed sounding winds in packages

### DIFF
--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -216,19 +216,18 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
     """Render a runnable CM1 namelist for the baseline shallow-cumulus package.
 
     The recovery baseline follows CM1's local ``les_ShallowCu`` reference case.
-    The external-sounding reproduction keeps ``testcase = 3``, 40 m nominal
-    vertical spacing, 18 km model top, reference Rayleigh damping, reference
-    wind profile, and reference surface stress/roughness settings, but switches
-    the thermodynamic source from built-in ``isnd = 19`` to CM1's external
-    ``input_sounding`` path via ``isnd = 17``. Run-size presets adjust runtime,
+    Generated reference packages keep ``isnd = 17`` with the reference wind path.
+    Observed-sounding packages use ``isnd = 7`` so CM1 reads the thermodynamic
+    and wind profile from ``input_sounding``. Run-size presets adjust runtime,
     saved-output cadence, and, for Deep Overnight, horizontal grid spacing while
     preserving the physical domain and Standard solver timestep. The intentional
-    product-path change outside the sounding source is
-    ``output_format = 2`` so Cloud Chamber can ingest NetCDF output when the local
-    CM1 build supports it.
+    product-path change outside the sounding source is ``output_format = 2`` so
+    Cloud Chamber can ingest NetCDF output when the local CM1 build supports it.
     """
 
     defaults = contract.cloud_scale_defaults
+    sounding_source_id = 7 if contract.observed_sounding is not None else 17
+    wind_profile_id = 0 if contract.observed_sounding is not None else 9
     return f"""
  &param0
  nx           =      {defaults.nx},
@@ -300,8 +299,8 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  irbc      =  4,
  roflux    =  0,
  nudgeobc  =  0,
- isnd      = 17,
- iwnd      =  9,
+ isnd      = {sounding_source_id:2d},
+ iwnd      = {wind_profile_id:2d},
  itern     =  0,
  iinit     =  0,
  irandp    =  1,

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -254,9 +254,9 @@ def _dry_run_report_payload(
             "cap_strength": manifest.controls.get("cap_strength"),
             "cap_height": manifest.controls.get("cap_height"),
             "mapping": (
-                "observed IGRA external input_sounding profile; namelist settings remain "
-                "inherited from the validated baseline; observed winds are preserved as metadata "
-                "while isnd=17/iwnd=9 keeps reference wind handling"
+                "observed IGRA external input_sounding profile; non-wind namelist settings "
+                "remain inherited from the validated baseline; observed wind direction/speed is "
+                "converted to u/v and applied through CM1 isnd=7 input_sounding handling"
                 if contract.observed_sounding is not None
                 else (
                     "external input_sounding profile; namelist settings remain inherited from "
@@ -310,6 +310,9 @@ def _observed_sounding_summary(record: ObservedSoundingRecord) -> dict[str, obje
         "lowest_model_z_m": record.levels[0].model_z_m if record.levels else None,
         "highest_model_z_m": record.levels[-1].model_z_m if record.levels else None,
         "wind_handling": record.wind_handling,
+        "wind_source": record.provenance.get("wind_source"),
+        "wind_units": record.converted_cm1_units.get("wind_components"),
+        "wind_conversion": record.conversion_choices.get("wind"),
         "validation_status": record.validation.status,
         "validation_errors": record.validation.errors,
         "caveats": record.validation.caveats,

--- a/app/backend/cloud_chamber/observed_sounding.py
+++ b/app/backend/cloud_chamber/observed_sounding.py
@@ -221,7 +221,9 @@ def render_observed_input_sounding(record: ObservedSoundingRecord) -> str:
     ]
     lines.extend(
         f"{level.model_z_m:10.1f} {level.potential_temperature_k:12.4f} "
-        f"{level.qv_g_kg:12.5f} {0.0:8.2f} {0.0:7.2f}"
+        f"{level.qv_g_kg:12.5f} "
+        f"{_required_wind_component(level.u_wind_m_s, 'u'):8.2f} "
+        f"{_required_wind_component(level.v_wind_m_s, 'v'):7.2f}"
         for level in body
     )
     return "\n".join(lines) + "\n"
@@ -291,8 +293,6 @@ def _normalize_sounding(
     )
     errors: list[str] = []
     caveats: list[str] = [
-        "Observed IGRA sounding winds preserved as metadata; current CM1 "
-        "package uses reference/generated wind handling.",
         "IGRA quality/source flags are preserved only as source-format provenance in v1.",
         "Place/time are preserved as metadata; radiation remains disabled in "
         "the generated package.",
@@ -342,13 +342,19 @@ def _normalize_sounding(
         source_vertical_coordinate_type="geopotential_height_msl",
         model_bottom_elevation_m_msl=station.elevation_m_msl or 0.0,
         levels=levels,
-        wind_handling=("observed_winds_metadata_only; generated CM1 namelist keeps isnd=17/iwnd=9"),
+        wind_handling=(
+            "observed_sounding_winds; generated CM1 namelist uses isnd=7 so "
+            "input_sounding u/v columns initialize the wind profile"
+        ),
         conversion_choices={
             "height": "IGRA GPH meters MSL converted to model_z_m relative to station elevation",
             "theta": "temperature and pressure converted to potential temperature",
             "moisture": "dewpoint depression preferred; relative humidity used if needed",
             "surface": "lowest usable level is copied to z=0 when above station surface",
-            "wind": "observed winds retained in metadata; CM1 run uses reference wind handling",
+            "wind": (
+                "IGRA wind direction/speed converted to CM1 u/v components and written "
+                "to input_sounding"
+            ),
         },
         validation=validation,
         provenance={
@@ -358,6 +364,7 @@ def _normalize_sounding(
                 "Observed IGRA sounding used as the initial vertical profile for an "
                 "idealized CM1 LES domain anchored to the sounding/site elevation."
             ),
+            "wind_source": "observed_igra_wind_profile",
         },
     )
 
@@ -488,6 +495,12 @@ def _validate_levels(
         ):
             errors.append("non_finite_required_profile_values")
             break
+        if level.u_wind_m_s is None or level.v_wind_m_s is None:
+            errors.append("observed_wind_profile_missing_or_incomplete")
+            break
+        if not math.isfinite(level.u_wind_m_s) or not math.isfinite(level.v_wind_m_s):
+            errors.append("non_finite_observed_wind_profile_values")
+            break
         if level.qv_g_kg < 0:
             errors.append("negative_moisture_value")
             break
@@ -568,3 +581,9 @@ def _wind_components(
         return None, None
     radians = math.radians(wind_direction_degrees)
     return -wind_speed_m_s * math.sin(radians), -wind_speed_m_s * math.cos(radians)
+
+
+def _required_wind_component(value: float | None, component: str) -> float:
+    if value is None or not math.isfinite(value):
+        raise ObservedSoundingError(f"Observed sounding is missing usable {component} wind values.")
+    return value

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -135,7 +135,7 @@ def test_parse_observed_sounding_api_returns_igra_review_payload() -> None:
     assert selected["source_vertical_coordinate_type"] == "geopotential_height_msl"
     assert selected["levels"][0]["model_z_m"] == pytest.approx(0.5)
     assert selected["levels"][-1]["model_z_m"] > 18000
-    assert "metadata_only" in selected["wind_handling"]
+    assert "observed_sounding_winds" in selected["wind_handling"]
 
 
 def test_parse_observed_sounding_api_blocks_malformed_upload() -> None:

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -103,11 +103,22 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
     assert report["variant_metadata"]["sounding_source"] == "observed_igra_station_text"
     assert report["observed_sounding"]["station_name"] == "Valley, Nebraska"
     assert report["observed_sounding"]["usable_levels"] >= 5
+    assert report["observed_sounding"]["wind_source"] == "observed_igra_wind_profile"
+    assert report["observed_sounding"]["wind_units"] == "m/s"
+    assert "input_sounding" in report["observed_sounding"]["wind_conversion"]
     assert case_manifest["contract"]["observed_sounding"]["station_id"] == "USM00072558"
-    assert "isnd      = 17," in namelist
-    assert "iwnd      =  9," in namelist
+    assert "isnd      =  7," in namelist
+    assert "iwnd      =  0," in namelist
     assert "USM00072558" not in sounding
     assert float(sounding.splitlines()[1].split()[0]) == pytest.approx(0.0)
+    assert float(sounding.splitlines()[1].split()[3]) == pytest.approx(
+        observed.levels[0].u_wind_m_s,
+        abs=0.01,
+    )
+    assert float(sounding.splitlines()[1].split()[4]) == pytest.approx(
+        observed.levels[0].v_wind_m_s,
+        abs=0.01,
+    )
     assert float(sounding.splitlines()[-1].split()[0]) > 18000
 
 

--- a/app/backend/tests/test_observed_sounding.py
+++ b/app/backend/tests/test_observed_sounding.py
@@ -37,7 +37,10 @@ def test_parse_igra_station_text_defaults_to_latest_sounding() -> None:
     assert record.levels[-1].model_z_m > 18000
     assert record.validation.status == "needs_review"
     assert "station elevation joined" in " ".join(record.validation.caveats)
-    assert "metadata_only" in record.wind_handling
+    assert "observed_sounding_winds" in record.wind_handling
+    assert record.provenance["wind_source"] == "observed_igra_wind_profile"
+    assert record.levels[0].u_wind_m_s is not None
+    assert record.levels[0].v_wind_m_s is not None
 
 
 def test_summarize_igra_station_text_lists_times_without_package_validation() -> None:
@@ -103,6 +106,8 @@ def test_validate_levels_allows_plausible_upper_level_theta_above_500k() -> None
             temperature_c=20.0,
             potential_temperature_k=293.0,
             qv_g_kg=10.0,
+            u_wind_m_s=1.0,
+            v_wind_m_s=2.0,
         ),
         ObservedSoundingLevel(
             pressure_pa=85000.0,
@@ -111,6 +116,8 @@ def test_validate_levels_allows_plausible_upper_level_theta_above_500k() -> None
             temperature_c=10.0,
             potential_temperature_k=296.0,
             qv_g_kg=8.0,
+            u_wind_m_s=1.0,
+            v_wind_m_s=2.0,
         ),
         ObservedSoundingLevel(
             pressure_pa=50000.0,
@@ -119,6 +126,8 @@ def test_validate_levels_allows_plausible_upper_level_theta_above_500k() -> None
             temperature_c=-15.0,
             potential_temperature_k=320.0,
             qv_g_kg=2.0,
+            u_wind_m_s=1.0,
+            v_wind_m_s=2.0,
         ),
         ObservedSoundingLevel(
             pressure_pa=20000.0,
@@ -127,6 +136,8 @@ def test_validate_levels_allows_plausible_upper_level_theta_above_500k() -> None
             temperature_c=-55.0,
             potential_temperature_k=430.0,
             qv_g_kg=0.1,
+            u_wind_m_s=1.0,
+            v_wind_m_s=2.0,
         ),
         ObservedSoundingLevel(
             pressure_pa=5000.0,
@@ -135,6 +146,8 @@ def test_validate_levels_allows_plausible_upper_level_theta_above_500k() -> None
             temperature_c=-60.0,
             potential_temperature_k=520.0,
             qv_g_kg=0.01,
+            u_wind_m_s=1.0,
+            v_wind_m_s=2.0,
         ),
     ]
     errors: list[str] = []
@@ -142,6 +155,16 @@ def test_validate_levels_allows_plausible_upper_level_theta_above_500k() -> None
     _validate_levels(levels, errors, [])
 
     assert "implausible_potential_temperature_value" not in errors
+
+
+def test_parse_igra_station_text_blocks_missing_wind_profile() -> None:
+    missing_wind = "\n".join(_blank_wind_fields(line) for line in IGRA_FIXTURE.splitlines())
+
+    with pytest.raises(ObservedSoundingError, match="observed_wind_profile_missing"):
+        parse_igra_station_text(
+            missing_wind,
+            uploaded_filename="USM00072558-data-beg2025.txt",
+        )
 
 
 def test_render_observed_input_sounding_is_numeric_cm1_facing() -> None:
@@ -157,5 +180,15 @@ def test_render_observed_input_sounding_is_numeric_cm1_facing() -> None:
     assert len(lines[1].split()) == 5
     assert float(lines[0].split()[0]) == pytest.approx(record.levels[0].pressure_pa / 100.0)
     assert float(lines[1].split()[0]) == pytest.approx(0.0)
+    assert float(lines[1].split()[3]) == pytest.approx(record.levels[0].u_wind_m_s, abs=0.01)
+    assert float(lines[1].split()[4]) == pytest.approx(record.levels[0].v_wind_m_s, abs=0.01)
+    assert float(lines[1].split()[3]) != pytest.approx(0.0)
+    assert float(lines[1].split()[4]) != pytest.approx(0.0)
     assert float(lines[-1].split()[0]) > 18000
     assert "USM00072558" not in rendered
+
+
+def _blank_wind_fields(line: str) -> str:
+    if line.startswith("#") or len(line) < 51:
+        return line
+    return f"{line[:40]}-9999{line[45:46]}-9999{line[51:]}"

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -123,7 +123,8 @@ const observedSoundingParseResponse = {
     },
     source_vertical_coordinate_type: "geopotential_height_msl",
     model_bottom_elevation_m_msl: 351.5,
-    wind_handling: "observed winds metadata only; CM1 wind profile remains baseline",
+    wind_handling:
+      "observed sounding winds; generated CM1 namelist uses isnd=7 so input_sounding u/v columns initialize the wind profile",
     levels: [
       {
         pressure_pa: 96500,
@@ -158,14 +159,14 @@ const observedSoundingParseResponse = {
     ],
     conversion_choices: {
       vertical_anchor: "station_surface",
-      wind_application: "metadata_only",
+      wind_application: "input_sounding_u_v",
     },
     validation: {
       status: "needs_review",
       errors: [],
       caveats: [
         "station_elevation_joined_from_igra_station_fixture",
-        "observed_winds_preserved_as_metadata_only",
+        "observed_sounding_winds_written_to_input_sounding",
       ],
     },
     provenance: {
@@ -408,7 +409,7 @@ export const results = [
     time_of_min_w_seconds: 2700,
     rain_present: false,
     first_rain_time_seconds: null,
-    caveats: ["observed_winds_preserved_as_metadata_only"],
+    caveats: ["observed_sounding_winds_written_to_input_sounding"],
     input_source: "observed_sounding",
     input_source_label: "Observed sounding: USM00072558 · Valley, Nebraska",
     observed_sounding: {

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -75,7 +75,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("USM00072558 · Valley, Nebraska")).toBeVisible();
     await expect(page.locator("#observed-sounding-time")).toHaveValue("2025-01-02T00:00:00Z");
     await expect(page.getByText(/CM1 z=0 is station surface at 351.5 m MSL/i)).toBeVisible();
-    await expect(page.getByText(/observed winds metadata only/i)).toBeVisible();
+    await expect(page.getByText(/generated CM1 namelist uses isnd=7/i)).toBeVisible();
 
     await page.getByText("Observed-sounding caveats").click();
     await expect(page.getByText("Station elevation joined from igra station fixture")).toBeVisible();

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -221,7 +221,8 @@ const observedSoundingParseResponse = {
         wind_speed_m_s: 6.3,
       },
     ],
-    wind_handling: "observed_winds_metadata_only; generated CM1 namelist keeps isnd=17/iwnd=9",
+    wind_handling:
+      "observed_sounding_winds; generated CM1 namelist uses isnd=7 so input_sounding u/v columns initialize the wind profile",
     conversion_choices: {
       height: "IGRA GPH meters MSL converted to model_z_m relative to station elevation",
     },
@@ -230,7 +231,7 @@ const observedSoundingParseResponse = {
       errors: [],
       caveats: [
         "station elevation joined from IGRA station metadata fixture",
-        "Observed IGRA sounding winds preserved as metadata; current CM1 package uses reference/generated wind handling.",
+        "Place/time are preserved as metadata; radiation remains disabled in the generated package.",
       ],
     },
     provenance: {
@@ -839,7 +840,8 @@ const observedSoundingResultCard = {
     usable_levels: 48,
     lowest_model_z_m: 0,
     highest_model_z_m: 18000,
-    wind_handling: "observed_winds_metadata_only",
+    wind_handling:
+      "observed_sounding_winds; generated CM1 namelist uses isnd=7 so input_sounding u/v columns initialize the wind profile",
     validation_status: "valid",
     validation_errors: [],
     caveats: [],
@@ -2259,7 +2261,7 @@ describe("App", () => {
     expect(await screen.findByText("Observed sounding validated for package review")).toBeInTheDocument();
     expect(screen.getByText("USM00072558 · Valley, Nebraska")).toBeInTheDocument();
     expect(screen.getByText(/CM1 z=0 is station surface at 351.5 m MSL/)).toBeInTheDocument();
-    expect(screen.getByText(/observed winds metadata only/)).toBeInTheDocument();
+    expect(screen.getByText(/observed sounding winds/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -205,13 +205,14 @@ observed record is stored with package metadata and includes station id/name,
 latitude/longitude/elevation when known, selected valid time, uploaded
 filename, source provider/format, source units, converted CM1 units,
 model-bottom elevation above mean sea level, levels relative to the station
-surface, validation status, and caveats. For v1, only the thermodynamic and
-moisture profile is generated into `input_sounding`; observed wind direction
-and speed remain metadata/provenance while the namelist preserves the validated
-external-sounding wind path (`isnd = 17`, `iwnd = 9`). Missing station elevation
-or profiles that do not cover the model depth must block package generation or
-surface an explicit `needs_review` caveat instead of silently normalizing to sea
-level.
+surface, validation status, and caveats. For v1, the thermodynamic, moisture,
+and wind profile is generated into `input_sounding`: observed wind
+direction/speed is converted to CM1 `u`/`v`, and observed-sounding packages use
+CM1's `isnd = 7` mode so those wind columns initialize the run. Missing station
+elevation, profiles that do not cover the model depth, or incomplete observed
+wind profiles must block package generation or surface an explicit
+`needs_review` caveat instead of silently normalizing to sea level or falling
+back to reference winds.
 
 Dry Failed Cumulus should branch from this validated reference-derived family,
 not from the invalid compact quick-look derivative. Architecturally, it is a

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -73,10 +73,11 @@ remote sounding archives in v1. The converted package anchors CM1 `z = 0` to
 the station surface elevation, converts geopotential height above mean sea
 level into model height above the station, preserves station/location/elevation,
 valid time, source format, units, wind metadata, and caveats, and renders a
-numeric CM1-readable `input_sounding`. Current observed wind values are
-preserved as metadata only; the generated CM1 namelist keeps the validated
-external-sounding wind-handling path until a separate validation accepts
-observed-wind forcing.
+numeric CM1-readable `input_sounding`. Observed wind direction/speed is
+converted to CM1 `u`/`v` wind components, written into the `input_sounding`
+profile, and applied through CM1's `isnd = 7` external-sounding path. Packages
+with missing or unusable observed winds should block rather than silently fall
+back to a reference wind profile.
 
 Cloud Chamber also owns a backend-only local cache foundation for recent IGRA
 station-period source files. V1 can refresh the NOAA/NCEI IGRA recent catalog,
@@ -534,13 +535,15 @@ The current Baseline Shallow Cumulus recovery contract renders CM1-facing `namel
 
 Observed IGRA sounding import uses the same external `input_sounding` route.
 The generated thermodynamic/moisture profile comes from the selected observed
-sounding after unit conversion and vertical-datum handling. The generated
+sounding after unit conversion and vertical-datum handling. Observed wind
+direction/speed is converted to CM1 `u`/`v`, written into `input_sounding`, and
+used by CM1 through `isnd = 7`. The generated
 package records the selected station, valid time, uploaded filename,
 provider/format, model-bottom elevation, conversion choices, wind-handling
-limitation, validation status, and caveats in the run manifest, case manifest,
-and dry-run report. It must not imply location/date/radiation behavior beyond
-the observed-profile provenance; radiation remains whatever the scenario
-package currently configures.
+method, validation status, and caveats in the run manifest, case manifest, and
+dry-run report. It must not imply location/date/radiation behavior beyond the
+observed-profile provenance; radiation remains whatever the scenario package
+currently configures.
 
 The first full-sequence NetCDF ingest of `dry-run-157b09a178e1` found 25 model-output files and 25 time steps, but no usable cloud or vertical velocity: `max_qc_kg_kg = 0.0`, `max_w_m_s = 0.0`, and multiple NaN/Infinity caveats in surface and thermodynamic fields. The generated quick-look package therefore now uses a fixed small ocean roughness length (`set_znt = 1`, `cnst_znt = 0.0002`) instead of the reference dynamic roughness / fixed friction-velocity path that produced invalid local output.
 

--- a/docs/contracts/realistic-les-input-specification.md
+++ b/docs/contracts/realistic-les-input-specification.md
@@ -209,7 +209,7 @@ Draft shape:
     "moisture": ["qv_or_mixing_ratio"],
     "wind": ["u", "v"]
   },
-  "wind_handling": "reference_wind",
+  "wind_handling": "observed_sounding_winds",
   "conversion_choices": {
     "smoothing": "none_or_documented_method",
     "interpolation": "native_to_cm1_required_levels",
@@ -229,9 +229,9 @@ Capability distinctions:
 | --- | --- |
 | Generated reference sounding through `input_sounding` | Currently supported by Cloud Chamber for the accepted external-sounding baseline path. |
 | CM1 external sounding input | Confirmed CM1 capability through external `input_sounding` paths such as `isnd = 7` and `isnd = 17`. |
-| Observed/detailed sounding conversion | Likely CM1 capability needing validation. |
+| Observed/detailed sounding conversion | Supported for local uploaded IGRA station text after package-review validation. |
 | `input_sounding` | Generated input file required. |
-| Observed winds from sounding | Likely capability needing validation; current Cloud Chamber path preserves reference/generated wind handling. |
+| Observed winds from sounding | Supported for uploaded observed-sounding packages: direction/speed converts to CM1 `u`/`v` and packages use `isnd = 7`. |
 | Smoothing/interpolation/truncation | Product/backend metadata required; implementation must be explicit. |
 | Arbitrary online sounding fetch | Future / unsupported until source, provenance, and failure behavior are designed. |
 
@@ -242,8 +242,8 @@ Rules:
   from the first implementation.
 - If radiation remains disabled, place/time metadata still travels as sounding
   provenance.
-- Do not silently replace missing observed winds with reference winds; record
-  `wind_handling`.
+- Do not silently replace missing observed winds with reference winds; block or
+  caveat clearly and record `wind_handling`.
 - If pressure-to-height or temperature-to-potential-temperature conversion is
   inferred, record the method and caveat.
 - Validation should fail clearly before package generation for obviously bad
@@ -694,8 +694,6 @@ Before implementation, PM/human review should decide:
 
 - Which observed sounding source format is first: pasted text, local file,
   tiny fixture, or a specific provider export.
-- Whether first observed-sounding support uses `isnd = 17` with reference wind
-  or validates `isnd = 7` with observed winds.
 - Which profile sanity checks are launch blockers versus caveats.
 - Where realistic input metadata lives before and after package generation:
   scenario controls, case manifest, run manifest, or a dedicated sidecar.

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -118,8 +118,9 @@ Goal: prove the first realistic-input path using observed or detailed sounding
 fixtures while preserving source metadata and conversion caveats.
 
 Scope: tiny fixture import, station/location/elevation, valid time/date, source,
-units, wind handling, conversion metadata, package-review provenance, and a
-local Build upload path for extracted IGRA station sounding-data files.
+units, observed wind conversion to CM1 `u`/`v`, conversion metadata,
+package-review provenance, and a local Build upload path for extracted IGRA
+station sounding-data files.
 
 Non-goals: Bench Mode UI, arbitrary GIS/map inputs, surface heterogeneity, or
 unvalidated scenario families.

--- a/docs/development.md
+++ b/docs/development.md
@@ -137,10 +137,11 @@ uploaded NOAA/NCEI IGRA station sounding-data text to the backend parse endpoint
 reviews the selected sounding and caveats, then includes the selected sounding
 record in the dry-run package request. The backend converts source
 geopotential-height/elevation metadata into CM1 height above station surface and
-renders numeric `input_sounding`; observed winds remain metadata-only until a
-separate validation changes wind forcing. Use tiny synthetic IGRA fixtures in
-tests. Large local station files, for example files in `~/Downloads`, are manual
-validation inputs and must not be copied into the repo.
+renders numeric `input_sounding`; observed winds are converted to CM1 `u`/`v`
+and applied through the observed-sounding `isnd = 7` package path. Use tiny
+synthetic IGRA fixtures in tests. Large local station files, for example files
+in `~/Downloads`, are manual validation inputs and must not be copied into the
+repo.
 
 Recent IGRA source-file discovery is backend-owned. The backend endpoints under
 `/api/igra/recent/*` can refresh a bounded NOAA/NCEI recent catalog, join station

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -54,8 +54,9 @@ Observed IGRA sounding tests must use tiny synthetic station-data fixtures in
 the repo. They should cover multiple available sounding times, latest-time
 default selection, explicit time selection, malformed uploads, too-shallow
 profiles, station-elevation/model-bottom anchoring, numeric CM1
-`input_sounding` rendering, run-manifest/report provenance, and the current
-metadata-only observed-wind limitation. Large real station downloads, such as a
+`input_sounding` rendering, run-manifest/report provenance, observed wind
+direction/speed conversion to CM1 `u`/`v`, `isnd = 7` observed-wind package
+handling, and missing-wind blocking. Large real station downloads, such as a
 full local IGRA file from `~/Downloads`, are manual validation inputs only and
 must not be committed.
 
@@ -572,12 +573,14 @@ NetCDF, ingests the full sequence, forms cloud, and preserves meaningful
 vertical motion before Dry Failed Cumulus dries the profile.
 
 Observed-sounding package tests should additionally assert that uploading an
-IGRA station sounding changes only the generated external thermodynamic/moisture
-profile and package metadata unless a later validated issue explicitly changes
-wind, radiation, surface, or location/date behavior. The package review should
-show station, valid time, uploaded filename, vertical datum, model-bottom
-elevation, usable level count, caveats, and wind-handling metadata before the
-package is created.
+IGRA station sounding changes the generated external thermodynamic/moisture/wind
+profile and package metadata while preserving the non-sounding baseline package
+settings. Observed-sounding packages should use CM1 `isnd = 7` so `input_sounding`
+`u`/`v` columns initialize the wind profile. Radiation, surface, and
+location/date behavior remain unchanged unless separately validated. The package
+review should show station, valid time, uploaded filename, vertical datum,
+model-bottom elevation, usable level count, caveats, and wind-handling metadata
+before the package is created.
 
 The external-sounding reproduction run, `dry-run-external-sounding-baseline-20260522185000`,
 completed with `exit_code = 0`, ingested 13 model-output time steps from 0 to


### PR DESCRIPTION
## Issue worked

#234 — Use observed sounding wind profile in Upload a Sounding packages

## Summary

- Converts observed IGRA wind direction/speed into CM1-facing `u`/`v` columns and writes them into `input_sounding`.
- Switches observed-sounding generated packages to `isnd = 7` and `iwnd = 0` so CM1 reads thermodynamics and wind from `input_sounding`; generated/reference packages keep the existing `isnd = 17` / `iwnd = 9` path.
- Blocks observed-sounding package validation when usable observed winds are missing instead of silently falling back to the reference wind profile.
- Updates dry-run reports, API fixtures, e2e fixtures, and docs so provenance says observed winds are actually applied.

## Tests added/updated

- Backend tests for parsed observed wind provenance, missing-wind blocking, rendered `input_sounding` u/v columns, observed-package namelist `isnd`/`iwnd`, and package report provenance.
- Frontend/component and Playwright fixture expectations updated for observed-sounding wind handling.
- Docs updated across product spec, architecture, testing, current roadmap, development, and the realistic LES input contract.

## Commands run

- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_observed_sounding.py app/backend/tests/test_dry_run_package.py app/backend/tests/test_app.py -q`
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Manual QA needed

Yes. A real observed IGRA package/run/ingest loop should validate CM1 accepts this `isnd = 7` observed-wind path outside CI:

1. Upload a real IGRA station file.
2. Select a sounding time.
3. Generate package.
4. Inspect `namelist.input` and `input_sounding` for `isnd = 7`, `iwnd = 0`, and nonzero observed u/v columns.
5. Run CM1 locally or via LAN worker.
6. Ingest completed output.
7. Open Results and Explore.
8. Confirm no generated artifacts are committed.

## Caveats / follow-up issues

- Existing ingested observed-sounding runs generated before this fix may still show old wind-handling metadata.
- #249 tracks stale local run manifests that remain `running` after CM1 completes.
- #250 tracks saved sounding candidates disappearing after refresh/session changes.
- #251 tracks making Uploaded Sounding a distinct experiment identity in Build/Results.
- #252 tracks the separate rain/surface precipitation/radar reflectivity investigation.

## Generated-artifact check

No generated CM1 output, NetCDF files, runtime folders, logs, screenshots, videos, traces, or large artifacts were committed.
