### PR TITLE
Fix stale run status and observed-sounding workflow states

### DIFF
--- a/app/backend/cloud_chamber/local_run_manager.py
+++ b/app/backend/cloud_chamber/local_run_manager.py
@@ -79,6 +79,7 @@ FLOATING_POINT_WARNING_FLAGS = (
     "IEEE_OVERFLOW_FLAG",
     "IEEE_UNDERFLOW_FLAG",
 )
+NORMAL_TERMINATION_MARKER = "Program terminated normally"
 
 
 def default_process_factory(
@@ -184,7 +185,10 @@ class LocalRunManager:
 
     def status(self, manifest_path: Path) -> RunStatus:
         self._refresh_active()
-        return _status_from_manifest(load_run_manifest(manifest_path), manifest_path)
+        manifest = load_run_manifest(manifest_path)
+        if self._active is None or self._active.manifest_path != manifest_path:
+            manifest = reconcile_completed_run_manifest(manifest_path, manifest)
+        return _status_from_manifest(manifest, manifest_path)
 
     def cancel(self) -> RunStatus:
         if self._active is None:
@@ -319,6 +323,63 @@ def _status_from_manifest(manifest: RunManifest, manifest_path: Path) -> RunStat
         stderr_log=stderr_log,
         exit_code=manifest.execution.exit_code,
     )
+
+
+def reconcile_completed_run_manifest(
+    manifest_path: Path,
+    manifest: RunManifest | None = None,
+) -> RunManifest:
+    """Promote stale running manifests when completed CM1 output is evident.
+
+    This covers app/backend restarts where the process watcher is gone but CM1
+    finished normally and wrote output. It deliberately requires both stdout
+    termination evidence and output artifacts before changing run state.
+    """
+    manifest = manifest or load_run_manifest(manifest_path)
+    if manifest.lifecycle_state not in {LifecycleState.QUEUED, LifecycleState.RUNNING}:
+        return manifest
+    stdout_log = _log_path(manifest.execution.stdout_log)
+    if not _stdout_indicates_normal_completion(stdout_log):
+        return manifest
+    run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
+    output_metadata = _detect_output_metadata(run_dir, manifest.execution.stderr_log)
+    if not (output_metadata.netcdf_paths or output_metadata.raw_cm1_artifacts):
+        return manifest
+
+    now = datetime.now(UTC)
+    execution = manifest.execution.model_copy(
+        update={
+            "finished_at": manifest.execution.finished_at or now,
+            "exit_code": 0
+            if manifest.execution.exit_code is None
+            else manifest.execution.exit_code,
+        }
+    )
+    updated = manifest.model_copy(
+        update={
+            "lifecycle_state": LifecycleState.COMPLETED,
+            "validation_status": manifest.validation_status,
+            "execution": ExecutionMetadata.model_validate(execution.model_dump()),
+            "outputs": output_metadata,
+            "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+            "updated_at": now,
+        }
+    )
+    write_run_manifest(manifest_path, updated)
+    return updated
+
+
+def _log_path(configured_path: str | None) -> Path | None:
+    if not configured_path:
+        return None
+    return Path(configured_path).expanduser()
+
+
+def _stdout_indicates_normal_completion(stdout_log: Path | None) -> bool:
+    if stdout_log is None or not stdout_log.exists():
+        return False
+    text = stdout_log.read_text(errors="replace")
+    return NORMAL_TERMINATION_MARKER in text
 
 
 def _existing_output_paths(run_dir: Path) -> tuple[Path, ...]:

--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -188,7 +188,8 @@ def _card_from_metadata(
     cloud = diagnostics.cloud if diagnostics else None
     vertical_velocity = diagnostics.vertical_velocity if diagnostics else None
     rain = diagnostics.rain if diagnostics else None
-    name = state.name or metadata.scenario_name or metadata.scenario_id
+    name = state.name or _default_result_card_name(metadata)
+    scenario_name = _display_scenario_name(metadata)
     caveats = list(metadata.warnings)
     if diagnostics:
         caveats.extend(diagnostics.caveats)
@@ -201,7 +202,7 @@ def _card_from_metadata(
         saved=state.saved,
         protected=state.protected or state.saved,
         scenario_id=metadata.scenario_id,
-        scenario_name=metadata.scenario_name,
+        scenario_name=scenario_name,
         run_size_preset=metadata.run_size_preset,
         physical_question=metadata.physical_question,
         controls=metadata.controls,
@@ -245,6 +246,31 @@ def _card_from_metadata(
         ingested_at=metadata.created_at,
         updated_at=state.updated_at or metadata.updated_at,
     )
+
+
+def _default_result_card_name(metadata: ResultMetadata) -> str:
+    if metadata.input_source == "observed_sounding":
+        station_name = _observed_sounding_value(metadata.observed_sounding, "station_name")
+        station_id = _observed_sounding_value(metadata.observed_sounding, "station_id")
+        if station_name:
+            return f"Uploaded Sounding — {station_name}"
+        if station_id:
+            return f"Uploaded Sounding — {station_id}"
+        return "Uploaded Sounding"
+    return metadata.scenario_name or metadata.scenario_id
+
+
+def _display_scenario_name(metadata: ResultMetadata) -> str | None:
+    if metadata.input_source == "observed_sounding":
+        return "Uploaded Sounding"
+    return metadata.scenario_name
+
+
+def _observed_sounding_value(observed_sounding: dict[str, object] | None, key: str) -> str | None:
+    if not observed_sounding:
+        return None
+    value = observed_sounding.get(key)
+    return value if isinstance(value, str) and value else None
 
 
 def _output_file_summary(metadata: ResultMetadata) -> OutputFileSummary:

--- a/app/backend/cloud_chamber/runtime_storage.py
+++ b/app/backend/cloud_chamber/runtime_storage.py
@@ -8,12 +8,12 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from cloud_chamber.local_run_manager import reconcile_completed_run_manifest
 from cloud_chamber.run_manifest import (
     LifecycleState,
     ProductState,
     RunManifest,
     RunManifestError,
-    load_run_manifest,
 )
 from cloud_chamber.settings import CloudChamberSettings
 
@@ -175,7 +175,7 @@ def _run_storage_entry(run_dir: Path) -> RunStorageEntry:
         )
 
     try:
-        manifest = load_run_manifest(manifest_path)
+        manifest = reconcile_completed_run_manifest(manifest_path)
     except (RunManifestError, OSError, ValueError) as exc:
         return RunStorageEntry(
             run_id=run_dir.name,

--- a/app/backend/tests/test_local_run_manager.py
+++ b/app/backend/tests/test_local_run_manager.py
@@ -160,6 +160,58 @@ def test_exit_zero_with_netcdf_output_marks_completed_result(tmp_path: Path) -> 
     assert manifest.outputs.raw_cm1_artifacts == []
 
 
+def test_status_reconciles_stale_running_manifest_with_completed_output(tmp_path: Path) -> None:
+    manifest_path = dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-001"
+    settings = fake_settings(tmp_path)
+    manager = LocalRunManager(
+        settings=settings,
+        process_factory=FakeProcessFactory(FakeProcess()),
+    )
+    status = manager.launch(manifest_path)
+    with status.stdout_log.open("a") as stdout:
+        stdout.write("Program terminated normally\n")
+    (run_dir / "cm1out_000001.nc").write_text("fake output")
+
+    restarted_manager = LocalRunManager(
+        settings=settings,
+        process_factory=FakeProcessFactory(FakeProcess()),
+    )
+    reconciled = restarted_manager.status(manifest_path)
+
+    assert reconciled.lifecycle_state == LifecycleState.COMPLETED
+    assert reconciled.exit_code == 0
+    manifest = load_run_manifest(manifest_path)
+    assert manifest.lifecycle_state == LifecycleState.COMPLETED
+    assert manifest.provenance.product_state == ProductState.COMPLETED_CM1_RESULT
+    assert manifest.outputs.netcdf_paths == [str(run_dir / "cm1out_000001.nc")]
+
+
+def test_status_does_not_reconcile_stale_running_manifest_without_normal_stdout(
+    tmp_path: Path,
+) -> None:
+    manifest_path = dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-001"
+    settings = fake_settings(tmp_path)
+    manager = LocalRunManager(
+        settings=settings,
+        process_factory=FakeProcessFactory(FakeProcess()),
+    )
+    manager.launch(manifest_path)
+    (run_dir / "cm1out_000001.nc").write_text("fake output")
+
+    restarted_manager = LocalRunManager(
+        settings=settings,
+        process_factory=FakeProcessFactory(FakeProcess()),
+    )
+    status = restarted_manager.status(manifest_path)
+
+    assert status.lifecycle_state == LifecycleState.RUNNING
+    manifest = load_run_manifest(manifest_path)
+    assert manifest.lifecycle_state == LifecycleState.RUNNING
+    assert manifest.provenance.product_state == ProductState.QUEUED_RUNNING_CM1_PROCESS
+
+
 def test_exit_zero_with_dat_ctl_outputs_marks_completed_result(tmp_path: Path) -> None:
     manifest_path = dry_run_manifest_path(tmp_path)
     run_dir = tmp_path / "CloudChamber" / "runs" / "run-001"

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -182,6 +182,9 @@ def test_result_card_exposes_observed_sounding_source(tmp_path: Path) -> None:
 
     card = get_result_card(settings, result_id)
 
+    assert card.name == "Uploaded Sounding — Valley, Nebraska"
+    assert card.scenario_id == "baseline-shallow-cumulus"
+    assert card.scenario_name == "Uploaded Sounding"
     assert card.input_source == "observed_sounding"
     assert card.input_source_label == "Observed sounding: USM00072558 · Valley, Nebraska"
     assert card.observed_sounding is not None

--- a/app/backend/tests/test_runtime_storage.py
+++ b/app/backend/tests/test_runtime_storage.py
@@ -5,6 +5,7 @@ import pytest
 
 from cloud_chamber.dry_run_package import generate_dry_run_package
 from cloud_chamber.run_manifest import (
+    ExecutionMetadata,
     LifecycleState,
     OutputMetadata,
     ProductState,
@@ -120,6 +121,50 @@ def test_inventory_classifies_valid_manifest_with_output_artifacts(tmp_path: Pat
     assert entry.run_size_preset == "quick_look"
     assert entry.output_artifact_count == 2
     assert entry.output_summary["raw_cm1_artifacts"] == 2
+
+
+def test_inventory_reconciles_stale_running_manifest_with_completed_output(
+    tmp_path: Path,
+) -> None:
+    settings = fake_settings(tmp_path)
+    manifest_path = create_run(tmp_path, "run-stale-completed")
+    run_dir = manifest_path.parent
+    log_dir = run_dir / "logs"
+    log_dir.mkdir()
+    stdout_log = log_dir / "stdout.log"
+    stderr_log = log_dir / "stderr.log"
+    stdout_log.write_text("Program terminated normally\n")
+    stderr_log.write_text("IEEE_UNDERFLOW_FLAG\n")
+    netcdf_path = run_dir / "cm1out_000001.nc"
+    netcdf_path.write_text("fake output")
+    manifest = load_run_manifest(manifest_path)
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": LifecycleState.RUNNING,
+                "provenance": ProvenanceMetadata(
+                    product_state=ProductState.QUEUED_RUNNING_CM1_PROCESS
+                ),
+                "execution": ExecutionMetadata(
+                    command=["cm1.exe"],
+                    stdout_log=str(stdout_log),
+                    stderr_log=str(stderr_log),
+                ),
+            }
+        ),
+    )
+
+    inventory = runtime_storage_inventory(settings)
+    entry = next(item for item in inventory.runs if item.run_id == "run-stale-completed")
+
+    assert entry.category == "completed_with_output"
+    assert entry.lifecycle_state == "completed"
+    assert entry.product_state == "completed_cm1_result"
+    assert entry.output_artifact_count == 1
+    manifest = load_run_manifest(manifest_path)
+    assert manifest.outputs.netcdf_paths == [str(netcdf_path)]
+    assert manifest.execution.exit_code == 0
 
 
 def test_inventory_classifies_missing_and_malformed_manifests(tmp_path: Path) -> None:

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -379,13 +379,13 @@ export const results = [
   {
     result_id: "result-observed-sounding",
     run_id: "dry-run-observed-sounding",
-    name: "Valley Observed Sounding — Quick Look",
+    name: "Uploaded Sounding — Valley, Nebraska",
     tags: ["observed-sounding", "quick-look"],
     notes: "Mocked observed IGRA sounding result for browser smoke tests.",
     saved: false,
     protected: false,
-    scenario_id: "observed-sounding",
-    scenario_name: "Observed Sounding",
+    scenario_id: "baseline-shallow-cumulus",
+    scenario_name: "Uploaded Sounding",
     run_size_preset: "quick_look",
     physical_question:
       "What cloud behavior emerges from the uploaded observed sounding profile?",
@@ -579,7 +579,7 @@ function resultMeta(resultId: string) {
     return {
       result_id: resultId,
       run_id: "dry-run-observed-sounding",
-      scenario_id: "observed-sounding",
+      scenario_id: "baseline-shallow-cumulus",
     };
   }
   if (resultId === "result-dry-failed") {

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -182,19 +182,24 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(resultsList.getByText(/first cloud 1,800 s/i).first()).toBeVisible();
 
     await filterBar.getByLabel("Search").fill("Valley");
-    await expect(resultsList.getByText("Valley Observed Sounding — Quick Look")).toBeVisible();
+    await expect(resultsList.getByText("Uploaded Sounding — Valley, Nebraska")).toBeVisible();
     await expect(resultsList.getByText("Observed sounding: USM00072558 · Valley, Nebraska")).toBeVisible();
     await expect(resultsList.getByText("Baseline Shallow Cumulus — Quick Look")).toHaveCount(0);
 
     await filterBar.getByLabel("Search").fill("");
+    await filterBar.getByLabel("Scenario").selectOption("input_source:observed_sounding");
+    await expect(resultsList.getByText("Uploaded Sounding — Valley, Nebraska")).toBeVisible();
+    await expect(resultsList.getByText("Baseline Shallow Cumulus — Quick Look")).toHaveCount(0);
+
+    await filterBar.getByLabel("Scenario").selectOption("all");
     await filterBar.getByLabel("Cloud outcome").selectOption("no");
     await expect(resultsList.getByText("Dry Failed Cumulus — Quick Look")).toBeVisible();
-    await expect(resultsList.getByText("Valley Observed Sounding — Quick Look")).toHaveCount(0);
+    await expect(resultsList.getByText("Uploaded Sounding — Valley, Nebraska")).toHaveCount(0);
 
     await filterBar.getByLabel("Cloud outcome").selectOption("all");
     await filterBar.getByLabel("Sort results").selectOption("max_updraft");
     await expect(resultsList.locator(".experiment-card").first()).toContainText(
-      "Valley Observed Sounding — Quick Look",
+      "Uploaded Sounding — Valley, Nebraska",
     );
   });
 

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -740,10 +740,10 @@ const observedSoundingResultCard = {
   ...resultCard,
   result_id: "result-observed-sounding",
   run_id: "dry-run-observed-sounding",
-  name: "Valley observed sounding quick-look",
+  name: "Uploaded Sounding — Valley, Nebraska",
   tags: ["observed-sounding", "valley"],
-  scenario_id: "observed-sounding",
-  scenario_name: "Observed Sounding",
+  scenario_id: "baseline-shallow-cumulus",
+  scenario_name: "Uploaded Sounding",
   input_source: "observed_sounding",
   input_source_label: "Observed sounding: USM00072558 · Valley, Nebraska",
   science_summary: {
@@ -2303,6 +2303,35 @@ describe("App", () => {
     });
   });
 
+  it("loads saved sounding candidates as soon as Upload a Sounding is selected", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/sounding-candidates/saved" && !init?.method) {
+        return Promise.resolve(
+          new Response(JSON.stringify(savedCandidatesResponse), { status: 200 }),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+
+    expect(
+      await screen.findByLabelText("Saved sounding candidate Valley, Nebraska (USM00072558)"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No saved candidates yet.")).not.toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalledWith("/api/igra/recent/refresh-catalog", expect.anything());
+    expect(fetch).not.toHaveBeenCalledWith("/api/sounding-candidates/screen", expect.anything());
+  });
+
   it("keeps secondary story matches visible and sorts missing LCL last", async () => {
     render(<App />);
 
@@ -2884,8 +2913,9 @@ describe("App", () => {
       screen.getAllByText("Observed sounding: USM00072558 · Valley, Nebraska").length,
     ).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole("button", { name: "Valley observed sounding quick-look" }));
+    fireEvent.click(screen.getByRole("button", { name: "Uploaded Sounding — Valley, Nebraska" }));
     const resultDetail = screen.getByLabelText("Result detail");
+    expect(resultDetail).toHaveTextContent("Uploaded Sounding");
     expect(resultDetail).toHaveTextContent("Observed sounding: USM00072558 · Valley, Nebraska");
     expect(resultDetail).toHaveTextContent("Input source");
   });
@@ -2898,14 +2928,23 @@ describe("App", () => {
     const resultsList = screen.getByLabelText("Results list");
 
     fireEvent.change(within(filterBar).getByLabelText("Search"), { target: { value: "Valley" } });
-    expect(within(resultsList).getByText("Valley observed sounding quick-look")).toBeInTheDocument();
+    expect(within(resultsList).getByText("Uploaded Sounding — Valley, Nebraska")).toBeInTheDocument();
     expect(within(resultsList).queryByText("Quick-look shallow cumulus")).not.toBeInTheDocument();
 
     fireEvent.change(within(filterBar).getByLabelText("Search"), { target: { value: "dry failed" } });
     expect(within(resultsList).getByText("Dry Failed Cumulus quick-look")).toBeInTheDocument();
-    expect(within(resultsList).queryByText("Valley observed sounding quick-look")).not.toBeInTheDocument();
+    expect(
+      within(resultsList).queryByText("Uploaded Sounding — Valley, Nebraska"),
+    ).not.toBeInTheDocument();
 
     fireEvent.change(within(filterBar).getByLabelText("Search"), { target: { value: "" } });
+    fireEvent.change(within(filterBar).getByLabelText("Scenario"), {
+      target: { value: "input_source:observed_sounding" },
+    });
+    expect(within(resultsList).getByText("Uploaded Sounding — Valley, Nebraska")).toBeInTheDocument();
+    expect(within(resultsList).queryByText("Quick-look shallow cumulus")).not.toBeInTheDocument();
+
+    fireEvent.change(within(filterBar).getByLabelText("Scenario"), { target: { value: "all" } });
     fireEvent.change(within(filterBar).getByLabelText("Cloud"), { target: { value: "no" } });
     expect(within(resultsList).getByText("Dry Failed Cumulus quick-look")).toBeInTheDocument();
     expect(within(resultsList).getAllByText("No cloud formed").length).toBeGreaterThan(0);
@@ -2925,7 +2964,7 @@ describe("App", () => {
 
     fireEvent.change(within(filterBar).getByLabelText("Sort"), { target: { value: "max_updraft" } });
     const sortedCards = resultsList.querySelectorAll(".experiment-card");
-    expect(sortedCards[0]).toHaveTextContent("Valley observed sounding quick-look");
+    expect(sortedCards[0]).toHaveTextContent("Uploaded Sounding — Valley, Nebraska");
     expect(sortedCards[0]).toHaveTextContent("max updraft 9.25 m/s");
 
     fireEvent.change(within(filterBar).getByLabelText("Search"), {
@@ -2938,7 +2977,7 @@ describe("App", () => {
 
     fireEvent.click(within(filterBar).getByRole("button", { name: "Clear filters" }));
     expect(within(resultsList).getByText("Quick-look shallow cumulus")).toBeInTheDocument();
-    expect(within(resultsList).getByText("Valley observed sounding quick-look")).toBeInTheDocument();
+    expect(within(resultsList).getByText("Uploaded Sounding — Valley, Nebraska")).toBeInTheDocument();
   });
 
   it("accepts legacy array results responses without crashing", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1481,6 +1481,25 @@ export function App() {
   }, [selectedScenario]);
 
   useEffect(() => {
+    if (!observedSoundingExperimentSelected) return;
+    let active = true;
+    fetchSavedSoundingCandidates()
+      .then((payload) => {
+        if (!active) return;
+        setSavedCandidates(payload.saved_candidates);
+      })
+      .catch((caught: unknown) => {
+        if (!active) return;
+        setCandidateError(
+          caught instanceof Error ? caught.message : "Unable to load saved sounding candidates.",
+        );
+      });
+    return () => {
+      active = false;
+    };
+  }, [observedSoundingExperimentSelected]);
+
+  useEffect(() => {
     if (!selectedResult) return;
     setResultDraft({
       name: selectedResult.name,
@@ -8624,7 +8643,9 @@ function filterAndSortResults(results: ResultCard[], filters: ResultsFilterState
   const query = filters.search.trim().toLowerCase();
   return [...results]
     .filter((result) => resultMatchesSearch(result, query))
-    .filter((result) => filters.scenario === "all" || result.scenario_id === filters.scenario)
+    .filter(
+      (result) => filters.scenario === "all" || resultScenarioFilterValue(result) === filters.scenario,
+    )
     .filter((result) => filters.preset === "all" || result.run_size_preset === filters.preset)
     .filter((result) => matchesBooleanFilter(cloudOutcome(result), filters.cloud, "Cloud formed", "No cloud formed"))
     .filter((result) => matchesBooleanFilter(rainOutcome(result.rain_present), filters.rain, "Rain detected", "No rain detected"))
@@ -8638,11 +8659,16 @@ function resultsFiltersActive(filters: ResultsFilterState): boolean {
 function resultScenarioOptions(results: ResultCard[]): Array<{ value: string; label: string }> {
   const seen = new Map<string, string>();
   for (const result of results) {
-    seen.set(result.scenario_id, result.scenario_name ?? humanize(result.scenario_id));
+    seen.set(resultScenarioFilterValue(result), result.scenario_name ?? humanize(result.scenario_id));
   }
   return [...seen.entries()]
     .map(([value, label]) => ({ value, label }))
     .sort((left, right) => left.label.localeCompare(right.label));
+}
+
+function resultScenarioFilterValue(result: ResultCard): string {
+  if (result.input_source === "observed_sounding") return "input_source:observed_sounding";
+  return `scenario:${result.scenario_id}`;
 }
 
 function resultPresetOptions(results: ResultCard[]): Array<{ value: string; label: string }> {
@@ -8726,6 +8752,7 @@ function resultPriority(result: ResultCard): number {
 
 function isValidatedQuickLookBaseline(result: ResultCard): boolean {
   return (
+    resultInputSource(result) === "generated_reference" &&
     result.scenario_id === "baseline-shallow-cumulus" &&
     result.run_size_preset === "quick_look" &&
     result.source_lifecycle_state === "completed" &&

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -103,13 +103,15 @@ provenance. The screening score remains a candidate-selection aid; CM1 output
 remains the source of truth.
 
 The Build UI consumes this layer through bounded JSON only. `Upload a Sounding`
-can call the recent-catalog/cache and candidate-screening endpoints, display the
-candidate list and saved candidates, and pass a selected candidate's
-`selected_sounding_payload` into the existing observed-sounding package review.
-The frontend does not read cached station text directly and does not compute the
-story scores. Candidate status is separate from run/result status: saved
-candidates are pre-run hypotheses, while generated packages, launched runs, and
-ingested results remain separate lifecycle objects.
+loads saved candidates immediately when that experiment is selected, before any
+catalog refresh or screening action. It can also call the
+recent-catalog/cache and candidate-screening endpoints, display the candidate
+list, and pass a selected candidate's `selected_sounding_payload` into the
+existing observed-sounding package review. The frontend does not read cached
+station text directly and does not compute the story scores. Candidate status is
+separate from run/result status: saved candidates are pre-run hypotheses, while
+generated packages, launched runs, and ingested results remain separate
+lifecycle objects.
 
 ## Suggested Stack
 
@@ -329,6 +331,12 @@ eligible states and offers only safe state-appropriate transitions:
 - open associated results in Results or Explore;
 - route cleanup decisions to Results / Storage.
 
+Runtime status refresh may reconcile a stale local manifest only when stdout
+contains normal CM1 termination evidence and output artifacts exist under the
+run directory. This repairs backend-restart cases where a completed local run
+was still labeled running, while avoiding silent completion claims for unknown
+or still-active runs.
+
 Storage remains the owner of deletion policy and cleanup actions. Build may link
 to Storage for cleanup, but it should not duplicate the delete workflow.
 
@@ -465,6 +473,13 @@ It does not rerun CM1 and does not parse raw output directly. It summarizes:
 - compact `science_summary`, `interesting_times`, and `default_time_by_field` values for Results filtering, sorting, and sensible Explore defaults;
 - provenance labels that distinguish completed CM1 result, ingested metadata, and notebook entry;
 - editable notebook fields: name, tags, and notes.
+
+When a result came from an uploaded observed sounding, Result Cards use
+`Uploaded Sounding` as the product-facing experiment identity and default
+notebook name while preserving the underlying generated scenario ID as technical
+lineage. Results filters treat uploaded-sounding results as their own
+scenario-like product category so they do not collapse into the baseline
+scenario bucket.
 
 Editable notebook state is stored as `result_card.json` beside `result_metadata.json`.
 Legacy `saved` and `protected` fields may remain in older `result_card.json`

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -100,7 +100,9 @@ beside the observed-sounding upload path. The workbench can refresh the bounded
 IGRA cache, screen cached soundings by experiment story, show package-ready and
 blocked candidates with evidence and caveats, save candidates for later review,
 and load a selected package-ready candidate into the observed-sounding package
-review. It must keep the language pre-run and provisional: a candidate is an
+review. Saved candidates should appear as soon as the user selects `Upload a
+Sounding`, without requiring a catalog refresh, cache action, or new screening
+run. It must keep the language pre-run and provisional: a candidate is an
 observed atmosphere worth trying, not a prediction that clouds, rain, or
 suppression will occur. When a candidate is used, its screening story, score,
 evidence, feature summary, and caveats should be copied into package metadata as
@@ -201,6 +203,11 @@ run launchpad for active and incomplete package/run work only: create packages,
 launch eligible packages, refresh running/failed/completed status, troubleshoot
 failed or no-output runs, and ingest completed output. Fully ingested results
 belong in Results and Storage.
+
+When a local backend restart leaves a completed CM1 run's manifest marked
+running, Build/Storage refresh may reconcile the state only if stdout contains
+normal CM1 termination evidence and output artifacts are present. The UI should
+then offer ingest rather than leaving the run stranded as running.
 
 The UI must continue to avoid raw CM1 namelist fields in the primary flow. Raw generated files can be listed in dry-run review because they are outputs of the package step, not user-facing controls.
 
@@ -1042,8 +1049,10 @@ interesting-time support state so the user can search, filter, and sort the
 experiment list by meaningful scientific evidence rather than raw file order.
 Result Cards must also distinguish generated-reference packages from runs
 created from an uploaded observed sounding, preserving station/time/source
-metadata as provenance and making observed-sounding results filterable in
-Results through the scenario and search surfaces.
+metadata as provenance. Observed-sounding results should read as `Uploaded
+Sounding` in notebook names, scenario labels, and scenario filtering while the
+underlying generated scenario ID remains available in technical details as
+lineage.
 Technical metadata such as raw lifecycle/product states, run IDs, provenance
 labels, controls, and detailed caveats remain available under disclosure rather
 than dominating the first read. The layout should be mobile-first: cards stack

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -79,14 +79,21 @@ not claim a scored candidate will produce a specific CM1 outcome.
 
 Frontend tests for the `Upload a Sounding` Build workflow should cover the same
 boundary. Component tests and mocked Playwright smoke tests should verify that
-the candidate workbench can refresh IGRA catalog metadata, cache a bounded batch
-of station files through mocked APIs, screen cached soundings by story, include
+saved candidates load immediately when `Upload a Sounding` is selected; the
+candidate workbench can refresh IGRA catalog metadata, cache a bounded batch of
+station files through mocked APIs, screen cached soundings by story, include
 secondary story-score matches in filtered results, sort missing metrics last,
 show blocked candidates as unusable, save candidates, load a package-ready
 candidate into the observed-sounding package review, and include
 candidate-screening provenance in the generated package request. Browser tests
 must mock the backend APIs and must not fetch NOAA/NCEI, parse raw station text,
 or imply that a candidate score predicts the CM1 outcome.
+
+Local run manager tests should cover stale-manifest reconciliation: if stdout
+contains normal CM1 termination evidence and output artifacts exist, status and
+runtime inventory refresh may promote a stale running manifest to completed
+with output. Tests should also prove that output files alone are not enough to
+claim completion.
 
 Dry-run package tests should use temporary runtime homes and assert overwrite protection, manifest/report content, CM1-facing input readiness, and absence of NetCDF output. A dry-run package is packaged configuration and metadata only; it is not a launched process or completed CM1 result.
 
@@ -336,7 +343,8 @@ Results science-filtering tests should use mocked Result Card payloads with
 `science_summary`, `interesting_times`, `default_time_by_field`, input-source
 metadata, and observed-sounding provenance. Component tests should cover search,
 scenario/run-size filters, cloud/rain filters, observed-sounding discovery via
-scenario/search, science-metric sorting, and empty-filter states. Playwright
+the `Uploaded Sounding` product identity rather than only the underlying base
+scenario ID, science-metric sorting, and empty-filter states. Playwright
 mocked-smoke tests should cover at least one browser path that narrows to an
 observed-sounding result and sorts by a science-derived metric without requiring
 real CM1 output.


### PR DESCRIPTION
## Issue worked

Fixes #249
Fixes #250
Fixes #251

## Summary

- Reconciles stale local `running`/`queued` manifests to completed only when both are true:
  - stdout contains CM1 normal termination evidence;
  - output artifacts exist under the run directory.
- Loads saved sounding candidates immediately when `Upload a Sounding` is selected in Build, without requiring a catalog refresh, cache action, or screening run.
- Gives observed-sounding results a product-facing `Uploaded Sounding` identity in Result Cards and Results filters while preserving the underlying scenario ID as technical lineage.
- Prevents uploaded-sounding quick-look runs from inheriting the validated baseline result-card copy.
- Updates docs around Build, Results, testing, saved candidates, stale-run reconciliation, and observed-sounding product identity.

## Tests added/updated

- Backend:
  - stale local run reconciliation in `local_run_manager`;
  - Storage inventory reconciliation for stale completed runs;
  - observed-sounding Result Card identity.
- Frontend:
  - saved candidates load as soon as `Upload a Sounding` is selected;
  - observed-sounding scenario filtering uses `Uploaded Sounding` identity;
  - observed-sounding result detail/search expectations.
- Playwright mocked smoke:
  - observed-sounding Result Card fixtures and Results filtering path updated.

## Commands run

```bash
app/backend/.venv/bin/python -m pytest app/backend/tests/test_local_run_manager.py app/backend/tests/test_runtime_storage.py app/backend/tests/test_result_cards.py
npm --prefix app/frontend test -- App.test.tsx --run
scripts/check.sh
scripts/check-e2e.sh
```

## Notes / caveats

- `scripts/check.sh` still reports the existing React `act(...)` warning in one frontend loading-state test and the existing NumPy binary-size RuntimeWarning in backend tests; both suites pass.
- Stale-run reconciliation intentionally does not use output artifacts alone. It requires the CM1 normal termination marker in stdout to avoid falsely completing an active or unknown run.

## Manual QA suggested

No broad manual QA checklist. Useful smoke checks:

- Select `Upload a Sounding` in Build and confirm saved candidates appear immediately before any refresh/screen action.
- Confirm an ingested observed-sounding run appears as `Uploaded Sounding` in Results, while the underlying scenario remains visible in technical details.
- Confirm a completed local run that had stale `running` state refreshes to completed/ingestable only when stdout and output evidence are present.

## Generated-artifact check

- `scripts/check.sh` forbidden artifact check passed.
- No generated CM1 output, NetCDF, runtime folders, screenshots, videos, traces, or logs are committed.
