### PR TITLE
Fix cloud-top units and surface science landmarks

### DIFF
--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -507,11 +507,14 @@ def _cloud_base_top(qc: Any, caveats: list[str]) -> tuple[float | None, float | 
         vertical_values = [float(index) for index in range(int(qc.sizes[vertical_name]))]
     else:
         vertical_coord = qc.coords[vertical_name]
-        vertical_values = [_to_float_or_none(value) for value in vertical_coord.values.tolist()]
+        vertical_values = [
+            _height_in_meters(_to_float_or_none(value), _attr_string(vertical_coord, "units"))
+            for value in vertical_coord.values.tolist()
+        ]
         units = _attr_string(vertical_coord, "units")
         if units is None:
             caveats.append("cloud_base_top_vertical_units_missing_assumed_meters")
-        elif units not in {"m", "meter", "meters"}:
+        elif _normalized_height_units(units) is None:
             caveats.append(f"cloud_base_top_vertical_units_not_meters:{units}")
     cloudy_by_vertical = (qc >= QC_CLOUD_THRESHOLD_KG_KG).any(
         dim=[dimension for dimension in qc.dims if dimension != vertical_name],
@@ -547,13 +550,36 @@ def _vertical_values(data_array: Any, vertical_name: str, caveats: list[str]) ->
         caveats.append("vertical_coordinate_inferred_from_index")
         return [float(index) for index in range(int(data_array.sizes[vertical_name]))]
     vertical_coord = data_array.coords[vertical_name]
-    vertical_values = [_to_float_or_none(value) for value in vertical_coord.values.tolist()]
+    vertical_values = [
+        _height_in_meters(_to_float_or_none(value), _attr_string(vertical_coord, "units"))
+        for value in vertical_coord.values.tolist()
+    ]
     units = _attr_string(vertical_coord, "units")
     if units is None:
         caveats.append("vertical_units_missing_assumed_meters")
-    elif units not in {"m", "meter", "meters"}:
+    elif _normalized_height_units(units) is None:
         caveats.append(f"vertical_units_not_meters:{units}")
     return vertical_values
+
+
+def _height_in_meters(value: float | None, units: str | None) -> float | None:
+    if value is None:
+        return None
+    normalized = _normalized_height_units(units)
+    if normalized == "km":
+        return value * 1000.0
+    return value
+
+
+def _normalized_height_units(units: str | None) -> str | None:
+    if units is None:
+        return "m"
+    normalized = units.strip().lower()
+    if normalized in {"m", "meter", "meters"}:
+        return "m"
+    if normalized in {"km", "kilometer", "kilometers"}:
+        return "km"
+    return None
 
 
 def _time_context(dataset: Any, time_dimension: str | None) -> _TimeContext:

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -19,9 +19,11 @@ def base_dataset(
     w_values: list[list[list[list[float]]]] | None = None,
     qr_values: list[list[list[list[float]]]] | None = None,
     include_time_coord: bool = True,
+    z_values: list[float] | None = None,
+    z_units: str | None = None,
 ) -> xr.Dataset:
     coords: dict[str, list[float]] = {
-        "z": [500.0, 1500.0],
+        "z": z_values or [500.0, 1500.0],
         "y": [0.0, 200.0, 400.0],
         "x": [0.0, 200.0, 400.0, 600.0],
     }
@@ -49,11 +51,15 @@ def base_dataset(
             {"units": "kg/kg"},
         )
     if include_time_coord:
-        return xr.Dataset(data_vars=data_vars, coords=coords)
-    return xr.Dataset(
-        data_vars=data_vars,
-        coords={key: value for key, value in coords.items() if key != "time"},
-    )
+        dataset = xr.Dataset(data_vars=data_vars, coords=coords)
+    else:
+        dataset = xr.Dataset(
+            data_vars=data_vars,
+            coords={key: value for key, value in coords.items() if key != "time"},
+        )
+    if z_units is not None:
+        dataset["z"].attrs["units"] = z_units
+    return dataset
 
 
 def zeros() -> list[list[list[list[float]]]]:
@@ -119,6 +125,32 @@ def test_cloud_formed_requires_ten_grid_cells_and_reports_base_top(tmp_path: Pat
         1500.0,
     ]
     assert diagnostics.cloud.cloud_present_time_steps == [300.0]
+
+
+def test_cloud_base_top_converts_km_vertical_coordinate_to_meters(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "cloud_km.nc",
+        base_dataset(
+            qc_values=with_cloud(12),
+            w_values=w_field(),
+            z_values=[0.5, 1.5],
+            z_units="km",
+        ),
+    )
+    caveats: list[str] = []
+
+    diagnostics = compute_baseline_diagnostics(dataset, caveats)
+
+    assert diagnostics.cloud.cloud_base_m == 500.0
+    assert diagnostics.cloud.cloud_top_m == 1500.0
+    assert [point.value for point in diagnostics.cloud.cloud_base_time_series] == [None, 500.0]
+    assert [point.value for point in diagnostics.cloud.cloud_top_time_series] == [None, 1500.0]
+    assert [point.value for point in diagnostics.cloud.max_qc_height_time_series] == [
+        500.0,
+        1500.0,
+    ]
+    assert "cloud_base_top_vertical_units_not_meters:km" not in caveats
+    assert "vertical_units_not_meters:km" not in caveats
 
 
 def test_fewer_than_ten_cloudy_grid_cells_does_not_count_as_cloud_formed(tmp_path: Path) -> None:

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1014,6 +1014,51 @@ td small {
   background: var(--color-subtle-background);
 }
 
+.science-landmarks {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.85rem;
+  background: var(--color-surface);
+}
+
+.section-heading-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.section-heading-row h4 {
+  margin: 0.1rem 0 0;
+}
+
+.science-landmark-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0.8rem 0 0;
+}
+
+.science-landmark-item {
+  min-width: 0;
+}
+
+.science-landmark-item dt {
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.science-landmark-item dd {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.2rem 0 0;
+}
+
+.muted-inline {
+  color: var(--color-text-muted);
+}
+
 .saved-badge,
 .plain-badge,
 .status-badge {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -575,6 +575,78 @@ const resultCard = {
       support_state: "supported",
       caveats: [],
     },
+    {
+      key: "highest_cloud_top",
+      label: "Highest cloud top",
+      time_index: 3,
+      time_seconds: 2700,
+      source_field: "qc",
+      source_diagnostic: "diagnostics.cloud.cloud_top_time_series",
+      value: 1940,
+      units: "m",
+      support_state: "supported",
+      caveats: [],
+    },
+    {
+      key: "max_updraft_w",
+      label: "Max updraft",
+      time_index: 4,
+      time_seconds: 3600,
+      source_field: "w",
+      source_diagnostic: "diagnostics.vertical_velocity.max_w_m_s",
+      value: 6.866957187652588,
+      units: "m/s",
+      support_state: "supported",
+      caveats: [],
+    },
+    {
+      key: "min_downdraft_w",
+      label: "Min downdraft",
+      time_index: 5,
+      time_seconds: 4500,
+      source_field: "w",
+      source_diagnostic: "diagnostics.vertical_velocity.min_w_m_s",
+      value: -4.21529483795166,
+      units: "m/s",
+      support_state: "supported",
+      caveats: [],
+    },
+    {
+      key: "rain_onset",
+      label: "Rain onset",
+      time_index: 6,
+      time_seconds: 5400,
+      source_field: "qr",
+      source_diagnostic: "diagnostics.rain.first_rain_time_seconds",
+      value: true,
+      units: null,
+      support_state: "supported",
+      caveats: [],
+    },
+    {
+      key: "latest_output",
+      label: "Latest output",
+      time_index: 12,
+      time_seconds: 10800,
+      source_field: null,
+      source_diagnostic: "output_manifest.time_index",
+      value: null,
+      units: null,
+      support_state: "supported",
+      caveats: [],
+    },
+    {
+      key: "field_default_time",
+      label: "Default Explore time",
+      time_index: 3,
+      time_seconds: 2700,
+      source_field: null,
+      source_diagnostic: "interesting_times.default_time_by_field",
+      value: null,
+      units: null,
+      support_state: "supported",
+      caveats: [],
+    },
   ],
   default_time_by_field: {
     qc: {
@@ -1018,10 +1090,10 @@ const fieldCatalogResponse = {
       display_name: "Cloud water",
       units: "kg/kg",
       dimensions: ["time", "zh", "yh", "xh"],
-      shape: [3, 2, 2, 3],
+      shape: [4, 2, 2, 3],
       native_grid: "zh/yh/xh",
       coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
-      time_coordinate_values: [0, 900, 1800],
+      time_coordinate_values: [0, 900, 1800, 2700],
       provenance,
       caveats: ["native_grid_view_no_interpolation"],
     },
@@ -1031,10 +1103,10 @@ const fieldCatalogResponse = {
       display_name: "Vertical velocity",
       units: "m/s",
       dimensions: ["time", "zf", "yh", "xh"],
-      shape: [3, 3, 2, 3],
+      shape: [4, 3, 2, 3],
       native_grid: "zf/yh/xh",
       coordinate_names: { time: "time", vertical: "zf", y: "yh", x: "xh" },
-      time_coordinate_values: [0, 900, 1800],
+      time_coordinate_values: [0, 900, 1800, 2700],
       provenance,
       caveats: ["native_grid_view_no_interpolation"],
     },
@@ -1044,10 +1116,10 @@ const fieldCatalogResponse = {
       display_name: "Rain water",
       units: "kg/kg",
       dimensions: ["time", "zh", "yh", "xh"],
-      shape: [3, 2, 2, 3],
+      shape: [4, 2, 2, 3],
       native_grid: "zh/yh/xh",
       coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
-      time_coordinate_values: [0, 900, 1800],
+      time_coordinate_values: [0, 900, 1800, 2700],
       provenance,
       caveats: ["native_grid_view_no_interpolation"],
     },
@@ -1057,10 +1129,10 @@ const fieldCatalogResponse = {
       display_name: "Potential temperature",
       units: "K",
       dimensions: ["time", "zh", "yh", "xh"],
-      shape: [3, 2, 2, 3],
+      shape: [4, 2, 2, 3],
       native_grid: "zh/yh/xh",
       coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
-      time_coordinate_values: [0, 900, 1800],
+      time_coordinate_values: [0, 900, 1800, 2700],
       provenance,
       caveats: ["native_grid_view_no_interpolation"],
     },
@@ -1070,10 +1142,10 @@ const fieldCatalogResponse = {
       display_name: "Temperature",
       units: "K",
       dimensions: ["time", "zh", "yh", "xh"],
-      shape: [3, 2, 2, 3],
+      shape: [4, 2, 2, 3],
       native_grid: "zh/yh/xh",
       coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
-      time_coordinate_values: [0, 900, 1800],
+      time_coordinate_values: [0, 900, 1800, 2700],
       provenance,
       caveats: ["native_grid_view_no_interpolation"],
     },
@@ -1083,10 +1155,10 @@ const fieldCatalogResponse = {
       display_name: "Water vapor",
       units: "kg/kg",
       dimensions: ["time", "zh", "yh", "xh"],
-      shape: [3, 2, 2, 3],
+      shape: [4, 2, 2, 3],
       native_grid: "zh/yh/xh",
       coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
-      time_coordinate_values: [0, 900, 1800],
+      time_coordinate_values: [0, 900, 1800, 2700],
       provenance,
       caveats: ["native_grid_view_no_interpolation"],
     },
@@ -1096,10 +1168,10 @@ const fieldCatalogResponse = {
       display_name: "Reflectivity",
       units: "dBZ",
       dimensions: ["time", "zh", "yh", "xh"],
-      shape: [3, 2, 2, 3],
+      shape: [4, 2, 2, 3],
       native_grid: "zh/yh/xh",
       coordinate_names: { time: "time", vertical: "zh", y: "yh", x: "xh" },
-      time_coordinate_values: [0, 900, 1800],
+      time_coordinate_values: [0, 900, 1800, 2700],
       provenance,
       caveats: ["native_grid_view_no_interpolation"],
     },
@@ -1109,10 +1181,10 @@ const fieldCatalogResponse = {
       display_name: "Accumulated surface rain",
       units: "mm",
       dimensions: ["time", "yh", "xh"],
-      shape: [3, 2, 3],
+      shape: [4, 2, 3],
       native_grid: "surface/yh/xh",
       coordinate_names: { time: "time", vertical: null, y: "yh", x: "xh" },
-      time_coordinate_values: [0, 900, 1800],
+      time_coordinate_values: [0, 900, 1800, 2700],
       provenance,
       caveats: ["native_grid_view_no_interpolation", "surface_field_no_vertical_dimension"],
     },
@@ -1412,7 +1484,7 @@ function sliceResponse({
     field: fieldMetadata,
     selection: {
       time_index: timeIndex,
-      time_seconds: [0, 900, 1800][timeIndex] ?? 1800,
+      time_seconds: [0, 900, 1800, 2700][timeIndex] ?? 1800,
       orientation,
       selected_dimension: isSurface
         ? "surface"
@@ -1565,7 +1637,7 @@ function pointCloudResponse({
     selection: {
       field,
       time_index: timeIndex,
-      time_seconds: [0, 900, 1800][timeIndex] ?? 1800,
+      time_seconds: [0, 900, 1800, 2700][timeIndex] ?? 1800,
       threshold,
       max_points: 50000,
     },
@@ -2888,9 +2960,16 @@ describe("App", () => {
     expect(screen.getAllByText("Cloud formed").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Rain detected").length).toBeGreaterThan(0);
     expect(screen.getByText("1,800 s")).toBeInTheDocument();
-    expect(screen.getByText("2.193e-3 kg/kg")).toBeInTheDocument();
-    expect(screen.getByText("6.867 m/s")).toBeInTheDocument();
-    expect(screen.getByText("-4.215 m/s")).toBeInTheDocument();
+    expect(screen.getAllByText("2.193e-3 kg/kg").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("6.867 m/s").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("-4.215 m/s").length).toBeGreaterThan(0);
+    expect(resultDetail).toHaveTextContent("Science landmarks");
+    expect(resultDetail).toHaveTextContent("Interesting times");
+    expect(resultDetail).toHaveTextContent("Highest cloud top");
+    expect(resultDetail).toHaveTextContent("1,940 m");
+    expect(resultDetail).toHaveTextContent("Rain onset");
+    expect(resultDetail).toHaveTextContent("Default Explore time");
+    expect(resultDetail).toHaveTextContent("2,700 s");
     fireEvent.click(within(resultDetail).getByText("Technical details"));
     expect(
       screen.getAllByText("13 model files, 13 time steps, 1 stats files").length,
@@ -3063,7 +3142,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     await screen.findByText("Comparison slices loaded");
     expect(screen.getByLabelText("Comparison field")).toHaveValue("qc");
-    expect(screen.getByLabelText("Comparison time")).toHaveValue("2");
+    expect(screen.getByLabelText("Comparison time")).toHaveValue("3");
     expect(screen.getByLabelText("Baseline comparison slice")).toHaveTextContent(
       "Baseline Shallow Cumulus",
     );
@@ -3463,6 +3542,28 @@ describe("App", () => {
       "active-control",
     );
     expect(screen.getByRole("img", { name: /Vertical x-z slice at y = .* heatmap/ })).toBeInTheDocument();
+  });
+
+  it("opens Explore at the result-card science default time", async () => {
+    render(<App />);
+
+    const resultDetail = await screen.findByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+
+    await screen.findByText("Slice synced");
+
+    expect(screen.getByLabelText("Time")).toHaveValue("3");
+    expect(screen.getAllByText("2,700 s").length).toBeGreaterThan(0);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "/api/results/result-dry-run-quicklook/visualization/point-cloud?field=qc&time_index=3",
+      ),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "/api/results/result-dry-run-quicklook/visualization/slice?field=qc&time_index=3",
+      ),
+    );
   });
 
   it("selects a slice region and renders backend Thermal Fate Inspector diagnostics", async () => {
@@ -4015,7 +4116,7 @@ describe("App", () => {
       screen.getByText("Slice planes: native-grid JSON slices from the backend"),
     ).toBeInTheDocument();
     expect(screen.getByText("3 of 3")).toBeInTheDocument();
-    expect(screen.getAllByText("1,800 s").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("2,700 s").length).toBeGreaterThan(0);
     expect(screen.getByText("2.000e-6 kg/kg to 8.000e-6 kg/kg")).toBeInTheDocument();
     expect(screen.getByText("Visualizer interpretation of CM1-derived output")).toBeInTheDocument();
     expect(
@@ -4026,9 +4127,9 @@ describe("App", () => {
     expect(screen.getByText("Rendering method: direct Three.js scalar point cloud"))
       .toBeInTheDocument();
     expect(screen.getByText("No raw NetCDF parsing in the browser")).toBeInTheDocument();
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("time_index=2"));
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("time_index=3"));
     expect(fetch).toHaveBeenCalledWith(
-      "/api/results/result-dry-run-quicklook/visualization/defaults?time_index=2",
+      "/api/results/result-dry-run-quicklook/visualization/defaults?time_index=3",
     );
   });
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -5801,9 +5801,11 @@ function ResultNotebookCard({
         <Metric label="Max qc" value={formatScientific(resultMaxQc(result), "kg/kg")} />
         <Metric label="Max updraft" value={formatNumber(resultMaxUpdraft(result), "m/s")} />
         <Metric label="Min downdraft" value={formatNumber(resultMinDowndraft(result), "m/s")} />
-        <Metric label="Cloud top" value={formatNumber(result.science_summary?.highest_cloud_top_m ?? null, "m")} />
+        <Metric label="Cloud top" value={formatNumber(resultCloudTopMeters(result), "m")} />
         <Metric label="Latest output" value={formatSeconds(resultLatestOutputTime(result))} />
       </dl>
+
+      <InterestingTimesSummary result={result} />
 
       <details className="technical-details">
         <summary>Technical details</summary>
@@ -5907,6 +5909,37 @@ function ResultNotebookCard({
           </button>
         </div>
       </form>
+    </section>
+  );
+}
+
+function InterestingTimesSummary({ result }: { result: ResultCard }) {
+  const records = visibleInterestingTimes(result);
+  if (records.length === 0) return null;
+  return (
+    <section className="science-landmarks" aria-labelledby="science-landmarks-title">
+      <div className="section-heading-row">
+        <div>
+          <p className="eyebrow">Science landmarks</p>
+          <h4 id="science-landmarks-title">Interesting times</h4>
+        </div>
+        <StatusBadge label={scienceSupportLabel(result)} tone="neutral" />
+      </div>
+      <dl className="science-landmark-list">
+        {records.map((record) => (
+          <div key={record.key} className="science-landmark-item">
+            <dt>{record.label}</dt>
+            <dd>
+              <span>{interestingTimePrimaryValue(record, result)}</span>
+              {interestingTimeShowsTimeSuffix(record) &&
+              record.time_seconds !== null &&
+              record.time_seconds !== undefined ? (
+                <span className="muted-inline">at {formatSeconds(record.time_seconds)}</span>
+              ) : null}
+            </dd>
+          </div>
+        ))}
+      </dl>
     </section>
   );
 }
@@ -8864,6 +8897,67 @@ function resultLatestOutputTime(result: ResultCard): number | null {
   return result.science_summary?.latest_output_time_seconds ?? result.output_file_summary.last_output_time_seconds;
 }
 
+function resultCloudTopMeters(result: ResultCard): number | null {
+  const value = result.science_summary?.highest_cloud_top_m ?? null;
+  if (value === null || value === undefined) return null;
+  if (legacyCloudTopWasStoredInKilometers(result)) return value * 1000;
+  return value;
+}
+
+function legacyCloudTopWasStoredInKilometers(result: ResultCard): boolean {
+  const caveats = [
+    ...result.caveats,
+    ...(result.science_summary?.interesting_time_caveats ?? []),
+    ...(result.interesting_time_caveats ?? []),
+  ];
+  return caveats.some((caveat) => caveat === "cloud_base_top_vertical_units_not_meters:km");
+}
+
+function visibleInterestingTimes(result: ResultCard): InterestingTimeRecord[] {
+  const priority = [
+    "first_cloud",
+    "max_qc",
+    "highest_cloud_top",
+    "max_updraft_w",
+    "min_downdraft_w",
+    "rain_onset",
+    "max_qr",
+    "latest_output",
+    "field_default_time",
+  ];
+  const byKey = new Map((result.interesting_times ?? []).map((record) => [record.key, record]));
+  return priority
+    .map((key) => byKey.get(key))
+    .filter((record): record is InterestingTimeRecord => Boolean(record))
+    .filter((record) => record.support_state === "supported" || record.support_state === "fallback");
+}
+
+function interestingTimePrimaryValue(record: InterestingTimeRecord, result: ResultCard): string {
+  if (record.key === "highest_cloud_top") {
+    const cloudTop = resultCloudTopMeters(result);
+    return cloudTop === null ? "Unavailable" : formatNumber(cloudTop, "m");
+  }
+  if (record.key === "latest_output" || record.key === "field_default_time") {
+    return record.time_seconds !== null && record.time_seconds !== undefined
+      ? formatSeconds(record.time_seconds)
+      : "Unavailable";
+  }
+  if (typeof record.value === "number") {
+    if (record.units === "kg/kg") return formatScientific(record.value, record.units);
+    return formatNumber(record.value, record.units ?? "");
+  }
+  if (typeof record.value === "boolean") {
+    return record.value ? "Detected" : "Not detected";
+  }
+  return record.time_seconds !== null && record.time_seconds !== undefined
+    ? formatSeconds(record.time_seconds)
+    : "Unavailable";
+}
+
+function interestingTimeShowsTimeSuffix(record: InterestingTimeRecord): boolean {
+  return record.key !== "latest_output" && record.key !== "field_default_time";
+}
+
 function resultInputSource(result: ResultCard): "generated_reference" | "observed_sounding" {
   if (result.input_source === "observed_sounding") return "observed_sounding";
   return "generated_reference";
@@ -9116,8 +9210,17 @@ function defaultTimeIndex(
   result: ResultCard,
   defaults: FieldViewDefaults | undefined,
 ): number {
-  if (defaults) return defaults.time_index;
-  return interestingTimeIndex(field?.time_coordinate_values ?? [], result);
+  const timeOptions = field?.time_coordinate_values ?? [];
+  const fieldDefault =
+    field?.raw_field_name !== undefined
+      ? result.default_time_by_field?.[field.raw_field_name]?.time_index
+      : undefined;
+  const resultDefault = fieldDefault ?? result.science_summary?.default_explore_time_index;
+  if (resultDefault !== null && resultDefault !== undefined) {
+    return clampIndex(resultDefault, timeOptions.length || 1);
+  }
+  if (defaults) return clampIndex(defaults.time_index, timeOptions.length || 1);
+  return interestingTimeIndex(timeOptions, result);
 }
 
 function interestingTimeIndex(
@@ -9125,7 +9228,9 @@ function interestingTimeIndex(
   result: ResultCard,
 ): number {
   const target =
-    result.first_cloud_time_seconds ?? result.output_file_summary.last_output_time_seconds;
+    result.science_summary?.default_explore_time_seconds ??
+    result.first_cloud_time_seconds ??
+    result.output_file_summary.last_output_time_seconds;
   return closestTimeIndex(timeOptions, target);
 }
 


### PR DESCRIPTION
## Summary
- converts km vertical coordinates to meters in baseline cloud-base/cloud-top diagnostics so future ingests do not report km values as meters
- shows #221 interesting-time records in the Result detail as science landmarks
- makes Explore prefer result-card/default-by-field science time before backend visualization defaults, so observed-sounding runs open on the meaningful frame instead of t=0
- keeps a display guard for legacy result metadata that already has the km-unit caveat

## Tests
- npm --prefix app/frontend test -- App.test.tsx --run
- scripts/check.sh
- scripts/check-e2e.sh

## Caveats
- existing result_metadata.json files are not rewritten by this PR; already-ingested legacy results display corrected cloud-top units in the UI when the km caveat is present, but a reingest/backfill would be needed to rewrite the stored metadata

## Generated artifacts
- no CM1 output, NetCDF, screenshots, logs, traces, or runtime folders committed
