### PR TITLE
feat: add Explore saved-output timelapse

### DIFF
--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -304,6 +304,48 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/selected point: x/i)).toBeVisible();
   });
 
+  test("Unified Explore plays through saved output times", async ({ page }) => {
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+
+    await expect(page.getByLabel("Explore viewer controls")).toBeVisible();
+    await expect(page.getByLabel("Timelapse playback controls")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Play time" })).toBeVisible();
+    await expect(page.getByLabel("Playback speed")).toHaveValue("1");
+    await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
+
+    await page.locator("#explore-time").selectOption("1");
+    await page.getByLabel("Playback speed").selectOption("2");
+    await page.getByRole("button", { name: "Play time" }).click();
+
+    await expect(page.getByRole("button", { name: "Pause time" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(
+      page.getByText("Pause playback to select a cell and explain this time step."),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/Animating 3-D scene at .*; slice and evidence remain at .* until playback is paused\./),
+    ).toBeVisible();
+    await expect(page.locator("#explore-time")).toHaveValue("2", { timeout: 2_000 });
+
+    await page.getByRole("button", { name: "Pause time" }).click();
+    await expect(page.getByRole("button", { name: "Play time" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+
+    await page.getByRole("button", { name: "Last frame" }).click();
+    await expect(page.locator("#explore-time")).toHaveValue("2");
+    await page.getByRole("button", { name: "Play time" }).click();
+    await expect(page.locator("#explore-time")).toHaveValue("0", { timeout: 2_000 });
+    await expect(page.getByRole("button", { name: "Play time" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
   test("Explore process evidence offers useful modes and moves unsupported modes secondary", async ({
     page,
   }) => {

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1222,12 +1222,13 @@ details[open] > summary {
   display: grid;
   grid-template-columns: minmax(12rem, 0.9fr) minmax(22rem, 1.55fr) minmax(16rem, 1fr);
   gap: 0.55rem;
-  align-items: stretch;
+  align-items: start;
 }
 
 .explore-control-card {
   display: grid;
   gap: 0.42rem;
+  align-content: start;
   min-width: 0;
   margin: 0;
   border: 1px solid rgba(47, 116, 168, 0.16);
@@ -1257,6 +1258,19 @@ details[open] > summary {
   font-weight: 750;
 }
 
+.timelapse-controls {
+  display: grid;
+  grid-template-columns: minmax(7rem, max-content) minmax(6rem, 1fr);
+  gap: 0.4rem;
+  align-items: end;
+}
+
+.timelapse-controls button[aria-pressed="true"] {
+  border-color: var(--color-accent-primary);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+}
+
 .explore-control-card select,
 .explore-control-card input {
   min-width: 0;
@@ -1270,7 +1284,7 @@ details[open] > summary {
 
 .explore-control-card-slice {
   grid-template-columns: minmax(10rem, 0.85fr) minmax(12rem, 1fr);
-  align-items: end;
+  align-items: start;
 }
 
 .explore-control-card-slice legend {
@@ -2498,6 +2512,7 @@ details[open] > summary {
 
   .explore-control-deck,
   .explore-control-card-slice,
+  .timelapse-controls,
   .true3d-controls {
     grid-template-columns: 1fr;
   }

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { App } from "./App";
@@ -2168,7 +2169,7 @@ afterEach(() => {
 
 async function openSelectedResultInExplore() {
   const resultDetail = await screen.findByLabelText("Result detail");
-  fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+  fireEvent.click(await within(resultDetail).findByRole("button", { name: "Open in Explore" }));
 }
 
 describe("App", () => {
@@ -3501,8 +3502,7 @@ describe("App", () => {
   it("opens the 2-D field inspector from a result and shows qc slices", async () => {
     render(<App />);
 
-    const resultDetail = await screen.findByLabelText("Result detail");
-    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+    await openSelectedResultInExplore();
 
     expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
     expect(await screen.findByLabelText("Explore viewer controls")).toBeInTheDocument();
@@ -3549,8 +3549,7 @@ describe("App", () => {
   it("opens Explore at the result-card science default time", async () => {
     render(<App />);
 
-    const resultDetail = await screen.findByLabelText("Result detail");
-    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+    await openSelectedResultInExplore();
 
     await screen.findByText("Slice synced");
 
@@ -3568,11 +3567,128 @@ describe("App", () => {
     );
   });
 
+  it("plays saved output times without refetching fields until pause and resets at the end", async () => {
+    render(<App />);
+
+    await openSelectedResultInExplore();
+    await screen.findByText("Slice synced");
+
+    const fetchMock = vi.mocked(fetch);
+
+    fireEvent.change(screen.getByLabelText("Time"), { target: { value: "1" } });
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("time_index=1")),
+    );
+    fetchMock.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Move down" }));
+    expect(screen.getByLabelText("Slice position")).toHaveValue("0");
+
+    const heatmap = screen.getAllByRole("img", { name: /heatmap/i })[0];
+    fireEvent.click(within(heatmap).getByRole("button", { name: /row 1, column 2/i }));
+    expect(await screen.findByText("Selected-point diagnostics loaded")).toBeInTheDocument();
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole("button", { name: "Play time" }));
+
+    expect(screen.getByRole("button", { name: "Pause time" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      screen.getByText("Pause playback to select a cell and explain this time step."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Selected point")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Animating 3-D scene at 900 s; slice and evidence remain at 900 s until playback is paused.",
+      ),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(screen.getByLabelText("Time")).toHaveValue("2");
+    expect(screen.getByLabelText("Saved output time")).toHaveValue("2");
+    expect(
+      screen.getByText(
+        "Animating 3-D scene at 1,800 s; slice and evidence remain at 900 s until playback is paused.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Slice position")).toHaveValue("0");
+    expect(
+      fetchMock.mock.calls.some(
+        ([url]) =>
+          String(url).includes("/visualization/point-cloud") &&
+          String(url).includes("time_index=2"),
+      ),
+    ).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(
+        ([url]) =>
+          String(url).includes("/visualization/slice") && String(url).includes("time_index=2"),
+      ),
+    ).toBe(false);
+    expect(
+      fetchMock.mock.calls.some(
+        ([url]) =>
+          String(url).includes("/visualization/defaults") && String(url).includes("time_index=2"),
+      ),
+    ).toBe(false);
+    expect(
+      screen.getByText("Pause playback to select a cell and explain this time step."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Pause time" }));
+    expect(screen.getByRole("button", { name: "Play time" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    vi.useRealTimers();
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(
+          ([url]) =>
+            String(url).includes("/visualization/slice") && String(url).includes("time_index=2"),
+        ),
+      ).toBe(true),
+    );
+    expect(
+      fetchMock.mock.calls.some(
+        ([url]) =>
+          String(url).includes("/visualization/defaults") && String(url).includes("time_index=2"),
+      ),
+    ).toBe(true);
+    expect(screen.getByLabelText("Slice position")).toHaveValue("0");
+
+    fireEvent.click(screen.getByRole("button", { name: "Last frame" }));
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("time_index=3")),
+    );
+    fetchMock.mockClear();
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole("button", { name: "Play time" }));
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(screen.getByRole("button", { name: "Play time" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByLabelText("Time")).toHaveValue("0");
+    expect(screen.getByLabelText("Saved output time")).toHaveValue("0");
+    vi.useRealTimers();
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("time_index=0")),
+    );
+  });
+
   it("selects a slice region and renders backend Thermal Fate Inspector diagnostics", async () => {
     render(<App />);
 
-    const resultDetail = await screen.findByLabelText("Result detail");
-    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+    await openSelectedResultInExplore();
     await screen.findByText("Slice synced");
 
     const heatmap = screen.getAllByRole("img", { name: /heatmap/i })[0];
@@ -3622,8 +3738,7 @@ describe("App", () => {
 
     render(<App />);
 
-    const resultDetail = await screen.findByLabelText("Result detail");
-    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+    await openSelectedResultInExplore();
     await screen.findByText("Slice synced");
 
     const heatmap = screen.getAllByRole("img", { name: /heatmap/i })[0];

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -6070,6 +6070,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   );
   const [selectedFieldName, setSelectedFieldName] = useState("");
   const [timeIndex, setTimeIndex] = useState(0);
+  const [playbackTimeIndex, setPlaybackTimeIndex] = useState(0);
+  const [isPlaybackRunning, setIsPlaybackRunning] = useState(false);
+  const [playbackSpeed, setPlaybackSpeed] = useState(1);
   const [threshold, setThreshold] = useState(1e-6);
   const [opacity, setOpacity] = useState(0.68);
   const [pointSize, setPointSize] = useState(11);
@@ -6105,6 +6108,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setSceneError(null);
     setSelectedFieldName("");
     setTimeIndex(0);
+    setPlaybackTimeIndex(0);
+    setIsPlaybackRunning(false);
+    setPlaybackSpeed(1);
     setThreshold(1e-6);
     setOpacity(0.68);
     setPointSize(11);
@@ -6159,6 +6165,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
         setSelectedFieldName(firstRenderable?.field.raw_field_name ?? "");
         setSliceFieldName(initialSliceField?.raw_field_name ?? "");
         setTimeIndex(initialTimeIndex);
+        setPlaybackTimeIndex(initialTimeIndex);
         setThreshold(firstRenderable?.defaultThreshold ?? 1e-6);
         setHorizontalSliceLevel(defaultHorizontalLevel(initialSliceField, initialDefaults));
         setVerticalSliceIndex(defaultVerticalIndex(initialSliceField, "vertical_x", initialDefaults));
@@ -6207,6 +6214,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const timeOptions = controlField?.time_coordinate_values ?? [];
   const timeMax = Math.max(0, timeOptions.length - 1);
   const resolvedTimeIndex = Math.min(timeIndex, timeMax);
+  const resolvedPlaybackTimeIndex = Math.min(playbackTimeIndex, timeMax);
+  const displayTimeIndex = isPlaybackRunning ? resolvedPlaybackTimeIndex : resolvedTimeIndex;
+  const sceneTimeIndex = displayTimeIndex;
   const wField = catalog?.available_fields.find((field) => field.raw_field_name === "w");
   const isNoCloudWithUpdraft =
     cloudOutcome(result) === "No cloud formed" && Boolean(wField) && (result.max_w_m_s ?? 0) > 0;
@@ -6243,6 +6253,13 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const selectedTimeSliceDefaults = defaultsForField(selectedTimeDefaults, sliceFieldName);
   const selectedTimeValue = timeOptions[resolvedTimeIndex] ?? null;
   const selectedTimeLabel = formatTimeValue(selectedTimeValue);
+  const displayTimeValue = timeOptions[displayTimeIndex] ?? null;
+  const displayTimeLabel = formatTimeValue(displayTimeValue);
+  const sceneTimeValue = timeOptions[sceneTimeIndex] ?? null;
+  const sceneTimeLabel = formatTimeValue(sceneTimeValue);
+  const playbackSpeedOptions = [0.5, 1, 2, 4];
+  const playbackIntervalMs = Math.max(150, Math.round(900 / playbackSpeed));
+  const canPlayTimelapse = timeOptions.length > 1;
   const activeSlice = activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice;
   const activeSliceLabel = slicePlainLabel(activeSlice, activeSlicePlane, activeSliceIndex);
   const selectedSliceValue = selectedSliceCellValue(activeSlice, selectedRegion);
@@ -6273,11 +6290,76 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
       : null,
   ].filter((preset): preset is { label: string; seconds: number } => preset !== null);
 
+  const clearSelectedRegionForTimeChange = useCallback(
+    (nextStatus = "Click a slice cell to inspect that point.") => {
+      setSelectedRegion(null);
+      setRegionDiagnostics(null);
+      setRegionError(null);
+      setRegionStatus(nextStatus);
+    },
+    [],
+  );
+
+  const handleTimeIndexChange = useCallback(
+    (nextIndex: number) => {
+      const clampedIndex = clampIndex(nextIndex, timeOptions.length || 1);
+      setIsPlaybackRunning(false);
+      setTimeIndex(clampedIndex);
+      setPlaybackTimeIndex(clampedIndex);
+      clearSelectedRegionForTimeChange();
+    },
+    [clearSelectedRegionForTimeChange, timeOptions.length],
+  );
+
+  const handlePlaybackToggle = useCallback(() => {
+    if (isPlaybackRunning) {
+      const clampedIndex = clampIndex(playbackTimeIndex, timeOptions.length || 1);
+      setIsPlaybackRunning(false);
+      setTimeIndex(clampedIndex);
+      setPlaybackTimeIndex(clampedIndex);
+      clearSelectedRegionForTimeChange();
+      return;
+    }
+    setPlaybackTimeIndex(resolvedTimeIndex);
+    setIsPlaybackRunning(true);
+    clearSelectedRegionForTimeChange("Pause playback to select a cell and explain this time step.");
+  }, [
+    clearSelectedRegionForTimeChange,
+    isPlaybackRunning,
+    playbackTimeIndex,
+    resolvedTimeIndex,
+    timeOptions.length,
+  ]);
+
   useEffect(() => {
     if (processMode !== activeProcessMode) {
       setProcessMode(activeProcessMode);
     }
   }, [activeProcessMode, processMode]);
+
+  useEffect(() => {
+    if (!canPlayTimelapse && isPlaybackRunning) {
+      setIsPlaybackRunning(false);
+      setPlaybackTimeIndex(resolvedTimeIndex);
+    }
+  }, [canPlayTimelapse, isPlaybackRunning, resolvedTimeIndex]);
+
+  useEffect(() => {
+    if (!isPlaybackRunning || !canPlayTimelapse) return undefined;
+    clearSelectedRegionForTimeChange("Pause playback to select a cell and explain this time step.");
+    const intervalId = window.setInterval(() => {
+      clearSelectedRegionForTimeChange("Pause playback to select a cell and explain this time step.");
+      setPlaybackTimeIndex((current) => {
+        if (current >= timeMax) {
+          setIsPlaybackRunning(false);
+          setTimeIndex(0);
+          return 0;
+        }
+        return current + 1;
+      });
+    }, playbackIntervalMs);
+    return () => window.clearInterval(intervalId);
+  }, [canPlayTimelapse, clearSelectedRegionForTimeChange, isPlaybackRunning, playbackIntervalMs, timeMax]);
 
   useEffect(() => {
     if (!sliceSupportsVertical && activeSlicePlane !== "horizontal") {
@@ -6296,7 +6378,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setSceneStatus(`Loading ${selectedEncoding.field.display_name.toLowerCase()} points...`);
     fetchVisualizationPointCloud(result.result_id, {
       field: selectedEncoding.field.raw_field_name,
-      timeIndex: resolvedTimeIndex,
+      timeIndex: sceneTimeIndex,
       threshold,
       maxPoints,
     })
@@ -6308,25 +6390,6 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
             ? selectedEncoding.statusLabel
             : emptyPointCloudStatus(payload, selectedEncoding),
         );
-        return fetchVisualizationDefaults(result.result_id, resolvedTimeIndex)
-          .then((defaults) => {
-            if (!active) return;
-            setSelectedTimeDefaults(defaults);
-            const fieldDefaults =
-              defaultsForField(defaults, sliceFieldName) ??
-              defaultsForField(defaults, selectedEncoding.field.raw_field_name);
-            if (fieldDefaults) {
-              setHorizontalSliceLevel(fieldDefaults.horizontal_level_index);
-              setVerticalSliceIndex(
-                sliceOrientation === "vertical_y"
-                  ? fieldDefaults.vertical_y_index
-                  : fieldDefaults.vertical_x_index,
-              );
-            }
-          })
-          .catch(() => {
-            if (active) setSelectedTimeDefaults(null);
-          });
       })
       .catch((caught: unknown) => {
         if (!active) return;
@@ -6342,12 +6405,29 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   }, [
     maxPoints,
     result.result_id,
-    resolvedTimeIndex,
+    sceneTimeIndex,
     selectedEncoding,
-    sliceFieldName,
-    sliceOrientation,
     threshold,
   ]);
+
+  useEffect(() => {
+    if (!catalog) {
+      setSelectedTimeDefaults(null);
+      return;
+    }
+    let active = true;
+    fetchVisualizationDefaults(result.result_id, resolvedTimeIndex)
+      .then((defaults) => {
+        if (!active) return;
+        setSelectedTimeDefaults(defaults);
+      })
+      .catch(() => {
+        if (active) setSelectedTimeDefaults(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, [catalog, result.result_id, resolvedTimeIndex]);
 
   useEffect(() => {
     if (!sliceField) {
@@ -6431,6 +6511,10 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
   }, [result.result_id, selectedRegion]);
 
   function selectPointFromSlice(slice: SliceResponse, rowIndex: number, columnIndex: number) {
+    if (isPlaybackRunning) {
+      clearSelectedRegionForTimeChange("Pause playback to select a cell and explain this time step.");
+      return;
+    }
     setSelectedRegion(selectionFromSlice(slice, rowIndex, columnIndex, "point"));
   }
 
@@ -6476,6 +6560,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
             selectedRegion={selectedRegion}
             coordinateSizes={{ x: sliceXSize, y: sliceYSize, z: sliceVerticalSize }}
             selectedTimeLabel={selectedTimeLabel}
+            sceneTimeLabel={sceneTimeLabel}
             thresholdLabel={formatScientific(threshold, selectedEncoding?.field.units ?? "")}
             opacity={opacity}
             pointSize={pointSize}
@@ -6493,13 +6578,57 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
             <section className="explore-control-deck" aria-label="Explore viewer controls">
               <fieldset className="explore-control-card explore-control-card-time">
                 <legend>Time</legend>
+                <div className="timelapse-controls" aria-label="Timelapse playback controls">
+                  <button
+                    type="button"
+                    disabled={!canPlayTimelapse}
+                    aria-pressed={isPlaybackRunning}
+                    onClick={handlePlaybackToggle}
+                  >
+                    {isPlaybackRunning ? "Pause time" : "Play time"}
+                  </button>
+                  <label htmlFor="explore-playback-speed">
+                    Speed
+                    <select
+                      id="explore-playback-speed"
+                      aria-label="Playback speed"
+                      value={playbackSpeed}
+                      onChange={(event) => setPlaybackSpeed(Number(event.target.value))}
+                    >
+                      {playbackSpeedOptions.map((speed) => (
+                        <option key={speed} value={speed}>
+                          {speed}x
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <label htmlFor="explore-time-scrubber">
+                  Saved output time
+                  <input
+                    id="explore-time-scrubber"
+                    aria-label="Saved output time"
+                    type="range"
+                    min={0}
+                    max={timeMax}
+                    value={displayTimeIndex}
+                    disabled={timeMax === 0}
+                    onChange={(event) => handleTimeIndexChange(Number(event.target.value))}
+                  />
+                  <span className="slice-position-label">
+                    <span>{displayTimeLabel}</span>
+                    <small>
+                      frame {displayTimeIndex + 1} of {Math.max(1, timeOptions.length)}
+                    </small>
+                  </span>
+                </label>
                 <label htmlFor="explore-time">
                   Output time
                   <select
                     id="explore-time"
                     aria-label="Time"
-                    value={resolvedTimeIndex}
-                    onChange={(event) => setTimeIndex(Number(event.target.value))}
+                    value={displayTimeIndex}
+                    onChange={(event) => handleTimeIndexChange(Number(event.target.value))}
                   >
                     {timeOptions.map((value, index) => (
                       <option key={`${value}-${index}`} value={index}>
@@ -6514,13 +6643,19 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                     <button
                       key={preset.label}
                       type="button"
-                      onClick={() => setTimeIndex(closestTimeIndex(timeOptions, preset.seconds))}
+                      onClick={() => handleTimeIndexChange(closestTimeIndex(timeOptions, preset.seconds))}
                     >
                       {preset.label}
                     </button>
                   ))}
-                  <button type="button" onClick={() => setTimeIndex(timeMax)}>Last frame</button>
+                  <button type="button" onClick={() => handleTimeIndexChange(timeMax)}>Last frame</button>
                 </div>
+                {isPlaybackRunning && (
+                  <p className="control-help">
+                    Animating 3-D scene at {sceneTimeLabel}; slice and evidence remain at{" "}
+                    {selectedTimeLabel} until playback is paused.
+                  </p>
+                )}
               </fieldset>
 
               <fieldset className="explore-control-card explore-control-card-slice">
@@ -6804,7 +6939,8 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                     : "Unavailable"
                 }
               />
-              <Metric label="Selected time" value={selectedTimeLabel} />
+              <Metric label="3-D scene time" value={sceneTimeLabel} />
+              <Metric label="Slice/evidence time" value={selectedTimeLabel} />
               <Metric label="Slice plane" value={activeSliceLabel} />
               <Metric label="Slice plane visible" value={showSlicePlanes ? "Yes" : "No"} />
               <Metric
@@ -6963,6 +7099,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
             diagnostics={regionDiagnostics}
             status={regionStatus}
             error={regionError}
+            playbackRunning={isPlaybackRunning}
           />
         </section>
       )}
@@ -7384,6 +7521,7 @@ function SelectedRegionInspector({
   diagnostics,
   status,
   error,
+  playbackRunning,
 }: {
   selectedRegion: SelectedRegionRequest | null;
   slice: SliceResponse | null;
@@ -7391,8 +7529,9 @@ function SelectedRegionInspector({
   diagnostics: SelectedRegionDiagnosticsResponse | null;
   status: string;
   error: string | null;
+  playbackRunning?: boolean;
 }) {
-  if (!selectedRegion && !error) {
+  if (!selectedRegion && !error && !playbackRunning) {
     return null;
   }
 
@@ -7403,10 +7542,16 @@ function SelectedRegionInspector({
           <p className="eyebrow">Explanation</p>
           <h3>What happened here?</h3>
         </div>
-        <p className="state-chip">{status}</p>
+        <p className="state-chip">
+          {playbackRunning && !selectedRegion && !error ? "Playback running" : status}
+        </p>
       </div>
 
       {error && <p role="alert">{error}</p>}
+
+      {playbackRunning && !selectedRegion && !error && (
+        <p>Pause playback to select a cell and explain this time step.</p>
+      )}
 
       {selectedRegion && (
         <SelectedPointContext

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -74,6 +74,7 @@ type True3DViewerProps = {
   selectedRegion: SelectedRegionRequest | null;
   coordinateSizes: { x: number; y: number; z: number };
   selectedTimeLabel: string;
+  sceneTimeLabel: string;
   thresholdLabel: string;
   opacity: number;
   pointSize: number;
@@ -130,6 +131,7 @@ export function True3DViewer({
   selectedRegion,
   coordinateSizes,
   selectedTimeLabel,
+  sceneTimeLabel,
   thresholdLabel,
   opacity,
   pointSize,
@@ -299,7 +301,7 @@ export function True3DViewer({
         />
         <div className="true3d-scene-label true3d-scene-label-context">
           <strong>{fieldLabel}</strong>
-          <span>{selectedTimeLabel}</span>
+          <span>{sceneTimeLabel || selectedTimeLabel}</span>
           <span>Threshold {thresholdLabel}</span>
         </div>
         {pointCloud && (

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -300,6 +300,7 @@ It should keep the current product loop focused on:
 selected-result trust
 -> 3-D scalar-field context
 -> shared time / field / slice controls
+-> saved-output timelapse playback without interpolation
 -> visible native-grid slice plane
 -> matching 2-D slice inspector
 -> click-cell "What happened here?" explanation
@@ -1127,6 +1128,22 @@ selected-point explanation panel. Selecting a result in Notebook or opening a
 comparison/storage row in Explore should preserve that context. If no selected
 result is available, Explore should tell the user to select an ingested result
 from Results.
+
+Shared time controls should operate on actual saved CM1 output times. Explore
+may provide play/pause timelapse playback and a scrubber across those saved
+time indices, but it must not interpolate between model outputs or imply a
+continuous movie. Manual time changes and pausing playback update the 3-D
+scalar context and 2-D slice inspector together, preserve the current camera,
+field, slice orientation, and slice position, and clear selected-cell
+explanation state because the old point evidence belongs to a different model
+time. While playback is running, Explore should update the main 3-D scalar
+layer for the visible saved output time, but it should not refetch or recompute
+all synchronized field products every frame. The 2-D slice, selected-point
+diagnostics, defaults, and evidence panels may remain on the last committed time
+until playback is paused. At the end of the saved-output sequence, playback
+should stop and reset to the first output time rather than looping indefinitely.
+The selected-point panel should invite the user to pause before asking `What
+happened here?`.
 
 The first-read Explore screen should be an explanation workspace, not a
 process-mode cockpit. The 3-D context renders only backend-supported scalar

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -226,8 +226,11 @@ contracts, output products, validation, or local bench maturity.
   products and inspection workflow are stable.
 - **#198 cloud + field overlay**: parked until scalar/signed overlay contracts
   are defined.
-- **#201 timelapse UI before time products**: parked until interesting-time and
-  time-index products exist.
+- **Renderer-style timelapse ambition**: parked until output products mature.
+  The near-term #201 scope is limited to saved-output play/pause and scrubbing
+  across explicit backend time indices without interpolation, with the main 3-D
+  scalar layer animating while synchronized slice/evidence payloads are deferred
+  until pause and no default looping.
 - **#43 remote/HPC compute**: deferred. The near-term compute extension is a
   trusted LAN worker used as a CM1 compute appliance while the MacBook remains
   the Cloud Chamber system of record.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -469,6 +469,15 @@ lighting, export, fly-through, or generated CM1 output. The 3-D point context is
 limited to explicitly supported scalar/floor layers; `w`, potential
 temperature, and direct temperature should be tested through synchronized slices
 unless a future issue adds a scientifically honest 3-D representation for them.
+Saved-output timelapse tests should verify that play/pause advances only
+through backend-provided saved output time indices, that playback updates the
+main 3-D scalar layer while deferring synchronized 2-D slice/default/evidence
+payloads until pause or manual time selection, that pausing or manually choosing
+a time commits the 3-D context and 2-D slice to the same model time, that
+camera/view/field/slice position are preserved across time changes, that
+selected-cell explanation state is cleared while playback tells the user to
+pause before asking `What happened here?`, and that playback stops and resets to
+the first saved output when it reaches the end rather than looping.
 Visual first-impression tests should also keep the validated quick-look baseline
 on a cloud-bearing time, show a visible point-cloud state, keep slice planes
 optional and secondary, and keep technical provenance reachable without making


### PR DESCRIPTION
## Issue worked
- Closes #201

## Summary
- Added saved-output timelapse controls in Explore using backend-provided output time indices only.
- Playback now animates the main 3-D scalar layer across saved model times while deferring synchronized 2-D slice/default/evidence payload updates until pause or manual time selection.
- Playback stops at the end and resets to the first saved output instead of looping indefinitely.
- Keeps camera, field, slice orientation, and slice position stable across time changes, and clears selected-point explanations while playback is running.
- Documents the no-interpolation/no-continuous-movie contract and the split between animated 3-D context and committed slice/evidence time.

## Tests added/updated
- Updated component coverage for saved-output playback, deferred slice/default fetches, end-of-sequence reset, and selected-explanation clearing.
- Updated Playwright mocked-smoke coverage for the Unified Explore timelapse workflow and no-loop reset.

## Commands run
- `npm --prefix app/frontend test -- App.test.tsx`
- `npm --prefix app/frontend run test:e2e:smoke -- --project=chromium -g "Unified Explore plays"`
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Playwright visual inspection
- Captured and inspected uncommitted screenshots:
  - `/tmp/cloud-chamber-issue201-explore-timelapse.png`
  - `/tmp/cloud-chamber-issue201-explore-timelapse-playing.png`
- The playing screenshot showed the 3-D scene label at the animated time while the slice inspector stayed on the committed time, with helper copy explaining the split.

## Manual QA needed
Yes. Please verify qualitatively that playback feels useful on the MacBook and that the 3-D animation is visible without making the rest of Explore feel sluggish.

## Caveats / follow-up issues
- This is saved-output playback only. It does not interpolate between model times and does not add Render Studio-style animation controls.
- No generated screenshots, reports, traces, NetCDF files, logs, or runtime folders were committed.
