### PR TITLE
Audit sounding candidate story scoring

### DIFF
--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -395,6 +395,9 @@ def _features_from_record(
     inversion_strength, inversion_base, inversion_top = _inversion_proxy(levels)
     moisture_depth = _moisture_depth(levels, min_qv_g_kg=6.0)
     usable_below_3km = sum(1 for level in levels if 0.0 <= level.model_z_m <= 3000.0)
+    observed_wind_available = all(
+        level.u_wind_m_s is not None and level.v_wind_m_s is not None for level in levels
+    )
     completeness = min(
         100.0,
         25.0
@@ -442,19 +445,32 @@ def _features_from_record(
         "profile_top_m_agl": round(top, 1),
         "lowest_level_m_agl": round(lowest, 1),
         "usable_levels_below_3km": usable_below_3km,
+        "observed_wind_available": observed_wind_available,
     }
 
 
 def _score_features(
     features: dict[str, float | int | str | bool | None], *, package_ready: bool
 ) -> tuple[list[StoryScore], list[EvidenceItem]]:
-    qv = _feature(features, "mean_qv_0_1000m_g_kg")
-    lcl = _feature(features, "estimated_lcl_height_m_agl")
-    lapse = _feature(features, "lapse_rate_0_1000m_c_per_km")
-    cap = _feature(features, "cap_strength_proxy")
-    moisture_depth = _feature(features, "moisture_depth_m")
-    completeness = _feature(features, "data_completeness_score")
-    midlevel_dry = _feature(features, "midlevel_dry_layer_proxy")
+    qv = _numeric_feature(features, "mean_qv_0_1000m_g_kg")
+    lcl = _numeric_feature(features, "estimated_lcl_height_m_agl")
+    lapse = _numeric_feature(features, "lapse_rate_0_1000m_c_per_km")
+    cap = _numeric_feature(features, "cap_strength_proxy")
+    moisture_depth = _numeric_feature(features, "moisture_depth_m")
+    completeness = _numeric_feature(features, "data_completeness_score")
+    midlevel_dry = _numeric_feature(features, "midlevel_dry_layer_proxy")
+    story_feature_names = [
+        "mean_qv_0_1000m_g_kg",
+        "estimated_lcl_height_m_agl",
+        "lapse_rate_0_1000m_c_per_km",
+        "cap_strength_proxy",
+        "moisture_depth_m",
+        "midlevel_dry_layer_proxy",
+    ]
+    missing_story_features = [
+        name for name in story_feature_names if _numeric_feature(features, name) is None
+    ]
+    missing_caveats = [f"missing_or_unavailable_feature:{name}" for name in missing_story_features]
 
     moist = _score_high(qv, low=4.0, high=10.0)
     dry = _score_low(qv, low=3.0, high=8.0)
@@ -467,6 +483,11 @@ def _score_features(
     shallow_moisture = _score_low(moisture_depth, low=500.0, high=1800.0)
     data_quality = _score_high(completeness, low=40.0, high=90.0)
     dry_layer = _score_high(midlevel_dry, low=2.0, high=8.0)
+    feature_coverage = (
+        (len(story_feature_names) - len(missing_story_features)) / len(story_feature_names)
+        if story_feature_names
+        else 1.0
+    )
 
     shallow = _weighted_score(
         [(moist, 0.28), (low_lcl, 0.22), (deep_moisture, 0.18), (weak_cap, 0.14), (thermal, 0.18)]
@@ -484,63 +505,135 @@ def _score_features(
     humid_rainy = _weighted_score(
         [(moist, 0.32), (low_lcl, 0.22), (deep_moisture, 0.26), (weak_cap, 0.20)]
     )
-    poor = max(0.0, 100.0 - data_quality)
+    poor = 100.0 if not package_ready else min(34.0, max(0.0, 100.0 - data_quality))
     if not package_ready:
         poor = 100.0
+    needs_review = min(
+        100.0,
+        max(
+            15.0,
+            60.0 - data_quality / 2.0,
+            len(missing_story_features) * 18.0,
+            70.0 - data_quality if data_quality < 70.0 else 0.0,
+        ),
+    )
+    if not package_ready:
+        needs_review = min(needs_review, 80.0)
     scores = [
         _story_score(
             "shallow_cumulus_candidate",
-            shallow * data_quality / 100.0,
+            shallow * data_quality / 100.0 * feature_coverage,
             reasons=["moderate moisture, plausible LCL, thermal lapse-rate and cap proxies"],
+            caveats=missing_caveats,
         ),
         _story_score(
             "dry_failed_candidate",
-            dry_failed * data_quality / 100.0,
+            dry_failed * data_quality / 100.0 * feature_coverage,
             reasons=["dryness/high LCL proxies with possible thermal lapse-rate support"],
+            caveats=missing_caveats,
         ),
         _story_score(
             "capped_suppressed_candidate",
-            capped * data_quality / 100.0,
+            capped * data_quality / 100.0 * feature_coverage,
             reasons=["moisture/LCL support with an inversion or cap proxy"],
+            caveats=missing_caveats,
         ),
         _story_score(
             "humid_rainy_candidate",
-            humid_rainy * data_quality / 100.0,
+            humid_rainy * data_quality / 100.0 * feature_coverage,
             reasons=["high low-level moisture, low LCL, deep moisture, weak-cap proxies"],
-            caveats=["Humid/rainy is heavily caveated because forcing remains idealized."],
+            caveats=[
+                "Humid/rainy is heavily caveated because forcing remains idealized.",
+                *missing_caveats,
+            ],
         ),
         _story_score(
             "needs_review",
-            min(100.0, max(15.0, 60.0 - data_quality / 2.0)),
+            needs_review,
             reasons=["heuristic screening is uncertain; CM1 run is required"],
+            caveats=missing_caveats,
         ),
         _story_score(
             "poor_or_incomplete_candidate",
             poor,
             reasons=["profile completeness or package-readiness issues"],
+            caveats=(["package_generation_blocked"] if not package_ready else missing_caveats),
         ),
     ]
     evidence = [
+        EvidenceItem(
+            label="Low-level qv",
+            value=features.get("low_level_qv_g_kg"),
+            units="g/kg",
+            interpretation=(
+                "Near-surface moisture helps distinguish moist, dry, and humid candidates."
+            ),
+            supports_story=[
+                "shallow_cumulus_candidate",
+                "dry_failed_candidate",
+                "humid_rainy_candidate",
+            ],
+            caveats=_feature_caveats(features, "low_level_qv_g_kg"),
+        ),
+        EvidenceItem(
+            label="Mean qv 0-500 m",
+            value=features.get("mean_qv_0_500m_g_kg"),
+            units="g/kg",
+            interpretation="Moisture close to cloud base supports cloud-forming hypotheses.",
+            supports_story=["shallow_cumulus_candidate", "humid_rainy_candidate"],
+            caveats=_feature_caveats(features, "mean_qv_0_500m_g_kg"),
+        ),
         EvidenceItem(
             label="Mean qv 0-1 km",
             value=features.get("mean_qv_0_1000m_g_kg"),
             units="g/kg",
             interpretation="Higher low-level moisture supports cloud-forming and humid candidates.",
             supports_story=["shallow_cumulus_candidate", "humid_rainy_candidate"],
+            caveats=_feature_caveats(features, "mean_qv_0_1000m_g_kg"),
+        ),
+        EvidenceItem(
+            label="Surface T-Td spread",
+            value=features.get("surface_t_td_spread_c"),
+            units="C",
+            interpretation=(
+                "Larger temperature-dewpoint spread raises LCL and supports dry-failed hypotheses."
+            ),
+            supports_story=["dry_failed_candidate"],
+            caveats=_feature_caveats(features, "surface_t_td_spread_c"),
         ),
         EvidenceItem(
             label="Estimated LCL",
             value=features.get("estimated_lcl_height_m_agl"),
             units="m AGL",
             interpretation="Lower LCL makes shallow cloud formation more plausible.",
-            supports_story=["shallow_cumulus_candidate", "humid_rainy_candidate"],
+            supports_story=[
+                "shallow_cumulus_candidate",
+                "dry_failed_candidate",
+                "humid_rainy_candidate",
+            ],
+            caveats=_feature_caveats(features, "estimated_lcl_height_m_agl"),
         ),
         EvidenceItem(
             label="Low-level lapse rate",
             value=features.get("lapse_rate_0_1000m_c_per_km"),
             units="C/km",
             interpretation="Steeper low-level lapse rate suggests thermals may develop.",
-            supports_story=["shallow_cumulus_candidate", "dry_failed_candidate"],
+            supports_story=[
+                "shallow_cumulus_candidate",
+                "dry_failed_candidate",
+                "capped_suppressed_candidate",
+            ],
+            caveats=_feature_caveats(features, "lapse_rate_0_1000m_c_per_km"),
+        ),
+        EvidenceItem(
+            label="Lapse rate 0-3 km",
+            value=features.get("lapse_rate_0_3000m_c_per_km"),
+            units="C/km",
+            interpretation=(
+                "Lower-atmosphere stability gives context for thermal growth and cap effects."
+            ),
+            supports_story=["capped_suppressed_candidate", "needs_review"],
+            caveats=_feature_caveats(features, "lapse_rate_0_3000m_c_per_km"),
         ),
         EvidenceItem(
             label="Cap strength proxy",
@@ -548,6 +641,73 @@ def _score_features(
             units="C",
             interpretation="A stronger inversion proxy supports capped/suppressed hypotheses.",
             supports_story=["capped_suppressed_candidate"],
+            caveats=_feature_caveats(features, "cap_strength_proxy"),
+        ),
+        EvidenceItem(
+            label="Cap height proxy",
+            value=features.get("cap_height_m_agl"),
+            units="m AGL",
+            interpretation=(
+                "Cap height helps judge whether inhibition sits in a useful lower-atmosphere range."
+            ),
+            supports_story=["capped_suppressed_candidate"],
+            caveats=_feature_caveats(features, "cap_height_m_agl"),
+        ),
+        EvidenceItem(
+            label="Moisture depth",
+            value=features.get("moisture_depth_m"),
+            units="m",
+            interpretation=(
+                "Deeper moisture supports humid/cloud-forming hypotheses; shallow moisture "
+                "supports dry-failed hypotheses."
+            ),
+            supports_story=[
+                "shallow_cumulus_candidate",
+                "dry_failed_candidate",
+                "humid_rainy_candidate",
+            ],
+            caveats=_feature_caveats(features, "moisture_depth_m"),
+        ),
+        EvidenceItem(
+            label="Midlevel dry-layer proxy",
+            value=features.get("midlevel_dry_layer_proxy"),
+            units="g/kg",
+            interpretation=(
+                "A stronger near-surface to midlevel moisture drop supports dry-failed hypotheses."
+            ),
+            supports_story=["dry_failed_candidate"],
+            caveats=_feature_caveats(features, "midlevel_dry_layer_proxy"),
+        ),
+        EvidenceItem(
+            label="Observed wind availability",
+            value=features.get("observed_wind_available"),
+            interpretation=(
+                "Observed winds are required for the current external-sounding package path."
+            ),
+            supports_story=["poor_or_incomplete_candidate", "needs_review"],
+            caveats=[]
+            if features.get("observed_wind_available") is True
+            else ["observed_wind_unavailable"],
+        ),
+        EvidenceItem(
+            label="Profile top",
+            value=features.get("profile_top_m_agl"),
+            units="m AGL",
+            interpretation=(
+                "Sufficient profile depth is required before a sounding is package-ready."
+            ),
+            supports_story=["poor_or_incomplete_candidate", "needs_review"],
+            caveats=_feature_caveats(features, "profile_top_m_agl"),
+        ),
+        EvidenceItem(
+            label="Lowest usable level",
+            value=features.get("lowest_level_m_agl"),
+            units="m AGL",
+            interpretation=(
+                "Profiles that begin too far above the station surface are blocked or caveated."
+            ),
+            supports_story=["poor_or_incomplete_candidate", "needs_review"],
+            caveats=_feature_caveats(features, "lowest_level_m_agl"),
         ),
         EvidenceItem(
             label="Profile completeness",
@@ -555,6 +715,17 @@ def _score_features(
             units="0-100",
             interpretation="Lower completeness weakens screening confidence.",
             supports_story=["poor_or_incomplete_candidate", "needs_review"],
+            caveats=_feature_caveats(features, "data_completeness_score"),
+        ),
+        EvidenceItem(
+            label="Package readiness",
+            value="ready" if package_ready else "blocked",
+            interpretation=(
+                "Package-ready candidates can enter the current observed-sounding package path; "
+                "blocked candidates need parser, metadata, or profile fixes first."
+            ),
+            supports_story=["poor_or_incomplete_candidate", "needs_review"],
+            caveats=[] if package_ready else ["package_generation_blocked"],
         ),
     ]
     return sorted(scores, key=lambda score: score.score_0_to_100, reverse=True), evidence
@@ -674,6 +845,19 @@ def _feature(features: dict[str, float | int | str | bool | None], name: str) ->
     if isinstance(value, bool) or value is None or isinstance(value, str):
         return 0.0
     return float(value)
+
+
+def _numeric_feature(
+    features: dict[str, float | int | str | bool | None], name: str
+) -> float | None:
+    value = features.get(name)
+    if isinstance(value, bool) or value is None or isinstance(value, str):
+        return None
+    return float(value)
+
+
+def _feature_caveats(features: dict[str, float | int | str | bool | None], name: str) -> list[str]:
+    return [] if _numeric_feature(features, name) is not None else [f"{name}_unavailable"]
 
 
 def _score_high(value: float | None, *, low: float, high: float) -> float:

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -155,83 +155,213 @@ def test_screen_cached_soundings_caveats_unreadable_files(tmp_path: Path) -> Non
 
 
 @pytest.mark.parametrize(
-    ("features", "expected_story"),
+    ("features", "package_ready", "expected_story"),
     [
         (
             {
                 "data_completeness_score": 95.0,
+                "low_level_qv_g_kg": 8.0,
+                "mean_qv_0_500m_g_kg": 8.0,
                 "mean_qv_0_1000m_g_kg": 8.0,
                 "surface_t_td_spread_c": 4.0,
                 "estimated_lcl_height_m_agl": 500.0,
                 "lapse_rate_0_1000m_c_per_km": 7.0,
+                "lapse_rate_0_3000m_c_per_km": 5.5,
                 "cap_strength_proxy": 0.5,
+                "cap_height_m_agl": 1100.0,
                 "moisture_depth_m": 1800.0,
                 "midlevel_dry_layer_proxy": 1.0,
+                "observed_wind_available": True,
+                "profile_top_m_agl": 18000.0,
+                "lowest_level_m_agl": 0.0,
             },
+            True,
             "shallow_cumulus_candidate",
         ),
         (
             {
                 "data_completeness_score": 95.0,
+                "low_level_qv_g_kg": 2.0,
+                "mean_qv_0_500m_g_kg": 2.0,
                 "mean_qv_0_1000m_g_kg": 2.0,
                 "surface_t_td_spread_c": 18.0,
                 "estimated_lcl_height_m_agl": 2300.0,
                 "lapse_rate_0_1000m_c_per_km": 7.5,
+                "lapse_rate_0_3000m_c_per_km": 6.0,
                 "cap_strength_proxy": 0.5,
+                "cap_height_m_agl": 1100.0,
                 "moisture_depth_m": 400.0,
                 "midlevel_dry_layer_proxy": 9.0,
+                "observed_wind_available": True,
+                "profile_top_m_agl": 18000.0,
+                "lowest_level_m_agl": 0.0,
             },
+            True,
             "dry_failed_candidate",
         ),
         (
             {
                 "data_completeness_score": 95.0,
+                "low_level_qv_g_kg": 8.0,
+                "mean_qv_0_500m_g_kg": 8.0,
                 "mean_qv_0_1000m_g_kg": 8.0,
                 "surface_t_td_spread_c": 4.0,
                 "estimated_lcl_height_m_agl": 500.0,
                 "lapse_rate_0_1000m_c_per_km": 7.0,
+                "lapse_rate_0_3000m_c_per_km": 3.0,
                 "cap_strength_proxy": 5.0,
+                "cap_height_m_agl": 1200.0,
                 "moisture_depth_m": 1300.0,
                 "midlevel_dry_layer_proxy": 2.0,
+                "observed_wind_available": True,
+                "profile_top_m_agl": 18000.0,
+                "lowest_level_m_agl": 0.0,
             },
+            True,
             "capped_suppressed_candidate",
         ),
         (
             {
                 "data_completeness_score": 95.0,
+                "low_level_qv_g_kg": 11.0,
+                "mean_qv_0_500m_g_kg": 11.0,
                 "mean_qv_0_1000m_g_kg": 11.0,
                 "surface_t_td_spread_c": 2.0,
                 "estimated_lcl_height_m_agl": 250.0,
                 "lapse_rate_0_1000m_c_per_km": 5.0,
+                "lapse_rate_0_3000m_c_per_km": 4.5,
                 "cap_strength_proxy": 0.0,
+                "cap_height_m_agl": None,
                 "moisture_depth_m": 3000.0,
                 "midlevel_dry_layer_proxy": 0.5,
+                "observed_wind_available": True,
+                "profile_top_m_agl": 18000.0,
+                "lowest_level_m_agl": 0.0,
             },
+            True,
             "humid_rainy_candidate",
         ),
         (
             {
                 "data_completeness_score": 15.0,
+                "low_level_qv_g_kg": 8.0,
+                "mean_qv_0_500m_g_kg": 8.0,
                 "mean_qv_0_1000m_g_kg": 8.0,
                 "surface_t_td_spread_c": 4.0,
                 "estimated_lcl_height_m_agl": 500.0,
                 "lapse_rate_0_1000m_c_per_km": 7.0,
+                "lapse_rate_0_3000m_c_per_km": 5.5,
                 "cap_strength_proxy": 0.5,
+                "cap_height_m_agl": 1100.0,
                 "moisture_depth_m": 1800.0,
                 "midlevel_dry_layer_proxy": 1.0,
+                "observed_wind_available": True,
+                "profile_top_m_agl": 18000.0,
+                "lowest_level_m_agl": 0.0,
             },
+            True,
+            "needs_review",
+        ),
+        (
+            {
+                "data_completeness_score": 15.0,
+                "mean_qv_0_1000m_g_kg": None,
+                "estimated_lcl_height_m_agl": None,
+                "lapse_rate_0_1000m_c_per_km": None,
+                "cap_strength_proxy": None,
+                "moisture_depth_m": None,
+                "midlevel_dry_layer_proxy": None,
+                "observed_wind_available": False,
+                "profile_top_m_agl": 800.0,
+                "lowest_level_m_agl": 700.0,
+            },
+            False,
             "poor_or_incomplete_candidate",
         ),
     ],
 )
 def test_story_scoring_selects_expected_hypothesis(
     features: dict[str, float | int | str | bool | None],
+    package_ready: bool,
     expected_story: str,
 ) -> None:
-    scores, evidence = _score_features(features, package_ready=True)
+    scores, evidence = _score_features(features, package_ready=package_ready)
 
     assert scores[0].story == expected_story
     assert evidence
+
+
+def test_story_scoring_missing_moisture_is_not_confident_dry() -> None:
+    scores, evidence = _score_features(
+        {
+            "data_completeness_score": 90.0,
+            "mean_qv_0_1000m_g_kg": None,
+            "estimated_lcl_height_m_agl": None,
+            "lapse_rate_0_1000m_c_per_km": 7.0,
+            "cap_strength_proxy": 0.5,
+            "moisture_depth_m": None,
+            "midlevel_dry_layer_proxy": None,
+        },
+        package_ready=True,
+    )
+
+    dry_score = next(score for score in scores if score.story == "dry_failed_candidate")
+    needs_review = next(score for score in scores if score.story == "needs_review")
+    assert dry_score.support == "unavailable"
+    assert dry_score.score_0_to_100 < needs_review.score_0_to_100
+    assert "missing_or_unavailable_feature:mean_qv_0_1000m_g_kg" in dry_score.caveats
+    assert any(item.label == "Mean qv 0-1 km" and item.caveats for item in evidence)
+
+
+def test_story_scores_and_evidence_are_traceable_to_soundings() -> None:
+    scores, evidence = _score_features(
+        {
+            "data_completeness_score": 95.0,
+            "low_level_qv_g_kg": 11.0,
+            "mean_qv_0_500m_g_kg": 11.0,
+            "mean_qv_0_1000m_g_kg": 11.0,
+            "surface_t_td_spread_c": 2.0,
+            "estimated_lcl_height_m_agl": 250.0,
+            "lapse_rate_0_1000m_c_per_km": 5.0,
+            "lapse_rate_0_3000m_c_per_km": 4.5,
+            "cap_strength_proxy": 0.0,
+            "cap_height_m_agl": None,
+            "moisture_depth_m": 3000.0,
+            "midlevel_dry_layer_proxy": 0.5,
+            "observed_wind_available": True,
+            "profile_top_m_agl": 18000.0,
+            "lowest_level_m_agl": 0.0,
+        },
+        package_ready=True,
+    )
+
+    assert {score.story for score in scores} == {
+        "shallow_cumulus_candidate",
+        "dry_failed_candidate",
+        "capped_suppressed_candidate",
+        "humid_rainy_candidate",
+        "needs_review",
+        "poor_or_incomplete_candidate",
+    }
+    assert all(score.reasons for score in scores)
+    assert {item.label for item in evidence} >= {
+        "Low-level qv",
+        "Mean qv 0-500 m",
+        "Mean qv 0-1 km",
+        "Surface T-Td spread",
+        "Estimated LCL",
+        "Low-level lapse rate",
+        "Lapse rate 0-3 km",
+        "Cap strength proxy",
+        "Cap height proxy",
+        "Moisture depth",
+        "Midlevel dry-layer proxy",
+        "Observed wind availability",
+        "Profile top",
+        "Lowest usable level",
+        "Profile completeness",
+        "Package readiness",
+    }
 
 
 def test_saved_candidates_round_trip_runtime_local(tmp_path: Path) -> None:

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -92,7 +92,9 @@ low-level lapse-rate, inversion/cap proxy, moisture depth, and profile
 coverage, and emits pre-run story-specific candidate matches. Stable story
 identifiers are `shallow_cumulus_candidate`, `dry_failed_candidate`,
 `capped_suppressed_candidate`, `humid_rainy_candidate`, `needs_review`, and
-`poor_or_incomplete_candidate`. Screening can target one story at a time because
+`poor_or_incomplete_candidate`; the auditable scoring contract lives in
+[contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
+Screening can target one story at a time because
 the useful sounding depends on the experiment question; a shallow-cumulus search
 and a humid/rainy search should not imply the same ranked list. Saved candidates
 are runtime-local cache state under `<runtime-home>/cache/sounding-candidates/`;

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -93,7 +93,9 @@ depends on the atmospheric question being tested. Match scores are transparent
 candidate-selection aids, not CM1 outcome predictions. Saved candidates live in
 the runtime cache and may be handed into package metadata as provenance for why
 a sounding was tried. The browser never parses remote directory listings, ZIP
-files, or station text files.
+files, or station text files. The current story identifiers, feature inputs,
+score support states, evidence requirements, and caveat rules are defined in
+[contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
 
 In Build, `Upload a Sounding` is the product-facing entry point for this
 candidate workflow. It should show a `Find interesting soundings` workbench

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -1,0 +1,216 @@
+# Sounding Candidate Screening Contract
+
+Status: v1 product/data contract
+
+Cloud Chamber sounding candidates are pre-run hypotheses for choosing an
+observed atmosphere to try in CM1. They are not forecasts, verification, or
+proof that a run will form cloud, rain, or suppression. CM1 output remains the
+source of truth.
+
+The browser does not parse IGRA station text, ZIP archives, or raw NetCDF.
+Candidate screening is backend-owned and uses cached IGRA station text plus
+runtime-local cache metadata.
+
+## Current Story Set
+
+The v1 candidate stories are:
+
+- `shallow_cumulus_candidate`
+- `dry_failed_candidate`
+- `capped_suppressed_candidate`
+- `humid_rainy_candidate`
+- `needs_review`
+- `poor_or_incomplete_candidate`
+
+Visible labels may be friendlier, but every visible story must be backed by
+`story_scores`, feature values, evidence items, caveats, and package readiness.
+
+## Feature Inputs
+
+The current backend scoring logic derives these features from the selected
+IGRA sounding after converting source height to model height above the station:
+
+- data completeness score
+- lowest usable model level
+- profile top
+- low-level qv
+- mean qv from 0-500 m
+- mean qv from 0-1000 m
+- surface or lowest-level temperature-dewpoint spread
+- estimated LCL
+- lapse rate from 0-1 km
+- lapse rate from 0-3 km
+- inversion/cap strength proxy
+- cap height proxy
+- moisture depth above a 6 g/kg qv threshold
+- low-level to midlevel qv drop / dry-layer proxy
+- observed wind availability
+- package readiness
+
+The v1 screen does not compute CAPE, CIN, LFC, EL, storm-relative helicity,
+map/GIS forcing, or radar/precipitation predictors. Those require separate
+research, diagnostics, and validation before becoming product-facing evidence.
+
+## Story Logic
+
+Scores are 0-100 candidate-selection aids. They are weighted heuristics, not
+probabilities. A score of `supported` means the available sounding-derived
+features support trying that story; it does not mean CM1 will produce that
+outcome.
+
+### Cloud-Forming Shallow Cumulus Candidate
+
+Uses:
+
+- moderate to high mean qv from 0-1 km
+- low to moderate estimated LCL
+- deeper low-level moisture
+- weak to moderate cap proxy
+- useful low-level lapse rate
+- profile completeness
+
+Evidence shown includes low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
+estimated LCL, low-level lapse rate, moisture depth, cap proxy, profile
+coverage, and package readiness.
+
+High support requires moisture, plausible LCL, thermal support, weak or
+moderate cap, and good data completeness. Missing moisture, LCL, lapse-rate,
+cap, or moisture-depth inputs caveat the score and push the candidate toward
+`needs_review`.
+
+### Dry Failed Cumulus Candidate
+
+Uses:
+
+- low mean qv from 0-1 km
+- high estimated LCL or large T-Td spread
+- shallow moisture depth
+- midlevel dry-layer proxy
+- useful low-level lapse rate
+- profile completeness
+
+Evidence shown includes qv, T-Td spread, estimated LCL, low-level lapse rate,
+moisture depth, dry-layer proxy, and package readiness.
+
+Missing moisture is not treated as dry air. Missing qv, LCL, moisture-depth,
+or dry-layer inputs produce caveats and weak or unavailable support rather than
+a confident dry-failed label.
+
+### Capped / Suppressed Candidate
+
+Uses:
+
+- available low-level moisture
+- plausible estimated LCL
+- strong inversion/cap proxy
+- cap height proxy
+- useful low-level lapse rate
+- profile completeness
+
+Evidence shown includes low-level moisture, estimated LCL, lapse rate, cap
+strength, cap height, profile coverage, and package readiness.
+
+This story supports the hypothesis that moisture and thermals may exist but a
+stable layer could limit depth. It does not prove that CM1 will suppress cloud
+growth.
+
+### Humid / Rainy Candidate
+
+Uses:
+
+- high low-level qv
+- low estimated LCL
+- deep moisture
+- weak cap proxy
+- profile completeness
+
+Evidence shown includes qv, LCL, moisture depth, weak-cap support, profile
+coverage, and package readiness.
+
+This story is deliberately caveated because current packages still use
+idealized local forcing. It should be read as “humid atmosphere worth trying,”
+not as a rain forecast.
+
+### Needs Review
+
+Uses:
+
+- weak data completeness
+- missing story-driving features
+- screening uncertainty
+- package-ready profiles whose evidence is not strong enough for a clear story
+
+`needs_review` can still be package-ready. It means the sounding may be worth
+manual inspection, not that it is unusable.
+
+### Poor Or Incomplete Candidate
+
+Uses:
+
+- blocked package generation
+- missing station elevation or unsafe height conversion
+- too few usable levels
+- profile top too low for the selected domain
+- lowest usable level too far above model bottom
+- nonmonotonic or nonfinite converted levels
+- missing required observed winds
+
+Poor/incomplete candidates are not package-ready in the current path. They may
+still be useful after parser, station metadata, or profile-quality improvements,
+but the UI must show why they are blocked.
+
+## Missing Data Rules
+
+Missing physical evidence is not interpreted as a physical condition. For
+example:
+
+- missing qv is not dry air;
+- missing LCL is not a high LCL;
+- missing cap proxy is not a weak cap;
+- missing wind is a package-readiness blocker for the current external-sounding
+  path.
+
+Missing features become score caveats and evidence caveats. Blocked parser or
+normalization states become `poor_or_incomplete_candidate`.
+
+## Package Readiness
+
+A package-ready candidate has a selected observed sounding payload that can
+enter the current external-sounding package path. Package readiness depends on
+the parser and normalization contract, including station elevation, model-z
+conversion, profile depth, required thermodynamic fields, and observed u/v wind
+components.
+
+Candidate screening metadata may be copied into `run_manifest.json`,
+`case_manifest.json`, and `dry_run_report.json` as provenance when a candidate
+is used to create a package.
+
+## UI Contract
+
+Candidate cards and details must keep this language:
+
+- Screening guidance only.
+- Candidate scores are pre-run hypotheses.
+- CM1 decides what actually happens.
+
+The UI may filter by a target story, but it must include secondary story
+matches when `story_scores` contain meaningful support for the selected story.
+It must not show a confident story label without evidence, caveats, and package
+readiness.
+
+## Testing Contract
+
+Automated tests use tiny synthetic IGRA-style fixtures or direct deterministic
+feature dictionaries. Tests must not fetch live NOAA/NCEI data, run CM1, parse
+station text in the browser, or commit cached station files.
+
+Tests should prove:
+
+- every current story can be produced deterministically;
+- every story has reasons and evidence;
+- missing features caveat or weaken support instead of producing confident
+  labels;
+- poor/incomplete candidates are blocked from package generation;
+- package-ready but weak profiles become `needs_review`;
+- candidate-screening provenance is copied into generated package metadata
+  when provided.

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -27,25 +27,55 @@ Visible labels may be friendlier, but every visible story must be backed by
 
 ## Feature Inputs
 
-The current backend scoring logic derives these features from the selected
-IGRA sounding after converting source height to model height above the station:
+The backend derives several feature groups from the selected IGRA sounding
+after converting source height to model height above the station. Not every
+derived or displayed field directly changes the story score.
+
+### Scoring Inputs
+
+The current story scores primarily use:
 
 - data completeness score
+- mean qv from 0-1000 m
+- estimated LCL
+- lapse rate from 0-1 km
+- inversion/cap strength proxy
+- moisture depth above a 6 g/kg qv threshold
+- low-level to midlevel qv drop / dry-layer proxy
+
+Missing scoring inputs weaken/caveat story support instead of being interpreted
+as meaningful physical zero values.
+
+### Evidence / Context Fields
+
+The candidate UI may also display these fields as evidence or context:
+
 - lowest usable model level
 - profile top
 - low-level qv
 - mean qv from 0-500 m
-- mean qv from 0-1000 m
 - surface or lowest-level temperature-dewpoint spread
-- estimated LCL
-- lapse rate from 0-1 km
 - lapse rate from 0-3 km
-- inversion/cap strength proxy
 - cap height proxy
-- moisture depth above a 6 g/kg qv threshold
-- low-level to midlevel qv drop / dry-layer proxy
 - observed wind availability
 - package readiness
+
+These fields help explain the sounding and package path. They do not directly
+drive story scores unless the implementation and tests are updated to say so.
+
+### Package-Readiness Fields
+
+Package readiness is determined by the observed-sounding parser and
+normalization path. It depends on station metadata and usable CM1-facing
+profile fields, including:
+
+- station elevation and model-z conversion
+- enough usable levels
+- profile top high enough for the selected domain
+- lowest usable level close enough to the model bottom
+- monotonic and finite converted levels
+- required thermodynamic fields
+- observed u/v wind components
 
 The v1 screen does not compute CAPE, CIN, LFC, EL, storm-relative helicity,
 map/GIS forcing, or radar/precipitation predictors. Those require separate
@@ -60,18 +90,23 @@ outcome.
 
 ### Cloud-Forming Shallow Cumulus Candidate
 
-Uses:
+Scoring primarily uses:
 
 - moderate to high mean qv from 0-1 km
 - low to moderate estimated LCL
-- deeper low-level moisture
+- deeper moisture depth
 - weak to moderate cap proxy
 - useful low-level lapse rate
 - profile completeness
 
-Evidence shown includes low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
-estimated LCL, low-level lapse rate, moisture depth, cap proxy, profile
-coverage, and package readiness.
+Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
+estimated LCL, low-level and 0-3 km lapse rates, moisture depth, cap
+strength/height context, profile coverage, wind availability, and package
+readiness.
+
+Package readiness depends on the observed-sounding parser and normalization
+path, including usable model-z conversion, profile depth, required
+thermodynamic fields, and observed u/v winds.
 
 High support requires moisture, plausible LCL, thermal support, weak or
 moderate cap, and good data completeness. Missing moisture, LCL, lapse-rate,
@@ -80,17 +115,22 @@ cap, or moisture-depth inputs caveat the score and push the candidate toward
 
 ### Dry Failed Cumulus Candidate
 
-Uses:
+Scoring primarily uses:
 
 - low mean qv from 0-1 km
-- high estimated LCL or large T-Td spread
+- high estimated LCL
 - shallow moisture depth
 - midlevel dry-layer proxy
 - useful low-level lapse rate
 - profile completeness
 
-Evidence shown includes qv, T-Td spread, estimated LCL, low-level lapse rate,
-moisture depth, dry-layer proxy, and package readiness.
+Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
+estimated LCL, low-level and 0-3 km lapse rates, moisture depth, dry-layer
+proxy, profile coverage, wind availability, and package readiness.
+
+Package readiness depends on the observed-sounding parser and normalization
+path, including usable model-z conversion, profile depth, required
+thermodynamic fields, and observed u/v winds.
 
 Missing moisture is not treated as dry air. Missing qv, LCL, moisture-depth,
 or dry-layer inputs produce caveats and weak or unavailable support rather than
@@ -98,17 +138,21 @@ a confident dry-failed label.
 
 ### Capped / Suppressed Candidate
 
-Uses:
+Scoring primarily uses:
 
-- available low-level moisture
+- mean qv from 0-1 km
 - plausible estimated LCL
 - strong inversion/cap proxy
-- cap height proxy
 - useful low-level lapse rate
 - profile completeness
 
-Evidence shown includes low-level moisture, estimated LCL, lapse rate, cap
-strength, cap height, profile coverage, and package readiness.
+Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
+estimated LCL, low-level and 0-3 km lapse rates, cap strength, cap height,
+moisture depth, profile coverage, wind availability, and package readiness.
+
+Package readiness depends on the observed-sounding parser and normalization
+path, including usable model-z conversion, profile depth, required
+thermodynamic fields, and observed u/v winds.
 
 This story supports the hypothesis that moisture and thermals may exist but a
 stable layer could limit depth. It does not prove that CM1 will suppress cloud
@@ -116,16 +160,21 @@ growth.
 
 ### Humid / Rainy Candidate
 
-Uses:
+Scoring primarily uses:
 
-- high low-level qv
+- high mean qv from 0-1 km
 - low estimated LCL
 - deep moisture
 - weak cap proxy
 - profile completeness
 
-Evidence shown includes qv, LCL, moisture depth, weak-cap support, profile
-coverage, and package readiness.
+Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread, LCL,
+low-level and 0-3 km lapse rates, moisture depth, weak-cap support, profile
+coverage, wind availability, and package readiness.
+
+Package readiness depends on the observed-sounding parser and normalization
+path, including usable model-z conversion, profile depth, required
+thermodynamic fields, and observed u/v winds.
 
 This story is deliberately caveated because current packages still use
 idealized local forcing. It should be read as “humid atmosphere worth trying,”
@@ -133,27 +182,36 @@ not as a rain forecast.
 
 ### Needs Review
 
-Uses:
+Scoring primarily uses:
 
 - weak data completeness
 - missing story-driving features
 - screening uncertainty
 - package-ready profiles whose evidence is not strong enough for a clear story
 
+Evidence also shows whatever profile, moisture, stability, wind, and
+package-readiness context is available.
+
 `needs_review` can still be package-ready. It means the sounding may be worth
 manual inspection, not that it is unusable.
 
 ### Poor Or Incomplete Candidate
 
-Uses:
+Scoring primarily uses:
 
 - blocked package generation
+
+Package readiness depends on:
+
 - missing station elevation or unsafe height conversion
 - too few usable levels
 - profile top too low for the selected domain
 - lowest usable level too far above model bottom
 - nonmonotonic or nonfinite converted levels
 - missing required observed winds
+
+Evidence also shows any available profile, moisture, stability, wind, and
+package-readiness context so the UI can explain why the candidate is blocked.
 
 Poor/incomplete candidates are not package-ready in the current path. They may
 still be useful after parser, station metadata, or profile-quality improvements,

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -46,6 +46,7 @@ Use these docs as the current strategic and contract sources:
 - [Output And Visualization Architecture Research](research/output-and-visualization-architecture.md)
 - [Realistic LES Input Specification](contracts/realistic-les-input-specification.md)
 - [Output Product Specification](contracts/output-product-specification.md)
+- [Sounding Candidate Screening Contract](contracts/sounding-candidate-screening.md)
 
 The research memos are PM input and evidence. The contract docs define the
 implementation boundary that future issues should build from.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -73,10 +73,14 @@ runtime cache directories only. They should verify that screening inputs come
 from cached station text, candidate match scores are deterministic for the
 stable story identifiers, story-specific screening can target one experiment
 question at a time, poor/incomplete inputs are caveated instead of silently
-treated as package-ready, saved candidates round-trip through runtime-local JSON,
-and candidate-screening metadata is copied into generated package manifests
-when provided. These tests validate pre-run hypothesis plumbing only; they must
-not claim a scored candidate will produce a specific CM1 outcome.
+treated as package-ready, missing moisture/LCL/cap inputs weaken or caveat
+support instead of becoming confident physical evidence, saved candidates
+round-trip through runtime-local JSON, and candidate-screening metadata is
+copied into generated package manifests when provided. These tests validate
+pre-run hypothesis plumbing only; they must not claim a scored candidate will
+produce a specific CM1 outcome. The expected feature inputs, story thresholds,
+evidence items, caveat behavior, and package-readiness boundary are documented
+in [contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
 
 Frontend tests for the `Upload a Sounding` Build workflow should cover the same
 boundary. Component tests and mocked Playwright smoke tests should verify that


### PR DESCRIPTION
## Issue worked

- Closes #255 when accepted/merged.

## Summary

- Tightened sounding-candidate story scoring so missing numeric story features become caveats and `needs_review`, rather than being interpreted as physical zero values.
- Added observed-wind availability to candidate features/evidence because the current external-sounding package path requires observed wind components.
- Expanded backend evidence items so candidate labels are traceable to sounding-derived features including low-level qv, LCL, lapse rates, cap proxy/height, moisture depth, dry-layer proxy, profile coverage, wind availability, and package readiness.
- Added `docs/contracts/sounding-candidate-screening.md` as the current scoring/evidence contract and linked it from product, architecture, roadmap, and testing docs.

## Trust/science behavior

- Candidate labels remain pre-run hypotheses only.
- Missing qv is not treated as dry air.
- Package-ready but weak evidence becomes `needs_review`.
- Blocked package generation maps to `poor_or_incomplete_candidate`.
- CM1 output remains the source of truth.

## Tests added/updated

- Updated deterministic story-scoring fixtures for all current story identifiers.
- Added regression coverage proving missing moisture does not produce a confident dry-failed label.
- Added coverage that story scores include reasons and evidence spans the expected feature set.

## Commands run

- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_sounding_candidates.py -q`
- `app/backend/.venv/bin/python -m ruff format --check app/backend/cloud_chamber/sounding_candidates.py app/backend/tests/test_sounding_candidates.py`
- `app/backend/.venv/bin/python -m ruff check app/backend/cloud_chamber/sounding_candidates.py app/backend/tests/test_sounding_candidates.py`
- `app/backend/.venv/bin/python -m mypy app/backend/cloud_chamber/sounding_candidates.py app/backend/tests/test_sounding_candidates.py`
- `scripts/check.sh`

## E2E

- Not run. This PR changes backend scoring/evidence payloads and docs; it does not change frontend candidate workflow behavior.

## Generated-artifact check

- No generated IGRA files, CM1 outputs, NetCDF files, runtime folders, logs, screenshots, videos, traces, or large artifacts are committed.

## Merge posture

- Do not merge until Tim reviews.
