### PR TITLE
Add severe and deep-convection sounding candidate scoring

### DIFF
--- a/app/backend/cloud_chamber/igra_recent_cli.py
+++ b/app/backend/cloud_chamber/igra_recent_cli.py
@@ -37,6 +37,12 @@ STORY_OPTION_TO_ID: dict[str, TargetStoryId] = {
     "dry-failed": "dry_failed_candidate",
     "capped-suppressed": "capped_suppressed_candidate",
     "humid-rainy": "humid_rainy_candidate",
+    "severe-thunderstorm": "severe_thunderstorm_environment",
+    "supercell": "supercell_environment",
+    "elevated-convection": "elevated_convection",
+    "dry-microburst": "dry_microburst_inverted_v",
+    "high-cape-pulse-storm": "high_cape_pulse_storm",
+    "squall-line-cold-pool": "squall_line_cold_pool_candidate",
     "needs-review": "needs_review",
     "poor-or-incomplete": "poor_or_incomplete_candidate",
 }

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -25,6 +25,7 @@ from cloud_chamber.observed_sounding import (
     summarize_igra_station_text,
 )
 from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.sounding_diagnostics import compute_sounding_diagnostics
 
 SCREENING_VERSION = "sounding-screening-v1"
 
@@ -33,6 +34,12 @@ StoryId = Literal[
     "dry_failed_candidate",
     "capped_suppressed_candidate",
     "humid_rainy_candidate",
+    "severe_thunderstorm_environment",
+    "supercell_environment",
+    "elevated_convection",
+    "dry_microburst_inverted_v",
+    "high_cape_pulse_storm",
+    "squall_line_cold_pool_candidate",
     "needs_review",
     "poor_or_incomplete_candidate",
 ]
@@ -41,19 +48,172 @@ TargetStoryId = Literal[
     "dry_failed_candidate",
     "capped_suppressed_candidate",
     "humid_rainy_candidate",
+    "severe_thunderstorm_environment",
+    "supercell_environment",
+    "elevated_convection",
+    "dry_microburst_inverted_v",
+    "high_cape_pulse_storm",
+    "squall_line_cold_pool_candidate",
     "needs_review",
     "poor_or_incomplete_candidate",
 ]
 Confidence = Literal["low", "medium", "high"]
 Support = Literal["supported", "weak", "unavailable"]
+StoryFamily = Literal["current_les", "deep_convection", "winter_future", "review"]
+ReadinessState = Literal[
+    "package_ready_now",
+    "runnable_caveated",
+    "future_package_needed",
+    "blocked_or_review",
+]
+CurrentPackageReadiness = Literal["yes", "caveated", "no"]
 
 STORY_LABELS: dict[StoryId, str] = {
     "shallow_cumulus_candidate": "Cloud-forming shallow cumulus candidate",
     "dry_failed_candidate": "Dry failed cumulus candidate",
     "capped_suppressed_candidate": "Capped / suppressed cumulus candidate",
     "humid_rainy_candidate": "Humid / rainy candidate",
+    "severe_thunderstorm_environment": "Severe thunderstorm environment",
+    "supercell_environment": "Supercell environment",
+    "elevated_convection": "Elevated convection environment",
+    "dry_microburst_inverted_v": "Dry microburst inverted-V environment",
+    "high_cape_pulse_storm": "High-CAPE pulse-storm environment",
+    "squall_line_cold_pool_candidate": "Squall-line / cold-pool candidate",
     "needs_review": "Needs review",
     "poor_or_incomplete_candidate": "Poor or incomplete data",
+}
+
+
+class StoryReadiness(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    story_family: StoryFamily
+    readiness_state: ReadinessState
+    package_readiness_label: str
+    screenable_from_sounding_now: bool = True
+    runnable_with_current_observed_sounding_package: CurrentPackageReadiness
+    specialized_package_recommended: bool = False
+    future_package_required: bool = False
+    package_readiness_caveats: list[str] = Field(default_factory=list)
+
+
+STORY_READINESS: dict[StoryId, StoryReadiness] = {
+    "shallow_cumulus_candidate": StoryReadiness(
+        story_family="current_les",
+        readiness_state="package_ready_now",
+        package_readiness_label="Current observed-sounding LES package",
+        runnable_with_current_observed_sounding_package="yes",
+    ),
+    "dry_failed_candidate": StoryReadiness(
+        story_family="current_les",
+        readiness_state="package_ready_now",
+        package_readiness_label="Current observed-sounding LES package",
+        runnable_with_current_observed_sounding_package="yes",
+    ),
+    "capped_suppressed_candidate": StoryReadiness(
+        story_family="current_les",
+        readiness_state="runnable_caveated",
+        package_readiness_label="Caveated current LES package",
+        runnable_with_current_observed_sounding_package="caveated",
+        specialized_package_recommended=True,
+        package_readiness_caveats=[
+            "Current package can explore the profile, but cap/stability validation "
+            "remains caveated."
+        ],
+    ),
+    "humid_rainy_candidate": StoryReadiness(
+        story_family="current_les",
+        readiness_state="runnable_caveated",
+        package_readiness_label="Caveated current LES package",
+        runnable_with_current_observed_sounding_package="caveated",
+        specialized_package_recommended=True,
+        package_readiness_caveats=[
+            "Current package can explore moist profiles, but rain production remains a CM1 outcome."
+        ],
+    ),
+    "severe_thunderstorm_environment": StoryReadiness(
+        story_family="deep_convection",
+        readiness_state="runnable_caveated",
+        package_readiness_label="Caveated profile exploration",
+        runnable_with_current_observed_sounding_package="caveated",
+        specialized_package_recommended=True,
+        package_readiness_caveats=[
+            "This is an environment screen, not a storm forecast.",
+            "A specialized deep-convection package is recommended before interpreting outcomes.",
+        ],
+    ),
+    "supercell_environment": StoryReadiness(
+        story_family="deep_convection",
+        readiness_state="future_package_needed",
+        package_readiness_label="Future deep-convection package required",
+        runnable_with_current_observed_sounding_package="no",
+        specialized_package_recommended=True,
+        future_package_required=True,
+        package_readiness_caveats=[
+            "Supercell exploration needs storm-mode controls and diagnostics not in "
+            "the current package."
+        ],
+    ),
+    "elevated_convection": StoryReadiness(
+        story_family="deep_convection",
+        readiness_state="future_package_needed",
+        package_readiness_label="Future elevated-convection package required",
+        runnable_with_current_observed_sounding_package="no",
+        specialized_package_recommended=True,
+        future_package_required=True,
+        package_readiness_caveats=[
+            "Elevated convection needs forcing and parcel diagnostics not in the current package."
+        ],
+    ),
+    "dry_microburst_inverted_v": StoryReadiness(
+        story_family="deep_convection",
+        readiness_state="runnable_caveated",
+        package_readiness_label="Caveated profile exploration",
+        runnable_with_current_observed_sounding_package="caveated",
+        specialized_package_recommended=True,
+        package_readiness_caveats=[
+            "Current package can inspect the profile, but it is not a validated microburst package."
+        ],
+    ),
+    "high_cape_pulse_storm": StoryReadiness(
+        story_family="deep_convection",
+        readiness_state="runnable_caveated",
+        package_readiness_label="Caveated profile exploration",
+        runnable_with_current_observed_sounding_package="caveated",
+        specialized_package_recommended=True,
+        package_readiness_caveats=[
+            "Current package can inspect the profile, but it cannot confirm "
+            "CAPE-driven pulse storms."
+        ],
+    ),
+    "squall_line_cold_pool_candidate": StoryReadiness(
+        story_family="deep_convection",
+        readiness_state="future_package_needed",
+        package_readiness_label="Future cold-pool package required",
+        runnable_with_current_observed_sounding_package="no",
+        specialized_package_recommended=True,
+        future_package_required=True,
+        package_readiness_caveats=[
+            "Squall-line and cold-pool exploration needs a specialized package and diagnostics."
+        ],
+    ),
+    "needs_review": StoryReadiness(
+        story_family="review",
+        readiness_state="blocked_or_review",
+        package_readiness_label="Review before package generation",
+        runnable_with_current_observed_sounding_package="caveated",
+        package_readiness_caveats=["Review the profile and caveats before package generation."],
+    ),
+    "poor_or_incomplete_candidate": StoryReadiness(
+        story_family="review",
+        readiness_state="blocked_or_review",
+        package_readiness_label="Blocked until data improves",
+        screenable_from_sounding_now=False,
+        runnable_with_current_observed_sounding_package="no",
+        package_readiness_caveats=[
+            "Package generation is blocked until parser/profile issues are fixed."
+        ],
+    ),
 }
 
 
@@ -64,6 +224,17 @@ class StoryScore(BaseModel):
     label: str
     score_0_to_100: float
     support: Support
+    story_family: StoryFamily = "current_les"
+    readiness_state: ReadinessState = "package_ready_now"
+    package_readiness_label: str = "Current observed-sounding LES package"
+    screenable_from_sounding_now: bool = True
+    runnable_with_current_observed_sounding_package: CurrentPackageReadiness = "yes"
+    specialized_package_recommended: bool = False
+    future_package_required: bool = False
+    package_readiness_caveats: list[str] = Field(default_factory=list)
+    required_diagnostics_used: list[str] = Field(default_factory=list)
+    unavailable_diagnostics: list[str] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
     reasons: list[str] = Field(default_factory=list)
     caveats: list[str] = Field(default_factory=list)
 
@@ -96,6 +267,14 @@ class SoundingCandidate(BaseModel):
     source_provider: str = "NOAA/NCEI IGRA"
     primary_story: StoryId
     primary_story_label: str
+    story_family: StoryFamily = "current_les"
+    readiness_state: ReadinessState = "package_ready_now"
+    package_readiness_label: str = "Current observed-sounding LES package"
+    specialized_package_recommended: bool = False
+    future_package_required: bool = False
+    required_diagnostics_used: list[str] = Field(default_factory=list)
+    unavailable_diagnostics: list[str] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
     story_scores: list[StoryScore]
     rank_score: float
     confidence: Confidence
@@ -138,6 +317,14 @@ class SavedSoundingCandidate(BaseModel):
     selected_sounding_payload: dict[str, Any] | None
     screening_version: str = SCREENING_VERSION
     primary_story: StoryId
+    story_family: StoryFamily = "current_les"
+    readiness_state: ReadinessState = "package_ready_now"
+    package_readiness_label: str = "Current observed-sounding LES package"
+    specialized_package_recommended: bool = False
+    future_package_required: bool = False
+    required_diagnostics_used: list[str] = Field(default_factory=list)
+    unavailable_diagnostics: list[str] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
     story_scores: list[StoryScore]
     features: dict[str, float | int | str | bool | None]
     evidence: list[EvidenceItem]
@@ -268,6 +455,14 @@ def save_candidate(
         candidate=request.candidate,
         selected_sounding_payload=request.candidate.selected_sounding_payload,
         primary_story=request.candidate.primary_story,
+        story_family=request.candidate.story_family,
+        readiness_state=request.candidate.readiness_state,
+        package_readiness_label=request.candidate.package_readiness_label,
+        specialized_package_recommended=request.candidate.specialized_package_recommended,
+        future_package_required=request.candidate.future_package_required,
+        required_diagnostics_used=request.candidate.required_diagnostics_used,
+        unavailable_diagnostics=request.candidate.unavailable_diagnostics,
+        assumptions=request.candidate.assumptions,
         story_scores=request.candidate.story_scores,
         features=request.candidate.features,
         evidence=request.candidate.evidence,
@@ -364,6 +559,14 @@ def _candidate_from_cached_sounding(
         source_file_hash=source_hash,
         primary_story=primary.story,
         primary_story_label=primary.label,
+        story_family=primary.story_family,
+        readiness_state=primary.readiness_state,
+        package_readiness_label=primary.package_readiness_label,
+        specialized_package_recommended=primary.specialized_package_recommended,
+        future_package_required=primary.future_package_required,
+        required_diagnostics_used=primary.required_diagnostics_used,
+        unavailable_diagnostics=primary.unavailable_diagnostics,
+        assumptions=primary.assumptions,
         story_scores=story_scores,
         rank_score=rank_score,
         confidence=_confidence(rank_score, package_ready, features),
@@ -379,86 +582,40 @@ def _candidate_from_cached_sounding(
 def _features_from_record(
     record: ObservedSoundingRecord,
 ) -> dict[str, float | int | str | bool | None]:
-    levels = record.levels
-    surface = levels[0]
-    lowest = surface.model_z_m
-    top = levels[-1].model_z_m
-    surface_dewpoint = _dewpoint_c_from_qv(surface.pressure_pa, surface.qv_g_kg)
-    ttd = surface.temperature_c - surface_dewpoint if surface_dewpoint is not None else None
-    lcl = 125.0 * ttd if ttd is not None else None
-    qv_0_500 = _mean_qv(levels, 0.0, 500.0)
-    qv_0_1000 = _mean_qv(levels, 0.0, 1000.0)
-    qv_0_3000 = _mean_qv(levels, 0.0, 3000.0)
-    qv_near_surface = _mean_qv(levels, 0.0, 100.0) or surface.qv_g_kg
-    lapse_0_1000 = _lapse_rate(levels, 0.0, 1000.0)
-    lapse_0_3000 = _lapse_rate(levels, 0.0, 3000.0)
-    inversion_strength, inversion_base, inversion_top = _inversion_proxy(levels)
-    moisture_depth = _moisture_depth(levels, min_qv_g_kg=6.0)
-    usable_below_3km = sum(1 for level in levels if 0.0 <= level.model_z_m <= 3000.0)
-    observed_wind_available = all(
-        level.u_wind_m_s is not None and level.v_wind_m_s is not None for level in levels
-    )
-    completeness = min(
-        100.0,
-        25.0
-        + min(25.0, usable_below_3km * 2.5)
-        + (25.0 if top >= 18000.0 else max(0.0, top / 18000.0 * 25.0))
-        + (25.0 if lowest <= 50.0 else max(0.0, 25.0 - lowest / 20.0)),
-    )
-    qv_drop = (
-        round(qv_near_surface - qv_0_3000, 3)
-        if qv_0_3000 is not None and qv_near_surface is not None
-        else None
-    )
-    midlevel_qv = _mean_qv(levels, 2000.0, 5000.0)
-    midlevel_dry_layer = (
-        round(max(0.0, qv_near_surface - midlevel_qv), 3)
-        if midlevel_qv is not None and qv_near_surface is not None
-        else None
-    )
-    return {
-        "data_completeness_score": round(completeness, 1),
-        "surface_or_lowest_pressure_hpa": round(surface.pressure_pa / 100.0, 1),
-        "surface_or_lowest_temperature_c": round(surface.temperature_c, 2),
-        "surface_or_lowest_dewpoint_c": (
-            round(surface_dewpoint, 2) if surface_dewpoint is not None else None
-        ),
-        "surface_t_td_spread_c": round(ttd, 2) if ttd is not None else None,
-        "estimated_lcl_height_m_agl": round(lcl, 1) if lcl is not None else None,
-        "low_level_qv_g_kg": round(qv_near_surface, 3),
-        "mean_qv_0_500m_g_kg": round(qv_0_500, 3) if qv_0_500 is not None else None,
-        "mean_qv_0_1000m_g_kg": round(qv_0_1000, 3) if qv_0_1000 is not None else None,
-        "moisture_depth_m": round(moisture_depth, 1) if moisture_depth is not None else None,
-        "qv_drop_0_3000m_g_kg": qv_drop,
-        "lapse_rate_0_1000m_c_per_km": (
-            round(lapse_0_1000, 2) if lapse_0_1000 is not None else None
-        ),
-        "lapse_rate_0_3000m_c_per_km": (
-            round(lapse_0_3000, 2) if lapse_0_3000 is not None else None
-        ),
-        "inversion_strength_c": round(inversion_strength, 2),
-        "inversion_base_m_agl": round(inversion_base, 1) if inversion_base is not None else None,
-        "inversion_top_m_agl": round(inversion_top, 1) if inversion_top is not None else None,
-        "cap_strength_proxy": round(inversion_strength, 2),
-        "cap_height_m_agl": round(inversion_base, 1) if inversion_base is not None else None,
-        "midlevel_dry_layer_proxy": midlevel_dry_layer,
-        "profile_top_m_agl": round(top, 1),
-        "lowest_level_m_agl": round(lowest, 1),
-        "usable_levels_below_3km": usable_below_3km,
-        "observed_wind_available": observed_wind_available,
+    diagnostics = compute_sounding_diagnostics(record)
+    features: dict[str, float | int | str | bool | None] = {
+        key: feature.value for key, feature in diagnostics.feature_values.items()
     }
+    features["observed_wind_available"] = bool(
+        features.get("has_observed_wind_profile") or features.get("wind_available")
+    )
+    features["sounding_diagnostic_version"] = diagnostics.diagnostic_version
+    return features
 
 
 def _score_features(
     features: dict[str, float | int | str | bool | None], *, package_ready: bool
 ) -> tuple[list[StoryScore], list[EvidenceItem]]:
     qv = _numeric_feature(features, "mean_qv_0_1000m_g_kg")
+    qv_3km = _numeric_feature(features, "mean_qv_0_3000m_g_kg")
     lcl = _numeric_feature(features, "estimated_lcl_height_m_agl")
     lapse = _numeric_feature(features, "lapse_rate_0_1000m_c_per_km")
+    lapse_3km = _numeric_feature(features, "lapse_rate_0_3000m_c_per_km")
+    midlevel_lapse = _numeric_feature(features, "midlevel_lapse_rate_700_500_hpa_c_per_km")
     cap = _numeric_feature(features, "cap_strength_proxy")
+    cap_height = _numeric_feature(features, "cap_height_m_agl")
+    inversion_strength = _numeric_feature(features, "inversion_strength_c")
     moisture_depth = _numeric_feature(features, "moisture_depth_m")
     completeness = _numeric_feature(features, "data_completeness_score")
     midlevel_dry = _numeric_feature(features, "midlevel_dry_layer_proxy")
+    surface_ttd = _numeric_feature(features, "surface_t_td_spread_c")
+    qv_drop = _numeric_feature(features, "qv_drop_0_3000m_g_kg")
+    dry_microburst_proxy = _numeric_feature(features, "dry_microburst_inverted_v_proxy")
+    shear_0_1 = _numeric_feature(features, "bulk_shear_0_1km_m_s")
+    shear_0_3 = _numeric_feature(features, "bulk_shear_0_3km_m_s")
+    shear_0_6 = _numeric_feature(features, "bulk_shear_0_6km_m_s")
+    freezing_level = _numeric_feature(features, "freezing_level_m_agl")
+    wind_available = features.get("observed_wind_available") is True
     story_feature_names = [
         "mean_qv_0_1000m_g_kg",
         "estimated_lcl_height_m_agl",
@@ -483,6 +640,20 @@ def _score_features(
     shallow_moisture = _score_low(moisture_depth, low=500.0, high=1800.0)
     data_quality = _score_high(completeness, low=40.0, high=90.0)
     dry_layer = _score_high(midlevel_dry, low=2.0, high=8.0)
+    deep_layer_moisture = _score_high(qv_3km, low=4.0, high=10.0)
+    steep_lower_troposphere = _score_high(lapse_3km, low=5.0, high=8.0)
+    steep_midlevel = _score_high(midlevel_lapse, low=5.5, high=8.5)
+    strong_deep_shear = _score_high(shear_0_6, low=12.0, high=30.0)
+    strong_low_shear = _score_high(shear_0_1, low=5.0, high=15.0)
+    strong_three_km_shear = _score_high(shear_0_3, low=10.0, high=25.0)
+    moderate_cap = _score_peak(cap, low=0.5, peak=2.0, high=5.0)
+    elevated_cap = _score_high(inversion_strength, low=2.0, high=7.0)
+    elevated_cap_height = _score_peak(cap_height, low=700.0, peak=1500.0, high=3000.0)
+    dry_surface = _score_high(surface_ttd, low=10.0, high=25.0)
+    strong_qv_drop = _score_high(qv_drop, low=2.0, high=8.0)
+    dry_microburst = _score_high(dry_microburst_proxy, low=35.0, high=85.0)
+    pulse_storm_shear = _score_low(shear_0_6, low=8.0, high=22.0)
+    warm_cloud_layer = _score_high(freezing_level, low=2500.0, high=4500.0)
     feature_coverage = (
         (len(story_feature_names) - len(missing_story_features)) / len(story_feature_names)
         if story_feature_names
@@ -505,6 +676,77 @@ def _score_features(
     humid_rainy = _weighted_score(
         [(moist, 0.32), (low_lcl, 0.22), (deep_moisture, 0.26), (weak_cap, 0.20)]
     )
+    severe = _weighted_score(
+        [
+            (moist, 0.16),
+            (low_lcl, 0.12),
+            (deep_layer_moisture, 0.12),
+            (steep_lower_troposphere, 0.18),
+            (steep_midlevel, 0.12),
+            (strong_deep_shear, 0.18),
+            (moderate_cap, 0.06),
+            (data_quality, 0.06),
+        ]
+    )
+    supercell = _weighted_score(
+        [
+            (moist, 0.12),
+            (low_lcl, 0.10),
+            (steep_midlevel, 0.14),
+            (strong_deep_shear, 0.26),
+            (strong_three_km_shear, 0.16),
+            (strong_low_shear, 0.12),
+            (moderate_cap, 0.05),
+            (data_quality, 0.05),
+        ]
+    )
+    elevated = _weighted_score(
+        [
+            (elevated_cap, 0.28),
+            (elevated_cap_height, 0.22),
+            (deep_layer_moisture, 0.18),
+            (steep_midlevel, 0.17),
+            (strong_three_km_shear, 0.10),
+            (data_quality, 0.05),
+        ]
+    )
+    dry_microburst_score = _weighted_score(
+        [
+            (dry_microburst, 0.30),
+            (dry_surface, 0.18),
+            (dry_layer, 0.18),
+            (strong_qv_drop, 0.16),
+            (thermal, 0.12),
+            (data_quality, 0.06),
+        ]
+    )
+    pulse = _weighted_score(
+        [
+            (moist, 0.20),
+            (low_lcl, 0.16),
+            (deep_layer_moisture, 0.16),
+            (steep_lower_troposphere, 0.22),
+            (pulse_storm_shear, 0.14),
+            (weak_cap, 0.06),
+            (data_quality, 0.06),
+        ]
+    )
+    squall_line = _weighted_score(
+        [
+            (moist, 0.12),
+            (deep_layer_moisture, 0.10),
+            (steep_lower_troposphere, 0.14),
+            (strong_deep_shear, 0.20),
+            (strong_three_km_shear, 0.14),
+            (dry_layer, 0.10),
+            (warm_cloud_layer, 0.08),
+            (data_quality, 0.12),
+        ]
+    )
+    if not wind_available:
+        severe *= 0.72
+        supercell *= 0.55
+        squall_line *= 0.65
     poor = 100.0 if not package_ready else min(34.0, max(0.0, 100.0 - data_quality))
     if not package_ready:
         poor = 100.0
@@ -545,6 +787,171 @@ def _score_features(
             caveats=[
                 "Humid/rainy is heavily caveated because forcing remains idealized.",
                 *missing_caveats,
+            ],
+        ),
+        _story_score(
+            "severe_thunderstorm_environment",
+            severe,
+            reasons=[
+                "moisture, lapse-rate, cap, and deep-shear proxies resemble a "
+                "severe-thunderstorm environment"
+            ],
+            caveats=_deep_convection_caveats(
+                features,
+                [
+                    "mean_qv_0_1000m_g_kg",
+                    "estimated_lcl_height_m_agl",
+                    "lapse_rate_0_3000m_c_per_km",
+                    "bulk_shear_0_6km_m_s",
+                ],
+            ),
+            required_diagnostics=[
+                "mean_qv_0_1000m_g_kg",
+                "estimated_lcl_height_m_agl",
+                "lapse_rate_0_3000m_c_per_km",
+                "bulk_shear_0_6km_m_s",
+            ],
+            assumptions=[
+                "Severe screening uses sounding proxies because CAPE, CIN, LFC, "
+                "EL, and SRH are unavailable.",
+                "This is an environment screen, not a storm forecast.",
+            ],
+        ),
+        _story_score(
+            "supercell_environment",
+            supercell,
+            reasons=[
+                "strong deep-layer and low-level shear proxies with moisture/instability context"
+            ],
+            caveats=_deep_convection_caveats(
+                features,
+                [
+                    "mean_qv_0_1000m_g_kg",
+                    "estimated_lcl_height_m_agl",
+                    "midlevel_lapse_rate_700_500_hpa_c_per_km",
+                    "bulk_shear_0_1km_m_s",
+                    "bulk_shear_0_3km_m_s",
+                    "bulk_shear_0_6km_m_s",
+                ],
+                extra=["storm_relative_helicity_unavailable"],
+            ),
+            required_diagnostics=[
+                "mean_qv_0_1000m_g_kg",
+                "midlevel_lapse_rate_700_500_hpa_c_per_km",
+                "bulk_shear_0_1km_m_s",
+                "bulk_shear_0_3km_m_s",
+                "bulk_shear_0_6km_m_s",
+            ],
+            assumptions=[
+                "Supercell screening is caveated because SRH and storm-motion "
+                "diagnostics are unavailable.",
+                "Current package generation is not a validated supercell scenario.",
+            ],
+        ),
+        _story_score(
+            "elevated_convection",
+            elevated,
+            reasons=["inversion/cap, elevated moisture, midlevel lapse-rate, and shear proxies"],
+            caveats=_deep_convection_caveats(
+                features,
+                [
+                    "inversion_strength_c",
+                    "cap_height_m_agl",
+                    "mean_qv_0_3000m_g_kg",
+                    "midlevel_lapse_rate_700_500_hpa_c_per_km",
+                ],
+                extra=["elevated_parcel_diagnostics_unavailable"],
+            ),
+            required_diagnostics=[
+                "inversion_strength_c",
+                "cap_height_m_agl",
+                "mean_qv_0_3000m_g_kg",
+                "midlevel_lapse_rate_700_500_hpa_c_per_km",
+            ],
+            assumptions=[
+                "Elevated-convection screening uses crude cap/moisture proxies "
+                "without parcel diagnostics.",
+                "Current package generation is not a validated elevated-convection scenario.",
+            ],
+        ),
+        _story_score(
+            "dry_microburst_inverted_v",
+            dry_microburst_score,
+            reasons=["large low-level T-Td spread, dry-layer, qv-drop, and lapse-rate proxies"],
+            caveats=_deep_convection_caveats(
+                features,
+                [
+                    "dry_microburst_inverted_v_proxy",
+                    "surface_t_td_spread_c",
+                    "midlevel_dry_layer_proxy",
+                    "qv_drop_0_3000m_g_kg",
+                    "lapse_rate_0_1000m_c_per_km",
+                ],
+            ),
+            required_diagnostics=[
+                "dry_microburst_inverted_v_proxy",
+                "surface_t_td_spread_c",
+                "midlevel_dry_layer_proxy",
+                "qv_drop_0_3000m_g_kg",
+                "lapse_rate_0_1000m_c_per_km",
+            ],
+            assumptions=[
+                "Dry-microburst screening is a sounding-shape hypothesis, not a "
+                "microburst forecast.",
+                "Current package generation is not a validated microburst scenario.",
+            ],
+        ),
+        _story_score(
+            "high_cape_pulse_storm",
+            pulse,
+            reasons=["moist, low-LCL, steep-lapse, weak-shear proxies resemble pulse-storm setups"],
+            caveats=_deep_convection_caveats(
+                features,
+                [
+                    "mean_qv_0_1000m_g_kg",
+                    "estimated_lcl_height_m_agl",
+                    "lapse_rate_0_3000m_c_per_km",
+                    "bulk_shear_0_6km_m_s",
+                ],
+                extra=["cape_unavailable"],
+            ),
+            required_diagnostics=[
+                "mean_qv_0_1000m_g_kg",
+                "estimated_lcl_height_m_agl",
+                "lapse_rate_0_3000m_c_per_km",
+                "bulk_shear_0_6km_m_s",
+            ],
+            assumptions=[
+                "High-CAPE pulse-storm screening uses moisture and lapse-rate "
+                "proxies because CAPE is unavailable.",
+                "Current package generation is not a validated pulse-storm scenario.",
+            ],
+        ),
+        _story_score(
+            "squall_line_cold_pool_candidate",
+            squall_line,
+            reasons=["moisture, shear, lapse-rate, dry-layer, and freezing-level proxies"],
+            caveats=_deep_convection_caveats(
+                features,
+                [
+                    "mean_qv_0_1000m_g_kg",
+                    "lapse_rate_0_3000m_c_per_km",
+                    "bulk_shear_0_3km_m_s",
+                    "bulk_shear_0_6km_m_s",
+                    "freezing_level_m_agl",
+                ],
+                extra=["cold_pool_diagnostics_unavailable"],
+            ),
+            required_diagnostics=[
+                "mean_qv_0_1000m_g_kg",
+                "lapse_rate_0_3000m_c_per_km",
+                "bulk_shear_0_3km_m_s",
+                "bulk_shear_0_6km_m_s",
+                "freezing_level_m_agl",
+            ],
+            assumptions=[
+                "Squall-line screening cannot validate cold-pool behavior before a CM1 run.",
+                "Current package generation is not a validated squall-line or cold-pool scenario.",
             ],
         ),
         _story_score(
@@ -632,8 +1039,26 @@ def _score_features(
             interpretation=(
                 "Lower-atmosphere stability gives context for thermal growth and cap effects."
             ),
-            supports_story=["capped_suppressed_candidate", "needs_review"],
+            supports_story=[
+                "capped_suppressed_candidate",
+                "severe_thunderstorm_environment",
+                "high_cape_pulse_storm",
+                "squall_line_cold_pool_candidate",
+                "needs_review",
+            ],
             caveats=_feature_caveats(features, "lapse_rate_0_3000m_c_per_km"),
+        ),
+        EvidenceItem(
+            label="Midlevel lapse rate",
+            value=features.get("midlevel_lapse_rate_700_500_hpa_c_per_km"),
+            units="C/km",
+            interpretation="Midlevel lapse-rate context helps screen deep-convection environments.",
+            supports_story=[
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "elevated_convection",
+            ],
+            caveats=_feature_caveats(features, "midlevel_lapse_rate_700_500_hpa_c_per_km"),
         ),
         EvidenceItem(
             label="Cap strength proxy",
@@ -675,8 +1100,50 @@ def _score_features(
             interpretation=(
                 "A stronger near-surface to midlevel moisture drop supports dry-failed hypotheses."
             ),
-            supports_story=["dry_failed_candidate"],
+            supports_story=[
+                "dry_failed_candidate",
+                "dry_microburst_inverted_v",
+                "squall_line_cold_pool_candidate",
+            ],
             caveats=_feature_caveats(features, "midlevel_dry_layer_proxy"),
+        ),
+        EvidenceItem(
+            label="Bulk shear 0-6 km",
+            value=features.get("bulk_shear_0_6km_m_s"),
+            units="m/s",
+            interpretation="Deep-layer shear is pre-run evidence for organized-convection screens.",
+            supports_story=[
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "squall_line_cold_pool_candidate",
+            ],
+            caveats=_feature_caveats(features, "bulk_shear_0_6km_m_s"),
+        ),
+        EvidenceItem(
+            label="Bulk shear 0-3 km",
+            value=features.get("bulk_shear_0_3km_m_s"),
+            units="m/s",
+            interpretation="Lower-tropospheric shear adds context for organized-storm screens.",
+            supports_story=["supercell_environment", "squall_line_cold_pool_candidate"],
+            caveats=_feature_caveats(features, "bulk_shear_0_3km_m_s"),
+        ),
+        EvidenceItem(
+            label="Dry microburst proxy",
+            value=features.get("dry_microburst_inverted_v_proxy"),
+            units="0-100",
+            interpretation=(
+                "High values indicate an inverted-V-like dry subcloud profile hypothesis."
+            ),
+            supports_story=["dry_microburst_inverted_v"],
+            caveats=_feature_caveats(features, "dry_microburst_inverted_v_proxy"),
+        ),
+        EvidenceItem(
+            label="Freezing level",
+            value=features.get("freezing_level_m_agl"),
+            units="m AGL",
+            interpretation="Freezing-level context helps precipitation and cold-pool screens.",
+            supports_story=["severe_thunderstorm_environment", "squall_line_cold_pool_candidate"],
+            caveats=_feature_caveats(features, "freezing_level_m_agl"),
         ),
         EvidenceItem(
             label="Observed wind availability",
@@ -749,6 +1216,12 @@ def _poor_candidate_scores(reason: str) -> tuple[list[StoryScore], list[Evidence
         _story_score("dry_failed_candidate", 0.0),
         _story_score("capped_suppressed_candidate", 0.0),
         _story_score("humid_rainy_candidate", 0.0),
+        _story_score("severe_thunderstorm_environment", 0.0),
+        _story_score("supercell_environment", 0.0),
+        _story_score("elevated_convection", 0.0),
+        _story_score("dry_microburst_inverted_v", 0.0),
+        _story_score("high_cape_pulse_storm", 0.0),
+        _story_score("squall_line_cold_pool_candidate", 0.0),
     ]
     evidence = [
         EvidenceItem(
@@ -767,6 +1240,8 @@ def _story_score(
     *,
     reasons: list[str] | None = None,
     caveats: list[str] | None = None,
+    required_diagnostics: list[str] | None = None,
+    assumptions: list[str] | None = None,
 ) -> StoryScore:
     rounded = round(max(0.0, min(100.0, score)), 1)
     support: Support
@@ -776,13 +1251,37 @@ def _story_score(
         support = "weak"
     else:
         support = "unavailable"
+    readiness = STORY_READINESS[story]
+    normalized_caveats = caveats or []
+    unavailable_diagnostics = [
+        caveat.removeprefix("missing_or_unavailable_feature:")
+        for caveat in normalized_caveats
+        if caveat.startswith("missing_or_unavailable_feature:")
+    ]
     return StoryScore(
         story=story,
         label=STORY_LABELS[story],
         score_0_to_100=rounded,
         support=support,
+        story_family=readiness.story_family,
+        readiness_state=readiness.readiness_state,
+        package_readiness_label=readiness.package_readiness_label,
+        screenable_from_sounding_now=readiness.screenable_from_sounding_now,
+        runnable_with_current_observed_sounding_package=(
+            readiness.runnable_with_current_observed_sounding_package
+        ),
+        specialized_package_recommended=readiness.specialized_package_recommended,
+        future_package_required=readiness.future_package_required,
+        package_readiness_caveats=readiness.package_readiness_caveats,
+        required_diagnostics_used=[
+            name
+            for name in (required_diagnostics or [])
+            if not _diagnostic_missing_from_caveats(normalized_caveats, name)
+        ],
+        unavailable_diagnostics=unavailable_diagnostics,
+        assumptions=assumptions or [],
         reasons=reasons or [],
-        caveats=caveats or [],
+        caveats=[*normalized_caveats, *readiness.package_readiness_caveats],
     )
 
 
@@ -860,6 +1359,30 @@ def _feature_caveats(features: dict[str, float | int | str | bool | None], name:
     return [] if _numeric_feature(features, name) is not None else [f"{name}_unavailable"]
 
 
+def _deep_convection_caveats(
+    features: dict[str, float | int | str | bool | None],
+    required_features: list[str],
+    *,
+    extra: list[str] | None = None,
+) -> list[str]:
+    missing = [
+        f"missing_or_unavailable_feature:{name}"
+        for name in required_features
+        if _numeric_feature(features, name) is None
+    ]
+    caveats = [
+        "screening_guidance_only_not_storm_forecast",
+        "cm1_output_remains_source_of_truth",
+        *missing,
+        *(extra or []),
+    ]
+    return caveats
+
+
+def _diagnostic_missing_from_caveats(caveats: list[str], name: str) -> bool:
+    return f"missing_or_unavailable_feature:{name}" in caveats
+
+
 def _score_high(value: float | None, *, low: float, high: float) -> float:
     if value is None:
         return 0.0
@@ -870,6 +1393,18 @@ def _score_low(value: float | None, *, low: float, high: float) -> float:
     if value is None:
         return 0.0
     return max(0.0, min(100.0, (high - value) / (high - low) * 100.0))
+
+
+def _score_peak(value: float | None, *, low: float, peak: float, high: float) -> float:
+    if value is None:
+        return 0.0
+    if value <= low or value >= high:
+        return 0.0
+    if math.isclose(value, peak):
+        return 100.0
+    if value < peak:
+        return max(0.0, min(100.0, (value - low) / (peak - low) * 100.0))
+    return max(0.0, min(100.0, (high - value) / (high - peak) * 100.0))
 
 
 def _weighted_score(parts: list[tuple[float, float]]) -> float:

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -340,6 +340,12 @@ def test_story_scores_and_evidence_are_traceable_to_soundings() -> None:
         "dry_failed_candidate",
         "capped_suppressed_candidate",
         "humid_rainy_candidate",
+        "severe_thunderstorm_environment",
+        "supercell_environment",
+        "elevated_convection",
+        "dry_microburst_inverted_v",
+        "high_cape_pulse_storm",
+        "squall_line_cold_pool_candidate",
         "needs_review",
         "poor_or_incomplete_candidate",
     }
@@ -354,14 +360,177 @@ def test_story_scores_and_evidence_are_traceable_to_soundings() -> None:
         "Lapse rate 0-3 km",
         "Cap strength proxy",
         "Cap height proxy",
+        "Midlevel lapse rate",
         "Moisture depth",
         "Midlevel dry-layer proxy",
+        "Bulk shear 0-6 km",
+        "Bulk shear 0-3 km",
+        "Dry microburst proxy",
+        "Freezing level",
         "Observed wind availability",
         "Profile top",
         "Lowest usable level",
         "Profile completeness",
         "Package readiness",
     }
+
+
+def _deep_convection_feature_set(
+    **overrides: float | int | str | bool | None,
+) -> dict[str, float | int | str | bool | None]:
+    features: dict[str, float | int | str | bool | None] = {
+        "data_completeness_score": 95.0,
+        "low_level_qv_g_kg": 12.0,
+        "mean_qv_0_500m_g_kg": 12.0,
+        "mean_qv_0_1000m_g_kg": 12.0,
+        "mean_qv_0_3000m_g_kg": 8.0,
+        "surface_t_td_spread_c": 5.0,
+        "estimated_lcl_height_m_agl": 625.0,
+        "lapse_rate_0_1000m_c_per_km": 7.5,
+        "lapse_rate_0_3000m_c_per_km": 7.5,
+        "midlevel_lapse_rate_700_500_hpa_c_per_km": 7.0,
+        "cap_strength_proxy": 2.0,
+        "cap_height_m_agl": 1200.0,
+        "inversion_strength_c": 2.0,
+        "moisture_depth_m": 3500.0,
+        "midlevel_dry_layer_proxy": 3.0,
+        "qv_drop_0_3000m_g_kg": 4.0,
+        "dry_microburst_inverted_v_proxy": 30.0,
+        "bulk_shear_0_1km_m_s": 8.0,
+        "bulk_shear_0_3km_m_s": 15.0,
+        "bulk_shear_0_6km_m_s": 25.0,
+        "freezing_level_m_agl": 3500.0,
+        "observed_wind_available": True,
+        "profile_top_m_agl": 18000.0,
+        "lowest_level_m_agl": 0.0,
+    }
+    features.update(overrides)
+    return features
+
+
+@pytest.mark.parametrize(
+    ("story", "overrides", "future_required", "readiness"),
+    [
+        ("severe_thunderstorm_environment", {}, False, "runnable_caveated"),
+        (
+            "supercell_environment",
+            {
+                "bulk_shear_0_1km_m_s": 16.0,
+                "bulk_shear_0_3km_m_s": 26.0,
+                "bulk_shear_0_6km_m_s": 35.0,
+            },
+            True,
+            "future_package_needed",
+        ),
+        (
+            "elevated_convection",
+            {
+                "inversion_strength_c": 7.0,
+                "cap_strength_proxy": 6.0,
+                "cap_height_m_agl": 1500.0,
+                "bulk_shear_0_3km_m_s": 20.0,
+            },
+            True,
+            "future_package_needed",
+        ),
+        (
+            "dry_microburst_inverted_v",
+            {
+                "mean_qv_0_1000m_g_kg": 5.0,
+                "surface_t_td_spread_c": 25.0,
+                "estimated_lcl_height_m_agl": 2500.0,
+                "midlevel_dry_layer_proxy": 9.0,
+                "qv_drop_0_3000m_g_kg": 8.0,
+                "dry_microburst_inverted_v_proxy": 90.0,
+            },
+            False,
+            "runnable_caveated",
+        ),
+        (
+            "high_cape_pulse_storm",
+            {"bulk_shear_0_6km_m_s": 8.0, "cap_strength_proxy": 0.2},
+            False,
+            "runnable_caveated",
+        ),
+        (
+            "squall_line_cold_pool_candidate",
+            {
+                "bulk_shear_0_3km_m_s": 24.0,
+                "bulk_shear_0_6km_m_s": 30.0,
+                "midlevel_dry_layer_proxy": 6.0,
+                "freezing_level_m_agl": 4200.0,
+            },
+            True,
+            "future_package_needed",
+        ),
+    ],
+)
+def test_deep_convection_story_scores_have_readiness_metadata(
+    story: str,
+    overrides: dict[str, float | int | str | bool | None],
+    future_required: bool,
+    readiness: str,
+) -> None:
+    scores, evidence = _score_features(
+        _deep_convection_feature_set(**overrides),
+        package_ready=True,
+    )
+
+    score = next(candidate for candidate in scores if candidate.story == story)
+    assert score.story_family == "deep_convection"
+    assert score.score_0_to_100 >= 65.0
+    assert score.support == "supported"
+    assert score.readiness_state == readiness
+    assert score.future_package_required is future_required
+    assert score.specialized_package_recommended is True
+    assert score.required_diagnostics_used
+    assert score.assumptions
+    assert "cm1_output_remains_source_of_truth" in score.caveats
+    assert evidence
+
+
+def test_deep_convection_missing_shear_is_caveated_not_confident() -> None:
+    scores, _evidence = _score_features(
+        _deep_convection_feature_set(
+            bulk_shear_0_1km_m_s=None,
+            bulk_shear_0_3km_m_s=None,
+            bulk_shear_0_6km_m_s=None,
+            observed_wind_available=False,
+        ),
+        package_ready=True,
+    )
+
+    severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
+    supercell = next(score for score in scores if score.story == "supercell_environment")
+    assert severe.support == "weak"
+    assert "bulk_shear_0_6km_m_s" in severe.unavailable_diagnostics
+    assert supercell.support == "unavailable"
+    assert "bulk_shear_0_1km_m_s" in supercell.unavailable_diagnostics
+    assert "storm_relative_helicity_unavailable" in supercell.caveats
+
+
+def test_saved_candidates_preserve_deep_convection_readiness_metadata(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    _write_cached_igra_station(settings)
+    candidate = screen_cached_soundings(
+        settings,
+        latest_per_station=1,
+        target_story="severe_thunderstorm_environment",
+    ).candidates[0]
+    severe_score = next(
+        score
+        for score in candidate.story_scores
+        if score.story == "severe_thunderstorm_environment"
+    )
+
+    saved = save_candidate(settings, SaveCandidateRequest(candidate=candidate))
+
+    assert saved.story_scores == candidate.story_scores
+    assert severe_score.story_family == "deep_convection"
+    assert any(
+        score.story == "severe_thunderstorm_environment" and score.specialized_package_recommended
+        for score in list_saved_candidates(settings)[0].story_scores
+    )
 
 
 def test_saved_candidates_round_trip_runtime_local(tmp_path: Path) -> None:

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -278,6 +278,61 @@ const blockedSoundingCandidate = {
   caveats: ["missing_surface_level"],
 };
 
+const severeSoundingCandidate = {
+  ...shallowSoundingCandidate,
+  candidate_id: "USM00072451-2025010500-severe",
+  station_id: "USM00072451",
+  station_name: "Dodge City, Kansas",
+  valid_time_utc: "2025-01-05T00:00:00Z",
+  primary_story: "severe_thunderstorm_environment",
+  primary_story_label: "Severe thunderstorm environment",
+  story_family: "deep_convection",
+  readiness_state: "runnable_caveated",
+  package_readiness_label: "Caveated profile exploration",
+  specialized_package_recommended: true,
+  future_package_required: false,
+  rank_score: 84,
+  story_scores: [
+    {
+      story: "severe_thunderstorm_environment",
+      label: "Severe thunderstorm environment",
+      score_0_to_100: 84,
+      support: "supported",
+      story_family: "deep_convection",
+      readiness_state: "runnable_caveated",
+      package_readiness_label: "Caveated profile exploration",
+      specialized_package_recommended: true,
+      future_package_required: false,
+      package_readiness_caveats: ["This is an environment screen, not a storm forecast."],
+      required_diagnostics_used: [
+        "mean_qv_0_1000m_g_kg",
+        "lapse_rate_0_3000m_c_per_km",
+        "bulk_shear_0_6km_m_s",
+      ],
+      unavailable_diagnostics: [],
+      assumptions: ["CM1 output decides what actually happens."],
+      reasons: ["Moisture, lapse-rate, and shear proxies support this environment screen."],
+      caveats: ["screening_guidance_only_not_storm_forecast"],
+    },
+  ],
+  features: {
+    ...shallowSoundingCandidate.features,
+    bulk_shear_0_6km_m_s: 28,
+    lapse_rate_0_3000m_c_per_km: 7.4,
+  },
+  evidence: [
+    {
+      label: "Bulk shear 0-6 km",
+      value: 28,
+      units: "m/s",
+      interpretation: "Deep-layer shear supports organized deep-convection screens.",
+      supports_story: ["severe_thunderstorm_environment"],
+      caveats: [],
+    },
+    ...shallowSoundingCandidate.evidence,
+  ],
+};
+
 export const results = [
   {
     result_id: "result-baseline",
@@ -1198,7 +1253,7 @@ export async function mockCloudChamberApis(page: Page) {
     json(route, {
       screening_version: "test-screening-v1",
       generated_at: "2026-07-01T12:00:00Z",
-      candidates: [shallowSoundingCandidate, blockedSoundingCandidate],
+      candidates: [shallowSoundingCandidate, blockedSoundingCandidate, severeSoundingCandidate],
       caveats: ["screening_guidance_only"],
     }),
   );

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -121,6 +121,15 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(blockedCard).toContainText("Blocked");
     await expect(blockedCard.getByRole("button", { name: "Use this sounding" })).toBeDisabled();
 
+    await page.getByLabel("Story filter").selectOption("severe_thunderstorm_environment");
+    const severeCard = page.getByLabel("Sounding candidate Dodge City, Kansas (USM00072451)");
+    await expect(severeCard).toBeVisible();
+    await expect(severeCard).toContainText("Severe thunderstorm environment");
+    await expect(severeCard).toContainText("Caveated profile exploration");
+    await expect(page.getByLabel("Candidate details")).toContainText(
+      "This is an environment screen, not a storm forecast",
+    );
+
     await page.getByLabel("Story filter").selectOption("all");
     await valleyCard.getByRole("button", { name: "Save candidate" }).click();
     await expect(page.getByText("Sounding candidate saved")).toBeVisible();

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -323,6 +323,10 @@ small {
   font-weight: 800;
 }
 
+.candidate-toolbar label:first-child {
+  grid-column: span 2;
+}
+
 .candidate-toolbar-actions {
   grid-column: 1 / -1;
   justify-content: start;
@@ -2495,6 +2499,10 @@ details[open] > summary {
 
 	  .candidate-detail-panel {
 	    position: static;
+	  }
+
+	  .candidate-toolbar label:first-child {
+	    grid-column: auto;
 	  }
 
 	  .candidate-card-main,

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -381,6 +381,89 @@ const missingLclCandidate = {
   evidence: shallowCandidate.evidence.filter((item) => item.label !== "Estimated LCL"),
 };
 
+const severeCandidate = {
+  ...shallowCandidate,
+  candidate_id: "USM00072451-2025010500-severe",
+  station_id: "USM00072451",
+  station_name: "Dodge City, Kansas",
+  valid_time_utc: "2025-01-05T00:00:00Z",
+  primary_story: "severe_thunderstorm_environment",
+  primary_story_label: "Severe thunderstorm environment",
+  story_family: "deep_convection",
+  readiness_state: "runnable_caveated",
+  package_readiness_label: "Caveated profile exploration",
+  specialized_package_recommended: true,
+  future_package_required: false,
+  rank_score: 84,
+  story_scores: [
+    {
+      story: "severe_thunderstorm_environment",
+      label: "Severe thunderstorm environment",
+      score_0_to_100: 84,
+      support: "supported",
+      story_family: "deep_convection",
+      readiness_state: "runnable_caveated",
+      package_readiness_label: "Caveated profile exploration",
+      specialized_package_recommended: true,
+      future_package_required: false,
+      package_readiness_caveats: ["This is an environment screen, not a storm forecast."],
+      required_diagnostics_used: [
+        "mean_qv_0_1000m_g_kg",
+        "lapse_rate_0_3000m_c_per_km",
+        "bulk_shear_0_6km_m_s",
+      ],
+      unavailable_diagnostics: [],
+      assumptions: ["CM1 output decides what actually happens."],
+      reasons: ["Moisture, lapse-rate, and shear proxies support this environment screen."],
+      caveats: ["screening_guidance_only_not_storm_forecast"],
+    },
+    {
+      story: "shallow_cumulus_candidate",
+      label: "Cloud-forming shallow cumulus",
+      score_0_to_100: 55,
+      support: "weak",
+      reasons: [],
+      caveats: [],
+    },
+    {
+      story: "supercell_environment",
+      label: "Supercell environment",
+      score_0_to_100: 72,
+      support: "supported",
+      story_family: "deep_convection",
+      readiness_state: "future_package_needed",
+      package_readiness_label: "Future deep-convection package required",
+      runnable_with_current_observed_sounding_package: "no",
+      specialized_package_recommended: true,
+      future_package_required: true,
+      package_readiness_caveats: [
+        "Supercell exploration needs storm-mode controls and diagnostics not in the current package.",
+      ],
+      required_diagnostics_used: ["bulk_shear_0_6km_m_s"],
+      unavailable_diagnostics: ["srh"],
+      assumptions: ["SRH is unavailable, so support remains caveated."],
+      reasons: ["Deep-layer shear supports an organized-convection screen."],
+      caveats: ["future_specialized_package_required"],
+    },
+  ],
+  features: {
+    ...shallowCandidate.features,
+    bulk_shear_0_6km_m_s: 28,
+    lapse_rate_0_3000m_c_per_km: 7.4,
+  },
+  evidence: [
+    {
+      label: "Bulk shear 0-6 km",
+      value: 28,
+      units: "m/s",
+      interpretation: "Deep-layer shear supports organized deep-convection screens.",
+      supports_story: ["severe_thunderstorm_environment"],
+      caveats: [],
+    },
+    ...shallowCandidate.evidence,
+  ],
+};
+
 const screeningInputsResponse = {
   inputs: [
     {
@@ -403,6 +486,7 @@ const screeningResponse = {
     blockedCandidate,
     secondaryShallowCandidate,
     missingLclCandidate,
+    severeCandidate,
   ],
   caveats: ["screening_guidance_only"],
 };
@@ -2436,6 +2520,43 @@ describe("App", () => {
     );
     expect(validLclIndex).toBeGreaterThanOrEqual(0);
     expect(missingLclIndex).toBeGreaterThan(validLclIndex);
+  });
+
+  it("shows deep-convection candidate filters with readiness caveats", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+
+    const storyFilter = screen.getByLabelText("Story filter");
+    expect(
+      within(storyFilter).getByRole("option", { name: "Severe thunderstorm environment" }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(storyFilter, {
+      target: { value: "severe_thunderstorm_environment" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Screen cached soundings" }));
+
+    expect(await screen.findByText("Screening guidance loaded")).toBeInTheDocument();
+    const severeCard = screen.getByLabelText("Sounding candidate Dodge City, Kansas (USM00072451)");
+    expect(severeCard).toHaveTextContent("Severe thunderstorm environment");
+    expect(severeCard).toHaveTextContent("Caveated profile exploration");
+    expect(screen.getByLabelText("Candidate details")).toHaveTextContent(
+      "This is an environment screen, not a storm forecast.",
+    );
+    expect(screen.getByLabelText("Candidate details")).toHaveTextContent(
+      "CM1 output decides what actually happens.",
+    );
+
+    fireEvent.change(storyFilter, {
+      target: { value: "supercell_environment" },
+    });
+    expect(severeCard).toHaveTextContent("Future deep-convection package required");
+    expect(severeCard).toHaveTextContent("Supercell environment");
+    expect(within(severeCard).getByRole("button", { name: "Use this sounding" })).toBeDisabled();
   });
 
   it("shows Deep Overnight as an expensive distinct generated package", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -163,6 +163,12 @@ type CandidateStoryId =
   | "dry_failed_candidate"
   | "capped_suppressed_candidate"
   | "humid_rainy_candidate"
+  | "severe_thunderstorm_environment"
+  | "supercell_environment"
+  | "elevated_convection"
+  | "dry_microburst_inverted_v"
+  | "high_cape_pulse_storm"
+  | "squall_line_cold_pool_candidate"
   | "needs_review"
   | "poor_or_incomplete_candidate";
 
@@ -172,6 +178,12 @@ type CandidateStoryFilter =
   | "dry_failed_candidate"
   | "capped_suppressed_candidate"
   | "humid_rainy_candidate"
+  | "severe_thunderstorm_environment"
+  | "supercell_environment"
+  | "elevated_convection"
+  | "dry_microburst_inverted_v"
+  | "high_cape_pulse_storm"
+  | "squall_line_cold_pool_candidate"
   | "needs_review";
 
 type CandidateSort =
@@ -187,6 +199,17 @@ type StoryScore = {
   label: string;
   score_0_to_100: number;
   support: string;
+  story_family?: "current_les" | "deep_convection" | "winter_future" | "review";
+  readiness_state?: string;
+  package_readiness_label?: string;
+  screenable_from_sounding_now?: boolean;
+  runnable_with_current_observed_sounding_package?: "yes" | "caveated" | "no";
+  specialized_package_recommended?: boolean;
+  future_package_required?: boolean;
+  package_readiness_caveats?: string[];
+  required_diagnostics_used?: string[];
+  unavailable_diagnostics?: string[];
+  assumptions?: string[];
   reasons: string[];
   caveats: string[];
 };
@@ -215,6 +238,14 @@ type SoundingCandidate = {
   source_provider: string;
   primary_story: CandidateStoryId;
   primary_story_label: string;
+  story_family?: "current_les" | "deep_convection" | "winter_future" | "review";
+  readiness_state?: string;
+  package_readiness_label?: string;
+  specialized_package_recommended?: boolean;
+  future_package_required?: boolean;
+  required_diagnostics_used?: string[];
+  unavailable_diagnostics?: string[];
+  assumptions?: string[];
   story_scores: StoryScore[];
   rank_score: number;
   confidence: "low" | "medium" | "high";
@@ -3002,11 +3033,27 @@ function ObservedAtmosphereCandidatesPanel({
             onChange={(event) => onStoryFilterChange(event.target.value as CandidateStoryFilter)}
           >
             <option value="all">All screening stories</option>
-            <option value="shallow_cumulus_candidate">Cloud-forming shallow cumulus</option>
-            <option value="dry_failed_candidate">Dry failed cumulus</option>
-            <option value="capped_suppressed_candidate">Capped / suppressed</option>
-            <option value="humid_rainy_candidate">Humid / rainy</option>
-            <option value="needs_review">Needs review</option>
+            <optgroup label="Current observed-sounding LES stories">
+              <option value="shallow_cumulus_candidate">Cloud-forming shallow cumulus</option>
+              <option value="dry_failed_candidate">Dry failed cumulus</option>
+              <option value="capped_suppressed_candidate">Capped / suppressed</option>
+              <option value="humid_rainy_candidate">Humid / rainy</option>
+            </optgroup>
+            <optgroup label="Deep-convection environments">
+              <option value="severe_thunderstorm_environment">
+                Severe thunderstorm environment
+              </option>
+              <option value="supercell_environment">Supercell environment</option>
+              <option value="elevated_convection">Elevated convection</option>
+              <option value="dry_microburst_inverted_v">Dry microburst inverted-V</option>
+              <option value="high_cape_pulse_storm">High-CAPE pulse storm</option>
+              <option value="squall_line_cold_pool_candidate">
+                Squall-line / cold-pool candidate
+              </option>
+            </optgroup>
+            <optgroup label="Review / data quality">
+              <option value="needs_review">Needs review</option>
+            </optgroup>
           </select>
         </label>
         <label>
@@ -3192,6 +3239,7 @@ function SoundingCandidateCard({
 }) {
   const story = storyFilter === "all" ? candidate.primary_story : storyFilter;
   const matchScore = candidateMatchScore(candidate, story);
+  const canUseCurrentPackage = candidateCanUseCurrentPackage(candidate, story);
   return (
     <article
       className={`candidate-card${selected ? " selected-candidate-card" : ""}`}
@@ -3206,8 +3254,8 @@ function SoundingCandidateCard({
           <StatusBadge label={candidateStoryLabel(story)} tone="neutral" />
           <StatusBadge label={`${formatNumber(matchScore, "%")} match`} tone="neutral" />
           <StatusBadge
-            label={candidate.package_ready ? "Package-ready" : "Blocked"}
-            tone={candidate.package_ready ? "good" : "warning"}
+            label={candidatePackageReadinessLabel(candidate, story)}
+            tone={candidatePackageReadinessTone(candidate, story)}
           />
         </span>
       </button>
@@ -3224,7 +3272,7 @@ function SoundingCandidateCard({
         </p>
       )}
       <div className="button-row">
-        <button type="button" disabled={!candidate.package_ready} onClick={onUse}>
+        <button type="button" disabled={!canUseCurrentPackage} onClick={onUse}>
           Use this sounding
         </button>
         <button type="button" className="secondary-button" disabled={saved} onClick={onSave}>
@@ -3270,18 +3318,26 @@ function SoundingCandidateDetail({
           </p>
         </div>
         <StatusBadge
-          label={candidate.package_ready ? "Ready for review" : "Blocked"}
-          tone={candidate.package_ready ? "good" : "warning"}
+          label={candidatePackageReadinessLabel(candidate, story)}
+          tone={candidatePackageReadinessTone(candidate, story)}
         />
       </div>
       <p>
-        Candidate match score is screening guidance only. CM1 decides whether clouds, rain, or
-        suppression actually happen.
+        Candidate match score is screening guidance only. It screens the observed environment; CM1
+        decides what actually happens.
       </p>
       <dl className="compact-metrics">
         <Metric label="Match score" value={formatNumber(candidateMatchScore(candidate, story), "%")} />
         <Metric label="Evidence level" value={humanize(candidate.confidence)} />
         <Metric label="Station ID" value={candidate.station_id} />
+        <Metric
+          label="Readiness"
+          value={candidatePackageReadinessLabel(candidate, story)}
+        />
+        <Metric
+          label="Story family"
+          value={humanize(candidateStoryScore(candidate, story)?.story_family ?? candidate.story_family ?? "current_les")}
+        />
         <Metric
           label="Location"
           value={
@@ -3304,6 +3360,16 @@ function SoundingCandidateDetail({
           ))}
         </ul>
       </section>
+      {candidatePackageReadinessCaveats(candidate, story).length > 0 && (
+        <section>
+          <h5>Package readiness</h5>
+          <ul className="compact-list">
+            {candidatePackageReadinessCaveats(candidate, story).map((caveat) => (
+              <li key={caveat}>{humanize(caveat)}</li>
+            ))}
+          </ul>
+        </section>
+      )}
       <details>
         <summary>All story scores</summary>
         <dl className="compact-metrics">
@@ -7870,6 +7936,18 @@ function candidateStoryLabel(story: CandidateStoryId | CandidateStoryFilter): st
       return "Capped / suppressed";
     case "humid_rainy_candidate":
       return "Humid / rainy";
+    case "severe_thunderstorm_environment":
+      return "Severe thunderstorm environment";
+    case "supercell_environment":
+      return "Supercell environment";
+    case "elevated_convection":
+      return "Elevated convection";
+    case "dry_microburst_inverted_v":
+      return "Dry microburst inverted-V";
+    case "high_cape_pulse_storm":
+      return "High-CAPE pulse storm";
+    case "squall_line_cold_pool_candidate":
+      return "Squall-line / cold-pool";
     case "poor_or_incomplete_candidate":
       return "Poor or incomplete";
     case "needs_review":
@@ -7877,6 +7955,51 @@ function candidateStoryLabel(story: CandidateStoryId | CandidateStoryFilter): st
     case "all":
       return "All screening stories";
   }
+}
+
+function candidatePackageReadinessLabel(
+  candidate: SoundingCandidate,
+  story: CandidateStoryId | CandidateStoryFilter,
+): string {
+  const score = candidateStoryScore(candidate, story);
+  if (score?.package_readiness_label) return score.package_readiness_label;
+  if (candidate.package_readiness_label) return candidate.package_readiness_label;
+  return candidate.package_ready ? "Package-ready" : "Blocked";
+}
+
+function candidatePackageReadinessTone(
+  candidate: SoundingCandidate,
+  story: CandidateStoryId | CandidateStoryFilter,
+): "good" | "warning" | "neutral" {
+  const score = candidateStoryScore(candidate, story);
+  if (!candidate.package_ready) return "warning";
+  if (score?.future_package_required || candidate.future_package_required) return "warning";
+  if (score?.specialized_package_recommended || candidate.specialized_package_recommended) {
+    return "neutral";
+  }
+  return "good";
+}
+
+function candidatePackageReadinessCaveats(
+  candidate: SoundingCandidate,
+  story: CandidateStoryId | CandidateStoryFilter,
+): string[] {
+  const score = candidateStoryScore(candidate, story);
+  return [
+    ...(score?.package_readiness_caveats ?? []),
+    ...(score?.assumptions ?? []),
+  ];
+}
+
+function candidateCanUseCurrentPackage(
+  candidate: SoundingCandidate,
+  story: CandidateStoryId | CandidateStoryFilter,
+): boolean {
+  const score = candidateStoryScore(candidate, story);
+  if (!candidate.package_ready) return false;
+  if (score?.future_package_required || candidate.future_package_required) return false;
+  if (score?.runnable_with_current_observed_sounding_package === "no") return false;
+  return true;
 }
 
 function candidateStationLabel(candidate: SoundingCandidate): string {
@@ -8030,6 +8153,14 @@ function candidateScreeningMetadata(
     saved_candidate_id: savedCandidate?.saved_candidate_id ?? null,
     screening_version: candidate.screening_version,
     primary_story: candidate.primary_story,
+    story_family: candidate.story_family ?? null,
+    readiness_state: candidate.readiness_state ?? null,
+    package_readiness_label: candidate.package_readiness_label ?? null,
+    specialized_package_recommended: candidate.specialized_package_recommended ?? false,
+    future_package_required: candidate.future_package_required ?? false,
+    required_diagnostics_used: candidate.required_diagnostics_used ?? [],
+    unavailable_diagnostics: candidate.unavailable_diagnostics ?? [],
+    assumptions: candidate.assumptions ?? [],
     story_scores: candidate.story_scores,
     rank_score: candidate.rank_score,
     confidence: candidate.confidence,

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -19,11 +19,19 @@ The v1 candidate stories are:
 - `dry_failed_candidate`
 - `capped_suppressed_candidate`
 - `humid_rainy_candidate`
+- `severe_thunderstorm_environment`
+- `supercell_environment`
+- `elevated_convection`
+- `dry_microburst_inverted_v`
+- `high_cape_pulse_storm`
+- `squall_line_cold_pool_candidate`
 - `needs_review`
 - `poor_or_incomplete_candidate`
 
 Visible labels may be friendlier, but every visible story must be backed by
 `story_scores`, feature values, evidence items, caveats, and package readiness.
+Story filters should group these as current observed-sounding LES stories,
+deep-convection environments, and review/data-quality stories.
 
 ## Feature Inputs
 
@@ -46,6 +54,13 @@ The current story scores primarily use:
 Missing scoring inputs weaken/caveat story support instead of being interpreted
 as meaningful physical zero values.
 
+Deep-convection environment scores additionally use available sounding
+diagnostics such as 0-3 km lapse rate, 700-500 hPa lapse-rate proxy, 0-1/0-3/0-6
+km bulk shear, inversion/cap proxies, dry-microburst inverted-V proxy, qv drop,
+and freezing-level proxy. CAPE, CIN, LFC, EL, storm motion, SRH, and cold-pool
+diagnostics remain unavailable and must be caveated rather than silently
+inferred.
+
 ### Evidence / Context Fields
 
 The candidate UI may also display these fields as evidence or context:
@@ -59,6 +74,7 @@ The candidate UI may also display these fields as evidence or context:
 - cap height proxy
 - observed wind availability
 - package readiness
+- deep-convection readiness labels and caveats
 
 These fields help explain the sounding and package path. They do not directly
 drive story scores unless the implementation and tests are updated to say so.
@@ -180,6 +196,46 @@ This story is deliberately caveated because current packages still use
 idealized local forcing. It should be read as “humid atmosphere worth trying,”
 not as a rain forecast.
 
+### Severe / Deep-Convection Environment Candidates
+
+The deep-convection story family includes:
+
+- `severe_thunderstorm_environment`
+- `supercell_environment`
+- `elevated_convection`
+- `dry_microburst_inverted_v`
+- `high_cape_pulse_storm`
+- `squall_line_cold_pool_candidate`
+
+Scoring primarily uses the sounding diagnostics available today:
+
+- low-level and lower-tropospheric moisture proxies
+- estimated LCL
+- 0-1 km and 0-3 km lapse rates
+- 700-500 hPa lapse-rate proxy when available
+- cap/inversion strength and height proxies
+- 0-1 km, 0-3 km, and 0-6 km bulk shear
+- dry-layer, qv-drop, and inverted-V proxies
+- freezing-level proxy for precipitation/cold-pool context
+- profile completeness
+
+Evidence also shows the same moisture, cap, lapse-rate, wind, profile-depth,
+and package-readiness values used elsewhere in the candidate UI.
+
+Package readiness is separate from story support:
+
+- `severe_thunderstorm_environment`, `high_cape_pulse_storm`, and
+  `dry_microburst_inverted_v` may enter the current observed-sounding package
+  only as caveated profile exploration.
+- `supercell_environment`, `elevated_convection`, and
+  `squall_line_cold_pool_candidate` require future specialized packages before
+  package generation should be presented as a useful current path.
+
+These labels are environment screens, not severe-weather forecasts and not
+validated CM1 scenario families. They must carry caveats that CAPE/CIN/LFC/EL,
+storm motion, SRH, forcing, cold-pool diagnostics, and storm-object behavior are
+not currently computed. CM1 output remains the source of truth.
+
 ### Needs Review
 
 Scoring primarily uses:
@@ -265,10 +321,13 @@ station text in the browser, or commit cached station files.
 Tests should prove:
 
 - every current story can be produced deterministically;
+- deep-convection stories have deterministic score and readiness metadata;
 - every story has reasons and evidence;
 - missing features caveat or weaken support instead of producing confident
   labels;
 - poor/incomplete candidates are blocked from package generation;
 - package-ready but weak profiles become `needs_review`;
+- future-package-required stories are not represented as current validated
+  package paths;
 - candidate-screening provenance is copied into generated package metadata
   when provided.


### PR DESCRIPTION
## Issue worked
- #259

## Summary
- Added severe/deep-convection sounding candidate story IDs and heuristic scoring for severe thunderstorm, supercell, elevated convection, dry microburst inverted-V, high-CAPE pulse storm, and squall-line/cold-pool environment screens.
- Added story-family and readiness metadata to story scores, candidates, saved candidates, and package-screening provenance so these remain screening hypotheses rather than validated CM1 package paths.
- Updated Build candidate filters to group current LES stories separately from deep-convection environments and review/data-quality stories.
- Added UI readiness copy and disabled current-package use for future-package-required story filters while keeping caveated profile-exploration candidates saveable/useable where allowed.
- Updated the sounding candidate screening contract to distinguish scoring inputs, evidence/context fields, and package-readiness fields.

## Tests added/updated
- Backend tests for deep-convection scoring/readiness metadata, missing-shear caveats, and saved-candidate metadata persistence.
- Frontend component tests for deep-convection story filters, readiness caveats, and future-package-required disabled use action.
- Playwright mocked smoke coverage for the Build candidate workflow with severe environment screening.

## Commands run
- `app/backend/.venv/bin/python -m ruff check app/backend/cloud_chamber/sounding_candidates.py app/backend/cloud_chamber/igra_recent_cli.py app/backend/tests/test_sounding_candidates.py`
- `app/backend/.venv/bin/python -m ruff format --check app/backend/cloud_chamber/sounding_candidates.py app/backend/cloud_chamber/igra_recent_cli.py app/backend/tests/test_sounding_candidates.py`
- `app/backend/.venv/bin/python -m mypy app/backend/cloud_chamber/sounding_candidates.py app/backend/cloud_chamber/igra_recent_cli.py app/backend/tests/test_sounding_candidates.py`
- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_sounding_candidates.py -q`
- `npm test -- --run App.test.tsx`
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Playwright/manual visual check
- Used Playwright against the local Build page to inspect the observed-atmosphere candidate controls and adjusted the story-filter width so long deep-convection labels remain readable.

## Manual QA needed
- Yes: sanity-review the Build > Upload a Sounding > Find interesting soundings workflow and confirm the severe/deep-convection story grouping and readiness copy feel clear.

## Caveats / follow-up
- These labels are environment screens only, not forecasts and not CM1 outcome predictions.
- No severe/deep-convection CM1 package generation was added.
- CAPE/CIN/SRH/storm-motion/cold-pool diagnostics remain unavailable/caveated.
- No generated IGRA, CM1, NetCDF, runtime, screenshot, video, trace, or log artifacts were committed.
