### PR TITLE
[codex] Add Deep Convection Trial package

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -11,7 +11,11 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from cloud_chamber.cli import ENGINE_NOTE
-from cloud_chamber.dry_run_package import generate_dry_run_package, read_dry_run_report
+from cloud_chamber.dry_run_package import (
+    DryRunPackageError,
+    generate_dry_run_package,
+    read_dry_run_report,
+)
 from cloud_chamber.igra_catalog import (
     IGRACatalogError,
     cache_station_zip_from_catalog,
@@ -99,6 +103,7 @@ class DryRunRequest(BaseModel):
     scenario_id: str = "baseline-shallow-cumulus"
     controls: dict[str, str | float | bool] = Field(default_factory=dict)
     run_size_preset: str = "quick_look"
+    package_family: str | None = None
     observed_sounding: dict[str, object] | None = None
     candidate_screening: dict[str, object] | None = None
 
@@ -158,15 +163,19 @@ def list_scenarios() -> dict[str, object]:
 def create_dry_run_package(request: DryRunRequest) -> dict[str, Any]:
     scenario = load_scenario_template(request.scenario_id)
     settings = load_settings()
-    result = generate_dry_run_package(
-        scenario_data=scenario.model_dump(mode="json"),
-        runtime_home=settings.runtime_home,
-        run_id=f"dry-run-{uuid4().hex[:12]}",
-        controls=request.controls,
-        run_size_preset=request.run_size_preset,
-        observed_sounding=request.observed_sounding,
-        candidate_screening=request.candidate_screening,
-    )
+    try:
+        result = generate_dry_run_package(
+            scenario_data=scenario.model_dump(mode="json"),
+            runtime_home=settings.runtime_home,
+            run_id=f"dry-run-{uuid4().hex[:12]}",
+            controls=request.controls,
+            run_size_preset=request.run_size_preset,
+            package_family=request.package_family,
+            observed_sounding=request.observed_sounding,
+            candidate_screening=request.candidate_screening,
+        )
+    except DryRunPackageError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     report = read_dry_run_report(result.report_path)
     return {
         "package_dir": str(result.package_dir),

--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -202,7 +202,7 @@ def build_cm1_input_contract(
         if observed_sounding is not None
         else "generated_reference",
         trigger_type=(
-            "warm_thermal_line"
+            "warm_bubble"
             if resolved_package_family == PackageFamily.DEEP_CONVECTION_TRIAL
             else None
         ),
@@ -258,9 +258,12 @@ def _deep_convection_defaults_for_preset(run_size_preset: str) -> CloudScaleDefa
         return CloudScaleDefaults(
             nx=240,
             ny=240,
-            horizontal_extent_km=48.0,
-            y_extent_km=48.0,
-            horizontal_spacing_m=200.0,
+            nz=40,
+            horizontal_extent_km=240.0,
+            y_extent_km=240.0,
+            horizontal_spacing_m=1000.0,
+            vertical_spacing_m=500,
+            time_step_seconds=6.0,
             runtime_seconds=21600,
             output_cadence_seconds=300,
             restart_cadence_seconds=10800,
@@ -270,23 +273,29 @@ def _deep_convection_defaults_for_preset(run_size_preset: str) -> CloudScaleDefa
         return CloudScaleDefaults(
             nx=160,
             ny=160,
-            horizontal_extent_km=40.0,
-            y_extent_km=40.0,
-            horizontal_spacing_m=250.0,
+            nz=40,
+            horizontal_extent_km=160.0,
+            y_extent_km=160.0,
+            horizontal_spacing_m=1000.0,
+            vertical_spacing_m=500,
+            time_step_seconds=6.0,
             runtime_seconds=21600,
             output_cadence_seconds=600,
             restart_cadence_seconds=10800,
             rayleigh_damping_start_m=15000,
         )
     return CloudScaleDefaults(
-        nx=96,
-        ny=96,
-        horizontal_extent_km=24.0,
-        y_extent_km=24.0,
-        horizontal_spacing_m=250.0,
-        runtime_seconds=10800,
+        nx=120,
+        ny=120,
+        nz=40,
+        horizontal_extent_km=120.0,
+        y_extent_km=120.0,
+        horizontal_spacing_m=1000.0,
+        vertical_spacing_m=500,
+        time_step_seconds=6.0,
+        runtime_seconds=7200,
         output_cadence_seconds=600,
-        restart_cadence_seconds=5400,
+        restart_cadence_seconds=3600,
         rayleigh_damping_start_m=15000,
     )
 
@@ -323,10 +332,10 @@ def _trigger_parameters(
     if package_family != PackageFamily.DEEP_CONVECTION_TRIAL:
         return {}
     return {
-        "cm1_iinit": 8,
+        "cm1_iinit": 3,
         "cm1_trigger": (
-            "CM1 built-in line thermal with small random perturbations; 2 K maximum "
-            "potential-temperature perturbation centered near 1.5 km AGL"
+            "CM1 built-in three warm bubbles with 2 K maximum potential-temperature "
+            "perturbations in a line near 1.4 km AGL"
         ),
         "raw_controls_exposed": False,
     }
@@ -343,7 +352,7 @@ def _package_caveats(package_family: PackageFamily, run_size_preset: str) -> tup
     if package_family != PackageFamily.DEEP_CONVECTION_TRIAL:
         return ()
     caveats = [
-        "Deep Convection Trial uses an idealized CM1 warm line-thermal trigger.",
+        "Deep Convection Trial uses an idealized CM1 three-warm-bubble trigger.",
         (
             "Storm mode, rotation, rain, downdraft, and cold-pool behavior are outcomes "
             "to inspect after the run."
@@ -359,7 +368,7 @@ def _package_caveats(package_family: PackageFamily, run_size_preset: str) -> tup
 
 def _manual_validation_status(package_family: PackageFamily) -> str:
     if package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
-        return "needs_manual_cm1_smoke_run"
+        return "manual_cm1_smoke_run_observed_deep_convection"
     return "existing_package_path"
 
 
@@ -400,13 +409,18 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
     idiss = 1 if deep_convection else 0
     wbc = ebc = sbc = nbc = 2 if deep_convection else 1
     bbc = 1 if deep_convection else 3
-    iinit = 8 if deep_convection else 0
+    iinit = 3 if deep_convection else 0
     irandp = 0 if deep_convection else 1
+    imove = 1 if deep_convection else 0
     isfcflx = 0 if deep_convection else 1
     sfcmodel = 0 if deep_convection else 1
     oceanmodel = 0 if deep_convection else 1
     set_flx = 0 if deep_convection else 1
     set_ust = 0 if deep_convection else 1
+    l_h = 100.0 if deep_convection else 0.0
+    lhref1 = 100.0 if deep_convection else 0.0
+    lhref2 = 1000.0 if deep_convection else 0.0
+    ndcnst = 250.0 if deep_convection else 100.0
     return f"""
  &param0
  nx           =      {defaults.nx},
@@ -486,7 +500,7 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  ibalance  =  0,
  iorigin   =  2,
  axisymm   =  0,
- imove     =  0,
+ imove     =  {imove},
  iptra     =  0,
  npt       =  1,
  pdtra     =  1,
@@ -507,11 +521,11 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  umove   = 12.5,
  vmove   =  3.0,
  v_t     =      7.0,
- l_h     =      0.0,
- lhref1  =      0.0,
- lhref2  =      0.0,
+ l_h     =  {l_h:7.1f},
+ lhref1  =  {lhref1:7.1f},
+ lhref2  =  {lhref2:7.1f},
  l_inf   =     75.0,
- ndcnst  =    100.0,
+ ndcnst  =  {ndcnst:7.1f},
  nt_c    =    250.0,
  csound  =    300.0,
  cstar   =     30.0,
@@ -742,15 +756,17 @@ def render_input_sounding_notes(contract: CM1InputContract) -> str:
 def render_cm1_input_sounding(contract: CM1InputContract) -> str:
     """Render a CM1-readable external sounding profile.
 
-    CM1 documents ``isnd = 17`` as the external ``input_sounding`` route that
-    reads thermodynamics from this file while preserving the namelist wind
-    profile. The profile is derived from the BOMEX/Siebesma shallow-cumulus
-    breakpoints used by CM1's ``isnd = 19`` reference case and extends above the
-    18 km model top as required by CM1's input_sounding reader.
+    CM1 observed-sounding packages use ``isnd = 7`` so CM1 reads
+    thermodynamics and wind from this file. Generated reference packages use
+    the external-sounding profile derived from the BOMEX/Siebesma
+    shallow-cumulus breakpoints used by CM1's ``isnd = 19`` reference case.
     """
 
     if contract.observed_sounding is not None:
-        return render_observed_input_sounding(contract.observed_sounding)
+        return render_observed_input_sounding(
+            contract.observed_sounding,
+            required_model_top_m=_required_sounding_top_m(contract.cloud_scale_defaults),
+        )
 
     header, body = _baseline_shallow_cumulus_sounding_profile(
         moisture_profile=contract.moisture_profile,
@@ -764,6 +780,13 @@ def render_cm1_input_sounding(contract: CM1InputContract) -> str:
         for z, theta, qv_gkg, u_ms, v_ms in body
     )
     return "\n".join(lines) + "\n"
+
+
+def _required_sounding_top_m(defaults: CloudScaleDefaults) -> float:
+    return max(
+        float(defaults.vertical_extent_km * 1000.0),
+        float(defaults.nz * defaults.vertical_spacing_m),
+    )
 
 
 def _baseline_shallow_cumulus_sounding_profile(

--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -22,6 +22,12 @@ class GeneratedFileRole(StrEnum):
     RUNTIME_FILE_CHECKLIST = "runtime_file_checklist"
 
 
+class PackageFamily(StrEnum):
+    SHALLOW_CUMULUS = "shallow_cumulus"
+    OBSERVED_SOUNDING_QUICKLOOK = "observed_sounding_quicklook"
+    DEEP_CONVECTION_TRIAL = "deep_convection_trial"
+
+
 @dataclass(frozen=True)
 class CloudScaleDefaults:
     nx: int = 64
@@ -82,6 +88,11 @@ class ControlMappingFragment:
 
 @dataclass(frozen=True)
 class CM1InputContract:
+    package_family: PackageFamily
+    package_display_name: str
+    input_source: str
+    trigger_type: str | None
+    trigger_parameters: dict[str, str | int | float | bool]
     scenario_id: str
     physical_question: str
     run_size_preset: str
@@ -91,8 +102,11 @@ class CM1InputContract:
     generated_files: tuple[GeneratedFileSpec, ...]
     control_fragments: tuple[ControlMappingFragment, ...]
     expected_diagnostics: tuple[str, ...]
+    expected_outputs: tuple[str, ...]
     visualization_defaults: dict[str, str | list[str]]
     limitations: tuple[str, ...]
+    package_caveats: tuple[str, ...]
+    manual_validation_status: str
     observed_sounding: ObservedSoundingRecord | None = None
 
 
@@ -153,8 +167,15 @@ def build_cm1_input_contract(
     selected_controls: dict[str, str | float | bool] | None = None,
     run_size_preset: str = "quick_look",
     observed_sounding: ObservedSoundingRecord | None = None,
+    package_family: str | PackageFamily | None = None,
 ) -> CM1InputContract:
     selected = selected_controls or {}
+    resolved_package_family = _resolve_package_family(package_family, observed_sounding)
+    if resolved_package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+        if observed_sounding is None:
+            raise ValueError("Deep Convection Trial requires a validated observed sounding.")
+        if not _has_observed_wind_profile(observed_sounding):
+            raise ValueError("Deep Convection Trial requires observed wind components.")
     control_fragments = tuple(
         ControlMappingFragment(
             control_id=control.id,
@@ -175,15 +196,30 @@ def build_cm1_input_contract(
     stability_profile = _stability_profile_from_controls(scenario.id, control_fragments)
 
     return CM1InputContract(
+        package_family=resolved_package_family,
+        package_display_name=_package_display_name(resolved_package_family),
+        input_source="observed_sounding"
+        if observed_sounding is not None
+        else "generated_reference",
+        trigger_type=(
+            "warm_thermal_line"
+            if resolved_package_family == PackageFamily.DEEP_CONVECTION_TRIAL
+            else None
+        ),
+        trigger_parameters=_trigger_parameters(resolved_package_family),
         scenario_id=scenario.id,
         physical_question=scenario.physical_question,
         run_size_preset=run_size_preset,
         moisture_profile=moisture_profile,
         stability_profile=stability_profile,
-        cloud_scale_defaults=cloud_scale_defaults_for_preset(run_size_preset),
+        cloud_scale_defaults=cloud_scale_defaults_for_preset(
+            run_size_preset,
+            package_family=resolved_package_family,
+        ),
         generated_files=GENERATED_FILE_SPECS,
         control_fragments=control_fragments,
         expected_diagnostics=_diagnostic_names(scenario),
+        expected_outputs=_expected_outputs(resolved_package_family),
         visualization_defaults={
             "primary_field": scenario.visualization_defaults.primary_field,
             "secondary_fields": scenario.visualization_defaults.secondary_fields,
@@ -192,11 +228,20 @@ def build_cm1_input_contract(
             "provenance_label": scenario.visualization_defaults.provenance_label,
         },
         limitations=tuple(scenario.limitations),
+        package_caveats=_package_caveats(resolved_package_family, run_size_preset),
+        manual_validation_status=_manual_validation_status(resolved_package_family),
         observed_sounding=observed_sounding,
     )
 
 
-def cloud_scale_defaults_for_preset(run_size_preset: str) -> CloudScaleDefaults:
+def cloud_scale_defaults_for_preset(
+    run_size_preset: str,
+    *,
+    package_family: str | PackageFamily | None = None,
+) -> CloudScaleDefaults:
+    resolved = _resolve_package_family(package_family, None)
+    if resolved == PackageFamily.DEEP_CONVECTION_TRIAL:
+        return _deep_convection_defaults_for_preset(run_size_preset)
     preset = RUNTIME_PRESETS.get(run_size_preset, RUNTIME_PRESETS["standard"])
     return CloudScaleDefaults(
         nx=preset.nx,
@@ -205,6 +250,122 @@ def cloud_scale_defaults_for_preset(run_size_preset: str) -> CloudScaleDefaults:
         time_step_seconds=preset.time_step_seconds,
         runtime_seconds=preset.runtime_seconds,
         output_cadence_seconds=preset.output_cadence_seconds,
+    )
+
+
+def _deep_convection_defaults_for_preset(run_size_preset: str) -> CloudScaleDefaults:
+    if run_size_preset == "deep_overnight":
+        return CloudScaleDefaults(
+            nx=240,
+            ny=240,
+            horizontal_extent_km=48.0,
+            y_extent_km=48.0,
+            horizontal_spacing_m=200.0,
+            runtime_seconds=21600,
+            output_cadence_seconds=300,
+            restart_cadence_seconds=10800,
+            rayleigh_damping_start_m=15000,
+        )
+    if run_size_preset == "standard":
+        return CloudScaleDefaults(
+            nx=160,
+            ny=160,
+            horizontal_extent_km=40.0,
+            y_extent_km=40.0,
+            horizontal_spacing_m=250.0,
+            runtime_seconds=21600,
+            output_cadence_seconds=600,
+            restart_cadence_seconds=10800,
+            rayleigh_damping_start_m=15000,
+        )
+    return CloudScaleDefaults(
+        nx=96,
+        ny=96,
+        horizontal_extent_km=24.0,
+        y_extent_km=24.0,
+        horizontal_spacing_m=250.0,
+        runtime_seconds=10800,
+        output_cadence_seconds=600,
+        restart_cadence_seconds=5400,
+        rayleigh_damping_start_m=15000,
+    )
+
+
+def _resolve_package_family(
+    package_family: str | PackageFamily | None,
+    observed_sounding: ObservedSoundingRecord | None,
+) -> PackageFamily:
+    if isinstance(package_family, PackageFamily):
+        return package_family
+    if package_family:
+        try:
+            return PackageFamily(package_family)
+        except ValueError as exc:
+            raise ValueError(f"Unknown package family: {package_family}") from exc
+    if observed_sounding is not None:
+        return PackageFamily.OBSERVED_SOUNDING_QUICKLOOK
+    return PackageFamily.SHALLOW_CUMULUS
+
+
+def _package_display_name(package_family: PackageFamily) -> str:
+    match package_family:
+        case PackageFamily.DEEP_CONVECTION_TRIAL:
+            return "Deep Convection Trial"
+        case PackageFamily.OBSERVED_SOUNDING_QUICKLOOK:
+            return "Observed Sounding Quick Look"
+        case PackageFamily.SHALLOW_CUMULUS:
+            return "Shallow Cumulus Package"
+
+
+def _trigger_parameters(
+    package_family: PackageFamily,
+) -> dict[str, str | int | float | bool]:
+    if package_family != PackageFamily.DEEP_CONVECTION_TRIAL:
+        return {}
+    return {
+        "cm1_iinit": 8,
+        "cm1_trigger": (
+            "CM1 built-in line thermal with small random perturbations; 2 K maximum "
+            "potential-temperature perturbation centered near 1.5 km AGL"
+        ),
+        "raw_controls_exposed": False,
+    }
+
+
+def _expected_outputs(package_family: PackageFamily) -> tuple[str, ...]:
+    base = ("qc", "qr", "qv", "th", "prs", "u", "v", "w", "rain", "dbz")
+    if package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+        return (*base, "tke", "km", "kh", "vorticity", "updraft_helicity")
+    return base
+
+
+def _package_caveats(package_family: PackageFamily, run_size_preset: str) -> tuple[str, ...]:
+    if package_family != PackageFamily.DEEP_CONVECTION_TRIAL:
+        return ()
+    caveats = [
+        "Deep Convection Trial uses an idealized CM1 warm line-thermal trigger.",
+        (
+            "Storm mode, rotation, rain, downdraft, and cold-pool behavior are outcomes "
+            "to inspect after the run."
+        ),
+        "Terrain, mesoscale lift, radiation, and map/GIS forcing are not part of v1.",
+    ]
+    if run_size_preset in {"standard", "deep_overnight"}:
+        caveats.append(
+            "This preset is intended for the LAN worker unless local performance is acceptable."
+        )
+    return tuple(caveats)
+
+
+def _manual_validation_status(package_family: PackageFamily) -> str:
+    if package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+        return "needs_manual_cm1_smoke_run"
+    return "existing_package_path"
+
+
+def _has_observed_wind_profile(record: ObservedSoundingRecord) -> bool:
+    return any(
+        level.u_wind_m_s is not None and level.v_wind_m_s is not None for level in record.levels
     )
 
 
@@ -228,6 +389,24 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
     defaults = contract.cloud_scale_defaults
     sounding_source_id = 7 if contract.observed_sounding is not None else 17
     wind_profile_id = 0 if contract.observed_sounding is not None else 9
+    deep_convection = contract.package_family == PackageFamily.DEEP_CONVECTION_TRIAL
+    testcase = 0 if deep_convection else 3
+    adapt_dt = 0 if deep_convection else 1
+    ptype = 5
+    ihail = 1 if deep_convection else 0
+    iautoc = 1 if deep_convection else 0
+    icor = 0 if deep_convection else 1
+    lspgrad = 0 if deep_convection else 2
+    idiss = 1 if deep_convection else 0
+    wbc = ebc = sbc = nbc = 2 if deep_convection else 1
+    bbc = 1 if deep_convection else 3
+    iinit = 8 if deep_convection else 0
+    irandp = 0 if deep_convection else 1
+    isfcflx = 0 if deep_convection else 1
+    sfcmodel = 0 if deep_convection else 1
+    oceanmodel = 0 if deep_convection else 1
+    set_flx = 0 if deep_convection else 1
+    set_ust = 0 if deep_convection else 1
     return f"""
  &param0
  nx           =      {defaults.nx},
@@ -255,8 +434,8 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
 
  &param2
  cm1setup  =  1,
- testcase  =  3,
- adapt_dt  =  1,
+ testcase  =  {testcase},
+ adapt_dt  =  {adapt_dt},
  irst      =  0,
  rstnum    =  1,
  iconly    =  0,
@@ -281,20 +460,20 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  irdamp    =  1,
  hrdamp    =  0,
  psolver   =  3,
- ptype     =  5,
- ihail     =  0,
- iautoc    =  0,
- icor      =  1,
- lspgrad   =  2,
+ ptype     =  {ptype},
+ ihail     =  {ihail},
+ iautoc    =  {iautoc},
+ icor      =  {icor},
+ lspgrad   =  {lspgrad},
  eqtset    =  2,
- idiss     =  0,
+ idiss     =  {idiss},
  efall     =  0,
  rterm     =  0,
- wbc       =  1,
- ebc       =  1,
- sbc       =  1,
- nbc       =  1,
- bbc       =  3,
+ wbc       =  {wbc},
+ ebc       =  {ebc},
+ sbc       =  {sbc},
+ nbc       =  {nbc},
+ bbc       =  {bbc},
  tbc       =  1,
  irbc      =  4,
  roflux    =  0,
@@ -302,8 +481,8 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  isnd      = {sounding_source_id:2d},
  iwnd      = {wind_profile_id:2d},
  itern     =  0,
- iinit     =  0,
- irandp    =  1,
+ iinit     =  {iinit},
+ irandp    =  {irandp},
  ibalance  =  0,
  iorigin   =  2,
  axisymm   =  0,
@@ -352,9 +531,9 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  /
 
  &param12
- isfcflx    =      1,
- sfcmodel   =      1,
- oceanmodel =      1,
+ isfcflx    =      {isfcflx},
+ sfcmodel   =      {sfcmodel},
+ oceanmodel =      {oceanmodel},
  initsfc    =      1,
  tsk0       = 299.28,
  tmn0       = 297.28,
@@ -369,12 +548,12 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  iz0tlnd    =      0,
  oml_hml0   =   50.0,
  oml_gamma  =   0.14,
- set_flx    =      1,
+ set_flx    =      {set_flx},
  cnst_shflx = 8.0e-3,
  cnst_lhflx = 5.2e-5,
  set_znt    =      0,
  cnst_znt   =   0.00,
- set_ust    =      1,
+ set_ust    =      {set_ust},
  cnst_ust   =   0.28,
  ramp_sgs   =      1,
  ramp_time  = 1800.0,
@@ -460,6 +639,8 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  output_vinterp   = 1,
  output_w         = 1,
  output_winterp   = 1,
+ output_vort      = 1,
+ output_uh        = 1,
  output_nm        = 1,
  output_def       = 1,
  output_lwp       = 1,

--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -6,10 +6,15 @@ It does not launch CM1 and does not write generated files.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from enum import StrEnum
 
-from cloud_chamber.observed_sounding import ObservedSoundingRecord, render_observed_input_sounding
+from cloud_chamber.observed_sounding import (
+    ObservedSoundingLevel,
+    ObservedSoundingRecord,
+    render_observed_input_sounding,
+)
 from cloud_chamber.scenario_schema import ControlAudience, ScenarioTemplate
 
 
@@ -171,11 +176,21 @@ def build_cm1_input_contract(
 ) -> CM1InputContract:
     selected = selected_controls or {}
     resolved_package_family = _resolve_package_family(package_family, observed_sounding)
+    defaults = cloud_scale_defaults_for_preset(
+        run_size_preset,
+        package_family=resolved_package_family,
+    )
     if resolved_package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
         if observed_sounding is None:
             raise ValueError("Deep Convection Trial requires a validated observed sounding.")
-        if not _has_observed_wind_profile(observed_sounding):
-            raise ValueError("Deep Convection Trial requires observed wind components.")
+        if not _has_observed_wind_profile(
+            observed_sounding,
+            required_model_top_m=_required_sounding_top_m(defaults),
+        ):
+            raise ValueError(
+                "Deep Convection Trial requires a complete finite observed u/v wind "
+                "profile for every input_sounding level."
+            )
     control_fragments = tuple(
         ControlMappingFragment(
             control_id=control.id,
@@ -212,10 +227,7 @@ def build_cm1_input_contract(
         run_size_preset=run_size_preset,
         moisture_profile=moisture_profile,
         stability_profile=stability_profile,
-        cloud_scale_defaults=cloud_scale_defaults_for_preset(
-            run_size_preset,
-            package_family=resolved_package_family,
-        ),
+        cloud_scale_defaults=defaults,
         generated_files=GENERATED_FILE_SPECS,
         control_fragments=control_fragments,
         expected_diagnostics=_diagnostic_names(scenario),
@@ -354,6 +366,10 @@ def _package_caveats(package_family: PackageFamily, run_size_preset: str) -> tup
     caveats = [
         "Deep Convection Trial uses an idealized CM1 three-warm-bubble trigger.",
         (
+            "Manual smoke evidence applies to the Deep Convection Trial package family; "
+            "each observed sounding remains an experiment to evaluate after CM1 completes."
+        ),
+        (
             "Storm mode, rotation, rain, downdraft, and cold-pool behavior are outcomes "
             "to inspect after the run."
         ),
@@ -368,14 +384,49 @@ def _package_caveats(package_family: PackageFamily, run_size_preset: str) -> tup
 
 def _manual_validation_status(package_family: PackageFamily) -> str:
     if package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
-        return "manual_cm1_smoke_run_observed_deep_convection"
+        return "deep_convection_trial_package_smoke_validated"
     return "existing_package_path"
 
 
-def _has_observed_wind_profile(record: ObservedSoundingRecord) -> bool:
-    return any(
-        level.u_wind_m_s is not None and level.v_wind_m_s is not None for level in record.levels
+def _has_observed_wind_profile(
+    record: ObservedSoundingRecord,
+    *,
+    required_model_top_m: float,
+) -> bool:
+    levels = _rendered_observed_wind_levels(
+        record,
+        required_model_top_m=required_model_top_m,
     )
+    return bool(levels) and all(
+        _finite_number(level.u_wind_m_s) and _finite_number(level.v_wind_m_s) for level in levels
+    )
+
+
+def _rendered_observed_wind_levels(
+    record: ObservedSoundingRecord,
+    *,
+    required_model_top_m: float,
+) -> list[ObservedSoundingLevel]:
+    levels = list(record.levels)
+    if not levels:
+        return []
+    body = list(levels)
+    if levels[0].model_z_m <= 0.01:
+        body = [level for level in levels if level.model_z_m > 0.01]
+        if not body:
+            body = list(levels)
+    if (
+        body
+        and math.isfinite(required_model_top_m)
+        and required_model_top_m > 0
+        and body[-1].model_z_m < required_model_top_m
+    ):
+        body = [*body, body[-1]]
+    return body
+
+
+def _finite_number(value: float | None) -> bool:
+    return value is not None and math.isfinite(value)
 
 
 def render_namelist_fragment(contract: CM1InputContract) -> str:

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -59,6 +59,7 @@ def generate_dry_run_package(
     app_commit: str | None = None,
     observed_sounding: dict[str, object] | ObservedSoundingRecord | None = None,
     candidate_screening: dict[str, object] | None = None,
+    package_family: str | None = None,
 ) -> DryRunPackageResult:
     scenario = validate_scenario_template(scenario_data)
     selected_controls = controls or {}
@@ -71,12 +72,16 @@ def generate_dry_run_package(
 
     observed_record = _observed_sounding_record(observed_sounding)
 
-    contract = build_cm1_input_contract(
-        scenario,
-        selected_controls=selected_controls,
-        run_size_preset=run_size_preset,
-        observed_sounding=observed_record,
-    )
+    try:
+        contract = build_cm1_input_contract(
+            scenario,
+            selected_controls=selected_controls,
+            run_size_preset=run_size_preset,
+            observed_sounding=observed_record,
+            package_family=package_family,
+        )
+    except ValueError as exc:
+        raise DryRunPackageError(str(exc)) from exc
     now = datetime.now(UTC)
 
     paths = {
@@ -119,6 +124,15 @@ def generate_dry_run_package(
             observed_record.model_dump(mode="json") if observed_record is not None else None
         ),
         candidate_screening=candidate_screening,
+        package_family=contract.package_family.value,
+        package_display_name=contract.package_display_name,
+        input_source=contract.input_source,
+        trigger_type=contract.trigger_type,
+        trigger_parameters=contract.trigger_parameters,
+        expected_outputs=list(contract.expected_outputs),
+        package_limitations=list(contract.limitations),
+        package_caveats=list(contract.package_caveats),
+        manual_validation_status=contract.manual_validation_status,
     )
 
     case_manifest = _case_manifest_payload(
@@ -213,15 +227,19 @@ def _case_manifest_payload(
     return {
         "scenario_id": scenario.id,
         "display_name": scenario.display_name,
+        "package_family": contract.package_family.value,
+        "package_display_name": contract.package_display_name,
+        "input_source": contract.input_source,
+        "trigger_type": contract.trigger_type,
+        "trigger_parameters": contract.trigger_parameters,
         "physical_question": scenario.physical_question,
         "learning_goals": scenario.learning_goals,
         "expected_behavior": scenario.expected_behavior,
         "warnings": scenario.warnings,
         "limitations": scenario.limitations,
-        "cm1_mapping_status": (
-            "CM1-ready provisional baseline package; still pending local/manual smoke-run "
-            "scientific validation"
-        ),
+        "package_caveats": contract.package_caveats,
+        "manual_validation_status": contract.manual_validation_status,
+        "cm1_mapping_status": _cm1_mapping_status(contract),
         "contract": _contract_payload(contract),
         "candidate_screening": candidate_screening,
     }
@@ -240,6 +258,11 @@ def _dry_run_report_payload(
         "not_a_completed_cm1_result": True,
         "cm1_was_launched": False,
         "scenario_id": scenario.id,
+        "package_family": contract.package_family.value,
+        "package_display_name": contract.package_display_name,
+        "input_source": contract.input_source,
+        "trigger_type": contract.trigger_type,
+        "trigger_parameters": contract.trigger_parameters,
         "physical_question": scenario.physical_question,
         "controls": manifest.controls,
         "variant_metadata": {
@@ -253,17 +276,7 @@ def _dry_run_report_payload(
             "low_level_humidity": manifest.controls.get("low_level_humidity"),
             "cap_strength": manifest.controls.get("cap_strength"),
             "cap_height": manifest.controls.get("cap_height"),
-            "mapping": (
-                "observed IGRA external input_sounding profile; non-wind namelist settings "
-                "remain inherited from the validated baseline; observed wind direction/speed is "
-                "converted to u/v and applied through CM1 isnd=7 input_sounding handling"
-                if contract.observed_sounding is not None
-                else (
-                    "external input_sounding profile; namelist settings remain inherited from "
-                    "the validated baseline; capped/suppressed variants change only stability "
-                    "near the cap when cap_strength is stronger"
-                )
-            ),
+            "mapping": _package_mapping_summary(contract),
         },
         "observed_sounding": (
             _observed_sounding_summary(contract.observed_sounding)
@@ -275,6 +288,9 @@ def _dry_run_report_payload(
         "run_size_details": run_size_details,
         "estimated_cost_or_size": run_size_details["cost_warning"],
         "expected_diagnostics": manifest.expected_diagnostics,
+        "expected_outputs": list(contract.expected_outputs),
+        "package_caveats": list(contract.package_caveats),
+        "manual_validation_status": contract.manual_validation_status,
         "visualization_defaults": contract.visualization_defaults,
         "generated_files": {name: str(path) for name, path in generated_files.items()},
         "provenance": {
@@ -322,7 +338,10 @@ def _observed_sounding_summary(record: ObservedSoundingRecord) -> dict[str, obje
 
 def _run_size_details(contract: CM1InputContract) -> dict[str, object]:
     defaults = contract.cloud_scale_defaults
-    standard = cloud_scale_defaults_for_preset("standard")
+    standard = cloud_scale_defaults_for_preset(
+        "standard",
+        package_family=contract.package_family,
+    )
     grid_cells = defaults.nx * defaults.ny * defaults.nz
     standard_grid_cells = standard.nx * standard.ny * standard.nz
     output_frames = _expected_output_frames(
@@ -338,6 +357,22 @@ def _run_size_details(contract: CM1InputContract) -> dict[str, object]:
     estimated_compute_multiplier = grid_multiplier * timestep_multiplier * runtime_multiplier
     estimated_output_volume_multiplier = grid_multiplier * output_frame_multiplier
     is_deep = contract.run_size_preset == "deep_overnight"
+    is_deep_convection = contract.package_family.value == "deep_convection_trial"
+    cost_warning = (
+        _deep_convection_cost_warning(contract.run_size_preset)
+        if is_deep_convection
+        else (
+            "Deep Overnight is an expensive local run intended to take roughly "
+            "10-12x Standard wall-clock after manual validation. It increases "
+            "horizontal resolution to about 33.333 m, saves output every 300 s, "
+            "and may produce much larger output for better Explore, cloud "
+            "appearance, field-view, and timelapse data."
+            if is_deep
+            else (
+                "Normal local run-size preset; estimates remain approximate until local validation."
+            )
+        )
+    )
     return {
         "preset": contract.run_size_preset,
         "runtime_seconds": defaults.runtime_seconds,
@@ -366,25 +401,76 @@ def _run_size_details(contract: CM1InputContract) -> dict[str, object]:
             estimated_output_volume_multiplier, 2
         ),
         "target_wall_clock_multiplier_vs_standard": "10-12x" if is_deep else "1x",
-        "cost_warning": (
-            "Deep Overnight is an expensive local run intended to take roughly "
-            "10-12x Standard wall-clock after manual validation. It increases "
-            "horizontal resolution to about 33.333 m, saves output every 300 s, "
-            "and may produce much larger output for better Explore, cloud "
-            "appearance, field-view, and timelapse data."
-            if is_deep
+        "cost_warning": cost_warning,
+        "validation_note": (
+            "Deep Convection Trial uses a wider idealized domain and observed winds. "
+            "Manual CM1 smoke runs calibrate package health, runtime, and interpretability."
+            if is_deep_convection
             else (
-                "Normal local run-size preset; estimates remain approximate until local validation."
+                "Deep Overnight preserves the physical domain and scenario controls while "
+                "changing horizontal resolution and saved-output cadence. Wall-clock "
+                "and storage estimates require manual local validation before launch."
+                if is_deep
+                else "Preset preserves the validated reference-derived spatial grid."
             )
         ),
-        "validation_note": (
-            "Deep Overnight preserves the physical domain and scenario controls while "
-            "changing horizontal resolution and saved-output cadence. Wall-clock "
-            "and storage estimates require manual local validation before launch."
-            if is_deep
-            else "Preset preserves the validated reference-derived spatial grid."
-        ),
     }
+
+
+def _package_mapping_summary(contract: CM1InputContract) -> str:
+    if contract.package_family.value == "deep_convection_trial":
+        return (
+            "observed IGRA external input_sounding profile with observed u/v winds; "
+            "Deep Convection Trial uses CM1 isnd=7, testcase=0, iinit=8 warm line-thermal "
+            "initiation, a wider idealized domain, NetCDF output, rain output, reflectivity "
+            "output, vorticity output, and updraft-helicity output"
+        )
+    if contract.observed_sounding is not None:
+        return (
+            "observed IGRA external input_sounding profile; non-wind namelist settings "
+            "remain inherited from the validated baseline; observed wind direction/speed is "
+            "converted to u/v and applied through CM1 isnd=7 input_sounding handling"
+        )
+    return (
+        "external input_sounding profile; namelist settings remain inherited from "
+        "the validated baseline; capped/suppressed variants change only stability "
+        "near the cap when cap_strength is stronger"
+    )
+
+
+def _cm1_mapping_status(contract: CM1InputContract) -> str:
+    if contract.package_family.value == "deep_convection_trial":
+        return (
+            "CM1-ready provisional Deep Convection Trial package; pending manual CM1 "
+            "smoke-run validation for package health, runtime, and interpretability"
+        )
+    if contract.observed_sounding is not None:
+        return (
+            "CM1-ready observed-sounding quick-look package; still pending "
+            "case-specific local/manual scientific interpretation"
+        )
+    return (
+        "CM1-ready provisional baseline package; still pending local/manual smoke-run "
+        "scientific validation"
+    )
+
+
+def _deep_convection_cost_warning(run_size_preset: str) -> str:
+    if run_size_preset == "quick_look":
+        return (
+            "Deep Convection Trial Quick Look uses a wider 24 km idealized domain with "
+            "a CM1 warm line-thermal trigger. It is the smallest local trial; CM1 still decides "
+            "whether deep convection develops."
+        )
+    if run_size_preset == "standard":
+        return (
+            "Deep Convection Trial Standard uses a 40 km idealized domain and should "
+            "generally run on the LAN worker."
+        )
+    return (
+        "Deep Convection Trial Deep Overnight uses a 48 km idealized domain with "
+        "frequent saved output and should run on the LAN worker."
+    )
 
 
 def _expected_output_frames(runtime_seconds: int, output_cadence_seconds: int) -> int:

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -421,9 +421,9 @@ def _package_mapping_summary(contract: CM1InputContract) -> str:
     if contract.package_family.value == "deep_convection_trial":
         return (
             "observed IGRA external input_sounding profile with observed u/v winds; "
-            "Deep Convection Trial uses CM1 isnd=7, testcase=0, iinit=8 warm line-thermal "
-            "initiation, a wider idealized domain, NetCDF output, rain output, reflectivity "
-            "output, vorticity output, and updraft-helicity output"
+            "Deep Convection Trial uses CM1 isnd=7, testcase=0, iinit=3 three-warm-bubble "
+            "line initiation, a storm-scale idealized domain, NetCDF output, rain output, "
+            "reflectivity output, vorticity output, and updraft-helicity output"
         )
     if contract.observed_sounding is not None:
         return (
@@ -441,8 +441,8 @@ def _package_mapping_summary(contract: CM1InputContract) -> str:
 def _cm1_mapping_status(contract: CM1InputContract) -> str:
     if contract.package_family.value == "deep_convection_trial":
         return (
-            "CM1-ready provisional Deep Convection Trial package; pending manual CM1 "
-            "smoke-run validation for package health, runtime, and interpretability"
+            "CM1-ready Deep Convection Trial package with manual CM1 smoke evidence "
+            "for deep-convection initiation; each observed sounding remains an experiment"
         )
     if contract.observed_sounding is not None:
         return (
@@ -458,17 +458,17 @@ def _cm1_mapping_status(contract: CM1InputContract) -> str:
 def _deep_convection_cost_warning(run_size_preset: str) -> str:
     if run_size_preset == "quick_look":
         return (
-            "Deep Convection Trial Quick Look uses a wider 24 km idealized domain with "
-            "a CM1 warm line-thermal trigger. It is the smallest local trial; CM1 still decides "
-            "whether deep convection develops."
+            "Deep Convection Trial Quick Look uses a 120 km storm-scale idealized domain with "
+            "CM1's built-in three-warm-bubble trigger. It is the smallest local trial; CM1 "
+            "still decides whether deep convection develops."
         )
     if run_size_preset == "standard":
         return (
-            "Deep Convection Trial Standard uses a 40 km idealized domain and should "
+            "Deep Convection Trial Standard uses a 160 km storm-scale idealized domain and should "
             "generally run on the LAN worker."
         )
     return (
-        "Deep Convection Trial Deep Overnight uses a 48 km idealized domain with "
+        "Deep Convection Trial Deep Overnight uses a 240 km storm-scale idealized domain with "
         "frequent saved output and should run on the LAN worker."
     )
 

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -68,7 +68,6 @@ def generate_dry_run_package(
     package_dir = runtime_home.expanduser() / "runs" / run_id
     if package_dir.exists() and not allow_overwrite:
         raise DryRunPackageError(f"Run package already exists: {package_dir}")
-    package_dir.mkdir(parents=True, exist_ok=allow_overwrite)
 
     observed_record = _observed_sounding_record(observed_sounding)
 
@@ -83,6 +82,8 @@ def generate_dry_run_package(
     except ValueError as exc:
         raise DryRunPackageError(str(exc)) from exc
     now = datetime.now(UTC)
+
+    package_dir.mkdir(parents=True, exist_ok=allow_overwrite)
 
     paths = {
         "manifest": package_dir / "run_manifest.json",
@@ -291,6 +292,7 @@ def _dry_run_report_payload(
         "expected_outputs": list(contract.expected_outputs),
         "package_caveats": list(contract.package_caveats),
         "manual_validation_status": contract.manual_validation_status,
+        "cm1_mapping_status": _cm1_mapping_status(contract),
         "visualization_defaults": contract.visualization_defaults,
         "generated_files": {name: str(path) for name, path in generated_files.items()},
         "provenance": {
@@ -404,7 +406,8 @@ def _run_size_details(contract: CM1InputContract) -> dict[str, object]:
         "cost_warning": cost_warning,
         "validation_note": (
             "Deep Convection Trial uses a wider idealized domain and observed winds. "
-            "Manual CM1 smoke runs calibrate package health, runtime, and interpretability."
+            "Manual CM1 smoke evidence applies to the package family; each observed "
+            "sounding remains an experiment until CM1 output is inspected."
             if is_deep_convection
             else (
                 "Deep Overnight preserves the physical domain and scenario controls while "

--- a/app/backend/cloud_chamber/igra_recent_cli.py
+++ b/app/backend/cloud_chamber/igra_recent_cli.py
@@ -26,13 +26,16 @@ from cloud_chamber.igra_catalog import (
 from cloud_chamber.observed_sounding import ObservedSoundingError, summarize_igra_station_text
 from cloud_chamber.settings import CloudChamberSettings, load_settings
 from cloud_chamber.sounding_candidates import (
+    DEEP_CONVECTION_STORY_IDS,
     STORY_LABELS,
     SoundingCandidate,
+    StoryId,
     TargetStoryId,
     screen_cached_soundings,
 )
 
 STORY_OPTION_TO_ID: dict[str, TargetStoryId] = {
+    "deep-convection": "deep_convection_trial",
     "shallow-cumulus": "shallow_cumulus_candidate",
     "dry-failed": "dry_failed_candidate",
     "capped-suppressed": "capped_suppressed_candidate",
@@ -401,7 +404,7 @@ def _cmd_candidates(args: argparse.Namespace, settings: CloudChamberSettings) ->
         )
         all_caveats.extend(result.caveats)
         if story_option == "all":
-            print(STORY_LABELS[story])
+            print(STORY_LABELS[cast(StoryId, story)])
         _print_candidates(result.candidates, target_story=story)
         any_candidates = any_candidates or bool(result.candidates)
         if story_option == "all" and index < len(stories) - 1:
@@ -552,6 +555,19 @@ def _candidate_story_match(
 ) -> float:
     if target_story is None:
         return candidate.rank_score
+    if target_story == "deep_convection_trial":
+        return (
+            max(
+                (
+                    score.score_0_to_100
+                    for score in candidate.story_scores
+                    if score.story in DEEP_CONVECTION_STORY_IDS
+                ),
+                default=0.0,
+            )
+            if candidate.package_ready
+            else 0.0
+        )
     for score in candidate.story_scores:
         if score.story == target_story:
             return score.score_0_to_100 if candidate.package_ready else 0.0

--- a/app/backend/cloud_chamber/igra_recent_cli.py
+++ b/app/backend/cloud_chamber/igra_recent_cli.py
@@ -37,6 +37,12 @@ STORY_OPTION_TO_ID: dict[str, TargetStoryId] = {
     "dry-failed": "dry_failed_candidate",
     "capped-suppressed": "capped_suppressed_candidate",
     "humid-rainy": "humid_rainy_candidate",
+    "severe-thunderstorm": "severe_thunderstorm_environment",
+    "supercell": "supercell_environment",
+    "high-cape-pulse": "high_cape_pulse_storm",
+    "dry-microburst": "dry_microburst_inverted_v",
+    "squall-line": "squall_line_cold_pool_candidate",
+    "elevated-convection": "elevated_convection",
     "needs-review": "needs_review",
     "poor-or-incomplete": "poor_or_incomplete_candidate",
 }
@@ -373,6 +379,12 @@ def _cmd_candidates(args: argparse.Namespace, settings: CloudChamberSettings) ->
             "dry_failed_candidate",
             "capped_suppressed_candidate",
             "humid_rainy_candidate",
+            "severe_thunderstorm_environment",
+            "supercell_environment",
+            "high_cape_pulse_storm",
+            "dry_microburst_inverted_v",
+            "squall_line_cold_pool_candidate",
+            "elevated_convection",
         ]
     else:
         stories = [STORY_OPTION_TO_ID[story_option]]

--- a/app/backend/cloud_chamber/observed_sounding.py
+++ b/app/backend/cloud_chamber/observed_sounding.py
@@ -204,17 +204,29 @@ def observed_sounding_from_payload(payload: object) -> ObservedSoundingRecord:
         raise ObservedSoundingError(str(exc)) from exc
 
 
-def render_observed_input_sounding(record: ObservedSoundingRecord) -> str:
+def render_observed_input_sounding(
+    record: ObservedSoundingRecord,
+    *,
+    required_model_top_m: float = _CM1_MODEL_TOP_M,
+) -> str:
     """Render a CM1-readable input_sounding file from a validated observed record."""
 
     levels = record.levels
     if not levels:
         raise ObservedSoundingError("Observed sounding record has no usable levels.")
     surface = levels[0]
-    body: list[ObservedSoundingLevel] = levels
+    body: list[ObservedSoundingLevel] = list(levels)
     if surface.model_z_m > 0:
         surface = surface.model_copy(update={"model_z_m": 0.0})
-        body = [surface, *levels]
+    else:
+        # The CM1 isnd=7 reader builds its surface level from the header line.
+        # Repeating the same z=0 thermodynamic level in the body can create a
+        # duplicate-height interval during interpolation, so body rows start
+        # with the first level above the model surface.
+        body = [level for level in levels if level.model_z_m > 0.01]
+        if not body:
+            body = list(levels)
+    body = _extend_levels_to_model_top(body, required_model_top_m)
     lines = [
         f"{surface.pressure_pa / 100.0:10.2f} "
         f"{surface.potential_temperature_k:12.4f} {surface.qv_g_kg:12.5f}",
@@ -227,6 +239,29 @@ def render_observed_input_sounding(record: ObservedSoundingRecord) -> str:
         for level in body
     )
     return "\n".join(lines) + "\n"
+
+
+def _extend_levels_to_model_top(
+    levels: list[ObservedSoundingLevel],
+    required_model_top_m: float,
+) -> list[ObservedSoundingLevel]:
+    if not levels:
+        return levels
+    if not math.isfinite(required_model_top_m) or required_model_top_m <= 0:
+        return levels
+    last = levels[-1]
+    if last.model_z_m >= required_model_top_m:
+        return levels
+    return [
+        *levels,
+        last.model_copy(
+            update={
+                "model_z_m": required_model_top_m,
+                "source_height_m_msl": last.source_height_m_msl
+                + (required_model_top_m - last.model_z_m),
+            }
+        ),
+    ]
 
 
 def _scan_headers(lines: list[str]) -> list[_IgraHeader]:
@@ -248,8 +283,11 @@ def _scan_headers(lines: list[str]) -> list[_IgraHeader]:
         latitude = _parse_scaled_int(line[55:62], 10000.0)
         longitude = _parse_scaled_int(line[63:71], 10000.0)
         if hour == 99:
-            raise ObservedSoundingError("Selected IGRA sounding has missing nominal hour.")
-        valid_time = datetime(year, month, day, hour, tzinfo=UTC)
+            continue
+        try:
+            valid_time = datetime(year, month, day, hour, tzinfo=UTC)
+        except ValueError:
+            continue
         headers.append(
             {
                 "line_index": index,
@@ -429,6 +467,9 @@ def _parse_levels(
         if deduped and math.isclose(level.model_z_m, deduped[-1].model_z_m, abs_tol=0.01):
             continue
         deduped.append(level)
+    if deduped and -50.0 <= deduped[0].model_z_m < 0.0:
+        caveats.append(f"lowest usable level at {deduped[0].model_z_m:.1f} m was anchored to z=0")
+        deduped[0] = deduped[0].model_copy(update={"model_z_m": 0.0})
     if used_relative_humidity:
         caveats.append(
             "relative humidity used for moisture conversion where dewpoint depression was missing"

--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -499,7 +499,7 @@ def _interesting_time_records(
             key="highest_cloud_top",
             label="Highest cloud top",
             series=cloud.cloud_top_time_series if cloud.available else [],
-            source_field="qc",
+            source_field="qc+qr+qi+qs+qg when available",
             source_diagnostic="diagnostics.cloud.cloud_top_time_series",
             units="m",
             output_manifest=output_manifest,

--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -87,6 +87,13 @@ class ResultCard(BaseModel):
     input_source: str = "generated_reference"
     input_source_label: str = "Generated reference"
     observed_sounding: dict[str, object] | None = None
+    package_family: str | None = None
+    package_display_name: str | None = None
+    trigger_type: str | None = None
+    trigger_parameters: dict[str, object] | None = None
+    expected_outputs: list[str] = Field(default_factory=list)
+    package_caveats: list[str] = Field(default_factory=list)
+    manual_validation_status: str | None = None
     provenance_labels: list[str] = Field(default_factory=list)
     diagnostics_summary: str | None = None
     thermal_fate_label: str | None = None
@@ -213,10 +220,18 @@ def _card_from_metadata(
         input_source=metadata.input_source,
         input_source_label=metadata.input_source_label,
         observed_sounding=metadata.observed_sounding,
+        package_family=metadata.package_family,
+        package_display_name=metadata.package_display_name,
+        trigger_type=metadata.trigger_type,
+        trigger_parameters=metadata.trigger_parameters,
+        expected_outputs=metadata.expected_outputs,
+        package_caveats=metadata.package_caveats,
+        manual_validation_status=metadata.manual_validation_status,
         provenance_labels=[
             f"source_model:{metadata.source_model}",
             f"source_product_state:{metadata.source_product_state}",
             f"result_state:{metadata.result_state}",
+            *([f"package_family:{metadata.package_family}"] if metadata.package_family else []),
         ],
         diagnostics_summary=metadata.diagnostics_summary,
         thermal_fate_label=interpretation.thermal_fate_label if interpretation else None,
@@ -249,6 +264,14 @@ def _card_from_metadata(
 
 
 def _default_result_card_name(metadata: ResultMetadata) -> str:
+    if metadata.package_family == "deep_convection_trial":
+        station_name = _observed_sounding_value(metadata.observed_sounding, "station_name")
+        station_id = _observed_sounding_value(metadata.observed_sounding, "station_id")
+        if station_name:
+            return f"Deep Convection Trial — {station_name}"
+        if station_id:
+            return f"Deep Convection Trial — {station_id}"
+        return "Deep Convection Trial"
     if metadata.input_source == "observed_sounding":
         station_name = _observed_sounding_value(metadata.observed_sounding, "station_name")
         station_id = _observed_sounding_value(metadata.observed_sounding, "station_id")
@@ -261,6 +284,8 @@ def _default_result_card_name(metadata: ResultMetadata) -> str:
 
 
 def _display_scenario_name(metadata: ResultMetadata) -> str | None:
+    if metadata.package_family == "deep_convection_trial" and metadata.package_display_name:
+        return metadata.package_display_name
     if metadata.input_source == "observed_sounding":
         return "Uploaded Sounding"
     return metadata.scenario_name

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -11,6 +11,7 @@ QC_CLOUD_THRESHOLD_KG_KG = 1e-6
 QR_RAIN_THRESHOLD_KG_KG = 1e-7
 MINIMUM_CLOUD_GRID_CELLS = 10
 MEANINGFUL_UPDRAFT_THRESHOLD_M_S = 0.5
+HYDROMETEOR_CLOUD_TOP_FIELDS = ("qr", "qi", "qs", "qg")
 
 TIME_DIMENSION_CANDIDATES = ("time", "mtime", "t")
 VERTICAL_COORDINATE_CANDIDATES = ("z", "zh", "height", "height_m")
@@ -353,7 +354,9 @@ def _cloud_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> 
         caveats.append("qc_field_entirely_non_finite")
         return CloudDiagnostics(available=False)
 
+    cloud_extent = _cloud_extent_array(dataset, qc, caveats)
     series_arrays = _time_slices(qc, time.dimension)
+    cloud_extent_series_arrays = _time_slices(cloud_extent, time.dimension)
     qc_max_series: list[TimeValue] = []
     cloud_fraction_series: list[TimeValue] = []
     cloud_base_series: list[TimeValue] = []
@@ -370,7 +373,10 @@ def _cloud_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> 
         cloudy_count = _threshold_count(array, QC_CLOUD_THRESHOLD_KG_KG)
         finite_count = _finite_count(array)
         cloud_fraction = (cloudy_count / finite_count) if finite_count else None
-        cloud_base, cloud_top = _cloud_base_top(array, caveats)
+        extent_array = (
+            cloud_extent_series_arrays[index] if index < len(cloud_extent_series_arrays) else array
+        )
+        cloud_base, cloud_top = _cloud_base_top(extent_array, caveats)
         qc_max_series.append(TimeValue(time_seconds=time_seconds, value=slice_max))
         cloud_fraction_series.append(TimeValue(time_seconds=time_seconds, value=cloud_fraction))
         cloud_base_series.append(TimeValue(time_seconds=time_seconds, value=cloud_base))
@@ -386,7 +392,7 @@ def _cloud_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> 
             max_qc = slice_max
             time_of_max_qc = time_seconds
 
-    cloud_base, cloud_top = _cloud_base_top(qc, caveats)
+    cloud_base, cloud_top = _cloud_base_top(cloud_extent, caveats)
     return CloudDiagnostics(
         formed=first_cloud_time is not None,
         first_cloud_time_seconds=first_cloud_time,
@@ -494,6 +500,33 @@ def _rain_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> R
         qr_max_time_series=max_series,
         user_message="Rain detected." if present else "No rain detected.",
     )
+
+
+def _cloud_extent_array(dataset: Any, qc: Any, caveats: list[str]) -> Any:
+    """Return the field used for cloud base/top diagnostics.
+
+    Liquid cloud water remains the source of truth for cloud formation and max-qc
+    diagnostics. For cloud top, deep-convection output can put the upper cloud in
+    ice/snow/graupel fields, so the vertical envelope should include compatible
+    hydrometeor mixing-ratio fields when they are present.
+    """
+
+    extent = qc
+    included_fields: list[str] = []
+    for field_name in HYDROMETEOR_CLOUD_TOP_FIELDS:
+        if field_name not in dataset.data_vars:
+            continue
+        field = dataset[field_name]
+        if field.dims != qc.dims:
+            caveats.append(f"cloud_top_skipped_{field_name}_dimension_mismatch")
+            continue
+        extent = extent + field
+        included_fields.append(field_name)
+    if included_fields:
+        caveat = "cloud_top_uses_total_hydrometeor_fields:qc," + ",".join(included_fields)
+        if caveat not in caveats:
+            caveats.append(caveat)
+    return extent
 
 
 def _cloud_base_top(qc: Any, caveats: list[str]) -> tuple[float | None, float | None]:

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -68,6 +68,13 @@ class ResultMetadata(BaseModel):
     input_source: str = "generated_reference"
     input_source_label: str = "Generated reference"
     observed_sounding: dict[str, Any] | None = None
+    package_family: str | None = None
+    package_display_name: str | None = None
+    trigger_type: str | None = None
+    trigger_parameters: dict[str, Any] | None = None
+    expected_outputs: list[str] = Field(default_factory=list)
+    package_caveats: list[str] = Field(default_factory=list)
+    manual_validation_status: str | None = None
     result_state: str = "ingested_result_metadata"
     raw_cm1_artifacts: list[str] = Field(default_factory=list)
     netcdf_paths: list[str] = Field(default_factory=list)
@@ -257,6 +264,13 @@ def _result_from_model_output_files(
         input_source=_input_source(manifest),
         input_source_label=_input_source_label(manifest),
         observed_sounding=manifest.observed_sounding,
+        package_family=manifest.package_family,
+        package_display_name=manifest.package_display_name,
+        trigger_type=manifest.trigger_type,
+        trigger_parameters=manifest.trigger_parameters,
+        expected_outputs=manifest.expected_outputs,
+        package_caveats=manifest.package_caveats,
+        manual_validation_status=manifest.manual_validation_status,
         raw_cm1_artifacts=manifest.outputs.raw_cm1_artifacts,
         netcdf_paths=[str(path) for path in netcdf_paths],
         model_output_paths=[str(path) for path in contributing_paths],
@@ -691,6 +705,13 @@ def _result_from_dataset(
         input_source=_input_source(manifest),
         input_source_label=_input_source_label(manifest),
         observed_sounding=manifest.observed_sounding,
+        package_family=manifest.package_family,
+        package_display_name=manifest.package_display_name,
+        trigger_type=manifest.trigger_type,
+        trigger_parameters=manifest.trigger_parameters,
+        expected_outputs=manifest.expected_outputs,
+        package_caveats=manifest.package_caveats,
+        manual_validation_status=manifest.manual_validation_status,
         raw_cm1_artifacts=manifest.outputs.raw_cm1_artifacts,
         netcdf_paths=[str(path) for path in netcdf_paths],
         model_output_paths=[str(path) for path in contributing_paths],

--- a/app/backend/cloud_chamber/run_manifest.py
+++ b/app/backend/cloud_chamber/run_manifest.py
@@ -147,6 +147,15 @@ class RunManifest(BaseModel):
     user: UserMetadata
     observed_sounding: dict[str, Any] | None = None
     candidate_screening: dict[str, Any] | None = None
+    package_family: str | None = None
+    package_display_name: str | None = None
+    input_source: str | None = None
+    trigger_type: str | None = None
+    trigger_parameters: dict[str, Any] | None = None
+    expected_outputs: list[str] = Field(default_factory=list)
+    package_limitations: list[str] = Field(default_factory=list)
+    package_caveats: list[str] = Field(default_factory=list)
+    manual_validation_status: str | None = None
 
     @model_validator(mode="after")
     def validate_state_contract(self) -> RunManifest:

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -25,6 +25,7 @@ from cloud_chamber.observed_sounding import (
     summarize_igra_station_text,
 )
 from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.sounding_diagnostics import compute_sounding_diagnostics
 
 SCREENING_VERSION = "sounding-screening-v1"
 
@@ -33,6 +34,12 @@ StoryId = Literal[
     "dry_failed_candidate",
     "capped_suppressed_candidate",
     "humid_rainy_candidate",
+    "severe_thunderstorm_environment",
+    "supercell_environment",
+    "high_cape_pulse_storm",
+    "dry_microburst_inverted_v",
+    "squall_line_cold_pool_candidate",
+    "elevated_convection",
     "needs_review",
     "poor_or_incomplete_candidate",
 ]
@@ -41,6 +48,12 @@ TargetStoryId = Literal[
     "dry_failed_candidate",
     "capped_suppressed_candidate",
     "humid_rainy_candidate",
+    "severe_thunderstorm_environment",
+    "supercell_environment",
+    "high_cape_pulse_storm",
+    "dry_microburst_inverted_v",
+    "squall_line_cold_pool_candidate",
+    "elevated_convection",
     "needs_review",
     "poor_or_incomplete_candidate",
 ]
@@ -52,6 +65,12 @@ STORY_LABELS: dict[StoryId, str] = {
     "dry_failed_candidate": "Dry failed cumulus candidate",
     "capped_suppressed_candidate": "Capped / suppressed cumulus candidate",
     "humid_rainy_candidate": "Humid / rainy candidate",
+    "severe_thunderstorm_environment": "Severe thunderstorm environment",
+    "supercell_environment": "Supercell-like environment",
+    "high_cape_pulse_storm": "High-CAPE pulse-storm candidate",
+    "dry_microburst_inverted_v": "Dry microburst / inverted-V candidate",
+    "squall_line_cold_pool_candidate": "Squall-line / cold-pool candidate",
+    "elevated_convection": "Elevated convection candidate",
     "needs_review": "Needs review",
     "poor_or_incomplete_candidate": "Poor or incomplete data",
 }
@@ -330,6 +349,8 @@ def _candidate_from_cached_sounding(
         features = _features_from_record(record)
         story_scores, evidence = _score_features(features, package_ready=True)
         caveats = list(record.validation.caveats)
+        if features.get("near_surface_discontinuity_flag") is True:
+            caveats.append("near_surface_discontinuity_caveat")
         selected_payload = record.model_dump(mode="json")
         source_time_text = record.source_time_text
         station_latitude = record.station_latitude
@@ -394,6 +415,7 @@ def _features_from_record(
     lapse_0_3000 = _lapse_rate(levels, 0.0, 3000.0)
     inversion_strength, inversion_base, inversion_top = _inversion_proxy(levels)
     moisture_depth = _moisture_depth(levels, min_qv_g_kg=6.0)
+    near_surface_jump = _near_surface_jump(levels)
     usable_below_3km = sum(1 for level in levels if 0.0 <= level.model_z_m <= 3000.0)
     observed_wind_available = all(
         level.u_wind_m_s is not None and level.v_wind_m_s is not None for level in levels
@@ -405,6 +427,8 @@ def _features_from_record(
         + (25.0 if top >= 18000.0 else max(0.0, top / 18000.0 * 25.0))
         + (25.0 if lowest <= 50.0 else max(0.0, 25.0 - lowest / 20.0)),
     )
+    if near_surface_jump["flag"]:
+        completeness = min(completeness, 70.0)
     qv_drop = (
         round(qv_near_surface - qv_0_3000, 3)
         if qv_0_3000 is not None and qv_near_surface is not None
@@ -416,7 +440,7 @@ def _features_from_record(
         if midlevel_qv is not None and qv_near_surface is not None
         else None
     )
-    return {
+    features: dict[str, float | int | str | bool | None] = {
         "data_completeness_score": round(completeness, 1),
         "surface_or_lowest_pressure_hpa": round(surface.pressure_pa / 100.0, 1),
         "surface_or_lowest_temperature_c": round(surface.temperature_c, 2),
@@ -446,19 +470,69 @@ def _features_from_record(
         "lowest_level_m_agl": round(lowest, 1),
         "usable_levels_below_3km": usable_below_3km,
         "observed_wind_available": observed_wind_available,
+        "near_surface_jump_depth_m": near_surface_jump["depth_m"],
+        "near_surface_temperature_jump_c": near_surface_jump["temperature_jump_c"],
+        "near_surface_qv_jump_g_kg": near_surface_jump["qv_jump_g_kg"],
+        "near_surface_discontinuity_flag": near_surface_jump["flag"],
     }
+    diagnostics = compute_sounding_diagnostics(record)
+    for key in (
+        "mean_qv_0_3000m_g_kg",
+        "precipitable_water_proxy_or_unavailable",
+        "midlevel_lapse_rate_700_500_hpa_c_per_km",
+        "has_observed_wind_profile",
+        "wind_profile_depth_m",
+        "bulk_shear_0_1km_m_s",
+        "bulk_shear_0_3km_m_s",
+        "bulk_shear_0_6km_m_s",
+        "mean_wind_0_6km_m_s",
+        "dry_microburst_inverted_v_proxy",
+        "freezing_level_m_agl",
+        "surface_based_cape_j_kg",
+        "mixed_layer_cape_j_kg",
+        "surface_based_cin_j_kg",
+        "mixed_layer_cin_j_kg",
+        "lfc_height_m_agl",
+        "el_height_m_agl",
+        "srh_0_1km_m2_s2",
+        "srh_0_3km_m2_s2",
+    ):
+        diagnostic = diagnostics.feature_values.get(key)
+        features[key] = diagnostic.value if diagnostic is not None else None
+    features["observed_wind_available"] = bool(
+        features.get("observed_wind_available") or features.get("has_observed_wind_profile")
+    )
+    return features
 
 
 def _score_features(
     features: dict[str, float | int | str | bool | None], *, package_ready: bool
 ) -> tuple[list[StoryScore], list[EvidenceItem]]:
     qv = _numeric_feature(features, "mean_qv_0_1000m_g_kg")
+    qv_500 = _numeric_feature(features, "mean_qv_0_500m_g_kg")
     lcl = _numeric_feature(features, "estimated_lcl_height_m_agl")
     lapse = _numeric_feature(features, "lapse_rate_0_1000m_c_per_km")
+    lapse_0_3km = _numeric_feature(features, "lapse_rate_0_3000m_c_per_km")
+    midlevel_lapse = _numeric_feature(features, "midlevel_lapse_rate_700_500_hpa_c_per_km")
     cap = _numeric_feature(features, "cap_strength_proxy")
     moisture_depth = _numeric_feature(features, "moisture_depth_m")
     completeness = _numeric_feature(features, "data_completeness_score")
     midlevel_dry = _numeric_feature(features, "midlevel_dry_layer_proxy")
+    qv_drop = _numeric_feature(features, "qv_drop_0_3000m_g_kg")
+    precipitable_water = _numeric_feature(features, "precipitable_water_proxy_or_unavailable")
+    shear_0_1km = _numeric_feature(features, "bulk_shear_0_1km_m_s")
+    shear_0_3km = _numeric_feature(features, "bulk_shear_0_3km_m_s")
+    shear_0_6km = _numeric_feature(features, "bulk_shear_0_6km_m_s")
+    freezing_level = _numeric_feature(features, "freezing_level_m_agl")
+    dry_microburst_proxy = _numeric_feature(features, "dry_microburst_inverted_v_proxy")
+    sbcape = _numeric_feature(features, "surface_based_cape_j_kg")
+    mlcape = _numeric_feature(features, "mixed_layer_cape_j_kg")
+    sbcin = _numeric_feature(features, "surface_based_cin_j_kg")
+    mlcin = _numeric_feature(features, "mixed_layer_cin_j_kg")
+    lfc = _numeric_feature(features, "lfc_height_m_agl")
+    el = _numeric_feature(features, "el_height_m_agl")
+    surface_ttd = _numeric_feature(features, "surface_t_td_spread_c")
+    observed_wind_available = features.get("observed_wind_available") is True
     story_feature_names = [
         "mean_qv_0_1000m_g_kg",
         "estimated_lcl_height_m_agl",
@@ -471,23 +545,109 @@ def _score_features(
         name for name in story_feature_names if _numeric_feature(features, name) is None
     ]
     missing_caveats = [f"missing_or_unavailable_feature:{name}" for name in missing_story_features]
+    deep_feature_names = [
+        "mean_qv_0_1000m_g_kg",
+        "estimated_lcl_height_m_agl",
+        "lapse_rate_0_3000m_c_per_km",
+        "midlevel_lapse_rate_700_500_hpa_c_per_km",
+        "surface_based_cape_j_kg",
+        "mixed_layer_cape_j_kg",
+        "surface_based_cin_j_kg",
+        "bulk_shear_0_6km_m_s",
+        "moisture_depth_m",
+    ]
+    missing_deep_features = [
+        name for name in deep_feature_names if _numeric_feature(features, name) is None
+    ]
+    deep_caveats = [f"missing_or_unavailable_feature:{name}" for name in missing_deep_features]
+    if not observed_wind_available:
+        deep_caveats.append("observed_wind_required_for_deep_convection_trial")
 
     moist = _score_high(qv, low=4.0, high=10.0)
     dry = _score_low(qv, low=3.0, high=8.0)
+    storm_moisture = _weighted_score(
+        [
+            (_score_high(qv, low=8.0, high=14.0), 0.55),
+            (_score_high(qv_500, low=8.0, high=14.0), 0.25),
+            (_score_high(precipitable_water, low=18.0, high=38.0), 0.20),
+        ]
+    )
     low_lcl = _score_low(lcl, low=400.0, high=1800.0)
     high_lcl = _score_high(lcl, low=900.0, high=2500.0)
     thermal = _score_high(lapse, low=4.0, high=8.0)
+    deep_lapse = _weighted_score(
+        [
+            (_score_high(lapse_0_3km, low=5.5, high=8.0), 0.55),
+            (_score_high(midlevel_lapse, low=5.5, high=7.5), 0.45),
+        ]
+    )
     weak_cap = _score_low(cap, low=0.5, high=4.0)
     strong_cap = _score_high(cap, low=1.5, high=5.0)
+    not_strong_cap = _score_low(cap, low=2.0, high=6.0)
     deep_moisture = _score_high(moisture_depth, low=800.0, high=2500.0)
     shallow_moisture = _score_low(moisture_depth, low=500.0, high=1800.0)
     data_quality = _score_high(completeness, low=40.0, high=90.0)
     dry_layer = _score_high(midlevel_dry, low=2.0, high=8.0)
+    qv_drop_score = _score_high(qv_drop, low=3.0, high=8.0)
+    deep_shear = _score_high(shear_0_6km, low=10.0, high=24.0)
+    supercell_deep_shear = _score_high(shear_0_6km, low=16.0, high=30.0)
+    low_level_shear = _score_high(shear_0_1km, low=4.0, high=14.0)
+    three_km_shear = _score_high(shear_0_3km, low=8.0, high=20.0)
+    pulse_shear = _score_low(shear_0_6km, low=8.0, high=22.0)
+    effective_cape = max(value for value in (sbcape or 0.0, mlcape or 0.0))
+    effective_cin = min(value for value in (sbcin or 0.0, mlcin or 0.0))
+    cape_score = _score_high(effective_cape, low=750.0, high=2500.0)
+    high_cape_score = _score_high(effective_cape, low=1500.0, high=3500.0)
+    cin_score = _score_low(abs(effective_cin), low=25.0, high=250.0)
+    low_lfc = _score_low(lfc, low=750.0, high=3000.0)
+    deep_el = _score_high(el, low=7000.0, high=12000.0)
+    instability = _weighted_score(
+        [
+            (cape_score, 0.55),
+            (cin_score, 0.25),
+            (low_lfc, 0.10),
+            (deep_el, 0.10),
+        ]
+    )
+    deep_environment = _weighted_score(
+        [
+            (instability, 0.45),
+            (deep_lapse, 0.25),
+            (deep_shear, 0.20),
+            (deep_moisture, 0.10),
+        ]
+    )
+    dry_microburst = _weighted_score(
+        [
+            (_score_high(dry_microburst_proxy, low=35.0, high=80.0), 0.35),
+            (_score_high(surface_ttd, low=10.0, high=28.0), 0.20),
+            (qv_drop_score, 0.20),
+            (deep_lapse, 0.15),
+            (_score_high(freezing_level, low=2500.0, high=4500.0), 0.10),
+        ]
+    )
     feature_coverage = (
         (len(story_feature_names) - len(missing_story_features)) / len(story_feature_names)
         if story_feature_names
         else 1.0
     )
+    deep_feature_coverage = (
+        (len(deep_feature_names) - len(missing_deep_features)) / len(deep_feature_names)
+        if deep_feature_names
+        else 1.0
+    )
+    wind_factor = 1.0 if observed_wind_available else 0.25
+    lowest_level = _numeric_feature(features, "lowest_level_m_agl")
+    surface_coverage_factor = 1.0
+    if lowest_level is None:
+        surface_coverage_factor = 0.5
+        deep_caveats.append("surface_level_unavailable_for_deep_convection_trial")
+    elif lowest_level > 250.0:
+        surface_coverage_factor = 0.25
+        deep_caveats.append("lowest_usable_level_too_high_for_deep_convection_trial")
+    elif lowest_level > 100.0:
+        surface_coverage_factor = 0.65
+        deep_caveats.append("lowest_usable_level_caveat_for_deep_convection_trial")
 
     shallow = _weighted_score(
         [(moist, 0.28), (low_lcl, 0.22), (deep_moisture, 0.18), (weak_cap, 0.14), (thermal, 0.18)]
@@ -505,6 +665,82 @@ def _score_features(
     humid_rainy = _weighted_score(
         [(moist, 0.32), (low_lcl, 0.22), (deep_moisture, 0.26), (weak_cap, 0.20)]
     )
+    severe = _weighted_score(
+        [
+            (instability, 0.32),
+            (storm_moisture, 0.16),
+            (low_lcl, 0.08),
+            (deep_lapse, 0.16),
+            (deep_shear, 0.18),
+            (not_strong_cap, 0.04),
+            (deep_moisture, 0.06),
+        ]
+    )
+    supercell = _weighted_score(
+        [
+            (instability, 0.24),
+            (storm_moisture, 0.12),
+            (deep_lapse, 0.12),
+            (supercell_deep_shear, 0.28),
+            (three_km_shear, 0.12),
+            (low_level_shear, 0.08),
+            (not_strong_cap, 0.04),
+        ]
+    )
+    high_cape_pulse = _weighted_score(
+        [
+            (high_cape_score, 0.35),
+            (cin_score, 0.16),
+            (storm_moisture, 0.18),
+            (low_lcl, 0.08),
+            (deep_lapse, 0.15),
+            (pulse_shear, 0.05),
+            (not_strong_cap, 0.03),
+        ]
+    )
+    squall_line = _weighted_score(
+        [
+            (instability, 0.24),
+            (storm_moisture, 0.12),
+            (deep_lapse, 0.14),
+            (deep_shear, 0.24),
+            (three_km_shear, 0.12),
+            (deep_moisture, 0.08),
+            (dry_layer, 0.06),
+        ]
+    )
+    elevated = _weighted_score(
+        [
+            (cape_score, 0.22),
+            (strong_cap, 0.20),
+            (storm_moisture, 0.16),
+            (deep_lapse, 0.14),
+            (deep_shear, 0.16),
+            (deep_moisture, 0.12),
+        ]
+    )
+    # Deep-convection stories already score buoyancy explicitly through the
+    # instability terms above. Do not use EL/deep-buoyancy as a second hard
+    # multiplier: many observed soundings provide useful CAPE/shear evidence
+    # while EL remains unavailable from the simple screening diagnostics.
+    deep_factor = (
+        data_quality / 100.0 * deep_feature_coverage * wind_factor * surface_coverage_factor
+    )
+    shallow_score = shallow * data_quality / 100.0 * feature_coverage
+    humid_score = humid_rainy * data_quality / 100.0 * feature_coverage
+    if observed_wind_available and effective_cape >= 1000.0 and deep_environment >= 55.0:
+        # The broad shallow/humid stories are easy to satisfy in moist warm-season
+        # profiles. When the same sounding has meaningful CAPE, shear, and deep
+        # lapse-rate support, keep those broad labels available but let the
+        # Deep Convection Trial story become the useful product recommendation.
+        shallow_score = min(shallow_score, 62.0)
+        humid_score = min(humid_score, 62.0)
+    elif observed_wind_available and effective_cape >= 250.0 and deep_environment >= 55.0:
+        # Moist profiles can still be shallow-cloud-capable, but when the same
+        # sounding has supported deep-convection evidence we should not let the
+        # broad shallow/humid labels hide the more useful package story.
+        shallow_score = min(shallow_score, 82.0)
+        humid_score = min(humid_score, 82.0)
     poor = 100.0 if not package_ready else min(34.0, max(0.0, 100.0 - data_quality))
     if not package_ready:
         poor = 100.0
@@ -522,7 +758,7 @@ def _score_features(
     scores = [
         _story_score(
             "shallow_cumulus_candidate",
-            shallow * data_quality / 100.0 * feature_coverage,
+            shallow_score,
             reasons=["moderate moisture, plausible LCL, thermal lapse-rate and cap proxies"],
             caveats=missing_caveats,
         ),
@@ -540,11 +776,98 @@ def _score_features(
         ),
         _story_score(
             "humid_rainy_candidate",
-            humid_rainy * data_quality / 100.0 * feature_coverage,
+            humid_score,
             reasons=["high low-level moisture, low LCL, deep moisture, weak-cap proxies"],
             caveats=[
                 "Humid/rainy is heavily caveated because forcing remains idealized.",
                 *missing_caveats,
+            ],
+        ),
+        _story_score(
+            "severe_thunderstorm_environment",
+            _deep_story_score(
+                severe * deep_factor, observed_wind_available=observed_wind_available
+            ),
+            reasons=[
+                "deep-convection proxy from simple CAPE/CIN, moisture, "
+                "LCL, lapse-rate, and shear evidence"
+            ],
+            caveats=[
+                "deep-convection candidate scores are pre-run hypotheses; "
+                "simple CAPE/CIN estimates are screening evidence only",
+                *deep_caveats,
+            ],
+        ),
+        _story_score(
+            "supercell_environment",
+            _deep_story_score(
+                supercell * deep_factor, observed_wind_available=observed_wind_available
+            ),
+            reasons=[
+                "supercell-like proxy from simple CAPE/CIN, moisture, and 0-6 km/low-level shear"
+            ],
+            caveats=[
+                "storm rotation and organization are CM1 outcomes to inspect after the run",
+                "SRH is unavailable because storm-motion assumptions are not implemented yet",
+                *deep_caveats,
+            ],
+        ),
+        _story_score(
+            "high_cape_pulse_storm",
+            _deep_story_score(
+                high_cape_pulse * deep_factor, observed_wind_available=observed_wind_available
+            ),
+            reasons=[
+                "pulse-storm proxy from high simple CAPE, rich moisture, "
+                "steep lapse rates, low LCL, and weaker deep shear"
+            ],
+            caveats=[
+                "CAPE is a simple screening estimate; CM1 output remains the outcome",
+                *deep_caveats,
+            ],
+        ),
+        _story_score(
+            "dry_microburst_inverted_v",
+            _deep_story_score(
+                dry_microburst * deep_factor, observed_wind_available=observed_wind_available
+            ),
+            reasons=[
+                "dry-microburst proxy from surface spread, qv drop, "
+                "midlevel dryness, and lapse-rate evidence"
+            ],
+            caveats=[
+                "microburst behavior requires precipitation and evaporative "
+                "cooling to develop in CM1",
+                *deep_caveats,
+            ],
+        ),
+        _story_score(
+            "squall_line_cold_pool_candidate",
+            _deep_story_score(
+                squall_line * deep_factor, observed_wind_available=observed_wind_available
+            ),
+            reasons=[
+                "squall-line proxy from simple CAPE/CIN, moisture, "
+                "lapse-rate, deep shear, and dry-layer context"
+            ],
+            caveats=[
+                "line/cold-pool-specific package support may come later; "
+                "v1 runs as Deep Convection Trial",
+                *deep_caveats,
+            ],
+        ),
+        _story_score(
+            "elevated_convection",
+            _deep_story_score(
+                elevated * deep_factor, observed_wind_available=observed_wind_available
+            ),
+            reasons=[
+                "elevated-convection proxy from simple CAPE, cap, moisture, "
+                "lapse-rate, and shear evidence"
+            ],
+            caveats=[
+                "elevated inflow/source-layer behavior may need a specialized package later",
+                *deep_caveats,
             ],
         ),
         _story_score(
@@ -588,8 +911,27 @@ def _score_features(
             value=features.get("mean_qv_0_1000m_g_kg"),
             units="g/kg",
             interpretation="Higher low-level moisture supports cloud-forming and humid candidates.",
-            supports_story=["shallow_cumulus_candidate", "humid_rainy_candidate"],
+            supports_story=[
+                "shallow_cumulus_candidate",
+                "humid_rainy_candidate",
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "high_cape_pulse_storm",
+                "squall_line_cold_pool_candidate",
+            ],
             caveats=_feature_caveats(features, "mean_qv_0_1000m_g_kg"),
+        ),
+        EvidenceItem(
+            label="Near-surface continuity",
+            value="large jump" if features.get("near_surface_discontinuity_flag") else "ok",
+            interpretation=(
+                "Large temperature or moisture jumps in the first shallow layer can make "
+                "pre-run scores overconfident."
+            ),
+            supports_story=["needs_review", "poor_or_incomplete_candidate"],
+            caveats=["near_surface_discontinuity_caveat"]
+            if features.get("near_surface_discontinuity_flag") is True
+            else [],
         ),
         EvidenceItem(
             label="Surface T-Td spread",
@@ -632,8 +974,30 @@ def _score_features(
             interpretation=(
                 "Lower-atmosphere stability gives context for thermal growth and cap effects."
             ),
-            supports_story=["capped_suppressed_candidate", "needs_review"],
+            supports_story=[
+                "capped_suppressed_candidate",
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "high_cape_pulse_storm",
+                "squall_line_cold_pool_candidate",
+                "elevated_convection",
+                "needs_review",
+            ],
             caveats=_feature_caveats(features, "lapse_rate_0_3000m_c_per_km"),
+        ),
+        EvidenceItem(
+            label="Midlevel lapse rate 700-500 hPa",
+            value=features.get("midlevel_lapse_rate_700_500_hpa_c_per_km"),
+            units="C/km",
+            interpretation="Steeper midlevel lapse rates support deep-convection trial hypotheses.",
+            supports_story=[
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "high_cape_pulse_storm",
+                "squall_line_cold_pool_candidate",
+                "elevated_convection",
+            ],
+            caveats=_feature_caveats(features, "midlevel_lapse_rate_700_500_hpa_c_per_km"),
         ),
         EvidenceItem(
             label="Cap strength proxy",
@@ -675,16 +1039,119 @@ def _score_features(
             interpretation=(
                 "A stronger near-surface to midlevel moisture drop supports dry-failed hypotheses."
             ),
-            supports_story=["dry_failed_candidate"],
+            supports_story=[
+                "dry_failed_candidate",
+                "dry_microburst_inverted_v",
+                "squall_line_cold_pool_candidate",
+            ],
             caveats=_feature_caveats(features, "midlevel_dry_layer_proxy"),
+        ),
+        EvidenceItem(
+            label="Surface-based CAPE",
+            value=features.get("surface_based_cape_j_kg"),
+            units="J/kg",
+            interpretation=(
+                "Simple pre-run parcel estimate; higher values support deep-convection trials."
+            ),
+            supports_story=[
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "high_cape_pulse_storm",
+                "squall_line_cold_pool_candidate",
+            ],
+            caveats=_feature_caveats(features, "surface_based_cape_j_kg"),
+        ),
+        EvidenceItem(
+            label="Surface-based CIN",
+            value=features.get("surface_based_cin_j_kg"),
+            units="J/kg",
+            interpretation=(
+                "Simple pre-run parcel estimate; strong inhibition lowers trial confidence."
+            ),
+            supports_story=[
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "high_cape_pulse_storm",
+                "elevated_convection",
+            ],
+            caveats=_feature_caveats(features, "surface_based_cin_j_kg"),
+        ),
+        EvidenceItem(
+            label="Bulk shear 0-1 km",
+            value=features.get("bulk_shear_0_1km_m_s"),
+            units="m/s",
+            interpretation=(
+                "Low-level shear gives context for organized or rotating deep-convection trials."
+            ),
+            supports_story=["supercell_environment"],
+            caveats=_feature_caveats(features, "bulk_shear_0_1km_m_s"),
+        ),
+        EvidenceItem(
+            label="Bulk shear 0-3 km",
+            value=features.get("bulk_shear_0_3km_m_s"),
+            units="m/s",
+            interpretation="0-3 km shear helps screen organized deep-convection candidates.",
+            supports_story=[
+                "supercell_environment",
+                "squall_line_cold_pool_candidate",
+                "elevated_convection",
+            ],
+            caveats=_feature_caveats(features, "bulk_shear_0_3km_m_s"),
+        ),
+        EvidenceItem(
+            label="Bulk shear 0-6 km",
+            value=features.get("bulk_shear_0_6km_m_s"),
+            units="m/s",
+            interpretation=(
+                "Deep-layer shear is a key pre-run clue for organized storm experiments."
+            ),
+            supports_story=[
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "squall_line_cold_pool_candidate",
+                "elevated_convection",
+            ],
+            caveats=_feature_caveats(features, "bulk_shear_0_6km_m_s"),
+        ),
+        EvidenceItem(
+            label="Dry microburst / inverted-V proxy",
+            value=features.get("dry_microburst_inverted_v_proxy"),
+            units="0-100",
+            interpretation=(
+                "High values mark dry low levels and moisture drop that may matter if "
+                "precipitation develops."
+            ),
+            supports_story=["dry_microburst_inverted_v"],
+            caveats=_feature_caveats(features, "dry_microburst_inverted_v_proxy"),
+        ),
+        EvidenceItem(
+            label="Freezing level",
+            value=features.get("freezing_level_m_agl"),
+            units="m AGL",
+            interpretation=(
+                "Freezing-level height gives context for precipitation and downdraft potential."
+            ),
+            supports_story=[
+                "severe_thunderstorm_environment",
+                "dry_microburst_inverted_v",
+                "squall_line_cold_pool_candidate",
+            ],
+            caveats=_feature_caveats(features, "freezing_level_m_agl"),
         ),
         EvidenceItem(
             label="Observed wind availability",
             value=features.get("observed_wind_available"),
             interpretation=(
-                "Observed winds are required for the current external-sounding package path."
+                "Observed winds are required for trustworthy Deep Convection Trial packages."
             ),
-            supports_story=["poor_or_incomplete_candidate", "needs_review"],
+            supports_story=[
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "squall_line_cold_pool_candidate",
+                "elevated_convection",
+                "poor_or_incomplete_candidate",
+                "needs_review",
+            ],
             caveats=[]
             if features.get("observed_wind_available") is True
             else ["observed_wind_unavailable"],
@@ -749,6 +1216,12 @@ def _poor_candidate_scores(reason: str) -> tuple[list[StoryScore], list[Evidence
         _story_score("dry_failed_candidate", 0.0),
         _story_score("capped_suppressed_candidate", 0.0),
         _story_score("humid_rainy_candidate", 0.0),
+        _story_score("severe_thunderstorm_environment", 0.0),
+        _story_score("supercell_environment", 0.0),
+        _story_score("high_cape_pulse_storm", 0.0),
+        _story_score("dry_microburst_inverted_v", 0.0),
+        _story_score("squall_line_cold_pool_candidate", 0.0),
+        _story_score("elevated_convection", 0.0),
     ]
     evidence = [
         EvidenceItem(
@@ -784,6 +1257,14 @@ def _story_score(
         reasons=reasons or [],
         caveats=caveats or [],
     )
+
+
+def _deep_story_score(score: float, *, observed_wind_available: bool) -> float:
+    """Let strong deep-convection evidence win over broad moist/shallow labels."""
+
+    if observed_wind_available and score >= 65.0:
+        return min(100.0, score + 5.0)
+    return score
 
 
 def _confidence(
@@ -858,6 +1339,38 @@ def _numeric_feature(
 
 def _feature_caveats(features: dict[str, float | int | str | bool | None], name: str) -> list[str]:
     return [] if _numeric_feature(features, name) is not None else [f"{name}_unavailable"]
+
+
+def _near_surface_jump(levels: list[Any]) -> dict[str, float | bool | None]:
+    usable = sorted(
+        [level for level in levels if math.isfinite(float(level.model_z_m))],
+        key=lambda level: float(level.model_z_m),
+    )
+    if len(usable) < 2:
+        return {
+            "depth_m": None,
+            "temperature_jump_c": None,
+            "qv_jump_g_kg": None,
+            "flag": False,
+        }
+    lower, upper = usable[0], usable[1]
+    depth = float(upper.model_z_m) - float(lower.model_z_m)
+    if depth <= 0.0:
+        return {
+            "depth_m": round(depth, 1),
+            "temperature_jump_c": None,
+            "qv_jump_g_kg": None,
+            "flag": True,
+        }
+    temperature_jump = abs(float(upper.temperature_c) - float(lower.temperature_c))
+    qv_jump = abs(float(upper.qv_g_kg) - float(lower.qv_g_kg))
+    flag = depth <= 150.0 and (temperature_jump >= 5.0 or qv_jump >= 5.0)
+    return {
+        "depth_m": round(depth, 1),
+        "temperature_jump_c": round(temperature_jump, 2),
+        "qv_jump_g_kg": round(qv_jump, 3),
+        "flag": flag,
+    }
 
 
 def _score_high(value: float | None, *, low: float, high: float) -> float:

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -44,6 +44,7 @@ StoryId = Literal[
     "poor_or_incomplete_candidate",
 ]
 TargetStoryId = Literal[
+    "deep_convection_trial",
     "shallow_cumulus_candidate",
     "dry_failed_candidate",
     "capped_suppressed_candidate",
@@ -74,6 +75,15 @@ STORY_LABELS: dict[StoryId, str] = {
     "needs_review": "Needs review",
     "poor_or_incomplete_candidate": "Poor or incomplete data",
 }
+
+DEEP_CONVECTION_STORY_IDS: tuple[StoryId, ...] = (
+    "severe_thunderstorm_environment",
+    "supercell_environment",
+    "high_cape_pulse_storm",
+    "dry_microburst_inverted_v",
+    "squall_line_cold_pool_candidate",
+    "elevated_convection",
+)
 
 
 class StoryScore(BaseModel):
@@ -272,6 +282,19 @@ def screen_cached_soundings(
 def _candidate_story_score(candidate: SoundingCandidate, story: TargetStoryId | None) -> float:
     if story is None:
         return candidate.rank_score
+    if story == "deep_convection_trial":
+        return (
+            max(
+                (
+                    score.score_0_to_100
+                    for score in candidate.story_scores
+                    if score.story in DEEP_CONVECTION_STORY_IDS
+                ),
+                default=0.0,
+            )
+            if candidate.package_ready
+            else 0.0
+        )
     for score in candidate.story_scores:
         if score.story == story:
             return score.score_0_to_100 if candidate.package_ready else 0.0

--- a/app/backend/cloud_chamber/sounding_diagnostics.py
+++ b/app/backend/cloud_chamber/sounding_diagnostics.py
@@ -7,6 +7,7 @@ are not forecasts and they are not CM1 outcomes.
 from __future__ import annotations
 
 import math
+from bisect import bisect_left
 from datetime import datetime
 from typing import Literal
 
@@ -379,32 +380,95 @@ def compute_sounding_diagnostics(record: ObservedSoundingRecord) -> SoundingDiag
         )
     )
 
-    for key, label, units in (
-        ("surface_based_cape_j_kg", "Surface-based CAPE", "J/kg"),
-        ("surface_based_cin_j_kg", "Surface-based CIN", "J/kg"),
-        ("mixed_layer_cape_j_kg", "Mixed-layer CAPE", "J/kg"),
-        ("mixed_layer_cin_j_kg", "Mixed-layer CIN", "J/kg"),
-        ("lfc_height_m_agl", "LFC height", "m AGL"),
-        ("el_height_m_agl", "EL height", "m AGL"),
-    ):
-        add(
-            _unavailable(
-                key,
-                label,
-                "Parcel diagnostics require a tested parcel model and "
-                "virtual-temperature assumptions.",
-                units=units,
-            )
+    surface_parcel = _simple_parcel_diagnostics(levels, source="surface")
+    mixed_layer_parcel = _simple_parcel_diagnostics(levels, source="mixed_layer_0_500m")
+    parcel_assumptions = [
+        "Uses a simple lifted-parcel approximation for screening only.",
+        "Uses the sounding vertical grid and approximate moist-adiabatic ascent above LCL.",
+        "Does not replace CM1 output or a full severe-weather parcel-analysis package.",
+    ]
+    add(
+        _feature(
+            "surface_based_cape_j_kg",
+            "Surface-based CAPE",
+            surface_parcel.cape_j_kg,
+            "J/kg",
+            "simple parcel estimate from the lowest sounding level",
+            assumptions=parcel_assumptions,
+            caveats=surface_parcel.caveats,
+            support_state="weak",
         )
+    )
+    add(
+        _feature(
+            "surface_based_cin_j_kg",
+            "Surface-based CIN",
+            surface_parcel.cin_j_kg,
+            "J/kg",
+            "simple parcel estimate from the lowest sounding level",
+            assumptions=parcel_assumptions,
+            caveats=surface_parcel.caveats,
+            support_state="weak",
+        )
+    )
+    add(
+        _feature(
+            "mixed_layer_cape_j_kg",
+            "Mixed-layer CAPE",
+            mixed_layer_parcel.cape_j_kg,
+            "J/kg",
+            "simple parcel estimate from mean 0-500 m temperature, moisture, and pressure",
+            assumptions=parcel_assumptions,
+            caveats=mixed_layer_parcel.caveats,
+            support_state="weak",
+        )
+    )
+    add(
+        _feature(
+            "mixed_layer_cin_j_kg",
+            "Mixed-layer CIN",
+            mixed_layer_parcel.cin_j_kg,
+            "J/kg",
+            "simple parcel estimate from mean 0-500 m temperature, moisture, and pressure",
+            assumptions=parcel_assumptions,
+            caveats=mixed_layer_parcel.caveats,
+            support_state="weak",
+        )
+    )
+    add(
+        _feature(
+            "lfc_height_m_agl",
+            "LFC height",
+            surface_parcel.lfc_height_m_agl,
+            "m AGL",
+            "first positive-buoyancy crossing in the simple surface-based parcel estimate",
+            assumptions=parcel_assumptions,
+            caveats=surface_parcel.caveats,
+            support_state="weak",
+        )
+    )
+    add(
+        _feature(
+            "el_height_m_agl",
+            "EL height",
+            surface_parcel.el_height_m_agl,
+            "m AGL",
+            "first negative-buoyancy crossing after LFC in the simple "
+            "surface-based parcel estimate",
+            assumptions=parcel_assumptions,
+            caveats=surface_parcel.caveats,
+            support_state="weak",
+        )
+    )
     add(
         _feature(
             "parcel_assumptions",
             "Parcel assumptions",
-            "not_implemented",
+            "simple_screening_parcel",
             None,
             "records parcel-diagnostic status",
-            support_state="unavailable",
-            caveats=["parcel_diagnostics_not_implemented"],
+            support_state="weak",
+            caveats=["parcel_diagnostics_are_screening_estimates"],
         )
     )
 
@@ -857,6 +921,195 @@ def _freezing_level(levels: list[ObservedSoundingLevel]) -> float | None:
             fraction = (0.0 - lower.temperature_c) / (upper.temperature_c - lower.temperature_c)
             return _round(lower.model_z_m + fraction * (upper.model_z_m - lower.model_z_m), 1)
     return None
+
+
+class _ParcelDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    cape_j_kg: float | None = None
+    cin_j_kg: float | None = None
+    lfc_height_m_agl: float | None = None
+    el_height_m_agl: float | None = None
+    caveats: list[str] = Field(default_factory=list)
+
+
+def _simple_parcel_diagnostics(
+    levels: list[ObservedSoundingLevel], *, source: Literal["surface", "mixed_layer_0_500m"]
+) -> _ParcelDiagnostics:
+    finite = [
+        level
+        for level in sorted(levels, key=lambda item: item.model_z_m)
+        if _finite(level.model_z_m, level.pressure_pa, level.temperature_c, level.qv_g_kg)
+        and level.pressure_pa > 0.0
+    ]
+    if len(finite) < 3:
+        return _ParcelDiagnostics(caveats=["parcel_profile_too_sparse"])
+
+    if source == "surface":
+        source_z = finite[0].model_z_m
+        source_pressure = finite[0].pressure_pa
+        source_temperature_c = finite[0].temperature_c
+        source_qv_g_kg = finite[0].qv_g_kg
+    else:
+        mixed = [level for level in finite if 0.0 <= level.model_z_m <= 500.0]
+        if len(mixed) < 2:
+            return _ParcelDiagnostics(caveats=["mixed_layer_profile_too_sparse"])
+        source_z = 0.0
+        mean_pressure = _mean([level.pressure_pa for level in mixed])
+        mean_temperature_c = _mean([level.temperature_c for level in mixed])
+        mean_qv_g_kg = _mean([level.qv_g_kg for level in mixed])
+        if mean_pressure is None or mean_temperature_c is None or mean_qv_g_kg is None:
+            return _ParcelDiagnostics(caveats=["mixed_layer_source_unavailable"])
+        source_pressure = mean_pressure
+        source_temperature_c = mean_temperature_c
+        source_qv_g_kg = mean_qv_g_kg
+
+    dewpoint_c = _dewpoint_c_from_qv(source_pressure, source_qv_g_kg)
+    if dewpoint_c is None:
+        return _ParcelDiagnostics(caveats=["parcel_dewpoint_unavailable"])
+    lcl_height = max(0.0, 125.0 * (source_temperature_c - dewpoint_c))
+    lcl_z = source_z + lcl_height
+
+    sample_heights = sorted(
+        {
+            source_z,
+            lcl_z,
+            *(
+                level.model_z_m
+                for level in finite
+                if level.model_z_m >= source_z and level.model_z_m <= finite[-1].model_z_m
+            ),
+        }
+    )
+    height_values = [level.model_z_m for level in finite]
+    pressure_values = [level.pressure_pa for level in finite]
+    temperature_values = [level.temperature_c for level in finite]
+    qv_values = [level.qv_g_kg for level in finite]
+
+    def interpolate(height: float, values: list[float]) -> float | None:
+        if not height_values or height < height_values[0] or height > height_values[-1]:
+            return None
+        index = bisect_left(height_values, height)
+        if index < len(height_values) and math.isclose(height_values[index], height):
+            return values[index]
+        if index == 0 or index >= len(height_values):
+            return None
+        h0 = height_values[index - 1]
+        h1 = height_values[index]
+        v0 = values[index - 1]
+        v1 = values[index]
+        if h1 == h0:
+            return v0
+        fraction = (height - h0) / (h1 - h0)
+        return v0 + fraction * (v1 - v0)
+
+    samples: list[tuple[float, float, float, float]] = []
+    for height in sample_heights:
+        pressure = interpolate(height, pressure_values)
+        env_temperature = interpolate(height, temperature_values)
+        env_qv = interpolate(height, qv_values)
+        if pressure is None or env_temperature is None or env_qv is None:
+            continue
+        samples.append((height, pressure, env_temperature + 273.15, env_qv / 1000.0))
+    if len(samples) < 3:
+        return _ParcelDiagnostics(caveats=["parcel_interpolation_failed"])
+
+    rd = 287.05
+    cp = 1004.0
+    kappa = rd / cp
+    g = 9.80665
+    theta0 = (source_temperature_c + 273.15) * (100000.0 / source_pressure) ** kappa
+    source_qv = source_qv_g_kg / 1000.0
+    parcel_temperatures: list[float] = []
+    previous_temperature: float | None = None
+    previous_height: float | None = None
+    previous_pressure: float | None = None
+    for height, pressure, _env_temperature_k, _env_qv in samples:
+        if height <= lcl_z:
+            parcel_temperature = theta0 * (pressure / 100000.0) ** kappa
+        else:
+            if previous_temperature is None or previous_height is None or previous_pressure is None:
+                lcl_pressure = interpolate(lcl_z, pressure_values) or pressure
+                previous_temperature = theta0 * (lcl_pressure / 100000.0) ** kappa
+                previous_height = lcl_z
+                previous_pressure = lcl_pressure
+            dz = max(0.0, height - previous_height)
+            gamma_m = _moist_lapse_rate_k_per_m(previous_temperature, previous_pressure)
+            parcel_temperature = previous_temperature - gamma_m * dz
+        parcel_temperatures.append(parcel_temperature)
+        previous_temperature = parcel_temperature
+        previous_height = height
+        previous_pressure = pressure
+
+    buoyancy: list[tuple[float, float]] = []
+    for (height, pressure, env_temperature_k, env_qv), parcel_temperature in zip(
+        samples, parcel_temperatures, strict=True
+    ):
+        if height <= lcl_z:
+            parcel_qv = source_qv
+        else:
+            parcel_qv = _saturation_mixing_ratio_kg_kg(pressure, parcel_temperature)
+        tv_parcel = parcel_temperature * (1.0 + 0.61 * parcel_qv)
+        tv_env = env_temperature_k * (1.0 + 0.61 * env_qv)
+        buoyancy.append((height, g * (tv_parcel - tv_env) / tv_env))
+
+    cape = 0.0
+    cin = 0.0
+    had_positive = False
+    lfc: float | None = None
+    el: float | None = None
+    for (z0, b0), (z1, b1) in zip(buoyancy, buoyancy[1:], strict=False):
+        dz = z1 - z0
+        if dz <= 0.0:
+            continue
+        avg = 0.5 * (b0 + b1)
+        if avg > 0.0:
+            cape += avg * dz
+            if not had_positive:
+                had_positive = True
+                lfc = _zero_crossing_height(z0, b0, z1, b1) or z0
+        elif not had_positive:
+            cin += avg * dz
+        elif el is None and b0 > 0.0 >= b1:
+            el = _zero_crossing_height(z0, b0, z1, b1) or z1
+    if cape <= 0.0:
+        lfc = None
+        el = None
+    return _ParcelDiagnostics(
+        cape_j_kg=_round(max(0.0, cape), 1),
+        cin_j_kg=_round(cin, 1),
+        lfc_height_m_agl=_round(lfc, 1),
+        el_height_m_agl=_round(el, 1),
+        caveats=["simple_parcel_estimate"],
+    )
+
+
+def _moist_lapse_rate_k_per_m(temperature_k: float, pressure_pa: float) -> float:
+    g = 9.80665
+    rd = 287.05
+    rv = 461.5
+    cp = 1004.0
+    lv = 2.5e6
+    rs = _saturation_mixing_ratio_kg_kg(pressure_pa, temperature_k)
+    numerator = g * (1.0 + (lv * rs) / (rd * temperature_k))
+    denominator = cp + (lv * lv * rs * 0.622) / (rv * temperature_k * temperature_k)
+    return numerator / denominator
+
+
+def _saturation_mixing_ratio_kg_kg(pressure_pa: float, temperature_k: float) -> float:
+    temperature_c = temperature_k - 273.15
+    es_hpa = 6.112 * math.exp((17.67 * temperature_c) / (temperature_c + 243.5))
+    es_pa = min(es_hpa * 100.0, pressure_pa * 0.95)
+    return 0.622 * es_pa / max(1.0, pressure_pa - es_pa)
+
+
+def _zero_crossing_height(z0: float, b0: float, z1: float, b1: float) -> float | None:
+    if math.isclose(b0, b1):
+        return None
+    fraction = (0.0 - b0) / (b1 - b0)
+    if not 0.0 <= fraction <= 1.0:
+        return None
+    return z0 + fraction * (z1 - z0)
 
 
 def _interpolate_by_height(

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -173,7 +173,12 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
     }
     assert "dbz" in manifest.expected_outputs
     assert "updraft_helicity" in manifest.expected_outputs
-    assert manifest.manual_validation_status == "manual_cm1_smoke_run_observed_deep_convection"
+    assert manifest.manual_validation_status == "deep_convection_trial_package_smoke_validated"
+    assert any(
+        "Manual smoke evidence applies to the Deep Convection Trial package family" in caveat
+        and "each observed sounding remains an experiment" in caveat
+        for caveat in manifest.package_caveats
+    )
     assert manifest.candidate_screening == candidate_screening
     assert report["package_family"] == "deep_convection_trial"
     assert report["package_display_name"] == "Deep Convection Trial"
@@ -182,8 +187,15 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
     assert "testcase=0" in report["variant_metadata"]["mapping"]
     assert "iinit=3 three-warm-bubble" in report["variant_metadata"]["mapping"]
     assert "reflectivity output" in report["variant_metadata"]["mapping"]
+    assert report["manual_validation_status"] == "deep_convection_trial_package_smoke_validated"
+    assert "manual CM1 smoke evidence" in report["cm1_mapping_status"]
+    assert "each observed sounding remains an experiment" in report["cm1_mapping_status"]
     assert case_manifest["package_family"] == "deep_convection_trial"
     assert case_manifest["contract"]["package_family"] == "deep_convection_trial"
+    assert (
+        case_manifest["contract"]["manual_validation_status"]
+        == "deep_convection_trial_package_smoke_validated"
+    )
 
     assert "testcase  =  0," in namelist
     assert "isnd      =  7," in namelist
@@ -245,7 +257,7 @@ def test_deep_convection_trial_requires_observed_wind_components(tmp_path: Path)
         }
     )
 
-    with pytest.raises(DryRunPackageError, match="requires observed wind components"):
+    with pytest.raises(DryRunPackageError, match="complete finite observed u/v wind profile"):
         generate_dry_run_package(
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
@@ -253,6 +265,36 @@ def test_deep_convection_trial_requires_observed_wind_components(tmp_path: Path)
             package_family="deep_convection_trial",
             observed_sounding=no_wind,
         )
+
+
+def test_deep_convection_trial_requires_complete_rendered_wind_profile(
+    tmp_path: Path,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    missing_mid_profile_wind = observed.model_copy(
+        update={
+            "levels": [
+                level.model_copy(update={"u_wind_m_s": None})
+                if index == len(observed.levels) // 2
+                else level
+                for index, level in enumerate(observed.levels)
+            ]
+        }
+    )
+
+    with pytest.raises(DryRunPackageError, match="complete finite observed u/v wind profile"):
+        generate_dry_run_package(
+            scenario_data=load_baseline_template(),
+            runtime_home=tmp_path,
+            run_id="run-deep-partial-wind",
+            package_family="deep_convection_trial",
+            observed_sounding=missing_mid_profile_wind,
+        )
+
+    assert not (tmp_path / "runs" / "run-deep-partial-wind").exists()
 
 
 def test_dry_run_package_refuses_to_overwrite_existing_run_dir(tmp_path: Path) -> None:

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -122,6 +122,119 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
     assert float(sounding.splitlines()[-1].split()[0]) > 18000
 
 
+def test_deep_convection_trial_package_uses_observed_sounding_and_warm_line_thermal(
+    tmp_path: Path,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    candidate_screening = {
+        "candidate_id": "USM00072558-deep-test",
+        "primary_story": "supercell_environment",
+        "rank_score": 91.0,
+    }
+
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-deep-convection-trial",
+        run_size_preset="quick_look",
+        package_family="deep_convection_trial",
+        observed_sounding=observed,
+        candidate_screening=candidate_screening,
+    )
+
+    manifest = load_run_manifest(result.manifest_path)
+    report = json.loads(result.report_path.read_text())
+    case_manifest = json.loads((result.package_dir / "case_manifest.json").read_text())
+    namelist = (result.package_dir / "namelist.input").read_text()
+    sounding = (result.package_dir / "input_sounding").read_text()
+
+    assert manifest.package_family == "deep_convection_trial"
+    assert manifest.package_display_name == "Deep Convection Trial"
+    assert manifest.input_source == "observed_sounding"
+    assert manifest.trigger_type == "warm_thermal_line"
+    assert manifest.trigger_parameters == {
+        "cm1_iinit": 8,
+        "cm1_trigger": (
+            "CM1 built-in line thermal with small random perturbations; 2 K maximum "
+            "potential-temperature perturbation centered near 1.5 km AGL"
+        ),
+        "raw_controls_exposed": False,
+    }
+    assert "dbz" in manifest.expected_outputs
+    assert "updraft_helicity" in manifest.expected_outputs
+    assert manifest.manual_validation_status == "needs_manual_cm1_smoke_run"
+    assert manifest.candidate_screening == candidate_screening
+    assert report["package_family"] == "deep_convection_trial"
+    assert report["package_display_name"] == "Deep Convection Trial"
+    assert report["trigger_type"] == "warm_thermal_line"
+    assert report["candidate_screening"] == candidate_screening
+    assert "testcase=0" in report["variant_metadata"]["mapping"]
+    assert "iinit=8 warm line-thermal" in report["variant_metadata"]["mapping"]
+    assert "reflectivity output" in report["variant_metadata"]["mapping"]
+    assert case_manifest["package_family"] == "deep_convection_trial"
+    assert case_manifest["contract"]["package_family"] == "deep_convection_trial"
+
+    assert "testcase  =  0," in namelist
+    assert "isnd      =  7," in namelist
+    assert "iwnd      =  0," in namelist
+    assert "iinit     =  8," in namelist
+    assert "irandp    =  0," in namelist
+    assert "ptype     =  5," in namelist
+    assert "ihail     =  1," in namelist
+    assert "iautoc    =  1," in namelist
+    assert "output_rain      = 1," in namelist
+    assert "output_dbz       = 1," in namelist
+    assert "output_vort      = 1," in namelist
+    assert "output_uh        = 1," in namelist
+    assert "nx           =      96," in namelist
+    assert "ny           =      96," in namelist
+    assert "dx     =   250.0," in namelist
+    assert "dy     =   250.0," in namelist
+    assert "tapfrq =  600.0," in namelist
+    assert "zd      =  15000.0," in namelist
+    assert float(sounding.splitlines()[1].split()[3]) == pytest.approx(
+        observed.levels[0].u_wind_m_s,
+        abs=0.01,
+    )
+
+
+def test_deep_convection_trial_requires_observed_sounding(tmp_path: Path) -> None:
+    with pytest.raises(DryRunPackageError, match="requires a validated observed sounding"):
+        generate_dry_run_package(
+            scenario_data=load_baseline_template(),
+            runtime_home=tmp_path,
+            run_id="run-deep-no-sounding",
+            package_family="deep_convection_trial",
+        )
+
+
+def test_deep_convection_trial_requires_observed_wind_components(tmp_path: Path) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    no_wind = observed.model_copy(
+        update={
+            "levels": [
+                level.model_copy(update={"u_wind_m_s": None, "v_wind_m_s": None})
+                for level in observed.levels
+            ]
+        }
+    )
+
+    with pytest.raises(DryRunPackageError, match="requires observed wind components"):
+        generate_dry_run_package(
+            scenario_data=load_baseline_template(),
+            runtime_home=tmp_path,
+            run_id="run-deep-no-wind",
+            package_family="deep_convection_trial",
+            observed_sounding=no_wind,
+        )
+
+
 def test_dry_run_package_refuses_to_overwrite_existing_run_dir(tmp_path: Path) -> None:
     generate_dry_run_package(
         scenario_data=load_baseline_template(),

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -5,7 +5,7 @@ import pytest
 from igra_fixtures import IGRA_FIXTURE
 
 from cloud_chamber.dry_run_package import DryRunPackageError, generate_dry_run_package
-from cloud_chamber.observed_sounding import parse_igra_station_text
+from cloud_chamber.observed_sounding import ObservedSoundingLevel, parse_igra_station_text
 from cloud_chamber.run_manifest import load_run_manifest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -24,6 +24,12 @@ def load_dry_failed_template() -> object:
 
 def load_capped_template() -> object:
     return json.loads(CAPPED_TEMPLATE.read_text())
+
+
+def _level_at_rendered_z(
+    levels: list[ObservedSoundingLevel], rendered_z: float
+) -> ObservedSoundingLevel:
+    return next(level for level in levels if level.model_z_m == pytest.approx(rendered_z))
 
 
 def test_generate_dry_run_package_writes_expected_files_to_temp_runtime_home(
@@ -110,19 +116,21 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
     assert "isnd      =  7," in namelist
     assert "iwnd      =  0," in namelist
     assert "USM00072558" not in sounding
-    assert float(sounding.splitlines()[1].split()[0]) == pytest.approx(0.0)
+    assert float(sounding.splitlines()[1].split()[0]) == pytest.approx(observed.levels[0].model_z_m)
+    first_body_z = float(sounding.splitlines()[1].split()[0])
+    first_body_level = _level_at_rendered_z(observed.levels, first_body_z)
     assert float(sounding.splitlines()[1].split()[3]) == pytest.approx(
-        observed.levels[0].u_wind_m_s,
+        first_body_level.u_wind_m_s,
         abs=0.01,
     )
     assert float(sounding.splitlines()[1].split()[4]) == pytest.approx(
-        observed.levels[0].v_wind_m_s,
+        first_body_level.v_wind_m_s,
         abs=0.01,
     )
     assert float(sounding.splitlines()[-1].split()[0]) > 18000
 
 
-def test_deep_convection_trial_package_uses_observed_sounding_and_warm_line_thermal(
+def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
     tmp_path: Path,
 ) -> None:
     observed = parse_igra_station_text(
@@ -154,25 +162,25 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_line_ther
     assert manifest.package_family == "deep_convection_trial"
     assert manifest.package_display_name == "Deep Convection Trial"
     assert manifest.input_source == "observed_sounding"
-    assert manifest.trigger_type == "warm_thermal_line"
+    assert manifest.trigger_type == "warm_bubble"
     assert manifest.trigger_parameters == {
-        "cm1_iinit": 8,
+        "cm1_iinit": 3,
         "cm1_trigger": (
-            "CM1 built-in line thermal with small random perturbations; 2 K maximum "
-            "potential-temperature perturbation centered near 1.5 km AGL"
+            "CM1 built-in three warm bubbles with 2 K maximum potential-temperature "
+            "perturbations in a line near 1.4 km AGL"
         ),
         "raw_controls_exposed": False,
     }
     assert "dbz" in manifest.expected_outputs
     assert "updraft_helicity" in manifest.expected_outputs
-    assert manifest.manual_validation_status == "needs_manual_cm1_smoke_run"
+    assert manifest.manual_validation_status == "manual_cm1_smoke_run_observed_deep_convection"
     assert manifest.candidate_screening == candidate_screening
     assert report["package_family"] == "deep_convection_trial"
     assert report["package_display_name"] == "Deep Convection Trial"
-    assert report["trigger_type"] == "warm_thermal_line"
+    assert report["trigger_type"] == "warm_bubble"
     assert report["candidate_screening"] == candidate_screening
     assert "testcase=0" in report["variant_metadata"]["mapping"]
-    assert "iinit=8 warm line-thermal" in report["variant_metadata"]["mapping"]
+    assert "iinit=3 three-warm-bubble" in report["variant_metadata"]["mapping"]
     assert "reflectivity output" in report["variant_metadata"]["mapping"]
     assert case_manifest["package_family"] == "deep_convection_trial"
     assert case_manifest["contract"]["package_family"] == "deep_convection_trial"
@@ -180,8 +188,9 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_line_ther
     assert "testcase  =  0," in namelist
     assert "isnd      =  7," in namelist
     assert "iwnd      =  0," in namelist
-    assert "iinit     =  8," in namelist
+    assert "iinit     =  3," in namelist
     assert "irandp    =  0," in namelist
+    assert "imove     =  1," in namelist
     assert "ptype     =  5," in namelist
     assert "ihail     =  1," in namelist
     assert "iautoc    =  1," in namelist
@@ -189,14 +198,25 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_line_ther
     assert "output_dbz       = 1," in namelist
     assert "output_vort      = 1," in namelist
     assert "output_uh        = 1," in namelist
-    assert "nx           =      96," in namelist
-    assert "ny           =      96," in namelist
-    assert "dx     =   250.0," in namelist
-    assert "dy     =   250.0," in namelist
+    assert "nx           =      120," in namelist
+    assert "ny           =      120," in namelist
+    assert "nz           =      40," in namelist
+    assert "dx     =   1000.0," in namelist
+    assert "dy     =   1000.0," in namelist
+    assert "dz     =   500.0," in namelist
+    assert "dtl    =   6.000," in namelist
+    assert "timax  = 7200.0," in namelist
     assert "tapfrq =  600.0," in namelist
     assert "zd      =  15000.0," in namelist
+    assert float(sounding.splitlines()[-1].split()[0]) >= 20000.0
+    first_body_z = float(sounding.splitlines()[1].split()[0])
+    first_body_level = _level_at_rendered_z(observed.levels, first_body_z)
     assert float(sounding.splitlines()[1].split()[3]) == pytest.approx(
-        observed.levels[0].u_wind_m_s,
+        first_body_level.u_wind_m_s,
+        abs=0.01,
+    )
+    assert float(sounding.splitlines()[1].split()[4]) == pytest.approx(
+        first_body_level.v_wind_m_s,
         abs=0.01,
     )
 

--- a/app/backend/tests/test_igra_recent_cli.py
+++ b/app/backend/tests/test_igra_recent_cli.py
@@ -423,6 +423,9 @@ def test_candidates_all_prints_story_specific_sections(
     assert "Dry failed cumulus candidate" in output
     assert "Capped / suppressed cumulus candidate" in output
     assert "Humid / rainy candidate" in output
+    assert "Severe thunderstorm environment" in output
+    assert "Supercell-like environment" in output
+    assert "High-CAPE pulse-storm candidate" in output
 
 
 def test_refresh_prints_next_commands(

--- a/app/backend/tests/test_observed_sounding.py
+++ b/app/backend/tests/test_observed_sounding.py
@@ -52,6 +52,19 @@ def test_summarize_igra_station_text_lists_times_without_package_validation() ->
     assert summaries[0].num_levels > 0
 
 
+def test_igra_missing_hour_headers_do_not_block_entire_file() -> None:
+    lines = IGRA_FIXTURE.splitlines()
+    missing_hour_lines = [
+        f"{line[:24]}99{line[26:]}" if line.startswith("#") and "2025 01 02" in line else line
+        for line in lines
+    ]
+
+    summaries = summarize_igra_station_text("\n".join(missing_hour_lines))
+
+    assert len(summaries) == 1
+    assert summaries[0].valid_time_utc == datetime(2025, 1, 1, tzinfo=UTC)
+
+
 def test_parse_igra_station_text_accepts_supplied_station_metadata() -> None:
     alternate_station_text = IGRA_FIXTURE.replace("USM00072558", "USM00072357")
     parsed = parse_igra_station_text(
@@ -72,7 +85,14 @@ def test_parse_igra_station_text_accepts_supplied_station_metadata() -> None:
     assert record.station_name == "Norman, Oklahoma"
     assert record.station_elevation_m_msl == pytest.approx(357.0)
     assert record.model_bottom_elevation_m_msl == pytest.approx(357.0)
+    assert record.levels[0].model_z_m == pytest.approx(0.0)
+    assert all(level.model_z_m >= 0.0 for level in record.levels)
     assert "station elevation joined from IGRA recent cache" in " ".join(record.validation.caveats)
+    assert "anchored to z=0" in " ".join(record.validation.caveats)
+    rendered = render_observed_input_sounding(record)
+    body_z_values = [float(line.split()[0]) for line in rendered.splitlines()[1:]]
+    assert body_z_values[0] > 0.0
+    assert body_z_values == sorted(body_z_values)
 
 
 def test_parse_igra_station_text_selects_requested_sounding_time() -> None:
@@ -179,7 +199,7 @@ def test_render_observed_input_sounding_is_numeric_cm1_facing() -> None:
     assert len(lines[0].split()) == 3
     assert len(lines[1].split()) == 5
     assert float(lines[0].split()[0]) == pytest.approx(record.levels[0].pressure_pa / 100.0)
-    assert float(lines[1].split()[0]) == pytest.approx(0.0)
+    assert float(lines[1].split()[0]) == pytest.approx(record.levels[0].model_z_m)
     assert float(lines[1].split()[3]) == pytest.approx(record.levels[0].u_wind_m_s, abs=0.01)
     assert float(lines[1].split()[4]) == pytest.approx(record.levels[0].v_wind_m_s, abs=0.01)
     assert float(lines[1].split()[3]) != pytest.approx(0.0)

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -47,6 +47,7 @@ def create_completed_result(
     run_id: str = "run-card",
     include_diagnostics_fields: bool = True,
     observed_sounding: dict[str, object] | None = None,
+    package_updates: dict[str, object] | None = None,
 ) -> tuple[CloudChamberSettings, str, Path]:
     settings = fake_settings(tmp_path)
     package = generate_dry_run_package(
@@ -59,20 +60,20 @@ def create_completed_result(
     write_result_netcdf(netcdf_path, include_diagnostics_fields=include_diagnostics_fields)
     manifest = load_run_manifest(package.manifest_path)
     finished_at = datetime(2026, 5, 22, 15, 32, 21, tzinfo=UTC)
+    update_payload = {
+        "lifecycle_state": LifecycleState.COMPLETED,
+        "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+        "execution": ExecutionMetadata(finished_at=finished_at, exit_code=0),
+        "outputs": OutputMetadata(
+            netcdf_paths=[str(netcdf_path)],
+            runtime_warnings=["CM1 stderr reported floating-point exception flags: TEST"],
+        ),
+        "observed_sounding": observed_sounding,
+    }
+    update_payload.update(package_updates or {})
     write_run_manifest(
         package.manifest_path,
-        manifest.model_copy(
-            update={
-                "lifecycle_state": LifecycleState.COMPLETED,
-                "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
-                "execution": ExecutionMetadata(finished_at=finished_at, exit_code=0),
-                "outputs": OutputMetadata(
-                    netcdf_paths=[str(netcdf_path)],
-                    runtime_warnings=["CM1 stderr reported floating-point exception flags: TEST"],
-                ),
-                "observed_sounding": observed_sounding,
-            }
-        ),
+        manifest.model_copy(update=update_payload),
     )
     result = ingest_completed_run(package.manifest_path)
     return settings, result.result_id, package.package_dir
@@ -189,6 +190,53 @@ def test_result_card_exposes_observed_sounding_source(tmp_path: Path) -> None:
     assert card.input_source_label == "Observed sounding: USM00072558 · Valley, Nebraska"
     assert card.observed_sounding is not None
     assert card.observed_sounding["station_id"] == "USM00072558"
+
+
+def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_completed_result(
+        tmp_path,
+        run_id="run-deep-card",
+        observed_sounding={
+            "source_type": "observed_sounding",
+            "source_format": "igra_station_text",
+            "station_id": "USM00072357",
+            "station_name": "Norman, Oklahoma",
+            "station_elevation_m_msl": 357.0,
+            "valid_time_utc": "2026-06-30T00:00:00Z",
+        },
+        package_updates={
+            "package_family": "deep_convection_trial",
+            "package_display_name": "Deep Convection Trial",
+            "input_source": "observed_sounding",
+            "trigger_type": "warm_thermal_line",
+            "trigger_parameters": {
+                "cm1_iinit": 8,
+                "cm1_trigger": "CM1 built-in line thermal with small random perturbations",
+                "raw_controls_exposed": False,
+            },
+            "expected_outputs": ["qc", "qr", "w", "dbz", "updraft_helicity"],
+            "package_caveats": [
+                "Deep Convection Trial uses an idealized CM1 warm line-thermal trigger."
+            ],
+            "manual_validation_status": "needs_manual_cm1_smoke_run",
+        },
+    )
+
+    card = get_result_card(settings, result_id)
+
+    assert card.name == "Deep Convection Trial — Norman, Oklahoma"
+    assert card.scenario_name == "Deep Convection Trial"
+    assert card.package_family == "deep_convection_trial"
+    assert card.package_display_name == "Deep Convection Trial"
+    assert card.trigger_type == "warm_thermal_line"
+    assert card.trigger_parameters is not None
+    assert card.trigger_parameters["cm1_iinit"] == 8
+    assert "dbz" in card.expected_outputs
+    assert card.package_caveats == [
+        "Deep Convection Trial uses an idealized CM1 warm line-thermal trigger."
+    ]
+    assert card.manual_validation_status == "needs_manual_cm1_smoke_run"
+    assert "package_family:deep_convection_trial" in card.provenance_labels
 
 
 def test_list_get_and_result_card_serialization_round_trip(tmp_path: Path) -> None:

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -208,17 +208,17 @@ def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: 
             "package_family": "deep_convection_trial",
             "package_display_name": "Deep Convection Trial",
             "input_source": "observed_sounding",
-            "trigger_type": "warm_thermal_line",
+            "trigger_type": "warm_bubble",
             "trigger_parameters": {
-                "cm1_iinit": 8,
-                "cm1_trigger": "CM1 built-in line thermal with small random perturbations",
+                "cm1_iinit": 3,
+                "cm1_trigger": "CM1 built-in three warm bubbles",
                 "raw_controls_exposed": False,
             },
             "expected_outputs": ["qc", "qr", "w", "dbz", "updraft_helicity"],
             "package_caveats": [
-                "Deep Convection Trial uses an idealized CM1 warm line-thermal trigger."
+                "Deep Convection Trial uses an idealized CM1 three-warm-bubble trigger."
             ],
-            "manual_validation_status": "needs_manual_cm1_smoke_run",
+            "manual_validation_status": "manual_cm1_smoke_run_observed_deep_convection",
         },
     )
 
@@ -228,14 +228,14 @@ def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: 
     assert card.scenario_name == "Deep Convection Trial"
     assert card.package_family == "deep_convection_trial"
     assert card.package_display_name == "Deep Convection Trial"
-    assert card.trigger_type == "warm_thermal_line"
+    assert card.trigger_type == "warm_bubble"
     assert card.trigger_parameters is not None
-    assert card.trigger_parameters["cm1_iinit"] == 8
+    assert card.trigger_parameters["cm1_iinit"] == 3
     assert "dbz" in card.expected_outputs
     assert card.package_caveats == [
-        "Deep Convection Trial uses an idealized CM1 warm line-thermal trigger."
+        "Deep Convection Trial uses an idealized CM1 three-warm-bubble trigger."
     ]
-    assert card.manual_validation_status == "needs_manual_cm1_smoke_run"
+    assert card.manual_validation_status == "manual_cm1_smoke_run_observed_deep_convection"
     assert "package_family:deep_convection_trial" in card.provenance_labels
 
 

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -218,7 +218,7 @@ def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: 
             "package_caveats": [
                 "Deep Convection Trial uses an idealized CM1 three-warm-bubble trigger."
             ],
-            "manual_validation_status": "manual_cm1_smoke_run_observed_deep_convection",
+            "manual_validation_status": "deep_convection_trial_package_smoke_validated",
         },
     )
 
@@ -235,7 +235,7 @@ def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: 
     assert card.package_caveats == [
         "Deep Convection Trial uses an idealized CM1 three-warm-bubble trigger."
     ]
-    assert card.manual_validation_status == "manual_cm1_smoke_run_observed_deep_convection"
+    assert card.manual_validation_status == "deep_convection_trial_package_smoke_validated"
     assert "package_family:deep_convection_trial" in card.provenance_labels
 
 

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -18,6 +18,9 @@ def base_dataset(
     qc_values: list[list[list[list[float]]]] | None = None,
     w_values: list[list[list[list[float]]]] | None = None,
     qr_values: list[list[list[list[float]]]] | None = None,
+    qi_values: list[list[list[list[float]]]] | None = None,
+    qs_values: list[list[list[list[float]]]] | None = None,
+    qg_values: list[list[list[list[float]]]] | None = None,
     include_time_coord: bool = True,
     z_values: list[float] | None = None,
     z_units: str | None = None,
@@ -50,6 +53,24 @@ def base_dataset(
             qr_values,
             {"units": "kg/kg"},
         )
+    if qi_values is not None:
+        data_vars["qi"] = (
+            ("time", "z", "y", "x"),
+            qi_values,
+            {"units": "kg/kg"},
+        )
+    if qs_values is not None:
+        data_vars["qs"] = (
+            ("time", "z", "y", "x"),
+            qs_values,
+            {"units": "kg/kg"},
+        )
+    if qg_values is not None:
+        data_vars["qg"] = (
+            ("time", "z", "y", "x"),
+            qg_values,
+            {"units": "kg/kg"},
+        )
     if include_time_coord:
         dataset = xr.Dataset(data_vars=data_vars, coords=coords)
     else:
@@ -62,9 +83,10 @@ def base_dataset(
     return dataset
 
 
-def zeros() -> list[list[list[list[float]]]]:
+def zeros(z_count: int = 2) -> list[list[list[list[float]]]]:
     return [
-        [[[0.0 for _x in range(4)] for _y in range(3)] for _z in range(2)] for _time in range(2)
+        [[[0.0 for _x in range(4)] for _y in range(3)] for _z in range(z_count)]
+        for _time in range(2)
     ]
 
 
@@ -87,6 +109,39 @@ def w_field() -> list[list[list[list[float]]]]:
     values[1][0][0][0] = -3.0
     values[1][1][2][3] = 4.0
     return values
+
+
+def test_cloud_top_uses_ice_and_snow_hydrometeor_envelope(tmp_path: Path) -> None:
+    qc_values = zeros(z_count=4)
+    qi_values = zeros(z_count=4)
+    qs_values = zeros(z_count=4)
+    for y_index in range(3):
+        for x_index in range(4):
+            qc_values[1][1][y_index][x_index] = 2e-6
+            qi_values[1][2][y_index][x_index] = 3e-6
+            qs_values[1][3][y_index][x_index] = 4e-6
+    dataset = write_dataset(
+        tmp_path / "deep_cloud.nc",
+        base_dataset(
+            qc_values=qc_values,
+            qi_values=qi_values,
+            qs_values=qs_values,
+            z_values=[500.0, 1500.0, 7500.0, 10500.0],
+        ),
+    )
+    caveats: list[str] = []
+
+    diagnostics = compute_baseline_diagnostics(dataset, caveats)
+
+    assert diagnostics.cloud.formed is True
+    assert diagnostics.cloud.cloud_base_m == 1500.0
+    assert diagnostics.cloud.cloud_top_m == 10500.0
+    assert [point.value for point in diagnostics.cloud.cloud_top_time_series] == [
+        None,
+        10500.0,
+    ]
+    assert diagnostics.cloud.max_qc_kg_kg == 2e-6
+    assert "cloud_top_uses_total_hydrometeor_fields:qc,qi,qs" in diagnostics.caveats
 
 
 def test_no_cloud_case(tmp_path: Path) -> None:

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -9,10 +9,12 @@ from igra_fixtures import IGRA_FIXTURE
 from cloud_chamber.app import app
 from cloud_chamber.dry_run_package import generate_dry_run_package, read_dry_run_report
 from cloud_chamber.igra_catalog import IGRACacheEntry, IGRACacheManifest, igra_cache_manifest_path
+from cloud_chamber.observed_sounding import parse_igra_station_text
 from cloud_chamber.run_manifest import load_run_manifest
 from cloud_chamber.settings import CloudChamberSettings
 from cloud_chamber.sounding_candidates import (
     SaveCandidateRequest,
+    _features_from_record,
     _score_features,
     list_saved_candidates,
     list_screening_inputs,
@@ -105,6 +107,12 @@ def test_screen_cached_soundings_returns_ranked_package_ready_candidates(
         "dry_failed_candidate",
         "capped_suppressed_candidate",
         "humid_rainy_candidate",
+        "severe_thunderstorm_environment",
+        "supercell_environment",
+        "high_cape_pulse_storm",
+        "dry_microburst_inverted_v",
+        "squall_line_cold_pool_candidate",
+        "elevated_convection",
         "needs_review",
         "poor_or_incomplete_candidate",
     }
@@ -113,10 +121,40 @@ def test_screen_cached_soundings_returns_ranked_package_ready_candidates(
         "estimated_lcl_height_m_agl",
         "lapse_rate_0_1000m_c_per_km",
         "cap_strength_proxy",
+        "bulk_shear_0_6km_m_s",
+        "midlevel_lapse_rate_700_500_hpa_c_per_km",
         "profile_top_m_agl",
     }
     assert candidate.evidence
     assert candidate.story_scores[0].score_0_to_100 >= candidate.story_scores[-1].score_0_to_100
+
+
+def test_near_surface_discontinuity_is_caveated_and_downgrades_data_quality() -> None:
+    record = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    levels = list(record.levels)
+    levels[0] = levels[0].model_copy(
+        update={"model_z_m": 0.0, "temperature_c": 30.5, "qv_g_kg": 28.0}
+    )
+    levels[1] = levels[1].model_copy(
+        update={"model_z_m": 80.0, "temperature_c": 22.2, "qv_g_kg": 16.8}
+    )
+    discontinuous = record.model_copy(update={"levels": levels})
+
+    features = _features_from_record(discontinuous)
+    _scores, evidence = _score_features(features, package_ready=True)
+
+    assert features["near_surface_discontinuity_flag"] is True
+    assert features["near_surface_temperature_jump_c"] == pytest.approx(8.3)
+    assert features["near_surface_qv_jump_g_kg"] == pytest.approx(11.2)
+    data_completeness = features["data_completeness_score"]
+    assert isinstance(data_completeness, int | float)
+    assert data_completeness <= 70.0
+    continuity = next(item for item in evidence if item.label == "Near-surface continuity")
+    assert continuity.value == "large jump"
+    assert "near_surface_discontinuity_caveat" in continuity.caveats
 
 
 def test_screen_cached_soundings_can_target_one_story(tmp_path: Path) -> None:
@@ -313,6 +351,235 @@ def test_story_scoring_missing_moisture_is_not_confident_dry() -> None:
     assert any(item.label == "Mean qv 0-1 km" and item.caveats for item in evidence)
 
 
+def test_deep_convection_scoring_finds_moist_sheared_profiles() -> None:
+    scores, evidence = _score_features(
+        {
+            "data_completeness_score": 98.0,
+            "low_level_qv_g_kg": 15.0,
+            "mean_qv_0_500m_g_kg": 15.0,
+            "mean_qv_0_1000m_g_kg": 14.5,
+            "mean_qv_0_3000m_g_kg": 10.0,
+            "precipitable_water_proxy_or_unavailable": 42.0,
+            "surface_t_td_spread_c": 4.5,
+            "estimated_lcl_height_m_agl": 562.5,
+            "lapse_rate_0_1000m_c_per_km": 8.0,
+            "lapse_rate_0_3000m_c_per_km": 7.5,
+            "midlevel_lapse_rate_700_500_hpa_c_per_km": 7.2,
+            "cap_strength_proxy": 0.5,
+            "cap_height_m_agl": 1400.0,
+            "moisture_depth_m": 4200.0,
+            "midlevel_dry_layer_proxy": 3.0,
+            "qv_drop_0_3000m_g_kg": 5.0,
+            "observed_wind_available": True,
+            "bulk_shear_0_1km_m_s": 9.0,
+            "bulk_shear_0_3km_m_s": 18.0,
+            "bulk_shear_0_6km_m_s": 31.0,
+            "dry_microburst_inverted_v_proxy": 20.0,
+            "freezing_level_m_agl": 4200.0,
+            "surface_based_cape_j_kg": 2800.0,
+            "mixed_layer_cape_j_kg": 2400.0,
+            "surface_based_cin_j_kg": -35.0,
+            "mixed_layer_cin_j_kg": -45.0,
+            "lfc_height_m_agl": 1100.0,
+            "el_height_m_agl": 12500.0,
+            "profile_top_m_agl": 18000.0,
+            "lowest_level_m_agl": 0.0,
+        },
+        package_ready=True,
+    )
+
+    score_by_story = {score.story: score for score in scores}
+    assert scores[0].story in {
+        "severe_thunderstorm_environment",
+        "supercell_environment",
+        "squall_line_cold_pool_candidate",
+    }
+    assert score_by_story["supercell_environment"].support == "supported"
+    assert score_by_story["severe_thunderstorm_environment"].support == "supported"
+    assert any(item.label == "Bulk shear 0-6 km" for item in evidence)
+    assert any(item.label == "Midlevel lapse rate 700-500 hPa" for item in evidence)
+
+
+def test_deep_convection_scoring_prioritizes_high_cape_story_over_shallow() -> None:
+    scores, _evidence = _score_features(
+        {
+            "data_completeness_score": 100.0,
+            "low_level_qv_g_kg": 20.0,
+            "mean_qv_0_500m_g_kg": 19.0,
+            "mean_qv_0_1000m_g_kg": 18.4,
+            "mean_qv_0_3000m_g_kg": 10.0,
+            "precipitable_water_proxy_or_unavailable": 45.0,
+            "surface_t_td_spread_c": 8.0,
+            "estimated_lcl_height_m_agl": 1000.0,
+            "lapse_rate_0_1000m_c_per_km": 8.0,
+            "lapse_rate_0_3000m_c_per_km": 7.5,
+            "midlevel_lapse_rate_700_500_hpa_c_per_km": 7.3,
+            "cap_strength_proxy": 0.0,
+            "cap_height_m_agl": None,
+            "moisture_depth_m": 2800.0,
+            "midlevel_dry_layer_proxy": 4.0,
+            "qv_drop_0_3000m_g_kg": 8.0,
+            "observed_wind_available": True,
+            "bulk_shear_0_1km_m_s": 5.0,
+            "bulk_shear_0_3km_m_s": 12.0,
+            "bulk_shear_0_6km_m_s": 21.0,
+            "dry_microburst_inverted_v_proxy": 30.0,
+            "freezing_level_m_agl": 4200.0,
+            "surface_based_cape_j_kg": 2100.0,
+            "mixed_layer_cape_j_kg": 1900.0,
+            "surface_based_cin_j_kg": 0.0,
+            "mixed_layer_cin_j_kg": -1.0,
+            "lfc_height_m_agl": 0.0,
+            "el_height_m_agl": 12500.0,
+            "profile_top_m_agl": 18000.0,
+            "lowest_level_m_agl": 0.0,
+        },
+        package_ready=True,
+    )
+
+    score_by_story = {score.story: score for score in scores}
+    assert scores[0].story == "severe_thunderstorm_environment"
+    assert score_by_story["severe_thunderstorm_environment"].support == "supported"
+    assert score_by_story["shallow_cumulus_candidate"].score_0_to_100 < (
+        score_by_story["severe_thunderstorm_environment"].score_0_to_100
+    )
+
+
+def test_deep_convection_scoring_does_not_require_el_when_cape_and_shear_are_supported() -> None:
+    scores, _evidence = _score_features(
+        {
+            "data_completeness_score": 100.0,
+            "low_level_qv_g_kg": 14.5,
+            "mean_qv_0_500m_g_kg": 14.5,
+            "mean_qv_0_1000m_g_kg": 14.4,
+            "mean_qv_0_3000m_g_kg": 9.5,
+            "precipitable_water_proxy_or_unavailable": 35.0,
+            "surface_t_td_spread_c": 4.6,
+            "estimated_lcl_height_m_agl": 575.0,
+            "lapse_rate_0_1000m_c_per_km": 6.0,
+            "lapse_rate_0_3000m_c_per_km": 6.4,
+            "midlevel_lapse_rate_700_500_hpa_c_per_km": 7.25,
+            "cap_strength_proxy": 0.7,
+            "cap_height_m_agl": 1400.0,
+            "moisture_depth_m": 1680.0,
+            "midlevel_dry_layer_proxy": 3.0,
+            "qv_drop_0_3000m_g_kg": 5.0,
+            "observed_wind_available": True,
+            "bulk_shear_0_1km_m_s": 9.0,
+            "bulk_shear_0_3km_m_s": 18.0,
+            "bulk_shear_0_6km_m_s": 36.0,
+            "dry_microburst_inverted_v_proxy": 20.0,
+            "freezing_level_m_agl": 4200.0,
+            "surface_based_cape_j_kg": 1050.0,
+            "mixed_layer_cape_j_kg": 870.0,
+            "surface_based_cin_j_kg": 0.0,
+            "mixed_layer_cin_j_kg": -0.5,
+            "lfc_height_m_agl": 0.0,
+            "el_height_m_agl": None,
+            "profile_top_m_agl": 18000.0,
+            "lowest_level_m_agl": 0.1,
+        },
+        package_ready=True,
+    )
+
+    score_by_story = {score.story: score for score in scores}
+    assert scores[0].story in {
+        "severe_thunderstorm_environment",
+        "supercell_environment",
+        "squall_line_cold_pool_candidate",
+    }
+    assert score_by_story["severe_thunderstorm_environment"].support == "supported"
+    assert score_by_story["shallow_cumulus_candidate"].score_0_to_100 < (
+        score_by_story["severe_thunderstorm_environment"].score_0_to_100
+    )
+
+
+def test_deep_convection_scoring_penalizes_profiles_that_start_well_above_surface() -> None:
+    scores, _evidence = _score_features(
+        {
+            "data_completeness_score": 100.0,
+            "low_level_qv_g_kg": 18.0,
+            "mean_qv_0_500m_g_kg": 18.0,
+            "mean_qv_0_1000m_g_kg": 18.0,
+            "mean_qv_0_3000m_g_kg": 11.0,
+            "precipitable_water_proxy_or_unavailable": 45.0,
+            "surface_t_td_spread_c": 8.0,
+            "estimated_lcl_height_m_agl": 1000.0,
+            "lapse_rate_0_1000m_c_per_km": 8.0,
+            "lapse_rate_0_3000m_c_per_km": 7.5,
+            "midlevel_lapse_rate_700_500_hpa_c_per_km": 7.3,
+            "cap_strength_proxy": 0.0,
+            "cap_height_m_agl": None,
+            "moisture_depth_m": 2800.0,
+            "midlevel_dry_layer_proxy": 4.0,
+            "qv_drop_0_3000m_g_kg": 8.0,
+            "observed_wind_available": True,
+            "bulk_shear_0_1km_m_s": 5.0,
+            "bulk_shear_0_3km_m_s": 12.0,
+            "bulk_shear_0_6km_m_s": 21.0,
+            "dry_microburst_inverted_v_proxy": 30.0,
+            "freezing_level_m_agl": 4200.0,
+            "surface_based_cape_j_kg": 2100.0,
+            "mixed_layer_cape_j_kg": 1900.0,
+            "surface_based_cin_j_kg": 0.0,
+            "mixed_layer_cin_j_kg": -1.0,
+            "lfc_height_m_agl": 0.0,
+            "el_height_m_agl": 12500.0,
+            "profile_top_m_agl": 18000.0,
+            "lowest_level_m_agl": 452.0,
+        },
+        package_ready=True,
+    )
+
+    severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
+    assert severe.support == "unavailable"
+    assert "lowest_usable_level_too_high_for_deep_convection_trial" in severe.caveats
+
+
+def test_deep_convection_scoring_requires_observed_wind_support() -> None:
+    scores, _evidence = _score_features(
+        {
+            "data_completeness_score": 98.0,
+            "low_level_qv_g_kg": 15.0,
+            "mean_qv_0_500m_g_kg": 15.0,
+            "mean_qv_0_1000m_g_kg": 14.5,
+            "mean_qv_0_3000m_g_kg": 10.0,
+            "precipitable_water_proxy_or_unavailable": 42.0,
+            "surface_t_td_spread_c": 4.5,
+            "estimated_lcl_height_m_agl": 562.5,
+            "lapse_rate_0_1000m_c_per_km": 8.0,
+            "lapse_rate_0_3000m_c_per_km": 7.5,
+            "midlevel_lapse_rate_700_500_hpa_c_per_km": 7.2,
+            "cap_strength_proxy": 0.5,
+            "cap_height_m_agl": 1400.0,
+            "moisture_depth_m": 4200.0,
+            "midlevel_dry_layer_proxy": 3.0,
+            "qv_drop_0_3000m_g_kg": 5.0,
+            "observed_wind_available": False,
+            "bulk_shear_0_1km_m_s": 9.0,
+            "bulk_shear_0_3km_m_s": 18.0,
+            "bulk_shear_0_6km_m_s": 31.0,
+            "dry_microburst_inverted_v_proxy": 20.0,
+            "freezing_level_m_agl": 4200.0,
+            "surface_based_cape_j_kg": 2800.0,
+            "mixed_layer_cape_j_kg": 2400.0,
+            "surface_based_cin_j_kg": -35.0,
+            "mixed_layer_cin_j_kg": -45.0,
+            "lfc_height_m_agl": 1100.0,
+            "el_height_m_agl": 12500.0,
+            "profile_top_m_agl": 18000.0,
+            "lowest_level_m_agl": 0.0,
+        },
+        package_ready=True,
+    )
+
+    supercell = next(score for score in scores if score.story == "supercell_environment")
+    severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
+    assert supercell.support == "unavailable"
+    assert severe.support == "unavailable"
+    assert "observed_wind_required_for_deep_convection_trial" in supercell.caveats
+
+
 def test_story_scores_and_evidence_are_traceable_to_soundings() -> None:
     scores, evidence = _score_features(
         {
@@ -340,6 +607,12 @@ def test_story_scores_and_evidence_are_traceable_to_soundings() -> None:
         "dry_failed_candidate",
         "capped_suppressed_candidate",
         "humid_rainy_candidate",
+        "severe_thunderstorm_environment",
+        "supercell_environment",
+        "high_cape_pulse_storm",
+        "dry_microburst_inverted_v",
+        "squall_line_cold_pool_candidate",
+        "elevated_convection",
         "needs_review",
         "poor_or_incomplete_candidate",
     }
@@ -356,6 +629,12 @@ def test_story_scores_and_evidence_are_traceable_to_soundings() -> None:
         "Cap height proxy",
         "Moisture depth",
         "Midlevel dry-layer proxy",
+        "Midlevel lapse rate 700-500 hPa",
+        "Bulk shear 0-1 km",
+        "Bulk shear 0-3 km",
+        "Bulk shear 0-6 km",
+        "Dry microburst / inverted-V proxy",
+        "Freezing level",
         "Observed wind availability",
         "Profile top",
         "Lowest usable level",

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -687,6 +687,17 @@ def test_sounding_candidate_api_screen_save_and_delete(
     candidate = screened.json()["candidates"][0]
     assert candidate["selected_sounding_payload"]["station_id"] == "USM00072558"
 
+    deep_screened = client.post(
+        "/api/sounding-candidates/screen",
+        json={
+            "station_id": "USM00072558",
+            "latest_per_station": 1,
+            "limit": 5,
+            "target_story": "deep_convection_trial",
+        },
+    )
+    assert deep_screened.status_code == 200
+
     saved = client.post(
         "/api/sounding-candidates/saved",
         json={"candidate": candidate, "tags": ["manual-review"]},

--- a/app/backend/tests/test_sounding_diagnostics.py
+++ b/app/backend/tests/test_sounding_diagnostics.py
@@ -38,18 +38,27 @@ def _qv_g_kg_from_dewpoint(pressure_pa: float, dewpoint_c: float) -> float:
 
 
 def _synthetic_record() -> ObservedSoundingRecord:
-    pressure_pa = [100000.0, 90000.0, 80000.0, 70000.0, 60000.0, 50000.0]
-    heights_m = [0.0, 1000.0, 2000.0, 3000.0, 4000.0, 6000.0]
-    temperatures_c = [20.0, 14.0, 8.0, 5.0, 7.0, -10.0]
+    pressure_pa = [100000.0, 95000.0, 90000.0, 80000.0, 70000.0, 60000.0, 50000.0]
+    heights_m = [0.0, 500.0, 1000.0, 2000.0, 3000.0, 4000.0, 6000.0]
+    temperatures_c = [20.0, 17.0, 14.0, 8.0, 5.0, 7.0, -10.0]
     qv_g_kg = [
         _qv_g_kg_from_dewpoint(100000.0, 16.0),
+        12.0,
         10.0,
         8.0,
         6.0,
         4.0,
         2.0,
     ]
-    winds = [(0.0, 0.0), (3.0, 4.0), (4.5, 6.0), (6.0, 8.0), (4.0, 9.0), (0.0, 12.0)]
+    winds = [
+        (0.0, 0.0),
+        (1.5, 2.0),
+        (3.0, 4.0),
+        (4.5, 6.0),
+        (6.0, 8.0),
+        (4.0, 9.0),
+        (0.0, 12.0),
+    ]
     levels = [
         ObservedSoundingLevel(
             pressure_pa=pressure,
@@ -111,6 +120,18 @@ def test_synthetic_profile_has_known_numeric_diagnostics() -> None:
     assert features["bulk_shear_0_3km_m_s"].value == pytest.approx(10.0)
     assert features["bulk_shear_0_6km_m_s"].value == pytest.approx(12.0)
     assert features["freezing_level_m_agl"].value == pytest.approx(4823.5)
+    assert features["surface_based_cape_j_kg"].support_state == "weak"
+    assert features["surface_based_cape_j_kg"].value == pytest.approx(0.0)
+    assert features["surface_based_cin_j_kg"].support_state == "weak"
+    assert features["surface_based_cin_j_kg"].value == pytest.approx(-1519.4)
+    assert features["mixed_layer_cape_j_kg"].support_state == "weak"
+    assert features["mixed_layer_cape_j_kg"].value == pytest.approx(2.9)
+    assert features["mixed_layer_cin_j_kg"].support_state == "weak"
+    assert features["mixed_layer_cin_j_kg"].value == pytest.approx(0.0)
+    assert features["lfc_height_m_agl"].support_state == "unavailable"
+    assert features["lfc_height_m_agl"].value is None
+    assert features["el_height_m_agl"].support_state == "unavailable"
+    assert features["el_height_m_agl"].value is None
 
 
 def test_sounding_diagnostics_payload_has_quality_provenance_and_required_features() -> None:
@@ -218,12 +239,6 @@ def test_missing_moisture_caveats_moisture_diagnostics_without_calling_it_dry() 
 @pytest.mark.parametrize(
     "key",
     [
-        "surface_based_cape_j_kg",
-        "surface_based_cin_j_kg",
-        "mixed_layer_cape_j_kg",
-        "mixed_layer_cin_j_kg",
-        "lfc_height_m_agl",
-        "el_height_m_agl",
         "srh_0_1km_m2_s2",
         "srh_0_3km_m2_s2",
         "wet_bulb_zero_m_agl_or_unavailable",

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -341,12 +341,6 @@ small {
   gap: 0.75rem;
 }
 
-.candidate-list {
-  max-height: min(44rem, 72vh);
-  overflow: auto;
-  padding-right: 0.25rem;
-}
-
 .candidate-card {
   display: grid;
   gap: 0.65rem;

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -2308,8 +2308,12 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Package type"), {
       target: { value: "deep_convection_trial" },
     });
-    expect(screen.getByText("Warm thermal trigger")).toBeInTheDocument();
-    expect(screen.getByText(/warm line-thermal trigger/i)).toBeInTheDocument();
+    expect(screen.getByText("Three-bubble trigger")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /observed temperature, moisture, and wind profile with an idealized CM1 three-warm-bubble trigger/i,
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText(/wider box for storm growth and precipitation/i)).toBeInTheDocument();
     expect(screen.getByText(/wider storm-growth domain than the shallow-cumulus quick look/i)).toBeInTheDocument();
 
@@ -2360,7 +2364,7 @@ describe("App", () => {
 
     expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
     expect(screen.getByLabelText("Package type")).toHaveValue("deep_convection_trial");
-    expect(screen.getByText("Warm thermal trigger")).toBeInTheDocument();
+    expect(screen.getByText("Three-bubble trigger")).toBeInTheDocument();
     expect(screen.getByText(/strong fit for Deep Convection Trial/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("create-package-btn"));

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -381,6 +381,44 @@ const missingLclCandidate = {
   evidence: shallowCandidate.evidence.filter((item) => item.label !== "Estimated LCL"),
 };
 
+const deepConvectionCandidate = {
+  ...shallowCandidate,
+  candidate_id: "USM00072357-2025052000-supercell",
+  station_id: "USM00072357",
+  station_name: "Norman, Oklahoma",
+  valid_time_utc: "2025-05-20T00:00:00Z",
+  primary_story: "supercell_environment",
+  primary_story_label: "Supercell-like environment",
+  rank_score: 93,
+  confidence: "high",
+  package_ready: true,
+  story_scores: [
+    {
+      story: "supercell_environment",
+      label: "Supercell-like environment",
+      score_0_to_100: 93,
+      support: "supported",
+    },
+    {
+      story: "severe_thunderstorm_environment",
+      label: "Severe thunderstorm environment",
+      score_0_to_100: 88,
+      support: "supported",
+    },
+  ],
+  evidence: [
+    {
+      label: "Deep-convection ingredients",
+      value: "strong",
+      units: null,
+      interpretation: "Instability and wind structure are worth trying in a triggered run.",
+      supports_story: ["supercell_environment", "severe_thunderstorm_environment"],
+      caveats: [],
+    },
+    ...shallowCandidate.evidence.slice(0, 2),
+  ],
+};
+
 const screeningInputsResponse = {
   inputs: [
     {
@@ -400,6 +438,7 @@ const screeningResponse = {
   generated_at: "2026-07-01T12:00:00Z",
   candidates: [
     shallowCandidate,
+    deepConvectionCandidate,
     blockedCandidate,
     secondaryShallowCandidate,
     missingLclCandidate,
@@ -2263,13 +2302,74 @@ describe("App", () => {
     expect(screen.getByText("USM00072558 · Valley, Nebraska")).toBeInTheDocument();
     expect(screen.getByText(/CM1 z=0 is station surface at 351.5 m MSL/)).toBeInTheDocument();
     expect(screen.getByText(/observed sounding winds/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Choose how to try this sounding" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Package type")).toHaveValue("observed_sounding_quicklook");
+
+    fireEvent.change(screen.getByLabelText("Package type"), {
+      target: { value: "deep_convection_trial" },
+    });
+    expect(screen.getByText("Warm thermal trigger")).toBeInTheDocument();
+    expect(screen.getByText(/warm line-thermal trigger/i)).toBeInTheDocument();
+    expect(screen.getByText(/wider box for storm growth and precipitation/i)).toBeInTheDocument();
+    expect(screen.getByText(/wider storm-growth domain than the shallow-cumulus quick look/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
     await waitFor(() => {
+      expect(dryRunBody).toContain('"package_family":"deep_convection_trial"');
       expect(dryRunBody).toContain('"observed_sounding"');
       expect(dryRunBody).toContain('"station_id":"USM00072558"');
       expect(dryRunBody).toContain('"model_bottom_elevation_m_msl":351.5');
+    });
+  });
+
+  it("defaults deep-convection candidates to the Deep Convection Trial package", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let dryRunBody = "";
+    let screenBody = "";
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/sounding-candidates/screen") {
+        screenBody = String(init?.body ?? "");
+      }
+      if (url === "/api/dry-run-package") {
+        dryRunBody = String(init?.body ?? "");
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+    fireEvent.change(await screen.findByLabelText("Story filter"), {
+      target: { value: "supercell_environment" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Screen cached soundings" }));
+
+    expect(await screen.findByText("Screening guidance loaded")).toBeInTheDocument();
+    expect(screenBody).toContain('"target_story":"supercell_environment"');
+    const deepCard = screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)");
+    expect(deepCard).toHaveTextContent("Supercell-like environment");
+
+    fireEvent.click(within(deepCard).getByRole("button", { name: "Use this sounding" }));
+
+    expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
+    expect(screen.getByLabelText("Package type")).toHaveValue("deep_convection_trial");
+    expect(screen.getByText("Warm thermal trigger")).toBeInTheDocument();
+    expect(screen.getByText(/strong fit for Deep Convection Trial/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("create-package-btn"));
+
+    await waitFor(() => {
+      expect(dryRunBody).toContain('"package_family":"deep_convection_trial"');
+      expect(dryRunBody).toContain('"candidate_screening"');
+      expect(dryRunBody).toContain('"primary_story":"supercell_environment"');
+      expect(dryRunBody).toContain('"candidate_id":"USM00072357-2025052000-supercell"');
     });
   });
 

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -2350,13 +2350,15 @@ describe("App", () => {
     fireEvent.change(await screen.findByLabelText("Experiment"), {
       target: { value: "__observed_sounding_upload__" },
     });
-    fireEvent.change(await screen.findByLabelText("Story filter"), {
-      target: { value: "supercell_environment" },
+    const storyFilter = await screen.findByLabelText("Story filter");
+    expect(storyFilter).toHaveTextContent("Deep Convection Trial stories");
+    fireEvent.change(storyFilter, {
+      target: { value: "deep_convection_trial" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Screen cached soundings" }));
 
     expect(await screen.findByText("Screening guidance loaded")).toBeInTheDocument();
-    expect(screenBody).toContain('"target_story":"supercell_environment"');
+    expect(screenBody).toContain('"target_story":"deep_convection_trial"');
     const deepCard = screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)");
     expect(deepCard).toHaveTextContent("Supercell-like environment");
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -74,12 +74,20 @@ type RunSizeDetails = {
 
 type DryRunReport = {
   scenario_id: string;
+  package_family?: PackageFamily;
+  package_display_name?: string;
+  input_source?: string;
+  trigger_type?: string | null;
+  trigger_parameters?: Record<string, string | number | boolean> | null;
   physical_question: string;
   controls: Record<string, string | number | boolean>;
   run_size_preset: string;
   estimated_cost_or_size: string;
   run_size_details?: RunSizeDetails;
   expected_diagnostics: string[];
+  expected_outputs?: string[];
+  package_caveats?: string[];
+  manual_validation_status?: string | null;
   visualization_defaults: Record<string, unknown>;
   generated_files: Record<string, string>;
   not_a_completed_cm1_result: boolean;
@@ -163,6 +171,12 @@ type CandidateStoryId =
   | "dry_failed_candidate"
   | "capped_suppressed_candidate"
   | "humid_rainy_candidate"
+  | "severe_thunderstorm_environment"
+  | "supercell_environment"
+  | "high_cape_pulse_storm"
+  | "dry_microburst_inverted_v"
+  | "squall_line_cold_pool_candidate"
+  | "elevated_convection"
   | "needs_review"
   | "poor_or_incomplete_candidate";
 
@@ -172,6 +186,12 @@ type CandidateStoryFilter =
   | "dry_failed_candidate"
   | "capped_suppressed_candidate"
   | "humid_rainy_candidate"
+  | "severe_thunderstorm_environment"
+  | "supercell_environment"
+  | "high_cape_pulse_storm"
+  | "dry_microburst_inverted_v"
+  | "squall_line_cold_pool_candidate"
+  | "elevated_convection"
   | "needs_review";
 
 type CandidateSort =
@@ -181,6 +201,13 @@ type CandidateSort =
   | "lowest_lcl"
   | "highest_moisture"
   | "strongest_cap";
+
+type PackageFamily =
+  | "shallow_cumulus"
+  | "observed_sounding_quicklook"
+  | "deep_convection_trial";
+
+type ObservedPackageFamily = "observed_sounding_quicklook" | "deep_convection_trial";
 
 type StoryScore = {
   story: CandidateStoryId;
@@ -468,6 +495,13 @@ type ResultCard = {
   input_source?: "generated_reference" | "observed_sounding" | string;
   input_source_label?: string;
   observed_sounding?: ObservedSoundingSummary | null;
+  package_family?: string | null;
+  package_display_name?: string | null;
+  trigger_type?: string | null;
+  trigger_parameters?: Record<string, unknown> | null;
+  expected_outputs?: string[];
+  package_caveats?: string[];
+  manual_validation_status?: string | null;
   provenance_labels: string[];
   diagnostics_summary: string | null;
   thermal_fate_label?: string | null;
@@ -822,6 +856,14 @@ const FIELD_LOAD_TIMEOUT_MS = 30000;
 const OBSERVED_SOUNDING_EXPERIMENT_ID = "__observed_sounding_upload__";
 const OBSERVED_SOUNDING_BASE_SCENARIO_ID = "baseline-shallow-cumulus";
 const OBSERVED_SOUNDING_VISIBLE_CONTROLS = new Set(["surface_heating"]);
+const deepConvectionStoryIds = new Set<string>([
+  "severe_thunderstorm_environment",
+  "supercell_environment",
+  "high_cape_pulse_storm",
+  "dry_microburst_inverted_v",
+  "squall_line_cold_pool_candidate",
+  "elevated_convection",
+]);
 
 async function fetchScenarioCatalog(): Promise<ScenarioResponse> {
   const response = await fetch("/api/scenarios");
@@ -835,6 +877,7 @@ async function requestDryRunPackage(
   scenarioId: string,
   controls: Record<string, string | number | boolean>,
   runSizePreset: string,
+  packageFamily?: PackageFamily | null,
   observedSounding?: ObservedSoundingRecord | null,
   candidateScreening?: Record<string, unknown> | null,
 ): Promise<DryRunResponse> {
@@ -845,6 +888,7 @@ async function requestDryRunPackage(
       scenario_id: scenarioId,
       controls,
       run_size_preset: runSizePreset,
+      package_family: packageFamily ?? null,
       observed_sounding: observedSounding ?? null,
       candidate_screening: candidateScreening ?? null,
     }),
@@ -1271,6 +1315,8 @@ export function App() {
   const [selectedScenarioId, setSelectedScenarioId] = useState("baseline-shallow-cumulus");
   const [controls, setControls] = useState<Record<string, string | number | boolean>>({});
   const [runSizePreset, setRunSizePreset] = useState("quick_look");
+  const [observedPackageFamily, setObservedPackageFamily] =
+    useState<ObservedPackageFamily>("observed_sounding_quicklook");
   const [observedSoundingFilename, setObservedSoundingFilename] = useState<string | null>(null);
   const [observedSoundingText, setObservedSoundingText] = useState<string | null>(null);
   const [observedSoundingParse, setObservedSoundingParse] =
@@ -1471,6 +1517,7 @@ export function App() {
     setObservedSoundingParse(null);
     setObservedSoundingStatus(null);
     setObservedSoundingError(null);
+    setObservedPackageFamily("observed_sounding_quicklook");
     setDryRun(null);
     setRunStatus(null);
     setRunWorkflowError(null);
@@ -1559,6 +1606,7 @@ export function App() {
     setObservedSoundingStatus(null);
     setObservedSoundingError(null);
     setSelectedCandidateScreening(null);
+    setObservedPackageFamily("observed_sounding_quicklook");
     setDryRun(null);
     setRunStatus(null);
     setRunWorkflowError(null);
@@ -1717,6 +1765,7 @@ export function App() {
     setObservedSoundingStatus("Candidate loaded into observed-sounding package review");
     setObservedSoundingError(null);
     setSelectedCandidateScreening(candidateScreeningMetadata(candidate, savedCandidate));
+    setObservedPackageFamily(defaultPackageFamilyForCandidate(candidate));
     setDryRun(null);
     setRunStatus(null);
     setRunWorkflowError(null);
@@ -1748,6 +1797,7 @@ export function App() {
         selectedScenario.id,
         controls,
         runSizePreset,
+        observedSoundingExperimentSelected ? observedPackageFamily : null,
         observedSoundingExperimentSelected ? observedSoundingParse?.selected_sounding : null,
         observedSoundingExperimentSelected ? selectedCandidateScreening : null,
       );
@@ -1766,6 +1816,7 @@ export function App() {
     setObservedSoundingError(null);
     setObservedSoundingParse(null);
     setSelectedCandidateScreening(null);
+    setObservedPackageFamily("observed_sounding_quicklook");
     setDryRun(null);
     setRunStatus(null);
     setLanWorkerStatus(null);
@@ -1776,6 +1827,7 @@ export function App() {
       const parsed = await parseObservedSoundingUpload(file.name, text);
       setObservedSoundingParse(parsed);
       setSelectedCandidateScreening(null);
+      setObservedPackageFamily("observed_sounding_quicklook");
       setObservedSoundingStatus("Observed sounding validated for package review");
     } catch (caught) {
       setObservedSoundingText(null);
@@ -1801,6 +1853,7 @@ export function App() {
       );
       setObservedSoundingParse(parsed);
       setSelectedCandidateScreening(null);
+      setObservedPackageFamily("observed_sounding_quicklook");
       setObservedSoundingStatus("Observed sounding validated for package review");
     } catch (caught) {
       setObservedSoundingError(
@@ -2198,6 +2251,7 @@ export function App() {
           observedSoundingExperimentSelected={observedSoundingExperimentSelected}
           controls={controls}
           runSizePreset={runSizePreset}
+          observedPackageFamily={observedPackageFamily}
           observedSoundingParse={observedSoundingParse}
           observedSoundingStatus={observedSoundingStatus}
           observedSoundingError={observedSoundingError}
@@ -2240,6 +2294,7 @@ export function App() {
             }))
           }
           onRunSizeChange={setRunSizePreset}
+          onObservedPackageFamilyChange={setObservedPackageFamily}
           onObservedSoundingFile={handleObservedSoundingFile}
           onObservedSoundingTimeChange={handleObservedSoundingTimeChange}
           onCandidateStoryFilterChange={setCandidateStoryFilter}
@@ -2364,6 +2419,7 @@ function BuildWorkspace({
   observedSoundingExperimentSelected,
   controls,
   runSizePreset,
+  observedPackageFamily,
   observedSoundingParse,
   observedSoundingStatus,
   observedSoundingError,
@@ -2401,6 +2457,7 @@ function BuildWorkspace({
   onSelectScenario,
   onControlChange,
   onRunSizeChange,
+  onObservedPackageFamilyChange,
   onObservedSoundingFile,
   onObservedSoundingTimeChange,
   onCandidateStoryFilterChange,
@@ -2447,6 +2504,7 @@ function BuildWorkspace({
   observedSoundingExperimentSelected: boolean;
   controls: Record<string, string | number | boolean>;
   runSizePreset: string;
+  observedPackageFamily: ObservedPackageFamily;
   observedSoundingParse: ObservedSoundingParseResponse | null;
   observedSoundingStatus: string | null;
   observedSoundingError: string | null;
@@ -2484,6 +2542,7 @@ function BuildWorkspace({
   onSelectScenario: (scenarioId: string) => void;
   onControlChange: (controlId: string, value: string) => void;
   onRunSizeChange: (presetId: string) => void;
+  onObservedPackageFamilyChange: (packageFamily: ObservedPackageFamily) => void;
   onObservedSoundingFile: (file: File) => void;
   onObservedSoundingTimeChange: (validTimeUtc: string) => void;
   onCandidateStoryFilterChange: (filter: CandidateStoryFilter) => void;
@@ -2528,6 +2587,8 @@ function BuildWorkspace({
   const selectedRunSize = selectedScenario?.run_size_presets.find(
     (preset) => preset.id === runSizePreset,
   );
+  const selectedDeepConvectionTrial =
+    observedSoundingExperimentSelected && observedPackageFamily === "deep_convection_trial";
 
   return (
     <section className="workspace-section" aria-labelledby="build-title">
@@ -2705,6 +2766,12 @@ function BuildWorkspace({
                     onFile={onObservedSoundingFile}
                     onTimeChange={onObservedSoundingTimeChange}
                   />
+                  <ObservedPackageFamilyPanel
+                    packageFamily={observedPackageFamily}
+                    runSizePreset={runSizePreset}
+                    selectedCandidateScreening={selectedCandidateScreening}
+                    onChange={onObservedPackageFamilyChange}
+                  />
                 </>
               )}
 
@@ -2724,8 +2791,7 @@ function BuildWorkspace({
               </select>
               {selectedRunSize && (
                 <p className="field-help">
-                  {selectedRunSize.purpose}. Expected runtime: {selectedRunSize.expected_runtime}.
-                  Confidence: {selectedRunSize.confidence}. Output: {selectedRunSize.output_notes}.
+                  {runSizeHelpText(selectedRunSize, selectedDeepConvectionTrial)}
                 </p>
               )}
               {runSizePreset === "deep_overnight" && (
@@ -3006,6 +3072,12 @@ function ObservedAtmosphereCandidatesPanel({
             <option value="dry_failed_candidate">Dry failed cumulus</option>
             <option value="capped_suppressed_candidate">Capped / suppressed</option>
             <option value="humid_rainy_candidate">Humid / rainy</option>
+            <option value="severe_thunderstorm_environment">Severe thunderstorm environment</option>
+            <option value="supercell_environment">Supercell-like environment</option>
+            <option value="high_cape_pulse_storm">High-CAPE pulse storm</option>
+            <option value="dry_microburst_inverted_v">Dry microburst / inverted-V</option>
+            <option value="squall_line_cold_pool_candidate">Squall-line / cold-pool candidate</option>
+            <option value="elevated_convection">Elevated convection</option>
             <option value="needs_review">Needs review</option>
           </select>
         </label>
@@ -3476,6 +3548,84 @@ function ObservedSoundingInputPanel({
                 </details>
               )}
         </section>
+      )}
+    </section>
+  );
+}
+
+function ObservedPackageFamilyPanel({
+  packageFamily,
+  runSizePreset,
+  selectedCandidateScreening,
+  onChange,
+}: {
+  packageFamily: ObservedPackageFamily;
+  runSizePreset: string;
+  selectedCandidateScreening: Record<string, unknown> | null;
+  onChange: (packageFamily: ObservedPackageFamily) => void;
+}) {
+  const selectedDeep = packageFamily === "deep_convection_trial";
+  const selectedStory = String(selectedCandidateScreening?.primary_story ?? "");
+  const candidateGuidance = selectedCandidateScreening
+    ? deepConvectionStoryIds.has(selectedStory)
+      ? "This saved/screened candidate is a strong fit for Deep Convection Trial."
+      : "This candidate can still use the observed-sounding quick look, or you can try the deep-convection package deliberately."
+    : "Upload or choose an observed sounding, then choose the CM1 package family to generate.";
+  const workerGuidance =
+    selectedDeep && runSizePreset !== "quick_look"
+      ? "Standard and Deep tiers should usually run on the LAN worker."
+      : selectedDeep
+        ? "Quick Look is the smallest Deep Convection Trial and may be reasonable locally."
+        : "Quick Look keeps the current observed-sounding package path.";
+
+  return (
+    <section className="experiment-summary" aria-labelledby="observed-package-family-title">
+      <div className="panel-heading-row">
+        <div>
+          <p className="eyebrow">CM1 package family</p>
+          <h3 id="observed-package-family-title">Choose how to try this sounding</h3>
+          <p className="field-help">{candidateGuidance}</p>
+        </div>
+        <StatusBadge
+          label={selectedDeep ? "Warm thermal trigger" : "Observed quick look"}
+          tone={selectedDeep ? "warning" : "neutral"}
+        />
+      </div>
+      <div className="control-row">
+        <span>
+          <label htmlFor="observed-package-family">
+            <strong>Package type</strong>
+          </label>
+          <small>
+            Deep Convection Trial uses the observed temperature, moisture, and wind profile with an
+            idealized CM1 warm line-thermal trigger.
+          </small>
+        </span>
+        <select
+          id="observed-package-family"
+          value={packageFamily}
+          onChange={(event) => onChange(event.target.value as ObservedPackageFamily)}
+        >
+          <option value="observed_sounding_quicklook">Observed Sounding Quick Look</option>
+          <option value="deep_convection_trial">Deep Convection Trial</option>
+        </select>
+      </div>
+      <dl className="compact-metrics">
+        <Metric
+          label="Initiation method"
+          value={selectedDeep ? "Idealized warm line thermal" : "No deep-convection trigger"}
+        />
+        <Metric
+          label="Domain intent"
+          value={selectedDeep ? "Wider box for storm growth and precipitation" : "Current quick-look observed atmosphere path"}
+        />
+        <Metric label="Runtime guidance" value={workerGuidance} />
+      </dl>
+      {selectedDeep && (
+        <p className="field-help">
+          This is an idealized CM1 experiment for learning and exploration: try the sounding,
+          inspect the outcome, and learn from the mismatch between the pre-run hypothesis and CM1.
+        </p>
       )}
     </section>
   );
@@ -7870,6 +8020,18 @@ function candidateStoryLabel(story: CandidateStoryId | CandidateStoryFilter): st
       return "Capped / suppressed";
     case "humid_rainy_candidate":
       return "Humid / rainy";
+    case "severe_thunderstorm_environment":
+      return "Severe thunderstorm environment";
+    case "supercell_environment":
+      return "Supercell-like environment";
+    case "high_cape_pulse_storm":
+      return "High-CAPE pulse storm";
+    case "dry_microburst_inverted_v":
+      return "Dry microburst / inverted-V";
+    case "squall_line_cold_pool_candidate":
+      return "Squall-line / cold-pool candidate";
+    case "elevated_convection":
+      return "Elevated convection";
     case "poor_or_incomplete_candidate":
       return "Poor or incomplete";
     case "needs_review":
@@ -7877,6 +8039,21 @@ function candidateStoryLabel(story: CandidateStoryId | CandidateStoryFilter): st
     case "all":
       return "All screening stories";
   }
+}
+
+function defaultPackageFamilyForCandidate(candidate: SoundingCandidate): ObservedPackageFamily {
+  if (deepConvectionStoryIds.has(candidate.primary_story)) return "deep_convection_trial";
+  if (
+    candidate.story_scores.some(
+      (score) =>
+        deepConvectionStoryIds.has(score.story) &&
+        score.score_0_to_100 > 0 &&
+        !["unavailable", "unsupported", "insufficient_evidence"].includes(score.support),
+    )
+  ) {
+    return "deep_convection_trial";
+  }
+  return "observed_sounding_quicklook";
 }
 
 function candidateStationLabel(candidate: SoundingCandidate): string {
@@ -8485,6 +8662,18 @@ function parseTags(value: string): string[] {
 function formatSeconds(value: number | null): string {
   if (value === null) return "Unavailable";
   return `${value.toLocaleString()} s`;
+}
+
+function runSizeHelpText(preset: RunSizePreset, deepConvectionTrial: boolean): string {
+  const purpose = preset.purpose.replace(/[.?!]+$/, "");
+  if (!deepConvectionTrial) {
+    return `${purpose}. Expected runtime: ${preset.expected_runtime}. Confidence: ${preset.confidence}. Output: ${preset.output_notes}.`;
+  }
+  const tierGuidance =
+    preset.id === "quick_look"
+      ? "This is the smallest triggered deep-convection package, but it uses a wider storm-growth domain than the shallow-cumulus quick look; local runtime can be longer."
+      : "This triggered deep-convection tier is intended for the LAN worker because it uses a wider domain and longer run/output targets.";
+  return `${purpose}. ${tierGuidance} Confidence: ${preset.confidence}. Output: ${preset.output_notes}.`;
 }
 
 function runSizeGridSummary(details: RunSizeDetails): string {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -3587,7 +3587,7 @@ function ObservedPackageFamilyPanel({
           <p className="field-help">{candidateGuidance}</p>
         </div>
         <StatusBadge
-          label={selectedDeep ? "Warm thermal trigger" : "Observed quick look"}
+          label={selectedDeep ? "Three-bubble trigger" : "Observed quick look"}
           tone={selectedDeep ? "warning" : "neutral"}
         />
       </div>
@@ -3598,7 +3598,7 @@ function ObservedPackageFamilyPanel({
           </label>
           <small>
             Deep Convection Trial uses the observed temperature, moisture, and wind profile with an
-            idealized CM1 warm line-thermal trigger.
+            idealized CM1 three-warm-bubble trigger.
           </small>
         </span>
         <select
@@ -3613,7 +3613,7 @@ function ObservedPackageFamilyPanel({
       <dl className="compact-metrics">
         <Metric
           label="Initiation method"
-          value={selectedDeep ? "Idealized warm line thermal" : "No deep-convection trigger"}
+          value={selectedDeep ? "Idealized three warm bubbles" : "No deep-convection trigger"}
         />
         <Metric
           label="Domain intent"
@@ -4571,12 +4571,15 @@ function RuntimeRunsTable({
           </tr>
         </thead>
         <tbody>
-          {runs.map((run) => {
+          {runs.map((run, index) => {
             const associatedResult = resultForRun(results, run.run_id);
             const displayName = storageDisplayName(run, associatedResult);
             const canIngest = canIngestStorageRun(run, associatedResult);
             return (
-              <tr key={run.run_id} className={focusedRunId === run.run_id ? "selected-row" : ""}>
+              <tr
+                key={`${run.run_id}-${run.path ?? run.manifest_path ?? index}`}
+                className={focusedRunId === run.run_id ? "selected-row" : ""}
+              >
                 <td>
                   <strong>{displayName}</strong>
                   <small>{storageScenarioSummary(run, associatedResult)}</small>
@@ -5217,9 +5220,9 @@ function LocalPipelinePanel({
         <p>No active or incomplete packages/runs need Build action. Ingested results are in Results, and cleanup is in Storage.</p>
       ) : (
         <div className="pipeline-run-list" aria-label="Local packages and runs">
-          {runs.map((run) => (
+          {runs.map((run, index) => (
             <PipelineRunCard
-              key={run.run_id}
+              key={`${run.run_id}-${run.path ?? run.manifest_path ?? index}`}
               run={run}
               result={resultForRun(results, run.run_id)}
               current={run.run_id === currentRunId}

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -182,6 +182,7 @@ type CandidateStoryId =
 
 type CandidateStoryFilter =
   | "all"
+  | "deep_convection_trial"
   | "shallow_cumulus_candidate"
   | "dry_failed_candidate"
   | "capped_suppressed_candidate"
@@ -1652,10 +1653,10 @@ export function App() {
       setIgraCatalog(catalog);
       await refreshSoundingCandidateState("IGRA station catalog refreshed");
     } catch (caught) {
-      setCandidateError(
-        caught instanceof Error ? caught.message : "Unable to refresh IGRA station catalog.",
-      );
-      setCandidateStatus("IGRA catalog refresh blocked");
+      const message =
+        caught instanceof Error ? caught.message : "Unable to refresh IGRA station catalog.";
+      setCandidateError(message);
+      setCandidateStatus(`IGRA catalog refresh blocked: ${message}`);
     }
   }
 
@@ -3068,6 +3069,7 @@ function ObservedAtmosphereCandidatesPanel({
             onChange={(event) => onStoryFilterChange(event.target.value as CandidateStoryFilter)}
           >
             <option value="all">All screening stories</option>
+            <option value="deep_convection_trial">Deep Convection Trial stories</option>
             <option value="shallow_cumulus_candidate">Cloud-forming shallow cumulus</option>
             <option value="dry_failed_candidate">Dry failed cumulus</option>
             <option value="capped_suppressed_candidate">Capped / suppressed</option>
@@ -3276,6 +3278,9 @@ function SoundingCandidateCard({
         </span>
         <span className="badge-row">
           <StatusBadge label={candidateStoryLabel(story)} tone="neutral" />
+          {storyFilter === "deep_convection_trial" && (
+            <StatusBadge label={candidate.primary_story_label} tone="neutral" />
+          )}
           <StatusBadge label={`${formatNumber(matchScore, "%")} match`} tone="neutral" />
           <StatusBadge
             label={candidate.package_ready ? "Package-ready" : "Blocked"}
@@ -8039,6 +8044,8 @@ function candidateStoryLabel(story: CandidateStoryId | CandidateStoryFilter): st
       return "Poor or incomplete";
     case "needs_review":
       return "Needs review";
+    case "deep_convection_trial":
+      return "Deep Convection Trial stories";
     case "all":
       return "All screening stories";
   }
@@ -8068,6 +8075,14 @@ function candidateMatchScore(
   story: CandidateStoryId | CandidateStoryFilter,
 ): number {
   if (story === "all") return candidate.rank_score;
+  if (story === "deep_convection_trial") {
+    return Math.max(
+      0,
+      ...candidate.story_scores
+        .filter((score) => deepConvectionStoryIds.has(score.story))
+        .map((score) => score.score_0_to_100),
+    );
+  }
   return (
     candidate.story_scores.find((score) => score.story === story)?.score_0_to_100 ??
     candidate.rank_score
@@ -8079,6 +8094,13 @@ function candidateStoryScore(
   story: CandidateStoryId | CandidateStoryFilter,
 ): StoryScore | null {
   if (story === "all") return null;
+  if (story === "deep_convection_trial") {
+    return (
+      candidate.story_scores
+        .filter((score) => deepConvectionStoryIds.has(score.story))
+        .sort((left, right) => right.score_0_to_100 - left.score_0_to_100)[0] ?? null
+    );
+  }
   return candidate.story_scores.find((score) => score.story === story) ?? null;
 }
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -118,14 +118,16 @@ states for unimplemented parcel, storm-relative, wet-bulb, and winter-phase
 diagnostics. The browser should consume these diagnostics only through bounded
 backend JSON; it must not parse station text or compute CAPE/CIN/SRH locally.
 
-Future sounding story families are architecture planning input, not current
-backend behavior. The expanded taxonomy in
+Sounding story families are architecture planning input until a backend
+screening and package-readiness path supports them. The expanded taxonomy in
 [research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md)
 defines readiness states for severe/deep-convection, boundary-layer, low-cloud,
-and winter/cold-season stories so future APIs can distinguish screenable
-environments from runnable package families. Until those stories have backend
-features, scoring tests, evidence, caveats, and package-readiness support, they
-must not be emitted as enabled package-ready labels.
+and winter/cold-season stories so APIs can distinguish screenable environments
+from runnable package families. Until a story has backend features, scoring
+tests, evidence, caveats, and package-readiness support, it must not be emitted
+as an enabled package-ready label. The first implemented severe/deep-convection
+path is `Deep Convection Trial`, which treats selected observed soundings as
+pre-run hypotheses for an idealized triggered CM1 experiment.
 
 The Build UI consumes this layer through bounded JSON only. `Upload a Sounding`
 loads saved candidates immediately when that experiment is selected, before any
@@ -137,6 +139,23 @@ station text directly and does not compute the story scores. Candidate status is
 separate from run/result status: saved candidates are pre-run hypotheses, while
 generated packages, launched runs, and ingested results remain separate
 lifecycle objects.
+
+Deep Convection Trial packages extend the same dry-run package contract rather
+than creating a separate workflow. The package records
+`package_family = deep_convection_trial`, `package_display_name = Deep
+Convection Trial`, `input_source = observed_sounding`, `trigger_type =
+warm_thermal_line`, trigger metadata, expected output fields, manual-validation
+status, package caveats, and any candidate-screening payload on the run
+manifest, case manifest, and dry-run report. The generated namelist uses the
+observed `input_sounding` route (`isnd = 7`), requires observed u/v winds,
+selects CM1's built-in warm line-thermal initialization (`iinit = 8`) with
+`testcase = 0`, uses an intentionally wider idealized domain for storm growth,
+and enables rain, reflectivity, vorticity, and updraft-helicity output. The
+trigger is described as fixed v1 package metadata rather than primary product
+controls because stock CM1 does not expose its warm line-thermal geometry as
+namelist-tunable fields. Ingest copies the package-family and trigger metadata
+into result metadata and Result Cards so Results and Explore do not lose the
+distinction between an observed-sounding quick look and a Deep Convection Trial.
 
 ## Suggested Stack
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -144,16 +144,15 @@ Deep Convection Trial packages extend the same dry-run package contract rather
 than creating a separate workflow. The package records
 `package_family = deep_convection_trial`, `package_display_name = Deep
 Convection Trial`, `input_source = observed_sounding`, `trigger_type =
-warm_thermal_line`, trigger metadata, expected output fields, manual-validation
+warm_bubble`, trigger metadata, expected output fields, manual-validation
 status, package caveats, and any candidate-screening payload on the run
 manifest, case manifest, and dry-run report. The generated namelist uses the
 observed `input_sounding` route (`isnd = 7`), requires observed u/v winds,
-selects CM1's built-in warm line-thermal initialization (`iinit = 8`) with
-`testcase = 0`, uses an intentionally wider idealized domain for storm growth,
+selects CM1's built-in three-warm-bubble initialization (`iinit = 3`) with
+`testcase = 0`, uses a storm-scale idealized domain for storm growth,
 and enables rain, reflectivity, vorticity, and updraft-helicity output. The
 trigger is described as fixed v1 package metadata rather than primary product
-controls because stock CM1 does not expose its warm line-thermal geometry as
-namelist-tunable fields. Ingest copies the package-family and trigger metadata
+controls. Ingest copies the package-family and trigger metadata
 into result metadata and Result Cards so Results and Explore do not lose the
 distinction between an observed-sounding quick look and a Deep Convection Trial.
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -144,13 +144,15 @@ Deep Convection Trial packages extend the same dry-run package contract rather
 than creating a separate workflow. The package records
 `package_family = deep_convection_trial`, `package_display_name = Deep
 Convection Trial`, `input_source = observed_sounding`, `trigger_type =
-warm_bubble`, trigger metadata, expected output fields, manual-validation
-status, package caveats, and any candidate-screening payload on the run
-manifest, case manifest, and dry-run report. The generated namelist uses the
+warm_bubble`, trigger metadata, expected output fields, package-family smoke
+validation status, package caveats, and any candidate-screening payload on the
+run manifest, case manifest, and dry-run report. The generated namelist uses the
 observed `input_sounding` route (`isnd = 7`), requires observed u/v winds,
 selects CM1's built-in three-warm-bubble initialization (`iinit = 3`) with
 `testcase = 0`, uses a storm-scale idealized domain for storm growth,
-and enables rain, reflectivity, vorticity, and updraft-helicity output. The
+and enables rain, reflectivity, vorticity, and updraft-helicity output. Manual
+smoke evidence applies to the package family; each observed sounding remains an
+experiment whose outcome must be inspected after CM1 completes. The
 trigger is described as fixed v1 package metadata rather than primary product
 controls. Ingest copies the package-family and trigger metadata
 into result metadata and Result Cards so Results and Explore do not lose the

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -96,12 +96,15 @@ a sounding was tried. The browser never parses remote directory listings, ZIP
 files, or station text files. The current story identifiers, feature inputs,
 score support states, evidence requirements, and caveat rules are defined in
 [contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
-Future real-sounding story families, including severe/deep-convection,
-boundary-layer, low-cloud, and winter/cold-season candidates, are defined as
-planning taxonomy in
+Real-sounding story families, including severe/deep-convection, boundary-layer,
+low-cloud, and winter/cold-season candidates, are defined in
 [research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md).
 Those labels must remain disabled, caveated, or absent from product UI until
 backend scoring, evidence, caveats, and package-readiness states support them.
+The first exception is the deep-convection family backed by the `Deep
+Convection Trial` package: severe/deep-convection candidates may be presented as
+pre-run hypotheses for an idealized triggered CM1 experiment, not as forecasts
+or guaranteed storm outcomes.
 The backend may compute richer sounding diagnostics such as profile quality,
 moisture/LCL proxies, lapse-rate and cap proxies, wind shear, dry-layer
 signals, and freezing-level context to support future screening. These are
@@ -122,6 +125,22 @@ observed atmosphere worth trying, not a prediction that clouds, rain, or
 suppression will occur. When a candidate is used, its screening story, score,
 evidence, feature summary, and caveats should be copied into package metadata as
 provenance.
+
+When an uploaded or saved observed sounding is package-ready, Build should let
+the user choose between `Observed Sounding Quick Look` and `Deep Convection
+Trial`. `Deep Convection Trial` is the first-class package family for
+severe/deep-convection observed-sounding experiments: it uses the observed
+temperature, moisture, and wind profile through CM1 `isnd = 7`, runs an
+idealized warm line-thermal trigger (`iinit = 8`), uses a wider model box
+suitable for storm growth and precipitation inspection, requests rain,
+reflectivity, vorticity, and updraft-helicity output, and records
+`package_family = deep_convection_trial` plus trigger,
+expected-output, caveat, and candidate-screening provenance in generated
+manifests. Quick Look may be tried locally when practical; Standard and Deep
+tiers should recommend the LAN worker. Raw trigger parameters remain
+metadata-only in v1 and should not become user controls until useful ranges are
+validated. The stock CM1 trigger is built into CM1 source, so Cloud Chamber does
+not pretend the namelist can tune it without a future Fortran/config change.
 
 Explore should be a focused visualization plus explanation screen for one
 selected result. Its core interaction is `What happened here?`: select a cloud,
@@ -1071,6 +1090,11 @@ metadata as provenance. Observed-sounding results should read as `Uploaded
 Sounding` in notebook names, scenario labels, and scenario filtering while the
 underlying generated scenario ID remains available in technical details as
 lineage.
+Deep Convection Trial results should retain their package-family identity after
+ingest: notebook names and scenario labels may say `Deep Convection Trial`,
+while the original observed station/time, generated scenario ID, warm thermal
+trigger, expected outputs, caveats, and candidate-screening hypothesis remain
+available as provenance.
 Technical metadata such as raw lifecycle/product states, run IDs, provenance
 labels, controls, and detailed caveats remain available under disclosure rather
 than dominating the first read. The layout should be mobile-first: cards stack

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -131,7 +131,7 @@ the user choose between `Observed Sounding Quick Look` and `Deep Convection
 Trial`. `Deep Convection Trial` is the first-class package family for
 severe/deep-convection observed-sounding experiments: it uses the observed
 temperature, moisture, and wind profile through CM1 `isnd = 7`, runs an
-idealized warm line-thermal trigger (`iinit = 8`), uses a wider model box
+idealized three-warm-bubble trigger (`iinit = 3`), uses a storm-scale model box
 suitable for storm growth and precipitation inspection, requests rain,
 reflectivity, vorticity, and updraft-helicity output, and records
 `package_family = deep_convection_trial` plus trigger,
@@ -139,8 +139,7 @@ expected-output, caveat, and candidate-screening provenance in generated
 manifests. Quick Look may be tried locally when practical; Standard and Deep
 tiers should recommend the LAN worker. Raw trigger parameters remain
 metadata-only in v1 and should not become user controls until useful ranges are
-validated. The stock CM1 trigger is built into CM1 source, so Cloud Chamber does
-not pretend the namelist can tune it without a future Fortran/config change.
+validated.
 
 Explore should be a focused visualization plus explanation screen for one
 selected result. Its core interaction is `What happened here?`: select a cloud,
@@ -1092,8 +1091,8 @@ underlying generated scenario ID remains available in technical details as
 lineage.
 Deep Convection Trial results should retain their package-family identity after
 ingest: notebook names and scenario labels may say `Deep Convection Trial`,
-while the original observed station/time, generated scenario ID, warm thermal
-trigger, expected outputs, caveats, and candidate-screening hypothesis remain
+while the original observed station/time, generated scenario ID, trigger
+metadata, expected outputs, caveats, and candidate-screening hypothesis remain
 available as provenance.
 Technical metadata such as raw lifecycle/product states, run IDs, provenance
 labels, controls, and detailed caveats remain available under disclosure rather

--- a/docs/development.md
+++ b/docs/development.md
@@ -188,19 +188,22 @@ scripts/igra-recent.sh cleanup
 scripts/igra-recent.sh refresh
 scripts/igra-recent.sh cache-all --limit 10
 scripts/igra-recent.sh candidates
+scripts/igra-recent.sh candidates --story deep-convection --limit 10
 scripts/igra-recent.sh candidates --story shallow-cumulus --limit 10
 scripts/igra-recent.sh candidates --story capped-suppressed --limit 10
 ```
 
 Candidate match scores are pre-run hypotheses only. There is no single best
-sounding independent of the experiment story: use `--story shallow-cumulus`,
-`--story dry-failed`, `--story capped-suppressed`, or `--story humid-rainy`
-depending on what you want to test. CM1 output remains the source of truth.
+sounding independent of the experiment story: use `--story deep-convection`,
+`--story shallow-cumulus`, `--story dry-failed`, `--story capped-suppressed`,
+or `--story humid-rainy` depending on what you want to test. CM1 output remains
+the source of truth.
 
 The same workflow is available in the app from Build -> `Upload a Sounding` ->
 `Find interesting soundings`. Use `Refresh IGRA catalog` to update station
 metadata, `Cache station files` to download a bounded batch of station-period
-files, choose a story filter, then `Screen cached soundings`.
+files, choose a story filter such as `Deep Convection Trial stories`, then
+`Screen cached soundings`.
 `Use this sounding` loads a package-ready candidate into the observed-sounding
 package review; it does not launch CM1 and it does not claim the candidate will
 produce the screened outcome. Blocked candidates remain reviewable but cannot be

--- a/docs/research/deep-convection-package-design.md
+++ b/docs/research/deep-convection-package-design.md
@@ -36,7 +36,7 @@ package_family = deep_convection_trial
 Recommended v1 design:
 
 ```text
-Observed sounding + observed winds + warm thermal trigger
+Observed sounding + observed winds + three-warm-bubble trigger
 ```
 
 This is an idealized CM1 experiment for learning and exploration. It tests what
@@ -52,20 +52,34 @@ Find an interesting real sounding
 
 Why this path first:
 
-- CM1 already has warm thermal initialization options (`iinit = 1` warm bubble
-  and `iinit = 8` warm line thermal with small random perturbations).
+- CM1 already has built-in initiation options, including `iinit = 1`
+  warm bubble, `iinit = 8` warm line thermal with small random perturbations,
+  and `iinit = 9` forced convergence.
 - CM1 already has examples that combine idealized deep convection with
   Morrison microphysics, surface rain, and reflectivity output.
 - Cloud Chamber already has an observed-sounding path that writes
   `input_sounding` and uses `isnd = 7`.
 - `isnd = 7` reads wind from `input_sounding`; `iwnd` is ignored.
-- A warm thermal trigger is easier to explain and validate than convergence forcing,
-  cold-pool insertion, or radiation-driven diurnal initiation.
+- CM1's stock supercell example already uses `iinit = 1` warm-bubble
+  initiation with Morrison microphysics, rain, and reflectivity output.
+- #261 validation found that the stock single `iinit = 1` warm bubble can be
+  too weak for several strong observed-sounding candidates in the Cloud Chamber
+  quick-look domain.
+- #261 validation found that CM1's built-in `iinit = 3` three-warm-bubble line
+  trigger produced an interpretable deep-convection result for a Fort Worth
+  severe candidate, with strong updraft, reflectivity, graupel/ice, rain, and
+  updraft helicity.
+- #261 validation found that stock `iinit = 9` forced convergence is not a
+  clean v1 package default: its trigger parameters are hard-coded in CM1
+  `init3d.F`, not exposed as package controls in the namelist. A forced-
+  convergence trial can be revisited later if Cloud Chamber intentionally owns
+  a custom CM1-source or patching path.
 
-Implementation note from #261: stock CM1 r21.1 does not expose the `iinit = 1`
-warm-bubble geometry/amplitude as namelist-tunable fields. The first Cloud
-Chamber implementation uses CM1's built-in `iinit = 8` warm line thermal because
-it is a stronger supported trigger without requiring Fortran edits.
+Implementation note from #261: Cloud Chamber's first Deep Convection Trial uses
+CM1's built-in `iinit = 3` three-warm-bubble line trigger in a storm-scale
+idealized domain. Single-bubble, forced-convergence, line-thermal, cold-pool,
+and custom triggers remain possible future package variants, but they are not
+the v1 default package.
 
 ## PM Decisions For V1 Implementation
 
@@ -84,7 +98,7 @@ These are the product/science decisions for the implementation issue:
 - **Standard and Deep tiers should clearly recommend the LAN worker.** Those
   tiers are where wider domains, longer runtime, and denser output become more
   useful.
-- **The warm thermal trigger should be visible to the user** as the initiation
+- **The three-warm-bubble trigger should be visible to the user** as the initiation
   method. Users should know they are asking CM1 to try an idealized triggered
   experiment.
 - **Exact numeric trigger parameters can remain package metadata in v1.**
@@ -134,7 +148,7 @@ Recommended stable metadata:
   "package_family": "deep_convection_trial",
   "input_source": "observed_sounding",
   "specialized_package_for": "severe/deep_convection",
-  "trigger_type": "warm_thermal_line",
+  "trigger_type": "warm_bubble",
   "candidate_screening_hypothesis": {},
   "limitations": [],
   "expected_outputs": [],
@@ -146,15 +160,16 @@ Recommended Build copy:
 
 ```text
 Deep Convection Trial
-Try this observed sounding with an idealized warm thermal trigger and see
+Try this observed sounding with an idealized three-warm-bubble trigger and see
 whether deep convection develops.
 ```
 
 Recommended limitations:
 
-- The warm thermal is an idealized trigger, not an observed storm initiation
-  mechanism.
-- It can over-trigger marginal environments.
+- The three warm bubbles are an idealized trigger, not an observed storm
+  initiation mechanism.
+- It can over-trigger marginal environments, and it can be too weak or
+  misplaced for some real soundings.
 - V1 does not represent surface heating/radiation, boundaries, terrain,
   land-surface heterogeneity, or mesoscale lift.
 - Storm structure is something to inspect after the run, not something assumed
@@ -165,7 +180,7 @@ Recommended limitations:
 
 ## Initiation Options Compared
 
-### Warm Line-Thermal Trigger
+### Three-Warm-Bubble Trigger
 
 Decision for v1: use this.
 
@@ -175,14 +190,15 @@ Likely CM1 settings:
 testcase = 0
 isnd = 7
 iwnd = 0 or ignored by CM1 because isnd = 7
-iinit = 8
+iinit = 3
 irandp = 0 initially
 ```
 
 Pros:
 
-- Strong idealized deep-convection trigger available in stock CM1.
 - Confirmed CM1 option.
+- #261 manual smoke testing produced a clear deep-convection result with this
+  trigger and a Fort Worth severe candidate.
 - Easy to explain to users.
 - Easy to verify in generated namelist tests.
 - Minimal new generated files beyond `input_sounding`.
@@ -192,27 +208,28 @@ Pros:
 Cons:
 
 - Artificial.
-- May initiate storms in marginal environments that would need a real boundary
-  or stronger forcing.
+- May initiate storms in marginal environments that would need a real boundary,
+  or fail to initiate if the fixed trigger is too weak or poorly matched for
+  the selected sounding.
 - Does not represent a front, dryline, outflow boundary, or terrain effect.
-- Stock CM1 line-thermal geometry/strength are source-code behavior rather
-  than Cloud Chamber product controls in v1.
+- Trigger details remain fixed package metadata in v1 rather than user-facing
+  raw controls.
 
 V1 trigger metadata should include:
 
 ```json
 {
-  "trigger_type": "warm_thermal_line",
+  "trigger_type": "warm_bubble",
   "trigger_parameters": {
-    "cm1_iinit": 8,
-    "cm1_trigger": "CM1 built-in line thermal with small random perturbations",
+    "cm1_iinit": 3,
+    "cm1_trigger": "CM1 built-in three warm bubbles",
     "raw_controls_exposed": false
   }
 }
 ```
 
-Future work can add a custom warm-bubble or point-thermal package if Cloud
-Chamber intentionally owns the required CM1 Fortran/configuration changes.
+Future work can add warm-bubble, line-thermal, cold-pool, or custom
+trigger packages if Cloud Chamber intentionally owns those package variants.
 
 ### Forced Convergence / Momentum Forcing
 
@@ -229,11 +246,15 @@ Pros:
 
 - Closer to a boundary/convergence initiation story than a warm bubble.
 - Potentially useful for dryline, front, and mesoscale lift experiments.
+- Stock CM1 can run these initialization options.
 
 Cons:
 
-- More configuration surface area.
-- Harder to explain and validate.
+- Stock `iinit = 9` forced-convergence parameters are hard-coded in CM1
+  `init3d.F` rather than controlled by the namelist, so Cloud Chamber cannot
+  honestly expose or tune them without a CM1-source patching path.
+- Still idealized and not an observed boundary, dryline, or frontal forcing.
+- Raw trigger parameters remain package metadata in v1.
 - May need additional forcing parameters and careful domain placement.
 - More likely to imply a real-world boundary that the input sounding alone does
   not provide.
@@ -343,7 +364,7 @@ Recommended starting point:
 ```text
 testcase = 0
 isnd = 7
-iinit = 8
+iinit = 3
 ptype = 5
 radopt = 0
 output_rain = 1
@@ -355,8 +376,8 @@ the analytic Weisman-Klemp sounding/wind with an observed `input_sounding`.
 
 Implementation must validate:
 
-- whether the built-in warm line thermal initiates interpretable convection for
-  selected real soundings;
+- whether the built-in three-warm-bubble trigger initiates interpretable
+  convection for selected real soundings;
 - whether `ibalance` should remain `0` for this package family;
 - whether `iorigin = 2` remains the right domain origin;
 - whether storm motion (`imove`, `umove`, `vmove`) should be off initially or
@@ -580,6 +601,14 @@ learning value depends on storm organization and shear.
 Manual QA for #261 should focus on package health, tuning, domain/runtime
 calibration, and whether Results/Explore make the outcome interpretable:
 
+Manual smoke evidence from #261: a Fort Worth observed-sounding severe
+candidate at 1997-05-27 00Z produced an interpretable deep-convection quick-look
+result with the `iinit = 3` three-warm-bubble trigger. The output showed a
+strong updraft, rain water, ice, graupel, surface rain, reflectivity, and
+updraft helicity. Several strong candidates using the single `iinit = 1` warm
+bubble remained weak or shallow, so v1 should not default to the single-bubble
+trigger.
+
 1. Choose one observed sounding with strong deep-convection screening evidence.
 2. Generate a `Deep Convection Trial` quick-look package.
 3. Inspect `input_sounding`:
@@ -591,7 +620,7 @@ calibration, and whether Results/Explore make the outcome interpretable:
 4. Inspect `namelist.input`:
    - `testcase = 0`;
    - `isnd = 7`;
-   - `iinit = 8`;
+   - `iinit = 3`;
    - microphysics, output rain, and reflectivity fields enabled;
    - trigger parameters recorded in the package report.
 5. Run quick-look locally or on the LAN worker.
@@ -603,7 +632,7 @@ calibration, and whether Results/Explore make the outcome interpretable:
      velocity, reflectivity, and surface rain when present;
    - interesting times include initiation/updraft/rain/reflectivity events when
      supported;
-   - caveats disclose the idealized warm thermal trigger.
+   - caveats disclose the idealized three-warm-bubble trigger.
 9. Compare against at least one weak or capped sounding to see how the same
    package behaves in a less favorable environment.
 10. Do not commit generated output.
@@ -629,7 +658,7 @@ Scope:
 
 - Add `deep_convection_trial` package family metadata.
 - Add package generation path using observed `input_sounding`, observed winds,
-  warm thermal trigger, Morrison microphysics, rain/reflectivity outputs, and
+  three-warm-bubble trigger, Morrison microphysics, rain/reflectivity outputs, and
   clear experiment limitations.
 - Add tiny fixture tests for namelist/package metadata.
 - Add manual QA instructions for one real sounding smoke run.
@@ -647,7 +676,8 @@ Non-goals for #261:
 - What is the first acceptable runtime target for quick-look: local MacBook,
   LAN worker, or both?
 - How much trigger parameter control should be exposed to users versus kept
-  as package metadata?
+  as package metadata if Cloud Chamber later adds source-backed or custom
+  trigger variants?
 
 ## Source References
 
@@ -657,9 +687,14 @@ Source breadcrumbs for future implementation:
   `input_sounding`; wind profile is also read from `input_sounding`; `iwnd` is
   ignored.
 - `/Users/timpeterson/cm1r21.1/README.namelist`: `iinit = 1` warm bubble,
-  `iinit = 2` cold pool, `iinit = 8` warm line thermal with random
-  perturbations, `iinit = 9` forced convergence, and `iinit = 10` momentum
-  forcing.
+  `iinit = 2` cold pool, `iinit = 3` three warm bubbles, `iinit = 8` warm line
+  thermal with random perturbations, `iinit = 9` forced convergence, and
+  `iinit = 10` momentum forcing.
+- `/Users/timpeterson/cm1r21.1/src/init3d.F`: stock `iinit = 1` warm-bubble,
+  stock `iinit = 3` three-warm-bubble, and stock `iinit = 9`
+  forced-convergence parameters are implemented in CM1 source. The
+  forced-convergence parameters are not exposed as Cloud-Chamber package
+  controls in the v1 namelist path.
 - `/Users/timpeterson/cm1r21.1/run/config_files/supercell/namelist.input`:
   stock CM1 supercell example uses `testcase = 0`, `iinit = 1`, `ptype = 5`,
   `output_rain = 1`, and `output_dbz = 1`.
@@ -669,7 +704,7 @@ Source breadcrumbs for future implementation:
   (`ptype = 5`).
 - `app/backend/cloud_chamber/cm1_input_contract.py`: current Cloud Chamber
   observed-sounding package path renders `isnd = 7`; the Deep Convection Trial
-  implementation selects `iinit = 8`, writes observed sounding metadata into
+  implementation selects `iinit = 3`, writes observed sounding metadata into
   package configuration, and treats trigger details as package metadata.
 - `app/backend/cloud_chamber/dry_run_package.py`: current package generation
   writes `input_sounding`, `namelist.input`, package reports, and run/case

--- a/docs/research/deep-convection-package-design.md
+++ b/docs/research/deep-convection-package-design.md
@@ -36,7 +36,7 @@ package_family = deep_convection_trial
 Recommended v1 design:
 
 ```text
-Observed sounding + observed winds + warm bubble trigger
+Observed sounding + observed winds + warm thermal trigger
 ```
 
 This is an idealized CM1 experiment for learning and exploration. It tests what
@@ -52,14 +52,20 @@ Find an interesting real sounding
 
 Why this path first:
 
-- CM1 already has a warm-bubble initialization option (`iinit = 1`).
+- CM1 already has warm thermal initialization options (`iinit = 1` warm bubble
+  and `iinit = 8` warm line thermal with small random perturbations).
 - CM1 already has examples that combine idealized deep convection with
   Morrison microphysics, surface rain, and reflectivity output.
 - Cloud Chamber already has an observed-sounding path that writes
   `input_sounding` and uses `isnd = 7`.
 - `isnd = 7` reads wind from `input_sounding`; `iwnd` is ignored.
-- A warm bubble is easier to explain and validate than convergence forcing,
+- A warm thermal trigger is easier to explain and validate than convergence forcing,
   cold-pool insertion, or radiation-driven diurnal initiation.
+
+Implementation note from #261: stock CM1 r21.1 does not expose the `iinit = 1`
+warm-bubble geometry/amplitude as namelist-tunable fields. The first Cloud
+Chamber implementation uses CM1's built-in `iinit = 8` warm line thermal because
+it is a stronger supported trigger without requiring Fortran edits.
 
 ## PM Decisions For V1 Implementation
 
@@ -78,11 +84,12 @@ These are the product/science decisions for the implementation issue:
 - **Standard and Deep tiers should clearly recommend the LAN worker.** Those
   tiers are where wider domains, longer runtime, and denser output become more
   useful.
-- **The warm-bubble trigger should be visible to the user** as the initiation
+- **The warm thermal trigger should be visible to the user** as the initiation
   method. Users should know they are asking CM1 to try an idealized triggered
   experiment.
-- **Exact numeric warm-bubble parameters can remain package metadata in v1.**
-  Do not expose raw bubble controls until useful ranges are validated.
+- **Exact numeric trigger parameters can remain package metadata in v1.**
+  Do not expose raw trigger controls until useful ranges are validated and
+  namelist/source-code support is explicit.
 - **Manual QA is for package health, tuning, domain/runtime calibration, and
   result interpretability.** It is not a gate on whether severe/deep-convection
   soundings are allowed to use this package.
@@ -127,7 +134,7 @@ Recommended stable metadata:
   "package_family": "deep_convection_trial",
   "input_source": "observed_sounding",
   "specialized_package_for": "severe/deep_convection",
-  "trigger_type": "warm_bubble",
+  "trigger_type": "warm_thermal_line",
   "candidate_screening_hypothesis": {},
   "limitations": [],
   "expected_outputs": [],
@@ -139,13 +146,13 @@ Recommended Build copy:
 
 ```text
 Deep Convection Trial
-Try this observed sounding with an idealized warm-bubble trigger and see
+Try this observed sounding with an idealized warm thermal trigger and see
 whether deep convection develops.
 ```
 
 Recommended limitations:
 
-- The warm bubble is an idealized trigger, not an observed storm initiation
+- The warm thermal is an idealized trigger, not an observed storm initiation
   mechanism.
 - It can over-trigger marginal environments.
 - V1 does not represent surface heating/radiation, boundaries, terrain,
@@ -158,7 +165,7 @@ Recommended limitations:
 
 ## Initiation Options Compared
 
-### Warm Bubble Trigger
+### Warm Line-Thermal Trigger
 
 Decision for v1: use this.
 
@@ -168,18 +175,19 @@ Likely CM1 settings:
 testcase = 0
 isnd = 7
 iwnd = 0 or ignored by CM1 because isnd = 7
-iinit = 1
+iinit = 8
 irandp = 0 initially
 ```
 
 Pros:
 
-- Common idealized deep-convection trigger.
+- Strong idealized deep-convection trigger available in stock CM1.
 - Confirmed CM1 option.
 - Easy to explain to users.
 - Easy to verify in generated namelist tests.
 - Minimal new generated files beyond `input_sounding`.
 - Fits current observed-sounding package architecture.
+- Does not require Cloud Chamber to edit CM1 Fortran source.
 
 Cons:
 
@@ -187,27 +195,24 @@ Cons:
 - May initiate storms in marginal environments that would need a real boundary
   or stronger forcing.
 - Does not represent a front, dryline, outflow boundary, or terrain effect.
-- Bubble strength, radius, height, and location need careful manual validation.
+- Stock CM1 line-thermal geometry/strength are source-code behavior rather
+  than Cloud Chamber product controls in v1.
 
 V1 trigger metadata should include:
 
 ```json
 {
-  "trigger_type": "warm_bubble",
+  "trigger_type": "warm_thermal_line",
   "trigger_parameters": {
-    "temperature_perturbation_k": "implementation_tbd",
-    "horizontal_radius_m": "implementation_tbd",
-    "vertical_radius_m": "implementation_tbd",
-    "center_x_m": 0,
-    "center_y_m": 0,
-    "center_z_m": "implementation_tbd"
+    "cm1_iinit": 8,
+    "cm1_trigger": "CM1 built-in line thermal with small random perturbations",
+    "raw_controls_exposed": false
   }
 }
 ```
 
-The exact bubble parameters should be selected in implementation after reading
-CM1 `init3d.F` defaults and running a manual smoke validation. This design
-should not invent validated values.
+Future work can add a custom warm-bubble or point-thermal package if Cloud
+Chamber intentionally owns the required CM1 Fortran/configuration changes.
 
 ### Forced Convergence / Momentum Forcing
 
@@ -338,7 +343,7 @@ Recommended starting point:
 ```text
 testcase = 0
 isnd = 7
-iinit = 1
+iinit = 8
 ptype = 5
 radopt = 0
 output_rain = 1
@@ -350,11 +355,9 @@ the analytic Weisman-Klemp sounding/wind with an observed `input_sounding`.
 
 Implementation must validate:
 
-- warm-bubble parameter names and defaults used by CM1;
-- whether additional namelist fields must be surfaced for bubble size,
-  strength, center, or pressure balance;
-- whether `ibalance` should remain `0` or use hydrostatic balance for the
-  selected bubble shape;
+- whether the built-in warm line thermal initiates interpretable convection for
+  selected real soundings;
+- whether `ibalance` should remain `0` for this package family;
 - whether `iorigin = 2` remains the right domain origin;
 - whether storm motion (`imove`, `umove`, `vmove`) should be off initially or
   configured from mean wind.
@@ -588,7 +591,7 @@ calibration, and whether Results/Explore make the outcome interpretable:
 4. Inspect `namelist.input`:
    - `testcase = 0`;
    - `isnd = 7`;
-   - `iinit = 1`;
+   - `iinit = 8`;
    - microphysics, output rain, and reflectivity fields enabled;
    - trigger parameters recorded in the package report.
 5. Run quick-look locally or on the LAN worker.
@@ -600,7 +603,7 @@ calibration, and whether Results/Explore make the outcome interpretable:
      velocity, reflectivity, and surface rain when present;
    - interesting times include initiation/updraft/rain/reflectivity events when
      supported;
-   - caveats disclose the idealized warm-bubble trigger.
+   - caveats disclose the idealized warm thermal trigger.
 9. Compare against at least one weak or capped sounding to see how the same
    package behaves in a less favorable environment.
 10. Do not commit generated output.
@@ -626,7 +629,7 @@ Scope:
 
 - Add `deep_convection_trial` package family metadata.
 - Add package generation path using observed `input_sounding`, observed winds,
-  warm bubble trigger, Morrison microphysics, rain/reflectivity outputs, and
+  warm thermal trigger, Morrison microphysics, rain/reflectivity outputs, and
   clear experiment limitations.
 - Add tiny fixture tests for namelist/package metadata.
 - Add manual QA instructions for one real sounding smoke run.
@@ -643,7 +646,7 @@ Non-goals for #261:
 
 - What is the first acceptable runtime target for quick-look: local MacBook,
   LAN worker, or both?
-- How much warm-bubble parameter control should be exposed to users versus kept
+- How much trigger parameter control should be exposed to users versus kept
   as package metadata?
 
 ## Source References
@@ -654,8 +657,9 @@ Source breadcrumbs for future implementation:
   `input_sounding`; wind profile is also read from `input_sounding`; `iwnd` is
   ignored.
 - `/Users/timpeterson/cm1r21.1/README.namelist`: `iinit = 1` warm bubble,
-  `iinit = 2` cold pool, `iinit = 9` forced convergence, and `iinit = 10`
-  momentum forcing.
+  `iinit = 2` cold pool, `iinit = 8` warm line thermal with random
+  perturbations, `iinit = 9` forced convergence, and `iinit = 10` momentum
+  forcing.
 - `/Users/timpeterson/cm1r21.1/run/config_files/supercell/namelist.input`:
   stock CM1 supercell example uses `testcase = 0`, `iinit = 1`, `ptype = 5`,
   `output_rain = 1`, and `output_dbz = 1`.
@@ -664,8 +668,9 @@ Source breadcrumbs for future implementation:
   definitions; `output_dbz` is available for Morrison microphysics
   (`ptype = 5`).
 - `app/backend/cloud_chamber/cm1_input_contract.py`: current Cloud Chamber
-  observed-sounding package path renders `isnd = 7` and writes observed
-  sounding metadata into package configuration.
+  observed-sounding package path renders `isnd = 7`; the Deep Convection Trial
+  implementation selects `iinit = 8`, writes observed sounding metadata into
+  package configuration, and treats trigger details as package metadata.
 - `app/backend/cloud_chamber/dry_run_package.py`: current package generation
   writes `input_sounding`, `namelist.input`, package reports, and run/case
   manifests.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -105,12 +105,50 @@ candidate-screening provenance in the generated package request. Browser tests
 must mock the backend APIs and must not fetch NOAA/NCEI, parse raw station text,
 or imply that a candidate score predicts the CM1 outcome.
 
-Expanded real-sounding story families are currently spec-only. Tests must not
-expect severe/deep-convection, winter/cold-season, cold-pool, fog/stratus, or
-other future taxonomy labels to appear as enabled Build filters until backend
-feature extraction, scoring, evidence, caveats, and package-readiness behavior
-are implemented. The readiness taxonomy is documented in
+Most expanded real-sounding story families are spec-only until backend feature
+extraction, scoring, evidence, caveats, and package-readiness behavior are
+implemented. Tests must not expect winter/cold-season, cold-pool, fog/stratus,
+or other future taxonomy labels to appear as enabled Build filters before that
+support exists. The readiness taxonomy is documented in
 [research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md).
+The implemented severe/deep-convection exception is `Deep Convection Trial`.
+Unit/component tests should prove that deep-convection candidates can default to
+that package family, that package requests include `package_family =
+deep_convection_trial` and candidate-screening provenance, and that ordinary
+observed-sounding quick looks remain available.
+
+### Deep Convection Trial Package Validation
+
+Automated tests for Deep Convection Trial must use tiny or mocked fixtures. They
+should verify that package generation:
+
+- requires an observed sounding and observed u/v wind components;
+- preserves candidate-screening metadata;
+- records package family, display name, trigger type, trigger metadata,
+  expected outputs, caveats, and manual-validation status on generated
+  manifests and reports;
+- writes CM1-facing `namelist.input` settings for the observed-sounding route,
+  warm line-thermal trigger, wider domain, rain output, reflectivity output,
+  vorticity output, and updraft-helicity output;
+- writes a numeric `input_sounding` with observed wind components; and
+- preserves package identity through ingest into Result Cards.
+
+Manual/local QA is required before treating the package as scientifically
+accepted. The manual smoke loop should:
+
+1. choose or upload a real observed sounding with usable winds;
+2. select `Deep Convection Trial`;
+3. generate a Quick Look package;
+4. inspect `run_manifest.json`, `dry_run_report.json`, `namelist.input`, and
+   `input_sounding`;
+5. confirm `isnd = 7`, `iinit = 8`, `testcase = 0`, rain/reflectivity/vorticity/
+   updraft-helicity output, observed u/v winds, and the wider model box;
+6. run CM1 locally or on the LAN worker outside CI;
+7. ingest completed output;
+8. open Results and Explore to confirm the notebook keeps the Deep Convection
+   Trial identity and the result is interpretable; and
+9. confirm no generated run folders, logs, NetCDF output, copied runtime files,
+   screenshots, or videos are committed.
 
 Local run manager tests should cover stale-manifest reconciliation: if stdout
 contains normal CM1 termination evidence and output artifacts exist, status and

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -125,7 +125,7 @@ should verify that package generation:
 - requires an observed sounding and observed u/v wind components;
 - preserves candidate-screening metadata;
 - records package family, display name, trigger type, trigger metadata,
-  expected outputs, caveats, and manual-validation status on generated
+  expected outputs, caveats, and package-family smoke-validation status on generated
   manifests and reports;
 - writes CM1-facing `namelist.input` settings for the observed-sounding route,
   three-warm-bubble trigger, storm-scale domain, rain output, reflectivity output,

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -128,21 +128,25 @@ should verify that package generation:
   expected outputs, caveats, and manual-validation status on generated
   manifests and reports;
 - writes CM1-facing `namelist.input` settings for the observed-sounding route,
-  warm line-thermal trigger, wider domain, rain output, reflectivity output,
+  three-warm-bubble trigger, storm-scale domain, rain output, reflectivity output,
   vorticity output, and updraft-helicity output;
 - writes a numeric `input_sounding` with observed wind components; and
 - preserves package identity through ingest into Result Cards.
 
 Manual/local QA is required before treating the package as scientifically
-accepted. The manual smoke loop should:
+accepted for a selected real sounding. #261 established package-health evidence
+for the v1 three-warm-bubble trigger using a Fort Worth severe candidate that
+produced strong updraft, reflectivity, rain water, ice, graupel, surface rain,
+and updraft helicity; new soundings remain experiments whose outcomes must be
+inspected after CM1 runs. The manual smoke loop should:
 
 1. choose or upload a real observed sounding with usable winds;
 2. select `Deep Convection Trial`;
 3. generate a Quick Look package;
 4. inspect `run_manifest.json`, `dry_run_report.json`, `namelist.input`, and
    `input_sounding`;
-5. confirm `isnd = 7`, `iinit = 8`, `testcase = 0`, rain/reflectivity/vorticity/
-   updraft-helicity output, observed u/v winds, and the wider model box;
+5. confirm `isnd = 7`, `iinit = 3`, `testcase = 0`, rain/reflectivity/vorticity/
+   updraft-helicity output, observed u/v winds, and the storm-scale model box;
 6. run CM1 locally or on the LAN worker outside CI;
 7. ingest completed output;
 8. open Results and Explore to confirm the notebook keeps the Deep Convection


### PR DESCRIPTION
## Issue worked

Closes #261

## Summary

- Added `Deep Convection Trial` as a first-class observed-sounding package family for severe/deep-convection experiments.
- Package generation accepts `package_family=deep_convection_trial`, requires a validated observed sounding with a complete finite observed u/v wind profile for every rendered `input_sounding` level, uses CM1 `isnd = 7` observed thermodynamics/winds, and selects CM1 `iinit = 3` three-warm-bubble line initiation.
- Deep Convection Trial uses storm-scale idealized domains by tier, enables rain/reflectivity/vorticity/updraft-helicity outputs, and records package family, trigger metadata, expected outputs, caveats, and package-family smoke validation status in manifests, reports, ingest metadata, and Result Cards.
- Build now exposes a grouped `Deep Convection Trial stories` candidate filter while preserving severe/supercell/high-CAPE/dry-microburst/elevated/squall-line story routing.
- Sounding screening/diagnostics were tightened so deep-convection stories are not crushed by missing EL/CAPE-adjacent fields when CAPE/shear evidence is present, while bad near-surface coverage and discontinuous profiles are caveated and penalized.
- Observed `input_sounding` rendering extends to the required model top and avoids duplicating the exact z=0 level in the body after using the header surface state.
- Build UI copy describes the three-warm-bubble trial path and keeps raw CM1 trigger parameters out of primary controls.
- Updated product/architecture/testing/development docs and the deep-convection package design memo to reflect the implemented CM1 three-warm-bubble trigger path, grouped story filter, and smoke-evidence scope.

## Important implementation note

Stock CM1 r21.1 exposes useful built-in initiation modes but does not expose arbitrary warm-bubble geometry/amplitude as normal namelist controls. This implementation uses CM1's built-in `iinit = 3` three-warm-bubble line trigger because local smoke testing showed it can initiate a real deep-convective storm from an observed sounding while remaining honest about the idealized trigger.

## Real CM1 smoke evidence

Initial validation with a weak Valley sounding proved only package plumbing; it did not prove deep-convection behavior. I kept testing and changed the package/scoring path rather than treating that weak result as success.

Successful product-generated smoke case:

- Observed sounding: Fort Worth, TX (`USM00072249`), `1997-05-27T00:00:00Z`
- Package family: `Deep Convection Trial`
- Trigger: CM1 `iinit = 3` three warm bubbles
- Runtime package: run ID `dry-run-deep-fort-worth-19970527-0000-current-iinit3`
- CM1 status: completed normally, `exit_code = 0`
- Outputs: 13 model NetCDF files plus `cm1out_stats.nc`
- Stderr caveat: `IEEE_UNDERFLOW_FLAG` only
- Final xarray scan, excluding `cm1out_stats.nc`:
  - `max w = 54.126 m/s`, `min w = -15.888 m/s`
  - `max dbz = 64.522 dBZ`
  - `max qc = 0.00648 kg/kg`
  - `max qr = 0.00662 kg/kg`
  - `max qi = 0.00219 kg/kg`
  - `max qs = 0.00133 kg/kg`
  - `max qg = 0.01033 kg/kg`
  - `max rain = 0.72143`
  - `max updraft helicity = 491.467`

This is strong evidence that the generated Deep Convection Trial package family can produce deep convection from an observed sounding. Each observed sounding remains an experiment; exact storm mode remains an outcome to inspect, not a pre-run claim.

No generated output, NetCDF files, logs, screenshots, traces, videos, runtime folders, SSH config, or local settings are committed.

## Playwright / visual QA

- `scripts/check-e2e.sh` passed all 23 mocked browser smoke tests, including Build observed-sounding flow, candidate screening/use flow, Results/Explore paths, and visualizer layout regressions.
- Frontend component tests cover package-family selection/copy, grouped Deep Convection Trial story filtering, package request payloads, and detailed refresh-blocked error copy.
- Manual browser check confirmed the candidate list no longer clips cards in the Build upload-sounding flow.

## Tests added/updated

- Backend package tests for Deep Convection Trial namelist settings, complete observed wind handling, package metadata, output flags, package-family smoke provenance, and refusal without observed sounding/wind components.
- Backend API tests for the grouped `deep_convection_trial` story target.
- Result Card tests proving Deep Convection Trial identity, trigger metadata, expected outputs, caveats, and provenance survive ingest.
- Sounding candidate/diagnostics tests for deep-convection scoring, missing-data behavior, near-surface discontinuity caveats, shear/lapse/inversion/freezing-level diagnostics, and package readiness.
- Observed-sounding rendering tests for surface/header handling and model-top extension.
- Frontend tests for uploaded-sounding package-family selection, grouped deep-convection candidate filtering/defaulting, and package request payloads.

## Commands run

- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_dry_run_package.py app/backend/tests/test_observed_sounding.py app/backend/tests/test_result_cards.py app/backend/tests/test_sounding_candidates.py -q`
- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_sounding_candidates.py -q`
- `npm test -- --run App.test.tsx`
- `scripts/check.sh`
- `scripts/check-e2e.sh`
- Local CM1 quick-look run and xarray inspection for run ID `dry-run-deep-fort-worth-19970527-0000-current-iinit3`

## Manual QA needed

No manual review blocker remains before merge. The package family has manual smoke evidence; each new observed sounding remains a CM1 experiment to inspect after completion.

## Caveats / follow-up

- Deep Convection Trial v1 still does not represent terrain, radiation, mesoscale lift, boundaries, or a configurable trigger geometry.
- Candidate labels remain pre-run hypotheses; CM1 output remains the source of truth.
- Severe/supercell/microburst/squall-line/elevated labels should be interpreted through Results/Explore after the run, not assumed from screening alone.