### PR TITLE
Add deep-convection Results and Explore diagnostics

### DIFF
--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -933,7 +933,7 @@ def _science_summary(
         else _latest_manifest_time(output_manifest),
         default_explore_time_index=default_source.time_index if default_source else None,
         default_explore_time_seconds=default_source.time_seconds if default_source else None,
-        cm1_outcome=_cm1_outcome(diagnostics),
+        cm1_outcome=_cm1_outcome(diagnostics) if is_deep_convection else None,
         diagnostic_availability=_diagnostic_availability(variables),
         interesting_time_support_state=support_state,
     )

--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -37,6 +37,9 @@ InterestingTimeSupportState = Literal[
     "unsupported_missing_diagnostic",
 ]
 
+DEEP_CLOUD_TOP_THRESHOLD_M = 8000.0
+STRONG_UPDRAFT_THRESHOLD_M_S = 10.0
+
 
 class OutputProductManifestError(RuntimeError):
     """Raised when an output product manifest cannot be built or resolved."""
@@ -123,11 +126,29 @@ class FieldDefaultTime(BaseModel):
     caveats: list[str] = Field(default_factory=list)
 
 
+class ScienceDiagnosticAvailability(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    label: str
+    support_state: InterestingTimeSupportState
+    source_field: str | None = None
+    value: float | bool | None = None
+    units: str | None = None
+    caveats: list[str] = Field(default_factory=list)
+
+
 class ScienceSummary(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    cloud_formed: bool | None = None
+    deep_cloud_formed: bool | None = None
+    deep_cloud_threshold_m: float = DEEP_CLOUD_TOP_THRESHOLD_M
+    strong_updraft_formed: bool | None = None
+    strong_updraft_threshold_m_s: float = STRONG_UPDRAFT_THRESHOLD_M_S
     first_cloud_time_seconds: float | None = None
     first_cloud_time_label: str | None = None
+    time_of_first_deep_convection_seconds: float | None = None
     max_qc_kg_kg: float | None = None
     max_qc_time_seconds: float | None = None
     max_updraft_w_m_s: float | None = None
@@ -137,9 +158,16 @@ class ScienceSummary(BaseModel):
     highest_cloud_top_m: float | None = None
     rain_onset_time_seconds: float | None = None
     max_qr_kg_kg: float | None = None
+    max_rain_or_surface_precip: float | None = None
+    max_dbz_or_reflectivity_proxy: float | None = None
+    cold_pool_proxy: float | None = None
+    near_surface_theta_perturbation_proxy: float | None = None
+    updraft_depth_proxy_m: float | None = None
     latest_output_time_seconds: float | None = None
     default_explore_time_index: int | None = None
     default_explore_time_seconds: float | None = None
+    cm1_outcome: str | None = None
+    diagnostic_availability: list[ScienceDiagnosticAvailability] = Field(default_factory=list)
     interesting_time_caveats: list[str] = Field(default_factory=list)
     interesting_time_support_state: str = "unavailable"
 
@@ -414,15 +442,24 @@ def build_interesting_time_product(
     diagnostics: ResultDiagnostics | None,
     output_manifest: OutputProductManifest,
     variables: list[str],
+    package_family: str | None = None,
 ) -> InterestingTimeProduct:
     """Build small science time landmarks from diagnostics and manifest time mapping."""
     records = _interesting_time_records(
         diagnostics=diagnostics,
         output_manifest=output_manifest,
         variables=set(variables),
+        package_family=package_family,
     )
     defaults = _field_defaults(records)
-    summary = _science_summary(diagnostics, output_manifest, records, defaults)
+    summary = _science_summary(
+        diagnostics,
+        output_manifest,
+        records,
+        defaults,
+        variables=set(variables),
+        package_family=package_family,
+    )
     caveats = _dedupe(
         [
             *(output_manifest.caveats or []),
@@ -445,6 +482,7 @@ def _interesting_time_records(
     diagnostics: ResultDiagnostics | None,
     output_manifest: OutputProductManifest,
     variables: set[str],
+    package_family: str | None,
 ) -> list[InterestingTimeRecord]:
     latest = _latest_time_record(output_manifest)
     if diagnostics is None:
@@ -506,6 +544,20 @@ def _interesting_time_records(
             unavailable_caveat="no_cloud_top_detected" if cloud.available else "missing_qc_field",
             support_state="unavailable" if cloud.available else "unsupported_missing_fields",
         ),
+        _event_record(
+            key="first_deep_convection",
+            label="First deep convection",
+            time_seconds=_first_deep_convection_time(diagnostics) if cloud.available else None,
+            source_field="qc+qr+qi+qs+qg when available",
+            source_diagnostic="diagnostics.cloud.cloud_top_time_series",
+            value=_deep_cloud_formed(diagnostics) if cloud.available else None,
+            units=None,
+            output_manifest=output_manifest,
+            unavailable_caveat="no_deep_cloud_detected" if cloud.available else "missing_qc_field",
+            support_state="unavailable" if cloud.available else "unsupported_missing_fields",
+        )
+        if package_family == "deep_convection_trial"
+        else None,
         _event_record(
             key="max_updraft_w",
             label="Max updraft",
@@ -576,8 +628,14 @@ def _interesting_time_records(
         ),
         latest,
     ]
-    records.append(_field_default_record(_default_source_record(records), fallback_reason=None))
-    return records
+    compact_records = [record for record in records if record is not None]
+    compact_records.append(
+        _field_default_record(
+            _default_source_record(compact_records, package_family=package_family),
+            fallback_reason=None,
+        )
+    )
+    return compact_records
 
 
 def _event_record(
@@ -808,17 +866,22 @@ def _science_summary(
     output_manifest: OutputProductManifest,
     records: list[InterestingTimeRecord],
     defaults: dict[str, FieldDefaultTime],
+    *,
+    variables: set[str],
+    package_family: str | None,
 ) -> ScienceSummary:
     record_by_key = {record.key: record for record in records}
     default_record = record_by_key.get("field_default_time")
     latest = record_by_key.get("latest_output")
     qc_default = defaults.get("qc")
+    is_deep_convection = package_family == "deep_convection_trial"
     if diagnostics is None:
         return ScienceSummary(
             latest_output_time_seconds=latest.time_seconds if latest else None,
             default_explore_time_index=default_record.time_index if default_record else None,
             default_explore_time_seconds=default_record.time_seconds if default_record else None,
             interesting_time_support_state="fallback",
+            diagnostic_availability=_diagnostic_availability(variables),
         )
     supported_science_keys = {
         "first_cloud",
@@ -837,9 +900,18 @@ def _science_summary(
         if record.key in supported_science_keys and record.support_state == "supported"
     )
     support_state = "supported" if supported_count > 0 else "fallback"
+    highest_cloud_top = _record_value(record_by_key.get("highest_cloud_top"))
+    first_deep_convection = _record_time(record_by_key.get("first_deep_convection"))
+    deep_cloud_formed = _deep_cloud_formed(diagnostics)
+    strong_updraft_formed = _strong_updraft_formed(diagnostics)
+    default_source = default_record if is_deep_convection else qc_default or default_record
     return ScienceSummary(
+        cloud_formed=diagnostics.cloud.formed if diagnostics.cloud.available else None,
+        deep_cloud_formed=deep_cloud_formed,
+        strong_updraft_formed=strong_updraft_formed,
         first_cloud_time_seconds=diagnostics.cloud.first_cloud_time_seconds,
         first_cloud_time_label=_format_time_label(diagnostics.cloud.first_cloud_time_seconds),
+        time_of_first_deep_convection_seconds=first_deep_convection,
         max_qc_kg_kg=diagnostics.cloud.max_qc_kg_kg if diagnostics.cloud.available else None,
         max_qc_time_seconds=diagnostics.cloud.time_of_max_qc_seconds
         if record_by_key.get("max_qc", None)
@@ -853,25 +925,32 @@ def _science_summary(
         if diagnostics.vertical_velocity.available
         else None,
         min_downdraft_time_seconds=diagnostics.vertical_velocity.time_of_min_w_seconds,
-        highest_cloud_top_m=_record_value(record_by_key.get("highest_cloud_top")),
+        highest_cloud_top_m=highest_cloud_top,
         rain_onset_time_seconds=diagnostics.rain.first_rain_time_seconds,
         max_qr_kg_kg=diagnostics.rain.max_qr_kg_kg if diagnostics.rain.available else None,
         latest_output_time_seconds=latest.time_seconds
         if latest
         else _latest_manifest_time(output_manifest),
-        default_explore_time_index=qc_default.time_index
-        if qc_default is not None
-        else (default_record.time_index if default_record else None),
-        default_explore_time_seconds=qc_default.time_seconds
-        if qc_default is not None
-        else (default_record.time_seconds if default_record else None),
+        default_explore_time_index=default_source.time_index if default_source else None,
+        default_explore_time_seconds=default_source.time_seconds if default_source else None,
+        cm1_outcome=_cm1_outcome(diagnostics),
+        diagnostic_availability=_diagnostic_availability(variables),
         interesting_time_support_state=support_state,
     )
 
 
-def _default_source_record(records: list[InterestingTimeRecord]) -> InterestingTimeRecord:
+def _default_source_record(
+    records: list[InterestingTimeRecord],
+    *,
+    package_family: str | None,
+) -> InterestingTimeRecord:
     by_key = {record.key: record for record in records}
-    for key in ("first_cloud", "max_qc", "max_updraft_w"):
+    preferred_keys = (
+        ("first_deep_convection", "max_updraft_w", "rain_onset", "max_qc")
+        if package_family == "deep_convection_trial"
+        else ("first_cloud", "max_qc", "max_updraft_w")
+    )
+    for key in preferred_keys:
         record = by_key.get(key)
         if record and record.support_state == "supported":
             return record
@@ -911,6 +990,125 @@ def _record_value(record: InterestingTimeRecord | None) -> float | None:
     if record is None or record.support_state != "supported":
         return None
     return float(record.value) if isinstance(record.value, (int, float)) else None
+
+
+def _record_time(record: InterestingTimeRecord | None) -> float | None:
+    if record is None or record.support_state != "supported":
+        return None
+    return record.time_seconds
+
+
+def _first_deep_convection_time(diagnostics: ResultDiagnostics) -> float | None:
+    for point in diagnostics.cloud.cloud_top_time_series:
+        if point.value is not None and point.value >= DEEP_CLOUD_TOP_THRESHOLD_M:
+            return point.time_seconds
+    return None
+
+
+def _deep_cloud_formed(diagnostics: ResultDiagnostics) -> bool | None:
+    if not diagnostics.cloud.available:
+        return None
+    return any(
+        point.value is not None and point.value >= DEEP_CLOUD_TOP_THRESHOLD_M
+        for point in diagnostics.cloud.cloud_top_time_series
+    )
+
+
+def _strong_updraft_formed(diagnostics: ResultDiagnostics) -> bool | None:
+    if not diagnostics.vertical_velocity.available:
+        return None
+    return (
+        diagnostics.vertical_velocity.max_w_m_s is not None
+        and diagnostics.vertical_velocity.max_w_m_s >= STRONG_UPDRAFT_THRESHOLD_M_S
+    )
+
+
+def _cm1_outcome(diagnostics: ResultDiagnostics) -> str:
+    deep_cloud = _deep_cloud_formed(diagnostics)
+    strong_updraft = _strong_updraft_formed(diagnostics)
+    if deep_cloud is None or strong_updraft is None:
+        return (
+            "Unable to evaluate deep convection because required cloud or updraft fields "
+            "are missing."
+        )
+    if deep_cloud and strong_updraft and diagnostics.rain.available and diagnostics.rain.present:
+        return "Deep convection formed with strong updraft and rain."
+    if deep_cloud and strong_updraft:
+        return "Deep convection formed with strong updraft; rain evidence is absent or unavailable."
+    if deep_cloud:
+        return "Deep cloud formed, but the updraft-strength threshold was not met."
+    if strong_updraft:
+        return "Strong updraft formed, but deep cloud did not reach the threshold."
+    return "Trigger failed to produce deep convection by current cloud-top and updraft thresholds."
+
+
+def _diagnostic_availability(variables: set[str]) -> list[ScienceDiagnosticAvailability]:
+    return [
+        _availability_record(
+            key="max_dbz_or_reflectivity_proxy",
+            label="Max reflectivity",
+            source_field="dbz",
+            field_present="dbz" in variables,
+            implemented=False,
+        ),
+        _availability_record(
+            key="max_rain_or_surface_precip",
+            label="Max surface rain",
+            source_field="rain",
+            field_present="rain" in variables,
+            implemented=False,
+        ),
+        _availability_record(
+            key="updraft_depth_proxy",
+            label="Updraft depth proxy",
+            source_field="w",
+            field_present="w" in variables,
+            implemented=False,
+        ),
+        _availability_record(
+            key="cold_pool_proxy",
+            label="Cold-pool proxy",
+            source_field="th",
+            field_present=bool({"th", "theta", "theta_v"} & variables),
+            implemented=False,
+        ),
+        _availability_record(
+            key="near_surface_theta_perturbation_proxy",
+            label="Near-surface theta perturbation",
+            source_field="th",
+            field_present=bool({"th", "theta", "theta_v"} & variables),
+            implemented=False,
+        ),
+    ]
+
+
+def _availability_record(
+    *,
+    key: str,
+    label: str,
+    source_field: str,
+    field_present: bool,
+    implemented: bool,
+) -> ScienceDiagnosticAvailability:
+    if implemented:
+        return ScienceDiagnosticAvailability(
+            key=key,
+            label=label,
+            source_field=source_field,
+            support_state="supported",
+        )
+    caveat = (
+        f"{key}_diagnostic_not_implemented" if field_present else f"missing_{source_field}_field"
+    )
+    return ScienceDiagnosticAvailability(
+        key=key,
+        label=label,
+        source_field=source_field,
+        support_state="unsupported_missing_diagnostic"
+        if field_present
+        else "unsupported_missing_fields",
+        caveats=[caveat],
+    )
 
 
 def _positive(value: float | None) -> bool:

--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from cloud_chamber.output_products import FieldDefaultTime, InterestingTimeRecord, ScienceSummary
 from cloud_chamber.result_ingest import (
     RESULT_METADATA_FILENAME,
+    CandidateHypothesisComparison,
     ResultIngestError,
     ResultMetadata,
     result_metadata_from_json,
@@ -94,6 +95,8 @@ class ResultCard(BaseModel):
     expected_outputs: list[str] = Field(default_factory=list)
     package_caveats: list[str] = Field(default_factory=list)
     manual_validation_status: str | None = None
+    candidate_screening: dict[str, object] | None = None
+    candidate_hypothesis_comparison: CandidateHypothesisComparison | None = None
     provenance_labels: list[str] = Field(default_factory=list)
     diagnostics_summary: str | None = None
     thermal_fate_label: str | None = None
@@ -227,6 +230,8 @@ def _card_from_metadata(
         expected_outputs=metadata.expected_outputs,
         package_caveats=metadata.package_caveats,
         manual_validation_status=metadata.manual_validation_status,
+        candidate_screening=metadata.candidate_screening,
+        candidate_hypothesis_comparison=metadata.candidate_hypothesis_comparison,
         provenance_labels=[
             f"source_model:{metadata.source_model}",
             f"source_product_state:{metadata.source_product_state}",

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -876,8 +876,10 @@ def _candidate_hypothesis_comparison(
         return CandidateHypothesisComparison(
             screened_as=screened_as,
             ran_as=ran_as,
-            cm1_outcome=science_summary.cm1_outcome
-            or "CM1 outcome was ingested, but this was not a Deep Convection Trial package.",
+            cm1_outcome=(
+                "Unable to evaluate candidate match because this was not a "
+                "Deep Convection Trial package."
+            ),
             match_status="unable_to_evaluate",
             match_status_label="Unable to evaluate",
             evidence=evidence,

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -37,6 +37,22 @@ from cloud_chamber.settings import CloudChamberSettings
 RESULT_METADATA_FILENAME = "result_metadata.json"
 MODEL_OUTPUT_PATTERN = re.compile(r"^cm1out_\d+\.nc(?:4)?$")
 STATS_OUTPUT_NAMES = {"cm1out_stats.nc", "cm1out_stats.nc4"}
+DEEP_CONVECTION_STORY_IDS = {
+    "severe_thunderstorm_environment",
+    "supercell_environment",
+    "high_cape_pulse_storm",
+    "dry_microburst_inverted_v",
+    "squall_line_cold_pool_candidate",
+    "elevated_convection",
+}
+DEEP_CONVECTION_STORY_LABELS = {
+    "severe_thunderstorm_environment": "Severe thunderstorm environment",
+    "supercell_environment": "Supercell-like environment",
+    "high_cape_pulse_storm": "High-CAPE pulse storm",
+    "dry_microburst_inverted_v": "Dry microburst / inverted-V",
+    "squall_line_cold_pool_candidate": "Squall-line / cold-pool candidate",
+    "elevated_convection": "Elevated convection",
+}
 
 
 class ResultIngestError(RuntimeError):
@@ -50,6 +66,18 @@ class FieldMetadata(BaseModel):
     dimensions: list[str]
     shape: list[int]
     units: str | None = None
+
+
+class CandidateHypothesisComparison(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    screened_as: str | None = None
+    ran_as: str
+    cm1_outcome: str
+    match_status: str
+    match_status_label: str
+    evidence: list[str] = Field(default_factory=list)
+    caveats: list[str] = Field(default_factory=list)
 
 
 class ResultMetadata(BaseModel):
@@ -75,6 +103,8 @@ class ResultMetadata(BaseModel):
     expected_outputs: list[str] = Field(default_factory=list)
     package_caveats: list[str] = Field(default_factory=list)
     manual_validation_status: str | None = None
+    candidate_screening: dict[str, Any] | None = None
+    candidate_hypothesis_comparison: CandidateHypothesisComparison | None = None
     result_state: str = "ingested_result_metadata"
     raw_cm1_artifacts: list[str] = Field(default_factory=list)
     netcdf_paths: list[str] = Field(default_factory=list)
@@ -155,6 +185,7 @@ def ingest_completed_run(manifest_path: Path) -> ResultMetadata:
         diagnostics=result.diagnostics,
         output_manifest=product_manifest,
         variables=result.variables,
+        package_family=result.package_family,
     )
     product_manifest = product_manifest.model_copy(
         update={"interesting_time_product": interesting_time_product}
@@ -166,6 +197,9 @@ def ingest_completed_run(manifest_path: Path) -> ResultMetadata:
             "science_summary": interesting_time_product.science_summary,
             "interesting_time_caveats": interesting_time_product.caveats,
         }
+    )
+    result = result.model_copy(
+        update={"candidate_hypothesis_comparison": _candidate_hypothesis_comparison(result)}
     )
     result_path.write_text(result.to_json_text())
     write_output_product_manifest(product_manifest_path, product_manifest)
@@ -271,6 +305,7 @@ def _result_from_model_output_files(
         expected_outputs=manifest.expected_outputs,
         package_caveats=manifest.package_caveats,
         manual_validation_status=manifest.manual_validation_status,
+        candidate_screening=manifest.candidate_screening,
         raw_cm1_artifacts=manifest.outputs.raw_cm1_artifacts,
         netcdf_paths=[str(path) for path in netcdf_paths],
         model_output_paths=[str(path) for path in contributing_paths],
@@ -712,6 +747,7 @@ def _result_from_dataset(
         expected_outputs=manifest.expected_outputs,
         package_caveats=manifest.package_caveats,
         manual_validation_status=manifest.manual_validation_status,
+        candidate_screening=manifest.candidate_screening,
         raw_cm1_artifacts=manifest.outputs.raw_cm1_artifacts,
         netcdf_paths=[str(path) for path in netcdf_paths],
         model_output_paths=[str(path) for path in contributing_paths],
@@ -788,6 +824,162 @@ def _to_float_or_none(value: object) -> float | None:
         return float(cast(Any, value))
     except (TypeError, ValueError):
         return None
+
+
+def _candidate_hypothesis_comparison(
+    result: ResultMetadata,
+) -> CandidateHypothesisComparison | None:
+    screening = result.candidate_screening
+    if not screening:
+        return None
+
+    primary_story = _screening_string(screening.get("primary_story"))
+    screened_as = _candidate_story_label(primary_story)
+    ran_as = result.package_display_name or _display_package_family(result.package_family)
+    if result.scenario_name and ran_as == "CM1 package":
+        ran_as = result.scenario_name
+
+    science_summary = result.science_summary
+    diagnostics = result.diagnostics
+    if science_summary is None or diagnostics is None:
+        return CandidateHypothesisComparison(
+            screened_as=screened_as,
+            ran_as=ran_as,
+            cm1_outcome="Unable to evaluate because result diagnostics are unavailable.",
+            match_status="unable_to_evaluate",
+            match_status_label="Unable to evaluate",
+            caveats=[
+                "candidate_screening_is_a_pre_run_hypothesis",
+                "result_diagnostics_unavailable",
+            ],
+        )
+
+    evidence = _candidate_outcome_evidence(science_summary)
+    caveats = [
+        "candidate_screening_is_a_pre_run_hypothesis",
+        "candidate_match_uses_simple_v1_deep_convection_rules",
+    ]
+    if primary_story not in DEEP_CONVECTION_STORY_IDS:
+        return CandidateHypothesisComparison(
+            screened_as=screened_as,
+            ran_as=ran_as,
+            cm1_outcome=science_summary.cm1_outcome
+            or "CM1 outcome was ingested, but no deep-convection comparison is available.",
+            match_status="unable_to_evaluate",
+            match_status_label="Unable to evaluate",
+            evidence=evidence,
+            caveats=_dedupe_strings(
+                [*caveats, "candidate_story_not_in_deep_convection_v1_rule_set"]
+            ),
+        )
+    if result.package_family != "deep_convection_trial":
+        return CandidateHypothesisComparison(
+            screened_as=screened_as,
+            ran_as=ran_as,
+            cm1_outcome=science_summary.cm1_outcome
+            or "CM1 outcome was ingested, but this was not a Deep Convection Trial package.",
+            match_status="unable_to_evaluate",
+            match_status_label="Unable to evaluate",
+            evidence=evidence,
+            caveats=_dedupe_strings(
+                [*caveats, "comparison_requires_deep_convection_trial_package"]
+            ),
+        )
+    if not diagnostics.cloud.available or not diagnostics.vertical_velocity.available:
+        return CandidateHypothesisComparison(
+            screened_as=screened_as,
+            ran_as=ran_as,
+            cm1_outcome=science_summary.cm1_outcome
+            or "Unable to evaluate because required cloud or updraft fields are missing.",
+            match_status="unable_to_evaluate",
+            match_status_label="Unable to evaluate",
+            evidence=evidence,
+            caveats=_dedupe_strings([*caveats, "missing_qc_or_w_fields"]),
+        )
+
+    deep_cloud = science_summary.deep_cloud_formed is True
+    strong_updraft = science_summary.strong_updraft_formed is True
+    rain_detected = diagnostics.rain.available and diagnostics.rain.present
+    if not deep_cloud and not strong_updraft:
+        match_status = "did_not_match"
+    elif deep_cloud and strong_updraft and rain_detected:
+        match_status = "matched"
+    elif deep_cloud or strong_updraft or rain_detected:
+        match_status = "partially_matched"
+    else:
+        match_status = "did_not_match"
+
+    if not diagnostics.rain.available:
+        caveats.append("rain_field_missing_or_unavailable")
+
+    return CandidateHypothesisComparison(
+        screened_as=screened_as,
+        ran_as=ran_as,
+        cm1_outcome=science_summary.cm1_outcome or "CM1 outcome unavailable.",
+        match_status=match_status,
+        match_status_label=_match_status_label(match_status),
+        evidence=evidence,
+        caveats=_dedupe_strings(caveats),
+    )
+
+
+def _candidate_outcome_evidence(science_summary: ScienceSummary) -> list[str]:
+    evidence: list[str] = []
+    if science_summary.deep_cloud_formed is not None:
+        evidence.append(
+            "deep cloud formed" if science_summary.deep_cloud_formed else "no deep cloud detected"
+        )
+    if science_summary.highest_cloud_top_m is not None:
+        evidence.append(f"cloud top {_format_metric(science_summary.highest_cloud_top_m, 'm')}")
+    if science_summary.max_updraft_w_m_s is not None:
+        evidence.append(f"max updraft {_format_metric(science_summary.max_updraft_w_m_s, 'm/s')}")
+    if science_summary.rain_onset_time_seconds is not None:
+        evidence.append(f"rain onset {_format_seconds(science_summary.rain_onset_time_seconds)}")
+    elif science_summary.max_qr_kg_kg is not None:
+        evidence.append(f"max rain water {_format_scientific(science_summary.max_qr_kg_kg)} kg/kg")
+    if science_summary.time_of_first_deep_convection_seconds is not None:
+        evidence.append(
+            "first deep convection "
+            f"{_format_seconds(science_summary.time_of_first_deep_convection_seconds)}"
+        )
+    return evidence
+
+
+def _screening_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _candidate_story_label(story: str | None) -> str | None:
+    if story is None:
+        return None
+    return DEEP_CONVECTION_STORY_LABELS.get(story, story.replace("_", " ").title())
+
+
+def _display_package_family(package_family: str | None) -> str:
+    if package_family == "deep_convection_trial":
+        return "Deep Convection Trial"
+    return "CM1 package"
+
+
+def _match_status_label(match_status: str) -> str:
+    return {
+        "matched": "Matched",
+        "partially_matched": "Partially matched",
+        "did_not_match": "Did not match",
+        "unable_to_evaluate": "Unable to evaluate",
+    }.get(match_status, match_status.replace("_", " ").title())
+
+
+def _format_metric(value: float, units: str) -> str:
+    return f"{value:g} {units}"
+
+
+def _format_seconds(value: float) -> str:
+    return f"{value:g} s"
+
+
+def _format_scientific(value: float) -> str:
+    return f"{value:.3e}"
 
 
 def _input_source(manifest: RunManifest) -> str:

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib
 import itertools
 import math
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Literal
 
@@ -321,7 +322,7 @@ def _metadata_view_defaults(
             visual_field,
             selected_time_index=time_index,
         )
-    preferred = "qc" if "qc" in fields else next(iter(fields), None)
+    preferred = _preferred_field(metadata, fields)
     return ViewDefaultsResponse(
         result_id=metadata.result_id,
         run_id=metadata.run_id,
@@ -524,7 +525,7 @@ def view_defaults(
                     field_name,
                     time_index=time_index,
                 )
-        preferred = "qc" if "qc" in fields else next(iter(fields), None)
+        preferred = _preferred_field(metadata, fields)
         return ViewDefaultsResponse(
             result_id=metadata.result_id,
             run_id=metadata.run_id,
@@ -822,6 +823,12 @@ def _fallback_view_defaults(
         else None,
         caveats=_dedupe([*caveats, "default_location_fell_back_to_domain_center"]),
     )
+
+
+def _preferred_field(metadata: ResultMetadata, fields: Mapping[str, object]) -> str | None:
+    if metadata.package_family == "deep_convection_trial" and "w" in fields:
+        return "w"
+    return "qc" if "qc" in fields else next(iter(fields), None)
 
 
 def field_slice(

--- a/app/backend/tests/test_output_products.py
+++ b/app/backend/tests/test_output_products.py
@@ -19,6 +19,7 @@ from cloud_chamber.result_diagnostics import (
     RainDiagnostics,
     ResultDiagnostics,
     TimeDiagnostics,
+    TimeValue,
     VerticalVelocityDiagnostics,
 )
 
@@ -269,3 +270,98 @@ def test_interesting_times_preserve_inferred_time_caveats(tmp_path: Path) -> Non
     assert "diagnostics_used_inferred_time" in product.caveats
     assert product.default_time_by_field["qc"].time_index == 1
     assert product.science_summary.default_explore_time_index == 1
+
+
+def test_deep_convection_interesting_times_and_unavailable_diagnostics(
+    tmp_path: Path,
+) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=[0.0, 600.0, 1200.0], values=[0.0, 1.0, 2.0])
+    manifest = build_manifest(tmp_path, [model])
+    diagnostics = ResultDiagnostics(
+        cloud=CloudDiagnostics(
+            formed=True,
+            first_cloud_time_seconds=600.0,
+            cloud_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=3500.0),
+                TimeValue(time_seconds=1200.0, value=10200.0),
+            ],
+            max_qc_kg_kg=2e-5,
+            time_of_max_qc_seconds=1200.0,
+        ),
+        vertical_velocity=VerticalVelocityDiagnostics(
+            max_w_m_s=14.0,
+            time_of_max_w_seconds=600.0,
+            min_w_m_s=-6.0,
+            time_of_min_w_seconds=1200.0,
+            units="m/s",
+        ),
+        rain=RainDiagnostics(
+            present=True,
+            first_rain_time_seconds=1200.0,
+            max_qr_kg_kg=3e-7,
+            time_of_max_qr_seconds=1200.0,
+        ),
+        time=TimeDiagnostics(source="netcdf_time_coordinate", fallback_used=False),
+    )
+
+    product = build_interesting_time_product(
+        result_id="result-deep",
+        diagnostics=diagnostics,
+        output_manifest=manifest,
+        variables=["qc", "w", "qr"],
+        package_family="deep_convection_trial",
+    )
+
+    records = {record.key: record for record in product.available_interesting_times}
+    assert records["first_deep_convection"].support_state == "supported"
+    assert records["first_deep_convection"].time_index == 2
+    assert records["max_updraft_w"].time_index == 1
+    assert product.science_summary.cloud_formed is True
+    assert product.science_summary.deep_cloud_formed is True
+    assert product.science_summary.strong_updraft_formed is True
+    assert product.science_summary.time_of_first_deep_convection_seconds == 1200.0
+    assert product.science_summary.highest_cloud_top_m == 10200.0
+    assert product.science_summary.default_explore_time_index == 2
+    assert (
+        product.science_summary.cm1_outcome
+        == "Deep convection formed with strong updraft and rain."
+    )
+    availability = {item.key: item for item in product.science_summary.diagnostic_availability}
+    assert availability["max_dbz_or_reflectivity_proxy"].support_state == (
+        "unsupported_missing_fields"
+    )
+    assert availability["cold_pool_proxy"].support_state == "unsupported_missing_fields"
+    assert "missing_dbz_field" in availability["max_dbz_or_reflectivity_proxy"].caveats
+
+
+def test_deep_convection_present_but_unsupported_fields_are_caveated(
+    tmp_path: Path,
+) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=[0.0], values=[0.0])
+    manifest = build_manifest(tmp_path, [model])
+    diagnostics = ResultDiagnostics(
+        cloud=CloudDiagnostics(formed=False),
+        vertical_velocity=VerticalVelocityDiagnostics(max_w_m_s=0.0, units="m/s"),
+        rain=RainDiagnostics(available=False, field_absent=True),
+        time=TimeDiagnostics(source="netcdf_time_coordinate", fallback_used=False),
+    )
+
+    product = build_interesting_time_product(
+        result_id="result-deep",
+        diagnostics=diagnostics,
+        output_manifest=manifest,
+        variables=["qc", "w", "dbz", "th"],
+        package_family="deep_convection_trial",
+    )
+
+    availability = {item.key: item for item in product.science_summary.diagnostic_availability}
+    assert availability["max_dbz_or_reflectivity_proxy"].support_state == (
+        "unsupported_missing_diagnostic"
+    )
+    assert availability["cold_pool_proxy"].support_state == "unsupported_missing_diagnostic"
+    assert "max_dbz_or_reflectivity_proxy_diagnostic_not_implemented" in (
+        availability["max_dbz_or_reflectivity_proxy"].caveats
+    )

--- a/app/backend/tests/test_output_products.py
+++ b/app/backend/tests/test_output_products.py
@@ -336,6 +336,47 @@ def test_deep_convection_interesting_times_and_unavailable_diagnostics(
     assert "missing_dbz_field" in availability["max_dbz_or_reflectivity_proxy"].caveats
 
 
+def test_non_deep_summary_does_not_emit_deep_convection_outcome(
+    tmp_path: Path,
+) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=[0.0, 600.0], values=[0.0, 1.0])
+    manifest = build_manifest(tmp_path, [model])
+    diagnostics = ResultDiagnostics(
+        cloud=CloudDiagnostics(
+            formed=False,
+            max_qc_kg_kg=0.0,
+            time_of_max_qc_seconds=0.0,
+            cloud_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=None),
+            ],
+        ),
+        vertical_velocity=VerticalVelocityDiagnostics(
+            max_w_m_s=1.5,
+            time_of_max_w_seconds=600.0,
+            min_w_m_s=-0.5,
+            time_of_min_w_seconds=0.0,
+            units="m/s",
+        ),
+        rain=RainDiagnostics(available=False, field_absent=True),
+        time=TimeDiagnostics(source="netcdf_time_coordinate", fallback_used=False),
+    )
+
+    product = build_interesting_time_product(
+        result_id="result-shallow",
+        diagnostics=diagnostics,
+        output_manifest=manifest,
+        variables=["qc", "w"],
+        package_family="observed_sounding_quicklook",
+    )
+
+    records = {record.key: record for record in product.available_interesting_times}
+    assert "first_deep_convection" not in records
+    assert product.science_summary.cm1_outcome is None
+    assert product.science_summary.time_of_first_deep_convection_seconds is None
+
+
 def test_deep_convection_present_but_unsupported_fields_are_caveated(
     tmp_path: Path,
 ) -> None:

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -205,6 +205,11 @@ def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: 
             "valid_time_utc": "2026-06-30T00:00:00Z",
         },
         package_updates={
+            "candidate_screening": {
+                "candidate_id": "USM00072357-2025052000-supercell",
+                "primary_story": "supercell_environment",
+                "rank_score": 93.0,
+            },
             "package_family": "deep_convection_trial",
             "package_display_name": "Deep Convection Trial",
             "input_source": "observed_sounding",
@@ -237,6 +242,12 @@ def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: 
     ]
     assert card.manual_validation_status == "deep_convection_trial_package_smoke_validated"
     assert "package_family:deep_convection_trial" in card.provenance_labels
+    assert card.candidate_screening is not None
+    assert card.candidate_screening["primary_story"] == "supercell_environment"
+    assert card.candidate_hypothesis_comparison is not None
+    assert card.candidate_hypothesis_comparison.screened_as == "Supercell-like environment"
+    assert card.candidate_hypothesis_comparison.ran_as == "Deep Convection Trial"
+    assert card.candidate_hypothesis_comparison.match_status == "did_not_match"
 
 
 def test_list_get_and_result_card_serialization_round_trip(tmp_path: Path) -> None:

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -373,6 +373,53 @@ def test_ingests_deep_convection_candidate_outcome_comparison(tmp_path: Path) ->
     )
 
 
+def test_non_deep_candidate_comparison_does_not_use_deep_outcome_language(
+    tmp_path: Path,
+) -> None:
+    manifest_path = create_manifest(tmp_path, run_id="run-observed-quicklook-candidate")
+    run_dir = manifest_path.parent
+    netcdf_path = run_dir / "cm1out_000001.nc"
+    candidate_screening = {
+        "candidate_id": "USM00072357-2025052000-supercell",
+        "primary_story": "supercell_environment",
+        "rank_score": 93.0,
+    }
+    write_model_netcdf(
+        netcdf_path,
+        times=[300.0],
+        qc_values=[0.0],
+        w_values=[1.0],
+        qr_values=[0.0],
+    )
+    complete_manifest(manifest_path, OutputMetadata(netcdf_paths=[str(netcdf_path)]))
+    manifest = load_run_manifest(manifest_path)
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(
+            update={
+                "candidate_screening": candidate_screening,
+                "package_family": "observed_sounding_quicklook",
+                "package_display_name": "Observed Sounding Quick Look",
+                "input_source": "observed_sounding",
+            }
+        ),
+    )
+
+    result = ingest_completed_run(manifest_path)
+
+    assert result.science_summary is not None
+    assert result.science_summary.cm1_outcome is None
+    assert result.candidate_hypothesis_comparison is not None
+    assert result.candidate_hypothesis_comparison.match_status == "unable_to_evaluate"
+    assert result.candidate_hypothesis_comparison.cm1_outcome == (
+        "Unable to evaluate candidate match because this was not a Deep Convection Trial package."
+    )
+    assert "Trigger failed" not in result.candidate_hypothesis_comparison.cm1_outcome
+    assert "comparison_requires_deep_convection_trial_package" in (
+        result.candidate_hypothesis_comparison.caveats
+    )
+
+
 def test_no_cloud_result_keeps_interesting_times_honest(tmp_path: Path) -> None:
     manifest_path = create_manifest(tmp_path, run_id="run-no-cloud-interesting-times")
     run_dir = manifest_path.parent

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -103,15 +103,18 @@ def write_model_netcdf(
     times: list[float],
     qc_values: list[float],
     w_values: list[float],
+    qr_values: list[float] | None = None,
+    z_values: list[float] | None = None,
     include_qc: bool = True,
     include_w: bool = True,
 ) -> None:
+    z_values = z_values or [500.0, 1500.0]
     data_vars = {}
     if include_qc:
         data_vars["qc"] = (
             ("time", "z", "y", "x"),
             [
-                [[[qc_value for _x in range(4)] for _y in range(3)] for _z in range(2)]
+                [[[qc_value for _x in range(4)] for _y in range(3)] for _z in z_values]
                 for qc_value in qc_values
             ],
             {"units": "kg/kg"},
@@ -120,16 +123,25 @@ def write_model_netcdf(
         data_vars["w"] = (
             ("time", "z", "y", "x"),
             [
-                [[[w_value for _x in range(4)] for _y in range(3)] for _z in range(2)]
+                [[[w_value for _x in range(4)] for _y in range(3)] for _z in z_values]
                 for w_value in w_values
             ],
             {"units": "m/s"},
+        )
+    if qr_values is not None:
+        data_vars["qr"] = (
+            ("time", "z", "y", "x"),
+            [
+                [[[qr_value for _x in range(4)] for _y in range(3)] for _z in z_values]
+                for qr_value in qr_values
+            ],
+            {"units": "kg/kg"},
         )
     xr.Dataset(
         data_vars=data_vars,
         coords={
             "time": times,
-            "z": [500.0, 1500.0],
+            "z": z_values,
             "y": [0.0, 200.0, 400.0],
             "x": [0.0, 200.0, 400.0, 600.0],
         },
@@ -290,6 +302,75 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     )
     assert product_manifest.interesting_time_product is not None
     assert product_manifest.interesting_time_product.science_summary == result.science_summary
+
+
+def test_ingests_deep_convection_candidate_outcome_comparison(tmp_path: Path) -> None:
+    manifest_path = create_manifest(tmp_path, run_id="run-deep-convection-result")
+    run_dir = manifest_path.parent
+    first = run_dir / "cm1out_000001.nc"
+    second = run_dir / "cm1out_000002.nc"
+    candidate_screening = {
+        "candidate_id": "USM00072357-2025052000-supercell",
+        "primary_story": "supercell_environment",
+        "rank_score": 93.0,
+        "confidence": "supported",
+    }
+    write_model_netcdf(
+        first,
+        times=[300.0],
+        qc_values=[0.0],
+        w_values=[2.0],
+        qr_values=[0.0],
+        z_values=[500.0, 1500.0, 9500.0],
+    )
+    write_model_netcdf(
+        second,
+        times=[900.0],
+        qc_values=[2e-6],
+        w_values=[15.0],
+        qr_values=[4e-7],
+        z_values=[500.0, 1500.0, 9500.0],
+    )
+    complete_manifest(
+        manifest_path,
+        OutputMetadata(netcdf_paths=[str(first), str(second)]),
+    )
+    manifest = load_run_manifest(manifest_path)
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(
+            update={
+                "candidate_screening": candidate_screening,
+                "package_family": "deep_convection_trial",
+                "package_display_name": "Deep Convection Trial",
+                "input_source": "observed_sounding",
+                "trigger_type": "warm_bubble",
+                "expected_outputs": ["qc", "qr", "w", "dbz", "updraft_helicity"],
+                "manual_validation_status": "deep_convection_trial_package_smoke_validated",
+            }
+        ),
+    )
+
+    result = ingest_completed_run(manifest_path)
+
+    assert result.candidate_screening == candidate_screening
+    assert result.science_summary is not None
+    assert result.science_summary.deep_cloud_formed is True
+    assert result.science_summary.strong_updraft_formed is True
+    assert result.science_summary.time_of_first_deep_convection_seconds == 900.0
+    assert result.science_summary.default_explore_time_seconds == 900.0
+    assert result.candidate_hypothesis_comparison is not None
+    assert result.candidate_hypothesis_comparison.screened_as == "Supercell-like environment"
+    assert result.candidate_hypothesis_comparison.ran_as == "Deep Convection Trial"
+    assert result.candidate_hypothesis_comparison.match_status == "matched"
+    assert result.candidate_hypothesis_comparison.cm1_outcome == (
+        "Deep convection formed with strong updraft and rain."
+    )
+    assert "max updraft 15 m/s" in result.candidate_hypothesis_comparison.evidence
+    availability = {item.key: item for item in result.science_summary.diagnostic_availability}
+    assert availability["max_dbz_or_reflectivity_proxy"].support_state == (
+        "unsupported_missing_fields"
+    )
 
 
 def test_no_cloud_result_keeps_interesting_times_honest(tmp_path: Path) -> None:

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -51,6 +51,7 @@ def create_visualization_result(
     include_qv: bool = True,
     include_dbz: bool = True,
     run_id: str = "run-visualization",
+    package_updates: dict[str, object] | None = None,
 ) -> tuple[CloudChamberSettings, str, Path]:
     settings = fake_settings(tmp_path)
     package = generate_dry_run_package(
@@ -69,16 +70,13 @@ def create_visualization_result(
         include_dbz=include_dbz,
     )
     manifest = load_run_manifest(package.manifest_path)
-    write_run_manifest(
-        package.manifest_path,
-        manifest.model_copy(
-            update={
-                "lifecycle_state": LifecycleState.COMPLETED,
-                "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
-                "outputs": OutputMetadata(netcdf_paths=[str(netcdf_path)]),
-            }
-        ),
-    )
+    update_payload = {
+        "lifecycle_state": LifecycleState.COMPLETED,
+        "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+        "outputs": OutputMetadata(netcdf_paths=[str(netcdf_path)]),
+    }
+    update_payload.update(package_updates or {})
+    write_run_manifest(package.manifest_path, manifest.model_copy(update=update_payload))
     result = ingest_completed_run(package.manifest_path)
     return settings, result.result_id, package.package_dir
 
@@ -615,6 +613,23 @@ def test_view_defaults_choose_native_grid_max_locations(tmp_path: Path) -> None:
     assert defaults.fields["rain"].source == "domain_center_missing_required_dimensions"
     assert "default_locations_are_native_grid_indices" in defaults.caveats
     assert defaults.provenance.processing_method == "backend_xarray_interesting_view_defaults"
+
+
+def test_deep_convection_view_defaults_prefer_updraft_field(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(
+        tmp_path,
+        run_id="run-deep-visualization",
+        package_updates={
+            "package_family": "deep_convection_trial",
+            "package_display_name": "Deep Convection Trial",
+        },
+    )
+
+    defaults = view_defaults(settings, result_id)
+
+    assert defaults.preferred_field == "w"
+    assert defaults.fields["w"].source == "max_w_native_grid_location"
+    assert defaults.fields["qc"].source == "max_qc_native_grid_location"
 
 
 def test_view_defaults_can_choose_selected_time_max_locations(tmp_path: Path) -> None:

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1015,6 +1015,13 @@ td small {
   background: var(--color-surface);
 }
 
+.candidate-outcome-summary {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.85rem;
+  background: var(--color-surface);
+}
+
 .section-heading-row {
   display: flex;
   align-items: flex-start;
@@ -1925,7 +1932,9 @@ details[open] > summary {
   border: 2px solid #b7791f;
   border-radius: 999px;
   background: rgba(255, 244, 216, 0.86);
-  box-shadow: 0 0 0 3px rgba(183, 121, 31, 0.24), 0 0 18px rgba(183, 121, 31, 0.42);
+  box-shadow:
+    0 0 0 3px rgba(183, 121, 31, 0.24),
+    0 0 18px rgba(183, 121, 31, 0.42);
   transform: translate(-50%, 50%);
 }
 
@@ -2076,7 +2085,10 @@ details[open] > summary {
 }
 
 .inspector-controls-primary {
-  grid-template-columns: minmax(26rem, 1.25fr) minmax(9rem, 0.55fr) minmax(8rem, 0.45fr) minmax(15rem, 0.9fr) auto;
+  grid-template-columns: minmax(26rem, 1.25fr) minmax(9rem, 0.55fr) minmax(8rem, 0.45fr) minmax(
+      15rem,
+      0.9fr
+    ) auto;
   gap: 0.4rem;
   align-items: end;
   border: 1px solid rgba(47, 116, 168, 0.18);
@@ -2431,12 +2443,12 @@ details[open] > summary {
   .workbench-status-strip,
   .visualizer-bottom-controls,
   .slice-grid,
-	  .control-row,
-	  .candidate-toolbar,
-	  .candidate-workspace,
-	  .explore-result-summary {
-	    grid-template-columns: 1fr;
-	  }
+  .control-row,
+  .candidate-toolbar,
+  .candidate-workspace,
+  .explore-result-summary {
+    grid-template-columns: 1fr;
+  }
 
   .visualizer-workbench {
     grid-template-areas:
@@ -2474,27 +2486,27 @@ details[open] > summary {
     display: grid;
   }
 
-	  .metric-grid {
-	    grid-template-columns: 1fr;
-	  }
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
 
-	  .candidate-cache-summary {
-	    grid-template-columns: repeat(2, minmax(0, 1fr));
-	  }
+  .candidate-cache-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 
-	  .candidate-toolbar-actions,
-	  .saved-candidate-card {
-	    justify-content: start;
-	  }
+  .candidate-toolbar-actions,
+  .saved-candidate-card {
+    justify-content: start;
+  }
 
-	  .candidate-detail-panel {
-	    position: static;
-	  }
+  .candidate-detail-panel {
+    position: static;
+  }
 
-	  .candidate-card-main,
-	  .saved-candidate-card {
-	    grid-template-columns: 1fr;
-	  }
+  .candidate-card-main,
+  .saved-candidate-card {
+    grid-template-columns: 1fr;
+  }
 
   .experiment-card {
     grid-template-columns: 1fr;

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -99,7 +99,8 @@ const dryRunResponse = {
       estimated_compute_multiplier_vs_standard: 0.5,
       estimated_output_volume_multiplier_vs_standard: 1.86,
       target_wall_clock_multiplier_vs_standard: "1x",
-      cost_warning: "Normal local run-size preset; estimates remain approximate until local validation.",
+      cost_warning:
+        "Normal local run-size preset; estimates remain approximate until local validation.",
       validation_note: "Preset preserves the validated reference-derived spatial grid.",
     },
     expected_diagnostics: ["first_cloud_time", "cloud_water_summary"],
@@ -889,6 +890,101 @@ const observedSoundingResultCard = {
   },
 };
 
+const deepConvectionResultCard = {
+  ...observedSoundingResultCard,
+  result_id: "result-deep-convection",
+  run_id: "dry-run-deep-convection",
+  name: "Deep Convection Trial — Norman, Oklahoma",
+  tags: ["deep-convection", "candidate"],
+  scenario_name: "Deep Convection Trial",
+  package_family: "deep_convection_trial",
+  package_display_name: "Deep Convection Trial",
+  trigger_type: "warm_bubble",
+  expected_outputs: ["qc", "qr", "w", "dbz", "updraft_helicity"],
+  candidate_screening: {
+    candidate_id: "USM00072357-2025052000-supercell",
+    primary_story: "supercell_environment",
+    rank_score: 93,
+  },
+  diagnostics_summary: "cloud formed; rain detected",
+  thermal_fate_label: "Growing cumulus",
+  max_w_m_s: 15,
+  time_of_max_w_seconds: 1800,
+  first_rain_time_seconds: 1800,
+  science_summary: {
+    ...resultCard.science_summary,
+    cloud_formed: true,
+    deep_cloud_formed: true,
+    deep_cloud_threshold_m: 8000,
+    strong_updraft_formed: true,
+    strong_updraft_threshold_m_s: 10,
+    first_cloud_time_seconds: 900,
+    time_of_first_deep_convection_seconds: 1800,
+    max_qc_kg_kg: 0.0008,
+    max_qc_time_seconds: 1800,
+    max_updraft_w_m_s: 15,
+    max_updraft_time_seconds: 1800,
+    min_downdraft_w_m_s: -7,
+    min_downdraft_time_seconds: 1800,
+    highest_cloud_top_m: 10200,
+    rain_onset_time_seconds: 1800,
+    max_qr_kg_kg: 4e-7,
+    latest_output_time_seconds: 2700,
+    default_explore_time_index: 2,
+    default_explore_time_seconds: 1800,
+    cm1_outcome: "Deep convection formed with strong updraft and rain.",
+    diagnostic_availability: [
+      {
+        key: "cold_pool_proxy",
+        label: "Cold-pool proxy",
+        support_state: "unsupported_missing_diagnostic",
+        source_field: "theta",
+        value: null,
+        units: null,
+        caveats: ["cold_pool_proxy_diagnostic_not_implemented"],
+      },
+    ],
+  },
+  interesting_times: [
+    {
+      key: "first_deep_convection",
+      label: "First deep convection",
+      time_index: 2,
+      time_seconds: 1800,
+      source_field: "qc+qr+qi+qs+qg when available",
+      source_diagnostic: "diagnostics.cloud.cloud_top_time_series",
+      value: true,
+      units: null,
+      support_state: "supported",
+      caveats: [],
+    },
+    ...resultCard.interesting_times,
+  ],
+  default_time_by_field: {
+    ...resultCard.default_time_by_field,
+    w: {
+      field: "w",
+      time_index: 2,
+      time_seconds: 1800,
+      source_interesting_time_key: "max_updraft_w",
+      support_state: "supported",
+      caveats: [],
+    },
+  },
+  candidate_hypothesis_comparison: {
+    screened_as: "Supercell-like environment",
+    ran_as: "Deep Convection Trial",
+    cm1_outcome: "Deep convection formed with strong updraft and rain.",
+    match_status: "matched",
+    match_status_label: "Matched",
+    evidence: ["deep cloud formed", "cloud top 10200 m", "max updraft 15 m/s"],
+    caveats: [
+      "candidate_screening_is_a_pre_run_hypothesis",
+      "candidate_match_uses_simple_v1_deep_convection_rules",
+    ],
+  },
+};
+
 const resultsResponse = {
   results: [
     resultCard,
@@ -1491,6 +1587,27 @@ const cappedFieldCatalogResponse = {
   })),
 };
 
+const deepConvectionFieldCatalogResponse = {
+  ...fieldCatalogResponse,
+  result_id: "result-deep-convection",
+  run_id: "dry-run-deep-convection",
+  scenario_id: "baseline-shallow-cumulus",
+  available_fields: fieldCatalogResponse.available_fields.map((field) => ({
+    ...field,
+    provenance: {
+      ...field.provenance,
+      result_id: "result-deep-convection",
+      run_id: "dry-run-deep-convection",
+    },
+  })),
+};
+
+const deepConvectionViewDefaultsResponse = {
+  ...viewDefaultsResponse,
+  result_id: "result-deep-convection",
+  run_id: "dry-run-deep-convection",
+  preferred_field: "w",
+};
 
 function sliceResponse({
   field = "qc",
@@ -1543,9 +1660,17 @@ function sliceResponse({
           : ([-3.2, 0, 3.2][levelIndex] ?? 0),
       level_units: orientation === "horizontal" ? "km" : null,
       level_coordinate_value:
-        orientation === "horizontal" ? (isSurface ? 0 : ([0.4, 0.8, 1.2][levelIndex] ?? 0.8)) : null,
+        orientation === "horizontal"
+          ? isSurface
+            ? 0
+            : ([0.4, 0.8, 1.2][levelIndex] ?? 0.8)
+          : null,
       level_meters:
-        orientation === "horizontal" ? (isSurface ? 0 : ([0.4, 0.8, 1.2][levelIndex] ?? 0.8) * 1000) : null,
+        orientation === "horizontal"
+          ? isSurface
+            ? 0
+            : ([0.4, 0.8, 1.2][levelIndex] ?? 0.8) * 1000
+          : null,
     },
     coordinate_units: isVertical ? { zh: "km", xh: "km" } : { yh: "km", xh: "km" },
     shape: [2, 3],
@@ -1565,7 +1690,10 @@ function sliceResponse({
   };
 }
 
-function mockSliceValues(field: MockVisualFieldName, timeIndex: number): Array<Array<number | null>> {
+function mockSliceValues(
+  field: MockVisualFieldName,
+  timeIndex: number,
+): Array<Array<number | null>> {
   if (field === "theta") {
     return timeIndex < 2
       ? [
@@ -1683,7 +1811,9 @@ function pointCloudResponse({
       threshold,
       max_points: 50000,
     },
-    coordinate_units: isSurface ? { xh: "km", yh: "km", z: "km" } : { xh: "km", yh: "km", zh: "km" },
+    coordinate_units: isSurface
+      ? { xh: "km", yh: "km", z: "km" }
+      : { xh: "km", yh: "km", zh: "km" },
     coordinate_extents: {
       xh: { min: -3.2, max: 3.2, units: "km" },
       yh: { min: -3.2, max: 3.2, units: "km" },
@@ -1720,8 +1850,7 @@ function pointCloudResponse({
       ...provenance,
       processing_method: "backend_xarray_native_grid_threshold",
       rendering_method: "thresholded_point_cloud",
-      provenance_label:
-        `CM1-derived ${fieldMetadata.display_name.toLowerCase()} point cloud; native-grid threshold; visualizer interpretation`,
+      provenance_label: `CM1-derived ${fieldMetadata.display_name.toLowerCase()} point cloud; native-grid threshold; visualizer interpretation`,
     },
     caveats: ["native_grid_thresholded_point_cloud", `visualizer_interpretation_of_cm1_${field}`],
   };
@@ -1882,7 +2011,12 @@ function selectedRegionResponse() {
 }
 
 function downsampledCloudSliceResponse() {
-  const base = sliceResponse({ field: "qc", orientation: "horizontal", timeIndex: 1, levelIndex: 1 });
+  const base = sliceResponse({
+    field: "qc",
+    orientation: "horizontal",
+    timeIndex: 1,
+    levelIndex: 1,
+  });
   const values = Array.from({ length: 64 }, () => Array.from({ length: 64 }, () => 0));
   values[0][1] = 0.000005;
   values[0][2] = 0.000002;
@@ -2135,7 +2269,8 @@ beforeEach(() => {
                 threshold: Number(parsed.searchParams.get("threshold") ?? 0.000001),
                 timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
                 points: isDryFailed ? [] : undefined,
-                fieldRange: isDryFailed && requestedField === "qc" ? { min: 0, max: 0, mean: 0 } : undefined,
+                fieldRange:
+                  isDryFailed && requestedField === "qc" ? { min: 0, max: 0, mean: 0 } : undefined,
               }),
             ),
             { status: 200 },
@@ -2237,9 +2372,15 @@ describe("App", () => {
     expect(screen.getAllByText(/Selected: Baseline/).length).toBeGreaterThan(0);
     expect(screen.getByText(/Expected runtime: roughly 10-20 minutes/)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Local run launchpad" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Packages and runs needing action" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Packages and runs needing action" }),
+    ).toBeInTheDocument();
     expect(screen.getAllByText("Not packaged yet").length).toBeGreaterThan(0);
-    expect(screen.getByText("No package has been created from the current setup in this browser session.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No package has been created from the current setup in this browser session.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("Experiment")).toHaveTextContent("Upload a Sounding");
     expect(screen.getByText("Build pipeline")).toBeInTheDocument();
     expect(screen.queryByText("Local experiment loop")).not.toBeInTheDocument();
@@ -2287,9 +2428,7 @@ describe("App", () => {
     expect(screen.getByText("Observed sounding profile, Surface heating")).toBeInTheDocument();
     expect(screen.queryByLabelText("Low-level humidity")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Surface heating")).not.toBeDisabled();
-    expect(
-      screen.queryByLabelText("Use uploaded sounding"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Use uploaded sounding")).not.toBeInTheDocument();
 
     const file = new File(["#USM00072558 2025 01 02 00"], "USM00072558-data-beg2025.txt", {
       type: "text/plain",
@@ -2298,11 +2437,15 @@ describe("App", () => {
       target: { files: [file] },
     });
 
-    expect(await screen.findByText("Observed sounding validated for package review")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Observed sounding validated for package review"),
+    ).toBeInTheDocument();
     expect(screen.getByText("USM00072558 · Valley, Nebraska")).toBeInTheDocument();
     expect(screen.getByText(/CM1 z=0 is station surface at 351.5 m MSL/)).toBeInTheDocument();
     expect(screen.getByText(/observed sounding winds/)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Choose how to try this sounding" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Choose how to try this sounding" }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("Package type")).toHaveValue("observed_sounding_quicklook");
 
     fireEvent.change(screen.getByLabelText("Package type"), {
@@ -2315,7 +2458,9 @@ describe("App", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText(/wider box for storm growth and precipitation/i)).toBeInTheDocument();
-    expect(screen.getByText(/wider storm-growth domain than the shallow-cumulus quick look/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/wider storm-growth domain than the shallow-cumulus quick look/i),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
@@ -2403,7 +2548,9 @@ describe("App", () => {
       target: { value: "__observed_sounding_upload__" },
     });
 
-    expect(await screen.findByRole("heading", { name: "Find interesting soundings" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Find interesting soundings" }),
+    ).toBeInTheDocument();
     expect(screen.getByText(/Screening guidance only/)).toBeInTheDocument();
     expect(screen.getByText("IGRA cache not checked yet")).toBeInTheDocument();
 
@@ -2470,7 +2617,9 @@ describe("App", () => {
     fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Use this sounding" }));
 
     expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
-    expect(screen.getByText("Candidate loaded into observed-sounding package review")).toBeInTheDocument();
+    expect(
+      screen.getByText("Candidate loaded into observed-sounding package review"),
+    ).toBeInTheDocument();
     expect(screen.getByText("USM00072558 · Valley, Nebraska")).toBeInTheDocument();
     expect(screen.getByText(/Screened as Cloud-forming shallow cumulus/)).toBeInTheDocument();
 
@@ -2695,9 +2844,7 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
-    expect(
-      await screen.findByRole("heading", { name: "Local run launchpad" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Local run launchpad" })).toBeInTheDocument();
     expect(screen.queryByText("Local experiment loop")).not.toBeInTheDocument();
     expect(screen.getByText("Build pipeline")).toBeInTheDocument();
     expect(screen.getByText("Packages and runs needing action")).toBeInTheDocument();
@@ -2798,10 +2945,9 @@ describe("App", () => {
       }
       if (url === "/api/results") {
         return Promise.resolve(
-          new Response(
-            JSON.stringify({ results: ingested ? [workerResult] : [] }),
-            { status: 200 },
-          ),
+          new Response(JSON.stringify({ results: ingested ? [workerResult] : [] }), {
+            status: 200,
+          }),
         );
       }
       if (url === "/api/lan-worker/collect") {
@@ -3025,9 +3171,7 @@ describe("App", () => {
     const packageReview = screen.getByTestId("package-review-panel");
     expect(packageReview).toHaveTextContent("Package ready");
     expect(packageReview).toHaveTextContent("/tmp/CloudChamber/runs/dry-run-001");
-    expect(packageReview).toHaveTextContent(
-      "/tmp/CloudChamber/runs/dry-run-001/run_manifest.json",
-    );
+    expect(packageReview).toHaveTextContent("/tmp/CloudChamber/runs/dry-run-001/run_manifest.json");
     expect(screen.getByText("Current lifecycle state").nextElementSibling).toHaveTextContent(
       "Package ready",
     );
@@ -3054,7 +3198,9 @@ describe("App", () => {
     expect(screen.getByRole("tab", { name: "Storage" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Experiment Notebook" })).toBeInTheDocument();
     expect(
-      screen.getByText("Review ingested cloud experiments, compare variants, and open results for explanation."),
+      screen.getByText(
+        "Review ingested cloud experiments, compare variants, and open results for explanation.",
+      ),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Results list")).toBeInTheDocument();
     const resultDetail = screen.getByLabelText("Result detail");
@@ -3108,6 +3254,69 @@ describe("App", () => {
     expect(resultDetail).toHaveTextContent("Input source");
   });
 
+  it("renders deep-convection candidate comparison and opens Explore on updraft time", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ results: [deepConvectionResultCard] }), { status: 200 }),
+        );
+      }
+      if (url === "/api/results/result-deep-convection/visualization/fields") {
+        return Promise.resolve(
+          new Response(JSON.stringify(deepConvectionFieldCatalogResponse), { status: 200 }),
+        );
+      }
+      if (url.startsWith("/api/results/result-deep-convection/visualization/defaults")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(deepConvectionViewDefaultsResponse), { status: 200 }),
+        );
+      }
+      if (url.includes("/visualization/point-cloud")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(pointCloudResponse({ field: "qc", timeIndex: 2 })), {
+            status: 200,
+          }),
+        );
+      }
+      if (url.includes("/visualization/slice")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(sliceResponse({ field: "w", timeIndex: 2 })), {
+            status: 200,
+          }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+
+    const resultDetail = await screen.findByLabelText("Result detail");
+    expect(resultDetail).toHaveTextContent("Deep Convection Trial — Norman, Oklahoma");
+    expect(resultDetail).toHaveTextContent("Deep convection formed");
+    expect(resultDetail).toHaveTextContent("Screening vs CM1");
+    expect(resultDetail).toHaveTextContent("Supercell-like environment");
+    expect(resultDetail).toHaveTextContent("Matched");
+    expect(resultDetail).toHaveTextContent("Deep convection formed with strong updraft and rain.");
+    expect(resultDetail).toHaveTextContent("max updraft 15 m/s");
+    expect(resultDetail).toHaveTextContent("First deep convection");
+
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+
+    expect(await screen.findByLabelText("Explore viewer controls")).toBeInTheDocument();
+    expect(screen.getByLabelText("Slice field")).toHaveValue("w");
+    expect(screen.getByLabelText("Time")).toHaveValue("2");
+    expect(screen.getByText(/Supercell-like environment · Matched/)).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "/api/results/result-deep-convection/visualization/slice?field=w&time_index=2",
+      ),
+    );
+  });
+
   it("filters Results by search text and cloud/rain outcomes", async () => {
     render(<App />);
 
@@ -3116,10 +3325,14 @@ describe("App", () => {
     const resultsList = screen.getByLabelText("Results list");
 
     fireEvent.change(within(filterBar).getByLabelText("Search"), { target: { value: "Valley" } });
-    expect(within(resultsList).getByText("Uploaded Sounding — Valley, Nebraska")).toBeInTheDocument();
+    expect(
+      within(resultsList).getByText("Uploaded Sounding — Valley, Nebraska"),
+    ).toBeInTheDocument();
     expect(within(resultsList).queryByText("Quick-look shallow cumulus")).not.toBeInTheDocument();
 
-    fireEvent.change(within(filterBar).getByLabelText("Search"), { target: { value: "dry failed" } });
+    fireEvent.change(within(filterBar).getByLabelText("Search"), {
+      target: { value: "dry failed" },
+    });
     expect(within(resultsList).getByText("Dry Failed Cumulus quick-look")).toBeInTheDocument();
     expect(
       within(resultsList).queryByText("Uploaded Sounding — Valley, Nebraska"),
@@ -3129,7 +3342,9 @@ describe("App", () => {
     fireEvent.change(within(filterBar).getByLabelText("Scenario"), {
       target: { value: "input_source:observed_sounding" },
     });
-    expect(within(resultsList).getByText("Uploaded Sounding — Valley, Nebraska")).toBeInTheDocument();
+    expect(
+      within(resultsList).getByText("Uploaded Sounding — Valley, Nebraska"),
+    ).toBeInTheDocument();
     expect(within(resultsList).queryByText("Quick-look shallow cumulus")).not.toBeInTheDocument();
 
     fireEvent.change(within(filterBar).getByLabelText("Scenario"), { target: { value: "all" } });
@@ -3140,7 +3355,9 @@ describe("App", () => {
     fireEvent.change(within(filterBar).getByLabelText("Cloud"), { target: { value: "all" } });
     fireEvent.change(within(filterBar).getByLabelText("Rain"), { target: { value: "yes" } });
     expect(within(resultsList).getAllByText("Rain detected").length).toBeGreaterThan(0);
-    expect(within(resultsList).queryByText("Dry Failed Cumulus quick-look")).not.toBeInTheDocument();
+    expect(
+      within(resultsList).queryByText("Dry Failed Cumulus quick-look"),
+    ).not.toBeInTheDocument();
   });
 
   it("sorts Results by science metrics and resets empty filters", async () => {
@@ -3150,7 +3367,9 @@ describe("App", () => {
     const filterBar = screen.getByLabelText("Filter and sort results");
     const resultsList = screen.getByLabelText("Results list");
 
-    fireEvent.change(within(filterBar).getByLabelText("Sort"), { target: { value: "max_updraft" } });
+    fireEvent.change(within(filterBar).getByLabelText("Sort"), {
+      target: { value: "max_updraft" },
+    });
     const sortedCards = resultsList.querySelectorAll(".experiment-card");
     expect(sortedCards[0]).toHaveTextContent("Uploaded Sounding — Valley, Nebraska");
     expect(sortedCards[0]).toHaveTextContent("max updraft 9.25 m/s");
@@ -3160,12 +3379,16 @@ describe("App", () => {
     });
     expect(screen.getByText("No results match the current filters.")).toBeInTheDocument();
     expect(
-      within(filterBar).getByText((_, node) => node?.textContent === "Showing 0 of 6 notebook entries"),
+      within(filterBar).getByText(
+        (_, node) => node?.textContent === "Showing 0 of 6 notebook entries",
+      ),
     ).toBeInTheDocument();
 
     fireEvent.click(within(filterBar).getByRole("button", { name: "Clear filters" }));
     expect(within(resultsList).getByText("Quick-look shallow cumulus")).toBeInTheDocument();
-    expect(within(resultsList).getByText("Uploaded Sounding — Valley, Nebraska")).toBeInTheDocument();
+    expect(
+      within(resultsList).getByText("Uploaded Sounding — Valley, Nebraska"),
+    ).toBeInTheDocument();
   });
 
   it("accepts legacy array results responses without crashing", async () => {
@@ -3296,9 +3519,13 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("tab", { name: "Compare" }));
     fireEvent.click(await screen.findByRole("button", { name: "Open Dry Failed in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     expect(await screen.findByLabelText("Explore viewer controls")).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { name: "Inspect the current slice" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Inspect the current slice" }),
+    ).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(
       "/api/results/result-dry-failed-cumulus/visualization/fields",
     );
@@ -3313,7 +3540,9 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open Dry Failed in Explore" }));
 
     expect(screen.getAllByText("Dry Failed Cumulus quick-look").length).toBeGreaterThan(0);
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("True 3-D scalar field viewer")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Inspect the current slice" })).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(
@@ -3426,19 +3655,29 @@ describe("App", () => {
     expect(screen.getByText("Needs cleanup review")).toBeInTheDocument();
 
     const runtimeRuns = screen.getByLabelText("Runtime runs");
-    const packageRow = within(runtimeRuns).getAllByText(/dry-run-packaged/)[0].closest("tr");
+    const packageRow = within(runtimeRuns)
+      .getAllByText(/dry-run-packaged/)[0]
+      .closest("tr");
     const ingestReadyRow = within(runtimeRuns)
       .getAllByText(/dry-run-uningested/)[0]
       .closest("tr");
-    const resultRow = within(runtimeRuns).getAllByText(/dry-run-quicklook/)[0].closest("tr");
-    const savedRow = within(runtimeRuns).getAllByText(/dry-run-saved/)[0].closest("tr");
-    const runningRow = within(runtimeRuns).getAllByText(/dry-run-running/)[0].closest("tr");
+    const resultRow = within(runtimeRuns)
+      .getAllByText(/dry-run-quicklook/)[0]
+      .closest("tr");
+    const savedRow = within(runtimeRuns)
+      .getAllByText(/dry-run-saved/)[0]
+      .closest("tr");
+    const runningRow = within(runtimeRuns)
+      .getAllByText(/dry-run-running/)[0]
+      .closest("tr");
     expect(packageRow).not.toBeNull();
     expect(ingestReadyRow).not.toBeNull();
     expect(resultRow).not.toBeNull();
     expect(savedRow).not.toBeNull();
     expect(runningRow).not.toBeNull();
-    expect(within(packageRow as HTMLElement).getByRole("button", { name: "Preview delete" })).toBeEnabled();
+    expect(
+      within(packageRow as HTMLElement).getByRole("button", { name: "Preview delete" }),
+    ).toBeEnabled();
     expect(
       within(ingestReadyRow as HTMLElement).getByRole("button", {
         name: "Ingest completed output",
@@ -3447,9 +3686,15 @@ describe("App", () => {
     expect(
       within(ingestReadyRow as HTMLElement).queryByRole("button", { name: "Open result" }),
     ).not.toBeInTheDocument();
-    expect(within(savedRow as HTMLElement).getByRole("button", { name: "Preview delete" })).toBeEnabled();
-    expect(within(runningRow as HTMLElement).getByRole("button", { name: "Preview delete" })).toBeDisabled();
-    expect(screen.queryByText("Saved/protected runs are not deleted from this UI.")).not.toBeInTheDocument();
+    expect(
+      within(savedRow as HTMLElement).getByRole("button", { name: "Preview delete" }),
+    ).toBeEnabled();
+    expect(
+      within(runningRow as HTMLElement).getByRole("button", { name: "Preview delete" }),
+    ).toBeDisabled();
+    expect(
+      screen.queryByText("Saved/protected runs are not deleted from this UI."),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Running runs cannot be deleted.")).toBeInTheDocument();
 
     fireEvent.click(
@@ -3469,28 +3714,46 @@ describe("App", () => {
       ),
     );
 
-    fireEvent.click(within(resultRow as HTMLElement).getByRole("button", { name: "Preview delete" }));
+    fireEvent.click(
+      within(resultRow as HTMLElement).getByRole("button", { name: "Preview delete" }),
+    );
 
     expect(
       await screen.findByRole("heading", { name: "Delete result and local run data preview" }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/result will disappear from Results, Explore, Compare, and Storage inventory/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /result will disappear from Results, Explore, Compare, and Storage inventory/,
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText(/does not touch the source repo/)).toBeInTheDocument();
     expect(screen.getByText("Dry run only; no files were deleted.")).toBeInTheDocument();
-    expect(screen.getAllByText("/tmp/CloudChamber/runs/dry-run-quicklook").length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "Confirm delete result and local run data" })).toBeInTheDocument();
+    expect(screen.getAllByText("/tmp/CloudChamber/runs/dry-run-quicklook").length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      screen.getByRole("button", { name: "Confirm delete result and local run data" }),
+    ).toBeInTheDocument();
 
-    fireEvent.click(within(packageRow as HTMLElement).getByRole("button", { name: "Preview delete" }));
+    fireEvent.click(
+      within(packageRow as HTMLElement).getByRole("button", { name: "Preview delete" }),
+    );
 
     expect(
       await screen.findByRole("heading", { name: "Delete local run data preview" }),
     ).toBeInTheDocument();
     expect(screen.getByText(/CM1 output\/logs if present/)).toBeInTheDocument();
-    expect(screen.queryByText(/result will disappear from Results, Explore, Compare, and Storage inventory/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        /result will disappear from Results, Explore, Compare, and Storage inventory/,
+      ),
+    ).not.toBeInTheDocument();
     expect(screen.getAllByText("/tmp/CloudChamber/runs/dry-run-packaged").length).toBeGreaterThan(
       0,
     );
-    expect(screen.getByRole("button", { name: "Confirm delete local run data" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Confirm delete local run data" }),
+    ).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(
       "/api/storage/delete-run",
       expect.objectContaining({
@@ -3531,10 +3794,14 @@ describe("App", () => {
       await screen.findByRole("heading", { name: "Runtime inventory and cleanup" }),
     ).toBeInTheDocument();
     const runtimeRuns = screen.getByLabelText("Runtime runs");
-    const focusedRow = within(runtimeRuns).getAllByText(/dry-run-quicklook/)[0].closest("tr");
+    const focusedRow = within(runtimeRuns)
+      .getAllByText(/dry-run-quicklook/)[0]
+      .closest("tr");
     expect(focusedRow).not.toBeNull();
     expect(focusedRow).toHaveClass("selected-row");
-    expect(within(focusedRow as HTMLElement).getByRole("button", { name: "Open result" })).toBeEnabled();
+    expect(
+      within(focusedRow as HTMLElement).getByRole("button", { name: "Open result" }),
+    ).toBeEnabled();
     expect(
       within(focusedRow as HTMLElement).getByRole("button", { name: "Open in Explore" }),
     ).toBeEnabled();
@@ -3544,19 +3811,27 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
-    expect(await screen.findByRole("heading", { name: "Packages and runs needing action" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Packages and runs needing action" }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Preview delete" })).not.toBeInTheDocument();
 
     const pipelineRuns = screen.getByLabelText("Local packages and runs");
-    const pipelineRun = within(pipelineRuns).getAllByText(/dry-run-uningested/)[0].closest("article");
+    const pipelineRun = within(pipelineRuns)
+      .getAllByText(/dry-run-uningested/)[0]
+      .closest("article");
     expect(pipelineRun).not.toBeNull();
-    fireEvent.click(within(pipelineRun as HTMLElement).getByRole("button", { name: "Manage cleanup" }));
+    fireEvent.click(
+      within(pipelineRun as HTMLElement).getByRole("button", { name: "Manage cleanup" }),
+    );
 
     expect(
       await screen.findByRole("heading", { name: "Runtime inventory and cleanup" }),
     ).toBeInTheDocument();
     const runtimeRuns = screen.getByLabelText("Runtime runs");
-    const focusedRow = within(runtimeRuns).getAllByText(/dry-run-uningested/)[0].closest("tr");
+    const focusedRow = within(runtimeRuns)
+      .getAllByText(/dry-run-uningested/)[0]
+      .closest("tr");
     expect(focusedRow).toHaveClass("selected-row");
   });
 
@@ -3610,7 +3885,9 @@ describe("App", () => {
 
     await openSelectedResultInExplore();
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     expect(await screen.findByLabelText("Explore viewer controls")).toBeInTheDocument();
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
@@ -3630,13 +3907,13 @@ describe("App", () => {
     expect(
       Boolean(
         screen.getByLabelText("Slice field").compareDocumentPosition(horizontalHeatmap) &
-          Node.DOCUMENT_POSITION_FOLLOWING,
+        Node.DOCUMENT_POSITION_FOLLOWING,
       ),
     ).toBe(true);
     expect(
       Boolean(
         horizontalHeatmap.compareDocumentPosition(screen.getByText("Technical slice details")) &
-          Node.DOCUMENT_POSITION_FOLLOWING,
+        Node.DOCUMENT_POSITION_FOLLOWING,
       ),
     ).toBe(true);
     expect(screen.getAllByText("2.000e-5 kg/kg").length).toBeGreaterThan(0);
@@ -3649,7 +3926,9 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "Vertical x-z slice" })).toHaveClass(
       "active-control",
     );
-    expect(screen.getByRole("img", { name: /Vertical x-z slice at y = .* heatmap/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: /Vertical x-z slice at y = .* heatmap/ }),
+    ).toBeInTheDocument();
   });
 
   it("opens Explore at the result-card science default time", async () => {
@@ -3825,7 +4104,6 @@ describe("App", () => {
         "/api/results/result-dry-run-quicklook/diagnostics/selected-region?region_type=point",
       ),
     );
-
   });
 
   it("selects the source grid point represented by a downsampled cloud-water block", async () => {
@@ -3858,9 +4136,7 @@ describe("App", () => {
     const selectedPoint = screen.getByLabelText("Selected point context");
     expect(within(selectedPoint).getByText("5.000e-6 kg/kg")).toBeInTheDocument();
     expect(within(selectedPoint).queryByText("0 kg/kg")).not.toBeInTheDocument();
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining("x_index=1&y_index=0&z_index=1"),
-    );
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("x_index=1&y_index=0&z_index=1"));
   });
 
   it("shows selected-region backend failures as actionable inspector errors", async () => {
@@ -3971,26 +4247,34 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     await screen.findAllByText("Cloud-water point layer loaded");
     expect(screen.getByText("Result explanation")).toBeInTheDocument();
-    expect(screen.getAllByText(/Cloud water formed in the validated quick-look baseline/).length)
-      .toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Cloud water formed in the validated quick-look baseline/).length,
+    ).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByText("Process evidence details"));
     const processMode = screen.getByLabelText("Process mode");
     expect(processMode).toHaveValue("thermal_fate");
-    expect(within(processMode).getByRole("option", { name: /Thermal Fate summary/ }))
-      .toBeInTheDocument();
+    expect(
+      within(processMode).getByRole("option", { name: /Thermal Fate summary/ }),
+    ).toBeInTheDocument();
     expect(within(processMode).getByRole("option", { name: "Cloud Water" })).toBeInTheDocument();
     expect(within(processMode).getByRole("option", { name: "Updrafts" })).toBeInTheDocument();
-    expect(within(processMode).getByRole("option", { name: /Cloud Lifecycle/ })).toBeInTheDocument();
+    expect(
+      within(processMode).getByRole("option", { name: /Cloud Lifecycle/ }),
+    ).toBeInTheDocument();
     expect(within(processMode).queryByRole("option", { name: /Moisture/ })).not.toBeInTheDocument();
     expect(within(processMode).queryByRole("option", { name: /Buoyancy/ })).not.toBeInTheDocument();
-    expect(within(processMode).queryByRole("option", { name: /Deep Breakthrough/ })).not
-      .toBeInTheDocument();
-    expect(within(processMode).queryByRole("option", { name: /Precipitation Feedback/ })).not
-      .toBeInTheDocument();
+    expect(
+      within(processMode).queryByRole("option", { name: /Deep Breakthrough/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(processMode).queryByRole("option", { name: /Precipitation Feedback/ }),
+    ).not.toBeInTheDocument();
 
     fireEvent.change(processMode, { target: { value: "cloud_water" } });
 
@@ -4012,12 +4296,15 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     await screen.findByText("Slice synced");
     fireEvent.click(screen.getByText("Process evidence details"));
     const processMode = screen.getByLabelText("Process mode");
-    expect(within(processMode).getByRole("option", { name: /Moisture \/ Saturation \(candidate\)/ }))
-      .toBeInTheDocument();
+    expect(
+      within(processMode).getByRole("option", { name: /Moisture \/ Saturation \(candidate\)/ }),
+    ).toBeInTheDocument();
     expect(within(processMode).queryByRole("option", { name: /Buoyancy/ })).not.toBeInTheDocument();
 
     fireEvent.change(processMode, { target: { value: "moisture" } });
@@ -4025,23 +4312,29 @@ describe("App", () => {
     expect(processMode).toHaveValue("moisture");
     expect(screen.getByRole("heading", { name: "Moisture / Saturation" })).toBeInTheDocument();
     expect(screen.getAllByText("Candidate").length).toBeGreaterThan(0);
-    expect(screen.getByText(/thermals are present while cloud water and rain stay below threshold/i))
-      .toBeInTheDocument();
+    expect(
+      screen.getByText(/thermals are present while cloud water and rain stay below threshold/i),
+    ).toBeInTheDocument();
   });
 
   it("shows capped-style results with cap inversion as a candidate focus", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Capped / Suppressed Cumulus quick-look" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Capped / Suppressed Cumulus quick-look" }),
+    );
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     await screen.findByText("Slice synced");
     fireEvent.click(screen.getByText("Process evidence details"));
     const processMode = screen.getByLabelText("Process mode");
-    expect(within(processMode).getByRole("option", { name: /Cap \/ Inversion \(candidate\)/ }))
-      .toBeInTheDocument();
+    expect(
+      within(processMode).getByRole("option", { name: /Cap \/ Inversion \(candidate\)/ }),
+    ).toBeInTheDocument();
 
     fireEvent.change(processMode, { target: { value: "cap" } });
 
@@ -4057,7 +4350,9 @@ describe("App", () => {
     const resultDetail = screen.getByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.queryByRole("option", { name: /qc/ })).not.toBeInTheDocument();
@@ -4071,22 +4366,24 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("True 3-D scalar field viewer")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Inspect the current slice" })).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length).toBeGreaterThan(
-      0,
-    );
+    expect(
+      screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length,
+    ).toBeGreaterThan(0);
 
     await screen.findAllByText("Cloud-water point layer loaded");
     expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length).toBeGreaterThan(
-      0,
-    );
+    expect(
+      screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length,
+    ).toBeGreaterThan(0);
   });
 
   it("separates 3-D scalar fields from slice-only fields", async () => {
@@ -4171,14 +4468,16 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("tab", { name: "Compare" }));
     fireEvent.click(await screen.findByRole("button", { name: "Open Dry Failed in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     await screen.findAllByText("Cloud water max is 0 kg/kg; no points are above 1.000e-6 kg/kg");
     expect(screen.getByRole("heading", { name: "Inspect the current slice" })).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length).toBeGreaterThan(
-      0,
-    );
+    expect(
+      screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length,
+    ).toBeGreaterThan(0);
     expect(
       screen.getAllByText(
         "Thermals rose, but low-level moisture stayed too dry for meaningful cloud water or rain.",
@@ -4278,7 +4577,9 @@ describe("App", () => {
 
     await screen.findAllByText("Cloud-water point layer loaded");
     await waitFor(() => {
-      expect(screen.queryByText("Visualization fields temporarily failed.")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Visualization fields temporarily failed."),
+      ).not.toBeInTheDocument();
     });
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
@@ -4288,7 +4589,9 @@ describe("App", () => {
 
     await openSelectedResultInExplore();
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     await screen.findAllByText("Cloud-water point layer loaded");
     expect(screen.getByText("Cloud formed in this result")).toBeInTheDocument();
     expect(screen.queryByText("Cloud formed here")).not.toBeInTheDocument();
@@ -4331,7 +4634,11 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "Vertical y-z slice" })).toBeInTheDocument();
     expect(screen.getByLabelText("Time")).toBeInTheDocument();
     expect(screen.getByLabelText("Show slice plane")).toBeChecked();
-    expect(screen.getAllByText("Current field max: 8.000e-6 kg/kg. Visible points above 1.000e-6 kg/kg: 3.").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(
+        "Current field max: 8.000e-6 kg/kg. Visible points above 1.000e-6 kg/kg: 3.",
+      ).length,
+    ).toBeGreaterThan(0);
     expect(screen.getByText("0 to 3 km")).toBeInTheDocument();
     expect(screen.getByText("0.8 km to 1.2 km")).toBeInTheDocument();
     expect(screen.getByText("x 2, y 1, z 1.2 km, value 8.000e-6")).toBeInTheDocument();
@@ -4347,8 +4654,9 @@ describe("App", () => {
         "Processing method: backend native-grid thresholded point cloud for supported scalar fields",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Rendering method: direct Three.js scalar point cloud"))
-      .toBeInTheDocument();
+    expect(
+      screen.getByText("Rendering method: direct Three.js scalar point cloud"),
+    ).toBeInTheDocument();
     expect(screen.getByText("No raw NetCDF parsing in the browser")).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining("time_index=3"));
     expect(fetch).toHaveBeenCalledWith(
@@ -4364,8 +4672,9 @@ describe("App", () => {
 
     const viewer = screen.getByLabelText("True 3-D scalar field viewer");
     expect(within(viewer).getByText(/Slice plane: Horizontal layer at z = /)).toBeInTheDocument();
-    expect(within(viewer).queryByText(/Slice plane: Vertical x-z slice at y = /))
-      .not.toBeInTheDocument();
+    expect(
+      within(viewer).queryByText(/Slice plane: Vertical x-z slice at y = /),
+    ).not.toBeInTheDocument();
     expect(screen.getAllByText("qc (Cloud water)").length).toBeGreaterThan(0);
     expect(screen.getAllByText("native_grid_view_no_interpolation").length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: "Move down" }));
@@ -4376,20 +4685,26 @@ describe("App", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Vertical x-z slice" }));
-    expect(screen.getByRole("button", { name: "Vertical x-z slice" })).toHaveClass("active-control");
+    expect(screen.getByRole("button", { name: "Vertical x-z slice" })).toHaveClass(
+      "active-control",
+    );
     expect(screen.getByLabelText("Slice position")).toBeInTheDocument();
     await waitFor(() => {
-      expect(within(viewer).getByText(/Slice plane: Vertical x-z slice at y = /))
-        .toBeInTheDocument();
+      expect(
+        within(viewer).getByText(/Slice plane: Vertical x-z slice at y = /),
+      ).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Vertical y-z slice" }));
-    expect(screen.getByRole("button", { name: "Vertical y-z slice" })).toHaveClass("active-control");
+    expect(screen.getByRole("button", { name: "Vertical y-z slice" })).toHaveClass(
+      "active-control",
+    );
     expect(screen.getByLabelText("Slice position")).toBeInTheDocument();
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(expect.stringContaining("orientation=vertical_y"));
-      expect(within(viewer).getByText(/Slice plane: Vertical y-z slice at x = /))
-        .toBeInTheDocument();
+      expect(
+        within(viewer).getByText(/Slice plane: Vertical y-z slice at x = /),
+      ).toBeInTheDocument();
     });
     fireEvent.click(screen.getByRole("button", { name: "Move back" }));
     await waitFor(() => {
@@ -4419,8 +4734,9 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Vertical x-z slice" }));
     const viewer = screen.getByLabelText("True 3-D scalar field viewer");
     await waitFor(() => {
-      expect(within(viewer).getByText(/Slice plane: Vertical x-z slice at y = /))
-        .toBeInTheDocument();
+      expect(
+        within(viewer).getByText(/Slice plane: Vertical x-z slice at y = /),
+      ).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Horizontal layer" }));
@@ -4431,7 +4747,9 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Slice field"), { target: { value: "w" } });
     fireEvent.click(screen.getByRole("button", { name: "Vertical y-z slice" }));
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
-    expect(screen.getByRole("button", { name: "Vertical y-z slice" })).toHaveClass("active-control");
+    expect(screen.getByRole("button", { name: "Vertical y-z slice" })).toHaveClass(
+      "active-control",
+    );
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(expect.stringContaining("field=w"));
     });
@@ -4446,8 +4764,7 @@ describe("App", () => {
     const cameraControls = screen.getByLabelText("3-D camera controls");
     expect(within(cameraControls).getByText(/Camera ready/)).toBeInTheDocument();
     fireEvent.click(within(cameraControls).getByRole("button", { name: "Top-down x-y" }));
-    expect(within(cameraControls).getByText(/Camera set to top-down x-y view/))
-      .toBeInTheDocument();
+    expect(within(cameraControls).getByText(/Camera set to top-down x-y view/)).toBeInTheDocument();
     fireEvent.click(within(cameraControls).getByRole("button", { name: "Look along x" }));
     expect(within(cameraControls).getByText(/Camera looking along the x axis/)).toBeInTheDocument();
     fireEvent.click(within(cameraControls).getByRole("button", { name: "Look along y" }));
@@ -4461,8 +4778,9 @@ describe("App", () => {
 
     fireEvent.click(within(cameraControls).getByRole("button", { name: "Reset camera" }));
 
-    expect(within(cameraControls).getByText(/Camera reset to shallow-cumulus overview/))
-      .toBeInTheDocument();
+    expect(
+      within(cameraControls).getByText(/Camera reset to shallow-cumulus overview/),
+    ).toBeInTheDocument();
   });
 
   it("updates cloud-water threshold opacity point size and time requests", async () => {
@@ -4473,7 +4791,9 @@ describe("App", () => {
 
     fireEvent.change(screen.getByLabelText("Cloud-water threshold"), { target: { value: "1" } });
 
-    await screen.findAllByText("Cloud water max is 8.000e-6 kg/kg; no points are above 1.000e+0 kg/kg");
+    await screen.findAllByText(
+      "Cloud water max is 8.000e-6 kg/kg; no points are above 1.000e+0 kg/kg",
+    );
     expect(
       screen.getByText("No cloud water above the selected threshold at this time."),
     ).toBeInTheDocument();
@@ -4497,7 +4817,9 @@ describe("App", () => {
     const resultDetail = screen.getByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     await screen.findAllByText("Slice fields ready; no 3-D scalar field available");
     expect(screen.getByText("No supported 3-D scalar field")).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
@@ -4511,7 +4833,9 @@ describe("App", () => {
     const resultDetail = screen.getByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(await screen.findByRole("heading", { name: "What happened in this result?" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "What happened in this result?" }),
+    ).toBeInTheDocument();
     await screen.findAllByText("No fields available");
     expect(
       screen.getByText("No visualization-ready fields are available for this result."),

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -203,10 +203,7 @@ type CandidateSort =
   | "highest_moisture"
   | "strongest_cap";
 
-type PackageFamily =
-  | "shallow_cumulus"
-  | "observed_sounding_quicklook"
-  | "deep_convection_trial";
+type PackageFamily = "shallow_cumulus" | "observed_sounding_quicklook" | "deep_convection_trial";
 
 type ObservedPackageFamily = "observed_sounding_quicklook" | "deep_convection_trial";
 
@@ -458,8 +455,14 @@ type FieldDefaultTime = {
 };
 
 type ScienceSummary = {
+  cloud_formed?: boolean | null;
+  deep_cloud_formed?: boolean | null;
+  deep_cloud_threshold_m?: number;
+  strong_updraft_formed?: boolean | null;
+  strong_updraft_threshold_m_s?: number;
   first_cloud_time_seconds?: number | null;
   first_cloud_time_label?: string | null;
+  time_of_first_deep_convection_seconds?: number | null;
   max_qc_kg_kg?: number | null;
   max_qc_time_seconds?: number | null;
   max_updraft_w_m_s?: number | null;
@@ -469,11 +472,38 @@ type ScienceSummary = {
   highest_cloud_top_m?: number | null;
   rain_onset_time_seconds?: number | null;
   max_qr_kg_kg?: number | null;
+  max_rain_or_surface_precip?: number | null;
+  max_dbz_or_reflectivity_proxy?: number | null;
+  cold_pool_proxy?: number | null;
+  near_surface_theta_perturbation_proxy?: number | null;
+  updraft_depth_proxy_m?: number | null;
   latest_output_time_seconds?: number | null;
   default_explore_time_index?: number | null;
   default_explore_time_seconds?: number | null;
+  cm1_outcome?: string | null;
+  diagnostic_availability?: ScienceDiagnosticAvailability[];
   interesting_time_caveats: string[];
   interesting_time_support_state: string;
+};
+
+type ScienceDiagnosticAvailability = {
+  key: string;
+  label: string;
+  support_state: string;
+  source_field?: string | null;
+  value?: number | boolean | null;
+  units?: string | null;
+  caveats: string[];
+};
+
+type CandidateHypothesisComparison = {
+  screened_as?: string | null;
+  ran_as: string;
+  cm1_outcome: string;
+  match_status: string;
+  match_status_label: string;
+  evidence: string[];
+  caveats: string[];
 };
 
 type ResultCard = {
@@ -503,6 +533,8 @@ type ResultCard = {
   expected_outputs?: string[];
   package_caveats?: string[];
   manual_validation_status?: string | null;
+  candidate_screening?: Record<string, unknown> | null;
+  candidate_hypothesis_comparison?: CandidateHypothesisComparison | null;
   provenance_labels: string[];
   diagnostics_summary: string | null;
   thermal_fate_label?: string | null;
@@ -991,7 +1023,9 @@ async function fetchSavedSoundingCandidates(): Promise<SavedCandidatesResponse> 
   return response.json() as Promise<SavedCandidatesResponse>;
 }
 
-async function saveSoundingCandidate(candidate: SoundingCandidate): Promise<SavedSoundingCandidate> {
+async function saveSoundingCandidate(
+  candidate: SoundingCandidate,
+): Promise<SavedSoundingCandidate> {
   const response = await fetch("/api/sounding-candidates/saved", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -1316,25 +1350,28 @@ export function App() {
   const [selectedScenarioId, setSelectedScenarioId] = useState("baseline-shallow-cumulus");
   const [controls, setControls] = useState<Record<string, string | number | boolean>>({});
   const [runSizePreset, setRunSizePreset] = useState("quick_look");
-  const [observedPackageFamily, setObservedPackageFamily] =
-    useState<ObservedPackageFamily>("observed_sounding_quicklook");
+  const [observedPackageFamily, setObservedPackageFamily] = useState<ObservedPackageFamily>(
+    "observed_sounding_quicklook",
+  );
   const [observedSoundingFilename, setObservedSoundingFilename] = useState<string | null>(null);
   const [observedSoundingText, setObservedSoundingText] = useState<string | null>(null);
   const [observedSoundingParse, setObservedSoundingParse] =
     useState<ObservedSoundingParseResponse | null>(null);
   const [observedSoundingStatus, setObservedSoundingStatus] = useState<string | null>(null);
   const [observedSoundingError, setObservedSoundingError] = useState<string | null>(null);
-  const [selectedCandidateScreening, setSelectedCandidateScreening] =
-    useState<Record<string, unknown> | null>(null);
+  const [selectedCandidateScreening, setSelectedCandidateScreening] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
   const [igraCatalog, setIgraCatalog] = useState<IGRACatalogResponse["catalog"] | null>(null);
   const [igraCache, setIgraCache] = useState<IGRACacheResponse | null>(null);
   const [screeningInputs, setScreeningInputs] = useState<ScreeningInput[]>([]);
-  const [candidateStoryFilter, setCandidateStoryFilter] =
-    useState<CandidateStoryFilter>("all");
+  const [candidateStoryFilter, setCandidateStoryFilter] = useState<CandidateStoryFilter>("all");
   const [candidateSort, setCandidateSort] = useState<CandidateSort>("best");
   const [candidateStationSearch, setCandidateStationSearch] = useState("");
-  const [candidateReadinessFilter, setCandidateReadinessFilter] =
-    useState<"all" | "package_ready" | "blocked">("all");
+  const [candidateReadinessFilter, setCandidateReadinessFilter] = useState<
+    "all" | "package_ready" | "blocked"
+  >("all");
   const [candidateCacheLimit, setCandidateCacheLimit] = useState("10");
   const [candidateLatestPerStation, setCandidateLatestPerStation] = useState("5");
   const [candidateResultLimit, setCandidateResultLimit] = useState("50");
@@ -1489,8 +1526,7 @@ export function App() {
       ) ?? scenarios[0],
     [scenarios, selectedScenarioId],
   );
-  const observedSoundingExperimentSelected =
-    selectedScenarioId === OBSERVED_SOUNDING_EXPERIMENT_ID;
+  const observedSoundingExperimentSelected = selectedScenarioId === OBSERVED_SOUNDING_EXPERIMENT_ID;
 
   const selectedResult = useMemo(
     () => results.find((result) => result.result_id === selectedResultId) ?? results[0],
@@ -1908,8 +1944,7 @@ export function App() {
       setStatus("Running CM1 on LAN worker");
       await refreshStorageAfterWorkflow("Local pipeline updated");
     } catch (caught) {
-      const message =
-        caught instanceof Error ? caught.message : "Unable to start LAN worker run.";
+      const message = caught instanceof Error ? caught.message : "Unable to start LAN worker run.";
       setLanWorkerError(message);
       setRunWorkflowError(message);
       setLanWorkerActionStatus("LAN worker launch blocked");
@@ -2106,7 +2141,9 @@ export function App() {
         setLanWorkerStatus(refreshed);
       }
       setLanWorkerActionStatus(lanWorkerStatusLabel(refreshed));
-      await refreshStorageAfterWorkflow(`LAN worker status refreshed at ${new Date().toLocaleTimeString()}`);
+      await refreshStorageAfterWorkflow(
+        `LAN worker status refreshed at ${new Date().toLocaleTimeString()}`,
+      );
       if (refreshed.state === "completed") {
         await collectAndIngestLanWorkerRun(manifestPath);
       }
@@ -2135,9 +2172,7 @@ export function App() {
     } catch (caught) {
       const message =
         caught instanceof Error ? caught.message : "Unable to ingest completed CM1 output.";
-      setRunWorkflowError(
-        message,
-      );
+      setRunWorkflowError(message);
       setStorageError(message);
       setStatus("Ingest blocked");
       setStorageStatus("Ingest blocked");
@@ -2167,7 +2202,9 @@ export function App() {
       updateResultInList(updated);
       setResultsStatus("Notebook changes saved");
     } catch (caught) {
-      setResultsError(caught instanceof Error ? caught.message : "Unable to save notebook changes.");
+      setResultsError(
+        caught instanceof Error ? caught.message : "Unable to save notebook changes.",
+      );
       setResultsStatus("Results loaded");
     }
   }
@@ -2403,9 +2440,7 @@ export function App() {
         />
       )}
 
-      {activeSection === "explore" && (
-        <ExploreWorkspace selectedResult={selectedResult} />
-      )}
+      {activeSection === "explore" && <ExploreWorkspace selectedResult={selectedResult} />}
     </main>
   );
 }
@@ -2797,9 +2832,9 @@ function BuildWorkspace({
               )}
               {runSizePreset === "deep_overnight" && (
                 <p className="field-help">
-                  Deep Overnight is the expensive opt-in preset. It targets roughly 10-12x
-                  Standard wall-clock for higher-resolution Explore/timelapse data; validate
-                  runtime and storage locally before treating it as calibrated.
+                  Deep Overnight is the expensive opt-in preset. It targets roughly 10-12x Standard
+                  wall-clock for higher-resolution Explore/timelapse data; validate runtime and
+                  storage locally before treating it as calibrated.
                 </p>
               )}
 
@@ -2816,7 +2851,6 @@ function BuildWorkspace({
                   <p>{packageError}</p>
                 </div>
               )}
-
             </>
           )}
         </form>
@@ -2831,12 +2865,12 @@ function BuildWorkspace({
             lanWorkerError={lanWorkerError}
             lanWorkerActionStatus={lanWorkerActionStatus}
             ingestedResultId={ingestedResultId}
-          showCreatePackageAction={scenarioControlsReady}
-          canCreatePackage={
-            validationMessages.length === 0 &&
+            showCreatePackageAction={scenarioControlsReady}
+            canCreatePackage={
+              validationMessages.length === 0 &&
               (!observedSoundingExperimentSelected ||
                 Boolean(observedSoundingParse?.selected_sounding))
-          }
+            }
             onLaunchRun={onLaunchRun}
             onRefreshRunStatus={onRefreshRunStatus}
             onLaunchLanWorkerRun={onLaunchLanWorkerRun}
@@ -3009,9 +3043,7 @@ function ObservedAtmosphereCandidatesPanel({
     () => new Set(savedCandidates.map((saved) => saved.candidate.candidate_id)),
     [savedCandidates],
   );
-  const cachedStations = new Set(
-    (cache?.entries ?? []).map((entry) => entry.station_id),
-  ).size;
+  const cachedStations = new Set((cache?.entries ?? []).map((entry) => entry.station_id)).size;
   const cachedStationFiles = cache?.entries.length ?? 0;
   const cachedCatalogFiles =
     catalog?.zip_references.filter((reference) => reference.cached_status !== "not_cached")
@@ -3035,8 +3067,8 @@ function ObservedAtmosphereCandidatesPanel({
           <p className="eyebrow">Observed atmosphere</p>
           <h3 id="sounding-candidates-title">Find interesting soundings</h3>
           <p className="field-help">
-            Screening guidance only. Use this to choose an observed atmosphere to try; CM1
-            decides what actually happens.
+            Screening guidance only. Use this to choose an observed atmosphere to try; CM1 decides
+            what actually happens.
           </p>
         </div>
         <p className="state-chip" role="status">
@@ -3078,14 +3110,19 @@ function ObservedAtmosphereCandidatesPanel({
             <option value="supercell_environment">Supercell-like environment</option>
             <option value="high_cape_pulse_storm">High-CAPE pulse storm</option>
             <option value="dry_microburst_inverted_v">Dry microburst / inverted-V</option>
-            <option value="squall_line_cold_pool_candidate">Squall-line / cold-pool candidate</option>
+            <option value="squall_line_cold_pool_candidate">
+              Squall-line / cold-pool candidate
+            </option>
             <option value="elevated_convection">Elevated convection</option>
             <option value="needs_review">Needs review</option>
           </select>
         </label>
         <label>
           Sort
-          <select value={sort} onChange={(event) => onSortChange(event.target.value as CandidateSort)}>
+          <select
+            value={sort}
+            onChange={(event) => onSortChange(event.target.value as CandidateSort)}
+          >
             <option value="best">Best match for story</option>
             <option value="latest">Latest</option>
             <option value="data_quality">Best data quality</option>
@@ -3201,8 +3238,8 @@ function ObservedAtmosphereCandidatesPanel({
           <div>
             <h4 id="saved-candidates-title">Saved sounding candidates</h4>
             <p>
-              Saved candidates are pre-run hypotheses. They are not Results and they do not prove
-              an atmospheric outcome.
+              Saved candidates are pre-run hypotheses. They are not Results and they do not prove an
+              atmospheric outcome.
             </p>
           </div>
         </div>
@@ -3271,7 +3308,11 @@ function SoundingCandidateCard({
       className={`candidate-card${selected ? " selected-candidate-card" : ""}`}
       aria-label={`Sounding candidate ${candidateStationLabel(candidate)}`}
     >
-      <button type="button" className="candidate-card-main candidate-card-select" onClick={onSelect}>
+      <button
+        type="button"
+        className="candidate-card-main candidate-card-select"
+        onClick={onSelect}
+      >
         <span>
           <strong>{candidateStationLabel(candidate)}</strong>
           <small>{formatDate(candidate.valid_time_utc)}</small>
@@ -3356,7 +3397,10 @@ function SoundingCandidateDetail({
         suppression actually happen.
       </p>
       <dl className="compact-metrics">
-        <Metric label="Match score" value={formatNumber(candidateMatchScore(candidate, story), "%")} />
+        <Metric
+          label="Match score"
+          value={formatNumber(candidateMatchScore(candidate, story), "%")}
+        />
         <Metric label="Evidence level" value={humanize(candidate.confidence)} />
         <Metric label="Station ID" value={candidate.station_id} />
         <Metric
@@ -3397,11 +3441,7 @@ function SoundingCandidateDetail({
         <summary>Feature values</summary>
         <dl className="compact-metrics">
           {featureRows.map(([label, key, units]) => (
-            <Metric
-              key={key}
-              label={label}
-              value={candidateFeatureValue(candidate, key, units)}
-            />
+            <Metric key={key} label={label} value={candidateFeatureValue(candidate, key, units)} />
           ))}
         </dl>
       </details>
@@ -3437,7 +3477,10 @@ function ObservedSoundingInputPanel({
   const selected = parsed?.selected_sounding;
 
   return (
-    <section className="experiment-summary observed-sounding-panel" aria-labelledby="observed-sounding-title">
+    <section
+      className="experiment-summary observed-sounding-panel"
+      aria-labelledby="observed-sounding-title"
+    >
       <div className="panel-heading-row">
         <div>
           <p className="eyebrow">Observed sounding</p>
@@ -3472,86 +3515,88 @@ function ObservedSoundingInputPanel({
 
       {parsed && selected && (
         <section className="observed-sounding-review" aria-label="Observed sounding review">
-              {selectedCandidateScreening && (
-                <div className="screening-guidance-note">
-                  <strong>Screening guidance only</strong>
-                  <span>
-                    Screened as{" "}
-                    {candidateStoryLabel(
-                      String(selectedCandidateScreening.primary_story ?? "needs_review") as CandidateStoryId,
-                    )}
-                    . CM1 decides what actually happens.
-                  </span>
-                </div>
-              )}
-              <div className="control-row">
-                <span>
-                  <label htmlFor="observed-sounding-time">
-                    <strong>Selected sounding time</strong>
-                  </label>
-                  <small>
-                    Latest available is selected by default. Choose another time from the uploaded
-                    station file if needed.
-                  </small>
-                </span>
-                <select
-                  id="observed-sounding-time"
-                  value={selected.valid_time_utc}
-                  onChange={(event) => onTimeChange(event.target.value)}
-                >
-                  {parsed.available_soundings.map((sounding) => (
-                    <option key={sounding.valid_time_utc} value={sounding.valid_time_utc}>
-                      {formatDate(sounding.valid_time_utc)} · {sounding.num_levels} source levels
-                    </option>
-                  ))}
-                </select>
-              </div>
+          {selectedCandidateScreening && (
+            <div className="screening-guidance-note">
+              <strong>Screening guidance only</strong>
+              <span>
+                Screened as{" "}
+                {candidateStoryLabel(
+                  String(
+                    selectedCandidateScreening.primary_story ?? "needs_review",
+                  ) as CandidateStoryId,
+                )}
+                . CM1 decides what actually happens.
+              </span>
+            </div>
+          )}
+          <div className="control-row">
+            <span>
+              <label htmlFor="observed-sounding-time">
+                <strong>Selected sounding time</strong>
+              </label>
+              <small>
+                Latest available is selected by default. Choose another time from the uploaded
+                station file if needed.
+              </small>
+            </span>
+            <select
+              id="observed-sounding-time"
+              value={selected.valid_time_utc}
+              onChange={(event) => onTimeChange(event.target.value)}
+            >
+              {parsed.available_soundings.map((sounding) => (
+                <option key={sounding.valid_time_utc} value={sounding.valid_time_utc}>
+                  {formatDate(sounding.valid_time_utc)} · {sounding.num_levels} source levels
+                </option>
+              ))}
+            </select>
+          </div>
 
-              <dl className="compact-metrics">
-                <Metric label="Source" value={`${parsed.source_provider} · ${parsed.source_format}`} />
-                <Metric label="Uploaded file" value={parsed.uploaded_filename} />
-                <Metric
-                  label="Station"
-                  value={`${selected.station_id}${selected.station_name ? ` · ${selected.station_name}` : ""}`}
-                />
-                <Metric
-                  label="Location"
-                  value={
-                    selected.station_latitude !== null &&
-                    selected.station_latitude !== undefined &&
-                    selected.station_longitude !== null &&
-                    selected.station_longitude !== undefined
-                      ? `${formatNumber(selected.station_latitude, "deg")}, ${formatNumber(selected.station_longitude, "deg")}`
-                      : "Not available"
-                  }
-                />
-                <Metric
-                  label="Model bottom / vertical datum"
-                  value={`CM1 z=0 is station surface at ${formatNumber(selected.model_bottom_elevation_m_msl, "m MSL")}`}
-                />
-                <Metric
-                  label="Source heights"
-                  value={`${humanize(selected.source_vertical_coordinate_type)} converted to height above station surface`}
-                />
-                <Metric
-                  label="Converted model z range"
-                  value={`${formatNumber(selected.levels[0]?.model_z_m ?? null, "m")} to ${formatNumber(selected.levels.at(-1)?.model_z_m ?? null, "m")}`}
-                />
-                <Metric label="Usable levels" value={selected.levels.length.toString()} />
-                <Metric label="Wind handling" value={humanize(selected.wind_handling)} />
-                <Metric label="Validation" value={humanize(selected.validation.status)} />
-              </dl>
+          <dl className="compact-metrics">
+            <Metric label="Source" value={`${parsed.source_provider} · ${parsed.source_format}`} />
+            <Metric label="Uploaded file" value={parsed.uploaded_filename} />
+            <Metric
+              label="Station"
+              value={`${selected.station_id}${selected.station_name ? ` · ${selected.station_name}` : ""}`}
+            />
+            <Metric
+              label="Location"
+              value={
+                selected.station_latitude !== null &&
+                selected.station_latitude !== undefined &&
+                selected.station_longitude !== null &&
+                selected.station_longitude !== undefined
+                  ? `${formatNumber(selected.station_latitude, "deg")}, ${formatNumber(selected.station_longitude, "deg")}`
+                  : "Not available"
+              }
+            />
+            <Metric
+              label="Model bottom / vertical datum"
+              value={`CM1 z=0 is station surface at ${formatNumber(selected.model_bottom_elevation_m_msl, "m MSL")}`}
+            />
+            <Metric
+              label="Source heights"
+              value={`${humanize(selected.source_vertical_coordinate_type)} converted to height above station surface`}
+            />
+            <Metric
+              label="Converted model z range"
+              value={`${formatNumber(selected.levels[0]?.model_z_m ?? null, "m")} to ${formatNumber(selected.levels.at(-1)?.model_z_m ?? null, "m")}`}
+            />
+            <Metric label="Usable levels" value={selected.levels.length.toString()} />
+            <Metric label="Wind handling" value={humanize(selected.wind_handling)} />
+            <Metric label="Validation" value={humanize(selected.validation.status)} />
+          </dl>
 
-              {selected.validation.caveats.length > 0 && (
-                <details>
-                  <summary>Observed-sounding caveats</summary>
-                  <ul className="compact-list">
-                    {selected.validation.caveats.map((caveat) => (
-                      <li key={caveat}>{humanize(caveat)}</li>
-                    ))}
-                  </ul>
-                </details>
-              )}
+          {selected.validation.caveats.length > 0 && (
+            <details>
+              <summary>Observed-sounding caveats</summary>
+              <ul className="compact-list">
+                {selected.validation.caveats.map((caveat) => (
+                  <li key={caveat}>{humanize(caveat)}</li>
+                ))}
+              </ul>
+            </details>
+          )}
         </section>
       )}
     </section>
@@ -3622,7 +3667,11 @@ function ObservedPackageFamilyPanel({
         />
         <Metric
           label="Domain intent"
-          value={selectedDeep ? "Wider box for storm growth and precipitation" : "Current quick-look observed atmosphere path"}
+          value={
+            selectedDeep
+              ? "Wider box for storm growth and precipitation"
+              : "Current quick-look observed atmosphere path"
+          }
         />
         <Metric label="Runtime guidance" value={workerGuidance} />
       </dl>
@@ -3700,7 +3749,9 @@ function ResultsWorkspace({
       <div className="section-heading">
         <div>
           <h2 id="results-title">Experiment Notebook</h2>
-          <p>Review ingested cloud experiments, compare variants, and open results for explanation.</p>
+          <p>
+            Review ingested cloud experiments, compare variants, and open results for explanation.
+          </p>
         </div>
       </div>
       {resultsStatus !== "Results loaded" && resultsStatus !== "Loading results..." && (
@@ -3889,6 +3940,13 @@ function ExploreResultSummary({ result }: { result: ResultCard }) {
           {result.completed_at ? ` · ${formatDate(result.completed_at)}` : ""}
         </p>
         <p>{resultStory(result)}</p>
+        {result.candidate_hypothesis_comparison && (
+          <p className="secondary-result-note">
+            {result.candidate_hypothesis_comparison.screened_as ?? "Screened candidate"} ·{" "}
+            {result.candidate_hypothesis_comparison.match_status_label}:{" "}
+            {result.candidate_hypothesis_comparison.cm1_outcome}
+          </p>
+        )}
       </div>
       <div className="badge-row">
         <OutcomeBadge result={result} />
@@ -4419,7 +4477,9 @@ function StorageWorkspace({
   onIngestRun: (manifestPath: string) => void;
 }) {
   const displayedRuns =
-    inventory && inventory.largest_runs.length > 0 ? inventory.largest_runs : inventory?.runs ?? [];
+    inventory && inventory.largest_runs.length > 0
+      ? inventory.largest_runs
+      : (inventory?.runs ?? []);
   const deletePreviewResult = deletePreview
     ? resultForRun(results, deletePreview.run_id)
     : undefined;
@@ -4626,10 +4686,7 @@ function RuntimeRunsTable({
                       </button>
                     )}
                     {canIngest && run.manifest_path && (
-                      <button
-                        type="button"
-                        onClick={() => onIngestRun(run.manifest_path!)}
-                      >
+                      <button type="button" onClick={() => onIngestRun(run.manifest_path!)}>
                         Ingest completed output
                       </button>
                     )}
@@ -4642,9 +4699,7 @@ function RuntimeRunsTable({
                       Preview delete
                     </button>
                   </div>
-                  {!canPreviewDelete(run) && (
-                    <small>{deleteDisabledReason(run)}</small>
-                  )}
+                  {!canPreviewDelete(run) && <small>{deleteDisabledReason(run)}</small>}
                 </td>
               </tr>
             );
@@ -4861,7 +4916,9 @@ function LocalRunWorkflowPanel({
             )}
             {showRefreshButton && (
               <button type="button" data-testid="refresh-status-btn" onClick={onRefreshRunStatus}>
-                {stage === "running" || stage === "failed" ? "View status / logs" : "Refresh status"}
+                {stage === "running" || stage === "failed"
+                  ? "View status / logs"
+                  : "Refresh status"}
               </button>
             )}
             {showIngestButton && (
@@ -4975,10 +5032,7 @@ function LocalRunWorkflowPanel({
                   />
                 </>
               )}
-              <Metric
-                label="CM1 launched"
-                value={dryRun.report.cm1_was_launched ? "Yes" : "No"}
-              />
+              <Metric label="CM1 launched" value={dryRun.report.cm1_was_launched ? "Yes" : "No"} />
               <Metric
                 label="Product state"
                 value={humanize(dryRun.report.provenance.product_state)}
@@ -5032,7 +5086,6 @@ function LocalRunWorkflowPanel({
         onOpenStorage={onOpenStorage}
         onRefreshStorage={onRefreshStorage}
       />
-
     </section>
   );
 }
@@ -5084,7 +5137,9 @@ function LanWorkerRunPanel({
           <h5>Run CM1 on LAN worker</h5>
         </div>
         <StatusBadge
-          label={status ? lanWorkerStatusLabel(status) : configured ? "Configured" : "Not configured"}
+          label={
+            status ? lanWorkerStatusLabel(status) : configured ? "Configured" : "Not configured"
+          }
           tone={lanWorkerTone(status, configured)}
         />
       </div>
@@ -5146,12 +5201,14 @@ function LanWorkerRunPanel({
           </div>
           {status?.state === "ready_for_local_ingest" && !ingestedResultId && (
             <p className="state-note">
-              Worker output is now on this MacBook. Cloud Chamber will ingest it locally and clean up
-              the worker copy after ingest succeeds.
+              Worker output is now on this MacBook. Cloud Chamber will ingest it locally and clean
+              up the worker copy after ingest succeeds.
             </p>
           )}
           {cleanupComplete && (
-            <p className="state-note">LAN worker cleanup complete. Results and Explore use the MacBook-local copy.</p>
+            <p className="state-note">
+              LAN worker cleanup complete. Results and Explore use the MacBook-local copy.
+            </p>
           )}
         </>
       )}
@@ -5222,7 +5279,10 @@ function LocalPipelinePanel({
       </div>
 
       {runs.length === 0 ? (
-        <p>No active or incomplete packages/runs need Build action. Ingested results are in Results, and cleanup is in Storage.</p>
+        <p>
+          No active or incomplete packages/runs need Build action. Ingested results are in Results,
+          and cleanup is in Storage.
+        </p>
       ) : (
         <div className="pipeline-run-list" aria-label="Local packages and runs">
           {runs.map((run, index) => (
@@ -5282,15 +5342,17 @@ function PipelineRunCard({
   onOpenStorage: (runId?: string | null) => void;
 }) {
   const displayName = result?.name ?? run.scenario_name ?? run.scenario_id ?? run.run_id;
-  const canLaunch = Boolean(run.manifest_path && run.category === "dry_run_only" && !run.worker_state);
+  const canLaunch = Boolean(
+    run.manifest_path && run.category === "dry_run_only" && !run.worker_state,
+  );
   const canRefreshWorker = Boolean(run.manifest_path && run.worker_state === "running");
   const canFinalizeWorker = Boolean(
     run.manifest_path && run.worker_state === "completed" && !result && autoFinalizeFailed,
   );
   const canIngest = Boolean(
     run.manifest_path &&
-      !result &&
-      (run.category === "completed_with_output" || run.worker_state === "ready_for_local_ingest"),
+    !result &&
+    (run.category === "completed_with_output" || run.worker_state === "ready_for_local_ingest"),
   );
   const stateLabel = pipelineRunStateLabel(run, result);
   const nextStep = pipelineRunNextStep(run, result);
@@ -5534,7 +5596,9 @@ function selectPipelineRuns(
     }
     const leftTime = Date.parse(left.updated_at ?? left.created_at ?? "");
     const rightTime = Date.parse(right.updated_at ?? right.created_at ?? "");
-    return (Number.isFinite(rightTime) ? rightTime : 0) - (Number.isFinite(leftTime) ? leftTime : 0);
+    return (
+      (Number.isFinite(rightTime) ? rightTime : 0) - (Number.isFinite(leftTime) ? leftTime : 0)
+    );
   });
   return sorted.slice(0, 6);
 }
@@ -5601,7 +5665,8 @@ function pipelineRunTone(
 
 function pipelineRunNextStep(run: RunStorageEntry, result: ResultCard | undefined): string {
   if (result) return "Review in Results or Explore fields; cleanup remains available in Storage.";
-  if (run.worker_state === "running") return "CM1 is running on the LAN worker; refresh runs for status.";
+  if (run.worker_state === "running")
+    return "CM1 is running on the LAN worker; refresh runs for status.";
   if (run.worker_state === "completed") {
     return "LAN worker output is complete; Cloud Chamber will copy it back, ingest locally, and clean up the worker copy.";
   }
@@ -5731,7 +5796,10 @@ function ResultsFilterBar({
         </label>
         <label>
           Scenario
-          <select value={filters.scenario} onChange={(event) => update({ scenario: event.target.value })}>
+          <select
+            value={filters.scenario}
+            onChange={(event) => update({ scenario: event.target.value })}
+          >
             <option value="all">All scenarios</option>
             {scenarioOptions.map((option) => (
               <option key={option.value} value={option.value}>
@@ -5742,7 +5810,10 @@ function ResultsFilterBar({
         </label>
         <label>
           Run size
-          <select value={filters.preset} onChange={(event) => update({ preset: event.target.value })}>
+          <select
+            value={filters.preset}
+            onChange={(event) => update({ preset: event.target.value })}
+          >
             <option value="all">All presets</option>
             {presetOptions.map((option) => (
               <option key={option.value} value={option.value}>
@@ -5834,9 +5905,7 @@ function ExperimentNotebookList({
       <section className="notebook-list-panel empty-results" aria-label="Results list">
         <p className="eyebrow">Notebook empty</p>
         <h3>No ingested CM1 results yet.</h3>
-        <p>
-          Completed and ingested CM1 runs will appear here as experiment notebook entries.
-        </p>
+        <p>Completed and ingested CM1 runs will appear here as experiment notebook entries.</p>
       </section>
     );
   }
@@ -5864,7 +5933,8 @@ function ExperimentNotebookList({
                 </button>
                 <p className="experiment-subtitle">
                   {result.scenario_name ?? humanize(result.scenario_id)} ·{" "}
-                  {humanize(result.run_size_preset)} · {formatDate(result.completed_at ?? result.created_at)}
+                  {humanize(result.run_size_preset)} ·{" "}
+                  {formatDate(result.completed_at ?? result.created_at)}
                 </p>
                 <div className="badge-row">
                   <OutcomeBadge result={result} />
@@ -5940,6 +6010,7 @@ function ResultNotebookCard({
       </div>
 
       <p className="result-story">{resultStory(result)}</p>
+      <CandidateHypothesisSummary result={result} />
 
       {(isValidatedQuickLookBaseline(result) || result.caveats.length > 0) && (
         <p className="secondary-result-note">
@@ -5960,6 +6031,9 @@ function ResultNotebookCard({
         <Metric label="Max updraft" value={formatNumber(resultMaxUpdraft(result), "m/s")} />
         <Metric label="Min downdraft" value={formatNumber(resultMinDowndraft(result), "m/s")} />
         <Metric label="Cloud top" value={formatNumber(resultCloudTopMeters(result), "m")} />
+        {isDeepConvectionTrial(result) && (
+          <Metric label="Deep convection" value={deepConvectionOutcome(result)} />
+        )}
         <Metric label="Latest output" value={formatSeconds(resultLatestOutputTime(result))} />
       </dl>
 
@@ -5974,7 +6048,10 @@ function ResultNotebookCard({
           <Metric label="Product state" value={result.source_product_state} />
           <Metric label="Result state" value={result.status} />
           <Metric label="Source model" value={result.source_model} />
-          <Metric label="Input source" value={result.input_source_label ?? resultInputSourceLabel(result)} />
+          <Metric
+            label="Input source"
+            value={result.input_source_label ?? resultInputSourceLabel(result)}
+          />
           <Metric label="Output" value={outputSummary(result.output_file_summary)} />
           <Metric
             label="Raw diagnostics"
@@ -6102,8 +6179,43 @@ function InterestingTimesSummary({ result }: { result: ResultCard }) {
   );
 }
 
+function CandidateHypothesisSummary({ result }: { result: ResultCard }) {
+  const comparison = result.candidate_hypothesis_comparison;
+  if (!comparison) return null;
+  return (
+    <section className="candidate-outcome-summary" aria-label="Candidate hypothesis comparison">
+      <div className="section-heading-row">
+        <div>
+          <p className="eyebrow">Candidate hypothesis</p>
+          <h4>Screening vs CM1</h4>
+        </div>
+        <StatusBadge
+          label={comparison.match_status_label}
+          tone={candidateMatchTone(comparison.match_status)}
+        />
+      </div>
+      <dl className="metric-grid">
+        <Metric label="Screened as" value={comparison.screened_as ?? "Not recorded"} />
+        <Metric label="Ran as" value={comparison.ran_as} />
+        <Metric label="CM1 outcome" value={comparison.cm1_outcome} />
+      </dl>
+      {comparison.evidence.length > 0 && (
+        <p className="secondary-result-note">Evidence: {comparison.evidence.join(" · ")}</p>
+      )}
+      {comparison.caveats.length > 0 && (
+        <p className="secondary-result-note">Caveats: {comparison.caveats.join(" · ")}</p>
+      )}
+    </section>
+  );
+}
+
 function threeDScalarEncoding(field: VisualizableField | undefined): ThreeDScalarEncoding | null {
-  if (!field || !field.coordinate_names.time || !field.coordinate_names.y || !field.coordinate_names.x) {
+  if (
+    !field ||
+    !field.coordinate_names.time ||
+    !field.coordinate_names.y ||
+    !field.coordinate_names.x
+  ) {
     return null;
   }
   if (field.raw_field_name === "w" || field.canonical_field_name === "vertical_velocity") {
@@ -6197,8 +6309,7 @@ function threeDScalarEncoding(field: VisualizableField | undefined): ThreeDScala
 function isSurfaceRainField(field: VisualizableField | undefined): boolean {
   if (!field) return false;
   return (
-    field.raw_field_name === "rain" ||
-    field.canonical_field_name === "accumulated_surface_rain"
+    field.raw_field_name === "rain" || field.canonical_field_name === "accumulated_surface_rain"
   );
 }
 
@@ -6317,7 +6428,8 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
           renderableEncodings.find((encoding) => encoding.field.raw_field_name === "qc") ??
           renderableEncodings[0] ??
           null;
-        const initialSliceField = firstPreferred ?? firstRenderable?.field ?? payload.available_fields[0];
+        const initialSliceField =
+          firstPreferred ?? firstRenderable?.field ?? payload.available_fields[0];
         const initialDefaults = defaultsForField(defaults, initialSliceField?.raw_field_name);
         const initialTimeIndex = defaultTimeIndex(initialSliceField, result, initialDefaults);
         setSelectedFieldName(firstRenderable?.field.raw_field_name ?? "");
@@ -6326,7 +6438,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
         setPlaybackTimeIndex(initialTimeIndex);
         setThreshold(firstRenderable?.defaultThreshold ?? 1e-6);
         setHorizontalSliceLevel(defaultHorizontalLevel(initialSliceField, initialDefaults));
-        setVerticalSliceIndex(defaultVerticalIndex(initialSliceField, "vertical_x", initialDefaults));
+        setVerticalSliceIndex(
+          defaultVerticalIndex(initialSliceField, "vertical_x", initialDefaults),
+        );
         setSceneStatus(
           payload.available_fields.length === 0
             ? "No fields available"
@@ -6506,7 +6620,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     if (!isPlaybackRunning || !canPlayTimelapse) return undefined;
     clearSelectedRegionForTimeChange("Pause playback to select a cell and explain this time step.");
     const intervalId = window.setInterval(() => {
-      clearSelectedRegionForTimeChange("Pause playback to select a cell and explain this time step.");
+      clearSelectedRegionForTimeChange(
+        "Pause playback to select a cell and explain this time step.",
+      );
       setPlaybackTimeIndex((current) => {
         if (current >= timeMax) {
           setIsPlaybackRunning(false);
@@ -6517,7 +6633,13 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
       });
     }, playbackIntervalMs);
     return () => window.clearInterval(intervalId);
-  }, [canPlayTimelapse, clearSelectedRegionForTimeChange, isPlaybackRunning, playbackIntervalMs, timeMax]);
+  }, [
+    canPlayTimelapse,
+    clearSelectedRegionForTimeChange,
+    isPlaybackRunning,
+    playbackIntervalMs,
+    timeMax,
+  ]);
 
   useEffect(() => {
     if (!sliceSupportsVertical && activeSlicePlane !== "horizontal") {
@@ -6560,13 +6682,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
     return () => {
       active = false;
     };
-  }, [
-    maxPoints,
-    result.result_id,
-    sceneTimeIndex,
-    selectedEncoding,
-    threshold,
-  ]);
+  }, [maxPoints, result.result_id, sceneTimeIndex, selectedEncoding, threshold]);
 
   useEffect(() => {
     if (!catalog) {
@@ -6670,7 +6786,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
 
   function selectPointFromSlice(slice: SliceResponse, rowIndex: number, columnIndex: number) {
     if (isPlaybackRunning) {
-      clearSelectedRegionForTimeChange("Pause playback to select a cell and explain this time step.");
+      clearSelectedRegionForTimeChange(
+        "Pause playback to select a cell and explain this time step.",
+      );
       return;
     }
     setSelectedRegion(selectionFromSlice(slice, rowIndex, columnIndex, "point"));
@@ -6709,7 +6827,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                 ? `${selectedEncoding.field.raw_field_name} — ${selectedEncoding.field.display_name}`
                 : "No supported 3-D scalar field"
             }
-            valueChannelLabel={selectedEncoding?.valueChannel ?? "3-D scalar rendering unavailable."}
+            valueChannelLabel={
+              selectedEncoding?.valueChannel ?? "3-D scalar rendering unavailable."
+            }
             activeSlice={
               activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice
             }
@@ -6801,12 +6921,16 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                     <button
                       key={preset.label}
                       type="button"
-                      onClick={() => handleTimeIndexChange(closestTimeIndex(timeOptions, preset.seconds))}
+                      onClick={() =>
+                        handleTimeIndexChange(closestTimeIndex(timeOptions, preset.seconds))
+                      }
                     >
                       {preset.label}
                     </button>
                   ))}
-                  <button type="button" onClick={() => handleTimeIndexChange(timeMax)}>Last frame</button>
+                  <button type="button" onClick={() => handleTimeIndexChange(timeMax)}>
+                    Last frame
+                  </button>
                 </div>
                 {isPlaybackRunning && (
                   <p className="control-help">
@@ -6831,7 +6955,9 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                       setSliceFieldName(event.target.value);
                       const nextDefaults = defaultsForField(viewDefaults, event.target.value);
                       setHorizontalSliceLevel(defaultHorizontalLevel(nextField, nextDefaults));
-                      setVerticalSliceIndex(defaultVerticalIndex(nextField, sliceOrientation, nextDefaults));
+                      setVerticalSliceIndex(
+                        defaultVerticalIndex(nextField, sliceOrientation, nextDefaults),
+                      );
                       if (!nextField?.coordinate_names.vertical) {
                         setActiveSlicePlane("horizontal");
                       }
@@ -6975,8 +7101,10 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                           setActiveSlicePlane("horizontal");
                         }
                         const nextDefaults =
-                          defaultsForField(selectedTimeDefaults, nextEncoding.field.raw_field_name) ??
-                          defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
+                          defaultsForField(
+                            selectedTimeDefaults,
+                            nextEncoding.field.raw_field_name,
+                          ) ?? defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
                         setHorizontalSliceLevel(
                           defaultHorizontalLevel(nextEncoding.field, nextDefaults),
                         );
@@ -7085,10 +7213,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
             <summary>Technical visualization details</summary>
             <dl className="metric-grid">
               <Metric label="Run ID" value={result.run_id} />
-              <Metric
-                label="Renderer"
-                value="Direct Three.js point cloud"
-              />
+              <Metric label="Renderer" value="Direct Three.js point cloud" />
               <Metric
                 label="3-D field"
                 value={
@@ -7171,7 +7296,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
                     ? `${sceneHorizontalSlice.selection.orientation} at ${sceneHorizontalSlice.selection.selected_dimension}[${sceneHorizontalSlice.selection.selected_index}]`
                     : sceneVerticalSlice
                       ? `${sceneVerticalSlice.selection.orientation} at ${sceneVerticalSlice.selection.selected_dimension}[${sceneVerticalSlice.selection.selected_index}]`
-                  : "Unavailable"
+                      : "Unavailable"
                 }
               />
               <Metric label="Domain x extent" value={extentLabel(pointCloud, "xh")} />
@@ -7227,8 +7352,7 @@ function VisualizerSceneShell({ result }: { result: ResultCard }) {
               <p className="eyebrow">Slice inspector</p>
               <h2 id="unified-slice-title">Inspect the current slice</h2>
               <p>
-                {activeSliceLabel} · {sliceField.raw_field_name} ·{" "}
-                {selectedTimeLabel}
+                {activeSliceLabel} · {sliceField.raw_field_name} · {selectedTimeLabel}
               </p>
             </div>
             <p className="state-chip">
@@ -7345,7 +7469,8 @@ function slicePlainLabel(
     };
     return fallbackLabels[activeSlicePlane];
   }
-  const coordinate = slice.selection.selected_coordinate_value ?? slice.selection.level_coordinate_value;
+  const coordinate =
+    slice.selection.selected_coordinate_value ?? slice.selection.level_coordinate_value;
   const units =
     slice.selection.level_units ?? slice.coordinate_units[slice.selection.selected_dimension];
   const coordinateText = coordinateTextWithUnits(coordinate, units, slice.selection.selected_index);
@@ -7359,7 +7484,9 @@ function slicePlainLabel(
 }
 
 function sliceAxisSummary(slice: SliceResponse | null, activeSlicePlane: SceneSlicePlane): string {
-  const fixed = slice ? slicePlainLabel(slice, activeSlicePlane, slice.selection.selected_index) : "";
+  const fixed = slice
+    ? slicePlainLabel(slice, activeSlicePlane, slice.selection.selected_index)
+    : "";
   if (activeSlicePlane === "horizontal") {
     return `x-axis = x; y-axis = y${fixed ? `; ${fixed}` : ""}`;
   }
@@ -7388,7 +7515,11 @@ function selectedSliceCellValue(
 ): number | null {
   if (!slice || !selectedRegion) return null;
   for (let rowIndex = 0; rowIndex < slice.values.length; rowIndex += 1) {
-    for (let columnIndex = 0; columnIndex < (slice.values[rowIndex]?.length ?? 0); columnIndex += 1) {
+    for (
+      let columnIndex = 0;
+      columnIndex < (slice.values[rowIndex]?.length ?? 0);
+      columnIndex += 1
+    ) {
       if (isSelectedSliceCell(slice, selectedRegion, rowIndex, columnIndex)) {
         return slice.values[rowIndex]?.[columnIndex] ?? null;
       }
@@ -7641,7 +7772,13 @@ function ProcessOverlayPanel({
         </div>
         <StatusBadge
           label={processSupportLabel(summary.support)}
-          tone={summary.support === "supported" ? "good" : summary.support === "candidate" ? "neutral" : "warning"}
+          tone={
+            summary.support === "supported"
+              ? "good"
+              : summary.support === "candidate"
+                ? "neutral"
+                : "warning"
+          }
         />
       </div>
       <p>{summary.description}</p>
@@ -7763,7 +7900,9 @@ function SelectedRegionInspector({
             />
             <Metric
               label="Local rain"
-              value={diagnostics.diagnostics.local_rain_present ? "Rain detected" : "No rain detected"}
+              value={
+                diagnostics.diagnostics.local_rain_present ? "Rain detected" : "No rain detected"
+              }
             />
           </dl>
 
@@ -7772,7 +7911,10 @@ function SelectedRegionInspector({
             <dl className="metric-grid">
               <Metric label="Region type" value={humanize(diagnostics.region.region_type)} />
               <Metric label="Native grid" value={diagnostics.region.native_grid ?? "Unavailable"} />
-              <Metric label="Cell count" value={String(diagnostics.region.cell_count ?? "unknown")} />
+              <Metric
+                label="Cell count"
+                value={String(diagnostics.region.cell_count ?? "unknown")}
+              />
               <Metric label="x" value={axisSelectionLabel(diagnostics.region.x)} />
               <Metric label="y" value={axisSelectionLabel(diagnostics.region.y)} />
               <Metric label="vertical" value={axisSelectionLabel(diagnostics.region.vertical)} />
@@ -7782,7 +7924,9 @@ function SelectedRegionInspector({
               />
               <Metric
                 label="Max qc fraction"
-                value={formatRatio(diagnostics.comparison_to_domain.local_max_qc_fraction_of_domain)}
+                value={formatRatio(
+                  diagnostics.comparison_to_domain.local_max_qc_fraction_of_domain,
+                )}
               />
               <Metric
                 label="First cloud delta"
@@ -7792,7 +7936,9 @@ function SelectedRegionInspector({
               />
               <Metric
                 label="Cloud-top fraction"
-                value={formatRatio(diagnostics.comparison_to_domain.local_cloud_top_fraction_of_domain)}
+                value={formatRatio(
+                  diagnostics.comparison_to_domain.local_cloud_top_fraction_of_domain,
+                )}
               />
             </dl>
             <p>{diagnostics.provenance.provenance_label}</p>
@@ -7825,8 +7971,12 @@ function SelectedPointContext({
   selectedValue: number | null;
   diagnostics: SelectedRegionDiagnosticsResponse | null;
 }) {
-  const x = diagnostics?.region.x ? axisSelectionLabel(diagnostics.region.x) : indexOrUnavailable(selectedRegion.xIndex);
-  const y = diagnostics?.region.y ? axisSelectionLabel(diagnostics.region.y) : indexOrUnavailable(selectedRegion.yIndex);
+  const x = diagnostics?.region.x
+    ? axisSelectionLabel(diagnostics.region.x)
+    : indexOrUnavailable(selectedRegion.xIndex);
+  const y = diagnostics?.region.y
+    ? axisSelectionLabel(diagnostics.region.y)
+    : indexOrUnavailable(selectedRegion.yIndex);
   const z = diagnostics?.region.vertical
     ? axisSelectionLabel(diagnostics.region.vertical)
     : indexOrUnavailable(selectedRegion.zIndex);
@@ -7836,12 +7986,18 @@ function SelectedPointContext({
       <dl className="metric-grid">
         <Metric
           label="Slice"
-          value={slice ? slicePlainLabel(slice, slice.selection.orientation, slice.selection.selected_index) : "Unavailable"}
+          value={
+            slice
+              ? slicePlainLabel(slice, slice.selection.orientation, slice.selection.selected_index)
+              : "Unavailable"
+          }
         />
         <Metric label="Time" value={formatSeconds(slice?.selection.time_seconds ?? null)} />
         <Metric
           label="Field"
-          value={slice ? `${slice.field.raw_field_name} (${slice.field.display_name})` : "Unavailable"}
+          value={
+            slice ? `${slice.field.raw_field_name} (${slice.field.display_name})` : "Unavailable"
+          }
         />
         <Metric
           label="Selected field value"
@@ -7878,7 +8034,9 @@ function SliceHeatmap({
                 type="button"
                 className={`heatmap-cell${selected ? " heatmap-cell-selected" : ""}`}
                 key={`${title}-heatmap-${displayRowIndex}-${displayColumnIndex}`}
-                title={cell.value === null ? "missing" : formatMaybeNumber(cell.value, slice.field.units)}
+                title={
+                  cell.value === null ? "missing" : formatMaybeNumber(cell.value, slice.field.units)
+                }
                 aria-label={`Inspect ${title} row ${displayRowIndex + 1}, column ${displayColumnIndex + 1}`}
                 style={sliceCellStyle(cell.value, slice)}
                 onClick={() => onSelectRegion?.(slice, cell.sourceRowIndex, cell.sourceColumnIndex)}
@@ -8010,10 +8168,12 @@ function sliceAggregationMode(field: VisualizableField): "max" | "largest_magnit
 
 function OutcomeBadge({ result }: { result: ResultCard }) {
   const label = cloudOutcome(result);
+  const goodOutcome = label === "Cloud formed" || label === "Deep convection formed";
+  const warningOutcome = label === "No cloud formed" || label === "Deep convection not detected";
   return (
     <StatusBadge
       label={label}
-      tone={label === "Cloud formed" ? "good" : label === "No cloud formed" ? "warning" : "neutral"}
+      tone={goodOutcome ? "good" : warningOutcome ? "warning" : "neutral"}
     />
   );
 }
@@ -8385,7 +8545,8 @@ function processModeSummary(
   }
 
   if (mode === "cap") {
-    const capped = result.scenario_id.includes("capped") || result.controls.cap_strength === "stronger";
+    const capped =
+      result.scenario_id.includes("capped") || result.controls.cap_strength === "stronger";
     return {
       support: capped ? "candidate" : "insufficient_evidence",
       evidenceType: "scenario/control proxy plus cloud-top diagnostics",
@@ -8453,12 +8614,14 @@ function processModeSummary(
     cap: "",
     moisture: "Moisture / saturation diagnostics need qv/RH or saturation-deficit fields.",
     buoyancy: "Buoyancy diagnostics need thermodynamic fields and a documented buoyancy method.",
-    deep_breakthrough: "Deep-breakthrough diagnostics need CAPE/CIN/LFC/EL and sustained-updraft context.",
+    deep_breakthrough:
+      "Deep-breakthrough diagnostics need CAPE/CIN/LFC/EL and sustained-updraft context.",
     precipitation_feedback:
       "Precipitation-feedback diagnostics need rain, downdraft, cold-pool, and outflow evidence.",
   };
   return {
-    support: mode === "buoyancy" || mode === "deep_breakthrough" ? "future" : "unsupported_missing_fields",
+    support:
+      mode === "buoyancy" || mode === "deep_breakthrough" ? "future" : "unsupported_missing_fields",
     evidenceType: "unavailable diagnostic group",
     source: "Required source fields were not ingested",
     description: unavailableLabels[mode],
@@ -8873,7 +9036,10 @@ function sliceCellStyle(value: number | null, slice: SliceResponse): CSSProperti
     return { background: "rgba(255, 255, 255, 0.36)" };
   }
 
-  if (slice.field.raw_field_name === "w" || slice.field.canonical_field_name === "vertical_velocity") {
+  if (
+    slice.field.raw_field_name === "w" ||
+    slice.field.canonical_field_name === "vertical_velocity"
+  ) {
     const maxMagnitude = Math.max(
       Math.abs(slice.stats.min ?? value),
       Math.abs(slice.stats.max ?? value),
@@ -9026,7 +9192,6 @@ const DEFAULT_RESULTS_FILTERS: ResultsFilterState = {
   sort: "newest",
 };
 
-
 function prioritizeResults(results: ResultCard[]): ResultCard[] {
   return [...results].sort((left, right) => resultPriority(right) - resultPriority(left));
 }
@@ -9036,11 +9201,21 @@ function filterAndSortResults(results: ResultCard[], filters: ResultsFilterState
   return [...results]
     .filter((result) => resultMatchesSearch(result, query))
     .filter(
-      (result) => filters.scenario === "all" || resultScenarioFilterValue(result) === filters.scenario,
+      (result) =>
+        filters.scenario === "all" || resultScenarioFilterValue(result) === filters.scenario,
     )
     .filter((result) => filters.preset === "all" || result.run_size_preset === filters.preset)
-    .filter((result) => matchesBooleanFilter(cloudOutcome(result), filters.cloud, "Cloud formed", "No cloud formed"))
-    .filter((result) => matchesBooleanFilter(rainOutcome(result.rain_present), filters.rain, "Rain detected", "No rain detected"))
+    .filter((result) =>
+      matchesBooleanFilter(cloudOutcome(result), filters.cloud, "Cloud formed", "No cloud formed"),
+    )
+    .filter((result) =>
+      matchesBooleanFilter(
+        rainOutcome(result.rain_present),
+        filters.rain,
+        "Rain detected",
+        "No rain detected",
+      ),
+    )
     .sort((left, right) => compareResults(left, right, filters.sort));
 }
 
@@ -9051,7 +9226,10 @@ function resultsFiltersActive(filters: ResultsFilterState): boolean {
 function resultScenarioOptions(results: ResultCard[]): Array<{ value: string; label: string }> {
   const seen = new Map<string, string>();
   for (const result of results) {
-    seen.set(resultScenarioFilterValue(result), result.scenario_name ?? humanize(result.scenario_id));
+    seen.set(
+      resultScenarioFilterValue(result),
+      result.scenario_name ?? humanize(result.scenario_id),
+    );
   }
   return [...seen.entries()]
     .map(([value, label]) => ({ value, label }))
@@ -9110,17 +9288,27 @@ function compareResults(left: ResultCard, right: ResultCard, sort: ResultsSortKe
   if (sort === "oldest") return dateSortValue(left) - dateSortValue(right);
   if (sort === "name") return left.name.localeCompare(right.name);
   if (sort === "scenario") {
-    return (left.scenario_name ?? left.scenario_id).localeCompare(right.scenario_name ?? right.scenario_id);
+    return (left.scenario_name ?? left.scenario_id).localeCompare(
+      right.scenario_name ?? right.scenario_id,
+    );
   }
-  if (sort === "first_cloud") return nullableNumberSort(resultFirstCloudTime(left), resultFirstCloudTime(right), "asc");
+  if (sort === "first_cloud")
+    return nullableNumberSort(resultFirstCloudTime(left), resultFirstCloudTime(right), "asc");
   if (sort === "max_qc") return nullableNumberSort(resultMaxQc(left), resultMaxQc(right), "desc");
-  if (sort === "max_updraft") return nullableNumberSort(resultMaxUpdraft(left), resultMaxUpdraft(right), "desc");
-  if (sort === "rain_onset") return nullableNumberSort(resultRainOnsetTime(left), resultRainOnsetTime(right), "asc");
-  if (sort === "latest_output") return nullableNumberSort(resultLatestOutputTime(left), resultLatestOutputTime(right), "desc");
+  if (sort === "max_updraft")
+    return nullableNumberSort(resultMaxUpdraft(left), resultMaxUpdraft(right), "desc");
+  if (sort === "rain_onset")
+    return nullableNumberSort(resultRainOnsetTime(left), resultRainOnsetTime(right), "asc");
+  if (sort === "latest_output")
+    return nullableNumberSort(resultLatestOutputTime(left), resultLatestOutputTime(right), "desc");
   return dateSortValue(right) - dateSortValue(left);
 }
 
-function nullableNumberSort(left: number | null, right: number | null, direction: "asc" | "desc"): number {
+function nullableNumberSort(
+  left: number | null,
+  right: number | null,
+  direction: "asc" | "desc",
+): number {
   if (left === null && right === null) return 0;
   if (left === null) return 1;
   if (right === null) return -1;
@@ -9207,6 +9395,16 @@ function comparisonMeaning(result: ResultCard | undefined): string {
 }
 
 function resultStory(result: ResultCard): string {
+  if (isDeepConvectionTrial(result)) {
+    const comparison = result.candidate_hypothesis_comparison;
+    if (comparison) {
+      return `${comparison.cm1_outcome} Candidate hypothesis ${comparison.match_status_label.toLowerCase()}.`;
+    }
+    return (
+      result.science_summary?.cm1_outcome ??
+      "Deep Convection Trial result is ready for field inspection."
+    );
+  }
   if (isDryFailedContrast(result)) {
     return "Thermals rose, but low-level moisture stayed too dry for meaningful cloud water or rain.";
   }
@@ -9223,11 +9421,34 @@ function resultStory(result: ResultCard): string {
 }
 
 function compactScienceSummary(result: ResultCard): string {
+  if (isDeepConvectionTrial(result)) {
+    const parts = [
+      deepConvectionOutcome(result),
+      resultMaxUpdraft(result) !== null
+        ? `max updraft ${formatNumber(resultMaxUpdraft(result), "m/s")}`
+        : null,
+      resultRainOnsetTime(result) !== null
+        ? `rain onset ${formatSeconds(resultRainOnsetTime(result))}`
+        : null,
+      resultCloudTopMeters(result) !== null
+        ? `cloud top ${formatNumber(resultCloudTopMeters(result), "m")}`
+        : null,
+    ].filter(Boolean);
+    return parts.join(" · ");
+  }
   const parts = [
-    resultFirstCloudTime(result) !== null ? `first cloud ${formatSeconds(resultFirstCloudTime(result))}` : null,
-    resultMaxQc(result) !== null ? `max qc ${formatScientific(resultMaxQc(result), "kg/kg")}` : null,
-    resultMaxUpdraft(result) !== null ? `max updraft ${formatNumber(resultMaxUpdraft(result), "m/s")}` : null,
-    resultRainOnsetTime(result) !== null ? `rain onset ${formatSeconds(resultRainOnsetTime(result))}` : null,
+    resultFirstCloudTime(result) !== null
+      ? `first cloud ${formatSeconds(resultFirstCloudTime(result))}`
+      : null,
+    resultMaxQc(result) !== null
+      ? `max qc ${formatScientific(resultMaxQc(result), "kg/kg")}`
+      : null,
+    resultMaxUpdraft(result) !== null
+      ? `max updraft ${formatNumber(resultMaxUpdraft(result), "m/s")}`
+      : null,
+    resultRainOnsetTime(result) !== null
+      ? `rain onset ${formatSeconds(resultRainOnsetTime(result))}`
+      : null,
   ].filter(Boolean);
   return parts.length > 0 ? parts.join(" · ") : "Science summary unavailable";
 }
@@ -9253,7 +9474,10 @@ function resultRainOnsetTime(result: ResultCard): number | null {
 }
 
 function resultLatestOutputTime(result: ResultCard): number | null {
-  return result.science_summary?.latest_output_time_seconds ?? result.output_file_summary.last_output_time_seconds;
+  return (
+    result.science_summary?.latest_output_time_seconds ??
+    result.output_file_summary.last_output_time_seconds
+  );
 }
 
 function resultCloudTopMeters(result: ResultCard): number | null {
@@ -9274,6 +9498,7 @@ function legacyCloudTopWasStoredInKilometers(result: ResultCard): boolean {
 
 function visibleInterestingTimes(result: ResultCard): InterestingTimeRecord[] {
   const priority = [
+    "first_deep_convection",
     "first_cloud",
     "max_qc",
     "highest_cloud_top",
@@ -9288,7 +9513,9 @@ function visibleInterestingTimes(result: ResultCard): InterestingTimeRecord[] {
   return priority
     .map((key) => byKey.get(key))
     .filter((record): record is InterestingTimeRecord => Boolean(record))
-    .filter((record) => record.support_state === "supported" || record.support_state === "fallback");
+    .filter(
+      (record) => record.support_state === "supported" || record.support_state === "fallback",
+    );
 }
 
 function interestingTimePrimaryValue(record: InterestingTimeRecord, result: ResultCard): string {
@@ -9324,7 +9551,9 @@ function resultInputSource(result: ResultCard): "generated_reference" | "observe
 
 function resultInputSourceLabel(result: ResultCard): string {
   if (result.input_source_label) return result.input_source_label;
-  return resultInputSource(result) === "observed_sounding" ? "Observed sounding" : "Generated reference";
+  return resultInputSource(result) === "observed_sounding"
+    ? "Observed sounding"
+    : "Generated reference";
 }
 
 function scienceSupportLabel(result: ResultCard): string {
@@ -9333,6 +9562,23 @@ function scienceSupportLabel(result: ResultCard): string {
   if (state === "supported") return "Interesting times supported";
   if (state === "fallback") return "Interesting-time fallback";
   return "Interesting times limited";
+}
+
+function isDeepConvectionTrial(result: ResultCard): boolean {
+  return result.package_family === "deep_convection_trial";
+}
+
+function deepConvectionOutcome(result: ResultCard): string {
+  const formed = result.science_summary?.deep_cloud_formed;
+  if (formed === true) return "Deep convection formed";
+  if (formed === false) return "Deep convection not detected";
+  return "Deep convection unknown";
+}
+
+function candidateMatchTone(matchStatus: string): "good" | "warning" | "neutral" {
+  if (matchStatus === "matched") return "good";
+  if (matchStatus === "did_not_match" || matchStatus === "unable_to_evaluate") return "warning";
+  return "neutral";
 }
 
 function userFacingStatus(result: ResultCard): string {
@@ -9357,6 +9603,7 @@ function caveatTone(result: ResultCard): "good" | "warning" | "neutral" {
 }
 
 function cloudOutcome(result: ResultCard): string {
+  if (isDeepConvectionTrial(result)) return deepConvectionOutcome(result);
   if (!result.diagnostics_summary) return "Unknown";
   return result.diagnostics_summary.includes("cloud formed") &&
     !result.diagnostics_summary.includes("no cloud formed")
@@ -9378,10 +9625,7 @@ function outputSummary(summary: OutputFileSummary): string {
       : safeSummary.netcdf_count !== undefined
         ? `${safeSummary.netcdf_count} NetCDF files`
         : "unknown output files";
-  const parts = [
-    outputFileLabel,
-    `${safeSummary.time_steps ?? "unknown"} time steps`,
-  ];
+  const parts = [outputFileLabel, `${safeSummary.time_steps ?? "unknown"} time steps`];
   if ((safeSummary.stats_netcdf_count ?? 0) > 0) {
     parts.push(`${safeSummary.stats_netcdf_count} stats files`);
   }
@@ -9392,11 +9636,15 @@ function outputSummary(summary: OutputFileSummary): string {
 }
 
 function storageDisplayName(run: RunStorageEntry, result: ResultCard | undefined): string {
-  return result?.name ?? run.scenario_name ?? (run.scenario_id ? humanize(run.scenario_id) : run.run_id);
+  return (
+    result?.name ?? run.scenario_name ?? (run.scenario_id ? humanize(run.scenario_id) : run.run_id)
+  );
 }
 
 function storageScenarioName(run: RunStorageEntry, result: ResultCard | undefined): string {
-  return result?.scenario_name ?? run.scenario_name ?? humanize(run.scenario_id ?? "unknown scenario");
+  return (
+    result?.scenario_name ?? run.scenario_name ?? humanize(run.scenario_id ?? "unknown scenario")
+  );
 }
 
 function storageScenarioSummary(run: RunStorageEntry, result: ResultCard | undefined): string {
@@ -9420,9 +9668,7 @@ function storageStateBadges(
   result: ResultCard | undefined,
 ): Array<{ label: string; tone: "good" | "warning" | "neutral" }> {
   if (result) {
-    return [
-      { label: "Ingested / ready to review", tone: "good" },
-    ];
+    return [{ label: "Ingested / ready to review", tone: "good" }];
   }
   const primary: Record<string, { label: string; tone: "good" | "warning" | "neutral" }> = {
     dry_run_only: { label: "Ready-to-run package", tone: "neutral" },
@@ -9445,8 +9691,10 @@ function storageNextStep(run: RunStorageEntry, result: ResultCard | undefined): 
   if (result) {
     return "Review in Results or Explore, or preview deletion here if you want to remove the result and local run data.";
   }
-  if (run.category === "dry_run_only") return "Package is generated and can be launched from Build.";
-  if (run.category === "running") return "CM1 is active or queued; cleanup is blocked until it stops.";
+  if (run.category === "dry_run_only")
+    return "Package is generated and can be launched from Build.";
+  if (run.category === "running")
+    return "CM1 is active or queued; cleanup is blocked until it stops.";
   if (run.category === "completed_with_output") {
     return "Output exists; ingest to create a notebook result before deciding cleanup.";
   }

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -261,6 +261,18 @@ support states such as `unavailable`, `unsupported_missing_fields`, and
 `unsupported_missing_diagnostic` rather than silently falling back to a
 misleading cloud/rain landmark.
 
+Deep Convection Trial results extend the same product with backend-owned
+summary fields for deep-cloud formation, first deep-convection time, strong
+updraft detection, cloud top, rain onset, max `qr`, and the default Explore
+time. Unsupported severe-storm diagnostics such as reflectivity maxima,
+surface-rain maxima, updraft-depth proxy, cold-pool proxy, and near-surface
+theta perturbation proxy must be recorded as unavailable or caveated until a
+supported backend diagnostic exists. When candidate-screening metadata is
+present, result metadata may include a compact `candidate_hypothesis_comparison`
+with `Screened as`, `Ran as`, `CM1 outcome`, match state, evidence, and caveats.
+The comparison uses simple v1 rules and remains a post-run interpretation of
+CM1 output, not proof that the observed sounding was validated in advance.
+
 ## Field Catalog Products
 
 The field catalog answers:


### PR DESCRIPTION
Summary:
- Added Deep Convection Trial science-summary fields for deep cloud formation, first deep-convection time, strong updraft detection, cloud top, rain onset, and honest unavailable states for unsupported reflectivity/surface-rain/cold-pool/theta/updraft-depth diagnostics.
- Preserved candidate_screening through ingest and Result Cards, with a compact candidate-vs-CM1 outcome comparison for Results and Explore.
- Made Deep Convection Trial Explore defaults prefer updraft inspection when w is available, while preserving shallow-cumulus defaults.

Verification:
- app/backend/.venv/bin/python -m pytest app/backend/tests/test_output_products.py app/backend/tests/test_result_ingest.py app/backend/tests/test_result_cards.py app/backend/tests/test_visualization_data.py
- npm test -- App.test.tsx
- scripts/check.sh
- scripts/check-e2e.sh

Notes:
- No CM1 execution is added to CI.
- Missing reflectivity, surface-rain, cold-pool, theta-perturbation, and updraft-depth diagnostics are reported as unavailable/caveated rather than inferred.

Closes #262