### PR TITLE
Fix candidate routing and Explore visibility trust

### DIFF
--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -624,6 +624,17 @@ def _score_features(
     cin_score = _score_low(abs(effective_cin), low=25.0, high=250.0)
     low_lfc = _score_low(lfc, low=750.0, high=3000.0)
     deep_el = _score_high(el, low=7000.0, high=12000.0)
+    initiation_support = _weighted_score(
+        [
+            (_score_high(effective_cape, low=250.0, high=1000.0), 0.50),
+            (low_lcl, 0.25),
+            (storm_moisture, 0.15),
+            (deep_moisture, 0.05),
+            (not_strong_cap, 0.05),
+        ]
+    )
+    if initiation_support < 45.0:
+        deep_caveats.append("weak_deep_initiation_screen_for_deep_convection_trial")
     instability = _weighted_score(
         [
             (cape_score, 0.55),
@@ -747,7 +758,12 @@ def _score_features(
     # multiplier: many observed soundings provide useful CAPE/shear evidence
     # while EL remains unavailable from the simple screening diagnostics.
     deep_factor = (
-        data_quality / 100.0 * deep_feature_coverage * wind_factor * surface_coverage_factor
+        data_quality
+        / 100.0
+        * deep_feature_coverage
+        * wind_factor
+        * surface_coverage_factor
+        * (0.30 + 0.70 * initiation_support / 100.0)
     )
     shallow_score = shallow * data_quality / 100.0 * feature_coverage
     humid_score = humid_rainy * data_quality / 100.0 * feature_coverage

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -361,7 +361,7 @@ def _metadata_field_view_defaults(
     *,
     selected_time_index: int | None,
 ) -> FieldViewDefaults:
-    time_size = _dimension_size(field, field.coordinate_names.time, fallback=1)
+    time_size = _metadata_time_size(metadata, field)
     vertical_size = _dimension_size(field, field.coordinate_names.vertical, fallback=1)
     y_size = _dimension_size(field, field.coordinate_names.y, fallback=1)
     x_size = _dimension_size(field, field.coordinate_names.x, fallback=1)
@@ -374,7 +374,7 @@ def _metadata_field_view_defaults(
         field=field.raw_field_name,
         time_index=resolved_time,
         time_seconds=_metadata_time_seconds(metadata, resolved_time),
-        horizontal_level_index=max(0, vertical_size // 2),
+        horizontal_level_index=_metadata_horizontal_level_index(metadata, field, vertical_size),
         vertical_x_index=max(0, y_size // 2),
         vertical_y_index=max(0, x_size // 2),
         source=(
@@ -391,9 +391,19 @@ def _metadata_field_view_defaults(
             [
                 *_field_caveats(field.raw_field_name, field.coordinate_names),
                 "default_location_uses_ingested_metadata_not_full_field_scan",
-                "default_location_fell_back_to_domain_center",
+                *_metadata_default_location_caveats(metadata, field.raw_field_name),
             ]
         ),
+    )
+
+
+def _metadata_time_size(metadata: ResultMetadata, field: VisualizableField) -> int:
+    return max(
+        1,
+        _dimension_size(field, field.coordinate_names.time, fallback=1),
+        len(field.time_coordinate_values),
+        metadata.time_steps or 0,
+        len(metadata.model_output_paths),
     )
 
 
@@ -404,6 +414,72 @@ def _dimension_size(field: VisualizableField, dimension: str | None, *, fallback
         if field_dimension == dimension and index < len(field.shape):
             return int(field.shape[index])
     return fallback
+
+
+def _metadata_horizontal_level_index(
+    metadata: ResultMetadata,
+    field: VisualizableField,
+    vertical_size: int,
+) -> int:
+    if vertical_size <= 1:
+        return 0
+    if field.raw_field_name not in {"qc", "qr", "dbz"} or metadata.diagnostics is None:
+        return max(0, vertical_size // 2)
+
+    target_height_m = _metadata_cloud_focus_height_m(metadata, field.raw_field_name)
+    if target_height_m is None:
+        return max(0, vertical_size // 2)
+
+    # Metadata-only defaults intentionally avoid opening large output sequences.
+    # CM1 deep-trial files currently expose 500 m-ish scalar levels; this maps
+    # shallow cloud-water metadata away from the domain midpoint without
+    # pretending we know the exact native coordinate.
+    estimated_index = math.ceil(max(0.0, target_height_m) / 500.0) - 1
+    return max(0, min(vertical_size - 1, estimated_index))
+
+
+def _metadata_cloud_focus_height_m(metadata: ResultMetadata, field_name: str) -> float | None:
+    diagnostics = metadata.diagnostics
+    if diagnostics is None or field_name not in {"qc", "qr", "dbz"}:
+        return None
+    if field_name == "qc" and diagnostics.cloud.time_of_max_qc_seconds is not None:
+        height = _time_value_at(
+            diagnostics.cloud.max_qc_height_time_series,
+            diagnostics.cloud.time_of_max_qc_seconds,
+        )
+        if height is not None:
+            return height
+    return diagnostics.cloud.cloud_top_m
+
+
+def _time_value_at(series: list[Any], target_seconds: float) -> float | None:
+    closest: tuple[float, float] | None = None
+    for point in series:
+        value = getattr(point, "value", None)
+        seconds = getattr(point, "time_seconds", None)
+        if value is None or seconds is None:
+            continue
+        try:
+            numeric_value = float(value)
+            numeric_seconds = float(seconds)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(numeric_value) or not math.isfinite(numeric_seconds):
+            continue
+        distance = abs(numeric_seconds - target_seconds)
+        if closest is None or distance < closest[0]:
+            closest = (distance, numeric_value)
+    return closest[1] if closest is not None else None
+
+
+def _metadata_default_location_caveats(
+    metadata: ResultMetadata,
+    field_name: str,
+) -> list[str]:
+    caveats = ["default_location_fell_back_to_domain_center"]
+    if field_name in {"qc", "qr", "dbz"} and _metadata_cloud_focus_height_m(metadata, field_name):
+        caveats.append("default_vertical_level_uses_ingested_cloud_height_estimate")
+    return caveats
 
 
 def _metadata_interesting_time_index(

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -494,6 +494,50 @@ def test_deep_convection_scoring_does_not_require_el_when_cape_and_shear_are_sup
     )
 
 
+def test_deep_convection_scoring_does_not_overpromote_low_cape_humid_profiles() -> None:
+    scores, _evidence = _score_features(
+        {
+            "data_completeness_score": 98.0,
+            "low_level_qv_g_kg": 18.0,
+            "mean_qv_0_500m_g_kg": 18.0,
+            "mean_qv_0_1000m_g_kg": 17.0,
+            "mean_qv_0_3000m_g_kg": 16.0,
+            "precipitable_water_proxy_or_unavailable": 45.0,
+            "surface_t_td_spread_c": 2.0,
+            "estimated_lcl_height_m_agl": 300.0,
+            "lapse_rate_0_1000m_c_per_km": 6.5,
+            "lapse_rate_0_3000m_c_per_km": 7.0,
+            "midlevel_lapse_rate_700_500_hpa_c_per_km": 7.0,
+            "cap_strength_proxy": 0.0,
+            "cap_height_m_agl": None,
+            "moisture_depth_m": 4000.0,
+            "midlevel_dry_layer_proxy": 3.0,
+            "qv_drop_0_3000m_g_kg": 3.0,
+            "observed_wind_available": True,
+            "bulk_shear_0_1km_m_s": 7.0,
+            "bulk_shear_0_3km_m_s": 15.0,
+            "bulk_shear_0_6km_m_s": 28.0,
+            "dry_microburst_inverted_v_proxy": 15.0,
+            "freezing_level_m_agl": 4200.0,
+            "surface_based_cape_j_kg": 120.0,
+            "mixed_layer_cape_j_kg": 80.0,
+            "surface_based_cin_j_kg": 0.0,
+            "mixed_layer_cin_j_kg": 0.0,
+            "lfc_height_m_agl": 0.0,
+            "el_height_m_agl": 12500.0,
+            "profile_top_m_agl": 18000.0,
+            "lowest_level_m_agl": 0.0,
+        },
+        package_ready=True,
+    )
+
+    score_by_story = {score.story: score for score in scores}
+    assert scores[0].story == "humid_rainy_candidate"
+    assert score_by_story["humid_rainy_candidate"].support == "supported"
+    assert score_by_story["severe_thunderstorm_environment"].support == "weak"
+    assert score_by_story["high_cape_pulse_storm"].support == "weak"
+
+
 def test_deep_convection_scoring_penalizes_profiles_that_start_well_above_surface() -> None:
     scores, _evidence = _score_features(
         {

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -327,6 +327,22 @@ def test_multifile_point_cloud_reads_requested_output_time_without_combining_all
     assert cloud.stats.max_value == pytest.approx(3e-5)
 
 
+def test_metadata_defaults_use_multifile_interesting_time_for_large_results(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, _run_dir = create_multifile_visualization_result(
+        tmp_path,
+        file_count=10,
+    )
+
+    defaults = view_defaults(settings, result_id)
+
+    assert defaults.provenance.processing_method == "ingested_result_metadata_view_defaults"
+    assert defaults.fields["qc"].time_index == 9
+    assert defaults.fields["qc"].time_seconds == 5400.0
+    assert defaults.fields["qc"].horizontal_level_index == 0
+
+
 def test_horizontal_qc_slice_uses_json_values_and_counts_non_finite(
     tmp_path: Path,
 ) -> None:

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -360,6 +360,12 @@ const secondaryShallowCandidate = {
       score_0_to_100: 61,
       support: "weak",
     },
+    {
+      story: "high_cape_pulse_storm",
+      label: "High-CAPE pulse storm",
+      score_0_to_100: 48.9,
+      support: "weak",
+    },
   ],
   features: {
     ...shallowCandidate.features,
@@ -2521,6 +2527,50 @@ describe("App", () => {
       expect(dryRunBody).toContain('"candidate_screening"');
       expect(dryRunBody).toContain('"primary_story":"supercell_environment"');
       expect(dryRunBody).toContain('"candidate_id":"USM00072357-2025052000-supercell"');
+    });
+  });
+
+  it("keeps humid/rainy candidates with weak deep scores on observed quick-look", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let dryRunBody = "";
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/dry-run-package") {
+        dryRunBody = String(init?.body ?? "");
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+    fireEvent.change(await screen.findByLabelText("Story filter"), {
+      target: { value: "humid_rainy_candidate" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Screen cached soundings" }));
+
+    expect(await screen.findByText("Screening guidance loaded")).toBeInTheDocument();
+    const humidCard = screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)");
+    expect(humidCard).toHaveTextContent("Humid / rainy");
+
+    fireEvent.click(within(humidCard).getByRole("button", { name: "Use this sounding" }));
+
+    expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
+    expect(screen.getByLabelText("Package type")).toHaveValue("observed_sounding_quicklook");
+
+    fireEvent.click(screen.getByTestId("create-package-btn"));
+
+    await waitFor(() => {
+      expect(dryRunBody).toContain('"package_family":"observed_sounding_quicklook"');
+      expect(dryRunBody).toContain('"primary_story":"humid_rainy_candidate"');
+      expect(dryRunBody).toContain(
+        '"candidate_id":"USM00072426-2025010300-humid-secondary-shallow"',
+      );
     });
   });
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -8215,10 +8215,7 @@ function defaultPackageFamilyForCandidate(candidate: SoundingCandidate): Observe
   if (deepConvectionStoryIds.has(candidate.primary_story)) return "deep_convection_trial";
   if (
     candidate.story_scores.some(
-      (score) =>
-        deepConvectionStoryIds.has(score.story) &&
-        score.score_0_to_100 > 0 &&
-        !["unavailable", "unsupported", "insufficient_evidence"].includes(score.support),
+      (score) => deepConvectionStoryIds.has(score.story) && score.support === "supported",
     )
   ) {
     return "deep_convection_trial";

--- a/app/frontend/src/True3DViewer.test.tsx
+++ b/app/frontend/src/True3DViewer.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { cameraDistanceLimits, scalarPointPixelSize } from "./True3DViewer.utils";
+
+describe("True3DViewer scalar point sizing", () => {
+  it("uses the UI point-size value as a bounded screen-pixel size", () => {
+    expect(scalarPointPixelSize(11)).toBe(11);
+    expect(scalarPointPixelSize(3)).toBe(3);
+    expect(scalarPointPixelSize(18)).toBe(18);
+    expect(scalarPointPixelSize(0)).toBe(3);
+    expect(scalarPointPixelSize(42)).toBe(18);
+    expect(scalarPointPixelSize(Number.NaN)).toBe(11);
+  });
+});
+
+describe("True3DViewer camera limits", () => {
+  it("scales orbit distance for large deep-convection domains", () => {
+    expect(cameraDistanceLimits(6.4)).toEqual({ minDistance: 1.5, maxDistance: 40 });
+    const largeDomainLimits = cameraDistanceLimits(120);
+    expect(largeDomainLimits.minDistance).toBeCloseTo(1.8);
+    expect(largeDomainLimits.maxDistance).toBe(360);
+  });
+});

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
+import { cameraDistanceLimits, scalarPointPixelSize } from "./True3DViewer.utils";
+
 type CoordinateExtent = { min: number; max: number; units: string | null };
 
 type ProvenancePayload = {
@@ -158,10 +160,13 @@ export function True3DViewer({
     setCameraStatus("Camera reset to shallow-cumulus overview");
   }, [bounds]);
 
-  const setCameraPreset = useCallback((preset: CameraPreset) => {
-    applyCameraPreset(preset, refs.current, bounds);
-    setCameraStatus(cameraPresetStatus(preset));
-  }, [bounds]);
+  const setCameraPreset = useCallback(
+    (preset: CameraPreset) => {
+      applyCameraPreset(preset, refs.current, bounds);
+      setCameraStatus(cameraPresetStatus(preset));
+    },
+    [bounds],
+  );
 
   const zoomCamera = useCallback((direction: "in" | "out") => {
     setCameraStatus(direction === "in" ? "Camera zoomed in" : "Camera zoomed out");
@@ -195,8 +200,9 @@ export function True3DViewer({
       controls.enableDamping = true;
       controls.dampingFactor = 0.08;
       controls.screenSpacePanning = true;
-      controls.minDistance = 1.5;
-      controls.maxDistance = 40;
+      const distanceLimits = cameraDistanceLimits(bounds.maxRange);
+      controls.minDistance = distanceLimits.minDistance;
+      controls.maxDistance = distanceLimits.maxDistance;
       controls.mouseButtons = {
         LEFT: THREE.MOUSE.ROTATE,
         MIDDLE: THREE.MOUSE.DOLLY,
@@ -481,7 +487,11 @@ function sceneBoundsFromSignature(signature: string): SceneBounds {
 function domainBox(bounds: SceneBounds): THREE.Object3D {
   const geometry = new THREE.BoxGeometry(bounds.xRange, bounds.zRange, bounds.yRange);
   const edges = new THREE.EdgesGeometry(geometry);
-  const material = new THREE.LineBasicMaterial({ color: 0x3f6f85, transparent: true, opacity: 0.75 });
+  const material = new THREE.LineBasicMaterial({
+    color: 0x3f6f85,
+    transparent: true,
+    opacity: 0.75,
+  });
   return new THREE.LineSegments(edges, material);
 }
 
@@ -514,7 +524,9 @@ function domainFloorGrid(bounds: SceneBounds): THREE.Group {
       new THREE.Vector3(x, floor, yMin),
       new THREE.Vector3(x, floor, yMax),
     ]);
-    group.add(new THREE.Line(geometry, gridLineMaterial(value, minorMaterial, majorMaterial, zeroMaterial)));
+    group.add(
+      new THREE.Line(geometry, gridLineMaterial(value, minorMaterial, majorMaterial, zeroMaterial)),
+    );
   }
 
   for (const value of gridTickValues(bounds.y, 0.5)) {
@@ -523,7 +535,9 @@ function domainFloorGrid(bounds: SceneBounds): THREE.Group {
       new THREE.Vector3(xMin, floor, y),
       new THREE.Vector3(xMax, floor, y),
     ]);
-    group.add(new THREE.Line(geometry, gridLineMaterial(value, minorMaterial, majorMaterial, zeroMaterial)));
+    group.add(
+      new THREE.Line(geometry, gridLineMaterial(value, minorMaterial, majorMaterial, zeroMaterial)),
+    );
   }
 
   return group;
@@ -556,15 +570,33 @@ function axisTickMarks(bounds: SceneBounds): THREE.Group {
 
   for (const value of majorTickValues(bounds.x)) {
     const x = centeredCoordinate(value, bounds.x);
-    group.add(axisLine(new THREE.Vector3(x, floor, yMin), new THREE.Vector3(x, floor, yMin - tickLength), 0x2f7fb5));
+    group.add(
+      axisLine(
+        new THREE.Vector3(x, floor, yMin),
+        new THREE.Vector3(x, floor, yMin - tickLength),
+        0x2f7fb5,
+      ),
+    );
   }
   for (const value of majorTickValues(bounds.y)) {
     const y = centeredCoordinate(value, bounds.y);
-    group.add(axisLine(new THREE.Vector3(xMin, floor, y), new THREE.Vector3(xMin - tickLength, floor, y), 0x4f8f7a));
+    group.add(
+      axisLine(
+        new THREE.Vector3(xMin, floor, y),
+        new THREE.Vector3(xMin - tickLength, floor, y),
+        0x4f8f7a,
+      ),
+    );
   }
   for (const value of majorTickValues(bounds.z)) {
     const z = centeredCoordinate(value, bounds.z);
-    group.add(axisLine(new THREE.Vector3(xMin, z, yMin), new THREE.Vector3(xMin - tickLength, z, yMin), 0xa76f24));
+    group.add(
+      axisLine(
+        new THREE.Vector3(xMin, z, yMin),
+        new THREE.Vector3(xMin - tickLength, z, yMin),
+        0xa76f24,
+      ),
+    );
   }
   return group;
 }
@@ -659,14 +691,17 @@ function cloudPointLayer(
   geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
   geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
   const material = new THREE.PointsMaterial({
-    size: Math.max(0.035, pointSize * 0.008),
+    size: scalarPointPixelSize(pointSize),
     vertexColors: true,
     transparent: true,
     opacity,
     depthWrite: false,
-    sizeAttenuation: true,
+    sizeAttenuation: false,
   });
-  return new THREE.Points(geometry, material);
+  const layer = new THREE.Points(geometry, material);
+  layer.name = "CM1 scalar point cloud";
+  layer.renderOrder = 20;
+  return layer;
 }
 
 function scalarPointColor(
@@ -923,7 +958,8 @@ function centeredCoordinate(value: number, extent: CoordinateExtent): number {
 }
 
 function sliceCoordinate(slice: SliceResponse): number {
-  const coordinate = slice.selection.selected_coordinate_value ?? slice.selection.level_coordinate_value;
+  const coordinate =
+    slice.selection.selected_coordinate_value ?? slice.selection.level_coordinate_value;
   const numeric = typeof coordinate === "number" ? coordinate : Number(coordinate);
   return Number.isFinite(numeric) ? numeric : 0;
 }
@@ -969,7 +1005,9 @@ function roundTick(value: number): number {
 
 function labeledTickValues(extent: CoordinateExtent): number[] {
   const ticks = majorTickValues(extent);
-  return ticks.filter((value) => value === 0 || Math.abs(value) === Math.max(...ticks.map(Math.abs)));
+  return ticks.filter(
+    (value) => value === 0 || Math.abs(value) === Math.max(...ticks.map(Math.abs)),
+  );
 }
 
 function normalize(value: number, min: number, max: number): number {

--- a/app/frontend/src/True3DViewer.utils.ts
+++ b/app/frontend/src/True3DViewer.utils.ts
@@ -1,0 +1,20 @@
+const DEFAULT_SCALAR_POINT_PIXEL_SIZE = 11;
+const MIN_SCALAR_POINT_PIXEL_SIZE = 3;
+const MAX_SCALAR_POINT_PIXEL_SIZE = 18;
+const DEFAULT_MAX_RANGE = 6.4;
+
+export function scalarPointPixelSize(pointSize: number): number {
+  const resolved = Number.isFinite(pointSize) ? pointSize : DEFAULT_SCALAR_POINT_PIXEL_SIZE;
+  return Math.min(MAX_SCALAR_POINT_PIXEL_SIZE, Math.max(MIN_SCALAR_POINT_PIXEL_SIZE, resolved));
+}
+
+export function cameraDistanceLimits(maxRange: number): {
+  minDistance: number;
+  maxDistance: number;
+} {
+  const resolvedMaxRange = Number.isFinite(maxRange) && maxRange > 0 ? maxRange : DEFAULT_MAX_RANGE;
+  return {
+    minDistance: Math.max(1.5, resolvedMaxRange * 0.015),
+    maxDistance: Math.max(40, resolvedMaxRange * 3),
+  };
+}


### PR DESCRIPTION
## Summary

- Kept humid/rainy or shallow observed candidates on observed quick-look unless the primary story is deep-convection or a deep story is explicitly supported.
- Softened deep-convection scoring for low-CAPE humid profiles so weak initiation evidence does not look like a high-confidence deep-trial recommendation.
- Fixed Explore defaults/rendering for large multi-file results so cloud-water frames open at the interesting time/height, sparse cloud-water points are visible, and large Deep Convection Trial domains allow the camera outside the box.

## Root Cause

Wilmington, OH (`USM00072426`) screened as `humid_rainy_candidate` with a 100 score, but the frontend package-family default treated any weak deep-story overlap as enough to select `deep_convection_trial`. That baked the large Deep Convection Trial domain and trigger into the package. Existing results should not be relabeled after the fact; rerun from a newly generated observed quick-look package for the intended humid/rainy experiment.

The Springfield Explore confusion had two separate pieces: metadata-only defaults could land on a non-cloud frame/height for multi-file results, and Three.js points were using attenuated world-unit sizing even though the UI labels the control in pixels.

## Verification

- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_visualization_data.py app/backend/tests/test_sounding_candidates.py`
- `npm run lint && npm test -- App.test.tsx True3DViewer.test.tsx && npm run build`
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Notes

- No generated CM1 outputs, NetCDF files, runtime directories, logs, screenshots, local settings, or SSH config are included.
- Local shallow-cumulus CM1 run observed during this fix: `dry-run-669061b4eca8` remained active and producing output files; it was not modified by this PR.
