### PR TITLE
Move ingested-result cleanup into Results

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -47,6 +47,7 @@ from cloud_chamber.result_ingest import (
 from cloud_chamber.run_manifest import RunManifestError, load_run_manifest
 from cloud_chamber.runtime_storage import (
     RuntimeStorageError,
+    delete_ingested_result,
     delete_runtime_run,
     runtime_storage_inventory,
 )
@@ -123,6 +124,10 @@ class DeleteRunRequest(BaseModel):
     dry_run: bool = True
     confirm: bool = False
     force_saved: bool = False
+
+
+class DeleteResultRequest(BaseModel):
+    confirm: bool = False
 
 
 class IngestResultRequest(BaseModel):
@@ -438,6 +443,38 @@ def get_result(result_id: str) -> dict[str, object]:
         result = get_result_card(load_settings(), result_id)
     except ResultIngestError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.post("/api/results/{result_id}/delete-preview")
+def preview_result_delete(result_id: str) -> dict[str, object]:
+    try:
+        result = delete_ingested_result(
+            load_settings(),
+            result_id=result_id,
+            dry_run=True,
+            confirm=False,
+        )
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeStorageError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.post("/api/results/{result_id}/delete")
+def delete_result(result_id: str, request: DeleteResultRequest) -> dict[str, object]:
+    try:
+        result = delete_ingested_result(
+            load_settings(),
+            result_id=result_id,
+            dry_run=False,
+            confirm=request.confirm,
+        )
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeStorageError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return result.model_dump(mode="json")
 
 

--- a/app/backend/cloud_chamber/runtime_storage.py
+++ b/app/backend/cloud_chamber/runtime_storage.py
@@ -9,6 +9,11 @@ from pathlib import Path
 from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.local_run_manager import reconcile_completed_run_manifest
+from cloud_chamber.result_ingest import (
+    RESULT_METADATA_FILENAME,
+    ResultIngestError,
+    result_metadata_from_json,
+)
 from cloud_chamber.run_manifest import (
     LifecycleState,
     ProductState,
@@ -79,6 +84,29 @@ class DeleteRunResult(BaseModel):
     message: str
 
 
+class ResultCleanupCategory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: str
+    description: str
+    present: bool
+    item_count: int
+
+
+class DeleteResultResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    run_id: str
+    run_directory: str
+    dry_run: bool
+    deleted: bool
+    size_bytes: int
+    message: str
+    affected_surfaces: list[str]
+    categories: list[ResultCleanupCategory]
+
+
 def runtime_storage_inventory(settings: CloudChamberSettings) -> RuntimeStorageInventory:
     """Return a conservative inventory of the configured runtime home."""
     runtime_home = settings.runtime_home.expanduser()
@@ -116,6 +144,93 @@ def delete_runtime_run(
     # Backward-compatible request shape: saved/protected is no longer a normal
     # product mode or deletion blocker, but older callers may still send this.
     _ = force_saved
+    plan = _runtime_delete_plan(settings, run_id)
+    if not dry_run and not confirm:
+        raise RuntimeStorageError("Real delete requires confirm=true.")
+
+    if dry_run:
+        return DeleteRunResult(
+            run_id=run_id,
+            run_directory=str(plan.run_dir),
+            dry_run=True,
+            deleted=False,
+            size_bytes=plan.entry.size_bytes,
+            message="Dry run only; no files were deleted.",
+        )
+
+    shutil.rmtree(plan.run_dir)
+    return DeleteRunResult(
+        run_id=run_id,
+        run_directory=str(plan.run_dir),
+        dry_run=False,
+        deleted=True,
+        size_bytes=plan.entry.size_bytes,
+        message="Run directory deleted.",
+    )
+
+
+def delete_ingested_result(
+    settings: CloudChamberSettings,
+    *,
+    result_id: str,
+    dry_run: bool,
+    confirm: bool,
+) -> DeleteResultResult:
+    """Delete an ingested result and its managed local run directory."""
+    metadata_path = _metadata_path_for_result(settings, result_id)
+    try:
+        metadata = result_metadata_from_json(metadata_path.read_text())
+    except (OSError, ValueError) as exc:
+        raise ResultIngestError(f"Result metadata is unreadable: {result_id}") from exc
+
+    run_dir = metadata_path.parent
+    if metadata.run_id != run_dir.name:
+        raise RuntimeStorageError(
+            "Result metadata run_id does not match its local run directory: "
+            f"{metadata.run_id} != {run_dir.name}"
+        )
+
+    plan = _runtime_delete_plan(settings, metadata.run_id)
+    categories = _result_cleanup_categories(run_dir)
+    if not dry_run and not confirm:
+        raise RuntimeStorageError("Real delete requires confirm=true.")
+
+    deleted = False
+    message = "Dry run only; no files were deleted."
+    if not dry_run:
+        shutil.rmtree(plan.run_dir)
+        deleted = True
+        message = "Result and local run data deleted."
+
+    return DeleteResultResult(
+        result_id=result_id,
+        run_id=metadata.run_id,
+        run_directory=str(plan.run_dir),
+        dry_run=dry_run,
+        deleted=deleted,
+        size_bytes=plan.entry.size_bytes,
+        message=message,
+        affected_surfaces=[
+            "Results",
+            "Explore",
+            "Compare",
+            "local inventory",
+        ],
+        categories=categories,
+    )
+
+
+class _RuntimeDeletePlan(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    run_dir: Path
+    entry: RunStorageEntry
+
+
+def _runtime_delete_plan(
+    settings: CloudChamberSettings,
+    run_id: str,
+) -> _RuntimeDeletePlan:
     runtime_home = settings.runtime_home.expanduser()
     runs_dir = runtime_home / "runs"
     run_dir = _safe_run_directory(runtime_home, run_id)
@@ -133,28 +248,7 @@ def delete_runtime_run(
     entry = _run_storage_entry(run_dir)
     if entry.category == "running":
         raise RuntimeStorageError(f"Refusing to delete running run: {run_id}")
-    if not dry_run and not confirm:
-        raise RuntimeStorageError("Real delete requires confirm=true.")
-
-    if dry_run:
-        return DeleteRunResult(
-            run_id=run_id,
-            run_directory=str(run_dir),
-            dry_run=True,
-            deleted=False,
-            size_bytes=entry.size_bytes,
-            message="Dry run only; no files were deleted.",
-        )
-
-    shutil.rmtree(run_dir)
-    return DeleteRunResult(
-        run_id=run_id,
-        run_directory=str(run_dir),
-        dry_run=False,
-        deleted=True,
-        size_bytes=entry.size_bytes,
-        message="Run directory deleted.",
-    )
+    return _RuntimeDeletePlan(run_dir=run_dir, entry=entry)
 
 
 def _run_directories(runs_dir: Path) -> list[Path]:
@@ -262,6 +356,81 @@ def _read_worker_status(path: Path) -> dict[str, object]:
     except (OSError, ValueError):
         return {}
     return loaded if isinstance(loaded, dict) else {}
+
+
+def _metadata_path_for_result(settings: CloudChamberSettings, result_id: str) -> Path:
+    runs_dir = settings.runtime_home.expanduser() / "runs"
+    if not runs_dir.exists():
+        raise ResultIngestError(f"Result not found: {result_id}")
+
+    for metadata_path in sorted(runs_dir.glob(f"*/{RESULT_METADATA_FILENAME}")):
+        try:
+            metadata = result_metadata_from_json(metadata_path.read_text())
+        except (OSError, ValueError):
+            continue
+        if metadata.result_id == result_id:
+            return metadata_path
+    raise ResultIngestError(f"Result not found: {result_id}")
+
+
+def _result_cleanup_categories(run_dir: Path) -> list[ResultCleanupCategory]:
+    specs = [
+        (
+            "Result metadata and notebook edits",
+            "Ingested result metadata plus editable notebook sidecar state.",
+            ["result_metadata.json", "result_card.json"],
+        ),
+        (
+            "Run manifests, package inputs, and reports",
+            "Run manifests, case setup, generated CM1 inputs, dry-run reports, "
+            "and file checklists.",
+            [
+                "run_manifest.json",
+                "case_manifest.json",
+                "namelist.input",
+                "input_sounding",
+                "dry_run_report.json",
+                "runtime_file_checklist.json",
+            ],
+        ),
+        (
+            "CM1 output and stats",
+            "Model-output NetCDF, stats files, and raw CM1 artifacts copied into this run.",
+            ["cm1out*.nc", "cm1out*.nc4", "cm1out*.dat", "cm1out*.ctl", "*.ctl"],
+        ),
+        (
+            "Logs and runtime sidecars",
+            "Local stdout/stderr logs, backend logs, and LAN-worker status sidecars.",
+            ["logs/**", "*.log", "stdout.log", "stderr.log", "worker_status.json"],
+        ),
+        (
+            "Derived diagnostics and Explore data",
+            "Derived product manifests, cached diagnostics, and visualization backing data.",
+            ["derived-products/**", "processed/**", "visualization/**"],
+        ),
+    ]
+    categories: list[ResultCleanupCategory] = []
+    for label, description, patterns in specs:
+        count = _matching_item_count(run_dir, patterns)
+        categories.append(
+            ResultCleanupCategory(
+                label=label,
+                description=description,
+                present=count > 0,
+                item_count=count,
+            )
+        )
+    return categories
+
+
+def _matching_item_count(run_dir: Path, patterns: list[str]) -> int:
+    matched: set[Path] = set()
+    for pattern in patterns:
+        for path in run_dir.glob(pattern):
+            if path == run_dir:
+                continue
+            matched.add(path)
+    return len(matched)
 
 
 def _string_or_none(value: object) -> str | None:

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -544,6 +544,83 @@ def test_results_ingest_and_lookup_api(
     assert get_response.json()["saved"] is False
 
 
+def test_result_delete_preview_and_confirm_api(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLOUD_CHAMBER_RUNTIME_HOME", str(tmp_path / "CloudChamber"))
+    package = generate_dry_run_package(
+        scenario_data=json.loads(BASELINE_TEMPLATE.read_text()),
+        runtime_home=tmp_path / "CloudChamber",
+        run_id="run-api-delete-result",
+    )
+    run_dir = package.package_dir
+    netcdf_path = run_dir / "cm1out_000001.nc"
+    (run_dir / "logs").mkdir()
+    (run_dir / "logs" / "stdout.log").write_text("Program terminated normally\n")
+    xr.Dataset(
+        data_vars={
+            "qc": (
+                ("time", "z", "y", "x"),
+                [[[[2e-6]]]],
+                {"units": "kg/kg"},
+            ),
+            "w": (
+                ("time", "z", "y", "x"),
+                [[[[1.0]]]],
+                {"units": "m/s"},
+            ),
+        },
+        coords={"time": [0.0], "z": [125.0], "y": [0.0], "x": [0.0]},
+    ).to_netcdf(netcdf_path, engine="scipy")
+    manifest = load_run_manifest(package.manifest_path)
+    write_run_manifest(
+        package.manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": LifecycleState.COMPLETED,
+                "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+                "outputs": OutputMetadata(netcdf_paths=[str(netcdf_path)]),
+            }
+        ),
+    )
+    client = TestClient(app)
+    ingest_response = client.post(
+        "/api/results/ingest",
+        json={"manifest_path": str(package.manifest_path)},
+    )
+    result_id = ingest_response.json()["result_id"]
+
+    preview = client.post(f"/api/results/{result_id}/delete-preview")
+    blocked = client.post(f"/api/results/{result_id}/delete", json={"confirm": False})
+    deleted = client.post(f"/api/results/{result_id}/delete", json={"confirm": True})
+    list_after_delete = client.get("/api/results")
+    get_after_delete = client.get(f"/api/results/{result_id}")
+
+    assert preview.status_code == 200
+    assert preview.json()["result_id"] == result_id
+    assert preview.json()["run_id"] == "run-api-delete-result"
+    assert preview.json()["deleted"] is False
+    assert "Results" in preview.json()["affected_surfaces"]
+    assert {
+        category["label"] for category in preview.json()["categories"] if category["present"]
+    } >= {
+        "Result metadata and notebook edits",
+        "Run manifests, package inputs, and reports",
+        "CM1 output and stats",
+        "Logs and runtime sidecars",
+        "Derived diagnostics and Explore data",
+    }
+    assert blocked.status_code == 400
+    assert blocked.json()["detail"] == "Real delete requires confirm=true."
+    assert deleted.status_code == 200
+    assert deleted.json()["deleted"] is True
+    assert not run_dir.exists()
+    assert list_after_delete.status_code == 200
+    assert list_after_delete.json()["results"] == []
+    assert get_after_delete.status_code == 404
+
+
 def test_result_card_update_and_save_api(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/app/backend/tests/test_runtime_storage.py
+++ b/app/backend/tests/test_runtime_storage.py
@@ -2,8 +2,21 @@ import json
 from pathlib import Path
 
 import pytest
+import xarray as xr
 
 from cloud_chamber.dry_run_package import generate_dry_run_package
+from cloud_chamber.result_cards import (
+    RESULT_CARD_FILENAME,
+    ResultCardUpdate,
+    get_result_card,
+    list_result_cards,
+    update_result_card,
+)
+from cloud_chamber.result_ingest import (
+    RESULT_METADATA_FILENAME,
+    ResultIngestError,
+    ingest_completed_run,
+)
 from cloud_chamber.run_manifest import (
     ExecutionMetadata,
     LifecycleState,
@@ -17,6 +30,7 @@ from cloud_chamber.run_manifest import (
 from cloud_chamber.runtime_storage import (
     DEFAULT_STORAGE_WARNING_THRESHOLD_BYTES,
     RuntimeStorageError,
+    delete_ingested_result,
     delete_runtime_run,
     runtime_storage_inventory,
 )
@@ -47,6 +61,76 @@ def create_run(tmp_path: Path, run_id: str) -> Path:
         run_id=run_id,
     )
     return result.manifest_path
+
+
+def create_ingested_result(
+    tmp_path: Path,
+    *,
+    run_id: str = "run-result-delete",
+    saved: bool = False,
+) -> tuple[CloudChamberSettings, str, Path, Path]:
+    settings = fake_settings(tmp_path)
+    manifest_path = create_run(tmp_path, run_id)
+    run_dir = manifest_path.parent
+    netcdf_path = run_dir / "cm1out_000001.nc"
+    stats_path = run_dir / "cm1out_stats.nc"
+    raw_path = run_dir / "cm1out_000001_s.dat"
+    ctl_path = run_dir / "cm1out_s.ctl"
+    log_dir = run_dir / "logs"
+    log_dir.mkdir()
+    (log_dir / "stdout.log").write_text("Program terminated normally\n")
+    (log_dir / "stderr.log").write_text("IEEE_UNDERFLOW_FLAG\n")
+    (run_dir / "worker_status.json").write_text('{"state": "worker_cleanup_complete"}\n')
+    raw_path.write_text("fake raw CM1 artifact")
+    ctl_path.write_text("fake CM1 descriptor")
+    write_model_netcdf(netcdf_path)
+    write_stats_netcdf(stats_path)
+    mark_manifest(
+        manifest_path,
+        lifecycle_state=LifecycleState.COMPLETED,
+        product_state=ProductState.COMPLETED_CM1_RESULT,
+        saved=saved,
+        outputs=OutputMetadata(
+            raw_cm1_artifacts=[str(raw_path), str(ctl_path)],
+            netcdf_paths=[str(netcdf_path), str(stats_path)],
+        ),
+    )
+    result = ingest_completed_run(manifest_path)
+    update_result_card(
+        settings,
+        result.result_id,
+        ResultCardUpdate(
+            name="Delete me",
+            tags=["cleanup"],
+            notes="Notebook state should be removed with the run directory.",
+        ),
+    )
+    return settings, result.result_id, run_dir, manifest_path
+
+
+def write_model_netcdf(path: Path) -> None:
+    xr.Dataset(
+        data_vars={
+            "qc": (
+                ("time", "z", "y", "x"),
+                [[[[2e-6 for _x in range(2)] for _y in range(2)] for _z in range(2)]],
+                {"units": "kg/kg"},
+            ),
+            "w": (
+                ("time", "z", "y", "x"),
+                [[[[1.0, 2.0], [3.0, 4.0]], [[1.5, 2.5], [3.5, 4.5]]]],
+                {"units": "m/s"},
+            ),
+        },
+        coords={"time": [1800.0], "z": [500.0, 1500.0], "y": [0.0, 200.0], "x": [0.0, 200.0]},
+    ).to_netcdf(path, engine="scipy")
+
+
+def write_stats_netcdf(path: Path) -> None:
+    xr.Dataset(
+        data_vars={"mass": (("time",), [1.0], {"units": "kg"})},
+        coords={"time": [0.0]},
+    ).to_netcdf(path, engine="scipy")
 
 
 def mark_manifest(
@@ -272,6 +356,122 @@ def test_delete_allows_legacy_saved_run_after_explicit_preview(tmp_path: Path) -
     result = delete_runtime_run(settings, run_id="run-saved", dry_run=False, confirm=True)
     assert result.deleted is True
     assert not manifest_path.parent.exists()
+
+
+def test_ingested_result_delete_preview_resolves_result_run_and_categories(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, run_dir, _manifest_path = create_ingested_result(tmp_path)
+
+    preview = delete_ingested_result(
+        settings,
+        result_id=result_id,
+        dry_run=True,
+        confirm=False,
+    )
+
+    assert preview.result_id == result_id
+    assert preview.run_id == "run-result-delete"
+    assert preview.run_directory == str(run_dir)
+    assert preview.deleted is False
+    assert preview.size_bytes > 0
+    assert run_dir.exists()
+    assert preview.affected_surfaces == ["Results", "Explore", "Compare", "local inventory"]
+    categories = {category.label: category for category in preview.categories}
+    assert categories["Result metadata and notebook edits"].present is True
+    assert categories["Run manifests, package inputs, and reports"].present is True
+    assert categories["CM1 output and stats"].item_count >= 3
+    assert categories["Logs and runtime sidecars"].present is True
+    assert categories["Derived diagnostics and Explore data"].present is True
+
+
+def test_delete_ingested_result_removes_result_and_managed_local_run_data(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, run_dir, _manifest_path = create_ingested_result(tmp_path)
+
+    result = delete_ingested_result(
+        settings,
+        result_id=result_id,
+        dry_run=False,
+        confirm=True,
+    )
+
+    assert result.deleted is True
+    assert not run_dir.exists()
+    assert list_result_cards(settings) == []
+    with pytest.raises(ResultIngestError, match="Result card not found"):
+        get_result_card(settings, result_id)
+    assert not (run_dir / RESULT_METADATA_FILENAME).exists()
+    assert not (run_dir / RESULT_CARD_FILENAME).exists()
+    assert not (run_dir / "cm1out_000001.nc").exists()
+    assert not (run_dir / "logs" / "stdout.log").exists()
+    assert not (run_dir / "derived-products" / "output_product_manifest.json").exists()
+
+
+def test_delete_ingested_result_blocks_running_result_run(tmp_path: Path) -> None:
+    settings, result_id, run_dir, manifest_path = create_ingested_result(
+        tmp_path,
+        run_id="run-result-running",
+    )
+    manifest = load_run_manifest(manifest_path)
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": LifecycleState.RUNNING,
+                "provenance": ProvenanceMetadata(
+                    product_state=ProductState.QUEUED_RUNNING_CM1_PROCESS
+                ),
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeStorageError, match="running run"):
+        delete_ingested_result(settings, result_id=result_id, dry_run=False, confirm=True)
+
+    assert run_dir.exists()
+    assert get_result_card(settings, result_id).run_id == "run-result-running"
+
+
+def test_delete_ingested_result_allows_legacy_saved_metadata(tmp_path: Path) -> None:
+    settings, result_id, run_dir, _manifest_path = create_ingested_result(
+        tmp_path,
+        run_id="run-result-saved",
+        saved=True,
+    )
+
+    preview = delete_ingested_result(
+        settings,
+        result_id=result_id,
+        dry_run=True,
+        confirm=False,
+    )
+    deleted = delete_ingested_result(
+        settings,
+        result_id=result_id,
+        dry_run=False,
+        confirm=True,
+    )
+
+    assert preview.deleted is False
+    assert deleted.deleted is True
+    assert not run_dir.exists()
+
+
+def test_delete_ingested_result_requires_ingested_metadata(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    manifest_path = create_run(tmp_path, "run-not-ingested")
+
+    with pytest.raises(ResultIngestError, match="Result not found"):
+        delete_ingested_result(
+            settings,
+            result_id="result-run-not-ingested",
+            dry_run=True,
+            confirm=False,
+        )
+
+    assert manifest_path.parent.exists()
 
 
 def test_delete_refuses_path_traversal_and_runtime_home_itself(tmp_path: Path) -> None:

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -1102,6 +1102,7 @@ export async function mockCloudChamberApis(page: Page) {
     created_at: string;
     updated_at: string;
   }> = [];
+  let currentResults = [...results];
 
   await page.route("**/api/scenarios", (route) =>
     json(route, { golden_path_scenario_id: "baseline-shallow-cumulus", scenarios: [scenario] }),
@@ -1310,7 +1311,74 @@ export async function mockCloudChamberApis(page: Page) {
     }),
   );
 
-  await page.route("**/api/results", (route) => json(route, { results }));
+  await page.route("**/api/results", (route) => json(route, { results: currentResults }));
+
+  await page.route("**/api/results/*/delete-preview", (route) => {
+    const resultId = resultIdFromUrl(route.request().url());
+    const result = currentResults.find((item) => item.result_id === resultId) ?? results[0];
+    return json(route, {
+      result_id: result.result_id,
+      run_id: result.run_id,
+      run_directory: `/tmp/cloud-chamber-e2e/runs/${result.run_id}`,
+      dry_run: true,
+      deleted: false,
+      size_bytes: 4096,
+      message: "Dry run only; no files were deleted.",
+      affected_surfaces: ["Results", "Explore", "Compare", "local inventory"],
+      categories: [
+        {
+          label: "Result metadata and notebook edits",
+          description: "Ingested result metadata plus editable notebook sidecar state.",
+          present: true,
+          item_count: 2,
+        },
+        {
+          label: "Run manifests, package inputs, and reports",
+          description:
+            "Run manifests, case setup, generated CM1 inputs, dry-run reports, and file checklists.",
+          present: true,
+          item_count: 6,
+        },
+        {
+          label: "CM1 output and stats",
+          description:
+            "Model-output NetCDF, stats files, and raw CM1 artifacts copied into this run.",
+          present: true,
+          item_count: 14,
+        },
+        {
+          label: "Logs and runtime sidecars",
+          description: "Local stdout/stderr logs, backend logs, and LAN-worker status sidecars.",
+          present: true,
+          item_count: 3,
+        },
+        {
+          label: "Derived diagnostics and Explore data",
+          description:
+            "Derived product manifests, cached diagnostics, and visualization backing data.",
+          present: true,
+          item_count: 1,
+        },
+      ],
+    });
+  });
+
+  await page.route("**/api/results/*/delete", (route) => {
+    const resultId = resultIdFromUrl(route.request().url());
+    const result = currentResults.find((item) => item.result_id === resultId) ?? results[0];
+    currentResults = currentResults.filter((item) => item.result_id !== resultId);
+    return json(route, {
+      result_id: result.result_id,
+      run_id: result.run_id,
+      run_directory: `/tmp/cloud-chamber-e2e/runs/${result.run_id}`,
+      dry_run: false,
+      deleted: true,
+      size_bytes: 4096,
+      message: "Result and local run data deleted.",
+      affected_surfaces: ["Results", "Explore", "Compare", "local inventory"],
+      categories: [],
+    });
+  });
 
   await page.route("**/api/results/*/visualization/fields", (route) =>
     json(route, fieldCatalog(resultIdFromUrl(route.request().url()))),

--- a/app/frontend/e2e/local-data/read-only.spec.ts
+++ b/app/frontend/e2e/local-data/read-only.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { gotoApp, gotoResults, openResultsTab, skipIfBackendUnavailable } from "../helpers";
+import { gotoApp, gotoBuild, gotoResults, skipIfBackendUnavailable } from "../helpers";
 
 test.describe("local data: read-only smoke", () => {
-  test("Results and Storage load against the local backend when available", async ({ page }) => {
+  test("Results and Build pipeline load against the local backend when available", async ({ page }) => {
     if (await skipIfBackendUnavailable(page)) {
       test.skip(true, "Local backend unavailable; start scripts/dev.sh for local-data tests.");
     }
@@ -11,8 +11,9 @@ test.describe("local data: read-only smoke", () => {
     await gotoApp(page);
     await gotoResults(page);
     await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Storage" })).toHaveCount(0);
 
-    await openResultsTab(page, /^Storage$/);
-    await expect(page.getByRole("heading", { name: "Runtime storage cleanup" })).toBeVisible();
+    await gotoBuild(page);
+    await expect(page.getByRole("heading", { name: "Packages and runs needing action" })).toBeVisible();
   });
 });

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -25,7 +25,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("Build pipeline")).toBeVisible();
     await expect(page.getByText("Local experiment loop")).not.toBeVisible();
     await expect(page.getByText("Ready to ingest")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open Storage cleanup" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Preview cleanup" }).first()).toBeVisible();
     await page.getByLabel("Low-level humidity").selectOption("more_humid");
     await expect(page.getByText(/Selected: More humid/i)).toBeVisible();
 
@@ -139,7 +139,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("Package ready").first()).toBeVisible();
   });
 
-  test("Results notebook, Compare, and Storage render with mocked data", async ({ page }) => {
+  test("Results notebook and Compare render with mocked data", async ({ page }) => {
     await gotoResults(page);
 
     await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
@@ -156,20 +156,17 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await resultDetail.getByText("Technical details").click();
     await expect(resultDetail.getByText("Run ID")).toBeVisible();
     await expect(resultDetail.getByText("Product state")).toBeVisible();
-    await expect(resultDetail.getByRole("button", { name: "Manage local files" })).toBeVisible();
+    await expect(
+      resultDetail.getByRole("button", { name: "Preview delete result and local run data" }),
+    ).toBeVisible();
+    await expect(resultDetail.getByText("Local data")).toBeVisible();
 
     await openResultsTab(page, /^Compare$/);
     await expect(
       page.getByRole("heading", { name: "Baseline vs Dry Failed Cumulus" }),
     ).toBeVisible();
     await expect(page.getByText("Moisture-limited", { exact: true })).toBeVisible();
-
-    await openResultsTab(page, /^Storage$/);
-    await expect(page.getByRole("heading", { name: "Runtime inventory and cleanup" })).toBeVisible();
-    await expect(page.getByText("/tmp/cloud-chamber-e2e").first()).toBeVisible();
-    await expect(page.getByText("Ready to ingest")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Ingest completed output" })).toBeVisible();
-    await expect(page.getByText("Running CM1 process")).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Storage" })).toHaveCount(0);
   });
 
   test("Results filters and sorts by science metadata", async ({ page }) => {
@@ -203,39 +200,40 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     );
   });
 
-  test("Results and Storage share lifecycle-aware local file actions", async ({ page }) => {
+  test("Results deletes ingested results and Build keeps non-ingested cleanup", async ({ page }) => {
     await gotoResults(page);
 
     const resultDetail = page.getByLabel("Result detail");
-    await resultDetail.getByRole("button", { name: "Manage local files" }).click();
-
-    await expect(page.getByRole("heading", { name: "Runtime inventory and cleanup" })).toBeVisible();
-    const savedRow = page.locator("tr", { hasText: "dry-run-baseline" });
-    await expect(savedRow.getByText("Baseline Shallow Cumulus — Quick Look")).toBeVisible();
-    await expect(savedRow.getByText("Run ID: dry-run-baseline")).toBeVisible();
-    await expect(savedRow.getByText("Ingested / ready to review", { exact: true }).first()).toBeVisible();
-    await expect(savedRow.getByRole("button", { name: "Preview delete" })).toBeEnabled();
-    await savedRow.getByRole("button", { name: "Preview delete" }).click();
+    await resultDetail.getByRole("button", { name: "Preview delete result and local run data" }).click();
     await expect(page.getByRole("heading", { name: "Delete result and local run data preview" })).toBeVisible();
-    await expect(page.getByText(/result will disappear from Results, Explore, Compare, and Storage inventory/)).toBeVisible();
-    await expect(page.getByRole("button", { name: "Confirm delete result and local run data" })).toBeVisible();
+    await expect(page.getByText(/result will disappear from Results, Explore, Compare, and local inventory/)).toBeVisible();
+    await expect(page.getByText("Result metadata and notebook edits")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Delete result and local run data", exact: true }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Delete result and local run data", exact: true }).click();
+    await expect(page.getByText(/Result and local run data deleted/)).toBeVisible();
+    await expect(page.getByLabel("Results list").getByText("Baseline Shallow Cumulus — Quick Look")).toHaveCount(0);
 
-    const ingestReadyRow = page.locator("tr", { hasText: "dry-run-disposable" });
-    await expect(ingestReadyRow.getByText("Ready to ingest")).toBeVisible();
-    await ingestReadyRow.getByRole("button", { name: "Preview delete" }).click();
-    await expect(page.getByRole("heading", { name: "Delete local run data preview" })).toBeVisible();
-    await expect(page.getByText(/CM1 output\/logs if present/)).toBeVisible();
-    await expect(page.getByText(/result will disappear from Results, Explore, Compare, and Storage inventory/)).not.toBeVisible();
+    await gotoBuild(page);
+    const pipelineRuns = page.getByLabel("Local packages and runs");
+    const ingestReadyRun = pipelineRuns.locator("article", { hasText: "dry-run-disposable" });
+    await expect(ingestReadyRun.getByText("Ready to ingest")).toBeVisible();
+    await expect(ingestReadyRun.getByRole("button", { name: "Preview cleanup" })).toBeEnabled();
+    await ingestReadyRun.getByRole("button", { name: "Preview cleanup" }).click();
+    await expect(page.getByRole("heading", { name: "Delete local package/run data preview" })).toBeVisible();
+    await expect(page.getByText(/does not touch Results entries/)).toBeVisible();
     await expect(page.getByRole("button", { name: "Confirm delete local run data" })).toBeVisible();
 
-    await ingestReadyRow.getByRole("button", { name: "Ingest completed output" }).click();
+    await ingestReadyRun.getByRole("button", { name: "Ingest output" }).click();
     await expect(page.getByText("Ingested result metadata")).toBeVisible();
 
-    const runningRow = page.locator("tr", { hasText: "dry-run-running" });
-    await expect(runningRow.getByText("Running CM1 process")).toBeVisible();
-    await expect(runningRow.getByRole("button", { name: "Preview delete" })).toBeDisabled();
+    const runningRun = pipelineRuns.locator("article", { hasText: "dry-run-running" });
+    await expect(runningRun.getByText("Running", { exact: true })).toBeVisible();
+    await expect(runningRun.getByRole("button", { name: "Preview cleanup" })).toBeDisabled();
 
-    await savedRow.getByRole("button", { name: "Open in Explore" }).click();
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
     await expect(page.getByText(/what happened in this result/i).first()).toBeVisible();
   });
 

--- a/app/frontend/e2e/mocked-smoke/navigation.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/navigation.spec.ts
@@ -61,7 +61,7 @@ test.describe("mocked smoke: app shell", () => {
     await gotoResults(page);
     await expect(page.getByRole("tab", { name: "Notebook" })).toBeVisible();
     await expect(page.getByRole("tab", { name: "Compare" })).toBeVisible();
-    await expect(page.getByRole("tab", { name: "Storage" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Storage" })).toHaveCount(0);
 
     await gotoExplore(page);
     await expect(page.getByLabel("Explore this result")).toBeVisible();

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1205,6 +1205,50 @@ const storageInventoryResponse = {
   largest_runs: storageRuns,
 };
 
+const resultDeletePreviewResponse = {
+  result_id: "result-dry-run-quicklook",
+  run_id: "dry-run-quicklook",
+  run_directory: "/tmp/CloudChamber/runs/dry-run-quicklook",
+  dry_run: true,
+  deleted: false,
+  size_bytes: 852 * 1024 ** 2,
+  message: "Dry run only; no files were deleted.",
+  affected_surfaces: ["Results", "Explore", "Compare", "local inventory"],
+  categories: [
+    {
+      label: "Result metadata and notebook edits",
+      description: "Ingested result metadata plus editable notebook sidecar state.",
+      present: true,
+      item_count: 2,
+    },
+    {
+      label: "Run manifests, package inputs, and reports",
+      description:
+        "Run manifests, case setup, generated CM1 inputs, dry-run reports, and file checklists.",
+      present: true,
+      item_count: 6,
+    },
+    {
+      label: "CM1 output and stats",
+      description: "Model-output NetCDF, stats files, and raw CM1 artifacts copied into this run.",
+      present: true,
+      item_count: 14,
+    },
+    {
+      label: "Logs and runtime sidecars",
+      description: "Local stdout/stderr logs, backend logs, and LAN-worker status sidecars.",
+      present: true,
+      item_count: 3,
+    },
+    {
+      label: "Derived diagnostics and Explore data",
+      description: "Derived product manifests, cached diagnostics, and visualization backing data.",
+      present: true,
+      item_count: 1,
+    },
+  ],
+};
+
 const provenance = {
   source_model: "CM1",
   result_id: "result-dry-run-quicklook",
@@ -2140,6 +2184,24 @@ beforeEach(() => {
       if (url === "/api/results") {
         return Promise.resolve(new Response(JSON.stringify(resultsResponse), { status: 200 }));
       }
+      if (url === "/api/results/result-dry-run-quicklook/delete-preview") {
+        return Promise.resolve(
+          new Response(JSON.stringify(resultDeletePreviewResponse), { status: 200 }),
+        );
+      }
+      if (url === "/api/results/result-dry-run-quicklook/delete") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ...resultDeletePreviewResponse,
+              dry_run: false,
+              deleted: true,
+              message: "Result and local run data deleted.",
+            }),
+            { status: 200 },
+          ),
+        );
+      }
       if (url === "/api/storage/inventory") {
         return Promise.resolve(
           new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
@@ -2908,7 +2970,7 @@ describe("App", () => {
     expect(screen.queryByRole("button", { name: "Run on LAN worker" })).not.toBeInTheDocument();
     expect(screen.getByTestId("create-package-btn")).toBeEnabled();
     expect(screen.getAllByRole("button", { name: "Create run package" })).toHaveLength(1);
-    expect(screen.getByRole("button", { name: "Open Storage cleanup" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Preview cleanup" }).length).toBeGreaterThan(0);
     expect(screen.queryByTestId("create-package-next-btn")).not.toBeInTheDocument();
     expect(screen.queryByText(/Preview estimate not implemented/)).not.toBeInTheDocument();
   });
@@ -3245,7 +3307,7 @@ describe("App", () => {
     expect(within(topNav).queryByRole("button", { name: "Visualize" })).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Notebook" })).toHaveClass("active-control");
     expect(screen.getByRole("tab", { name: "Compare" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Storage" })).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Storage" })).not.toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Experiment Notebook" })).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -3677,80 +3739,93 @@ describe("App", () => {
     expect(screen.queryByText(/vertical slice/i)).not.toBeInTheDocument();
   });
 
-  it("shows runtime storage inventory and safe cleanup affordances", async () => {
+  it("shows result delete preview and confirm inside Results", async () => {
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("tab", { name: "Storage" }));
+    expect(await screen.findByLabelText("Result detail")).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Storage" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Runtime inventory and cleanup" })).not.toBeInTheDocument();
+    const resultDetail = screen.getByLabelText("Result detail");
+    expect(resultDetail).toHaveTextContent("Local data");
+    expect(resultDetail).toHaveTextContent("Run-directory backed");
 
-    expect(
-      await screen.findByRole("heading", { name: "Runtime inventory and cleanup" }),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Review generated packages, running CM1 jobs/)).toBeInTheDocument();
-    expect(screen.getByText("/tmp/CloudChamber")).toBeInTheDocument();
-    expect(screen.getByText("60 GB")).toBeInTheDocument();
-    expect(screen.getByText("50 GB")).toBeInTheDocument();
-    expect(screen.getByText("At or above 50 GB warning threshold")).toBeInTheDocument();
-    expect(screen.getByText(/dry-run cleanup/)).toBeInTheDocument();
-    expect(screen.getAllByText("Quick-look shallow cumulus").length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/dry-run-quicklook/).length).toBeGreaterThan(0);
-    expect(screen.getByText("852 MB")).toBeInTheDocument();
-    expect(
-      screen.getAllByText("13 model files, 13 time steps, 1 stats files").length,
-    ).toBeGreaterThan(0);
-    expect(screen.queryByText("Saved/protected")).not.toBeInTheDocument();
-    expect(screen.getByText("Ready-to-run package")).toBeInTheDocument();
-    expect(screen.getAllByText("Ready to ingest").length).toBeGreaterThan(0);
-    expect(screen.getByText("Completed with no usable output")).toBeInTheDocument();
-    expect(screen.getByText("Failed run")).toBeInTheDocument();
-    expect(screen.getByText("Needs cleanup review")).toBeInTheDocument();
-
-    const runtimeRuns = screen.getByLabelText("Runtime runs");
-    const packageRow = within(runtimeRuns)
-      .getAllByText(/dry-run-packaged/)[0]
-      .closest("tr");
-    const ingestReadyRow = within(runtimeRuns)
-      .getAllByText(/dry-run-uningested/)[0]
-      .closest("tr");
-    const resultRow = within(runtimeRuns)
-      .getAllByText(/dry-run-quicklook/)[0]
-      .closest("tr");
-    const savedRow = within(runtimeRuns)
-      .getAllByText(/dry-run-saved/)[0]
-      .closest("tr");
-    const runningRow = within(runtimeRuns)
-      .getAllByText(/dry-run-running/)[0]
-      .closest("tr");
-    expect(packageRow).not.toBeNull();
-    expect(ingestReadyRow).not.toBeNull();
-    expect(resultRow).not.toBeNull();
-    expect(savedRow).not.toBeNull();
-    expect(runningRow).not.toBeNull();
-    expect(
-      within(packageRow as HTMLElement).getByRole("button", { name: "Preview delete" }),
-    ).toBeEnabled();
-    expect(
-      within(ingestReadyRow as HTMLElement).getByRole("button", {
-        name: "Ingest completed output",
+    fireEvent.click(
+      within(resultDetail).getByRole("button", {
+        name: "Preview delete result and local run data",
       }),
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Delete result and local run data preview" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/result will disappear from Results, Explore, Compare, and local inventory/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Storage inventory/)).not.toBeInTheDocument();
+    expect(screen.getByText("Result metadata and notebook edits")).toBeInTheDocument();
+    expect(screen.getByText("CM1 output and stats")).toBeInTheDocument();
+    expect(screen.getByText("Derived diagnostics and Explore data")).toBeInTheDocument();
+    expect(screen.getByText("Dry run only; no files were deleted.")).toBeInTheDocument();
+    expect(screen.getByText("/tmp/CloudChamber/runs/dry-run-quicklook")).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/results/result-dry-run-quicklook/delete-preview",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete result and local run data" }));
+
+    expect(await screen.findByText(/Result and local run data deleted/)).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/results/result-dry-run-quicklook/delete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ confirm: true }),
+      }),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Quick-look shallow cumulus" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps non-ingested cleanup preview in Build", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    expect(
+      await screen.findByRole("heading", { name: "Packages and runs needing action" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Runtime inventory and cleanup" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Storage" })).not.toBeInTheDocument();
+
+    const pipelineRuns = screen.getByLabelText("Local packages and runs");
+    const packageRun = within(pipelineRuns)
+      .getAllByText(/dry-run-packaged/)[0]
+      .closest("article");
+    const ingestReadyRun = within(pipelineRuns)
+      .getAllByText(/dry-run-uningested/)[0]
+      .closest("article");
+    const runningRun = within(pipelineRuns)
+      .getAllByText(/dry-run-running/)[0]
+      .closest("article");
+    expect(packageRun).not.toBeNull();
+    expect(ingestReadyRun).not.toBeNull();
+    expect(runningRun).not.toBeNull();
+    expect(
+      within(packageRun as HTMLElement).getByRole("button", { name: "Preview cleanup" }),
     ).toBeEnabled();
     expect(
-      within(ingestReadyRow as HTMLElement).queryByRole("button", { name: "Open result" }),
+      within(ingestReadyRun as HTMLElement).getByRole("button", { name: "Ingest output" }),
+    ).toBeEnabled();
+    expect(
+      within(ingestReadyRun as HTMLElement).queryByRole("button", { name: "Open result" }),
     ).not.toBeInTheDocument();
     expect(
-      within(savedRow as HTMLElement).getByRole("button", { name: "Preview delete" }),
-    ).toBeEnabled();
-    expect(
-      within(runningRow as HTMLElement).getByRole("button", { name: "Preview delete" }),
+      within(runningRun as HTMLElement).getByRole("button", { name: "Preview cleanup" }),
     ).toBeDisabled();
-    expect(
-      screen.queryByText("Saved/protected runs are not deleted from this UI."),
-    ).not.toBeInTheDocument();
     expect(screen.getByText("Running runs cannot be deleted.")).toBeInTheDocument();
 
     fireEvent.click(
-      within(ingestReadyRow as HTMLElement).getByRole("button", {
-        name: "Ingest completed output",
-      }),
+      within(ingestReadyRun as HTMLElement).getByRole("button", { name: "Ingest output" }),
     );
     await waitFor(() =>
       expect(fetch).toHaveBeenCalledWith(
@@ -3765,39 +3840,15 @@ describe("App", () => {
     );
 
     fireEvent.click(
-      within(resultRow as HTMLElement).getByRole("button", { name: "Preview delete" }),
+      within(packageRun as HTMLElement).getByRole("button", { name: "Preview cleanup" }),
     );
 
     expect(
-      await screen.findByRole("heading", { name: "Delete result and local run data preview" }),
+      await screen.findByRole("heading", { name: "Delete local package/run data preview" }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        /result will disappear from Results, Explore, Compare, and Storage inventory/,
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/does not touch the source repo/)).toBeInTheDocument();
+    expect(screen.getByText(/does not touch Results entries/)).toBeInTheDocument();
+    expect(screen.getByText(/the source repo/)).toBeInTheDocument();
     expect(screen.getByText("Dry run only; no files were deleted.")).toBeInTheDocument();
-    expect(screen.getAllByText("/tmp/CloudChamber/runs/dry-run-quicklook").length).toBeGreaterThan(
-      0,
-    );
-    expect(
-      screen.getByRole("button", { name: "Confirm delete result and local run data" }),
-    ).toBeInTheDocument();
-
-    fireEvent.click(
-      within(packageRow as HTMLElement).getByRole("button", { name: "Preview delete" }),
-    );
-
-    expect(
-      await screen.findByRole("heading", { name: "Delete local run data preview" }),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/CM1 output\/logs if present/)).toBeInTheDocument();
-    expect(
-      screen.queryByText(
-        /result will disappear from Results, Explore, Compare, and Storage inventory/,
-      ),
-    ).not.toBeInTheDocument();
     expect(screen.getAllByText("/tmp/CloudChamber/runs/dry-run-packaged").length).toBeGreaterThan(
       0,
     );
@@ -3834,57 +3885,6 @@ describe("App", () => {
     );
   });
 
-  it("routes Results notebook entries to their local Storage row", async () => {
-    render(<App />);
-
-    const resultDetail = await screen.findByLabelText("Result detail");
-    fireEvent.click(within(resultDetail).getByRole("button", { name: "Manage local files" }));
-
-    expect(
-      await screen.findByRole("heading", { name: "Runtime inventory and cleanup" }),
-    ).toBeInTheDocument();
-    const runtimeRuns = screen.getByLabelText("Runtime runs");
-    const focusedRow = within(runtimeRuns)
-      .getAllByText(/dry-run-quicklook/)[0]
-      .closest("tr");
-    expect(focusedRow).not.toBeNull();
-    expect(focusedRow).toHaveClass("selected-row");
-    expect(
-      within(focusedRow as HTMLElement).getByRole("button", { name: "Open result" }),
-    ).toBeEnabled();
-    expect(
-      within(focusedRow as HTMLElement).getByRole("button", { name: "Open in Explore" }),
-    ).toBeEnabled();
-  });
-
-  it("routes Build pipeline cleanup to Storage without adding delete controls to Build", async () => {
-    render(<App />);
-
-    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
-    expect(
-      await screen.findByRole("heading", { name: "Packages and runs needing action" }),
-    ).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Preview delete" })).not.toBeInTheDocument();
-
-    const pipelineRuns = screen.getByLabelText("Local packages and runs");
-    const pipelineRun = within(pipelineRuns)
-      .getAllByText(/dry-run-uningested/)[0]
-      .closest("article");
-    expect(pipelineRun).not.toBeNull();
-    fireEvent.click(
-      within(pipelineRun as HTMLElement).getByRole("button", { name: "Manage cleanup" }),
-    );
-
-    expect(
-      await screen.findByRole("heading", { name: "Runtime inventory and cleanup" }),
-    ).toBeInTheDocument();
-    const runtimeRuns = screen.getByLabelText("Runtime runs");
-    const focusedRow = within(runtimeRuns)
-      .getAllByText(/dry-run-uningested/)[0]
-      .closest("tr");
-    expect(focusedRow).toHaveClass("selected-row");
-  });
-
   it("shows cleanup failure details without deleting from unsafe UI paths", async () => {
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -3911,8 +3911,8 @@ describe("App", () => {
 
     render(<App />);
 
-    fireEvent.click(await screen.findByRole("tab", { name: "Storage" }));
-    fireEvent.click((await screen.findAllByRole("button", { name: "Preview delete" }))[0]);
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.click((await screen.findAllByRole("button", { name: "Preview cleanup" }))[0]);
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Refusing to delete outside runtime home",

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3772,6 +3772,18 @@ describe("App", () => {
       expect.objectContaining({ method: "POST" }),
     );
 
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByLabelText("Result delete preview")).not.toBeInTheDocument();
+
+    fireEvent.click(
+      within(resultDetail).getByRole("button", {
+        name: "Preview delete result and local run data",
+      }),
+    );
+    expect(
+      await screen.findByRole("heading", { name: "Delete result and local run data preview" }),
+    ).toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: "Delete result and local run data" }));
 
     expect(await screen.findByText(/Result and local run data deleted/)).toBeInTheDocument();
@@ -3784,6 +3796,35 @@ describe("App", () => {
     );
     expect(
       screen.queryByRole("button", { name: "Quick-look shallow cumulus" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears result delete preview when a different result is selected", async () => {
+    render(<App />);
+
+    const resultDetail = await screen.findByLabelText("Result detail");
+    expect(resultDetail).toHaveTextContent("Quick-look shallow cumulus");
+
+    fireEvent.click(
+      within(resultDetail).getByRole("button", {
+        name: "Preview delete result and local run data",
+      }),
+    );
+
+    expect(await screen.findByLabelText("Result delete preview")).toBeInTheDocument();
+    expect(screen.getByText("/tmp/CloudChamber/runs/dry-run-quicklook")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dry Failed Cumulus quick-look" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Result detail")).toHaveTextContent(
+        "Dry Failed Cumulus quick-look",
+      );
+    });
+    expect(screen.queryByLabelText("Result delete preview")).not.toBeInTheDocument();
+    expect(screen.queryByText("/tmp/CloudChamber/runs/dry-run-quicklook")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete result and local run data" }),
     ).not.toBeInTheDocument();
   });
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -639,8 +639,27 @@ type DeleteRunResponse = {
   message: string;
 };
 
+type ResultCleanupCategory = {
+  label: string;
+  description: string;
+  present: boolean;
+  item_count: number;
+};
+
+type DeleteResultResponse = {
+  result_id: string;
+  run_id: string;
+  run_directory: string;
+  dry_run: boolean;
+  deleted: boolean;
+  size_bytes: number;
+  message: string;
+  affected_surfaces: string[];
+  categories: ResultCleanupCategory[];
+};
+
 type WorkspaceSection = "build" | "results" | "explore";
-type ResultsTab = "notebook" | "compare" | "storage";
+type ResultsTab = "notebook" | "compare";
 type ScenarioLoadState = "loading" | "loaded" | "failed" | "empty";
 
 type ProvenancePayload = {
@@ -1191,7 +1210,7 @@ async function patchResultCard(
 async function fetchStorageInventory(): Promise<StorageInventoryResponse> {
   const response = await fetch("/api/storage/inventory");
   if (!response.ok) {
-    throw new Error(await responseError(response, "Unable to load runtime storage inventory."));
+    throw new Error(await responseError(response, "Unable to load runtime run inventory."));
   }
   return response.json() as Promise<StorageInventoryResponse>;
 }
@@ -1228,6 +1247,28 @@ async function confirmRunDelete(runId: string): Promise<DeleteRunResponse> {
     throw new Error(await responseError(response, "Unable to delete selected run."));
   }
   return response.json() as Promise<DeleteRunResponse>;
+}
+
+async function requestResultDeletePreview(resultId: string): Promise<DeleteResultResponse> {
+  const response = await fetch(`/api/results/${resultId}/delete-preview`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to preview result deletion."));
+  }
+  return response.json() as Promise<DeleteResultResponse>;
+}
+
+async function confirmResultDelete(resultId: string): Promise<DeleteResultResponse> {
+  const response = await fetch(`/api/results/${resultId}/delete`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ confirm: true }),
+  });
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to delete selected result."));
+  }
+  return response.json() as Promise<DeleteResultResponse>;
 }
 
 async function fetchVisualizationFields(resultId: string): Promise<FieldCatalogResponse> {
@@ -1397,11 +1438,14 @@ export function App() {
   const [resultDraft, setResultDraft] = useState({ name: "", tags: "", notes: "" });
   const [resultsStatus, setResultsStatus] = useState("Loading results...");
   const [storageInventory, setStorageInventory] = useState<StorageInventoryResponse | null>(null);
-  const [storageStatus, setStorageStatus] = useState("Loading storage inventory...");
+  const [storageStatus, setStorageStatus] = useState("Loading run inventory...");
   const [storageError, setStorageError] = useState<string | null>(null);
-  const [focusedStorageRunId, setFocusedStorageRunId] = useState<string | null>(null);
-  const [deletePreview, setDeletePreview] = useState<DeleteRunResponse | null>(null);
-  const [deleteMessage, setDeleteMessage] = useState<string | null>(null);
+  const [runDeletePreview, setRunDeletePreview] = useState<DeleteRunResponse | null>(null);
+  const [runDeleteMessage, setRunDeleteMessage] = useState<string | null>(null);
+  const [resultDeletePreview, setResultDeletePreview] = useState<DeleteResultResponse | null>(
+    null,
+  );
+  const [resultDeleteMessage, setResultDeleteMessage] = useState<string | null>(null);
   const [, setStatus] = useState("Loading scenarios...");
   const [scenarioLoadState, setScenarioLoadState] = useState<ScenarioLoadState>("loading");
   const [scenarioError, setScenarioError] = useState<string | null>(null);
@@ -1506,13 +1550,13 @@ export function App() {
         const payload = await fetchStorageInventory();
         if (!active) return;
         setStorageInventory(payload);
-        setStorageStatus(payload.runs.length > 0 ? "Storage inventory loaded" : "No runtime runs");
+        setStorageStatus(payload.runs.length > 0 ? "Run inventory loaded" : "No runtime runs");
       } catch (caught) {
         if (!active) return;
         setStorageError(
-          caught instanceof Error ? caught.message : "Unable to load runtime storage inventory.",
+          caught instanceof Error ? caught.message : "Unable to load runtime run inventory.",
         );
-        setStorageStatus("Storage unavailable");
+        setStorageStatus("Run inventory unavailable");
       }
     }
   }, []);
@@ -1529,7 +1573,10 @@ export function App() {
   const observedSoundingExperimentSelected = selectedScenarioId === OBSERVED_SOUNDING_EXPERIMENT_ID;
 
   const selectedResult = useMemo(
-    () => results.find((result) => result.result_id === selectedResultId) ?? results[0],
+    () =>
+      selectedResultId
+        ? results.find((result) => result.result_id === selectedResultId)
+        : results[0],
     [results, selectedResultId],
   );
   const comparisonPair = useMemo(() => defaultComparisonPair(results), [results]);
@@ -1625,13 +1672,13 @@ export function App() {
       setStorageInventory(payload);
       setStorageStatus(
         statusWhenLoaded ??
-          (payload.runs.length > 0 ? "Storage inventory loaded" : "No runtime runs"),
+          (payload.runs.length > 0 ? "Run inventory loaded" : "No runtime runs"),
       );
     } catch (caught) {
       setStorageError(
-        caught instanceof Error ? caught.message : "Unable to load runtime storage inventory.",
+        caught instanceof Error ? caught.message : "Unable to load runtime run inventory.",
       );
-      setStorageStatus("Storage unavailable");
+      setStorageStatus("Run inventory unavailable");
     }
   }
 
@@ -2211,32 +2258,32 @@ export function App() {
 
   async function handleRefreshStorage() {
     setStorageError(null);
-    setStorageStatus("Refreshing storage inventory");
-    setDeletePreview(null);
-    setDeleteMessage(null);
+    setStorageStatus("Refreshing run inventory");
+    setRunDeletePreview(null);
+    setRunDeleteMessage(null);
     try {
       const payload = await fetchStorageInventory();
       setStorageInventory(payload);
-      setStorageStatus(payload.runs.length > 0 ? "Storage inventory loaded" : "No runtime runs");
+      setStorageStatus(payload.runs.length > 0 ? "Run inventory loaded" : "No runtime runs");
     } catch (caught) {
       setStorageError(
-        caught instanceof Error ? caught.message : "Unable to load runtime storage inventory.",
+        caught instanceof Error ? caught.message : "Unable to load runtime run inventory.",
       );
-      setStorageStatus("Storage unavailable");
+      setStorageStatus("Run inventory unavailable");
     }
   }
 
   async function handlePreviewRunDelete(runId: string) {
     setStorageError(null);
-    setDeleteMessage(null);
+    setRunDeleteMessage(null);
     setStorageStatus("Preparing delete preview");
     try {
       const preview = await requestRunDeletePreview(runId);
-      setDeletePreview(preview);
+      setRunDeletePreview(preview);
       setStorageStatus("Delete preview ready");
     } catch (caught) {
       setStorageError(caught instanceof Error ? caught.message : "Unable to preview run deletion.");
-      setStorageStatus("Storage inventory loaded");
+      setStorageStatus("Run inventory loaded");
     }
   }
 
@@ -2245,14 +2292,52 @@ export function App() {
     setStorageStatus("Deleting selected run");
     try {
       const deleted = await confirmRunDelete(runId);
-      setDeleteMessage(`${deleted.message} Reclaimed ${formatBytes(deleted.size_bytes)}.`);
-      setDeletePreview(null);
+      setRunDeleteMessage(`${deleted.message} Reclaimed ${formatBytes(deleted.size_bytes)}.`);
+      setRunDeletePreview(null);
       const payload = await fetchStorageInventory();
       setStorageInventory(payload);
       setStorageStatus("Run deleted");
     } catch (caught) {
       setStorageError(caught instanceof Error ? caught.message : "Unable to delete selected run.");
       setStorageStatus("Delete failed");
+    }
+  }
+
+  async function handlePreviewResultDelete(resultId: string) {
+    setResultsError(null);
+    setResultDeleteMessage(null);
+    setResultsStatus("Preparing result delete preview");
+    try {
+      const preview = await requestResultDeletePreview(resultId);
+      setResultDeletePreview(preview);
+      setResultsStatus("Result delete preview ready");
+    } catch (caught) {
+      setResultsError(
+        caught instanceof Error ? caught.message : "Unable to preview result deletion.",
+      );
+      setResultsStatus("Results loaded");
+    }
+  }
+
+  async function handleConfirmResultDelete(resultId: string) {
+    setResultsError(null);
+    setResultsStatus("Deleting selected result");
+    try {
+      const deleted = await confirmResultDelete(resultId);
+      const remaining = results.filter((result) => result.result_id !== resultId);
+      setResults(remaining);
+      setSelectedResultId((current) =>
+        current === resultId ? (remaining[0]?.result_id ?? null) : current,
+      );
+      setResultDeletePreview(null);
+      setResultDeleteMessage(
+        `${deleted.message} Reclaimed ${formatBytes(deleted.size_bytes)} from local storage.`,
+      );
+      setResultsStatus(remaining.length > 0 ? "Results loaded" : "No ingested results");
+      await refreshStorageAfterWorkflow("Local pipeline updated");
+    } catch (caught) {
+      setResultsError(caught instanceof Error ? caught.message : "Unable to delete selected result.");
+      setResultsStatus("Delete failed");
     }
   }
 
@@ -2321,6 +2406,8 @@ export function App() {
           storageInventory={storageInventory}
           storageStatus={storageStatus}
           storageError={storageError}
+          runDeletePreview={runDeletePreview}
+          runDeleteMessage={runDeleteMessage}
           results={results}
           autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIdSet}
           failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIdSet}
@@ -2380,12 +2467,9 @@ export function App() {
             setSelectedResultId(resultId);
             setActiveSection("explore");
           }}
-          onOpenStorage={(runId) => {
-            setFocusedStorageRunId(runId ?? null);
-            setActiveSection("results");
-            setActiveResultsTab("storage");
-          }}
           onRefreshStorage={handleRefreshStorage}
+          onPreviewRunDelete={handlePreviewRunDelete}
+          onConfirmRunDelete={handleConfirmRunDelete}
           onRetryScenarios={() => {
             void loadScenarios();
           }}
@@ -2397,16 +2481,12 @@ export function App() {
           activeTab={activeResultsTab}
           results={results}
           selectedResult={selectedResult}
-          selectedResultId={selectedResult?.result_id ?? null}
+          selectedResultId={selectedResultId}
           resultsStatus={resultsStatus}
           resultsError={resultsError}
           comparisonPair={comparisonPair}
-          storageInventory={storageInventory}
-          storageStatus={storageStatus}
-          storageError={storageError}
-          focusedRunId={focusedStorageRunId}
-          deletePreview={deletePreview}
-          deleteMessage={deleteMessage}
+          resultDeletePreview={resultDeletePreview}
+          resultDeleteMessage={resultDeleteMessage}
           onTabChange={setActiveResultsTab}
           draft={resultDraft}
           onSelectResult={setSelectedResultId}
@@ -2416,27 +2496,12 @@ export function App() {
           onInspect={() => {
             setActiveSection("explore");
           }}
-          onManageLocalFiles={(result) => {
-            setSelectedResultId(result.result_id);
-            setFocusedStorageRunId(result.run_id);
-            setActiveResultsTab("storage");
-          }}
           onCompareInspect={(resultId) => {
             setSelectedResultId(resultId);
             setActiveSection("explore");
           }}
-          onStorageOpenResult={(resultId) => {
-            setSelectedResultId(resultId);
-            setActiveResultsTab("notebook");
-          }}
-          onStorageExploreResult={(resultId) => {
-            setSelectedResultId(resultId);
-            setActiveSection("explore");
-          }}
-          onStorageIngestRun={handleIngestStoredRun}
-          onRefreshStorage={handleRefreshStorage}
-          onPreviewDelete={handlePreviewRunDelete}
-          onConfirmDelete={handleConfirmRunDelete}
+          onPreviewResultDelete={handlePreviewResultDelete}
+          onConfirmResultDelete={handleConfirmResultDelete}
         />
       )}
 
@@ -2487,6 +2552,8 @@ function BuildWorkspace({
   storageInventory,
   storageStatus,
   storageError,
+  runDeletePreview,
+  runDeleteMessage,
   results,
   autoFinalizingWorkerRunIds,
   failedAutoFinalizingWorkerRunIds,
@@ -2527,8 +2594,9 @@ function BuildWorkspace({
   onInspectIngested,
   onOpenStoredResult,
   onExploreStoredResult,
-  onOpenStorage,
   onRefreshStorage,
+  onPreviewRunDelete,
+  onConfirmRunDelete,
   onRetryScenarios,
 }: {
   scenarioLoadState: ScenarioLoadState;
@@ -2572,6 +2640,8 @@ function BuildWorkspace({
   storageInventory: StorageInventoryResponse | null;
   storageStatus: string;
   storageError: string | null;
+  runDeletePreview: DeleteRunResponse | null;
+  runDeleteMessage: string | null;
   results: ResultCard[];
   autoFinalizingWorkerRunIds: Set<string>;
   failedAutoFinalizingWorkerRunIds: Set<string>;
@@ -2615,8 +2685,9 @@ function BuildWorkspace({
   onInspectIngested: () => void;
   onOpenStoredResult: (resultId: string) => void;
   onExploreStoredResult: (resultId: string) => void;
-  onOpenStorage: (runId?: string | null) => void;
   onRefreshStorage: () => void;
+  onPreviewRunDelete: (runId: string) => void;
+  onConfirmRunDelete: (runId: string) => void;
   onRetryScenarios: () => void;
 }) {
   const scenarioControlsReady = scenarioLoadState === "loaded" && selectedScenario !== undefined;
@@ -2881,6 +2952,8 @@ function BuildWorkspace({
             storageInventory={storageInventory}
             storageStatus={storageStatus}
             storageError={storageError}
+            runDeletePreview={runDeletePreview}
+            runDeleteMessage={runDeleteMessage}
             results={results}
             autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIds}
             failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIds}
@@ -2893,8 +2966,9 @@ function BuildWorkspace({
             onInspectIngested={onInspectIngested}
             onOpenStoredResult={onOpenStoredResult}
             onExploreStoredResult={onExploreStoredResult}
-            onOpenStorage={onOpenStorage}
             onRefreshStorage={onRefreshStorage}
+            onPreviewRunDelete={onPreviewRunDelete}
+            onConfirmRunDelete={onConfirmRunDelete}
           />
         </aside>
       </section>
@@ -3693,12 +3767,8 @@ function ResultsWorkspace({
   resultsStatus,
   resultsError,
   comparisonPair,
-  storageInventory,
-  storageStatus,
-  storageError,
-  focusedRunId,
-  deletePreview,
-  deleteMessage,
+  resultDeletePreview,
+  resultDeleteMessage,
   onTabChange,
   draft,
   onSelectResult,
@@ -3706,14 +3776,9 @@ function ResultsWorkspace({
   onSubmit,
   onRefreshResults,
   onInspect,
-  onManageLocalFiles,
   onCompareInspect,
-  onStorageOpenResult,
-  onStorageExploreResult,
-  onStorageIngestRun,
-  onRefreshStorage,
-  onPreviewDelete,
-  onConfirmDelete,
+  onPreviewResultDelete,
+  onConfirmResultDelete,
 }: {
   activeTab: ResultsTab;
   results: ResultCard[];
@@ -3722,12 +3787,8 @@ function ResultsWorkspace({
   resultsStatus: string;
   resultsError: string | null;
   comparisonPair: { baseline: ResultCard | undefined; dryFailed: ResultCard | undefined };
-  storageInventory: StorageInventoryResponse | null;
-  storageStatus: string;
-  storageError: string | null;
-  focusedRunId: string | null;
-  deletePreview: DeleteRunResponse | null;
-  deleteMessage: string | null;
+  resultDeletePreview: DeleteResultResponse | null;
+  resultDeleteMessage: string | null;
   onTabChange: (tab: ResultsTab) => void;
   draft: { name: string; tags: string; notes: string };
   onSelectResult: (resultId: string) => void;
@@ -3735,14 +3796,9 @@ function ResultsWorkspace({
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onRefreshResults: () => void;
   onInspect: () => void;
-  onManageLocalFiles: (result: ResultCard) => void;
   onCompareInspect: (resultId: string) => void;
-  onStorageOpenResult: (resultId: string) => void;
-  onStorageExploreResult: (resultId: string) => void;
-  onStorageIngestRun: (manifestPath: string) => void;
-  onRefreshStorage: () => void;
-  onPreviewDelete: (runId: string) => void;
-  onConfirmDelete: (runId: string) => void;
+  onPreviewResultDelete: (resultId: string) => void;
+  onConfirmResultDelete: (resultId: string) => void;
 }) {
   return (
     <section className="results-library" aria-labelledby="results-title">
@@ -3761,7 +3817,7 @@ function ResultsWorkspace({
       )}
 
       <nav className="subtab-nav" role="tablist" aria-label="Results views">
-        {(["notebook", "compare", "storage"] as ResultsTab[]).map((tab) => (
+        {(["notebook", "compare"] as ResultsTab[]).map((tab) => (
           <button
             key={tab}
             type="button"
@@ -3790,9 +3846,12 @@ function ResultsWorkspace({
           onSubmit={onSubmit}
           onRefreshResults={onRefreshResults}
           onInspect={onInspect}
-          onManageLocalFiles={onManageLocalFiles}
           onCompare={() => onTabChange("compare")}
           onOpenResultInExplore={onCompareInspect}
+          deletePreview={resultDeletePreview}
+          deleteMessage={resultDeleteMessage}
+          onPreviewDelete={onPreviewResultDelete}
+          onConfirmDelete={onConfirmResultDelete}
         />
       )}
 
@@ -3804,24 +3863,6 @@ function ResultsWorkspace({
             onSelectResult(resultId);
             onTabChange("notebook");
           }}
-        />
-      )}
-
-      {activeTab === "storage" && (
-        <StorageWorkspace
-          inventory={storageInventory}
-          results={results}
-          status={storageStatus}
-          error={storageError}
-          focusedRunId={focusedRunId}
-          deletePreview={deletePreview}
-          deleteMessage={deleteMessage}
-          onRefresh={onRefreshStorage}
-          onPreviewDelete={onPreviewDelete}
-          onConfirmDelete={onConfirmDelete}
-          onOpenResult={onStorageOpenResult}
-          onExploreResult={onStorageExploreResult}
-          onIngestRun={onStorageIngestRun}
         />
       )}
     </section>
@@ -3838,9 +3879,12 @@ function NotebookWorkspace({
   onSubmit,
   onRefreshResults,
   onInspect,
-  onManageLocalFiles,
   onCompare,
   onOpenResultInExplore,
+  deletePreview,
+  deleteMessage,
+  onPreviewDelete,
+  onConfirmDelete,
 }: {
   results: ResultCard[];
   selectedResult: ResultCard | undefined;
@@ -3851,9 +3895,12 @@ function NotebookWorkspace({
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onRefreshResults: () => void;
   onInspect: () => void;
-  onManageLocalFiles: (result: ResultCard) => void;
   onCompare: () => void;
   onOpenResultInExplore: (resultId: string) => void;
+  deletePreview: DeleteResultResponse | null;
+  deleteMessage: string | null;
+  onPreviewDelete: (resultId: string) => void;
+  onConfirmDelete: (resultId: string) => void;
 }) {
   const [filters, setFilters] = useState<ResultsFilterState>(DEFAULT_RESULTS_FILTERS);
   const scenarioOptions = useMemo(() => resultScenarioOptions(results), [results]);
@@ -3902,8 +3949,11 @@ function NotebookWorkspace({
           onDraftChange={onDraftChange}
           onSubmit={onSubmit}
           onInspect={onInspect}
-          onManageLocalFiles={onManageLocalFiles}
           onCompare={onCompare}
+          deletePreview={deletePreview}
+          deleteMessage={deleteMessage}
+          onPreviewDelete={onPreviewDelete}
+          onConfirmDelete={onConfirmDelete}
         />
       </div>
     </section>
@@ -4447,269 +4497,6 @@ function ComparisonTechnicalDetails({
   );
 }
 
-function StorageWorkspace({
-  inventory,
-  results,
-  status,
-  error,
-  focusedRunId,
-  deletePreview,
-  deleteMessage,
-  onRefresh,
-  onPreviewDelete,
-  onConfirmDelete,
-  onOpenResult,
-  onExploreResult,
-  onIngestRun,
-}: {
-  inventory: StorageInventoryResponse | null;
-  results: ResultCard[];
-  status: string;
-  error: string | null;
-  focusedRunId: string | null;
-  deletePreview: DeleteRunResponse | null;
-  deleteMessage: string | null;
-  onRefresh: () => void;
-  onPreviewDelete: (runId: string) => void;
-  onConfirmDelete: (runId: string) => void;
-  onOpenResult: (resultId: string) => void;
-  onExploreResult: (resultId: string) => void;
-  onIngestRun: (manifestPath: string) => void;
-}) {
-  const displayedRuns =
-    inventory && inventory.largest_runs.length > 0
-      ? inventory.largest_runs
-      : (inventory?.runs ?? []);
-  const deletePreviewResult = deletePreview
-    ? resultForRun(results, deletePreview.run_id)
-    : undefined;
-  const deletePreviewHasResult = Boolean(deletePreviewResult);
-
-  return (
-    <section
-      className="storage-workspace"
-      role="tabpanel"
-      id="storage-panel"
-      aria-labelledby="storage-tab storage-title"
-    >
-      <div className="section-heading">
-        <div>
-          <p className="eyebrow">Storage</p>
-          <h2 id="storage-title">Runtime inventory and cleanup</h2>
-          <p>
-            Review generated packages, running CM1 jobs, completed output, ingested results, and
-            cleanup candidates under the local runtime home.
-          </p>
-        </div>
-        <p className="state-chip">{status}</p>
-      </div>
-
-      {error && <p role="alert">{error}</p>}
-      {deleteMessage && <p role="status">{deleteMessage}</p>}
-
-      <section className="storage-summary" aria-label="Runtime storage summary">
-        <dl className="metric-grid">
-          <Metric label="Runtime home" value={inventory?.runtime_home ?? "Unavailable"} />
-          <Metric label="Runs directory" value={inventory?.runs_directory ?? "Unavailable"} />
-          <Metric
-            label="Total runtime-home size"
-            value={inventory ? formatBytes(inventory.total_size_bytes) : "Unavailable"}
-          />
-          <Metric
-            label="Warning threshold"
-            value={inventory ? formatBytes(inventory.warning_threshold_bytes) : "Unavailable"}
-          />
-          <Metric
-            label="Threshold status"
-            value={
-              inventory
-                ? inventory.above_warning_threshold
-                  ? "At or above 50 GB warning threshold"
-                  : "Below 50 GB warning threshold"
-                : "Unavailable"
-            }
-          />
-          <Metric label="Run directories" value={String(inventory?.runs.length ?? 0)} />
-        </dl>
-        {inventory?.warning_message && (
-          <p className="validation" role="status">
-            {inventory.warning_message}
-          </p>
-        )}
-        <div className="button-row">
-          <button type="button" onClick={onRefresh}>
-            Refresh storage
-          </button>
-        </div>
-      </section>
-
-      {deletePreview && (
-        <section className="delete-preview" aria-label="Delete preview">
-          <h3>
-            {deletePreviewHasResult
-              ? "Delete result and local run data preview"
-              : "Delete local run data preview"}
-          </h3>
-          {deletePreviewHasResult ? (
-            <p>
-              Cleanup removes local generated package files, copied runtime files, CM1 output, logs,
-              result metadata, notebook edits, diagnostics, and Explore backing references stored
-              under the selected run directory. The result will disappear from Results, Explore,
-              Compare, and Storage inventory after confirmation. It does not touch the source repo,
-              the runtime home itself, or the external CM1 install. No files have been deleted yet.
-            </p>
-          ) : (
-            <p>
-              Cleanup removes local generated package files, copied runtime files, CM1 output/logs
-              if present, and any metadata stored under the selected run directory. It does not
-              touch the source repo, the runtime home itself, or the external CM1 install. No files
-              have been deleted yet.
-            </p>
-          )}
-          <dl className="metric-grid">
-            <Metric label="Run ID" value={deletePreview.run_id} />
-            <Metric label="Selected path" value={deletePreview.run_directory} />
-            <Metric label="Estimated reclaimed" value={formatBytes(deletePreview.size_bytes)} />
-            <Metric label="Preview status" value={deletePreview.message} />
-          </dl>
-          <button
-            type="button"
-            className="danger-button"
-            onClick={() => onConfirmDelete(deletePreview.run_id)}
-          >
-            {deletePreviewHasResult
-              ? "Confirm delete result and local run data"
-              : "Confirm delete local run data"}
-          </button>
-        </section>
-      )}
-
-      <RuntimeRunsTable
-        runs={displayedRuns}
-        results={results}
-        focusedRunId={focusedRunId}
-        onPreviewDelete={onPreviewDelete}
-        onOpenResult={onOpenResult}
-        onExploreResult={onExploreResult}
-        onIngestRun={onIngestRun}
-      />
-    </section>
-  );
-}
-
-function RuntimeRunsTable({
-  runs,
-  results,
-  focusedRunId,
-  onPreviewDelete,
-  onOpenResult,
-  onExploreResult,
-  onIngestRun,
-}: {
-  runs: RunStorageEntry[];
-  results: ResultCard[];
-  focusedRunId: string | null;
-  onPreviewDelete: (runId: string) => void;
-  onOpenResult: (resultId: string) => void;
-  onExploreResult: (resultId: string) => void;
-  onIngestRun: (manifestPath: string) => void;
-}) {
-  if (runs.length === 0) {
-    return (
-      <section className="status-panel" aria-label="Runtime runs">
-        <p>No local Cloud Chamber run directories were found.</p>
-      </section>
-    );
-  }
-
-  return (
-    <section className="table-panel" aria-label="Runtime runs">
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">Run</th>
-            <th scope="col">Scenario</th>
-            <th scope="col">State</th>
-            <th scope="col">Output</th>
-            <th scope="col">Size</th>
-            <th scope="col">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {runs.map((run, index) => {
-            const associatedResult = resultForRun(results, run.run_id);
-            const displayName = storageDisplayName(run, associatedResult);
-            const canIngest = canIngestStorageRun(run, associatedResult);
-            return (
-              <tr
-                key={`${run.run_id}-${run.path ?? run.manifest_path ?? index}`}
-                className={focusedRunId === run.run_id ? "selected-row" : ""}
-              >
-                <td>
-                  <strong>{displayName}</strong>
-                  <small>{storageScenarioSummary(run, associatedResult)}</small>
-                  <small>Run ID: {run.run_id}</small>
-                  <small>{run.path}</small>
-                  {run.manifest_error && <small>{run.manifest_error}</small>}
-                </td>
-                <td>
-                  {storageScenarioName(run, associatedResult)}
-                  <small>{storagePresetAndControls(run, associatedResult)}</small>
-                </td>
-                <td>
-                  <div className="badge-row">
-                    {storageStateBadges(run, associatedResult).map((badge) => (
-                      <StatusBadge key={badge.label} label={badge.label} tone={badge.tone} />
-                    ))}
-                  </div>
-                  <small>{storageNextStep(run, associatedResult)}</small>
-                </td>
-                <td>{storageResultOutputSummary(run, associatedResult)}</td>
-                <td>{formatBytes(run.size_bytes)}</td>
-                <td>
-                  <div className="button-row">
-                    {associatedResult && (
-                      <button
-                        type="button"
-                        onClick={() => onOpenResult(associatedResult.result_id)}
-                      >
-                        Open result
-                      </button>
-                    )}
-                    {associatedResult && (
-                      <button
-                        type="button"
-                        className="secondary-button"
-                        onClick={() => onExploreResult(associatedResult.result_id)}
-                      >
-                        Open in Explore
-                      </button>
-                    )}
-                    {canIngest && run.manifest_path && (
-                      <button type="button" onClick={() => onIngestRun(run.manifest_path!)}>
-                        Ingest completed output
-                      </button>
-                    )}
-                    <button
-                      type="button"
-                      className="secondary-button"
-                      disabled={!canPreviewDelete(run)}
-                      onClick={() => onPreviewDelete(run.run_id)}
-                    >
-                      Preview delete
-                    </button>
-                  </div>
-                  {!canPreviewDelete(run) && <small>{deleteDisabledReason(run)}</small>}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </section>
-  );
-}
-
 function LocalRunWorkflowPanel({
   dryRun,
   runStatus,
@@ -4722,6 +4509,8 @@ function LocalRunWorkflowPanel({
   storageInventory,
   storageStatus,
   storageError,
+  runDeletePreview,
+  runDeleteMessage,
   results,
   autoFinalizingWorkerRunIds,
   failedAutoFinalizingWorkerRunIds,
@@ -4743,8 +4532,9 @@ function LocalRunWorkflowPanel({
   onInspectIngested,
   onOpenStoredResult,
   onExploreStoredResult,
-  onOpenStorage,
   onRefreshStorage,
+  onPreviewRunDelete,
+  onConfirmRunDelete,
 }: {
   dryRun: DryRunResponse | null;
   runStatus: RunStatusResponse | null;
@@ -4757,6 +4547,8 @@ function LocalRunWorkflowPanel({
   storageInventory: StorageInventoryResponse | null;
   storageStatus: string;
   storageError: string | null;
+  runDeletePreview: DeleteRunResponse | null;
+  runDeleteMessage: string | null;
   results: ResultCard[];
   autoFinalizingWorkerRunIds: Set<string>;
   failedAutoFinalizingWorkerRunIds: Set<string>;
@@ -4778,8 +4570,9 @@ function LocalRunWorkflowPanel({
   onInspectIngested: () => void;
   onOpenStoredResult: (resultId: string) => void;
   onExploreStoredResult: (resultId: string) => void;
-  onOpenStorage: (runId?: string | null) => void;
   onRefreshStorage: () => void;
+  onPreviewRunDelete: (runId: string) => void;
+  onConfirmRunDelete: (runId: string) => void;
 }) {
   const stage = buildRunStage(dryRun, runStatus, ingestedResultId, lanWorkerStatus);
   const canIngestLocal =
@@ -5071,6 +4864,8 @@ function LocalRunWorkflowPanel({
         inventory={storageInventory}
         status={storageStatus}
         error={storageError}
+        deletePreview={runDeletePreview}
+        deleteMessage={runDeleteMessage}
         results={results}
         currentRunId={currentRunId}
         lanWorkerConfigured={lanWorkerConfig?.configured ?? false}
@@ -5083,8 +4878,9 @@ function LocalRunWorkflowPanel({
         onIngestStoredRun={onIngestStoredRun}
         onOpenStoredResult={onOpenStoredResult}
         onExploreStoredResult={onExploreStoredResult}
-        onOpenStorage={onOpenStorage}
         onRefreshStorage={onRefreshStorage}
+        onPreviewDelete={onPreviewRunDelete}
+        onConfirmDelete={onConfirmRunDelete}
       />
     </section>
   );
@@ -5220,6 +5016,8 @@ function LocalPipelinePanel({
   inventory,
   status,
   error,
+  deletePreview,
+  deleteMessage,
   results,
   currentRunId,
   lanWorkerConfigured,
@@ -5232,12 +5030,15 @@ function LocalPipelinePanel({
   onIngestStoredRun,
   onOpenStoredResult,
   onExploreStoredResult,
-  onOpenStorage,
   onRefreshStorage,
+  onPreviewDelete,
+  onConfirmDelete,
 }: {
   inventory: StorageInventoryResponse | null;
   status: string;
   error: string | null;
+  deletePreview: DeleteRunResponse | null;
+  deleteMessage: string | null;
   results: ResultCard[];
   currentRunId: string | null;
   lanWorkerConfigured: boolean;
@@ -5250,8 +5051,9 @@ function LocalPipelinePanel({
   onIngestStoredRun: (manifestPath: string) => void;
   onOpenStoredResult: (resultId: string) => void;
   onExploreStoredResult: (resultId: string) => void;
-  onOpenStorage: (runId?: string | null) => void;
   onRefreshStorage: () => void;
+  onPreviewDelete: (runId: string) => void;
+  onConfirmDelete: (runId: string) => void;
 }) {
   const runs = selectPipelineRuns(inventory?.runs ?? [], results, currentRunId);
 
@@ -5266,22 +5068,45 @@ function LocalPipelinePanel({
       </div>
       <p className="state-note">
         Active packages and runs that still need launch, status review, troubleshooting, or ingest.
-        Ingested results live in Results and Storage.
+        Ingested results live in Results; non-ingested package and run cleanup stays here.
       </p>
       {error && <p role="alert">{error}</p>}
+      {deleteMessage && <p role="status">{deleteMessage}</p>}
       <div className="button-row">
         <button type="button" className="secondary-button" onClick={onRefreshStorage}>
           Refresh runs
         </button>
-        <button type="button" className="secondary-button" onClick={() => onOpenStorage()}>
-          Open Storage cleanup
-        </button>
       </div>
+
+      {deletePreview && (
+        <section className="delete-preview" aria-label="Local run delete preview">
+          <h5>Delete local package/run data preview</h5>
+          <p>
+            Cleanup removes local generated package files, copied runtime files, CM1 output/logs if
+            present, and local sidecars stored under this run directory. It does not touch Results
+            entries, the source repo, the runtime home itself, or the external CM1 install. No files
+            have been deleted yet.
+          </p>
+          <dl className="metric-grid">
+            <Metric label="Run ID" value={deletePreview.run_id} />
+            <Metric label="Selected path" value={deletePreview.run_directory} />
+            <Metric label="Estimated reclaimed" value={formatBytes(deletePreview.size_bytes)} />
+            <Metric label="Preview status" value={deletePreview.message} />
+          </dl>
+          <button
+            type="button"
+            className="danger-button"
+            onClick={() => onConfirmDelete(deletePreview.run_id)}
+          >
+            Confirm delete local run data
+          </button>
+        </section>
+      )}
 
       {runs.length === 0 ? (
         <p>
-          No active or incomplete packages/runs need Build action. Ingested results are in Results,
-          and cleanup is in Storage.
+          No active or incomplete packages/runs need Build action. Ingested experiments are managed
+          in Results.
         </p>
       ) : (
         <div className="pipeline-run-list" aria-label="Local packages and runs">
@@ -5301,7 +5126,7 @@ function LocalPipelinePanel({
               onIngestStoredRun={onIngestStoredRun}
               onOpenStoredResult={onOpenStoredResult}
               onExploreStoredResult={onExploreStoredResult}
-              onOpenStorage={onOpenStorage}
+              onPreviewDelete={onPreviewDelete}
             />
           ))}
         </div>
@@ -5324,7 +5149,7 @@ function PipelineRunCard({
   onIngestStoredRun,
   onOpenStoredResult,
   onExploreStoredResult,
-  onOpenStorage,
+  onPreviewDelete,
 }: {
   run: RunStorageEntry;
   result: ResultCard | undefined;
@@ -5339,7 +5164,7 @@ function PipelineRunCard({
   onIngestStoredRun: (manifestPath: string) => void;
   onOpenStoredResult: (resultId: string) => void;
   onExploreStoredResult: (resultId: string) => void;
-  onOpenStorage: (runId?: string | null) => void;
+  onPreviewDelete: (runId: string) => void;
 }) {
   const displayName = result?.name ?? run.scenario_name ?? run.scenario_id ?? run.run_id;
   const canLaunch = Boolean(
@@ -5456,14 +5281,18 @@ function PipelineRunCard({
             Open in Explore
           </button>
         )}
-        <button
-          type="button"
-          className="secondary-button"
-          onClick={() => onOpenStorage(run.run_id)}
-        >
-          Manage cleanup
-        </button>
+        {!result && (
+          <button
+            type="button"
+            className="secondary-button"
+            disabled={!canPreviewDelete(run)}
+            onClick={() => onPreviewDelete(run.run_id)}
+          >
+            Preview cleanup
+          </button>
+        )}
       </div>
+      {!result && !canPreviewDelete(run) && <small>{deleteDisabledReason(run)}</small>}
     </article>
   );
 }
@@ -5664,7 +5493,7 @@ function pipelineRunTone(
 }
 
 function pipelineRunNextStep(run: RunStorageEntry, result: ResultCard | undefined): string {
-  if (result) return "Review in Results or Explore fields; cleanup remains available in Storage.";
+  if (result) return "Review and local result cleanup are available in Results.";
   if (run.worker_state === "running")
     return "CM1 is running on the LAN worker; refresh runs for status.";
   if (run.worker_state === "completed") {
@@ -5688,7 +5517,7 @@ function pipelineRunNextStep(run: RunStorageEntry, result: ResultCard | undefine
   if (run.category === "missing_manifest" || run.category === "malformed_manifest") {
     return "Run directory needs cleanup review before trusting it.";
   }
-  return "Review in Storage for the safest next action.";
+  return "Review the local run state before cleanup.";
 }
 
 function workerProgressSummary(run: RunStorageEntry): string | null {
@@ -5972,16 +5801,22 @@ function ResultNotebookCard({
   onDraftChange,
   onSubmit,
   onInspect,
-  onManageLocalFiles,
   onCompare,
+  deletePreview,
+  deleteMessage,
+  onPreviewDelete,
+  onConfirmDelete,
 }: {
   result: ResultCard | undefined;
   draft: { name: string; tags: string; notes: string };
   onDraftChange: (draft: { name: string; tags: string; notes: string }) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onInspect: () => void;
-  onManageLocalFiles: (result: ResultCard) => void;
   onCompare: () => void;
+  deletePreview: DeleteResultResponse | null;
+  deleteMessage: string | null;
+  onPreviewDelete: (resultId: string) => void;
+  onConfirmDelete: (resultId: string) => void;
 }) {
   if (!result) {
     return (
@@ -6035,9 +5870,47 @@ function ResultNotebookCard({
           <Metric label="Deep convection" value={deepConvectionOutcome(result)} />
         )}
         <Metric label="Latest output" value={formatSeconds(resultLatestOutputTime(result))} />
+        <Metric
+          label="Local data"
+          value="Run-directory backed; delete removes the result and local run files"
+        />
       </dl>
 
       <InterestingTimesSummary result={result} />
+      {deleteMessage && <p role="status">{deleteMessage}</p>}
+      {deletePreview?.result_id === result.result_id && (
+        <section className="delete-preview result-delete-preview" aria-label="Result delete preview">
+          <h4>Delete result and local run data preview</h4>
+          <p>
+            This removes the ingested result, notebook edits, diagnostics, derived products, CM1
+            output, logs, and local run files stored under this run directory. The result will
+            disappear from Results, Explore, Compare, and local inventory after confirmation. It
+            does not touch the source repo, runtime home itself, or external CM1 install. No files
+            have been deleted yet.
+          </p>
+          <dl className="metric-grid">
+            <Metric label="Run ID" value={deletePreview.run_id} />
+            <Metric label="Selected path" value={deletePreview.run_directory} />
+            <Metric label="Estimated reclaimed" value={formatBytes(deletePreview.size_bytes)} />
+            <Metric label="Preview status" value={deletePreview.message} />
+          </dl>
+          <ul className="compact-list">
+            {deletePreview.categories.map((category) => (
+              <li key={category.label}>
+                <strong>{category.label}</strong>: {category.description}{" "}
+                {category.present ? `(${category.item_count} local item(s))` : "(none found)"}
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            className="danger-button"
+            onClick={() => onConfirmDelete(deletePreview.result_id)}
+          >
+            Delete result and local run data
+          </button>
+        </section>
+      )}
 
       <details className="technical-details">
         <summary>Technical details</summary>
@@ -6134,10 +6007,10 @@ function ResultNotebookCard({
           </button>
           <button
             type="button"
-            className="secondary-button"
-            onClick={() => onManageLocalFiles(result)}
+            className="danger-button"
+            onClick={() => onPreviewDelete(result.result_id)}
           >
-            Manage local files
+            Preview delete result and local run data
           </button>
           <button type="submit" className="secondary-button">
             Save changes
@@ -9175,7 +9048,6 @@ function resultsTabLabel(tab: ResultsTab): string {
   const labels: Record<ResultsTab, string> = {
     notebook: "Notebook",
     compare: "Compare",
-    storage: "Storage",
   };
   return labels[tab];
 }
@@ -9632,81 +9504,6 @@ function outputSummary(summary: OutputFileSummary): string {
   return parts.join(", ");
 }
 
-function storageDisplayName(run: RunStorageEntry, result: ResultCard | undefined): string {
-  return (
-    result?.name ?? run.scenario_name ?? (run.scenario_id ? humanize(run.scenario_id) : run.run_id)
-  );
-}
-
-function storageScenarioName(run: RunStorageEntry, result: ResultCard | undefined): string {
-  return (
-    result?.scenario_name ?? run.scenario_name ?? humanize(run.scenario_id ?? "unknown scenario")
-  );
-}
-
-function storageScenarioSummary(run: RunStorageEntry, result: ResultCard | undefined): string {
-  const scenario = storageScenarioName(run, result);
-  const preset = humanize(result?.run_size_preset ?? run.run_size_preset ?? "preset unknown");
-  return `${scenario} · ${preset}`;
-}
-
-function storagePresetAndControls(run: RunStorageEntry, result: ResultCard | undefined): string {
-  const preset = humanize(result?.run_size_preset ?? run.run_size_preset ?? "preset unknown");
-  if (!result) return preset;
-  return `${preset} · ${storageControlSummary(result.controls)}`;
-}
-
-function canIngestStorageRun(run: RunStorageEntry, result: ResultCard | undefined): boolean {
-  return Boolean(!result && run.manifest_path && run.category === "completed_with_output");
-}
-
-function storageStateBadges(
-  run: RunStorageEntry,
-  result: ResultCard | undefined,
-): Array<{ label: string; tone: "good" | "warning" | "neutral" }> {
-  if (result) {
-    return [{ label: "Ingested / ready to review", tone: "good" }];
-  }
-  const primary: Record<string, { label: string; tone: "good" | "warning" | "neutral" }> = {
-    dry_run_only: { label: "Ready-to-run package", tone: "neutral" },
-    running: { label: "Running CM1 process", tone: "neutral" },
-    completed_with_output: { label: "Ready to ingest", tone: "good" },
-    completed_no_output: { label: "Completed with no usable output", tone: "warning" },
-    failed: { label: "Failed run", tone: "warning" },
-    canceled: { label: "Canceled run", tone: "warning" },
-    missing_manifest: { label: "Needs cleanup review", tone: "warning" },
-    malformed_manifest: { label: "Needs cleanup review", tone: "warning" },
-    saved_or_protected: { label: "Cleanup review", tone: "neutral" },
-    unknown: { label: "Needs cleanup review", tone: "warning" },
-  };
-  const badge = primary[run.category] ?? { label: humanize(run.category), tone: "neutral" };
-  const badges = [badge];
-  return badges;
-}
-
-function storageNextStep(run: RunStorageEntry, result: ResultCard | undefined): string {
-  if (result) {
-    return "Review in Results or Explore, or preview deletion here if you want to remove the result and local run data.";
-  }
-  if (run.category === "dry_run_only")
-    return "Package is generated and can be launched from Build.";
-  if (run.category === "running")
-    return "CM1 is active or queued; cleanup is blocked until it stops.";
-  if (run.category === "completed_with_output") {
-    return "Output exists; ingest to create a notebook result before deciding cleanup.";
-  }
-  if (run.category === "completed_no_output") {
-    return "No usable output was detected; inspect logs or preview cleanup.";
-  }
-  if (run.category === "failed" || run.category === "canceled") {
-    return "Run did not complete; inspect logs or preview cleanup.";
-  }
-  if (run.category === "missing_manifest" || run.category === "malformed_manifest") {
-    return "Manifest is missing or unreadable; review carefully before cleanup.";
-  }
-  return "Review the local directory state before cleanup.";
-}
-
 function storageOutputSummary(run: RunStorageEntry): string {
   const netcdf = run.output_summary.netcdf_paths ?? 0;
   const raw = run.output_summary.raw_cm1_artifacts ?? 0;
@@ -9717,11 +9514,6 @@ function storageOutputSummary(run: RunStorageEntry): string {
   if (raw > 0) parts.push(`${raw} raw CM1 files`);
   if (processed > 0) parts.push(`${processed} processed files`);
   return parts.length > 0 ? parts.join(", ") : `${run.output_artifact_count} output artifacts`;
-}
-
-function storageResultOutputSummary(run: RunStorageEntry, result: ResultCard | undefined): string {
-  if (result) return outputSummary(result.output_file_summary);
-  return storageOutputSummary(run);
 }
 
 function pipelineRunOutputSummary(run: RunStorageEntry, result: ResultCard | undefined): string {
@@ -9738,15 +9530,6 @@ function pipelineRunOutputSummary(run: RunStorageEntry, result: ResultCard | und
 
 function resultForRun(results: ResultCard[], runId: string): ResultCard | undefined {
   return results.find((result) => result.run_id === runId);
-}
-
-function storageControlSummary(controls: ResultCard["controls"]): string {
-  const keys = ["low_level_humidity", "surface_heating", "cap_strength"];
-  const parts = keys.flatMap((key) => {
-    const value = controls[key];
-    return value === undefined ? [] : `${humanize(key)} ${humanize(String(value))}`;
-  });
-  return parts.length > 0 ? parts.join(" · ") : "controls recorded";
 }
 
 function canPreviewDelete(run: RunStorageEntry): boolean {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, FormEvent } from "react";
 
 import "./App.css";
@@ -1435,6 +1435,7 @@ export function App() {
   const [ingestedResultId, setIngestedResultId] = useState<string | null>(null);
   const [results, setResults] = useState<ResultCard[]>([]);
   const [selectedResultId, setSelectedResultId] = useState<string | null>(null);
+  const selectedResultIdRef = useRef<string | null>(null);
   const [resultDraft, setResultDraft] = useState({ name: "", tags: "", notes: "" });
   const [resultsStatus, setResultsStatus] = useState("Loading results...");
   const [storageInventory, setStorageInventory] = useState<StorageInventoryResponse | null>(null);
@@ -1579,6 +1580,12 @@ export function App() {
         : results[0],
     [results, selectedResultId],
   );
+
+  useEffect(() => {
+    selectedResultIdRef.current = selectedResultId;
+    setResultDeletePreview(null);
+    setResultDeleteMessage(null);
+  }, [selectedResultId]);
   const comparisonPair = useMemo(() => defaultComparisonPair(results), [results]);
   const autoFinalizingWorkerRunIdSet = useMemo(
     () => new Set(autoFinalizingWorkerRunIds),
@@ -2309,6 +2316,7 @@ export function App() {
     setResultsStatus("Preparing result delete preview");
     try {
       const preview = await requestResultDeletePreview(resultId);
+      if (selectedResultIdRef.current !== resultId) return;
       setResultDeletePreview(preview);
       setResultsStatus("Result delete preview ready");
     } catch (caught) {
@@ -2320,20 +2328,28 @@ export function App() {
   }
 
   async function handleConfirmResultDelete(resultId: string) {
+    if (resultDeletePreview?.result_id !== resultId) {
+      setResultDeletePreview(null);
+      setResultDeleteMessage(null);
+      setResultsError("Delete preview is stale. Preview deletion again before confirming.");
+      setResultsStatus("Delete preview expired");
+      return;
+    }
     setResultsError(null);
     setResultsStatus("Deleting selected result");
     try {
       const deleted = await confirmResultDelete(resultId);
       const remaining = results.filter((result) => result.result_id !== resultId);
+      const deleteMessage = `${deleted.message} Reclaimed ${formatBytes(
+        deleted.size_bytes,
+      )} from local storage.`;
       setResults(remaining);
       setSelectedResultId((current) =>
         current === resultId ? (remaining[0]?.result_id ?? null) : current,
       );
       setResultDeletePreview(null);
-      setResultDeleteMessage(
-        `${deleted.message} Reclaimed ${formatBytes(deleted.size_bytes)} from local storage.`,
-      );
-      setResultsStatus(remaining.length > 0 ? "Results loaded" : "No ingested results");
+      setResultDeleteMessage(deleteMessage);
+      setResultsStatus(deleteMessage);
       await refreshStorageAfterWorkflow("Local pipeline updated");
     } catch (caught) {
       setResultsError(caught instanceof Error ? caught.message : "Unable to delete selected result.");
@@ -2502,6 +2518,11 @@ export function App() {
           }}
           onPreviewResultDelete={handlePreviewResultDelete}
           onConfirmResultDelete={handleConfirmResultDelete}
+          onCancelResultDelete={() => {
+            setResultDeletePreview(null);
+            setResultDeleteMessage(null);
+            setResultsStatus("Results loaded");
+          }}
         />
       )}
 
@@ -3779,6 +3800,7 @@ function ResultsWorkspace({
   onCompareInspect,
   onPreviewResultDelete,
   onConfirmResultDelete,
+  onCancelResultDelete,
 }: {
   activeTab: ResultsTab;
   results: ResultCard[];
@@ -3799,6 +3821,7 @@ function ResultsWorkspace({
   onCompareInspect: (resultId: string) => void;
   onPreviewResultDelete: (resultId: string) => void;
   onConfirmResultDelete: (resultId: string) => void;
+  onCancelResultDelete: () => void;
 }) {
   return (
     <section className="results-library" aria-labelledby="results-title">
@@ -3852,6 +3875,7 @@ function ResultsWorkspace({
           deleteMessage={resultDeleteMessage}
           onPreviewDelete={onPreviewResultDelete}
           onConfirmDelete={onConfirmResultDelete}
+          onCancelDelete={onCancelResultDelete}
         />
       )}
 
@@ -3885,6 +3909,7 @@ function NotebookWorkspace({
   deleteMessage,
   onPreviewDelete,
   onConfirmDelete,
+  onCancelDelete,
 }: {
   results: ResultCard[];
   selectedResult: ResultCard | undefined;
@@ -3901,6 +3926,7 @@ function NotebookWorkspace({
   deleteMessage: string | null;
   onPreviewDelete: (resultId: string) => void;
   onConfirmDelete: (resultId: string) => void;
+  onCancelDelete: () => void;
 }) {
   const [filters, setFilters] = useState<ResultsFilterState>(DEFAULT_RESULTS_FILTERS);
   const scenarioOptions = useMemo(() => resultScenarioOptions(results), [results]);
@@ -3954,6 +3980,7 @@ function NotebookWorkspace({
           deleteMessage={deleteMessage}
           onPreviewDelete={onPreviewDelete}
           onConfirmDelete={onConfirmDelete}
+          onCancelDelete={onCancelDelete}
         />
       </div>
     </section>
@@ -5806,6 +5833,7 @@ function ResultNotebookCard({
   deleteMessage,
   onPreviewDelete,
   onConfirmDelete,
+  onCancelDelete,
 }: {
   result: ResultCard | undefined;
   draft: { name: string; tags: string; notes: string };
@@ -5817,6 +5845,7 @@ function ResultNotebookCard({
   deleteMessage: string | null;
   onPreviewDelete: (resultId: string) => void;
   onConfirmDelete: (resultId: string) => void;
+  onCancelDelete: () => void;
 }) {
   if (!result) {
     return (
@@ -5825,6 +5854,9 @@ function ResultNotebookCard({
       </section>
     );
   }
+
+  const visibleDeletePreview =
+    deletePreview?.result_id === result.result_id ? deletePreview : null;
 
   return (
     <section className="notebook-card" aria-label="Result detail">
@@ -5878,7 +5910,7 @@ function ResultNotebookCard({
 
       <InterestingTimesSummary result={result} />
       {deleteMessage && <p role="status">{deleteMessage}</p>}
-      {deletePreview?.result_id === result.result_id && (
+      {visibleDeletePreview && (
         <section className="delete-preview result-delete-preview" aria-label="Result delete preview">
           <h4>Delete result and local run data preview</h4>
           <p>
@@ -5889,26 +5921,34 @@ function ResultNotebookCard({
             have been deleted yet.
           </p>
           <dl className="metric-grid">
-            <Metric label="Run ID" value={deletePreview.run_id} />
-            <Metric label="Selected path" value={deletePreview.run_directory} />
-            <Metric label="Estimated reclaimed" value={formatBytes(deletePreview.size_bytes)} />
-            <Metric label="Preview status" value={deletePreview.message} />
+            <Metric label="Run ID" value={visibleDeletePreview.run_id} />
+            <Metric label="Selected path" value={visibleDeletePreview.run_directory} />
+            <Metric
+              label="Estimated reclaimed"
+              value={formatBytes(visibleDeletePreview.size_bytes)}
+            />
+            <Metric label="Preview status" value={visibleDeletePreview.message} />
           </dl>
           <ul className="compact-list">
-            {deletePreview.categories.map((category) => (
+            {visibleDeletePreview.categories.map((category) => (
               <li key={category.label}>
                 <strong>{category.label}</strong>: {category.description}{" "}
                 {category.present ? `(${category.item_count} local item(s))` : "(none found)"}
               </li>
             ))}
           </ul>
-          <button
-            type="button"
-            className="danger-button"
-            onClick={() => onConfirmDelete(deletePreview.result_id)}
-          >
-            Delete result and local run data
-          </button>
+          <div className="button-row">
+            <button type="button" onClick={onCancelDelete}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="danger-button"
+              onClick={() => onConfirmDelete(visibleDeletePreview.result_id)}
+            >
+              Delete result and local run data
+            </button>
+          </div>
         </section>
       )}
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -53,7 +53,7 @@ The [Cloud Chamber output product specification](contracts/output-product-specif
 defines the next data-contract layer between raw CM1 NetCDF output, result
 metadata, derived scientific products, visualization-ready payloads, future
 render-ready products, and external export bundles. Future backend ingest,
-Results, Explore, Storage, Diagnostics Lab, and Render Studio work should use
+Results, Explore, runtime cleanup, Diagnostics Lab, and Render Studio work should use
 that contract instead of inventing ad hoc output discovery or browser-side
 NetCDF parsing.
 
@@ -367,7 +367,7 @@ packaged-only, running, completed with output, completed without usable output,
 failed, ingested, legacy saved/protected metadata, or missing/malformed manifest.
 Build shows only active or incomplete package/run work that still needs launch,
 status review, troubleshooting, or ingest. Fully ingested results belong in
-Results and Storage. The launchpad uses the runtime storage inventory to show
+Results. The launchpad uses the runtime storage inventory to show
 eligible states and offers only safe state-appropriate transitions:
 
 - create a new package through `POST /api/dry-run-package`;
@@ -375,7 +375,7 @@ eligible states and offers only safe state-appropriate transitions:
 - refresh current status through `GET /api/runs/status`;
 - ingest completed output through `POST /api/results/ingest`;
 - open associated results in Results or Explore;
-- route cleanup decisions to Results / Storage.
+- preview and confirm cleanup for non-ingested package/run directories.
 
 Runtime status refresh may reconcile a stale local manifest only when stdout
 contains normal CM1 termination evidence and output artifacts exist under the
@@ -383,17 +383,11 @@ run directory. This repairs backend-restart cases where a completed local run
 was still labeled running, while avoiding silent completion claims for unknown
 or still-active runs.
 
-Storage remains the owner of deletion policy and cleanup actions. Build may link
-to Storage for cleanup, but it should not duplicate the delete workflow.
-
-Results / Storage is the canonical local runtime inventory for these same
-states. It joins storage entries to Result Cards when possible so the notebook
-name becomes the primary identity and run ID/path stay secondary technical
-metadata. Rows expose only state-appropriate non-destructive actions: open the
-associated result, open it in Explore, or ingest completed output when a
-completed-with-output run has a manifest and no associated result. Delete
-preview/confirmation remains scoped to Storage and is blocked for running or
-otherwise unsafe runs.
+Results owns cleanup for ingested results. It resolves the selected result to
+its managed run directory, previews user-facing cleanup categories, and requires
+explicit confirmation before deleting the result and local run data. Non-ingested
+run-directory cleanup stays in Build. Running or otherwise unsafe runs remain
+blocked by backend storage safety checks.
 
 ### Preview Engine
 
@@ -467,12 +461,12 @@ Deletion is explicit and scoped to one selected run directory. The cleanup servi
 Deleting a run removes local generated CM1 inputs, copied runtime files, logs, raw CM1 output, NetCDF output, processed artifacts, and any local metadata stored inside that run directory. It does not delete repo files or the external CM1 installation.
 
 The current code-backed lifecycle contract is documented in [Ingest, Results,
-And Storage Lifecycle Audit](ingest-results-storage-lifecycle.md). As of that
-audit, `result_metadata.json` and `result_card.json` live inside the selected
-run directory, so deleting the whole directory also removes the implemented
-Result/Explore record. The frontend Storage workspace makes that consequence
-explicit before confirmation instead of treating legacy saved/protected flags as
-the primary product model.
+And Runtime Cleanup Lifecycle Audit](ingest-results-storage-lifecycle.md). As of
+that audit, `result_metadata.json` and `result_card.json` live inside the
+selected run directory, so deleting the whole directory also removes the
+implemented Result/Explore record. Results makes that consequence explicit
+before confirmation instead of treating legacy saved/protected flags as the
+primary product model.
 
 ### Output Ingester
 
@@ -837,15 +831,11 @@ Explore
 ```
 
 `Results` is the default landing section so the selected result context is
-obvious before field inspection or 3-D visualization. It contains `Notebook`,
-`Compare`, and `Storage` sub-tabs. `Compare` remains result-pair oriented, while
-`Storage` joins runtime folders to result cards when possible so the user sees a
-result display name first and raw run IDs/paths second. Storage also surfaces
-ready-to-run packages, running/queued processes, completed output that is ready
-to ingest, completed runs with no usable output, failed/canceled runs, ingested
-results, legacy saved/protected metadata, and missing/malformed manifests as
-distinct cleanup/review states. Running runs block cleanup; non-running run
-directories require explicit preview and confirmation.
+obvious before field inspection or 3-D visualization. It contains `Notebook` and
+`Compare` sub-tabs. `Compare` remains result-pair oriented. Ingested-result
+cleanup lives on the selected notebook entry as a secondary/danger preview
+action, and deleting a result removes the result plus the local managed run data
+after explicit confirmation.
 
 `Notebook` renders result-card metadata as mobile-first experiment notebook
 entries rather than an admin table. The primary view should surface the result
@@ -856,11 +846,11 @@ provenance labels, and detailed caveats remains in disclosure so it is available
 without overwhelming the first read.
 
 `Explore` is one desktop workflow for one selected result, not separate
-implementation destinations. The selected result ID flows from Results /
-Notebook, Results / Compare, and Results / Storage into Explore; that workspace
-then requests backend-prepared field catalogs, defaults, point-cloud payloads,
-slices, and selected-point diagnostics for the same result. The browser does not
-open NetCDF files or classify the physics itself.
+implementation destinations. The selected result ID flows from Results Notebook
+and Results Compare into Explore; that workspace then requests backend-prepared
+field catalogs, defaults, point-cloud payloads, slices, and selected-point
+diagnostics for the same result. The browser does not open NetCDF files or
+classify the physics itself.
 
 Explore's UI contract is explanation-first. The selected result summary,
 cloud/no-cloud state, field-loading state, shared field/time/slice controls,

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -54,7 +54,7 @@ See [Cloud Chamber output product specification](contracts/output-product-specif
 for the contract that separates raw CM1 NetCDF output, result metadata,
 derived scientific products, visualization-ready payloads, future render-ready
 products, and external export bundles. Future Explore, Diagnostics Lab, Render
-Studio, Storage, and export work should preserve that browser/backend boundary:
+Studio, runtime cleanup, and export work should preserve that browser/backend boundary:
 the browser receives bounded backend-prepared products and does not parse raw
 NetCDF.
 
@@ -235,10 +235,10 @@ cleanup at the same time. The Build workspace should include a compact local
 run launchpad for active and incomplete package/run work only: create packages,
 launch eligible packages, refresh running/failed/completed status, troubleshoot
 failed or no-output runs, and ingest completed output. Fully ingested results
-belong in Results and Storage.
+belong in Results.
 
 When a local backend restart leaves a completed CM1 run's manifest marked
-running, Build/Storage refresh may reconcile the state only if stdout contains
+running, Build refresh may reconcile the state only if stdout contains
 normal CM1 termination evidence and output artifacts are present. The UI should
 then offer ingest rather than leaving the run stranded as running.
 
@@ -264,7 +264,7 @@ Current behavior is a placeholder only. It must explicitly say preview is not im
    runtime inventory when they still need Build action: packaged-only, running,
    completed with output and not yet ingested, completed without usable output,
    failed/canceled, or malformed/missing manifest. Fully ingested results are
-   reviewed in Results and managed in Storage.
+   reviewed and managed in Results.
 
 ### Workflow 3 — Launch CM1 Run
 
@@ -299,21 +299,38 @@ created Result Cards in Results or Explore. It is a pipeline view over local
 runtime state, not a single active wizard. This is local-first orchestration
 only; CI still uses fake fixtures and never runs CM1.
 
-### Workflow 4.5 — Manage Runtime Storage
+### Workflow 4.5 — Manage Runtime Cleanup
 
-Results / Storage exposes the runtime-home inventory from the backend. It shows total runtime-home size, the 50 GB warning-threshold status, run directories sorted by size, and lifecycle-aware identities for each run directory. When a run has an associated Result Card / notebook entry, the notebook name is primary and the raw run ID/path are secondary. If no result exists yet, Storage falls back to scenario name, scenario ID, and then run ID.
+Build exposes runtime-home inventory for active, incomplete, and non-ingested
+package/run work. It shows lifecycle-aware identities for run directories that
+still need launch, status review, troubleshooting, ingest, or cleanup. Fully
+ingested results are omitted from Build cleanup and managed from Results.
 
-Storage should describe each local run directory as part of the experiment lifecycle: ready-to-run package, running/queued CM1 process, completed with usable output, completed with no usable output, failed/canceled, ready to ingest, ingested/ready to review, legacy saved/protected metadata, or missing/malformed manifest that needs cleanup review. It should avoid duplicate or contradictory badges.
+Build should describe each non-ingested local run directory as part of the
+experiment lifecycle: ready-to-run package, running/queued CM1 process,
+completed with usable output, completed with no usable output, failed/canceled,
+ready to ingest, or missing/malformed manifest that needs cleanup review. It
+should avoid duplicate or contradictory badges.
 
-Storage offers non-destructive state transitions where they belong: open associated results in Results or Explore, and ingest completed output when a completed-with-output run has a manifest but no associated result. Destructive cleanup remains only in Storage behind preview and confirmation.
+Build offers non-destructive state transitions where they belong: launch
+packaged runs, refresh status, and ingest completed output when a
+completed-with-output run has a manifest but no associated result. Cleanup for
+non-ingested run directories remains behind preview and confirmation.
 
-Deletion is always explicit. The UI first requests a dry-run delete preview for one selected run, then requires a separate confirm action before deleting. Running runs cannot be deleted from the UI. Legacy saved/protected metadata does not make a non-running run undeletable; instead Storage states plainly that deleting the selected run directory removes local generated package/runtime/output/log files plus result metadata, notebook edits, diagnostics, and Explore backing references stored there. The warning threshold never auto-deletes anything.
+Results owns destructive cleanup for ingested results. The selected notebook
+entry offers a secondary/danger action to preview deletion by result ID. The
+preview states that deleting removes the ingested result, notebook edits,
+diagnostics, derived products, CM1 output, logs, and local run files stored
+under the run directory, and that the result will disappear from Results,
+Explore, Compare, and local inventory after confirmation.
 
-Build may link to Storage for cleanup, but it should not duplicate deletion
-logic. Results may link a selected notebook entry to its local files in Storage,
-but Results is not a deletion surface. The relationship should be clear:
-Build moves local runs forward, Results reviews and edits experiment notebook
-entries, and Storage manages local generated files safely.
+Deletion is always explicit. The UI first requests a dry-run delete preview for
+one selected run/result, then requires a separate confirm action before
+deleting. Running runs cannot be deleted. Legacy saved/protected metadata does
+not make a non-running run/result undeletable. The warning threshold never
+auto-deletes anything. The relationship should be clear: Build moves local runs
+forward and cleans up non-ingested runs; Results reviews, compares, edits, and
+deletes ingested experiment notebook entries plus their backing local data.
 
 ### Workflow 5 — Open Result
 
@@ -999,7 +1016,7 @@ Completed CM1 result
 Failed/canceled CM1 run
 Ingested result metadata
 Visualizer interpretation
-Saved result/notebook entry
+Editable result/notebook entry
 ```
 
 A preview or dry-run package is not a completed CM1 result. A visualization is an interpretation of CM1 output, not a new physical source of truth.
@@ -1012,7 +1029,7 @@ Product copy and state names should prefer nouns that reveal provenance:
 - `Completed CM1 result`
 - `Ingested result metadata`
 - `Visualizer interpretation`
-- `Saved experiment notebook entry`
+- `Editable experiment notebook entry`
 
 ## Result Card / Experiment Notebook
 
@@ -1146,14 +1163,12 @@ motion, and keeps cloud water below threshold. Its primary badges should read
 like an accepted moisture-limited outcome: `No cloud formed`, `No rain
 detected`, and `Moisture-limited`, with caveats secondary.
 
-`Results` contains `Notebook`, `Compare`, and `Storage` sub-tabs. Notebook is
-the Result Card / Experiment Notebook: a scan-friendly list of experiment cards
-plus a selected notebook detail, with technical run metadata kept secondary.
-Compare is result-pair oriented and belongs with Results because it compares
-experiment outcomes. Storage is also part of Results because it manages local
-run directories and their relationship to named result cards. Storage should
-read as local runtime inventory for the experiment lifecycle, not a raw folder
-table keyed by run ID.
+`Results` contains `Notebook` and `Compare` sub-tabs. Notebook is the Result
+Card / Experiment Notebook: a scan-friendly list of experiment cards plus a
+selected notebook detail, with technical run metadata kept secondary. Compare is
+result-pair oriented and belongs with Results because it compares experiment
+outcomes. Ingested-result cleanup lives on the selected notebook detail as a
+secondary/danger preview action, not as a separate Storage workspace.
 
 `Explore` is one desktop cloud-context and slice-inspection workflow for a
 single selected result. The old `2-D Slices` / `3-D View` split was useful
@@ -1162,7 +1177,7 @@ is now a unified instrument: compact selected-result context, shared
 field/time/slice controls, a 3-D scalar-field context, a visible native-grid
 slice plane, the matching 2-D slice inspector, and a `What happened here?`
 selected-point explanation panel. Selecting a result in Notebook or opening a
-comparison/storage row in Explore should preserve that context. If no selected
+comparison row in Explore should preserve that context. If no selected
 result is available, Explore should tell the user to select an ingested result
 from Results.
 

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -81,11 +81,13 @@ renderer technology, or new scenario families.
 
 ## Recently Completed
 
-#204/#205/#218 cleaned up the Build/Results/Storage lifecycle model.
+#204/#205/#218/#236 cleaned up the Build/Results/runtime-cleanup lifecycle
+model.
 
 - **Build** shows active and incomplete package/run/ingest pipeline work.
-- **Results** owns ingested notebook review.
-- **Storage** owns explicit destructive cleanup.
+- **Build** owns cleanup for non-ingested local packages and runs.
+- **Results** owns ingested notebook review plus explicit ingested-result
+  cleanup.
 
 ## Recommended Issue Candidates
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 Cloud Chamber is a local-first, personal-use CM1 experiment builder, run manager, and visualizer. CM1 is the high-fidelity simulation engine; Cloud Chamber should make CM1 easier to configure, run, inspect, visualize, and learn from.
 
-The first Golden Path is Baseline Shallow Cumulus. Saved results are meant to be replayed and inspected as experiment notebook entries. Optional remote/cloud compute is not a development dependency for the MVP. The near-term heavier-run path is a trusted LAN worker documented in [Trusted LAN Worker CM1 Setup](research/lan-worker-cm1-setup.md), with the MacBook still acting as Cloud Chamber's system of record.
+The first Golden Path is Baseline Shallow Cumulus. Result notebook entries are meant to be replayed and inspected as experiment evidence. Optional remote/cloud compute is not a development dependency for the MVP. The near-term heavier-run path is a trusted LAN worker documented in [Trusted LAN Worker CM1 Setup](research/lan-worker-cm1-setup.md), with the MacBook still acting as Cloud Chamber's system of record.
 
 Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later. Warm rain remains early, but it does not block the Baseline Shallow Cumulus Golden Path.
 
@@ -233,14 +233,17 @@ Required runtime files such as `LANDUSE.TBL` are copied from the configured loca
 
 Runtime output can grow quickly. The storage inventory endpoint scans only the configured Cloud Chamber runtime home, normally `~/CloudChamber`, and reports total size plus per-run size, manifest metadata, output artifact counts, and conservative cleanup categories such as `dry_run_only`, `completed_with_output`, `completed_no_output`, `failed`, `canceled`, `saved_or_protected`, `missing_manifest`, and `malformed_manifest`. Legacy `saved_or_protected` categories may still appear in manifests, but they are no longer a user-facing Results mode.
 
-Results / Storage uses the same endpoints. It shows the runtime-home summary, the 50 GB warning-threshold state, largest run directories first, result-card names when associated, output artifact counts, ingestion/review state, and cleanup categories. It never deletes automatically.
+Build uses the runtime inventory for active, incomplete, and non-ingested
+package/run work. Results owns ingested-result cleanup by resolving a selected
+result to its backing run directory, previewing cleanup categories, and requiring
+explicit confirmation. Cleanup never deletes automatically.
 
 The MVP storage warning threshold is 50 GB for the configured runtime home. Inventory reports the threshold and whether runtime storage is at or above it. This is a configurable product default, not a hard scientific limit, and it never auto-deletes anything. When the threshold is reached, use the inventory's largest-run list and dry-run cleanup mode before confirming deletion of selected runs.
 
 Run deletion is explicit and conservative. A preview request uses `dry_run: true`; a real delete requires `dry_run: false` and `confirm: true`. Cleanup only targets `~/CloudChamber/runs/<run-id>/`, refuses path traversal and symlink escapes, and refuses running runs. Deleting a run removes its local generated package, output artifacts, copied runtime files, logs, result metadata, notebook edits, diagnostics, and Explore backing references stored under that run directory. Cleanup must never target the source repo, home directory, runtime home itself, or the external CM1 installation.
 
-For the current code-backed package/run/result/storage contract, see
-[Ingest, Results, And Storage Lifecycle Audit](ingest-results-storage-lifecycle.md).
+For the current code-backed package/run/result/cleanup contract, see
+[Ingest, Results, And Runtime Cleanup Lifecycle Audit](ingest-results-storage-lifecycle.md).
 Today `result_metadata.json` and `result_card.json` are local sidecar files
 inside the generated run directory, so deleting that whole directory also
 removes the implemented Results/Explore record for that run. Treat this as a

--- a/docs/ingest-results-storage-lifecycle.md
+++ b/docs/ingest-results-storage-lifecycle.md
@@ -1,8 +1,8 @@
-# Ingest, Results, And Storage Lifecycle Audit
+# Ingest, Results, And Runtime Cleanup Lifecycle Audit
 
 This audit records the current implementation contract for generated packages,
 local CM1 runs, ingested result metadata, Result Cards, Explore data, and
-Storage cleanup.
+runtime cleanup.
 
 It is evidence, not a redesign. The code paths cited below are the current
 source of truth.
@@ -24,35 +24,35 @@ source of truth.
   `app/backend/cloud_chamber/result_cards.py`.
 - Explore data: `field_catalog`, `field_slice`, `point_cloud`, and
   `view_defaults` in `app/backend/cloud_chamber/visualization_data.py`.
-- Storage inventory and deletion: `runtime_storage_inventory`,
+- Runtime inventory and deletion: `runtime_storage_inventory`,
   `delete_runtime_run`, `_entry_from_manifest`, and `_classify_run` in
   `app/backend/cloud_chamber/runtime_storage.py`.
 - API routing: `/api/dry-run-package`, `/api/runs/launch`,
   `/api/runs/status`, `/api/results/ingest`, `/api/results`,
-  `/api/results/{result_id}`, `/api/results/{result_id}/visualization/*`,
-  `/api/storage/inventory`, and `/api/storage/delete-run` in
-  `app/backend/cloud_chamber/app.py`.
+  `/api/results/{result_id}`, `/api/results/{result_id}/delete-preview`,
+  `/api/results/{result_id}/delete`,
+  `/api/results/{result_id}/visualization/*`, `/api/storage/inventory`, and
+  `/api/storage/delete-run` in `app/backend/cloud_chamber/app.py`.
 - Frontend ownership and joins: `requestDryRunPackage`, `launchLocalRun`,
   `ingestCompletedRun`, `fetchResults`, `patchResultCard`,
   `saveResultCard`, `fetchStorageInventory`, `requestRunDeletePreview`,
-  `confirmRunDelete`, `StorageWorkspace`, `RuntimeRunsTable`,
-  `ResultNotebookCard`, `canIngestStorageRun`, and `storageStateBadges` in
-  `app/frontend/src/App.tsx`.
+  `confirmRunDelete`, `requestResultDeletePreview`, `confirmResultDelete`,
+  `LocalPipelinePanel`, and `ResultNotebookCard` in `app/frontend/src/App.tsx`.
 
 ## Current Lifecycle Table
 
 | Stage | Files/records created | UI page that owns it | Actions available | Cleanup behavior | Notes/caveats |
 | --- | --- | --- | --- | --- | --- |
-| Generated package | `~/CloudChamber/runs/<run-id>/run_manifest.json`, `case_manifest.json`, `namelist.input`, `input_sounding`, `dry_run_report.json`, `runtime_file_checklist.json` | Build creates it; Storage inventories it | Launch from Build or stored-package actions; review generated paths/details | Category `dry_run_only`; eligible for Storage preview/delete unless a future guard blocks it | Manifest is `lifecycle_state=packaged` and `product_state=packaged_dry_run_output`; it is not a CM1 result. |
-| Launched/running run | Same run directory plus `logs/stdout.log`, `logs/stderr.log`; manifest execution command/log paths/timestamps; staged runtime files such as `LANDUSE.TBL` if needed | Build launches and polls; Storage inventories | Refresh status; cancel active run through backend API | Category `running`; Storage backend refuses deletion | One local process is allowed at a time by `LocalRunManager`. |
-| Completed run with output | Manifest updated to `lifecycle_state=completed`, `product_state=completed_cm1_result`, exit code, finish time, detected NetCDF/raw artifact paths, runtime warnings | Build/Storage can show completed output; Storage can offer ingest | Ingest completed output | Category `completed_with_output`; eligible for Storage preview/delete unless the run is active or otherwise unsafe | Output detection looks for NetCDF patterns and raw CM1 `.dat/.ctl` patterns in the run directory. |
-| Completed run without usable output | Manifest updated to `lifecycle_state=completed`, `product_state=process_completed_no_output`, `validation_status=needs_review` | Build/Storage | Inspect logs; cleanup review | Category `completed_no_output`; eligible for Storage preview/delete | Cannot be ingested by current NetCDF ingest because it lacks model-field NetCDF. |
-| Failed/canceled run | Manifest updated to `failed` or `canceled`, failed/canceled product state, exit code/timestamps when available | Build/Storage | Inspect logs; cleanup review | Category `failed` or `canceled`; eligible for Storage preview/delete unless the run is active or otherwise unsafe | Failed launch after queued state can leave logs/manifest but no useful output. |
-| Ingested result | `result_metadata.json` written inside the same run directory | Results owns review; Explore uses it; Storage joins to result list in the frontend | Open in Results, open in Explore, edit notebook fields | Backend Storage still classifies from manifest and files; frontend Storage treats associated result state as review-ready | Ingest does not move metadata to a separate database. It derives metadata from local NetCDF files and keeps source paths pointing at the run directory. |
-| Editable notebook entry | Optional `result_card.json` beside `result_metadata.json` in the run directory | Results / Notebook | Rename, edit tags/notes, save changes | Explicit Storage deletion removes this file when it deletes the selected run directory | `result_card.json` stores user-editable state: `name`, `tags`, `notes`, and compatibility fields such as `saved`, `protected`, and `updated_at` in older cards. |
-| Legacy saved/protected metadata | `result_card.json` or older manifest `user.saved` may still carry `saved=true` / `protected=true` | Compatibility / historical local state | Display only as technical metadata when relevant | No longer the user-facing Results mode and no longer blocks explicit non-running run deletion after preview/confirmation | The current product model is: ingested results appear in Results; notebook edits save changes; Storage deletion is explicit and explains that run-directory deletion removes local result metadata. |
-| Cleanup-eligible run/result | No new file; eligibility is derived from manifest category and frontend result join | Storage | Dry-run delete preview, then confirmed delete | Deletes the entire selected `~/CloudChamber/runs/<run-id>/` directory | Deleting a run directory deletes generated package files, outputs, logs, `result_metadata.json`, and `result_card.json` if present. |
-| Deleted run directory | Run directory removed with `shutil.rmtree` | Storage | None after deletion except refresh | Removed from inventory and Results/Explore if their metadata lived there | If metadata/card lived only in the deleted directory, Results and Explore can no longer load that result. |
+| Generated package | `~/CloudChamber/runs/<run-id>/run_manifest.json`, `case_manifest.json`, `namelist.input`, `input_sounding`, `dry_run_report.json`, `runtime_file_checklist.json` | Build creates it and inventories it | Launch from Build or stored-package actions; review generated paths/details; preview cleanup for non-ingested packages | Category `dry_run_only`; eligible for Build preview/delete unless a future guard blocks it | Manifest is `lifecycle_state=packaged` and `product_state=packaged_dry_run_output`; it is not a CM1 result. |
+| Launched/running run | Same run directory plus `logs/stdout.log`, `logs/stderr.log`; manifest execution command/log paths/timestamps; staged runtime files such as `LANDUSE.TBL` if needed | Build launches, polls, and inventories it | Refresh status; cancel active run through backend API | Category `running`; backend refuses deletion | One local process is allowed at a time by `LocalRunManager`. |
+| Completed run with output | Manifest updated to `lifecycle_state=completed`, `product_state=completed_cm1_result`, exit code, finish time, detected NetCDF/raw artifact paths, runtime warnings | Build can show completed output before ingest | Ingest completed output; preview cleanup only while non-ingested | Category `completed_with_output`; eligible for Build preview/delete unless the run is active or otherwise unsafe | Output detection looks for NetCDF patterns and raw CM1 `.dat/.ctl` patterns in the run directory. |
+| Completed run without usable output | Manifest updated to `lifecycle_state=completed`, `product_state=process_completed_no_output`, `validation_status=needs_review` | Build | Inspect logs; cleanup review | Category `completed_no_output`; eligible for Build preview/delete | Cannot be ingested by current NetCDF ingest because it lacks model-field NetCDF. |
+| Failed/canceled run | Manifest updated to `failed` or `canceled`, failed/canceled product state, exit code/timestamps when available | Build | Inspect logs; cleanup review | Category `failed` or `canceled`; eligible for Build preview/delete unless the run is active or otherwise unsafe | Failed launch after queued state can leave logs/manifest but no useful output. |
+| Ingested result | `result_metadata.json` written inside the same run directory | Results owns review and cleanup; Explore uses it | Open in Results, open in Explore, compare, edit notebook fields, preview/delete result and local run data | Result delete resolves `result_id` to the managed run directory, lists user-facing cleanup categories, and deletes the whole run directory after confirmation | Ingest does not move metadata to a separate database. It derives metadata from local NetCDF files and keeps source paths pointing at the run directory. |
+| Editable notebook entry | Optional `result_card.json` beside `result_metadata.json` in the run directory | Results / Notebook | Rename, edit tags/notes, save changes | Explicit Results deletion removes this file when it deletes the selected result's run directory | `result_card.json` stores user-editable state: `name`, `tags`, `notes`, and compatibility fields such as `saved`, `protected`, and `updated_at` in older cards. |
+| Legacy saved/protected metadata | `result_card.json` or older manifest `user.saved` may still carry `saved=true` / `protected=true` | Compatibility / historical local state | Not a current user-facing mode | No longer blocks explicit non-running run/result deletion after preview/confirmation | The current product model is: ingested results appear in Results; notebook edits save changes; deletion copy explains that run-directory deletion removes local result metadata. |
+| Cleanup-eligible non-ingested run | No new file; eligibility is derived from manifest category and result join | Build | Dry-run delete preview, then confirmed delete | Deletes the entire selected `~/CloudChamber/runs/<run-id>/` directory | Applies to generated packages, failed/canceled runs, completed-no-output runs, and completed-with-output runs not yet ingested. |
+| Deleted run directory | Run directory removed with `shutil.rmtree` | Build for non-ingested runs; Results for ingested results | None after deletion except refresh | Removed from inventory and Results/Explore if their metadata lived there | If metadata/card lived only in the deleted directory, Results and Explore can no longer load that result. |
 
 ## Direct Answers
 
@@ -146,7 +146,7 @@ Yes. Explore requires:
 If the original run directory is deleted, Explore loses both the metadata and
 the source NetCDF files.
 
-### 10. What does Storage cleanup delete?
+### 10. What does runtime cleanup delete?
 
 `delete_runtime_run` deletes one directory:
 
@@ -159,17 +159,22 @@ generated package files, copied runtime files, CM1 output, logs, and local
 metadata stored under the selected run directory. It does not target the repo,
 runtime home itself, home directory, or external CM1 install.
 
+For ingested results, `delete_ingested_result` first resolves
+`result_id -> result_metadata.json -> run directory`, reuses the same path and
+running-run safety checks, returns user-facing cleanup categories, and then
+deletes the same managed run directory only after confirmation.
+
 ### 11. What exactly does the current `saved` field do?
 
 There are two current saved fields:
 
 1. `RunManifest.user.saved` in `run_manifest.json`.
-   - Used by backend Storage classification and delete refusal.
+   - Used by backend runtime inventory classification.
    - If true, `_classify_run` returns `saved_or_protected`.
-   - `delete_runtime_run` refuses deletion unless `force_saved=true`.
+   - It no longer blocks explicit non-running deletion after preview and
+     confirmation.
 2. `ResultCardState.saved` in `result_card.json`.
-   - Used by Results to show saved/not saved and by frontend Storage after it
-     joins results to runs.
+   - Kept for compatibility with older result-card state.
    - `save_result_card` sets `saved=true` and `protected=true`.
    - It does not update `run_manifest.json`.
 
@@ -182,10 +187,10 @@ Result Card notebook state.
 sets `protected=true`, and `_card_from_metadata` returns `protected` as
 `state.protected or state.saved`.
 
-The backend Storage delete guard does not currently read `result_card.json`, so
-Result Card protection blocks normal cleanup in the frontend join, not in the
-storage backend's own inventory/delete contract. Backend hard protection still
-comes from `run_manifest.json` `user.saved`.
+The backend cleanup guard does not currently read `result_card.json`, and
+Result Card protection is not a current user-facing deletion mode. Running runs
+and unsafe paths remain blocked; old saved/protected metadata does not block an
+intentional delete after preview and confirmation.
 
 ### 13. What happens if a run directory is deleted after ingest?
 
@@ -220,23 +225,21 @@ and NetCDF files remain available.
 
 ### 15. What user-facing labels/actions currently map to these backend fields?
 
-- `Ready-to-run package` maps to Storage category `dry_run_only`, derived from
+- `Ready-to-run package` maps to runtime category `dry_run_only`, derived from
   manifest lifecycle `packaged`.
-- `Running CM1 process` maps to Storage category `running`, derived from
+- `Running CM1 process` maps to runtime category `running`, derived from
   manifest lifecycle `queued` or `running`.
-- `Ready to ingest` maps to Storage category `completed_with_output` when no
+- `Ready to ingest` maps to runtime category `completed_with_output` when no
   associated Result Card exists.
-- `Ingested / ready to review` maps to a frontend join where a Result Card has
-  the same `run_id` as the Storage entry.
 - `Saved/protected` is legacy compatibility metadata, not the current
   user-facing Results mode.
 - `Open result` and `Open in Explore` require an associated Result Card.
-- `Ingest completed output` requires category `completed_with_output`, a
+- `Ingest output` requires category `completed_with_output`, a
   manifest path, and no associated Result Card.
-- `Preview delete` is disabled in the UI when the run is running. Explicit
-  preview/confirmation is available for other run directories, including ones
-  with legacy saved/protected metadata, and the copy must explain that deleting
-  the run directory removes result metadata and notebook edits stored there.
+- `Preview cleanup` in Build is for non-ingested package/run directories and is
+  disabled while a run is running.
+- `Preview delete result and local run data` in Results is for ingested results
+  and resolves the selected result to its backing run directory.
 
 ## Mismatches And Caveats
 
@@ -253,8 +256,7 @@ The desired distinction:
 
 ```text
 Save changes = title/notes/tags edits.
-Storage cleanup = explicit delete of the selected run directory and everything
-inside it.
+Cleanup = explicit delete of the selected run directory and everything inside it.
 ```
 
 `PATCH /api/results/{result_id}` writes name/tags/notes to `result_card.json`,
@@ -276,7 +278,7 @@ Desired future model to evaluate:
 ```text
 Ingested = appears in Results as an experiment notebook entry.
 Save changes = title/notes/tags edits.
-Storage protection = whether bulky local run data can be cleaned up.
+Local data retention = whether bulky local run data remains available.
 ```
 
 Current compatibility: **partially compatible, blocked by storage architecture.**
@@ -300,8 +302,8 @@ Before changing UI labels or cleanup behavior, decide these separately:
    `runs/<run-id>`?
 2. Should `result_card.json` remain sidecar state, or become part of a central
    notebook store?
-3. Should Storage cleanup support "remove bulky output but keep metadata/card"
-   as a distinct action from "delete entire run directory"?
+3. Should cleanup support "remove bulky output but keep metadata/card" as a
+   distinct action from "delete entire run directory"?
 4. Should backend delete protection read Result Card state, update manifest
    state when a card is saved, or both?
 5. Should "Saved" mean editable notebook changes are persisted, or should the

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -281,7 +281,7 @@ Completed CM1 result
 Failed/canceled CM1 run
 Ingested result metadata
 Visualizer interpretation
-Saved result/notebook entry
+Editable result/notebook entry
 ```
 
 Never imply:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -429,21 +429,22 @@ Build can be tested without real local packages in every state:
 - legacy saved/protected metadata;
 - missing or malformed manifest.
 
-These tests should assert that Build presents only active and incomplete package/run work that still needs launch, troubleshooting, status review, or ingest, and routes cleanup to Results / Storage instead of duplicating deletion behavior. Fully ingested results belong in Results/Storage, not the Build action list.
+These tests should assert that Build presents only active and incomplete
+package/run work that still needs launch, troubleshooting, status review,
+ingest, or non-ingested cleanup. Fully ingested results belong in Results, not
+the Build action list.
 They should also cover missing local CM1 settings or preflight failures as
 actionable UI errors. Automated tests must not execute `cm1.exe`, parse real
 local NetCDF output in the browser, or write generated run directories into the
 repo.
 
-Storage lifecycle UI tests should use mocked inventory/results joins. They
-should verify notebook names are primary when a result card exists, raw run IDs
-and paths remain secondary, completed-with-output runs without results expose
-`Ingest completed output`, associated results expose `Open result` and `Open in
-Explore`, running runs block normal delete preview, and explicit delete preview
-copy explains that deleting the run directory also removes result metadata,
-notebook edits, diagnostics, and Explore backing references stored there.
-Results notebook tests should verify `Manage local files` routes the selected
-experiment to Results / Storage without adding delete controls to Results.
+Runtime cleanup UI tests should use mocked inventory/results data. They should
+verify completed-with-output runs without results expose `Ingest output`, Build
+shows preview cleanup only for non-ingested runs, running runs block cleanup
+preview, and Results exposes `Preview delete result and local run data` for
+ingested results. Result delete preview copy should explain that deleting the
+run directory also removes result metadata, notebook edits, diagnostics, derived
+products, CM1 output, logs, and Explore backing references stored there.
 
 Comparison tests should use mocked Result Card data for the accepted Baseline
 Shallow Cumulus quick-look and Dry Failed Cumulus quick-look pair. They should


### PR DESCRIPTION
## Summary

- Removed Storage as a user-facing workspace; Results now owns ingested-result preview/delete by result id.
- Added backend result cleanup preview/delete APIs that reuse strict runtime-storage safety checks and report user-facing cleanup categories.
- Kept Build responsible for active, incomplete, and non-ingested local package/run cleanup.
- Updated component tests, mocked E2E coverage, and lifecycle/product docs for the new ownership model.

## Verification

- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_runtime_storage.py app/backend/tests/test_app.py`
- `npm test -- App.test.tsx`
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Notes

- Opened as draft and auto-merge is not enabled because this changes destructive local cleanup behavior.
- No generated CM1 outputs, NetCDF files, runtime folders, logs, screenshots, traces, videos, or local settings are committed.

Closes #236
