### PR TITLE
Add Build run progress summaries

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -45,6 +45,7 @@ from cloud_chamber.result_ingest import (
     ingest_completed_run,
 )
 from cloud_chamber.run_manifest import RunManifestError, load_run_manifest
+from cloud_chamber.run_progress import run_progress_from_manifest
 from cloud_chamber.runtime_storage import (
     RuntimeStorageError,
     delete_ingested_result,
@@ -650,6 +651,7 @@ def _run_status_payload(status: RunStatus) -> dict[str, object]:
                 "processed_artifacts": 0,
             },
             "runtime_warnings": [],
+            "progress": None,
         }
     return {
         "run_id": status.run_id,
@@ -675,6 +677,7 @@ def _run_status_payload(status: RunStatus) -> dict[str, object]:
             "processed_artifacts": len(manifest.outputs.processed_artifacts),
         },
         "runtime_warnings": manifest.outputs.runtime_warnings,
+        "progress": run_progress_from_manifest(manifest),
     }
 
 

--- a/app/backend/cloud_chamber/run_progress.py
+++ b/app/backend/cloud_chamber/run_progress.py
@@ -1,0 +1,225 @@
+"""CM1 run progress summaries for Build status surfaces."""
+
+from __future__ import annotations
+
+import math
+import re
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from cloud_chamber.cm1_input_contract import cloud_scale_defaults_for_preset
+from cloud_chamber.run_manifest import LifecycleState, RunManifest
+
+CM1_MODEL_MINUTE_RE = re.compile(
+    r"(?m)^\s*\d+\s+([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][+-]?\d+)?)\s+min\s*$"
+)
+TAIL_BYTES = 2_000_000
+TERMINAL_STATES = {
+    LifecycleState.COMPLETED,
+    LifecycleState.FAILED,
+    LifecycleState.CANCELED,
+    LifecycleState.INGESTED,
+    LifecycleState.SAVED,
+}
+
+
+def run_progress_from_manifest(
+    manifest: RunManifest,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Return bounded progress metadata from manifest config and CM1 stdout."""
+
+    checked_at = _utc(now or datetime.now(UTC))
+    caveats: list[str] = []
+    total_model_time, total_source, total_caveats = _configured_model_time_seconds(manifest)
+    caveats.extend(total_caveats)
+    model_time, model_source = _latest_model_time_seconds(manifest)
+
+    if (
+        manifest.lifecycle_state in {LifecycleState.COMPLETED, LifecycleState.INGESTED}
+        and manifest.execution.exit_code == 0
+        and total_model_time is not None
+    ):
+        model_time = total_model_time
+        model_source = "completed_run_state"
+
+    elapsed = _elapsed_wall_seconds(manifest, checked_at)
+    percent = _percent_complete(model_time, total_model_time)
+    remaining = _estimated_remaining_wall_seconds(
+        elapsed_wall_seconds=elapsed,
+        model_time_seconds=model_time,
+        total_model_time_seconds=total_model_time,
+        lifecycle_state=manifest.lifecycle_state,
+    )
+    finish_at = checked_at + timedelta(seconds=remaining) if remaining is not None else None
+
+    return {
+        "elapsed_wall_seconds": elapsed,
+        "model_time_seconds": model_time,
+        "total_model_time_seconds": total_model_time,
+        "percent_complete": percent,
+        "estimated_remaining_wall_seconds": remaining,
+        "estimated_finish_at": _isoformat_z(finish_at) if finish_at else None,
+        "last_refreshed_at": _isoformat_z(checked_at),
+        "stale": False,
+        "model_time_source": model_source,
+        "total_model_time_source": total_source,
+        "unavailable_reason": _unavailable_reason(manifest, model_time, total_model_time),
+        "caveats": caveats,
+    }
+
+
+def _configured_model_time_seconds(
+    manifest: RunManifest,
+) -> tuple[float | None, str | None, list[str]]:
+    namelist_path = manifest.generated_inputs.namelist_input
+    if namelist_path:
+        value = _namelist_float(Path(namelist_path).expanduser(), "timax")
+        if value is not None and math.isfinite(value) and value > 0:
+            return value, "namelist.input timax", []
+
+    defaults = cloud_scale_defaults_for_preset(
+        manifest.run_size_preset,
+        package_family=manifest.package_family,
+    )
+    return (
+        float(defaults.runtime_seconds),
+        "package preset fallback",
+        ["configured_model_time_fell_back_to_package_preset"],
+    )
+
+
+def _latest_model_time_seconds(manifest: RunManifest) -> tuple[float | None, str | None]:
+    stdout_log = manifest.execution.stdout_log
+    if not stdout_log:
+        return None, None
+    latest_minutes = _latest_cm1_model_minutes(Path(stdout_log).expanduser())
+    if latest_minutes is None:
+        return None, None
+    return latest_minutes * 60.0, "stdout model-minute progress"
+
+
+def _latest_cm1_model_minutes(path: Path) -> float | None:
+    if not path.exists():
+        return None
+    try:
+        text = _read_tail_text(path)
+    except OSError:
+        return None
+    matches = CM1_MODEL_MINUTE_RE.findall(text)
+    if not matches:
+        return None
+    try:
+        latest = float(matches[-1])
+    except ValueError:
+        return None
+    return latest if math.isfinite(latest) and latest >= 0 else None
+
+
+def _namelist_float(path: Path, name: str) -> float | None:
+    if not path.exists():
+        return None
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        return None
+    prefix = name.lower()
+    for line in text.splitlines():
+        stripped = line.split("!", 1)[0].strip()
+        if not stripped.lower().startswith(prefix) or "=" not in stripped:
+            continue
+        value = stripped.split("=", 1)[1].split(",", 1)[0].strip()
+        try:
+            parsed = float(value)
+        except ValueError:
+            return None
+        return parsed if math.isfinite(parsed) else None
+    return None
+
+
+def _elapsed_wall_seconds(manifest: RunManifest, now: datetime) -> float | None:
+    if manifest.execution.started_at is None:
+        return None
+    started_at = _utc(manifest.execution.started_at)
+    finished_at = _utc(manifest.execution.finished_at) if manifest.execution.finished_at else None
+    end = finished_at if manifest.lifecycle_state in TERMINAL_STATES and finished_at else now
+    elapsed = (end - started_at).total_seconds()
+    return round(elapsed, 3) if math.isfinite(elapsed) and elapsed >= 0 else None
+
+
+def _percent_complete(
+    model_time_seconds: float | None,
+    total_model_time_seconds: float | None,
+) -> float | None:
+    if (
+        model_time_seconds is None
+        or total_model_time_seconds is None
+        or total_model_time_seconds <= 0
+    ):
+        return None
+    percent = max(0.0, min(100.0, model_time_seconds / total_model_time_seconds * 100.0))
+    return round(percent, 1)
+
+
+def _estimated_remaining_wall_seconds(
+    *,
+    elapsed_wall_seconds: float | None,
+    model_time_seconds: float | None,
+    total_model_time_seconds: float | None,
+    lifecycle_state: LifecycleState,
+) -> float | None:
+    if lifecycle_state in TERMINAL_STATES:
+        return None
+    if (
+        elapsed_wall_seconds is None
+        or model_time_seconds is None
+        or total_model_time_seconds is None
+        or model_time_seconds <= 0
+        or total_model_time_seconds <= 0
+    ):
+        return None
+    if elapsed_wall_seconds < 60 or model_time_seconds < 60:
+        return None
+    remaining_model_seconds = total_model_time_seconds - model_time_seconds
+    if remaining_model_seconds <= 0:
+        return None
+    seconds_per_model_second = elapsed_wall_seconds / model_time_seconds
+    remaining = remaining_model_seconds * seconds_per_model_second
+    return round(remaining, 3) if math.isfinite(remaining) and remaining > 0 else None
+
+
+def _unavailable_reason(
+    manifest: RunManifest,
+    model_time_seconds: float | None,
+    total_model_time_seconds: float | None,
+) -> str | None:
+    if manifest.execution.started_at is None:
+        return "Run has not started."
+    if total_model_time_seconds is None:
+        return "Configured model time is unavailable because timax could not be read."
+    if model_time_seconds is None:
+        return (
+            "CM1 model-time progress is unavailable until stdout contains "
+            "model-minute progress lines."
+        )
+    return None
+
+
+def _read_tail_text(path: Path) -> str:
+    size = path.stat().st_size
+    with path.open("rb") as handle:
+        if size > TAIL_BYTES:
+            handle.seek(-TAIL_BYTES, 2)
+        return handle.read().decode("utf-8", errors="replace")
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _isoformat_z(value: datetime) -> str:
+    return _utc(value).isoformat().replace("+00:00", "Z")

--- a/app/backend/cloud_chamber/runtime_storage.py
+++ b/app/backend/cloud_chamber/runtime_storage.py
@@ -20,6 +20,7 @@ from cloud_chamber.run_manifest import (
     RunManifest,
     RunManifestError,
 )
+from cloud_chamber.run_progress import run_progress_from_manifest
 from cloud_chamber.settings import CloudChamberSettings
 
 DEFAULT_STORAGE_WARNING_THRESHOLD_BYTES = 50 * 1024**3
@@ -50,6 +51,7 @@ class RunStorageEntry(BaseModel):
     category: str
     manifest_path: str | None = None
     manifest_error: str | None = None
+    progress: dict[str, object] | None = None
     worker_state: str | None = None
     worker_message: str | None = None
     worker_started_at: str | None = None
@@ -58,6 +60,7 @@ class RunStorageEntry(BaseModel):
     worker_remote_dir: str | None = None
     worker_netcdf_count: int | None = None
     worker_raw_artifact_count: int | None = None
+    worker_progress: dict[str, object] | None = None
 
 
 class RuntimeStorageInventory(BaseModel):
@@ -312,6 +315,7 @@ def _entry_from_manifest(
         path=str(run_dir),
         category=_classify_run(manifest, worker_status),
         manifest_path=str(manifest_path),
+        progress=run_progress_from_manifest(manifest),
         worker_state=_string_or_none(worker_status.get("state")),
         worker_message=_string_or_none(worker_status.get("message")),
         worker_started_at=_string_or_none(worker_status.get("started_at")),
@@ -320,6 +324,7 @@ def _entry_from_manifest(
         worker_remote_dir=_string_or_none(worker_status.get("remote_dir")),
         worker_netcdf_count=_int_or_none(worker_status.get("netcdf_count")),
         worker_raw_artifact_count=_int_or_none(worker_status.get("raw_artifact_count")),
+        worker_progress=_dict_or_none(worker_status.get("progress")),
     )
 
 
@@ -356,6 +361,10 @@ def _read_worker_status(path: Path) -> dict[str, object]:
     except (OSError, ValueError):
         return {}
     return loaded if isinstance(loaded, dict) else {}
+
+
+def _dict_or_none(value: object) -> dict[str, object] | None:
+    return value if isinstance(value, dict) else None
 
 
 def _metadata_path_for_result(settings: CloudChamberSettings, result_id: str) -> Path:

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -18,6 +18,7 @@ from cloud_chamber.igra_catalog import (
 )
 from cloud_chamber.local_run_manager import LocalRunManagerError, RunStatus
 from cloud_chamber.run_manifest import (
+    ExecutionMetadata,
     LifecycleState,
     OutputMetadata,
     ProductState,
@@ -293,6 +294,130 @@ def test_launch_run_api_returns_status(monkeypatch: pytest.MonkeyPatch) -> None:
     assert payload["lifecycle_state"] == "running"
     assert payload["command"] == ["/tmp/cm1/run/cm1.exe"]
     assert fake_manager.launched_manifest_path == Path("/tmp/run_manifest.json")
+
+
+def test_run_status_api_reports_stdout_model_time_progress(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = generate_dry_run_package(
+        scenario_data=json.loads(BASELINE_TEMPLATE.read_text()),
+        runtime_home=tmp_path / "CloudChamber",
+        run_id="run-progress",
+    )
+    stdout_log = package.package_dir / "logs" / "stdout.log"
+    stderr_log = package.package_dir / "logs" / "stderr.log"
+    stdout_log.parent.mkdir()
+    stdout_log.write_text("          592             48.700000 min \n")
+    stderr_log.write_text("")
+    manifest = load_run_manifest(package.manifest_path)
+    started_at = datetime(2026, 5, 22, 15, 15, 36, tzinfo=UTC)
+    write_run_manifest(
+        package.manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": LifecycleState.RUNNING,
+                "provenance": ProvenanceMetadata(
+                    product_state=ProductState.QUEUED_RUNNING_CM1_PROCESS
+                ),
+                "execution": ExecutionMetadata(
+                    command=["/tmp/cm1/run/cm1.exe"],
+                    started_at=started_at,
+                    stdout_log=str(stdout_log),
+                    stderr_log=str(stderr_log),
+                ),
+            }
+        ),
+    )
+    fake_manager = FakeRunManager(
+        RunStatus(
+            run_id="run-progress",
+            lifecycle_state=LifecycleState.RUNNING,
+            manifest_path=package.manifest_path,
+            command=("/tmp/cm1/run/cm1.exe",),
+            stdout_log=stdout_log,
+            stderr_log=stderr_log,
+            exit_code=None,
+        )
+    )
+    monkeypatch.setattr("cloud_chamber.app._local_run_manager", fake_manager)
+
+    response = TestClient(app).get(
+        "/api/runs/status",
+        params={"manifest_path": str(package.manifest_path)},
+    )
+
+    assert response.status_code == 200
+    progress = response.json()["progress"]
+    assert progress["model_time_seconds"] == pytest.approx(2922.0)
+    assert progress["total_model_time_seconds"] == pytest.approx(10800.0)
+    assert progress["percent_complete"] == pytest.approx(27.1)
+    assert progress["estimated_remaining_wall_seconds"] is not None
+    assert progress["model_time_source"] == "stdout model-minute progress"
+    assert progress["total_model_time_source"] == "namelist.input timax"
+
+
+def test_run_status_api_reports_completed_elapsed_and_full_model_time(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = generate_dry_run_package(
+        scenario_data=json.loads(BASELINE_TEMPLATE.read_text()),
+        runtime_home=tmp_path / "CloudChamber",
+        run_id="run-completed-progress",
+    )
+    manifest = load_run_manifest(package.manifest_path)
+    started_at = datetime(2026, 5, 22, 15, 15, 36, tzinfo=UTC)
+    finished_at = datetime(2026, 5, 22, 15, 45, 36, tzinfo=UTC)
+    stdout_log = package.package_dir / "logs" / "stdout.log"
+    stderr_log = package.package_dir / "logs" / "stderr.log"
+    stdout_log.parent.mkdir()
+    stdout_log.write_text("Program terminated normally\n")
+    stderr_log.write_text("")
+    write_run_manifest(
+        package.manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": LifecycleState.COMPLETED,
+                "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+                "execution": ExecutionMetadata(
+                    command=["/tmp/cm1/run/cm1.exe"],
+                    started_at=started_at,
+                    finished_at=finished_at,
+                    exit_code=0,
+                    stdout_log=str(stdout_log),
+                    stderr_log=str(stderr_log),
+                ),
+                "outputs": OutputMetadata(netcdf_paths=[str(package.package_dir / "cm1out.nc")]),
+            }
+        ),
+    )
+    fake_manager = FakeRunManager(
+        RunStatus(
+            run_id="run-completed-progress",
+            lifecycle_state=LifecycleState.COMPLETED,
+            manifest_path=package.manifest_path,
+            command=("/tmp/cm1/run/cm1.exe",),
+            stdout_log=stdout_log,
+            stderr_log=stderr_log,
+            exit_code=0,
+        )
+    )
+    monkeypatch.setattr("cloud_chamber.app._local_run_manager", fake_manager)
+
+    response = TestClient(app).get(
+        "/api/runs/status",
+        params={"manifest_path": str(package.manifest_path)},
+    )
+
+    assert response.status_code == 200
+    progress = response.json()["progress"]
+    assert progress["elapsed_wall_seconds"] == pytest.approx(1800.0)
+    assert progress["model_time_seconds"] == pytest.approx(10800.0)
+    assert progress["total_model_time_seconds"] == pytest.approx(10800.0)
+    assert progress["percent_complete"] == pytest.approx(100.0)
+    assert progress["estimated_remaining_wall_seconds"] is None
+    assert progress["model_time_source"] == "completed_run_state"
 
 
 def test_launch_run_api_reports_clear_failure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/app/backend/tests/test_lan_worker_run_script.py
+++ b/app/backend/tests/test_lan_worker_run_script.py
@@ -198,11 +198,21 @@ def test_worker_status_parses_cm1_command_and_environment() -> None:
             "cm1_exe": "/opt/cm1/run/cm1.exe",
             "cm1_command": "mpirun -np 4 /opt/cm1/run/cm1.exe",
             "cm1_env": {"OMP_NUM_THREADS": "4"},
+            "progress": {
+                "model_time_seconds": 7200,
+                "total_model_time_seconds": 10800,
+                "percent_complete": 66.7,
+            },
         }
     )
 
     assert status.cm1_command == "mpirun -np 4 /opt/cm1/run/cm1.exe"
     assert status.cm1_env == {"OMP_NUM_THREADS": "4"}
+    assert status.progress == {
+        "model_time_seconds": 7200,
+        "total_model_time_seconds": 10800,
+        "percent_complete": 66.7,
+    }
 
 
 def test_cleanup_already_removed_updates_local_worker_status(

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -520,6 +520,20 @@ const runningRunStatus = {
     processed_artifacts: 0,
   },
   runtime_warnings: [],
+  progress: {
+    elapsed_wall_seconds: 300,
+    model_time_seconds: 2922,
+    total_model_time_seconds: 10800,
+    percent_complete: 27.1,
+    estimated_remaining_wall_seconds: 808.6,
+    estimated_finish_at: "2026-05-22T15:34:04Z",
+    last_refreshed_at: new Date().toISOString(),
+    stale: false,
+    model_time_source: "stdout model-minute progress",
+    total_model_time_source: "namelist.input timax",
+    unavailable_reason: null,
+    caveats: [],
+  },
 };
 
 const completedRunStatus = {
@@ -537,6 +551,20 @@ const completedRunStatus = {
     processed_artifacts: 0,
   },
   runtime_warnings: ["CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"],
+  progress: {
+    elapsed_wall_seconds: 1800,
+    model_time_seconds: 10800,
+    total_model_time_seconds: 10800,
+    percent_complete: 100,
+    estimated_remaining_wall_seconds: null,
+    estimated_finish_at: null,
+    last_refreshed_at: new Date().toISOString(),
+    stale: false,
+    model_time_source: "completed_run_state",
+    total_model_time_source: "namelist.input timax",
+    unavailable_reason: null,
+    caveats: [],
+  },
 };
 
 const resultCard = {
@@ -1097,6 +1125,7 @@ const storageRuns = [
     category: "completed_with_output",
     manifest_path: "/tmp/CloudChamber/runs/dry-run-uningested/run_manifest.json",
     manifest_error: null,
+    progress: completedRunStatus.progress,
   },
   {
     run_id: "dry-run-saved",
@@ -1145,6 +1174,7 @@ const storageRuns = [
     category: "running",
     manifest_path: "/tmp/CloudChamber/runs/dry-run-running/run_manifest.json",
     manifest_error: null,
+    progress: runningRunStatus.progress,
   },
   {
     run_id: "dry-run-no-output",
@@ -3037,6 +3067,20 @@ describe("App", () => {
       worker_remote_dir: "/worker/runs/dry-run-worker-completed",
       worker_started_at: "2026-07-01T04:30:07Z",
       worker_finished_at: "2026-07-01T04:39:23Z",
+      worker_progress: {
+        elapsed_wall_seconds: 556,
+        model_time_seconds: 10800,
+        total_model_time_seconds: 10800,
+        percent_complete: 100,
+        estimated_remaining_wall_seconds: null,
+        estimated_finish_at: null,
+        last_refreshed_at: new Date().toISOString(),
+        stale: false,
+        model_time_source: "completed_worker_state",
+        total_model_time_source: "namelist.input timax",
+        unavailable_reason: null,
+        caveats: [],
+      },
     };
     const workerResult = {
       ...resultCard,
@@ -3167,6 +3211,149 @@ describe("App", () => {
     expect(screen.queryByRole("button", { name: "Copy back and ingest" })).not.toBeInTheDocument();
   });
 
+  it("shows parsed LAN worker model-time progress when worker status includes it", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      if (url === "/api/dry-run-package") {
+        return Promise.resolve(new Response(JSON.stringify(dryRunResponse), { status: 200 }));
+      }
+      if (url === "/api/lan-worker/config") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              configured: true,
+              available: true,
+              message: "LAN worker configured.",
+              cm1_env_keys: [],
+              cm1_env_settings: [],
+              custom_launch_command: false,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/lan-worker/start" && init?.method === "POST") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              run_id: "dry-run-001",
+              state: "running",
+              message: "CM1 is running on the LAN worker.",
+              netcdf_count: 0,
+              raw_artifact_count: 0,
+              started_at: "2026-05-22T15:15:36Z",
+              progress: {
+                elapsed_wall_seconds: 600,
+                model_time_seconds: 3600,
+                total_model_time_seconds: 10800,
+                percent_complete: 33.3,
+                estimated_remaining_wall_seconds: 1200,
+                estimated_finish_at: "2026-05-22T15:45:36Z",
+                last_refreshed_at: new Date().toISOString(),
+                stale: false,
+                model_time_source: "stdout model-minute progress",
+                total_model_time_source: "namelist.input timax",
+                unavailable_reason: null,
+                caveats: [],
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.click(await screen.findByTestId("create-package-btn"));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Run on LAN worker" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Worker model-time progress").nextElementSibling).toHaveTextContent(
+        "60 min / 180 min (33.3%)",
+      );
+      expect(screen.getByText("Worker ETA").nextElementSibling).toHaveTextContent(
+        "20 min remaining",
+      );
+    });
+  });
+
+  it("shows LAN worker model-time progress as unavailable when status has no parsed progress", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      if (url === "/api/dry-run-package") {
+        return Promise.resolve(new Response(JSON.stringify(dryRunResponse), { status: 200 }));
+      }
+      if (url === "/api/lan-worker/config") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              configured: true,
+              available: true,
+              message: "LAN worker configured.",
+              cm1_env_keys: [],
+              cm1_env_settings: [],
+              custom_launch_command: false,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/lan-worker/start" && init?.method === "POST") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              run_id: "dry-run-001",
+              state: "running",
+              message: "CM1 is running on the LAN worker.",
+              netcdf_count: 0,
+              raw_artifact_count: 0,
+              started_at: "2026-05-22T15:15:36Z",
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.click(await screen.findByTestId("create-package-btn"));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Run on LAN worker" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Worker model-time progress").nextElementSibling).toHaveTextContent(
+        "Model-time progress unavailable from current status.",
+      );
+    });
+  });
+
   it("requests a dry-run package and displays generated files without claiming CM1 ran", async () => {
     render(<App />);
 
@@ -3239,6 +3426,14 @@ describe("App", () => {
       expect(screen.getAllByText("Running").length).toBeGreaterThan(0);
     });
     expect(screen.getByText("stdout log").nextElementSibling).toHaveTextContent("stdout.log");
+    expect(screen.getByText("Elapsed runtime").nextElementSibling).toHaveTextContent("5 min");
+    expect(screen.getByText("Model-time progress").nextElementSibling).toHaveTextContent(
+      "48.7 min / 180 min (27.1%)",
+    );
+    expect(screen.getByText("ETA").nextElementSibling).toHaveTextContent("13 min 29 s remaining");
+    expect(screen.getByText("Progress source").nextElementSibling).toHaveTextContent(
+      "stdout model-minute progress",
+    );
     expect(screen.getByText("CM1 started")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "View status / logs" }));
@@ -3247,6 +3442,12 @@ describe("App", () => {
       expect(screen.getAllByText("Completed CM1 result").length).toBeGreaterThan(0);
     });
     expect(screen.getByText("Output summary").nextElementSibling).toHaveTextContent("14 NetCDF");
+    expect(screen.getByText("Final elapsed runtime").nextElementSibling).toHaveTextContent(
+      "30 min",
+    );
+    expect(screen.getByText("Model-time progress").nextElementSibling).toHaveTextContent(
+      "180 min / 180 min (100.0%)",
+    );
     expect(screen.getAllByText(/IEEE_INVALID_FLAG/).length).toBeGreaterThan(0);
     expect(screen.getByTestId("ingest-results-btn")).toBeEnabled();
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -344,6 +344,21 @@ type ObservedSoundingSummary = {
   provenance: Record<string, string>;
 };
 
+type RunProgressResponse = {
+  elapsed_wall_seconds?: number | null;
+  model_time_seconds?: number | null;
+  total_model_time_seconds?: number | null;
+  percent_complete?: number | null;
+  estimated_remaining_wall_seconds?: number | null;
+  estimated_finish_at?: string | null;
+  last_refreshed_at?: string | null;
+  stale?: boolean;
+  model_time_source?: string | null;
+  total_model_time_source?: string | null;
+  unavailable_reason?: string | null;
+  caveats?: string[];
+};
+
 type RunStatusResponse = {
   run_id: string;
   lifecycle_state: string;
@@ -364,6 +379,7 @@ type RunStatusResponse = {
     processed_artifacts: number;
   };
   runtime_warnings: string[];
+  progress: RunProgressResponse | null;
 };
 
 type LanWorkerConfigResponse = {
@@ -386,6 +402,7 @@ type LanWorkerRunResponse = {
   finished_at?: string | null;
   local_package_dir?: string | null;
   ready_for_ingest?: boolean;
+  progress?: RunProgressResponse | null;
 };
 
 type IngestResponse = {
@@ -614,6 +631,7 @@ type RunStorageEntry = {
   category: string;
   manifest_path: string | null;
   manifest_error: string | null;
+  progress?: RunProgressResponse | null;
   worker_state: string | null;
   worker_message: string | null;
   worker_started_at: string | null;
@@ -622,6 +640,7 @@ type RunStorageEntry = {
   worker_remote_dir: string | null;
   worker_netcdf_count: number | null;
   worker_raw_artifact_count: number | null;
+  worker_progress?: RunProgressResponse | null;
 };
 
 type StorageInventoryResponse = {
@@ -4788,6 +4807,24 @@ function LocalRunWorkflowPanel({
               <Metric label="Exit code" value={runStatus.exit_code?.toString() ?? "Running"} />
               <Metric label="Started" value={runStatus.started_at ?? "Not recorded"} />
               <Metric label="Finished" value={runStatus.finished_at ?? "Not finished"} />
+              <Metric
+                label={
+                  runStatus.lifecycle_state === "completed"
+                    ? "Final elapsed runtime"
+                    : "Elapsed runtime"
+                }
+                value={elapsedRuntimeLabel(runStatus.progress)}
+              />
+              <Metric
+                label="Model-time progress"
+                value={modelTimeProgressLabel(runStatus.progress)}
+              />
+              <Metric label="ETA" value={runProgressEtaLabel(runStatus.progress)} />
+              <Metric
+                label="Last status refresh"
+                value={runProgressRefreshLabel(runStatus.progress)}
+              />
+              <Metric label="Progress source" value={runProgressSourceLabel(runStatus.progress)} />
               <Metric label="stdout log" value={runStatus.stdout_log || "Unavailable"} />
               <Metric label="stderr log" value={runStatus.stderr_log || "Unavailable"} />
               <Metric
@@ -5005,6 +5042,19 @@ function LanWorkerRunPanel({
                     : "Default worker environment"
               }
             />
+            {status && (
+              <Metric
+                label="Worker model-time progress"
+                value={modelTimeProgressLabel(status.progress ?? null)}
+              />
+            )}
+            {status && <Metric label="Worker ETA" value={runProgressEtaLabel(status.progress)} />}
+            {status && (
+              <Metric
+                label="Worker status refresh"
+                value={runProgressRefreshLabel(status.progress)}
+              />
+            )}
             {status?.message && <Metric label="Worker message" value={status.message} />}
           </dl>
           <div className="button-row">
@@ -5216,6 +5266,7 @@ function PipelineRunCard({
   const stateLabel = pipelineRunStateLabel(run, result);
   const nextStep = pipelineRunNextStep(run, result);
   const showWorkerMessage = Boolean(run.worker_message && !run.worker_state);
+  const runProgress = pipelineRunProgressSummary(run);
   const workerProgress = workerProgressSummary(run);
 
   return (
@@ -5238,6 +5289,7 @@ function PipelineRunCard({
       <p className="state-note">
         {pipelineRunOutputSummary(run, result)} · Local package {formatBytes(run.size_bytes)}
       </p>
+      {runProgress && <p className="state-note">{runProgress}</p>}
       {workerProgress && <p className="state-note">{workerProgress}</p>}
       {showWorkerMessage && <p className="state-note">{run.worker_message}</p>}
       {autoFinalizing && (
@@ -5554,8 +5606,21 @@ function pipelineRunNextStep(run: RunStorageEntry, result: ResultCard | undefine
   return "Review the local run state before cleanup.";
 }
 
+function pipelineRunProgressSummary(run: RunStorageEntry): string | null {
+  if (!run.worker_state && run.category === "dry_run_only") return null;
+  const progress = run.worker_state ? run.worker_progress : run.progress;
+  if (!progress) return null;
+  const parts = [modelTimeProgressLabel(progress)];
+  const eta = runProgressEtaLabel(progress);
+  if (eta !== "Unavailable") parts.push(eta);
+  const refresh = runProgressRefreshLabel(progress);
+  if (refresh !== "Unavailable") parts.push(`Last refreshed ${refresh}`);
+  return parts.join(" · ");
+}
+
 function workerProgressSummary(run: RunStorageEntry): string | null {
   if (!run.worker_state) return null;
+  if (run.worker_progress) return null;
   const parts: string[] = [];
   if (run.worker_status_updated_at) {
     parts.push(`Last checked ${formatShortTime(run.worker_status_updated_at)}`);
@@ -5589,6 +5654,85 @@ function expectedOutputFramesForPreset(preset: string | null): number | null {
   if (preset === "standard") return 7;
   if (preset === "deep_overnight") return 73;
   return null;
+}
+
+function elapsedRuntimeLabel(progress: RunProgressResponse | null | undefined): string {
+  return formatRunDuration(progress?.elapsed_wall_seconds);
+}
+
+function modelTimeProgressLabel(progress: RunProgressResponse | null | undefined): string {
+  if (!progress) return "Model-time progress unavailable from current status.";
+  const modelTime = progress.model_time_seconds;
+  const totalTime = progress.total_model_time_seconds;
+  const percent = progress.percent_complete;
+  if (isFiniteNumber(modelTime) && isFiniteNumber(totalTime)) {
+    const percentText = isFiniteNumber(percent) ? ` (${percent.toFixed(1)}%)` : "";
+    return `${formatModelTime(modelTime)} / ${formatModelTime(totalTime)}${percentText}`;
+  }
+  if (isFiniteNumber(modelTime)) return `${formatModelTime(modelTime)} reached`;
+  if (isFiniteNumber(totalTime)) {
+    return `${progress.unavailable_reason ?? "Latest model time unavailable."} Total ${formatModelTime(totalTime)}.`;
+  }
+  return progress.unavailable_reason ?? "Model-time progress unavailable from current status.";
+}
+
+function runProgressEtaLabel(progress: RunProgressResponse | null | undefined): string {
+  if (!progress || !isFiniteNumber(progress.estimated_remaining_wall_seconds)) {
+    return "Unavailable";
+  }
+  const finish = progress.estimated_finish_at
+    ? `; finish about ${formatShortTime(progress.estimated_finish_at)}`
+    : "";
+  return `${formatRunDuration(progress.estimated_remaining_wall_seconds)} remaining${finish}`;
+}
+
+function runProgressRefreshLabel(progress: RunProgressResponse | null | undefined): string {
+  if (!progress?.last_refreshed_at) return "Unavailable";
+  const stale = progress.stale || isProgressRefreshStale(progress);
+  return `${formatShortTime(progress.last_refreshed_at)}${stale ? " (stale)" : ""}`;
+}
+
+function runProgressSourceLabel(progress: RunProgressResponse | null | undefined): string {
+  if (!progress) return "Unavailable";
+  const sources = [progress.model_time_source, progress.total_model_time_source].filter(Boolean);
+  const caveats = progress.caveats ?? [];
+  if (sources.length === 0 && caveats.length === 0) return "Unavailable";
+  return [...sources, ...caveats].join("; ");
+}
+
+function formatRunDuration(seconds: number | null | undefined): string {
+  if (!isFiniteNumber(seconds)) return "Unavailable";
+  const roundedSeconds = Math.max(0, Math.round(seconds));
+  const hours = Math.floor(roundedSeconds / 3600);
+  const minutes = Math.floor((roundedSeconds % 3600) / 60);
+  const remainingSeconds = roundedSeconds % 60;
+  if (hours > 0) {
+    return `${hours} hr ${minutes} min`;
+  }
+  if (minutes > 0) {
+    return remainingSeconds > 0 ? `${minutes} min ${remainingSeconds} s` : `${minutes} min`;
+  }
+  return `${remainingSeconds} s`;
+}
+
+function formatModelTime(seconds: number): string {
+  const minutes = seconds / 60;
+  if (minutes >= 1) {
+    const rounded = Math.abs(minutes - Math.round(minutes)) < 0.05 ? Math.round(minutes) : minutes;
+    return `${rounded.toLocaleString(undefined, { maximumFractionDigits: 1 })} min`;
+  }
+  return `${Math.round(seconds)} s`;
+}
+
+function isProgressRefreshStale(progress: RunProgressResponse): boolean {
+  if (!progress.last_refreshed_at || progress.percent_complete === 100) return false;
+  const refreshedAt = Date.parse(progress.last_refreshed_at);
+  if (!Number.isFinite(refreshedAt)) return false;
+  return Date.now() - refreshedAt > 15 * 60 * 1000;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
 }
 
 function formatShortTime(value: string): string {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -356,10 +356,15 @@ POST /api/dry-run-package
 
 The browser receives only API summaries: run/package paths, lifecycle/product
 states, stdout/stderr log paths and short tails, output artifact counts, runtime
-warnings, storage inventory entries, associated result-card identities when
-available, and the ingested result ID. It does not read local files directly,
-does not parse NetCDF, and does not imply that a dry-run package is already a
-completed or ingested result.
+warnings, storage inventory entries, progress metadata, associated result-card
+identities when available, and the ingested result ID. Progress metadata is a
+bounded status summary: elapsed wall time from manifest execution timestamps,
+total configured model time from `namelist.input` `timax` with package-preset
+fallback, latest model time from CM1 stdout model-minute progress lines when
+available, percent/ETA only when those inputs are present, and clear unavailable
+copy otherwise. It does not read local files directly, does not parse NetCDF in
+the browser, and does not imply that a dry-run package is already a completed or
+ingested result.
 
 Build is intentionally not modeled as one single active package. Local runtime
 state can contain multiple package/run folders in different lifecycle stages:
@@ -382,6 +387,11 @@ contains normal CM1 termination evidence and output artifacts exist under the
 run directory. This repairs backend-restart cases where a completed local run
 was still labeled running, while avoiding silent completion claims for unknown
 or still-active runs.
+
+LAN worker status follows the same bounded progress contract when the worker
+status refresh can inspect remote `namelist.input` and `logs/stdout.log`. Older
+or just-started worker sidecars may have no progress payload; Build should show
+model-time progress as unavailable rather than infer it from raw counts.
 
 Results owns cleanup for ingested results. It resolves the selected result to
 its managed run directory, previews user-facing cleanup categories, and requires

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -294,10 +294,12 @@ For each run:
 
 The Build workspace provides the first guided local launchpad without curl
 commands: create package, launch eligible local CM1 packages, refresh status/log
-summaries, see output-artifact counts, ingest completed NetCDF output, and open
-created Result Cards in Results or Explore. It is a pipeline view over local
-runtime state, not a single active wizard. This is local-first orchestration
-only; CI still uses fake fixtures and never runs CM1.
+summaries, see output-artifact counts, inspect elapsed wall-clock and model-time
+progress when CM1 logs expose it, ingest completed NetCDF output, and open
+created Result Cards in Results or Explore. Percent complete and ETA should only
+appear when configured model time and latest model time are both known. It is a
+pipeline view over local runtime state, not a single active wizard. This is
+local-first orchestration only; CI still uses fake fixtures and never runs CM1.
 
 ### Workflow 4.5 — Manage Runtime Cleanup
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -109,7 +109,7 @@ Implemented backend API endpoints:
 - `GET /api/scenarios` lists validated scenario templates for the Scenario Builder and marks Baseline Shallow Cumulus as the Golden Path scenario.
 - `POST /api/dry-run-package` validates selected controls and writes a reviewable dry-run package under the configured runtime home. It does not launch CM1, create NetCDF output, or write generated packages into the repo during tests.
 - `POST /api/runs/launch` starts one local CM1 run from a generated manifest when local CM1 settings validate.
-- `GET /api/runs/status?manifest_path=...` refreshes and returns lifecycle status, product/validation state, command/log paths, short stdout/stderr tails, output-artifact counts, runtime warnings, and timestamps for a run manifest.
+- `GET /api/runs/status?manifest_path=...` refreshes and returns lifecycle status, product/validation state, command/log paths, short stdout/stderr tails, output-artifact counts, runtime warnings, timestamps, and bounded progress metadata for a run manifest. Progress uses configured `timax` plus parsed CM1 stdout model-minute lines when available; if model time is not available, the payload says so rather than inventing a percent complete.
 - `POST /api/runs/cancel` cancels the active local run when technically practical.
 - `GET /api/storage/inventory` reports configured runtime-home disk usage and per-run metadata under `~/CloudChamber/runs/`.
 - `POST /api/storage/delete-run` previews or deletes one selected run directory under the configured runtime home.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -438,6 +438,12 @@ actionable UI errors. Automated tests must not execute `cm1.exe`, parse real
 local NetCDF output in the browser, or write generated run directories into the
 repo.
 
+Build status tests should also cover timing/progress display without real CM1:
+active local runs with parsed stdout model-minute progress, completed local runs
+with final elapsed runtime and complete model time, LAN worker progress when the
+worker status sidecar includes log-derived progress, unavailable model-time copy
+when progress is absent, and stale refresh labeling from old status timestamps.
+
 Runtime cleanup UI tests should use mocked inventory/results data. They should
 verify completed-with-output runs without results expose `Ingest output`, Build
 shows preview cleanup only for non-ingested runs, running runs block cleanup

--- a/scripts/lan_worker_run.py
+++ b/scripts/lan_worker_run.py
@@ -89,6 +89,7 @@ class WorkerStatus:
     netcdf_count: int = 0
     raw_artifact_count: int = 0
     message: str | None = None
+    progress: dict[str, Any] | None = None
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -425,6 +426,7 @@ def collect_worker_run(args: argparse.Namespace) -> None:
             else "Worker run was copied back and promoted locally, but it is not a "
             "successful output-producing run ready for ingest."
         ),
+        status.__dict__,
     )
     if not args.keep_incoming:
         shutil.rmtree(incoming_dir)
@@ -692,7 +694,10 @@ def fetch_worker_status(config: WorkerConfig, run_id: str) -> WorkerStatus:
     command = f"""python3 - {remote_dir_q} <<'PY'
 import glob
 import json
+import math
+import re
 import sys
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 run_dir = Path(sys.argv[1])
@@ -712,6 +717,111 @@ data["raw_artifact_count"] = len(
         for path in run_dir.glob(pattern)
     )
 )
+MODEL_MINUTE_RE = re.compile(r"(?m)^\\s*\\d+\\s+([+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[Ee][+-]?\\d+)?)\\s+min\\s*$")
+TAIL_BYTES = 2000000
+
+def iso_z(value):
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+def parse_time(value):
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError:
+        return None
+
+def read_tail(path):
+    if not path.exists():
+        return ""
+    size = path.stat().st_size
+    with path.open("rb") as handle:
+        if size > TAIL_BYTES:
+            handle.seek(-TAIL_BYTES, 2)
+        return handle.read().decode("utf-8", errors="replace")
+
+def namelist_float(path, name):
+    if not path.exists():
+        return None
+    prefix = name.lower()
+    for line in path.read_text(errors="replace").splitlines():
+        stripped = line.split("!", 1)[0].strip()
+        if not stripped.lower().startswith(prefix) or "=" not in stripped:
+            continue
+        try:
+            parsed = float(stripped.split("=", 1)[1].split(",", 1)[0].strip())
+        except ValueError:
+            return None
+        return parsed if math.isfinite(parsed) else None
+    return None
+
+def latest_model_seconds(stdout_path):
+    text = read_tail(stdout_path)
+    matches = MODEL_MINUTE_RE.findall(text)
+    if not matches:
+        return None
+    try:
+        latest_minutes = float(matches[-1])
+    except ValueError:
+        return None
+    if not math.isfinite(latest_minutes) or latest_minutes < 0:
+        return None
+    return latest_minutes * 60.0
+
+def percent_complete(model_time, total_time):
+    if model_time is None or total_time is None or total_time <= 0:
+        return None
+    return round(max(0.0, min(100.0, model_time / total_time * 100.0)), 1)
+
+def worker_progress(payload, directory):
+    now = datetime.now(UTC)
+    total_time = namelist_float(directory / "namelist.input", "timax")
+    total_source = "namelist.input timax" if total_time and total_time > 0 else None
+    model_time = latest_model_seconds(directory / "logs" / "stdout.log")
+    model_source = "stdout model-minute progress" if model_time is not None else None
+    state = str(payload.get("state") or "")
+    if state in ("completed", "copied_back_to_mac", "ready_for_local_ingest") and payload.get("exit_code") == 0 and total_time:
+        model_time = total_time
+        model_source = "completed_worker_state"
+    started_at = parse_time(payload.get("started_at"))
+    finished_at = parse_time(payload.get("finished_at"))
+    end_at = finished_at if state != "running" and finished_at else now
+    elapsed = (end_at - started_at).total_seconds() if started_at else None
+    if elapsed is not None and (not math.isfinite(elapsed) or elapsed < 0):
+        elapsed = None
+    percent = percent_complete(model_time, total_time)
+    remaining = None
+    finish_at = None
+    if state == "running" and elapsed is not None and model_time and total_time and elapsed >= 60 and model_time >= 60:
+        remaining_model = total_time - model_time
+        if remaining_model > 0:
+            candidate = remaining_model * (elapsed / model_time)
+            if math.isfinite(candidate) and candidate > 0:
+                remaining = round(candidate, 3)
+                finish_at = now + timedelta(seconds=remaining)
+    unavailable_reason = None
+    if not started_at:
+        unavailable_reason = "Run has not started."
+    elif total_time is None:
+        unavailable_reason = "Configured model time is unavailable because timax could not be read."
+    elif model_time is None:
+        unavailable_reason = "CM1 model-time progress is unavailable until stdout contains model-minute progress lines."
+    return dict(
+        elapsed_wall_seconds=round(elapsed, 3) if elapsed is not None else None,
+        model_time_seconds=model_time,
+        total_model_time_seconds=total_time,
+        percent_complete=percent,
+        estimated_remaining_wall_seconds=remaining,
+        estimated_finish_at=iso_z(finish_at) if finish_at else None,
+        last_refreshed_at=iso_z(now),
+        stale=False,
+        model_time_source=model_source,
+        total_model_time_source=total_source,
+        unavailable_reason=unavailable_reason,
+        caveats=[],
+    )
+
+data["progress"] = worker_progress(data, run_dir)
 print(json.dumps(data, sort_keys=True))
 PY"""
     result = run_command(
@@ -749,6 +859,7 @@ def worker_status_from_mapping(data: dict[str, Any]) -> WorkerStatus:
         netcdf_count=int(data.get("netcdf_count") or 0),
         raw_artifact_count=int(data.get("raw_artifact_count") or 0),
         message=_optional_str(data.get("message")),
+        progress=data.get("progress") if isinstance(data.get("progress"), dict) else None,
     )
 
 


### PR DESCRIPTION
## Summary
- Adds bounded CM1 run progress payloads for local run status and runtime inventory: elapsed wall time, configured model time, parsed stdout model time, percent complete, ETA when enough progress exists, refresh time, and unavailable reasons.
- Extends LAN worker status refresh to derive the same progress from remote namelist/stdout when available, while preserving clear unavailable copy for older or just-started sidecars.
- Updates Build UI, frontend/backend tests, and docs for the additive status contract.

## Verification
- app/backend/.venv/bin/python -m pytest app/backend/tests/test_app.py app/backend/tests/test_lan_worker_run_script.py app/backend/tests/test_runtime_storage.py app/backend/tests/test_local_run_manager.py
- cd app/frontend && npm test -- App.test.tsx
- scripts/check.sh
- scripts/check-e2e.sh

## Notes
- Refs #248.
- This does not run CM1 in CI and does not commit generated outputs or runtime artifacts.
- Per request, this PR is not merged.