### PR TITLE
Add serial local CM1 run queue

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -32,6 +32,7 @@ from cloud_chamber.lan_worker import (
     start_lan_worker_run,
 )
 from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError, RunStatus
+from cloud_chamber.local_run_queue import LocalRunQueueError, LocalRunQueueManager
 from cloud_chamber.observed_sounding import ObservedSoundingError, parse_igra_station_text
 from cloud_chamber.result_cards import (
     ResultCardUpdate,
@@ -89,6 +90,7 @@ app = FastAPI(
 )
 
 _local_run_manager: LocalRunManager | None = None
+_local_run_queue: LocalRunQueueManager | None = None
 
 
 @app.get("/health")
@@ -344,6 +346,24 @@ def launch_run(request: LaunchRunRequest) -> dict[str, object]:
     except LocalRunManagerError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return _run_status_payload(status)
+
+
+@app.post("/api/runs/queue")
+def enqueue_run(request: LaunchRunRequest) -> dict[str, object]:
+    try:
+        state = _get_local_run_queue().enqueue(Path(request.manifest_path).expanduser())
+    except LocalRunQueueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return state.model_dump(mode="json")
+
+
+@app.get("/api/runs/queue")
+def run_queue_status() -> dict[str, object]:
+    try:
+        state = _get_local_run_queue().refresh()
+    except LocalRunQueueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return state.model_dump(mode="json")
 
 
 @app.get("/api/runs/status")
@@ -625,6 +645,16 @@ def _get_local_run_manager() -> LocalRunManager:
     if _local_run_manager is None:
         _local_run_manager = LocalRunManager(settings=load_settings())
     return _local_run_manager
+
+
+def _get_local_run_queue() -> LocalRunQueueManager:
+    global _local_run_queue
+    if _local_run_queue is None:
+        _local_run_queue = LocalRunQueueManager(
+            settings=load_settings(),
+            run_manager=_get_local_run_manager(),
+        )
+    return _local_run_queue
 
 
 def _run_status_payload(status: RunStatus) -> dict[str, object]:

--- a/app/backend/cloud_chamber/local_run_queue.py
+++ b/app/backend/cloud_chamber/local_run_queue.py
@@ -1,0 +1,261 @@
+"""Serial local CM1 run queue and auto-ingest coordinator."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.local_run_manager import LocalRunManagerError, RunStatus
+from cloud_chamber.result_ingest import ResultIngestError, ingest_completed_run
+from cloud_chamber.run_manifest import (
+    LifecycleState,
+    ProductState,
+    RunManifestError,
+    load_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings
+
+
+class LocalRunQueueError(RuntimeError):
+    """Raised when the serial run queue cannot be updated safely."""
+
+
+class LocalRunManagerLike(Protocol):
+    def launch(self, manifest_path: Path) -> RunStatus: ...
+
+    def status(self, manifest_path: Path) -> RunStatus: ...
+
+
+class RunQueueEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    manifest_path: str
+    state: str
+    queued_at: str
+    updated_at: str
+    started_at: str | None = None
+    finished_at: str | None = None
+    result_id: str | None = None
+    message: str | None = None
+    error: str | None = None
+    cleanup_status: str | None = None
+
+
+class RunQueueState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = "1"
+    entries: list[RunQueueEntry] = Field(default_factory=list)
+    active_run_id: str | None = None
+    queued_count: int = 0
+    updated_at: str
+
+
+class _RunQueueStore(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = "1"
+    entries: list[RunQueueEntry] = Field(default_factory=list)
+
+
+OPEN_ENTRY_STATES = {"queued", "running"}
+TERMINAL_ENTRY_STATES = {
+    "ingested",
+    "ingest_failed",
+    "completed_no_output",
+    "failed",
+    "canceled",
+    "launch_failed",
+}
+
+
+class LocalRunQueueManager:
+    """Persist and advance one-at-a-time local CM1 package launches."""
+
+    def __init__(
+        self,
+        *,
+        settings: CloudChamberSettings,
+        run_manager: LocalRunManagerLike,
+    ) -> None:
+        self._settings = settings
+        self._run_manager = run_manager
+
+    def enqueue(self, manifest_path: Path) -> RunQueueState:
+        manifest_path = manifest_path.expanduser()
+        try:
+            manifest = load_run_manifest(manifest_path)
+        except (OSError, RunManifestError) as exc:
+            raise LocalRunQueueError(f"Unable to read run manifest for queueing: {exc}") from exc
+        if manifest.lifecycle_state != LifecycleState.PACKAGED:
+            raise LocalRunQueueError(
+                "Only packaged runs can be queued for local CM1 execution; "
+                f"found {manifest.lifecycle_state.value}."
+            )
+
+        entries = self._load_entries()
+        existing = _matching_open_entry(entries, manifest_path)
+        if existing is None:
+            now = _now()
+            entries.append(
+                RunQueueEntry(
+                    run_id=manifest.run_id,
+                    manifest_path=str(manifest_path),
+                    state="queued",
+                    queued_at=now,
+                    updated_at=now,
+                    message="Queued for serial local CM1 execution.",
+                )
+            )
+            self._save_entries(entries)
+        return self.refresh()
+
+    def refresh(self) -> RunQueueState:
+        entries = self._load_entries()
+        active = _first_entry_with_state(entries, "running")
+        if active is not None:
+            self._refresh_active_entry(active)
+
+        if _first_entry_with_state(entries, "running") is None:
+            next_entry = _first_entry_with_state(entries, "queued")
+            if next_entry is not None:
+                self._launch_entry(next_entry)
+
+        self._save_entries(entries)
+        return self._state(entries)
+
+    def _refresh_active_entry(self, entry: RunQueueEntry) -> None:
+        try:
+            status = self._run_manager.status(Path(entry.manifest_path))
+        except LocalRunManagerError as exc:
+            entry.error = str(exc)
+            entry.message = "Unable to refresh the active local CM1 run."
+            entry.updated_at = _now()
+            return
+
+        if status.lifecycle_state in {LifecycleState.QUEUED, LifecycleState.RUNNING}:
+            entry.message = "CM1 is running; waiting for terminal status before auto-ingest."
+            entry.updated_at = _now()
+            return
+
+        self._finalize_terminal_entry(entry, status)
+
+    def _launch_entry(self, entry: RunQueueEntry) -> None:
+        try:
+            status = self._run_manager.launch(Path(entry.manifest_path))
+        except LocalRunManagerError as exc:
+            now = _now()
+            entry.state = "launch_failed"
+            entry.error = str(exc)
+            entry.message = "Local CM1 launch failed; fix settings and queue this package again."
+            entry.finished_at = now
+            entry.updated_at = now
+            return
+
+        now = _now()
+        entry.state = "running"
+        entry.started_at = now
+        entry.updated_at = now
+        entry.message = f"Running local CM1 process for {status.run_id}."
+        entry.error = None
+
+    def _finalize_terminal_entry(self, entry: RunQueueEntry, status: RunStatus) -> None:
+        now = _now()
+        entry.finished_at = now
+        entry.updated_at = now
+        try:
+            manifest = load_run_manifest(status.manifest_path)
+        except (OSError, RunManifestError) as exc:
+            entry.state = "failed"
+            entry.error = f"Unable to read terminal run manifest: {exc}"
+            entry.message = "Run reached terminal status, but the manifest could not be trusted."
+            return
+
+        if status.lifecycle_state == LifecycleState.COMPLETED:
+            if manifest.provenance.product_state == ProductState.COMPLETED_CM1_RESULT:
+                self._auto_ingest_entry(entry, status.manifest_path)
+                return
+            entry.state = "completed_no_output"
+            entry.message = "CM1 completed without output that can be auto-ingested."
+            return
+
+        if status.lifecycle_state == LifecycleState.CANCELED:
+            entry.state = "canceled"
+            entry.message = "Local CM1 run was canceled; serial queue can continue."
+            return
+
+        entry.state = "failed"
+        entry.message = "Local CM1 run failed; serial queue can continue after recording failure."
+        entry.error = f"Run ended with lifecycle state {status.lifecycle_state.value}."
+
+    def _auto_ingest_entry(self, entry: RunQueueEntry, manifest_path: Path) -> None:
+        try:
+            result = ingest_completed_run(manifest_path)
+        except ResultIngestError as exc:
+            entry.state = "ingest_failed"
+            entry.error = str(exc)
+            entry.message = (
+                "CM1 output exists, but automatic ingest failed; manual retry is available."
+            )
+            return
+
+        entry.state = "ingested"
+        entry.result_id = result.result_id
+        entry.error = None
+        entry.cleanup_status = "queue_finalized_result_backing_run_retained"
+        entry.message = (
+            "Result auto-ingested. The queue entry is finalized; the local run directory is "
+            "retained because it backs Results and Explore."
+        )
+
+    def _load_entries(self) -> list[RunQueueEntry]:
+        path = self._queue_path()
+        if not path.exists():
+            return []
+        try:
+            store = _RunQueueStore.model_validate_json(path.read_text())
+        except ValueError as exc:
+            raise LocalRunQueueError(f"Run queue file is unreadable: {path}") from exc
+        return store.entries
+
+    def _save_entries(self, entries: list[RunQueueEntry]) -> None:
+        path = self._queue_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        store = _RunQueueStore(entries=entries)
+        path.write_text(store.model_dump_json(indent=2) + "\n")
+
+    def _queue_path(self) -> Path:
+        return self._settings.runtime_home.expanduser() / "run-queue.json"
+
+    @staticmethod
+    def _state(entries: list[RunQueueEntry]) -> RunQueueState:
+        active = _first_entry_with_state(entries, "running")
+        return RunQueueState(
+            entries=entries,
+            active_run_id=active.run_id if active else None,
+            queued_count=len([entry for entry in entries if entry.state == "queued"]),
+            updated_at=_now(),
+        )
+
+
+def _matching_open_entry(
+    entries: list[RunQueueEntry],
+    manifest_path: Path,
+) -> RunQueueEntry | None:
+    manifest_text = str(manifest_path)
+    for entry in entries:
+        if entry.manifest_path == manifest_text and entry.state in OPEN_ENTRY_STATES:
+            return entry
+    return None
+
+
+def _first_entry_with_state(entries: list[RunQueueEntry], state: str) -> RunQueueEntry | None:
+    return next((entry for entry in entries if entry.state == state), None)
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -17,6 +17,7 @@ from cloud_chamber.igra_catalog import (
     IGRAStationZipReference,
 )
 from cloud_chamber.local_run_manager import LocalRunManagerError, RunStatus
+from cloud_chamber.local_run_queue import RunQueueEntry, RunQueueState
 from cloud_chamber.run_manifest import (
     ExecutionMetadata,
     LifecycleState,
@@ -61,6 +62,37 @@ class FakeRunManager:
         if self.error:
             raise self.error
         return self.fake_status
+
+
+class FakeRunQueue:
+    def __init__(self) -> None:
+        self.enqueued_manifest_path: Path | None = None
+
+    def enqueue(self, manifest_path: Path) -> RunQueueState:
+        self.enqueued_manifest_path = manifest_path
+        return fake_queue_state("run-queued", "running")
+
+    def refresh(self) -> RunQueueState:
+        return fake_queue_state("run-queued", "running")
+
+
+def fake_queue_state(run_id: str, state: str) -> RunQueueState:
+    return RunQueueState(
+        entries=[
+            RunQueueEntry(
+                run_id=run_id,
+                manifest_path="/tmp/run_manifest.json",
+                state=state,
+                queued_at="2026-05-22T15:15:36Z",
+                started_at="2026-05-22T15:15:37Z",
+                updated_at="2026-05-22T15:15:37Z",
+                message="Running local CM1 process.",
+            )
+        ],
+        active_run_id=run_id if state == "running" else None,
+        queued_count=0,
+        updated_at="2026-05-22T15:15:37Z",
+    )
 
 
 def test_health_endpoint_identifies_scaffold_without_cm1() -> None:
@@ -433,6 +465,22 @@ def test_launch_run_api_reports_clear_failure(monkeypatch: pytest.MonkeyPatch) -
 
     assert response.status_code == 400
     assert response.json()["detail"] == "CM1 is not ready"
+
+
+def test_run_queue_endpoints_surface_serial_queue_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_queue = FakeRunQueue()
+    monkeypatch.setattr("cloud_chamber.app._local_run_queue", fake_queue)
+    client = TestClient(app)
+
+    queued = client.post("/api/runs/queue", json={"manifest_path": "/tmp/run_manifest.json"})
+    refreshed = client.get("/api/runs/queue")
+
+    assert queued.status_code == 200
+    assert queued.json()["active_run_id"] == "run-queued"
+    assert queued.json()["entries"][0]["state"] == "running"
+    assert refreshed.status_code == 200
+    assert refreshed.json()["entries"][0]["message"] == "Running local CM1 process."
+    assert fake_queue.enqueued_manifest_path == Path("/tmp/run_manifest.json")
 
 
 def test_lan_worker_config_endpoint_returns_sanitized_status(

--- a/app/backend/tests/test_local_run_queue.py
+++ b/app/backend/tests/test_local_run_queue.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from cloud_chamber.dry_run_package import generate_dry_run_package
+from cloud_chamber.local_run_manager import LocalRunManagerError, RunStatus
+from cloud_chamber.local_run_queue import LocalRunQueueManager
+from cloud_chamber.result_ingest import ResultIngestError
+from cloud_chamber.run_manifest import (
+    LifecycleState,
+    OutputMetadata,
+    ProductState,
+    ProvenanceMetadata,
+    load_run_manifest,
+    write_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
+
+
+class FakeRunManager:
+    def __init__(self) -> None:
+        self.launched: list[Path] = []
+        self.completed: set[Path] = set()
+        self.launch_error: LocalRunManagerError | None = None
+
+    def launch(self, manifest_path: Path) -> RunStatus:
+        if self.launch_error:
+            raise self.launch_error
+        self.launched.append(manifest_path)
+        return status_for_manifest(manifest_path, LifecycleState.RUNNING)
+
+    def status(self, manifest_path: Path) -> RunStatus:
+        if manifest_path in self.completed:
+            return status_for_manifest(manifest_path, LifecycleState.COMPLETED, exit_code=0)
+        return status_for_manifest(manifest_path, LifecycleState.RUNNING)
+
+
+def fake_settings(tmp_path: Path) -> CloudChamberSettings:
+    return CloudChamberSettings(
+        runtime_home=tmp_path / "CloudChamber",
+        cm1_root=tmp_path / "cm1",
+        cm1_run_dir=tmp_path / "cm1" / "run",
+        cache_dir=tmp_path / "CloudChamber" / "cache",
+        log_dir=tmp_path / "CloudChamber" / "logs",
+    )
+
+
+def create_manifest(tmp_path: Path, run_id: str) -> Path:
+    result = generate_dry_run_package(
+        scenario_data=json.loads(BASELINE_TEMPLATE.read_text()),
+        runtime_home=tmp_path / "CloudChamber",
+        run_id=run_id,
+    )
+    return result.manifest_path
+
+
+def mark_completed_with_output(manifest_path: Path) -> None:
+    manifest = load_run_manifest(manifest_path)
+    netcdf_path = manifest_path.parent / "cm1out_000001.nc"
+    netcdf_path.write_text("fake output")
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": LifecycleState.COMPLETED,
+                "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+                "outputs": OutputMetadata(netcdf_paths=[str(netcdf_path)]),
+            }
+        ),
+    )
+
+
+def status_for_manifest(
+    manifest_path: Path,
+    lifecycle_state: LifecycleState,
+    *,
+    exit_code: int | None = None,
+) -> RunStatus:
+    manifest = load_run_manifest(manifest_path)
+    return RunStatus(
+        run_id=manifest.run_id,
+        lifecycle_state=lifecycle_state,
+        manifest_path=manifest_path,
+        command=("cm1.exe",),
+        stdout_log=Path("stdout.log"),
+        stderr_log=Path("stderr.log"),
+        exit_code=exit_code,
+    )
+
+
+def test_queue_runs_packages_serially_and_auto_ingests_completed_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = create_manifest(tmp_path, "run-queue-first")
+    second = create_manifest(tmp_path, "run-queue-second")
+    fake_manager = FakeRunManager()
+    ingested_paths: list[Path] = []
+
+    def fake_ingest(manifest_path: Path) -> object:
+        ingested_paths.append(manifest_path)
+        return SimpleNamespace(result_id=f"result-{load_run_manifest(manifest_path).run_id}")
+
+    monkeypatch.setattr("cloud_chamber.local_run_queue.ingest_completed_run", fake_ingest)
+    queue = LocalRunQueueManager(settings=fake_settings(tmp_path), run_manager=fake_manager)
+
+    first_state = queue.enqueue(first)
+    second_state = queue.enqueue(second)
+
+    assert first_state.active_run_id == "run-queue-first"
+    assert second_state.active_run_id == "run-queue-first"
+    assert second_state.queued_count == 1
+    assert [path.name for path in fake_manager.launched] == ["run_manifest.json"]
+
+    mark_completed_with_output(first)
+    fake_manager.completed.add(first)
+    refreshed = queue.refresh()
+
+    entries = {entry.run_id: entry for entry in refreshed.entries}
+    assert entries["run-queue-first"].state == "ingested"
+    assert entries["run-queue-first"].result_id == "result-run-queue-first"
+    assert (
+        entries["run-queue-first"].cleanup_status == "queue_finalized_result_backing_run_retained"
+    )
+    assert entries["run-queue-second"].state == "running"
+    assert refreshed.active_run_id == "run-queue-second"
+    assert ingested_paths == [first]
+    assert fake_manager.launched == [first, second]
+
+
+def test_queue_records_ingest_failure_and_still_starts_next_package(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = create_manifest(tmp_path, "run-ingest-fails")
+    second = create_manifest(tmp_path, "run-after-ingest-failure")
+    fake_manager = FakeRunManager()
+
+    def fake_ingest(_manifest_path: Path) -> object:
+        raise ResultIngestError("diagnostics missing")
+
+    monkeypatch.setattr("cloud_chamber.local_run_queue.ingest_completed_run", fake_ingest)
+    queue = LocalRunQueueManager(settings=fake_settings(tmp_path), run_manager=fake_manager)
+    queue.enqueue(first)
+    queue.enqueue(second)
+    mark_completed_with_output(first)
+    fake_manager.completed.add(first)
+
+    refreshed = queue.refresh()
+
+    entries = {entry.run_id: entry for entry in refreshed.entries}
+    assert entries["run-ingest-fails"].state == "ingest_failed"
+    assert entries["run-ingest-fails"].error == "diagnostics missing"
+    assert entries["run-after-ingest-failure"].state == "running"
+    assert refreshed.active_run_id == "run-after-ingest-failure"
+
+
+def test_queue_records_launch_failures_when_local_launch_remains_blocked(tmp_path: Path) -> None:
+    first = create_manifest(tmp_path, "run-launch-fails")
+    second = create_manifest(tmp_path, "run-waits")
+    fake_manager = FakeRunManager()
+    fake_manager.launch_error = LocalRunManagerError("CM1 is not ready")
+    queue = LocalRunQueueManager(settings=fake_settings(tmp_path), run_manager=fake_manager)
+
+    failed_state = queue.enqueue(first)
+    queued_state = queue.enqueue(second)
+
+    entries = {entry.run_id: entry for entry in queued_state.entries}
+    assert failed_state.entries[0].state == "launch_failed"
+    assert failed_state.entries[0].message == (
+        "Local CM1 launch failed; fix settings and queue this package again."
+    )
+    assert entries["run-launch-fails"].state == "launch_failed"
+    assert entries["run-waits"].state == "launch_failed"
+    assert queued_state.active_run_id is None

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -1111,6 +1111,17 @@ export async function mockCloudChamberApis(page: Page) {
     updated_at: string;
   }> = [];
   let currentResults = [...results];
+  let localRunQueue: {
+    entries: Array<Record<string, unknown>>;
+    active_run_id: string | null;
+    queued_count: number;
+    updated_at: string;
+  } = {
+    entries: [],
+    active_run_id: null,
+    queued_count: 0,
+    updated_at: "2026-05-22T15:15:00Z",
+  };
 
   await page.route("**/api/scenarios", (route) =>
     json(route, { golden_path_scenario_id: "baseline-shallow-cumulus", scenarios: [scenario] }),
@@ -1290,6 +1301,33 @@ export async function mockCloudChamberApis(page: Page) {
       runtime_warnings: [],
     }),
   );
+
+  await page.route("**/api/runs/queue", (route) => {
+    if (route.request().method() === "POST") {
+      localRunQueue = {
+        entries: [
+          {
+            run_id: "run",
+            manifest_path: "/tmp/cloud-chamber-e2e/run/run_manifest.json",
+            package_dir: "/tmp/cloud-chamber-e2e/run",
+            state: "ingested",
+            queued_at: "2026-05-22T15:15:00Z",
+            started_at: "2026-05-22T15:15:36Z",
+            finished_at: "2026-05-22T15:32:21Z",
+            updated_at: "2026-05-22T15:32:21Z",
+            result_id: "result-baseline",
+            cleanup_status: "queue_finalized_result_backing_run_retained",
+            message:
+              "Completed local CM1 output was ingested automatically; local run directory retained for Results/Explore.",
+          },
+        ],
+        active_run_id: null,
+        queued_count: 0,
+        updated_at: "2026-05-22T15:32:21Z",
+      };
+    }
+    return json(route, localRunQueue);
+  });
 
   await page.route("**/api/runs/status**", (route) =>
     json(route, {

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -44,12 +44,15 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByTestId("launch-cm1-btn")).toBeEnabled();
 
     await page.getByTestId("launch-cm1-btn").click();
-    await expect(page.getByText("Completed").first()).toBeVisible();
-    await expect(page.getByTestId("ingest-results-btn")).toBeEnabled();
+    await expect(
+      page.getByLabel("Local serial run queue").getByText("Auto-ingested", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByTestId("ingest-results-btn")).toHaveCount(0);
 
-    await page.getByTestId("ingest-results-btn").click();
-    await expect(page.getByText("Ingested").first()).toBeVisible();
-    await page.getByRole("button", { name: "Open in Results" }).click();
+    await page
+      .getByLabel("Ingested result actions")
+      .getByRole("button", { name: "Open in Results" })
+      .click();
     await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
   });
 
@@ -212,7 +215,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       page.getByRole("button", { name: "Delete result and local run data", exact: true }),
     ).toBeVisible();
     await page.getByRole("button", { name: "Delete result and local run data", exact: true }).click();
-    await expect(page.getByText(/Result and local run data deleted/)).toBeVisible();
+    await expect(
+      page.getByRole("status").filter({ hasText: /Result and local run data deleted/ }),
+    ).toBeVisible();
     await expect(page.getByLabel("Results list").getByText("Baseline Shallow Cumulus — Quick Look")).toHaveCount(0);
 
     await gotoBuild(page);

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -567,6 +567,54 @@ const completedRunStatus = {
   },
 };
 
+const emptyRunQueue = {
+  schema_version: "1",
+  entries: [],
+  active_run_id: null,
+  queued_count: 0,
+  updated_at: new Date().toISOString(),
+};
+
+const runningRunQueue = {
+  schema_version: "1",
+  entries: [
+    {
+      run_id: "dry-run-001",
+      manifest_path: "/tmp/CloudChamber/runs/dry-run-001/run_manifest.json",
+      state: "running",
+      queued_at: "2026-05-22T15:15:35Z",
+      started_at: "2026-05-22T15:15:36Z",
+      updated_at: new Date().toISOString(),
+      message: "Running local CM1 process for dry-run-001.",
+    },
+  ],
+  active_run_id: "dry-run-001",
+  queued_count: 0,
+  updated_at: new Date().toISOString(),
+};
+
+const autoIngestedRunQueue = {
+  schema_version: "1",
+  entries: [
+    {
+      run_id: "dry-run-001",
+      manifest_path: "/tmp/CloudChamber/runs/dry-run-001/run_manifest.json",
+      state: "ingested",
+      queued_at: "2026-05-22T15:15:35Z",
+      started_at: "2026-05-22T15:15:36Z",
+      finished_at: "2026-05-22T15:45:36Z",
+      updated_at: new Date().toISOString(),
+      result_id: "result-dry-run-quicklook",
+      cleanup_status: "queue_finalized_result_backing_run_retained",
+      message:
+        "Result auto-ingested. The queue entry is finalized; the local run directory is retained because it backs Results and Explore.",
+    },
+  ],
+  active_run_id: null,
+  queued_count: 0,
+  updated_at: new Date().toISOString(),
+};
+
 const resultCard = {
   result_id: "result-dry-run-quicklook",
   run_id: "dry-run-quicklook",
@@ -2138,6 +2186,7 @@ function downsampledCloudSliceResponse() {
 }
 
 beforeEach(() => {
+  let runStatusRefreshCount = 0;
   vi.stubGlobal(
     "fetch",
     vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
@@ -2204,6 +2253,12 @@ beforeEach(() => {
       if (url === "/api/runs/launch") {
         return Promise.resolve(new Response(JSON.stringify(runningRunStatus), { status: 200 }));
       }
+      if (url === "/api/runs/queue" && init?.method === "POST") {
+        return Promise.resolve(new Response(JSON.stringify(runningRunQueue), { status: 200 }));
+      }
+      if (url === "/api/runs/queue") {
+        return Promise.resolve(new Response(JSON.stringify(emptyRunQueue), { status: 200 }));
+      }
       if (url === "/api/lan-worker/config") {
         return Promise.resolve(
           new Response(
@@ -2220,7 +2275,13 @@ beforeEach(() => {
         );
       }
       if (url.startsWith("/api/runs/status")) {
-        return Promise.resolve(new Response(JSON.stringify(completedRunStatus), { status: 200 }));
+        runStatusRefreshCount += 1;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(runStatusRefreshCount === 1 ? runningRunStatus : completedRunStatus),
+            { status: 200 },
+          ),
+        );
       }
       if (url === "/api/results/ingest") {
         return Promise.resolve(
@@ -3049,6 +3110,120 @@ describe("App", () => {
     expect(await screen.findByText(/Result metadata created/)).toBeInTheDocument();
   });
 
+  it("queues a stored package for serial local CM1 execution", async () => {
+    const queuedPackage = {
+      ...runningRunQueue,
+      entries: [
+        {
+          ...runningRunQueue.entries[0],
+          run_id: "dry-run-packaged",
+          manifest_path: "/tmp/CloudChamber/runs/dry-run-packaged/run_manifest.json",
+          message: "Running local CM1 process for dry-run-packaged.",
+        },
+      ],
+      active_run_id: "dry-run-packaged",
+    };
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(new Response(JSON.stringify(resultsResponse), { status: 200 }));
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      if (url === "/api/runs/queue" && init?.method === "POST") {
+        return Promise.resolve(new Response(JSON.stringify(queuedPackage), { status: 200 }));
+      }
+      if (url === "/api/runs/queue") {
+        return Promise.resolve(new Response(JSON.stringify(emptyRunQueue), { status: 200 }));
+      }
+      if (url.startsWith("/api/runs/status")) {
+        return Promise.resolve(new Response(JSON.stringify(runningRunStatus), { status: 200 }));
+      }
+      if (url === "/api/lan-worker/config") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              configured: false,
+              available: false,
+              message: "LAN worker is not configured.",
+              cm1_env_keys: [],
+              cm1_env_settings: [],
+              custom_launch_command: false,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    const queueButtons = await screen.findAllByRole("button", { name: "Queue local CM1 run" });
+    fireEvent.click(queueButtons[0]);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/runs/queue",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            manifest_path: "/tmp/CloudChamber/runs/dry-run-packaged/run_manifest.json",
+          }),
+        }),
+      );
+    });
+    expect(await screen.findByText(/Running dry-run-packaged/)).toBeInTheDocument();
+  });
+
+  it("shows auto-ingested queue entries without implying result-backed data was deleted", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(new Response(JSON.stringify(resultsResponse), { status: 200 }));
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      if (url === "/api/runs/queue") {
+        return Promise.resolve(new Response(JSON.stringify(autoIngestedRunQueue), { status: 200 }));
+      }
+      if (url === "/api/lan-worker/config") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              configured: false,
+              available: false,
+              message: "LAN worker is not configured.",
+              cm1_env_keys: [],
+              cm1_env_settings: [],
+              custom_launch_command: false,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+
+    expect(await screen.findByText("Auto-ingested")).toBeInTheDocument();
+    expect(screen.getByText(/package retained for Results\/Explore/)).toBeInTheDocument();
+  });
+
   it("automatically copies back, ingests, and cleans LAN worker output after completion", async () => {
     let ingested = false;
     const workerRun = {
@@ -3458,7 +3633,7 @@ describe("App", () => {
     expect(screen.getAllByRole("button", { name: "Open in Explore" }).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Ingested").length).toBeGreaterThan(0);
     expect(fetch).toHaveBeenCalledWith(
-      "/api/runs/launch",
+      "/api/runs/queue",
       expect.objectContaining({ method: "POST" }),
     );
     expect(fetch).toHaveBeenCalledWith(
@@ -3489,12 +3664,15 @@ describe("App", () => {
           new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
         );
       }
-      if (url === "/api/runs/launch" && init?.method === "POST") {
+      if (url === "/api/runs/queue" && init?.method === "POST") {
         return Promise.resolve(
           new Response(JSON.stringify({ detail: "CM1 executable is missing. Missing: cm1.exe" }), {
             status: 400,
           }),
         );
+      }
+      if (url === "/api/runs/queue") {
+        return Promise.resolve(new Response(JSON.stringify(emptyRunQueue), { status: 200 }));
       }
       return Promise.resolve(new Response("not found", { status: 404 }));
     });

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -382,6 +382,28 @@ type RunStatusResponse = {
   progress: RunProgressResponse | null;
 };
 
+type RunQueueEntry = {
+  run_id: string;
+  manifest_path: string;
+  state: string;
+  queued_at: string;
+  updated_at: string;
+  started_at?: string | null;
+  finished_at?: string | null;
+  result_id?: string | null;
+  message?: string | null;
+  error?: string | null;
+  cleanup_status?: string | null;
+};
+
+type RunQueueResponse = {
+  schema_version: string;
+  entries: RunQueueEntry[];
+  active_run_id: string | null;
+  queued_count: number;
+  updated_at: string;
+};
+
 type LanWorkerConfigResponse = {
   configured: boolean;
   available: boolean;
@@ -1108,16 +1130,24 @@ async function readUploadedTextFile(file: File): Promise<string> {
   });
 }
 
-async function launchLocalRun(manifestPath: string): Promise<RunStatusResponse> {
-  const response = await fetch("/api/runs/launch", {
+async function enqueueLocalRun(manifestPath: string): Promise<RunQueueResponse> {
+  const response = await fetch("/api/runs/queue", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ manifest_path: manifestPath }),
   });
   if (!response.ok) {
-    throw new Error(await responseError(response, "Unable to launch local CM1."));
+    throw new Error(await responseError(response, "Unable to queue local CM1 run."));
   }
-  return response.json() as Promise<RunStatusResponse>;
+  return response.json() as Promise<RunQueueResponse>;
+}
+
+async function fetchRunQueue(): Promise<RunQueueResponse> {
+  const response = await fetch("/api/runs/queue");
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to refresh local run queue."));
+  }
+  return response.json() as Promise<RunQueueResponse>;
 }
 
 async function fetchRunStatus(manifestPath: string): Promise<RunStatusResponse> {
@@ -1447,6 +1477,8 @@ export function App() {
   const [candidateDetailId, setCandidateDetailId] = useState<string | null>(null);
   const [dryRun, setDryRun] = useState<DryRunResponse | null>(null);
   const [runStatus, setRunStatus] = useState<RunStatusResponse | null>(null);
+  const [runQueue, setRunQueue] = useState<RunQueueResponse | null>(null);
+  const [runQueueStatus, setRunQueueStatus] = useState("Local run queue not checked yet");
   const [runWorkflowError, setRunWorkflowError] = useState<string | null>(null);
   const [lanWorkerConfig, setLanWorkerConfig] = useState<LanWorkerConfigResponse | null>(null);
   const [lanWorkerStatus, setLanWorkerStatus] = useState<LanWorkerRunResponse | null>(null);
@@ -1619,6 +1651,7 @@ export function App() {
     () => new Set(failedAutoFinalizingWorkerRunIds),
     [failedAutoFinalizingWorkerRunIds],
   );
+  const runQueuePollKey = useMemo(() => runQueuePollingKey(runQueue), [runQueue]);
 
   useEffect(() => {
     if (!selectedScenario) return;
@@ -1687,6 +1720,22 @@ export function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoFinalizingWorkerRunIdSet, failedAutoFinalizingWorkerRunIdSet, results, storageInventory]);
 
+  useEffect(() => {
+    void refreshLocalRunQueue("Local run queue refreshed");
+    // refreshLocalRunQueue intentionally mutates several workflow surfaces after auto-ingest.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!runQueueHasOpenEntries(runQueue)) return;
+    const intervalId = window.setInterval(() => {
+      void refreshLocalRunQueue();
+    }, 10000);
+    return () => window.clearInterval(intervalId);
+    // refreshLocalRunQueue intentionally reads current dryRun/results/storage state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runQueuePollKey]);
+
   const validationMessages = useMemo(() => {
     if (!selectedScenario) return [];
     return selectedScenario.controls.flatMap((control) => {
@@ -1711,6 +1760,47 @@ export function App() {
       );
       setStorageStatus("Run inventory unavailable");
     }
+  }
+
+  async function refreshLocalRunQueue(statusWhenLoaded?: string): Promise<RunQueueResponse | null> {
+    try {
+      const payload = await fetchRunQueue();
+      setRunQueue(payload);
+      setRunQueueStatus(statusWhenLoaded ?? runQueueSummary(payload));
+      await syncCurrentRunStatusFromQueue(payload);
+      await processAutoIngestedQueue(payload);
+      return payload;
+    } catch (caught) {
+      setRunQueueStatus("Local run queue unavailable");
+      setRunWorkflowError(
+        caught instanceof Error ? caught.message : "Unable to refresh local run queue.",
+      );
+      return null;
+    }
+  }
+
+  async function syncCurrentRunStatusFromQueue(queue: RunQueueResponse): Promise<void> {
+    if (!dryRun) return;
+    const currentRunId = runIdFromPackage(dryRun);
+    const currentEntry = queue.entries.find((entry) => entry.run_id === currentRunId);
+    if (!currentEntry || !queueEntryIsOpen(currentEntry)) return;
+    try {
+      const refreshed = await fetchRunStatus(dryRun.manifest_path);
+      setRunStatus(refreshed);
+      setStatus(userFacingRunWorkflowStatus(refreshed));
+    } catch {
+      // The queue panel still shows serial state; status refresh can be retried manually.
+    }
+  }
+
+  async function processAutoIngestedQueue(queue: RunQueueResponse): Promise<void> {
+    const latestIngestedEntry = latestAutoIngestedQueueEntry(queue);
+    if (!latestIngestedEntry?.result_id) return;
+    if (dryRun && latestIngestedEntry.run_id === runIdFromPackage(dryRun)) {
+      setIngestedResultId(latestIngestedEntry.result_id);
+    }
+    await refreshResults(latestIngestedEntry.result_id);
+    await refreshStorageAfterWorkflow("Auto-ingested completed local run");
   }
 
   function handleSelectScenario(scenarioId: string) {
@@ -1981,15 +2071,18 @@ export function App() {
   async function handleLaunchRun() {
     if (!dryRun) return;
     setRunWorkflowError(null);
-    setStatus("Launching local CM1");
+    setStatus("Queueing local CM1 run");
     try {
-      const launched = await launchLocalRun(dryRun.manifest_path);
-      setRunStatus(launched);
-      setStatus(userFacingRunWorkflowStatus(launched));
+      const queued = await enqueueLocalRun(dryRun.manifest_path);
+      setRunQueue(queued);
+      setRunQueueStatus(runQueueSummary(queued));
+      setStatus(runQueueSummary(queued));
+      await syncCurrentRunStatusFromQueue(queued);
+      await processAutoIngestedQueue(queued);
       await refreshStorageAfterWorkflow("Local pipeline updated");
     } catch (caught) {
-      setRunWorkflowError(caught instanceof Error ? caught.message : "Unable to launch local CM1.");
-      setStatus("Launch blocked");
+      setRunWorkflowError(caught instanceof Error ? caught.message : "Unable to queue local CM1.");
+      setStatus("Queue blocked");
     }
   }
 
@@ -2000,6 +2093,7 @@ export function App() {
       const refreshed = await fetchRunStatus(dryRun.manifest_path);
       setRunStatus(refreshed);
       setStatus(userFacingRunWorkflowStatus(refreshed));
+      await refreshLocalRunQueue();
       await refreshStorageAfterWorkflow("Local pipeline updated");
     } catch (caught) {
       setRunWorkflowError(
@@ -2178,15 +2272,18 @@ export function App() {
 
   async function handleLaunchStoredRun(manifestPath: string) {
     setRunWorkflowError(null);
-    setStatus("Launching selected local package");
+    setStatus("Queueing selected local package");
     try {
-      const launched = await launchLocalRun(manifestPath);
-      setRunStatus(launched);
-      setStatus(userFacingRunWorkflowStatus(launched));
+      const queued = await enqueueLocalRun(manifestPath);
+      setRunQueue(queued);
+      setRunQueueStatus(runQueueSummary(queued));
+      setStatus(runQueueSummary(queued));
+      await syncCurrentRunStatusFromQueue(queued);
+      await processAutoIngestedQueue(queued);
       await refreshStorageAfterWorkflow("Local pipeline updated");
     } catch (caught) {
-      setRunWorkflowError(caught instanceof Error ? caught.message : "Unable to launch local CM1.");
-      setStatus("Launch blocked");
+      setRunWorkflowError(caught instanceof Error ? caught.message : "Unable to queue local CM1.");
+      setStatus("Queue blocked");
     }
   }
 
@@ -2437,6 +2534,8 @@ export function App() {
           validationMessages={validationMessages}
           dryRun={dryRun}
           runStatus={runStatus}
+          runQueue={runQueue}
+          runQueueStatus={runQueueStatus}
           runWorkflowError={runWorkflowError}
           lanWorkerConfig={lanWorkerConfig}
           lanWorkerStatus={lanWorkerStatus}
@@ -2588,6 +2687,8 @@ function BuildWorkspace({
   validationMessages,
   dryRun,
   runStatus,
+  runQueue,
+  runQueueStatus,
   runWorkflowError,
   lanWorkerConfig,
   lanWorkerStatus,
@@ -2676,6 +2777,8 @@ function BuildWorkspace({
   validationMessages: string[];
   dryRun: DryRunResponse | null;
   runStatus: RunStatusResponse | null;
+  runQueue: RunQueueResponse | null;
+  runQueueStatus: string;
   runWorkflowError: string | null;
   lanWorkerConfig: LanWorkerConfigResponse | null;
   lanWorkerStatus: LanWorkerRunResponse | null;
@@ -2975,6 +3078,8 @@ function BuildWorkspace({
           <LocalRunWorkflowPanel
             dryRun={dryRun}
             runStatus={runStatus}
+            runQueue={runQueue}
+            runQueueStatus={runQueueStatus}
             error={runWorkflowError}
             lanWorkerConfig={lanWorkerConfig}
             lanWorkerStatus={lanWorkerStatus}
@@ -4553,6 +4658,8 @@ function ComparisonTechnicalDetails({
 function LocalRunWorkflowPanel({
   dryRun,
   runStatus,
+  runQueue,
+  runQueueStatus,
   error,
   lanWorkerConfig,
   lanWorkerStatus,
@@ -4591,6 +4698,8 @@ function LocalRunWorkflowPanel({
 }: {
   dryRun: DryRunResponse | null;
   runStatus: RunStatusResponse | null;
+  runQueue: RunQueueResponse | null;
+  runQueueStatus: string;
   error: string | null;
   lanWorkerConfig: LanWorkerConfigResponse | null;
   lanWorkerStatus: LanWorkerRunResponse | null;
@@ -4757,7 +4866,7 @@ function LocalRunWorkflowPanel({
           <div className="button-row">
             {showLaunchButton && (
               <button type="button" data-testid="launch-cm1-btn" onClick={onLaunchRun}>
-                Run with local CM1
+                Queue local CM1 run
               </button>
             )}
             {showRefreshButton && (
@@ -4797,6 +4906,8 @@ function LocalRunWorkflowPanel({
             onCleanup={onCleanupLanWorkerRun}
           />
         )}
+
+        <LocalRunQueuePanel queue={runQueue} status={runQueueStatus} />
 
         {runStatus ? (
           <div className="run-status-panel" aria-label="Local run status">
@@ -4939,6 +5050,7 @@ function LocalRunWorkflowPanel({
         deleteMessage={runDeleteMessage}
         results={results}
         currentRunId={currentRunId}
+        runQueue={runQueue}
         lanWorkerConfigured={lanWorkerConfig?.configured ?? false}
         autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIds}
         failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIds}
@@ -4953,6 +5065,59 @@ function LocalRunWorkflowPanel({
         onPreviewDelete={onPreviewRunDelete}
         onConfirmDelete={onConfirmRunDelete}
       />
+    </section>
+  );
+}
+
+function LocalRunQueuePanel({
+  queue,
+  status,
+}: {
+  queue: RunQueueResponse | null;
+  status: string;
+}) {
+  const visibleEntries = queue ? queue.entries.slice(-5).reverse() : [];
+  return (
+    <section className="run-status-panel" aria-label="Local serial run queue">
+      <div className="panel-heading-row">
+        <div>
+          <p className="eyebrow">Local serial queue</p>
+          <h5>Queued CM1 packages</h5>
+        </div>
+        <StatusBadge
+          label={queue?.active_run_id ? "Running one package" : "Queue idle"}
+          tone={queue?.active_run_id ? "neutral" : "good"}
+        />
+      </div>
+      <p className="state-note">{status}</p>
+      {queue && (
+        <dl className="compact-metrics">
+          <Metric label="Active run" value={queue.active_run_id ?? "None"} />
+          <Metric label="Waiting" value={queue.queued_count.toLocaleString()} />
+          <Metric label="Last queue refresh" value={formatShortTime(queue.updated_at)} />
+        </dl>
+      )}
+      {visibleEntries.length > 0 ? (
+        <ol className="queue-list">
+          {visibleEntries.map((entry) => (
+            <li key={`${entry.run_id}-${entry.queued_at}`}>
+              <strong>{entry.run_id}</strong>{" "}
+              <span className="muted-inline">{runQueueEntryLabel(entry)}</span>
+              {entry.result_id && (
+                <span className="muted-inline"> result {entry.result_id}</span>
+              )}
+              {entry.cleanup_status && (
+                <span className="muted-inline"> package retained for Results/Explore</span>
+              )}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="state-note">
+          Queue local CM1 runs from package cards. Cloud Chamber starts the next package only after
+          the active run reaches terminal status.
+        </p>
+      )}
     </section>
   );
 }
@@ -5104,6 +5269,7 @@ function LocalPipelinePanel({
   deleteMessage,
   results,
   currentRunId,
+  runQueue,
   lanWorkerConfigured,
   autoFinalizingWorkerRunIds,
   failedAutoFinalizingWorkerRunIds,
@@ -5125,6 +5291,7 @@ function LocalPipelinePanel({
   deleteMessage: string | null;
   results: ResultCard[];
   currentRunId: string | null;
+  runQueue: RunQueueResponse | null;
   lanWorkerConfigured: boolean;
   autoFinalizingWorkerRunIds: Set<string>;
   failedAutoFinalizingWorkerRunIds: Set<string>;
@@ -5200,6 +5367,7 @@ function LocalPipelinePanel({
               run={run}
               result={resultForRun(results, run.run_id)}
               current={run.run_id === currentRunId}
+              queueEntry={queueEntryForRun(runQueue, run.run_id)}
               lanWorkerConfigured={lanWorkerConfigured}
               autoFinalizing={autoFinalizingWorkerRunIds.has(run.run_id)}
               autoFinalizeFailed={failedAutoFinalizingWorkerRunIds.has(run.run_id)}
@@ -5223,6 +5391,7 @@ function PipelineRunCard({
   run,
   result,
   current,
+  queueEntry,
   lanWorkerConfigured,
   autoFinalizing,
   autoFinalizeFailed,
@@ -5238,6 +5407,7 @@ function PipelineRunCard({
   run: RunStorageEntry;
   result: ResultCard | undefined;
   current: boolean;
+  queueEntry: RunQueueEntry | undefined;
   lanWorkerConfigured: boolean;
   autoFinalizing: boolean;
   autoFinalizeFailed: boolean;
@@ -5252,7 +5422,10 @@ function PipelineRunCard({
 }) {
   const displayName = result?.name ?? run.scenario_name ?? run.scenario_id ?? run.run_id;
   const canLaunch = Boolean(
-    run.manifest_path && run.category === "dry_run_only" && !run.worker_state,
+    run.manifest_path &&
+      run.category === "dry_run_only" &&
+      !run.worker_state &&
+      !queueEntryIsOpen(queueEntry),
   );
   const canRefreshWorker = Boolean(run.manifest_path && run.worker_state === "running");
   const canFinalizeWorker = Boolean(
@@ -5280,6 +5453,12 @@ function PipelineRunCard({
       </div>
       <div className="badge-row">
         <StatusBadge label={stateLabel} tone={pipelineRunTone(run, result)} />
+        {queueEntry && (
+          <StatusBadge
+            label={runQueueEntryLabel(queueEntry)}
+            tone={runQueueEntryTone(queueEntry)}
+          />
+        )}
         {!result && <StatusBadge label="Not ingested" tone="neutral" />}
       </div>
       <p>
@@ -5292,6 +5471,12 @@ function PipelineRunCard({
       {runProgress && <p className="state-note">{runProgress}</p>}
       {workerProgress && <p className="state-note">{workerProgress}</p>}
       {showWorkerMessage && <p className="state-note">{run.worker_message}</p>}
+      {queueEntry?.message && <p className="state-note">{queueEntry.message}</p>}
+      {queueEntry?.error && (
+        <p className="state-note" role="alert">
+          {queueEntry.error}
+        </p>
+      )}
       {autoFinalizing && (
         <p className="state-note" role="status">
           Copying worker output back and ingesting locally.
@@ -5304,13 +5489,13 @@ function PipelineRunCard({
       )}
       <p className="state-note">{nextStep}</p>
       <div className="button-row">
-        {canLaunch && current && run.manifest_path && (
+        {canLaunch && run.manifest_path && (
           <button
             type="button"
             className="secondary-button"
             onClick={() => onLaunchStoredRun(run.manifest_path!)}
           >
-            Run with local CM1
+            Queue local CM1 run
           </button>
         )}
         {canLaunch && lanWorkerConfigured && run.manifest_path && (
@@ -5472,6 +5657,75 @@ function lanWorkerTone(
     status.state === "failed" ||
     status.state === "completed_no_output" ||
     status.state === "worker_cleanup_failed"
+  ) {
+    return "warning";
+  }
+  return "neutral";
+}
+
+function runQueueSummary(queue: RunQueueResponse): string {
+  if (queue.active_run_id && queue.queued_count > 0) {
+    return `Running ${queue.active_run_id}; ${queue.queued_count.toLocaleString()} queued.`;
+  }
+  if (queue.active_run_id) return `Running ${queue.active_run_id}.`;
+  if (queue.queued_count > 0) return `${queue.queued_count.toLocaleString()} local runs queued.`;
+  const latest = queue.entries.at(-1);
+  if (latest?.state === "ingested" && latest.result_id) {
+    return `Auto-ingested ${latest.result_id}; queue idle.`;
+  }
+  if (latest?.state === "ingest_failed") return "Auto-ingest needs manual retry.";
+  if (latest?.state === "launch_failed") return "Local queue launch blocked.";
+  return "Local run queue idle.";
+}
+
+function runQueuePollingKey(queue: RunQueueResponse | null): string {
+  if (!queue) return "none";
+  return queue.entries
+    .map((entry) => `${entry.run_id}:${entry.state}:${entry.updated_at}`)
+    .join("|");
+}
+
+function runQueueHasOpenEntries(queue: RunQueueResponse | null): boolean {
+  return Boolean(queue?.entries.some((entry) => queueEntryIsOpen(entry)));
+}
+
+function queueEntryIsOpen(entry: RunQueueEntry | undefined): boolean {
+  return Boolean(entry && (entry.state === "queued" || entry.state === "running"));
+}
+
+function latestAutoIngestedQueueEntry(queue: RunQueueResponse): RunQueueEntry | undefined {
+  return [...queue.entries].reverse().find((entry) => entry.state === "ingested" && entry.result_id);
+}
+
+function queueEntryForRun(
+  queue: RunQueueResponse | null,
+  runId: string,
+): RunQueueEntry | undefined {
+  return queue?.entries.find((entry) => entry.run_id === runId);
+}
+
+function runQueueEntryLabel(entry: RunQueueEntry): string {
+  const labels: Record<string, string> = {
+    queued: "Queued",
+    running: "Running in serial queue",
+    ingested: "Auto-ingested",
+    ingest_failed: "Auto-ingest failed",
+    completed_no_output: "Completed with no ingestable output",
+    failed: "Run failed",
+    canceled: "Canceled",
+    launch_failed: "Launch failed",
+  };
+  return labels[entry.state] ?? humanize(entry.state);
+}
+
+function runQueueEntryTone(entry: RunQueueEntry): "good" | "warning" | "neutral" {
+  if (entry.state === "ingested") return "good";
+  if (
+    entry.state === "ingest_failed" ||
+    entry.state === "completed_no_output" ||
+    entry.state === "failed" ||
+    entry.state === "canceled" ||
+    entry.state === "launch_failed"
   ) {
     return "warning";
   }

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -348,7 +348,8 @@ backend contracts:
 
 ```text
 POST /api/dry-run-package
--> POST /api/runs/launch
+-> POST /api/runs/queue
+-> GET /api/runs/queue
 -> GET /api/runs/status?manifest_path=...
 -> POST /api/results/ingest
 -> GET /api/results
@@ -376,11 +377,22 @@ Results. The launchpad uses the runtime storage inventory to show
 eligible states and offers only safe state-appropriate transitions:
 
 - create a new package through `POST /api/dry-run-package`;
-- launch an eligible packaged run through `POST /api/runs/launch`;
+- queue an eligible packaged run through `POST /api/runs/queue`;
+- refresh and advance the serial local queue through `GET /api/runs/queue`;
 - refresh current status through `GET /api/runs/status`;
 - ingest completed output through `POST /api/results/ingest`;
 - open associated results in Results or Explore;
 - preview and confirm cleanup for non-ingested package/run directories.
+
+The local serial queue is persisted under the configured runtime home, outside
+the repo. It may contain several packaged runs, but it must launch only one
+local CM1 process at a time. Queue refresh is intentionally stateful: it checks
+the active run, records terminal status, auto-ingests completed NetCDF-producing
+runs when ingest succeeds, and then starts the next queued package. If ingest
+fails, output is left in place and manual retry remains available. After
+successful auto-ingest, the queue entry is finalized, but the Mac-local run
+directory is retained because it backs Results and Explore; destructive cleanup
+still belongs to the explicit Results cleanup flow.
 
 Runtime status refresh may reconcile a stale local manifest only when stdout
 contains normal CM1 termination evidence and output artifacts exist under the

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -301,6 +301,13 @@ appear when configured model time and latest model time are both known. It is a
 pipeline view over local runtime state, not a single active wizard. This is
 local-first orchestration only; CI still uses fake fixtures and never runs CM1.
 
+Local package launch should go through a serial queue. Users can queue multiple
+ready packages, but Cloud Chamber must run only one local CM1 process at a time.
+When a queued run completes with usable NetCDF output, Build should auto-ingest
+the result and show the generated Result ID. Failed, no-output, or ingest-failed
+runs stay visible with manual fallback actions. Auto-ingest should finalize
+queue state, not silently delete result-backed local run data.
+
 ### Workflow 4.5 — Manage Runtime Cleanup
 
 Build exposes runtime-home inventory for active, incomplete, and non-ingested

--- a/docs/development.md
+++ b/docs/development.md
@@ -109,6 +109,8 @@ Implemented backend API endpoints:
 - `GET /api/scenarios` lists validated scenario templates for the Scenario Builder and marks Baseline Shallow Cumulus as the Golden Path scenario.
 - `POST /api/dry-run-package` validates selected controls and writes a reviewable dry-run package under the configured runtime home. It does not launch CM1, create NetCDF output, or write generated packages into the repo during tests.
 - `POST /api/runs/launch` starts one local CM1 run from a generated manifest when local CM1 settings validate.
+- `POST /api/runs/queue` adds a packaged run to the local serial CM1 queue. The queue starts at most one local CM1 process at a time, advances on queue refresh, and auto-ingests completed output-producing runs.
+- `GET /api/runs/queue` refreshes the local serial queue, updates active run status, starts the next queued package when safe, and reports auto-ingest or fallback errors.
 - `GET /api/runs/status?manifest_path=...` refreshes and returns lifecycle status, product/validation state, command/log paths, short stdout/stderr tails, output-artifact counts, runtime warnings, timestamps, and bounded progress metadata for a run manifest. Progress uses configured `timax` plus parsed CM1 stdout model-minute lines when available; if model time is not available, the payload says so rather than inventing a percent complete.
 - `POST /api/runs/cancel` cancels the active local run when technically practical.
 - `GET /api/storage/inventory` reports configured runtime-home disk usage and per-run metadata under `~/CloudChamber/runs/`.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -444,6 +444,12 @@ with final elapsed runtime and complete model time, LAN worker progress when the
 worker status sidecar includes log-derived progress, unavailable model-time copy
 when progress is absent, and stale refresh labeling from old status timestamps.
 
+Local run queue tests should use fake CM1 process/status fixtures. They should
+cover enqueueing multiple packaged runs, one-at-a-time launch, active-run
+terminal refresh, successful auto-ingest, ingest-failure fallback that leaves
+manual retry possible, launch failure, and the rule that auto-ingest retains the
+result-backed local run directory for Results and Explore.
+
 Runtime cleanup UI tests should use mocked inventory/results data. They should
 verify completed-with-output runs without results expose `Ingest output`, Build
 shows preview cleanup only for non-ingested runs, running runs block cleanup


### PR DESCRIPTION
## What changed

- Added a persisted local serial CM1 queue at `/api/runs/queue` so multiple packaged runs can be queued while only one local CM1 process starts at a time.
- Added queue refresh/finalization that checks terminal run state, auto-ingests completed NetCDF-producing runs, records ingest failures for manual retry, and starts the next queued package.
- Updated Build to queue packages instead of launching directly, show serial queue state, and surface auto-ingested Result IDs without requiring the old manual ingest click.
- Updated docs/tests/e2e mocks for the queue and auto-ingest workflow.

## Data and cleanup boundary

Successful auto-ingest finalizes queue state and removes the package from the ready-to-run path, but it does not delete the local run directory. That directory is still retained because it backs Results and Explore; destructive deletion remains the explicit Results cleanup flow.

Closes #279

## Verification

- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_local_run_queue.py app/backend/tests/test_app.py`
- `npm test -- App.test.tsx`
- `scripts/check.sh`
- `scripts/check-e2e.sh`
