### PR TITLE
docs: rebase roadmap around configurable runs

### DIFF
--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -8,6 +8,24 @@ CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
 experiment builder, run manager, result notebook, diagnostics layer, and
 visualizer.
 
+The current user-facing architecture is:
+
+```text
+Build = configure and launch one CM1 run
+Results = notebook for completed/ingested runs
+Explore = inspect one result with CM1-derived evidence
+```
+
+Runtime inventory and cleanup are not a separate top-level workspace. Build owns
+active, incomplete, and non-ingested package/run work; Results owns ingested
+notebook entries and explicit ingested-result cleanup.
+
+Observed-sounding presets seed a CM1-facing configuration, but they should not
+be modeled as rigid product cages. The data model may keep internal
+`package_family` values where they preserve compatibility, while the product
+model treats those values as implementation/provenance metadata beneath a
+configurable run builder.
+
 The first MVP target is a 2024 MacBook Air with 8GB RAM. Design for one local CM1 run at a time, conservative output handling, and backend-side processing/downsampling. Optional cloud compute can be researched later, but it is not part of the core architecture.
 
 Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later and should not drive the first result storage model.
@@ -123,11 +141,12 @@ screening and package-readiness path supports them. The expanded taxonomy in
 [research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md)
 defines readiness states for severe/deep-convection, boundary-layer, low-cloud,
 and winter/cold-season stories so APIs can distinguish screenable environments
-from runnable package families. Until a story has backend features, scoring
+from runnable configuration paths. Until a story has backend features, scoring
 tests, evidence, caveats, and package-readiness support, it must not be emitted
 as an enabled package-ready label. The first implemented severe/deep-convection
-path is `Deep Convection Trial`, which treats selected observed soundings as
-pre-run hypotheses for an idealized triggered CM1 experiment.
+path is the deep-convection observed-sounding preset, backed internally by
+`package_family = deep_convection_trial`, which treats selected observed
+soundings as pre-run hypotheses for an idealized triggered CM1 experiment.
 
 The Build UI consumes this layer through bounded JSON only. `Upload a Sounding`
 loads saved candidates immediately when that experiment is selected, before any
@@ -140,23 +159,24 @@ separate from run/result status: saved candidates are pre-run hypotheses, while
 generated packages, launched runs, and ingested results remain separate
 lifecycle objects.
 
-Deep Convection Trial packages extend the same dry-run package contract rather
-than creating a separate workflow. The package records
-`package_family = deep_convection_trial`, `package_display_name = Deep
-Convection Trial`, `input_source = observed_sounding`, `trigger_type =
-warm_bubble`, trigger metadata, expected output fields, package-family smoke
-validation status, package caveats, and any candidate-screening payload on the
-run manifest, case manifest, and dry-run report. The generated namelist uses the
-observed `input_sounding` route (`isnd = 7`), requires observed u/v winds,
+Deep-convection observed-sounding packages extend the same dry-run package
+contract rather than creating a separate workflow. The package records
+`package_family = deep_convection_trial`, a deep-convection display label,
+`input_source = observed_sounding`, `trigger_type = warm_bubble`, trigger
+metadata, expected output fields, package-family smoke validation status,
+package caveats, and any candidate-screening payload on the run manifest, case
+manifest, and dry-run report. The generated namelist uses the observed
+`input_sounding` route (`isnd = 7`), requires complete usable observed u/v winds,
 selects CM1's built-in three-warm-bubble initialization (`iinit = 3`) with
-`testcase = 0`, uses a storm-scale idealized domain for storm growth,
-and enables rain, reflectivity, vorticity, and updraft-helicity output. Manual
-smoke evidence applies to the package family; each observed sounding remains an
-experiment whose outcome must be inspected after CM1 completes. The
-trigger is described as fixed v1 package metadata rather than primary product
-controls. Ingest copies the package-family and trigger metadata
-into result metadata and Result Cards so Results and Explore do not lose the
-distinction between an observed-sounding quick look and a Deep Convection Trial.
+`testcase = 0`, uses a storm-scale idealized domain for storm growth, and
+enables rain-water-aloft, surface-rain, reflectivity, vorticity, and
+updraft-helicity output. Manual smoke evidence applies to the package path and
+basic run/ingest health; each observed sounding remains an experiment whose
+outcome must be inspected after CM1 completes. The trigger is described as
+fixed v1 package metadata rather than a primary product control. Ingest copies
+the package-family and trigger metadata into result metadata and Result Cards so
+Results and Explore do not lose the distinction between an observed-sounding
+quick look and a deep-convection configured run.
 
 ## Suggested Stack
 
@@ -234,6 +254,13 @@ The earlier Cloud Chamber quick-look derivative is not scientifically accepted: 
 The first reference-derived validation run, `dry-run-les-shallowcu-20260522140642`, completed locally with NetCDF output and ingested 7 model-output time steps over 21600 seconds. It produced cloud water and vertical velocity diagnostics, so the architecture should treat the reference-derived package as the recovery baseline and the earlier compact derivative as invalid evidence rather than a tuning base.
 
 Run-size presets are generated package promises, not labels. The standard/reference package preserves `timax = 21600.0`, `tapfrq = 3600.0`, and the 64 x 64 x 75 / 100 m horizontal grid. The first quick-look variant preserves every reference-derived science/numerics setting and changes only `timax = 10800.0` and `tapfrq = 900.0`. The Deep Overnight variant is the expensive opt-in preset: it preserves the physical 6.4 km x 6.4 km domain and the accepted scenario controls, but increases horizontal resolution to 192 x 192 at about 33.333 m, saves output every 300 s, and keeps the Standard solver timestep. Vertical spacing, domain top, surface stress/roughness path, moisture/sounding, surface fluxes, turbulence/SGS settings, damping settings, boundary conditions, NetCDF output, and reference `LANDUSE.TBL` staging should remain unchanged.
+
+Future observed-sounding run controls should evolve from this preset contract:
+duration, grid/detail, output cadence, forcing, and requested output fields are
+normal guarded configuration levers. Raw numerical timestep is not a normal v1
+control. Presets should expose their derived CM1-facing values in advanced
+metadata so dry-run reports and Build UI can show exactly what will be written
+without requiring raw namelist editing.
 
 The first quick-look validation run, `dry-run-quicklook-les-shallowcu-20260522151536`, preserved those settings, completed locally, and ingested 13 model-output time steps over 10800 seconds. Diagnostics still reported cloud formation, vertical motion, and rain, so the architecture can treat this runtime-only quick-look preset as the first validated shorter Baseline Shallow Cumulus variant.
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -214,7 +214,7 @@ Later, package with Tauri/Electron if needed.
 
 ### Scenario Catalog
 
-Stores preset scenario definitions.
+Stores scenario definitions, starting presets, and run-configuration defaults.
 
 Responsibilities:
 
@@ -223,12 +223,19 @@ Responsibilities:
 - map friendly controls to CM1 configuration
 - define expected outputs
 - define visualization defaults
-- define run-size presets and one-control variation metadata around a baseline
+- define run-configuration presets as editable starting points
+- define recommended story threads or comparison patterns around a baseline
 - define the physical question and learning goals
 
 Baseline Shallow Cumulus is the first hero case. Warm rain remains early but does not block the Golden Path.
 
-Scenario templates are validated before package generation. The schema supports stable IDs, display names, descriptions, physical questions, learning goals, friendly controls, advanced/developer-only settings, run-size presets, expected diagnostics, CM1 mapping notes, visualization defaults, warnings, limitations, and one-control variation metadata. Invalid templates should fail with actionable validation messages before any CM1-facing files are generated.
+Scenario templates are validated before package generation. The schema supports
+stable IDs, display names, descriptions, physical questions, learning goals,
+friendly controls, advanced/developer-only settings, run-configuration defaults,
+optional starting presets, expected diagnostics, CM1 mapping notes,
+visualization defaults, warnings, limitations, and validation policy. Invalid
+templates should fail with actionable validation messages before any CM1-facing
+files are generated.
 
 The local FastAPI backend exposes the implemented catalog through `GET /api/scenarios`. The response should include the Golden Path scenario ID and product-facing scenario summaries only; advanced/developer controls can remain in the template but should not appear in the primary Scenario Builder flow.
 
@@ -243,24 +250,37 @@ Turns a scenario + user controls into:
 - dry-run report
 - visualization defaults
 
-For the Baseline Shallow Cumulus Golden Path, the generated package should preserve the physical question, curated controls, run-size preset, expected diagnostics, expected output fields, and provenance labels before CM1 starts.
+For the Baseline Shallow Cumulus Golden Path, the generated package should preserve the physical question, curated controls, selected run configuration or legacy preset, expected diagnostics, expected output fields, and provenance labels before CM1 starts.
 
 The CM1 input generation contract is deterministic and testable before full package generation. It documents the expected generated files and preserves product-facing controls separately from raw namelist/developer settings.
 
-For Baseline Shallow Cumulus, the recovery package is derived from CM1's local `les_ShallowCu` reference case. It preserves `testcase = 3`, the reference grid, runtime, domain top, Rayleigh damping, surface/ocean/flux settings, surface stress path, and wind profile as much as possible. The external-sounding reproduction changes the thermodynamic source from the built-in BOMEX analytic sounding (`isnd = 19`) to CM1's `input_sounding` route (`isnd = 17`) so future one-control moisture experiments have a validated profile path. The intentional Cloud Chamber output-path change remains NetCDF output (`output_format = 2`) so the completed run can flow into ingest and diagnostics.
+For Baseline Shallow Cumulus, the recovery package is derived from CM1's local `les_ShallowCu` reference case. It preserves `testcase = 3`, the reference grid, runtime, domain top, Rayleigh damping, surface/ocean/flux settings, surface stress path, and wind profile as much as possible. The external-sounding reproduction changes the thermodynamic source from the built-in BOMEX analytic sounding (`isnd = 19`) to CM1's `input_sounding` route (`isnd = 17`) so the current moisture-contrast scaffold has a validated profile path. The intentional Cloud Chamber output-path change remains NetCDF output (`output_format = 2`) so the completed run can flow into ingest and diagnostics.
 
 The earlier Cloud Chamber quick-look derivative is not scientifically accepted: full-sequence ingest evaluated all 25 model-output files, but the run produced no cloud, no vertical motion, and NaN/Infinity caveats; a fixed-roughness follow-up still failed in the same way. Quick-look scaling should happen only after the reference-derived package works, and future changes should be introduced one at a time with manual CM1 validation.
 
 The first reference-derived validation run, `dry-run-les-shallowcu-20260522140642`, completed locally with NetCDF output and ingested 7 model-output time steps over 21600 seconds. It produced cloud water and vertical velocity diagnostics, so the architecture should treat the reference-derived package as the recovery baseline and the earlier compact derivative as invalid evidence rather than a tuning base.
 
-Run-size presets are generated package promises, not labels. The standard/reference package preserves `timax = 21600.0`, `tapfrq = 3600.0`, and the 64 x 64 x 75 / 100 m horizontal grid. The first quick-look variant preserves every reference-derived science/numerics setting and changes only `timax = 10800.0` and `tapfrq = 900.0`. The Deep Overnight variant is the expensive opt-in preset: it preserves the physical 6.4 km x 6.4 km domain and the accepted scenario controls, but increases horizontal resolution to 192 x 192 at about 33.333 m, saves output every 300 s, and keeps the Standard solver timestep. Vertical spacing, domain top, surface stress/roughness path, moisture/sounding, surface fluxes, turbulence/SGS settings, damping settings, boundary conditions, NetCDF output, and reference `LANDUSE.TBL` staging should remain unchanged.
+Current legacy run-size presets are generated package promises for the existing
+baseline/scaffold implementation, not the future architecture. The
+standard/reference package preserves `timax = 21600.0`, `tapfrq = 3600.0`, and
+the 64 x 64 x 75 / 100 m horizontal grid. The first quick-look variant
+preserves every reference-derived science/numerics setting and changes only
+`timax = 10800.0` and `tapfrq = 900.0`. The Deep Overnight variant is the
+expensive opt-in preset: it preserves the physical 6.4 km x 6.4 km domain and
+the accepted scenario controls, but increases horizontal resolution to 192 x
+192 at about 33.333 m, saves output every 300 s, and keeps the Standard solver
+timestep. Vertical spacing, domain top, surface stress/roughness path,
+moisture/sounding, surface fluxes, turbulence/SGS settings, damping settings,
+boundary conditions, NetCDF output, and reference `LANDUSE.TBL` staging should
+remain unchanged for that historical/current implementation path.
 
-Future observed-sounding run controls should evolve from this preset contract:
-duration, grid/detail, output cadence, forcing, and requested output fields are
-normal guarded configuration levers. Raw numerical timestep is not a normal v1
-control. Presets should expose their derived CM1-facing values in advanced
-metadata so dry-run reports and Build UI can show exactly what will be written
-without requiring raw namelist editing.
+Forward observed-sounding run configuration should use guarded fields for
+duration, grid/detail, domain size, output cadence, output field density,
+forcing, requested fields, advanced CM1-facing values, and a pre-run validation
+report. Raw numerical timestep is not a normal v1 control. Presets should seed
+those fields and expose their derived CM1-facing values in advanced metadata so
+dry-run reports and Build UI can show exactly what will be written without
+requiring raw namelist editing.
 
 The first quick-look validation run, `dry-run-quicklook-les-shallowcu-20260522151536`, preserved those settings, completed locally, and ingested 13 model-output time steps over 10800 seconds. Diagnostics still reported cloud formation, vertical motion, and rain, so the architecture can treat this runtime-only quick-look preset as the first validated shorter Baseline Shallow Cumulus variant.
 
@@ -345,7 +365,8 @@ still producing rain. That is enough to treat it as an accepted-with-notes
 cap/stability contrast candidate, not enough to claim rain suppression or a
 fully diagnosed cap-limitation mechanism.
 
-Cloud-scale defaults for the first lower-atmosphere contract are:
+Current lower-atmosphere scaffold defaults are historical/current
+implementation evidence:
 
 ```text
 domain/grid: 64 x 64 x 75
@@ -364,11 +385,17 @@ output cadence: 900 s
 unchanged: reference-derived grid/domain/surface/damping/boundary settings
 ```
 
-Scenario-specific deviations from these defaults must be explicit in the scenario template or generated report.
+Configuration-specific deviations from these defaults must be explicit in the
+scenario template, generated report, or pre-run validation report.
 
 Dry-run package generation uses the validated scenario template and CM1 input contract to create a reviewable package under the configured runtime home, normally `~/CloudChamber/runs/<run-id>/`. The package writer should refuse to overwrite existing run directories, validate controls before writing, and produce only package inputs/reports, not CM1 output.
 
-The implemented dry-run API is `POST /api/dry-run-package`. It accepts scenario ID, selected product controls, and run-size preset, then returns the package paths and dry-run report summary for UI review. It must not launch CM1, write NetCDF, or place generated packages inside the source tree during tests.
+The implemented dry-run API is `POST /api/dry-run-package`. It currently accepts
+scenario ID, selected product controls, and a legacy run-size preset, then
+returns the package paths and dry-run report summary for UI review. The forward
+API should accept a selected run configuration with optional preset provenance.
+It must not launch CM1, write NetCDF, or place generated packages inside the
+source tree during tests.
 
 The Build workspace is the first guided app-side launchpad over the existing
 backend contracts:
@@ -529,7 +556,7 @@ Responsibilities:
 - create thumbnails/previews
 - record provenance
 
-The first implemented ingest step creates `result_metadata.json` in the completed run directory. It reads NetCDF with xarray and records result ID, run ID, scenario, physical question, controls, run-size preset, source lifecycle/product/provenance state, raw CM1 artifacts, NetCDF paths, processed artifact placeholders, dimensions, coordinates, variables, units, time coordinate, grid shape, warnings, and timestamps.
+The first implemented ingest step creates `result_metadata.json` in the completed run directory. It reads NetCDF with xarray and records result ID, run ID, scenario, physical question, controls, selected run configuration or legacy run-size preset, source lifecycle/product/provenance state, raw CM1 artifacts, NetCDF paths, processed artifact placeholders, dimensions, coordinates, variables, units, time coordinate, grid shape, warnings, and timestamps.
 
 The next implemented step attaches first-pass diagnostics to that result metadata.
 Diagnostics read NetCDF fields through the backend and summarize `qc`, `w`,
@@ -565,7 +592,7 @@ CM1.
 The backend result-card layer is the product-facing view over ingested metadata.
 It does not rerun CM1 and does not parse raw output directly. It summarizes:
 
-- run ID, scenario, run-size preset, and physical question;
+- run ID, scenario, selected run configuration or legacy preset, and physical question;
 - diagnostics summary, first cloud time, max `qc`, max/min `w`, rain water
   aloft, surface rain, reflectivity, and caveats;
 - output file summary, including NetCDF/model-output/stat/raw/processed counts and time-step range;
@@ -1016,7 +1043,13 @@ scenario + controls
 → run manifest
 ```
 
-Runtime tier metadata should flow through this path: scenario templates define available run-size presets, generated run packages record the selected preset, run manifests preserve it during execution, and result metadata keeps it available for later inspection.
+Run-configuration metadata should flow through this path: scenario templates
+define editable configuration defaults and optional starting presets, generated
+run packages record the selected duration, grid/detail, domain, output cadence,
+output field density, forcing, requested fields, advanced CM1-facing values,
+and validation report, run manifests preserve them during execution, and result
+metadata keeps them available for later inspection. Legacy run-size preset names
+may remain as compatibility provenance.
 
 If size/runtime estimates are not validated yet, manifests and reports should record that explicitly rather than presenting guessed precision.
 
@@ -1070,7 +1103,7 @@ The result manifest should be able to answer:
 What scenario was this?
 What physical question was tested?
 What controls were used?
-What run-size preset was selected?
+What run configuration was selected?
 What did CM1 do?
 What diagnostics summarize the cloud evolution?
 Can I replay it?
@@ -1155,7 +1188,10 @@ scenarios/
 
 Run manifests should record the scenario template, adjusted controls, generated CM1-facing files, runtime paths, lifecycle state, validation status, timestamps, and later output paths. A manifest should not require NetCDF output to exist.
 
-Run manifests should also record the selected run-size preset, physical question, expected diagnostics, and visualization defaults when those concepts are available from the scenario template.
+Run manifests should also record the selected run configuration, optional
+legacy run-size preset, physical question, expected diagnostics, and
+visualization defaults when those concepts are available from the scenario
+template.
 
 The backend run-manifest schema records run ID, scenario reference/version, adjusted controls, generated CM1 input paths, CM1 root/run paths, app metadata, timestamps, lifecycle state, validation status, output paths, user notes/tags, and provenance labels. It serializes/deserializes as JSON and does not require NetCDF output.
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -22,6 +22,20 @@ The current UX reset direction is:
 Cloud Chamber is a guided experiment notebook for understanding why clouds formed, failed, stayed shallow, or grew stronger.
 ```
 
+The current product model is:
+
+```text
+Build = configure and launch one CM1 run
+Results = notebook for completed/ingested runs
+Explore = inspect one result with CM1-derived evidence
+```
+
+Build should be organized around configurable observed-sounding runs. Presets
+are useful starting points, not separate product cages: a user should be able to
+start from a sane preset, inspect the actual CM1-facing settings, and adjust
+duration, grid/detail, output cadence, forcing, and output fields within guarded
+bounds.
+
 See [UX Reset: Guided Experiment Notebook](ux-reset-guided-experiment-notebook.md)
 for the PM/design source of truth for future UX work.
 
@@ -101,10 +115,12 @@ low-cloud, and winter/cold-season candidates, are defined in
 [research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md).
 Those labels must remain disabled, caveated, or absent from product UI until
 backend scoring, evidence, caveats, and package-readiness states support them.
-The first exception is the deep-convection family backed by the `Deep
-Convection Trial` package: severe/deep-convection candidates may be presented as
-pre-run hypotheses for an idealized triggered CM1 experiment, not as forecasts
-or guaranteed storm outcomes.
+The first exception is the deep-convection observed-sounding preset backed by
+the internal `deep_convection_trial` package path: severe/deep-convection
+candidates may be presented as pre-run hypotheses for an idealized triggered
+CM1 experiment, not as forecasts or guaranteed storm outcomes. User-facing copy
+should emphasize a configurable deep-convection run starting point instead of a
+half-state "Trial" product when that distinction matters.
 The backend may compute richer sounding diagnostics such as profile quality,
 moisture/LCL proxies, lapse-rate and cap proxies, wind shear, dry-layer
 signals, and freezing-level context to support future screening. These are
@@ -127,17 +143,21 @@ evidence, feature summary, and caveats should be copied into package metadata as
 provenance.
 
 When an uploaded or saved observed sounding is package-ready, Build should let
-the user choose between `Observed Sounding Quick Look` and `Deep Convection
-Trial`. `Deep Convection Trial` is the first-class package family for
-severe/deep-convection observed-sounding experiments: it uses the observed
-temperature, moisture, and wind profile through CM1 `isnd = 7`, runs an
-idealized three-warm-bubble trigger (`iinit = 3`), uses a storm-scale model box
-suitable for storm growth and precipitation inspection, requests rain,
-reflectivity, vorticity, and updraft-helicity output, and records
-`package_family = deep_convection_trial` plus trigger,
-expected-output, caveat, and candidate-screening provenance in generated
-manifests. Quick Look may be tried locally when practical; Standard and Deep
-tiers should recommend the LAN worker. Raw trigger parameters remain
+the user start from observed-sounding quick-look or deep-convection presets and
+then review the CM1-facing configuration those presets imply. The
+deep-convection preset is first-class for severe/deep-convection
+observed-sounding experiments: it uses the observed temperature, moisture, and
+complete wind profile through CM1 `isnd = 7`, runs an idealized
+three-warm-bubble trigger (`iinit = 3`), uses a storm-scale model box suitable
+for storm growth and precipitation inspection, requests rain water aloft,
+surface rain, reflectivity, vorticity, and updraft-helicity output, and records
+`package_family = deep_convection_trial` plus trigger, expected-output, caveat,
+and candidate-screening provenance in generated manifests. That internal
+`package_family` value may remain until renaming it is worth the migration
+cost, but product copy should describe the run as a deep-convection
+observed-sounding configuration rather than a separate "Trial" status. Quick
+tiers must still run long enough to be meteorologically useful; Standard and
+Deep tiers should recommend the LAN worker. Raw trigger parameters remain
 metadata-only in v1 and should not become user controls until useful ranges are
 validated.
 
@@ -457,7 +477,7 @@ Product diagnostics should be framed at three levels:
   surface-heating/deep-breakthrough cases.
 
 Deep-convection breakthrough and precipitation-feedback/cold-pool diagnostics
-are first-class product families, but they should remain unavailable,
+are first-class science directions, but they should remain unavailable,
 candidate, or insufficient-evidence states until the required CM1 fields and
 derived diagnostics exist.
 
@@ -469,12 +489,34 @@ is selected, and expose growing/fair-weather cumulus candidate labels from
 available cloud-top and cloud-water diagnostics. It does not compute buoyancy,
 entrainment, CAPE/CIN/LFC/EL, cold pools, or selected-region explanations yet.
 
+## Run Configuration Rules
+
+Build should present presets as starting points for a CM1-facing configuration,
+not as rigid experiment families. The user should be able to inspect the actual
+duration, grid/detail, output cadence, forcing, requested output fields, and
+important namelist-derived values implied by a preset in an advanced drawer.
+
+Quick means quick to execute on the available compute target; it must not mean
+meteorologically too short to produce useful evolution. Smoke checks prove that
+package generation, CM1 launch, output production, ingest, and basic
+visualization wiring are healthy. They are not evidence that a specific observed
+sounding validates a science hypothesis. Science runs should use enough model
+time, domain, and output cadence for the atmospheric question being asked.
+
+Grid/detail and output cadence are the main user-facing cost levers. Raw
+numerical timestep is not a normal v1 user control. Cloud Chamber should warn or
+caveat unvalidated control combinations when they can be safely generated,
+block configurations that cannot be rendered or launched honestly, and avoid
+silently replacing bad observed-sounding input with reference defaults.
+
 ## Run Size Presets
 
 ### Quick look
 
-- Target: roughly 10-20 minutes when feasible on the local Mac.
-- Purpose: sanity checks, setup inspection, and rough cloud behavior.
+- Target: quick to execute when feasible on the selected local or LAN-worker
+  compute path, while preserving enough model time for useful evolution.
+- Purpose: setup inspection, package/run/ingest health, and rough cloud
+  behavior. Treat short smoke runs as plumbing evidence, not science results.
 - For Baseline Shallow Cumulus, this is the first runtime-only variant derived from the validated `les_ShallowCu` baseline: `timax = 10800.0` and `tapfrq = 900.0`.
 - It preserves the reference grid, vertical spacing, domain top, surface stress/roughness path, moisture/sounding, surface fluxes, turbulence/SGS settings, damping settings, boundary conditions, NetCDF output, and reference `LANDUSE.TBL` staging behavior.
 - Lower confidence is acceptable if clearly labeled; do not use the old compact quick-look derivative as evidence or as a tuning base.
@@ -1115,11 +1157,11 @@ metadata as provenance. Observed-sounding results should read as `Uploaded
 Sounding` in notebook names, scenario labels, and scenario filtering while the
 underlying generated scenario ID remains available in technical details as
 lineage.
-Deep Convection Trial results should retain their package-family identity after
-ingest: notebook names and scenario labels may say `Deep Convection Trial`,
-while the original observed station/time, generated scenario ID, trigger
-metadata, expected outputs, caveats, and candidate-screening hypothesis remain
-available as provenance.
+Deep-convection observed-sounding results should retain their package-family
+provenance after ingest: notebook names and scenario labels may identify the
+run as deep convection, while the original observed station/time, generated
+scenario ID, internal `package_family`, trigger metadata, expected outputs,
+caveats, and candidate-screening hypothesis remain available as provenance.
 Technical metadata such as raw lifecycle/product states, run IDs, provenance
 labels, controls, and detailed caveats remain available under disclosure rather
 than dominating the first read. The layout should be mobile-first: cards stack

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -156,8 +156,10 @@ and candidate-screening provenance in generated manifests. That internal
 `package_family` value may remain until renaming it is worth the migration
 cost, but product copy should describe the run as a deep-convection
 observed-sounding configuration rather than a separate "Trial" status. Quick
-tiers must still run long enough to be meteorologically useful; Standard and
-Deep tiers should recommend the LAN worker. Raw trigger parameters remain
+tiers must still run long enough to be meteorologically useful. Build should
+show expected cost, runtime, and output volume, and note when a configuration is
+better suited to larger compute instead of making machine choice the primary
+product axis. Raw trigger parameters remain
 metadata-only in v1 and should not become user controls until useful ranges are
 validated.
 
@@ -192,7 +194,7 @@ The first complete product loop is:
 ```text
 Pick Baseline Shallow Cumulus
 -> adjust curated controls
--> choose run-size preset
+-> choose or adjust run configuration
 -> validate setup
 -> generate CM1 run package
 -> launch local CM1
@@ -246,7 +248,12 @@ Exact morphology is not pass/fail. The acceptance question is whether the produc
 4. See expected behavior, controls, run cost, and output fields.
 5. Optionally adjust controls.
 
-The first implemented Scenario Builder flow is intentionally narrow: it loads validated scenario templates from the local backend, defaults to Baseline Shallow Cumulus, displays the scenario description and physical question, exposes only product-facing curated controls, lets the user choose a run-size preset, and requests a dry-run package for review.
+The first implemented Scenario Builder flow is intentionally narrow: it loads
+validated scenario templates from the local backend, defaults to Baseline
+Shallow Cumulus, displays the scenario description and physical question,
+exposes only product-facing curated controls, lets the user choose from current
+run-size presets, and requests a dry-run package for review. The forward Build
+flow should generalize that choice into the run-configuration model above.
 
 Build should not assume the user is working one perfectly linear package at a
 time. Local experiments can be packaged, running, failed, completed-but-not-
@@ -278,7 +285,7 @@ Current behavior is a placeholder only. It must explicitly say preview is not im
 1. Request a dry-run package from the Scenario Builder.
 2. Backend validates the scenario template and selected controls.
 3. Backend writes package files under the configured runtime home, not the repo.
-4. UI displays run ID, package path, manifest path, scenario, validation/product state, generated files, physical question, selected run-size preset, expected diagnostics, and cost/size notes.
+4. UI displays run ID, package path, manifest path, scenario, validation/product state, generated files, physical question, selected run configuration, expected diagnostics, and cost/size notes.
 5. UI states that CM1 was not launched and the package is not a completed CM1 result.
 6. The launchpad also surfaces other local package/run directories from the
    runtime inventory when they still need Build action: packaged-only, running,
@@ -489,14 +496,15 @@ is selected, and expose growing/fair-weather cumulus candidate labels from
 available cloud-top and cloud-water diagnostics. It does not compute buoyancy,
 entrainment, CAPE/CIN/LFC/EL, cold pools, or selected-region explanations yet.
 
-## Run Configuration Rules
+## Run Configuration Model
 
-Build should present presets as starting points for a CM1-facing configuration,
-not as rigid experiment families. The user should be able to inspect the actual
-duration, grid/detail, output cadence, forcing, requested output fields, and
-important namelist-derived values implied by a preset in an advanced drawer.
+Build should present presets as starting points for a CM1-facing run
+configuration, not as rigid experiment families or mandatory
+quick/standard/deep schema slots. The user should be able to start from a
+trusted preset, inspect what it means, adjust guarded settings, and receive a
+pre-run validation report before package generation or launch.
 
-Quick means quick to execute on the available compute target; it must not mean
+Quick means quick to execute for the selected configuration; it must not mean
 meteorologically too short to produce useful evolution. Smoke checks prove that
 package generation, CM1 launch, output production, ingest, and basic
 visualization wiring are healthy. They are not evidence that a specific observed
@@ -509,12 +517,65 @@ caveat unvalidated control combinations when they can be safely generated,
 block configurations that cannot be rendered or launched honestly, and avoid
 silently replacing bad observed-sounding input with reference defaults.
 
-## Run Size Presets
+Forward run configuration should include:
+
+```yaml
+run_configuration:
+  preset_id:
+    optional starting point, not a required product family
+  duration:
+    model_time_seconds
+    purpose: smoke_check | quick_science | standard_science | extended_science
+  grid_detail:
+    label
+    nx
+    ny
+    nz
+    dx_m
+    dy_m
+    vertical_grid_summary
+  domain:
+    width_m
+    depth_m
+    model_top_m
+  output_cadence:
+    model_seconds_between_outputs
+    expected_saved_frames
+  output_field_density:
+    minimal | standard | expanded
+    requested_fields
+  forcing:
+    surface_sensible_heat_flux
+    surface_latent_heat_flux
+    radiation_mode
+    place_time_context
+  advanced_cm1_values:
+    namelist_summary
+    input_sounding_summary
+    runtime_files_needed
+  pre_run_validation_report:
+    status
+    blocking_errors
+    caveats
+    estimated_runtime
+    estimated_output_volume
+```
+
+Presets may populate these fields, and existing package metadata may keep
+legacy names such as `quick_look`, `standard`, or `deep_overnight` for
+compatibility. Future docs and UI should treat those names as implementation
+details unless a specific historical validation note requires them.
+
+## Current Legacy Run-Size Presets
+
+The current lower-atmosphere scaffold still uses quick/standard/deep run-size
+presets. These are implementation details for existing Baseline Shallow Cumulus
+and related scaffold behavior, not the forward product contract.
 
 ### Quick look
 
-- Target: quick to execute when feasible on the selected local or LAN-worker
-  compute path, while preserving enough model time for useful evolution.
+- Target: quick to execute within its expected cost/runtime/output-volume
+  envelope while preserving enough model time for useful evolution.
 - Purpose: setup inspection, package/run/ingest health, and rough cloud
   behavior. Treat short smoke runs as plumbing evidence, not science results.
 - For Baseline Shallow Cumulus, this is the first runtime-only variant derived from the validated `les_ShallowCu` baseline: `timax = 10800.0` and `tapfrq = 900.0`.
@@ -549,11 +610,17 @@ silently replacing bad observed-sounding input with reference defaults.
 
 Runtime estimates are approximate until locally validated for a specific CM1 build, scenario, and machine. The first local hardware target is a 2024 MacBook Air with 8GB RAM, so the MVP should assume one local CM1 run at a time and conservative output handling.
 
-Runtime tier metadata should be carried through scenario templates, generated run packages, dry-run reports, run manifests, result metadata, and result cards. If estimate data is not locally validated yet, the UI/report should say `unknown until validated` instead of inventing precision.
+Run-configuration estimate metadata should be carried through scenario
+templates, generated run packages, dry-run reports, run manifests, result
+metadata, and result cards. If estimate data is not locally validated yet, the
+UI/report should say `unknown until validated` instead of inventing precision.
 
-## Preset Scenario Schema
+## Run Configuration And Preset Schema
 
-Backend scenario templates are validated by the `ScenarioTemplate` contract. Each scenario should define:
+Backend scenario templates are validated by the `ScenarioTemplate` contract.
+The current implementation can keep legacy fields for compatibility, but the
+forward-compatible schema should define presets as optional seeds for a
+`run_configuration` object:
 
 ```yaml
 id:
@@ -573,6 +640,46 @@ cm1_template:
   namelist_template
   input_sounding_template
   runtime_files_needed
+presets:
+  - id
+  - label
+  - description
+  - run_configuration_defaults
+run_configuration:
+  duration:
+    model_time_seconds
+  grid_detail:
+    nx
+    ny
+    nz
+    dx_m
+    dy_m
+    vertical_grid_summary
+  domain:
+    width_m
+    depth_m
+    model_top_m
+  output_cadence:
+    model_seconds_between_outputs
+    expected_saved_frames
+  output_field_density:
+    level
+    requested_fields
+  forcing:
+    surface_sensible_heat_flux
+    surface_latent_heat_flux
+    radiation_mode
+    place_time_context
+  advanced_cm1_values:
+    namelist_summary
+    input_sounding_summary
+    runtime_files_needed
+pre_run_validation_report:
+  status:
+  blocking_errors:
+  caveats:
+  estimated_runtime:
+  estimated_output_volume:
 outputs_expected:
   fields
   diagnostics
@@ -580,14 +687,11 @@ visualization_defaults:
   camera
   fields
   color/opacity
-run_size_presets:
-  quick_look
-  standard
-  deep_overnight
 physical_question:
 learning_goals:
 variation_policy:
-  one_control_at_a_time_from_baseline: true
+  recommended_story_thread:
+  recommended_comparison_pattern:
 validation_status:
   unrun | generated | accepted | needs_calibration
 notes:
@@ -596,15 +700,19 @@ notes:
 Validation rules should reject templates that:
 
 - omit product-facing controls
+- omit a valid run-configuration default for package generation
 - define a choice control whose default is not one of its options
 - define a number control without a valid range
-- omit one of the quick / standard / deep run-size presets
-- reference unknown controls from the one-control variation policy
+- reference unknown controls from presets or validation policy
 - include undeclared fields
 
-The schema is intentionally product-first. Raw CM1/developer controls can exist as advanced metadata, but product-facing controls remain the primary path.
+The schema is intentionally product-first. Raw CM1/developer controls can exist
+as advanced metadata, but product-facing controls and the pre-run validation
+report remain the primary path. Legacy `run_size_presets` can remain on current
+templates while the run-builder model is implemented; they should not be treated
+as a required future shape.
 
-Thermal Fate scenario families should include:
+Thermal Fate diagnostic directions should include:
 
 1. Moisture-limited thermal fate: Baseline, Dry Failed, and humidity ladder.
 2. Surface-heating-driven thermal fate: weaker/baseline/stronger heating,
@@ -926,7 +1034,11 @@ Dry-run package generation creates these files for review without launching CM1:
 - `dry_run_report.json`
 - `runtime_file_checklist.json`
 
-The dry-run report must state that it is not a completed CM1 result, record that CM1 was not launched, include selected run-size preset, include physical question and controls, include expected diagnostics and visualization defaults, and use `unknown until validated` for unvalidated cost/size estimates.
+The dry-run report must state that it is not a completed CM1 result, record
+that CM1 was not launched, include the selected run configuration or legacy
+preset, include physical question and controls, include expected diagnostics and
+visualization defaults, show expected runtime/cost/output-volume information
+when available, and use `unknown until validated` for unvalidated estimates.
 
 Launch preflight must reject placeholder-only CM1-facing files, including old `&cloud_chamber_domain` fragments or notes-only `input_sounding` artifacts. Required external runtime files such as `LANDUSE.TBL` are copied from the configured local CM1 run directory into the generated runtime package at launch time. These staged files are local/generated artifacts and must not be committed.
 
@@ -1009,6 +1121,16 @@ cm1_run_dir:
 output_dir:
 configuration:
   controls:
+  run_configuration:
+    duration:
+    grid_detail:
+    domain:
+    output_cadence:
+    output_field_density:
+    forcing:
+    advanced_cm1_values:
+    pre_run_validation_report:
+  legacy_run_size_preset:
   namelist_parameters:
   input_sounding:
 preview:
@@ -1099,7 +1221,8 @@ physical question
 created_at
 completed_at
 controls used
-run-size preset
+run configuration
+legacy run-size preset when present
 CM1 version/path metadata
 status
 generated config paths
@@ -1124,7 +1247,7 @@ card over ingested result metadata:
 ```text
 run id
 scenario
-run-size preset
+run configuration or legacy preset
 physical question
 diagnostics summary
 first cloud time
@@ -1143,9 +1266,9 @@ but the current product does not expose a separate save/protect mode.
 
 The Results Library UI is an experiment notebook, not an admin table. It lists
 result cards from the backend as scan-friendly experiment entries, lets the user
-select one result, and shows a detail/notebook card with scenario, run-size
-preset, cloud/rain outcome, diagnostics summary, first cloud time, max `qc`,
-max/min `w`, caveats, output summary, and editable name/tags/notes. Notebook
+select one result, and shows a detail/notebook card with scenario, run
+configuration or legacy preset, cloud/rain outcome, diagnostics summary, first
+cloud time, max `qc`, max/min `w`, caveats, output summary, and editable name/tags/notes. Notebook
 edits use `Save changes`; ingested results already appear in Results.
 The notebook also exposes backend-derived science summary fields such as
 first-cloud time, max `qc`, max updraft, rain onset, latest output time, and

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -1,6 +1,6 @@
 # Current Roadmap
 
-Status: active roadmap after input/output contracts
+Status: active roadmap for configurable observed-sounding CM1 runs
 
 This is the active planning source for Cloud Chamber. The previous long
 issue-by-issue roadmap is archived at
@@ -21,21 +21,35 @@ interpretations around that source data.
 
 ## Current Product Model
 
-- **Build** = construct and run one credible LES experiment.
-- **Results** = experiment notebook for ingested and completed runs.
+- **Build** = configure and launch one CM1 run from a selected atmosphere,
+  starting preset, and guarded run settings. Build owns active, incomplete, and
+  non-ingested package/run work.
+- **Results** = experiment notebook for completed and ingested runs. Results owns
+  ingested-result review, notes, and explicit ingested-result cleanup.
 - **Explore** = scientific inspection of one result using CM1-derived evidence.
-- **Storage** = lifecycle-aware runtime inventory and destructive cleanup.
+
+Runtime inventory and cleanup are contextual actions inside Build and Results,
+not a separate top-level Storage workspace.
 
 ## Hard Product Rules
 
 - LES only for the current planning horizon.
 - Local-first: local CM1, local runtime home, local result evidence.
+- CM1 output is the source of truth for cloud evolution.
+- Always distinguish preview estimate, CM1 run configuration, CM1
+  running/completed result, and visualization interpretation.
 - The browser must not parse raw NetCDF.
 - Generated artifacts do not go in git.
-- Contracts before UI.
-- Output products before renderer ambition.
-- Observed or detailed sounding before GIS/map realism.
-- Storage owns destructive cleanup.
+- Quick means quick to execute, not meteorologically too short to be useful.
+- A smoke check proves package/run/ingest health; it is not a science result.
+- Science runs need enough model time to produce meaningful evolution.
+- Grid/detail and output cadence are the primary user-facing cost levers.
+- Raw numerical timestep is not a normal v1 user control.
+- Presets are starting points. They should expose actual CM1-facing values in an
+  advanced drawer instead of becoming rigid product families.
+- Warn or caveat unvalidated control combinations instead of hiding every
+  control.
+- Build owns non-ingested cleanup; Results owns ingested-result cleanup.
 - Explore remains scientific inspection, not Render Studio.
 
 ## Active Source Documents
@@ -53,196 +67,144 @@ Use these docs as the current strategic and contract sources:
 The research memos are PM input and evidence. The contract docs define the
 implementation boundary that future issues should build from.
 
-The expanded sounding taxonomy is product/science planning input for future
-story families. It does not make severe, winter, cold-pool, or specialized
-boundary-layer stories package-ready until their scoring, evidence, and package
-readiness are implemented and tested.
+The expanded sounding taxonomy is product/science planning input for pre-run
+candidate stories. It does not make severe, winter, cold-pool, or specialized
+boundary-layer stories scientifically validated until their scoring, evidence,
+caveats, and package-readiness states are implemented and tested.
 
-The deep-convection package design is a research decision memo for a future
-observed-sounding package family. It recommends a first package direction but
-does not make deep-convection generation available until implementation,
-fixtures, and manual CM1 validation exist.
+The deep-convection package design backs the current deep-convection
+observed-sounding preset and package path. User-facing docs should describe this
+as a configurable deep-convection run starting point, not as a separate
+half-state "Trial" product. Internal metadata such as
+`package_family = deep_convection_trial` may remain where renaming would create
+more churn than clarity.
 
-## Active Execution Sequence
+## Current State
 
-1. Implement output product manifest plus robust file/time index mapping.
-2. Add interesting-time output products.
-3. Prototype observed/detailed sounding import with metadata and provenance
-   using tiny fixtures.
-4. Add profile/time-height derived product skeletons.
-5. Expand the field catalog for realistic LES outputs.
-6. Audit and validate land/radiation reference paths.
-7. Prototype external visualization/diagnostics exports.
-8. Only then decide Render Studio or Diagnostics Lab product surfaces.
+- Observed-sounding upload and package generation now work through the backend
+  parser and CM1 `input_sounding` route. Observed temperature, moisture, and
+  complete usable u/v wind profiles are package inputs, not decorative metadata.
+- Cached IGRA recent sounding refresh, local cached-sounding inspection,
+  candidate screening, saved candidates, and package-ready/blocked candidate
+  states exist. Candidate scores are pre-run selection aids, not CM1 outcome
+  predictions.
+- The deep-convection observed-sounding preset can generate storm-scale CM1
+  packages with fixed v1 warm-bubble trigger metadata, expected deep-output
+  fields, and package-family smoke evidence. Each observed sounding remains its
+  own experiment whose result must be evaluated after CM1 runs.
+- Build owns active package/run work, including generated packages, queued or
+  running local CM1 work, failed or incomplete runs, completed-but-not-ingested
+  output, serial local queue state, auto-ingest for completed usable output, and
+  LAN-worker status/progress summaries.
+- Results owns ingested notebook entries, result-card review, notes/tags, and
+  explicit cleanup for ingested results plus their backing local data.
+- Explore consumes bounded backend output products, interesting times,
+  diagnostics summaries, native-grid slices, and visualization-ready point
+  layers. The browser still does not parse raw NetCDF.
 
-This order is intentional. It keeps the product grounded in trustworthy local
-LES inputs and bounded output products before adding broader UI surfaces,
-renderer technology, or new scenario families.
+## Next Roadmap Lanes
 
-## Recently Completed
-
-#204/#205/#218/#236 cleaned up the Build/Results/runtime-cleanup lifecycle
-model.
-
-- **Build** shows active and incomplete package/run/ingest pipeline work.
-- **Build** owns cleanup for non-ingested local packages and runs.
-- **Results** owns ingested notebook review plus explicit ingested-result
-  cleanup.
-
-## Recommended Issue Candidates
-
-These are candidate implementation issues for PM review. Do not create them
+These are candidate implementation lanes for PM review. Do not create them
 automatically from this roadmap.
 
-### Implement Output Product Manifest And Time Index
+### Cached-Sounding Analysis And Sorting
 
-Goal: create the first local output product manifest with robust global
-time-index to source-file mapping.
+Goal: make the cached IGRA workbench useful for choosing observed atmospheres
+without pretending the score predicts CM1 success.
 
-Scope: product manifest skeleton, source file fingerprints, model-output versus
-stats-file distinction, global/local time index mapping, provenance, caveats,
-and tests with tiny fixtures.
+Scope: richer cached-sounding analysis, transparent sorting/filtering by story,
+quality and support-state explanations, saved-candidate ergonomics, and clearer
+blocked/package-ready evidence. Keep shallow, humid/rainy, and
+deep-convection-oriented candidate stories as pre-run hypotheses.
 
-Non-goals: new renderer UI, external exports, CM1 package generation changes,
-or real CM1 execution in CI.
+Non-goals: universal "best sounding" ranking, forecast language, browser-side
+station parsing, or unsupported story labels that look package-ready.
 
-Why now: this is the backend foundation for deep-output Explore performance,
-interesting times, profiles, time-height products, and future render-ready
-artifacts.
+Why now: configurable observed-sounding runs need a better way to find and
+compare input atmospheres before packaging.
 
-Dependencies: [Output Product Specification](contracts/output-product-specification.md).
+### Configurable Observed-Sounding Run Controls
 
-### Add Interesting-Time Output Products
+Goal: let Build start from a sane preset and then adjust run settings that map
+to real CM1 configuration.
 
-Goal: make first cloud, max cloud water, max updraft, rain onset, and related
-time landmarks reusable by Results, Explore, comparison, and future time-based
-views.
+Scope: controls for model duration, grid/detail, output cadence, forcing, and
+requested output fields within guarded bounds. Presets should remain available
+as starting points, and an advanced drawer should expose the actual CM1-facing
+values those presets imply.
 
-Scope: metadata-backed or bounded-product-backed interesting-time records,
-tests using tiny synthetic outputs, and documentation of fallback/caveat rules.
+Non-goals: raw numerical timestep as a normal v1 control, raw trigger controls,
+new trigger types, or a full Build redesign in one issue.
 
-Non-goals: timelapse UI, renderer animation, or new diagnostics lab surfaces.
+Why now: the product direction is configurable runs, not rigid scenario or
+package-family cages. Grid/detail and output cadence are the main cost levers;
+duration controls must preserve enough model time for meaningful evolution.
 
-Why now: users need meaningful time defaults before time-heavy UI work.
+### Pre-Run Configuration Validation
 
-Dependencies: output product manifest and time-index mapping.
+Goal: validate the selected atmosphere, preset, and adjusted CM1-facing settings
+before package generation or launch.
 
-### Prototype Observed Sounding Import With Metadata
+Scope: backend validation for missing required observed fields, incomplete wind
+profiles, suspicious duration/cadence combinations, unsupported output-field
+requests, runtime-file requirements, cost/storage caveats, and clear dry-run
+messages. Unvalidated combinations should warn or caveat when safe rather than
+being hidden by default.
 
-Goal: prove the first realistic-input path using observed or detailed sounding
-fixtures while preserving source metadata and conversion caveats.
+Non-goals: running CM1 in CI, declaring scientific success before CM1 output,
+or silently patching bad input into something packageable.
 
-Scope: tiny fixture import, station/location/elevation, valid time/date, source,
-units, observed wind conversion to CM1 `u`/`v`, conversion metadata,
-package-review provenance, and a local Build upload path for extracted IGRA
-station sounding-data files.
+Why now: configurable controls need trust boundaries before they become normal
+Build workflow.
 
-Non-goals: Bench Mode UI, arbitrary GIS/map inputs, surface heterogeneity, or
-unvalidated scenario families.
+### Deep-Convection Configuration Validation Across Soundings
 
-Why now: observed soundings are the closest realistic input layer to the
-existing external `input_sounding` path.
+Goal: keep the deep-convection observed-sounding preset first-class while
+measuring where its current configuration is package-ready, caveated, or
+misleading.
 
-Dependencies:
-[Realistic LES Input Specification](contracts/realistic-les-input-specification.md).
+Scope: validate complete observed-wind requirements, storm-scale box choices,
+duration tiers, output cadence, expected fields, LAN-worker guidance, and
+candidate-provenance copy across selected observed soundings. Separate
+package/run/ingest smoke checks from science outcomes.
 
-### Expand Field Catalog For Realistic LES Outputs
+Non-goals: removing the deep-convection path, exposing raw trigger controls,
+adding trigger types, or treating a smoke run as evidence that a specific
+observed sounding should produce deep convection.
 
-Goal: make realistic LES output fields discoverable and honestly classified
-before Explore, diagnostics, or future render/export tools expose them.
+Why now: deep-convection packaging exists and is useful, but the trust language
+must stay honest while configuration coverage expands.
 
-Scope: field catalog expansion for realistic-output fields such as `qv`,
-theta/temperature/pressure, surface sensible and latent fluxes, surface
-diagnostics, radiation terms when present, `lwp`, `CAPE`, `CIN`, `LCL`, and
-`LFC` when present. Include capability classification, units, coordinates,
-native-grid metadata, supported product types, provenance, caveats, and tiny
-fixture or metadata-backed tests.
+### Surface-Flux And Radiation Control Validation
 
-Non-goals: package-generation changes, browser NetCDF parsing, arbitrary raw
-field dump UI, renderer work, or new scenario families.
+Goal: determine which surface-flux, radiation, date/time, and location-derived
+settings can be safely exposed for observed-sounding runs.
 
-Why now: realistic inputs will only be useful if Results and Explore can
-explain which model fields exist, what Cloud Chamber can safely do with them,
-and which fields are merely present versus scientifically supported.
+Scope: audit CM1 reference paths and runtime-file requirements, define supported
+and caveated control combinations, document manual smoke-run expectations, and
+connect findings to pre-run validation.
 
-Dependencies: output product manifest, time-index mapping, and the
-[Output Product Specification](contracts/output-product-specification.md).
+Non-goals: GIS/map realism, arbitrary real-world terrain/surface initialization,
+or product promises that the current CM1 configuration cannot support.
 
-### Implement Expanded Sounding Story Readiness
+Why now: observed soundings preserve place/time provenance, but location and
+radiation behavior must be validated before the UI implies real-world forcing.
 
-Goal: turn selected portions of the expanded sounding taxonomy into backend
-story-readiness metadata without making unsupported stories look package-ready.
+### Evolved-Sounding Output Products
 
-Scope: choose one future story family, add backend feature prerequisites,
-story-readiness states, evidence/caveat payloads, disabled or caveated UI
-grouping if appropriate, and tiny fixture tests. Start with the taxonomy in
-[Expanded Sounding Candidate Taxonomy](research/expanded-sounding-candidate-taxonomy.md)
-and keep current shallow-LES stories governed by the existing screening
-contract.
+Goal: make completed observed-sounding runs explain how the simulated atmosphere
+changed, not only whether cloud water or vertical velocity appeared.
 
-Non-goals: new CM1 package families, severe-weather forecasts, CAPE/CIN/SRH
-implementation unless the selected story explicitly requires and tests it,
-browser-side station parsing, or enabled labels without backend evidence.
+Scope: profile and time-height products, evolved thermodynamic/moisture/wind
+summaries, bounded field catalog expansion, provenance, caveats, and tiny
+fixture tests. Results and Explore should consume these as backend-prepared
+products.
 
-Why later: the taxonomy prevents product drift now, but implementation should
-wait until the output-product foundation and realistic-field catalog can support
-the evidence users need.
+Non-goals: browser-side NetCDF parsing, broad diagnostics-lab UI, or external
+export bundles before core result explanation is stable.
 
-Dependencies: sounding candidate screening contract, realistic LES input
-contract, expanded field catalog, and explicit PM choice of the first future
-story family.
-
-### Define Profile And Time-Height Output Products
-
-Goal: specify and add skeleton derived products that make realistic-input runs
-explainable beyond point clouds and slices.
-
-Scope: profile/time-height product shapes, bounded APIs, provenance, caveats,
-and tiny fixture tests.
-
-Non-goals: Diagnostics Lab UI, Panel/hvPlot integration, or broad scientific
-diagnostic expansion.
-
-Why now: profiles and time-height products are the bridge between raw fields
-and scientific explanations for realistic LES inputs.
-
-Dependencies: output product manifest, time-index mapping, and field catalog.
-
-### Audit Land/Radiation Reference Paths
-
-Goal: determine what Cloud Chamber can safely borrow from CM1 land/diurnal LES
-reference cases before exposing location/date/radiation controls.
-
-Scope: package audit, runtime-file requirements, namelist differences,
-validation checklist, and a manual smoke-run plan.
-
-Non-goals: GIS/map realism, arbitrary real-world locations, or UI controls.
-
-Why now: location/date/radiation should come after observed sounding metadata
-and before any map-like product promise.
-
-Dependencies: realistic LES input contract and observed sounding prototype.
-
-### Prototype External Visualization / Diagnostics Exports
-
-Goal: test whether Cloud Chamber should hand selected output products to
-external visualization or diagnostics tools after the internal product
-contracts exist.
-
-Scope: prototype export manifests or small bundles for tools such as VAPOR,
-ParaView/VTK, xarray-style notebooks, or future local diagnostics sidecars.
-Use bounded output products rather than raw browser-side NetCDF parsing, and
-document provenance, caveats, file sizes, and cleanup expectations.
-
-Non-goals: immediate product UI, renderer dependencies, Render Studio,
-Diagnostics Lab, or committing generated export artifacts.
-
-Why later: exports are valuable only after output product manifests,
-time-index mapping, field catalogs, interesting times, and profile/time-height
-products define what Cloud Chamber can safely hand off.
-
-Dependencies: output product manifest, expanded field catalog, profile/time-
-height products, and explicit PM review of external-tool direction.
+Why now: observed-sounding experiments become much more useful when users can
+compare the initial profile to CM1-evolved structure.
 
 ## Not Now / Parked
 
@@ -255,8 +217,14 @@ contracts, output products, validation, or local bench maturity.
   initialization, and surface-data architecture evidence.
 - **#153 surface heterogeneity**: blocked by realistic surface contract and
   validation; do not treat it as the next scenario step.
-- **#154 deep convection**: parked until the shallow-LES bench and output
-  products are mature.
+- **Additional severe-weather or deep-convection products**: the current
+  deep-convection observed-sounding preset stays first-class, but additional
+  severe-weather promises should wait for validation, evidence, and clear
+  caveats.
+- **Raw trigger controls and new trigger types**: keep trigger settings as
+  fixed package metadata until useful ranges are validated.
+- **Rigid experiment-family expansion**: prefer configurable observed-sounding
+  runs with presets as starting points over more separate user-facing families.
 - **#155 precipitation/cold-pool scenarios**: parked until output products can
   support precipitation, downdraft, and surface-response evidence.
 - **#183 3-D vertical velocity layer**: useful later, but blocked by signed-flow

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -88,10 +88,13 @@ more churn than clarity.
   candidate screening, saved candidates, and package-ready/blocked candidate
   states exist. Candidate scores are pre-run selection aids, not CM1 outcome
   predictions.
-- The deep-convection observed-sounding preset can generate storm-scale CM1
-  packages with fixed v1 warm-bubble trigger metadata, expected deep-output
-  fields, and package-family smoke evidence. Each observed sounding remains its
-  own experiment whose result must be evaluated after CM1 runs.
+- The deep-convection observed-sounding package path exists and has
+  package/run/ingest smoke evidence. It can generate storm-scale CM1 packages
+  with fixed v1 warm-bubble trigger metadata and expected deep-output fields,
+  but it has not yet been characterized across a broad selected candidate set.
+  #285 is needed before treating its defaults as broadly validated. Each
+  observed sounding remains its own experiment whose result must be evaluated
+  after CM1 runs.
 - Build owns active package/run work, including generated packages, queued or
   running local CM1 work, failed or incomplete runs, completed-but-not-ingested
   output, serial local queue state, auto-ingest for completed usable output, and
@@ -164,7 +167,8 @@ measuring where its current configuration is package-ready, caveated, or
 misleading.
 
 Scope: validate complete observed-wind requirements, storm-scale box choices,
-duration tiers, output cadence, expected fields, LAN-worker guidance, and
+duration, grid/detail, domain size, output cadence, expected fields, expected
+cost/runtime/output volume, larger-compute suitability notes, and
 candidate-provenance copy across selected observed soundings. Separate
 package/run/ingest smoke checks from science outcomes.
 
@@ -175,20 +179,38 @@ observed sounding should produce deep convection.
 Why now: deep-convection packaging exists and is useful, but the trust language
 must stay honest while configuration coverage expands.
 
-### Surface-Flux And Radiation Control Validation
+### Surface Sensible/Latent Heat Flux Control Validation
 
-Goal: determine which surface-flux, radiation, date/time, and location-derived
-settings can be safely exposed for observed-sounding runs.
+Goal: determine which surface sensible and latent heat flux controls can be
+safely exposed for observed-sounding runs.
 
 Scope: audit CM1 reference paths and runtime-file requirements, define supported
-and caveated control combinations, document manual smoke-run expectations, and
-connect findings to pre-run validation.
+and caveated sensible/latent heat flux combinations, document manual smoke-run
+expectations, connect findings to pre-run validation, and decide how flux
+settings are represented in advanced CM1-facing values.
 
-Non-goals: GIS/map realism, arbitrary real-world terrain/surface initialization,
+Non-goals: atmospheric radiation validation, GIS/map realism, arbitrary
+real-world terrain/surface initialization, or product promises that the current
+CM1 configuration cannot support.
+
+Why now: surface forcing is a direct run-builder control and should be validated
+before the UI implies it can be varied safely across observed soundings.
+
+### Atmospheric Radiation And Place-Time Control Validation
+
+Goal: determine which radiation, date/time, and location-derived settings can be
+safely exposed for observed-sounding runs.
+
+Scope: audit CM1 radiation/place-time reference paths and runtime-file
+requirements, define supported and caveated combinations, document manual
+smoke-run expectations, and connect findings to pre-run validation.
+
+Non-goals: arbitrary real-world terrain/surface initialization, GIS/map realism,
 or product promises that the current CM1 configuration cannot support.
 
-Why now: observed soundings preserve place/time provenance, but location and
-radiation behavior must be validated before the UI implies real-world forcing.
+Why later: observed soundings preserve place/time provenance, but radiation and
+place-time behavior should follow surface-flux validation unless a later PM
+decision changes that order.
 
 ### Evolved-Sounding Output Products
 


### PR DESCRIPTION
## Summary

- Reframes the active roadmap around Build/Results/Explore and configurable observed-sounding CM1 runs.
- Clarifies presets as starting points, quick/smoke/science run semantics, cleanup ownership, and deep-convection provenance language.
- Aligns the product spec and architecture docs while preserving internal `package_family` metadata where useful.

Closes #281

## Verification

- `scripts/check.sh`

## Notes

- Docs only; no CM1 runs or generated artifacts.
- Auto-merge intentionally not enabled per request.