### PR TITLE
feat: add cached sounding analysis workbench

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -66,13 +66,22 @@ from cloud_chamber.selected_region_diagnostics import (
 )
 from cloud_chamber.settings import load_settings
 from cloud_chamber.sounding_candidates import (
+    CandidateReadinessFilter,
+    CandidateSortDirection,
+    CandidateSortKey,
+    CandidateStoryFamilyFilter,
+    CandidateStoryFilter,
+    CandidateSupportFilter,
     SaveCandidateRequest,
     TargetStoryId,
+    UpdateSavedCandidateRequest,
+    analyze_cached_soundings,
     delete_saved_candidate,
     list_saved_candidates,
     list_screening_inputs,
     save_candidate,
     screen_cached_soundings,
+    update_saved_candidate,
 )
 from cloud_chamber.visualization_data import (
     VisualizationDataError,
@@ -156,6 +165,19 @@ class SoundingCandidateScreenRequest(BaseModel):
     latest_per_station: int = 5
     limit: int = 50
     target_story: TargetStoryId | None = None
+
+
+class SoundingCandidateAnalysisRequest(BaseModel):
+    station_id: str | None = None
+    latest_per_station: int = 5
+    limit: int = 50
+    story_filter: CandidateStoryFilter = "all"
+    story_family: CandidateStoryFamilyFilter = "all"
+    support: CandidateSupportFilter = "all"
+    readiness: CandidateReadinessFilter = "all"
+    station_search: str = ""
+    sort_by: CandidateSortKey = "best_match"
+    sort_direction: CandidateSortDirection | None = None
 
 
 @app.get("/api/scenarios")
@@ -312,6 +334,27 @@ def screen_sounding_candidates(request: SoundingCandidateScreenRequest) -> dict[
     return result.model_dump(mode="json")
 
 
+@app.post("/api/sounding-candidates/analyze")
+def analyze_sounding_candidates(request: SoundingCandidateAnalysisRequest) -> dict[str, object]:
+    try:
+        result = analyze_cached_soundings(
+            load_settings(),
+            station_id=request.station_id,
+            latest_per_station=request.latest_per_station,
+            limit=request.limit,
+            story_filter=request.story_filter,
+            story_family=request.story_family,
+            support=request.support,
+            readiness=request.readiness,
+            station_search=request.station_search,
+            sort_by=request.sort_by,
+            sort_direction=request.sort_direction,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
 @app.get("/api/sounding-candidates/saved")
 def get_saved_sounding_candidates() -> dict[str, object]:
     try:
@@ -327,6 +370,19 @@ def create_saved_sounding_candidate(request: SaveCandidateRequest) -> dict[str, 
         saved = save_candidate(load_settings(), request)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return saved.model_dump(mode="json")
+
+
+@app.patch("/api/sounding-candidates/saved/{saved_candidate_id}")
+def update_saved_sounding_candidate(
+    saved_candidate_id: str, request: UpdateSavedCandidateRequest
+) -> dict[str, object]:
+    try:
+        saved = update_saved_candidate(load_settings(), saved_candidate_id, request)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if saved is None:
+        raise HTTPException(status_code=404, detail="Saved sounding candidate not found")
     return saved.model_dump(mode="json")
 
 

--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -119,6 +119,9 @@ class DryRunRequest(BaseModel):
     package_family: str | None = None
     observed_sounding: dict[str, object] | None = None
     candidate_screening: dict[str, object] | None = None
+    user_name: str | None = None
+    user_tags: list[str] = Field(default_factory=list)
+    user_notes: str | None = None
 
 
 class ObservedSoundingParseRequest(BaseModel):
@@ -203,6 +206,9 @@ def create_dry_run_package(request: DryRunRequest) -> dict[str, Any]:
             package_family=request.package_family,
             observed_sounding=request.observed_sounding,
             candidate_screening=request.candidate_screening,
+            user_name=request.user_name,
+            user_tags=request.user_tags,
+            user_notes=request.user_notes,
         )
     except DryRunPackageError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -738,6 +744,12 @@ def _run_status_payload(status: RunStatus) -> dict[str, object]:
             },
             "runtime_warnings": [],
             "progress": None,
+            "user": None,
+            "observed_sounding": None,
+            "candidate_screening": None,
+            "package_family": None,
+            "package_display_name": None,
+            "input_source": None,
         }
     return {
         "run_id": status.run_id,
@@ -764,6 +776,12 @@ def _run_status_payload(status: RunStatus) -> dict[str, object]:
         },
         "runtime_warnings": manifest.outputs.runtime_warnings,
         "progress": run_progress_from_manifest(manifest),
+        "user": manifest.user.model_dump(mode="json"),
+        "observed_sounding": manifest.observed_sounding,
+        "candidate_screening": manifest.candidate_screening,
+        "package_family": manifest.package_family,
+        "package_display_name": manifest.package_display_name,
+        "input_source": manifest.input_source,
     }
 
 

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -59,6 +59,8 @@ def generate_dry_run_package(
     app_commit: str | None = None,
     observed_sounding: dict[str, object] | ObservedSoundingRecord | None = None,
     candidate_screening: dict[str, object] | None = None,
+    user_tags: list[str] | None = None,
+    user_notes: str | None = None,
     package_family: str | None = None,
 ) -> DryRunPackageResult:
     scenario = validate_scenario_template(scenario_data)
@@ -120,7 +122,11 @@ def generate_dry_run_package(
         provenance=ProvenanceMetadata(product_state=ProductState.PACKAGED_DRY_RUN_OUTPUT),
         created_at=now,
         updated_at=now,
-        user=UserMetadata(name=user_name or scenario.display_name),
+        user=UserMetadata(
+            name=user_name or scenario.display_name,
+            tags=_normalize_user_tags(user_tags),
+            notes=_normalize_user_notes(user_notes),
+        ),
         observed_sounding=(
             observed_record.model_dump(mode="json") if observed_record is not None else None
         ),
@@ -285,6 +291,7 @@ def _dry_run_report_payload(
             else None
         ),
         "candidate_screening": manifest.candidate_screening,
+        "user": manifest.user.model_dump(mode="json"),
         "run_size_preset": manifest.run_size_preset,
         "run_size_details": run_size_details,
         "estimated_cost_or_size": run_size_details["cost_warning"],
@@ -336,6 +343,28 @@ def _observed_sounding_summary(record: ObservedSoundingRecord) -> dict[str, obje
         "caveats": record.validation.caveats,
         "provenance": record.provenance,
     }
+
+
+def _normalize_user_tags(tags: list[str] | None) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for tag in tags or []:
+        cleaned = tag.strip()
+        if not cleaned:
+            continue
+        key = cleaned.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(cleaned)
+    return normalized
+
+
+def _normalize_user_notes(notes: str | None) -> str | None:
+    if notes is None:
+        return None
+    cleaned = notes.strip()
+    return cleaned or None
 
 
 def _run_size_details(contract: CM1InputContract) -> dict[str, object]:

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import math
 from datetime import UTC, datetime
+from functools import cmp_to_key
 from pathlib import Path
 from typing import Any, Literal
 
@@ -60,6 +61,113 @@ TargetStoryId = Literal[
 ]
 Confidence = Literal["low", "medium", "high"]
 Support = Literal["supported", "weak", "unavailable"]
+CandidateStoryFamily = Literal["lower_atmosphere", "deep_convection", "review"]
+CandidateStoryFamilyFilter = Literal["all", "lower_atmosphere", "deep_convection", "review"]
+CandidateStoryFilter = Literal[
+    "all",
+    "deep_convection_trial",
+    "shallow_cumulus_candidate",
+    "dry_failed_candidate",
+    "capped_suppressed_candidate",
+    "humid_rainy_candidate",
+    "severe_thunderstorm_environment",
+    "supercell_environment",
+    "high_cape_pulse_storm",
+    "dry_microburst_inverted_v",
+    "squall_line_cold_pool_candidate",
+    "elevated_convection",
+    "needs_review",
+    "poor_or_incomplete_candidate",
+]
+CandidateSupportFilter = Literal["all", "supported", "weak", "unavailable"]
+CandidateReadinessFilter = Literal["all", "package_ready", "blocked"]
+CandidateSortDirection = Literal["asc", "desc"]
+CandidateSortKey = Literal[
+    "best_match",
+    "valid_time",
+    "station_id",
+    "station_name",
+    "primary_story",
+    "story_family",
+    "rank_score",
+    "confidence",
+    "support",
+    "package_readiness",
+    "observed_wind_available",
+    "profile_top_m_agl",
+    "lowest_level_m_agl",
+    "data_completeness_score",
+    "low_level_qv_g_kg",
+    "mean_qv_0_500m_g_kg",
+    "mean_qv_0_1000m_g_kg",
+    "surface_t_td_spread_c",
+    "estimated_lcl_height_m_agl",
+    "lapse_rate_0_1000m_c_per_km",
+    "midlevel_lapse_rate_700_500_hpa_c_per_km",
+    "cap_strength_proxy",
+    "cap_height_m_agl",
+    "bulk_shear_0_1km_m_s",
+    "bulk_shear_0_3km_m_s",
+    "bulk_shear_0_6km_m_s",
+    "midlevel_dry_layer_proxy",
+    "dry_microburst_inverted_v_proxy",
+    "freezing_level_m_agl",
+]
+SortValue = bool | float | str | datetime
+
+_FEATURE_SORT_KEYS: dict[CandidateSortKey, str] = {
+    "observed_wind_available": "observed_wind_available",
+    "profile_top_m_agl": "profile_top_m_agl",
+    "lowest_level_m_agl": "lowest_level_m_agl",
+    "data_completeness_score": "data_completeness_score",
+    "low_level_qv_g_kg": "low_level_qv_g_kg",
+    "mean_qv_0_500m_g_kg": "mean_qv_0_500m_g_kg",
+    "mean_qv_0_1000m_g_kg": "mean_qv_0_1000m_g_kg",
+    "surface_t_td_spread_c": "surface_t_td_spread_c",
+    "estimated_lcl_height_m_agl": "estimated_lcl_height_m_agl",
+    "lapse_rate_0_1000m_c_per_km": "lapse_rate_0_1000m_c_per_km",
+    "midlevel_lapse_rate_700_500_hpa_c_per_km": ("midlevel_lapse_rate_700_500_hpa_c_per_km"),
+    "cap_strength_proxy": "cap_strength_proxy",
+    "cap_height_m_agl": "cap_height_m_agl",
+    "bulk_shear_0_1km_m_s": "bulk_shear_0_1km_m_s",
+    "bulk_shear_0_3km_m_s": "bulk_shear_0_3km_m_s",
+    "bulk_shear_0_6km_m_s": "bulk_shear_0_6km_m_s",
+    "midlevel_dry_layer_proxy": "midlevel_dry_layer_proxy",
+    "dry_microburst_inverted_v_proxy": "dry_microburst_inverted_v_proxy",
+    "freezing_level_m_agl": "freezing_level_m_agl",
+}
+
+_DEFAULT_SORT_DIRECTIONS: dict[CandidateSortKey, CandidateSortDirection] = {
+    "best_match": "desc",
+    "valid_time": "desc",
+    "station_id": "asc",
+    "station_name": "asc",
+    "primary_story": "asc",
+    "story_family": "asc",
+    "rank_score": "desc",
+    "confidence": "desc",
+    "support": "desc",
+    "package_readiness": "desc",
+    "observed_wind_available": "desc",
+    "profile_top_m_agl": "desc",
+    "lowest_level_m_agl": "asc",
+    "data_completeness_score": "desc",
+    "low_level_qv_g_kg": "desc",
+    "mean_qv_0_500m_g_kg": "desc",
+    "mean_qv_0_1000m_g_kg": "desc",
+    "surface_t_td_spread_c": "asc",
+    "estimated_lcl_height_m_agl": "asc",
+    "lapse_rate_0_1000m_c_per_km": "desc",
+    "midlevel_lapse_rate_700_500_hpa_c_per_km": "desc",
+    "cap_strength_proxy": "desc",
+    "cap_height_m_agl": "asc",
+    "bulk_shear_0_1km_m_s": "desc",
+    "bulk_shear_0_3km_m_s": "desc",
+    "bulk_shear_0_6km_m_s": "desc",
+    "midlevel_dry_layer_proxy": "desc",
+    "dry_microburst_inverted_v_proxy": "desc",
+    "freezing_level_m_agl": "desc",
+}
 
 STORY_LABELS: dict[StoryId, str] = {
     "shallow_cumulus_candidate": "Cloud-forming shallow cumulus candidate",
@@ -125,6 +233,7 @@ class SoundingCandidate(BaseModel):
     source_provider: str = "NOAA/NCEI IGRA"
     primary_story: StoryId
     primary_story_label: str
+    story_family: CandidateStoryFamily = "lower_atmosphere"
     story_scores: list[StoryScore]
     rank_score: float
     confidence: Confidence
@@ -159,6 +268,42 @@ class ScreeningResult(BaseModel):
     caveats: list[str] = Field(default_factory=list)
 
 
+class CandidateSortOption(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: CandidateSortKey
+    label: str
+    units: str | None = None
+    default_direction: CandidateSortDirection
+    missing_behavior: str = "Unavailable values sort last and are not treated as zero."
+
+
+class CandidateAnalysisFilterSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    station_id: str | None = None
+    story_filter: CandidateStoryFilter = "all"
+    story_family: CandidateStoryFamilyFilter = "all"
+    support: CandidateSupportFilter = "all"
+    readiness: CandidateReadinessFilter = "all"
+    station_search: str = ""
+
+
+class CandidateAnalysisResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    screening_version: str = SCREENING_VERSION
+    generated_at: datetime
+    candidates: list[SoundingCandidate]
+    total_candidate_count: int
+    filtered_candidate_count: int
+    sort_by: CandidateSortKey
+    sort_direction: CandidateSortDirection
+    filters: CandidateAnalysisFilterSummary
+    sort_options: list[CandidateSortOption]
+    caveats: list[str] = Field(default_factory=list)
+
+
 class SavedSoundingCandidate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -167,6 +312,7 @@ class SavedSoundingCandidate(BaseModel):
     selected_sounding_payload: dict[str, Any] | None
     screening_version: str = SCREENING_VERSION
     primary_story: StoryId
+    story_family: CandidateStoryFamily = "lower_atmosphere"
     story_scores: list[StoryScore]
     features: dict[str, float | int | str | bool | None]
     evidence: list[EvidenceItem]
@@ -185,6 +331,125 @@ class SaveCandidateRequest(BaseModel):
     candidate: SoundingCandidate
     tags: list[str] = Field(default_factory=list)
     notes: str | None = None
+
+
+class UpdateSavedCandidateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tags: list[str] | None = None
+    notes: str | None = None
+
+
+SORT_OPTIONS: tuple[CandidateSortOption, ...] = (
+    CandidateSortOption(
+        key="best_match", label="Best match for selected story", default_direction="desc"
+    ),
+    CandidateSortOption(key="valid_time", label="Valid time", default_direction="desc"),
+    CandidateSortOption(key="station_id", label="Station ID", default_direction="asc"),
+    CandidateSortOption(key="station_name", label="Station name", default_direction="asc"),
+    CandidateSortOption(key="primary_story", label="Primary story", default_direction="asc"),
+    CandidateSortOption(key="story_family", label="Story family", default_direction="asc"),
+    CandidateSortOption(
+        key="rank_score", label="Rank score", units="0-100", default_direction="desc"
+    ),
+    CandidateSortOption(key="confidence", label="Confidence", default_direction="desc"),
+    CandidateSortOption(key="support", label="Support state", default_direction="desc"),
+    CandidateSortOption(
+        key="package_readiness", label="Package readiness", default_direction="desc"
+    ),
+    CandidateSortOption(
+        key="observed_wind_available",
+        label="Observed wind availability",
+        default_direction="desc",
+    ),
+    CandidateSortOption(
+        key="profile_top_m_agl", label="Profile top", units="m AGL", default_direction="desc"
+    ),
+    CandidateSortOption(
+        key="lowest_level_m_agl",
+        label="Lowest usable level",
+        units="m AGL",
+        default_direction="asc",
+    ),
+    CandidateSortOption(
+        key="data_completeness_score",
+        label="Data completeness",
+        units="0-100",
+        default_direction="desc",
+    ),
+    CandidateSortOption(
+        key="low_level_qv_g_kg", label="Low-level qv", units="g/kg", default_direction="desc"
+    ),
+    CandidateSortOption(
+        key="mean_qv_0_500m_g_kg",
+        label="Mean qv 0-500 m",
+        units="g/kg",
+        default_direction="desc",
+    ),
+    CandidateSortOption(
+        key="mean_qv_0_1000m_g_kg",
+        label="Mean qv 0-1 km",
+        units="g/kg",
+        default_direction="desc",
+    ),
+    CandidateSortOption(
+        key="surface_t_td_spread_c",
+        label="Surface T-Td spread",
+        units="C",
+        default_direction="asc",
+    ),
+    CandidateSortOption(
+        key="estimated_lcl_height_m_agl",
+        label="Estimated LCL",
+        units="m AGL",
+        default_direction="asc",
+    ),
+    CandidateSortOption(
+        key="lapse_rate_0_1000m_c_per_km",
+        label="Low-level lapse rate",
+        units="C/km",
+        default_direction="desc",
+    ),
+    CandidateSortOption(
+        key="midlevel_lapse_rate_700_500_hpa_c_per_km",
+        label="Midlevel lapse rate",
+        units="C/km",
+        default_direction="desc",
+    ),
+    CandidateSortOption(
+        key="cap_strength_proxy",
+        label="Cap/inversion strength",
+        units="C",
+        default_direction="desc",
+    ),
+    CandidateSortOption(
+        key="cap_height_m_agl", label="Cap/inversion height", units="m AGL", default_direction="asc"
+    ),
+    CandidateSortOption(
+        key="bulk_shear_0_1km_m_s", label="Bulk shear 0-1 km", units="m/s", default_direction="desc"
+    ),
+    CandidateSortOption(
+        key="bulk_shear_0_3km_m_s", label="Bulk shear 0-3 km", units="m/s", default_direction="desc"
+    ),
+    CandidateSortOption(
+        key="bulk_shear_0_6km_m_s", label="Bulk shear 0-6 km", units="m/s", default_direction="desc"
+    ),
+    CandidateSortOption(
+        key="midlevel_dry_layer_proxy",
+        label="Dry-layer proxy",
+        units="g/kg",
+        default_direction="desc",
+    ),
+    CandidateSortOption(
+        key="dry_microburst_inverted_v_proxy",
+        label="Inverted-V proxy",
+        units="0-100",
+        default_direction="desc",
+    ),
+    CandidateSortOption(
+        key="freezing_level_m_agl", label="Freezing level", units="m AGL", default_direction="desc"
+    ),
+)
 
 
 def list_screening_inputs(settings: CloudChamberSettings) -> list[ScreeningInput]:
@@ -279,6 +544,75 @@ def screen_cached_soundings(
     )
 
 
+def analyze_cached_soundings(
+    settings: CloudChamberSettings,
+    *,
+    station_id: str | None = None,
+    latest_per_station: int = 5,
+    limit: int = 50,
+    story_filter: CandidateStoryFilter = "all",
+    story_family: CandidateStoryFamilyFilter = "all",
+    support: CandidateSupportFilter = "all",
+    readiness: CandidateReadinessFilter = "all",
+    station_search: str = "",
+    sort_by: CandidateSortKey = "best_match",
+    sort_direction: CandidateSortDirection | None = None,
+) -> CandidateAnalysisResult:
+    """Analyze cached sounding candidates with backend-owned filters and sorts."""
+
+    if latest_per_station < 1:
+        raise ValueError("latest_per_station must be at least 1")
+    if limit < 1:
+        raise ValueError("limit must be at least 1")
+    selected_direction = sort_direction or _DEFAULT_SORT_DIRECTIONS[sort_by]
+    target_story = _target_story_for_filter(story_filter, story_family)
+    pool_limit = max(limit, 10_000)
+    screened = screen_cached_soundings(
+        settings,
+        station_id=station_id,
+        latest_per_station=latest_per_station,
+        limit=pool_limit,
+        target_story=target_story,
+    )
+    normalized_search = station_search.strip()
+    filtered = [
+        candidate
+        for candidate in screened.candidates
+        if _candidate_matches_analysis_filters(
+            candidate,
+            story_filter=story_filter,
+            story_family=story_family,
+            support=support,
+            readiness=readiness,
+            station_search=normalized_search,
+        )
+    ]
+    sorted_candidates = _sort_analysis_candidates(
+        filtered,
+        sort_by=sort_by,
+        sort_direction=selected_direction,
+        story_filter=story_filter,
+    )
+    return CandidateAnalysisResult(
+        generated_at=datetime.now(UTC),
+        candidates=sorted_candidates[:limit],
+        total_candidate_count=len(screened.candidates),
+        filtered_candidate_count=len(filtered),
+        sort_by=sort_by,
+        sort_direction=selected_direction,
+        filters=CandidateAnalysisFilterSummary(
+            station_id=station_id,
+            story_filter=story_filter,
+            story_family=story_family,
+            support=support,
+            readiness=readiness,
+            station_search=normalized_search,
+        ),
+        sort_options=list(SORT_OPTIONS),
+        caveats=screened.caveats,
+    )
+
+
 def _candidate_story_score(candidate: SoundingCandidate, story: TargetStoryId | None) -> float:
     if story is None:
         return candidate.rank_score
@@ -301,6 +635,195 @@ def _candidate_story_score(candidate: SoundingCandidate, story: TargetStoryId | 
     return 0.0
 
 
+def _candidate_story_score_model(
+    candidate: SoundingCandidate, story: CandidateStoryFilter
+) -> StoryScore | None:
+    if story == "all":
+        return max(candidate.story_scores, key=lambda score: score.score_0_to_100, default=None)
+    if story == "deep_convection_trial":
+        return max(
+            (score for score in candidate.story_scores if score.story in DEEP_CONVECTION_STORY_IDS),
+            key=lambda score: score.score_0_to_100,
+            default=None,
+        )
+    return next((score for score in candidate.story_scores if score.story == story), None)
+
+
+def _target_story_for_filter(
+    story_filter: CandidateStoryFilter, story_family: CandidateStoryFamilyFilter
+) -> TargetStoryId | None:
+    if story_filter != "all":
+        return story_filter
+    if story_family == "deep_convection":
+        return "deep_convection_trial"
+    return None
+
+
+def _candidate_matches_analysis_filters(
+    candidate: SoundingCandidate,
+    *,
+    story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter,
+    support: CandidateSupportFilter,
+    readiness: CandidateReadinessFilter,
+    station_search: str,
+) -> bool:
+    if readiness == "package_ready" and not candidate.package_ready:
+        return False
+    if readiness == "blocked" and candidate.package_ready:
+        return False
+    if story_family != "all" and _candidate_story_family(candidate) != story_family:
+        return False
+    score = _candidate_story_score_model(candidate, story_filter)
+    if story_filter != "all":
+        if score is None or score.score_0_to_100 <= 0 or score.support == "unavailable":
+            return False
+    if support != "all" and (score is None or score.support != support):
+        return False
+    if station_search:
+        normalized = station_search.lower()
+        searchable = " ".join(
+            str(value)
+            for value in (
+                candidate.station_id,
+                candidate.station_name,
+                candidate.source_file_name,
+                candidate.primary_story_label,
+                candidate.story_family,
+            )
+            if value
+        ).lower()
+        if normalized not in searchable:
+            return False
+    return True
+
+
+def _sort_analysis_candidates(
+    candidates: list[SoundingCandidate],
+    *,
+    sort_by: CandidateSortKey,
+    sort_direction: CandidateSortDirection,
+    story_filter: CandidateStoryFilter,
+) -> list[SoundingCandidate]:
+    def compare(left: SoundingCandidate, right: SoundingCandidate) -> int:
+        return _compare_candidates(
+            left,
+            right,
+            sort_by=sort_by,
+            sort_direction=sort_direction,
+            story_filter=story_filter,
+        )
+
+    return sorted(candidates, key=cmp_to_key(compare))
+
+
+def _compare_candidates(
+    left: SoundingCandidate,
+    right: SoundingCandidate,
+    *,
+    sort_by: CandidateSortKey,
+    sort_direction: CandidateSortDirection,
+    story_filter: CandidateStoryFilter,
+) -> int:
+    left_value = _candidate_sort_value(left, sort_by, story_filter)
+    right_value = _candidate_sort_value(right, sort_by, story_filter)
+    if left_value is None and right_value is not None:
+        return 1
+    if right_value is None and left_value is not None:
+        return -1
+    if left_value is not None and right_value is not None:
+        comparison = _compare_sort_values(left_value, right_value)
+        if comparison != 0:
+            return comparison if sort_direction == "asc" else -comparison
+    return _compare_candidate_tie_breakers(left, right, story_filter)
+
+
+def _candidate_sort_value(
+    candidate: SoundingCandidate,
+    sort_by: CandidateSortKey,
+    story_filter: CandidateStoryFilter,
+) -> SortValue | None:
+    if sort_by == "best_match":
+        score = _candidate_story_score_model(candidate, story_filter)
+        return score.score_0_to_100 if score else candidate.rank_score
+    if sort_by == "valid_time":
+        return candidate.valid_time_utc
+    if sort_by == "station_id":
+        return candidate.station_id
+    if sort_by == "station_name":
+        return candidate.station_name or candidate.station_id
+    if sort_by == "primary_story":
+        return candidate.primary_story_label
+    if sort_by == "story_family":
+        return _candidate_story_family(candidate)
+    if sort_by == "rank_score":
+        return candidate.rank_score
+    if sort_by == "confidence":
+        return {"low": 0.0, "medium": 1.0, "high": 2.0}[candidate.confidence]
+    if sort_by == "support":
+        score = _candidate_story_score_model(candidate, story_filter)
+        return {"unavailable": 0.0, "weak": 1.0, "supported": 2.0}[score.support] if score else None
+    if sort_by == "package_readiness":
+        return candidate.package_ready
+    feature_key = _FEATURE_SORT_KEYS.get(sort_by)
+    if feature_key is None:
+        return None
+    value = candidate.features.get(feature_key)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float) and math.isfinite(float(value)):
+        return float(value)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _compare_sort_values(
+    left: SortValue,
+    right: SortValue,
+) -> int:
+    if left == right:
+        return 0
+    if isinstance(left, bool) and isinstance(right, bool):
+        return _compare_floats(float(left), float(right))
+    if isinstance(left, float) and isinstance(right, float):
+        return _compare_floats(left, right)
+    if isinstance(left, str) and isinstance(right, str):
+        return -1 if left < right else 1
+    if isinstance(left, datetime) and isinstance(right, datetime):
+        return -1 if left < right else 1
+    return -1 if str(left) < str(right) else 1
+
+
+def _compare_floats(left: float, right: float) -> int:
+    if left == right:
+        return 0
+    return -1 if left < right else 1
+
+
+def _compare_candidate_tie_breakers(
+    left: SoundingCandidate,
+    right: SoundingCandidate,
+    story_filter: CandidateStoryFilter,
+) -> int:
+    left_score = _candidate_story_score_model(left, story_filter)
+    right_score = _candidate_story_score_model(right, story_filter)
+    for left_value, right_value, direction in (
+        (left.package_ready, right.package_ready, "desc"),
+        (
+            left_score.score_0_to_100 if left_score else left.rank_score,
+            right_score.score_0_to_100 if right_score else right.rank_score,
+            "desc",
+        ),
+        (left.valid_time_utc, right.valid_time_utc, "desc"),
+        (left.station_id, right.station_id, "asc"),
+    ):
+        comparison = _compare_sort_values(left_value, right_value)
+        if comparison != 0:
+            return comparison if direction == "asc" else -comparison
+    return 0
+
+
 def save_candidate(
     settings: CloudChamberSettings,
     request: SaveCandidateRequest,
@@ -310,11 +833,12 @@ def save_candidate(
         candidate=request.candidate,
         selected_sounding_payload=request.candidate.selected_sounding_payload,
         primary_story=request.candidate.primary_story,
+        story_family=_candidate_story_family(request.candidate),
         story_scores=request.candidate.story_scores,
         features=request.candidate.features,
         evidence=request.candidate.evidence,
         caveats=request.candidate.caveats,
-        tags=request.tags,
+        tags=_normalize_tags(request.tags),
         notes=request.notes,
         created_at=datetime.now(UTC),
     )
@@ -335,6 +859,31 @@ def list_saved_candidates(settings: CloudChamberSettings) -> list[SavedSoundingC
     if not isinstance(loaded, list):
         raise ValueError(f"Saved candidates file must contain a JSON list: {path}")
     return [SavedSoundingCandidate.model_validate(item) for item in loaded]
+
+
+def update_saved_candidate(
+    settings: CloudChamberSettings,
+    saved_candidate_id: str,
+    request: UpdateSavedCandidateRequest,
+) -> SavedSoundingCandidate | None:
+    existing = list_saved_candidates(settings)
+    updated: list[SavedSoundingCandidate] = []
+    selected: SavedSoundingCandidate | None = None
+    for candidate in existing:
+        if candidate.saved_candidate_id != saved_candidate_id:
+            updated.append(candidate)
+            continue
+        updates: dict[str, object] = {}
+        if "tags" in request.model_fields_set:
+            updates["tags"] = _normalize_tags(request.tags or [])
+        if "notes" in request.model_fields_set:
+            updates["notes"] = request.notes
+        selected = candidate.model_copy(update=updates)
+        updated.append(selected)
+    if selected is None:
+        return None
+    _write_saved_candidates(settings, updated)
+    return selected
 
 
 def delete_saved_candidate(settings: CloudChamberSettings, saved_candidate_id: str) -> bool:
@@ -395,6 +944,7 @@ def _candidate_from_cached_sounding(
         package_ready = False
     primary = max(story_scores, key=lambda score: score.score_0_to_100)
     rank_score = _rank_score(primary, package_ready)
+    story_family = _story_family_for_story(primary.story)
     return SoundingCandidate(
         candidate_id=_candidate_id(entry.station_id, selected_time, source_path.name, source_hash),
         station_id=entry.station_id,
@@ -408,6 +958,7 @@ def _candidate_from_cached_sounding(
         source_file_hash=source_hash,
         primary_story=primary.story,
         primary_story_label=primary.label,
+        story_family=story_family,
         story_scores=story_scores,
         rank_score=rank_score,
         confidence=_confidence(rank_score, package_ready, features),
@@ -1337,6 +1888,30 @@ def _station_metadata_from_cache_entry(entry: IGRACacheEntry) -> StationMetadata
 def _candidate_id(station_id: str, valid_time: datetime, filename: str, source_hash: str) -> str:
     raw = f"{station_id}|{valid_time.isoformat()}|{filename}|{source_hash}"
     return "sounding-candidate-" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _candidate_story_family(candidate: SoundingCandidate) -> CandidateStoryFamily:
+    return _story_family_for_story(candidate.primary_story)
+
+
+def _story_family_for_story(story: StoryId) -> CandidateStoryFamily:
+    if story in DEEP_CONVECTION_STORY_IDS:
+        return "deep_convection"
+    if story in {"needs_review", "poor_or_incomplete_candidate"}:
+        return "review"
+    return "lower_atmosphere"
+
+
+def _normalize_tags(tags: list[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        cleaned = tag.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        normalized.append(cleaned)
+    return normalized
 
 
 def _cached_text_entries(settings: CloudChamberSettings) -> list[IGRACacheEntry]:

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -605,6 +605,7 @@ def analyze_cached_soundings(
             sort_by=sort_by,
             sort_direction=selected_direction,
             story_filter=story_filter,
+            story_family=story_family,
         )
     return CandidateAnalysisResult(
         generated_at=datetime.now(UTC),
@@ -648,27 +649,47 @@ def _candidate_story_score(candidate: SoundingCandidate, story: TargetStoryId | 
     return 0.0
 
 
-def _candidate_story_score_model(
-    candidate: SoundingCandidate, story: CandidateStoryFilter
-) -> StoryScore | None:
-    if story == "all":
+def _candidate_story_scores_for_scope(
+    candidate: SoundingCandidate,
+    *,
+    story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter = "all",
+) -> list[StoryScore]:
+    scores = candidate.story_scores
+    if story_filter == "deep_convection_trial":
+        scores = [score for score in scores if score.story in DEEP_CONVECTION_STORY_IDS]
+    elif story_filter != "all":
+        scores = [score for score in scores if score.story == story_filter]
+
+    if story_family != "all":
+        scores = [score for score in scores if _story_family_for_story(score.story) == story_family]
+
+    if story_filter == "all" and story_family == "all":
         package_ready_scores = [
-            score
-            for score in candidate.story_scores
-            if score.story != "poor_or_incomplete_candidate"
+            score for score in scores if score.story != "poor_or_incomplete_candidate"
         ]
-        return max(
-            package_ready_scores or candidate.story_scores,
-            key=lambda score: score.score_0_to_100,
-            default=None,
-        )
-    if story == "deep_convection_trial":
-        return max(
-            (score for score in candidate.story_scores if score.story in DEEP_CONVECTION_STORY_IDS),
-            key=lambda score: score.score_0_to_100,
-            default=None,
-        )
-    return next((score for score in candidate.story_scores if score.story == story), None)
+        return package_ready_scores or scores
+    return scores
+
+
+def _candidate_story_score_model(
+    candidate: SoundingCandidate,
+    story: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter = "all",
+) -> StoryScore | None:
+    return max(
+        _candidate_story_scores_for_scope(
+            candidate,
+            story_filter=story,
+            story_family=story_family,
+        ),
+        key=lambda score: score.score_0_to_100,
+        default=None,
+    )
+
+
+def _meaningful_story_score(score: StoryScore) -> bool:
+    return score.score_0_to_100 > 0 and score.support != "unavailable"
 
 
 def _uses_default_discovery_view(
@@ -760,14 +781,23 @@ def _candidate_matches_analysis_filters(
         return False
     if readiness == "blocked" and candidate.package_ready:
         return False
-    if story_family != "all" and _candidate_story_family(candidate) != story_family:
+    scoped_scores = _candidate_story_scores_for_scope(
+        candidate,
+        story_filter=story_filter,
+        story_family=story_family,
+    )
+    if story_family != "all" and not any(_meaningful_story_score(score) for score in scoped_scores):
         return False
-    score = _candidate_story_score_model(candidate, story_filter)
+    score = max(scoped_scores, key=lambda item: item.score_0_to_100, default=None)
     if story_filter != "all":
-        if score is None or score.score_0_to_100 <= 0 or score.support == "unavailable":
+        if score is None or not _meaningful_story_score(score):
             return False
-    if support != "all" and (score is None or score.support != support):
-        return False
+    if support != "all":
+        if story_filter == "all" and story_family == "all":
+            if score is None or score.support != support:
+                return False
+        elif not any(score.support == support for score in scoped_scores):
+            return False
     if station_search:
         normalized = station_search.lower()
         searchable = " ".join(
@@ -792,6 +822,7 @@ def _sort_analysis_candidates(
     sort_by: CandidateSortKey,
     sort_direction: CandidateSortDirection,
     story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter = "all",
 ) -> list[SoundingCandidate]:
     def compare(left: SoundingCandidate, right: SoundingCandidate) -> int:
         return _compare_candidates(
@@ -800,6 +831,7 @@ def _sort_analysis_candidates(
             sort_by=sort_by,
             sort_direction=sort_direction,
             story_filter=story_filter,
+            story_family=story_family,
         )
 
     return sorted(candidates, key=cmp_to_key(compare))
@@ -812,9 +844,10 @@ def _compare_candidates(
     sort_by: CandidateSortKey,
     sort_direction: CandidateSortDirection,
     story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter,
 ) -> int:
-    left_value = _candidate_sort_value(left, sort_by, story_filter)
-    right_value = _candidate_sort_value(right, sort_by, story_filter)
+    left_value = _candidate_sort_value(left, sort_by, story_filter, story_family)
+    right_value = _candidate_sort_value(right, sort_by, story_filter, story_family)
     if left_value is None and right_value is not None:
         return 1
     if right_value is None and left_value is not None:
@@ -823,16 +856,17 @@ def _compare_candidates(
         comparison = _compare_sort_values(left_value, right_value)
         if comparison != 0:
             return comparison if sort_direction == "asc" else -comparison
-    return _compare_candidate_tie_breakers(left, right, story_filter)
+    return _compare_candidate_tie_breakers(left, right, story_filter, story_family)
 
 
 def _candidate_sort_value(
     candidate: SoundingCandidate,
     sort_by: CandidateSortKey,
     story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter,
 ) -> SortValue | None:
     if sort_by == "best_match":
-        score = _candidate_story_score_model(candidate, story_filter)
+        score = _candidate_story_score_model(candidate, story_filter, story_family)
         return score.score_0_to_100 if score else candidate.rank_score
     if sort_by == "valid_time":
         return candidate.valid_time_utc
@@ -843,13 +877,14 @@ def _candidate_sort_value(
     if sort_by == "primary_story":
         return candidate.primary_story_label
     if sort_by == "story_family":
-        return _candidate_story_family(candidate)
+        score = _candidate_story_score_model(candidate, story_filter, story_family)
+        return _story_family_for_story(score.story) if score else _candidate_story_family(candidate)
     if sort_by == "rank_score":
         return candidate.rank_score
     if sort_by == "confidence":
         return {"low": 0.0, "medium": 1.0, "high": 2.0}[candidate.confidence]
     if sort_by == "support":
-        score = _candidate_story_score_model(candidate, story_filter)
+        score = _candidate_story_score_model(candidate, story_filter, story_family)
         return {"unavailable": 0.0, "weak": 1.0, "supported": 2.0}[score.support] if score else None
     if sort_by == "package_readiness":
         return candidate.package_ready
@@ -893,9 +928,10 @@ def _compare_candidate_tie_breakers(
     left: SoundingCandidate,
     right: SoundingCandidate,
     story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter,
 ) -> int:
-    left_score = _candidate_story_score_model(left, story_filter)
-    right_score = _candidate_story_score_model(right, story_filter)
+    left_score = _candidate_story_score_model(left, story_filter, story_family)
+    right_score = _candidate_story_score_model(right, story_filter, story_family)
     for left_value, right_value, direction in (
         (left.package_ready, right.package_ready, "desc"),
         (

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -242,6 +242,9 @@ class SoundingCandidate(BaseModel):
     evidence: list[EvidenceItem]
     caveats: list[str] = Field(default_factory=list)
     selected_sounding_payload: dict[str, Any] | None = None
+    interest_summary: str | None = None
+    interest_reasons: list[str] = Field(default_factory=list)
+    discovery_bucket: str | None = None
     screening_version: str = SCREENING_VERSION
     created_at: datetime
 
@@ -587,12 +590,22 @@ def analyze_cached_soundings(
             station_search=normalized_search,
         )
     ]
-    sorted_candidates = _sort_analysis_candidates(
-        filtered,
-        sort_by=sort_by,
-        sort_direction=selected_direction,
+    if _uses_default_discovery_view(
         story_filter=story_filter,
-    )
+        story_family=story_family,
+        support=support,
+        readiness=readiness,
+        station_search=normalized_search,
+        sort_by=sort_by,
+    ):
+        sorted_candidates = _diverse_recommendations(filtered)
+    else:
+        sorted_candidates = _sort_analysis_candidates(
+            filtered,
+            sort_by=sort_by,
+            sort_direction=selected_direction,
+            story_filter=story_filter,
+        )
     return CandidateAnalysisResult(
         generated_at=datetime.now(UTC),
         candidates=sorted_candidates[:limit],
@@ -639,7 +652,16 @@ def _candidate_story_score_model(
     candidate: SoundingCandidate, story: CandidateStoryFilter
 ) -> StoryScore | None:
     if story == "all":
-        return max(candidate.story_scores, key=lambda score: score.score_0_to_100, default=None)
+        package_ready_scores = [
+            score
+            for score in candidate.story_scores
+            if score.story != "poor_or_incomplete_candidate"
+        ]
+        return max(
+            package_ready_scores or candidate.story_scores,
+            key=lambda score: score.score_0_to_100,
+            default=None,
+        )
     if story == "deep_convection_trial":
         return max(
             (score for score in candidate.story_scores if score.story in DEEP_CONVECTION_STORY_IDS),
@@ -647,6 +669,72 @@ def _candidate_story_score_model(
             default=None,
         )
     return next((score for score in candidate.story_scores if score.story == story), None)
+
+
+def _uses_default_discovery_view(
+    *,
+    story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter,
+    support: CandidateSupportFilter,
+    readiness: CandidateReadinessFilter,
+    station_search: str,
+    sort_by: CandidateSortKey,
+) -> bool:
+    return (
+        story_filter == "all"
+        and story_family == "all"
+        and support == "all"
+        and readiness == "all"
+        and station_search == ""
+        and sort_by == "best_match"
+    )
+
+
+def _diverse_recommendations(candidates: list[SoundingCandidate]) -> list[SoundingCandidate]:
+    ranked = sorted(candidates, key=_discovery_sort_key)
+    selected: list[SoundingCandidate] = []
+    selected_ids: set[str] = set()
+    station_counts: dict[str, int] = {}
+    for per_station_limit in (1, 2, 3, 10_000):
+        for candidate in ranked:
+            if candidate.candidate_id in selected_ids:
+                continue
+            station_count = station_counts.get(candidate.station_id, 0)
+            if station_count >= per_station_limit:
+                continue
+            selected.append(candidate)
+            selected_ids.add(candidate.candidate_id)
+            station_counts[candidate.station_id] = station_count + 1
+        if len(selected) == len(ranked):
+            break
+    return selected
+
+
+def _discovery_sort_key(candidate: SoundingCandidate) -> tuple[float, float, str]:
+    return (
+        -_discovery_score(candidate),
+        -candidate.valid_time_utc.timestamp(),
+        candidate.station_id,
+    )
+
+
+def _discovery_score(candidate: SoundingCandidate) -> float:
+    if not candidate.package_ready:
+        return max(0.0, _candidate_story_score(candidate, "needs_review")) * 0.25
+    best_score = max(
+        (
+            score.score_0_to_100
+            for score in candidate.story_scores
+            if score.story != "poor_or_incomplete_candidate"
+        ),
+        default=candidate.rank_score,
+    )
+    deep_score = _candidate_story_score(candidate, "deep_convection_trial")
+    completeness = _numeric_feature(candidate.features, "data_completeness_score") or 0.0
+    wind_bonus = 6.0 if candidate.features.get("observed_wind_available") is True else 0.0
+    deep_bonus = min(10.0, deep_score * 0.10) if deep_score >= 35.0 else 0.0
+    caveat_penalty = min(10.0, len(candidate.caveats) * 1.5)
+    return best_score + completeness * 0.10 + wind_bonus + deep_bonus - caveat_penalty
 
 
 def _target_story_for_filter(
@@ -945,6 +1033,12 @@ def _candidate_from_cached_sounding(
     primary = max(story_scores, key=lambda score: score.score_0_to_100)
     rank_score = _rank_score(primary, package_ready)
     story_family = _story_family_for_story(primary.story)
+    interest_reasons = _candidate_interest_reasons(
+        primary=primary,
+        story_scores=story_scores,
+        features=features,
+        package_ready=package_ready,
+    )
     return SoundingCandidate(
         candidate_id=_candidate_id(entry.station_id, selected_time, source_path.name, source_hash),
         station_id=entry.station_id,
@@ -967,6 +1061,9 @@ def _candidate_from_cached_sounding(
         evidence=evidence,
         caveats=caveats,
         selected_sounding_payload=selected_payload,
+        interest_summary=interest_reasons[0] if interest_reasons else None,
+        interest_reasons=interest_reasons,
+        discovery_bucket=_candidate_discovery_bucket(primary, story_scores, package_ready),
         created_at=created_at,
     )
 
@@ -1872,6 +1969,87 @@ def _rank_score(primary: StoryScore, package_ready: bool) -> float:
     if not package_ready or primary.story == "poor_or_incomplete_candidate":
         return 0.0
     return round(primary.score_0_to_100, 2)
+
+
+def _candidate_interest_reasons(
+    *,
+    primary: StoryScore,
+    story_scores: list[StoryScore],
+    features: dict[str, float | int | str | bool | None],
+    package_ready: bool,
+) -> list[str]:
+    if not package_ready:
+        return [
+            "Worth reviewing because package generation is blocked or caveated.",
+            "Use the caveats to decide whether this cached sounding needs parser or metadata work.",
+        ]
+
+    reasons: list[str] = []
+    deep_score = max(
+        (
+            score.score_0_to_100
+            for score in story_scores
+            if score.story in DEEP_CONVECTION_STORY_IDS
+        ),
+        default=0.0,
+    )
+    if deep_score >= 65.0:
+        reasons.append("Strong deep-convection ingredients with observed wind support.")
+    elif deep_score >= 35.0:
+        reasons.append(
+            "Some deep-convection ingredients are present, but the evidence is caveated."
+        )
+
+    qv = _numeric_feature(features, "mean_qv_0_1000m_g_kg")
+    qv_500 = _numeric_feature(features, "mean_qv_0_500m_g_kg")
+    lcl = _numeric_feature(features, "estimated_lcl_height_m_agl")
+    cap = _numeric_feature(features, "cap_strength_proxy")
+    shear_0_6km = _numeric_feature(features, "bulk_shear_0_6km_m_s")
+    midlevel_dry = _numeric_feature(features, "midlevel_dry_layer_proxy")
+    completeness = _numeric_feature(features, "data_completeness_score")
+
+    if qv is not None and qv >= 14.0:
+        reasons.append("Very moist lower atmosphere.")
+    elif qv_500 is not None and qv_500 >= 12.0:
+        reasons.append("Rich moisture near likely cloud base.")
+    if lcl is not None and lcl <= 900.0:
+        reasons.append("Low estimated LCL makes cloud formation easier to test.")
+    if cap is not None and cap >= 2.0:
+        reasons.append("Cap or inversion signal makes suppression worth inspecting.")
+    if shear_0_6km is not None and shear_0_6km >= 12.0:
+        reasons.append("Observed 0-6 km shear gives storm-organization context.")
+    if midlevel_dry is not None and midlevel_dry >= 4.0:
+        reasons.append("Dry-layer signal could matter for entrainment or downdraft behavior.")
+    if completeness is not None and completeness >= 85.0:
+        reasons.append("Profile coverage is strong enough for package review.")
+
+    if not reasons:
+        reasons.append(primary.reasons[0] if primary.reasons else primary.label)
+    return reasons[:4]
+
+
+def _candidate_discovery_bucket(
+    primary: StoryScore, story_scores: list[StoryScore], package_ready: bool
+) -> str:
+    if not package_ready:
+        return "Needs review"
+    deep_score = max(
+        (
+            score.score_0_to_100
+            for score in story_scores
+            if score.story in DEEP_CONVECTION_STORY_IDS
+        ),
+        default=0.0,
+    )
+    if deep_score >= 35.0:
+        return "Deep convection"
+    if primary.story == "humid_rainy_candidate":
+        return "Humid / rainy"
+    if primary.story == "capped_suppressed_candidate":
+        return "Capped / suppressed"
+    if primary.story == "dry_failed_candidate":
+        return "Dry / failed"
+    return "Cloud-forming"
 
 
 def _station_metadata_from_cache_entry(entry: IGRACacheEntry) -> StationMetadata:

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -13,13 +13,14 @@ import math
 from datetime import UTC, datetime
 from functools import cmp_to_key
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.igra_catalog import IGRACacheEntry, read_igra_cache_manifest
 from cloud_chamber.observed_sounding import (
     ObservedSoundingError,
+    ObservedSoundingLevel,
     ObservedSoundingRecord,
     StationMetadata,
     parse_igra_station_text,
@@ -63,6 +64,14 @@ Confidence = Literal["low", "medium", "high"]
 Support = Literal["supported", "weak", "unavailable"]
 CandidateStoryFamily = Literal["lower_atmosphere", "deep_convection", "review"]
 CandidateStoryFamilyFilter = Literal["all", "lower_atmosphere", "deep_convection", "review"]
+CandidateRecipeFitStatus = Literal[
+    "testable_now",
+    "partially_testable",
+    "requires_triggered_deep_potential",
+    "requires_surface_forcing_recipe",
+    "not_testable_with_current_recipes",
+    "blocked_profile",
+]
 CandidateStoryFilter = Literal[
     "all",
     "deep_convection_trial",
@@ -216,6 +225,13 @@ class EvidenceItem(BaseModel):
     caveats: list[str] = Field(default_factory=list)
 
 
+class _RecipeFit(TypedDict):
+    status: CandidateRecipeFitStatus
+    label: str
+    summary: str
+    caveats: list[str]
+
+
 class SoundingCandidate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -245,6 +261,13 @@ class SoundingCandidate(BaseModel):
     interest_summary: str | None = None
     interest_reasons: list[str] = Field(default_factory=list)
     discovery_bucket: str | None = None
+    recipe_fit_status: CandidateRecipeFitStatus = "partially_testable"
+    recipe_fit_label: str = "Partially testable with current observed-sounding run"
+    recipe_fit_summary: str = (
+        "Scores rank sounding ingredients only. They do not predict what the current "
+        "CM1 package will produce."
+    )
+    recipe_fit_caveats: list[str] = Field(default_factory=list)
     screening_version: str = SCREENING_VERSION
     created_at: datetime
 
@@ -345,7 +368,7 @@ class UpdateSavedCandidateRequest(BaseModel):
 
 SORT_OPTIONS: tuple[CandidateSortOption, ...] = (
     CandidateSortOption(
-        key="best_match", label="Best match for selected story", default_direction="desc"
+        key="best_match", label="Highest ingredient score", default_direction="desc"
     ),
     CandidateSortOption(key="valid_time", label="Valid time", default_direction="desc"),
     CandidateSortOption(key="station_id", label="Station ID", default_direction="asc"),
@@ -1069,6 +1092,9 @@ def _candidate_from_cached_sounding(
     primary = max(story_scores, key=lambda score: score.score_0_to_100)
     rank_score = _rank_score(primary, package_ready)
     story_family = _story_family_for_story(primary.story)
+    recipe_fit = _candidate_recipe_fit(
+        primary.story, features=features, package_ready=package_ready
+    )
     interest_reasons = _candidate_interest_reasons(
         primary=primary,
         story_scores=story_scores,
@@ -1100,8 +1126,88 @@ def _candidate_from_cached_sounding(
         interest_summary=interest_reasons[0] if interest_reasons else None,
         interest_reasons=interest_reasons,
         discovery_bucket=_candidate_discovery_bucket(primary, story_scores, package_ready),
+        recipe_fit_status=recipe_fit["status"],
+        recipe_fit_label=recipe_fit["label"],
+        recipe_fit_summary=recipe_fit["summary"],
+        recipe_fit_caveats=recipe_fit["caveats"],
         created_at=created_at,
     )
+
+
+def _candidate_recipe_fit(
+    story: StoryId,
+    *,
+    features: dict[str, float | int | str | bool | None],
+    package_ready: bool,
+) -> _RecipeFit:
+    if not package_ready or story == "poor_or_incomplete_candidate":
+        return {
+            "status": "blocked_profile",
+            "label": "blocked profile",
+            "summary": (
+                "This cached sounding cannot be packaged until the profile or parser caveats "
+                "are resolved."
+            ),
+            "caveats": ["profile_or_package_generation_blocked"],
+        }
+    if story == "needs_review":
+        return {
+            "status": "not_testable_with_current_recipes",
+            "label": "not testable with current package path",
+            "summary": (
+                "The analyzer could not identify a trustworthy story to test with the current "
+                "observed-sounding package path."
+            ),
+            "caveats": ["candidate_requires_manual_screening_review"],
+        }
+    if story in DEEP_CONVECTION_STORY_IDS:
+        caveats = ["observed_sounding_quicklook_does_not_test_deep_potential"]
+        if features.get("observed_wind_available") is not True:
+            caveats.append("complete_observed_wind_profile_required_for_deep_potential")
+        return {
+            "status": "requires_triggered_deep_potential",
+            "label": "requires triggered deep-potential run",
+            "summary": (
+                "This story screens deep-convection ingredients. Observed Sounding Quick Look "
+                "does not test that hypothesis without the triggered deep-potential package."
+            ),
+            "caveats": caveats,
+        }
+    if story == "humid_rainy_candidate":
+        return {
+            "status": "partially_testable",
+            "label": "partially testable with current observed-sounding run",
+            "summary": (
+                "The current observed-sounding path can inspect moist evolution, but later "
+                "comparison needs rain-water, surface-rain, and/or reflectivity outputs."
+            ),
+            "caveats": ["rain_water_surface_rain_or_reflectivity_outputs_required"],
+        }
+    if story == "capped_suppressed_candidate":
+        caveats = ["run_duration_and_output_fields_must_be_checked_for_cap_story"]
+        if (
+            _numeric_feature(features, "cap_strength_proxy") is None
+            and _numeric_feature(features, "cap_height_m_agl") is None
+        ):
+            caveats.append("cap_or_inversion_evidence_unavailable")
+        return {
+            "status": "partially_testable",
+            "label": "partially testable with current observed-sounding run",
+            "summary": (
+                "The current observed-sounding path can inspect capped or suppressed evolution "
+                "when cap evidence, duration, and output fields are adequate."
+            ),
+            "caveats": caveats,
+        }
+    return {
+        "status": "partially_testable",
+        "label": "partially testable with current observed-sounding run",
+        "summary": (
+            "The current observed-sounding path can inspect untriggered shallow/evolution "
+            "behavior, but the recipe still shapes what CM1 can test."
+        ),
+        "caveats": ["observed_sounding_quicklook_is_recipe_dependent"],
+    }
 
 
 def _features_from_record(
@@ -1124,8 +1230,8 @@ def _features_from_record(
     moisture_depth = _moisture_depth(levels, min_qv_g_kg=6.0)
     near_surface_jump = _near_surface_jump(levels)
     usable_below_3km = sum(1 for level in levels if 0.0 <= level.model_z_m <= 3000.0)
-    observed_wind_available = all(
-        level.u_wind_m_s is not None and level.v_wind_m_s is not None for level in levels
+    partial_observed_wind_available = any(
+        _level_has_finite_observed_wind(level) for level in levels
     )
     completeness = min(
         100.0,
@@ -1176,7 +1282,8 @@ def _features_from_record(
         "profile_top_m_agl": round(top, 1),
         "lowest_level_m_agl": round(lowest, 1),
         "usable_levels_below_3km": usable_below_3km,
-        "observed_wind_available": observed_wind_available,
+        "observed_wind_available": False,
+        "has_partial_observed_wind_profile": partial_observed_wind_available,
         "near_surface_jump_depth_m": near_surface_jump["depth_m"],
         "near_surface_temperature_jump_c": near_surface_jump["temperature_jump_c"],
         "near_surface_qv_jump_g_kg": near_surface_jump["qv_jump_g_kg"],
@@ -1206,10 +1313,17 @@ def _features_from_record(
     ):
         diagnostic = diagnostics.feature_values.get(key)
         features[key] = diagnostic.value if diagnostic is not None else None
-    features["observed_wind_available"] = bool(
-        features.get("observed_wind_available") or features.get("has_observed_wind_profile")
-    )
+    features["observed_wind_available"] = features.get("has_observed_wind_profile") is True
     return features
+
+
+def _level_has_finite_observed_wind(level: ObservedSoundingLevel) -> bool:
+    return (
+        level.u_wind_m_s is not None
+        and level.v_wind_m_s is not None
+        and math.isfinite(float(level.u_wind_m_s))
+        and math.isfinite(float(level.v_wind_m_s))
+    )
 
 
 def _score_features(

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -18,6 +18,7 @@ from cloud_chamber.igra_catalog import (
 )
 from cloud_chamber.local_run_manager import LocalRunManagerError, RunStatus
 from cloud_chamber.local_run_queue import RunQueueEntry, RunQueueState
+from cloud_chamber.observed_sounding import parse_igra_station_text
 from cloud_chamber.run_manifest import (
     ExecutionMetadata,
     LifecycleState,
@@ -387,6 +388,74 @@ def test_run_status_api_reports_stdout_model_time_progress(
     assert progress["estimated_remaining_wall_seconds"] is not None
     assert progress["model_time_source"] == "stdout model-minute progress"
     assert progress["total_model_time_source"] == "namelist.input timax"
+
+
+def test_run_status_api_includes_observed_sounding_and_notes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    package = generate_dry_run_package(
+        scenario_data=json.loads(BASELINE_TEMPLATE.read_text()),
+        runtime_home=tmp_path / "CloudChamber",
+        run_id="run-observed-notes",
+        observed_sounding=observed,
+        user_tags=["compare", "saved"],
+        user_notes="Compare this sounding against the humid case.",
+    )
+    manifest = load_run_manifest(package.manifest_path)
+    stdout_log = package.package_dir / "logs" / "stdout.log"
+    stderr_log = package.package_dir / "logs" / "stderr.log"
+    stdout_log.parent.mkdir()
+    stdout_log.write_text("")
+    stderr_log.write_text("")
+    write_run_manifest(
+        package.manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": LifecycleState.RUNNING,
+                "provenance": ProvenanceMetadata(
+                    product_state=ProductState.QUEUED_RUNNING_CM1_PROCESS
+                ),
+                "execution": ExecutionMetadata(
+                    command=["/tmp/cm1/run/cm1.exe"],
+                    started_at=datetime(2026, 5, 22, 15, 15, 36, tzinfo=UTC),
+                    stdout_log=str(stdout_log),
+                    stderr_log=str(stderr_log),
+                ),
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.app._local_run_manager",
+        FakeRunManager(
+            RunStatus(
+                run_id="run-observed-notes",
+                lifecycle_state=LifecycleState.RUNNING,
+                manifest_path=package.manifest_path,
+                command=("/tmp/cm1/run/cm1.exe",),
+                stdout_log=stdout_log,
+                stderr_log=stderr_log,
+                exit_code=None,
+            )
+        ),
+    )
+
+    response = TestClient(app).get(
+        "/api/runs/status",
+        params={"manifest_path": str(package.manifest_path)},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["observed_sounding"]["station_id"] == "USM00072558"
+    assert payload["observed_sounding"]["station_name"] == "Valley, Nebraska"
+    assert payload["observed_sounding"]["valid_time_utc"] == "2025-01-02T00:00:00Z"
+    assert payload["user"]["tags"] == ["compare", "saved"]
+    assert payload["user"]["notes"] == "Compare this sounding against the humid case."
 
 
 def test_run_status_api_reports_completed_elapsed_and_full_model_time(

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -95,6 +95,8 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
         run_id="run-observed-sounding",
         run_size_preset="quick_look",
         observed_sounding=observed,
+        user_tags=["compare", "candidate", "compare"],
+        user_notes="  Compare against humid/rainy candidates.  ",
     )
 
     manifest = load_run_manifest(result.manifest_path)
@@ -106,8 +108,12 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
     assert manifest.observed_sounding is not None
     assert manifest.observed_sounding["station_id"] == "USM00072558"
     assert manifest.observed_sounding["model_bottom_elevation_m_msl"] == pytest.approx(351.5)
+    assert manifest.user.tags == ["compare", "candidate"]
+    assert manifest.user.notes == "Compare against humid/rainy candidates."
     assert report["variant_metadata"]["sounding_source"] == "observed_igra_station_text"
     assert report["observed_sounding"]["station_name"] == "Valley, Nebraska"
+    assert report["user"]["tags"] == ["compare", "candidate"]
+    assert report["user"]["notes"] == "Compare against humid/rainy candidates."
     assert report["observed_sounding"]["usable_levels"] >= 5
     assert report["observed_sounding"]["wind_source"] == "observed_igra_wind_profile"
     assert report["observed_sounding"]["wind_units"] == "m/s"

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -14,12 +14,16 @@ from cloud_chamber.run_manifest import load_run_manifest
 from cloud_chamber.settings import CloudChamberSettings
 from cloud_chamber.sounding_candidates import (
     SaveCandidateRequest,
+    UpdateSavedCandidateRequest,
     _features_from_record,
     _score_features,
+    _sort_analysis_candidates,
+    analyze_cached_soundings,
     list_saved_candidates,
     list_screening_inputs,
     save_candidate,
     screen_cached_soundings,
+    update_saved_candidate,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -65,12 +69,20 @@ def _write_cached_igra_station(
         downloaded_at=datetime(2026, 7, 1, tzinfo=UTC),
         extracted_at=datetime(2026, 7, 1, tzinfo=UTC),
     )
+    path = igra_cache_manifest_path(settings)
+    existing_entries: list[IGRACacheEntry] = []
+    if path.exists():
+        existing = IGRACacheManifest.model_validate_json(path.read_text())
+        existing_entries = [
+            existing_entry
+            for existing_entry in existing.entries
+            if existing_entry.station_id != station_id
+        ]
     manifest = IGRACacheManifest(
         cache_root=str(settings.cache_dir / "igra" / "recent"),
-        entries=[entry],
+        entries=[*existing_entries, entry],
         updated_at=datetime(2026, 7, 1, tzinfo=UTC),
     )
-    path = igra_cache_manifest_path(settings)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(manifest.model_dump_json(indent=2) + "\n")
     return text_path
@@ -178,6 +190,100 @@ def test_screen_cached_soundings_can_target_one_story(tmp_path: Path) -> None:
         for candidate in result.candidates
     ]
     assert target_scores == sorted(target_scores, reverse=True)
+
+
+def test_analyze_cached_soundings_filters_and_sorts_multiple_cached_blocks(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_cached_igra_station(
+        settings,
+        station_id="USM00072558",
+        station_name="Valley, Nebraska",
+    )
+    _write_cached_igra_station(
+        settings,
+        station_id="USM00072426",
+        station_name="Wilmington, Ohio",
+    )
+    seed = analyze_cached_soundings(settings, latest_per_station=1, limit=10)
+    target_story = seed.candidates[0].primary_story
+    target_support = next(
+        score.support for score in seed.candidates[0].story_scores if score.story == target_story
+    )
+
+    result = analyze_cached_soundings(
+        settings,
+        latest_per_station=1,
+        limit=10,
+        story_filter=target_story,
+        support=target_support,
+        readiness="package_ready",
+        sort_by="station_name",
+    )
+
+    assert result.total_candidate_count == 2
+    assert result.filtered_candidate_count == 2
+    assert result.filters.story_filter == target_story
+    assert result.filters.support == target_support
+    assert result.sort_by == "station_name"
+    assert [candidate.station_name for candidate in result.candidates] == [
+        "Valley, Nebraska",
+        "Wilmington, Ohio",
+    ]
+    assert all(candidate.package_ready for candidate in result.candidates)
+    for candidate in result.candidates:
+        story_score = next(score for score in candidate.story_scores if score.story == target_story)
+        assert story_score.support == target_support
+
+
+def test_analysis_sorts_physical_fields_with_missing_values_last(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    _write_cached_igra_station(settings)
+    parsed_candidate = analyze_cached_soundings(settings, latest_per_station=1).candidates[0]
+    low_lcl = parsed_candidate.model_copy(
+        update={
+            "candidate_id": "low-lcl",
+            "station_id": "LOW00000000",
+            "features": {
+                **parsed_candidate.features,
+                "estimated_lcl_height_m_agl": 600.0,
+            },
+        }
+    )
+    high_lcl = parsed_candidate.model_copy(
+        update={
+            "candidate_id": "high-lcl",
+            "station_id": "HIGH0000000",
+            "features": {
+                **parsed_candidate.features,
+                "estimated_lcl_height_m_agl": 1800.0,
+            },
+        }
+    )
+    missing_lcl = parsed_candidate.model_copy(
+        update={
+            "candidate_id": "missing-lcl",
+            "station_id": "MISS0000000",
+            "features": {
+                **parsed_candidate.features,
+                "estimated_lcl_height_m_agl": None,
+            },
+        }
+    )
+
+    sorted_candidates = _sort_analysis_candidates(
+        [missing_lcl, high_lcl, low_lcl],
+        sort_by="estimated_lcl_height_m_agl",
+        sort_direction="asc",
+        story_filter="all",
+    )
+
+    assert [candidate.candidate_id for candidate in sorted_candidates] == [
+        "low-lcl",
+        "high-lcl",
+        "missing-lcl",
+    ]
 
 
 def test_screen_cached_soundings_caveats_unreadable_files(tmp_path: Path) -> None:
@@ -704,6 +810,19 @@ def test_saved_candidates_round_trip_runtime_local(tmp_path: Path) -> None:
     assert json.loads(saved_path.read_text())[0]["tags"] == ["candidate"]
     assert list_saved_candidates(settings)[0].notes == "try this"
 
+    updated = update_saved_candidate(
+        settings,
+        saved.saved_candidate_id,
+        UpdateSavedCandidateRequest(
+            tags=["Deep convection candidates", "Needs review", "Needs review"],
+            notes="tagged for follow-up",
+        ),
+    )
+
+    assert updated is not None
+    assert updated.tags == ["Deep convection candidates", "Needs review"]
+    assert list_saved_candidates(settings)[0].notes == "tagged for follow-up"
+
 
 def test_sounding_candidate_api_screen_save_and_delete(
     tmp_path: Path,
@@ -742,6 +861,24 @@ def test_sounding_candidate_api_screen_save_and_delete(
     )
     assert deep_screened.status_code == 200
 
+    analyzed = client.post(
+        "/api/sounding-candidates/analyze",
+        json={
+            "station_id": "USM00072558",
+            "latest_per_station": 1,
+            "limit": 5,
+            "story_filter": "shallow_cumulus_candidate",
+            "support": "weak",
+            "readiness": "package_ready",
+            "sort_by": "mean_qv_0_1000m_g_kg",
+        },
+    )
+    assert analyzed.status_code == 200
+    analyzed_payload = analyzed.json()
+    assert analyzed_payload["filters"]["story_filter"] == "shallow_cumulus_candidate"
+    assert analyzed_payload["sort_by"] == "mean_qv_0_1000m_g_kg"
+    assert analyzed_payload["sort_options"]
+
     saved = client.post(
         "/api/sounding-candidates/saved",
         json={"candidate": candidate, "tags": ["manual-review"]},
@@ -749,9 +886,21 @@ def test_sounding_candidate_api_screen_save_and_delete(
     assert saved.status_code == 200
     saved_id = saved.json()["saved_candidate_id"]
 
+    patched = client.patch(
+        f"/api/sounding-candidates/saved/{saved_id}",
+        json={"tags": ["Surface-forced candidates", "Needs review"], "notes": "try longer"},
+    )
+    assert patched.status_code == 200
+    assert patched.json()["tags"] == ["Surface-forced candidates", "Needs review"]
+    assert patched.json()["notes"] == "try longer"
+
     listed = client.get("/api/sounding-candidates/saved")
     assert listed.status_code == 200
     assert listed.json()["saved_candidates"][0]["saved_candidate_id"] == saved_id
+    assert listed.json()["saved_candidates"][0]["tags"] == [
+        "Surface-forced candidates",
+        "Needs review",
+    ]
 
     deleted = client.delete(f"/api/sounding-candidates/saved/{saved_id}")
     assert deleted.status_code == 200

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -237,6 +237,33 @@ def test_analyze_cached_soundings_filters_and_sorts_multiple_cached_blocks(
         assert story_score.support == target_support
 
 
+def test_analyze_cached_soundings_default_recommendations_are_explained_and_diverse(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_cached_igra_station(
+        settings,
+        station_id="USM00072558",
+        station_name="Valley, Nebraska",
+    )
+    _write_cached_igra_station(
+        settings,
+        station_id="USM00072426",
+        station_name="Wilmington, Ohio",
+    )
+
+    result = analyze_cached_soundings(settings, latest_per_station=2, limit=4)
+
+    assert len(result.candidates) == 4
+    assert {candidate.station_id for candidate in result.candidates[:2]} == {
+        "USM00072426",
+        "USM00072558",
+    }
+    assert all(candidate.interest_summary for candidate in result.candidates)
+    assert all(candidate.interest_reasons for candidate in result.candidates)
+    assert all(candidate.discovery_bucket for candidate in result.candidates)
+
+
 def test_analysis_sorts_physical_fields_with_missing_values_last(tmp_path: Path) -> None:
     settings = _settings(tmp_path)
     _write_cached_igra_station(settings)

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -243,6 +243,29 @@ def test_near_surface_discontinuity_is_caveated_and_downgrades_data_quality() ->
     assert "near_surface_discontinuity_caveat" in continuity.caveats
 
 
+def test_observed_wind_available_requires_complete_finite_profile() -> None:
+    record = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    levels = list(record.levels)
+    missing_wind_index = next(
+        index for index, level in enumerate(levels) if level.model_z_m >= 3000.0
+    )
+    levels[missing_wind_index] = levels[missing_wind_index].model_copy(update={"u_wind_m_s": None})
+    partial_wind_record = record.model_copy(update={"levels": levels})
+
+    features = _features_from_record(partial_wind_record)
+    scores, _evidence = _score_features(features, package_ready=True)
+
+    assert features["has_partial_observed_wind_profile"] is True
+    assert features["has_observed_wind_profile"] is False
+    assert features["observed_wind_available"] is False
+    supercell = next(score for score in scores if score.story == "supercell_environment")
+    assert supercell.support == "unavailable"
+    assert "observed_wind_required_for_deep_convection_trial" in supercell.caveats
+
+
 def test_screen_cached_soundings_can_target_one_story(tmp_path: Path) -> None:
     settings = _settings(tmp_path)
     _write_cached_igra_station(settings)

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from igra_fixtures import IGRA_FIXTURE
 
+import cloud_chamber.sounding_candidates as sounding_candidates
 from cloud_chamber.app import app
 from cloud_chamber.dry_run_package import generate_dry_run_package, read_dry_run_report
 from cloud_chamber.igra_catalog import IGRACacheEntry, IGRACacheManifest, igra_cache_manifest_path
@@ -14,6 +15,12 @@ from cloud_chamber.run_manifest import load_run_manifest
 from cloud_chamber.settings import CloudChamberSettings
 from cloud_chamber.sounding_candidates import (
     SaveCandidateRequest,
+    ScreeningResult,
+    SoundingCandidate,
+    StoryId,
+    StoryScore,
+    Support,
+    TargetStoryId,
     UpdateSavedCandidateRequest,
     _features_from_record,
     _score_features,
@@ -86,6 +93,73 @@ def _write_cached_igra_station(
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(manifest.model_dump_json(indent=2) + "\n")
     return text_path
+
+
+def _analysis_candidate(
+    candidate_id: str,
+    *,
+    primary_score: float = 90.0,
+    primary_support: Support = "supported",
+    deep_score: float = 70.0,
+    deep_support: Support = "supported",
+    deep_story: StoryId = "supercell_environment",
+) -> SoundingCandidate:
+    story_scores = [
+        StoryScore(
+            story="humid_rainy_candidate",
+            label="Humid / rainy candidate",
+            score_0_to_100=primary_score,
+            support=primary_support,
+        ),
+        StoryScore(
+            story=deep_story,
+            label="Supercell-like environment",
+            score_0_to_100=deep_score,
+            support=deep_support,
+        ),
+    ]
+    return SoundingCandidate(
+        candidate_id=candidate_id,
+        station_id=f"USM0000{len(candidate_id):04d}",
+        station_name=candidate_id,
+        valid_time_utc=datetime(2026, 7, 1, tzinfo=UTC),
+        source_time_text="2026-07-01 00 UTC",
+        source_file_name=f"{candidate_id}.txt",
+        source_file_hash=f"hash-{candidate_id}",
+        primary_story="humid_rainy_candidate",
+        primary_story_label="Humid / rainy candidate",
+        story_family="lower_atmosphere",
+        story_scores=story_scores,
+        rank_score=primary_score,
+        confidence="high",
+        package_ready=True,
+        features={},
+        evidence=[],
+        created_at=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+
+
+def _patch_screened_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+    candidates: list[SoundingCandidate],
+) -> None:
+    def fake_screen_cached_soundings(
+        settings: CloudChamberSettings,
+        *,
+        station_id: str | None = None,
+        latest_per_station: int = 5,
+        limit: int = 50,
+        target_story: TargetStoryId | None = None,
+    ) -> ScreeningResult:
+        return ScreeningResult(
+            generated_at=datetime(2026, 7, 1, tzinfo=UTC),
+            candidates=candidates[:limit],
+            caveats=[],
+        )
+
+    monkeypatch.setattr(
+        sounding_candidates, "screen_cached_soundings", fake_screen_cached_soundings
+    )
 
 
 def test_screening_inputs_list_cached_station_text(tmp_path: Path) -> None:
@@ -310,6 +384,85 @@ def test_analysis_sorts_physical_fields_with_missing_values_last(tmp_path: Path)
         "low-lcl",
         "high-lcl",
         "missing-lcl",
+    ]
+
+
+def test_analysis_family_filter_includes_supported_secondary_deep_story(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    candidate = _analysis_candidate(
+        "primary-humid-supported-secondary-supercell",
+        primary_score=92.0,
+        deep_score=74.0,
+        deep_support="supported",
+    )
+    _patch_screened_candidates(monkeypatch, [candidate])
+
+    result = analyze_cached_soundings(
+        _settings(tmp_path),
+        story_family="deep_convection",
+        support="all",
+    )
+
+    assert [item.candidate_id for item in result.candidates] == [
+        "primary-humid-supported-secondary-supercell"
+    ]
+    assert result.filtered_candidate_count == 1
+
+
+def test_analysis_family_support_filter_uses_deep_family_scores(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    supported = _analysis_candidate(
+        "secondary-deep-supported",
+        primary_score=92.0,
+        deep_score=74.0,
+        deep_support="supported",
+    )
+    weak = _analysis_candidate(
+        "secondary-deep-weak",
+        primary_score=96.0,
+        deep_score=48.0,
+        deep_support="weak",
+    )
+    _patch_screened_candidates(monkeypatch, [weak, supported])
+
+    result = analyze_cached_soundings(
+        _settings(tmp_path),
+        story_family="deep_convection",
+        support="supported",
+    )
+
+    assert [item.candidate_id for item in result.candidates] == ["secondary-deep-supported"]
+    assert result.filtered_candidate_count == 1
+
+
+def test_analysis_deep_family_best_match_sort_uses_best_deep_score(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    humid_but_weaker_deep = _analysis_candidate(
+        "humid-high-weaker-deep",
+        primary_score=99.0,
+        deep_score=67.0,
+        deep_support="supported",
+    )
+    lower_primary_better_deep = _analysis_candidate(
+        "humid-lower-better-deep",
+        primary_score=76.0,
+        deep_score=91.0,
+        deep_support="supported",
+    )
+    _patch_screened_candidates(monkeypatch, [humid_but_weaker_deep, lower_primary_better_deep])
+
+    result = analyze_cached_soundings(
+        _settings(tmp_path),
+        story_family="deep_convection",
+        sort_by="best_match",
+    )
+
+    assert [item.candidate_id for item in result.candidates] == [
+        "humid-lower-better-deep",
+        "humid-high-weaker-deep",
     ]
 
 

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -191,6 +191,7 @@ const shallowSoundingCandidate = {
   source_provider: "NOAA/NCEI IGRA",
   primary_story: "shallow_cumulus_candidate",
   primary_story_label: "Cloud-forming shallow cumulus",
+  story_family: "lower_atmosphere",
   rank_score: 82,
   confidence: "medium",
   package_ready: true,
@@ -261,6 +262,7 @@ const blockedSoundingCandidate = {
   valid_time_utc: "2025-01-01T00:00:00Z",
   primary_story: "needs_review",
   primary_story_label: "Needs review",
+  story_family: "review",
   rank_score: 40,
   confidence: "low",
   package_ready: false,
@@ -1214,14 +1216,37 @@ export async function mockCloudChamberApis(page: Page) {
     }),
   );
 
-  await page.route("**/api/sounding-candidates/screen", (route) =>
-    json(route, {
+  await page.route("**/api/sounding-candidates/analyze", (route) => {
+    const request = JSON.parse(route.request().postData() ?? "{}") as {
+      story_filter?: string;
+      sort_by?: string;
+    };
+    const storyFilter = request.story_filter ?? "all";
+    const candidates = [shallowSoundingCandidate, blockedSoundingCandidate].filter((candidate) => {
+      if (storyFilter === "all") return true;
+      return candidate.story_scores.some(
+        (score) => score.story === storyFilter && score.support !== "unavailable",
+      );
+    });
+    return json(route, {
       screening_version: "test-screening-v1",
       generated_at: "2026-07-01T12:00:00Z",
-      candidates: [shallowSoundingCandidate, blockedSoundingCandidate],
+      candidates,
+      total_candidate_count: 2,
+      filtered_candidate_count: candidates.length,
+      sort_by: request.sort_by ?? "best_match",
+      sort_direction: "desc",
+      filters: {
+        station_id: null,
+        story_filter: storyFilter,
+        story_family: "all",
+        support: "all",
+        readiness: "all",
+        station_search: "",
+      },
       caveats: ["screening_guidance_only"],
-    }),
-  );
+    });
+  });
 
   await page.route("**/api/sounding-candidates/saved", (route) => {
     if (route.request().method() === "POST") {

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -123,7 +123,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(valleyCard).toContainText("Package-ready");
     await expect(valleyCard).toContainText("Low-level moisture: 10.2 g/kg");
     await expect(page.getByLabel("Candidate details")).toContainText(
-      "Candidate match score is screening guidance only",
+      "Scores rank sounding ingredients only",
     );
 
     await storySelect.selectOption("needs_review");

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -106,9 +106,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("Cached 1 station file")).toBeVisible();
 
     await page.getByLabel("Story filter").selectOption("shallow_cumulus_candidate");
-    await page.getByRole("button", { name: "Screen cached soundings" }).click();
+    await page.getByRole("button", { name: "Analyze cached soundings" }).click();
 
-    await expect(page.getByText("Screening guidance loaded")).toBeVisible();
+    await expect(page.getByText("Cached sounding analysis loaded")).toBeVisible();
     const valleyCard = page.getByLabel("Sounding candidate Valley, Nebraska (USM00072558)");
     await expect(valleyCard).toBeVisible();
     await expect(valleyCard).toContainText("Cloud-forming shallow cumulus");
@@ -119,12 +119,14 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     );
 
     await page.getByLabel("Story filter").selectOption("needs_review");
+    await page.getByRole("button", { name: "Analyze cached soundings" }).click();
     const blockedCard = page.getByLabel("Sounding candidate Norman, Oklahoma (USM00072357)");
     await expect(blockedCard).toBeVisible();
     await expect(blockedCard).toContainText("Blocked");
     await expect(blockedCard.getByRole("button", { name: "Use this sounding" })).toBeDisabled();
 
     await page.getByLabel("Story filter").selectOption("all");
+    await page.getByRole("button", { name: "Analyze cached soundings" }).click();
     await valleyCard.getByRole("button", { name: "Save candidate" }).click();
     await expect(page.getByText("Sounding candidate saved")).toBeVisible();
     await expect(

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -100,7 +100,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
 
     await page.getByRole("button", { name: "Refresh IGRA catalog" }).click();
     await expect(page.getByText("IGRA station catalog refreshed")).toBeVisible();
-    await expect(page.getByText("Screenable soundings").locator("..")).toContainText("2 soundings");
+    await expect(page.getByText("Cached sounding inventory").locator("..")).toContainText(
+      "2 cached soundings",
+    );
+    await expect(page.getByText("Planned analysis slice").locator("..")).toContainText(
+      "Up to 2 soundings",
+    );
 
     await page.getByRole("button", { name: "Cache station files" }).click();
     await expect(page.getByText("Cached 1 station file")).toBeVisible();

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -105,8 +105,11 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await page.getByRole("button", { name: "Cache station files" }).click();
     await expect(page.getByText("Cached 1 station file")).toBeVisible();
 
-    await page.getByLabel("Story filter").selectOption("shallow_cumulus_candidate");
-    await page.getByRole("button", { name: "Analyze cached soundings" }).click();
+    await page.getByText("Advanced filters").click();
+    const candidateControls = page.getByLabel("Advanced sounding candidate controls");
+    const storySelect = candidateControls.getByRole("combobox").first();
+    await storySelect.selectOption("shallow_cumulus_candidate");
+    await page.getByRole("button", { name: "Analyze recommendations" }).click();
 
     await expect(page.getByText("Cached sounding analysis loaded")).toBeVisible();
     const valleyCard = page.getByLabel("Sounding candidate Valley, Nebraska (USM00072558)");
@@ -118,15 +121,15 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       "Candidate match score is screening guidance only",
     );
 
-    await page.getByLabel("Story filter").selectOption("needs_review");
-    await page.getByRole("button", { name: "Analyze cached soundings" }).click();
+    await storySelect.selectOption("needs_review");
+    await page.getByRole("button", { name: "Analyze recommendations" }).click();
     const blockedCard = page.getByLabel("Sounding candidate Norman, Oklahoma (USM00072357)");
     await expect(blockedCard).toBeVisible();
     await expect(blockedCard).toContainText("Blocked");
     await expect(blockedCard.getByRole("button", { name: "Use this sounding" })).toBeDisabled();
 
-    await page.getByLabel("Story filter").selectOption("all");
-    await page.getByRole("button", { name: "Analyze cached soundings" }).click();
+    await storySelect.selectOption("all");
+    await page.getByRole("button", { name: "Analyze recommendations" }).click();
     await valleyCard.getByRole("button", { name: "Save candidate" }).click();
     await expect(page.getByText("Sounding candidate saved")).toBeVisible();
     await expect(

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -478,9 +478,24 @@ small {
 
 .saved-candidate-card {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) minmax(13rem, 18rem) auto;
   gap: 0.75rem;
   align-items: center;
+}
+
+.saved-candidate-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: end;
+}
+
+.saved-candidate-controls label {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 12rem;
+  color: var(--color-text-primary);
+  font-weight: 800;
 }
 
 .screening-guidance-note {

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -295,7 +295,7 @@ small {
 
 .candidate-cache-summary {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
   gap: 0.6rem;
   margin: 0;
 }
@@ -2073,10 +2073,9 @@ details[open] > summary {
 }
 
 .inspector-controls-primary {
-  grid-template-columns: minmax(26rem, 1.25fr) minmax(9rem, 0.55fr) minmax(8rem, 0.45fr) minmax(
-      15rem,
-      0.9fr
-    ) auto;
+  grid-template-columns:
+    minmax(26rem, 1.25fr) minmax(9rem, 0.55fr) minmax(8rem, 0.45fr) minmax(15rem, 0.9fr)
+    auto;
   gap: 0.4rem;
   align-items: end;
   border: 1px solid rgba(47, 116, 168, 0.18);

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -309,6 +309,29 @@ small {
   background: rgba(255, 255, 255, 0.76);
 }
 
+.candidate-discovery-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.candidate-advanced-filters {
+  border-top: 1px solid rgba(215, 226, 232, 0.72);
+  padding-top: 0.25rem;
+}
+
+.candidate-advanced-filters summary {
+  width: fit-content;
+  color: var(--color-accent-primary);
+  cursor: pointer;
+  font-weight: 850;
+}
+
+.candidate-advanced-filters[open] summary {
+  margin-bottom: 0.7rem;
+}
+
 .candidate-toolbar {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -339,6 +362,17 @@ small {
 .saved-candidate-list {
   display: grid;
   gap: 0.75rem;
+}
+
+.candidate-list-heading {
+  display: grid;
+  gap: 0.2rem;
+  margin-bottom: 0.75rem;
+}
+
+.candidate-list-heading h4,
+.candidate-list-heading p {
+  margin-bottom: 0;
 }
 
 .candidate-card {
@@ -389,6 +423,16 @@ small {
   display: block;
 }
 
+.candidate-interest-summary {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.candidate-reason-list {
+  margin-top: -0.1rem;
+}
+
 .candidate-detail-panel {
   display: grid;
   gap: 0.75rem;
@@ -398,6 +442,31 @@ small {
 
 .candidate-detail-panel h5 {
   margin: 0 0 0.3rem;
+}
+
+.candidate-notes-form {
+  display: grid;
+  gap: 0.65rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.8rem;
+}
+
+.candidate-notes-form label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.candidate-tag-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.candidate-tag-suggestions button {
+  padding: 0.42rem 0.56rem;
+  font-size: 0.82rem;
 }
 
 .saved-candidates-panel {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -556,10 +556,27 @@ function screeningResponseForRequest(init?: RequestInit) {
     .filter((candidate) => {
       if (readiness === "package_ready" && !candidate.package_ready) return false;
       if (readiness === "blocked" && candidate.package_ready) return false;
-      if (storyFamily !== "all" && candidate.story_family !== storyFamily) return false;
-      const score = storyScoreForTest(candidate, storyFilter);
-      if (storyFilter !== "all" && (!score || score.support === "unavailable")) return false;
-      if (support !== "all" && score?.support !== support) return false;
+      const scopedScores = storyScoresForTest(candidate, storyFilter, storyFamily);
+      if (
+        storyFamily !== "all" &&
+        !scopedScores.some((score) => meaningfulStoryScoreForTest(score))
+      ) {
+        return false;
+      }
+      const score = storyScoreForTest(candidate, storyFilter, storyFamily);
+      if (
+        storyFilter !== "all" &&
+        (!score || !meaningfulStoryScoreForTest(score))
+      ) {
+        return false;
+      }
+      if (support !== "all") {
+        if (storyFilter === "all" && storyFamily === "all") {
+          if (!score || score.support !== support) return false;
+        } else if (!scopedScores.some((scopeScore) => scopeScore.support === support)) {
+          return false;
+        }
+      }
       if (!stationSearch) return true;
       return [candidate.station_id, candidate.station_name, candidate.primary_story_label]
         .filter(Boolean)
@@ -567,7 +584,7 @@ function screeningResponseForRequest(init?: RequestInit) {
         .toLowerCase()
         .includes(stationSearch);
     })
-    .sort((left, right) => compareCandidateFixtures(left, right, storyFilter, sortBy));
+    .sort((left, right) => compareCandidateFixtures(left, right, storyFilter, storyFamily, sortBy));
   return {
     ...screeningResponse,
     candidates,
@@ -588,28 +605,55 @@ function screeningResponseForRequest(init?: RequestInit) {
 function storyScoreForTest(
   candidate: (typeof screeningResponse.candidates)[number],
   storyFilter: string,
+  storyFamily: string = "all",
 ) {
-  if (storyFilter === "all") {
-    return candidate.story_scores[0] ?? null;
-  }
+  return (
+    [...storyScoresForTest(candidate, storyFilter, storyFamily)].sort(
+      (left, right) => right.score_0_to_100 - left.score_0_to_100,
+    )[0] ?? null
+  );
+}
+
+function storyScoresForTest(
+  candidate: (typeof screeningResponse.candidates)[number],
+  storyFilter: string,
+  storyFamily: string = "all",
+) {
+  let scores = candidate.story_scores;
   if (storyFilter === "deep_convection_trial") {
-    return (
-      candidate.story_scores
-        .filter((score) => testDeepConvectionStoryIds.has(score.story))
-        .sort((left, right) => right.score_0_to_100 - left.score_0_to_100)[0] ?? null
-    );
+    scores = scores.filter((score) => testDeepConvectionStoryIds.has(score.story));
+  } else if (storyFilter !== "all") {
+    scores = scores.filter((score) => score.story === storyFilter);
   }
-  return candidate.story_scores.find((score) => score.story === storyFilter) ?? null;
+  if (storyFamily !== "all") {
+    scores = scores.filter((score) => storyFamilyForTest(score.story) === storyFamily);
+  }
+  if (storyFilter === "all" && storyFamily === "all") {
+    const readyScores = scores.filter((score) => score.story !== "poor_or_incomplete_candidate");
+    return readyScores.length > 0 ? readyScores : scores;
+  }
+  return scores;
+}
+
+function storyFamilyForTest(story: string) {
+  if (testDeepConvectionStoryIds.has(story)) return "deep_convection";
+  if (story === "needs_review" || story === "poor_or_incomplete_candidate") return "review";
+  return "lower_atmosphere";
+}
+
+function meaningfulStoryScoreForTest(score: { score_0_to_100: number; support: string }) {
+  return score.score_0_to_100 > 0 && score.support !== "unavailable";
 }
 
 function compareCandidateFixtures(
   left: (typeof screeningResponse.candidates)[number],
   right: (typeof screeningResponse.candidates)[number],
   storyFilter: string,
+  storyFamily: string,
   sortBy: string,
 ) {
-  const leftValue = candidateSortValueForTest(left, storyFilter, sortBy);
-  const rightValue = candidateSortValueForTest(right, storyFilter, sortBy);
+  const leftValue = candidateSortValueForTest(left, storyFilter, storyFamily, sortBy);
+  const rightValue = candidateSortValueForTest(right, storyFilter, storyFamily, sortBy);
   if (leftValue === null && rightValue !== null) return 1;
   if (rightValue === null && leftValue !== null) return -1;
   if (leftValue !== null && rightValue !== null && leftValue !== rightValue) {
@@ -618,8 +662,8 @@ function compareCandidateFixtures(
   }
   return (
     Number(right.package_ready) - Number(left.package_ready) ||
-    (storyScoreForTest(right, storyFilter)?.score_0_to_100 ?? right.rank_score) -
-      (storyScoreForTest(left, storyFilter)?.score_0_to_100 ?? left.rank_score) ||
+    (storyScoreForTest(right, storyFilter, storyFamily)?.score_0_to_100 ?? right.rank_score) -
+      (storyScoreForTest(left, storyFilter, storyFamily)?.score_0_to_100 ?? left.rank_score) ||
     new Date(right.valid_time_utc).getTime() - new Date(left.valid_time_utc).getTime()
   );
 }
@@ -627,10 +671,14 @@ function compareCandidateFixtures(
 function candidateSortValueForTest(
   candidate: (typeof screeningResponse.candidates)[number],
   storyFilter: string,
+  storyFamily: string,
   sortBy: string,
 ) {
   if (sortBy === "best_match") {
-    return storyScoreForTest(candidate, storyFilter)?.score_0_to_100 ?? candidate.rank_score;
+    return (
+      storyScoreForTest(candidate, storyFilter, storyFamily)?.score_0_to_100 ??
+      candidate.rank_score
+    );
   }
   if (sortBy === "valid_time") return new Date(candidate.valid_time_utc).getTime();
   if (sortBy === "station_name") return candidate.station_name ?? candidate.station_id;
@@ -3158,6 +3206,43 @@ describe("App", () => {
     expect(screen.queryByText("No saved candidates yet.")).not.toBeInTheDocument();
     expect(fetch).not.toHaveBeenCalledWith("/api/igra/recent/refresh-catalog", expect.anything());
     expect(fetch).not.toHaveBeenCalledWith("/api/sounding-candidates/analyze", expect.anything());
+  });
+
+  it("shows secondary family matches with the scoped story score", async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+
+    fireEvent.click(screen.getByText("Advanced filters"));
+    fireEvent.change(screen.getByLabelText("Story family"), {
+      target: { value: "deep_convection" },
+    });
+    fireEvent.change(screen.getByLabelText("Support"), {
+      target: { value: "weak" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+
+    const wilmingtonCard = await screen.findByLabelText(
+      "Sounding candidate Wilmington, Ohio (USM00072426)",
+    );
+    expect(wilmingtonCard).toHaveTextContent("High-CAPE pulse storm");
+    expect(wilmingtonCard).toHaveTextContent("Primary: Humid / rainy");
+    expect(wilmingtonCard).toHaveTextContent("48.9 % match");
+    expect(
+      screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(within(wilmingtonCard).getByRole("button", { name: /Wilmington, Ohio/ }));
+    const candidateDetails = screen.getByLabelText("Candidate details");
+    expect(candidateDetails).toHaveTextContent("High-CAPE pulse storm");
+    expect(candidateDetails).toHaveTextContent("Matched story family");
+    expect(candidateDetails).toHaveTextContent("Deep convection stories");
+    expect(candidateDetails).toHaveTextContent("Primary story");
+    expect(candidateDetails).toHaveTextContent("Humid / rainy");
+    expect(candidateDetails).toHaveTextContent("48.9 %");
   });
 
   it("keeps secondary story matches visible and sorts missing LCL last", async () => {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -104,6 +104,14 @@ const dryRunResponse = {
       validation_note: "Preset preserves the validated reference-derived spatial grid.",
     },
     expected_diagnostics: ["first_cloud_time", "cloud_water_summary"],
+    observed_sounding: null,
+    candidate_screening: null,
+    user: {
+      name: "Baseline Shallow Cumulus",
+      tags: [],
+      notes: null,
+      saved: false,
+    },
     visualization_defaults: { primary_field: "qc" },
     generated_files: {
       manifest: "/tmp/CloudChamber/runs/dry-run-001/run_manifest.json",
@@ -241,6 +249,32 @@ const observedSoundingParseResponse = {
     },
   },
 };
+
+function dryRunResponseForRequest(init?: RequestInit) {
+  const body = JSON.parse(String(init?.body ?? "{}")) as {
+    package_family?: string | null;
+    observed_sounding?: Record<string, unknown> | null;
+    candidate_screening?: Record<string, unknown> | null;
+    user_name?: string | null;
+    user_tags?: string[];
+    user_notes?: string | null;
+  };
+  return {
+    ...dryRunResponse,
+    report: {
+      ...dryRunResponse.report,
+      package_family: body.package_family ?? undefined,
+      observed_sounding: body.observed_sounding ?? null,
+      candidate_screening: body.candidate_screening ?? null,
+      user: {
+        name: body.user_name ?? "Baseline Shallow Cumulus",
+        tags: body.user_tags ?? [],
+        notes: body.user_notes ?? null,
+        saved: false,
+      },
+    },
+  };
+}
 
 const shallowCandidate = {
   candidate_id: "USM00072558-2025010200-shallow",
@@ -2432,7 +2466,9 @@ beforeEach(() => {
         );
       }
       if (url === "/api/dry-run-package") {
-        return Promise.resolve(new Response(JSON.stringify(dryRunResponse), { status: 200 }));
+        return Promise.resolve(
+          new Response(JSON.stringify(dryRunResponseForRequest(init)), { status: 200 }),
+        );
       }
       if (url === "/api/runs/launch") {
         return Promise.resolve(new Response(JSON.stringify(runningRunStatus), { status: 200 }));
@@ -2975,8 +3011,11 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Refresh IGRA catalog" }));
 
     expect(await screen.findByText("IGRA station catalog refreshed")).toBeInTheDocument();
-    expect(screen.getByText("Screenable soundings").nextElementSibling).toHaveTextContent(
-      "2 soundings",
+    expect(screen.getByText("Cached sounding inventory").nextElementSibling).toHaveTextContent(
+      "2 cached soundings",
+    );
+    expect(screen.getByText("Planned analysis slice").nextElementSibling).toHaveTextContent(
+      "Up to 2 soundings (5 per cached file)",
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Cache station files" }));
@@ -3026,6 +3065,26 @@ describe("App", () => {
     expect(savedCard).toHaveTextContent("Tags: compare, rerun");
     expect(savedCard).toHaveTextContent("Notes: Compare this against the humid case.");
 
+    fireEvent.click(within(savedCard).getByRole("button", { name: "Use to create package" }));
+
+    expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
+    expect(
+      screen.getByText("Candidate loaded into observed-sounding package review"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("create-package-btn"));
+
+    await waitFor(() => {
+      expect(dryRunBody).toContain('"user_tags":["compare","rerun"]');
+      expect(dryRunBody).toContain('"user_notes":"Compare this against the humid case."');
+      expect(dryRunBody).toContain('"saved_notes":"Compare this against the humid case."');
+    });
+    expect(screen.getByText("Package notes").nextElementSibling).toHaveTextContent(
+      "Compare this against the humid case.",
+    );
+    expect(screen.getByText("Sounding").nextElementSibling).toHaveTextContent(
+      "Valley, Nebraska (USM00072558)",
+    );
+
     fireEvent.click(within(savedCard).getByRole("button", { name: "Remove saved" }));
     expect(await screen.findByText("Saved sounding candidate removed")).toBeInTheDocument();
     expect(
@@ -3049,7 +3108,9 @@ describe("App", () => {
     const selectedValleyCard = await screen.findByLabelText(
       "Sounding candidate Valley, Nebraska (USM00072558)",
     );
-    expect(screen.getByRole("heading", { name: "Recommended cached soundings" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Recommended cached soundings" }),
+    ).toBeInTheDocument();
 
     fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Use this sounding" }));
 
@@ -4094,9 +4155,7 @@ describe("App", () => {
     fireEvent.change(within(filterBar).getByLabelText("Rain-water outcome"), {
       target: { value: "yes" },
     });
-    expect(within(resultsList).getAllByText("Rain water aloft detected").length).toBeGreaterThan(
-      0,
-    );
+    expect(within(resultsList).getAllByText("Rain water aloft detected").length).toBeGreaterThan(0);
     expect(
       within(resultsList).queryByText("Dry Failed Cumulus quick-look"),
     ).not.toBeInTheDocument();
@@ -4236,7 +4295,9 @@ describe("App", () => {
 
     expect(await screen.findByLabelText("Result detail")).toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Storage" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Runtime inventory and cleanup" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Runtime inventory and cleanup" }),
+    ).not.toBeInTheDocument();
     const resultDetail = screen.getByLabelText("Result detail");
     expect(resultDetail).toHaveTextContent("Local data");
     expect(resultDetail).toHaveTextContent("Run-directory backed");
@@ -4327,7 +4388,9 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { name: "Packages and runs needing action" }),
     ).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Runtime inventory and cleanup" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Runtime inventory and cleanup" }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Storage" })).not.toBeInTheDocument();
 
     const pipelineRuns = screen.getByLabelText("Local packages and runs");

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -2964,7 +2964,16 @@ describe("App", () => {
     expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
     expect(screen.getByLabelText("Package type")).toHaveValue("deep_convection_trial");
     expect(screen.getByText("Three-bubble trigger")).toBeInTheDocument();
-    expect(screen.getByText(/strong fit for Deep Convection Trial/)).toBeInTheDocument();
+    expect(screen.getByText(/Candidate screening is ingredient guidance/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Package type"), {
+      target: { value: "observed_sounding_quicklook" },
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Observed Sounding Quick Look does not test that hypothesis",
+    );
+    fireEvent.change(screen.getByLabelText("Package type"), {
+      target: { value: "deep_convection_trial" },
+    });
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
@@ -3009,6 +3018,9 @@ describe("App", () => {
 
     expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
     expect(screen.getByLabelText("Package type")).toHaveValue("observed_sounding_quicklook");
+    expect(
+      screen.getByText(/Predicted rain behavior needs rain-water, surface-rain, and\/or reflectivity outputs/),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
@@ -3092,7 +3104,7 @@ describe("App", () => {
       screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
     ).not.toBeInTheDocument();
     expect(screen.getByLabelText("Candidate details")).toHaveTextContent(
-      "Candidate match score is screening guidance only",
+      "Scores rank sounding ingredients only",
     );
 
     const candidateDetails = screen.getByLabelText("Candidate details");
@@ -3208,7 +3220,117 @@ describe("App", () => {
     expect(fetch).not.toHaveBeenCalledWith("/api/sounding-candidates/analyze", expect.anything());
   });
 
-  it("shows secondary family matches with the scoped story score", async () => {
+  it("updates saved candidate working sets and preserves tags through reload", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let savedStore: Array<(typeof savedCandidatesResponse.saved_candidates)[number]> = [];
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/sounding-candidates/saved" && init?.method === "POST") {
+        const body = JSON.parse(String(init.body ?? "{}")) as {
+          candidate?: typeof shallowCandidate;
+          tags?: string[];
+          notes?: string | null;
+        };
+        const candidate = body.candidate ?? shallowCandidate;
+        const saved = {
+          ...savedCandidatesResponse.saved_candidates[0],
+          saved_candidate_id: candidate.candidate_id,
+          candidate,
+          primary_story: candidate.primary_story,
+          story_scores: candidate.story_scores,
+          features: candidate.features,
+          evidence: candidate.evidence,
+          caveats: candidate.caveats,
+          tags: body.tags ?? [],
+          notes: body.notes ?? "",
+        };
+        savedStore = [saved];
+        return Promise.resolve(new Response(JSON.stringify(saved), { status: 200 }));
+      }
+      if (url.startsWith("/api/sounding-candidates/saved/") && init?.method === "PATCH") {
+        const savedCandidateId = url.split("/").at(-1);
+        const body = JSON.parse(String(init.body ?? "{}")) as {
+          tags?: string[];
+          notes?: string | null;
+        };
+        const updated = savedStore.map((saved) =>
+          saved.saved_candidate_id === savedCandidateId
+            ? {
+                ...saved,
+                tags: body.tags ?? saved.tags,
+                notes: body.notes ?? saved.notes,
+              }
+            : saved,
+        );
+        savedStore = updated;
+        return Promise.resolve(
+          new Response(JSON.stringify(savedStore[0]), { status: 200 }),
+        );
+      }
+      if (url === "/api/sounding-candidates/saved") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ saved_candidates: savedStore }), { status: 200 }),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+    fireEvent.click(screen.getByText("Advanced filters"));
+    fireEvent.change(screen.getByLabelText("Story"), {
+      target: { value: "shallow_cumulus_candidate" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+
+    const valleyCard = await screen.findByLabelText(
+      "Sounding candidate Valley, Nebraska (USM00072558)",
+    );
+    fireEvent.click(within(valleyCard).getByRole("button", { name: /Valley, Nebraska/ }));
+    const candidateDetails = screen.getByLabelText("Candidate details");
+    fireEvent.change(within(candidateDetails).getByLabelText("Tags"), {
+      target: { value: "Maybe rerun" },
+    });
+    fireEvent.change(within(candidateDetails).getByLabelText("Notes"), {
+      target: { value: "Keep this one in the candidate notebook." },
+    });
+    fireEvent.click(within(candidateDetails).getByRole("button", { name: "Save candidate" }));
+
+    const savedCard = await screen.findByLabelText(
+      "Saved sounding candidate Valley, Nebraska (USM00072558)",
+    );
+    expect(savedCard).toHaveTextContent("Tags: Maybe rerun");
+    fireEvent.change(
+      within(savedCard).getByLabelText("Working set for Valley, Nebraska (USM00072558)"),
+      { target: { value: "Deep convection candidates" } },
+    );
+    fireEvent.click(within(savedCard).getByRole("button", { name: "Update working set" }));
+
+    expect(await screen.findByText("Saved sounding candidate updated")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+
+    const reloadedSavedCard = await screen.findByLabelText(
+      "Saved sounding candidate Valley, Nebraska (USM00072558)",
+    );
+    expect(reloadedSavedCard).toHaveTextContent("Tags: Deep convection candidates");
+    expect(reloadedSavedCard).toHaveTextContent(
+      "Notes: Keep this one in the candidate notebook.",
+    );
+  });
+
+  it("shows secondary family candidates with the scoped story ingredient score", async () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
@@ -3230,7 +3352,8 @@ describe("App", () => {
     );
     expect(wilmingtonCard).toHaveTextContent("High-CAPE pulse storm");
     expect(wilmingtonCard).toHaveTextContent("Primary: Humid / rainy");
-    expect(wilmingtonCard).toHaveTextContent("48.9 % match");
+    expect(wilmingtonCard).toHaveTextContent("48.9 % ingredient score");
+    expect(wilmingtonCard).toHaveTextContent("Recipe fit: requires triggered deep-potential run");
     expect(
       screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
     ).not.toBeInTheDocument();
@@ -3238,7 +3361,7 @@ describe("App", () => {
     fireEvent.click(within(wilmingtonCard).getByRole("button", { name: /Wilmington, Ohio/ }));
     const candidateDetails = screen.getByLabelText("Candidate details");
     expect(candidateDetails).toHaveTextContent("High-CAPE pulse storm");
-    expect(candidateDetails).toHaveTextContent("Matched story family");
+    expect(candidateDetails).toHaveTextContent("Screened story family");
     expect(candidateDetails).toHaveTextContent("Deep convection stories");
     expect(candidateDetails).toHaveTextContent("Primary story");
     expect(candidateDetails).toHaveTextContent("Humid / rainy");

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -257,6 +257,7 @@ const shallowCandidate = {
   source_provider: "NOAA/NCEI IGRA",
   primary_story: "shallow_cumulus_candidate",
   primary_story_label: "Cloud-forming shallow cumulus",
+  story_family: "lower_atmosphere",
   rank_score: 82,
   confidence: "medium",
   package_ready: true,
@@ -323,6 +324,7 @@ const blockedCandidate = {
   valid_time_utc: "2025-01-01T00:00:00Z",
   primary_story: "needs_review",
   primary_story_label: "Needs review",
+  story_family: "review",
   rank_score: 40,
   confidence: "low",
   package_ready: false,
@@ -346,6 +348,7 @@ const secondaryShallowCandidate = {
   valid_time_utc: "2025-01-03T00:00:00Z",
   primary_story: "humid_rainy_candidate",
   primary_story_label: "Humid / rainy",
+  story_family: "lower_atmosphere",
   rank_score: 86,
   story_scores: [
     {
@@ -396,6 +399,7 @@ const deepConvectionCandidate = {
   valid_time_utc: "2025-05-20T00:00:00Z",
   primary_story: "supercell_environment",
   primary_story_label: "Supercell-like environment",
+  story_family: "deep_convection",
   rank_score: 93,
   confidence: "high",
   package_ready: true,
@@ -442,6 +446,7 @@ const screeningInputsResponse = {
 
 const screeningResponse = {
   story: "all",
+  screening_version: "test-screening-v1",
   generated_at: "2026-07-01T12:00:00Z",
   candidates: [
     shallowCandidate,
@@ -450,8 +455,131 @@ const screeningResponse = {
     secondaryShallowCandidate,
     missingLclCandidate,
   ],
+  total_candidate_count: 5,
+  filtered_candidate_count: 5,
+  sort_by: "best_match",
+  sort_direction: "desc",
+  filters: {
+    station_id: null,
+    story_filter: "all",
+    story_family: "all",
+    support: "all",
+    readiness: "all",
+    station_search: "",
+  },
   caveats: ["screening_guidance_only"],
 };
+
+const testDeepConvectionStoryIds = new Set([
+  "severe_thunderstorm_environment",
+  "supercell_environment",
+  "high_cape_pulse_storm",
+  "dry_microburst_inverted_v",
+  "squall_line_cold_pool_candidate",
+  "elevated_convection",
+]);
+
+function screeningResponseForRequest(init?: RequestInit) {
+  const request = JSON.parse(String(init?.body ?? "{}")) as {
+    story_filter?: string;
+    story_family?: string;
+    support?: string;
+    readiness?: string;
+    station_search?: string;
+    sort_by?: string;
+  };
+  const storyFilter = request.story_filter ?? "all";
+  const storyFamily = request.story_family ?? "all";
+  const support = request.support ?? "all";
+  const readiness = request.readiness ?? "all";
+  const stationSearch = (request.station_search ?? "").trim().toLowerCase();
+  const sortBy = request.sort_by ?? "best_match";
+  const candidates = [...screeningResponse.candidates]
+    .filter((candidate) => {
+      if (readiness === "package_ready" && !candidate.package_ready) return false;
+      if (readiness === "blocked" && candidate.package_ready) return false;
+      if (storyFamily !== "all" && candidate.story_family !== storyFamily) return false;
+      const score = storyScoreForTest(candidate, storyFilter);
+      if (storyFilter !== "all" && (!score || score.support === "unavailable")) return false;
+      if (support !== "all" && score?.support !== support) return false;
+      if (!stationSearch) return true;
+      return [candidate.station_id, candidate.station_name, candidate.primary_story_label]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(stationSearch);
+    })
+    .sort((left, right) => compareCandidateFixtures(left, right, storyFilter, sortBy));
+  return {
+    ...screeningResponse,
+    candidates,
+    total_candidate_count: screeningResponse.candidates.length,
+    filtered_candidate_count: candidates.length,
+    sort_by: sortBy,
+    filters: {
+      station_id: null,
+      story_filter: storyFilter,
+      story_family: storyFamily,
+      support,
+      readiness,
+      station_search: request.station_search ?? "",
+    },
+  };
+}
+
+function storyScoreForTest(
+  candidate: (typeof screeningResponse.candidates)[number],
+  storyFilter: string,
+) {
+  if (storyFilter === "all") {
+    return candidate.story_scores[0] ?? null;
+  }
+  if (storyFilter === "deep_convection_trial") {
+    return (
+      candidate.story_scores
+        .filter((score) => testDeepConvectionStoryIds.has(score.story))
+        .sort((left, right) => right.score_0_to_100 - left.score_0_to_100)[0] ?? null
+    );
+  }
+  return candidate.story_scores.find((score) => score.story === storyFilter) ?? null;
+}
+
+function compareCandidateFixtures(
+  left: (typeof screeningResponse.candidates)[number],
+  right: (typeof screeningResponse.candidates)[number],
+  storyFilter: string,
+  sortBy: string,
+) {
+  const leftValue = candidateSortValueForTest(left, storyFilter, sortBy);
+  const rightValue = candidateSortValueForTest(right, storyFilter, sortBy);
+  if (leftValue === null && rightValue !== null) return 1;
+  if (rightValue === null && leftValue !== null) return -1;
+  if (leftValue !== null && rightValue !== null && leftValue !== rightValue) {
+    const direction = sortBy === "estimated_lcl_height_m_agl" ? "asc" : "desc";
+    return (leftValue < rightValue ? -1 : 1) * (direction === "asc" ? 1 : -1);
+  }
+  return (
+    Number(right.package_ready) - Number(left.package_ready) ||
+    (storyScoreForTest(right, storyFilter)?.score_0_to_100 ?? right.rank_score) -
+      (storyScoreForTest(left, storyFilter)?.score_0_to_100 ?? left.rank_score) ||
+    new Date(right.valid_time_utc).getTime() - new Date(left.valid_time_utc).getTime()
+  );
+}
+
+function candidateSortValueForTest(
+  candidate: (typeof screeningResponse.candidates)[number],
+  storyFilter: string,
+  sortBy: string,
+) {
+  if (sortBy === "best_match") {
+    return storyScoreForTest(candidate, storyFilter)?.score_0_to_100 ?? candidate.rank_score;
+  }
+  if (sortBy === "valid_time") return new Date(candidate.valid_time_utc).getTime();
+  if (sortBy === "station_name") return candidate.station_name ?? candidate.station_id;
+  if (sortBy === "package_readiness") return Number(candidate.package_ready);
+  const value = (candidate.features as Record<string, unknown>)[sortBy];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
 
 const savedCandidatesResponse = {
   saved_candidates: [
@@ -2229,8 +2357,10 @@ beforeEach(() => {
           new Response(JSON.stringify(screeningInputsResponse), { status: 200 }),
         );
       }
-      if (url === "/api/sounding-candidates/screen") {
-        return Promise.resolve(new Response(JSON.stringify(screeningResponse), { status: 200 }));
+      if (url === "/api/sounding-candidates/analyze") {
+        return Promise.resolve(
+          new Response(JSON.stringify(screeningResponseForRequest(init)), { status: 200 }),
+        );
       }
       if (url === "/api/sounding-candidates/saved" && init?.method === "POST") {
         return Promise.resolve(
@@ -2661,7 +2791,7 @@ describe("App", () => {
     let screenBody = "";
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/api/sounding-candidates/screen") {
+      if (url === "/api/sounding-candidates/analyze") {
         screenBody = String(init?.body ?? "");
       }
       if (url === "/api/dry-run-package") {
@@ -2683,10 +2813,10 @@ describe("App", () => {
     fireEvent.change(storyFilter, {
       target: { value: "deep_convection_trial" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Screen cached soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
 
-    expect(await screen.findByText("Screening guidance loaded")).toBeInTheDocument();
-    expect(screenBody).toContain('"target_story":"deep_convection_trial"');
+    expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
+    expect(screenBody).toContain('"story_filter":"deep_convection_trial"');
     const deepCard = screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)");
     expect(deepCard).toHaveTextContent("Supercell-like environment");
 
@@ -2729,9 +2859,9 @@ describe("App", () => {
     fireEvent.change(await screen.findByLabelText("Story filter"), {
       target: { value: "humid_rainy_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Screen cached soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
 
-    expect(await screen.findByText("Screening guidance loaded")).toBeInTheDocument();
+    expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
     const humidCard = screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)");
     expect(humidCard).toHaveTextContent("Humid / rainy");
 
@@ -2757,7 +2887,7 @@ describe("App", () => {
     let screenBody = "";
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/api/sounding-candidates/screen") {
+      if (url === "/api/sounding-candidates/analyze") {
         screenBody = String(init?.body ?? "");
       }
       if (url === "/api/dry-run-package") {
@@ -2794,10 +2924,10 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Story filter"), {
       target: { value: "shallow_cumulus_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Screen cached soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
 
-    expect(await screen.findByText("Screening guidance loaded")).toBeInTheDocument();
-    expect(screenBody).toContain('"target_story":"shallow_cumulus_candidate"');
+    expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
+    expect(screenBody).toContain('"story_filter":"shallow_cumulus_candidate"');
     const valleyCard = screen.getByLabelText("Sounding candidate Valley, Nebraska (USM00072558)");
     expect(valleyCard).toHaveTextContent("Cloud-forming shallow cumulus");
     expect(valleyCard).toHaveTextContent("Package-ready");
@@ -2815,6 +2945,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Story filter"), {
       target: { value: "needs_review" },
     });
+    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
     const normanCard = await screen.findByLabelText(
       "Sounding candidate Norman, Oklahoma (USM00072357)",
     );
@@ -2824,6 +2955,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Story filter"), {
       target: { value: "all" },
     });
+    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
     const selectedValleyCard = await screen.findByLabelText(
       "Sounding candidate Valley, Nebraska (USM00072558)",
     );
@@ -2886,7 +3018,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("No saved candidates yet.")).not.toBeInTheDocument();
     expect(fetch).not.toHaveBeenCalledWith("/api/igra/recent/refresh-catalog", expect.anything());
-    expect(fetch).not.toHaveBeenCalledWith("/api/sounding-candidates/screen", expect.anything());
+    expect(fetch).not.toHaveBeenCalledWith("/api/sounding-candidates/analyze", expect.anything());
   });
 
   it("keeps secondary story matches visible and sorts missing LCL last", async () => {
@@ -2897,27 +3029,31 @@ describe("App", () => {
       target: { value: "__observed_sounding_upload__" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Screen cached soundings" }));
-    expect(await screen.findByText("Screening guidance loaded")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+    expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Story filter"), {
       target: { value: "shallow_cumulus_candidate" },
     });
+    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
     expect(
       screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
     ).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Sort"), {
-      target: { value: "lowest_lcl" },
+      target: { value: "estimated_lcl_height_m_agl" },
     });
-    const candidateCards = screen.getAllByLabelText(/^Sounding candidate /);
-    const visibleOrder = candidateCards.map((card) => card.textContent ?? "");
-    const validLclIndex = visibleOrder.findIndex((text) => text.includes("Wilmington, Ohio"));
-    const missingLclIndex = visibleOrder.findIndex((text) =>
-      text.includes("Springfield, Missouri"),
-    );
-    expect(validLclIndex).toBeGreaterThanOrEqual(0);
-    expect(missingLclIndex).toBeGreaterThan(validLclIndex);
+    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+    await waitFor(() => {
+      const candidateCards = screen.getAllByLabelText(/^Sounding candidate /);
+      const visibleOrder = candidateCards.map((card) => card.textContent ?? "");
+      const validLclIndex = visibleOrder.findIndex((text) => text.includes("Wilmington, Ohio"));
+      const missingLclIndex = visibleOrder.findIndex((text) =>
+        text.includes("Springfield, Missouri"),
+      );
+      expect(validLclIndex).toBeGreaterThanOrEqual(0);
+      expect(missingLclIndex).toBeGreaterThan(validLclIndex);
+    });
   });
 
   it("shows Deep Overnight as an expensive distinct generated package", async () => {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -311,6 +311,12 @@ const shallowCandidate = {
     profile_top_m_agl: 18816.5,
     data_completeness_score: 94,
   },
+  interest_summary: "Low estimated LCL makes cloud formation easier to test.",
+  interest_reasons: [
+    "Low estimated LCL makes cloud formation easier to test.",
+    "Profile coverage is strong enough for package review.",
+  ],
+  discovery_bucket: "Cloud-forming",
   caveats: ["screening_is_not_cm1_outcome_prediction"],
   screening_version: "test-screening-v1",
   created_at: "2026-07-01T12:00:00Z",
@@ -337,6 +343,12 @@ const blockedCandidate = {
       support: "weak",
     },
   ],
+  interest_summary: "Worth reviewing because package generation is blocked or caveated.",
+  interest_reasons: [
+    "Worth reviewing because package generation is blocked or caveated.",
+    "Use the caveats to decide whether this cached sounding needs parser or metadata work.",
+  ],
+  discovery_bucket: "Needs review",
   caveats: ["missing_surface_level"],
 };
 
@@ -375,6 +387,12 @@ const secondaryShallowCandidate = {
     mean_qv_0_1000m_g_kg: 13.6,
     estimated_lcl_height_m_agl: 640,
   },
+  interest_summary: "Very moist lower atmosphere.",
+  interest_reasons: [
+    "Very moist lower atmosphere.",
+    "Low estimated LCL makes cloud formation easier to test.",
+  ],
+  discovery_bucket: "Humid / rainy",
 };
 
 const missingLclCandidate = {
@@ -428,6 +446,12 @@ const deepConvectionCandidate = {
     },
     ...shallowCandidate.evidence.slice(0, 2),
   ],
+  interest_summary: "Strong deep-convection ingredients with observed wind support.",
+  interest_reasons: [
+    "Strong deep-convection ingredients with observed wind support.",
+    "Observed 0-6 km shear gives storm-organization context.",
+  ],
+  discovery_bucket: "Deep convection",
 };
 
 const screeningInputsResponse = {
@@ -2363,10 +2387,24 @@ beforeEach(() => {
         );
       }
       if (url === "/api/sounding-candidates/saved" && init?.method === "POST") {
+        const body = JSON.parse(String(init.body ?? "{}")) as {
+          candidate?: typeof shallowCandidate;
+          tags?: string[];
+          notes?: string | null;
+        };
+        const candidate = body.candidate ?? shallowCandidate;
         return Promise.resolve(
-          new Response(JSON.stringify(savedCandidatesResponse.saved_candidates[0]), {
-            status: 200,
-          }),
+          new Response(
+            JSON.stringify({
+              ...savedCandidatesResponse.saved_candidates[0],
+              saved_candidate_id: candidate.candidate_id,
+              candidate,
+              primary_story: candidate.primary_story,
+              tags: body.tags ?? [],
+              notes: body.notes ?? null,
+            }),
+            { status: 200 },
+          ),
         );
       }
       if (url === "/api/sounding-candidates/saved") {
@@ -2376,6 +2414,22 @@ beforeEach(() => {
       }
       if (url.startsWith("/api/sounding-candidates/saved/") && init?.method === "DELETE") {
         return Promise.resolve(new Response(JSON.stringify({ removed: true }), { status: 200 }));
+      }
+      if (url.startsWith("/api/sounding-candidates/saved/") && init?.method === "PATCH") {
+        const body = JSON.parse(String(init.body ?? "{}")) as {
+          tags?: string[];
+          notes?: string | null;
+        };
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ...savedCandidatesResponse.saved_candidates[0],
+              tags: body.tags ?? [],
+              notes: body.notes ?? null,
+            }),
+            { status: 200 },
+          ),
+        );
       }
       if (url === "/api/dry-run-package") {
         return Promise.resolve(new Response(JSON.stringify(dryRunResponse), { status: 200 }));
@@ -2808,12 +2862,13 @@ describe("App", () => {
     fireEvent.change(await screen.findByLabelText("Experiment"), {
       target: { value: "__observed_sounding_upload__" },
     });
-    const storyFilter = await screen.findByLabelText("Story filter");
+    fireEvent.click(await screen.findByText("Advanced filters"));
+    const storyFilter = await screen.findByLabelText("Story");
     expect(storyFilter).toHaveTextContent("Deep Convection Trial stories");
     fireEvent.change(storyFilter, {
       target: { value: "deep_convection_trial" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
 
     expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
     expect(screenBody).toContain('"story_filter":"deep_convection_trial"');
@@ -2856,10 +2911,11 @@ describe("App", () => {
     fireEvent.change(await screen.findByLabelText("Experiment"), {
       target: { value: "__observed_sounding_upload__" },
     });
-    fireEvent.change(await screen.findByLabelText("Story filter"), {
+    fireEvent.click(await screen.findByText("Advanced filters"));
+    fireEvent.change(await screen.findByLabelText("Story"), {
       target: { value: "humid_rainy_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
 
     expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
     const humidCard = screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)");
@@ -2885,10 +2941,14 @@ describe("App", () => {
     const defaultFetch = vi.mocked(fetch).getMockImplementation();
     let dryRunBody = "";
     let screenBody = "";
+    let saveBody = "";
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url === "/api/sounding-candidates/analyze") {
         screenBody = String(init?.body ?? "");
+      }
+      if (url === "/api/sounding-candidates/saved" && init?.method === "POST") {
+        saveBody = String(init.body ?? "");
       }
       if (url === "/api/dry-run-package") {
         dryRunBody = String(init?.body ?? "");
@@ -2910,6 +2970,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/Screening guidance only/)).toBeInTheDocument();
     expect(screen.getByText("IGRA cache not checked yet")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Save into")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh IGRA catalog" }));
 
@@ -2921,17 +2982,22 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Cache station files" }));
     expect(await screen.findByText("Cached 1 station file")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("Story filter"), {
+    fireEvent.click(screen.getByText("Advanced filters"));
+    fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "shallow_cumulus_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
 
     expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
     expect(screenBody).toContain('"story_filter":"shallow_cumulus_candidate"');
+    expect(screen.getByRole("heading", { name: "Refined candidates" })).toBeInTheDocument();
+    expect(screen.getByText(/Refined view/)).toBeInTheDocument();
     const valleyCard = screen.getByLabelText("Sounding candidate Valley, Nebraska (USM00072558)");
     expect(valleyCard).toHaveTextContent("Cloud-forming shallow cumulus");
     expect(valleyCard).toHaveTextContent("Package-ready");
+    expect(valleyCard).toHaveTextContent("Low estimated LCL makes cloud formation easier to test.");
     expect(valleyCard).toHaveTextContent("Low-level moisture: 10.2 g/kg");
+    fireEvent.click(within(valleyCard).getByRole("button", { name: /Valley, Nebraska/ }));
     expect(
       screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
     ).toHaveTextContent("Cloud-forming shallow cumulus");
@@ -2942,36 +3008,48 @@ describe("App", () => {
       "Candidate match score is screening guidance only",
     );
 
-    fireEvent.change(screen.getByLabelText("Story filter"), {
-      target: { value: "needs_review" },
+    const candidateDetails = screen.getByLabelText("Candidate details");
+    fireEvent.change(within(candidateDetails).getByLabelText("Tags"), {
+      target: { value: "compare, rerun" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
-    const normanCard = await screen.findByLabelText(
-      "Sounding candidate Norman, Oklahoma (USM00072357)",
-    );
-    expect(normanCard).toHaveTextContent("Blocked");
-    expect(within(normanCard).getByRole("button", { name: "Use this sounding" })).toBeDisabled();
-
-    fireEvent.change(screen.getByLabelText("Story filter"), {
-      target: { value: "all" },
+    fireEvent.change(within(candidateDetails).getByLabelText("Notes"), {
+      target: { value: "Compare this against the humid case." },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
-    const selectedValleyCard = await screen.findByLabelText(
-      "Sounding candidate Valley, Nebraska (USM00072558)",
-    );
-    fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Save candidate" }));
+    fireEvent.click(within(candidateDetails).getByRole("button", { name: "Save candidate" }));
 
     expect(await screen.findByText("Sounding candidate saved")).toBeInTheDocument();
-    const savedCard = screen.getByLabelText(
+    expect(saveBody).toContain('"tags":["compare","rerun"]');
+    expect(saveBody).toContain('"notes":"Compare this against the humid case."');
+    const savedCard = await screen.findByLabelText(
       "Saved sounding candidate Valley, Nebraska (USM00072558)",
     );
-    expect(savedCard).toHaveTextContent("Cloud-forming shallow cumulus");
+    expect(savedCard).toHaveTextContent("Tags: compare, rerun");
+    expect(savedCard).toHaveTextContent("Notes: Compare this against the humid case.");
 
     fireEvent.click(within(savedCard).getByRole("button", { name: "Remove saved" }));
     expect(await screen.findByText("Saved sounding candidate removed")).toBeInTheDocument();
     expect(
       screen.queryByLabelText("Saved sounding candidate Valley, Nebraska (USM00072558)"),
     ).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Story"), {
+      target: { value: "needs_review" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    const normanCard = await screen.findByLabelText(
+      "Sounding candidate Norman, Oklahoma (USM00072357)",
+    );
+    expect(normanCard).toHaveTextContent("Blocked");
+    expect(within(normanCard).getByRole("button", { name: "Use this sounding" })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Story"), {
+      target: { value: "all" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    const selectedValleyCard = await screen.findByLabelText(
+      "Sounding candidate Valley, Nebraska (USM00072558)",
+    );
+    expect(screen.getByRole("heading", { name: "Recommended cached soundings" })).toBeInTheDocument();
 
     fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Use this sounding" }));
 
@@ -3029,13 +3107,14 @@ describe("App", () => {
       target: { value: "__observed_sounding_upload__" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
     expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("Story filter"), {
+    fireEvent.click(screen.getByText("Advanced filters"));
+    fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "shallow_cumulus_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
     expect(
       screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
     ).toBeInTheDocument();
@@ -3043,7 +3122,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Sort"), {
       target: { value: "estimated_lcl_height_m_agl" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
     await waitFor(() => {
       const candidateCards = screen.getAllByLabelText(/^Sounding candidate /);
       const visibleOrder = candidateCards.map((card) => card.textContent ?? "");

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -3707,6 +3707,7 @@ function ObservedAtmosphereCandidatesPanel({
                   key={candidate.candidate_id}
                   candidate={candidate}
                   storyFilter={storyFilter}
+                  storyFamilyFilter={storyFamilyFilter}
                   selected={selectedCandidate?.candidate_id === candidate.candidate_id}
                   saved={savedCandidateIds.has(candidate.candidate_id)}
                   onSelect={() => onCandidateDetailChange(candidate.candidate_id)}
@@ -3728,6 +3729,7 @@ function ObservedAtmosphereCandidatesPanel({
         <SoundingCandidateDetail
           candidate={selectedCandidate}
           storyFilter={storyFilter}
+          storyFamilyFilter={storyFamilyFilter}
           savedCandidate={selectedSavedCandidate}
           onSave={onSave}
         />
@@ -3789,6 +3791,7 @@ function ObservedAtmosphereCandidatesPanel({
 function SoundingCandidateCard({
   candidate,
   storyFilter,
+  storyFamilyFilter,
   selected,
   saved,
   onSelect,
@@ -3797,14 +3800,18 @@ function SoundingCandidateCard({
 }: {
   candidate: SoundingCandidate;
   storyFilter: CandidateStoryFilter;
+  storyFamilyFilter: CandidateStoryFamilyFilter;
   selected: boolean;
   saved: boolean;
   onSelect: () => void;
   onSave: () => void;
   onUse: () => void;
 }) {
-  const story = storyFilter === "all" ? candidate.primary_story : storyFilter;
-  const matchScore = candidateMatchScore(candidate, story);
+  const activeScore = candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter);
+  const story = activeScore?.story ?? (storyFilter === "all" ? candidate.primary_story : storyFilter);
+  const activeFamily = activeScore ? candidateStoryFamilyForStory(activeScore.story) : candidate.story_family;
+  const matchScore =
+    activeScore?.score_0_to_100 ?? candidateMatchScore(candidate, storyFilter, storyFamilyFilter);
   const reasons = candidateInterestReasons(candidate);
   return (
     <article
@@ -3825,10 +3832,10 @@ function SoundingCandidateCard({
             <StatusBadge label={candidate.discovery_bucket} tone="neutral" />
           )}
           <StatusBadge label={candidateStoryLabel(story)} tone="neutral" />
-          {storyFilter === "deep_convection_trial" && (
-            <StatusBadge label={candidate.primary_story_label} tone="neutral" />
+          {activeScore && activeScore.story !== candidate.primary_story && (
+            <StatusBadge label={`Primary: ${candidate.primary_story_label}`} tone="neutral" />
           )}
-          <StatusBadge label={candidateStoryFamilyLabel(candidate.story_family)} tone="neutral" />
+          <StatusBadge label={candidateStoryFamilyLabel(activeFamily)} tone="neutral" />
           <StatusBadge label={`${formatNumber(matchScore, "%")} match`} tone="neutral" />
           <StatusBadge
             label={candidate.package_ready ? "Package-ready" : "Blocked"}
@@ -3871,11 +3878,13 @@ function SoundingCandidateCard({
 function SoundingCandidateDetail({
   candidate,
   storyFilter,
+  storyFamilyFilter,
   savedCandidate,
   onSave,
 }: {
   candidate: SoundingCandidate | null;
   storyFilter: CandidateStoryFilter;
+  storyFamilyFilter: CandidateStoryFamilyFilter;
   savedCandidate: SavedSoundingCandidate | null;
   onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
 }) {
@@ -3898,7 +3907,14 @@ function SoundingCandidateDetail({
     );
   }
   const activeCandidate = candidate;
-  const story = storyFilter === "all" ? activeCandidate.primary_story : storyFilter;
+  const activeScore = candidateActiveStoryScore(activeCandidate, storyFilter, storyFamilyFilter);
+  const story = activeScore?.story ?? (storyFilter === "all" ? activeCandidate.primary_story : storyFilter);
+  const activeFamily = activeScore
+    ? candidateStoryFamilyForStory(activeScore.story)
+    : activeCandidate.story_family;
+  const matchScore =
+    activeScore?.score_0_to_100 ??
+    candidateMatchScore(activeCandidate, storyFilter, storyFamilyFilter);
   const reasons = candidateInterestReasons(activeCandidate);
   const savedTagValues = parseTags(tagDraft);
   function handleTagSuggestion(tag: string) {
@@ -3956,12 +3972,12 @@ function SoundingCandidateDetail({
         </ul>
       </section>
       <dl className="compact-metrics">
-        <Metric
-          label="Match score"
-          value={formatNumber(candidateMatchScore(candidate, story), "%")}
-        />
+        <Metric label="Match score" value={formatNumber(matchScore, "%")} />
         <Metric label="Evidence level" value={humanize(candidate.confidence)} />
-        <Metric label="Story family" value={candidateStoryFamilyLabel(candidate.story_family)} />
+        <Metric label="Matched story family" value={candidateStoryFamilyLabel(activeFamily)} />
+        {activeScore && activeScore.story !== candidate.primary_story && (
+          <Metric label="Primary story" value={candidate.primary_story_label} />
+        )}
         <Metric label="Station ID" value={candidate.station_id} />
         <Metric
           label="Location"
@@ -8403,6 +8419,12 @@ function candidateStoryFamilyLabel(family: CandidateStoryFamilyFilter | undefine
   }
 }
 
+function candidateStoryFamilyForStory(story: CandidateStoryId): CandidateStoryFamilyFilter {
+  if (deepConvectionStoryIds.has(story)) return "deep_convection";
+  if (story === "needs_review" || story === "poor_or_incomplete_candidate") return "review";
+  return "lower_atmosphere";
+}
+
 function candidateSortLabel(sort: CandidateSort): string {
   const labels: Record<CandidateSort, string> = {
     best_match: "Recommended",
@@ -8478,21 +8500,48 @@ function observedSoundingLocationLabel(observed: ObservedSoundingSummary): strin
 
 function candidateMatchScore(
   candidate: SoundingCandidate,
-  story: CandidateStoryId | CandidateStoryFilter,
+  storyFilter: CandidateStoryFilter,
+  storyFamilyFilter: CandidateStoryFamilyFilter = "all",
 ): number {
-  if (story === "all") return candidate.rank_score;
-  if (story === "deep_convection_trial") {
-    return Math.max(
-      0,
-      ...candidate.story_scores
-        .filter((score) => deepConvectionStoryIds.has(score.story))
-        .map((score) => score.score_0_to_100),
-    );
-  }
   return (
-    candidate.story_scores.find((score) => score.story === story)?.score_0_to_100 ??
+    candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter)?.score_0_to_100 ??
     candidate.rank_score
   );
+}
+
+function candidateActiveStoryScore(
+  candidate: SoundingCandidate,
+  storyFilter: CandidateStoryFilter,
+  storyFamilyFilter: CandidateStoryFamilyFilter,
+): StoryScore | null {
+  return (
+    [...candidateStoryScoresForScope(candidate, storyFilter, storyFamilyFilter)].sort(
+      (left, right) => right.score_0_to_100 - left.score_0_to_100,
+    )[0] ?? null
+  );
+}
+
+function candidateStoryScoresForScope(
+  candidate: SoundingCandidate,
+  storyFilter: CandidateStoryFilter,
+  storyFamilyFilter: CandidateStoryFamilyFilter,
+): StoryScore[] {
+  let scores = candidate.story_scores;
+  if (storyFilter === "deep_convection_trial") {
+    scores = scores.filter((score) => deepConvectionStoryIds.has(score.story));
+  } else if (storyFilter !== "all") {
+    scores = scores.filter((score) => score.story === storyFilter);
+  }
+  if (storyFamilyFilter !== "all") {
+    scores = scores.filter(
+      (score) => candidateStoryFamilyForStory(score.story) === storyFamilyFilter,
+    );
+  }
+  if (storyFilter === "all" && storyFamilyFilter === "all") {
+    const readyScores = scores.filter((score) => score.story !== "poor_or_incomplete_candidate");
+    return readyScores.length > 0 ? readyScores : scores;
+  }
+  return scores;
 }
 
 function candidateInterestReasons(candidate: SoundingCandidate): string[] {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -193,15 +193,43 @@ type CandidateStoryFilter =
   | "dry_microburst_inverted_v"
   | "squall_line_cold_pool_candidate"
   | "elevated_convection"
-  | "needs_review";
+  | "needs_review"
+  | "poor_or_incomplete_candidate";
 
 type CandidateSort =
-  | "best"
-  | "latest"
-  | "data_quality"
-  | "lowest_lcl"
-  | "highest_moisture"
-  | "strongest_cap";
+  | "best_match"
+  | "valid_time"
+  | "station_id"
+  | "station_name"
+  | "primary_story"
+  | "story_family"
+  | "rank_score"
+  | "confidence"
+  | "support"
+  | "package_readiness"
+  | "observed_wind_available"
+  | "profile_top_m_agl"
+  | "lowest_level_m_agl"
+  | "data_completeness_score"
+  | "low_level_qv_g_kg"
+  | "mean_qv_0_500m_g_kg"
+  | "mean_qv_0_1000m_g_kg"
+  | "surface_t_td_spread_c"
+  | "estimated_lcl_height_m_agl"
+  | "lapse_rate_0_1000m_c_per_km"
+  | "midlevel_lapse_rate_700_500_hpa_c_per_km"
+  | "cap_strength_proxy"
+  | "cap_height_m_agl"
+  | "bulk_shear_0_1km_m_s"
+  | "bulk_shear_0_3km_m_s"
+  | "bulk_shear_0_6km_m_s"
+  | "midlevel_dry_layer_proxy"
+  | "dry_microburst_inverted_v_proxy"
+  | "freezing_level_m_agl";
+
+type CandidateStoryFamilyFilter = "all" | "lower_atmosphere" | "deep_convection" | "review";
+type CandidateSupportFilter = "all" | "supported" | "weak" | "unavailable";
+type CandidateReadinessFilter = "all" | "package_ready" | "blocked";
 
 type PackageFamily = "shallow_cumulus" | "observed_sounding_quicklook" | "deep_convection_trial";
 
@@ -240,6 +268,7 @@ type SoundingCandidate = {
   source_provider: string;
   primary_story: CandidateStoryId;
   primary_story_label: string;
+  story_family?: CandidateStoryFamilyFilter;
   story_scores: StoryScore[];
   rank_score: number;
   confidence: "low" | "medium" | "high";
@@ -272,6 +301,18 @@ type ScreeningResult = {
   generated_at: string;
   candidates: SoundingCandidate[];
   caveats: string[];
+  total_candidate_count?: number;
+  filtered_candidate_count?: number;
+  sort_by?: CandidateSort;
+  sort_direction?: "asc" | "desc";
+  filters?: {
+    station_id?: string | null;
+    story_filter: CandidateStoryFilter;
+    story_family: CandidateStoryFamilyFilter;
+    support: CandidateSupportFilter;
+    readiness: CandidateReadinessFilter;
+    station_search: string;
+  };
 };
 
 type SavedSoundingCandidate = {
@@ -961,6 +1002,14 @@ const deepConvectionStoryIds = new Set<string>([
   "squall_line_cold_pool_candidate",
   "elevated_convection",
 ]);
+const candidateWorkingSetTags = [
+  "Deep convection candidates",
+  "Surface-forced candidates",
+  "Needs longer run",
+  "Needs finer output cadence",
+  "Maybe rerun",
+  "Needs review",
+] as const;
 
 async function fetchScenarioCatalog(): Promise<ScenarioResponse> {
   const response = await fetch("/api/scenarios");
@@ -1061,20 +1110,33 @@ async function fetchScreeningInputs(): Promise<ScreeningInputsResponse> {
 }
 
 async function screenSoundingCandidates(
-  story: CandidateStoryFilter,
-  options: { latestPerStation: number; limit: number },
+  options: {
+    story: CandidateStoryFilter;
+    storyFamily: CandidateStoryFamilyFilter;
+    support: CandidateSupportFilter;
+    readiness: CandidateReadinessFilter;
+    stationSearch: string;
+    sort: CandidateSort;
+    latestPerStation: number;
+    limit: number;
+  },
 ): Promise<ScreeningResult> {
-  const response = await fetch("/api/sounding-candidates/screen", {
+  const response = await fetch("/api/sounding-candidates/analyze", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       latest_per_station: options.latestPerStation,
       limit: options.limit,
-      target_story: story === "all" ? null : story,
+      story_filter: options.story,
+      story_family: options.storyFamily,
+      support: options.support,
+      readiness: options.readiness,
+      station_search: options.stationSearch,
+      sort_by: options.sort,
     }),
   });
   if (!response.ok) {
-    throw new Error(await responseError(response, "Unable to screen cached soundings."));
+    throw new Error(await responseError(response, "Unable to analyze cached soundings."));
   }
   return response.json() as Promise<ScreeningResult>;
 }
@@ -1089,11 +1151,12 @@ async function fetchSavedSoundingCandidates(): Promise<SavedCandidatesResponse> 
 
 async function saveSoundingCandidate(
   candidate: SoundingCandidate,
+  workingSetTag: string,
 ): Promise<SavedSoundingCandidate> {
   const response = await fetch("/api/sounding-candidates/saved", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ candidate, tags: ["build-candidate"] }),
+    body: JSON.stringify({ candidate, tags: [workingSetTag] }),
   });
   if (!response.ok) {
     throw new Error(await responseError(response, "Unable to save sounding candidate."));
@@ -1460,11 +1523,16 @@ export function App() {
   const [igraCache, setIgraCache] = useState<IGRACacheResponse | null>(null);
   const [screeningInputs, setScreeningInputs] = useState<ScreeningInput[]>([]);
   const [candidateStoryFilter, setCandidateStoryFilter] = useState<CandidateStoryFilter>("all");
-  const [candidateSort, setCandidateSort] = useState<CandidateSort>("best");
+  const [candidateStoryFamilyFilter, setCandidateStoryFamilyFilter] =
+    useState<CandidateStoryFamilyFilter>("all");
+  const [candidateSupportFilter, setCandidateSupportFilter] =
+    useState<CandidateSupportFilter>("all");
+  const [candidateSort, setCandidateSort] = useState<CandidateSort>("best_match");
   const [candidateStationSearch, setCandidateStationSearch] = useState("");
-  const [candidateReadinessFilter, setCandidateReadinessFilter] = useState<
-    "all" | "package_ready" | "blocked"
-  >("all");
+  const [candidateReadinessFilter, setCandidateReadinessFilter] =
+    useState<CandidateReadinessFilter>("all");
+  const [candidateWorkingSetTag, setCandidateWorkingSetTag] =
+    useState<(typeof candidateWorkingSetTags)[number]>("Maybe rerun");
   const [candidateCacheLimit, setCandidateCacheLimit] = useState("10");
   const [candidateLatestPerStation, setCandidateLatestPerStation] = useState("5");
   const [candidateResultLimit, setCandidateResultLimit] = useState("50");
@@ -1891,9 +1959,15 @@ export function App() {
 
   async function handleScreenSoundingCandidates() {
     setCandidateError(null);
-    setCandidateStatus("Screening cached soundings");
+    setCandidateStatus("Analyzing cached soundings");
     try {
-      const result = await screenSoundingCandidates(candidateStoryFilter, {
+      const result = await screenSoundingCandidates({
+        story: candidateStoryFilter,
+        storyFamily: candidateStoryFamilyFilter,
+        support: candidateSupportFilter,
+        readiness: candidateReadinessFilter,
+        stationSearch: candidateStationSearch,
+        sort: candidateSort,
         latestPerStation: boundedInteger(candidateLatestPerStation, 1, 50, 5),
         limit: boundedInteger(candidateResultLimit, 1, 200, 50),
       });
@@ -1901,16 +1975,16 @@ export function App() {
       setCandidateDetailId(result.candidates[0]?.candidate_id ?? null);
       setCandidateStatus(
         result.candidates.length > 0
-          ? "Screening guidance loaded"
+          ? "Cached sounding analysis loaded"
           : "No candidate matches found in cached soundings",
       );
       const savedPayload = await fetchSavedSoundingCandidates();
       setSavedCandidates(savedPayload.saved_candidates);
     } catch (caught) {
       setCandidateError(
-        caught instanceof Error ? caught.message : "Unable to screen cached soundings.",
+        caught instanceof Error ? caught.message : "Unable to analyze cached soundings.",
       );
-      setCandidateStatus("Candidate screening failed");
+      setCandidateStatus("Candidate analysis failed");
     }
   }
 
@@ -1918,7 +1992,7 @@ export function App() {
     setCandidateError(null);
     setCandidateStatus("Saving sounding candidate");
     try {
-      const saved = await saveSoundingCandidate(candidate);
+      const saved = await saveSoundingCandidate(candidate, candidateWorkingSetTag);
       setSavedCandidates((current) => [
         saved,
         ...current.filter((item) => item.saved_candidate_id !== saved.saved_candidate_id),
@@ -2517,9 +2591,12 @@ export function App() {
           igraCache={igraCache}
           screeningInputs={screeningInputs}
           candidateStoryFilter={candidateStoryFilter}
+          candidateStoryFamilyFilter={candidateStoryFamilyFilter}
+          candidateSupportFilter={candidateSupportFilter}
           candidateSort={candidateSort}
           candidateStationSearch={candidateStationSearch}
           candidateReadinessFilter={candidateReadinessFilter}
+          candidateWorkingSetTag={candidateWorkingSetTag}
           candidateCacheLimit={candidateCacheLimit}
           candidateLatestPerStation={candidateLatestPerStation}
           candidateResultLimit={candidateResultLimit}
@@ -2559,9 +2636,12 @@ export function App() {
           onObservedSoundingFile={handleObservedSoundingFile}
           onObservedSoundingTimeChange={handleObservedSoundingTimeChange}
           onCandidateStoryFilterChange={setCandidateStoryFilter}
+          onCandidateStoryFamilyFilterChange={setCandidateStoryFamilyFilter}
+          onCandidateSupportFilterChange={setCandidateSupportFilter}
           onCandidateSortChange={setCandidateSort}
           onCandidateStationSearchChange={setCandidateStationSearch}
           onCandidateReadinessFilterChange={setCandidateReadinessFilter}
+          onCandidateWorkingSetTagChange={setCandidateWorkingSetTag}
           onCandidateCacheLimitChange={setCandidateCacheLimit}
           onCandidateLatestPerStationChange={setCandidateLatestPerStation}
           onCandidateResultLimitChange={setCandidateResultLimit}
@@ -2661,9 +2741,12 @@ function BuildWorkspace({
   igraCache,
   screeningInputs,
   candidateStoryFilter,
+  candidateStoryFamilyFilter,
+  candidateSupportFilter,
   candidateSort,
   candidateStationSearch,
   candidateReadinessFilter,
+  candidateWorkingSetTag,
   candidateCacheLimit,
   candidateLatestPerStation,
   candidateResultLimit,
@@ -2698,9 +2781,12 @@ function BuildWorkspace({
   onObservedSoundingFile,
   onObservedSoundingTimeChange,
   onCandidateStoryFilterChange,
+  onCandidateStoryFamilyFilterChange,
+  onCandidateSupportFilterChange,
   onCandidateSortChange,
   onCandidateStationSearchChange,
   onCandidateReadinessFilterChange,
+  onCandidateWorkingSetTagChange,
   onCandidateCacheLimitChange,
   onCandidateLatestPerStationChange,
   onCandidateResultLimitChange,
@@ -2751,9 +2837,12 @@ function BuildWorkspace({
   igraCache: IGRACacheResponse | null;
   screeningInputs: ScreeningInput[];
   candidateStoryFilter: CandidateStoryFilter;
+  candidateStoryFamilyFilter: CandidateStoryFamilyFilter;
+  candidateSupportFilter: CandidateSupportFilter;
   candidateSort: CandidateSort;
   candidateStationSearch: string;
-  candidateReadinessFilter: "all" | "package_ready" | "blocked";
+  candidateReadinessFilter: CandidateReadinessFilter;
+  candidateWorkingSetTag: (typeof candidateWorkingSetTags)[number];
   candidateCacheLimit: string;
   candidateLatestPerStation: string;
   candidateResultLimit: string;
@@ -2788,9 +2877,12 @@ function BuildWorkspace({
   onObservedSoundingFile: (file: File) => void;
   onObservedSoundingTimeChange: (validTimeUtc: string) => void;
   onCandidateStoryFilterChange: (filter: CandidateStoryFilter) => void;
+  onCandidateStoryFamilyFilterChange: (filter: CandidateStoryFamilyFilter) => void;
+  onCandidateSupportFilterChange: (filter: CandidateSupportFilter) => void;
   onCandidateSortChange: (sort: CandidateSort) => void;
   onCandidateStationSearchChange: (value: string) => void;
-  onCandidateReadinessFilterChange: (filter: "all" | "package_ready" | "blocked") => void;
+  onCandidateReadinessFilterChange: (filter: CandidateReadinessFilter) => void;
+  onCandidateWorkingSetTagChange: (tag: (typeof candidateWorkingSetTags)[number]) => void;
   onCandidateCacheLimitChange: (value: string) => void;
   onCandidateLatestPerStationChange: (value: string) => void;
   onCandidateResultLimitChange: (value: string) => void;
@@ -2975,9 +3067,12 @@ function BuildWorkspace({
                     cache={igraCache}
                     screeningInputs={screeningInputs}
                     storyFilter={candidateStoryFilter}
+                    storyFamilyFilter={candidateStoryFamilyFilter}
+                    supportFilter={candidateSupportFilter}
                     sort={candidateSort}
                     stationSearch={candidateStationSearch}
                     readinessFilter={candidateReadinessFilter}
+                    workingSetTag={candidateWorkingSetTag}
                     cacheLimit={candidateCacheLimit}
                     latestPerStation={candidateLatestPerStation}
                     resultLimit={candidateResultLimit}
@@ -2987,9 +3082,12 @@ function BuildWorkspace({
                     savedCandidates={savedCandidates}
                     selectedCandidateId={candidateDetailId}
                     onStoryFilterChange={onCandidateStoryFilterChange}
+                    onStoryFamilyFilterChange={onCandidateStoryFamilyFilterChange}
+                    onSupportFilterChange={onCandidateSupportFilterChange}
                     onSortChange={onCandidateSortChange}
                     onStationSearchChange={onCandidateStationSearchChange}
                     onReadinessFilterChange={onCandidateReadinessFilterChange}
+                    onWorkingSetTagChange={onCandidateWorkingSetTagChange}
                     onCacheLimitChange={onCandidateCacheLimitChange}
                     onLatestPerStationChange={onCandidateLatestPerStationChange}
                     onResultLimitChange={onCandidateResultLimitChange}
@@ -3181,9 +3279,12 @@ function ObservedAtmosphereCandidatesPanel({
   cache,
   screeningInputs,
   storyFilter,
+  storyFamilyFilter,
+  supportFilter,
   sort,
   stationSearch,
   readinessFilter,
+  workingSetTag,
   cacheLimit,
   latestPerStation,
   resultLimit,
@@ -3193,9 +3294,12 @@ function ObservedAtmosphereCandidatesPanel({
   savedCandidates,
   selectedCandidateId,
   onStoryFilterChange,
+  onStoryFamilyFilterChange,
+  onSupportFilterChange,
   onSortChange,
   onStationSearchChange,
   onReadinessFilterChange,
+  onWorkingSetTagChange,
   onCacheLimitChange,
   onLatestPerStationChange,
   onResultLimitChange,
@@ -3211,9 +3315,12 @@ function ObservedAtmosphereCandidatesPanel({
   cache: IGRACacheResponse | null;
   screeningInputs: ScreeningInput[];
   storyFilter: CandidateStoryFilter;
+  storyFamilyFilter: CandidateStoryFamilyFilter;
+  supportFilter: CandidateSupportFilter;
   sort: CandidateSort;
   stationSearch: string;
-  readinessFilter: "all" | "package_ready" | "blocked";
+  readinessFilter: CandidateReadinessFilter;
+  workingSetTag: (typeof candidateWorkingSetTags)[number];
   cacheLimit: string;
   latestPerStation: string;
   resultLimit: string;
@@ -3223,9 +3330,12 @@ function ObservedAtmosphereCandidatesPanel({
   savedCandidates: SavedSoundingCandidate[];
   selectedCandidateId: string | null;
   onStoryFilterChange: (filter: CandidateStoryFilter) => void;
+  onStoryFamilyFilterChange: (filter: CandidateStoryFamilyFilter) => void;
+  onSupportFilterChange: (filter: CandidateSupportFilter) => void;
   onSortChange: (sort: CandidateSort) => void;
   onStationSearchChange: (value: string) => void;
-  onReadinessFilterChange: (filter: "all" | "package_ready" | "blocked") => void;
+  onReadinessFilterChange: (filter: CandidateReadinessFilter) => void;
+  onWorkingSetTagChange: (tag: (typeof candidateWorkingSetTags)[number]) => void;
   onCacheLimitChange: (value: string) => void;
   onLatestPerStationChange: (value: string) => void;
   onResultLimitChange: (value: string) => void;
@@ -3237,16 +3347,7 @@ function ObservedAtmosphereCandidatesPanel({
   onRemoveSaved: (savedCandidateId: string) => void;
   onUse: (candidate: SoundingCandidate, savedCandidate?: SavedSoundingCandidate) => void;
 }) {
-  const visibleCandidates = useMemo(
-    () =>
-      sortSoundingCandidates(screening?.candidates ?? [], {
-        story: storyFilter,
-        sort,
-        stationSearch,
-        readiness: readinessFilter,
-      }),
-    [readinessFilter, screening?.candidates, sort, stationSearch, storyFilter],
-  );
+  const visibleCandidates = screening?.candidates ?? [];
   const selectedCandidate =
     visibleCandidates.find((candidate) => candidate.candidate_id === selectedCandidateId) ??
     visibleCandidates[0] ??
@@ -3327,6 +3428,35 @@ function ObservedAtmosphereCandidatesPanel({
             </option>
             <option value="elevated_convection">Elevated convection</option>
             <option value="needs_review">Needs review</option>
+            <option value="poor_or_incomplete_candidate">Poor or incomplete</option>
+          </select>
+        </label>
+        <label>
+          Story family
+          <select
+            value={storyFamilyFilter}
+            onChange={(event) =>
+              onStoryFamilyFilterChange(event.target.value as CandidateStoryFamilyFilter)
+            }
+          >
+            <option value="all">All families</option>
+            <option value="lower_atmosphere">Lower-atmosphere stories</option>
+            <option value="deep_convection">Deep-convection stories</option>
+            <option value="review">Needs review / incomplete</option>
+          </select>
+        </label>
+        <label>
+          Support
+          <select
+            value={supportFilter}
+            onChange={(event) =>
+              onSupportFilterChange(event.target.value as CandidateSupportFilter)
+            }
+          >
+            <option value="all">All support states</option>
+            <option value="supported">Supported</option>
+            <option value="weak">Weak support</option>
+            <option value="unavailable">Unavailable</option>
           </select>
         </label>
         <label>
@@ -3335,12 +3465,37 @@ function ObservedAtmosphereCandidatesPanel({
             value={sort}
             onChange={(event) => onSortChange(event.target.value as CandidateSort)}
           >
-            <option value="best">Best match for story</option>
-            <option value="latest">Latest</option>
-            <option value="data_quality">Best data quality</option>
-            <option value="lowest_lcl">Lowest LCL</option>
-            <option value="highest_moisture">Highest low-level moisture</option>
-            <option value="strongest_cap">Strongest cap</option>
+            <option value="best_match">Best match for story</option>
+            <option value="valid_time">Valid time</option>
+            <option value="station_id">Station ID</option>
+            <option value="station_name">Station name</option>
+            <option value="primary_story">Primary story</option>
+            <option value="story_family">Story family</option>
+            <option value="rank_score">Rank score</option>
+            <option value="confidence">Confidence</option>
+            <option value="support">Support state</option>
+            <option value="package_readiness">Package readiness</option>
+            <option value="observed_wind_available">Observed wind availability</option>
+            <option value="profile_top_m_agl">Profile top</option>
+            <option value="lowest_level_m_agl">Lowest usable level</option>
+            <option value="data_completeness_score">Data completeness</option>
+            <option value="low_level_qv_g_kg">Low-level qv</option>
+            <option value="mean_qv_0_500m_g_kg">Mean qv 0-500 m</option>
+            <option value="mean_qv_0_1000m_g_kg">Mean qv 0-1 km</option>
+            <option value="surface_t_td_spread_c">Surface T-Td spread</option>
+            <option value="estimated_lcl_height_m_agl">Estimated LCL</option>
+            <option value="lapse_rate_0_1000m_c_per_km">Low-level lapse rate</option>
+            <option value="midlevel_lapse_rate_700_500_hpa_c_per_km">
+              Midlevel lapse rate
+            </option>
+            <option value="cap_strength_proxy">Cap/inversion strength</option>
+            <option value="cap_height_m_agl">Cap/inversion height</option>
+            <option value="bulk_shear_0_1km_m_s">Bulk shear 0-1 km</option>
+            <option value="bulk_shear_0_3km_m_s">Bulk shear 0-3 km</option>
+            <option value="bulk_shear_0_6km_m_s">Bulk shear 0-6 km</option>
+            <option value="midlevel_dry_layer_proxy">Dry-layer proxy</option>
+            <option value="dry_microburst_inverted_v_proxy">Inverted-V proxy</option>
+            <option value="freezing_level_m_agl">Freezing level</option>
           </select>
         </label>
         <label>
@@ -3357,12 +3512,27 @@ function ObservedAtmosphereCandidatesPanel({
           <select
             value={readinessFilter}
             onChange={(event) =>
-              onReadinessFilterChange(event.target.value as "all" | "package_ready" | "blocked")
+              onReadinessFilterChange(event.target.value as CandidateReadinessFilter)
             }
           >
             <option value="all">All readiness states</option>
             <option value="package_ready">Package-ready only</option>
             <option value="blocked">Blocked / needs review</option>
+          </select>
+        </label>
+        <label>
+          Save into
+          <select
+            value={workingSetTag}
+            onChange={(event) =>
+              onWorkingSetTagChange(event.target.value as (typeof candidateWorkingSetTags)[number])
+            }
+          >
+            {candidateWorkingSetTags.map((tag) => (
+              <option key={tag} value={tag}>
+                {tag}
+              </option>
+            ))}
           </select>
         </label>
         <label>
@@ -3403,7 +3573,7 @@ function ObservedAtmosphereCandidatesPanel({
             Cache station files
           </button>
           <button type="button" onClick={onScreen}>
-            Screen cached soundings
+            Analyze cached soundings
           </button>
         </div>
       </div>
@@ -3412,8 +3582,10 @@ function ObservedAtmosphereCandidatesPanel({
         <section aria-label="Screened sounding candidates">
           {screening && (
             <p className="field-help">
-              Showing {visibleCandidates.length.toLocaleString()} of{" "}
-              {screening.candidates.length.toLocaleString()} screened candidates.
+              Showing {visibleCandidates.length.toLocaleString()} backend-filtered candidates
+              {screening.total_candidate_count !== undefined
+                ? ` from ${screening.total_candidate_count.toLocaleString()} cached-sounding hypotheses`
+                : ""}. Unavailable feature values are caveated and sorted last by the backend.
             </p>
           )}
           {visibleCandidates.length === 0 ? (
@@ -3421,7 +3593,7 @@ function ObservedAtmosphereCandidatesPanel({
               <h4>No screened candidates loaded</h4>
               <p>
                 Refresh the IGRA catalog to check available stations, cache a bounded batch of
-                station files, then screen cached soundings by atmospheric story.
+                station files, then analyze cached soundings by atmospheric story.
               </p>
             </div>
           ) : (
@@ -3471,6 +3643,7 @@ function ObservedAtmosphereCandidatesPanel({
                     {formatDate(saved.candidate.valid_time_utc)} ·{" "}
                     {candidateStoryLabel(saved.primary_story)}
                   </small>
+                  {saved.tags.length > 0 && <small>Working set: {saved.tags.join(", ")}</small>}
                   {saved.linked_run_ids.length > 0 && (
                     <small>Used in {saved.linked_run_ids.join(", ")}</small>
                   )}
@@ -3534,6 +3707,10 @@ function SoundingCandidateCard({
           {storyFilter === "deep_convection_trial" && (
             <StatusBadge label={candidate.primary_story_label} tone="neutral" />
           )}
+          <StatusBadge
+            label={candidateStoryFamilyLabel(candidate.story_family)}
+            tone="neutral"
+          />
           <StatusBadge label={`${formatNumber(matchScore, "%")} match`} tone="neutral" />
           <StatusBadge
             label={candidate.package_ready ? "Package-ready" : "Blocked"}
@@ -3582,13 +3759,26 @@ function SoundingCandidateDetail({
   }
   const story = storyFilter === "all" ? candidate.primary_story : storyFilter;
   const featureRows = [
+    ["Observed wind profile", "observed_wind_available", ""],
+    ["Profile top", "profile_top_m_agl", "m AGL"],
+    ["Lowest usable level", "lowest_level_m_agl", "m AGL"],
+    ["Data completeness", "data_completeness_score", "%"],
+    ["Low-level qv", "low_level_qv_g_kg", "g/kg"],
+    ["Mean qv 0-500 m", "mean_qv_0_500m_g_kg", "g/kg"],
     ["Low-level moisture", "mean_qv_0_1000m_g_kg", "g/kg"],
+    ["Surface T-Td spread", "surface_t_td_spread_c", "C"],
     ["Estimated LCL", "estimated_lcl_height_m_agl", "m AGL"],
     ["Low-level lapse rate", "lapse_rate_0_1000m_c_per_km", "C/km"],
-    ["Cap proxy", "cap_strength_proxy", ""],
+    ["Midlevel lapse rate", "midlevel_lapse_rate_700_500_hpa_c_per_km", "C/km"],
+    ["Cap / inversion strength", "cap_strength_proxy", "C"],
+    ["Cap / inversion height", "cap_height_m_agl", "m AGL"],
+    ["Bulk shear 0-1 km", "bulk_shear_0_1km_m_s", "m/s"],
+    ["Bulk shear 0-3 km", "bulk_shear_0_3km_m_s", "m/s"],
+    ["Bulk shear 0-6 km", "bulk_shear_0_6km_m_s", "m/s"],
+    ["Dry-layer proxy", "midlevel_dry_layer_proxy", "g/kg"],
+    ["Inverted-V proxy", "dry_microburst_inverted_v_proxy", "0-100"],
+    ["Freezing level", "freezing_level_m_agl", "m AGL"],
     ["Moisture depth", "moisture_depth_m", "m"],
-    ["Profile top", "profile_top_m_agl", "m AGL"],
-    ["Data completeness", "data_completeness_score", "%"],
   ] as const;
   return (
     <aside className="candidate-detail-panel" aria-label="Candidate details">
@@ -3614,6 +3804,7 @@ function SoundingCandidateDetail({
           value={formatNumber(candidateMatchScore(candidate, story), "%")}
         />
         <Metric label="Evidence level" value={humanize(candidate.confidence)} />
+        <Metric label="Story family" value={candidateStoryFamilyLabel(candidate.story_family)} />
         <Metric label="Station ID" value={candidate.station_id} />
         <Metric
           label="Location"
@@ -7977,6 +8168,20 @@ function candidateStoryLabel(story: CandidateStoryId | CandidateStoryFilter): st
   }
 }
 
+function candidateStoryFamilyLabel(family: CandidateStoryFamilyFilter | undefined): string {
+  switch (family) {
+    case "deep_convection":
+      return "Deep convection stories";
+    case "review":
+      return "Review / incomplete";
+    case "lower_atmosphere":
+      return "Lower-atmosphere stories";
+    case "all":
+    case undefined:
+      return "Story family unavailable";
+  }
+}
+
 function defaultPackageFamilyForCandidate(candidate: SoundingCandidate): ObservedPackageFamily {
   if (deepConvectionStoryIds.has(candidate.primary_story)) return "deep_convection_trial";
   if (
@@ -8010,99 +8215,6 @@ function candidateMatchScore(
     candidate.story_scores.find((score) => score.story === story)?.score_0_to_100 ??
     candidate.rank_score
   );
-}
-
-function candidateStoryScore(
-  candidate: SoundingCandidate,
-  story: CandidateStoryId | CandidateStoryFilter,
-): StoryScore | null {
-  if (story === "all") return null;
-  if (story === "deep_convection_trial") {
-    return (
-      candidate.story_scores
-        .filter((score) => deepConvectionStoryIds.has(score.story))
-        .sort((left, right) => right.score_0_to_100 - left.score_0_to_100)[0] ?? null
-    );
-  }
-  return candidate.story_scores.find((score) => score.story === story) ?? null;
-}
-
-function candidateSupportsStory(
-  candidate: SoundingCandidate,
-  story: CandidateStoryFilter,
-): boolean {
-  if (story === "all") return true;
-  const score = candidateStoryScore(candidate, story);
-  if (!score) return false;
-  if (score.score_0_to_100 <= 0) return false;
-  return !["unavailable", "unsupported", "insufficient_evidence"].includes(score.support);
-}
-
-function sortSoundingCandidates(
-  candidates: SoundingCandidate[],
-  options: {
-    story: CandidateStoryFilter;
-    sort: CandidateSort;
-    stationSearch: string;
-    readiness: "all" | "package_ready" | "blocked";
-  },
-): SoundingCandidate[] {
-  const { story, sort, stationSearch, readiness } = options;
-  const valueForSort = (candidate: SoundingCandidate): number => {
-    switch (sort) {
-      case "latest":
-        return new Date(candidate.valid_time_utc).getTime();
-      case "data_quality":
-        return numberFeature(candidate, "data_completeness_score", Number.NEGATIVE_INFINITY);
-      case "lowest_lcl":
-        return -numberFeature(candidate, "estimated_lcl_height_m_agl", Number.POSITIVE_INFINITY);
-      case "highest_moisture":
-        return numberFeature(candidate, "mean_qv_0_1000m_g_kg", Number.NEGATIVE_INFINITY);
-      case "strongest_cap":
-        return numberFeature(candidate, "cap_strength_proxy", Number.NEGATIVE_INFINITY);
-      case "best":
-        return candidateMatchScore(candidate, story);
-    }
-  };
-  const normalizedSearch = stationSearch.trim().toLowerCase();
-  const filtered = candidates
-    .filter((candidate) => candidateSupportsStory(candidate, story))
-    .filter((candidate) =>
-      readiness === "all"
-        ? true
-        : readiness === "package_ready"
-          ? candidate.package_ready
-          : !candidate.package_ready,
-    )
-    .filter((candidate) => {
-      if (!normalizedSearch) return true;
-      return [
-        candidate.station_id,
-        candidate.station_name,
-        candidate.source_file_name,
-        candidate.primary_story_label,
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase()
-        .includes(normalizedSearch);
-    });
-  return [...filtered].sort((a, b) => {
-    const readiness = Number(b.package_ready) - Number(a.package_ready);
-    if (readiness !== 0) return readiness;
-    const score = valueForSort(b) - valueForSort(a);
-    if (score !== 0) return score;
-    return new Date(b.valid_time_utc).getTime() - new Date(a.valid_time_utc).getTime();
-  });
-}
-
-function numberFeature(
-  candidate: SoundingCandidate,
-  key: string,
-  missingValue = Number.NEGATIVE_INFINITY,
-): number {
-  const value = candidate.features[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : missingValue;
 }
 
 function boundedInteger(value: string, min: number, max: number, fallback: number): number {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -231,6 +231,19 @@ type CandidateSort =
 type CandidateStoryFamilyFilter = "all" | "lower_atmosphere" | "deep_convection" | "review";
 type CandidateSupportFilter = "all" | "supported" | "weak" | "unavailable";
 type CandidateReadinessFilter = "all" | "package_ready" | "blocked";
+type CandidateRecipeFitStatus =
+  | "testable_now"
+  | "partially_testable"
+  | "requires_triggered_deep_potential"
+  | "requires_surface_forcing_recipe"
+  | "not_testable_with_current_recipes"
+  | "blocked_profile";
+type CandidateRecipeFitDisplay = {
+  status: CandidateRecipeFitStatus;
+  label: string;
+  summary: string;
+  caveats: string[];
+};
 
 type PackageFamily = "shallow_cumulus" | "observed_sounding_quicklook" | "deep_convection_trial";
 
@@ -281,6 +294,10 @@ type SoundingCandidate = {
   interest_summary?: string | null;
   interest_reasons?: string[];
   discovery_bucket?: string | null;
+  recipe_fit_status?: CandidateRecipeFitStatus;
+  recipe_fit_label?: string;
+  recipe_fit_summary?: string;
+  recipe_fit_caveats?: string[];
   screening_version: string;
   created_at: string;
 };
@@ -2011,7 +2028,7 @@ export function App() {
       setCandidateStatus(
         result.candidates.length > 0
           ? "Cached sounding analysis loaded"
-          : "No candidate matches found in cached soundings",
+          : "No candidates found in cached soundings",
       );
       const savedPayload = await fetchSavedSoundingCandidates();
       setSavedCandidates(savedPayload.saved_candidates);
@@ -2053,7 +2070,7 @@ export function App() {
             item.saved_candidate_id === saved.saved_candidate_id ? saved : item,
           ),
         );
-        setCandidateStatus("Saved sounding candidate notes updated");
+        setCandidateStatus("Saved sounding candidate updated");
       } else {
         const saved = await saveSoundingCandidate(candidate, tags, notes);
         setSavedCandidates((current) => [
@@ -2090,6 +2107,7 @@ export function App() {
   function handleUseSoundingCandidate(
     candidate: SoundingCandidate,
     savedCandidate?: SavedSoundingCandidate,
+    activeStory?: CandidateStoryId,
   ) {
     if (!candidate.package_ready || !candidate.selected_sounding_payload) {
       setCandidateError(
@@ -2104,8 +2122,8 @@ export function App() {
     setObservedSoundingParse(observedSoundingParseFromCandidate(candidate, selectedSounding));
     setObservedSoundingStatus("Candidate loaded into observed-sounding package review");
     setObservedSoundingError(null);
-    setSelectedCandidateScreening(candidateScreeningMetadata(candidate, savedCandidate));
-    setObservedPackageFamily(defaultPackageFamilyForCandidate(candidate));
+    setSelectedCandidateScreening(candidateScreeningMetadata(candidate, savedCandidate, activeStory));
+    setObservedPackageFamily(defaultPackageFamilyForCandidate(candidate, activeStory));
     setDryRun(null);
     setRunStatus(null);
     setRunWorkflowError(null);
@@ -3409,7 +3427,11 @@ function ObservedAtmosphereCandidatesPanel({
   onScreen: () => void;
   onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
   onRemoveSaved: (savedCandidateId: string) => void;
-  onUse: (candidate: SoundingCandidate, savedCandidate?: SavedSoundingCandidate) => void;
+  onUse: (
+    candidate: SoundingCandidate,
+    savedCandidate?: SavedSoundingCandidate,
+    activeStory?: CandidateStoryId,
+  ) => void;
 }) {
   const visibleCandidates = screening?.candidates ?? [];
   const selectedCandidate =
@@ -3454,7 +3476,7 @@ function ObservedAtmosphereCandidatesPanel({
   const lastAnalysisSummary = screening
     ? `${visibleCandidates.length.toLocaleString()} shown from ${(
         screening.filtered_candidate_count ?? visibleCandidates.length
-      ).toLocaleString()} matching / ${(screening.total_candidate_count ?? visibleCandidates.length).toLocaleString()} analyzed`
+      ).toLocaleString()} selected / ${(screening.total_candidate_count ?? visibleCandidates.length).toLocaleString()} analyzed`
     : "Not run yet";
   const activeRefinements = [
     storyFilter !== "all" ? `Story: ${candidateStoryLabel(storyFilter)}` : null,
@@ -3688,7 +3710,8 @@ function ObservedAtmosphereCandidatesPanel({
                 {screening.total_candidate_count !== undefined
                   ? ` from ${screening.total_candidate_count.toLocaleString()} analyzed cached soundings`
                   : ""}
-                . Each score is screening guidance; CM1 still decides what happens.
+                . Scores rank sounding ingredients only. They do not predict what the current CM1
+                package will produce.
               </p>
             </div>
           )}
@@ -3712,12 +3735,13 @@ function ObservedAtmosphereCandidatesPanel({
                   saved={savedCandidateIds.has(candidate.candidate_id)}
                   onSelect={() => onCandidateDetailChange(candidate.candidate_id)}
                   onSave={() => onSave(candidate)}
-                  onUse={() =>
+                  onUse={(activeStory) =>
                     onUse(
                       candidate,
                       savedCandidates.find(
                         (saved) => saved.candidate.candidate_id === candidate.candidate_id,
                       ),
+                      activeStory,
                     )
                   }
                 />
@@ -3750,41 +3774,87 @@ function ObservedAtmosphereCandidatesPanel({
         ) : (
           <div className="saved-candidate-list">
             {savedCandidates.map((saved) => (
-              <article
-                className="saved-candidate-card"
+              <SavedSoundingCandidateCard
                 key={saved.saved_candidate_id}
-                aria-label={`Saved sounding candidate ${candidateStationLabel(saved.candidate)}`}
-              >
-                <div>
-                  <strong>{candidateStationLabel(saved.candidate)}</strong>
-                  <small>
-                    {formatDate(saved.candidate.valid_time_utc)} ·{" "}
-                    {candidateStoryLabel(saved.primary_story)}
-                  </small>
-                  {saved.tags.length > 0 && <small>Tags: {saved.tags.join(", ")}</small>}
-                  {saved.notes && <small>Notes: {saved.notes}</small>}
-                  {saved.linked_run_ids.length > 0 && (
-                    <small>Used in {saved.linked_run_ids.join(", ")}</small>
-                  )}
-                </div>
-                <div className="button-row">
-                  <button type="button" onClick={() => onUse(saved.candidate, saved)}>
-                    Use to create package
-                  </button>
-                  <button
-                    type="button"
-                    className="secondary-button"
-                    onClick={() => onRemoveSaved(saved.saved_candidate_id)}
-                  >
-                    Remove saved
-                  </button>
-                </div>
-              </article>
+                saved={saved}
+                onUpdateWorkingSet={(tags) => onSave(saved.candidate, tags, saved.notes ?? null)}
+                onUse={() => onUse(saved.candidate, saved)}
+                onRemove={() => onRemoveSaved(saved.saved_candidate_id)}
+              />
             ))}
           </div>
         )}
       </section>
     </section>
+  );
+}
+
+function SavedSoundingCandidateCard({
+  saved,
+  onUpdateWorkingSet,
+  onUse,
+  onRemove,
+}: {
+  saved: SavedSoundingCandidate;
+  onUpdateWorkingSet: (tags: string[]) => void;
+  onUse: () => void;
+  onRemove: () => void;
+}) {
+  const currentWorkingSet = saved.tags.find(isCandidateSuggestedTag) ?? "";
+  const [workingSetDraft, setWorkingSetDraft] = useState(currentWorkingSet);
+  useEffect(() => {
+    setWorkingSetDraft(currentWorkingSet);
+  }, [saved.saved_candidate_id, currentWorkingSet]);
+  const freeformTags = saved.tags.filter((tag) => !isCandidateSuggestedTag(tag));
+  const nextTags = _dedupeStrings(
+    [workingSetDraft, ...freeformTags].filter((tag): tag is string => Boolean(tag)),
+  );
+  return (
+    <article
+      className="saved-candidate-card"
+      aria-label={`Saved sounding candidate ${candidateStationLabel(saved.candidate)}`}
+    >
+      <div>
+        <strong>{candidateStationLabel(saved.candidate)}</strong>
+        <small>
+          {formatDate(saved.candidate.valid_time_utc)} · {candidateStoryLabel(saved.primary_story)}
+        </small>
+        {saved.tags.length > 0 && <small>Tags: {saved.tags.join(", ")}</small>}
+        {saved.notes && <small>Notes: {saved.notes}</small>}
+        {saved.linked_run_ids.length > 0 && (
+          <small>Used in {saved.linked_run_ids.join(", ")}</small>
+        )}
+      </div>
+      <div className="saved-candidate-controls">
+        <label htmlFor={`saved-working-set-${saved.saved_candidate_id}`}>
+          Working set
+          <select
+            id={`saved-working-set-${saved.saved_candidate_id}`}
+            aria-label={`Working set for ${candidateStationLabel(saved.candidate)}`}
+            value={workingSetDraft}
+            onChange={(event) => setWorkingSetDraft(event.target.value)}
+          >
+            <option value="">No working set</option>
+            {candidateSuggestedTags.map((tag) => (
+              <option key={tag} value={tag}>
+                {tag}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button type="button" className="secondary-button" onClick={() => onUpdateWorkingSet(nextTags)}>
+          Update working set
+        </button>
+      </div>
+      <div className="button-row">
+        <button type="button" onClick={onUse}>
+          Use to create package
+        </button>
+        <button type="button" className="secondary-button" onClick={onRemove}>
+          Remove saved
+        </button>
+      </div>
+    </article>
   );
 }
 
@@ -3805,13 +3875,14 @@ function SoundingCandidateCard({
   saved: boolean;
   onSelect: () => void;
   onSave: () => void;
-  onUse: () => void;
+  onUse: (activeStory: CandidateStoryId) => void;
 }) {
   const activeScore = candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter);
-  const story = activeScore?.story ?? (storyFilter === "all" ? candidate.primary_story : storyFilter);
+  const story = activeScore?.story ?? candidate.primary_story;
   const activeFamily = activeScore ? candidateStoryFamilyForStory(activeScore.story) : candidate.story_family;
-  const matchScore =
-    activeScore?.score_0_to_100 ?? candidateMatchScore(candidate, storyFilter, storyFamilyFilter);
+  const ingredientScore =
+    activeScore?.score_0_to_100 ?? candidateIngredientScore(candidate, storyFilter, storyFamilyFilter);
+  const recipeFit = candidateRecipeFitForStory(candidate, story);
   const reasons = candidateInterestReasons(candidate);
   return (
     <article
@@ -3836,7 +3907,11 @@ function SoundingCandidateCard({
             <StatusBadge label={`Primary: ${candidate.primary_story_label}`} tone="neutral" />
           )}
           <StatusBadge label={candidateStoryFamilyLabel(activeFamily)} tone="neutral" />
-          <StatusBadge label={`${formatNumber(matchScore, "%")} match`} tone="neutral" />
+          <StatusBadge label={`${formatNumber(ingredientScore, "%")} ingredient score`} tone="neutral" />
+          <StatusBadge
+            label={`Recipe fit: ${recipeFit.label}`}
+            tone={candidateRecipeFitTone(recipeFit.status)}
+          />
           <StatusBadge
             label={candidate.package_ready ? "Package-ready" : "Blocked"}
             tone={candidate.package_ready ? "good" : "warning"}
@@ -3864,7 +3939,7 @@ function SoundingCandidateCard({
         </p>
       )}
       <div className="button-row">
-        <button type="button" disabled={!candidate.package_ready} onClick={onUse}>
+        <button type="button" disabled={!candidate.package_ready} onClick={() => onUse(story)}>
           Use this sounding
         </button>
         <button type="button" className="secondary-button" disabled={saved} onClick={onSave}>
@@ -3908,13 +3983,14 @@ function SoundingCandidateDetail({
   }
   const activeCandidate = candidate;
   const activeScore = candidateActiveStoryScore(activeCandidate, storyFilter, storyFamilyFilter);
-  const story = activeScore?.story ?? (storyFilter === "all" ? activeCandidate.primary_story : storyFilter);
+  const story = activeScore?.story ?? activeCandidate.primary_story;
   const activeFamily = activeScore
     ? candidateStoryFamilyForStory(activeScore.story)
     : activeCandidate.story_family;
-  const matchScore =
+  const ingredientScore =
     activeScore?.score_0_to_100 ??
-    candidateMatchScore(activeCandidate, storyFilter, storyFamilyFilter);
+    candidateIngredientScore(activeCandidate, storyFilter, storyFamilyFilter);
+  const recipeFit = candidateRecipeFitForStory(activeCandidate, story);
   const reasons = candidateInterestReasons(activeCandidate);
   const savedTagValues = parseTags(tagDraft);
   function handleTagSuggestion(tag: string) {
@@ -3960,9 +4036,10 @@ function SoundingCandidateDetail({
         />
       </div>
       <p>
-        Candidate match score is screening guidance only. CM1 decides whether clouds, rain, or
-        suppression actually happen.
+        Scores rank sounding ingredients only. They do not predict what the current CM1 package
+        will produce. CM1 decides whether clouds, rain, or suppression actually happen.
       </p>
+      <p className="field-help">Recipe fit: {recipeFit.summary}</p>
       <section>
         <h5>Why this is interesting</h5>
         <ul className="compact-list candidate-reason-list">
@@ -3972,9 +4049,10 @@ function SoundingCandidateDetail({
         </ul>
       </section>
       <dl className="compact-metrics">
-        <Metric label="Match score" value={formatNumber(matchScore, "%")} />
+        <Metric label="Ingredient score" value={formatNumber(ingredientScore, "%")} />
         <Metric label="Evidence level" value={humanize(candidate.confidence)} />
-        <Metric label="Matched story family" value={candidateStoryFamilyLabel(activeFamily)} />
+        <Metric label="Screened story family" value={candidateStoryFamilyLabel(activeFamily)} />
+        <Metric label="Recipe fit" value={recipeFit.label} />
         {activeScore && activeScore.story !== candidate.primary_story && (
           <Metric label="Primary story" value={candidate.primary_story_label} />
         )}
@@ -4002,7 +4080,7 @@ function SoundingCandidateDetail({
         </ul>
       </section>
       <details>
-        <summary>All story scores</summary>
+        <summary>All ingredient scores</summary>
         <dl className="compact-metrics">
           {candidate.story_scores.map((score) => (
             <Metric
@@ -4227,11 +4305,12 @@ function ObservedPackageFamilyPanel({
   onChange: (packageFamily: ObservedPackageFamily) => void;
 }) {
   const selectedDeep = packageFamily === "deep_convection_trial";
-  const selectedStory = String(selectedCandidateScreening?.primary_story ?? "");
+  const packageMismatchWarning = candidatePackageMismatchWarning(
+    selectedCandidateScreening,
+    packageFamily,
+  );
   const candidateGuidance = selectedCandidateScreening
-    ? deepConvectionStoryIds.has(selectedStory)
-      ? "This saved/screened candidate is a strong fit for Deep Convection Trial."
-      : "This candidate can still use the observed-sounding quick look, or you can try the deep-convection package deliberately."
+    ? "Candidate screening is ingredient guidance. Choose the package based on what the run can actually test."
     : "Upload or choose an observed sounding, then choose the CM1 package family to generate.";
   const workerGuidance =
     selectedDeep && runSizePreset !== "quick_look"
@@ -4272,6 +4351,11 @@ function ObservedPackageFamilyPanel({
           <option value="deep_convection_trial">Deep Convection Trial</option>
         </select>
       </div>
+      {packageMismatchWarning && (
+        <div className="validation" role="alert">
+          {packageMismatchWarning}
+        </div>
+      )}
       <dl className="compact-metrics">
         <Metric
           label="Initiation method"
@@ -8460,7 +8544,11 @@ function candidateSortLabel(sort: CandidateSort): string {
   return labels[sort];
 }
 
-function defaultPackageFamilyForCandidate(candidate: SoundingCandidate): ObservedPackageFamily {
+function defaultPackageFamilyForCandidate(
+  candidate: SoundingCandidate,
+  activeStory?: CandidateStoryId,
+): ObservedPackageFamily {
+  if (activeStory && deepConvectionStoryIds.has(activeStory)) return "deep_convection_trial";
   if (deepConvectionStoryIds.has(candidate.primary_story)) return "deep_convection_trial";
   if (
     candidate.story_scores.some(
@@ -8470,6 +8558,159 @@ function defaultPackageFamilyForCandidate(candidate: SoundingCandidate): Observe
     return "deep_convection_trial";
   }
   return "observed_sounding_quicklook";
+}
+
+function candidateRecipeFitForStory(
+  candidate: SoundingCandidate,
+  story: CandidateStoryId,
+): CandidateRecipeFitDisplay {
+  if (
+    story === candidate.primary_story &&
+    candidate.recipe_fit_status &&
+    candidate.recipe_fit_label &&
+    candidate.recipe_fit_summary
+  ) {
+    return {
+      status: candidate.recipe_fit_status,
+      label: candidate.recipe_fit_label,
+      summary: candidate.recipe_fit_summary,
+      caveats: candidate.recipe_fit_caveats ?? [],
+    };
+  }
+  if (!candidate.package_ready || story === "poor_or_incomplete_candidate") {
+    return {
+      status: "blocked_profile",
+      label: "blocked profile",
+      summary: "This cached sounding cannot be packaged until profile caveats are resolved.",
+      caveats: ["profile_or_package_generation_blocked"],
+    };
+  }
+  if (story === "needs_review") {
+    return {
+      status: "not_testable_with_current_recipes",
+      label: "not testable with current package path",
+      summary: "This candidate needs manual screening before it maps to a current run path.",
+      caveats: ["candidate_requires_manual_screening_review"],
+    };
+  }
+  if (deepConvectionStoryIds.has(story)) {
+    const caveats = ["observed_sounding_quicklook_does_not_test_deep_potential"];
+    if (candidate.features.observed_wind_available !== true) {
+      caveats.push("complete_observed_wind_profile_required_for_deep_potential");
+    }
+    return {
+      status: "requires_triggered_deep_potential",
+      label: "requires triggered deep-potential run",
+      summary:
+        "This story screens deep-convection ingredients. Observed Sounding Quick Look does not test that hypothesis without the triggered deep-potential package.",
+      caveats,
+    };
+  }
+  if (story === "humid_rainy_candidate") {
+    return {
+      status: "partially_testable",
+      label: "partially testable with current observed-sounding run",
+      summary:
+        "The current observed-sounding path can inspect moist evolution, but later comparison needs rain-water, surface-rain, and/or reflectivity outputs.",
+      caveats: ["rain_water_surface_rain_or_reflectivity_outputs_required"],
+    };
+  }
+  if (story === "capped_suppressed_candidate") {
+    return {
+      status: "partially_testable",
+      label: "partially testable with current observed-sounding run",
+      summary:
+        "The current observed-sounding path can inspect capped or suppressed evolution when cap evidence, duration, and output fields are adequate.",
+      caveats: ["run_duration_and_output_fields_must_be_checked_for_cap_story"],
+    };
+  }
+  return {
+    status: "partially_testable",
+    label: "partially testable with current observed-sounding run",
+    summary:
+      "The current observed-sounding path can inspect untriggered shallow/evolution behavior, but the recipe still shapes what CM1 can test.",
+    caveats: ["observed_sounding_quicklook_is_recipe_dependent"],
+  };
+}
+
+function candidateRecipeFitTone(status: CandidateRecipeFitStatus): "good" | "warning" | "neutral" {
+  if (status === "testable_now") return "good";
+  if (status === "partially_testable") return "neutral";
+  return "warning";
+}
+
+function isCandidateSuggestedTag(tag: string): tag is (typeof candidateSuggestedTags)[number] {
+  return (candidateSuggestedTags as readonly string[]).includes(tag);
+}
+
+function candidatePackageMismatchWarning(
+  selectedCandidateScreening: Record<string, unknown> | null,
+  packageFamily: ObservedPackageFamily,
+): string | null {
+  if (!selectedCandidateScreening) return null;
+  const activeStory =
+    typeof selectedCandidateScreening.active_story === "string"
+      ? selectedCandidateScreening.active_story
+      : "";
+  const primaryStory =
+    typeof selectedCandidateScreening.primary_story === "string"
+      ? selectedCandidateScreening.primary_story
+      : "";
+  const storyScores = candidateScreeningStoryScores(selectedCandidateScreening);
+  const hasMeaningfulDeepStory =
+    deepConvectionStoryIds.has(activeStory) ||
+    (!activeStory &&
+      (deepConvectionStoryIds.has(primaryStory) ||
+        storyScores.some(
+          (score) =>
+            deepConvectionStoryIds.has(score.story) &&
+            score.score_0_to_100 > 0 &&
+            score.support !== "unavailable",
+        )));
+  if (packageFamily === "observed_sounding_quicklook" && hasMeaningfulDeepStory) {
+    return "This candidate was screened for deep-convection potential. Observed Sounding Quick Look does not test that hypothesis. Choose the triggered deep-potential run, or treat this as an untriggered shallow/evolution experiment.";
+  }
+  const hasHumidRainyStory =
+    activeStory === "humid_rainy_candidate" ||
+    (!activeStory &&
+      (primaryStory === "humid_rainy_candidate" ||
+        storyScores.some(
+          (score) =>
+            score.story === "humid_rainy_candidate" &&
+            score.score_0_to_100 > 0 &&
+            score.support !== "unavailable",
+        )));
+  if (hasHumidRainyStory) {
+    return "This candidate was screened as humid/rainy. Predicted rain behavior needs rain-water, surface-rain, and/or reflectivity outputs to compare later.";
+  }
+  return null;
+}
+
+function candidateScreeningStoryScores(
+  selectedCandidateScreening: Record<string, unknown>,
+): Array<Pick<StoryScore, "story" | "score_0_to_100" | "support">> {
+  if (!Array.isArray(selectedCandidateScreening.story_scores)) return [];
+  return selectedCandidateScreening.story_scores.flatMap((score) => {
+    if (
+      score &&
+      typeof score === "object" &&
+      "story" in score &&
+      "score_0_to_100" in score &&
+      "support" in score &&
+      typeof score.story === "string" &&
+      typeof score.score_0_to_100 === "number" &&
+      typeof score.support === "string"
+    ) {
+      return [
+        {
+          story: score.story as CandidateStoryId,
+          score_0_to_100: score.score_0_to_100,
+          support: score.support,
+        },
+      ];
+    }
+    return [];
+  });
 }
 
 function candidateStationLabel(candidate: SoundingCandidate): string {
@@ -8498,7 +8739,7 @@ function observedSoundingLocationLabel(observed: ObservedSoundingSummary): strin
   return "Not available";
 }
 
-function candidateMatchScore(
+function candidateIngredientScore(
   candidate: SoundingCandidate,
   storyFilter: CandidateStoryFilter,
   storyFamilyFilter: CandidateStoryFamilyFilter = "all",
@@ -8599,12 +8840,18 @@ function observedSoundingParseFromCandidate(
 function candidateScreeningMetadata(
   candidate: SoundingCandidate,
   savedCandidate?: SavedSoundingCandidate,
+  activeStory?: CandidateStoryId,
 ): Record<string, unknown> {
+  const activeScore = activeStory
+    ? candidate.story_scores.find((score) => score.story === activeStory)
+    : null;
   return {
     candidate_id: candidate.candidate_id,
     saved_candidate_id: savedCandidate?.saved_candidate_id ?? null,
     screening_version: candidate.screening_version,
     primary_story: candidate.primary_story,
+    active_story: activeStory ?? candidate.primary_story,
+    active_story_label: activeScore?.label ?? candidate.primary_story_label,
     story_scores: candidate.story_scores,
     rank_score: candidate.rank_score,
     confidence: candidate.confidence,
@@ -8614,6 +8861,10 @@ function candidateScreeningMetadata(
     interest_summary: candidate.interest_summary ?? null,
     interest_reasons: candidate.interest_reasons ?? [],
     discovery_bucket: candidate.discovery_bucket ?? null,
+    recipe_fit_status: candidate.recipe_fit_status ?? null,
+    recipe_fit_label: candidate.recipe_fit_label ?? null,
+    recipe_fit_summary: candidate.recipe_fit_summary ?? null,
+    recipe_fit_caveats: candidate.recipe_fit_caveats ?? [],
     source_file_name: candidate.source_file_name,
     source_file_hash: candidate.source_file_hash,
     saved_tags: savedCandidate?.tags ?? [],

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -99,6 +99,7 @@ type DryRunReport = {
     visualizer_is_interpretation: boolean;
   };
   observed_sounding?: ObservedSoundingSummary | null;
+  user?: UserRunMetadata | null;
 };
 
 type DryRunResponse = {
@@ -318,6 +319,13 @@ type ScreeningResult = {
   };
 };
 
+type UserRunMetadata = {
+  name: string;
+  tags: string[];
+  notes?: string | null;
+  saved?: boolean;
+};
+
 type SavedSoundingCandidate = {
   saved_candidate_id: string;
   candidate: SoundingCandidate;
@@ -424,6 +432,12 @@ type RunStatusResponse = {
   };
   runtime_warnings: string[];
   progress: RunProgressResponse | null;
+  user?: UserRunMetadata | null;
+  observed_sounding?: ObservedSoundingSummary | null;
+  candidate_screening?: Record<string, unknown> | null;
+  package_family?: PackageFamily | string | null;
+  package_display_name?: string | null;
+  input_source?: string | null;
 };
 
 type RunQueueEntry = {
@@ -1029,6 +1043,11 @@ async function requestDryRunPackage(
   packageFamily?: PackageFamily | null,
   observedSounding?: ObservedSoundingRecord | null,
   candidateScreening?: Record<string, unknown> | null,
+  userMetadata?: {
+    name?: string | null;
+    tags?: string[];
+    notes?: string | null;
+  } | null,
 ): Promise<DryRunResponse> {
   const response = await fetch("/api/dry-run-package", {
     method: "POST",
@@ -1040,6 +1059,9 @@ async function requestDryRunPackage(
       package_family: packageFamily ?? null,
       observed_sounding: observedSounding ?? null,
       candidate_screening: candidateScreening ?? null,
+      user_name: userMetadata?.name ?? null,
+      user_tags: userMetadata?.tags ?? [],
+      user_notes: userMetadata?.notes ?? null,
     }),
   });
   if (!response.ok) {
@@ -1112,18 +1134,16 @@ async function fetchScreeningInputs(): Promise<ScreeningInputsResponse> {
   return response.json() as Promise<ScreeningInputsResponse>;
 }
 
-async function screenSoundingCandidates(
-  options: {
-    story: CandidateStoryFilter;
-    storyFamily: CandidateStoryFamilyFilter;
-    support: CandidateSupportFilter;
-    readiness: CandidateReadinessFilter;
-    stationSearch: string;
-    sort: CandidateSort;
-    latestPerStation: number;
-    limit: number;
-  },
-): Promise<ScreeningResult> {
+async function screenSoundingCandidates(options: {
+  story: CandidateStoryFilter;
+  storyFamily: CandidateStoryFamilyFilter;
+  support: CandidateSupportFilter;
+  readiness: CandidateReadinessFilter;
+  stationSearch: string;
+  sort: CandidateSort;
+  latestPerStation: number;
+  limit: number;
+}): Promise<ScreeningResult> {
   const response = await fetch("/api/sounding-candidates/analyze", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -1179,9 +1199,7 @@ async function updateSavedSoundingCandidate(
     body: JSON.stringify({ tags, notes }),
   });
   if (!response.ok) {
-    throw new Error(
-      await responseError(response, "Unable to update saved sounding candidate."),
-    );
+    throw new Error(await responseError(response, "Unable to update saved sounding candidate."));
   }
   return response.json() as Promise<SavedSoundingCandidate>;
 }
@@ -1585,9 +1603,7 @@ export function App() {
   const [storageError, setStorageError] = useState<string | null>(null);
   const [runDeletePreview, setRunDeletePreview] = useState<DeleteRunResponse | null>(null);
   const [runDeleteMessage, setRunDeleteMessage] = useState<string | null>(null);
-  const [resultDeletePreview, setResultDeletePreview] = useState<DeleteResultResponse | null>(
-    null,
-  );
+  const [resultDeletePreview, setResultDeletePreview] = useState<DeleteResultResponse | null>(null);
   const [resultDeleteMessage, setResultDeleteMessage] = useState<string | null>(null);
   const [, setStatus] = useState("Loading scenarios...");
   const [scenarioLoadState, setScenarioLoadState] = useState<ScenarioLoadState>("loading");
@@ -1836,8 +1852,7 @@ export function App() {
       const payload = await fetchStorageInventory();
       setStorageInventory(payload);
       setStorageStatus(
-        statusWhenLoaded ??
-          (payload.runs.length > 0 ? "Run inventory loaded" : "No runtime runs"),
+        statusWhenLoaded ?? (payload.runs.length > 0 ? "Run inventory loaded" : "No runtime runs"),
       );
     } catch (caught) {
       setStorageError(
@@ -2027,7 +2042,9 @@ export function App() {
     const existing = savedCandidates.find(
       (saved) => saved.candidate.candidate_id === candidate.candidate_id,
     );
-    setCandidateStatus(existing ? "Updating saved sounding candidate" : "Saving sounding candidate");
+    setCandidateStatus(
+      existing ? "Updating saved sounding candidate" : "Saving sounding candidate",
+    );
     try {
       if (existing) {
         const saved = await updateSavedSoundingCandidate(existing.saved_candidate_id, tags, notes);
@@ -2115,6 +2132,9 @@ export function App() {
     setLanWorkerError(null);
     setLanWorkerActionStatus(null);
     setIngestedResultId(null);
+    const packageUserMetadata = observedSoundingExperimentSelected
+      ? runUserMetadataFromCandidateScreening(selectedCandidateScreening)
+      : null;
     try {
       const result = await requestDryRunPackage(
         selectedScenario.id,
@@ -2123,6 +2143,7 @@ export function App() {
         observedSoundingExperimentSelected ? observedPackageFamily : null,
         observedSoundingExperimentSelected ? observedSoundingParse?.selected_sounding : null,
         observedSoundingExperimentSelected ? selectedCandidateScreening : null,
+        packageUserMetadata,
       );
       setDryRun(result);
       setStatus("Packaged dry-run output");
@@ -2591,7 +2612,9 @@ export function App() {
       setResultsStatus(deleteMessage);
       await refreshStorageAfterWorkflow("Local pipeline updated");
     } catch (caught) {
-      setResultsError(caught instanceof Error ? caught.message : "Unable to delete selected result.");
+      setResultsError(
+        caught instanceof Error ? caught.message : "Unable to delete selected result.",
+      );
       setResultsStatus("Delete failed");
     }
   }
@@ -3400,9 +3423,9 @@ function ObservedAtmosphereCandidatesPanel({
   const selectedSavedCandidate =
     selectedCandidate === null
       ? null
-      : savedCandidates.find(
+      : (savedCandidates.find(
           (saved) => saved.candidate.candidate_id === selectedCandidate.candidate_id,
-        ) ?? null;
+        ) ?? null);
   const cachedStations = new Set((cache?.entries ?? []).map((entry) => entry.station_id)).size;
   const cachedStationFiles = cache?.entries.length ?? 0;
   const cachedCatalogFiles =
@@ -3412,10 +3435,27 @@ function ObservedAtmosphereCandidatesPanel({
     (total, input) => total + (input.sounding_count ?? 0),
     0,
   );
-  const screenableSummary =
+  const cachedInventorySummary =
     screenableSoundingCount > 0
-      ? `${screenableSoundingCount.toLocaleString()} soundings`
+      ? `${screenableSoundingCount.toLocaleString()} cached soundings`
       : `${screeningInputs.length.toLocaleString()} cached files`;
+  const latestPerCachedFile = boundedInteger(latestPerStation, 1, 50, 5);
+  const plannedAnalysisCount = screeningInputs.reduce((total, input) => {
+    const count = input.sounding_count;
+    if (typeof count === "number" && Number.isFinite(count)) {
+      return total + Math.min(count, latestPerCachedFile);
+    }
+    return total + latestPerCachedFile;
+  }, 0);
+  const plannedAnalysisSummary =
+    screeningInputs.length > 0
+      ? `Up to ${plannedAnalysisCount.toLocaleString()} soundings (${latestPerCachedFile.toLocaleString()} per cached file)`
+      : "No cached files";
+  const lastAnalysisSummary = screening
+    ? `${visibleCandidates.length.toLocaleString()} shown from ${(
+        screening.filtered_candidate_count ?? visibleCandidates.length
+      ).toLocaleString()} matching / ${(screening.total_candidate_count ?? visibleCandidates.length).toLocaleString()} analyzed`
+    : "Not run yet";
   const activeRefinements = [
     storyFilter !== "all" ? `Story: ${candidateStoryLabel(storyFilter)}` : null,
     storyFamilyFilter !== "all" ? `Family: ${candidateStoryFamilyLabel(storyFamilyFilter)}` : null,
@@ -3435,8 +3475,8 @@ function ObservedAtmosphereCandidatesPanel({
           <p className="eyebrow">Observed atmosphere</p>
           <h3 id="sounding-candidates-title">Find interesting soundings</h3>
           <p className="field-help">
-            Screening guidance only. Use this to choose an observed atmosphere to try; CM1 decides
-            what actually happens.
+            Screening guidance only. The cache inventory is local data; recommendations analyze the
+            latest bounded slice from those cached files.
           </p>
         </div>
         <p className="state-chip" role="status">
@@ -3452,7 +3492,9 @@ function ObservedAtmosphereCandidatesPanel({
         />
         <Metric label="Cached stations" value={cachedStations.toString()} />
         <Metric label="Cached station files" value={cachedCatalogFiles.toString()} />
-        <Metric label="Screenable soundings" value={screenableSummary} />
+        <Metric label="Cached sounding inventory" value={cachedInventorySummary} />
+        <Metric label="Planned analysis slice" value={plannedAnalysisSummary} />
+        <Metric label="Last analysis" value={lastAnalysisSummary} />
       </dl>
 
       {error && (
@@ -3498,7 +3540,9 @@ function ObservedAtmosphereCandidatesPanel({
               <option value="dry_failed_candidate">Dry failed cumulus</option>
               <option value="capped_suppressed_candidate">Capped / suppressed</option>
               <option value="humid_rainy_candidate">Humid / rainy</option>
-              <option value="severe_thunderstorm_environment">Severe thunderstorm environment</option>
+              <option value="severe_thunderstorm_environment">
+                Severe thunderstorm environment
+              </option>
               <option value="supercell_environment">Supercell-like environment</option>
               <option value="high_cape_pulse_storm">High-CAPE pulse storm</option>
               <option value="dry_microburst_inverted_v">Dry microburst / inverted-V</option>
@@ -3540,7 +3584,10 @@ function ObservedAtmosphereCandidatesPanel({
           </label>
           <label>
             Sort
-            <select value={sort} onChange={(event) => onSortChange(event.target.value as CandidateSort)}>
+            <select
+              value={sort}
+              onChange={(event) => onSortChange(event.target.value as CandidateSort)}
+            >
               <option value="best_match">Recommended</option>
               <option value="valid_time">Valid time</option>
               <option value="station_id">Station ID</option>
@@ -3561,9 +3608,7 @@ function ObservedAtmosphereCandidatesPanel({
               <option value="surface_t_td_spread_c">Surface T-Td spread</option>
               <option value="estimated_lcl_height_m_agl">Estimated LCL</option>
               <option value="lapse_rate_0_1000m_c_per_km">Low-level lapse rate</option>
-              <option value="midlevel_lapse_rate_700_500_hpa_c_per_km">
-                Midlevel lapse rate
-              </option>
+              <option value="midlevel_lapse_rate_700_500_hpa_c_per_km">Midlevel lapse rate</option>
               <option value="cap_strength_proxy">Cap/inversion strength</option>
               <option value="cap_height_m_agl">Cap/inversion height</option>
               <option value="bulk_shear_0_1km_m_s">Bulk shear 0-1 km</option>
@@ -3597,7 +3642,7 @@ function ObservedAtmosphereCandidatesPanel({
             </select>
           </label>
           <label>
-            Cache up to
+            Cache station files up to
             <input
               type="number"
               min="1"
@@ -3607,7 +3652,7 @@ function ObservedAtmosphereCandidatesPanel({
             />
           </label>
           <label>
-            Latest per station
+            Latest per cached file
             <input
               type="number"
               min="1"
@@ -3617,7 +3662,7 @@ function ObservedAtmosphereCandidatesPanel({
             />
           </label>
           <label>
-            Candidate limit
+            Returned candidate limit
             <input
               type="number"
               min="1"
@@ -3633,12 +3678,17 @@ function ObservedAtmosphereCandidatesPanel({
         <section aria-label="Screened sounding candidates">
           {screening && (
             <div className="candidate-list-heading">
-              <h4>{activeRefinements.length > 0 ? "Refined candidates" : "Recommended cached soundings"}</h4>
+              <h4>
+                {activeRefinements.length > 0
+                  ? "Refined candidates"
+                  : "Recommended cached soundings"}
+              </h4>
               <p className="field-help">
                 Showing {visibleCandidates.length.toLocaleString()} candidates
                 {screening.total_candidate_count !== undefined
-                  ? ` from ${screening.total_candidate_count.toLocaleString()} cached sounding hypotheses`
-                  : ""}. Each score is screening guidance; CM1 still decides what happens.
+                  ? ` from ${screening.total_candidate_count.toLocaleString()} analyzed cached soundings`
+                  : ""}
+                . Each score is screening guidance; CM1 still decides what happens.
               </p>
             </div>
           )}
@@ -3661,7 +3711,14 @@ function ObservedAtmosphereCandidatesPanel({
                   saved={savedCandidateIds.has(candidate.candidate_id)}
                   onSelect={() => onCandidateDetailChange(candidate.candidate_id)}
                   onSave={() => onSave(candidate)}
-                  onUse={() => onUse(candidate)}
+                  onUse={() =>
+                    onUse(
+                      candidate,
+                      savedCandidates.find(
+                        (saved) => saved.candidate.candidate_id === candidate.candidate_id,
+                      ),
+                    )
+                  }
                 />
               ))}
             </div>
@@ -3771,10 +3828,7 @@ function SoundingCandidateCard({
           {storyFilter === "deep_convection_trial" && (
             <StatusBadge label={candidate.primary_story_label} tone="neutral" />
           )}
-          <StatusBadge
-            label={candidateStoryFamilyLabel(candidate.story_family)}
-            tone="neutral"
-          />
+          <StatusBadge label={candidateStoryFamilyLabel(candidate.story_family)} tone="neutral" />
           <StatusBadge label={`${formatNumber(matchScore, "%")} match`} tone="neutral" />
           <StatusBadge
             label={candidate.package_ready ? "Package-ready" : "Blocked"}
@@ -4344,10 +4398,7 @@ function NotebookWorkspace({
   const filtersActive = resultsFiltersActive(filters);
 
   return (
-    <section
-      className="workspace-section"
-      aria-label="Notebook entries"
-    >
+    <section className="workspace-section" aria-label="Notebook entries">
       <ResultsFilterBar
         filters={filters}
         scenarioOptions={scenarioOptions}
@@ -4532,6 +4583,8 @@ function LocalRunWorkflowPanel({
   const showIngestButton = Boolean(dryRun && canIngest);
   const showActionRow =
     showCreatePackageButton || showLaunchButton || showRefreshButton || showIngestButton;
+  const packageObservedSounding = dryRun?.report.observed_sounding ?? null;
+  const packageUserMetadata = dryRun?.report.user ?? null;
 
   return (
     <section
@@ -4582,6 +4635,21 @@ function LocalRunWorkflowPanel({
           <>
             <dl className="compact-metrics">
               <Metric label="Run ID" value={runIdFromPackage(dryRun)} />
+              {packageObservedSounding && (
+                <>
+                  <Metric label="Sounding" value={observedSoundingLabel(packageObservedSounding)} />
+                  <Metric
+                    label="Sounding location"
+                    value={observedSoundingLocationLabel(packageObservedSounding)}
+                  />
+                </>
+              )}
+              {packageUserMetadata?.tags.length ? (
+                <Metric label="Package tags" value={packageUserMetadata.tags.join(", ")} />
+              ) : null}
+              {packageUserMetadata?.notes ? (
+                <Metric label="Package notes" value={packageUserMetadata.notes} />
+              ) : null}
               <Metric label="Package path" value={dryRun.package_dir} />
               <Metric label="Manifest path" value={dryRun.manifest_path} />
               <Metric label="Expected output directory" value={dryRun.package_dir} />
@@ -4690,6 +4758,24 @@ function LocalRunWorkflowPanel({
           <div className="run-status-panel" aria-label="Local run status">
             <dl>
               <Metric label="Lifecycle state" value={humanize(runStatus.lifecycle_state)} />
+              {runStatus.observed_sounding && (
+                <>
+                  <Metric
+                    label="Sounding"
+                    value={observedSoundingLabel(runStatus.observed_sounding)}
+                  />
+                  <Metric
+                    label="Sounding location"
+                    value={observedSoundingLocationLabel(runStatus.observed_sounding)}
+                  />
+                </>
+              )}
+              {runStatus.user?.tags.length ? (
+                <Metric label="Run tags" value={runStatus.user.tags.join(", ")} />
+              ) : null}
+              {runStatus.user?.notes ? (
+                <Metric label="Run notes" value={runStatus.user.notes} />
+              ) : null}
               <Metric label="Product state" value={humanize(runStatus.product_state)} />
               <Metric label="Validation" value={humanize(runStatus.validation_status)} />
               <Metric label="Exit code" value={runStatus.exit_code?.toString() ?? "Running"} />
@@ -4846,13 +4932,7 @@ function LocalRunWorkflowPanel({
   );
 }
 
-function LocalRunQueuePanel({
-  queue,
-  status,
-}: {
-  queue: RunQueueResponse | null;
-  status: string;
-}) {
+function LocalRunQueuePanel({ queue, status }: { queue: RunQueueResponse | null; status: string }) {
   const visibleEntries = queue ? queue.entries.slice(-5).reverse() : [];
   return (
     <section className="run-status-panel" aria-label="Local serial run queue">
@@ -4880,9 +4960,7 @@ function LocalRunQueuePanel({
             <li key={`${entry.run_id}-${entry.queued_at}`}>
               <strong>{entry.run_id}</strong>{" "}
               <span className="muted-inline">{runQueueEntryLabel(entry)}</span>
-              {entry.result_id && (
-                <span className="muted-inline"> result {entry.result_id}</span>
-              )}
+              {entry.result_id && <span className="muted-inline"> result {entry.result_id}</span>}
               {entry.cleanup_status && (
                 <span className="muted-inline"> package retained for Results/Explore</span>
               )}
@@ -5200,9 +5278,9 @@ function PipelineRunCard({
   const displayName = result?.name ?? run.scenario_name ?? run.scenario_id ?? run.run_id;
   const canLaunch = Boolean(
     run.manifest_path &&
-      run.category === "dry_run_only" &&
-      !run.worker_state &&
-      !queueEntryIsOpen(queueEntry),
+    run.category === "dry_run_only" &&
+    !run.worker_state &&
+    !queueEntryIsOpen(queueEntry),
   );
   const canRefreshWorker = Boolean(run.manifest_path && run.worker_state === "running");
   const canFinalizeWorker = Boolean(
@@ -5471,7 +5549,9 @@ function queueEntryIsOpen(entry: RunQueueEntry | undefined): boolean {
 }
 
 function latestAutoIngestedQueueEntry(queue: RunQueueResponse): RunQueueEntry | undefined {
-  return [...queue.entries].reverse().find((entry) => entry.state === "ingested" && entry.result_id);
+  return [...queue.entries]
+    .reverse()
+    .find((entry) => entry.state === "ingested" && entry.result_id);
 }
 
 function queueEntryForRun(
@@ -6035,8 +6115,7 @@ function ResultNotebookCard({
     );
   }
 
-  const visibleDeletePreview =
-    deletePreview?.result_id === result.result_id ? deletePreview : null;
+  const visibleDeletePreview = deletePreview?.result_id === result.result_id ? deletePreview : null;
 
   return (
     <section className="notebook-card" aria-label="Result detail">
@@ -6093,14 +6172,17 @@ function ResultNotebookCard({
       <InterestingTimesSummary result={result} />
       {deleteMessage && <p role="status">{deleteMessage}</p>}
       {visibleDeletePreview && (
-        <section className="delete-preview result-delete-preview" aria-label="Result delete preview">
+        <section
+          className="delete-preview result-delete-preview"
+          aria-label="Result delete preview"
+        >
           <h4>Delete result and local run data preview</h4>
           <p>
             This removes the ingested result, notebook edits, diagnostics, derived products, CM1
             output, logs, and local run files stored under this run directory. The result will
-            disappear from Results, Explore, and local inventory after confirmation. It
-            does not touch the source repo, runtime home itself, or external CM1 install. No files
-            have been deleted yet.
+            disappear from Results, Explore, and local inventory after confirmation. It does not
+            touch the source repo, runtime home itself, or external CM1 install. No files have been
+            deleted yet.
           </p>
           <dl className="metric-grid">
             <Metric label="Run ID" value={visibleDeletePreview.run_id} />
@@ -8372,6 +8454,28 @@ function candidateStationLabel(candidate: SoundingCandidate): string {
   return `${candidate.station_name ?? "Observed sounding"} (${candidate.station_id})`;
 }
 
+function observedSoundingLabel(observed: ObservedSoundingSummary): string {
+  const station = observed.station_name
+    ? `${observed.station_name} (${observed.station_id})`
+    : observed.station_id;
+  return `${station} - ${formatDate(observed.valid_time_utc)}`;
+}
+
+function observedSoundingLocationLabel(observed: ObservedSoundingSummary): string {
+  if (
+    observed.station_latitude !== null &&
+    observed.station_latitude !== undefined &&
+    observed.station_longitude !== null &&
+    observed.station_longitude !== undefined
+  ) {
+    return `${formatNumber(observed.station_latitude, "deg")}, ${formatNumber(
+      observed.station_longitude,
+      "deg",
+    )}`;
+  }
+  return "Not available";
+}
+
 function candidateMatchScore(
   candidate: SoundingCandidate,
   story: CandidateStoryId | CandidateStoryFilter,
@@ -8463,7 +8567,24 @@ function candidateScreeningMetadata(
     discovery_bucket: candidate.discovery_bucket ?? null,
     source_file_name: candidate.source_file_name,
     source_file_hash: candidate.source_file_hash,
+    saved_tags: savedCandidate?.tags ?? [],
+    saved_notes: savedCandidate?.notes ?? null,
   };
+}
+
+function runUserMetadataFromCandidateScreening(
+  candidateScreening: Record<string, unknown> | null,
+): { tags: string[]; notes: string | null } | null {
+  if (!candidateScreening) return null;
+  const tags = Array.isArray(candidateScreening.saved_tags)
+    ? candidateScreening.saved_tags.filter((tag): tag is string => typeof tag === "string")
+    : [];
+  const notes =
+    typeof candidateScreening.saved_notes === "string" && candidateScreening.saved_notes.trim()
+      ? candidateScreening.saved_notes.trim()
+      : null;
+  if (tags.length === 0 && !notes) return null;
+  return { tags, notes };
 }
 
 function StatusBadge({ label, tone }: { label: string; tone: "good" | "warning" | "neutral" }) {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -277,6 +277,9 @@ type SoundingCandidate = {
   evidence: EvidenceItem[];
   caveats: string[];
   selected_sounding_payload?: ObservedSoundingRecord | null;
+  interest_summary?: string | null;
+  interest_reasons?: string[];
+  discovery_bucket?: string | null;
   screening_version: string;
   created_at: string;
 };
@@ -1002,7 +1005,7 @@ const deepConvectionStoryIds = new Set<string>([
   "squall_line_cold_pool_candidate",
   "elevated_convection",
 ]);
-const candidateWorkingSetTags = [
+const candidateSuggestedTags = [
   "Deep convection candidates",
   "Surface-forced candidates",
   "Needs longer run",
@@ -1151,15 +1154,34 @@ async function fetchSavedSoundingCandidates(): Promise<SavedCandidatesResponse> 
 
 async function saveSoundingCandidate(
   candidate: SoundingCandidate,
-  workingSetTag: string,
+  tags: string[],
+  notes: string | null,
 ): Promise<SavedSoundingCandidate> {
   const response = await fetch("/api/sounding-candidates/saved", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ candidate, tags: [workingSetTag] }),
+    body: JSON.stringify({ candidate, tags, notes }),
   });
   if (!response.ok) {
     throw new Error(await responseError(response, "Unable to save sounding candidate."));
+  }
+  return response.json() as Promise<SavedSoundingCandidate>;
+}
+
+async function updateSavedSoundingCandidate(
+  savedCandidateId: string,
+  tags: string[],
+  notes: string | null,
+): Promise<SavedSoundingCandidate> {
+  const response = await fetch(`/api/sounding-candidates/saved/${savedCandidateId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tags, notes }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      await responseError(response, "Unable to update saved sounding candidate."),
+    );
   }
   return response.json() as Promise<SavedSoundingCandidate>;
 }
@@ -1531,8 +1553,6 @@ export function App() {
   const [candidateStationSearch, setCandidateStationSearch] = useState("");
   const [candidateReadinessFilter, setCandidateReadinessFilter] =
     useState<CandidateReadinessFilter>("all");
-  const [candidateWorkingSetTag, setCandidateWorkingSetTag] =
-    useState<(typeof candidateWorkingSetTags)[number]>("Maybe rerun");
   const [candidateCacheLimit, setCandidateCacheLimit] = useState("10");
   const [candidateLatestPerStation, setCandidateLatestPerStation] = useState("5");
   const [candidateResultLimit, setCandidateResultLimit] = useState("50");
@@ -1988,16 +2008,43 @@ export function App() {
     }
   }
 
-  async function handleSaveSoundingCandidate(candidate: SoundingCandidate) {
+  function handleClearCandidateAnalysisFilters() {
+    setCandidateStoryFilter("all");
+    setCandidateStoryFamilyFilter("all");
+    setCandidateSupportFilter("all");
+    setCandidateStationSearch("");
+    setCandidateReadinessFilter("all");
+    setCandidateSort("best_match");
+    setCandidateStatus("Showing default discovery settings; run Analyze recommendations");
+  }
+
+  async function handleSaveSoundingCandidate(
+    candidate: SoundingCandidate,
+    tags: string[] = [],
+    notes: string | null = null,
+  ) {
     setCandidateError(null);
-    setCandidateStatus("Saving sounding candidate");
+    const existing = savedCandidates.find(
+      (saved) => saved.candidate.candidate_id === candidate.candidate_id,
+    );
+    setCandidateStatus(existing ? "Updating saved sounding candidate" : "Saving sounding candidate");
     try {
-      const saved = await saveSoundingCandidate(candidate, candidateWorkingSetTag);
-      setSavedCandidates((current) => [
-        saved,
-        ...current.filter((item) => item.saved_candidate_id !== saved.saved_candidate_id),
-      ]);
-      setCandidateStatus("Sounding candidate saved");
+      if (existing) {
+        const saved = await updateSavedSoundingCandidate(existing.saved_candidate_id, tags, notes);
+        setSavedCandidates((current) =>
+          current.map((item) =>
+            item.saved_candidate_id === saved.saved_candidate_id ? saved : item,
+          ),
+        );
+        setCandidateStatus("Saved sounding candidate notes updated");
+      } else {
+        const saved = await saveSoundingCandidate(candidate, tags, notes);
+        setSavedCandidates((current) => [
+          saved,
+          ...current.filter((item) => item.saved_candidate_id !== saved.saved_candidate_id),
+        ]);
+        setCandidateStatus("Sounding candidate saved");
+      }
     } catch (caught) {
       setCandidateError(
         caught instanceof Error ? caught.message : "Unable to save sounding candidate.",
@@ -2596,7 +2643,6 @@ export function App() {
           candidateSort={candidateSort}
           candidateStationSearch={candidateStationSearch}
           candidateReadinessFilter={candidateReadinessFilter}
-          candidateWorkingSetTag={candidateWorkingSetTag}
           candidateCacheLimit={candidateCacheLimit}
           candidateLatestPerStation={candidateLatestPerStation}
           candidateResultLimit={candidateResultLimit}
@@ -2641,7 +2687,7 @@ export function App() {
           onCandidateSortChange={setCandidateSort}
           onCandidateStationSearchChange={setCandidateStationSearch}
           onCandidateReadinessFilterChange={setCandidateReadinessFilter}
-          onCandidateWorkingSetTagChange={setCandidateWorkingSetTag}
+          onClearCandidateAnalysisFilters={handleClearCandidateAnalysisFilters}
           onCandidateCacheLimitChange={setCandidateCacheLimit}
           onCandidateLatestPerStationChange={setCandidateLatestPerStation}
           onCandidateResultLimitChange={setCandidateResultLimit}
@@ -2746,7 +2792,6 @@ function BuildWorkspace({
   candidateSort,
   candidateStationSearch,
   candidateReadinessFilter,
-  candidateWorkingSetTag,
   candidateCacheLimit,
   candidateLatestPerStation,
   candidateResultLimit,
@@ -2786,7 +2831,7 @@ function BuildWorkspace({
   onCandidateSortChange,
   onCandidateStationSearchChange,
   onCandidateReadinessFilterChange,
-  onCandidateWorkingSetTagChange,
+  onClearCandidateAnalysisFilters,
   onCandidateCacheLimitChange,
   onCandidateLatestPerStationChange,
   onCandidateResultLimitChange,
@@ -2842,7 +2887,6 @@ function BuildWorkspace({
   candidateSort: CandidateSort;
   candidateStationSearch: string;
   candidateReadinessFilter: CandidateReadinessFilter;
-  candidateWorkingSetTag: (typeof candidateWorkingSetTags)[number];
   candidateCacheLimit: string;
   candidateLatestPerStation: string;
   candidateResultLimit: string;
@@ -2882,7 +2926,7 @@ function BuildWorkspace({
   onCandidateSortChange: (sort: CandidateSort) => void;
   onCandidateStationSearchChange: (value: string) => void;
   onCandidateReadinessFilterChange: (filter: CandidateReadinessFilter) => void;
-  onCandidateWorkingSetTagChange: (tag: (typeof candidateWorkingSetTags)[number]) => void;
+  onClearCandidateAnalysisFilters: () => void;
   onCandidateCacheLimitChange: (value: string) => void;
   onCandidateLatestPerStationChange: (value: string) => void;
   onCandidateResultLimitChange: (value: string) => void;
@@ -3072,7 +3116,6 @@ function BuildWorkspace({
                     sort={candidateSort}
                     stationSearch={candidateStationSearch}
                     readinessFilter={candidateReadinessFilter}
-                    workingSetTag={candidateWorkingSetTag}
                     cacheLimit={candidateCacheLimit}
                     latestPerStation={candidateLatestPerStation}
                     resultLimit={candidateResultLimit}
@@ -3087,7 +3130,7 @@ function BuildWorkspace({
                     onSortChange={onCandidateSortChange}
                     onStationSearchChange={onCandidateStationSearchChange}
                     onReadinessFilterChange={onCandidateReadinessFilterChange}
-                    onWorkingSetTagChange={onCandidateWorkingSetTagChange}
+                    onClearFilters={onClearCandidateAnalysisFilters}
                     onCacheLimitChange={onCandidateCacheLimitChange}
                     onLatestPerStationChange={onCandidateLatestPerStationChange}
                     onResultLimitChange={onCandidateResultLimitChange}
@@ -3284,7 +3327,6 @@ function ObservedAtmosphereCandidatesPanel({
   sort,
   stationSearch,
   readinessFilter,
-  workingSetTag,
   cacheLimit,
   latestPerStation,
   resultLimit,
@@ -3299,7 +3341,7 @@ function ObservedAtmosphereCandidatesPanel({
   onSortChange,
   onStationSearchChange,
   onReadinessFilterChange,
-  onWorkingSetTagChange,
+  onClearFilters,
   onCacheLimitChange,
   onLatestPerStationChange,
   onResultLimitChange,
@@ -3320,7 +3362,6 @@ function ObservedAtmosphereCandidatesPanel({
   sort: CandidateSort;
   stationSearch: string;
   readinessFilter: CandidateReadinessFilter;
-  workingSetTag: (typeof candidateWorkingSetTags)[number];
   cacheLimit: string;
   latestPerStation: string;
   resultLimit: string;
@@ -3335,7 +3376,7 @@ function ObservedAtmosphereCandidatesPanel({
   onSortChange: (sort: CandidateSort) => void;
   onStationSearchChange: (value: string) => void;
   onReadinessFilterChange: (filter: CandidateReadinessFilter) => void;
-  onWorkingSetTagChange: (tag: (typeof candidateWorkingSetTags)[number]) => void;
+  onClearFilters: () => void;
   onCacheLimitChange: (value: string) => void;
   onLatestPerStationChange: (value: string) => void;
   onResultLimitChange: (value: string) => void;
@@ -3343,7 +3384,7 @@ function ObservedAtmosphereCandidatesPanel({
   onRefreshIGRAData: () => void;
   onCacheStationFiles: () => void;
   onScreen: () => void;
-  onSave: (candidate: SoundingCandidate) => void;
+  onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
   onRemoveSaved: (savedCandidateId: string) => void;
   onUse: (candidate: SoundingCandidate, savedCandidate?: SavedSoundingCandidate) => void;
 }) {
@@ -3356,6 +3397,12 @@ function ObservedAtmosphereCandidatesPanel({
     () => new Set(savedCandidates.map((saved) => saved.candidate.candidate_id)),
     [savedCandidates],
   );
+  const selectedSavedCandidate =
+    selectedCandidate === null
+      ? null
+      : savedCandidates.find(
+          (saved) => saved.candidate.candidate_id === selectedCandidate.candidate_id,
+        ) ?? null;
   const cachedStations = new Set((cache?.entries ?? []).map((entry) => entry.station_id)).size;
   const cachedStationFiles = cache?.entries.length ?? 0;
   const cachedCatalogFiles =
@@ -3369,6 +3416,14 @@ function ObservedAtmosphereCandidatesPanel({
     screenableSoundingCount > 0
       ? `${screenableSoundingCount.toLocaleString()} soundings`
       : `${screeningInputs.length.toLocaleString()} cached files`;
+  const activeRefinements = [
+    storyFilter !== "all" ? `Story: ${candidateStoryLabel(storyFilter)}` : null,
+    storyFamilyFilter !== "all" ? `Family: ${candidateStoryFamilyLabel(storyFamilyFilter)}` : null,
+    supportFilter !== "all" ? `Support: ${humanize(supportFilter)}` : null,
+    readinessFilter !== "all" ? `Readiness: ${humanize(readinessFilter)}` : null,
+    stationSearch.trim() ? `Station search: ${stationSearch.trim()}` : null,
+    sort !== "best_match" ? `Sort: ${candidateSortLabel(sort)}` : null,
+  ].filter((item): item is string => item !== null);
 
   return (
     <section
@@ -3406,194 +3461,193 @@ function ObservedAtmosphereCandidatesPanel({
         </div>
       )}
 
-      <div className="candidate-toolbar" aria-label="Sounding candidate controls">
-        <label>
-          Story filter
-          <select
-            value={storyFilter}
-            onChange={(event) => onStoryFilterChange(event.target.value as CandidateStoryFilter)}
-          >
-            <option value="all">All screening stories</option>
-            <option value="deep_convection_trial">Deep Convection Trial stories</option>
-            <option value="shallow_cumulus_candidate">Cloud-forming shallow cumulus</option>
-            <option value="dry_failed_candidate">Dry failed cumulus</option>
-            <option value="capped_suppressed_candidate">Capped / suppressed</option>
-            <option value="humid_rainy_candidate">Humid / rainy</option>
-            <option value="severe_thunderstorm_environment">Severe thunderstorm environment</option>
-            <option value="supercell_environment">Supercell-like environment</option>
-            <option value="high_cape_pulse_storm">High-CAPE pulse storm</option>
-            <option value="dry_microburst_inverted_v">Dry microburst / inverted-V</option>
-            <option value="squall_line_cold_pool_candidate">
-              Squall-line / cold-pool candidate
-            </option>
-            <option value="elevated_convection">Elevated convection</option>
-            <option value="needs_review">Needs review</option>
-            <option value="poor_or_incomplete_candidate">Poor or incomplete</option>
-          </select>
-        </label>
-        <label>
-          Story family
-          <select
-            value={storyFamilyFilter}
-            onChange={(event) =>
-              onStoryFamilyFilterChange(event.target.value as CandidateStoryFamilyFilter)
-            }
-          >
-            <option value="all">All families</option>
-            <option value="lower_atmosphere">Lower-atmosphere stories</option>
-            <option value="deep_convection">Deep-convection stories</option>
-            <option value="review">Needs review / incomplete</option>
-          </select>
-        </label>
-        <label>
-          Support
-          <select
-            value={supportFilter}
-            onChange={(event) =>
-              onSupportFilterChange(event.target.value as CandidateSupportFilter)
-            }
-          >
-            <option value="all">All support states</option>
-            <option value="supported">Supported</option>
-            <option value="weak">Weak support</option>
-            <option value="unavailable">Unavailable</option>
-          </select>
-        </label>
-        <label>
-          Sort
-          <select
-            value={sort}
-            onChange={(event) => onSortChange(event.target.value as CandidateSort)}
-          >
-            <option value="best_match">Best match for story</option>
-            <option value="valid_time">Valid time</option>
-            <option value="station_id">Station ID</option>
-            <option value="station_name">Station name</option>
-            <option value="primary_story">Primary story</option>
-            <option value="story_family">Story family</option>
-            <option value="rank_score">Rank score</option>
-            <option value="confidence">Confidence</option>
-            <option value="support">Support state</option>
-            <option value="package_readiness">Package readiness</option>
-            <option value="observed_wind_available">Observed wind availability</option>
-            <option value="profile_top_m_agl">Profile top</option>
-            <option value="lowest_level_m_agl">Lowest usable level</option>
-            <option value="data_completeness_score">Data completeness</option>
-            <option value="low_level_qv_g_kg">Low-level qv</option>
-            <option value="mean_qv_0_500m_g_kg">Mean qv 0-500 m</option>
-            <option value="mean_qv_0_1000m_g_kg">Mean qv 0-1 km</option>
-            <option value="surface_t_td_spread_c">Surface T-Td spread</option>
-            <option value="estimated_lcl_height_m_agl">Estimated LCL</option>
-            <option value="lapse_rate_0_1000m_c_per_km">Low-level lapse rate</option>
-            <option value="midlevel_lapse_rate_700_500_hpa_c_per_km">
-              Midlevel lapse rate
-            </option>
-            <option value="cap_strength_proxy">Cap/inversion strength</option>
-            <option value="cap_height_m_agl">Cap/inversion height</option>
-            <option value="bulk_shear_0_1km_m_s">Bulk shear 0-1 km</option>
-            <option value="bulk_shear_0_3km_m_s">Bulk shear 0-3 km</option>
-            <option value="bulk_shear_0_6km_m_s">Bulk shear 0-6 km</option>
-            <option value="midlevel_dry_layer_proxy">Dry-layer proxy</option>
-            <option value="dry_microburst_inverted_v_proxy">Inverted-V proxy</option>
-            <option value="freezing_level_m_agl">Freezing level</option>
-          </select>
-        </label>
-        <label>
-          Station search
-          <input
-            type="search"
-            value={stationSearch}
-            placeholder="Station name, ID, or state"
-            onChange={(event) => onStationSearchChange(event.target.value)}
-          />
-        </label>
-        <label>
-          Readiness
-          <select
-            value={readinessFilter}
-            onChange={(event) =>
-              onReadinessFilterChange(event.target.value as CandidateReadinessFilter)
-            }
-          >
-            <option value="all">All readiness states</option>
-            <option value="package_ready">Package-ready only</option>
-            <option value="blocked">Blocked / needs review</option>
-          </select>
-        </label>
-        <label>
-          Save into
-          <select
-            value={workingSetTag}
-            onChange={(event) =>
-              onWorkingSetTagChange(event.target.value as (typeof candidateWorkingSetTags)[number])
-            }
-          >
-            {candidateWorkingSetTags.map((tag) => (
-              <option key={tag} value={tag}>
-                {tag}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Cache up to
-          <input
-            type="number"
-            min="1"
-            max="100"
-            value={cacheLimit}
-            onChange={(event) => onCacheLimitChange(event.target.value)}
-          />
-        </label>
-        <label>
-          Latest per station
-          <input
-            type="number"
-            min="1"
-            max="50"
-            value={latestPerStation}
-            onChange={(event) => onLatestPerStationChange(event.target.value)}
-          />
-        </label>
-        <label>
-          Candidate limit
-          <input
-            type="number"
-            min="1"
-            max="200"
-            value={resultLimit}
-            onChange={(event) => onResultLimitChange(event.target.value)}
-          />
-        </label>
-        <div className="button-row candidate-toolbar-actions">
-          <button type="button" onClick={onRefreshIGRAData}>
-            Refresh IGRA catalog
-          </button>
-          <button type="button" className="secondary-button" onClick={onCacheStationFiles}>
-            Cache station files
-          </button>
-          <button type="button" onClick={onScreen}>
-            Analyze cached soundings
+      <div className="candidate-discovery-actions" aria-label="Sounding candidate actions">
+        <button type="button" onClick={onScreen}>
+          Analyze recommendations
+        </button>
+        <button type="button" className="secondary-button" onClick={onRefreshIGRAData}>
+          Refresh IGRA catalog
+        </button>
+        <button type="button" className="secondary-button" onClick={onCacheStationFiles}>
+          Cache station files
+        </button>
+      </div>
+
+      {activeRefinements.length > 0 && (
+        <div className="screening-guidance-note">
+          <strong>Refined view</strong>
+          <span>{activeRefinements.join(" · ")}</span>
+          <button type="button" className="link-button" onClick={onClearFilters}>
+            Clear refinements
           </button>
         </div>
-      </div>
+      )}
+
+      <details className="candidate-advanced-filters" open={activeRefinements.length > 0}>
+        <summary>Advanced filters</summary>
+        <div className="candidate-toolbar" aria-label="Advanced sounding candidate controls">
+          <label>
+            Story
+            <select
+              value={storyFilter}
+              onChange={(event) => onStoryFilterChange(event.target.value as CandidateStoryFilter)}
+            >
+              <option value="all">All screening stories</option>
+              <option value="deep_convection_trial">Deep Convection Trial stories</option>
+              <option value="shallow_cumulus_candidate">Cloud-forming shallow cumulus</option>
+              <option value="dry_failed_candidate">Dry failed cumulus</option>
+              <option value="capped_suppressed_candidate">Capped / suppressed</option>
+              <option value="humid_rainy_candidate">Humid / rainy</option>
+              <option value="severe_thunderstorm_environment">Severe thunderstorm environment</option>
+              <option value="supercell_environment">Supercell-like environment</option>
+              <option value="high_cape_pulse_storm">High-CAPE pulse storm</option>
+              <option value="dry_microburst_inverted_v">Dry microburst / inverted-V</option>
+              <option value="squall_line_cold_pool_candidate">
+                Squall-line / cold-pool candidate
+              </option>
+              <option value="elevated_convection">Elevated convection</option>
+              <option value="needs_review">Needs review</option>
+              <option value="poor_or_incomplete_candidate">Poor or incomplete</option>
+            </select>
+          </label>
+          <label>
+            Story family
+            <select
+              value={storyFamilyFilter}
+              onChange={(event) =>
+                onStoryFamilyFilterChange(event.target.value as CandidateStoryFamilyFilter)
+              }
+            >
+              <option value="all">All families</option>
+              <option value="lower_atmosphere">Lower-atmosphere stories</option>
+              <option value="deep_convection">Deep-convection stories</option>
+              <option value="review">Needs review / incomplete</option>
+            </select>
+          </label>
+          <label>
+            Support
+            <select
+              value={supportFilter}
+              onChange={(event) =>
+                onSupportFilterChange(event.target.value as CandidateSupportFilter)
+              }
+            >
+              <option value="all">All support states</option>
+              <option value="supported">Supported</option>
+              <option value="weak">Weak support</option>
+              <option value="unavailable">Unavailable</option>
+            </select>
+          </label>
+          <label>
+            Sort
+            <select value={sort} onChange={(event) => onSortChange(event.target.value as CandidateSort)}>
+              <option value="best_match">Recommended</option>
+              <option value="valid_time">Valid time</option>
+              <option value="station_id">Station ID</option>
+              <option value="station_name">Station name</option>
+              <option value="primary_story">Primary story</option>
+              <option value="story_family">Story family</option>
+              <option value="rank_score">Rank score</option>
+              <option value="confidence">Confidence</option>
+              <option value="support">Support state</option>
+              <option value="package_readiness">Package readiness</option>
+              <option value="observed_wind_available">Observed wind availability</option>
+              <option value="profile_top_m_agl">Profile top</option>
+              <option value="lowest_level_m_agl">Lowest usable level</option>
+              <option value="data_completeness_score">Data completeness</option>
+              <option value="low_level_qv_g_kg">Low-level qv</option>
+              <option value="mean_qv_0_500m_g_kg">Mean qv 0-500 m</option>
+              <option value="mean_qv_0_1000m_g_kg">Mean qv 0-1 km</option>
+              <option value="surface_t_td_spread_c">Surface T-Td spread</option>
+              <option value="estimated_lcl_height_m_agl">Estimated LCL</option>
+              <option value="lapse_rate_0_1000m_c_per_km">Low-level lapse rate</option>
+              <option value="midlevel_lapse_rate_700_500_hpa_c_per_km">
+                Midlevel lapse rate
+              </option>
+              <option value="cap_strength_proxy">Cap/inversion strength</option>
+              <option value="cap_height_m_agl">Cap/inversion height</option>
+              <option value="bulk_shear_0_1km_m_s">Bulk shear 0-1 km</option>
+              <option value="bulk_shear_0_3km_m_s">Bulk shear 0-3 km</option>
+              <option value="bulk_shear_0_6km_m_s">Bulk shear 0-6 km</option>
+              <option value="midlevel_dry_layer_proxy">Dry-layer proxy</option>
+              <option value="dry_microburst_inverted_v_proxy">Inverted-V proxy</option>
+              <option value="freezing_level_m_agl">Freezing level</option>
+            </select>
+          </label>
+          <label>
+            Station search
+            <input
+              type="search"
+              value={stationSearch}
+              placeholder="Station name, ID, or state"
+              onChange={(event) => onStationSearchChange(event.target.value)}
+            />
+          </label>
+          <label>
+            Readiness
+            <select
+              value={readinessFilter}
+              onChange={(event) =>
+                onReadinessFilterChange(event.target.value as CandidateReadinessFilter)
+              }
+            >
+              <option value="all">All readiness states</option>
+              <option value="package_ready">Package-ready only</option>
+              <option value="blocked">Blocked / needs review</option>
+            </select>
+          </label>
+          <label>
+            Cache up to
+            <input
+              type="number"
+              min="1"
+              max="100"
+              value={cacheLimit}
+              onChange={(event) => onCacheLimitChange(event.target.value)}
+            />
+          </label>
+          <label>
+            Latest per station
+            <input
+              type="number"
+              min="1"
+              max="50"
+              value={latestPerStation}
+              onChange={(event) => onLatestPerStationChange(event.target.value)}
+            />
+          </label>
+          <label>
+            Candidate limit
+            <input
+              type="number"
+              min="1"
+              max="200"
+              value={resultLimit}
+              onChange={(event) => onResultLimitChange(event.target.value)}
+            />
+          </label>
+        </div>
+      </details>
 
       <div className="candidate-workspace">
         <section aria-label="Screened sounding candidates">
           {screening && (
-            <p className="field-help">
-              Showing {visibleCandidates.length.toLocaleString()} backend-filtered candidates
-              {screening.total_candidate_count !== undefined
-                ? ` from ${screening.total_candidate_count.toLocaleString()} cached-sounding hypotheses`
-                : ""}. Unavailable feature values are caveated and sorted last by the backend.
-            </p>
+            <div className="candidate-list-heading">
+              <h4>{activeRefinements.length > 0 ? "Refined candidates" : "Recommended cached soundings"}</h4>
+              <p className="field-help">
+                Showing {visibleCandidates.length.toLocaleString()} candidates
+                {screening.total_candidate_count !== undefined
+                  ? ` from ${screening.total_candidate_count.toLocaleString()} cached sounding hypotheses`
+                  : ""}. Each score is screening guidance; CM1 still decides what happens.
+              </p>
+            </div>
           )}
           {visibleCandidates.length === 0 ? (
             <div className="scenario-state-panel">
               <h4>No screened candidates loaded</h4>
               <p>
-                Refresh the IGRA catalog to check available stations, cache a bounded batch of
-                station files, then analyze cached soundings by atmospheric story.
+                Refresh the IGRA catalog if needed, cache station files, then analyze
+                recommendations from the soundings already cached locally.
               </p>
             </div>
           ) : (
@@ -3614,7 +3668,12 @@ function ObservedAtmosphereCandidatesPanel({
           )}
         </section>
 
-        <SoundingCandidateDetail candidate={selectedCandidate} storyFilter={storyFilter} />
+        <SoundingCandidateDetail
+          candidate={selectedCandidate}
+          storyFilter={storyFilter}
+          savedCandidate={selectedSavedCandidate}
+          onSave={onSave}
+        />
       </div>
 
       <section className="saved-candidates-panel" aria-labelledby="saved-candidates-title">
@@ -3643,7 +3702,8 @@ function ObservedAtmosphereCandidatesPanel({
                     {formatDate(saved.candidate.valid_time_utc)} ·{" "}
                     {candidateStoryLabel(saved.primary_story)}
                   </small>
-                  {saved.tags.length > 0 && <small>Working set: {saved.tags.join(", ")}</small>}
+                  {saved.tags.length > 0 && <small>Tags: {saved.tags.join(", ")}</small>}
+                  {saved.notes && <small>Notes: {saved.notes}</small>}
                   {saved.linked_run_ids.length > 0 && (
                     <small>Used in {saved.linked_run_ids.join(", ")}</small>
                   )}
@@ -3688,6 +3748,7 @@ function SoundingCandidateCard({
 }) {
   const story = storyFilter === "all" ? candidate.primary_story : storyFilter;
   const matchScore = candidateMatchScore(candidate, story);
+  const reasons = candidateInterestReasons(candidate);
   return (
     <article
       className={`candidate-card${selected ? " selected-candidate-card" : ""}`}
@@ -3703,6 +3764,9 @@ function SoundingCandidateCard({
           <small>{formatDate(candidate.valid_time_utc)}</small>
         </span>
         <span className="badge-row">
+          {candidate.discovery_bucket && (
+            <StatusBadge label={candidate.discovery_bucket} tone="neutral" />
+          )}
           <StatusBadge label={candidateStoryLabel(story)} tone="neutral" />
           {storyFilter === "deep_convection_trial" && (
             <StatusBadge label={candidate.primary_story_label} tone="neutral" />
@@ -3718,6 +3782,14 @@ function SoundingCandidateCard({
           />
         </span>
       </button>
+      <p className="candidate-interest-summary">{reasons[0]}</p>
+      {reasons.length > 1 && (
+        <ul className="compact-list candidate-reason-list">
+          {reasons.slice(1, 3).map((reason) => (
+            <li key={`${candidate.candidate_id}-${reason}`}>{reason}</li>
+          ))}
+        </ul>
+      )}
       <ul className="compact-list">
         {candidate.evidence.slice(0, 3).map((item) => (
           <li key={`${candidate.candidate_id}-${item.label}`}>
@@ -3745,10 +3817,24 @@ function SoundingCandidateCard({
 function SoundingCandidateDetail({
   candidate,
   storyFilter,
+  savedCandidate,
+  onSave,
 }: {
   candidate: SoundingCandidate | null;
   storyFilter: CandidateStoryFilter;
+  savedCandidate: SavedSoundingCandidate | null;
+  onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
 }) {
+  const [tagDraft, setTagDraft] = useState("");
+  const [notesDraft, setNotesDraft] = useState("");
+  const candidateId = candidate?.candidate_id ?? "";
+  const savedTagsText = savedCandidate?.tags.join(", ") ?? "";
+  const savedNotesText = savedCandidate?.notes ?? "";
+  useEffect(() => {
+    setTagDraft(savedTagsText);
+    setNotesDraft(savedNotesText);
+  }, [candidateId, savedCandidate?.saved_candidate_id, savedTagsText, savedNotesText]);
+
   if (!candidate) {
     return (
       <aside className="candidate-detail-panel">
@@ -3757,7 +3843,16 @@ function SoundingCandidateDetail({
       </aside>
     );
   }
-  const story = storyFilter === "all" ? candidate.primary_story : storyFilter;
+  const activeCandidate = candidate;
+  const story = storyFilter === "all" ? activeCandidate.primary_story : storyFilter;
+  const reasons = candidateInterestReasons(activeCandidate);
+  const savedTagValues = parseTags(tagDraft);
+  function handleTagSuggestion(tag: string) {
+    setTagDraft(_dedupeStrings([...savedTagValues, tag]).join(", "));
+  }
+  function handleAnnotationSubmit() {
+    onSave(activeCandidate, parseTags(tagDraft), notesDraft.trim() || null);
+  }
   const featureRows = [
     ["Observed wind profile", "observed_wind_available", ""],
     ["Profile top", "profile_top_m_agl", "m AGL"],
@@ -3798,6 +3893,14 @@ function SoundingCandidateDetail({
         Candidate match score is screening guidance only. CM1 decides whether clouds, rain, or
         suppression actually happen.
       </p>
+      <section>
+        <h5>Why this is interesting</h5>
+        <ul className="compact-list candidate-reason-list">
+          {reasons.map((reason) => (
+            <li key={`${candidate.candidate_id}-detail-${reason}`}>{reason}</li>
+          ))}
+        </ul>
+      </section>
       <dl className="compact-metrics">
         <Metric
           label="Match score"
@@ -3858,6 +3961,42 @@ function SoundingCandidateDetail({
           </ul>
         </details>
       )}
+      <div className="candidate-notes-form">
+        <h5>{savedCandidate ? "Candidate notes" : "Save candidate notes"}</h5>
+        <label htmlFor={`candidate-tags-${candidate.candidate_id}`}>
+          Tags
+          <input
+            id={`candidate-tags-${candidate.candidate_id}`}
+            value={tagDraft}
+            placeholder="deep convection, rerun, compare"
+            onChange={(event) => setTagDraft(event.target.value)}
+          />
+        </label>
+        <div className="candidate-tag-suggestions" aria-label="Suggested tags">
+          {candidateSuggestedTags.map((tag) => (
+            <button
+              type="button"
+              className="secondary-button"
+              key={tag}
+              onClick={() => handleTagSuggestion(tag)}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+        <label htmlFor={`candidate-notes-${candidate.candidate_id}`}>
+          Notes
+          <textarea
+            id={`candidate-notes-${candidate.candidate_id}`}
+            value={notesDraft}
+            placeholder="What makes this worth running or comparing?"
+            onChange={(event) => setNotesDraft(event.target.value)}
+          />
+        </label>
+        <button type="button" onClick={handleAnnotationSubmit}>
+          {savedCandidate ? "Update saved candidate" : "Save candidate"}
+        </button>
+      </div>
     </aside>
   );
 }
@@ -8182,6 +8321,41 @@ function candidateStoryFamilyLabel(family: CandidateStoryFamilyFilter | undefine
   }
 }
 
+function candidateSortLabel(sort: CandidateSort): string {
+  const labels: Record<CandidateSort, string> = {
+    best_match: "Recommended",
+    valid_time: "Valid time",
+    station_id: "Station ID",
+    station_name: "Station name",
+    primary_story: "Primary story",
+    story_family: "Story family",
+    rank_score: "Rank score",
+    confidence: "Confidence",
+    support: "Support state",
+    package_readiness: "Package readiness",
+    observed_wind_available: "Observed wind availability",
+    profile_top_m_agl: "Profile top",
+    lowest_level_m_agl: "Lowest usable level",
+    data_completeness_score: "Data completeness",
+    low_level_qv_g_kg: "Low-level qv",
+    mean_qv_0_500m_g_kg: "Mean qv 0-500 m",
+    mean_qv_0_1000m_g_kg: "Mean qv 0-1 km",
+    surface_t_td_spread_c: "Surface T-Td spread",
+    estimated_lcl_height_m_agl: "Estimated LCL",
+    lapse_rate_0_1000m_c_per_km: "Low-level lapse rate",
+    midlevel_lapse_rate_700_500_hpa_c_per_km: "Midlevel lapse rate",
+    cap_strength_proxy: "Cap/inversion strength",
+    cap_height_m_agl: "Cap/inversion height",
+    bulk_shear_0_1km_m_s: "Bulk shear 0-1 km",
+    bulk_shear_0_3km_m_s: "Bulk shear 0-3 km",
+    bulk_shear_0_6km_m_s: "Bulk shear 0-6 km",
+    midlevel_dry_layer_proxy: "Dry-layer proxy",
+    dry_microburst_inverted_v_proxy: "Inverted-V proxy",
+    freezing_level_m_agl: "Freezing level",
+  };
+  return labels[sort];
+}
+
 function defaultPackageFamilyForCandidate(candidate: SoundingCandidate): ObservedPackageFamily {
   if (deepConvectionStoryIds.has(candidate.primary_story)) return "deep_convection_trial";
   if (
@@ -8215,6 +8389,17 @@ function candidateMatchScore(
     candidate.story_scores.find((score) => score.story === story)?.score_0_to_100 ??
     candidate.rank_score
   );
+}
+
+function candidateInterestReasons(candidate: SoundingCandidate): string[] {
+  const explicitReasons = candidate.interest_reasons?.filter(Boolean) ?? [];
+  if (explicitReasons.length > 0) return explicitReasons;
+  if (candidate.interest_summary) return [candidate.interest_summary];
+  const evidenceReasons = candidate.evidence
+    .map((item) => item.interpretation)
+    .filter((reason): reason is string => Boolean(reason));
+  if (evidenceReasons.length > 0) return evidenceReasons.slice(0, 3);
+  return [candidate.primary_story_label];
 }
 
 function boundedInteger(value: string, min: number, max: number, fallback: number): number {
@@ -8273,6 +8458,9 @@ function candidateScreeningMetadata(
     features: candidate.features,
     evidence: candidate.evidence,
     caveats: candidate.caveats,
+    interest_summary: candidate.interest_summary ?? null,
+    interest_reasons: candidate.interest_reasons ?? [],
+    discovery_bucket: candidate.discovery_bucket ?? null,
     source_file_name: candidate.source_file_name,
     source_file_hash: candidate.source_file_hash,
   };
@@ -8716,10 +8904,12 @@ function _dedupeStrings(values: string[]): string[] {
 }
 
 function parseTags(value: string): string[] {
-  return value
-    .split(",")
-    .map((tag) => tag.trim())
-    .filter(Boolean);
+  return _dedupeStrings(
+    value
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean),
+  );
 }
 
 function formatSeconds(value: number | null): string {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -127,7 +127,7 @@ as zero. Saved candidates, freeform tags, and notes are runtime-local cache stat
 under
 `<runtime-home>/cache/sounding-candidates/`; they are not Result Cards and are
 not committed. When a saved candidate is used to generate a package, its
-screening summary may be copied into
+screening summary and saved tags/notes may be copied into
 `run_manifest.json`, `case_manifest.json`, and `dry_run_report.json` as
 provenance. The screening score remains a candidate-selection aid; CM1 output
 remains the source of truth.
@@ -402,11 +402,12 @@ scenario template, generated report, or pre-run validation report.
 Dry-run package generation uses the validated scenario template and CM1 input contract to create a reviewable package under the configured runtime home, normally `~/CloudChamber/runs/<run-id>/`. The package writer should refuse to overwrite existing run directories, validate controls before writing, and produce only package inputs/reports, not CM1 output.
 
 The implemented dry-run API is `POST /api/dry-run-package`. It currently accepts
-scenario ID, selected product controls, and a legacy run-size preset, then
-returns the package paths and dry-run report summary for UI review. The forward
-API should accept a selected run configuration with optional preset provenance.
-It must not launch CM1, write NetCDF, or place generated packages inside the
-source tree during tests.
+scenario ID, selected product controls, a legacy run-size preset, optional
+observed-sounding/candidate-screening provenance, and optional user-facing
+tags/notes, then returns the package paths and dry-run report summary for UI
+review. The forward API should accept a selected run configuration with optional
+preset provenance. It must not launch CM1, write NetCDF, or place generated
+packages inside the source tree during tests.
 
 The Build workspace is the first guided app-side launchpad over the existing
 backend contracts:
@@ -444,7 +445,8 @@ eligible states and offers only safe state-appropriate transitions:
 - create a new package through `POST /api/dry-run-package`;
 - queue an eligible packaged run through `POST /api/runs/queue`;
 - refresh and advance the serial local queue through `GET /api/runs/queue`;
-- refresh current status through `GET /api/runs/status`;
+- refresh current status, observed-sounding context, and package notes through
+  `GET /api/runs/status`;
 - ingest completed output through `POST /api/results/ingest`;
 - open associated results in Results or Explore;
 - preview and confirm cleanup for non-ingested package/run directories.
@@ -1204,7 +1206,7 @@ legacy run-size preset, physical question, expected diagnostics, and
 visualization defaults when those concepts are available from the scenario
 template.
 
-The backend run-manifest schema records run ID, scenario reference/version, adjusted controls, generated CM1 input paths, CM1 root/run paths, app metadata, timestamps, lifecycle state, validation status, output paths, user notes/tags, and provenance labels. It serializes/deserializes as JSON and does not require NetCDF output.
+The backend run-manifest schema records run ID, scenario reference/version, adjusted controls, generated CM1 input paths, CM1 root/run paths, app metadata, timestamps, lifecycle state, validation status, output paths, observed-sounding context when present, user notes/tags, and provenance labels. It serializes/deserializes as JSON and does not require NetCDF output.
 
 Output metadata distinguishes:
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -103,21 +103,28 @@ When cached station metadata is available, the observed-sounding parser can use
 it for station name, location, and elevation instead of relying only on built-in
 fixture metadata.
 
-The sounding-candidate screening layer consumes only cached station text plus
-cache metadata. It reuses the canonical observed-sounding parser, computes
-transparent low-order features such as low-level moisture, estimated LCL,
-low-level lapse-rate, inversion/cap proxy, moisture depth, and profile
-coverage, and emits pre-run story-specific candidate matches. Stable story
-identifiers are `shallow_cumulus_candidate`, `dry_failed_candidate`,
+The sounding-candidate screening and analysis layer consumes only cached station
+text plus cache metadata. It reuses the canonical observed-sounding parser,
+computes transparent low-order features such as low-level moisture, estimated
+LCL, low-level lapse-rate, inversion/cap proxy, moisture depth, profile
+coverage, observed-wind availability, bulk-shear proxies when winds exist,
+dry-layer/inverted-V proxies, and freezing-level context, and emits pre-run
+story-specific candidate matches. Stable story identifiers are
+`shallow_cumulus_candidate`, `dry_failed_candidate`,
 `capped_suppressed_candidate`, `humid_rainy_candidate`, `needs_review`, and
-`poor_or_incomplete_candidate`; the auditable scoring contract lives in
+`poor_or_incomplete_candidate`; severe/deep-convection story identifiers remain
+pre-run hypotheses for Deep Convection Trial routing. The auditable scoring
+contract lives in
 [contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
-Screening can target one story at a time because
-the useful sounding depends on the experiment question; a shallow-cumulus search
-and a humid/rainy search should not imply the same ranked list. Saved candidates
-are runtime-local cache state under `<runtime-home>/cache/sounding-candidates/`;
-they are not Result Cards and are not committed. When a saved candidate is used
-to generate a package, its screening summary may be copied into
+Analysis can target story, story family, support state, package readiness,
+station search, and backend-owned sort keys because the useful sounding depends
+on the experiment question; a shallow-cumulus search and a humid/rainy search
+should not imply the same ranked list. Missing feature values stay unavailable
+and sort last instead of being treated as zero. Saved candidates and working-set
+tags are runtime-local cache state under
+`<runtime-home>/cache/sounding-candidates/`; they are not Result Cards and are
+not committed. When a saved candidate is used to generate a package, its
+screening summary may be copied into
 `run_manifest.json`, `case_manifest.json`, and `dry_run_report.json` as
 provenance. The screening score remains a candidate-selection aid; CM1 output
 remains the source of truth.
@@ -150,14 +157,14 @@ soundings as pre-run hypotheses for an idealized triggered CM1 experiment.
 
 The Build UI consumes this layer through bounded JSON only. `Upload a Sounding`
 loads saved candidates immediately when that experiment is selected, before any
-catalog refresh or screening action. It can also call the
-recent-catalog/cache and candidate-screening endpoints, display the candidate
-list, and pass a selected candidate's `selected_sounding_payload` into the
-existing observed-sounding package review. The frontend does not read cached
-station text directly and does not compute the story scores. Candidate status is
-separate from run/result status: saved candidates are pre-run hypotheses, while
-generated packages, launched runs, and ingested results remain separate
-lifecycle objects.
+catalog refresh or analysis action. It can also call the recent-catalog/cache
+and candidate-analysis endpoints, display the backend-filtered candidate list,
+save candidates into working-set tags, and pass a selected candidate's
+`selected_sounding_payload` into the existing observed-sounding package review.
+The frontend does not read cached station text directly, compute the story
+scores, or sort raw feature values itself. Candidate status is separate from
+run/result status: saved candidates are pre-run hypotheses, while generated
+packages, launched runs, and ingested results remain separate lifecycle objects.
 
 Deep-convection observed-sounding packages extend the same dry-run package
 contract rather than creating a separate workflow. The package records

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -116,12 +116,15 @@ story-specific candidate matches. Stable story identifiers are
 pre-run hypotheses for Deep Convection Trial routing. The auditable scoring
 contract lives in
 [contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
-Analysis can target story, story family, support state, package readiness,
-station search, and backend-owned sort keys because the useful sounding depends
-on the experiment question; a shallow-cumulus search and a humid/rainy search
-should not imply the same ranked list. Missing feature values stay unavailable
-and sort last instead of being treated as zero. Saved candidates and working-set
-tags are runtime-local cache state under
+Analysis has a default recommendation mode that answers which cached soundings
+look interesting and why, using backend-owned interest reasons and station
+diversity before exposing refinements. It can also target story, story family,
+support state, package readiness, station search, and backend-owned sort keys
+because the useful sounding depends on the experiment question; shallow-cumulus
+and humid/rainy searches should not imply the same ranked list.
+Missing feature values stay unavailable and sort last instead of being treated
+as zero. Saved candidates, freeform tags, and notes are runtime-local cache state
+under
 `<runtime-home>/cache/sounding-candidates/`; they are not Result Cards and are
 not committed. When a saved candidate is used to generate a package, its
 screening summary may be copied into
@@ -158,9 +161,10 @@ soundings as pre-run hypotheses for an idealized triggered CM1 experiment.
 The Build UI consumes this layer through bounded JSON only. `Upload a Sounding`
 loads saved candidates immediately when that experiment is selected, before any
 catalog refresh or analysis action. It can also call the recent-catalog/cache
-and candidate-analysis endpoints, display the backend-filtered candidate list,
-save candidates into working-set tags, and pass a selected candidate's
-`selected_sounding_payload` into the existing observed-sounding package review.
+and candidate-analysis endpoints, display backend recommendations and advanced
+refinements, save candidates with freeform tags/notes, and pass a selected
+candidate's `selected_sounding_payload` into the existing observed-sounding
+package review.
 The frontend does not read cached station text directly, compute the story
 scores, or sort raw feature values itself. Candidate status is separate from
 run/result status: saved candidates are pre-run hypotheses, while generated

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -109,7 +109,7 @@ computes transparent low-order features such as low-level moisture, estimated
 LCL, low-level lapse-rate, inversion/cap proxy, moisture depth, profile
 coverage, observed-wind availability, bulk-shear proxies when winds exist,
 dry-layer/inverted-V proxies, and freezing-level context, and emits pre-run
-story-specific candidate matches. Stable story identifiers are
+story-specific candidate scores. Stable story identifiers are
 `shallow_cumulus_candidate`, `dry_failed_candidate`,
 `capped_suppressed_candidate`, `humid_rainy_candidate`, `needs_review`, and
 `poor_or_incomplete_candidate`; severe/deep-convection story identifiers remain
@@ -129,8 +129,9 @@ under
 not committed. When a saved candidate is used to generate a package, its
 screening summary and saved tags/notes may be copied into
 `run_manifest.json`, `case_manifest.json`, and `dry_run_report.json` as
-provenance. The screening score remains a candidate-selection aid; CM1 output
-remains the source of truth.
+provenance. The screening score remains a candidate-selection aid that ranks
+sounding ingredients only; it does not predict what the selected CM1 package
+will produce. CM1 output remains the source of truth.
 
 The sounding-diagnostics layer is a backend-only feature extractor for observed
 soundings. It produces bounded `SoundingDiagnostics` payloads with

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -131,12 +131,14 @@ are implemented and tested.
 In Build, `Upload a Sounding` is the product-facing entry point for this
 candidate workflow. It should show a `Find interesting soundings` workbench
 beside the observed-sounding upload path. The workbench can refresh the bounded
-IGRA cache, analyze cached soundings by experiment story, story family, support,
-package readiness, station search, and sounding-derived backend sort keys, show
+IGRA cache, analyze cached soundings into station-diverse recommendations, show
+why each candidate is interesting, expose story, story-family, support,
+readiness, station-search, and sort controls as advanced refinements, show
 package-ready and blocked candidates with evidence and caveats, save candidates
-into working sets for later review, and load a selected package-ready candidate
-into the observed-sounding package review. Missing sounding-derived features
-must remain unavailable/caveated and must not sort as zero-valued evidence.
+with freeform tags and notes for later review, and load a selected package-ready
+candidate into the observed-sounding package review. Missing sounding-derived
+features must remain unavailable/caveated and must not sort as zero-valued
+evidence.
 Saved candidates should appear as soon as the user selects `Upload a Sounding`,
 without requiring a catalog refresh, cache action, or new analysis run. It must
 keep the language pre-run and provisional: a candidate is an observed atmosphere

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -103,12 +103,13 @@ batch of recent soundings without hand-written HTTP requests. A backend
 screening layer can match cached sounding times against explicit pre-run
 experiment stories such as shallow cumulus, dry failed, capped/suppressed, or
 humid/rainy. There is no universal "best sounding" ranking: the useful candidate
-depends on the atmospheric question being tested. Match scores are transparent
-candidate-selection aids, not CM1 outcome predictions. Saved candidates live in
-the runtime cache and may be handed into package metadata as provenance for why
-a sounding was tried. The browser never parses remote directory listings, ZIP
-files, or station text files. The current story identifiers, feature inputs,
-score support states, evidence requirements, and caveat rules are defined in
+depends on the atmospheric question being tested. Ingredient scores are
+transparent candidate-selection aids that rank sounding ingredients only; they
+are not CM1 outcome predictions. Saved candidates live in the runtime cache and
+may be handed into package metadata as provenance for why a sounding was tried.
+The browser never parses remote directory listings, ZIP files, or station text
+files. The current story identifiers, feature inputs, score support states,
+evidence requirements, and caveat rules are defined in
 [contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
 Real-sounding story families, including severe/deep-convection, boundary-layer,
 low-cloud, and winter/cold-season candidates, are defined in

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -131,15 +131,18 @@ are implemented and tested.
 In Build, `Upload a Sounding` is the product-facing entry point for this
 candidate workflow. It should show a `Find interesting soundings` workbench
 beside the observed-sounding upload path. The workbench can refresh the bounded
-IGRA cache, screen cached soundings by experiment story, show package-ready and
-blocked candidates with evidence and caveats, save candidates for later review,
-and load a selected package-ready candidate into the observed-sounding package
-review. Saved candidates should appear as soon as the user selects `Upload a
-Sounding`, without requiring a catalog refresh, cache action, or new screening
-run. It must keep the language pre-run and provisional: a candidate is an
-observed atmosphere worth trying, not a prediction that clouds, rain, or
-suppression will occur. When a candidate is used, its screening story, score,
-evidence, feature summary, and caveats should be copied into package metadata as
+IGRA cache, analyze cached soundings by experiment story, story family, support,
+package readiness, station search, and sounding-derived backend sort keys, show
+package-ready and blocked candidates with evidence and caveats, save candidates
+into working sets for later review, and load a selected package-ready candidate
+into the observed-sounding package review. Missing sounding-derived features
+must remain unavailable/caveated and must not sort as zero-valued evidence.
+Saved candidates should appear as soon as the user selects `Upload a Sounding`,
+without requiring a catalog refresh, cache action, or new analysis run. It must
+keep the language pre-run and provisional: a candidate is an observed atmosphere
+worth trying, not a prediction that clouds, rain, or suppression will occur.
+When a candidate is used, its screening story, score, evidence, feature summary,
+and caveats should be copied into package metadata as
 provenance.
 
 When an uploaded or saved observed sounding is package-ready, Build should let

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -8,8 +8,8 @@ proof that a run will form cloud, rain, or suppression. CM1 output remains the
 source of truth.
 
 The browser does not parse IGRA station text, ZIP archives, or raw NetCDF.
-Candidate screening is backend-owned and uses cached IGRA station text plus
-runtime-local cache metadata.
+Candidate screening and analysis are backend-owned and use cached IGRA station
+text plus runtime-local cache metadata.
 
 ## Current Story Set
 
@@ -19,11 +19,19 @@ The v1 candidate stories are:
 - `dry_failed_candidate`
 - `capped_suppressed_candidate`
 - `humid_rainy_candidate`
+- `severe_thunderstorm_environment`
+- `supercell_environment`
+- `high_cape_pulse_storm`
+- `dry_microburst_inverted_v`
+- `squall_line_cold_pool_candidate`
+- `elevated_convection`
 - `needs_review`
 - `poor_or_incomplete_candidate`
 
 Visible labels may be friendlier, but every visible story must be backed by
 `story_scores`, feature values, evidence items, caveats, and package readiness.
+Deep-convection-oriented stories are pre-run hypotheses for Deep Convection
+Trial routing, not outcome claims.
 
 ## Feature Inputs
 
@@ -58,6 +66,10 @@ The candidate UI may also display these fields as evidence or context:
 - lapse rate from 0-3 km
 - cap height proxy
 - observed wind availability
+- midlevel lapse rate when available
+- bulk shear from 0-1, 0-3, and 0-6 km when observed winds exist
+- dry microburst / inverted-V proxy
+- freezing-level proxy
 - package readiness
 
 These fields help explain the sounding and package path. They do not directly
@@ -251,10 +263,19 @@ Candidate cards and details must keep this language:
 - Candidate scores are pre-run hypotheses.
 - CM1 decides what actually happens.
 
-The UI may filter by a target story, but it must include secondary story
-matches when `story_scores` contain meaningful support for the selected story.
-It must not show a confident story label without evidence, caveats, and package
-readiness.
+The backend analysis API owns story, story-family, support-state, readiness,
+station-search, and sort-key filtering. The UI may expose these controls, but
+it must display the backend-returned candidate list rather than parsing raw
+sounding files or recomputing story scores in the browser. Analysis must include
+secondary story matches when `story_scores` contain meaningful support for the
+selected story. Missing feature values must remain unavailable/caveated and sort
+last instead of becoming zero-valued evidence. The UI must not show a confident
+story label without evidence, caveats, and package readiness.
+
+Saved candidates may carry working-set tags such as `Deep convection
+candidates`, `Surface-forced candidates`, `Needs longer run`, `Needs finer
+output cadence`, `Maybe rerun`, and `Needs review`. These tags are runtime-local
+pre-run organization metadata; they are not Results and are not committed.
 
 ## Testing Contract
 
@@ -268,6 +289,10 @@ Tests should prove:
 - every story has reasons and evidence;
 - missing features caveat or weaken support instead of producing confident
   labels;
+- backend analysis works across multiple cached sounding blocks;
+- physical-field sorting keeps missing values last;
+- story, support, and readiness filters are backend-owned;
+- saved working-set tags round-trip through runtime-local JSON;
 - poor/incomplete candidates are blocked from package generation;
 - package-ready but weak profiles become `needs_review`;
 - candidate-screening provenance is copied into generated package metadata

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -263,19 +263,22 @@ Candidate cards and details must keep this language:
 - Candidate scores are pre-run hypotheses.
 - CM1 decides what actually happens.
 
-The backend analysis API owns story, story-family, support-state, readiness,
-station-search, and sort-key filtering. The UI may expose these controls, but
-it must display the backend-returned candidate list rather than parsing raw
-sounding files or recomputing story scores in the browser. Analysis must include
+The backend analysis API owns default recommendations, interest reasons,
+discovery buckets, story/story-family/support/readiness/station-search
+refinements, and sort-key ordering. The default UI should answer which cached
+soundings are interesting and why before exposing advanced refinements. It must
+display the backend-returned candidate list rather than parsing raw sounding
+files or recomputing story scores in the browser. Analysis must include
 secondary story matches when `story_scores` contain meaningful support for the
 selected story. Missing feature values must remain unavailable/caveated and sort
 last instead of becoming zero-valued evidence. The UI must not show a confident
 story label without evidence, caveats, and package readiness.
 
-Saved candidates may carry working-set tags such as `Deep convection
+Saved candidates may carry freeform tags and notes such as `Deep convection
 candidates`, `Surface-forced candidates`, `Needs longer run`, `Needs finer
-output cadence`, `Maybe rerun`, and `Needs review`. These tags are runtime-local
-pre-run organization metadata; they are not Results and are not committed.
+output cadence`, `Maybe rerun`, and `Needs review`. These annotations are
+runtime-local pre-run organization metadata; they are not Results and are not
+committed.
 
 ## Testing Contract
 
@@ -291,8 +294,9 @@ Tests should prove:
   labels;
 - backend analysis works across multiple cached sounding blocks;
 - physical-field sorting keeps missing values last;
-- story, support, and readiness filters are backend-owned;
-- saved working-set tags round-trip through runtime-local JSON;
+- default recommendations and interest reasons are backend-owned;
+- story, support, and readiness refinements are backend-owned;
+- saved tags and notes round-trip through runtime-local JSON;
 - poor/incomplete candidates are blocked from package generation;
 - package-ready but weak profiles become `needs_review`;
 - candidate-screening provenance is copied into generated package metadata

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -272,9 +272,13 @@ soundings are interesting and why before exposing advanced refinements. It must
 display the backend-returned candidate list rather than parsing raw sounding
 files or recomputing story scores in the browser. Analysis must include
 secondary story matches when `story_scores` contain meaningful support for the
-selected story. Missing feature values must remain unavailable/caveated and sort
-last instead of becoming zero-valued evidence. The UI must not show a confident
-story label without evidence, caveats, and package readiness.
+selected story or selected story family. Story-family filtering, support
+filtering, and best-match sorting must use the same family-scoped `story_scores`
+set, so a sounding with a lower-atmosphere primary story can still appear as a
+deep-convection recommendation when a secondary deep-convection score has
+meaningful support. Missing feature values must remain unavailable/caveated and
+sort last instead of becoming zero-valued evidence. The UI must not show a
+confident story label without evidence, caveats, and package readiness.
 
 Saved candidates may carry freeform tags and notes such as `Deep convection
 candidates`, `Surface-forced candidates`, `Needs longer run`, `Needs finer

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -253,7 +253,9 @@ components.
 
 Candidate screening metadata may be copied into `run_manifest.json`,
 `case_manifest.json`, and `dry_run_report.json` as provenance when a candidate
-is used to create a package.
+is used to create a package. If the candidate was saved with tags or notes,
+those annotations may also be copied into package user metadata and run-status
+payloads so the generated package remains tied to the reason it was selected.
 
 ## UI Contract
 
@@ -297,6 +299,7 @@ Tests should prove:
 - default recommendations and interest reasons are backend-owned;
 - story, support, and readiness refinements are backend-owned;
 - saved tags and notes round-trip through runtime-local JSON;
+- saved tags and notes follow a used candidate into package metadata;
 - poor/incomplete candidates are blocked from package generation;
 - package-ready but weak profiles become `needs_review`;
 - candidate-screening provenance is copied into generated package metadata

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -262,7 +262,8 @@ payloads so the generated package remains tied to the reason it was selected.
 Candidate cards and details must keep this language:
 
 - Screening guidance only.
-- Candidate scores are pre-run hypotheses.
+- Candidate ingredient/screening scores rank sounding ingredients only.
+- Scores do not predict what the current CM1 package will produce.
 - CM1 decides what actually happens.
 
 The backend analysis API owns default recommendations, interest reasons,
@@ -271,14 +272,18 @@ refinements, and sort-key ordering. The default UI should answer which cached
 soundings are interesting and why before exposing advanced refinements. It must
 display the backend-returned candidate list rather than parsing raw sounding
 files or recomputing story scores in the browser. Analysis must include
-secondary story matches when `story_scores` contain meaningful support for the
+secondary story scores when `story_scores` contain meaningful support for the
 selected story or selected story family. Story-family filtering, support
-filtering, and best-match sorting must use the same family-scoped `story_scores`
+filtering, and highest-ingredient-score sorting must use the same family-scoped `story_scores`
 set, so a sounding with a lower-atmosphere primary story can still appear as a
 deep-convection recommendation when a secondary deep-convection score has
 meaningful support. Missing feature values must remain unavailable/caveated and
 sort last instead of becoming zero-valued evidence. The UI must not show a
 confident story label without evidence, caveats, and package readiness.
+The workbench should also show a minimal recipe-fit status, such as
+`partially_testable`, `requires_triggered_deep_potential`, or `blocked_profile`,
+so candidate interest remains separate from what the current package path can
+actually test.
 
 Saved candidates may carry freeform tags and notes such as `Deep convection
 candidates`, `Surface-forced candidates`, `Needs longer run`, `Needs finer

--- a/docs/development.md
+++ b/docs/development.md
@@ -195,11 +195,12 @@ scripts/igra-recent.sh candidates --story shallow-cumulus --limit 10
 scripts/igra-recent.sh candidates --story capped-suppressed --limit 10
 ```
 
-Candidate match scores are pre-run hypotheses only. There is no single best
-sounding independent of the experiment story: use `--story deep-convection`,
-`--story shallow-cumulus`, `--story dry-failed`, `--story capped-suppressed`,
-or `--story humid-rainy` depending on what you want to test. CM1 output remains
-the source of truth.
+Candidate ingredient scores are pre-run screening guidance only. They rank
+sounding ingredients; they do not predict what the current CM1 package will
+produce. There is no single best sounding independent of the experiment story:
+use `--story deep-convection`, `--story shallow-cumulus`, `--story dry-failed`,
+`--story capped-suppressed`, or `--story humid-rainy` depending on what you want
+to test. CM1 output remains the source of truth.
 
 The same workflow is available in the app from Build -> `Upload a Sounding` ->
 `Find interesting soundings`. Use `Refresh IGRA catalog` to update station

--- a/docs/development.md
+++ b/docs/development.md
@@ -204,16 +204,16 @@ the source of truth.
 The same workflow is available in the app from Build -> `Upload a Sounding` ->
 `Find interesting soundings`. Use `Refresh IGRA catalog` to update station
 metadata, `Cache station files` to download a bounded batch of station-period
-files, choose a story filter such as `Deep Convection Trial stories`, then
-`Analyze cached soundings`. The workbench asks the backend to sort and filter
-cached candidates by story, story family, support, readiness, station search,
-and sounding-derived fields; missing feature values remain unavailable rather
-than becoming zero-valued evidence.
+files, then `Analyze recommendations`. The default view asks the backend which
+cached soundings look interesting and why, with station-diverse recommendations
+and explanation fields. Advanced refinements can narrow by story, story family,
+support, readiness, station search, and sounding-derived sort keys; missing
+feature values remain unavailable rather than becoming zero-valued evidence.
 `Use this sounding` loads a package-ready candidate into the observed-sounding
 package review; it does not launch CM1 and it does not claim the candidate will
 produce the screened outcome. Blocked candidates remain reviewable but cannot be
 used for package generation until their caveats are resolved. Saved candidates
-can be placed into working-set tags such as `Deep convection candidates`,
+can carry freeform tags and notes such as `Deep convection candidates`,
 `Needs longer run`, or `Needs review`.
 
 To reset the recent IGRA cache and test from a clean state, use the script

--- a/docs/development.md
+++ b/docs/development.md
@@ -205,11 +205,16 @@ The same workflow is available in the app from Build -> `Upload a Sounding` ->
 `Find interesting soundings`. Use `Refresh IGRA catalog` to update station
 metadata, `Cache station files` to download a bounded batch of station-period
 files, choose a story filter such as `Deep Convection Trial stories`, then
-`Screen cached soundings`.
+`Analyze cached soundings`. The workbench asks the backend to sort and filter
+cached candidates by story, story family, support, readiness, station search,
+and sounding-derived fields; missing feature values remain unavailable rather
+than becoming zero-valued evidence.
 `Use this sounding` loads a package-ready candidate into the observed-sounding
 package review; it does not launch CM1 and it does not claim the candidate will
 produce the screened outcome. Blocked candidates remain reviewable but cannot be
-used for package generation until their caveats are resolved.
+used for package generation until their caveats are resolved. Saved candidates
+can be placed into working-set tags such as `Deep convection candidates`,
+`Needs longer run`, or `Needs review`.
 
 To reset the recent IGRA cache and test from a clean state, use the script
 cleanup command, then rerun `status` / `refresh`:

--- a/docs/development.md
+++ b/docs/development.md
@@ -107,11 +107,11 @@ Normal backend checks must not require a local CM1 runtime. Real CM1 paths belon
 Implemented backend API endpoints:
 
 - `GET /api/scenarios` lists validated scenario templates for the Scenario Builder and marks Baseline Shallow Cumulus as the Golden Path scenario.
-- `POST /api/dry-run-package` validates selected controls and writes a reviewable dry-run package under the configured runtime home. It does not launch CM1, create NetCDF output, or write generated packages into the repo during tests.
+- `POST /api/dry-run-package` validates selected controls and writes a reviewable dry-run package under the configured runtime home. Observed-sounding packages may include selected sounding metadata, candidate-screening provenance, and user-facing tags/notes from saved candidate annotations. It does not launch CM1, create NetCDF output, or write generated packages into the repo during tests.
 - `POST /api/runs/launch` starts one local CM1 run from a generated manifest when local CM1 settings validate.
 - `POST /api/runs/queue` adds a packaged run to the local serial CM1 queue. The queue starts at most one local CM1 process at a time, advances on queue refresh, and auto-ingests completed output-producing runs.
 - `GET /api/runs/queue` refreshes the local serial queue, updates active run status, starts the next queued package when safe, and reports auto-ingest or fallback errors.
-- `GET /api/runs/status?manifest_path=...` refreshes and returns lifecycle status, product/validation state, command/log paths, short stdout/stderr tails, output-artifact counts, runtime warnings, timestamps, and bounded progress metadata for a run manifest. Progress uses configured `timax` plus parsed CM1 stdout model-minute lines when available; if model time is not available, the payload says so rather than inventing a percent complete.
+- `GET /api/runs/status?manifest_path=...` refreshes and returns lifecycle status, product/validation state, observed-sounding context, package/user tags and notes, command/log paths, short stdout/stderr tails, output-artifact counts, runtime warnings, timestamps, and bounded progress metadata for a run manifest. Progress uses configured `timax` plus parsed CM1 stdout model-minute lines when available; if model time is not available, the payload says so rather than inventing a percent complete.
 - `POST /api/runs/cancel` cancels the active local run when technically practical.
 - `GET /api/storage/inventory` reports configured runtime-home disk usage and per-run metadata under `~/CloudChamber/runs/`.
 - `POST /api/storage/delete-run` previews or deletes one selected run directory under the configured runtime home.
@@ -214,7 +214,9 @@ package review; it does not launch CM1 and it does not claim the candidate will
 produce the screened outcome. Blocked candidates remain reviewable but cannot be
 used for package generation until their caveats are resolved. Saved candidates
 can carry freeform tags and notes such as `Deep convection candidates`,
-`Needs longer run`, or `Needs review`.
+`Needs longer run`, or `Needs review`; when a saved candidate is used to create a
+package, those annotations are copied into package provenance and run-status
+payloads.
 
 To reset the recent IGRA cache and test from a clean state, use the script
 cleanup command, then rerun `status` / `refresh`:

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -70,8 +70,8 @@ write downloaded ZIP/text/cache manifests outside temp runtime homes.
 
 Sounding-candidate screening tests must use tiny cached IGRA fixtures and temp
 runtime cache directories only. They should verify that screening inputs come
-from cached station text, candidate match scores are deterministic for the
-stable story identifiers, story-specific screening can target one experiment
+from cached station text, candidate ingredient scores are deterministic for
+the stable story identifiers, story-specific screening can target one experiment
 question at a time, poor/incomplete inputs are caveated instead of silently
 treated as package-ready, missing moisture/LCL/cap inputs weaken or caveat
 support instead of becoming confident physical evidence, saved candidates

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -97,13 +97,14 @@ Frontend tests for the `Upload a Sounding` Build workflow should cover the same
 boundary. Component tests and mocked Playwright smoke tests should verify that
 saved candidates load immediately when `Upload a Sounding` is selected; the
 candidate workbench can refresh IGRA catalog metadata, cache a bounded batch of
-station files through mocked APIs, screen cached soundings by story, include
+station files through mocked APIs, analyze cached soundings by story, story
+family, support, readiness, station search, and backend-owned sort keys, include
 secondary story-score matches in filtered results, sort missing metrics last,
-show blocked candidates as unusable, save candidates, load a package-ready
-candidate into the observed-sounding package review, and include
+show blocked candidates as unusable, save candidates with working-set tags, load
+a package-ready candidate into the observed-sounding package review, and include
 candidate-screening provenance in the generated package request. Browser tests
 must mock the backend APIs and must not fetch NOAA/NCEI, parse raw station text,
-or imply that a candidate score predicts the CM1 outcome.
+compute story scores, or imply that a candidate score predicts the CM1 outcome.
 
 Most expanded real-sounding story families are spec-only until backend feature
 extraction, scoring, evidence, caveats, and package-readiness behavior are

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -97,11 +97,12 @@ Frontend tests for the `Upload a Sounding` Build workflow should cover the same
 boundary. Component tests and mocked Playwright smoke tests should verify that
 saved candidates load immediately when `Upload a Sounding` is selected; the
 candidate workbench can refresh IGRA catalog metadata, cache a bounded batch of
-station files through mocked APIs, analyze cached soundings by story, story
-family, support, readiness, station search, and backend-owned sort keys, include
-secondary story-score matches in filtered results, sort missing metrics last,
-show blocked candidates as unusable, save candidates with working-set tags, load
-a package-ready candidate into the observed-sounding package review, and include
+station files through mocked APIs, show station-diverse backend recommendations
+with why-interesting reasons, refine by story, story family, support, readiness,
+station search, and backend-owned sort keys when requested, include secondary
+story-score matches in refined results, sort missing metrics last, show blocked
+candidates as unusable, save candidates with freeform tags and notes, load a
+package-ready candidate into the observed-sounding package review, and include
 candidate-screening provenance in the generated package request. Browser tests
 must mock the backend APIs and must not fetch NOAA/NCEI, parse raw station text,
 compute story scores, or imply that a candidate score predicts the CM1 outcome.


### PR DESCRIPTION
## Summary
- rework the cached-sounding workbench around backend-owned recommendations: the default view now answers which cached soundings look interesting and why before exposing advanced refinements
- distinguish cached sounding inventory from the bounded analysis slice and last recommendation run so catalog/cache controls no longer imply all cached timestamps are analyzed each time
- add recommendation metadata to candidate payloads (`interest_summary`, `interest_reasons`, `discovery_bucket`) and diversify default recommendations across stations
- rename pre-run story score copy to ingredient/screening score language; scores rank sounding ingredients only and do not predict what the current CM1 package will produce
- add minimal recipe-fit status/copy so shallow/humid/capped/dry stories are separated from deep-potential stories that require the triggered Deep Convection Trial path
- show non-blocking package mismatch warnings when a selected package does not test the active candidate story, including deep-potential candidates on Observed Sounding Quick Look and humid/rainy candidates that need rain-water/surface-rain/reflectivity outputs for later comparison
- tighten `observed_wind_available` so it means a complete finite observed u/v profile across usable rendered levels, with partial wind exposed separately
- replace rigid saved-candidate working-set selection with freeform tags/notes plus a saved-card working-set updater, including non-destructive updates for already-saved candidates
- carry saved candidate tags/notes plus observed sounding place/time into generated package metadata, dry-run reports, package review, and run status payloads
- keep story/story-family/support/readiness/station/sort controls as advanced refinements, with missing feature values unavailable/caveated and sorted last
- scope story-family filtering, support filtering, and ingredient-score sorting to the matching `story_scores` set so secondary deep-convection evidence remains discoverable even when the primary story is lower-atmosphere
- update docs, component tests, backend tests, and mocked Playwright coverage for the recommendation-first workflow

Closes #282

## Verification
- app/backend/.venv/bin/python -m pytest app/backend/tests/test_sounding_candidates.py
- cd app/frontend && npm test -- App.test.tsx
- scripts/check.sh
- scripts/check-e2e.sh

## Merge
- Do not merge yet per request.
