### PR TITLE
Define evolved sounding output products

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -84,11 +84,18 @@ from cloud_chamber.sounding_candidates import (
     update_saved_candidate,
 )
 from cloud_chamber.visualization_data import (
+    ProfileAggregationMethod,
+    TimeHeightAggregationMethod,
+    TimeSeriesAggregationMethod,
     VisualizationDataError,
     VisualizationOrientation,
     field_catalog,
     field_slice,
+    output_product_catalog,
     point_cloud,
+    time_height_product,
+    time_series_product,
+    vertical_profile,
     view_defaults,
 )
 
@@ -652,6 +659,102 @@ def get_visualization_point_cloud(
             threshold=threshold,
             max_points=max_points,
             encoding="json",
+        )
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except VisualizationDataError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/results/{result_id}/output-products")
+def get_output_product_catalog(result_id: str) -> dict[str, object]:
+    try:
+        result = output_product_catalog(load_settings(), result_id)
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except VisualizationDataError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/results/{result_id}/output-products/profile")
+def get_output_product_profile(
+    result_id: str,
+    field: str,
+    time_index: int = 0,
+    aggregation_method: str = "domain_mean",
+    x_index: int | None = None,
+    y_index: int | None = None,
+) -> dict[str, object]:
+    if aggregation_method not in {"domain_mean", "domain_min", "domain_max", "selected_column"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported profile aggregation_method: {aggregation_method}",
+        )
+    try:
+        result = vertical_profile(
+            load_settings(),
+            result_id,
+            field=field,
+            time_index=time_index,
+            aggregation_method=cast(ProfileAggregationMethod, aggregation_method),
+            x_index=x_index,
+            y_index=y_index,
+        )
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except VisualizationDataError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/results/{result_id}/output-products/time-height")
+def get_output_product_time_height(
+    result_id: str,
+    field: str,
+    aggregation_method: str = "domain_mean",
+    threshold: float | None = None,
+) -> dict[str, object]:
+    if aggregation_method not in {"cloud_fraction", "domain_mean", "domain_min", "domain_max"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported time-height aggregation_method: {aggregation_method}",
+        )
+    try:
+        result = time_height_product(
+            load_settings(),
+            result_id,
+            field=field,
+            aggregation_method=cast(TimeHeightAggregationMethod, aggregation_method),
+            threshold=threshold,
+        )
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except VisualizationDataError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/results/{result_id}/output-products/time-series")
+def get_output_product_time_series(
+    result_id: str,
+    field: str,
+    aggregation_method: str = "domain_max",
+    threshold: float | None = None,
+) -> dict[str, object]:
+    if aggregation_method not in {"cloud_fraction", "domain_mean", "domain_min", "domain_max"}:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported time-series aggregation_method: {aggregation_method}",
+        )
+    try:
+        result = time_series_product(
+            load_settings(),
+            result_id,
+            field=field,
+            aggregation_method=cast(TimeSeriesAggregationMethod, aggregation_method),
+            threshold=threshold,
         )
     except ResultIngestError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -15,8 +15,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
 
+from cloud_chamber.output_products import (
+    OutputProductManifestError,
+    default_output_product_manifest_path,
+    output_product_manifest_from_json,
+    resolve_time_index,
+)
+from cloud_chamber.result_diagnostics import QC_CLOUD_THRESHOLD_KG_KG
 from cloud_chamber.result_ingest import (
     ResultMetadata,
     get_result_metadata,
@@ -25,6 +33,11 @@ from cloud_chamber.settings import CloudChamberSettings
 
 VisualizationOrientation = Literal["horizontal", "vertical_x", "vertical_y"]
 VisualizationEncoding = Literal["json"]
+OutputProductKind = Literal["vertical_profile", "time_height", "time_series", "future_diagnostic"]
+OutputProductStatus = Literal["available", "unavailable"]
+ProfileAggregationMethod = Literal["domain_mean", "domain_min", "domain_max", "selected_column"]
+TimeHeightAggregationMethod = Literal["cloud_fraction", "domain_mean", "domain_min", "domain_max"]
+TimeSeriesAggregationMethod = Literal["cloud_fraction", "domain_mean", "domain_min", "domain_max"]
 
 
 @dataclass(frozen=True)
@@ -363,6 +376,139 @@ class FieldCatalogResponse(BaseModel):
     source_model: str
     available_fields: list[VisualizableField]
     unavailable_fields: list[UnavailableField] = Field(default_factory=list)
+    provenance: ProvenancePayload
+    caveats: list[str] = Field(default_factory=list)
+
+
+class OutputProductDescriptor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product_key: str
+    product_kind: OutputProductKind
+    status: OutputProductStatus
+    raw_field_name: str | None = None
+    canonical_field_name: str | None = None
+    display_name: str
+    units: str | None = None
+    aggregation_methods: list[str] = Field(default_factory=list)
+    required_fields: list[str] = Field(default_factory=list)
+    reason: str | None = None
+    caveats: list[str] = Field(default_factory=list)
+
+
+class OutputProductCatalogResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    run_id: str
+    scenario_id: str
+    source_model: str
+    available_profile_products: list[OutputProductDescriptor]
+    available_time_height_products: list[OutputProductDescriptor]
+    available_time_series_products: list[OutputProductDescriptor]
+    unavailable_products: list[OutputProductDescriptor] = Field(default_factory=list)
+    provenance: ProvenancePayload
+    caveats: list[str] = Field(default_factory=list)
+
+
+class OutputTimeAxisMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time_indices: list[int]
+    time_seconds: list[float | None]
+    source_time_values: list[float | str | None]
+    source_files: list[str | None]
+    local_time_indices: list[int | None]
+    time_source: str | None = None
+    time_caveats: list[str] = Field(default_factory=list)
+
+
+class VerticalProfileSelectionMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    time_index: int
+    time_seconds: float | None = None
+    source_file: str | None = None
+    local_time_index: int | None = None
+    aggregation_method: ProfileAggregationMethod
+    x_index: int | None = None
+    y_index: int | None = None
+    x_coordinate_value: float | str | None = None
+    y_coordinate_value: float | str | None = None
+
+
+class VerticalProfileResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    run_id: str
+    scenario_id: str
+    field: VisualizableField
+    selection: VerticalProfileSelectionMetadata
+    vertical_dimension: str
+    vertical_units: str | None = None
+    vertical_coordinate_values: list[float | str | None]
+    values: list[float | None]
+    finite_counts: list[int]
+    non_finite_counts: list[int]
+    aggregation_method: ProfileAggregationMethod
+    provenance: ProvenancePayload
+    caveats: list[str] = Field(default_factory=list)
+
+
+class TimeHeightSelectionMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    aggregation_method: TimeHeightAggregationMethod
+    threshold: float | None = None
+
+
+class TimeHeightResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    run_id: str
+    scenario_id: str
+    field: VisualizableField
+    selection: TimeHeightSelectionMetadata
+    time_axis: OutputTimeAxisMetadata
+    vertical_dimension: str
+    vertical_units: str | None = None
+    vertical_coordinate_values: list[float | str | None]
+    shape: list[int]
+    size_class: str
+    values: list[list[float | None]]
+    finite_counts: list[list[int]]
+    non_finite_counts: list[list[int]]
+    aggregation_method: TimeHeightAggregationMethod
+    provenance: ProvenancePayload
+    caveats: list[str] = Field(default_factory=list)
+
+
+class TimeSeriesSelectionMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    aggregation_method: TimeSeriesAggregationMethod
+    threshold: float | None = None
+
+
+class TimeSeriesResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    run_id: str
+    scenario_id: str
+    field: VisualizableField
+    selection: TimeSeriesSelectionMetadata
+    time_axis: OutputTimeAxisMetadata
+    units: str | None = None
+    values: list[float | None]
+    finite_counts: list[int]
+    non_finite_counts: list[int]
+    aggregation_method: TimeSeriesAggregationMethod
     provenance: ProvenancePayload
     caveats: list[str] = Field(default_factory=list)
 
@@ -853,6 +999,344 @@ def field_catalog(settings: CloudChamberSettings, result_id: str) -> FieldCatalo
         ),
         caveats=_dedupe(_catalog_caveats(metadata, fields, unavailable_fields)),
     )
+
+
+def output_product_catalog(
+    settings: CloudChamberSettings, result_id: str
+) -> OutputProductCatalogResponse:
+    """Return bounded backend output-product options for an ingested result."""
+    metadata = get_result_metadata(settings, result_id)
+    catalog = field_catalog(settings, result_id)
+    profile_products: list[OutputProductDescriptor] = []
+    time_height_products: list[OutputProductDescriptor] = []
+    time_series_products: list[OutputProductDescriptor] = []
+    for field in catalog.available_fields:
+        if field.capabilities.profile_candidate:
+            profile_products.append(_profile_product_descriptor(field))
+        if field.capabilities.time_height_candidate:
+            time_height_products.append(_time_height_product_descriptor(field))
+        if _time_series_methods_for_field(field):
+            time_series_products.append(_time_series_product_descriptor(field))
+
+    unavailable = [
+        OutputProductDescriptor(
+            product_key="boundary_layer_depth_time_series",
+            product_kind="future_diagnostic",
+            status="unavailable",
+            display_name="Boundary-layer depth time series",
+            aggregation_methods=[],
+            required_fields=["theta", "qv", "surface_fluxes"],
+            reason="future_diagnostic_method_not_validated",
+            caveats=[
+                "boundary_layer_depth_proxy_not_implemented",
+                "method_must_be_documented_and_tested_before_science_use",
+            ],
+        )
+    ]
+    unavailable.extend(
+        _unavailable_product_descriptor(field) for field in catalog.unavailable_fields
+    )
+    return OutputProductCatalogResponse(
+        result_id=metadata.result_id,
+        run_id=metadata.run_id,
+        scenario_id=metadata.scenario_id,
+        source_model=metadata.source_model,
+        available_profile_products=profile_products,
+        available_time_height_products=time_height_products,
+        available_time_series_products=time_series_products,
+        unavailable_products=unavailable,
+        provenance=_provenance(
+            metadata,
+            processing_method="backend_output_product_catalog",
+            rendering_method="profile_time_height_time_series_product_options",
+            provenance_label=(
+                "CM1-derived output-product catalog; backend-owned bounded products; "
+                "raw NetCDF stays backend-owned"
+            ),
+        ),
+        caveats=_dedupe(
+            [
+                *catalog.caveats,
+                "diagnostics_lab_ui_not_added",
+                "browser_does_not_parse_raw_netcdf",
+            ]
+        ),
+    )
+
+
+def vertical_profile(
+    settings: CloudChamberSettings,
+    result_id: str,
+    *,
+    field: str,
+    time_index: int,
+    aggregation_method: ProfileAggregationMethod,
+    x_index: int | None = None,
+    y_index: int | None = None,
+) -> VerticalProfileResponse:
+    """Return a bounded vertical profile product for a supported field."""
+    metadata = get_result_metadata(settings, result_id)
+    dataset, close_datasets, local_time_index = _open_dataset_for_time(metadata, time_index)
+    try:
+        if _field_definition(field) is None:
+            raise VisualizationDataError(f"Unsupported profile field: {field}")
+        if field not in dataset.data_vars:
+            raise VisualizationDataError(
+                f"Profile product unavailable; field is missing from this result: {field}"
+            )
+        data_array = dataset[field]
+        dims = _field_dimensions(data_array)
+        visual_field = _visualizable_field(metadata, dataset, field)
+        if not visual_field.capabilities.profile_candidate:
+            raise VisualizationDataError(f"Field {field} is not profile-capable.")
+        if not dims.time or not dims.vertical:
+            raise VisualizationDataError(f"Field {field} requires time and vertical dimensions.")
+        _validate_index(local_time_index, int(data_array.sizes[dims.time]), "time_index")
+        at_time = data_array.isel({dims.time: local_time_index})
+        profile_values, finite_counts, non_finite_counts = _profile_product_values(
+            at_time,
+            dims=dims,
+            aggregation_method=aggregation_method,
+            x_index=x_index,
+            y_index=y_index,
+        )
+        resolved_time = _resolved_output_time(metadata, dataset, dims.time, time_index)
+        caveats = _dedupe(
+            [
+                *_field_caveats(field, visual_field.coordinate_names),
+                "json_profile_product_mvp",
+                "native_grid_profile_no_interpolation",
+                *resolved_time.time_caveats,
+                *(
+                    ["selected_column_requires_native_x_y_indices"]
+                    if aggregation_method == "selected_column"
+                    else []
+                ),
+            ]
+        )
+        return VerticalProfileResponse(
+            result_id=metadata.result_id,
+            run_id=metadata.run_id,
+            scenario_id=metadata.scenario_id,
+            field=visual_field,
+            selection=VerticalProfileSelectionMetadata(
+                field=field,
+                time_index=time_index,
+                time_seconds=resolved_time.time_seconds[0],
+                source_file=resolved_time.source_files[0],
+                local_time_index=resolved_time.local_time_indices[0],
+                aggregation_method=aggregation_method,
+                x_index=x_index,
+                y_index=y_index,
+                x_coordinate_value=_coordinate_value(dataset, dims.x, x_index)
+                if dims.x and x_index is not None
+                else None,
+                y_coordinate_value=_coordinate_value(dataset, dims.y, y_index)
+                if dims.y and y_index is not None
+                else None,
+            ),
+            vertical_dimension=str(dims.vertical),
+            vertical_units=_coordinate_units(dataset, dims.vertical),
+            vertical_coordinate_values=_coordinate_values(dataset, dims.vertical),
+            values=profile_values,
+            finite_counts=finite_counts,
+            non_finite_counts=non_finite_counts,
+            aggregation_method=aggregation_method,
+            provenance=_provenance(
+                metadata,
+                processing_method="backend_xarray_vertical_profile_product",
+                rendering_method="json_vertical_profile",
+                provenance_label=(
+                    "CM1-derived vertical profile product; backend aggregation; "
+                    "native vertical coordinate; no interpolation"
+                ),
+            ),
+            caveats=caveats,
+        )
+    finally:
+        _close_all(close_datasets)
+
+
+def time_height_product(
+    settings: CloudChamberSettings,
+    result_id: str,
+    *,
+    field: str,
+    aggregation_method: TimeHeightAggregationMethod,
+    threshold: float | None = None,
+) -> TimeHeightResponse:
+    """Return a bounded time-height product for a supported 3-D field."""
+    metadata = get_result_metadata(settings, result_id)
+    dataset, close_datasets = _open_dataset_sequence(metadata)
+    try:
+        if _field_definition(field) is None:
+            raise VisualizationDataError(f"Unsupported time-height field: {field}")
+        if field not in dataset.data_vars:
+            raise VisualizationDataError(
+                f"Time-height product unavailable; field is missing from this result: {field}"
+            )
+        data_array = dataset[field]
+        dims = _field_dimensions(data_array)
+        visual_field = _visualizable_field(metadata, dataset, field)
+        if not visual_field.capabilities.time_height_candidate:
+            raise VisualizationDataError(f"Field {field} is not time-height-capable.")
+        if not dims.time or not dims.vertical:
+            raise VisualizationDataError(f"Field {field} requires time and vertical dimensions.")
+        if not dims.y or not dims.x:
+            raise VisualizationDataError(
+                f"Field {field} requires horizontal dimensions for time-height aggregation."
+            )
+        resolved_threshold = (
+            QC_CLOUD_THRESHOLD_KG_KG
+            if aggregation_method == "cloud_fraction" and threshold is None
+            else threshold
+        )
+        values, finite_counts, non_finite_counts = _time_height_product_values(
+            data_array,
+            dims=dims,
+            aggregation_method=aggregation_method,
+            threshold=resolved_threshold,
+        )
+        time_axis = _resolved_output_time_axis(
+            metadata,
+            dataset,
+            dims.time,
+            time_size=int(data_array.sizes[dims.time]),
+        )
+        caveats = _dedupe(
+            [
+                *_field_caveats(field, visual_field.coordinate_names),
+                "json_time_height_product_mvp",
+                "native_grid_time_height_no_interpolation",
+                *time_axis.time_caveats,
+                *(
+                    [f"cloud_fraction_threshold_kg_kg:{resolved_threshold:g}"]
+                    if aggregation_method == "cloud_fraction" and resolved_threshold is not None
+                    else []
+                ),
+            ]
+        )
+        return TimeHeightResponse(
+            result_id=metadata.result_id,
+            run_id=metadata.run_id,
+            scenario_id=metadata.scenario_id,
+            field=visual_field,
+            selection=TimeHeightSelectionMetadata(
+                field=field,
+                aggregation_method=aggregation_method,
+                threshold=resolved_threshold,
+            ),
+            time_axis=time_axis,
+            vertical_dimension=str(dims.vertical),
+            vertical_units=_coordinate_units(dataset, dims.vertical),
+            vertical_coordinate_values=_coordinate_values(dataset, dims.vertical),
+            shape=[len(values), len(values[0]) if values else 0],
+            size_class=_array_size_class(len(values) * (len(values[0]) if values else 0)),
+            values=values,
+            finite_counts=finite_counts,
+            non_finite_counts=non_finite_counts,
+            aggregation_method=aggregation_method,
+            provenance=_provenance(
+                metadata,
+                processing_method="backend_xarray_time_height_product",
+                rendering_method="json_time_height_array",
+                provenance_label=(
+                    "CM1-derived time-height product; backend aggregation; "
+                    "global output time index; no browser NetCDF parsing"
+                ),
+            ),
+            caveats=caveats,
+        )
+    finally:
+        _close_all(close_datasets)
+
+
+def time_series_product(
+    settings: CloudChamberSettings,
+    result_id: str,
+    *,
+    field: str,
+    aggregation_method: TimeSeriesAggregationMethod,
+    threshold: float | None = None,
+) -> TimeSeriesResponse:
+    """Return a bounded field time-series product for an evolved run."""
+    metadata = get_result_metadata(settings, result_id)
+    dataset, close_datasets = _open_dataset_sequence(metadata)
+    try:
+        if _field_definition(field) is None:
+            raise VisualizationDataError(f"Unsupported time-series field: {field}")
+        if field not in dataset.data_vars:
+            raise VisualizationDataError(
+                f"Time-series product unavailable; field is missing from this result: {field}"
+            )
+        data_array = dataset[field]
+        dims = _field_dimensions(data_array)
+        visual_field = _visualizable_field(metadata, dataset, field)
+        if not dims.time:
+            raise VisualizationDataError(f"Field {field} requires a time dimension.")
+        if aggregation_method not in _time_series_methods_for_field(visual_field):
+            raise VisualizationDataError(
+                f"Field {field} does not support {aggregation_method} time-series products."
+            )
+        resolved_threshold = (
+            QC_CLOUD_THRESHOLD_KG_KG
+            if aggregation_method == "cloud_fraction" and threshold is None
+            else threshold
+        )
+        values, finite_counts, non_finite_counts = _time_series_product_values(
+            data_array,
+            dims=dims,
+            aggregation_method=aggregation_method,
+            threshold=resolved_threshold,
+        )
+        time_axis = _resolved_output_time_axis(
+            metadata,
+            dataset,
+            dims.time,
+            time_size=int(data_array.sizes[dims.time]),
+        )
+        caveats = _dedupe(
+            [
+                *_field_caveats(field, visual_field.coordinate_names),
+                "json_time_series_product_mvp",
+                "native_grid_time_series_no_interpolation",
+                *time_axis.time_caveats,
+                *(
+                    [f"cloud_fraction_threshold_kg_kg:{resolved_threshold:g}"]
+                    if aggregation_method == "cloud_fraction" and resolved_threshold is not None
+                    else []
+                ),
+            ]
+        )
+        return TimeSeriesResponse(
+            result_id=metadata.result_id,
+            run_id=metadata.run_id,
+            scenario_id=metadata.scenario_id,
+            field=visual_field,
+            selection=TimeSeriesSelectionMetadata(
+                field=field,
+                aggregation_method=aggregation_method,
+                threshold=resolved_threshold,
+            ),
+            time_axis=time_axis,
+            units=visual_field.units,
+            values=values,
+            finite_counts=finite_counts,
+            non_finite_counts=non_finite_counts,
+            aggregation_method=aggregation_method,
+            provenance=_provenance(
+                metadata,
+                processing_method="backend_xarray_time_series_product",
+                rendering_method="json_time_series",
+                provenance_label=(
+                    "CM1-derived time-series product; backend aggregation; "
+                    "global output time index; no browser NetCDF parsing"
+                ),
+            ),
+            caveats=caveats,
+        )
+    finally:
+        _close_all(close_datasets)
 
 
 def view_defaults(
@@ -1674,6 +2158,331 @@ def _field_capabilities(
     )
 
 
+def _profile_product_descriptor(field: VisualizableField) -> OutputProductDescriptor:
+    methods: list[str] = ["domain_mean", "domain_min", "domain_max"]
+    if field.capabilities.selected_column:
+        methods.append("selected_column")
+    return OutputProductDescriptor(
+        product_key=f"profile:{field.raw_field_name}",
+        product_kind="vertical_profile",
+        status="available",
+        raw_field_name=field.raw_field_name,
+        canonical_field_name=field.canonical_field_name,
+        display_name=f"{field.display_name} vertical profile",
+        units=field.units,
+        aggregation_methods=methods,
+        required_fields=[field.raw_field_name],
+        caveats=_dedupe(["bounded_json_profile", *field.caveats]),
+    )
+
+
+def _time_height_product_descriptor(field: VisualizableField) -> OutputProductDescriptor:
+    methods: list[str] = ["domain_mean", "domain_min", "domain_max"]
+    if field.canonical_field_name == "cloud_water":
+        methods.insert(0, "cloud_fraction")
+    return OutputProductDescriptor(
+        product_key=f"time_height:{field.raw_field_name}",
+        product_kind="time_height",
+        status="available",
+        raw_field_name=field.raw_field_name,
+        canonical_field_name=field.canonical_field_name,
+        display_name=f"{field.display_name} time-height",
+        units=field.units,
+        aggregation_methods=methods,
+        required_fields=[field.raw_field_name],
+        caveats=_dedupe(["bounded_json_time_height", *field.caveats]),
+    )
+
+
+def _time_series_product_descriptor(field: VisualizableField) -> OutputProductDescriptor:
+    methods = _time_series_methods_for_field(field)
+    return OutputProductDescriptor(
+        product_key=f"time_series:{field.raw_field_name}",
+        product_kind="time_series",
+        status="available",
+        raw_field_name=field.raw_field_name,
+        canonical_field_name=field.canonical_field_name,
+        display_name=f"{field.display_name} time series",
+        units=field.units,
+        aggregation_methods=list(methods),
+        required_fields=[field.raw_field_name],
+        caveats=_dedupe(["bounded_json_time_series", *field.caveats]),
+    )
+
+
+def _unavailable_product_descriptor(field: UnavailableField) -> OutputProductDescriptor:
+    return OutputProductDescriptor(
+        product_key=f"unavailable:{field.raw_field_name}",
+        product_kind="future_diagnostic",
+        status="unavailable",
+        raw_field_name=field.raw_field_name,
+        canonical_field_name=field.canonical_field_name,
+        display_name=field.display_name,
+        required_fields=[field.raw_field_name],
+        reason=field.reason,
+        caveats=field.caveats,
+    )
+
+
+def _time_series_methods_for_field(
+    field: VisualizableField,
+) -> tuple[TimeSeriesAggregationMethod, ...]:
+    if not field.time_available:
+        return ()
+    if field.canonical_field_name == "cloud_water":
+        return ("cloud_fraction", "domain_max", "domain_mean")
+    if field.native_grid_class in {"volume_3d", "surface_2d"}:
+        return ("domain_max", "domain_mean", "domain_min")
+    return ()
+
+
+def _profile_product_values(
+    at_time: Any,
+    *,
+    dims: _FieldDimensions,
+    aggregation_method: ProfileAggregationMethod,
+    x_index: int | None,
+    y_index: int | None,
+) -> tuple[list[float | None], list[int], list[int]]:
+    if dims.vertical is None:
+        raise VisualizationDataError("Profile product requires a vertical dimension.")
+    vertical_size = int(at_time.sizes[dims.vertical])
+    if aggregation_method == "selected_column":
+        if dims.y is None or dims.x is None:
+            raise VisualizationDataError("Selected-column profile requires y/x dimensions.")
+        if x_index is None or y_index is None:
+            raise VisualizationDataError("selected_column profile requires x_index and y_index.")
+        _validate_index(y_index, int(at_time.sizes[dims.y]), "y_index")
+        _validate_index(x_index, int(at_time.sizes[dims.x]), "x_index")
+        selected = at_time.isel({dims.y: y_index, dims.x: x_index}).transpose(dims.vertical)
+        values = _json_vector(selected.values)
+        finite = [1 if value is not None else 0 for value in values]
+        return values, finite, [1 - count for count in finite]
+
+    if dims.y is None or dims.x is None:
+        raise VisualizationDataError("Domain profile aggregation requires y/x dimensions.")
+    reduced = _reduce_data_array(
+        at_time,
+        reduce_dims=[dims.y, dims.x],
+        aggregation_method=aggregation_method,
+    ).transpose(dims.vertical)
+    finite_counts, non_finite_counts = _finite_counts(
+        at_time.transpose(dims.vertical, dims.y, dims.x).values,
+        reduce_axes=(1, 2),
+        total_per_cell=int(at_time.sizes[dims.y]) * int(at_time.sizes[dims.x]),
+    )
+    values = _json_vector(reduced.values)
+    if len(values) != vertical_size:
+        raise VisualizationDataError("Profile product produced an unexpected vertical shape.")
+    return values, _json_int_vector(finite_counts), _json_int_vector(non_finite_counts)
+
+
+def _time_height_product_values(
+    data_array: Any,
+    *,
+    dims: _FieldDimensions,
+    aggregation_method: TimeHeightAggregationMethod,
+    threshold: float | None,
+) -> tuple[list[list[float | None]], list[list[int]], list[list[int]]]:
+    if dims.time is None or dims.vertical is None or dims.y is None or dims.x is None:
+        raise VisualizationDataError("Time-height product requires time/z/y/x dimensions.")
+    ordered = data_array.transpose(dims.time, dims.vertical, dims.y, dims.x)
+    finite_counts, non_finite_counts = _finite_counts(
+        ordered.values,
+        reduce_axes=(2, 3),
+        total_per_cell=int(data_array.sizes[dims.y]) * int(data_array.sizes[dims.x]),
+    )
+    if aggregation_method == "cloud_fraction":
+        if threshold is None or not math.isfinite(threshold):
+            raise VisualizationDataError("cloud_fraction requires a finite threshold.")
+        values = _fraction_values(ordered.values, threshold=threshold, reduce_axes=(2, 3))
+        return (
+            _json_matrix(values),
+            _json_int_matrix(finite_counts),
+            _json_int_matrix(non_finite_counts),
+        )
+    reduced = _reduce_data_array(
+        ordered,
+        reduce_dims=[dims.y, dims.x],
+        aggregation_method=aggregation_method,
+    ).transpose(dims.time, dims.vertical)
+    return (
+        _json_matrix(reduced.values),
+        _json_int_matrix(finite_counts),
+        _json_int_matrix(non_finite_counts),
+    )
+
+
+def _time_series_product_values(
+    data_array: Any,
+    *,
+    dims: _FieldDimensions,
+    aggregation_method: TimeSeriesAggregationMethod,
+    threshold: float | None,
+) -> tuple[list[float | None], list[int], list[int]]:
+    if dims.time is None:
+        raise VisualizationDataError("Time-series product requires a time dimension.")
+    reduce_dims = [dimension for dimension in data_array.dims if dimension != dims.time]
+    ordered = data_array.transpose(dims.time, *reduce_dims)
+    reduce_axes = tuple(range(1, len(ordered.shape)))
+    total_per_time = math.prod(int(data_array.sizes[dimension]) for dimension in reduce_dims)
+    finite_counts, non_finite_counts = _finite_counts(
+        ordered.values,
+        reduce_axes=reduce_axes,
+        total_per_cell=total_per_time,
+    )
+    if aggregation_method == "cloud_fraction":
+        if threshold is None or not math.isfinite(threshold):
+            raise VisualizationDataError("cloud_fraction requires a finite threshold.")
+        values = _fraction_values(ordered.values, threshold=threshold, reduce_axes=reduce_axes)
+        return (
+            _json_vector(values),
+            _json_int_vector(finite_counts),
+            _json_int_vector(non_finite_counts),
+        )
+    reduced = _reduce_data_array(
+        ordered,
+        reduce_dims=reduce_dims,
+        aggregation_method=aggregation_method,
+    ).transpose(dims.time)
+    return (
+        _json_vector(reduced.values),
+        _json_int_vector(finite_counts),
+        _json_int_vector(non_finite_counts),
+    )
+
+
+def _reduce_data_array(
+    data_array: Any,
+    *,
+    reduce_dims: list[str],
+    aggregation_method: str,
+) -> Any:
+    finite = data_array.where(np.isfinite(data_array))
+    if aggregation_method == "domain_mean":
+        return finite.mean(dim=reduce_dims, skipna=True)
+    if aggregation_method == "domain_min":
+        return finite.min(dim=reduce_dims, skipna=True)
+    if aggregation_method == "domain_max":
+        return finite.max(dim=reduce_dims, skipna=True)
+    raise VisualizationDataError(f"Unsupported aggregation method: {aggregation_method}")
+
+
+def _finite_counts(
+    values: Any,
+    *,
+    reduce_axes: tuple[int, ...],
+    total_per_cell: int,
+) -> tuple[Any, Any]:
+    finite_mask = np.isfinite(values)
+    finite_counts = finite_mask.sum(axis=reduce_axes)
+    non_finite_counts = total_per_cell - finite_counts
+    return finite_counts, non_finite_counts
+
+
+def _fraction_values(values: Any, *, threshold: float, reduce_axes: tuple[int, ...]) -> Any:
+    finite_mask = np.isfinite(values)
+    cloudy_counts = (finite_mask & (values >= threshold)).sum(axis=reduce_axes)
+    finite_counts = finite_mask.sum(axis=reduce_axes)
+    return np.divide(
+        cloudy_counts,
+        finite_counts,
+        out=np.full_like(cloudy_counts, np.nan, dtype=float),
+        where=finite_counts > 0,
+    )
+
+
+def _resolved_output_time(
+    metadata: ResultMetadata,
+    dataset: Any,
+    time_dimension: str | None,
+    time_index: int,
+) -> OutputTimeAxisMetadata:
+    return _resolved_output_time_axis(
+        metadata,
+        dataset,
+        time_dimension,
+        time_size=1,
+        requested_indices=[time_index],
+    )
+
+
+def _resolved_output_time_axis(
+    metadata: ResultMetadata,
+    dataset: Any,
+    time_dimension: str | None,
+    *,
+    time_size: int,
+    requested_indices: list[int] | None = None,
+) -> OutputTimeAxisMetadata:
+    indices = requested_indices if requested_indices is not None else list(range(time_size))
+    manifest, manifest_caveats = _load_output_product_manifest(metadata)
+    time_seconds: list[float | None] = []
+    source_time_values: list[float | str | None] = []
+    source_files: list[str | None] = []
+    local_time_indices: list[int | None] = []
+    sources: list[str] = []
+    caveats = list(manifest_caveats)
+    for index in indices:
+        if manifest is not None:
+            try:
+                resolved = resolve_time_index(manifest, index)
+            except OutputProductManifestError as exc:
+                caveats.append(f"output_time_index_resolution_failed:{exc}")
+            else:
+                time_seconds.append(resolved.time_seconds)
+                source_time_values.append(resolved.time_seconds)
+                source_files.append(resolved.source_file)
+                local_time_indices.append(resolved.local_time_index)
+                sources.append(resolved.time_source)
+                caveats.extend(resolved.time_caveats)
+                continue
+        time_seconds.append(_time_value_seconds(dataset, time_dimension, index))
+        source_time_values.append(_coordinate_value(dataset, time_dimension, index))
+        source_files.append(None)
+        local_time_indices.append(index)
+        sources.append("dataset_sequence_index")
+    return OutputTimeAxisMetadata(
+        time_indices=indices,
+        time_seconds=time_seconds,
+        source_time_values=source_time_values,
+        source_files=source_files,
+        local_time_indices=local_time_indices,
+        time_source=sources[0]
+        if sources and all(source == sources[0] for source in sources)
+        else None,
+        time_caveats=_dedupe(caveats),
+    )
+
+
+def _load_output_product_manifest(metadata: ResultMetadata) -> tuple[Any | None, list[str]]:
+    candidate_paths = [
+        Path(path).expanduser()
+        for path in metadata.processed_artifacts
+        if Path(path).name == "output_product_manifest.json"
+    ]
+    source_paths = [Path(path).expanduser() for path in metadata.model_output_paths]
+    if source_paths:
+        candidate_paths.append(default_output_product_manifest_path(source_paths[0].parent))
+    for path in _dedupe([str(path) for path in candidate_paths]):
+        manifest_path = Path(path)
+        if not manifest_path.exists():
+            continue
+        try:
+            return output_product_manifest_from_json(manifest_path.read_text()), []
+        except Exception as exc:
+            return None, [f"output_product_manifest_unreadable:{manifest_path}:{exc}"]
+    return None, ["output_product_manifest_not_available"]
+
+
+def _array_size_class(cell_count: int) -> str:
+    if cell_count <= 10_000:
+        return "tiny_json"
+    if cell_count <= 250_000:
+        return "bounded_json"
+    return "large_future_binary_or_chunked_candidate"
+
+
 def _catalog_caveats(
     metadata: ResultMetadata,
     fields: list[VisualizableField],
@@ -1768,7 +2577,11 @@ def _coordinate_values(dataset: Any, coordinate_name: str | None) -> list[float 
     return [_json_scalar(value) for value in values]
 
 
-def _coordinate_value(dataset: Any, coordinate_name: str, index: int) -> float | str | None:
+def _coordinate_value(
+    dataset: Any, coordinate_name: str | None, index: int | None
+) -> float | str | None:
+    if coordinate_name is None or index is None:
+        return None
     values = _coordinate_values(dataset, coordinate_name)
     if index < len(values):
         return values[index]
@@ -1812,6 +2625,28 @@ def _json_values(data_array: Any) -> list[list[float | None]]:
     for row in values:
         rows.append([_finite_json_number(value) for value in row])
     return rows
+
+
+def _json_vector(values: Any) -> list[float | None]:
+    return [_finite_json_number(value) for value in np.asarray(values).reshape(-1).tolist()]
+
+
+def _json_matrix(values: Any) -> list[list[float | None]]:
+    array = np.asarray(values)
+    if array.ndim != 2:
+        raise VisualizationDataError("Expected a 2-D array for JSON matrix encoding.")
+    return [[_finite_json_number(value) for value in row] for row in array.tolist()]
+
+
+def _json_int_vector(values: Any) -> list[int]:
+    return [int(value) for value in np.asarray(values).reshape(-1).tolist()]
+
+
+def _json_int_matrix(values: Any) -> list[list[int]]:
+    array = np.asarray(values)
+    if array.ndim != 2:
+        raise VisualizationDataError("Expected a 2-D array for integer matrix encoding.")
+    return [[int(value) for value in row] for row in array.tolist()]
 
 
 def _slice_stats(data_array: Any) -> SliceStats:

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -70,6 +70,38 @@ FIELD_DEFINITIONS: dict[str, FieldDefinition] = {
         "Slice/profile-first field; signed-flow 3-D rendering is not supported yet.",
         caveats=("signed_flow_field_slice_only",),
     ),
+    "u": FieldDefinition(
+        "east_west_wind",
+        "East-west wind",
+        "wind",
+        (
+            "Native-grid wind component; supported for slices, profiles, and time-height "
+            "summaries without vector interpolation."
+        ),
+        caveats=(
+            "native_staggered_wind_component",
+            "u_native_x_staggered_grid",
+            "signed_flow_field_slice_only",
+            "no_vector_interpolation",
+            "wind_component_not_wind_gust_outflow_or_rotation_diagnostic",
+        ),
+    ),
+    "v": FieldDefinition(
+        "north_south_wind",
+        "North-south wind",
+        "wind",
+        (
+            "Native-grid wind component; supported for slices, profiles, and time-height "
+            "summaries without vector interpolation."
+        ),
+        caveats=(
+            "native_staggered_wind_component",
+            "v_native_y_staggered_grid",
+            "signed_flow_field_slice_only",
+            "no_vector_interpolation",
+            "wind_component_not_wind_gust_outflow_or_rotation_diagnostic",
+        ),
+    ),
     "qr": FieldDefinition(
         "rain_water",
         "Rain water aloft",
@@ -285,14 +317,14 @@ FIELD_DEFINITIONS: dict[str, FieldDefinition] = {
     ),
 }
 
-SIGNED_FLOW_FIELDS = {"w"}
+SIGNED_FLOW_FIELDS = {"u", "v", "w"}
 SURFACE_POINT_FIELDS = {"rain"}
 
 TIME_DIMENSION_CANDIDATES = ("time", "mtime", "t")
 VERTICAL_DIMENSION_CANDIDATES = ("zh", "zf", "z", "height", "height_m", "height_km")
 SURFACE_VERTICAL_CANDIDATES = ("zf", "zh", "z", "height", "height_m", "height_km")
-Y_DIMENSION_CANDIDATES = ("yh", "y")
-X_DIMENSION_CANDIDATES = ("xh", "x")
+Y_DIMENSION_CANDIDATES = ("yh", "yf", "y")
+X_DIMENSION_CANDIDATES = ("xh", "xf", "x")
 
 
 class VisualizationDataError(RuntimeError):
@@ -1033,6 +1065,7 @@ def output_product_catalog(
             ],
         )
     ]
+    unavailable.extend(_near_surface_wind_unavailable_descriptors(catalog.available_fields))
     unavailable.extend(
         _unavailable_product_descriptor(field) for field in catalog.unavailable_fields
     )
@@ -2222,6 +2255,34 @@ def _unavailable_product_descriptor(field: UnavailableField) -> OutputProductDes
         reason=field.reason,
         caveats=field.caveats,
     )
+
+
+def _near_surface_wind_unavailable_descriptors(
+    fields: list[VisualizableField],
+) -> list[OutputProductDescriptor]:
+    descriptors: list[OutputProductDescriptor] = []
+    for field in fields:
+        if field.canonical_field_name not in {"east_west_wind", "north_south_wind"}:
+            continue
+        descriptors.append(
+            OutputProductDescriptor(
+                product_key=f"near_surface_wind_time_series:{field.raw_field_name}",
+                product_kind="future_diagnostic",
+                status="unavailable",
+                raw_field_name=field.raw_field_name,
+                canonical_field_name=field.canonical_field_name,
+                display_name=f"Near-surface {field.display_name.lower()} time series",
+                required_fields=[field.raw_field_name],
+                reason="near_surface_wind_diagnostic_not_implemented",
+                caveats=[
+                    "lowest_level_wind_selection_method_not_finalized",
+                    "native_staggered_wind_component",
+                    "no_vector_interpolation",
+                    "wind_component_not_wind_gust_outflow_or_rotation_diagnostic",
+                ],
+            )
+        )
+    return descriptors
 
 
 def _time_series_methods_for_field(

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -23,7 +23,11 @@ from cloud_chamber.visualization_data import (
     VisualizationDataError,
     field_catalog,
     field_slice,
+    output_product_catalog,
     point_cloud,
+    time_height_product,
+    time_series_product,
+    vertical_profile,
     view_defaults,
 )
 
@@ -520,6 +524,202 @@ def test_pressure_slice_is_available_but_pressure_point_cloud_is_blocked(
             time_index=0,
             threshold=0,
             max_points=50_000,
+        )
+
+
+def test_output_product_catalog_advertises_bounded_products_and_unavailable_diagnostics(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, _run_dir = create_realistic_field_catalog_result(tmp_path)
+
+    catalog = output_product_catalog(settings, result_id)
+
+    profile_keys = {product.product_key for product in catalog.available_profile_products}
+    time_height_keys = {product.product_key for product in catalog.available_time_height_products}
+    time_series_keys = {product.product_key for product in catalog.available_time_series_products}
+    unavailable = {product.product_key: product for product in catalog.unavailable_products}
+
+    assert "profile:qv" in profile_keys
+    assert "profile:prs" in profile_keys
+    assert "time_height:qv" in time_height_keys
+    assert "time_height:swten" in time_height_keys
+    assert "time_series:hfx" in time_series_keys
+    assert "time_series:lhfx" in time_series_keys
+    assert unavailable["boundary_layer_depth_time_series"].status == "unavailable"
+    assert unavailable["boundary_layer_depth_time_series"].reason == (
+        "future_diagnostic_method_not_validated"
+    )
+    assert unavailable["unavailable:dbz"].reason == (
+        "expected_known_field_missing_from_result_metadata"
+    )
+    assert "browser_does_not_parse_raw_netcdf" in catalog.caveats
+
+
+def test_vertical_profile_domain_mean_preserves_units_coordinates_and_time_index(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    profile = vertical_profile(
+        settings,
+        result_id,
+        field="qv",
+        time_index=0,
+        aggregation_method="domain_mean",
+    )
+
+    assert profile.field.canonical_field_name == "water_vapor"
+    assert profile.field.units == "kg/kg"
+    assert profile.vertical_dimension == "zh"
+    assert profile.vertical_units == "km"
+    assert profile.vertical_coordinate_values == [0.4, 0.8]
+    assert profile.selection.time_index == 0
+    assert profile.selection.local_time_index == 0
+    assert profile.selection.source_file is not None
+    assert profile.values == pytest.approx([0.010055, 0.010175])
+    assert profile.finite_counts == [12, 12]
+    assert profile.non_finite_counts == [0, 0]
+    assert profile.aggregation_method == "domain_mean"
+    assert "native_grid_profile_no_interpolation" in profile.caveats
+
+
+def test_selected_column_profile_preserves_xy_selection_and_values(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    profile = vertical_profile(
+        settings,
+        result_id,
+        field="qc",
+        time_index=0,
+        aggregation_method="selected_column",
+        x_index=3,
+        y_index=2,
+    )
+
+    assert profile.selection.x_index == 3
+    assert profile.selection.y_index == 2
+    assert profile.selection.x_coordinate_value == 3.0
+    assert profile.selection.y_coordinate_value == 2.0
+    assert profile.values == pytest.approx([1.1e-5, 2.3e-5])
+    assert profile.finite_counts == [1, 1]
+    assert profile.non_finite_counts == [0, 0]
+    assert "selected_column_requires_native_x_y_indices" in profile.caveats
+
+
+def test_time_height_products_compute_cloud_fraction_and_w_extrema(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    cloud_fraction = time_height_product(
+        settings,
+        result_id,
+        field="qc",
+        aggregation_method="cloud_fraction",
+    )
+    max_w = time_height_product(
+        settings,
+        result_id,
+        field="w",
+        aggregation_method="domain_max",
+    )
+
+    assert cloud_fraction.selection.threshold == pytest.approx(1e-6)
+    assert cloud_fraction.shape == [2, 2]
+    assert cloud_fraction.time_axis.time_indices == [0, 1]
+    assert cloud_fraction.time_axis.time_seconds == [0.0, 900.0]
+    assert cloud_fraction.vertical_coordinate_values == [0.4, 0.8]
+    assert cloud_fraction.values[0] == pytest.approx([1.0, 1.0])
+    assert cloud_fraction.values[1] == pytest.approx([1.0, 1.0])
+    assert cloud_fraction.finite_counts == [[11, 12], [12, 11]]
+    assert cloud_fraction.non_finite_counts == [[1, 0], [0, 1]]
+    assert "cloud_fraction_threshold_kg_kg:1e-06" in cloud_fraction.caveats
+
+    assert max_w.field.canonical_field_name == "vertical_velocity"
+    assert max_w.vertical_dimension == "zf"
+    assert max_w.vertical_coordinate_values == [0.0, 0.4, 0.8]
+    assert max_w.values[0] == pytest.approx([11.0, 23.0, 35.0])
+    assert max_w.values[1] == pytest.approx([47.0, 59.0, 71.0])
+    assert max_w.finite_counts == [[12, 12, 12], [12, 12, 12]]
+    assert "native_grid_time_height_no_interpolation" in max_w.caveats
+
+
+def test_time_height_supports_qv_and_temperature_domain_mean(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    qv = time_height_product(
+        settings,
+        result_id,
+        field="qv",
+        aggregation_method="domain_mean",
+    )
+    temperature = time_height_product(
+        settings,
+        result_id,
+        field="temperature",
+        aggregation_method="domain_mean",
+    )
+
+    assert qv.values[0] == pytest.approx([0.010055, 0.010175])
+    assert qv.values[1] == pytest.approx([0.010295, 0.010415])
+    assert temperature.field.canonical_field_name == "temperature"
+    assert temperature.values[0] == pytest.approx([286.1, 288.5])
+    assert temperature.values[1] == pytest.approx([290.9, 293.3])
+
+
+def test_time_series_products_cover_surface_rain_reflectivity_and_fluxes(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path / "core")
+    flux_settings, flux_result_id, _run_dir = create_realistic_field_catalog_result(
+        tmp_path / "flux"
+    )
+
+    surface_rain = time_series_product(
+        settings,
+        result_id,
+        field="rain",
+        aggregation_method="domain_max",
+    )
+    reflectivity = time_series_product(
+        settings,
+        result_id,
+        field="dbz",
+        aggregation_method="domain_max",
+    )
+    surface_flux = time_series_product(
+        flux_settings,
+        flux_result_id,
+        field="hfx",
+        aggregation_method="domain_mean",
+    )
+
+    assert surface_rain.field.canonical_field_name == "accumulated_surface_rain"
+    assert surface_rain.units == "mm"
+    assert surface_rain.values == pytest.approx([2.75, 5.75])
+    assert surface_rain.finite_counts == [12, 12]
+    assert reflectivity.field.canonical_field_name == "reflectivity"
+    assert reflectivity.values == pytest.approx([13.0, 37.0])
+    assert surface_flux.field.canonical_field_name == "surface_sensible_heat_flux"
+    assert surface_flux.values == pytest.approx([5.5, 17.5])
+    assert "native_grid_time_series_no_interpolation" in surface_flux.caveats
+
+
+def test_output_products_report_missing_fields_without_late_rendering_failure(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, _run_dir = create_realistic_field_catalog_result(tmp_path)
+
+    catalog = output_product_catalog(settings, result_id)
+    unavailable = {product.product_key: product for product in catalog.unavailable_products}
+
+    assert "unavailable:dbz" in unavailable
+    with pytest.raises(VisualizationDataError, match="missing from this result"):
+        time_series_product(
+            settings,
+            result_id,
+            field="dbz",
+            aggregation_method="domain_max",
         )
 
 
@@ -1104,3 +1304,49 @@ def test_visualization_api_returns_field_catalog_and_slice(
     assert payload["dimension_order"] == ["yh", "xh"]
     assert payload["stats"]["finite_count"] == 11
     assert payload["stats"]["non_finite_count"] == 1
+
+
+def test_output_product_api_returns_profile_time_height_and_time_series(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+    monkeypatch.setenv("CLOUD_CHAMBER_RUNTIME_HOME", str(settings.runtime_home))
+    client = TestClient(app)
+
+    catalog = client.get(f"/api/results/{result_id}/output-products")
+    profile = client.get(
+        f"/api/results/{result_id}/output-products/profile",
+        params={"field": "qv", "time_index": 0, "aggregation_method": "domain_mean"},
+    )
+    time_height = client.get(
+        f"/api/results/{result_id}/output-products/time-height",
+        params={"field": "w", "aggregation_method": "domain_max"},
+    )
+    time_series = client.get(
+        f"/api/results/{result_id}/output-products/time-series",
+        params={"field": "rain", "aggregation_method": "domain_max"},
+    )
+    bad_profile = client.get(
+        f"/api/results/{result_id}/output-products/profile",
+        params={"field": "rain", "time_index": 0, "aggregation_method": "domain_mean"},
+    )
+
+    assert catalog.status_code == 200
+    assert any(
+        product["product_key"] == "profile:qv"
+        for product in catalog.json()["available_profile_products"]
+    )
+    assert catalog.json()["unavailable_products"][0]["product_key"] == (
+        "boundary_layer_depth_time_series"
+    )
+    assert profile.status_code == 200
+    assert profile.json()["values"] == pytest.approx([0.010055, 0.010175])
+    assert time_height.status_code == 200
+    assert time_height.json()["shape"] == [2, 3]
+    assert time_height.json()["values"][0] == pytest.approx([11.0, 23.0, 35.0])
+    assert time_height.json()["values"][1] == pytest.approx([47.0, 59.0, 71.0])
+    assert time_series.status_code == 200
+    assert time_series.json()["values"] == pytest.approx([2.75, 5.75])
+    assert bad_profile.status_code == 400
+    assert "not profile-capable" in bad_profile.json()["detail"]

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -51,6 +51,8 @@ def create_visualization_result(
     *,
     include_qc: bool = True,
     include_w: bool = True,
+    include_u: bool = True,
+    include_v: bool = True,
     include_qr: bool = False,
     include_qv: bool = True,
     include_dbz: bool = True,
@@ -69,6 +71,8 @@ def create_visualization_result(
         netcdf_path,
         include_qc=include_qc,
         include_w=include_w,
+        include_u=include_u,
+        include_v=include_v,
         include_qr=include_qr,
         include_qv=include_qv,
         include_dbz=include_dbz,
@@ -146,6 +150,8 @@ def create_realistic_field_catalog_result(
                 "expected_outputs": [
                     "qc",
                     "w",
+                    "u",
+                    "v",
                     "qv",
                     "prs",
                     "hfx",
@@ -170,6 +176,8 @@ def write_visualization_netcdf(
     *,
     include_qc: bool,
     include_w: bool,
+    include_u: bool,
+    include_v: bool,
     include_qr: bool,
     include_qv: bool,
     include_dbz: bool,
@@ -189,6 +197,20 @@ def write_visualization_netcdf(
         data_vars["w"] = (
             ("time", "zf", "yh", "xh"),
             w,
+            {"units": "m/s"},
+        )
+    if include_u:
+        u = 5.0 + np.arange(2 * 2 * 3 * 5, dtype=float).reshape(2, 2, 3, 5) * 0.1
+        data_vars["u"] = (
+            ("time", "zh", "yh", "xf"),
+            u,
+            {"units": "m/s"},
+        )
+    if include_v:
+        v = -2.0 + np.arange(2 * 2 * 4 * 4, dtype=float).reshape(2, 2, 4, 4) * 0.2
+        data_vars["v"] = (
+            ("time", "zh", "yf", "xh"),
+            v,
             {"units": "m/s"},
         )
     if include_qr:
@@ -235,7 +257,9 @@ def write_visualization_netcdf(
             "zh": ("zh", [0.4, 0.8], {"units": "km"}),
             "zf": ("zf", [0.0, 0.4, 0.8], {"units": "km"}),
             "yh": ("yh", [0.0, 1.0, 2.0], {"units": "km"}),
+            "yf": ("yf", [-0.5, 0.5, 1.5, 2.5], {"units": "km"}),
             "xh": ("xh", [0.0, 1.0, 2.0, 3.0], {"units": "km"}),
+            "xf": ("xf", [-0.5, 0.5, 1.5, 2.5, 3.5], {"units": "km"}),
         },
     ).to_netcdf(path, engine="scipy")
 
@@ -255,6 +279,16 @@ def write_realistic_field_catalog_netcdf(path: Path) -> None:
             "w": (
                 ("time", "zf", "yh", "xh"),
                 np.arange(2 * 3 * 3 * 4, dtype=float).reshape(2, 3, 3, 4),
+                {"units": "m/s"},
+            ),
+            "u": (
+                ("time", "zh", "yh", "xf"),
+                5.0 + np.arange(2 * 2 * 3 * 5, dtype=float).reshape(2, 2, 3, 5) * 0.1,
+                {"units": "m/s"},
+            ),
+            "v": (
+                ("time", "zh", "yf", "xh"),
+                -2.0 + np.arange(2 * 2 * 4 * 4, dtype=float).reshape(2, 2, 4, 4) * 0.2,
                 {"units": "m/s"},
             ),
             "qv": (
@@ -318,7 +352,9 @@ def write_realistic_field_catalog_netcdf(path: Path) -> None:
             "zh": ("zh", [0.4, 0.8], {"units": "km"}),
             "zf": ("zf", [0.0, 0.4, 0.8], {"units": "km"}),
             "yh": ("yh", [0.0, 1.0, 2.0], {"units": "km"}),
+            "yf": ("yf", [-0.5, 0.5, 1.5, 2.5], {"units": "km"}),
             "xh": ("xh", [0.0, 1.0, 2.0, 3.0], {"units": "km"}),
+            "xf": ("xf", [-0.5, 0.5, 1.5, 2.5, 3.5], {"units": "km"}),
         },
     ).to_netcdf(path, engine="scipy")
 
@@ -367,6 +403,14 @@ def test_field_catalog_includes_qc_and_w_with_provenance(tmp_path: Path) -> None
     assert fields["w"].canonical_field_name == "vertical_velocity"
     assert fields["w"].native_grid == "zf/yh/xh"
     assert fields["w"].coordinate_names.vertical == "zf"
+    assert fields["u"].canonical_field_name == "east_west_wind"
+    assert fields["u"].native_grid == "zh/yh/xf"
+    assert fields["u"].coordinate_names.x == "xf"
+    assert "native_staggered_wind_component" in fields["u"].caveats
+    assert fields["v"].canonical_field_name == "north_south_wind"
+    assert fields["v"].native_grid == "zh/yf/xh"
+    assert fields["v"].coordinate_names.y == "yf"
+    assert "native_staggered_wind_component" in fields["v"].caveats
     assert fields["theta"].canonical_field_name == "potential_temperature"
     assert fields["theta"].units == "K"
     assert fields["temperature"].canonical_field_name == "temperature"
@@ -541,16 +585,29 @@ def test_output_product_catalog_advertises_bounded_products_and_unavailable_diag
 
     assert "profile:qv" in profile_keys
     assert "profile:prs" in profile_keys
+    assert "profile:u" in profile_keys
+    assert "profile:v" in profile_keys
     assert "time_height:qv" in time_height_keys
     assert "time_height:swten" in time_height_keys
+    assert "time_height:u" in time_height_keys
+    assert "time_height:v" in time_height_keys
     assert "time_series:hfx" in time_series_keys
     assert "time_series:lhfx" in time_series_keys
+    assert "time_series:u" in time_series_keys
+    assert "time_series:v" in time_series_keys
     assert unavailable["boundary_layer_depth_time_series"].status == "unavailable"
     assert unavailable["boundary_layer_depth_time_series"].reason == (
         "future_diagnostic_method_not_validated"
     )
     assert unavailable["unavailable:dbz"].reason == (
         "expected_known_field_missing_from_result_metadata"
+    )
+    assert unavailable["near_surface_wind_time_series:u"].reason == (
+        "near_surface_wind_diagnostic_not_implemented"
+    )
+    assert (
+        "wind_component_not_wind_gust_outflow_or_rotation_diagnostic"
+        in unavailable["near_surface_wind_time_series:v"].caveats
     )
     assert "browser_does_not_parse_raw_netcdf" in catalog.caveats
 
@@ -606,6 +663,47 @@ def test_selected_column_profile_preserves_xy_selection_and_values(tmp_path: Pat
     assert "selected_column_requires_native_x_y_indices" in profile.caveats
 
 
+def test_wind_component_profiles_preserve_native_staggered_grid_and_caveats(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    u_profile = vertical_profile(
+        settings,
+        result_id,
+        field="u",
+        time_index=0,
+        aggregation_method="domain_mean",
+    )
+    v_profile = vertical_profile(
+        settings,
+        result_id,
+        field="v",
+        time_index=0,
+        aggregation_method="selected_column",
+        x_index=3,
+        y_index=3,
+    )
+
+    assert u_profile.field.canonical_field_name == "east_west_wind"
+    assert u_profile.field.field_family == "wind"
+    assert u_profile.field.units == "m/s"
+    assert u_profile.field.native_grid == "zh/yh/xf"
+    assert u_profile.values == pytest.approx([5.7, 7.2])
+    assert u_profile.finite_counts == [15, 15]
+    assert "native_staggered_wind_component" in u_profile.caveats
+    assert "no_vector_interpolation" in u_profile.caveats
+    assert "wind_component_not_wind_gust_outflow_or_rotation_diagnostic" in u_profile.caveats
+
+    assert v_profile.field.canonical_field_name == "north_south_wind"
+    assert v_profile.field.native_grid == "zh/yf/xh"
+    assert v_profile.selection.x_coordinate_value == 3.0
+    assert v_profile.selection.y_coordinate_value == 2.5
+    assert v_profile.values == pytest.approx([1.0, 4.2])
+    assert "v_native_y_staggered_grid" in v_profile.caveats
+    assert "wind_component_not_wind_gust_outflow_or_rotation_diagnostic" in v_profile.caveats
+
+
 def test_time_height_products_compute_cloud_fraction_and_w_extrema(
     tmp_path: Path,
 ) -> None:
@@ -642,6 +740,40 @@ def test_time_height_products_compute_cloud_fraction_and_w_extrema(
     assert max_w.values[1] == pytest.approx([47.0, 59.0, 71.0])
     assert max_w.finite_counts == [[12, 12, 12], [12, 12, 12]]
     assert "native_grid_time_height_no_interpolation" in max_w.caveats
+
+
+def test_wind_component_time_height_products_work_without_vector_claims(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, _run_dir = create_visualization_result(tmp_path)
+
+    u = time_height_product(
+        settings,
+        result_id,
+        field="u",
+        aggregation_method="domain_mean",
+    )
+    v = time_height_product(
+        settings,
+        result_id,
+        field="v",
+        aggregation_method="domain_max",
+    )
+
+    assert u.field.canonical_field_name == "east_west_wind"
+    assert u.vertical_dimension == "zh"
+    assert u.values[0] == pytest.approx([5.7, 7.2])
+    assert u.values[1] == pytest.approx([8.7, 10.2])
+    assert u.finite_counts == [[15, 15], [15, 15]]
+    assert "u_native_x_staggered_grid" in u.caveats
+    assert "wind_component_not_wind_gust_outflow_or_rotation_diagnostic" in u.caveats
+
+    assert v.field.canonical_field_name == "north_south_wind"
+    assert v.values[0] == pytest.approx([1.0, 4.2])
+    assert v.values[1] == pytest.approx([7.4, 10.600000000000001])
+    assert v.finite_counts == [[16, 16], [16, 16]]
+    assert "v_native_y_staggered_grid" in v.caveats
+    assert "no_vector_interpolation" in v.caveats
 
 
 def test_time_height_supports_qv_and_temperature_domain_mean(tmp_path: Path) -> None:

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -390,6 +390,15 @@ Profile products should preserve:
 - aggregation method;
 - caveats for missing or inferred coordinates.
 
+The current backend skeleton exposes bounded vertical profile products through
+the result output-products API. Supported MVP aggregations are domain mean,
+domain min, domain max, and selected column for profile-capable 3-D fields.
+Payloads include the global output `time_index`, resolved local source-file
+index when the output product manifest is available, vertical coordinate values,
+finite/non-finite counts, provenance, and caveats. Surface-only fields such as
+surface rain and surface fluxes remain unavailable for vertical profiles rather
+than being reshaped into misleading columns.
+
 ## Time-Height Products
 
 Time-height products summarize evolution across output times and vertical
@@ -413,6 +422,28 @@ Rules:
 - They should be cacheable because they may require reading the full sequence.
 - JSON is acceptable for tiny fixtures; binary/chunked formats should be
   considered for real deep outputs.
+
+The current backend skeleton exposes time-height products for time-height-capable
+3-D fields. Supported MVP aggregations are domain mean, domain min, domain max,
+and cloud fraction for `qc` using the documented cloud-water threshold. Payloads
+include global output time indices, source-file/local-time mappings when
+available, vertical coordinates, shape and size class, finite/non-finite counts,
+provenance, and caveats. The browser consumes the bounded payload only; it does
+not parse raw NetCDF.
+
+## Evolved-Run Time-Series Products
+
+Simple time-series products summarize scalar evolution across saved output
+times. Initial supported aggregations are domain max, domain mean, domain min,
+and cloud fraction where the field supports it. These products cover current
+MVP fields such as surface rain, rain water aloft, reflectivity, cloud water,
+surface sensible/latent heat flux, and other known field-catalog entries when
+present.
+
+Missing fields must return an unavailable/caveated catalog state or a clear
+product error, not a guessed scientific result. Boundary-layer-depth and
+mixed-layer-depth style products remain future diagnostics until a defensible
+method is documented and tested.
 
 ## Selected-Point And Selected-Column Products
 

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -437,13 +437,21 @@ Simple time-series products summarize scalar evolution across saved output
 times. Initial supported aggregations are domain max, domain mean, domain min,
 and cloud fraction where the field supports it. These products cover current
 MVP fields such as surface rain, rain water aloft, reflectivity, cloud water,
-surface sensible/latent heat flux, and other known field-catalog entries when
-present.
+`u` / `v` / `w` wind components, surface sensible/latent heat flux, and other
+known field-catalog entries when present.
 
 Missing fields must return an unavailable/caveated catalog state or a clear
 product error, not a guessed scientific result. Boundary-layer-depth and
 mixed-layer-depth style products remain future diagnostics until a defensible
 method is documented and tested.
+
+Wind-component products are scalar summaries of native-grid CM1 `u` and `v`
+components. They may support vertical profiles and time-height products when
+the fields and coordinates are present, but they must carry native staggered-grid
+and no-vector-interpolation caveats. They are not wind gust, outflow, rotation,
+or storm-organization diagnostics. Near-surface wind time-series products remain
+explicitly unavailable until the lowest-level selection method is defined and
+tested.
 
 ## Selected-Point And Selected-Column Products
 


### PR DESCRIPTION
## Summary
- Added backend-owned output-product catalog payloads for vertical profiles, time-height arrays, and evolved-run time series.
- Added bounded profile, time-height, and time-series builders that preserve units, coordinates, aggregation methods, finite/non-finite counts, provenance, and output time-index/source-file metadata when available.
- Added conservative `u` / `v` wind-component field catalog support with native staggered-grid, no-vector-interpolation, and no gust/outflow/rotation diagnostic caveats.
- Added FastAPI endpoints under `/api/results/{result_id}/output-products*` without adding Diagnostics Lab UI or browser NetCDF parsing.
- Added tiny NetCDF-backed tests for domain and selected-column profiles, cloud-fraction and `w` time-height products, `u`/`v` wind profiles/time-height products, `qv`/temperature time-height products, surface rain/reflectivity/flux time series, missing-field behavior, and route smoke coverage.
- Updated the output product contract with the current backend skeleton behavior, wind-component caveats, near-surface wind unavailable state, and boundary-layer future-diagnostic caveat.

## Verification
- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_visualization_data.py -q`
- `scripts/check.sh`

## Merge note
Prepared for review, but intentionally not merging per request.

Closes #224
