### PR TITLE
Add hypothesis-to-run-recipe pre-run validation report

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -123,7 +123,7 @@ class DryRunRequest(BaseModel):
     scenario_id: str = "baseline-shallow-cumulus"
     controls: dict[str, str | float | bool] = Field(default_factory=dict)
     run_configuration: dict[str, object] | None = None
-    package_family: str | None = None
+    run_recipe: str | None = None
     observed_sounding: dict[str, object] | None = None
     candidate_screening: dict[str, object] | None = None
     user_name: str | None = None
@@ -210,7 +210,7 @@ def create_dry_run_package(request: DryRunRequest) -> dict[str, Any]:
             run_id=f"dry-run-{uuid4().hex[:12]}",
             controls=request.controls,
             run_configuration=request.run_configuration,
-            package_family=request.package_family,
+            run_recipe=request.run_recipe,
             observed_sounding=request.observed_sounding,
             candidate_screening=request.candidate_screening,
             user_name=request.user_name,
@@ -858,8 +858,8 @@ def _run_status_payload(status: RunStatus) -> dict[str, object]:
             "user": None,
             "observed_sounding": None,
             "candidate_screening": None,
-            "package_family": None,
-            "package_display_name": None,
+            "run_recipe": None,
+            "run_recipe_display_name": None,
             "input_source": None,
             "run_configuration": None,
             "pre_run_validation_report": None,
@@ -892,8 +892,8 @@ def _run_status_payload(status: RunStatus) -> dict[str, object]:
         "user": manifest.user.model_dump(mode="json"),
         "observed_sounding": manifest.observed_sounding,
         "candidate_screening": manifest.candidate_screening,
-        "package_family": manifest.package_family,
-        "package_display_name": manifest.package_display_name,
+        "run_recipe": manifest.run_recipe,
+        "run_recipe_display_name": manifest.run_recipe_display_name,
         "input_source": manifest.input_source,
         "run_configuration": manifest.run_configuration,
         "pre_run_validation_report": manifest.pre_run_validation_report,

--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -218,6 +218,14 @@ def create_dry_run_package(request: DryRunRequest) -> dict[str, Any]:
             user_notes=request.user_notes,
         )
     except DryRunPackageError as exc:
+        if exc.pre_run_validation_report is not None:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "message": str(exc),
+                    "pre_run_validation_report": exc.pre_run_validation_report,
+                },
+            ) from exc
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     report = read_dry_run_report(result.report_path)
     return {
@@ -854,6 +862,7 @@ def _run_status_payload(status: RunStatus) -> dict[str, object]:
             "package_display_name": None,
             "input_source": None,
             "run_configuration": None,
+            "pre_run_validation_report": None,
         }
     return {
         "run_id": status.run_id,
@@ -887,6 +896,7 @@ def _run_status_payload(status: RunStatus) -> dict[str, object]:
         "package_display_name": manifest.package_display_name,
         "input_source": manifest.input_source,
         "run_configuration": manifest.run_configuration,
+        "pre_run_validation_report": manifest.pre_run_validation_report,
     }
 
 

--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -1,6 +1,6 @@
 """CM1-facing input generation contract.
 
-This module defines deterministic metadata and CM1-facing text for package generation.
+This module defines deterministic metadata and CM1-facing text for run generation.
 It does not launch CM1 and does not write generated files.
 """
 
@@ -31,10 +31,10 @@ class GeneratedFileRole(StrEnum):
     RUNTIME_FILE_CHECKLIST = "runtime_file_checklist"
 
 
-class PackageFamily(StrEnum):
-    SHALLOW_CUMULUS = "shallow_cumulus"
-    OBSERVED_SOUNDING_QUICKLOOK = "observed_sounding_quicklook"
-    DEEP_CONVECTION_TRIAL = "deep_convection_trial"
+class RunRecipe(StrEnum):
+    GENERATED_REFERENCE_LOWER_ATMOSPHERE = "generated_reference_lower_atmosphere"
+    UNTRIGGERED_OBSERVED_EVOLUTION = "untriggered_observed_evolution"
+    TRIGGERED_DEEP_POTENTIAL = "triggered_deep_potential"
 
 
 @dataclass(frozen=True)
@@ -74,8 +74,8 @@ class ControlMappingFragment:
 
 @dataclass(frozen=True)
 class CM1InputContract:
-    package_family: PackageFamily
-    package_display_name: str
+    run_recipe: RunRecipe
+    run_recipe_display_name: str
     input_source: str
     trigger_type: str | None
     trigger_parameters: dict[str, str | int | float | bool]
@@ -91,7 +91,7 @@ class CM1InputContract:
     expected_outputs: tuple[str, ...]
     visualization_defaults: dict[str, str | list[str]]
     limitations: tuple[str, ...]
-    package_caveats: tuple[str, ...]
+    run_caveats: tuple[str, ...]
     manual_validation_status: str
     observed_sounding: ObservedSoundingRecord | None = None
 
@@ -109,7 +109,7 @@ GENERATED_FILE_SPECS = (
     GeneratedFileSpec(
         role=GeneratedFileRole.CASE_MANIFEST,
         relative_path="case_manifest.json",
-        description="Scenario-facing case metadata used to review the generated package.",
+        description="Scenario-facing case metadata used to review the generated run inputs.",
         scientific_status="metadata contract",
     ),
     GeneratedFileSpec(
@@ -153,24 +153,24 @@ def build_cm1_input_contract(
     selected_controls: dict[str, str | float | bool] | None = None,
     run_configuration: dict[str, object] | RunConfiguration | None = None,
     observed_sounding: ObservedSoundingRecord | None = None,
-    package_family: str | PackageFamily | None = None,
+    run_recipe: str | RunRecipe | None = None,
 ) -> CM1InputContract:
     selected = selected_controls or {}
-    resolved_package_family = _resolve_package_family(package_family, observed_sounding)
+    resolved_run_recipe = _resolve_run_recipe(run_recipe, observed_sounding)
     resolved_run_configuration = resolve_run_configuration(
         run_configuration=run_configuration,
-        package_family=resolved_package_family.value,
+        run_recipe=resolved_run_recipe.value,
     )
     defaults = cloud_scale_defaults_for_configuration(resolved_run_configuration)
-    if resolved_package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+    if resolved_run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
         if observed_sounding is None:
-            raise ValueError("Deep Convection Trial requires a validated observed sounding.")
+            raise ValueError("Triggered deep-potential run requires a validated observed sounding.")
         if not _has_observed_wind_profile(
             observed_sounding,
             required_model_top_m=_required_sounding_top_m(defaults),
         ):
             raise ValueError(
-                "Deep Convection Trial requires a complete finite observed u/v wind "
+                "Triggered deep-potential runs require a complete finite observed u/v wind "
                 "profile for every input_sounding level."
             )
     control_fragments = tuple(
@@ -193,17 +193,15 @@ def build_cm1_input_contract(
     stability_profile = _stability_profile_from_controls(scenario.id, control_fragments)
 
     return CM1InputContract(
-        package_family=resolved_package_family,
-        package_display_name=_package_display_name(resolved_package_family),
+        run_recipe=resolved_run_recipe,
+        run_recipe_display_name=_run_recipe_display_name(resolved_run_recipe),
         input_source="observed_sounding"
         if observed_sounding is not None
         else "generated_reference",
         trigger_type=(
-            "warm_bubble"
-            if resolved_package_family == PackageFamily.DEEP_CONVECTION_TRIAL
-            else None
+            "warm_bubble" if resolved_run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL else None
         ),
-        trigger_parameters=_trigger_parameters(resolved_package_family),
+        trigger_parameters=_trigger_parameters(resolved_run_recipe),
         scenario_id=scenario.id,
         physical_question=scenario.physical_question,
         run_configuration=resolved_run_configuration,
@@ -214,8 +212,8 @@ def build_cm1_input_contract(
         control_fragments=control_fragments,
         expected_diagnostics=_diagnostic_names(scenario),
         expected_outputs=_expected_outputs(
-            resolved_package_family,
-            resolved_run_configuration.output_field_density_preset,
+            resolved_run_recipe,
+            resolved_run_configuration.diagnostic_set,
         ),
         visualization_defaults={
             "primary_field": scenario.visualization_defaults.primary_field,
@@ -225,8 +223,8 @@ def build_cm1_input_contract(
             "provenance_label": scenario.visualization_defaults.provenance_label,
         },
         limitations=tuple(scenario.limitations),
-        package_caveats=_package_caveats(resolved_package_family, resolved_run_configuration),
-        manual_validation_status=_manual_validation_status(resolved_package_family),
+        run_caveats=_run_caveats(resolved_run_recipe, resolved_run_configuration),
+        manual_validation_status=_manual_validation_status(resolved_run_recipe),
         observed_sounding=observed_sounding,
     )
 
@@ -250,36 +248,36 @@ def cloud_scale_defaults_for_configuration(configuration: RunConfiguration) -> C
     )
 
 
-def _resolve_package_family(
-    package_family: str | PackageFamily | None,
+def _resolve_run_recipe(
+    run_recipe: str | RunRecipe | None,
     observed_sounding: ObservedSoundingRecord | None,
-) -> PackageFamily:
-    if isinstance(package_family, PackageFamily):
-        return package_family
-    if package_family:
+) -> RunRecipe:
+    if isinstance(run_recipe, RunRecipe):
+        return run_recipe
+    if run_recipe:
         try:
-            return PackageFamily(package_family)
+            return RunRecipe(run_recipe)
         except ValueError as exc:
-            raise ValueError(f"Unknown package family: {package_family}") from exc
+            raise ValueError(f"Unknown run recipe: {run_recipe}") from exc
     if observed_sounding is not None:
-        return PackageFamily.OBSERVED_SOUNDING_QUICKLOOK
-    return PackageFamily.SHALLOW_CUMULUS
+        return RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION
+    return RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE
 
 
-def _package_display_name(package_family: PackageFamily) -> str:
-    match package_family:
-        case PackageFamily.DEEP_CONVECTION_TRIAL:
-            return "Deep Convection Trial"
-        case PackageFamily.OBSERVED_SOUNDING_QUICKLOOK:
-            return "Observed Sounding Quick Look"
-        case PackageFamily.SHALLOW_CUMULUS:
-            return "Shallow Cumulus Package"
+def _run_recipe_display_name(run_recipe: RunRecipe) -> str:
+    match run_recipe:
+        case RunRecipe.TRIGGERED_DEEP_POTENTIAL:
+            return "Triggered Deep-Potential Experiment"
+        case RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
+            return "Untriggered Observed Evolution"
+        case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
+            return "Generated Lower-Atmosphere Reference"
 
 
 def _trigger_parameters(
-    package_family: PackageFamily,
+    run_recipe: RunRecipe,
 ) -> dict[str, str | int | float | bool]:
-    if package_family != PackageFamily.DEEP_CONVECTION_TRIAL:
+    if run_recipe != RunRecipe.TRIGGERED_DEEP_POTENTIAL:
         return {}
     return {
         "cm1_iinit": 3,
@@ -292,33 +290,33 @@ def _trigger_parameters(
 
 
 def _expected_outputs(
-    package_family: PackageFamily,
-    output_field_density_preset: str,
+    run_recipe: RunRecipe,
+    diagnostic_set: str,
 ) -> tuple[str, ...]:
     base = ("qc", "qr", "qv", "th", "prs", "u", "v", "w", "rain", "dbz")
     analysis = (*base, "psfc", "hfx", "lhfx", "lwp")
     rich = (*analysis, "tke", "km", "kh", "vorticity", "updraft_helicity")
-    if output_field_density_preset == "core":
+    if diagnostic_set == "essential":
         return base
-    if output_field_density_preset == "analysis":
+    if diagnostic_set == "process":
         return analysis
-    if package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+    if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
         return rich
     return rich
 
 
-def _package_caveats(
-    package_family: PackageFamily,
+def _run_caveats(
+    run_recipe: RunRecipe,
     run_configuration: RunConfiguration,
 ) -> tuple[str, ...]:
     caveats = list(run_configuration.caveats)
-    if package_family != PackageFamily.DEEP_CONVECTION_TRIAL:
+    if run_recipe != RunRecipe.TRIGGERED_DEEP_POTENTIAL:
         return tuple(caveats)
     caveats.extend(
         [
-            "Deep Convection Trial uses an idealized CM1 three-warm-bubble trigger.",
+            "Triggered deep-potential runs use an idealized CM1 three-warm-bubble trigger.",
             (
-                "Manual smoke evidence applies to the Deep Convection Trial package family; "
+                "Manual smoke evidence applies to the triggered deep-potential recipe; "
                 "each observed sounding remains an experiment to evaluate after CM1 completes."
             ),
             (
@@ -336,14 +334,14 @@ def _package_caveats(
     return tuple(caveats)
 
 
-def _manual_validation_status(package_family: PackageFamily) -> str:
-    if package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
-        return "deep_convection_trial_package_smoke_validated"
-    return "existing_package_path"
+def _manual_validation_status(run_recipe: RunRecipe) -> str:
+    if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
+        return "triggered_deep_potential_recipe_smoke_validated"
+    return "current_run_recipe_path"
 
 
 def _output_switches(
-    output_field_density_preset: str,
+    diagnostic_set: str,
     *,
     deep_convection: bool,
 ) -> dict[str, int]:
@@ -359,7 +357,7 @@ def _output_switches(
         "uh": 0,
         "lwp": 0,
     }
-    if output_field_density_preset in {"analysis", "rich"}:
+    if diagnostic_set in {"process", "full"}:
         switches.update(
             {
                 "sfcflx": 1,
@@ -369,7 +367,7 @@ def _output_switches(
                 "lwp": 1,
             }
         )
-    if output_field_density_preset == "rich" or deep_convection:
+    if diagnostic_set == "full" or deep_convection:
         switches.update(
             {
                 "tke": 1,
@@ -428,14 +426,14 @@ def render_namelist_fragment(contract: CM1InputContract) -> str:
 
 
 def render_cm1_namelist(contract: CM1InputContract) -> str:
-    """Render a runnable CM1 namelist for the baseline shallow-cumulus package.
+    """Render a runnable CM1 namelist for the baseline shallow-cumulus run.
 
     The recovery baseline follows CM1's local ``les_ShallowCu`` reference case.
-    Generated reference packages keep ``isnd = 17`` with the reference wind path.
-    Observed-sounding packages use ``isnd = 7`` so CM1 reads the thermodynamic
+    Generated reference runs keep ``isnd = 17`` with the reference wind path.
+    Observed-sounding runs use ``isnd = 7`` so CM1 reads the thermodynamic
     and wind profile from ``input_sounding``. The resolved run configuration
-    controls runtime, grid/detail, domain size, saved-output cadence, and
-    output-field density before CM1 is launched. The intentional
+    controls runtime, horizontal cells, domain size, saved-output cadence, and
+    diagnostic set before CM1 is launched. The intentional
     product-path change outside the sounding source is ``output_format = 2`` so
     Cloud Chamber can ingest NetCDF output when the local CM1 build supports it.
     """
@@ -443,7 +441,7 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
     defaults = contract.cloud_scale_defaults
     sounding_source_id = 7 if contract.observed_sounding is not None else 17
     wind_profile_id = 0 if contract.observed_sounding is not None else 9
-    deep_convection = contract.package_family == PackageFamily.DEEP_CONVECTION_TRIAL
+    deep_convection = contract.run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL
     testcase = 0 if deep_convection else 3
     adapt_dt = 0 if deep_convection else 1
     ptype = 5
@@ -458,7 +456,7 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
     irandp = 0 if deep_convection else 1
     imove = 1 if deep_convection else 0
     output = _output_switches(
-        contract.run_configuration.output_field_density_preset,
+        contract.run_configuration.diagnostic_set,
         deep_convection=deep_convection,
     )
     isfcflx = 0 if deep_convection else 1
@@ -805,8 +803,8 @@ def render_input_sounding_notes(contract: CM1InputContract) -> str:
 def render_cm1_input_sounding(contract: CM1InputContract) -> str:
     """Render a CM1-readable external sounding profile.
 
-    CM1 observed-sounding packages use ``isnd = 7`` so CM1 reads
-    thermodynamics and wind from this file. Generated reference packages use
+    CM1 observed-sounding runs use ``isnd = 7`` so CM1 reads
+    thermodynamics and wind from this file. Generated reference runs use
     the external-sounding profile derived from the BOMEX/Siebesma
     shallow-cumulus breakpoints used by CM1's ``isnd = 19`` reference case.
     """

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -75,7 +75,7 @@ def generate_dry_run_package(
     candidate_screening: dict[str, object] | None = None,
     user_tags: list[str] | None = None,
     user_notes: str | None = None,
-    package_family: str | None = None,
+    run_recipe: str | None = None,
     run_configuration: dict[str, object] | None = None,
 ) -> DryRunPackageResult:
     scenario = validate_scenario_template(scenario_data)
@@ -94,14 +94,14 @@ def generate_dry_run_package(
             selected_controls=selected_controls,
             run_configuration=run_configuration,
             observed_sounding=observed_record,
-            package_family=package_family,
+            run_recipe=run_recipe,
         )
     except ValueError as exc:
         error_message = _user_facing_validation_error(str(exc))
         report = blocked_pre_run_validation_report(
             scenario=scenario,
             controls=selected_controls,
-            package_family=package_family,
+            run_recipe=run_recipe,
             run_configuration=run_configuration,
             observed_sounding=observed_sounding,
             candidate_screening=candidate_screening,
@@ -171,14 +171,14 @@ def generate_dry_run_package(
         ),
         candidate_screening=candidate_screening,
         pre_run_validation_report=pre_run_validation_report,
-        package_family=contract.package_family.value,
-        package_display_name=contract.package_display_name,
+        run_recipe=contract.run_recipe.value,
+        run_recipe_display_name=contract.run_recipe_display_name,
         input_source=contract.input_source,
         trigger_type=contract.trigger_type,
         trigger_parameters=contract.trigger_parameters,
         expected_outputs=list(contract.expected_outputs),
-        package_limitations=list(contract.limitations),
-        package_caveats=list(contract.package_caveats),
+        run_limitations=list(contract.limitations),
+        run_caveats=list(contract.run_caveats),
         manual_validation_status=contract.manual_validation_status,
     )
 
@@ -252,11 +252,11 @@ def _observed_sounding_record(
 
 def _user_facing_validation_error(message: str) -> str:
     replacements = {
-        "duration_preset": "duration preset",
-        "grid_detail_preset": "grid detail preset",
-        "domain_size_preset": "domain size preset",
-        "output_cadence_preset": "output cadence preset",
-        "output_field_density_preset": "output field density preset",
+        "duration": "duration",
+        "horizontal_cell_count": "horizontal cell count",
+        "domain_size": "domain size",
+        "output_cadence": "output cadence",
+        "diagnostic_set": "diagnostic set",
     }
     for internal, label in replacements.items():
         message = message.replace(internal, label)
@@ -290,8 +290,8 @@ def _case_manifest_payload(
     return {
         "scenario_id": scenario.id,
         "display_name": scenario.display_name,
-        "package_family": contract.package_family.value,
-        "package_display_name": contract.package_display_name,
+        "run_recipe": contract.run_recipe.value,
+        "run_recipe_display_name": contract.run_recipe_display_name,
         "input_source": contract.input_source,
         "trigger_type": contract.trigger_type,
         "trigger_parameters": contract.trigger_parameters,
@@ -300,7 +300,7 @@ def _case_manifest_payload(
         "expected_behavior": scenario.expected_behavior,
         "warnings": scenario.warnings,
         "limitations": scenario.limitations,
-        "package_caveats": contract.package_caveats,
+        "run_caveats": contract.run_caveats,
         "manual_validation_status": contract.manual_validation_status,
         "run_configuration": contract.run_configuration.model_dump(mode="json"),
         "pre_run_validation_report": pre_run_validation_report,
@@ -324,8 +324,8 @@ def _dry_run_report_payload(
         "not_a_completed_cm1_result": True,
         "cm1_was_launched": False,
         "scenario_id": scenario.id,
-        "package_family": contract.package_family.value,
-        "package_display_name": contract.package_display_name,
+        "run_recipe": contract.run_recipe.value,
+        "run_recipe_display_name": contract.run_recipe_display_name,
         "input_source": contract.input_source,
         "trigger_type": contract.trigger_type,
         "trigger_parameters": contract.trigger_parameters,
@@ -342,7 +342,7 @@ def _dry_run_report_payload(
             "low_level_humidity": manifest.controls.get("low_level_humidity"),
             "cap_strength": manifest.controls.get("cap_strength"),
             "cap_height": manifest.controls.get("cap_height"),
-            "mapping": _package_mapping_summary(contract),
+            "mapping": _run_recipe_mapping_summary(contract),
         },
         "observed_sounding": (
             _observed_sounding_summary(contract.observed_sounding)
@@ -357,7 +357,7 @@ def _dry_run_report_payload(
         "estimated_cost_or_size": run_configuration_summary["cost_warning"],
         "expected_diagnostics": manifest.expected_diagnostics,
         "expected_outputs": list(contract.expected_outputs),
-        "package_caveats": list(contract.package_caveats),
+        "run_caveats": list(contract.run_caveats),
         "manual_validation_status": contract.manual_validation_status,
         "cm1_mapping_status": _cm1_mapping_status(contract),
         "visualization_defaults": contract.visualization_defaults,
@@ -431,7 +431,7 @@ def _normalize_user_notes(notes: str | None) -> str | None:
 def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
     defaults = contract.cloud_scale_defaults
     reference_configuration = resolve_run_configuration(
-        package_family=contract.package_family.value,
+        run_recipe=contract.run_recipe.value,
     )
     standard = cloud_scale_defaults_for_configuration(reference_configuration)
     grid_cells = defaults.nx * defaults.ny * defaults.nz
@@ -449,10 +449,10 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
     estimated_compute_multiplier = grid_multiplier * timestep_multiplier * runtime_multiplier
     estimated_output_volume_multiplier = grid_multiplier * output_frame_multiplier
     is_smoke = contract.run_configuration.mode == "smoke"
-    is_deep_convection = contract.package_family.value == "deep_convection_trial"
+    is_triggered_deep_potential = contract.run_recipe.value == "triggered_deep_potential"
     cost_warning = (
-        _deep_convection_cost_warning(contract.run_configuration)
-        if is_deep_convection
+        _triggered_deep_potential_cost_warning(contract.run_configuration)
+        if is_triggered_deep_potential
         else (
             (
                 "Short smoke mode checks package health and CM1 startup behavior; "
@@ -460,8 +460,8 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
             )
             if is_smoke
             else (
-                "Configuration cost depends on duration, grid/detail, domain, cadence, "
-                "and output-field density. Review the CM1-facing values before launch."
+                "Configuration cost depends on duration, horizontal cells, domain, cadence, "
+                "and diagnostic set. Review the CM1-facing values before launch."
             )
         )
     )
@@ -469,11 +469,11 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
         "configuration_id": contract.run_configuration.configuration_id,
         "mode": contract.run_configuration.mode,
         "label": contract.run_configuration.label,
-        "duration_preset": contract.run_configuration.duration_preset,
-        "grid_detail_preset": contract.run_configuration.grid_detail_preset,
-        "domain_size_preset": contract.run_configuration.domain_size_preset,
-        "output_cadence_preset": contract.run_configuration.output_cadence_preset,
-        "output_field_density_preset": contract.run_configuration.output_field_density_preset,
+        "duration": contract.run_configuration.duration,
+        "horizontal_cell_count": contract.run_configuration.horizontal_cell_count,
+        "domain_size": contract.run_configuration.domain_size,
+        "output_cadence": contract.run_configuration.output_cadence,
+        "diagnostic_set": contract.run_configuration.diagnostic_set,
         "runtime_seconds": defaults.runtime_seconds,
         "output_cadence_seconds": defaults.output_cadence_seconds,
         "expected_output_frames": output_frames,
@@ -486,9 +486,9 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
         "model_top_m": defaults.vertical_extent_km * 1000.0,
         "time_step_seconds": defaults.time_step_seconds,
         "time_step_note": (
-            "Deep Convection Trial uses a larger solver timestep for the storm-scale "
-            "triggered-potential setup."
-            if is_deep_convection
+            "Triggered deep-potential runs use a larger solver timestep for the storm-scale "
+            "idealized-trigger setup."
+            if is_triggered_deep_potential
             else "CM1 solver timestep is resolved from the selected run configuration."
         ),
         "grid_cell_count": grid_cells,
@@ -501,30 +501,31 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
         ),
         "cost_warning": cost_warning,
         "validation_note": (
-            "Deep Convection Trial uses a wider idealized domain and observed winds. "
-            "Manual CM1 smoke evidence applies to the package family; each observed "
-            "sounding remains an experiment until CM1 output is inspected."
-            if is_deep_convection
+            "Triggered deep-potential runs use a wider idealized domain, observed winds, "
+            "and a warm-bubble trigger. Manual CM1 smoke evidence applies to the recipe; "
+            "each observed sounding remains an experiment until CM1 output is inspected."
+            if is_triggered_deep_potential
             else (
-                "Short smoke mode is separated from science runs; use Quick science or longer "
+                "Short smoke mode is separated from science runs; use short evolution or longer "
                 "configurations for meteorological evolution."
                 if is_smoke
                 else (
-                    "Run configuration preserves explicit duration, grid/detail, domain, "
-                    "cadence, and output-density choices."
+                    "Run configuration preserves explicit duration, horizontal cell count, "
+                    "domain, cadence, and diagnostic-set choices."
                 )
             )
         ),
     }
 
 
-def _package_mapping_summary(contract: CM1InputContract) -> str:
-    if contract.package_family.value == "deep_convection_trial":
+def _run_recipe_mapping_summary(contract: CM1InputContract) -> str:
+    if contract.run_recipe.value == "triggered_deep_potential":
         return (
             "observed IGRA external input_sounding profile with observed u/v winds; "
-            "Deep Convection Trial uses CM1 isnd=7, testcase=0, iinit=3 three-warm-bubble "
-            "line initiation, a storm-scale idealized domain, NetCDF output, rain output, "
-            "reflectivity output, vorticity output, and updraft-helicity output"
+            "triggered deep-potential recipe uses CM1 isnd=7, testcase=0, iinit=3 "
+            "three-warm-bubble line initiation, a storm-scale idealized domain, NetCDF "
+            "output, rain output, reflectivity output, vorticity output, and "
+            "updraft-helicity output"
         )
     if contract.observed_sounding is not None:
         return (
@@ -540,33 +541,33 @@ def _package_mapping_summary(contract: CM1InputContract) -> str:
 
 
 def _cm1_mapping_status(contract: CM1InputContract) -> str:
-    if contract.package_family.value == "deep_convection_trial":
+    if contract.run_recipe.value == "triggered_deep_potential":
         return (
-            "CM1-ready Deep Convection Trial package with manual CM1 smoke evidence "
-            "for deep-convection initiation; each observed sounding remains an experiment"
+            "CM1-ready triggered deep-potential run with manual CM1 smoke evidence "
+            "for the recipe; each observed sounding remains an experiment"
         )
     if contract.observed_sounding is not None:
         return (
-            "CM1-ready observed-sounding quick-look package; still pending "
+            "CM1-ready untriggered observed-evolution run; still pending "
             "case-specific local/manual scientific interpretation"
         )
     return (
-        "CM1-ready provisional baseline package; still pending local/manual smoke-run "
+        "CM1-ready generated-reference run; still pending local/manual smoke-run "
         "scientific validation"
     )
 
 
-def _deep_convection_cost_warning(run_configuration: object) -> str:
+def _triggered_deep_potential_cost_warning(run_configuration: object) -> str:
     mode = getattr(run_configuration, "mode", "")
-    domain = getattr(run_configuration, "domain_size_preset", "storm_120km")
-    cadence = getattr(run_configuration, "output_cadence_preset", "standard_15min")
+    domain = getattr(run_configuration, "domain_size", "storm_120km")
+    cadence = getattr(run_configuration, "output_cadence", "standard_15min")
     if mode == "smoke":
         return (
-            "Deep Convection Trial smoke mode checks package health with the triggered "
+            "Smoke mode checks run-input health with the triggered "
             "storm-scale setup; it is not a science-duration result."
         )
     return (
-        "Deep Convection Trial uses a triggered storm-scale domain. Review expected "
+        "Triggered deep-potential runs use a storm-scale domain. Review expected "
         f"cost/runtime/output volume for {domain} and {cadence}; larger configurations "
         "may be better suited to larger compute."
     )

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -9,6 +9,7 @@ import json
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from cloud_chamber import __version__
 from cloud_chamber.cm1_input_contract import (
@@ -19,6 +20,10 @@ from cloud_chamber.cm1_input_contract import (
     render_namelist_fragment,
 )
 from cloud_chamber.observed_sounding import ObservedSoundingRecord, observed_sounding_from_payload
+from cloud_chamber.pre_run_validation import (
+    blocked_pre_run_validation_report,
+    build_pre_run_validation_report,
+)
 from cloud_chamber.run_configuration import resolve_run_configuration
 from cloud_chamber.run_manifest import (
     AppMetadata,
@@ -37,6 +42,15 @@ from cloud_chamber.scenario_schema import ScenarioTemplate, validate_scenario_te
 
 class DryRunPackageError(RuntimeError):
     """Raised when a dry-run package cannot be generated."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        pre_run_validation_report: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.pre_run_validation_report = pre_run_validation_report
 
 
 @dataclass(frozen=True)
@@ -83,8 +97,32 @@ def generate_dry_run_package(
             package_family=package_family,
         )
     except ValueError as exc:
-        raise DryRunPackageError(str(exc)) from exc
+        error_message = _user_facing_validation_error(str(exc))
+        report = blocked_pre_run_validation_report(
+            scenario=scenario,
+            controls=selected_controls,
+            package_family=package_family,
+            run_configuration=run_configuration,
+            observed_sounding=observed_sounding,
+            candidate_screening=candidate_screening,
+            error_message=error_message,
+        )
+        raise DryRunPackageError(error_message, pre_run_validation_report=report) from exc
     now = datetime.now(UTC)
+
+    pre_run_validation_report = build_pre_run_validation_report(
+        scenario=scenario,
+        contract=contract,
+        candidate_screening=candidate_screening,
+    )
+    if pre_run_validation_report["status"] == "blocked":
+        message = "; ".join(
+            str(error) for error in pre_run_validation_report.get("blocking_errors", [])
+        )
+        raise DryRunPackageError(
+            f"Pre-run validation blocked package creation: {message}",
+            pre_run_validation_report=pre_run_validation_report,
+        )
 
     package_dir.mkdir(parents=True, exist_ok=allow_overwrite)
 
@@ -132,6 +170,7 @@ def generate_dry_run_package(
             observed_record.model_dump(mode="json") if observed_record is not None else None
         ),
         candidate_screening=candidate_screening,
+        pre_run_validation_report=pre_run_validation_report,
         package_family=contract.package_family.value,
         package_display_name=contract.package_display_name,
         input_source=contract.input_source,
@@ -147,12 +186,14 @@ def generate_dry_run_package(
         scenario,
         contract,
         candidate_screening=candidate_screening,
+        pre_run_validation_report=pre_run_validation_report,
     )
     report = _dry_run_report_payload(
         scenario=scenario,
         manifest=manifest,
         contract=contract,
         generated_files=paths,
+        pre_run_validation_report=pre_run_validation_report,
     )
     runtime_checklist = {
         "status": "external_runtime_files_not_committed",
@@ -209,6 +250,19 @@ def _observed_sounding_record(
         raise DryRunPackageError(f"Invalid observed sounding: {exc}") from exc
 
 
+def _user_facing_validation_error(message: str) -> str:
+    replacements = {
+        "duration_preset": "duration preset",
+        "grid_detail_preset": "grid detail preset",
+        "domain_size_preset": "domain size preset",
+        "output_cadence_preset": "output cadence preset",
+        "output_field_density_preset": "output field density preset",
+    }
+    for internal, label in replacements.items():
+        message = message.replace(internal, label)
+    return message
+
+
 def _effective_controls(
     scenario: ScenarioTemplate,
     selected_controls: dict[str, str | float | bool],
@@ -231,6 +285,7 @@ def _case_manifest_payload(
     contract: CM1InputContract,
     *,
     candidate_screening: dict[str, object] | None = None,
+    pre_run_validation_report: dict[str, object] | None = None,
 ) -> dict[str, object]:
     return {
         "scenario_id": scenario.id,
@@ -248,6 +303,7 @@ def _case_manifest_payload(
         "package_caveats": contract.package_caveats,
         "manual_validation_status": contract.manual_validation_status,
         "run_configuration": contract.run_configuration.model_dump(mode="json"),
+        "pre_run_validation_report": pre_run_validation_report,
         "cm1_mapping_status": _cm1_mapping_status(contract),
         "contract": _contract_payload(contract),
         "candidate_screening": candidate_screening,
@@ -260,6 +316,7 @@ def _dry_run_report_payload(
     manifest: RunManifest,
     contract: CM1InputContract,
     generated_files: dict[str, Path],
+    pre_run_validation_report: dict[str, object],
 ) -> dict[str, object]:
     run_configuration_summary = _run_configuration_summary(contract)
     return {
@@ -296,6 +353,7 @@ def _dry_run_report_payload(
         "user": manifest.user.model_dump(mode="json"),
         "run_configuration": contract.run_configuration.model_dump(mode="json"),
         "run_configuration_summary": run_configuration_summary,
+        "pre_run_validation_report": pre_run_validation_report,
         "estimated_cost_or_size": run_configuration_summary["cost_warning"],
         "expected_diagnostics": manifest.expected_diagnostics,
         "expected_outputs": list(contract.expected_outputs),

--- a/app/backend/cloud_chamber/local_run_manager.py
+++ b/app/backend/cloud_chamber/local_run_manager.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol, TextIO
 
+from cloud_chamber.pre_run_validation import report_blocks_execution
 from cloud_chamber.run_manifest import (
     ExecutionMetadata,
     LifecycleState,
@@ -124,6 +125,8 @@ class LocalRunManager:
                 f"Run {manifest.run_id} must be packaged before launch; "
                 f"found {manifest.lifecycle_state.value}."
             )
+        if report_blocks_execution(manifest.pre_run_validation_report):
+            raise LocalRunManagerError("Pre-run validation blocked CM1 launch for this package.")
 
         run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
         if not run_dir.exists():

--- a/app/backend/cloud_chamber/local_run_queue.py
+++ b/app/backend/cloud_chamber/local_run_queue.py
@@ -9,6 +9,7 @@ from typing import Protocol
 from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.local_run_manager import LocalRunManagerError, RunStatus
+from cloud_chamber.pre_run_validation import report_blocks_execution
 from cloud_chamber.result_ingest import ResultIngestError, ingest_completed_run
 from cloud_chamber.run_manifest import (
     LifecycleState,
@@ -95,6 +96,10 @@ class LocalRunQueueManager:
             raise LocalRunQueueError(
                 "Only packaged runs can be queued for local CM1 execution; "
                 f"found {manifest.lifecycle_state.value}."
+            )
+        if report_blocks_execution(manifest.pre_run_validation_report):
+            raise LocalRunQueueError(
+                "Pre-run validation blocked queueing this package for CM1 execution."
             )
 
         entries = self._load_entries()

--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -442,14 +442,14 @@ def build_interesting_time_product(
     diagnostics: ResultDiagnostics | None,
     output_manifest: OutputProductManifest,
     variables: list[str],
-    package_family: str | None = None,
+    run_recipe: str | None = None,
 ) -> InterestingTimeProduct:
     """Build small science time landmarks from diagnostics and manifest time mapping."""
     records = _interesting_time_records(
         diagnostics=diagnostics,
         output_manifest=output_manifest,
         variables=set(variables),
-        package_family=package_family,
+        run_recipe=run_recipe,
     )
     defaults = _field_defaults(records)
     summary = _science_summary(
@@ -458,7 +458,7 @@ def build_interesting_time_product(
         records,
         defaults,
         variables=set(variables),
-        package_family=package_family,
+        run_recipe=run_recipe,
     )
     caveats = _dedupe(
         [
@@ -482,7 +482,7 @@ def _interesting_time_records(
     diagnostics: ResultDiagnostics | None,
     output_manifest: OutputProductManifest,
     variables: set[str],
-    package_family: str | None,
+    run_recipe: str | None,
 ) -> list[InterestingTimeRecord]:
     latest = _latest_time_record(output_manifest)
     if diagnostics is None:
@@ -556,7 +556,7 @@ def _interesting_time_records(
             unavailable_caveat="no_deep_cloud_detected" if cloud.available else "missing_qc_field",
             support_state="unavailable" if cloud.available else "unsupported_missing_fields",
         )
-        if package_family == "deep_convection_trial"
+        if run_recipe == "triggered_deep_potential"
         else None,
         _event_record(
             key="max_updraft_w",
@@ -667,7 +667,7 @@ def _interesting_time_records(
     compact_records = [record for record in records if record is not None]
     compact_records.append(
         _field_default_record(
-            _default_source_record(compact_records, package_family=package_family),
+            _default_source_record(compact_records, run_recipe=run_recipe),
             fallback_reason=None,
         )
     )
@@ -905,13 +905,13 @@ def _science_summary(
     defaults: dict[str, FieldDefaultTime],
     *,
     variables: set[str],
-    package_family: str | None,
+    run_recipe: str | None,
 ) -> ScienceSummary:
     record_by_key = {record.key: record for record in records}
     default_record = record_by_key.get("field_default_time")
     latest = record_by_key.get("latest_output")
     qc_default = defaults.get("qc")
-    is_deep_convection = package_family == "deep_convection_trial"
+    is_deep_convection = run_recipe == "triggered_deep_potential"
     if diagnostics is None:
         return ScienceSummary(
             latest_output_time_seconds=latest.time_seconds if latest else None,
@@ -985,12 +985,12 @@ def _science_summary(
 def _default_source_record(
     records: list[InterestingTimeRecord],
     *,
-    package_family: str | None,
+    run_recipe: str | None,
 ) -> InterestingTimeRecord:
     by_key = {record.key: record for record in records}
     preferred_keys = (
         ("first_deep_convection", "max_updraft_w", "rain_onset", "max_qc")
-        if package_family == "deep_convection_trial"
+        if run_recipe == "triggered_deep_potential"
         else ("first_cloud", "max_qc", "max_updraft_w")
     )
     for key in preferred_keys:

--- a/app/backend/cloud_chamber/pre_run_validation.py
+++ b/app/backend/cloud_chamber/pre_run_validation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from cloud_chamber.cm1_input_contract import CM1InputContract, PackageFamily
+from cloud_chamber.cm1_input_contract import CM1InputContract, RunRecipe
 from cloud_chamber.observed_sounding import ObservedSoundingRecord
 from cloud_chamber.run_configuration import resolve_run_configuration
 from cloud_chamber.scenario_schema import ScenarioTemplate
@@ -35,16 +35,16 @@ def build_pre_run_validation_report(
     candidate_screening: dict[str, Any] | None,
 ) -> dict[str, Any]:
     story = _selected_story(candidate_screening)
-    required_outputs = _required_outputs_for_story(story, contract.package_family)
+    required_outputs = _required_outputs_for_story(story, contract.run_recipe)
     missing_outputs = [
         field for field in required_outputs if field not in set(contract.expected_outputs)
     ]
-    alignment = _hypothesis_recipe_alignment(story, contract.package_family)
+    alignment = _hypothesis_recipe_alignment(story, contract.run_recipe)
     blocking_errors = list(alignment["blocking_errors"])
     caveats = _dedupe(
         [
             *contract.run_configuration.caveats,
-            *contract.package_caveats,
+            *contract.run_caveats,
             *alignment["caveats"],
             *[f"missing_required_output_field:{field}" for field in missing_outputs],
         ]
@@ -89,23 +89,23 @@ def blocked_pre_run_validation_report(
     *,
     scenario: ScenarioTemplate,
     controls: dict[str, str | float | bool],
-    package_family: str | None,
+    run_recipe: str | None,
     run_configuration: dict[str, object] | None,
     observed_sounding: dict[str, object] | ObservedSoundingRecord | None,
     candidate_screening: dict[str, Any] | None,
     error_message: str,
 ) -> dict[str, Any]:
-    resolved_family = _family_value(package_family, observed_sounding)
-    run_shape = _run_shape_from_payload(run_configuration, resolved_family)
+    resolved_recipe = _run_recipe_value(run_recipe, observed_sounding)
+    run_shape = _run_shape_from_payload(run_configuration, resolved_recipe)
     story = _selected_story(candidate_screening)
     return {
         "status": "blocked",
         "selected_candidate": _selected_candidate_payload(candidate_screening, observed_sounding),
         "selected_hypothesis": _selected_hypothesis_payload(candidate_screening, story),
         "selected_run_recipe": {
-            "recipe_id": resolved_family,
-            "display_name": _package_display_name(resolved_family),
-            "assumption_set_id": _assumption_set_id(resolved_family),
+            "recipe_id": resolved_recipe,
+            "display_name": _run_recipe_display_name(resolved_recipe),
+            "assumption_set_id": _assumption_set_id(resolved_recipe),
         },
         "hypothesis_recipe_alignment": {
             "status": "blocked",
@@ -121,16 +121,16 @@ def blocked_pre_run_validation_report(
             "caveats": [],
         },
         "run_shape_validation": run_shape,
-        "forcing_validation": _forcing_validation_for_family(resolved_family),
+        "forcing_validation": _forcing_validation_for_recipe(resolved_recipe),
         "output_validation": {
-            "required_fields": _required_outputs_for_story(story, _package_family(resolved_family)),
+            "required_fields": _required_outputs_for_story(story, _run_recipe(resolved_recipe)),
             "enabled_fields": [],
             "missing_fields": [],
         },
         "runtime_file_validation": {
             "required_files": list(scenario.cm1_template.runtime_files_needed),
             "staging_status": "not_reached",
-            "caveats": ["package_generation_blocked_before_runtime_file_staging"],
+            "caveats": ["run_generation_blocked_before_runtime_file_staging"],
         },
         "blocking_errors": [error_message],
         "caveats": [],
@@ -144,7 +144,7 @@ def report_blocks_execution(report: dict[str, Any] | None) -> bool:
 
 def _hypothesis_recipe_alignment(
     story: str | None,
-    package_family: PackageFamily,
+    run_recipe: RunRecipe,
 ) -> dict[str, list[str] | str]:
     if story is None:
         return {
@@ -157,15 +157,15 @@ def _hypothesis_recipe_alignment(
     if story in REVIEW_OR_BLOCKED_STORIES:
         return {
             "status": "blocked",
-            "reasons": ["Selected sounding story is not package-ready."],
-            "missing_assumptions": ["package_ready_candidate_hypothesis"],
+            "reasons": ["Selected sounding story is not ready to run."],
+            "missing_assumptions": ["run_ready_candidate_hypothesis"],
             "blocking_errors": [
-                "Selected candidate story is not package-ready and cannot be packaged honestly."
+                "Selected candidate story is not ready to run and cannot be generated honestly."
             ],
             "caveats": [],
         }
     if story in DEEP_CONVECTION_STORIES:
-        if package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+        if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
             return {
                 "status": "aligned",
                 "reasons": [
@@ -184,7 +184,7 @@ def _hypothesis_recipe_alignment(
             ],
             "caveats": [],
         }
-    if story in NORMAL_EVOLUTION_STORIES and package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+    if story in NORMAL_EVOLUTION_STORIES and run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
         return {
             "status": "blocked",
             "reasons": [
@@ -253,9 +253,9 @@ def _selected_hypothesis_payload(
 
 def _selected_run_recipe_payload(contract: CM1InputContract) -> dict[str, str]:
     return {
-        "recipe_id": contract.package_family.value,
-        "display_name": contract.package_display_name,
-        "assumption_set_id": _assumption_set_id(contract.package_family.value),
+        "recipe_id": contract.run_recipe.value,
+        "display_name": contract.run_recipe_display_name,
+        "assumption_set_id": _assumption_set_id(contract.run_recipe.value),
     }
 
 
@@ -271,7 +271,7 @@ def _input_validation_payload(
             "model_bottom_elevation": "generated_reference",
             "caveats": [],
         }
-    wind_required = contract.package_family == PackageFamily.DEEP_CONVECTION_TRIAL
+    wind_required = contract.run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL
     wind_status = (
         ("present_required" if wind_required else "present_optional")
         if observed_sounding.wind_handling
@@ -291,17 +291,18 @@ def _input_validation_payload(
 def _run_shape_validation_payload(contract: CM1InputContract) -> dict[str, Any]:
     values = contract.run_configuration.cm1_values
     return {
-        "duration": contract.run_configuration.duration_preset,
+        "duration": contract.run_configuration.duration,
         "duration_seconds": values.runtime_seconds,
-        "domain": contract.run_configuration.domain_size_preset,
+        "domain": contract.run_configuration.domain_size,
         "domain_x_km": values.domain_x_km,
         "domain_y_km": values.domain_y_km,
         "model_top": values.model_top_m,
-        "grid_detail": contract.run_configuration.grid_detail_preset,
+        "horizontal_cell_count": contract.run_configuration.horizontal_cell_count,
         "dx_m": values.dx_m,
         "dy_m": values.dy_m,
-        "output_cadence": contract.run_configuration.output_cadence_preset,
+        "output_cadence": contract.run_configuration.output_cadence,
         "output_cadence_seconds": values.output_cadence_seconds,
+        "diagnostic_set": contract.run_configuration.diagnostic_set,
         "estimated_frames": values.expected_output_frames,
         "estimated_output_volume": contract.run_configuration.output_volume_summary,
     }
@@ -309,25 +310,28 @@ def _run_shape_validation_payload(contract: CM1InputContract) -> dict[str, Any]:
 
 def _run_shape_from_payload(
     run_configuration: dict[str, object] | None,
-    package_family: str,
+    run_recipe: str,
 ) -> dict[str, Any]:
     try:
         resolved = resolve_run_configuration(
             run_configuration=run_configuration,
-            package_family=package_family,
+            run_recipe=run_recipe,
         )
     except ValueError:
         return {
-            "duration": run_configuration.get("duration_preset")
+            "duration": run_configuration.get("duration")
             if isinstance(run_configuration, dict)
             else None,
-            "domain": run_configuration.get("domain_size_preset")
+            "domain": run_configuration.get("domain_size")
             if isinstance(run_configuration, dict)
             else None,
-            "grid_detail": run_configuration.get("grid_detail_preset")
+            "horizontal_cell_count": run_configuration.get("horizontal_cell_count")
             if isinstance(run_configuration, dict)
             else None,
-            "output_cadence": run_configuration.get("output_cadence_preset")
+            "output_cadence": run_configuration.get("output_cadence")
+            if isinstance(run_configuration, dict)
+            else None,
+            "diagnostic_set": run_configuration.get("diagnostic_set")
             if isinstance(run_configuration, dict)
             else None,
             "estimated_frames": None,
@@ -335,30 +339,31 @@ def _run_shape_from_payload(
         }
     values = resolved.cm1_values
     return {
-        "duration": resolved.duration_preset,
+        "duration": resolved.duration,
         "duration_seconds": values.runtime_seconds,
-        "domain": resolved.domain_size_preset,
+        "domain": resolved.domain_size,
         "domain_x_km": values.domain_x_km,
         "domain_y_km": values.domain_y_km,
         "model_top": values.model_top_m,
-        "grid_detail": resolved.grid_detail_preset,
+        "horizontal_cell_count": resolved.horizontal_cell_count,
         "dx_m": values.dx_m,
         "dy_m": values.dy_m,
-        "output_cadence": resolved.output_cadence_preset,
+        "output_cadence": resolved.output_cadence,
         "output_cadence_seconds": values.output_cadence_seconds,
+        "diagnostic_set": resolved.diagnostic_set,
         "estimated_frames": values.expected_output_frames,
         "estimated_output_volume": resolved.output_volume_summary,
     }
 
 
 def _forcing_validation_payload(contract: CM1InputContract) -> dict[str, str]:
-    return _forcing_validation_for_family(contract.package_family.value)
+    return _forcing_validation_for_recipe(contract.run_recipe.value)
 
 
-def _forcing_validation_for_family(package_family: str) -> dict[str, str]:
+def _forcing_validation_for_recipe(run_recipe: str) -> dict[str, str]:
     trigger = (
         "warm_bubble_required_for_triggered_deep_potential"
-        if package_family == PackageFamily.DEEP_CONVECTION_TRIAL.value
+        if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL.value
         else "none"
     )
     return {
@@ -371,9 +376,9 @@ def _forcing_validation_for_family(package_family: str) -> dict[str, str]:
 
 def _required_outputs_for_story(
     story: str | None,
-    package_family: PackageFamily,
+    run_recipe: RunRecipe,
 ) -> list[str]:
-    if story in DEEP_CONVECTION_STORIES or package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+    if story in DEEP_CONVECTION_STORIES or run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
         return ["qc", "w", "qr", "rain", "dbz", "updraft_helicity"]
     if story == "humid_rainy_candidate":
         return ["qc", "qr", "rain", "dbz"]
@@ -430,36 +435,36 @@ def _number_or_none(payload: dict[str, Any] | None, key: str) -> float | None:
     return float(value) if isinstance(value, int | float) else None
 
 
-def _family_value(
-    package_family: str | None,
+def _run_recipe_value(
+    run_recipe: str | None,
     observed_sounding: dict[str, object] | ObservedSoundingRecord | None,
 ) -> str:
-    if package_family:
-        return package_family
+    if run_recipe:
+        return run_recipe
     if observed_sounding is not None:
-        return PackageFamily.OBSERVED_SOUNDING_QUICKLOOK.value
-    return PackageFamily.SHALLOW_CUMULUS.value
+        return RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION.value
+    return RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE.value
 
 
-def _package_family(value: str) -> PackageFamily:
+def _run_recipe(value: str) -> RunRecipe:
     try:
-        return PackageFamily(value)
+        return RunRecipe(value)
     except ValueError:
-        return PackageFamily.SHALLOW_CUMULUS
+        return RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE
 
 
-def _package_display_name(package_family: str) -> str:
-    if package_family == PackageFamily.DEEP_CONVECTION_TRIAL.value:
-        return "Deep Convection Trial"
-    if package_family == PackageFamily.OBSERVED_SOUNDING_QUICKLOOK.value:
-        return "Observed Sounding Quick Look"
-    return "Baseline Shallow Cumulus"
+def _run_recipe_display_name(run_recipe: str) -> str:
+    if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL.value:
+        return "Triggered Deep-Potential Experiment"
+    if run_recipe == RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION.value:
+        return "Untriggered Observed Evolution"
+    return "Generated Lower-Atmosphere Reference"
 
 
-def _assumption_set_id(package_family: str) -> str:
-    if package_family == PackageFamily.DEEP_CONVECTION_TRIAL.value:
+def _assumption_set_id(run_recipe: str) -> str:
+    if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL.value:
         return "triggered_deep_potential_warm_bubble_v1"
-    if package_family == PackageFamily.OBSERVED_SOUNDING_QUICKLOOK.value:
+    if run_recipe == RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION.value:
         return "normal_evolution_current_observed_sounding_v1"
     return "generated_reference_lower_atmosphere_v1"
 

--- a/app/backend/cloud_chamber/pre_run_validation.py
+++ b/app/backend/cloud_chamber/pre_run_validation.py
@@ -1,0 +1,475 @@
+"""Pre-run validation for candidate hypotheses, recipes, and run shape."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cloud_chamber.cm1_input_contract import CM1InputContract, PackageFamily
+from cloud_chamber.observed_sounding import ObservedSoundingRecord
+from cloud_chamber.run_configuration import resolve_run_configuration
+from cloud_chamber.scenario_schema import ScenarioTemplate
+
+DEEP_CONVECTION_STORIES = {
+    "severe_thunderstorm_environment",
+    "supercell_environment",
+    "high_cape_pulse_storm",
+    "dry_microburst_inverted_v",
+    "squall_line_cold_pool_candidate",
+    "elevated_convection",
+}
+
+NORMAL_EVOLUTION_STORIES = {
+    "shallow_cumulus_candidate",
+    "dry_failed_candidate",
+    "capped_suppressed_candidate",
+    "humid_rainy_candidate",
+}
+
+REVIEW_OR_BLOCKED_STORIES = {"needs_review", "poor_or_incomplete_candidate"}
+
+
+def build_pre_run_validation_report(
+    *,
+    scenario: ScenarioTemplate,
+    contract: CM1InputContract,
+    candidate_screening: dict[str, Any] | None,
+) -> dict[str, Any]:
+    story = _selected_story(candidate_screening)
+    required_outputs = _required_outputs_for_story(story, contract.package_family)
+    missing_outputs = [
+        field for field in required_outputs if field not in set(contract.expected_outputs)
+    ]
+    alignment = _hypothesis_recipe_alignment(story, contract.package_family)
+    blocking_errors = list(alignment["blocking_errors"])
+    caveats = _dedupe(
+        [
+            *contract.run_configuration.caveats,
+            *contract.package_caveats,
+            *alignment["caveats"],
+            *[f"missing_required_output_field:{field}" for field in missing_outputs],
+        ]
+    )
+    if alignment["status"] == "partial" and missing_outputs:
+        caveats.append("output_fields_support_partial_comparison_only")
+
+    status = "blocked" if blocking_errors else ("caveated" if caveats else "valid")
+    return {
+        "status": status,
+        "selected_candidate": _selected_candidate_payload(
+            candidate_screening,
+            contract.observed_sounding,
+        ),
+        "selected_hypothesis": _selected_hypothesis_payload(candidate_screening, story),
+        "selected_run_recipe": _selected_run_recipe_payload(contract),
+        "hypothesis_recipe_alignment": {
+            "status": alignment["status"],
+            "reasons": alignment["reasons"],
+            "missing_assumptions": alignment["missing_assumptions"],
+            "missing_outputs": missing_outputs,
+        },
+        "input_validation": _input_validation_payload(contract.observed_sounding, contract),
+        "run_shape_validation": _run_shape_validation_payload(contract),
+        "forcing_validation": _forcing_validation_payload(contract),
+        "output_validation": {
+            "required_fields": required_outputs,
+            "enabled_fields": list(contract.expected_outputs),
+            "missing_fields": missing_outputs,
+        },
+        "runtime_file_validation": {
+            "required_files": list(scenario.cm1_template.runtime_files_needed),
+            "staging_status": "checked_at_launch",
+            "caveats": ["external_runtime_files_are_not_committed"],
+        },
+        "blocking_errors": blocking_errors,
+        "caveats": caveats,
+    }
+
+
+def blocked_pre_run_validation_report(
+    *,
+    scenario: ScenarioTemplate,
+    controls: dict[str, str | float | bool],
+    package_family: str | None,
+    run_configuration: dict[str, object] | None,
+    observed_sounding: dict[str, object] | ObservedSoundingRecord | None,
+    candidate_screening: dict[str, Any] | None,
+    error_message: str,
+) -> dict[str, Any]:
+    resolved_family = _family_value(package_family, observed_sounding)
+    run_shape = _run_shape_from_payload(run_configuration, resolved_family)
+    story = _selected_story(candidate_screening)
+    return {
+        "status": "blocked",
+        "selected_candidate": _selected_candidate_payload(candidate_screening, observed_sounding),
+        "selected_hypothesis": _selected_hypothesis_payload(candidate_screening, story),
+        "selected_run_recipe": {
+            "recipe_id": resolved_family,
+            "display_name": _package_display_name(resolved_family),
+            "assumption_set_id": _assumption_set_id(resolved_family),
+        },
+        "hypothesis_recipe_alignment": {
+            "status": "blocked",
+            "reasons": [error_message],
+            "missing_assumptions": [],
+            "missing_outputs": [],
+        },
+        "input_validation": {
+            "observed_temperature_profile": "unknown",
+            "observed_moisture_profile": "unknown",
+            "observed_wind_profile": "blocked" if "wind" in error_message.lower() else "unknown",
+            "model_bottom_elevation": "unknown",
+            "caveats": [],
+        },
+        "run_shape_validation": run_shape,
+        "forcing_validation": _forcing_validation_for_family(resolved_family),
+        "output_validation": {
+            "required_fields": _required_outputs_for_story(story, _package_family(resolved_family)),
+            "enabled_fields": [],
+            "missing_fields": [],
+        },
+        "runtime_file_validation": {
+            "required_files": list(scenario.cm1_template.runtime_files_needed),
+            "staging_status": "not_reached",
+            "caveats": ["package_generation_blocked_before_runtime_file_staging"],
+        },
+        "blocking_errors": [error_message],
+        "caveats": [],
+        "controls": controls,
+    }
+
+
+def report_blocks_execution(report: dict[str, Any] | None) -> bool:
+    return bool(report and report.get("status") == "blocked")
+
+
+def _hypothesis_recipe_alignment(
+    story: str | None,
+    package_family: PackageFamily,
+) -> dict[str, list[str] | str]:
+    if story is None:
+        return {
+            "status": "aligned",
+            "reasons": ["No selected candidate hypothesis; validating the run configuration only."],
+            "missing_assumptions": [],
+            "blocking_errors": [],
+            "caveats": [],
+        }
+    if story in REVIEW_OR_BLOCKED_STORIES:
+        return {
+            "status": "blocked",
+            "reasons": ["Selected sounding story is not package-ready."],
+            "missing_assumptions": ["package_ready_candidate_hypothesis"],
+            "blocking_errors": [
+                "Selected candidate story is not package-ready and cannot be packaged honestly."
+            ],
+            "caveats": [],
+        }
+    if story in DEEP_CONVECTION_STORIES:
+        if package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+            return {
+                "status": "aligned",
+                "reasons": [
+                    "Deep-convection hypothesis is paired with the triggered deep-potential recipe."
+                ],
+                "missing_assumptions": [],
+                "blocking_errors": [],
+                "caveats": [],
+            }
+        return {
+            "status": "blocked",
+            "reasons": ["Deep-convection hypothesis is paired with an untriggered/shallow recipe."],
+            "missing_assumptions": ["triggered_deep_potential_warm_bubble_v1"],
+            "blocking_errors": [
+                "Selected run recipe does not test this deep-convection hypothesis."
+            ],
+            "caveats": [],
+        }
+    if story in NORMAL_EVOLUTION_STORIES and package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+        return {
+            "status": "blocked",
+            "reasons": [
+                "Normal-evolution hypothesis is paired with an explicitly triggered recipe."
+            ],
+            "missing_assumptions": ["normal_evolution_without_explicit_trigger"],
+            "blocking_errors": [
+                "Selected triggered recipe would make comparison metadata misleading "
+                "for this hypothesis."
+            ],
+            "caveats": [],
+        }
+    if story == "humid_rainy_candidate":
+        return {
+            "status": "partial",
+            "reasons": [
+                "Humid/rainy hypothesis can be inspected, but comparison depends on "
+                "rain-water, surface-rain, and reflectivity outputs."
+            ],
+            "missing_assumptions": [],
+            "blocking_errors": [],
+            "caveats": ["humid_rainy_prediction_requires_precipitation_output_review"],
+        }
+    return {
+        "status": "aligned",
+        "reasons": ["Selected hypothesis and run recipe are compatible."],
+        "missing_assumptions": [],
+        "blocking_errors": [],
+        "caveats": [],
+    }
+
+
+def _selected_candidate_payload(
+    candidate_screening: dict[str, Any] | None,
+    observed_sounding: dict[str, object] | ObservedSoundingRecord | None,
+) -> dict[str, Any]:
+    observed = (
+        observed_sounding.model_dump(mode="json")
+        if isinstance(observed_sounding, ObservedSoundingRecord)
+        else observed_sounding
+        if isinstance(observed_sounding, dict)
+        else {}
+    )
+    return {
+        "candidate_id": _string_or_none(candidate_screening, "candidate_id"),
+        "station_id": observed.get("station_id") if isinstance(observed, dict) else None,
+        "valid_time_utc": observed.get("valid_time_utc") if isinstance(observed, dict) else None,
+    }
+
+
+def _selected_hypothesis_payload(
+    candidate_screening: dict[str, Any] | None,
+    story: str | None,
+) -> dict[str, Any]:
+    score = _active_story_score(candidate_screening, story)
+    return {
+        "hypothesis_id": story,
+        "story_id": story,
+        "story_label": _string_or_none(candidate_screening, "active_story_label"),
+        "ingredient_score": score
+        if score is not None
+        else _number_or_none(candidate_screening, "rank_score"),
+        "predicted_output_signature": _predicted_output_signature(story),
+    }
+
+
+def _selected_run_recipe_payload(contract: CM1InputContract) -> dict[str, str]:
+    return {
+        "recipe_id": contract.package_family.value,
+        "display_name": contract.package_display_name,
+        "assumption_set_id": _assumption_set_id(contract.package_family.value),
+    }
+
+
+def _input_validation_payload(
+    observed_sounding: ObservedSoundingRecord | None,
+    contract: CM1InputContract,
+) -> dict[str, Any]:
+    if observed_sounding is None:
+        return {
+            "observed_temperature_profile": "generated_reference",
+            "observed_moisture_profile": "generated_reference",
+            "observed_wind_profile": "generated_reference",
+            "model_bottom_elevation": "generated_reference",
+            "caveats": [],
+        }
+    wind_required = contract.package_family == PackageFamily.DEEP_CONVECTION_TRIAL
+    wind_status = (
+        ("present_required" if wind_required else "present_optional")
+        if observed_sounding.wind_handling
+        else ("missing_required" if wind_required else "optional_missing")
+    )
+    return {
+        "observed_temperature_profile": "present",
+        "observed_moisture_profile": "present",
+        "observed_wind_profile": wind_status,
+        "model_bottom_elevation": (
+            "present" if observed_sounding.model_bottom_elevation_m_msl is not None else "missing"
+        ),
+        "caveats": list(observed_sounding.validation.caveats),
+    }
+
+
+def _run_shape_validation_payload(contract: CM1InputContract) -> dict[str, Any]:
+    values = contract.run_configuration.cm1_values
+    return {
+        "duration": contract.run_configuration.duration_preset,
+        "duration_seconds": values.runtime_seconds,
+        "domain": contract.run_configuration.domain_size_preset,
+        "domain_x_km": values.domain_x_km,
+        "domain_y_km": values.domain_y_km,
+        "model_top": values.model_top_m,
+        "grid_detail": contract.run_configuration.grid_detail_preset,
+        "dx_m": values.dx_m,
+        "dy_m": values.dy_m,
+        "output_cadence": contract.run_configuration.output_cadence_preset,
+        "output_cadence_seconds": values.output_cadence_seconds,
+        "estimated_frames": values.expected_output_frames,
+        "estimated_output_volume": contract.run_configuration.output_volume_summary,
+    }
+
+
+def _run_shape_from_payload(
+    run_configuration: dict[str, object] | None,
+    package_family: str,
+) -> dict[str, Any]:
+    try:
+        resolved = resolve_run_configuration(
+            run_configuration=run_configuration,
+            package_family=package_family,
+        )
+    except ValueError:
+        return {
+            "duration": run_configuration.get("duration_preset")
+            if isinstance(run_configuration, dict)
+            else None,
+            "domain": run_configuration.get("domain_size_preset")
+            if isinstance(run_configuration, dict)
+            else None,
+            "grid_detail": run_configuration.get("grid_detail_preset")
+            if isinstance(run_configuration, dict)
+            else None,
+            "output_cadence": run_configuration.get("output_cadence_preset")
+            if isinstance(run_configuration, dict)
+            else None,
+            "estimated_frames": None,
+            "estimated_output_volume": None,
+        }
+    values = resolved.cm1_values
+    return {
+        "duration": resolved.duration_preset,
+        "duration_seconds": values.runtime_seconds,
+        "domain": resolved.domain_size_preset,
+        "domain_x_km": values.domain_x_km,
+        "domain_y_km": values.domain_y_km,
+        "model_top": values.model_top_m,
+        "grid_detail": resolved.grid_detail_preset,
+        "dx_m": values.dx_m,
+        "dy_m": values.dy_m,
+        "output_cadence": resolved.output_cadence_preset,
+        "output_cadence_seconds": values.output_cadence_seconds,
+        "estimated_frames": values.expected_output_frames,
+        "estimated_output_volume": resolved.output_volume_summary,
+    }
+
+
+def _forcing_validation_payload(contract: CM1InputContract) -> dict[str, str]:
+    return _forcing_validation_for_family(contract.package_family.value)
+
+
+def _forcing_validation_for_family(package_family: str) -> dict[str, str]:
+    trigger = (
+        "warm_bubble_required_for_triggered_deep_potential"
+        if package_family == PackageFamily.DEEP_CONVECTION_TRIAL.value
+        else "none"
+    )
+    return {
+        "trigger": trigger,
+        "surface_fluxes": "current_recipe_default",
+        "radiation": "disabled_or_future",
+        "large_scale_forcing": "not_supported_v1",
+    }
+
+
+def _required_outputs_for_story(
+    story: str | None,
+    package_family: PackageFamily,
+) -> list[str]:
+    if story in DEEP_CONVECTION_STORIES or package_family == PackageFamily.DEEP_CONVECTION_TRIAL:
+        return ["qc", "w", "qr", "rain", "dbz", "updraft_helicity"]
+    if story == "humid_rainy_candidate":
+        return ["qc", "qr", "rain", "dbz"]
+    return ["qc", "w"]
+
+
+def _predicted_output_signature(story: str | None) -> list[str]:
+    if story in DEEP_CONVECTION_STORIES:
+        return ["deep_cloud", "strong_updraft", "rain_water_aloft", "reflectivity"]
+    if story == "humid_rainy_candidate":
+        return ["cloud_water", "rain_water_aloft_or_surface_rain"]
+    if story == "dry_failed_candidate":
+        return ["updraft_without_meaningful_cloud_water"]
+    if story == "capped_suppressed_candidate":
+        return ["suppressed_or_shallow_cloud", "limited_cloud_top"]
+    if story == "shallow_cumulus_candidate":
+        return ["shallow_cloud_water", "modest_vertical_velocity"]
+    return []
+
+
+def _selected_story(candidate_screening: dict[str, Any] | None) -> str | None:
+    if not candidate_screening:
+        return None
+    active = candidate_screening.get("active_story")
+    if isinstance(active, str) and active:
+        return active
+    primary = candidate_screening.get("primary_story")
+    return primary if isinstance(primary, str) and primary else None
+
+
+def _active_story_score(
+    candidate_screening: dict[str, Any] | None, story: str | None
+) -> float | None:
+    if not candidate_screening or story is None:
+        return None
+    scores = candidate_screening.get("story_scores")
+    if not isinstance(scores, list):
+        return None
+    for score in scores:
+        if not isinstance(score, dict) or score.get("story") != story:
+            continue
+        value = score.get("score_0_to_100")
+        return float(value) if isinstance(value, int | float) else None
+    return None
+
+
+def _string_or_none(payload: dict[str, Any] | None, key: str) -> str | None:
+    value = payload.get(key) if payload else None
+    return value if isinstance(value, str) else None
+
+
+def _number_or_none(payload: dict[str, Any] | None, key: str) -> float | None:
+    value = payload.get(key) if payload else None
+    return float(value) if isinstance(value, int | float) else None
+
+
+def _family_value(
+    package_family: str | None,
+    observed_sounding: dict[str, object] | ObservedSoundingRecord | None,
+) -> str:
+    if package_family:
+        return package_family
+    if observed_sounding is not None:
+        return PackageFamily.OBSERVED_SOUNDING_QUICKLOOK.value
+    return PackageFamily.SHALLOW_CUMULUS.value
+
+
+def _package_family(value: str) -> PackageFamily:
+    try:
+        return PackageFamily(value)
+    except ValueError:
+        return PackageFamily.SHALLOW_CUMULUS
+
+
+def _package_display_name(package_family: str) -> str:
+    if package_family == PackageFamily.DEEP_CONVECTION_TRIAL.value:
+        return "Deep Convection Trial"
+    if package_family == PackageFamily.OBSERVED_SOUNDING_QUICKLOOK.value:
+        return "Observed Sounding Quick Look"
+    return "Baseline Shallow Cumulus"
+
+
+def _assumption_set_id(package_family: str) -> str:
+    if package_family == PackageFamily.DEEP_CONVECTION_TRIAL.value:
+        return "triggered_deep_potential_warm_bubble_v1"
+    if package_family == PackageFamily.OBSERVED_SOUNDING_QUICKLOOK.value:
+        return "normal_evolution_current_observed_sounding_v1"
+    return "generated_reference_lower_atmosphere_v1"
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped

--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -89,12 +89,12 @@ class ResultCard(BaseModel):
     input_source: str = "generated_reference"
     input_source_label: str = "Generated reference"
     observed_sounding: dict[str, object] | None = None
-    package_family: str | None = None
-    package_display_name: str | None = None
+    run_recipe: str | None = None
+    run_recipe_display_name: str | None = None
     trigger_type: str | None = None
     trigger_parameters: dict[str, object] | None = None
     expected_outputs: list[str] = Field(default_factory=list)
-    package_caveats: list[str] = Field(default_factory=list)
+    run_caveats: list[str] = Field(default_factory=list)
     manual_validation_status: str | None = None
     candidate_screening: dict[str, object] | None = None
     pre_run_validation_report: dict[str, Any] | None = None
@@ -232,12 +232,12 @@ def _card_from_metadata(
         input_source=metadata.input_source,
         input_source_label=metadata.input_source_label,
         observed_sounding=metadata.observed_sounding,
-        package_family=metadata.package_family,
-        package_display_name=metadata.package_display_name,
+        run_recipe=metadata.run_recipe,
+        run_recipe_display_name=metadata.run_recipe_display_name,
         trigger_type=metadata.trigger_type,
         trigger_parameters=metadata.trigger_parameters,
         expected_outputs=metadata.expected_outputs,
-        package_caveats=metadata.package_caveats,
+        run_caveats=metadata.run_caveats,
         manual_validation_status=metadata.manual_validation_status,
         candidate_screening=metadata.candidate_screening,
         pre_run_validation_report=metadata.pre_run_validation_report,
@@ -246,7 +246,7 @@ def _card_from_metadata(
             f"source_model:{metadata.source_model}",
             f"source_product_state:{metadata.source_product_state}",
             f"result_state:{metadata.result_state}",
-            *([f"package_family:{metadata.package_family}"] if metadata.package_family else []),
+            *([f"run_recipe:{metadata.run_recipe}"] if metadata.run_recipe else []),
         ],
         diagnostics_summary=metadata.diagnostics_summary,
         thermal_fate_label=interpretation.thermal_fate_label if interpretation else None,
@@ -284,30 +284,30 @@ def _card_from_metadata(
 
 
 def _default_result_card_name(metadata: ResultMetadata) -> str:
-    if metadata.package_family == "deep_convection_trial":
+    if metadata.run_recipe == "triggered_deep_potential":
         station_name = _observed_sounding_value(metadata.observed_sounding, "station_name")
         station_id = _observed_sounding_value(metadata.observed_sounding, "station_id")
         if station_name:
-            return f"Deep Convection Trial — {station_name}"
+            return f"Triggered Deep-Potential Experiment — {station_name}"
         if station_id:
-            return f"Deep Convection Trial — {station_id}"
-        return "Deep Convection Trial"
+            return f"Triggered Deep-Potential Experiment — {station_id}"
+        return "Triggered Deep-Potential Experiment"
     if metadata.input_source == "observed_sounding":
         station_name = _observed_sounding_value(metadata.observed_sounding, "station_name")
         station_id = _observed_sounding_value(metadata.observed_sounding, "station_id")
         if station_name:
-            return f"Uploaded Sounding — {station_name}"
+            return f"Untriggered Observed Evolution — {station_name}"
         if station_id:
-            return f"Uploaded Sounding — {station_id}"
-        return "Uploaded Sounding"
+            return f"Untriggered Observed Evolution — {station_id}"
+        return "Untriggered Observed Evolution"
     return metadata.scenario_name or metadata.scenario_id
 
 
 def _display_scenario_name(metadata: ResultMetadata) -> str | None:
-    if metadata.package_family == "deep_convection_trial" and metadata.package_display_name:
-        return metadata.package_display_name
+    if metadata.run_recipe == "triggered_deep_potential" and metadata.run_recipe_display_name:
+        return metadata.run_recipe_display_name
     if metadata.input_source == "observed_sounding":
-        return "Uploaded Sounding"
+        return "Untriggered Observed Evolution"
     return metadata.scenario_name
 
 

--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -96,6 +97,7 @@ class ResultCard(BaseModel):
     package_caveats: list[str] = Field(default_factory=list)
     manual_validation_status: str | None = None
     candidate_screening: dict[str, object] | None = None
+    pre_run_validation_report: dict[str, Any] | None = None
     candidate_hypothesis_comparison: CandidateHypothesisComparison | None = None
     provenance_labels: list[str] = Field(default_factory=list)
     diagnostics_summary: str | None = None
@@ -238,6 +240,7 @@ def _card_from_metadata(
         package_caveats=metadata.package_caveats,
         manual_validation_status=metadata.manual_validation_status,
         candidate_screening=metadata.candidate_screening,
+        pre_run_validation_report=metadata.pre_run_validation_report,
         candidate_hypothesis_comparison=metadata.candidate_hypothesis_comparison,
         provenance_labels=[
             f"source_model:{metadata.source_model}",

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -106,6 +106,7 @@ class ResultMetadata(BaseModel):
     package_caveats: list[str] = Field(default_factory=list)
     manual_validation_status: str | None = None
     candidate_screening: dict[str, Any] | None = None
+    pre_run_validation_report: dict[str, Any] | None = None
     candidate_hypothesis_comparison: CandidateHypothesisComparison | None = None
     result_state: str = "ingested_result_metadata"
     raw_cm1_artifacts: list[str] = Field(default_factory=list)
@@ -308,6 +309,7 @@ def _result_from_model_output_files(
         package_caveats=manifest.package_caveats,
         manual_validation_status=manifest.manual_validation_status,
         candidate_screening=manifest.candidate_screening,
+        pre_run_validation_report=manifest.pre_run_validation_report,
         raw_cm1_artifacts=manifest.outputs.raw_cm1_artifacts,
         netcdf_paths=[str(path) for path in netcdf_paths],
         model_output_paths=[str(path) for path in contributing_paths],
@@ -823,6 +825,7 @@ def _result_from_dataset(
         package_caveats=manifest.package_caveats,
         manual_validation_status=manifest.manual_validation_status,
         candidate_screening=manifest.candidate_screening,
+        pre_run_validation_report=manifest.pre_run_validation_report,
         raw_cm1_artifacts=manifest.outputs.raw_cm1_artifacts,
         netcdf_paths=[str(path) for path in netcdf_paths],
         model_output_paths=[str(path) for path in contributing_paths],

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -98,12 +98,12 @@ class ResultMetadata(BaseModel):
     input_source: str = "generated_reference"
     input_source_label: str = "Generated reference"
     observed_sounding: dict[str, Any] | None = None
-    package_family: str | None = None
-    package_display_name: str | None = None
+    run_recipe: str | None = None
+    run_recipe_display_name: str | None = None
     trigger_type: str | None = None
     trigger_parameters: dict[str, Any] | None = None
     expected_outputs: list[str] = Field(default_factory=list)
-    package_caveats: list[str] = Field(default_factory=list)
+    run_caveats: list[str] = Field(default_factory=list)
     manual_validation_status: str | None = None
     candidate_screening: dict[str, Any] | None = None
     pre_run_validation_report: dict[str, Any] | None = None
@@ -188,7 +188,7 @@ def ingest_completed_run(manifest_path: Path) -> ResultMetadata:
         diagnostics=result.diagnostics,
         output_manifest=product_manifest,
         variables=result.variables,
-        package_family=result.package_family,
+        run_recipe=result.run_recipe,
     )
     product_manifest = product_manifest.model_copy(
         update={"interesting_time_product": interesting_time_product}
@@ -301,12 +301,12 @@ def _result_from_model_output_files(
         input_source=_input_source(manifest),
         input_source_label=_input_source_label(manifest),
         observed_sounding=manifest.observed_sounding,
-        package_family=manifest.package_family,
-        package_display_name=manifest.package_display_name,
+        run_recipe=manifest.run_recipe,
+        run_recipe_display_name=manifest.run_recipe_display_name,
         trigger_type=manifest.trigger_type,
         trigger_parameters=manifest.trigger_parameters,
         expected_outputs=manifest.expected_outputs,
-        package_caveats=manifest.package_caveats,
+        run_caveats=manifest.run_caveats,
         manual_validation_status=manifest.manual_validation_status,
         candidate_screening=manifest.candidate_screening,
         pre_run_validation_report=manifest.pre_run_validation_report,
@@ -817,12 +817,12 @@ def _result_from_dataset(
         input_source=_input_source(manifest),
         input_source_label=_input_source_label(manifest),
         observed_sounding=manifest.observed_sounding,
-        package_family=manifest.package_family,
-        package_display_name=manifest.package_display_name,
+        run_recipe=manifest.run_recipe,
+        run_recipe_display_name=manifest.run_recipe_display_name,
         trigger_type=manifest.trigger_type,
         trigger_parameters=manifest.trigger_parameters,
         expected_outputs=manifest.expected_outputs,
-        package_caveats=manifest.package_caveats,
+        run_caveats=manifest.run_caveats,
         manual_validation_status=manifest.manual_validation_status,
         candidate_screening=manifest.candidate_screening,
         pre_run_validation_report=manifest.pre_run_validation_report,
@@ -913,8 +913,8 @@ def _candidate_hypothesis_comparison(
 
     primary_story = _screening_string(screening.get("primary_story"))
     screened_as = _candidate_story_label(primary_story)
-    ran_as = result.package_display_name or _display_package_family(result.package_family)
-    if result.scenario_name and ran_as == "CM1 package":
+    ran_as = result.run_recipe_display_name or _display_run_recipe(result.run_recipe)
+    if result.scenario_name and ran_as == "CM1 run":
         ran_as = result.scenario_name
 
     science_summary = result.science_summary
@@ -950,20 +950,18 @@ def _candidate_hypothesis_comparison(
                 [*caveats, "candidate_story_not_in_deep_convection_v1_rule_set"]
             ),
         )
-    if result.package_family != "deep_convection_trial":
+    if result.run_recipe != "triggered_deep_potential":
         return CandidateHypothesisComparison(
             screened_as=screened_as,
             ran_as=ran_as,
             cm1_outcome=(
                 "Unable to evaluate candidate match because this was not a "
-                "Deep Convection Trial package."
+                "triggered deep-potential run."
             ),
             match_status="unable_to_evaluate",
             match_status_label="Unable to evaluate",
             evidence=evidence,
-            caveats=_dedupe_strings(
-                [*caveats, "comparison_requires_deep_convection_trial_package"]
-            ),
+            caveats=_dedupe_strings([*caveats, "comparison_requires_triggered_deep_potential_run"]),
         )
     if not diagnostics.cloud.available or not diagnostics.vertical_velocity.available:
         return CandidateHypothesisComparison(
@@ -1039,10 +1037,12 @@ def _candidate_story_label(story: str | None) -> str | None:
     return DEEP_CONVECTION_STORY_LABELS.get(story, story.replace("_", " ").title())
 
 
-def _display_package_family(package_family: str | None) -> str:
-    if package_family == "deep_convection_trial":
-        return "Deep Convection Trial"
-    return "CM1 package"
+def _display_run_recipe(run_recipe: str | None) -> str:
+    if run_recipe == "triggered_deep_potential":
+        return "Triggered Deep-Potential Experiment"
+    if run_recipe == "untriggered_observed_evolution":
+        return "Untriggered Observed Evolution"
+    return "CM1 run"
 
 
 def _match_status_label(match_status: str) -> str:

--- a/app/backend/cloud_chamber/run_configuration.py
+++ b/app/backend/cloud_chamber/run_configuration.py
@@ -1,7 +1,7 @@
-"""Run-configuration choices for CM1 package generation.
+"""Run-configuration choices for CM1 run generation.
 
-The product model is intentionally explicit: duration, grid/detail, domain,
-output cadence, and output-field density are separate levers. The backend
+The product model is intentionally explicit: duration, horizontal cell budget,
+domain size, output cadence, and diagnostic set are separate levers. The backend
 resolves those choices into CM1-facing values before package creation.
 """
 
@@ -41,13 +41,13 @@ class RunConfiguration(BaseModel):
     configuration_id: str
     mode: RunMode
     label: str
-    duration_preset: str
+    duration: str
     duration_seconds: int
-    grid_detail_preset: str
-    domain_size_preset: str
-    output_cadence_preset: str
+    horizontal_cell_count: int
+    domain_size: str
+    output_cadence: str
     output_cadence_seconds: int
-    output_field_density_preset: str
+    diagnostic_set: str
     cost_runtime_summary: str
     output_volume_summary: str
     cm1_values: RunConfigurationCM1Values
@@ -62,10 +62,10 @@ class _DurationChoice(BaseModel):
     label: str
 
 
-class _GridChoice(BaseModel):
+class _HorizontalCellChoice(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    dx_m: float
+    cells: int
     label: str
 
 
@@ -89,21 +89,18 @@ class _CadenceChoice(BaseModel):
 
 DURATION_CHOICES: dict[str, _DurationChoice] = {
     "smoke_1h": _DurationChoice(seconds=3600, mode="smoke", label="Smoke check"),
-    "quick_6h": _DurationChoice(seconds=21600, mode="science", label="Quick science"),
-    "standard_12h": _DurationChoice(seconds=43200, mode="science", label="Standard science"),
+    "short_6h": _DurationChoice(seconds=21600, mode="science", label="Short evolution"),
+    "standard_12h": _DurationChoice(seconds=43200, mode="science", label="Standard evolution"),
     "long_24h": _DurationChoice(seconds=86400, mode="science", label="Long evolution"),
 }
 
-SHALLOW_GRID_CHOICES: dict[str, _GridChoice] = {
-    "coarse": _GridChoice(dx_m=200.0, label="Coarse"),
-    "standard": _GridChoice(dx_m=100.0, label="Standard"),
-    "fine": _GridChoice(dx_m=50.0, label="Fine"),
-}
-
-DEEP_GRID_CHOICES: dict[str, _GridChoice] = {
-    "coarse": _GridChoice(dx_m=2000.0, label="Coarse"),
-    "standard": _GridChoice(dx_m=1000.0, label="Standard"),
-    "fine": _GridChoice(dx_m=500.0, label="Fine"),
+HORIZONTAL_CELL_CHOICES: dict[str, _HorizontalCellChoice] = {
+    "cells_64": _HorizontalCellChoice(cells=64, label="Scout 64 x 64"),
+    "cells_96": _HorizontalCellChoice(cells=96, label="Light 96 x 96"),
+    "cells_128": _HorizontalCellChoice(cells=128, label="Standard 128 x 128"),
+    "cells_192": _HorizontalCellChoice(cells=192, label="Detailed 192 x 192"),
+    "cells_256": _HorizontalCellChoice(cells=256, label="High detail 256 x 256"),
+    "cells_384": _HorizontalCellChoice(cells=384, label="Very high detail 384 x 384"),
 }
 
 SHALLOW_DOMAIN_CHOICES: dict[str, _DomainChoice] = {
@@ -122,6 +119,22 @@ SHALLOW_DOMAIN_CHOICES: dict[str, _DomainChoice] = {
         dz_m=40.0,
         model_top_m=18000.0,
         label="Wide 12 km",
+    ),
+    "regional_60km": _DomainChoice(
+        x_km=60.0,
+        y_km=60.0,
+        nz=75,
+        dz_m=40.0,
+        model_top_m=18000.0,
+        label="Regional 60 km",
+    ),
+    "regional_120km": _DomainChoice(
+        x_km=120.0,
+        y_km=120.0,
+        nz=75,
+        dz_m=40.0,
+        model_top_m=18000.0,
+        label="Regional 120 km",
     ),
 }
 
@@ -158,120 +171,131 @@ CADENCE_CHOICES: dict[str, _CadenceChoice] = {
     "detailed_5min": _CadenceChoice(seconds=300, label="Detailed 5 min"),
 }
 
-FIELD_DENSITY_CHOICES = {"core", "analysis", "rich"}
+DIAGNOSTIC_SET_CHOICES = {"essential", "process", "full"}
 
 
-def default_run_configuration_payload(package_family: str | None = None) -> dict[str, str]:
-    if package_family == "deep_convection_trial":
+def default_run_configuration_payload(run_recipe: str | None = None) -> dict[str, str]:
+    if run_recipe == "triggered_deep_potential":
         return {
-            "duration_preset": "quick_6h",
-            "grid_detail_preset": "standard",
-            "domain_size_preset": "storm_120km",
-            "output_cadence_preset": "standard_15min",
-            "output_field_density_preset": "rich",
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "storm_120km",
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "full",
         }
-    if package_family == "observed_sounding_quicklook":
+    if run_recipe == "untriggered_observed_evolution":
         return {
-            "duration_preset": "quick_6h",
-            "grid_detail_preset": "standard",
-            "domain_size_preset": "wide_12km",
-            "output_cadence_preset": "standard_15min",
-            "output_field_density_preset": "analysis",
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "wide_12km",
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "process",
         }
     return {
-        "duration_preset": "quick_6h",
-        "grid_detail_preset": "standard",
-        "domain_size_preset": "local_6km",
-        "output_cadence_preset": "standard_15min",
-        "output_field_density_preset": "analysis",
+        "duration": "short_6h",
+        "horizontal_cell_count": "cells_64",
+        "domain_size": "local_6km",
+        "output_cadence": "standard_15min",
+        "diagnostic_set": "process",
     }
 
 
 def resolve_run_configuration(
     *,
     run_configuration: dict[str, Any] | RunConfiguration | None = None,
-    package_family: str | None = None,
+    run_recipe: str | None = None,
 ) -> RunConfiguration:
     if isinstance(run_configuration, RunConfiguration):
-        payload = run_configuration.model_dump()
-    elif run_configuration is None:
-        payload = default_run_configuration_payload(package_family)
+        return run_configuration
+    if run_configuration is None:
+        payload = default_run_configuration_payload(run_recipe)
     else:
         payload = dict(run_configuration)
 
     payload = {
-        **default_run_configuration_payload(package_family),
+        **default_run_configuration_payload(run_recipe),
         **payload,
     }
 
-    if package_family == "deep_convection_trial":
-        if payload.get("domain_size_preset") in SHALLOW_DOMAIN_CHOICES:
-            payload["domain_size_preset"] = "storm_120km"
-    elif payload.get("domain_size_preset") in DEEP_DOMAIN_CHOICES:
-        payload["domain_size_preset"] = "local_6km"
+    if run_recipe == "triggered_deep_potential":
+        if payload.get("domain_size") in SHALLOW_DOMAIN_CHOICES:
+            payload["domain_size"] = "storm_120km"
+    elif payload.get("domain_size") in DEEP_DOMAIN_CHOICES:
+        payload["domain_size"] = "local_6km"
 
-    is_deep_convection = package_family == "deep_convection_trial"
-    duration = _choice(DURATION_CHOICES, payload.get("duration_preset"), "duration_preset")
-    grid_choices = DEEP_GRID_CHOICES if is_deep_convection else SHALLOW_GRID_CHOICES
-    grid = _choice(grid_choices, payload.get("grid_detail_preset"), "grid_detail_preset")
-    domains = DEEP_DOMAIN_CHOICES if is_deep_convection else SHALLOW_DOMAIN_CHOICES
-    domain = _choice(domains, payload.get("domain_size_preset"), "domain_size_preset")
+    is_triggered_deep_potential = run_recipe == "triggered_deep_potential"
+    duration = _choice(DURATION_CHOICES, payload.get("duration"), "duration")
+    horizontal_cells = _choice(
+        HORIZONTAL_CELL_CHOICES,
+        payload.get("horizontal_cell_count"),
+        "horizontal_cell_count",
+    )
+    domains = DEEP_DOMAIN_CHOICES if is_triggered_deep_potential else SHALLOW_DOMAIN_CHOICES
+    domain = _choice(domains, payload.get("domain_size"), "domain_size")
     cadence = _choice(
         CADENCE_CHOICES,
-        payload.get("output_cadence_preset"),
-        "output_cadence_preset",
+        payload.get("output_cadence"),
+        "output_cadence",
     )
-    field_density = str(payload.get("output_field_density_preset", "analysis"))
-    if field_density not in FIELD_DENSITY_CHOICES:
-        raise ValueError(f"Unknown output_field_density_preset: {field_density}")
+    diagnostic_set = str(payload.get("diagnostic_set", "process"))
+    if diagnostic_set not in DIAGNOSTIC_SET_CHOICES:
+        raise ValueError(f"Unknown diagnostic_set: {diagnostic_set}")
 
-    nx = max(1, round(domain.x_km * 1000.0 / grid.dx_m))
-    ny = max(1, round(domain.y_km * 1000.0 / grid.dx_m))
+    nx = horizontal_cells.cells
+    ny = horizontal_cells.cells
+    dx_m = domain.x_km * 1000.0 / nx
+    dy_m = domain.y_km * 1000.0 / ny
     restart_seconds = max(cadence.seconds, min(duration.seconds, 10800))
     frames = _expected_output_frames(duration.seconds, cadence.seconds)
     grid_cells = nx * ny * domain.nz
     configuration_id = _configuration_id(
-        duration_preset=str(payload["duration_preset"]),
-        grid_detail_preset=str(payload["grid_detail_preset"]),
-        domain_size_preset=str(payload["domain_size_preset"]),
-        output_cadence_preset=str(payload["output_cadence_preset"]),
-        output_field_density_preset=field_density,
+        duration=str(payload["duration"]),
+        horizontal_cell_count=str(payload["horizontal_cell_count"]),
+        domain_size=str(payload["domain_size"]),
+        output_cadence=str(payload["output_cadence"]),
+        diagnostic_set=diagnostic_set,
     )
     caveats = _configuration_caveats(
         mode=duration.mode,
-        package_family=package_family,
-        field_density=field_density,
-        grid_detail_preset=str(payload["grid_detail_preset"]),
-        domain_size_preset=str(payload["domain_size_preset"]),
+        run_recipe=run_recipe,
+        diagnostic_set=diagnostic_set,
+        horizontal_cell_count=horizontal_cells.cells,
+        domain_size=str(payload["domain_size"]),
     )
     return RunConfiguration(
         configuration_id=configuration_id,
         mode=duration.mode,
-        label=_configuration_label(duration.label, domain.label, grid.label, cadence.label),
-        duration_preset=str(payload["duration_preset"]),
+        label=_configuration_label(
+            duration.label,
+            domain.label,
+            horizontal_cells.label,
+            dx_m,
+            cadence.label,
+        ),
+        duration=str(payload["duration"]),
         duration_seconds=duration.seconds,
-        grid_detail_preset=str(payload["grid_detail_preset"]),
-        domain_size_preset=str(payload["domain_size_preset"]),
-        output_cadence_preset=str(payload["output_cadence_preset"]),
+        horizontal_cell_count=horizontal_cells.cells,
+        domain_size=str(payload["domain_size"]),
+        output_cadence=str(payload["output_cadence"]),
         output_cadence_seconds=cadence.seconds,
-        output_field_density_preset=field_density,
+        diagnostic_set=diagnostic_set,
         cost_runtime_summary=_runtime_summary(duration.seconds, grid_cells, cadence.seconds),
-        output_volume_summary=_output_summary(frames, grid_cells, field_density),
+        output_volume_summary=_output_summary(frames, grid_cells, diagnostic_set),
         cm1_values=RunConfigurationCM1Values(
             nx=nx,
             ny=ny,
             nz=domain.nz,
-            dx_m=grid.dx_m,
-            dy_m=grid.dx_m,
+            dx_m=dx_m,
+            dy_m=dy_m,
             dz_m=domain.dz_m,
             model_top_m=domain.model_top_m,
             domain_x_km=domain.x_km,
             domain_y_km=domain.y_km,
-            time_step_seconds=_time_step_seconds(package_family),
+            time_step_seconds=_time_step_seconds(run_recipe),
             runtime_seconds=duration.seconds,
             output_cadence_seconds=cadence.seconds,
             restart_cadence_seconds=restart_seconds,
-            rayleigh_damping_start_m=_rayleigh_damping_start_m(package_family),
+            rayleigh_damping_start_m=_rayleigh_damping_start_m(run_recipe),
             expected_output_frames=frames,
             grid_cell_count=grid_cells,
         ),
@@ -287,25 +311,26 @@ def _choice[T](choices: dict[str, T], value: object, label: str) -> T:
 
 def _configuration_id(
     *,
-    duration_preset: str,
-    grid_detail_preset: str,
-    domain_size_preset: str,
-    output_cadence_preset: str,
-    output_field_density_preset: str,
+    duration: str,
+    horizontal_cell_count: str,
+    domain_size: str,
+    output_cadence: str,
+    diagnostic_set: str,
 ) -> str:
-    return (
-        f"{duration_preset}__{grid_detail_preset}__{domain_size_preset}__"
-        f"{output_cadence_preset}__{output_field_density_preset}"
-    )
+    return f"{duration}__{horizontal_cell_count}__{domain_size}__{output_cadence}__{diagnostic_set}"
 
 
 def _configuration_label(
     duration_label: str,
     domain_label: str,
-    grid_label: str,
+    horizontal_cells_label: str,
+    dx_m: float,
     cadence_label: str,
 ) -> str:
-    return f"{duration_label}; {domain_label}; {grid_label}; {cadence_label}"
+    return (
+        f"{duration_label}; {domain_label}; {horizontal_cells_label}; "
+        f"{_format_spacing(dx_m)} dx/dy; {cadence_label}"
+    )
 
 
 def _runtime_summary(duration_seconds: int, grid_cells: int, cadence_seconds: int) -> str:
@@ -315,41 +340,54 @@ def _runtime_summary(duration_seconds: int, grid_cells: int, cadence_seconds: in
     )
 
 
-def _output_summary(frames: int, grid_cells: int, field_density: str) -> str:
-    return f"{frames:,} saved frames, {field_density} output fields, {grid_cells:,} cells per frame"
+def _output_summary(frames: int, grid_cells: int, diagnostic_set: str) -> str:
+    return f"{frames:,} saved frames, {diagnostic_set} diagnostics, {grid_cells:,} cells per frame"
 
 
 def _configuration_caveats(
     *,
     mode: RunMode,
-    package_family: str | None,
-    field_density: str,
-    grid_detail_preset: str,
-    domain_size_preset: str,
+    run_recipe: str | None,
+    diagnostic_set: str,
+    horizontal_cell_count: int,
+    domain_size: str,
 ) -> list[str]:
     caveats: list[str] = []
     if mode == "smoke":
         caveats.append("short_smoke_mode_is_for_package_health_not_science_evolution")
     if mode == "science":
         caveats.append("science_run_configuration_minimum_duration_6h")
-    if package_family == "deep_convection_trial":
-        caveats.append("deep_convection_trial_uses_triggered_potential_not_normal_evolution")
-    if field_density == "core":
-        caveats.append("core_output_density_limits_later_diagnostics")
-    if grid_detail_preset == "fine" or domain_size_preset in {"wide_12km", "storm_240km"}:
+    if run_recipe == "triggered_deep_potential":
+        caveats.append("triggered_deep_potential_is_not_normal_evolution")
+    if diagnostic_set == "essential":
+        caveats.append("essential_diagnostic_set_limits_later_diagnostics")
+    if horizontal_cell_count >= 256 or domain_size in {
+        "wide_12km",
+        "regional_60km",
+        "regional_120km",
+        "storm_240km",
+    }:
         caveats.append("configuration_better_suited_to_larger_compute")
     return caveats
 
 
-def _time_step_seconds(package_family: str | None) -> float:
-    return 6.0 if package_family == "deep_convection_trial" else 3.0
+def _time_step_seconds(run_recipe: str | None) -> float:
+    return 6.0 if run_recipe == "triggered_deep_potential" else 3.0
 
 
-def _rayleigh_damping_start_m(package_family: str | None) -> int:
-    return 15000 if package_family == "deep_convection_trial" else 2500
+def _rayleigh_damping_start_m(run_recipe: str | None) -> int:
+    return 15000 if run_recipe == "triggered_deep_potential" else 2500
 
 
 def _expected_output_frames(runtime_seconds: int, output_cadence_seconds: int) -> int:
     if output_cadence_seconds <= 0:
         return 0
     return runtime_seconds // output_cadence_seconds + 1
+
+
+def _format_spacing(dx_m: float) -> str:
+    if dx_m >= 1000.0:
+        return f"{dx_m / 1000.0:.2g} km"
+    if dx_m >= 100.0:
+        return f"{dx_m:.0f} m"
+    return f"{dx_m:.1f} m"

--- a/app/backend/cloud_chamber/run_manifest.py
+++ b/app/backend/cloud_chamber/run_manifest.py
@@ -147,6 +147,7 @@ class RunManifest(BaseModel):
     user: UserMetadata
     observed_sounding: dict[str, Any] | None = None
     candidate_screening: dict[str, Any] | None = None
+    pre_run_validation_report: dict[str, Any] | None = None
     package_family: str | None = None
     package_display_name: str | None = None
     input_source: str | None = None

--- a/app/backend/cloud_chamber/run_manifest.py
+++ b/app/backend/cloud_chamber/run_manifest.py
@@ -148,14 +148,14 @@ class RunManifest(BaseModel):
     observed_sounding: dict[str, Any] | None = None
     candidate_screening: dict[str, Any] | None = None
     pre_run_validation_report: dict[str, Any] | None = None
-    package_family: str | None = None
-    package_display_name: str | None = None
+    run_recipe: str | None = None
+    run_recipe_display_name: str | None = None
     input_source: str | None = None
     trigger_type: str | None = None
     trigger_parameters: dict[str, Any] | None = None
     expected_outputs: list[str] = Field(default_factory=list)
-    package_limitations: list[str] = Field(default_factory=list)
-    package_caveats: list[str] = Field(default_factory=list)
+    run_limitations: list[str] = Field(default_factory=list)
+    run_caveats: list[str] = Field(default_factory=list)
     manual_validation_status: str | None = None
 
     @model_validator(mode="after")

--- a/app/backend/cloud_chamber/runtime_storage.py
+++ b/app/backend/cloud_chamber/runtime_storage.py
@@ -40,6 +40,7 @@ class RunStorageEntry(BaseModel):
     validation_status: str | None = None
     product_state: str | None = None
     run_configuration: dict[str, object] | None = None
+    pre_run_validation_report: dict[str, object] | None = None
     created_at: str | None = None
     updated_at: str | None = None
     saved: bool = False
@@ -304,6 +305,7 @@ def _entry_from_manifest(
         validation_status=manifest.validation_status.value,
         product_state=manifest.provenance.product_state.value,
         run_configuration=manifest.run_configuration,
+        pre_run_validation_report=manifest.pre_run_validation_report,
         created_at=manifest.created_at.isoformat(),
         updated_at=manifest.updated_at.isoformat(),
         saved=manifest.user.saved,

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -1145,31 +1145,31 @@ def _candidate_recipe_fit(
             "status": "blocked_profile",
             "label": "blocked profile",
             "summary": (
-                "This cached sounding cannot be packaged until the profile or parser caveats "
+                "This cached sounding cannot be used for a run until the profile or parser caveats "
                 "are resolved."
             ),
-            "caveats": ["profile_or_package_generation_blocked"],
+            "caveats": ["profile_or_run_generation_blocked"],
         }
     if story == "needs_review":
         return {
             "status": "not_testable_with_current_recipes",
-            "label": "not testable with current package path",
+            "label": "not testable with current run recipe",
             "summary": (
                 "The analyzer could not identify a trustworthy story to test with the current "
-                "observed-sounding package path."
+                "observed-sounding run recipes."
             ),
             "caveats": ["candidate_requires_manual_screening_review"],
         }
     if story in DEEP_CONVECTION_STORY_IDS:
-        caveats = ["observed_sounding_quicklook_does_not_test_deep_potential"]
+        caveats = ["untriggered_observed_evolution_does_not_test_deep_potential"]
         if features.get("observed_wind_available") is not True:
             caveats.append("complete_observed_wind_profile_required_for_deep_potential")
         return {
             "status": "requires_triggered_deep_potential",
             "label": "requires triggered deep-potential run",
             "summary": (
-                "This story screens deep-convection ingredients. Observed Sounding Quick Look "
-                "does not test that hypothesis without the triggered deep-potential package."
+                "This story screens deep-convection ingredients. Untriggered observed evolution "
+                "does not test that hypothesis without the triggered deep-potential recipe."
             ),
             "caveats": caveats,
         }
@@ -1184,7 +1184,7 @@ def _candidate_recipe_fit(
             "caveats": ["rain_water_surface_rain_or_reflectivity_outputs_required"],
         }
     if story == "capped_suppressed_candidate":
-        caveats = ["run_duration_and_output_fields_must_be_checked_for_cap_story"]
+        caveats = ["run_duration_and_diagnostics_must_be_checked_for_cap_story"]
         if (
             _numeric_feature(features, "cap_strength_proxy") is None
             and _numeric_feature(features, "cap_height_m_agl") is None
@@ -1195,7 +1195,7 @@ def _candidate_recipe_fit(
             "label": "partially testable with current observed-sounding run",
             "summary": (
                 "The current observed-sounding path can inspect capped or suppressed evolution "
-                "when cap evidence, duration, and output fields are adequate."
+                "when cap evidence, duration, and diagnostics are adequate."
             ),
             "caveats": caveats,
         }
@@ -1206,7 +1206,7 @@ def _candidate_recipe_fit(
             "The current observed-sounding path can inspect untriggered shallow/evolution "
             "behavior, but the recipe still shapes what CM1 can test."
         ),
-        "caveats": ["observed_sounding_quicklook_is_recipe_dependent"],
+        "caveats": ["untriggered_observed_evolution_is_recipe_dependent"],
     }
 
 
@@ -1382,7 +1382,7 @@ def _score_features(
     ]
     deep_caveats = [f"missing_or_unavailable_feature:{name}" for name in missing_deep_features]
     if not observed_wind_available:
-        deep_caveats.append("observed_wind_required_for_deep_convection_trial")
+        deep_caveats.append("observed_wind_required_for_triggered_deep_potential")
 
     moist = _score_high(qv, low=4.0, high=10.0)
     dry = _score_low(qv, low=3.0, high=8.0)
@@ -1432,7 +1432,7 @@ def _score_features(
         ]
     )
     if initiation_support < 45.0:
-        deep_caveats.append("weak_deep_initiation_screen_for_deep_convection_trial")
+        deep_caveats.append("weak_deep_initiation_screen_for_triggered_deep_potential")
     instability = _weighted_score(
         [
             (cape_score, 0.55),
@@ -1473,13 +1473,13 @@ def _score_features(
     surface_coverage_factor = 1.0
     if lowest_level is None:
         surface_coverage_factor = 0.5
-        deep_caveats.append("surface_level_unavailable_for_deep_convection_trial")
+        deep_caveats.append("surface_level_unavailable_for_triggered_deep_potential")
     elif lowest_level > 250.0:
         surface_coverage_factor = 0.25
-        deep_caveats.append("lowest_usable_level_too_high_for_deep_convection_trial")
+        deep_caveats.append("lowest_usable_level_too_high_for_triggered_deep_potential")
     elif lowest_level > 100.0:
         surface_coverage_factor = 0.65
-        deep_caveats.append("lowest_usable_level_caveat_for_deep_convection_trial")
+        deep_caveats.append("lowest_usable_level_caveat_for_triggered_deep_potential")
 
     shallow = _weighted_score(
         [(moist, 0.28), (low_lcl, 0.22), (deep_moisture, 0.18), (weak_cap, 0.14), (thermal, 0.18)]
@@ -1569,13 +1569,13 @@ def _score_features(
         # The broad shallow/humid stories are easy to satisfy in moist warm-season
         # profiles. When the same sounding has meaningful CAPE, shear, and deep
         # lapse-rate support, keep those broad labels available but let the
-        # Deep Convection Trial story become the useful product recommendation.
+        # triggered deep-potential recommendation become the useful product path.
         shallow_score = min(shallow_score, 62.0)
         humid_score = min(humid_score, 62.0)
     elif observed_wind_available and effective_cape >= 250.0 and deep_environment >= 55.0:
         # Moist profiles can still be shallow-cloud-capable, but when the same
         # sounding has supported deep-convection evidence we should not let the
-        # broad shallow/humid labels hide the more useful package story.
+        # broad shallow/humid labels hide the more useful run story.
         shallow_score = min(shallow_score, 82.0)
         humid_score = min(humid_score, 82.0)
     poor = 100.0 if not package_ready else min(34.0, max(0.0, 100.0 - data_quality))
@@ -1688,8 +1688,8 @@ def _score_features(
                 "lapse-rate, deep shear, and dry-layer context"
             ],
             caveats=[
-                "line/cold-pool-specific package support may come later; "
-                "v1 runs as Deep Convection Trial",
+                "line/cold-pool-specific recipe support may come later; "
+                "v1 runs as triggered deep potential",
                 *deep_caveats,
             ],
         ),
@@ -1979,7 +1979,7 @@ def _score_features(
             label="Observed wind availability",
             value=features.get("observed_wind_available"),
             interpretation=(
-                "Observed winds are required for trustworthy Deep Convection Trial packages."
+                "Observed winds are required for trustworthy triggered deep-potential runs."
             ),
             supports_story=[
                 "severe_thunderstorm_environment",

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -1694,7 +1694,7 @@ def _fallback_view_defaults(
 
 
 def _preferred_field(metadata: ResultMetadata, fields: Mapping[str, object]) -> str | None:
-    if metadata.package_family == "deep_convection_trial" and "w" in fields:
+    if metadata.run_recipe == "triggered_deep_potential" and "w" in fields:
         return "w"
     return "qc" if "qc" in fields else next(iter(fields), None)
 

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -152,7 +152,40 @@ def test_create_dry_run_package_api_uses_runtime_home_override(
     assert payload["report"]["controls"]["low_level_humidity"] == "more_humid"
     assert payload["report"]["not_a_completed_cm1_result"] is True
     assert payload["report"]["cm1_was_launched"] is False
+    assert (
+        payload["report"]["pre_run_validation_report"]["run_shape_validation"]["estimated_frames"]
+        == 25
+    )
     assert not list(tmp_path.glob("**/*.nc"))
+
+
+def test_create_dry_run_package_api_returns_blocked_pre_run_validation_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLOUD_CHAMBER_RUNTIME_HOME", str(tmp_path))
+
+    response = TestClient(app).post(
+        "/api/dry-run-package",
+        json={
+            "scenario_id": "baseline-shallow-cumulus",
+            "run_configuration": {
+                "duration_preset": "quick_6h",
+                "grid_detail_preset": "standard",
+                "domain_size_preset": "not_a_real_domain",
+                "output_cadence_preset": "standard_15min",
+                "output_field_density_preset": "analysis",
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["message"] == "Unknown domain size preset: not_a_real_domain"
+    report = detail["pre_run_validation_report"]
+    assert report["status"] == "blocked"
+    assert report["run_shape_validation"]["domain"] == "not_a_real_domain"
+    assert not list(tmp_path.glob("runs/*"))
 
 
 def test_parse_observed_sounding_api_returns_igra_review_payload() -> None:

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -136,11 +136,11 @@ def test_create_dry_run_package_api_uses_runtime_home_override(
             "scenario_id": "baseline-shallow-cumulus",
             "controls": {"low_level_humidity": "more_humid"},
             "run_configuration": {
-                "duration_preset": "quick_6h",
-                "grid_detail_preset": "standard",
-                "domain_size_preset": "local_6km",
-                "output_cadence_preset": "standard_15min",
-                "output_field_density_preset": "analysis",
+                "duration": "short_6h",
+                "horizontal_cell_count": "cells_128",
+                "domain_size": "local_6km",
+                "output_cadence": "standard_15min",
+                "diagnostic_set": "process",
             },
         },
     )
@@ -170,18 +170,18 @@ def test_create_dry_run_package_api_returns_blocked_pre_run_validation_report(
         json={
             "scenario_id": "baseline-shallow-cumulus",
             "run_configuration": {
-                "duration_preset": "quick_6h",
-                "grid_detail_preset": "standard",
-                "domain_size_preset": "not_a_real_domain",
-                "output_cadence_preset": "standard_15min",
-                "output_field_density_preset": "analysis",
+                "duration": "short_6h",
+                "horizontal_cell_count": "cells_128",
+                "domain_size": "not_a_real_domain",
+                "output_cadence": "standard_15min",
+                "diagnostic_set": "process",
             },
         },
     )
 
     assert response.status_code == 400
     detail = response.json()["detail"]
-    assert detail["message"] == "Unknown domain size preset: not_a_real_domain"
+    assert detail["message"] == "Unknown domain size: not_a_real_domain"
     report = detail["pre_run_validation_report"]
     assert report["status"] == "blocked"
     assert report["run_shape_validation"]["domain"] == "not_a_real_domain"

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -35,9 +35,9 @@ def test_cm1_contract_documents_expected_generated_files_and_default_run_configu
     contract = build_cm1_input_contract(baseline_scenario())
 
     assert contract.scenario_id == "baseline-shallow-cumulus"
-    assert contract.run_configuration.duration_preset == "quick_6h"
-    assert contract.run_configuration.domain_size_preset == "local_6km"
-    assert contract.run_configuration.output_field_density_preset == "analysis"
+    assert contract.run_configuration.duration == "short_6h"
+    assert contract.run_configuration.domain_size == "local_6km"
+    assert contract.run_configuration.diagnostic_set == "process"
     assert {file.role for file in contract.generated_files} == set(GeneratedFileRole)
     assert contract.cloud_scale_defaults.nx == 64
     assert contract.cloud_scale_defaults.ny == 64
@@ -104,11 +104,11 @@ def test_rendered_namelist_smoke_mode_is_short_package_health_run() -> None:
     contract = build_cm1_input_contract(
         baseline_scenario(),
         run_configuration={
-            "duration_preset": "smoke_1h",
-            "grid_detail_preset": "standard",
-            "domain_size_preset": "local_6km",
-            "output_cadence_preset": "standard_15min",
-            "output_field_density_preset": "core",
+            "duration": "smoke_1h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "local_6km",
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "essential",
         },
     )
     namelist = render_namelist_fragment(contract)
@@ -119,11 +119,11 @@ def test_rendered_namelist_smoke_mode_is_short_package_health_run() -> None:
     )
     assert "timax  = 3600.0," in namelist
     assert "tapfrq =  900.0," in namelist
-    assert "nx           =      64," in namelist
-    assert "ny           =      64," in namelist
+    assert "nx           =      128," in namelist
+    assert "ny           =      128," in namelist
     assert "nz           =      75," in namelist
-    assert "dx     =   100.0," in namelist
-    assert "dy     =   100.0," in namelist
+    assert "dx     =   50.0," in namelist
+    assert "dy     =   50.0," in namelist
     assert "dz     =   40.0," in namelist
     assert "ztop      = 18000.0," in namelist
     assert "zd      =  2500.0," in namelist
@@ -141,11 +141,11 @@ def test_rendered_namelist_explicit_configuration_changes_domain_detail_and_cade
     contract = build_cm1_input_contract(
         baseline_scenario(),
         run_configuration={
-            "duration_preset": "standard_12h",
-            "grid_detail_preset": "fine",
-            "domain_size_preset": "wide_12km",
-            "output_cadence_preset": "detailed_5min",
-            "output_field_density_preset": "rich",
+            "duration": "standard_12h",
+            "horizontal_cell_count": "cells_256",
+            "domain_size": "wide_12km",
+            "output_cadence": "detailed_5min",
+            "diagnostic_set": "full",
         },
     )
     namelist = render_namelist_fragment(contract)

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -66,8 +66,8 @@ def test_dry_run_manifest_and_report_include_golden_path_metadata(tmp_path: Path
     report = json.loads(result.report_path.read_text())
 
     assert manifest.lifecycle_state.value == "packaged"
-    assert manifest.run_configuration["duration_preset"] == "quick_6h"
-    assert manifest.run_configuration["domain_size_preset"] == "local_6km"
+    assert manifest.run_configuration["duration"] == "short_6h"
+    assert manifest.run_configuration["domain_size"] == "local_6km"
     assert manifest.pre_run_validation_report is not None
     assert manifest.pre_run_validation_report["hypothesis_recipe_alignment"]["status"] == "aligned"
     assert manifest.scenario.id == "baseline-shallow-cumulus"
@@ -75,8 +75,8 @@ def test_dry_run_manifest_and_report_include_golden_path_metadata(tmp_path: Path
     assert report["not_a_completed_cm1_result"] is True
     assert report["cm1_was_launched"] is False
     assert report["estimated_cost_or_size"] == (
-        "Configuration cost depends on duration, grid/detail, domain, cadence, "
-        "and output-field density. Review the CM1-facing values before launch."
+        "Configuration cost depends on duration, horizontal cells, domain, cadence, "
+        "and diagnostic set. Review the CM1-facing values before launch."
     )
     assert report["physical_question"] == manifest.physical_question
     assert report["visualization_defaults"]["primary_field"] == "qc"
@@ -116,7 +116,7 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
     assert manifest.observed_sounding is not None
     assert manifest.observed_sounding["station_id"] == "USM00072558"
     assert manifest.observed_sounding["model_bottom_elevation_m_msl"] == pytest.approx(351.5)
-    assert manifest.run_configuration["domain_size_preset"] == "wide_12km"
+    assert manifest.run_configuration["domain_size"] == "wide_12km"
     assert manifest.run_configuration["cm1_values"]["nx"] == 128
     assert manifest.run_configuration["cm1_values"]["runtime_seconds"] == 21600
     assert manifest.pre_run_validation_report is not None
@@ -166,7 +166,7 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
         scenario_data=load_baseline_template(),
         runtime_home=tmp_path,
         run_id="run-deep-convection-trial",
-        package_family="deep_convection_trial",
+        run_recipe="triggered_deep_potential",
         observed_sounding=observed,
         candidate_screening=candidate_screening,
     )
@@ -177,8 +177,8 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
     namelist = (result.package_dir / "namelist.input").read_text()
     sounding = (result.package_dir / "input_sounding").read_text()
 
-    assert manifest.package_family == "deep_convection_trial"
-    assert manifest.package_display_name == "Deep Convection Trial"
+    assert manifest.run_recipe == "triggered_deep_potential"
+    assert manifest.run_recipe_display_name == "Triggered Deep-Potential Experiment"
     assert manifest.input_source == "observed_sounding"
     assert manifest.trigger_type == "warm_bubble"
     assert manifest.trigger_parameters == {
@@ -191,11 +191,11 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
     }
     assert "dbz" in manifest.expected_outputs
     assert "updraft_helicity" in manifest.expected_outputs
-    assert manifest.manual_validation_status == "deep_convection_trial_package_smoke_validated"
+    assert manifest.manual_validation_status == "triggered_deep_potential_recipe_smoke_validated"
     assert any(
-        "Manual smoke evidence applies to the Deep Convection Trial package family" in caveat
+        "Manual smoke evidence applies to the triggered deep-potential recipe" in caveat
         and "each observed sounding remains an experiment" in caveat
-        for caveat in manifest.package_caveats
+        for caveat in manifest.run_caveats
     )
     assert manifest.candidate_screening == candidate_screening
     assert manifest.pre_run_validation_report is not None
@@ -208,26 +208,26 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
     assert manifest.pre_run_validation_report["hypothesis_recipe_alignment"]["status"] == (
         "aligned"
     )
-    assert manifest.run_configuration["duration_preset"] == "quick_6h"
-    assert manifest.run_configuration["domain_size_preset"] == "storm_120km"
-    assert manifest.run_configuration["grid_detail_preset"] == "standard"
-    assert manifest.run_configuration["output_field_density_preset"] == "rich"
-    assert report["package_family"] == "deep_convection_trial"
-    assert report["package_display_name"] == "Deep Convection Trial"
+    assert manifest.run_configuration["duration"] == "short_6h"
+    assert manifest.run_configuration["domain_size"] == "storm_120km"
+    assert manifest.run_configuration["horizontal_cell_count"] == 128
+    assert manifest.run_configuration["diagnostic_set"] == "full"
+    assert report["run_recipe"] == "triggered_deep_potential"
+    assert report["run_recipe_display_name"] == "Triggered Deep-Potential Experiment"
     assert report["trigger_type"] == "warm_bubble"
     assert report["candidate_screening"] == candidate_screening
     assert report["pre_run_validation_report"] == manifest.pre_run_validation_report
     assert "testcase=0" in report["variant_metadata"]["mapping"]
     assert "iinit=3 three-warm-bubble" in report["variant_metadata"]["mapping"]
     assert "reflectivity output" in report["variant_metadata"]["mapping"]
-    assert report["manual_validation_status"] == "deep_convection_trial_package_smoke_validated"
+    assert report["manual_validation_status"] == "triggered_deep_potential_recipe_smoke_validated"
     assert "manual CM1 smoke evidence" in report["cm1_mapping_status"]
     assert "each observed sounding remains an experiment" in report["cm1_mapping_status"]
-    assert case_manifest["package_family"] == "deep_convection_trial"
-    assert case_manifest["contract"]["package_family"] == "deep_convection_trial"
+    assert case_manifest["run_recipe"] == "triggered_deep_potential"
+    assert case_manifest["contract"]["run_recipe"] == "triggered_deep_potential"
     assert (
         case_manifest["contract"]["manual_validation_status"]
-        == "deep_convection_trial_package_smoke_validated"
+        == "triggered_deep_potential_recipe_smoke_validated"
     )
 
     assert "testcase  =  0," in namelist
@@ -243,11 +243,11 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
     assert "output_dbz       = 1," in namelist
     assert "output_vort      = 1," in namelist
     assert "output_uh        = 1," in namelist
-    assert "nx           =      120," in namelist
-    assert "ny           =      120," in namelist
+    assert "nx           =      128," in namelist
+    assert "ny           =      128," in namelist
     assert "nz           =      40," in namelist
-    assert "dx     =   1000.0," in namelist
-    assert "dy     =   1000.0," in namelist
+    assert "dx     =   937.5," in namelist
+    assert "dy     =   937.5," in namelist
     assert "dz     =   500.0," in namelist
     assert "dtl    =   6.000," in namelist
     assert "timax  = 21600.0," in namelist
@@ -272,7 +272,7 @@ def test_deep_convection_trial_requires_observed_sounding(tmp_path: Path) -> Non
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
             run_id="run-deep-no-sounding",
-            package_family="deep_convection_trial",
+            run_recipe="triggered_deep_potential",
         )
 
 
@@ -296,7 +296,7 @@ def test_pre_run_validation_blocks_deep_hypothesis_on_observed_quicklook(
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
             run_id="run-deep-hypothesis-quicklook",
-            package_family="observed_sounding_quicklook",
+            run_recipe="untriggered_observed_evolution",
             observed_sounding=observed,
             candidate_screening=candidate_screening,
         )
@@ -305,7 +305,7 @@ def test_pre_run_validation_blocks_deep_hypothesis_on_observed_quicklook(
     assert report is not None
     assert report["status"] == "blocked"
     assert report["selected_hypothesis"]["story_id"] == "supercell_environment"
-    assert report["selected_run_recipe"]["recipe_id"] == "observed_sounding_quicklook"
+    assert report["selected_run_recipe"]["recipe_id"] == "untriggered_observed_evolution"
     assert report["hypothesis_recipe_alignment"]["status"] == "blocked"
     assert (
         "triggered_deep_potential_warm_bubble_v1"
@@ -315,17 +315,17 @@ def test_pre_run_validation_blocks_deep_hypothesis_on_observed_quicklook(
 
 
 def test_pre_run_validation_blocks_invalid_run_configuration(tmp_path: Path) -> None:
-    with pytest.raises(DryRunPackageError, match="Unknown domain size preset") as excinfo:
+    with pytest.raises(DryRunPackageError, match="Unknown domain size") as excinfo:
         generate_dry_run_package(
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
             run_id="run-invalid-domain",
             run_configuration={
-                "duration_preset": "quick_6h",
-                "grid_detail_preset": "standard",
-                "domain_size_preset": "planetary_9000km",
-                "output_cadence_preset": "standard_15min",
-                "output_field_density_preset": "analysis",
+                "duration": "short_6h",
+                "horizontal_cell_count": "cells_128",
+                "domain_size": "planetary_9000km",
+                "output_cadence": "standard_15min",
+                "diagnostic_set": "process",
             },
         )
 
@@ -333,7 +333,7 @@ def test_pre_run_validation_blocks_invalid_run_configuration(tmp_path: Path) -> 
     assert report is not None
     assert report["status"] == "blocked"
     assert report["run_shape_validation"]["domain"] == "planetary_9000km"
-    assert "Unknown domain size preset" in report["blocking_errors"][0]
+    assert "Unknown domain size" in report["blocking_errors"][0]
     assert not (tmp_path / "runs" / "run-invalid-domain").exists()
 
 
@@ -349,7 +349,7 @@ def test_pre_run_validation_caveats_missing_deep_comparison_outputs(
         scenario_data=load_baseline_template(),
         runtime_home=tmp_path,
         run_id="run-deep-core-output",
-        package_family="deep_convection_trial",
+        run_recipe="triggered_deep_potential",
         observed_sounding=observed,
         candidate_screening={
             "candidate_id": "USM00072558-supercell",
@@ -357,11 +357,11 @@ def test_pre_run_validation_caveats_missing_deep_comparison_outputs(
             "active_story": "supercell_environment",
         },
         run_configuration={
-            "duration_preset": "quick_6h",
-            "grid_detail_preset": "standard",
-            "domain_size_preset": "storm_120km",
-            "output_cadence_preset": "standard_15min",
-            "output_field_density_preset": "core",
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_64",
+            "domain_size": "storm_120km",
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "essential",
         },
     )
 
@@ -392,7 +392,7 @@ def test_deep_convection_trial_requires_observed_wind_components(tmp_path: Path)
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
             run_id="run-deep-no-wind",
-            package_family="deep_convection_trial",
+            run_recipe="triggered_deep_potential",
             observed_sounding=no_wind,
         )
 
@@ -420,7 +420,7 @@ def test_deep_convection_trial_requires_complete_rendered_wind_profile(
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
             run_id="run-deep-partial-wind",
-            package_family="deep_convection_trial",
+            run_recipe="triggered_deep_potential",
             observed_sounding=missing_mid_profile_wind,
         )
 
@@ -499,11 +499,11 @@ def test_dry_run_package_smoke_mode_is_short_package_health_run(tmp_path: Path) 
         runtime_home=tmp_path,
         run_id="run-006",
         run_configuration={
-            "duration_preset": "smoke_1h",
-            "grid_detail_preset": "standard",
-            "domain_size_preset": "local_6km",
-            "output_cadence_preset": "standard_15min",
-            "output_field_density_preset": "core",
+            "duration": "smoke_1h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "local_6km",
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "essential",
         },
     )
     namelist = (result.package_dir / "namelist.input").read_text()
@@ -512,11 +512,11 @@ def test_dry_run_package_smoke_mode_is_short_package_health_run(tmp_path: Path) 
     assert report["run_configuration"]["mode"] == "smoke"
     assert "timax  = 3600.0," in namelist
     assert "tapfrq =  900.0," in namelist
-    assert "nx           =      64," in namelist
-    assert "ny           =      64," in namelist
+    assert "nx           =      128," in namelist
+    assert "ny           =      128," in namelist
     assert "nz           =      75," in namelist
-    assert "dx     =   100.0," in namelist
-    assert "dy     =   100.0," in namelist
+    assert "dx     =   50.0," in namelist
+    assert "dy     =   50.0," in namelist
     assert "dz     =   40.0," in namelist
     assert "ztop      = 18000.0," in namelist
     assert "set_znt    =      0," in namelist
@@ -536,19 +536,19 @@ def test_dry_run_package_explicit_high_detail_configuration_reports_cost(
         runtime_home=tmp_path,
         run_id="run-deep-001",
         run_configuration={
-            "duration_preset": "standard_12h",
-            "grid_detail_preset": "fine",
-            "domain_size_preset": "wide_12km",
-            "output_cadence_preset": "detailed_5min",
-            "output_field_density_preset": "rich",
+            "duration": "standard_12h",
+            "horizontal_cell_count": "cells_256",
+            "domain_size": "wide_12km",
+            "output_cadence": "detailed_5min",
+            "diagnostic_set": "full",
         },
     )
     namelist = (result.package_dir / "namelist.input").read_text()
     report = json.loads(result.report_path.read_text())
     details = report["run_configuration_summary"]
 
-    assert report["run_configuration"]["duration_preset"] == "standard_12h"
-    assert "duration, grid/detail, domain, cadence" in report["estimated_cost_or_size"]
+    assert report["run_configuration"]["duration"] == "standard_12h"
+    assert "duration, horizontal cells, domain, cadence" in report["estimated_cost_or_size"]
     assert details["nx"] == 256
     assert details["ny"] == 256
     assert details["nz"] == 75

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -68,6 +68,8 @@ def test_dry_run_manifest_and_report_include_golden_path_metadata(tmp_path: Path
     assert manifest.lifecycle_state.value == "packaged"
     assert manifest.run_configuration["duration_preset"] == "quick_6h"
     assert manifest.run_configuration["domain_size_preset"] == "local_6km"
+    assert manifest.pre_run_validation_report is not None
+    assert manifest.pre_run_validation_report["hypothesis_recipe_alignment"]["status"] == "aligned"
     assert manifest.scenario.id == "baseline-shallow-cumulus"
     assert "first_cloud_time" in manifest.expected_diagnostics
     assert report["not_a_completed_cm1_result"] is True
@@ -82,6 +84,8 @@ def test_dry_run_manifest_and_report_include_golden_path_metadata(tmp_path: Path
         report["run_configuration"]["configuration_id"]
         == (manifest.run_configuration["configuration_id"])
     )
+    assert report["pre_run_validation_report"] == manifest.pre_run_validation_report
+    assert report["pre_run_validation_report"]["run_shape_validation"]["estimated_frames"] == 25
     summary = report["run_configuration_summary"]
     assert summary["runtime_seconds"] == 21600
     assert summary["output_cadence_seconds"] == 900
@@ -115,6 +119,8 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
     assert manifest.run_configuration["domain_size_preset"] == "wide_12km"
     assert manifest.run_configuration["cm1_values"]["nx"] == 128
     assert manifest.run_configuration["cm1_values"]["runtime_seconds"] == 21600
+    assert manifest.pre_run_validation_report is not None
+    assert manifest.pre_run_validation_report["run_shape_validation"]["domain"] == "wide_12km"
     assert manifest.user.tags == ["compare", "candidate"]
     assert manifest.user.notes == "Compare against humid/rainy candidates."
     assert report["variant_metadata"]["sounding_source"] == "observed_igra_station_text"
@@ -192,6 +198,16 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
         for caveat in manifest.package_caveats
     )
     assert manifest.candidate_screening == candidate_screening
+    assert manifest.pre_run_validation_report is not None
+    assert manifest.pre_run_validation_report["selected_hypothesis"]["story_id"] == (
+        "supercell_environment"
+    )
+    assert manifest.pre_run_validation_report["selected_run_recipe"]["assumption_set_id"] == (
+        "triggered_deep_potential_warm_bubble_v1"
+    )
+    assert manifest.pre_run_validation_report["hypothesis_recipe_alignment"]["status"] == (
+        "aligned"
+    )
     assert manifest.run_configuration["duration_preset"] == "quick_6h"
     assert manifest.run_configuration["domain_size_preset"] == "storm_120km"
     assert manifest.run_configuration["grid_detail_preset"] == "standard"
@@ -200,6 +216,7 @@ def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
     assert report["package_display_name"] == "Deep Convection Trial"
     assert report["trigger_type"] == "warm_bubble"
     assert report["candidate_screening"] == candidate_screening
+    assert report["pre_run_validation_report"] == manifest.pre_run_validation_report
     assert "testcase=0" in report["variant_metadata"]["mapping"]
     assert "iinit=3 three-warm-bubble" in report["variant_metadata"]["mapping"]
     assert "reflectivity output" in report["variant_metadata"]["mapping"]
@@ -257,6 +274,103 @@ def test_deep_convection_trial_requires_observed_sounding(tmp_path: Path) -> Non
             run_id="run-deep-no-sounding",
             package_family="deep_convection_trial",
         )
+
+
+def test_pre_run_validation_blocks_deep_hypothesis_on_observed_quicklook(
+    tmp_path: Path,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    candidate_screening = {
+        "candidate_id": "USM00072558-supercell",
+        "primary_story": "supercell_environment",
+        "active_story": "supercell_environment",
+        "active_story_label": "Supercell-like environment",
+        "rank_score": 93.0,
+    }
+
+    with pytest.raises(DryRunPackageError, match="does not test this deep-convection") as excinfo:
+        generate_dry_run_package(
+            scenario_data=load_baseline_template(),
+            runtime_home=tmp_path,
+            run_id="run-deep-hypothesis-quicklook",
+            package_family="observed_sounding_quicklook",
+            observed_sounding=observed,
+            candidate_screening=candidate_screening,
+        )
+
+    report = excinfo.value.pre_run_validation_report
+    assert report is not None
+    assert report["status"] == "blocked"
+    assert report["selected_hypothesis"]["story_id"] == "supercell_environment"
+    assert report["selected_run_recipe"]["recipe_id"] == "observed_sounding_quicklook"
+    assert report["hypothesis_recipe_alignment"]["status"] == "blocked"
+    assert (
+        "triggered_deep_potential_warm_bubble_v1"
+        in report["hypothesis_recipe_alignment"]["missing_assumptions"]
+    )
+    assert not (tmp_path / "runs" / "run-deep-hypothesis-quicklook").exists()
+
+
+def test_pre_run_validation_blocks_invalid_run_configuration(tmp_path: Path) -> None:
+    with pytest.raises(DryRunPackageError, match="Unknown domain size preset") as excinfo:
+        generate_dry_run_package(
+            scenario_data=load_baseline_template(),
+            runtime_home=tmp_path,
+            run_id="run-invalid-domain",
+            run_configuration={
+                "duration_preset": "quick_6h",
+                "grid_detail_preset": "standard",
+                "domain_size_preset": "planetary_9000km",
+                "output_cadence_preset": "standard_15min",
+                "output_field_density_preset": "analysis",
+            },
+        )
+
+    report = excinfo.value.pre_run_validation_report
+    assert report is not None
+    assert report["status"] == "blocked"
+    assert report["run_shape_validation"]["domain"] == "planetary_9000km"
+    assert "Unknown domain size preset" in report["blocking_errors"][0]
+    assert not (tmp_path / "runs" / "run-invalid-domain").exists()
+
+
+def test_pre_run_validation_caveats_missing_deep_comparison_outputs(
+    tmp_path: Path,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-deep-core-output",
+        package_family="deep_convection_trial",
+        observed_sounding=observed,
+        candidate_screening={
+            "candidate_id": "USM00072558-supercell",
+            "primary_story": "supercell_environment",
+            "active_story": "supercell_environment",
+        },
+        run_configuration={
+            "duration_preset": "quick_6h",
+            "grid_detail_preset": "standard",
+            "domain_size_preset": "storm_120km",
+            "output_cadence_preset": "standard_15min",
+            "output_field_density_preset": "core",
+        },
+    )
+
+    manifest = load_run_manifest(result.manifest_path)
+    report = manifest.pre_run_validation_report
+    assert report is not None
+    assert report["status"] == "caveated"
+    assert "updraft_helicity" in report["output_validation"]["missing_fields"]
+    assert "missing_required_output_field:updraft_helicity" in report["caveats"]
 
 
 def test_deep_convection_trial_requires_observed_wind_components(tmp_path: Path) -> None:

--- a/app/backend/tests/test_output_products.py
+++ b/app/backend/tests/test_output_products.py
@@ -313,7 +313,7 @@ def test_deep_convection_interesting_times_and_unavailable_diagnostics(
         diagnostics=diagnostics,
         output_manifest=manifest,
         variables=["qc", "w", "qr"],
-        package_family="deep_convection_trial",
+        run_recipe="triggered_deep_potential",
     )
 
     records = {record.key: record for record in product.available_interesting_times}
@@ -435,7 +435,7 @@ def test_non_deep_summary_does_not_emit_deep_convection_outcome(
         diagnostics=diagnostics,
         output_manifest=manifest,
         variables=["qc", "w"],
-        package_family="observed_sounding_quicklook",
+        run_recipe="untriggered_observed_evolution",
     )
 
     records = {record.key: record for record in product.available_interesting_times}
@@ -462,7 +462,7 @@ def test_deep_convection_present_but_unsupported_fields_are_caveated(
         diagnostics=diagnostics,
         output_manifest=manifest,
         variables=["qc", "w", "dbz", "th"],
-        package_family="deep_convection_trial",
+        run_recipe="triggered_deep_potential",
     )
 
     availability = {item.key: item for item in product.science_summary.diagnostic_availability}

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -130,6 +130,8 @@ def test_result_card_created_from_ingested_metadata(tmp_path: Path) -> None:
     assert card.scenario_id == "baseline-shallow-cumulus"
     assert card.run_configuration["duration_preset"] == "quick_6h"
     assert card.run_configuration["domain_size_preset"] == "local_6km"
+    assert card.pre_run_validation_report is not None
+    assert card.pre_run_validation_report["selected_run_recipe"]["recipe_id"] == "shallow_cumulus"
     assert card.physical_question
     assert card.diagnostics_summary == (
         "cloud formed; rain water aloft detected; surface rain reached ground; "

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -128,10 +128,12 @@ def test_result_card_created_from_ingested_metadata(tmp_path: Path) -> None:
     assert card.run_id == "run-card"
     assert card.name == "baseline-shallow-cumulus"
     assert card.scenario_id == "baseline-shallow-cumulus"
-    assert card.run_configuration["duration_preset"] == "quick_6h"
-    assert card.run_configuration["domain_size_preset"] == "local_6km"
+    assert card.run_configuration["duration"] == "short_6h"
+    assert card.run_configuration["domain_size"] == "local_6km"
     assert card.pre_run_validation_report is not None
-    assert card.pre_run_validation_report["selected_run_recipe"]["recipe_id"] == "shallow_cumulus"
+    assert card.pre_run_validation_report["selected_run_recipe"]["recipe_id"] == (
+        "generated_reference_lower_atmosphere"
+    )
     assert card.physical_question
     assert card.diagnostics_summary == (
         "cloud formed; rain water aloft detected; surface rain reached ground; "
@@ -199,9 +201,9 @@ def test_result_card_exposes_observed_sounding_source(tmp_path: Path) -> None:
 
     card = get_result_card(settings, result_id)
 
-    assert card.name == "Uploaded Sounding — Valley, Nebraska"
+    assert card.name == "Untriggered Observed Evolution — Valley, Nebraska"
     assert card.scenario_id == "baseline-shallow-cumulus"
-    assert card.scenario_name == "Uploaded Sounding"
+    assert card.scenario_name == "Untriggered Observed Evolution"
     assert card.input_source == "observed_sounding"
     assert card.input_source_label == "Observed sounding: USM00072558 · Valley, Nebraska"
     assert card.observed_sounding is not None
@@ -226,8 +228,8 @@ def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: 
                 "primary_story": "supercell_environment",
                 "rank_score": 93.0,
             },
-            "package_family": "deep_convection_trial",
-            "package_display_name": "Deep Convection Trial",
+            "run_recipe": "triggered_deep_potential",
+            "run_recipe_display_name": "Triggered Deep-Potential Experiment",
             "input_source": "observed_sounding",
             "trigger_type": "warm_bubble",
             "trigger_parameters": {
@@ -236,33 +238,36 @@ def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: 
                 "raw_controls_exposed": False,
             },
             "expected_outputs": ["qc", "qr", "w", "dbz", "updraft_helicity"],
-            "package_caveats": [
-                "Deep Convection Trial uses an idealized CM1 three-warm-bubble trigger."
+            "run_caveats": [
+                (
+                    "Triggered Deep-Potential Experiment uses an idealized CM1 "
+                    "three-warm-bubble trigger."
+                )
             ],
-            "manual_validation_status": "deep_convection_trial_package_smoke_validated",
+            "manual_validation_status": "triggered_deep_potential_recipe_smoke_validated",
         },
     )
 
     card = get_result_card(settings, result_id)
 
-    assert card.name == "Deep Convection Trial — Norman, Oklahoma"
-    assert card.scenario_name == "Deep Convection Trial"
-    assert card.package_family == "deep_convection_trial"
-    assert card.package_display_name == "Deep Convection Trial"
+    assert card.name == "Triggered Deep-Potential Experiment — Norman, Oklahoma"
+    assert card.scenario_name == "Triggered Deep-Potential Experiment"
+    assert card.run_recipe == "triggered_deep_potential"
+    assert card.run_recipe_display_name == "Triggered Deep-Potential Experiment"
     assert card.trigger_type == "warm_bubble"
     assert card.trigger_parameters is not None
     assert card.trigger_parameters["cm1_iinit"] == 3
     assert "dbz" in card.expected_outputs
-    assert card.package_caveats == [
-        "Deep Convection Trial uses an idealized CM1 three-warm-bubble trigger."
+    assert card.run_caveats == [
+        "Triggered Deep-Potential Experiment uses an idealized CM1 three-warm-bubble trigger."
     ]
-    assert card.manual_validation_status == "deep_convection_trial_package_smoke_validated"
-    assert "package_family:deep_convection_trial" in card.provenance_labels
+    assert card.manual_validation_status == "triggered_deep_potential_recipe_smoke_validated"
+    assert "run_recipe:triggered_deep_potential" in card.provenance_labels
     assert card.candidate_screening is not None
     assert card.candidate_screening["primary_story"] == "supercell_environment"
     assert card.candidate_hypothesis_comparison is not None
     assert card.candidate_hypothesis_comparison.screened_as == "Supercell-like environment"
-    assert card.candidate_hypothesis_comparison.ran_as == "Deep Convection Trial"
+    assert card.candidate_hypothesis_comparison.ran_as == "Triggered Deep-Potential Experiment"
     assert card.candidate_hypothesis_comparison.match_status == "did_not_match"
 
 

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -199,6 +199,8 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
     assert result.physical_question
     assert result.run_configuration["duration_preset"] == "quick_6h"
     assert result.run_configuration["cm1_values"]["expected_output_frames"] == 25
+    assert result.pre_run_validation_report is not None
+    assert result.pre_run_validation_report["run_shape_validation"]["estimated_frames"] == 25
     assert result.source_lifecycle_state == "completed"
     assert result.source_product_state == "completed_cm1_result"
     assert result.source_model == "CM1"

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -197,7 +197,7 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
     assert result.run_id == "run-ingest"
     assert result.scenario_id == "baseline-shallow-cumulus"
     assert result.physical_question
-    assert result.run_configuration["duration_preset"] == "quick_6h"
+    assert result.run_configuration["duration"] == "short_6h"
     assert result.run_configuration["cm1_values"]["expected_output_frames"] == 25
     assert result.pre_run_validation_report is not None
     assert result.pre_run_validation_report["run_shape_validation"]["estimated_frames"] == 25
@@ -401,12 +401,12 @@ def test_ingests_deep_convection_candidate_outcome_comparison(tmp_path: Path) ->
         manifest.model_copy(
             update={
                 "candidate_screening": candidate_screening,
-                "package_family": "deep_convection_trial",
-                "package_display_name": "Deep Convection Trial",
+                "run_recipe": "triggered_deep_potential",
+                "run_recipe_display_name": "Triggered Deep-Potential Experiment",
                 "input_source": "observed_sounding",
                 "trigger_type": "warm_bubble",
                 "expected_outputs": ["qc", "qr", "w", "dbz", "updraft_helicity"],
-                "manual_validation_status": "deep_convection_trial_package_smoke_validated",
+                "manual_validation_status": "triggered_deep_potential_recipe_smoke_validated",
             }
         ),
     )
@@ -421,7 +421,7 @@ def test_ingests_deep_convection_candidate_outcome_comparison(tmp_path: Path) ->
     assert result.science_summary.default_explore_time_seconds == 900.0
     assert result.candidate_hypothesis_comparison is not None
     assert result.candidate_hypothesis_comparison.screened_as == "Supercell-like environment"
-    assert result.candidate_hypothesis_comparison.ran_as == "Deep Convection Trial"
+    assert result.candidate_hypothesis_comparison.ran_as == "Triggered Deep-Potential Experiment"
     assert result.candidate_hypothesis_comparison.match_status == "matched"
     assert result.candidate_hypothesis_comparison.cm1_outcome == (
         "Deep convection formed with strong updraft and rain water aloft."
@@ -459,8 +459,8 @@ def test_non_deep_candidate_comparison_does_not_use_deep_outcome_language(
         manifest.model_copy(
             update={
                 "candidate_screening": candidate_screening,
-                "package_family": "observed_sounding_quicklook",
-                "package_display_name": "Observed Sounding Quick Look",
+                "run_recipe": "untriggered_observed_evolution",
+                "run_recipe_display_name": "Untriggered Observed Evolution",
                 "input_source": "observed_sounding",
             }
         ),
@@ -473,10 +473,10 @@ def test_non_deep_candidate_comparison_does_not_use_deep_outcome_language(
     assert result.candidate_hypothesis_comparison is not None
     assert result.candidate_hypothesis_comparison.match_status == "unable_to_evaluate"
     assert result.candidate_hypothesis_comparison.cm1_outcome == (
-        "Unable to evaluate candidate match because this was not a Deep Convection Trial package."
+        "Unable to evaluate candidate match because this was not a triggered deep-potential run."
     )
     assert "Trigger failed" not in result.candidate_hypothesis_comparison.cm1_outcome
-    assert "comparison_requires_deep_convection_trial_package" in (
+    assert "comparison_requires_triggered_deep_potential_run" in (
         result.candidate_hypothesis_comparison.caveats
     )
 

--- a/app/backend/tests/test_run_manifest.py
+++ b/app/backend/tests/test_run_manifest.py
@@ -23,12 +23,12 @@ def valid_manifest_data() -> dict[str, object]:
         },
         "controls": {"low_level_humidity": "baseline", "surface_heating": "baseline"},
         "run_configuration": {
-            "configuration_id": "quick_6h__standard__local_6km__standard_15min__analysis",
-            "duration_preset": "quick_6h",
-            "domain_size_preset": "local_6km",
-            "grid_detail_preset": "standard",
-            "output_cadence_preset": "standard_15min",
-            "output_field_density_preset": "analysis",
+            "configuration_id": "short_6h__cells_64__local_6km__standard_15min__process",
+            "duration": "short_6h",
+            "domain_size": "local_6km",
+            "horizontal_cell_count": 64,
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "process",
             "cm1_values": {
                 "runtime_seconds": 21600,
                 "output_cadence_seconds": 900,

--- a/app/backend/tests/test_runtime_storage.py
+++ b/app/backend/tests/test_runtime_storage.py
@@ -203,7 +203,7 @@ def test_inventory_classifies_valid_manifest_with_output_artifacts(tmp_path: Pat
     assert entry.validation_status == "valid"
     assert entry.product_state == "completed_cm1_result"
     assert entry.run_configuration is not None
-    assert entry.run_configuration["duration_preset"] == "quick_6h"
+    assert entry.run_configuration["duration"] == "short_6h"
     assert entry.pre_run_validation_report is not None
     assert entry.pre_run_validation_report["status"] in {"valid", "caveated"}
     assert entry.output_artifact_count == 2

--- a/app/backend/tests/test_runtime_storage.py
+++ b/app/backend/tests/test_runtime_storage.py
@@ -204,6 +204,8 @@ def test_inventory_classifies_valid_manifest_with_output_artifacts(tmp_path: Pat
     assert entry.product_state == "completed_cm1_result"
     assert entry.run_configuration is not None
     assert entry.run_configuration["duration_preset"] == "quick_6h"
+    assert entry.pre_run_validation_report is not None
+    assert entry.pre_run_validation_report["status"] in {"valid", "caveated"}
     assert entry.output_artifact_count == 2
     assert entry.output_summary["raw_cm1_artifacts"] == 2
 

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -263,7 +263,7 @@ def test_observed_wind_available_requires_complete_finite_profile() -> None:
     assert features["observed_wind_available"] is False
     supercell = next(score for score in scores if score.story == "supercell_environment")
     assert supercell.support == "unavailable"
-    assert "observed_wind_required_for_deep_convection_trial" in supercell.caveats
+    assert "observed_wind_required_for_triggered_deep_potential" in supercell.caveats
 
 
 def test_screen_cached_soundings_can_target_one_story(tmp_path: Path) -> None:
@@ -886,7 +886,7 @@ def test_deep_convection_scoring_penalizes_profiles_that_start_well_above_surfac
 
     severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
     assert severe.support == "unavailable"
-    assert "lowest_usable_level_too_high_for_deep_convection_trial" in severe.caveats
+    assert "lowest_usable_level_too_high_for_triggered_deep_potential" in severe.caveats
 
 
 def test_deep_convection_scoring_requires_observed_wind_support() -> None:
@@ -930,7 +930,7 @@ def test_deep_convection_scoring_requires_observed_wind_support() -> None:
     severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
     assert supercell.support == "unavailable"
     assert severe.support == "unavailable"
-    assert "observed_wind_required_for_deep_convection_trial" in supercell.caveats
+    assert "observed_wind_required_for_triggered_deep_potential" in supercell.caveats
 
 
 def test_story_scores_and_evidence_are_traceable_to_soundings() -> None:

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -1201,8 +1201,8 @@ def test_deep_convection_view_defaults_prefer_updraft_field(tmp_path: Path) -> N
         tmp_path,
         run_id="run-deep-visualization",
         package_updates={
-            "package_family": "deep_convection_trial",
-            "package_display_name": "Deep Convection Trial",
+            "run_recipe": "triggered_deep_potential",
+            "run_recipe_display_name": "Triggered Deep-Potential Experiment",
         },
     )
 

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -1,18 +1,18 @@
 import type { Page, Route } from "@playwright/test";
 
 const defaultRunConfiguration = {
-  configuration_id: "quick_6h__standard__local_6km__standard_15min__analysis",
+  configuration_id: "short_6h__cells_64__local_6km__standard_15min__process",
   mode: "science",
-  label: "Quick science; Local 6 km; Standard; Standard 15 min",
-  duration_preset: "quick_6h",
+  label: "Short evolution; Local 6 km; Scout 64 x 64; 100 m dx/dy; Standard 15 min",
+  duration: "short_6h",
   duration_seconds: 21600,
-  grid_detail_preset: "standard",
-  domain_size_preset: "local_6km",
-  output_cadence_preset: "standard_15min",
+  horizontal_cell_count: 64,
+  domain_size: "local_6km",
+  output_cadence: "standard_15min",
   output_cadence_seconds: 900,
-  output_field_density_preset: "analysis",
+  diagnostic_set: "process",
   cost_runtime_summary: "6 h model time, 307,200 cells, 15 min saved-output cadence",
-  output_volume_summary: "25 saved frames, analysis output fields, 307,200 cells per frame",
+  output_volume_summary: "25 saved frames, process diagnostics, 307,200 cells per frame",
   cm1_values: {
     nx: 64,
     ny: 64,
@@ -38,11 +38,11 @@ const defaultRunConfigurationSummary = {
   configuration_id: defaultRunConfiguration.configuration_id,
   mode: defaultRunConfiguration.mode,
   label: defaultRunConfiguration.label,
-  duration_preset: defaultRunConfiguration.duration_preset,
-  grid_detail_preset: defaultRunConfiguration.grid_detail_preset,
-  domain_size_preset: defaultRunConfiguration.domain_size_preset,
-  output_cadence_preset: defaultRunConfiguration.output_cadence_preset,
-  output_field_density_preset: defaultRunConfiguration.output_field_density_preset,
+  duration: defaultRunConfiguration.duration,
+  horizontal_cell_count: defaultRunConfiguration.horizontal_cell_count,
+  domain_size: defaultRunConfiguration.domain_size,
+  output_cadence: defaultRunConfiguration.output_cadence,
+  diagnostic_set: defaultRunConfiguration.diagnostic_set,
   runtime_seconds: 21600,
   output_cadence_seconds: 900,
   expected_output_frames: 25,
@@ -62,9 +62,9 @@ const defaultRunConfigurationSummary = {
   estimated_compute_multiplier_vs_default: 1,
   estimated_output_volume_multiplier_vs_default: 1,
   cost_warning:
-    "Configuration cost depends on duration, grid/detail, domain, cadence, and output-field density. Review the CM1-facing values before launch.",
+    "Configuration cost depends on duration, horizontal cell count, domain, cadence, and diagnostic set. Review the CM1-facing values before launch.",
   validation_note:
-    "Run configuration preserves explicit duration, grid/detail, domain, cadence, and output-density choices.",
+    "Run configuration preserves explicit duration, horizontal cell count, domain, cadence, and diagnostic-set choices.",
 };
 
 const defaultPreRunValidationReport = {
@@ -82,8 +82,8 @@ const defaultPreRunValidationReport = {
     predicted_output_signature: [],
   },
   selected_run_recipe: {
-    recipe_id: "shallow_cumulus",
-    display_name: "Baseline Shallow Cumulus",
+    recipe_id: "generated_reference_lower_atmosphere",
+    display_name: "Generated Lower-Atmosphere Reference",
     assumption_set_id: "generated_reference_lower_atmosphere_v1",
   },
   hypothesis_recipe_alignment: {
@@ -93,13 +93,14 @@ const defaultPreRunValidationReport = {
     missing_outputs: [],
   },
   run_shape_validation: {
-    duration: "quick_6h",
+    duration: "short_6h",
     duration_seconds: 21600,
     domain: "local_6km",
-    grid_detail: "standard",
+    horizontal_cell_count: 64,
     output_cadence: "standard_15min",
+    diagnostic_set: "process",
     estimated_frames: 25,
-    estimated_output_volume: "25 saved frames, analysis output fields, 307,200 cells per frame",
+    estimated_output_volume: "25 saved frames, process diagnostics, 307,200 cells per frame",
   },
   output_validation: {
     required_fields: ["qc", "w"],

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -67,6 +67,49 @@ const defaultRunConfigurationSummary = {
     "Run configuration preserves explicit duration, grid/detail, domain, cadence, and output-density choices.",
 };
 
+const defaultPreRunValidationReport = {
+  status: "caveated",
+  selected_candidate: {
+    candidate_id: null,
+    station_id: null,
+    valid_time_utc: null,
+  },
+  selected_hypothesis: {
+    hypothesis_id: null,
+    story_id: null,
+    story_label: null,
+    ingredient_score: null,
+    predicted_output_signature: [],
+  },
+  selected_run_recipe: {
+    recipe_id: "shallow_cumulus",
+    display_name: "Baseline Shallow Cumulus",
+    assumption_set_id: "generated_reference_lower_atmosphere_v1",
+  },
+  hypothesis_recipe_alignment: {
+    status: "aligned",
+    reasons: ["No selected candidate hypothesis; validating the run configuration only."],
+    missing_assumptions: [],
+    missing_outputs: [],
+  },
+  run_shape_validation: {
+    duration: "quick_6h",
+    duration_seconds: 21600,
+    domain: "local_6km",
+    grid_detail: "standard",
+    output_cadence: "standard_15min",
+    estimated_frames: 25,
+    estimated_output_volume: "25 saved frames, analysis output fields, 307,200 cells per frame",
+  },
+  output_validation: {
+    required_fields: ["qc", "w"],
+    enabled_fields: ["qc", "qr", "qv", "th", "prs", "u", "v", "w", "rain", "dbz"],
+    missing_fields: [],
+  },
+  blocking_errors: [],
+  caveats: ["science_run_configuration_minimum_duration_6h"],
+};
+
 const scenario = {
   id: "baseline-shallow-cumulus",
   display_name: "Baseline Shallow Cumulus",
@@ -1349,6 +1392,7 @@ export async function mockCloudChamberApis(page: Page) {
         },
         run_configuration: defaultRunConfiguration,
         run_configuration_summary: defaultRunConfigurationSummary,
+        pre_run_validation_report: defaultPreRunValidationReport,
         estimated_cost_or_size: "unknown until validated",
         expected_diagnostics: ["first cloud time", "max qc", "max w"],
         visualization_defaults: {},

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -221,7 +221,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     ).toBeVisible();
     await page.getByRole("button", { name: "Delete result and local run data", exact: true }).click();
     await expect(
-      resultDetail.getByRole("status").filter({ hasText: /Result and local run data deleted/ }),
+      page.getByRole("status").filter({ hasText: /Result and local run data deleted/ }),
     ).toBeVisible();
     await expect(page.getByLabel("Results list").getByText("Baseline Shallow Cumulus — Quick Look")).toHaveCount(0);
 

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -160,7 +160,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(resultsList).toBeVisible();
     await expect(page.getByText("Baseline Shallow Cumulus — Quick Look").first()).toBeVisible();
     await expect(
-      resultsList.getByText(/Cloud water formed in the validated quick-look baseline/i),
+      resultsList.getByText(/Cloud water formed in the validated reference baseline/i),
     ).toBeVisible();
     await expect(resultsList.getByText("Cloud formed").first()).toBeVisible();
     await expect(resultsList.getByText("Rain water aloft detected").first()).toBeVisible();
@@ -256,7 +256,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(resultsList).toBeVisible();
     await expect(page.getByText("Baseline Shallow Cumulus — Quick Look").first()).toBeVisible();
     await expect(
-      resultsList.getByText(/Cloud water formed in the validated quick-look baseline/i),
+      resultsList.getByText(/Cloud water formed in the validated reference baseline/i),
     ).toBeVisible();
     await expect(page.getByLabel("Result detail")).toBeVisible();
     await expect(page.getByRole("button", { name: "Open in Explore" }).first()).toBeVisible();

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -71,6 +71,66 @@ const defaultRunConfigurationSummary = {
     "Run configuration preserves explicit duration, grid/detail, domain, cadence, and output-density choices.",
 };
 
+const defaultPreRunValidationReport = {
+  status: "caveated",
+  selected_candidate: {
+    candidate_id: null,
+    station_id: null,
+    valid_time_utc: null,
+  },
+  selected_hypothesis: {
+    hypothesis_id: null,
+    story_id: null,
+    story_label: null,
+    ingredient_score: null,
+    predicted_output_signature: [],
+  },
+  selected_run_recipe: {
+    recipe_id: "shallow_cumulus",
+    display_name: "Baseline Shallow Cumulus",
+    assumption_set_id: "generated_reference_lower_atmosphere_v1",
+  },
+  hypothesis_recipe_alignment: {
+    status: "aligned",
+    reasons: ["No selected candidate hypothesis; validating the run configuration only."],
+    missing_assumptions: [],
+    missing_outputs: [],
+  },
+  run_shape_validation: {
+    duration: "quick_6h",
+    duration_seconds: 21600,
+    domain: "local_6km",
+    domain_x_km: 6.4,
+    domain_y_km: 6.4,
+    model_top: 18000,
+    grid_detail: "standard",
+    dx_m: 100,
+    dy_m: 100,
+    output_cadence: "standard_15min",
+    output_cadence_seconds: 900,
+    estimated_frames: 25,
+    estimated_output_volume: "25 saved frames, analysis output fields, 307,200 cells per frame",
+  },
+  forcing_validation: {
+    trigger: "none",
+    surface_fluxes: "current_recipe_default",
+    radiation: "disabled_or_future",
+    large_scale_forcing: "not_supported_v1",
+  },
+  output_validation: {
+    required_fields: ["qc", "w"],
+    enabled_fields: ["qc", "qr", "qv", "th", "prs", "u", "v", "w", "rain", "dbz"],
+    missing_fields: [],
+  },
+  runtime_file_validation: {
+    required_files: ["LANDUSE.TBL"],
+    staging_status: "checked_at_launch",
+    caveats: ["external_runtime_files_are_not_committed"],
+  },
+  blocking_errors: [],
+  caveats: ["science_run_configuration_minimum_duration_6h"],
+};
+
 const highDetailRunConfiguration = {
   ...defaultRunConfiguration,
   configuration_id: "standard_12h__fine__wide_12km__detailed_5min__rich",
@@ -161,6 +221,7 @@ const dryRunResponse = {
     estimated_cost_or_size: "unknown until validated",
     run_configuration: defaultRunConfiguration,
     run_configuration_summary: defaultRunConfigurationSummary,
+    pre_run_validation_report: defaultPreRunValidationReport,
     expected_diagnostics: ["first_cloud_time", "cloud_water_summary"],
     observed_sounding: null,
     candidate_screening: null,
@@ -319,12 +380,75 @@ function dryRunResponseForRequest(init?: RequestInit) {
       package_family: body.package_family ?? undefined,
       observed_sounding: body.observed_sounding ?? null,
       candidate_screening: body.candidate_screening ?? null,
+      pre_run_validation_report: preRunValidationReportForRequest(body),
       user: {
         name: body.user_name ?? "Baseline Shallow Cumulus",
         tags: body.user_tags ?? [],
         notes: body.user_notes ?? null,
         saved: false,
       },
+    },
+  };
+}
+
+function preRunValidationReportForRequest(body: {
+  package_family?: string | null;
+  observed_sounding?: Record<string, unknown> | null;
+  candidate_screening?: Record<string, unknown> | null;
+}) {
+  const packageFamily =
+    body.package_family ?? (body.observed_sounding ? "observed_sounding_quicklook" : "shallow_cumulus");
+  const deep = packageFamily === "deep_convection_trial";
+  const activeStory =
+    typeof body.candidate_screening?.active_story === "string"
+      ? body.candidate_screening.active_story
+      : typeof body.candidate_screening?.primary_story === "string"
+        ? body.candidate_screening.primary_story
+        : null;
+  const activeLabel =
+    typeof body.candidate_screening?.active_story_label === "string"
+      ? body.candidate_screening.active_story_label
+      : typeof body.candidate_screening?.primary_story_label === "string"
+        ? body.candidate_screening.primary_story_label
+        : null;
+  return {
+    ...defaultPreRunValidationReport,
+    selected_candidate: {
+      candidate_id:
+        typeof body.candidate_screening?.candidate_id === "string"
+          ? body.candidate_screening.candidate_id
+          : null,
+      station_id:
+        typeof body.observed_sounding?.station_id === "string"
+          ? body.observed_sounding.station_id
+          : null,
+      valid_time_utc:
+        typeof body.observed_sounding?.valid_time_utc === "string"
+          ? body.observed_sounding.valid_time_utc
+          : null,
+    },
+    selected_hypothesis: {
+      hypothesis_id: activeStory,
+      story_id: activeStory,
+      story_label: activeLabel,
+      ingredient_score:
+        typeof body.candidate_screening?.rank_score === "number"
+          ? body.candidate_screening.rank_score
+          : null,
+      predicted_output_signature: deep ? ["deep_cloud", "strong_updraft"] : [],
+    },
+    selected_run_recipe: {
+      recipe_id: packageFamily,
+      display_name: deep
+        ? "Deep Convection Trial"
+        : packageFamily === "observed_sounding_quicklook"
+          ? "Observed Sounding Quick Look"
+          : "Baseline Shallow Cumulus",
+      assumption_set_id: deep
+        ? "triggered_deep_potential_warm_bubble_v1"
+        : packageFamily === "observed_sounding_quicklook"
+          ? "normal_evolution_current_observed_sounding_v1"
+          : "generated_reference_lower_atmosphere_v1",
     },
   };
 }
@@ -3507,11 +3631,87 @@ describe("App", () => {
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
     const packageReview = await screen.findByTestId("package-review-panel");
+    expect(packageReview).toHaveTextContent("Pre-run validation");
+    expect(packageReview).toHaveTextContent("Valid with caveats");
+    expect(packageReview).toHaveTextContent("generated_reference_lower_atmosphere_v1");
     expect(packageReview).toHaveTextContent("256 x 256 x 75");
     expect(packageReview).toHaveTextContent("dx/dy 50 m");
     expect(packageReview).toHaveTextContent("300 s output");
     expect(packageReview).toHaveTextContent("145 saved frames");
     expect(packageReview).toHaveTextContent("92.8x output volume");
+  });
+
+  it("shows blocked pre-run validation details when package creation is refused", async () => {
+    const blockedReport = {
+      ...defaultPreRunValidationReport,
+      status: "blocked",
+      selected_hypothesis: {
+        hypothesis_id: "supercell_environment",
+        story_id: "supercell_environment",
+        story_label: "Supercell-like environment",
+        ingredient_score: 93,
+        predicted_output_signature: ["deep_cloud", "strong_updraft"],
+      },
+      selected_run_recipe: {
+        recipe_id: "observed_sounding_quicklook",
+        display_name: "Observed Sounding Quick Look",
+        assumption_set_id: "normal_evolution_current_observed_sounding_v1",
+      },
+      hypothesis_recipe_alignment: {
+        status: "blocked",
+        reasons: ["Deep-convection hypothesis is paired with an untriggered/shallow recipe."],
+        missing_assumptions: ["triggered_deep_potential_warm_bubble_v1"],
+        missing_outputs: [],
+      },
+      blocking_errors: [
+        "Selected run recipe does not test this deep-convection hypothesis.",
+      ],
+      caveats: [],
+    };
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/dry-run-package") {
+        expect(init?.body).toEqual(expect.stringContaining("baseline-shallow-cumulus"));
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              detail: {
+                message:
+                  "Pre-run validation blocked package creation: Selected run recipe does not test this deep-convection hypothesis.",
+                pre_run_validation_report: blockedReport,
+              },
+            }),
+            { status: 400 },
+          ),
+        );
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(new Response(JSON.stringify(resultsResponse), { status: 200 }));
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.click(await screen.findByTestId("create-package-btn"));
+
+    expect(await screen.findByText(/Pre-run validation blocked package creation/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Pre-run validation report")).toHaveTextContent("Blocked");
+    expect(screen.getByLabelText("Pre-run validation report")).toHaveTextContent(
+      "Selected run recipe does not test this deep-convection hypothesis.",
+    );
+    expect(screen.getByLabelText("Pre-run validation report")).toHaveTextContent(
+      "triggered_deep_potential_warm_bubble_v1",
+    );
   });
 
   it("shows an explicit loading state before scenario package controls are available", async () => {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -5,18 +5,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 
 const defaultRunConfiguration = {
-  configuration_id: "quick_6h__standard__local_6km__standard_15min__analysis",
+  configuration_id: "short_6h__cells_64__local_6km__standard_15min__process",
   mode: "science",
-  label: "Quick science; Local 6 km; Standard; Standard 15 min",
-  duration_preset: "quick_6h",
+  label: "Short evolution; Local 6 km; Scout 64 x 64; 100 m dx/dy; Standard 15 min",
+  duration: "short_6h",
   duration_seconds: 21600,
-  grid_detail_preset: "standard",
-  domain_size_preset: "local_6km",
-  output_cadence_preset: "standard_15min",
+  horizontal_cell_count: 64,
+  domain_size: "local_6km",
+  output_cadence: "standard_15min",
   output_cadence_seconds: 900,
-  output_field_density_preset: "analysis",
+  diagnostic_set: "process",
   cost_runtime_summary: "6 h model time, 307,200 cells, 15 min saved-output cadence",
-  output_volume_summary: "25 saved frames, analysis output fields, 307,200 cells per frame",
+  output_volume_summary: "25 saved frames, process diagnostics, 307,200 cells per frame",
   cm1_values: {
     nx: 64,
     ny: 64,
@@ -42,11 +42,11 @@ const defaultRunConfigurationSummary = {
   configuration_id: defaultRunConfiguration.configuration_id,
   mode: defaultRunConfiguration.mode,
   label: defaultRunConfiguration.label,
-  duration_preset: defaultRunConfiguration.duration_preset,
-  grid_detail_preset: defaultRunConfiguration.grid_detail_preset,
-  domain_size_preset: defaultRunConfiguration.domain_size_preset,
-  output_cadence_preset: defaultRunConfiguration.output_cadence_preset,
-  output_field_density_preset: defaultRunConfiguration.output_field_density_preset,
+  duration: defaultRunConfiguration.duration,
+  horizontal_cell_count: defaultRunConfiguration.horizontal_cell_count,
+  domain_size: defaultRunConfiguration.domain_size,
+  output_cadence: defaultRunConfiguration.output_cadence,
+  diagnostic_set: defaultRunConfiguration.diagnostic_set,
   runtime_seconds: 21600,
   output_cadence_seconds: 900,
   expected_output_frames: 25,
@@ -66,9 +66,9 @@ const defaultRunConfigurationSummary = {
   estimated_compute_multiplier_vs_default: 1,
   estimated_output_volume_multiplier_vs_default: 1,
   cost_warning:
-    "Configuration cost depends on duration, grid/detail, domain, cadence, and output-field density. Review the CM1-facing values before launch.",
+    "Configuration cost depends on duration, horizontal cell count, domain, cadence, and diagnostic set. Review the CM1-facing values before launch.",
   validation_note:
-    "Run configuration preserves explicit duration, grid/detail, domain, cadence, and output-density choices.",
+    "Run configuration preserves explicit duration, horizontal cell count, domain, cadence, and diagnostic-set choices.",
 };
 
 const defaultPreRunValidationReport = {
@@ -86,8 +86,8 @@ const defaultPreRunValidationReport = {
     predicted_output_signature: [],
   },
   selected_run_recipe: {
-    recipe_id: "shallow_cumulus",
-    display_name: "Baseline Shallow Cumulus",
+    recipe_id: "generated_reference_lower_atmosphere",
+    display_name: "Generated Lower-Atmosphere Reference",
     assumption_set_id: "generated_reference_lower_atmosphere_v1",
   },
   hypothesis_recipe_alignment: {
@@ -97,19 +97,20 @@ const defaultPreRunValidationReport = {
     missing_outputs: [],
   },
   run_shape_validation: {
-    duration: "quick_6h",
+    duration: "short_6h",
     duration_seconds: 21600,
     domain: "local_6km",
     domain_x_km: 6.4,
     domain_y_km: 6.4,
     model_top: 18000,
-    grid_detail: "standard",
+    horizontal_cell_count: 64,
     dx_m: 100,
     dy_m: 100,
     output_cadence: "standard_15min",
     output_cadence_seconds: 900,
+    diagnostic_set: "process",
     estimated_frames: 25,
-    estimated_output_volume: "25 saved frames, analysis output fields, 307,200 cells per frame",
+    estimated_output_volume: "25 saved frames, process diagnostics, 307,200 cells per frame",
   },
   forcing_validation: {
     trigger: "none",
@@ -133,17 +134,17 @@ const defaultPreRunValidationReport = {
 
 const highDetailRunConfiguration = {
   ...defaultRunConfiguration,
-  configuration_id: "standard_12h__fine__wide_12km__detailed_5min__rich",
-  label: "Standard science; Wide 12 km; Fine; Detailed 5 min",
-  duration_preset: "standard_12h",
+  configuration_id: "standard_12h__cells_256__wide_12km__detailed_5min__full",
+  label: "Standard evolution; Wide 12 km; High detail 256 x 256; 50 m dx/dy; Detailed 5 min",
+  duration: "standard_12h",
   duration_seconds: 43200,
-  grid_detail_preset: "fine",
-  domain_size_preset: "wide_12km",
-  output_cadence_preset: "detailed_5min",
+  horizontal_cell_count: 256,
+  domain_size: "wide_12km",
+  output_cadence: "detailed_5min",
   output_cadence_seconds: 300,
-  output_field_density_preset: "rich",
+  diagnostic_set: "full",
   cost_runtime_summary: "12 h model time, 4,915,200 cells, 5 min saved-output cadence",
-  output_volume_summary: "145 saved frames, rich output fields, 4,915,200 cells per frame",
+  output_volume_summary: "145 saved frames, full diagnostics, 4,915,200 cells per frame",
   cm1_values: {
     ...defaultRunConfiguration.cm1_values,
     nx: 256,
@@ -255,16 +256,16 @@ const deepDryRunResponse = {
     ...dryRunResponse.report,
     run_configuration: highDetailRunConfiguration,
     estimated_cost_or_size:
-      "Configuration cost depends on duration, grid/detail, domain, cadence, and output-field density. Review the CM1-facing values before launch.",
+      "Configuration cost depends on duration, horizontal cell count, domain, cadence, and diagnostic set. Review the CM1-facing values before launch.",
     run_configuration_summary: {
       ...defaultRunConfigurationSummary,
       configuration_id: highDetailRunConfiguration.configuration_id,
       label: highDetailRunConfiguration.label,
-      duration_preset: "standard_12h",
-      grid_detail_preset: "fine",
-      domain_size_preset: "wide_12km",
-      output_cadence_preset: "detailed_5min",
-      output_field_density_preset: "rich",
+      duration: "standard_12h",
+      horizontal_cell_count: 256,
+      domain_size: "wide_12km",
+      output_cadence: "detailed_5min",
+      diagnostic_set: "full",
       runtime_seconds: 43200,
       output_cadence_seconds: 300,
       expected_output_frames: 145,
@@ -366,7 +367,7 @@ const observedSoundingParseResponse = {
 
 function dryRunResponseForRequest(init?: RequestInit) {
   const body = JSON.parse(String(init?.body ?? "{}")) as {
-    package_family?: string | null;
+    run_recipe?: string | null;
     observed_sounding?: Record<string, unknown> | null;
     candidate_screening?: Record<string, unknown> | null;
     user_name?: string | null;
@@ -377,7 +378,7 @@ function dryRunResponseForRequest(init?: RequestInit) {
     ...dryRunResponse,
     report: {
       ...dryRunResponse.report,
-      package_family: body.package_family ?? undefined,
+      run_recipe: body.run_recipe ?? undefined,
       observed_sounding: body.observed_sounding ?? null,
       candidate_screening: body.candidate_screening ?? null,
       pre_run_validation_report: preRunValidationReportForRequest(body),
@@ -392,13 +393,16 @@ function dryRunResponseForRequest(init?: RequestInit) {
 }
 
 function preRunValidationReportForRequest(body: {
-  package_family?: string | null;
+  run_recipe?: string | null;
   observed_sounding?: Record<string, unknown> | null;
   candidate_screening?: Record<string, unknown> | null;
 }) {
-  const packageFamily =
-    body.package_family ?? (body.observed_sounding ? "observed_sounding_quicklook" : "shallow_cumulus");
-  const deep = packageFamily === "deep_convection_trial";
+  const runRecipe =
+    body.run_recipe ??
+    (body.observed_sounding
+      ? "untriggered_observed_evolution"
+      : "generated_reference_lower_atmosphere");
+  const deep = runRecipe === "triggered_deep_potential";
   const activeStory =
     typeof body.candidate_screening?.active_story === "string"
       ? body.candidate_screening.active_story
@@ -438,15 +442,15 @@ function preRunValidationReportForRequest(body: {
       predicted_output_signature: deep ? ["deep_cloud", "strong_updraft"] : [],
     },
     selected_run_recipe: {
-      recipe_id: packageFamily,
+      recipe_id: runRecipe,
       display_name: deep
-        ? "Deep Convection Trial"
-        : packageFamily === "observed_sounding_quicklook"
-          ? "Observed Sounding Quick Look"
-          : "Baseline Shallow Cumulus",
+        ? "Triggered Deep-Potential Experiment"
+        : runRecipe === "untriggered_observed_evolution"
+          ? "Untriggered Observed Evolution"
+          : "Generated Lower-Atmosphere Reference",
       assumption_set_id: deep
         ? "triggered_deep_potential_warm_bubble_v1"
-        : packageFamily === "observed_sounding_quicklook"
+        : runRecipe === "untriggered_observed_evolution"
           ? "normal_evolution_current_observed_sounding_v1"
           : "generated_reference_lower_atmosphere_v1",
     },
@@ -1409,11 +1413,11 @@ const deepConvectionResultCard = {
   ...observedSoundingResultCard,
   result_id: "result-deep-convection",
   run_id: "dry-run-deep-convection",
-  name: "Deep Convection Trial — Norman, Oklahoma",
+  name: "Triggered Deep-Potential Experiment — Norman, Oklahoma",
   tags: ["deep-convection", "candidate"],
-  scenario_name: "Deep Convection Trial",
-  package_family: "deep_convection_trial",
-  package_display_name: "Deep Convection Trial",
+  scenario_name: "Triggered Deep-Potential Experiment",
+  run_recipe: "triggered_deep_potential",
+  run_recipe_display_name: "Triggered Deep-Potential Experiment",
   trigger_type: "warm_bubble",
   expected_outputs: ["qc", "qr", "w", "dbz", "updraft_helicity"],
   candidate_screening: {
@@ -1489,7 +1493,7 @@ const deepConvectionResultCard = {
   },
   candidate_hypothesis_comparison: {
     screened_as: "Supercell-like environment",
-    ran_as: "Deep Convection Trial",
+    ran_as: "Triggered Deep-Potential Experiment",
     cm1_outcome: "Deep convection formed with strong updraft and rain water aloft.",
     match_status: "matched",
     match_status_label: "Matched",
@@ -2999,7 +3003,9 @@ describe("App", () => {
     expect(screen.getByLabelText("Surface heating")).toBeInTheDocument();
     expect(screen.getAllByText(/Selected: Baseline/).length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Choose what CM1 will actually run" })).toBeInTheDocument();
-    expect(screen.getByText("Quick science; Local 6 km; Standard; Standard 15 min")).toBeInTheDocument();
+    expect(
+      screen.getByText("Short evolution; Local 6 km; Scout 64 x 64; 100 m dx/dy; Standard 15 min"),
+    ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Local run launchpad" })).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Packages and runs needing action" }),
@@ -3073,37 +3079,37 @@ describe("App", () => {
     expect(screen.getByText(/CM1 z=0 is station surface at 351.5 m MSL/)).toBeInTheDocument();
     expect(screen.getByText(/observed sounding winds/)).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Choose how to try this sounding" }),
+      screen.getByRole("heading", { name: "What is this run testing?" }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText("Package type")).toHaveValue("observed_sounding_quicklook");
+    expect(screen.getByRole("button", { name: "Untriggered observed evolution" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
 
-    fireEvent.change(screen.getByLabelText("Package type"), {
-      target: { value: "deep_convection_trial" },
-    });
-    expect(screen.getByText("Three-bubble trigger")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Triggered deep potential" }));
+    expect(screen.getByText("Idealized three warm bubbles")).toBeInTheDocument();
     expect(
       screen.getByText(
-        /observed temperature, moisture, and wind profile with an idealized CM1 three-warm-bubble trigger/i,
+        /triggered deep-convection potential from this observed profile/i,
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText(/wider box for storm growth and precipitation/i)).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Run configuration controls duration, grid\/detail, domain size, output cadence, and fields separately/i,
+        /This is not normal atmospheric evolution/i,
       ),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
     await waitFor(() => {
-      expect(dryRunBody).toContain('"package_family":"deep_convection_trial"');
+      expect(dryRunBody).toContain('"run_recipe":"triggered_deep_potential"');
       expect(dryRunBody).toContain('"observed_sounding"');
       expect(dryRunBody).toContain('"station_id":"USM00072558"');
       expect(dryRunBody).toContain('"model_bottom_elevation_m_msl":351.5');
     });
   });
 
-  it("defaults deep-convection candidates to the Deep Convection Trial package", async () => {
+  it("defaults deep-convection candidates to the Triggered Deep-Potential Experiment package", async () => {
     const defaultFetch = vi.mocked(fetch).getMockImplementation();
     let dryRunBody = "";
     let screenBody = "";
@@ -3128,7 +3134,7 @@ describe("App", () => {
     });
     fireEvent.click(await screen.findByText("Advanced filters"));
     const storyFilter = await screen.findByLabelText("Story");
-    expect(storyFilter).toHaveTextContent("Deep Convection Trial stories");
+    expect(storyFilter).toHaveTextContent("Deep-convection stories");
     fireEvent.change(storyFilter, {
       target: { value: "deep_convection_trial" },
     });
@@ -3142,23 +3148,22 @@ describe("App", () => {
     fireEvent.click(within(deepCard).getByRole("button", { name: "Use this sounding" }));
 
     expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
-    expect(screen.getByLabelText("Package type")).toHaveValue("deep_convection_trial");
-    expect(screen.getByText("Three-bubble trigger")).toBeInTheDocument();
-    expect(screen.getByText(/Candidate screening is ingredient guidance/)).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText("Package type"), {
-      target: { value: "observed_sounding_quicklook" },
-    });
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Observed Sounding Quick Look does not test that hypothesis",
+    expect(screen.getByRole("button", { name: "Triggered deep potential" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
     );
-    fireEvent.change(screen.getByLabelText("Package type"), {
-      target: { value: "deep_convection_trial" },
-    });
+    expect(screen.getByText("Idealized three warm bubbles")).toBeInTheDocument();
+    expect(screen.getByText(/Candidate screening is ingredient guidance/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Untriggered observed evolution" }));
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Untriggered observed evolution does not test that hypothesis",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Triggered deep potential" }));
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
     await waitFor(() => {
-      expect(dryRunBody).toContain('"package_family":"deep_convection_trial"');
+      expect(dryRunBody).toContain('"run_recipe":"triggered_deep_potential"');
       expect(dryRunBody).toContain('"candidate_screening"');
       expect(dryRunBody).toContain('"primary_story":"supercell_environment"');
       expect(dryRunBody).toContain('"candidate_id":"USM00072357-2025052000-supercell"');
@@ -3197,7 +3202,10 @@ describe("App", () => {
     fireEvent.click(within(humidCard).getByRole("button", { name: "Use this sounding" }));
 
     expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
-    expect(screen.getByLabelText("Package type")).toHaveValue("observed_sounding_quicklook");
+    expect(screen.getByRole("button", { name: "Untriggered observed evolution" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
     expect(
       screen.getByText(/Predicted rain behavior needs rain-water, surface-rain, and\/or reflectivity outputs/),
     ).toBeInTheDocument();
@@ -3205,7 +3213,7 @@ describe("App", () => {
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
     await waitFor(() => {
-      expect(dryRunBody).toContain('"package_family":"observed_sounding_quicklook"');
+      expect(dryRunBody).toContain('"run_recipe":"untriggered_observed_evolution"');
       expect(dryRunBody).toContain('"primary_story":"humid_rainy_candidate"');
       expect(dryRunBody).toContain(
         '"candidate_id":"USM00072426-2025010300-humid-secondary-shallow"',
@@ -3591,13 +3599,13 @@ describe("App", () => {
         return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
       }
       if (url === "/api/dry-run-package") {
-        expect(init?.body).toEqual(expect.stringContaining('"duration_preset":"standard_12h"'));
-        expect(init?.body).toEqual(expect.stringContaining('"grid_detail_preset":"fine"'));
-        expect(init?.body).toEqual(expect.stringContaining('"domain_size_preset":"wide_12km"'));
+        expect(init?.body).toEqual(expect.stringContaining('"duration":"standard_12h"'));
+        expect(init?.body).toEqual(expect.stringContaining('"horizontal_cell_count":"cells_256"'));
+        expect(init?.body).toEqual(expect.stringContaining('"domain_size":"wide_12km"'));
         expect(init?.body).toEqual(
-          expect.stringContaining('"output_cadence_preset":"detailed_5min"'),
+          expect.stringContaining('"output_cadence":"detailed_5min"'),
         );
-        expect(init?.body).toEqual(expect.stringContaining('"output_field_density_preset":"rich"'));
+        expect(init?.body).toEqual(expect.stringContaining('"diagnostic_set":"full"'));
         return Promise.resolve(new Response(JSON.stringify(deepDryRunResponse), { status: 200 }));
       }
       if (url === "/api/results") {
@@ -3622,11 +3630,13 @@ describe("App", () => {
     fireEvent.change(await screen.findByLabelText("Duration"), {
       target: { value: "standard_12h" },
     });
-    fireEvent.change(screen.getByLabelText("Grid / detail"), { target: { value: "fine" } });
+    fireEvent.change(screen.getByLabelText("Horizontal cells"), {
+      target: { value: "cells_256" },
+    });
     fireEvent.change(screen.getByLabelText("Output cadence"), {
       target: { value: "detailed_5min" },
     });
-    fireEvent.change(screen.getByLabelText("Output fields"), { target: { value: "rich" } });
+    fireEvent.change(screen.getByLabelText("Diagnostic set"), { target: { value: "full" } });
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
@@ -3653,8 +3663,8 @@ describe("App", () => {
         predicted_output_signature: ["deep_cloud", "strong_updraft"],
       },
       selected_run_recipe: {
-        recipe_id: "observed_sounding_quicklook",
-        display_name: "Observed Sounding Quick Look",
+        recipe_id: "untriggered_observed_evolution",
+        display_name: "Untriggered Observed Evolution",
         assumption_set_id: "normal_evolution_current_observed_sounding_v1",
       },
       hypothesis_recipe_alignment: {
@@ -4469,12 +4479,14 @@ describe("App", () => {
     expect(screen.getByLabelText("Results list")).toBeInTheDocument();
     const resultDetail = screen.getByLabelText("Result detail");
     expect(resultDetail).toHaveTextContent("Quick-look shallow cumulus");
-    expect(screen.getAllByText(/Validated quick-look baseline/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Validated reference baseline/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Minor caveat/).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: "Open in Explore" }).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Quick-look shallow cumulus" })).toBeInTheDocument();
     expect(screen.getAllByText(/Baseline Shallow Cumulus/).length).toBeGreaterThan(0);
-    expect(resultDetail).toHaveTextContent("Quick science; Local 6 km; Standard; Standard 15 min");
+    expect(resultDetail).toHaveTextContent(
+      "Short evolution; Local 6 km; Scout 64 x 64; 100 m dx/dy; Standard 15 min",
+    );
     expect(
       screen.getAllByText(
         "cloud formed; rain water aloft detected; surface rain reached ground; reflectivity available",
@@ -4564,7 +4576,7 @@ describe("App", () => {
     render(<App />);
 
     const resultDetail = await screen.findByLabelText("Result detail");
-    expect(resultDetail).toHaveTextContent("Deep Convection Trial — Norman, Oklahoma");
+    expect(resultDetail).toHaveTextContent("Triggered Deep-Potential Experiment — Norman, Oklahoma");
     expect(resultDetail).toHaveTextContent("Deep convection formed");
     expect(resultDetail).toHaveTextContent("Screening vs CM1");
     expect(resultDetail).toHaveTextContent("Supercell-like environment");
@@ -5371,7 +5383,7 @@ describe("App", () => {
     await screen.findAllByText("Cloud-water point layer loaded");
     expect(screen.getByText("Result explanation")).toBeInTheDocument();
     expect(
-      screen.getAllByText(/Cloud water formed in the validated quick-look baseline/).length,
+      screen.getAllByText(/Cloud water formed in the validated reference baseline/).length,
     ).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByText("Process evidence details"));

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -745,10 +745,7 @@ function screeningResponseForRequest(init?: RequestInit) {
         return false;
       }
       const score = storyScoreForTest(candidate, storyFilter, storyFamily);
-      if (
-        storyFilter !== "all" &&
-        (!score || !meaningfulStoryScoreForTest(score))
-      ) {
+      if (storyFilter !== "all" && (!score || !meaningfulStoryScoreForTest(score))) {
         return false;
       }
       if (support !== "all") {
@@ -857,8 +854,7 @@ function candidateSortValueForTest(
 ) {
   if (sortBy === "best_match") {
     return (
-      storyScoreForTest(candidate, storyFilter, storyFamily)?.score_0_to_100 ??
-      candidate.rank_score
+      storyScoreForTest(candidate, storyFilter, storyFamily)?.score_0_to_100 ?? candidate.rank_score
     );
   }
   if (sortBy === "valid_time") return new Date(candidate.valid_time_utc).getTime();
@@ -3002,7 +2998,9 @@ describe("App", () => {
     expect(screen.getByLabelText("Low-level humidity")).toBeInTheDocument();
     expect(screen.getByLabelText("Surface heating")).toBeInTheDocument();
     expect(screen.getAllByText(/Selected: Baseline/).length).toBeGreaterThan(0);
-    expect(screen.getByRole("heading", { name: "Choose what CM1 will actually run" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Choose what CM1 will actually run" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByText("Short evolution; Local 6 km; Scout 64 x 64; 100 m dx/dy; Standard 15 min"),
     ).toBeInTheDocument();
@@ -3079,7 +3077,10 @@ describe("App", () => {
     expect(screen.getByText(/CM1 z=0 is station surface at 351.5 m MSL/)).toBeInTheDocument();
     expect(screen.getByText(/observed sounding winds/)).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "What is this run testing?" }),
+      screen.getByRole("heading", { name: "What atmospheric outcome are we checking?" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Surface heating: Baseline; no added deep-initiation trigger/i),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Untriggered observed evolution" })).toHaveAttribute(
       "aria-pressed",
@@ -3089,15 +3090,9 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Triggered deep potential" }));
     expect(screen.getByText("Idealized three warm bubbles")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        /triggered deep-convection potential from this observed profile/i,
-      ),
+      screen.getByText(/Surface heating: Baseline; plus idealized warm-bubble initiation/i),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        /This is not normal atmospheric evolution/i,
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/This is not normal atmospheric evolution/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
@@ -3153,7 +3148,14 @@ describe("App", () => {
       "true",
     );
     expect(screen.getByText("Idealized three warm bubbles")).toBeInTheDocument();
-    expect(screen.getByText(/Candidate screening is ingredient guidance/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/The candidate story is the atmospheric hypothesis/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Deep cloud")).toBeInTheDocument();
+    expect(screen.getByText("Strong updraft")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Surface heating: Baseline; plus idealized warm-bubble initiation/i),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Untriggered observed evolution" }));
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Untriggered observed evolution does not test that hypothesis",
@@ -3207,7 +3209,9 @@ describe("App", () => {
       "true",
     );
     expect(
-      screen.getByText(/Predicted rain behavior needs rain-water, surface-rain, and\/or reflectivity outputs/),
+      screen.getByText(
+        /Predicted rain behavior needs rain-water, surface-rain, and\/or reflectivity outputs/,
+      ),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
@@ -3451,9 +3455,7 @@ describe("App", () => {
             : saved,
         );
         savedStore = updated;
-        return Promise.resolve(
-          new Response(JSON.stringify(savedStore[0]), { status: 200 }),
-        );
+        return Promise.resolve(new Response(JSON.stringify(savedStore[0]), { status: 200 }));
       }
       if (url === "/api/sounding-candidates/saved") {
         return Promise.resolve(
@@ -3513,9 +3515,7 @@ describe("App", () => {
       "Saved sounding candidate Valley, Nebraska (USM00072558)",
     );
     expect(reloadedSavedCard).toHaveTextContent("Tags: Deep convection candidates");
-    expect(reloadedSavedCard).toHaveTextContent(
-      "Notes: Keep this one in the candidate notebook.",
-    );
+    expect(reloadedSavedCard).toHaveTextContent("Notes: Keep this one in the candidate notebook.");
   });
 
   it("shows secondary family candidates with the scoped story ingredient score", async () => {
@@ -3602,9 +3602,7 @@ describe("App", () => {
         expect(init?.body).toEqual(expect.stringContaining('"duration":"standard_12h"'));
         expect(init?.body).toEqual(expect.stringContaining('"horizontal_cell_count":"cells_256"'));
         expect(init?.body).toEqual(expect.stringContaining('"domain_size":"wide_12km"'));
-        expect(init?.body).toEqual(
-          expect.stringContaining('"output_cadence":"detailed_5min"'),
-        );
+        expect(init?.body).toEqual(expect.stringContaining('"output_cadence":"detailed_5min"'));
         expect(init?.body).toEqual(expect.stringContaining('"diagnostic_set":"full"'));
         return Promise.resolve(new Response(JSON.stringify(deepDryRunResponse), { status: 200 }));
       }
@@ -3673,9 +3671,7 @@ describe("App", () => {
         missing_assumptions: ["triggered_deep_potential_warm_bubble_v1"],
         missing_outputs: [],
       },
-      blocking_errors: [
-        "Selected run recipe does not test this deep-convection hypothesis.",
-      ],
+      blocking_errors: ["Selected run recipe does not test this deep-convection hypothesis."],
       caveats: [],
     };
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -3714,7 +3710,9 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
     fireEvent.click(await screen.findByTestId("create-package-btn"));
 
-    expect(await screen.findByText(/Pre-run validation blocked package creation/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Pre-run validation blocked package creation/),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("Pre-run validation report")).toHaveTextContent("Blocked");
     expect(screen.getByLabelText("Pre-run validation report")).toHaveTextContent(
       "Selected run recipe does not test this deep-convection hypothesis.",
@@ -4212,7 +4210,18 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
     fireEvent.click(await screen.findByTestId("create-package-btn"));
 
-    fireEvent.click(await screen.findByRole("button", { name: "Run on LAN worker" }));
+    await screen.findByRole("heading", { name: "Package ready for CM1" });
+    const packageQueuePanel = screen.getByLabelText("Package and queue");
+    const lanLaunchButton = within(packageQueuePanel).getByRole("button", {
+      name: "Run on LAN worker",
+    });
+    expect(lanLaunchButton).toBeEnabled();
+    expect(
+      within(screen.getByLabelText("LAN worker run status")).queryByRole("button", {
+        name: "Run on LAN worker",
+      }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(lanLaunchButton);
 
     await waitFor(() => {
       expect(screen.getByText("Worker model-time progress").nextElementSibling).toHaveTextContent(
@@ -4278,7 +4287,12 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
     fireEvent.click(await screen.findByTestId("create-package-btn"));
 
-    fireEvent.click(await screen.findByRole("button", { name: "Run on LAN worker" }));
+    await screen.findByRole("heading", { name: "Package ready for CM1" });
+    fireEvent.click(
+      within(screen.getByLabelText("Package and queue")).getByRole("button", {
+        name: "Run on LAN worker",
+      }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Worker model-time progress").nextElementSibling).toHaveTextContent(
@@ -4309,6 +4323,21 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "Create another package" })).toHaveClass(
       "secondary-button",
     );
+    const packageQueuePanel = screen.getByLabelText("Package and queue");
+    expect(
+      within(packageQueuePanel).getByRole("button", { name: "Queue local CM1 run" }),
+    ).toBeEnabled();
+    expect(
+      within(packageQueuePanel).getByRole("button", { name: "Run on LAN worker" }),
+    ).toBeDisabled();
+    expect(
+      within(packageQueuePanel).getByText(/LAN worker execution is unavailable/i),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("LAN worker run status")).queryByRole("button", {
+        name: "Run on LAN worker",
+      }),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Expected output directory").nextElementSibling).toHaveTextContent(
       "/tmp/CloudChamber/runs/dry-run-001",
     );
@@ -4576,7 +4605,9 @@ describe("App", () => {
     render(<App />);
 
     const resultDetail = await screen.findByLabelText("Result detail");
-    expect(resultDetail).toHaveTextContent("Triggered Deep-Potential Experiment — Norman, Oklahoma");
+    expect(resultDetail).toHaveTextContent(
+      "Triggered Deep-Potential Experiment — Norman, Oklahoma",
+    );
     expect(resultDetail).toHaveTextContent("Deep convection formed");
     expect(resultDetail).toHaveTextContent("Screening vs CM1");
     expect(resultDetail).toHaveTextContent("Supercell-like environment");

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1114,6 +1114,20 @@ const FIELD_LOAD_TIMEOUT_MS = 30000;
 const OBSERVED_SOUNDING_EXPERIMENT_ID = "__observed_sounding_upload__";
 const OBSERVED_SOUNDING_BASE_SCENARIO_ID = "baseline-shallow-cumulus";
 const OBSERVED_SOUNDING_VISIBLE_CONTROLS = new Set(["surface_heating"]);
+const candidateStoryIdValues = new Set<string>([
+  "shallow_cumulus_candidate",
+  "dry_failed_candidate",
+  "capped_suppressed_candidate",
+  "humid_rainy_candidate",
+  "severe_thunderstorm_environment",
+  "supercell_environment",
+  "high_cape_pulse_storm",
+  "dry_microburst_inverted_v",
+  "squall_line_cold_pool_candidate",
+  "elevated_convection",
+  "needs_review",
+  "poor_or_incomplete_candidate",
+]);
 const deepConvectionStoryIds = new Set<string>([
   "severe_thunderstorm_environment",
   "supercell_environment",
@@ -1213,10 +1227,12 @@ async function dryRunErrorDetail(
 ): Promise<{ message: string; preRunValidationReport: PreRunValidationReport | null }> {
   try {
     const payload = (await response.json()) as {
-      detail?: string | {
-        message?: string;
-        pre_run_validation_report?: unknown;
-      };
+      detail?:
+        | string
+        | {
+            message?: string;
+            pre_run_validation_report?: unknown;
+          };
     };
     if (typeof payload.detail === "string") {
       return { message: payload.detail, preRunValidationReport: null };
@@ -1224,9 +1240,7 @@ async function dryRunErrorDetail(
     if (payload.detail && typeof payload.detail === "object") {
       return {
         message: payload.detail.message ?? "Unable to create dry-run package.",
-        preRunValidationReport: isPreRunValidationReport(
-          payload.detail.pre_run_validation_report,
-        )
+        preRunValidationReport: isPreRunValidationReport(payload.detail.pre_run_validation_report)
           ? payload.detail.pre_run_validation_report
           : null,
       };
@@ -2105,7 +2119,9 @@ export function App() {
 
   function handleObservedRunRecipeChange(runRecipe: ObservedRunRecipe) {
     setObservedRunRecipe(runRecipe);
-    setRunConfiguration(defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID, runRecipe));
+    setRunConfiguration(
+      defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID, runRecipe),
+    );
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
     setRunStatus(null);
@@ -2300,7 +2316,9 @@ export function App() {
     setObservedSoundingParse(observedSoundingParseFromCandidate(candidate, selectedSounding));
     setObservedSoundingStatus("Candidate loaded into observed-sounding package review");
     setObservedSoundingError(null);
-    setSelectedCandidateScreening(candidateScreeningMetadata(candidate, savedCandidate, activeStory));
+    setSelectedCandidateScreening(
+      candidateScreeningMetadata(candidate, savedCandidate, activeStory),
+    );
     const nextRunRecipe = defaultRunRecipeForCandidate(candidate, activeStory);
     setObservedRunRecipe(nextRunRecipe);
     setRunConfiguration(
@@ -3200,9 +3218,7 @@ function BuildWorkspace({
     observedSoundingExperimentSelected && observedRunRecipe === "triggered_deep_potential";
   const runConfigurationPreview = previewRunConfiguration(
     runConfiguration,
-    observedSoundingExperimentSelected
-      ? observedRunRecipe
-      : "generated_reference_lower_atmosphere",
+    observedSoundingExperimentSelected ? observedRunRecipe : "generated_reference_lower_atmosphere",
   );
 
   return (
@@ -3388,6 +3404,7 @@ function BuildWorkspace({
                   />
                   <ObservedRunRecipePanel
                     runRecipe={observedRunRecipe}
+                    controls={controls}
                     selectedCandidateScreening={selectedCandidateScreening}
                     onChange={onObservedRunRecipeChange}
                   />
@@ -3423,12 +3440,14 @@ function BuildWorkspace({
                 dryRun={dryRun}
                 runStatus={runStatus}
                 lanWorkerStatus={lanWorkerStatus}
+                lanWorkerConfigured={lanWorkerConfig?.configured ?? false}
                 canCreatePackage={
                   validationMessages.length === 0 &&
                   (!observedSoundingExperimentSelected ||
                     Boolean(observedSoundingParse?.selected_sounding))
                 }
                 onLaunchRun={onLaunchRun}
+                onLaunchLanWorkerRun={onLaunchLanWorkerRun}
               />
             </>
           )}
@@ -3621,14 +3640,18 @@ function BuildRunActionPanel({
   dryRun,
   runStatus,
   lanWorkerStatus,
+  lanWorkerConfigured,
   canCreatePackage,
   onLaunchRun,
+  onLaunchLanWorkerRun,
 }: {
   dryRun: DryRunResponse | null;
   runStatus: RunStatusResponse | null;
   lanWorkerStatus: LanWorkerRunResponse | null;
+  lanWorkerConfigured: boolean;
   canCreatePackage: boolean;
   onLaunchRun: () => void;
+  onLaunchLanWorkerRun: () => void;
 }) {
   const packageReadyForQueue = Boolean(dryRun && !runStatus && !lanWorkerStatus);
   return (
@@ -3639,7 +3662,7 @@ function BuildRunActionPanel({
           <h3>{dryRun ? "Package ready for CM1" : "Ready to package this setup"}</h3>
           <p className="field-help">
             Create the run package from the selected sounding, hypothesis, and CM1 run settings.
-            Then queue that package for local CM1 execution when you are ready.
+            Then choose whether this package should run locally or on the trusted LAN worker.
           </p>
         </div>
         <StatusBadge
@@ -3658,11 +3681,27 @@ function BuildRunActionPanel({
           {dryRun ? "Create another package" : "Create run package"}
         </button>
         {packageReadyForQueue && (
-          <button type="button" data-testid="launch-cm1-btn" onClick={onLaunchRun}>
-            Queue local CM1 run
-          </button>
+          <>
+            <button type="button" data-testid="launch-cm1-btn" onClick={onLaunchRun}>
+              Queue local CM1 run
+            </button>
+            <button
+              type="button"
+              className="secondary-button"
+              data-testid="launch-lan-worker-btn"
+              onClick={onLaunchLanWorkerRun}
+              disabled={!lanWorkerConfigured}
+            >
+              Run on LAN worker
+            </button>
+          </>
         )}
       </div>
+      {packageReadyForQueue && !lanWorkerConfigured && (
+        <p className="state-note">
+          LAN worker execution is unavailable until an ignored local worker config is present.
+        </p>
+      )}
     </section>
   );
 }
@@ -3773,8 +3812,14 @@ function RunConfigurationPanel({
       <details className="technical-details">
         <summary>CM1-facing values</summary>
         <dl className="compact-metrics">
-          <Metric label="nx / ny / nz" value={`${preview.cm1_values.nx} / ${preview.cm1_values.ny} / ${preview.cm1_values.nz}`} />
-          <Metric label="dx / dy / dz" value={`${formatMeters(preview.cm1_values.dx_m)} / ${formatMeters(preview.cm1_values.dy_m)} / ${formatMeters(preview.cm1_values.dz_m)}`} />
+          <Metric
+            label="nx / ny / nz"
+            value={`${preview.cm1_values.nx} / ${preview.cm1_values.ny} / ${preview.cm1_values.nz}`}
+          />
+          <Metric
+            label="dx / dy / dz"
+            value={`${formatMeters(preview.cm1_values.dx_m)} / ${formatMeters(preview.cm1_values.dy_m)} / ${formatMeters(preview.cm1_values.dz_m)}`}
+          />
           <Metric label="Model top" value={formatMeters(preview.cm1_values.model_top_m)} />
           <Metric label="Timestep" value={formatSeconds(preview.cm1_values.time_step_seconds)} />
           <Metric
@@ -4384,9 +4429,12 @@ function SoundingCandidateCard({
 }) {
   const activeScore = candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter);
   const story = activeScore?.story ?? candidate.primary_story;
-  const activeFamily = activeScore ? candidateStoryFamilyForStory(activeScore.story) : candidate.story_family;
+  const activeFamily = activeScore
+    ? candidateStoryFamilyForStory(activeScore.story)
+    : candidate.story_family;
   const ingredientScore =
-    activeScore?.score_0_to_100 ?? candidateIngredientScore(candidate, storyFilter, storyFamilyFilter);
+    activeScore?.score_0_to_100 ??
+    candidateIngredientScore(candidate, storyFilter, storyFamilyFilter);
   const recipeFit = candidateRecipeFitForStory(candidate, story);
   const reasons = candidateInterestReasons(candidate);
   return (
@@ -4412,7 +4460,10 @@ function SoundingCandidateCard({
             <StatusBadge label={`Primary: ${candidate.primary_story_label}`} tone="neutral" />
           )}
           <StatusBadge label={candidateStoryFamilyLabel(activeFamily)} tone="neutral" />
-          <StatusBadge label={`${formatNumber(ingredientScore, "%")} ingredient score`} tone="neutral" />
+          <StatusBadge
+            label={`${formatNumber(ingredientScore, "%")} ingredient score`}
+            tone="neutral"
+          />
           <StatusBadge
             label={`Recipe fit: ${recipeFit.label}`}
             tone={candidateRecipeFitTone(recipeFit.status)}
@@ -4541,8 +4592,8 @@ function SoundingCandidateDetail({
         />
       </div>
       <p>
-        Scores rank sounding ingredients only. They do not predict what the current CM1 package
-        will produce. CM1 decides whether clouds, rain, or suppression actually happen.
+        Scores rank sounding ingredients only. They do not predict what the current CM1 package will
+        produce. CM1 decides whether clouds, rain, or suppression actually happen.
       </p>
       <p className="field-help">Recipe fit: {recipeFit.summary}</p>
       <section>
@@ -4800,38 +4851,76 @@ function ObservedSoundingInputPanel({
 
 function ObservedRunRecipePanel({
   runRecipe,
+  controls,
   selectedCandidateScreening,
   onChange,
 }: {
   runRecipe: ObservedRunRecipe;
+  controls: Record<string, string | number | boolean>;
   selectedCandidateScreening: Record<string, unknown> | null;
   onChange: (runRecipe: ObservedRunRecipe) => void;
 }) {
   const selectedDeep = runRecipe === "triggered_deep_potential";
-  const packageMismatchWarning = candidateRecipeMismatchWarning(
+  const activeStory = observedRecipeStoryId(selectedCandidateScreening);
+  const recipeMismatchWarning = candidateRecipeMismatchWarning(
     selectedCandidateScreening,
     runRecipe,
   );
   const activeStoryLabel = observedRecipeStoryLabel(selectedCandidateScreening);
+  const expectedSignatures = observedRecipeSignatureLabels(activeStory);
+  const hypothesisSummary = observedRecipeHypothesisSummary(activeStory);
+  const evidenceSummary = observedRecipeEvidenceSummary(selectedCandidateScreening);
+  const recipeFitSummary = observedRecipeFitSummary(selectedCandidateScreening, activeStory);
+  const appliedForcing = observedRecipeAppliedForcing(controls, selectedDeep);
   const candidateGuidance = selectedCandidateScreening
-    ? "Candidate screening is ingredient guidance. Pick the run recipe by what CM1 can honestly test."
-    : "Uploaded soundings start as an untriggered observed-atmosphere run. Use a triggered deep-potential recipe only when that is the experiment.";
+    ? "The candidate story is the atmospheric hypothesis. Surface heating and initiation choices are the forcing used to test it."
+    : "No screened candidate is selected yet. This run can still inspect the observed profile, but there is no saved atmospheric hypothesis to compare.";
+  const methodScope = selectedDeep
+    ? "Forced-initiation test of deep-convection potential; not normal atmospheric evolution."
+    : "No added deep trigger; CM1 evolves the observed profile with the selected surface-heating forcing.";
 
   return (
     <section className="experiment-summary" aria-labelledby="observed-run-recipe-title">
       <div className="panel-heading-row">
         <div>
-          <p className="eyebrow">Hypothesis run recipe</p>
-          <h3 id="observed-run-recipe-title">What is this run testing?</h3>
+          <p className="eyebrow">Candidate hypothesis</p>
+          <h3 id="observed-run-recipe-title">What atmospheric outcome are we checking?</h3>
           <p className="field-help">{candidateGuidance}</p>
         </div>
         <StatusBadge
-          label={selectedDeep ? "Triggered deep potential" : "Untriggered observed evolution"}
-          tone={selectedDeep ? "warning" : "neutral"}
+          label={activeStoryLabel}
+          tone={selectedCandidateScreening ? "neutral" : "warning"}
         />
       </div>
 
-      <div className="button-row" role="group" aria-label="Run recipe">
+      <dl className="compact-metrics">
+        <Metric label="Atmospheric hypothesis" value={activeStoryLabel} />
+        <Metric label="Expected evolution to check" value={hypothesisSummary} />
+        <Metric label="Why this sounding looked interesting" value={evidenceSummary} />
+        <Metric label="Applied forcing" value={appliedForcing} />
+        <Metric label="Can this run test it?" value={recipeFitSummary} />
+      </dl>
+
+      {expectedSignatures.length > 0 && (
+        <div>
+          <p className="eyebrow">CM1-observable signatures</p>
+          <ul className="compact-list">
+            {expectedSignatures.map((signature) => (
+              <li key={signature}>{signature}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div>
+        <p className="eyebrow">Run method</p>
+        <p className="field-help">
+          Choose the CM1 assumption set. This changes initiation and comparison context; surface
+          heating remains its own forcing control.
+        </p>
+      </div>
+
+      <div className="button-row" role="group" aria-label="Run method">
         <button
           type="button"
           className={!selectedDeep ? "active-control" : "secondary-button"}
@@ -4850,25 +4939,21 @@ function ObservedRunRecipePanel({
         </button>
       </div>
 
-      {packageMismatchWarning && (
+      {recipeMismatchWarning && (
         <div className="validation" role="alert">
-          {packageMismatchWarning}
+          {recipeMismatchWarning}
         </div>
       )}
       <dl className="compact-metrics">
-        <Metric label="Screened hypothesis" value={activeStoryLabel} />
+        <Metric
+          label="Selected run method"
+          value={selectedDeep ? "Triggered deep potential" : "Untriggered observed evolution"}
+        />
         <Metric
           label="Initiation"
           value={selectedDeep ? "Idealized three warm bubbles" : "No added deep trigger"}
         />
-        <Metric
-          label="What CM1 can test"
-          value={
-            selectedDeep
-              ? "Triggered deep-convection potential from this observed profile"
-              : "Untriggered cloud, updraft, moisture, and precipitation evolution"
-          }
-        />
+        <Metric label="Method scope" value={methodScope} />
       </dl>
       {selectedDeep && (
         <p className="field-help">
@@ -5169,7 +5254,6 @@ function LocalRunWorkflowPanel({
     : 0;
   const generatedInputNames = dryRun ? generatedInputSummary(dryRun) : [];
   const currentRunId = dryRun ? runIdFromPackage(dryRun) : null;
-  const packageReadyForLaunch = Boolean(dryRun && !runStatus && !lanWorkerStatus);
   const showRefreshButton = Boolean(dryRun && runStatus);
   const showIngestButton = Boolean(dryRun && canIngest);
   const showActionRow = showRefreshButton || showIngestButton;
@@ -5248,7 +5332,9 @@ function LocalRunWorkflowPanel({
                   />
                   <Metric
                     label="Estimated output volume"
-                    value={runConfigurationSummaryMultiplier(dryRun.report.run_configuration_summary)}
+                    value={runConfigurationSummaryMultiplier(
+                      dryRun.report.run_configuration_summary,
+                    )}
                   />
                 </>
               )}
@@ -5315,7 +5401,7 @@ function LocalRunWorkflowPanel({
             actionStatus={lanWorkerActionStatus}
             error={lanWorkerError}
             ingestedResultId={ingestedResultId}
-            canStart={packageReadyForLaunch}
+            canStart={false}
             onLaunch={onLaunchLanWorkerRun}
             onRefresh={onRefreshLanWorkerStatus}
             onCollect={onCollectLanWorkerRun}
@@ -5423,10 +5509,7 @@ function LocalRunWorkflowPanel({
             <summary>Technical package details</summary>
             <dl className="compact-metrics">
               <Metric label="Scenario ID" value={dryRun.report.scenario_id} />
-              <Metric
-                label="Run configuration"
-                value={dryRun.report.run_configuration.label}
-              />
+              <Metric label="Run configuration" value={dryRun.report.run_configuration.label} />
               <Metric label="Cost / size" value={dryRun.report.estimated_cost_or_size} />
               {dryRun.report.run_configuration_summary && (
                 <>
@@ -5595,7 +5678,7 @@ function LanWorkerRunPanel({
       <div className="panel-heading-row">
         <div>
           <p className="eyebrow">Trusted LAN worker</p>
-          <h5>Run CM1 on LAN worker</h5>
+          <h5>LAN worker status</h5>
         </div>
         <StatusBadge
           label={
@@ -5607,7 +5690,9 @@ function LanWorkerRunPanel({
 
       <p className="state-note">
         {configured
-          ? "Use the LAN worker as a compute appliance. Copy completed output back, ingest locally, then clean up the worker copy."
+          ? status
+            ? "Use the LAN worker as a compute appliance. Copy completed output back, ingest locally, then clean up the worker copy."
+            : "Use Package and queue to start this package on the LAN worker. This panel tracks worker progress, copy-back, ingest, and cleanup after launch."
           : "LAN worker execution is unavailable until an ignored local worker config is present."}
       </p>
       {!configured && <p className="state-note">{configMessage}</p>}
@@ -9034,14 +9119,14 @@ function candidateRecipeFitForStory(
     return {
       status: "blocked_profile",
       label: "blocked profile",
-      summary: "This cached sounding cannot be packaged until profile caveats are resolved.",
-      caveats: ["profile_or_package_generation_blocked"],
+      summary: "This cached sounding cannot be used for a run until profile caveats are resolved.",
+      caveats: ["profile_or_run_generation_blocked"],
     };
   }
   if (story === "needs_review") {
     return {
       status: "not_testable_with_current_recipes",
-      label: "not testable with current package path",
+      label: "not testable with current run recipe",
       summary: "This candidate needs manual screening before it maps to a current run path.",
       caveats: ["candidate_requires_manual_screening_review"],
     };
@@ -9094,6 +9179,127 @@ function candidateRecipeFitTone(status: CandidateRecipeFitStatus): "good" | "war
 
 function isCandidateSuggestedTag(tag: string): tag is (typeof candidateSuggestedTags)[number] {
   return (candidateSuggestedTags as readonly string[]).includes(tag);
+}
+
+function observedRecipeStoryId(
+  selectedCandidateScreening: Record<string, unknown> | null,
+): CandidateStoryId | null {
+  if (!selectedCandidateScreening) return null;
+  const activeStory = selectedCandidateScreening.active_story;
+  if (typeof activeStory === "string" && candidateStoryIdValues.has(activeStory)) {
+    return activeStory as CandidateStoryId;
+  }
+  const primaryStory = selectedCandidateScreening.primary_story;
+  if (typeof primaryStory === "string" && candidateStoryIdValues.has(primaryStory)) {
+    return primaryStory as CandidateStoryId;
+  }
+  return null;
+}
+
+function observedRecipeHypothesisSummary(story: CandidateStoryId | null): string {
+  if (!story) {
+    return "Inspect cloud, updraft, moisture, and precipitation evolution without a saved pre-run story.";
+  }
+  if (deepConvectionStoryIds.has(story)) {
+    return "Deep-convection ingredients are present; check whether supplied initiation can produce deep cloud, strong updraft, and precipitation signatures.";
+  }
+  switch (story) {
+    case "shallow_cumulus_candidate":
+      return "Shallow cloud formation is plausible; check whether cloud water appears with modest vertical motion.";
+    case "dry_failed_candidate":
+      return "Cloud failure is plausible; check whether vertical motion occurs without meaningful cloud water.";
+    case "capped_suppressed_candidate":
+      return "Suppressed or delayed growth is plausible; check whether cloud stays shallow or capped.";
+    case "humid_rainy_candidate":
+      return "Moist cloud and precipitation processes are plausible; check cloud water, rain water aloft, surface rain, and reflectivity separately.";
+    case "needs_review":
+      return "The analyzer could not identify a trustworthy story; inspect manually before treating this as a comparison case.";
+    case "poor_or_incomplete_candidate":
+      return "The profile is incomplete or unsafe for comparison until blocking caveats are resolved.";
+  }
+  return "Inspect the CM1-observable output signatures that match this candidate story.";
+}
+
+function observedRecipeSignatureLabels(story: CandidateStoryId | null): string[] {
+  if (!story) return [];
+  if (deepConvectionStoryIds.has(story)) {
+    return ["Deep cloud", "Strong updraft", "Rain water aloft", "Reflectivity if requested"];
+  }
+  switch (story) {
+    case "shallow_cumulus_candidate":
+      return ["Shallow cloud water", "Modest vertical velocity"];
+    case "dry_failed_candidate":
+      return ["Vertical motion without meaningful cloud water"];
+    case "capped_suppressed_candidate":
+      return ["Suppressed or shallow cloud", "Limited cloud top"];
+    case "humid_rainy_candidate":
+      return [
+        "Cloud water",
+        "Rain water aloft",
+        "Surface rain or accumulated precipitation",
+        "Reflectivity if requested",
+      ];
+    case "needs_review":
+    case "poor_or_incomplete_candidate":
+      return [];
+  }
+  return ["Cloud water", "Vertical velocity", "Moisture evolution"];
+}
+
+function observedRecipeEvidenceSummary(
+  selectedCandidateScreening: Record<string, unknown> | null,
+): string {
+  if (!selectedCandidateScreening) {
+    return "No cached-sounding recommendation is attached.";
+  }
+  const interestReasons = selectedCandidateScreening.interest_reasons;
+  if (Array.isArray(interestReasons)) {
+    const reasons = interestReasons.filter(
+      (reason): reason is string => typeof reason === "string" && reason.length > 0,
+    );
+    if (reasons.length > 0) return reasons.slice(0, 2).join(" ");
+  }
+  const interestSummary = selectedCandidateScreening.interest_summary;
+  if (typeof interestSummary === "string" && interestSummary.length > 0) {
+    return interestSummary;
+  }
+  const rankScore = selectedCandidateScreening.rank_score;
+  if (typeof rankScore === "number") {
+    return `${Math.round(rankScore)}% ingredient match from cached-sounding screening.`;
+  }
+  return "Screening evidence is attached in the candidate details.";
+}
+
+function observedRecipeFitSummary(
+  selectedCandidateScreening: Record<string, unknown> | null,
+  story: CandidateStoryId | null,
+): string {
+  if (!selectedCandidateScreening) {
+    return "Inspectable, but not comparable to a saved candidate hypothesis.";
+  }
+  const fitSummary = selectedCandidateScreening.recipe_fit_summary;
+  if (typeof fitSummary === "string" && fitSummary.length > 0) {
+    return fitSummary;
+  }
+  if (story && deepConvectionStoryIds.has(story)) {
+    return "Needs the triggered deep-potential method to test the deep-convection hypothesis.";
+  }
+  return "The selected observed-sounding method can inspect this story when duration, cadence, and requested fields are adequate.";
+}
+
+function observedRecipeAppliedForcing(
+  controls: Record<string, string | number | boolean>,
+  selectedDeep: boolean,
+): string {
+  const surfaceHeating = controls.surface_heating;
+  const surfaceHeatingLabel =
+    typeof surfaceHeating === "string" && surfaceHeating.length > 0
+      ? humanize(surfaceHeating)
+      : "Baseline";
+  const initiation = selectedDeep
+    ? "plus idealized warm-bubble initiation"
+    : "no added deep-initiation trigger";
+  return `Surface heating: ${surfaceHeatingLabel}; ${initiation}.`;
 }
 
 function candidateRecipeMismatchWarning(
@@ -9973,7 +10179,11 @@ function previewRunConfiguration(
   };
 }
 
-function durationValue(value: string): { seconds: number; mode: "smoke" | "science"; label: string } {
+function durationValue(value: string): {
+  seconds: number;
+  mode: "smoke" | "science";
+  label: string;
+} {
   if (value === "smoke_1h") return { seconds: 3600, mode: "smoke", label: "Smoke check" };
   if (value === "standard_12h") {
     return { seconds: 43200, mode: "science", label: "Standard evolution" };
@@ -9994,7 +10204,15 @@ function horizontalCellValue(value: string): { cells: number; label: string } {
 function domainValue(
   value: string,
   deep: boolean,
-): { value: string; xKm: number; yKm: number; nz: number; dzM: number; modelTopM: number; label: string } {
+): {
+  value: string;
+  xKm: number;
+  yKm: number;
+  nz: number;
+  dzM: number;
+  modelTopM: number;
+  label: string;
+} {
   if (deep) {
     if (value === "storm_160km") {
       return {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -107,6 +107,48 @@ type RunConfigurationSummary = {
   validation_note: string;
 };
 
+type PreRunValidationReport = {
+  status: "valid" | "caveated" | "blocked" | string;
+  selected_candidate?: {
+    candidate_id?: string | null;
+    station_id?: string | null;
+    valid_time_utc?: string | null;
+  } | null;
+  selected_hypothesis?: {
+    hypothesis_id?: string | null;
+    story_id?: string | null;
+    story_label?: string | null;
+    ingredient_score?: number | null;
+    predicted_output_signature?: string[];
+  } | null;
+  selected_run_recipe?: {
+    recipe_id?: string | null;
+    display_name?: string | null;
+    assumption_set_id?: string | null;
+  } | null;
+  hypothesis_recipe_alignment?: {
+    status?: string;
+    reasons?: string[];
+    missing_assumptions?: string[];
+    missing_outputs?: string[];
+  } | null;
+  run_shape_validation?: {
+    estimated_frames?: number | null;
+    estimated_output_volume?: string | null;
+    duration?: string | null;
+    domain?: string | null;
+    grid_detail?: string | null;
+    output_cadence?: string | null;
+  } | null;
+  output_validation?: {
+    required_fields?: string[];
+    enabled_fields?: string[];
+    missing_fields?: string[];
+  } | null;
+  blocking_errors?: string[];
+  caveats?: string[];
+};
+
 type DryRunReport = {
   scenario_id: string;
   package_family?: PackageFamily;
@@ -118,6 +160,7 @@ type DryRunReport = {
   controls: Record<string, string | number | boolean>;
   run_configuration: RunConfiguration;
   run_configuration_summary?: RunConfigurationSummary;
+  pre_run_validation_report?: PreRunValidationReport | null;
   estimated_cost_or_size: string;
   expected_diagnostics: string[];
   expected_outputs?: string[];
@@ -491,6 +534,7 @@ type RunStatusResponse = {
   package_display_name?: string | null;
   input_source?: string | null;
   run_configuration?: RunConfiguration | null;
+  pre_run_validation_report?: PreRunValidationReport | null;
 };
 
 type RunQueueEntry = {
@@ -667,6 +711,7 @@ type ResultCard = {
   scenario_id: string;
   scenario_name: string | null;
   run_configuration: RunConfiguration;
+  pre_run_validation_report?: PreRunValidationReport | null;
   physical_question: string;
   controls: Record<string, string | number | boolean>;
   status: string;
@@ -748,6 +793,7 @@ type RunStorageEntry = {
   validation_status: string | null;
   product_state: string | null;
   run_configuration: RunConfiguration | null;
+  pre_run_validation_report?: PreRunValidationReport | null;
   created_at: string | null;
   updated_at: string | null;
   saved: boolean;
@@ -1104,6 +1150,16 @@ const DEFAULT_DEEP_CONVECTION_RUN_CONFIGURATION: RunConfigurationInput = {
   output_field_density_preset: "rich",
 };
 
+class DryRunRequestError extends Error {
+  preRunValidationReport: PreRunValidationReport | null;
+
+  constructor(message: string, preRunValidationReport: PreRunValidationReport | null = null) {
+    super(message);
+    this.name = "DryRunRequestError";
+    this.preRunValidationReport = preRunValidationReport;
+  }
+}
+
 async function fetchScenarioCatalog(): Promise<ScenarioResponse> {
   const response = await fetch("/api/scenarios");
   if (!response.ok) {
@@ -1141,9 +1197,43 @@ async function requestDryRunPackage(
     }),
   });
   if (!response.ok) {
-    throw new Error("Unable to create dry-run package.");
+    const detail = await dryRunErrorDetail(response);
+    throw new DryRunRequestError(detail.message, detail.preRunValidationReport);
   }
   return response.json() as Promise<DryRunResponse>;
+}
+
+async function dryRunErrorDetail(
+  response: Response,
+): Promise<{ message: string; preRunValidationReport: PreRunValidationReport | null }> {
+  try {
+    const payload = (await response.json()) as {
+      detail?: string | {
+        message?: string;
+        pre_run_validation_report?: unknown;
+      };
+    };
+    if (typeof payload.detail === "string") {
+      return { message: payload.detail, preRunValidationReport: null };
+    }
+    if (payload.detail && typeof payload.detail === "object") {
+      return {
+        message: payload.detail.message ?? "Unable to create dry-run package.",
+        preRunValidationReport: isPreRunValidationReport(
+          payload.detail.pre_run_validation_report,
+        )
+          ? payload.detail.pre_run_validation_report
+          : null,
+      };
+    }
+  } catch {
+    return { message: "Unable to create dry-run package.", preRunValidationReport: null };
+  }
+  return { message: "Unable to create dry-run package.", preRunValidationReport: null };
+}
+
+function isPreRunValidationReport(value: unknown): value is PreRunValidationReport {
+  return Boolean(value && typeof value === "object" && "status" in value);
 }
 
 async function parseObservedSoundingUpload(
@@ -1658,6 +1748,8 @@ export function App() {
   const [savedCandidates, setSavedCandidates] = useState<SavedSoundingCandidate[]>([]);
   const [candidateDetailId, setCandidateDetailId] = useState<string | null>(null);
   const [dryRun, setDryRun] = useState<DryRunResponse | null>(null);
+  const [blockedPreRunValidationReport, setBlockedPreRunValidationReport] =
+    useState<PreRunValidationReport | null>(null);
   const [runStatus, setRunStatus] = useState<RunStatusResponse | null>(null);
   const [runQueue, setRunQueue] = useState<RunQueueResponse | null>(null);
   const [runQueueStatus, setRunQueueStatus] = useState("Local run queue not checked yet");
@@ -1696,6 +1788,7 @@ export function App() {
     setStatus("Loading scenarios...");
     setScenarios([]);
     setDryRun(null);
+    setBlockedPreRunValidationReport(null);
     setRunStatus(null);
     setRunWorkflowError(null);
     setLanWorkerStatus(null);
@@ -1848,6 +1941,7 @@ export function App() {
     setObservedSoundingError(null);
     setObservedPackageFamily("observed_sounding_quicklook");
     setDryRun(null);
+    setBlockedPreRunValidationReport(null);
     setRunStatus(null);
     setRunWorkflowError(null);
     setLanWorkerStatus(null);
@@ -1995,6 +2089,7 @@ export function App() {
     setObservedPackageFamily(nextPackageFamily);
     setRunConfiguration(defaultRunConfigurationForSelection(scenarioId, nextPackageFamily));
     setDryRun(null);
+    setBlockedPreRunValidationReport(null);
     setRunStatus(null);
     setRunWorkflowError(null);
     setLanWorkerStatus(null);
@@ -2007,6 +2102,7 @@ export function App() {
     setObservedPackageFamily(packageFamily);
     setRunConfiguration(defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID, packageFamily));
     setDryRun(null);
+    setBlockedPreRunValidationReport(null);
     setRunStatus(null);
     setRunWorkflowError(null);
     setLanWorkerStatus(null);
@@ -2206,6 +2302,7 @@ export function App() {
       defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID, nextPackageFamily),
     );
     setDryRun(null);
+    setBlockedPreRunValidationReport(null);
     setRunStatus(null);
     setRunWorkflowError(null);
     setLanWorkerStatus(null);
@@ -2225,6 +2322,7 @@ export function App() {
     setStatus("Creating dry-run package");
     setError(null);
     setDryRun(null);
+    setBlockedPreRunValidationReport(null);
     setRunStatus(null);
     setRunWorkflowError(null);
     setLanWorkerStatus(null);
@@ -2245,9 +2343,13 @@ export function App() {
         packageUserMetadata,
       );
       setDryRun(result);
+      setBlockedPreRunValidationReport(null);
       setStatus("Packaged dry-run output");
       await refreshStorageAfterWorkflow("Package added to local pipeline");
     } catch (caught) {
+      if (caught instanceof DryRunRequestError) {
+        setBlockedPreRunValidationReport(caught.preRunValidationReport);
+      }
       setError(caught instanceof Error ? caught.message : "Unable to create dry-run package.");
       setStatus("Scenario setup");
     }
@@ -2261,6 +2363,7 @@ export function App() {
     setSelectedCandidateScreening(null);
     setObservedPackageFamily("observed_sounding_quicklook");
     setDryRun(null);
+    setBlockedPreRunValidationReport(null);
     setRunStatus(null);
     setLanWorkerStatus(null);
     try {
@@ -2775,6 +2878,7 @@ export function App() {
           candidateDetailId={candidateDetailId}
           validationMessages={validationMessages}
           dryRun={dryRun}
+          blockedPreRunValidationReport={blockedPreRunValidationReport}
           runStatus={runStatus}
           runQueue={runQueue}
           runQueueStatus={runQueueStatus}
@@ -2924,6 +3028,7 @@ function BuildWorkspace({
   candidateDetailId,
   validationMessages,
   dryRun,
+  blockedPreRunValidationReport,
   runStatus,
   runQueue,
   runQueueStatus,
@@ -3019,6 +3124,7 @@ function BuildWorkspace({
   candidateDetailId: string | null;
   validationMessages: string[];
   dryRun: DryRunResponse | null;
+  blockedPreRunValidationReport: PreRunValidationReport | null;
   runStatus: RunStatusResponse | null;
   runQueue: RunQueueResponse | null;
   runQueueStatus: string;
@@ -3301,6 +3407,22 @@ function BuildWorkspace({
                   <p>{packageError}</p>
                 </div>
               )}
+
+              {blockedPreRunValidationReport && (
+                <PreRunValidationReportPanel report={blockedPreRunValidationReport} />
+              )}
+
+              <BuildRunActionPanel
+                dryRun={dryRun}
+                runStatus={runStatus}
+                lanWorkerStatus={lanWorkerStatus}
+                canCreatePackage={
+                  validationMessages.length === 0 &&
+                  (!observedSoundingExperimentSelected ||
+                    Boolean(observedSoundingParse?.selected_sounding))
+                }
+                onLaunchRun={onLaunchRun}
+              />
             </>
           )}
         </form>
@@ -3317,13 +3439,6 @@ function BuildWorkspace({
             lanWorkerError={lanWorkerError}
             lanWorkerActionStatus={lanWorkerActionStatus}
             ingestedResultId={ingestedResultId}
-            showCreatePackageAction={scenarioControlsReady}
-            canCreatePackage={
-              validationMessages.length === 0 &&
-              (!observedSoundingExperimentSelected ||
-                Boolean(observedSoundingParse?.selected_sounding))
-            }
-            onLaunchRun={onLaunchRun}
             onRefreshRunStatus={onRefreshRunStatus}
             onLaunchLanWorkerRun={onLaunchLanWorkerRun}
             onRefreshLanWorkerStatus={onRefreshLanWorkerStatus}
@@ -3392,6 +3507,156 @@ function BuildControlRow({
         ))}
       </select>
     </div>
+  );
+}
+
+function PreRunValidationReportPanel({ report }: { report: PreRunValidationReport }) {
+  const hypothesis = report.selected_hypothesis ?? null;
+  const recipe = report.selected_run_recipe ?? null;
+  const alignment = report.hypothesis_recipe_alignment ?? null;
+  const runShape = report.run_shape_validation ?? null;
+  const outputValidation = report.output_validation ?? null;
+  const blockingErrors = report.blocking_errors ?? [];
+  const caveats = report.caveats ?? [];
+
+  return (
+    <section
+      className="experiment-summary pre-run-validation-panel"
+      aria-label="Pre-run validation report"
+    >
+      <div className="panel-heading-row">
+        <div>
+          <p className="eyebrow">Pre-run validation</p>
+          <h3>Hypothesis and run recipe check</h3>
+          <p className="field-help">
+            Cloud Chamber checks whether the selected hypothesis, recipe, fields, and run shape can
+            be compared honestly before CM1 is launched.
+          </p>
+        </div>
+        <StatusBadge
+          label={preRunValidationStatusLabel(report.status)}
+          tone={preRunValidationTone(report.status)}
+        />
+      </div>
+
+      <dl className="compact-metrics">
+        <Metric
+          label="Hypothesis"
+          value={
+            hypothesis?.story_label ??
+            humanize(hypothesis?.story_id ?? hypothesis?.hypothesis_id ?? "none")
+          }
+        />
+        {typeof hypothesis?.ingredient_score === "number" && (
+          <Metric label="Ingredient score" value={`${Math.round(hypothesis.ingredient_score)} %`} />
+        )}
+        <Metric
+          label="Run recipe"
+          value={recipe?.display_name ?? humanize(recipe?.recipe_id ?? "unknown")}
+        />
+        <Metric label="Assumption set" value={recipe?.assumption_set_id ?? "Not declared"} />
+        <Metric
+          label="Run shape"
+          value={
+            runShape
+              ? preRunValidationRunShapeLabel(runShape)
+              : "Run shape unavailable before package generation"
+          }
+        />
+        <Metric
+          label="Required outputs"
+          value={compactList(outputValidation?.required_fields, "No specific fields required")}
+        />
+        <Metric
+          label="Missing assumptions"
+          value={compactList(alignment?.missing_assumptions, "None")}
+        />
+        <Metric
+          label="Missing outputs"
+          value={compactList(outputValidation?.missing_fields, "None")}
+        />
+      </dl>
+
+      {alignment?.reasons?.length ? (
+        <ul>
+          {alignment.reasons.map((reason) => (
+            <li key={reason}>{reason}</li>
+          ))}
+        </ul>
+      ) : null}
+
+      {blockingErrors.length > 0 && (
+        <div className="validation">
+          <h4>Blocking issues</h4>
+          <ul>
+            {blockingErrors.map((error) => (
+              <li key={error}>{error}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {caveats.length > 0 && (
+        <details className="technical-details">
+          <summary>Validation caveats</summary>
+          <ul>
+            {caveats.map((caveat) => (
+              <li key={caveat}>{humanize(caveat)}</li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </section>
+  );
+}
+
+function BuildRunActionPanel({
+  dryRun,
+  runStatus,
+  lanWorkerStatus,
+  canCreatePackage,
+  onLaunchRun,
+}: {
+  dryRun: DryRunResponse | null;
+  runStatus: RunStatusResponse | null;
+  lanWorkerStatus: LanWorkerRunResponse | null;
+  canCreatePackage: boolean;
+  onLaunchRun: () => void;
+}) {
+  const packageReadyForQueue = Boolean(dryRun && !runStatus && !lanWorkerStatus);
+  return (
+    <section className="experiment-summary build-run-action-panel" aria-label="Package and queue">
+      <div className="panel-heading-row">
+        <div>
+          <p className="eyebrow">Package and queue</p>
+          <h3>{dryRun ? "Package ready for CM1" : "Ready to package this setup"}</h3>
+          <p className="field-help">
+            Create the run package from the selected sounding, hypothesis, and CM1 run settings.
+            Then queue that package for local CM1 execution when you are ready.
+          </p>
+        </div>
+        <StatusBadge
+          label={dryRun ? "Package ready" : canCreatePackage ? "Ready" : "Needs setup"}
+          tone={dryRun ? "good" : canCreatePackage ? "good" : "warning"}
+        />
+      </div>
+
+      <div className="button-row">
+        <button
+          type="submit"
+          data-testid="create-package-btn"
+          className={dryRun ? "secondary-button" : undefined}
+          disabled={!canCreatePackage}
+        >
+          {dryRun ? "Create another package" : "Create run package"}
+        </button>
+        {packageReadyForQueue && (
+          <button type="button" data-testid="launch-cm1-btn" onClick={onLaunchRun}>
+            Queue local CM1 run
+          </button>
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -4027,13 +4292,14 @@ function SavedSoundingCandidateCard({
 }) {
   const currentWorkingSet = saved.tags.find(isCandidateSuggestedTag) ?? "";
   const [workingSetDraft, setWorkingSetDraft] = useState(currentWorkingSet);
+  const workingSetDraftRef = useRef(currentWorkingSet);
   useEffect(() => {
+    workingSetDraftRef.current = currentWorkingSet;
     setWorkingSetDraft(currentWorkingSet);
   }, [saved.saved_candidate_id, currentWorkingSet]);
   const freeformTags = saved.tags.filter((tag) => !isCandidateSuggestedTag(tag));
-  const nextTags = _dedupeStrings(
-    [workingSetDraft, ...freeformTags].filter((tag): tag is string => Boolean(tag)),
-  );
+  const workingSetTags = (draft: string) =>
+    _dedupeStrings([draft, ...freeformTags].filter((tag): tag is string => Boolean(tag)));
   return (
     <article
       className="saved-candidate-card"
@@ -4057,7 +4323,10 @@ function SavedSoundingCandidateCard({
             id={`saved-working-set-${saved.saved_candidate_id}`}
             aria-label={`Working set for ${candidateStationLabel(saved.candidate)}`}
             value={workingSetDraft}
-            onChange={(event) => setWorkingSetDraft(event.target.value)}
+            onChange={(event) => {
+              workingSetDraftRef.current = event.target.value;
+              setWorkingSetDraft(event.target.value);
+            }}
           >
             <option value="">No working set</option>
             {candidateSuggestedTags.map((tag) => (
@@ -4067,7 +4336,11 @@ function SavedSoundingCandidateCard({
             ))}
           </select>
         </label>
-        <button type="button" className="secondary-button" onClick={() => onUpdateWorkingSet(nextTags)}>
+        <button
+          type="button"
+          className="secondary-button"
+          onClick={() => onUpdateWorkingSet(workingSetTags(workingSetDraftRef.current))}
+        >
           Update working set
         </button>
       </div>
@@ -4819,9 +5092,6 @@ function LocalRunWorkflowPanel({
   results,
   autoFinalizingWorkerRunIds,
   failedAutoFinalizingWorkerRunIds,
-  showCreatePackageAction,
-  canCreatePackage,
-  onLaunchRun,
   onRefreshRunStatus,
   onLaunchLanWorkerRun,
   onRefreshLanWorkerStatus,
@@ -4859,9 +5129,6 @@ function LocalRunWorkflowPanel({
   results: ResultCard[];
   autoFinalizingWorkerRunIds: Set<string>;
   failedAutoFinalizingWorkerRunIds: Set<string>;
-  showCreatePackageAction: boolean;
-  canCreatePackage: boolean;
-  onLaunchRun: () => void;
   onRefreshRunStatus: () => void;
   onLaunchLanWorkerRun: () => void;
   onRefreshLanWorkerStatus: () => void;
@@ -4894,12 +5161,10 @@ function LocalRunWorkflowPanel({
     : 0;
   const generatedInputNames = dryRun ? generatedInputSummary(dryRun) : [];
   const currentRunId = dryRun ? runIdFromPackage(dryRun) : null;
-  const showCreatePackageButton = showCreatePackageAction;
-  const showLaunchButton = Boolean(dryRun && !runStatus && !lanWorkerStatus);
+  const packageReadyForLaunch = Boolean(dryRun && !runStatus && !lanWorkerStatus);
   const showRefreshButton = Boolean(dryRun && runStatus);
   const showIngestButton = Boolean(dryRun && canIngest);
-  const showActionRow =
-    showCreatePackageButton || showLaunchButton || showRefreshButton || showIngestButton;
+  const showActionRow = showRefreshButton || showIngestButton;
   const packageObservedSounding = dryRun?.report.observed_sounding ?? null;
   const packageUserMetadata = dryRun?.report.user ?? null;
 
@@ -4920,33 +5185,18 @@ function LocalRunWorkflowPanel({
       <div className="run-state-card package-setup-card">
         <div className="panel-heading-row">
           <div>
-            <p className="eyebrow">Package this setup</p>
-            <h4>{dryRun ? "Latest generated package" : "Create a local run package"}</h4>
+            <p className="eyebrow">Package status</p>
+            <h4>{dryRun ? "Latest generated package" : "No generated package yet"}</h4>
           </div>
           <strong className="next-action">{buildStageLabel(stage)}</strong>
         </div>
 
         <p className="state-note">
-          Packages are repeatable local run directories. Create a new package for this setup, then
-          use the package list below to run CM1, ingest completed output, or route old runs to
-          cleanup.
+          Package creation and queueing live at the end of the setup flow. This rail keeps the
+          generated package, queue, ingest, worker, and cleanup state visible while you work.
         </p>
 
         {error && <p role="alert">{error}</p>}
-
-        {showCreatePackageButton && (
-          <div className="button-row">
-            <button
-              type="submit"
-              form="build-run-package-form"
-              data-testid="create-package-btn"
-              className={dryRun ? "secondary-button" : undefined}
-              disabled={!canCreatePackage}
-            >
-              {dryRun ? "Create another package" : "Create run package"}
-            </button>
-          </div>
-        )}
 
         {dryRun ? (
           <>
@@ -5007,6 +5257,9 @@ function LocalRunWorkflowPanel({
                 value={runStatus ? userFacingRunWorkflowStatus(runStatus) : "Package ready"}
               />
             </dl>
+            {dryRun.report.pre_run_validation_report && (
+              <PreRunValidationReportPanel report={dryRun.report.pre_run_validation_report} />
+            )}
             <p className="state-note">
               A generated package is not a completed CM1 result. Launch, output detection, ingest,
               and saved result review are separate states.
@@ -5024,11 +5277,6 @@ function LocalRunWorkflowPanel({
 
         {showActionRow && dryRun && (
           <div className="button-row">
-            {showLaunchButton && (
-              <button type="button" data-testid="launch-cm1-btn" onClick={onLaunchRun}>
-                Queue local CM1 run
-              </button>
-            )}
             {showRefreshButton && (
               <button type="button" data-testid="refresh-status-btn" onClick={onRefreshRunStatus}>
                 {stage === "running" || stage === "failed"
@@ -5059,7 +5307,7 @@ function LocalRunWorkflowPanel({
             actionStatus={lanWorkerActionStatus}
             error={lanWorkerError}
             ingestedResultId={ingestedResultId}
-            canStart={showLaunchButton}
+            canStart={packageReadyForLaunch}
             onLaunch={onLaunchLanWorkerRun}
             onRefresh={onRefreshLanWorkerStatus}
             onCollect={onCollectLanWorkerRun}
@@ -9082,6 +9330,38 @@ function runUserMetadataFromCandidateScreening(
       : null;
   if (tags.length === 0 && !notes) return null;
   return { tags, notes };
+}
+
+function preRunValidationStatusLabel(status: string): string {
+  if (status === "valid") return "Valid";
+  if (status === "caveated") return "Valid with caveats";
+  if (status === "blocked") return "Blocked";
+  return humanize(status);
+}
+
+function preRunValidationTone(status: string): "good" | "warning" | "neutral" {
+  if (status === "valid") return "good";
+  if (status === "caveated" || status === "blocked") return "warning";
+  return "neutral";
+}
+
+function preRunValidationRunShapeLabel(
+  runShape: NonNullable<PreRunValidationReport["run_shape_validation"]>,
+): string {
+  const parts = [
+    runShape.duration ? humanize(runShape.duration) : null,
+    runShape.domain ? humanize(runShape.domain) : null,
+    runShape.grid_detail ? humanize(runShape.grid_detail) : null,
+    runShape.output_cadence ? `${humanize(runShape.output_cadence)} output` : null,
+    typeof runShape.estimated_frames === "number"
+      ? `${runShape.estimated_frames.toLocaleString()} saved frames`
+      : null,
+  ].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(" · ") : "Not resolved";
+}
+
+function compactList(values: string[] | undefined | null, fallback: string): string {
+  return values?.length ? values.join(", ") : fallback;
 }
 
 function StatusBadge({ label, tone }: { label: string; tone: "good" | "warning" | "neutral" }) {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -38,11 +38,11 @@ type ScenarioResponse = {
 };
 
 type RunConfigurationInput = {
-  duration_preset: string;
-  grid_detail_preset: string;
-  domain_size_preset: string;
-  output_cadence_preset: string;
-  output_field_density_preset: string;
+  duration: string;
+  horizontal_cell_count: string;
+  domain_size: string;
+  output_cadence: string;
+  diagnostic_set: string;
 };
 
 type RunConfigurationCM1Values = {
@@ -64,10 +64,11 @@ type RunConfigurationCM1Values = {
   grid_cell_count: number;
 };
 
-type RunConfiguration = RunConfigurationInput & {
+type RunConfiguration = Omit<RunConfigurationInput, "horizontal_cell_count"> & {
   configuration_id: string;
   mode: "smoke" | "science";
   label: string;
+  horizontal_cell_count: string | number;
   duration_seconds: number;
   output_cadence_seconds: number;
   cost_runtime_summary: string;
@@ -80,11 +81,11 @@ type RunConfigurationSummary = {
   configuration_id: string;
   mode: "smoke" | "science";
   label: string;
-  duration_preset: string;
-  grid_detail_preset: string;
-  domain_size_preset: string;
-  output_cadence_preset: string;
-  output_field_density_preset: string;
+  duration: string;
+  horizontal_cell_count: string | number;
+  domain_size: string;
+  output_cadence: string;
+  diagnostic_set: string;
   runtime_seconds: number;
   output_cadence_seconds: number;
   expected_output_frames: number;
@@ -137,8 +138,9 @@ type PreRunValidationReport = {
     estimated_output_volume?: string | null;
     duration?: string | null;
     domain?: string | null;
-    grid_detail?: string | null;
+    horizontal_cell_count?: number | string | null;
     output_cadence?: string | null;
+    diagnostic_set?: string | null;
   } | null;
   output_validation?: {
     required_fields?: string[];
@@ -151,8 +153,8 @@ type PreRunValidationReport = {
 
 type DryRunReport = {
   scenario_id: string;
-  package_family?: PackageFamily;
-  package_display_name?: string;
+  run_recipe?: RunRecipe;
+  run_recipe_display_name?: string;
   input_source?: string;
   trigger_type?: string | null;
   trigger_parameters?: Record<string, string | number | boolean> | null;
@@ -164,7 +166,7 @@ type DryRunReport = {
   estimated_cost_or_size: string;
   expected_diagnostics: string[];
   expected_outputs?: string[];
-  package_caveats?: string[];
+  run_caveats?: string[];
   manual_validation_status?: string | null;
   visualization_defaults: Record<string, unknown>;
   generated_files: Record<string, string>;
@@ -323,9 +325,12 @@ type CandidateRecipeFitDisplay = {
   caveats: string[];
 };
 
-type PackageFamily = "shallow_cumulus" | "observed_sounding_quicklook" | "deep_convection_trial";
+type RunRecipe =
+  | "generated_reference_lower_atmosphere"
+  | "untriggered_observed_evolution"
+  | "triggered_deep_potential";
 
-type ObservedPackageFamily = "observed_sounding_quicklook" | "deep_convection_trial";
+type ObservedRunRecipe = "untriggered_observed_evolution" | "triggered_deep_potential";
 
 type StoryScore = {
   story: CandidateStoryId;
@@ -530,8 +535,8 @@ type RunStatusResponse = {
   user?: UserRunMetadata | null;
   observed_sounding?: ObservedSoundingSummary | null;
   candidate_screening?: Record<string, unknown> | null;
-  package_family?: PackageFamily | string | null;
-  package_display_name?: string | null;
+  run_recipe?: RunRecipe | string | null;
+  run_recipe_display_name?: string | null;
   input_source?: string | null;
   run_configuration?: RunConfiguration | null;
   pre_run_validation_report?: PreRunValidationReport | null;
@@ -721,12 +726,12 @@ type ResultCard = {
   input_source?: "generated_reference" | "observed_sounding" | string;
   input_source_label?: string;
   observed_sounding?: ObservedSoundingSummary | null;
-  package_family?: string | null;
-  package_display_name?: string | null;
+  run_recipe?: string | null;
+  run_recipe_display_name?: string | null;
   trigger_type?: string | null;
   trigger_parameters?: Record<string, unknown> | null;
   expected_outputs?: string[];
-  package_caveats?: string[];
+  run_caveats?: string[];
   manual_validation_status?: string | null;
   candidate_screening?: Record<string, unknown> | null;
   candidate_hypothesis_comparison?: CandidateHypothesisComparison | null;
@@ -1127,27 +1132,27 @@ const candidateSuggestedTags = [
 ] as const;
 
 const DEFAULT_SHALLOW_RUN_CONFIGURATION: RunConfigurationInput = {
-  duration_preset: "quick_6h",
-  grid_detail_preset: "standard",
-  domain_size_preset: "local_6km",
-  output_cadence_preset: "standard_15min",
-  output_field_density_preset: "analysis",
+  duration: "short_6h",
+  horizontal_cell_count: "cells_64",
+  domain_size: "local_6km",
+  output_cadence: "standard_15min",
+  diagnostic_set: "process",
 };
 
 const DEFAULT_OBSERVED_RUN_CONFIGURATION: RunConfigurationInput = {
-  duration_preset: "quick_6h",
-  grid_detail_preset: "standard",
-  domain_size_preset: "wide_12km",
-  output_cadence_preset: "standard_15min",
-  output_field_density_preset: "analysis",
+  duration: "short_6h",
+  horizontal_cell_count: "cells_128",
+  domain_size: "wide_12km",
+  output_cadence: "standard_15min",
+  diagnostic_set: "process",
 };
 
-const DEFAULT_DEEP_CONVECTION_RUN_CONFIGURATION: RunConfigurationInput = {
-  duration_preset: "quick_6h",
-  grid_detail_preset: "standard",
-  domain_size_preset: "storm_120km",
-  output_cadence_preset: "standard_15min",
-  output_field_density_preset: "rich",
+const DEFAULT_TRIGGERED_DEEP_POTENTIAL_RUN_CONFIGURATION: RunConfigurationInput = {
+  duration: "short_6h",
+  horizontal_cell_count: "cells_128",
+  domain_size: "storm_120km",
+  output_cadence: "standard_15min",
+  diagnostic_set: "full",
 };
 
 class DryRunRequestError extends Error {
@@ -1172,7 +1177,7 @@ async function requestDryRunPackage(
   scenarioId: string,
   controls: Record<string, string | number | boolean>,
   runConfiguration: RunConfigurationInput,
-  packageFamily?: PackageFamily | null,
+  runRecipe?: RunRecipe | null,
   observedSounding?: ObservedSoundingRecord | null,
   candidateScreening?: Record<string, unknown> | null,
   userMetadata?: {
@@ -1188,7 +1193,7 @@ async function requestDryRunPackage(
       scenario_id: scenarioId,
       controls,
       run_configuration: runConfiguration,
-      package_family: packageFamily ?? null,
+      run_recipe: runRecipe ?? null,
       observed_sounding: observedSounding ?? null,
       candidate_screening: candidateScreening ?? null,
       user_name: userMetadata?.name ?? null,
@@ -1714,8 +1719,8 @@ export function App() {
   const [runConfiguration, setRunConfiguration] = useState<RunConfigurationInput>(
     DEFAULT_SHALLOW_RUN_CONFIGURATION,
   );
-  const [observedPackageFamily, setObservedPackageFamily] = useState<ObservedPackageFamily>(
-    "observed_sounding_quicklook",
+  const [observedRunRecipe, setObservedRunRecipe] = useState<ObservedRunRecipe>(
+    "untriggered_observed_evolution",
   );
   const [observedSoundingFilename, setObservedSoundingFilename] = useState<string | null>(null);
   const [observedSoundingText, setObservedSoundingText] = useState<string | null>(null);
@@ -1932,14 +1937,14 @@ export function App() {
     );
     setControls(defaults);
     setRunConfiguration(
-      defaultRunConfigurationForSelection(selectedScenarioId, "observed_sounding_quicklook"),
+      defaultRunConfigurationForSelection(selectedScenarioId, "untriggered_observed_evolution"),
     );
     setObservedSoundingFilename(null);
     setObservedSoundingText(null);
     setObservedSoundingParse(null);
     setObservedSoundingStatus(null);
     setObservedSoundingError(null);
-    setObservedPackageFamily("observed_sounding_quicklook");
+    setObservedRunRecipe("untriggered_observed_evolution");
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
     setRunStatus(null);
@@ -2078,7 +2083,7 @@ export function App() {
   }
 
   function handleSelectScenario(scenarioId: string) {
-    const nextPackageFamily: ObservedPackageFamily = "observed_sounding_quicklook";
+    const nextRunRecipe: ObservedRunRecipe = "untriggered_observed_evolution";
     setSelectedScenarioId(scenarioId);
     setObservedSoundingFilename(null);
     setObservedSoundingText(null);
@@ -2086,8 +2091,8 @@ export function App() {
     setObservedSoundingStatus(null);
     setObservedSoundingError(null);
     setSelectedCandidateScreening(null);
-    setObservedPackageFamily(nextPackageFamily);
-    setRunConfiguration(defaultRunConfigurationForSelection(scenarioId, nextPackageFamily));
+    setObservedRunRecipe(nextRunRecipe);
+    setRunConfiguration(defaultRunConfigurationForSelection(scenarioId, nextRunRecipe));
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
     setRunStatus(null);
@@ -2098,9 +2103,9 @@ export function App() {
     setIngestedResultId(null);
   }
 
-  function handleObservedPackageFamilyChange(packageFamily: ObservedPackageFamily) {
-    setObservedPackageFamily(packageFamily);
-    setRunConfiguration(defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID, packageFamily));
+  function handleObservedRunRecipeChange(runRecipe: ObservedRunRecipe) {
+    setObservedRunRecipe(runRecipe);
+    setRunConfiguration(defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID, runRecipe));
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
     setRunStatus(null);
@@ -2296,10 +2301,10 @@ export function App() {
     setObservedSoundingStatus("Candidate loaded into observed-sounding package review");
     setObservedSoundingError(null);
     setSelectedCandidateScreening(candidateScreeningMetadata(candidate, savedCandidate, activeStory));
-    const nextPackageFamily = defaultPackageFamilyForCandidate(candidate, activeStory);
-    setObservedPackageFamily(nextPackageFamily);
+    const nextRunRecipe = defaultRunRecipeForCandidate(candidate, activeStory);
+    setObservedRunRecipe(nextRunRecipe);
     setRunConfiguration(
-      defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID, nextPackageFamily),
+      defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID, nextRunRecipe),
     );
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
@@ -2337,7 +2342,7 @@ export function App() {
         selectedScenario.id,
         controls,
         runConfiguration,
-        observedSoundingExperimentSelected ? observedPackageFamily : null,
+        observedSoundingExperimentSelected ? observedRunRecipe : null,
         observedSoundingExperimentSelected ? observedSoundingParse?.selected_sounding : null,
         observedSoundingExperimentSelected ? selectedCandidateScreening : null,
         packageUserMetadata,
@@ -2361,7 +2366,7 @@ export function App() {
     setObservedSoundingError(null);
     setObservedSoundingParse(null);
     setSelectedCandidateScreening(null);
-    setObservedPackageFamily("observed_sounding_quicklook");
+    setObservedRunRecipe("untriggered_observed_evolution");
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
     setRunStatus(null);
@@ -2373,7 +2378,7 @@ export function App() {
       const parsed = await parseObservedSoundingUpload(file.name, text);
       setObservedSoundingParse(parsed);
       setSelectedCandidateScreening(null);
-      setObservedPackageFamily("observed_sounding_quicklook");
+      setObservedRunRecipe("untriggered_observed_evolution");
       setObservedSoundingStatus("Observed sounding validated for package review");
     } catch (caught) {
       setObservedSoundingText(null);
@@ -2399,7 +2404,7 @@ export function App() {
       );
       setObservedSoundingParse(parsed);
       setSelectedCandidateScreening(null);
-      setObservedPackageFamily("observed_sounding_quicklook");
+      setObservedRunRecipe("untriggered_observed_evolution");
       setObservedSoundingStatus("Observed sounding validated for package review");
     } catch (caught) {
       setObservedSoundingError(
@@ -2854,7 +2859,7 @@ export function App() {
           observedSoundingExperimentSelected={observedSoundingExperimentSelected}
           controls={controls}
           runConfiguration={runConfiguration}
-          observedPackageFamily={observedPackageFamily}
+          observedRunRecipe={observedRunRecipe}
           observedSoundingParse={observedSoundingParse}
           observedSoundingStatus={observedSoundingStatus}
           observedSoundingError={observedSoundingError}
@@ -2904,7 +2909,7 @@ export function App() {
             }))
           }
           onRunConfigurationChange={setRunConfiguration}
-          onObservedPackageFamilyChange={handleObservedPackageFamilyChange}
+          onObservedRunRecipeChange={handleObservedRunRecipeChange}
           onObservedSoundingFile={handleObservedSoundingFile}
           onObservedSoundingTimeChange={handleObservedSoundingTimeChange}
           onCandidateStoryFilterChange={setCandidateStoryFilter}
@@ -3004,7 +3009,7 @@ function BuildWorkspace({
   observedSoundingExperimentSelected,
   controls,
   runConfiguration,
-  observedPackageFamily,
+  observedRunRecipe,
   observedSoundingParse,
   observedSoundingStatus,
   observedSoundingError,
@@ -3049,7 +3054,7 @@ function BuildWorkspace({
   onSelectScenario,
   onControlChange,
   onRunConfigurationChange,
-  onObservedPackageFamilyChange,
+  onObservedRunRecipeChange,
   onObservedSoundingFile,
   onObservedSoundingTimeChange,
   onCandidateStoryFilterChange,
@@ -3100,7 +3105,7 @@ function BuildWorkspace({
   observedSoundingExperimentSelected: boolean;
   controls: Record<string, string | number | boolean>;
   runConfiguration: RunConfigurationInput;
-  observedPackageFamily: ObservedPackageFamily;
+  observedRunRecipe: ObservedRunRecipe;
   observedSoundingParse: ObservedSoundingParseResponse | null;
   observedSoundingStatus: string | null;
   observedSoundingError: string | null;
@@ -3145,7 +3150,7 @@ function BuildWorkspace({
   onSelectScenario: (scenarioId: string) => void;
   onControlChange: (controlId: string, value: string) => void;
   onRunConfigurationChange: (configuration: RunConfigurationInput) => void;
-  onObservedPackageFamilyChange: (packageFamily: ObservedPackageFamily) => void;
+  onObservedRunRecipeChange: (runRecipe: ObservedRunRecipe) => void;
   onObservedSoundingFile: (file: File) => void;
   onObservedSoundingTimeChange: (validTimeUtc: string) => void;
   onCandidateStoryFilterChange: (filter: CandidateStoryFilter) => void;
@@ -3191,11 +3196,13 @@ function BuildWorkspace({
   onRetryScenarios: () => void;
 }) {
   const scenarioControlsReady = scenarioLoadState === "loaded" && selectedScenario !== undefined;
-  const selectedDeepConvectionTrial =
-    observedSoundingExperimentSelected && observedPackageFamily === "deep_convection_trial";
+  const selectedTriggeredDeepPotential =
+    observedSoundingExperimentSelected && observedRunRecipe === "triggered_deep_potential";
   const runConfigurationPreview = previewRunConfiguration(
     runConfiguration,
-    observedSoundingExperimentSelected ? observedPackageFamily : "shallow_cumulus",
+    observedSoundingExperimentSelected
+      ? observedRunRecipe
+      : "generated_reference_lower_atmosphere",
   );
 
   return (
@@ -3379,10 +3386,10 @@ function BuildWorkspace({
                     onFile={onObservedSoundingFile}
                     onTimeChange={onObservedSoundingTimeChange}
                   />
-                  <ObservedPackageFamilyPanel
-                    packageFamily={observedPackageFamily}
+                  <ObservedRunRecipePanel
+                    runRecipe={observedRunRecipe}
                     selectedCandidateScreening={selectedCandidateScreening}
-                    onChange={onObservedPackageFamilyChange}
+                    onChange={onObservedRunRecipeChange}
                   />
                 </>
               )}
@@ -3390,7 +3397,7 @@ function BuildWorkspace({
               <RunConfigurationPanel
                 configuration={runConfiguration}
                 preview={runConfigurationPreview}
-                deepConvectionTrial={selectedDeepConvectionTrial}
+                triggeredDeepPotential={selectedTriggeredDeepPotential}
                 onChange={onRunConfigurationChange}
               />
 
@@ -3663,15 +3670,15 @@ function BuildRunActionPanel({
 function RunConfigurationPanel({
   configuration,
   preview,
-  deepConvectionTrial,
+  triggeredDeepPotential,
   onChange,
 }: {
   configuration: RunConfigurationInput;
   preview: RunConfiguration;
-  deepConvectionTrial: boolean;
+  triggeredDeepPotential: boolean;
   onChange: (configuration: RunConfigurationInput) => void;
 }) {
-  const domainOptions = deepConvectionTrial ? DEEP_DOMAIN_OPTIONS : SHALLOW_DOMAIN_OPTIONS;
+  const domainOptions = triggeredDeepPotential ? DEEP_DOMAIN_OPTIONS : SHALLOW_DOMAIN_OPTIONS;
   const update = (key: keyof RunConfigurationInput, value: string) => {
     onChange({ ...configuration, [key]: value });
   };
@@ -3683,7 +3690,7 @@ function RunConfigurationPanel({
           <h3 id="run-configuration-title">Choose what CM1 will actually run</h3>
           <p className="field-help">
             Smoke checks package health. Science configurations are long enough to inspect
-            evolution; cost is controlled by grid/detail, domain, cadence, and fields.
+            evolution; cost is controlled by horizontal cells, domain, cadence, and diagnostics.
           </p>
         </div>
         <StatusBadge
@@ -3696,50 +3703,50 @@ function RunConfigurationPanel({
         <RunConfigurationSelect
           id="run-duration"
           label="Duration"
-          description="Model-time length. Quick science is the shortest normal evolution run."
-          value={configuration.duration_preset}
+          description="Model-time length. Short evolution is the shortest normal science run."
+          value={configuration.duration}
           options={DURATION_OPTIONS}
-          onChange={(value) => update("duration_preset", value)}
+          onChange={(value) => update("duration", value)}
         />
         <RunConfigurationSelect
           id="run-grid"
-          label="Grid / detail"
+          label="Horizontal cells"
           description={
-            deepConvectionTrial
-              ? "Storm-scale spacing; Standard resolves the 120 km domain at 1 km."
-              : "Lower-atmosphere spacing; Standard resolves the local domain at 100 m."
+            triggeredDeepPotential
+              ? "Storm-scale cell budget. CM1 spacing is derived from domain width divided by cells."
+              : "Observed-evolution cell budget. More cells reduce dx/dy and increase compute and output volume."
           }
-          value={configuration.grid_detail_preset}
-          options={GRID_DETAIL_OPTIONS}
-          onChange={(value) => update("grid_detail_preset", value)}
+          value={configuration.horizontal_cell_count}
+          options={HORIZONTAL_CELL_OPTIONS}
+          onChange={(value) => update("horizontal_cell_count", value)}
         />
         <RunConfigurationSelect
           id="run-domain"
           label="Domain size"
           description={
-            deepConvectionTrial
+            triggeredDeepPotential
               ? "Storm-growth domain for triggered-potential experiments."
               : "Observed soundings default wider so winds do not make the setup misleading."
           }
-          value={configuration.domain_size_preset}
+          value={configuration.domain_size}
           options={domainOptions}
-          onChange={(value) => update("domain_size_preset", value)}
+          onChange={(value) => update("domain_size", value)}
         />
         <RunConfigurationSelect
           id="run-cadence"
           label="Output cadence"
           description="Saved-output interval for Results and Explore."
-          value={configuration.output_cadence_preset}
+          value={configuration.output_cadence}
           options={OUTPUT_CADENCE_OPTIONS}
-          onChange={(value) => update("output_cadence_preset", value)}
+          onChange={(value) => update("output_cadence", value)}
         />
         <RunConfigurationSelect
           id="run-fields"
-          label="Output fields"
-          description="Field density controls later diagnostics and storage volume."
-          value={configuration.output_field_density_preset}
-          options={FIELD_DENSITY_OPTIONS}
-          onChange={(value) => update("output_field_density_preset", value)}
+          label="Diagnostic set"
+          description="Controls which CM1 variables are written for Results and Explore. More diagnostics mainly increase disk use and I/O, while enabling better explanations."
+          value={configuration.diagnostic_set}
+          options={DIAGNOSTIC_SET_OPTIONS}
+          onChange={(value) => update("diagnostic_set", value)}
         />
       </div>
 
@@ -4047,7 +4054,7 @@ function ObservedAtmosphereCandidatesPanel({
               onChange={(event) => onStoryFilterChange(event.target.value as CandidateStoryFilter)}
             >
               <option value="all">All screening stories</option>
-              <option value="deep_convection_trial">Deep Convection Trial stories</option>
+              <option value="deep_convection_trial">Deep-convection stories</option>
               <option value="shallow_cumulus_candidate">Cloud-forming shallow cumulus</option>
               <option value="dry_failed_candidate">Dry failed cumulus</option>
               <option value="capped_suppressed_candidate">Capped / suppressed</option>
@@ -4791,82 +4798,83 @@ function ObservedSoundingInputPanel({
   );
 }
 
-function ObservedPackageFamilyPanel({
-  packageFamily,
+function ObservedRunRecipePanel({
+  runRecipe,
   selectedCandidateScreening,
   onChange,
 }: {
-  packageFamily: ObservedPackageFamily;
+  runRecipe: ObservedRunRecipe;
   selectedCandidateScreening: Record<string, unknown> | null;
-  onChange: (packageFamily: ObservedPackageFamily) => void;
+  onChange: (runRecipe: ObservedRunRecipe) => void;
 }) {
-  const selectedDeep = packageFamily === "deep_convection_trial";
-  const packageMismatchWarning = candidatePackageMismatchWarning(
+  const selectedDeep = runRecipe === "triggered_deep_potential";
+  const packageMismatchWarning = candidateRecipeMismatchWarning(
     selectedCandidateScreening,
-    packageFamily,
+    runRecipe,
   );
+  const activeStoryLabel = observedRecipeStoryLabel(selectedCandidateScreening);
   const candidateGuidance = selectedCandidateScreening
-    ? "Candidate screening is ingredient guidance. Choose the package based on what the run can actually test."
-    : "Upload or choose an observed sounding, then choose the CM1 package family to generate.";
-  const workerGuidance =
-    "Run configuration controls duration, grid/detail, domain size, output cadence, and fields separately after the package family is selected.";
+    ? "Candidate screening is ingredient guidance. Pick the run recipe by what CM1 can honestly test."
+    : "Uploaded soundings start as an untriggered observed-atmosphere run. Use a triggered deep-potential recipe only when that is the experiment.";
 
   return (
-    <section className="experiment-summary" aria-labelledby="observed-package-family-title">
+    <section className="experiment-summary" aria-labelledby="observed-run-recipe-title">
       <div className="panel-heading-row">
         <div>
-          <p className="eyebrow">CM1 package family</p>
-          <h3 id="observed-package-family-title">Choose how to try this sounding</h3>
+          <p className="eyebrow">Hypothesis run recipe</p>
+          <h3 id="observed-run-recipe-title">What is this run testing?</h3>
           <p className="field-help">{candidateGuidance}</p>
         </div>
         <StatusBadge
-          label={selectedDeep ? "Three-bubble trigger" : "Observed quick look"}
+          label={selectedDeep ? "Triggered deep potential" : "Untriggered observed evolution"}
           tone={selectedDeep ? "warning" : "neutral"}
         />
       </div>
-      <div className="control-row">
-        <span>
-          <label htmlFor="observed-package-family">
-            <strong>Package type</strong>
-          </label>
-          <small>
-            Deep Convection Trial uses the observed temperature, moisture, and wind profile with an
-            idealized CM1 three-warm-bubble trigger.
-          </small>
-        </span>
-        <select
-          id="observed-package-family"
-          value={packageFamily}
-          onChange={(event) => onChange(event.target.value as ObservedPackageFamily)}
+
+      <div className="button-row" role="group" aria-label="Run recipe">
+        <button
+          type="button"
+          className={!selectedDeep ? "active-control" : "secondary-button"}
+          aria-pressed={!selectedDeep}
+          onClick={() => onChange("untriggered_observed_evolution")}
         >
-          <option value="observed_sounding_quicklook">Observed Sounding Quick Look</option>
-          <option value="deep_convection_trial">Deep Convection Trial</option>
-        </select>
+          Untriggered observed evolution
+        </button>
+        <button
+          type="button"
+          className={selectedDeep ? "active-control" : "secondary-button"}
+          aria-pressed={selectedDeep}
+          onClick={() => onChange("triggered_deep_potential")}
+        >
+          Triggered deep potential
+        </button>
       </div>
+
       {packageMismatchWarning && (
         <div className="validation" role="alert">
           {packageMismatchWarning}
         </div>
       )}
       <dl className="compact-metrics">
+        <Metric label="Screened hypothesis" value={activeStoryLabel} />
         <Metric
-          label="Initiation method"
-          value={selectedDeep ? "Idealized three warm bubbles" : "No deep-convection trigger"}
+          label="Initiation"
+          value={selectedDeep ? "Idealized three warm bubbles" : "No added deep trigger"}
         />
         <Metric
-          label="Domain intent"
+          label="What CM1 can test"
           value={
             selectedDeep
-              ? "Wider box for storm growth and precipitation"
-              : "Current quick-look observed atmosphere path"
+              ? "Triggered deep-convection potential from this observed profile"
+              : "Untriggered cloud, updraft, moisture, and precipitation evolution"
           }
         />
-        <Metric label="Runtime guidance" value={workerGuidance} />
       </dl>
       {selectedDeep && (
         <p className="field-help">
-          This is an idealized CM1 experiment for learning and exploration: try the sounding,
-          inspect the outcome, and learn from the mismatch between the pre-run hypothesis and CM1.
+          This is not normal atmospheric evolution. It adds an idealized trigger so you can inspect
+          whether this observed profile can support deeper convection under a deliberately forced
+          experiment.
         </p>
       )}
     </section>
@@ -6686,7 +6694,7 @@ function ResultNotebookCard({
       {(isValidatedQuickLookBaseline(result) || result.caveats.length > 0) && (
         <p className="secondary-result-note">
           {[
-            isValidatedQuickLookBaseline(result) ? "Validated quick-look baseline" : null,
+            isValidatedQuickLookBaseline(result) ? "Validated reference baseline" : null,
             result.caveats.length > 0 ? caveatLabel(result) : null,
           ]
             .filter(Boolean)
@@ -6704,7 +6712,7 @@ function ResultNotebookCard({
         <Metric label="Max updraft" value={formatNumber(resultMaxUpdraft(result), "m/s")} />
         <Metric label="Min downdraft" value={formatNumber(resultMinDowndraft(result), "m/s")} />
         <Metric label="Cloud top" value={formatNumber(resultCloudTopMeters(result), "m")} />
-        {isDeepConvectionTrial(result) && (
+        {isTriggeredDeepPotentialRun(result) && (
           <Metric label="Deep convection" value={deepConvectionOutcome(result)} />
         )}
         <Metric label="Latest output" value={formatSeconds(resultLatestOutputTime(result))} />
@@ -6837,7 +6845,7 @@ function ResultNotebookCard({
           id="result-tags"
           value={draft.tags}
           onChange={(event) => onDraftChange({ ...draft, tags: event.target.value })}
-          placeholder="baseline, quick-look"
+          placeholder="baseline, reference"
         />
 
         <label htmlFor="result-notes">Notes</label>
@@ -8928,7 +8936,7 @@ function candidateStoryLabel(story: CandidateStoryId | CandidateStoryFilter): st
     case "needs_review":
       return "Needs review";
     case "deep_convection_trial":
-      return "Deep Convection Trial stories";
+      return "Deep-convection stories";
     case "all":
       return "All screening stories";
   }
@@ -8989,20 +8997,20 @@ function candidateSortLabel(sort: CandidateSort): string {
   return labels[sort];
 }
 
-function defaultPackageFamilyForCandidate(
+function defaultRunRecipeForCandidate(
   candidate: SoundingCandidate,
   activeStory?: CandidateStoryId,
-): ObservedPackageFamily {
-  if (activeStory && deepConvectionStoryIds.has(activeStory)) return "deep_convection_trial";
-  if (deepConvectionStoryIds.has(candidate.primary_story)) return "deep_convection_trial";
+): ObservedRunRecipe {
+  if (activeStory && deepConvectionStoryIds.has(activeStory)) return "triggered_deep_potential";
+  if (deepConvectionStoryIds.has(candidate.primary_story)) return "triggered_deep_potential";
   if (
     candidate.story_scores.some(
       (score) => deepConvectionStoryIds.has(score.story) && score.support === "supported",
     )
   ) {
-    return "deep_convection_trial";
+    return "triggered_deep_potential";
   }
-  return "observed_sounding_quicklook";
+  return "untriggered_observed_evolution";
 }
 
 function candidateRecipeFitForStory(
@@ -9039,7 +9047,7 @@ function candidateRecipeFitForStory(
     };
   }
   if (deepConvectionStoryIds.has(story)) {
-    const caveats = ["observed_sounding_quicklook_does_not_test_deep_potential"];
+    const caveats = ["untriggered_observed_evolution_does_not_test_deep_potential"];
     if (candidate.features.observed_wind_available !== true) {
       caveats.push("complete_observed_wind_profile_required_for_deep_potential");
     }
@@ -9047,7 +9055,7 @@ function candidateRecipeFitForStory(
       status: "requires_triggered_deep_potential",
       label: "requires triggered deep-potential run",
       summary:
-        "This story screens deep-convection ingredients. Observed Sounding Quick Look does not test that hypothesis without the triggered deep-potential package.",
+        "This story screens deep-convection ingredients. An untriggered observed-evolution run does not test that hypothesis without the triggered deep-potential recipe.",
       caveats,
     };
   }
@@ -9065,8 +9073,8 @@ function candidateRecipeFitForStory(
       status: "partially_testable",
       label: "partially testable with current observed-sounding run",
       summary:
-        "The current observed-sounding path can inspect capped or suppressed evolution when cap evidence, duration, and output fields are adequate.",
-      caveats: ["run_duration_and_output_fields_must_be_checked_for_cap_story"],
+        "The current observed-sounding path can inspect capped or suppressed evolution when cap evidence, duration, and diagnostics are adequate.",
+      caveats: ["run_duration_and_diagnostics_must_be_checked_for_cap_story"],
     };
   }
   return {
@@ -9074,7 +9082,7 @@ function candidateRecipeFitForStory(
     label: "partially testable with current observed-sounding run",
     summary:
       "The current observed-sounding path can inspect untriggered shallow/evolution behavior, but the recipe still shapes what CM1 can test.",
-    caveats: ["observed_sounding_quicklook_is_recipe_dependent"],
+    caveats: ["untriggered_observed_evolution_is_recipe_dependent"],
   };
 }
 
@@ -9088,9 +9096,9 @@ function isCandidateSuggestedTag(tag: string): tag is (typeof candidateSuggested
   return (candidateSuggestedTags as readonly string[]).includes(tag);
 }
 
-function candidatePackageMismatchWarning(
+function candidateRecipeMismatchWarning(
   selectedCandidateScreening: Record<string, unknown> | null,
-  packageFamily: ObservedPackageFamily,
+  runRecipe: ObservedRunRecipe,
 ): string | null {
   if (!selectedCandidateScreening) return null;
   const activeStory =
@@ -9112,8 +9120,8 @@ function candidatePackageMismatchWarning(
             score.score_0_to_100 > 0 &&
             score.support !== "unavailable",
         )));
-  if (packageFamily === "observed_sounding_quicklook" && hasMeaningfulDeepStory) {
-    return "This candidate was screened for deep-convection potential. Observed Sounding Quick Look does not test that hypothesis. Choose the triggered deep-potential run, or treat this as an untriggered shallow/evolution experiment.";
+  if (runRecipe === "untriggered_observed_evolution" && hasMeaningfulDeepStory) {
+    return "This candidate was screened for deep-convection potential. Untriggered observed evolution does not test that hypothesis. Choose the triggered deep-potential recipe, or treat this as an untriggered evolution experiment.";
   }
   const hasHumidRainyStory =
     activeStory === "humid_rainy_candidate" ||
@@ -9129,6 +9137,25 @@ function candidatePackageMismatchWarning(
     return "This candidate was screened as humid/rainy. Predicted rain behavior needs rain-water, surface-rain, and/or reflectivity outputs to compare later.";
   }
   return null;
+}
+
+function observedRecipeStoryLabel(
+  selectedCandidateScreening: Record<string, unknown> | null,
+): string {
+  if (!selectedCandidateScreening) return "Uploaded observed sounding";
+  if (typeof selectedCandidateScreening.active_story_label === "string") {
+    return selectedCandidateScreening.active_story_label;
+  }
+  if (typeof selectedCandidateScreening.primary_story_label === "string") {
+    return selectedCandidateScreening.primary_story_label;
+  }
+  if (typeof selectedCandidateScreening.active_story === "string") {
+    return candidateStoryLabel(selectedCandidateScreening.active_story as CandidateStoryId);
+  }
+  if (typeof selectedCandidateScreening.primary_story === "string") {
+    return candidateStoryLabel(selectedCandidateScreening.primary_story as CandidateStoryId);
+  }
+  return "Selected candidate hypothesis";
 }
 
 function candidateScreeningStoryScores(
@@ -9351,8 +9378,11 @@ function preRunValidationRunShapeLabel(
   const parts = [
     runShape.duration ? humanize(runShape.duration) : null,
     runShape.domain ? humanize(runShape.domain) : null,
-    runShape.grid_detail ? humanize(runShape.grid_detail) : null,
+    runShape.horizontal_cell_count
+      ? `${runShape.horizontal_cell_count.toLocaleString()} x ${runShape.horizontal_cell_count.toLocaleString()} horizontal cells`
+      : null,
     runShape.output_cadence ? `${humanize(runShape.output_cadence)} output` : null,
+    runShape.diagnostic_set ? `${humanize(runShape.diagnostic_set)} diagnostics` : null,
     typeof runShape.estimated_frames === "number"
       ? `${runShape.estimated_frames.toLocaleString()} saved frames`
       : null,
@@ -9812,20 +9842,25 @@ function parseTags(value: string): string[] {
 
 const DURATION_OPTIONS = [
   { value: "smoke_1h", label: "Smoke check (1 h)" },
-  { value: "quick_6h", label: "Quick science (6 h)" },
-  { value: "standard_12h", label: "Standard science (12 h)" },
+  { value: "short_6h", label: "Short evolution (6 h)" },
+  { value: "standard_12h", label: "Standard evolution (12 h)" },
   { value: "long_24h", label: "Long evolution (24 h)" },
 ];
 
-const GRID_DETAIL_OPTIONS = [
-  { value: "coarse", label: "Coarse" },
-  { value: "standard", label: "Standard" },
-  { value: "fine", label: "Fine" },
+const HORIZONTAL_CELL_OPTIONS = [
+  { value: "cells_64", label: "Scout (64 x 64)" },
+  { value: "cells_96", label: "Light (96 x 96)" },
+  { value: "cells_128", label: "Standard (128 x 128)" },
+  { value: "cells_192", label: "Detailed (192 x 192)" },
+  { value: "cells_256", label: "High detail (256 x 256)" },
+  { value: "cells_384", label: "Very high detail (384 x 384)" },
 ];
 
 const SHALLOW_DOMAIN_OPTIONS = [
   { value: "local_6km", label: "Local 6 km" },
   { value: "wide_12km", label: "Wide 12 km" },
+  { value: "regional_60km", label: "Regional 60 km" },
+  { value: "regional_120km", label: "Regional 120 km" },
 ];
 
 const DEEP_DOMAIN_OPTIONS = [
@@ -9840,18 +9875,18 @@ const OUTPUT_CADENCE_OPTIONS = [
   { value: "detailed_5min", label: "Detailed (5 min)" },
 ];
 
-const FIELD_DENSITY_OPTIONS = [
-  { value: "core", label: "Core" },
-  { value: "analysis", label: "Analysis" },
-  { value: "rich", label: "Rich" },
+const DIAGNOSTIC_SET_OPTIONS = [
+  { value: "essential", label: "Essential" },
+  { value: "process", label: "Process" },
+  { value: "full", label: "Full" },
 ];
 
 function defaultRunConfigurationForSelection(
   scenarioId: string,
-  packageFamily: PackageFamily,
+  runRecipe: RunRecipe,
 ): RunConfigurationInput {
-  if (packageFamily === "deep_convection_trial") {
-    return { ...DEFAULT_DEEP_CONVECTION_RUN_CONFIGURATION };
+  if (runRecipe === "triggered_deep_potential") {
+    return { ...DEFAULT_TRIGGERED_DEEP_POTENTIAL_RUN_CONFIGURATION };
   }
   if (scenarioId === OBSERVED_SOUNDING_EXPERIMENT_ID) {
     return { ...DEFAULT_OBSERVED_RUN_CONFIGURATION };
@@ -9861,16 +9896,18 @@ function defaultRunConfigurationForSelection(
 
 function previewRunConfiguration(
   configuration: RunConfigurationInput,
-  packageFamily: PackageFamily,
+  runRecipe: RunRecipe,
 ): RunConfiguration {
-  const deep = packageFamily === "deep_convection_trial";
-  const duration = durationValue(configuration.duration_preset);
-  const grid = gridValue(configuration.grid_detail_preset, deep);
-  const domain = domainValue(configuration.domain_size_preset, deep);
-  const cadence = cadenceValue(configuration.output_cadence_preset);
-  const fieldDensity = fieldDensityValue(configuration.output_field_density_preset);
-  const nx = Math.max(1, Math.round((domain.xKm * 1000) / grid.dxM));
-  const ny = Math.max(1, Math.round((domain.yKm * 1000) / grid.dxM));
+  const deep = runRecipe === "triggered_deep_potential";
+  const duration = durationValue(configuration.duration);
+  const horizontalCells = horizontalCellValue(configuration.horizontal_cell_count);
+  const domain = domainValue(configuration.domain_size, deep);
+  const cadence = cadenceValue(configuration.output_cadence);
+  const diagnosticSet = diagnosticSetValue(configuration.diagnostic_set);
+  const nx = horizontalCells.cells;
+  const ny = horizontalCells.cells;
+  const dxM = (domain.xKm * 1000) / nx;
+  const dyM = (domain.yKm * 1000) / ny;
   const gridCellCount = nx * ny * domain.nz;
   const expectedFrames = Math.floor(duration.seconds / cadence.seconds) + 1;
   const caveats: string[] = [];
@@ -9881,14 +9918,16 @@ function previewRunConfiguration(
     caveats.push("science_run_configuration_minimum_duration_6h");
   }
   if (deep) {
-    caveats.push("deep_convection_trial_uses_triggered_potential_not_normal_evolution");
+    caveats.push("triggered_deep_potential_is_not_normal_evolution");
   }
-  if (fieldDensity.value === "core") {
-    caveats.push("core_output_density_limits_later_diagnostics");
+  if (diagnosticSet.value === "essential") {
+    caveats.push("essential_diagnostic_set_limits_later_diagnostics");
   }
   if (
-    configuration.grid_detail_preset === "fine" ||
+    horizontalCells.cells >= 256 ||
     domain.value === "wide_12km" ||
+    domain.value === "regional_60km" ||
+    domain.value === "regional_120km" ||
     domain.value === "storm_240km"
   ) {
     caveats.push("configuration_better_suited_to_larger_compute");
@@ -9897,8 +9936,8 @@ function previewRunConfiguration(
     nx,
     ny,
     nz: domain.nz,
-    dx_m: grid.dxM,
-    dy_m: grid.dxM,
+    dx_m: dxM,
+    dy_m: dyM,
     dz_m: domain.dzM,
     model_top_m: domain.modelTopM,
     domain_x_km: domain.xKm,
@@ -9916,19 +9955,19 @@ function previewRunConfiguration(
   return {
     ...configuration,
     configuration_id: [
-      configuration.duration_preset,
-      configuration.grid_detail_preset,
-      configuration.domain_size_preset,
-      configuration.output_cadence_preset,
-      fieldDensity.value,
+      configuration.duration,
+      configuration.horizontal_cell_count,
+      configuration.domain_size,
+      configuration.output_cadence,
+      diagnosticSet.value,
     ].join("__"),
     mode: duration.mode,
-    label: `${duration.label}; ${domain.label}; ${grid.label}; ${cadence.label}`,
+    label: `${duration.label}; ${domain.label}; ${horizontalCells.label}; ${formatMeters(dxM)} dx/dy; ${cadence.label}`,
     duration_seconds: duration.seconds,
     output_cadence_seconds: cadence.seconds,
-    output_field_density_preset: fieldDensity.value,
+    diagnostic_set: diagnosticSet.value,
     cost_runtime_summary: `${hours.toLocaleString()} h model time, ${gridCellCount.toLocaleString()} cells, ${cadenceMinutes.toLocaleString()} min saved-output cadence`,
-    output_volume_summary: `${expectedFrames.toLocaleString()} saved frames, ${fieldDensity.value} output fields, ${gridCellCount.toLocaleString()} cells per frame`,
+    output_volume_summary: `${expectedFrames.toLocaleString()} saved frames, ${diagnosticSet.value} diagnostics, ${gridCellCount.toLocaleString()} cells per frame`,
     cm1_values: cm1Values,
     caveats,
   };
@@ -9937,21 +9976,19 @@ function previewRunConfiguration(
 function durationValue(value: string): { seconds: number; mode: "smoke" | "science"; label: string } {
   if (value === "smoke_1h") return { seconds: 3600, mode: "smoke", label: "Smoke check" };
   if (value === "standard_12h") {
-    return { seconds: 43200, mode: "science", label: "Standard science" };
+    return { seconds: 43200, mode: "science", label: "Standard evolution" };
   }
   if (value === "long_24h") return { seconds: 86400, mode: "science", label: "Long evolution" };
-  return { seconds: 21600, mode: "science", label: "Quick science" };
+  return { seconds: 21600, mode: "science", label: "Short evolution" };
 }
 
-function gridValue(value: string, deep: boolean): { dxM: number; label: string } {
-  if (deep) {
-    if (value === "coarse") return { dxM: 2000, label: "Coarse" };
-    if (value === "fine") return { dxM: 500, label: "Fine" };
-    return { dxM: 1000, label: "Standard" };
-  }
-  if (value === "coarse") return { dxM: 200, label: "Coarse" };
-  if (value === "fine") return { dxM: 50, label: "Fine" };
-  return { dxM: 100, label: "Standard" };
+function horizontalCellValue(value: string): { cells: number; label: string } {
+  if (value === "cells_64") return { cells: 64, label: "Scout 64 x 64" };
+  if (value === "cells_96") return { cells: 96, label: "Light 96 x 96" };
+  if (value === "cells_192") return { cells: 192, label: "Detailed 192 x 192" };
+  if (value === "cells_256") return { cells: 256, label: "High detail 256 x 256" };
+  if (value === "cells_384") return { cells: 384, label: "Very high detail 384 x 384" };
+  return { cells: 128, label: "Standard 128 x 128" };
 }
 
 function domainValue(
@@ -10002,6 +10039,28 @@ function domainValue(
       label: "Wide 12 km",
     };
   }
+  if (value === "regional_60km") {
+    return {
+      value,
+      xKm: 60,
+      yKm: 60,
+      nz: 75,
+      dzM: 40,
+      modelTopM: 18000,
+      label: "Regional 60 km",
+    };
+  }
+  if (value === "regional_120km") {
+    return {
+      value,
+      xKm: 120,
+      yKm: 120,
+      nz: 75,
+      dzM: 40,
+      modelTopM: 18000,
+      label: "Regional 120 km",
+    };
+  }
   return {
     value: "local_6km",
     xKm: 6.4,
@@ -10019,9 +10078,9 @@ function cadenceValue(value: string): { seconds: number; label: string } {
   return { seconds: 900, label: "Standard 15 min" };
 }
 
-function fieldDensityValue(value: string): { value: string } {
-  if (value === "core" || value === "rich") return { value };
-  return { value: "analysis" };
+function diagnosticSetValue(value: string): { value: string } {
+  if (value === "essential" || value === "full") return { value };
+  return { value: "process" };
 }
 
 function runConfigurationGridSummary(configuration: RunConfiguration): string {
@@ -10515,21 +10574,21 @@ function isDryFailedContrast(result: ResultCard): boolean {
 }
 
 function resultStory(result: ResultCard): string {
-  if (isDeepConvectionTrial(result)) {
+  if (isTriggeredDeepPotentialRun(result)) {
     const comparison = result.candidate_hypothesis_comparison;
     if (comparison) {
       return `${comparison.cm1_outcome} Candidate hypothesis ${comparison.match_status_label.toLowerCase()}.`;
     }
     return (
       result.science_summary?.cm1_outcome ??
-      "Deep Convection Trial result is ready for field inspection."
+      "Triggered deep-potential result is ready for field inspection."
     );
   }
   if (isDryFailedContrast(result)) {
     return "Thermals rose, but low-level moisture stayed too dry for meaningful cloud water or rain.";
   }
   if (isValidatedQuickLookBaseline(result)) {
-    return "Cloud water formed in the validated quick-look baseline; vertical motion and rain were both detected.";
+    return "Cloud water formed in the validated reference baseline; vertical motion and rain were both detected.";
   }
   if (cloudOutcome(result) === "Cloud formed") {
     return "Cloud water formed during this run. Open it in Explore to inspect the cloud and updraft structure.";
@@ -10541,7 +10600,7 @@ function resultStory(result: ResultCard): string {
 }
 
 function compactScienceSummary(result: ResultCard): string {
-  if (isDeepConvectionTrial(result)) {
+  if (isTriggeredDeepPotentialRun(result)) {
     const parts = [
       deepConvectionOutcome(result),
       resultMaxUpdraft(result) !== null
@@ -10684,8 +10743,8 @@ function scienceSupportLabel(result: ResultCard): string {
   return "Interesting times limited";
 }
 
-function isDeepConvectionTrial(result: ResultCard): boolean {
-  return result.package_family === "deep_convection_trial";
+function isTriggeredDeepPotentialRun(result: ResultCard): boolean {
+  return result.run_recipe === "triggered_deep_potential";
 }
 
 function deepConvectionOutcome(result: ResultCard): string {
@@ -10717,7 +10776,7 @@ function caveatLabel(result: ResultCard): string {
 }
 
 function cloudOutcome(result: ResultCard): string {
-  if (isDeepConvectionTrial(result)) return deepConvectionOutcome(result);
+  if (isTriggeredDeepPotentialRun(result)) return deepConvectionOutcome(result);
   if (!result.diagnostics_summary) return "Unknown";
   return result.diagnostics_summary.includes("cloud formed") &&
     !result.diagnostics_summary.includes("no cloud formed")

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -21,10 +21,10 @@ active, incomplete, and non-ingested package/run work; Results owns ingested
 notebook entries and explicit ingested-result cleanup.
 
 Observed-sounding run directions seed a CM1-facing configuration, but they
-should not be modeled as rigid product cages. The data model may keep internal
-`package_family` values as provenance metadata, while the product model treats
-duration, grid/detail, domain, cadence, and output fields as explicit run-builder
-choices.
+should not be modeled as rigid product cages. The data model uses explicit
+`run_recipe` and `run_configuration` values: duration, horizontal cell budget,
+domain, cadence, diagnostic set, forcing assumptions, requested fields, and
+pre-run validation are the run-builder contract.
 
 The first MVP target is a 2024 MacBook Air with 8GB RAM. Design for one local CM1 run at a time, conservative output handling, and backend-side processing/downsampling. Optional cloud compute can be researched later, but it is not part of the core architecture.
 
@@ -113,13 +113,13 @@ story-specific candidate scores. Stable story identifiers are
 `shallow_cumulus_candidate`, `dry_failed_candidate`,
 `capped_suppressed_candidate`, `humid_rainy_candidate`, `needs_review`, and
 `poor_or_incomplete_candidate`; severe/deep-convection story identifiers remain
-pre-run hypotheses for Deep Convection Trial routing. The auditable scoring
+pre-run hypotheses for triggered deep-potential recipe routing. The auditable scoring
 contract lives in
 [contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
 Analysis has a default recommendation mode that answers which cached soundings
 look interesting and why, using backend-owned interest reasons and station
 diversity before exposing refinements. It can also target story, story family,
-support state, package readiness, station search, and backend-owned sort keys
+support state, recipe readiness, station search, and backend-owned sort keys
 because the useful sounding depends on the experiment question; shallow-cumulus
 and humid/rainy searches should not imply the same ranked list.
 Missing feature values stay unavailable and sort last instead of being treated
@@ -161,16 +161,15 @@ diagnostics. The browser should consume these diagnostics only through bounded
 backend JSON; it must not parse station text or compute CAPE/CIN/SRH locally.
 
 Sounding story families are architecture planning input until a backend
-screening and package-readiness path supports them. The expanded taxonomy in
+screening and recipe-fit path supports them. The expanded taxonomy in
 [research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md)
 defines readiness states for severe/deep-convection, boundary-layer, low-cloud,
 and winter/cold-season stories so APIs can distinguish screenable environments
 from runnable configuration paths. Until a story has backend features, scoring
-tests, evidence, caveats, and package-readiness support, it must not be emitted
-as an enabled package-ready label. The first implemented severe/deep-convection
-path is the deep-convection observed-sounding preset, backed internally by
-`package_family = deep_convection_trial`, which treats selected observed
-soundings as pre-run hypotheses for an idealized triggered CM1 experiment.
+tests, evidence, caveats, and recipe-fit support, it must not be emitted as an
+enabled runnable label. The first implemented severe/deep-convection path is the
+triggered deep-potential run recipe, which treats selected observed soundings as
+pre-run hypotheses for an idealized triggered CM1 experiment.
 
 The Build UI consumes this layer through bounded JSON only. `Upload a Sounding`
 loads saved candidates immediately when that experiment is selected, before any
@@ -184,24 +183,23 @@ scores, or sort raw feature values itself. Candidate status is separate from
 run/result status: saved candidates are pre-run hypotheses, while generated
 packages, launched runs, and ingested results remain separate lifecycle objects.
 
-Deep-convection observed-sounding packages extend the same dry-run package
+Triggered deep-potential observed-sounding runs extend the same dry-run package
 contract rather than creating a separate workflow. The package records
-`package_family = deep_convection_trial`, a deep-convection display label,
-`input_source = observed_sounding`, `trigger_type = warm_bubble`, trigger
-metadata, expected output fields, package-family smoke validation status,
-package caveats, and any candidate-screening payload on the run manifest, case
-manifest, and dry-run report. The generated namelist uses the observed
-`input_sounding` route (`isnd = 7`), requires complete usable observed u/v winds,
-selects CM1's built-in three-warm-bubble initialization (`iinit = 3`) with
-`testcase = 0`, uses a storm-scale idealized domain for storm growth, and
-enables rain-water-aloft, surface-rain, reflectivity, vorticity, and
-updraft-helicity output. Manual smoke evidence applies to the package path and
+`run_recipe = triggered_deep_potential`, `input_source = observed_sounding`,
+`trigger_type = warm_bubble`, trigger metadata, expected output fields,
+recipe smoke-validation status, run caveats, and any candidate-screening payload
+on the run manifest, case manifest, and dry-run report. The generated namelist
+uses the observed `input_sounding` route (`isnd = 7`), requires complete usable
+observed u/v winds, selects CM1's built-in three-warm-bubble initialization
+(`iinit = 3`) with `testcase = 0`, uses a storm-scale idealized domain for storm
+growth, and enables rain-water-aloft, surface-rain, reflectivity, vorticity, and
+updraft-helicity output. Manual smoke evidence applies to the recipe path and
 basic run/ingest health; each observed sounding remains an experiment whose
-outcome must be inspected after CM1 completes. The trigger is described as
-fixed v1 package metadata rather than a primary product control. Ingest copies
-the package-family and trigger metadata into result metadata and Result Cards so
-Results and Explore do not lose the distinction between an observed-sounding
-quick look and a deep-convection configured run.
+outcome must be inspected after CM1 completes. The trigger is described as fixed
+v1 recipe metadata rather than a primary product control. Ingest copies the run
+recipe and trigger metadata into result metadata and Result Cards so Results and
+Explore do not lose the distinction between untriggered observed evolution and a
+triggered deep-potential run.
 
 ## Suggested Stack
 
@@ -286,8 +284,8 @@ The earlier Cloud Chamber quick-look derivative is not scientifically accepted: 
 
 The first reference-derived validation run, `dry-run-les-shallowcu-20260522140642`, completed locally with NetCDF output and ingested 7 model-output time steps over 21600 seconds. It produced cloud water and vertical velocity diagnostics, so the architecture should treat the reference-derived package as the recovery baseline and the earlier compact derivative as invalid evidence rather than a tuning base.
 
-Run configuration uses guarded fields for duration, grid/detail, domain size,
-output cadence, output field density, forcing, requested fields, advanced
+Run configuration uses guarded fields for duration, horizontal cell budget,
+domain size, output cadence, diagnostic set, forcing, requested fields, advanced
 CM1-facing values, and a pre-run validation report. Raw numerical timestep is
 not a normal v1 control. Defaults must expose their derived CM1-facing values in
 advanced metadata so dry-run reports and Build UI can show exactly what will be
@@ -1074,10 +1072,10 @@ scenario + controls
 
 Run-configuration metadata should flow through this path: scenario templates
 define editable configuration defaults, generated run packages record the
-selected duration, grid/detail, domain, output cadence, output field density,
-forcing, requested fields, advanced CM1-facing values, and validation report,
-run manifests preserve them during execution, and result metadata keeps them
-available for later inspection.
+selected duration, horizontal cell budget, domain, output cadence, diagnostic
+set, forcing, requested fields, advanced CM1-facing values, and validation
+report, run manifests preserve them during execution, and result metadata keeps
+them available for later inspection.
 
 If size/runtime estimates are not validated yet, manifests and reports should record that explicitly rather than presenting guessed precision.
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -415,6 +415,16 @@ tags/notes, then returns the package paths and dry-run report summary for UI
 review. It must not launch CM1, write NetCDF, or place generated
 packages inside the source tree during tests.
 
+Before writing a package directory, the backend builds a pre-run validation
+report from the CM1 input contract, selected candidate/hypothesis, and selected
+run configuration. The report records candidate and recipe selection,
+hypothesis/recipe alignment, observed-input checks, run-shape estimates,
+forcing support, required/enabled outputs, runtime-file staging status,
+blocking errors, and caveats. Blocked reports are returned in the dry-run API
+error response and must prevent local launch, queueing, and run-directory
+creation; valid or caveated reports persist through run manifests, run status,
+storage inventory, ingest metadata, and result cards.
+
 The Build workspace is the first guided app-side launchpad over the existing
 backend contracts:
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -270,14 +270,21 @@ Shallow Cumulus, displays the scenario description and physical question,
 exposes only product-facing curated controls, lets the user adjust explicit
 run-configuration choices, and requests a dry-run package for review.
 
+The primary current-run path should stay in one vertical flow: choose the
+atmosphere, choose or confirm the hypothesis, configure the CM1 run, review
+pre-run validation, then create the package and queue that package. The
+right-side launchpad is a status rail for generated packages, queue state,
+ingest, worker status, and cleanup; it should not force the user to hunt there
+for the next action after choosing a sounding or run configuration.
+
 Build should not assume the user is working one perfectly linear package at a
 time. Local experiments can be packaged, running, failed, completed-but-not-
 ingested, ingested, carrying legacy saved/protected metadata, or ready for
 cleanup at the same time. The Build workspace should include a compact local
-run launchpad for active and incomplete package/run work only: create packages,
-launch eligible packages, refresh running/failed/completed status, troubleshoot
-failed or no-output runs, and ingest completed output. Fully ingested results
-belong in Results.
+run launchpad for active and incomplete package/run work only: show generated
+package details, launch eligible stored packages, refresh running/failed/
+completed status, troubleshoot failed or no-output runs, and ingest completed
+output. Fully ingested results belong in Results.
 
 When a local backend restart leaves a completed CM1 run's manifest marked
 running, Build refresh may reconcile the state only if stdout contains
@@ -310,7 +317,8 @@ Current behavior is a placeholder only. It must explicitly say preview is not im
 
 ### Workflow 3 — Launch CM1 Run
 
-1. Click `Run with local CM1` from an eligible packaged run in the launchpad.
+1. Click `Queue local CM1 run` from the end of the current setup flow, or from
+   an eligible stored-package card in the launchpad.
 2. Backend launches local CM1 from the generated run package only after preflight passes.
 3. UI shows the running state, command/log paths, stdout/stderr tail when available, and one-local-run-at-a-time policy.
 4. If local CM1 settings are missing, the UI shows the backend failure reason and no run is implied.
@@ -531,6 +539,14 @@ numerical timestep is not a normal v1 user control. Cloud Chamber should warn or
 caveat unvalidated control combinations when they can be safely generated,
 block configurations that cannot be rendered or launched honestly, and avoid
 silently replacing bad observed-sounding input with reference defaults.
+
+Generated packages include a backend-owned pre-run validation report. The
+report records the selected candidate/hypothesis, selected run recipe and
+assumption set, hypothesis/recipe alignment, observed-input validation,
+run-shape estimates, forcing support, required/enabled output fields, runtime
+file staging status, blocking errors, and caveats. Blocked reports stop package
+creation before a run directory is written; caveated reports may be packaged but
+must remain visibly caveated before launch and after ingest.
 
 Forward run configuration should include:
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -33,8 +33,8 @@ Explore = inspect one result with CM1-derived evidence
 Build should be organized around configurable observed-sounding runs. Presets
 are useful starting points, not separate product cages: a user should be able to
 start from a sane preset, inspect the actual CM1-facing settings, and adjust
-duration, grid/detail, output cadence, forcing, and output fields within guarded
-bounds.
+duration, horizontal cell budget, domain size, output cadence, forcing, and
+diagnostic set within guarded bounds.
 
 See [UX Reset: Guided Experiment Notebook](ux-reset-guided-experiment-notebook.md)
 for the PM/design source of truth for future UX work.
@@ -157,21 +157,19 @@ When a candidate is used, its screening story, score, evidence, feature summary,
 and caveats should be copied into package metadata as
 provenance.
 
-When an uploaded or saved observed sounding is package-ready, Build should let
-the user choose an observed-sounding run direction and adjust the explicit
-CM1-facing run configuration. The deep-convection configuration is first-class
-for severe/deep-convection
-observed-sounding experiments: it uses the observed temperature, moisture, and
-complete wind profile through CM1 `isnd = 7`, runs an idealized
-three-warm-bubble trigger (`iinit = 3`), uses a storm-scale model box suitable
-for storm growth and precipitation inspection, requests rain water aloft,
-surface rain, reflectivity, vorticity, and updraft-helicity output, and records
-`package_family = deep_convection_trial` plus trigger, expected-output, caveat,
-and candidate-screening provenance in generated manifests. That internal
-`package_family` value is provenance metadata, not the run-shape default.
-Product copy should describe the run as a deep-convection observed-sounding
-configuration rather than a separate "Trial" status. Quick science
-configurations must still run long enough to be meteorologically useful. Build
+When an uploaded or saved observed sounding is run-ready, Build should let the
+user choose an observed-sounding run recipe and adjust the explicit CM1-facing
+run configuration. The triggered deep-potential recipe is first-class for
+severe/deep-convection observed-sounding experiments: it uses the observed
+temperature, moisture, and complete wind profile through CM1 `isnd = 7`, runs an
+idealized three-warm-bubble trigger (`iinit = 3`), uses a storm-scale model box
+suitable for storm growth and precipitation inspection, requests rain water
+aloft, surface rain, reflectivity, vorticity, and updraft-helicity output, and
+records `run_recipe = triggered_deep_potential` plus trigger, expected-output,
+caveat, and candidate-screening provenance in generated manifests. Product copy
+should describe the run as a triggered deep-potential experiment with explicit
+assumptions and output requirements. Short science configurations must still run
+long enough to be meteorologically useful. Build
 should show expected cost, runtime, and output volume, and note when a configuration is
 better suited to larger compute instead of making machine choice the primary
 product axis. Raw trigger parameters remain
@@ -261,7 +259,7 @@ Exact morphology is not pass/fail. The acceptance question is whether the produc
 2. Choose scenario category.
 3. Select a starting scenario or observed-sounding run direction.
 4. See expected behavior, controls, run cost, and output fields.
-5. Adjust duration, grid/detail, domain, output cadence, and output fields
+5. Adjust duration, horizontal cells, domain, output cadence, and diagnostic set
    before package review.
 
 The Scenario Builder flow is intentionally bounded: it loads
@@ -601,15 +599,15 @@ of truth.
 
 Current defaults are product choices, not compatibility holdovers:
 
-- Baseline lower-atmosphere scenarios default to `quick_6h`, `standard`
-  grid/detail, `local_6km`, `standard_15min`, and `analysis` fields. This keeps
-  the first run cheap enough to iterate while still giving six hours of model
+- Baseline lower-atmosphere scenarios default to `short_6h`, `cells_64`,
+  `local_6km`, `standard_15min`, and `process` diagnostics. This keeps the
+  first run cheap enough to iterate while still giving six hours of model
   evolution and enough fields for Results/Explore diagnostics.
 - Uploaded observed-sounding normal-evolution runs default to the same duration,
-  detail, cadence, and field density, but use `wide_12km` so observed winds do
-  not make the package misleadingly small by default.
-- Deep-convection observed-sounding runs default to `quick_6h`, `standard`
-  storm-scale detail, `storm_120km`, `standard_15min`, and `rich` fields. That
+  cadence, and diagnostic set, but use `cells_128` and `wide_12km` so observed
+  winds do not make the package misleadingly small by default.
+- Triggered deep-potential observed-sounding runs default to `short_6h`,
+  `cells_128`, `storm_120km`, `standard_15min`, and `full` diagnostics. That
   setup is deliberately wider and better instrumented because it is asking a
   storm-scale triggered-potential question.
 - `smoke_1h` is an explicit smoke-check mode for package health, CM1 startup,
@@ -1273,17 +1271,17 @@ The notebook also exposes backend-derived science summary fields such as
 first-cloud time, max `qc`, max updraft, rain onset, latest output time, and
 interesting-time support state so the user can search, filter, and sort the
 experiment list by meaningful scientific evidence rather than raw file order.
-Result Cards must also distinguish generated-reference packages from runs
+Result Cards must also distinguish generated-reference runs from runs
 created from an uploaded observed sounding, preserving station/time/source
 metadata as provenance. Observed-sounding results should read as `Uploaded
-Sounding` in notebook names, scenario labels, and scenario filtering while the
-underlying generated scenario ID remains available in technical details as
-lineage.
-Deep-convection observed-sounding results should retain their package-family
-provenance after ingest: notebook names and scenario labels may identify the
-run as deep convection, while the original observed station/time, generated
-scenario ID, internal `package_family`, trigger metadata, expected outputs,
-caveats, and candidate-screening hypothesis remain available as provenance.
+Sounding` or the active observed run recipe in notebook names, scenario labels,
+and scenario filtering while the underlying generated scenario ID remains
+available in technical details as lineage.
+Triggered deep-potential observed-sounding results should retain their run-recipe
+provenance after ingest: notebook names and scenario labels may identify the run
+as triggered deep potential, while the original observed station/time, generated
+scenario ID, `run_recipe`, trigger metadata, expected outputs, caveats, and
+candidate-screening hypothesis remain available as provenance.
 Technical metadata such as raw lifecycle/product states, run IDs, provenance
 labels, controls, and detailed caveats remain available under disclosure rather
 than dominating the first read. The layout should be mobile-first: cards stack
@@ -1304,9 +1302,9 @@ Explore
 `Build` creates and runs experiments. `Results` reviews, edits, and
 manages experiment results. `Explore` inspects and visualizes one selected
 result's CM1 fields. The app should open on `Results`, because the most useful
-first click path is to choose the validated quick-look Baseline Shallow Cumulus
+first click path is to choose the validated reference Baseline Shallow Cumulus
 result and open it in Explore or 3-D. Results should prioritize completed, ingested, cloud-forming
-quick-look baseline entries ahead of failed/no-cloud or historical
+reference baseline entries ahead of failed/no-cloud or historical
 attempts. User-facing labels should say `Completed CM1 result`, `Ingested`,
 `Needs review`, `Cloud formed`, `No cloud`, and `Rain detected` rather
 than leading with raw lifecycle strings. Raw lifecycle/product/provenance labels
@@ -1550,7 +1548,7 @@ interpolation caveats and rendering provenance must stay available, but long
 technical labels belong under `About this visualization` rather than dominating
 the primary view.
 
-The first 3-D impression should make the validated quick-look baseline obvious:
+The first 3-D impression should make the validated reference baseline obvious:
 opening from Results should land on the first-cloud or max-cloud-water time when
 available, show a visible cloud-water point cloud, show the domain box, axes,
 ground/base plane, current time, and threshold, keep slice planes optional and

--- a/docs/contracts/analyzer-hypothesis-output-signature.md
+++ b/docs/contracts/analyzer-hypothesis-output-signature.md
@@ -174,7 +174,7 @@ output or a clearly labeled supported diagnostic, not from cloud water alone.
 | Cloud depth/top | `qc`, vertical coordinate, time coordinate | Must report threshold and cloud-top method. |
 | Shallow cloud persistence | `qc`, time coordinate | Needs enough duration and cadence to distinguish transient noise from evolution. |
 | Updraft strength | `w`, time coordinate | May include height/region caveats when available. |
-| Deep breakthrough | `qc`, `w`, vertical coordinate, time coordinate | Deep Convection Trial only until normal-evolution deep signatures are separately validated. |
+| Deep breakthrough | `qc`, `w`, vertical coordinate, time coordinate | Triggered deep-potential recipe only until normal-evolution deep signatures are separately validated. |
 | Rain water aloft | `qr`, time coordinate | User-facing label should say rain water aloft. |
 | Surface rain | `rain` or supported surface precipitation field | Must preserve units and must not be inferred from `qr`. |
 | Reflectivity | `dbz` or supported reflectivity diagnostic | Unsupported reflectivity stays unavailable. |
@@ -195,13 +195,19 @@ shape below is the analyzer payload reference to that contract.
 recommended_run_recipes:
   - recipe_id: string
     label: string
-    package_family: observed_sounding_quicklook | deep_convection_trial | future
+    run_recipe:
+      generated_reference_lower_atmosphere
+      | untriggered_observed_evolution
+      | triggered_deep_potential
+      | future
     run_configuration:
       duration_seconds: number | null
-      grid_detail_preset: string | null
+      horizontal_cell_count: number | null
       domain_width_m: number | null
+      dx_m: number | null
       model_top_m: number | null
       output_cadence_seconds: number | null
+      diagnostic_set: essential | process | full | null
       requested_fields: [string]
       forcing: string
     suitability:
@@ -221,7 +227,7 @@ Examples:
   surface `rain`, and/or `dbz` outputs are enabled according to the predicted
   signature.
 - A supercell or severe-thunderstorm hypothesis requires a triggered
-  deep-potential recipe; Observed Sounding Quick Look can still be run
+  deep-potential recipe; untriggered observed evolution can still be run
   deliberately, but it tests untriggered evolution, not the deep-potential
   hypothesis.
 - A surface-flux or radiation/place-time hypothesis requires the matching

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -261,7 +261,7 @@ support states such as `unavailable`, `unsupported_missing_fields`, and
 `unsupported_missing_diagnostic` rather than silently falling back to a
 misleading cloud/rain-water landmark.
 
-Deep Convection Trial results extend the same product with backend-owned
+Triggered deep-potential results extend the same product with backend-owned
 summary fields for deep-cloud formation, first deep-convection time, strong
 updraft detection, cloud top, rain-water onset, max `qr`, and the default Explore
 time. Unsupported severe-storm diagnostics such as reflectivity maxima,

--- a/docs/contracts/realistic-les-input-specification.md
+++ b/docs/contracts/realistic-les-input-specification.md
@@ -533,7 +533,7 @@ Capability distinctions:
 
 | Item | Status |
 | --- | --- |
-| Explicit run-configuration choices | Supported by Cloud Chamber package generation through duration, grid/detail, domain, cadence, and output-field density. |
+| Explicit run-configuration choices | Supported by Cloud Chamber package generation through duration, horizontal cell budget, domain, cadence, and diagnostic set. |
 | Local Mac deep runs with larger grids and more output | Supported but expensive; estimates need validation per scenario. |
 | Additional output fields for realistic cases | Likely CM1 capability needing output/product validation. |
 | Workstation/remote/HPC tiers | Future / unsupported as local product flow. |

--- a/docs/contracts/run-recipe-and-story-mapping.md
+++ b/docs/contracts/run-recipe-and-story-mapping.md
@@ -25,10 +25,10 @@ This is a docs and data-contract issue. It does not implement package
 generation, add raw namelist editing, run CM1 in CI, add a generic Compare tab,
 or commit generated artifacts.
 
-The current implementation may keep internal `package_family` metadata such as
-`observed_sounding_quicklook` and `deep_convection_trial` for compatibility.
-Product surfaces should describe the user-facing recipe and question rather
-than turning package-family metadata into rigid product cages.
+The current implementation uses `run_recipe` plus explicit run-configuration
+fields. Product surfaces should describe the user-facing recipe and question;
+there is no separate package-family compatibility layer in the forward
+contract.
 
 ## Core Terms
 
@@ -51,8 +51,7 @@ than turning package-family metadata into rigid product cages.
 
 ## Run Recipe Object
 
-Run recipes should be represented as structured backend-owned data, even while
-the first implementation is static docs plus existing package metadata.
+Run recipes should be represented as structured backend-owned data.
 
 ```yaml
 run_recipe:
@@ -69,12 +68,14 @@ run_recipe:
     | future
   run_shape:
     duration_seconds: number | null
-    grid_detail_preset: string | null
-    domain_width_m: number | null
-    domain_depth_m: number | null
+    horizontal_cell_count: number | null
+    domain_x_m: number | null
+    domain_y_m: number | null
+    dx_m: number | null
+    dy_m: number | null
     model_top_m: number | null
     output_cadence_seconds: number | null
-    output_field_density: minimal | standard | dense | null
+    diagnostic_set: essential | process | full | null
   forcing:
     trigger:
       mode: none | warm_bubble | future_explicit_trigger | unavailable
@@ -112,13 +113,17 @@ run_recipe:
     status: supported | caveated | blocked | future
     caveats: [string]
   cm1_mapping:
-    package_family: observed_sounding_quicklook | deep_convection_trial | future
+    run_recipe:
+      generated_reference_lower_atmosphere
+      | untriggered_observed_evolution
+      | triggered_deep_potential
+      | future
     run_configuration_defaults:
-      duration_preset: string | null
-      grid_detail_preset: string | null
-      domain_size_preset: string | null
-      output_cadence_preset: string | null
-      output_field_density_preset: string | null
+      duration: string | null
+      horizontal_cell_count: string | null
+      domain_size: string | null
+      output_cadence: string | null
+      diagnostic_set: string | null
     namelist_summary: [string]
     runtime_files_needed: [string]
   comparison_contract:
@@ -173,11 +178,11 @@ assumption_set_id: normal_evolution_current_observed_sounding_v1
 assumption_mode: normal_evolution
 run_shape:
   duration_seconds: 21600 | configured
-  grid_detail_preset: coarse | standard | fine
-  domain_width_m: 6400 | 12800 | configured
+  horizontal_cell_count: 64 | 96 | 128 | 192 | 256 | 384 | configured
+  domain_width_m: 6400 | 12800 | 60000 | 120000 | configured
   model_top_m: current observed-sounding LES model top
   output_cadence_seconds: 3600 | 900 | 300 | configured
-  output_field_density: core | analysis | rich
+  diagnostic_set: essential | process | full
 forcing:
   trigger: {mode: none}
   surface_sensible_heat_flux: {mode: current_recipe_default}
@@ -198,7 +203,13 @@ current_support:
     - Current recipe defaults are not a real place/time surface-energy budget.
     - Scores remain ingredient guidance until a predicted signature exists.
 cm1_mapping:
-  package_family: observed_sounding_quicklook
+  run_recipe: untriggered_observed_evolution
+  run_configuration_defaults:
+    duration: short_6h
+    horizontal_cell_count: cells_128
+    domain_size: wide_12km
+    output_cadence: standard_15min
+    diagnostic_set: process
 ```
 
 This recipe can test shallow cloud and dry-failed signatures when the predicted
@@ -227,7 +238,7 @@ current_support:
     - Comparison needs enough model time and cadence to distinguish delayed
       growth from missing output.
 cm1_mapping:
-  package_family: observed_sounding_quicklook
+  run_recipe: untriggered_observed_evolution
 ```
 
 This recipe is a specialized view of the current untriggered observed-sounding
@@ -261,7 +272,7 @@ current_support:
     - `qr` is rain water aloft, `rain` is surface rain, and `dbz` is
       reflectivity; they must be evaluated separately.
 cm1_mapping:
-  package_family: observed_sounding_quicklook
+  run_recipe: untriggered_observed_evolution
 ```
 
 This is the honest bridge for `humid_rainy_candidate`: Cloud Chamber may run a
@@ -279,11 +290,11 @@ assumption_set_id: triggered_deep_potential_warm_bubble_v1
 assumption_mode: triggered_deep_potential
 run_shape:
   duration_seconds: 21600 | configured
-  grid_detail_preset: coarse | standard | fine
+  horizontal_cell_count: 128 | configured
   domain_width_m: 120000 | 160000 | 240000
   model_top_m: 20000
   output_cadence_seconds: 3600 | 900 | 300 | configured
-  output_field_density: rich
+  diagnostic_set: full
 forcing:
   trigger:
     mode: warm_bubble
@@ -316,7 +327,13 @@ current_support:
     - Storm mode, rotation, downdraft, cold pool, and surface rain are outcomes
       to inspect after CM1 completes.
 cm1_mapping:
-  package_family: deep_convection_trial
+  run_recipe: triggered_deep_potential
+  run_configuration_defaults:
+    duration: short_6h
+    horizontal_cell_count: cells_128
+    domain_size: storm_120km
+    output_cadence: standard_15min
+    diagnostic_set: full
 ```
 
 This recipe is first-class. Its caveats are scientific trust boundaries, not a
@@ -338,7 +355,7 @@ required_outputs:
 current_support:
   status: future
 cm1_mapping:
-  package_family: future
+  run_recipe: future
 ```
 
 The current triggered-deep recipe may be a caveated first experiment, but it
@@ -359,7 +376,7 @@ required_outputs:
 current_support:
   status: future
 cm1_mapping:
-  package_family: future
+  run_recipe: future
 ```
 
 Elevated convection is not comparable unless the recipe can represent the
@@ -373,7 +390,7 @@ source layer and forcing assumptions being tested.
 | `dry_failed_candidate` | `observed_normal_evolution_v1` | `testable_now` when duration/cadence can support a no-cloud conclusion | no explicit trigger; current observed-sounding LES defaults; complete observed profile | `qc`, `w`, time coordinate | weak/no cloud with meaningful vertical motion; moisture limitation remains caveated |
 | `capped_suppressed_candidate` | `observed_capped_evolution_v1` | `partially_testable` | no explicit trigger; cap comes from observed profile; enough run time to observe delayed growth | `qc`, `w`, `th`, time and vertical coordinates | reduced cloud depth, delayed cloud, or capped vertical motion |
 | `humid_rainy_candidate` | `surface_forced_moist_evolution_v1` | `partially_testable` until surface flux controls are validated | explicit current or future surface-flux assumptions; no deep trigger; precipitation fields requested | `qc`, `w`, `qr`, `rain`, `dbz` when precipitation is predicted | cloud, rain water aloft, surface rain, and reflectivity evaluated separately |
-| `severe_thunderstorm_environment` | `triggered_deep_potential_v1` | `partially_testable` with current Deep Convection Trial caveats | explicit warm-bubble trigger; complete observed wind profile; storm-scale domain | `qc`, `w`, `qr`, `rain`, `dbz`, updraft diagnostics | whether triggered initiation supports deep convection and precipitation signatures |
+| `severe_thunderstorm_environment` | `triggered_deep_potential_v1` | `partially_testable` with current triggered deep-potential caveats | explicit warm-bubble trigger; complete observed wind profile; storm-scale domain | `qc`, `w`, `qr`, `rain`, `dbz`, updraft diagnostics | whether triggered initiation supports deep convection and precipitation signatures |
 | `supercell_environment` | `triggered_deep_potential_v1` | `partially_testable` | explicit warm-bubble trigger; complete observed wind profile; storm-scale domain; rotation diagnostics caveated | `qc`, `w`, `qr`, `rain`, `dbz`, `u`, `v`, updraft-helicity when available | deep convection and organization evidence; not a tornado or forecast product |
 | `high_cape_pulse_storm` | `triggered_deep_potential_v1` | `partially_testable` | explicit warm-bubble trigger; high-CAPE interpretation caveated until parcel diagnostics are implemented | `qc`, `w`, `qr`, `rain`, `dbz` | strong buoyant updraft and deep cloud under triggered initiation |
 | `dry_microburst_inverted_v` | `triggered_deep_potential_v1` | `partially_testable` only if precipitation/downdraft pathway develops | explicit trigger; precipitation aloft; subcloud dry-layer evidence; downdraft diagnostics caveated | `qr`, `rain`, `w`, `th`, near-surface wind fields when implemented | rain water aloft, downdraft/cooling/outflow evidence; not a wind-gust forecast |
@@ -447,8 +464,8 @@ Comparison rules:
 - Keep `qr` as rain water aloft, `rain` as surface rain or accumulated
   precipitation at ground, and `dbz` as reflectivity.
 
-Do not use Deep Convection Trial trigger-failed language for non-deep recipes
-or for deliberate normal-evolution runs.
+Do not use triggered deep-potential trigger-failed language for non-deep recipes
+or for deliberate untriggered observed-evolution runs.
 
 ## Product Copy Rules
 

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -74,12 +74,10 @@ candidate stories. It does not make severe, winter, cold-pool, or specialized
 boundary-layer stories scientifically validated until their scoring, evidence,
 caveats, and package-readiness states are implemented and tested.
 
-The deep-convection package design backs the current deep-convection
-observed-sounding preset and package path. User-facing docs should describe this
-as a configurable deep-convection run starting point, not as a separate
-half-state "Trial" product. Internal metadata such as
-`package_family = deep_convection_trial` may remain where renaming would create
-more churn than clarity.
+The deep-convection package design now maps to the triggered deep-potential run
+recipe. User-facing docs should describe this as a configurable
+triggered-potential experiment, not as a separate half-state "Trial" product or
+package-family compatibility layer.
 
 ## Current State
 
@@ -137,17 +135,18 @@ compare input atmospheres before packaging.
 Goal: let Build start from a sane preset and then adjust run settings that map
 to real CM1 configuration.
 
-Scope: controls for model duration, grid/detail, output cadence, forcing, and
-requested output fields within guarded bounds. Presets should remain available
-as starting points, and an advanced drawer should expose the actual CM1-facing
-values those presets imply.
+Scope: controls for model duration, horizontal cell budget, domain size, output
+cadence, forcing, and diagnostic set within guarded bounds. Starting points
+should remain available, and an advanced drawer should expose the actual
+CM1-facing values those choices imply.
 
 Non-goals: raw numerical timestep as a normal v1 control, raw trigger controls,
 new trigger types, or a full Build redesign in one issue.
 
 Why now: the product direction is configurable runs, not rigid scenario or
-package-family cages. Grid/detail and output cadence are the main cost levers;
-duration controls must preserve enough model time for meaningful evolution.
+package-family cages. Horizontal cell budget, domain, diagnostic set, and
+output cadence are the main cost levers; duration controls must preserve enough
+model time for meaningful evolution.
 
 ### Pre-Run Configuration Validation
 
@@ -168,13 +167,13 @@ Build workflow.
 
 ### Deep-Convection Configuration Validation Across Soundings
 
-Goal: keep the deep-convection observed-sounding preset first-class while
-measuring where its current configuration is package-ready, caveated, or
+Goal: keep the triggered deep-potential observed-sounding recipe first-class
+while measuring where its current configuration is run-ready, caveated, or
 misleading.
 
 Scope: validate complete observed-wind requirements, storm-scale box choices,
-duration, grid/detail, domain size, output cadence, expected fields, expected
-cost/runtime/output volume, larger-compute suitability notes, and
+duration, horizontal cell budget, domain size, output cadence, diagnostic set,
+expected fields, expected cost/runtime/output volume, larger-compute suitability notes, and
 candidate-provenance copy across selected observed soundings. Separate
 package/run/ingest smoke checks from science outcomes.
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -125,21 +125,21 @@ implemented. Tests must not expect winter/cold-season, cold-pool, fog/stratus,
 or other future taxonomy labels to appear as enabled Build filters before that
 support exists. The readiness taxonomy is documented in
 [research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md).
-The implemented severe/deep-convection exception is `Deep Convection Trial`.
-Unit/component tests should prove that deep-convection candidates can default to
-that package family, that package requests include `package_family =
-deep_convection_trial` and candidate-screening provenance, and that ordinary
-observed-sounding quick looks remain available.
+The implemented severe/deep-convection exception is the triggered
+deep-potential run recipe. Unit/component tests should prove that
+deep-convection candidates can default to that recipe, that package requests
+include `run_recipe = triggered_deep_potential` and candidate-screening
+provenance, and that untriggered observed-evolution runs remain available.
 
-### Deep Convection Trial Package Validation
+### Triggered Deep-Potential Recipe Validation
 
-Automated tests for Deep Convection Trial must use tiny or mocked fixtures. They
+Automated tests for triggered deep-potential runs must use tiny or mocked fixtures. They
 should verify that package generation:
 
 - requires an observed sounding and observed u/v wind components;
 - preserves candidate-screening metadata;
-- records package family, display name, trigger type, trigger metadata,
-  expected outputs, caveats, and package-family smoke-validation status on generated
+- records run recipe, display name, trigger type, trigger metadata,
+  expected outputs, caveats, and recipe smoke-validation status on generated
   manifests and reports;
 - writes CM1-facing `namelist.input` settings for the observed-sounding route,
   three-warm-bubble trigger, storm-scale domain, rain output, reflectivity output,
@@ -155,8 +155,8 @@ and updraft helicity; new soundings remain experiments whose outcomes must be
 inspected after CM1 runs. The manual smoke loop should:
 
 1. choose or upload a real observed sounding with usable winds;
-2. select `Deep Convection Trial`;
-3. generate a Quick Look package;
+2. select `Triggered deep potential`;
+3. generate a short-evolution package;
 4. inspect `run_manifest.json`, `dry_run_report.json`, `namelist.input`, and
    `input_sounding`;
 5. confirm `isnd = 7`, `iinit = 3`, `testcase = 0`, rain/reflectivity/vorticity/
@@ -402,7 +402,7 @@ one desktop cloud-context and slice-inspection workflow rather than separate
 selected-result context flows from Results into Explore; and the old
 implementation pages (`Compare`, `Storage`, `Inspect`, `Visualize`) are no
 longer top-level workspaces. They should also cover prioritizing a validated cloud-forming
-quick-look baseline over historical attempts, user-facing status labels
+reference baseline over historical attempts, user-facing status labels
 replacing raw internal lifecycle strings, and technical details keeping raw
 provenance available without dominating the main view. They should distinguish
 successful cloud-forming results with minor caveats from results that truly need
@@ -531,7 +531,7 @@ than expecting shallow-cumulus runs to contain strong radar echoes.
 
 The consolidated Results/Explore shell and fixed Explore workbench should also
 get a real browser smoke check after layout changes, not only component tests.
-Open the app, navigate to Results, open the validated quick-look baseline in
+Open the app, navigate to Results, open the validated reference baseline in
 Explore, and confirm by screenshot or direct browser inspection that the 3-D
 scalar-field context, visible slice plane, shared controls, matching slice
 inspector, and selected-point explanation are all reachable without the render
@@ -562,7 +562,7 @@ camera/view/field/slice position are preserved across time changes, that
 selected-cell explanation state is cleared while playback tells the user to
 pause before asking `What happened here?`, and that playback stops and resets to
 the first saved output when it reaches the end rather than looping.
-Visual first-impression tests should also keep the validated quick-look baseline
+Visual first-impression tests should also keep the validated reference baseline
 on a cloud-bearing time, show a visible point-cloud state, keep slice planes
 optional and secondary, and keep technical provenance reachable without making
 it the primary reading path.
@@ -605,7 +605,7 @@ Manual validation should record:
 - the CM1 version and local runtime path
 - the Cloud Chamber commit
 - the selected run configuration
-- the grid/domain, runtime, output cadence, and output field density
+- the horizontal cell budget, domain, runtime, output cadence, and diagnostic set
 - diagnostics such as cloud base, cloud top, first cloud time, rain onset, and updraft strength
 - cloud-water max or summary
 - log warnings/errors


### PR DESCRIPTION
## Summary
- adds a backend-owned pre-run validation report for run generation, run manifests, run status, storage inventory, ingest metadata, result cards, and dry-run API errors
- replaces user-facing quick-look/deep-trial package-family presets with explicit `run_recipe` values: generated lower-atmosphere reference, untriggered observed evolution, and triggered deep-potential experiment
- makes run configuration explicit around duration, horizontal cell budget, domain size, output cadence, and diagnostic set, with derived CM1-facing values such as nx/ny, dx/dy, total cells, runtime, and output volume
- keeps deep-convection candidate routing first-class while making the triggered-deep-potential assumptions visible and caveated; untriggered observed evolution remains available without pretending to test deep-potential hypotheses
- updates Build UI, backend models, result ingest/cards, visualization defaults, tests, E2E fixtures, and active docs to the new run-recipe/run-configuration contract

## Verification
- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_cm1_input_contract.py app/backend/tests/test_dry_run_package.py app/backend/tests/test_app.py app/backend/tests/test_run_manifest.py app/backend/tests/test_result_cards.py app/backend/tests/test_result_ingest.py app/backend/tests/test_output_products.py app/backend/tests/test_visualization_data.py app/backend/tests/test_runtime_storage.py app/backend/tests/test_sounding_candidates.py -q`
- `cd app/frontend && npm test -- App.test.tsx`
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Notes
- Per request, this PR is not merged and auto-merge is not enabled.
- `scripts/check.sh` still prints the existing React `act(...)` warning in the scenario-loading test, the existing Vite chunk-size warning, and the existing backend numpy binary-compatibility warning, but exits cleanly.

Closes #284
