### PR TITLE
feat: rationalize Build around atmosphere run plans

### DIFF
--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -86,13 +86,15 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("USM00072558 · Valley, Nebraska")).toBeVisible();
     await expect(page.locator("#observed-sounding-time")).toHaveValue("2025-01-02T00:00:00Z");
     await expect(page.getByText(/CM1 z=0 is station surface at 351.5 m MSL/i)).toBeVisible();
-    await expect(page.getByText(/generated CM1 namelist uses isnd=7/i)).toBeVisible();
+    await expect(page.getByText(/generated CM1 namelist uses isnd=7/i).first()).toBeVisible();
 
     await page.getByText("Observed-sounding caveats").click();
     await expect(page.getByText("Station elevation joined from igra station fixture")).toBeVisible();
 
-    await page.getByRole("button", { name: "Add uploaded sounding to run plan" }).click();
-    await expect(page.getByText("Uploaded sounding added to the run plan")).toBeVisible();
+    await page.getByRole("button", { name: "Add selected sounding to run plan" }).click();
+    await expect(
+      page.getByText("Valley, Nebraska (USM00072558) added to the run plan"),
+    ).toBeVisible();
     await expect(
       page.getByLabel("Run plan").getByLabel("Recipe", { exact: true }).first(),
     ).toHaveValue("untriggered_observed_evolution");
@@ -140,7 +142,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     const blockedCard = page.getByLabel("Sounding candidate Norman, Oklahoma (USM00072357)");
     await expect(blockedCard).toBeVisible();
     await expect(blockedCard).toContainText("Blocked");
-    await expect(blockedCard.getByRole("button", { name: "Add to run plan" })).toBeDisabled();
+    await expect(blockedCard.getByRole("button", { name: "Select for run setup" })).toBeDisabled();
 
     await storySelect.selectOption("all");
     await page.getByText("Advanced filters").click();
@@ -150,12 +152,13 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("Sounding candidate saved")).toBeVisible();
     await page.getByRole("tab", { name: /Saved candidates/ }).click();
     const savedCard = page.getByLabel("Saved sounding candidate Valley, Nebraska (USM00072558)");
-    await expect(
-      savedCard,
-    ).toBeVisible();
+    await expect(savedCard).toBeVisible();
 
-    await savedCard.getByRole("button", { name: "Add to run plan" }).click();
-    await expect(page.getByText("Valley, Nebraska (USM00072558) added to the run plan")).toBeVisible();
+    await savedCard.getByRole("button", { name: "Select for run setup" }).click();
+    await page.getByRole("button", { name: "Add selected sounding to run plan" }).click();
+    await expect(
+      page.getByText("Valley, Nebraska (USM00072558) added to the run plan"),
+    ).toBeVisible();
     await expect(
       page.getByLabel("Run plan").getByLabel("Recipe", { exact: true }).first(),
     ).toHaveValue("untriggered_observed_evolution");

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -83,15 +83,17 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     });
 
     await expect(page.getByText("Observed sounding validated for package review")).toBeVisible();
-    await expect(page.getByText("USM00072558 · Valley, Nebraska")).toBeVisible();
+    await expect(page.getByText("Valley, Nebraska (USM00072558)").first()).toBeVisible();
     await expect(page.locator("#observed-sounding-time")).toHaveValue("2025-01-02T00:00:00Z");
+    await page.getByText("Uploaded-sounding review").click();
+    await expect(page.getByText("USM00072558 · Valley, Nebraska")).toBeVisible();
     await expect(page.getByText(/CM1 z=0 is station surface at 351.5 m MSL/i)).toBeVisible();
     await expect(page.getByText(/generated CM1 namelist uses isnd=7/i).first()).toBeVisible();
 
     await page.getByText("Observed-sounding caveats").click();
     await expect(page.getByText("Station elevation joined from igra station fixture")).toBeVisible();
 
-    await page.getByRole("button", { name: "Add selected sounding to run plan" }).click();
+    await page.getByRole("button", { name: "Add to run plan" }).click();
     await expect(
       page.getByText("Valley, Nebraska (USM00072558) added to the run plan"),
     ).toBeVisible();
@@ -155,7 +157,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(savedCard).toBeVisible();
 
     await savedCard.getByRole("button", { name: "Select for run setup" }).click();
-    await page.getByRole("button", { name: "Add selected sounding to run plan" }).click();
+    await page.getByRole("button", { name: "Add to run plan" }).click();
     await expect(
       page.getByText("Valley, Nebraska (USM00072558) added to the run plan"),
     ).toBeVisible();

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -17,6 +17,8 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.locator("select").first()).toBeVisible();
     await expect(page.getByText(/physical question/i).first()).toBeVisible();
     await expect(page.getByText(/how do low-level moisture/i).first()).toBeVisible();
+    await expect(page.getByText("Run monitor")).toBeVisible();
+    await page.getByText("Run monitor").click();
     await expect(page.getByRole("heading", { name: "Local run launchpad" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Packages and runs needing action" })).toBeVisible();
     await expect(
@@ -63,9 +65,15 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
 
     await page.getByLabel("Experiment", { exact: true }).selectOption("__observed_sounding_upload__");
     await expect(page.getByRole("heading", { name: "Upload a Sounding" })).toBeVisible();
-    await expect(page.getByText("Observed sounding profile, Surface heating")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Find interesting soundings" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Cached recommendations" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page.getByLabel("IGRA station sounding-data file")).not.toBeVisible();
+    await page.getByRole("tab", { name: "Upload IGRA station text" }).click();
+    await expect(page.getByLabel("IGRA station sounding-data file")).toBeVisible();
     await expect(page.getByLabel("Low-level humidity")).not.toBeVisible();
-    await expect(page.getByLabel("Surface heating")).toBeEnabled();
     await expect(page.getByLabel("Use uploaded sounding")).not.toBeVisible();
 
     await page.getByLabel("IGRA station sounding-data file").setInputFiles({
@@ -83,11 +91,15 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await page.getByText("Observed-sounding caveats").click();
     await expect(page.getByText("Station elevation joined from igra station fixture")).toBeVisible();
 
-    await page.getByTestId("create-package-btn").scrollIntoViewIfNeeded();
-    await page.getByTestId("create-package-btn").click();
+    await page.getByRole("button", { name: "Add uploaded sounding to run plan" }).click();
+    await expect(page.getByText("Uploaded sounding added to the run plan")).toBeVisible();
+    await expect(
+      page.getByLabel("Run plan").getByLabel("Recipe", { exact: true }).first(),
+    ).toHaveValue("untriggered_observed_evolution");
 
-    await expect(page.getByText("Package ready").first()).toBeVisible();
-    await expect(page.getByText("/tmp/cloud-chamber-e2e/run/run_manifest.json")).toBeVisible();
+    await page.getByRole("button", { name: "Create packages and queue selected runs" }).click();
+    await expect(page.getByText("Queued for local serial CM1 run.")).toBeVisible();
+    await expect(page.getByText("1 queued locally")).toBeVisible();
   });
 
   test("Build can screen, save, and use observed sounding candidates", async ({ page }) => {
@@ -98,58 +110,61 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/Screening guidance only/i).first()).toBeVisible();
     await expect(page.getByText("IGRA cache not checked yet")).toBeVisible();
 
+    await page.getByText("Advanced filters").click();
     await page.getByRole("button", { name: "Refresh IGRA catalog" }).click();
     await expect(page.getByText("IGRA station catalog refreshed")).toBeVisible();
-    await expect(page.getByText("Cached sounding inventory").locator("..")).toContainText(
-      "2 cached soundings",
-    );
-    await expect(page.getByText("Planned analysis slice").locator("..")).toContainText(
-      "Up to 2 soundings",
-    );
+    await expect(page.getByText("Parsed soundings")).toBeVisible();
+    await expect(page.getByText("2 cached soundings")).toBeVisible();
+    await expect(page.getByText("Ready to search")).toBeVisible();
 
     await page.getByRole("button", { name: "Cache station files" }).click();
     await expect(page.getByText("Cached 1 station file")).toBeVisible();
 
-    await page.getByText("Advanced filters").click();
     const candidateControls = page.getByLabel("Advanced sounding candidate controls");
     const storySelect = candidateControls.getByRole("combobox").first();
     await storySelect.selectOption("shallow_cumulus_candidate");
-    await page.getByRole("button", { name: "Analyze recommendations" }).click();
+    await page.getByRole("button", { name: "Run analyzer only" }).click();
 
     await expect(page.getByText("Cached sounding analysis loaded")).toBeVisible();
     const valleyCard = page.getByLabel("Sounding candidate Valley, Nebraska (USM00072558)");
     await expect(valleyCard).toBeVisible();
     await expect(valleyCard).toContainText("Cloud-forming shallow cumulus");
     await expect(valleyCard).toContainText("Package-ready");
-    await expect(valleyCard).toContainText("Low-level moisture: 10.2 g/kg");
+    await expect(valleyCard).toContainText("Key caveat:");
     await expect(page.getByLabel("Candidate details")).toContainText(
       "Scores rank sounding ingredients only",
     );
 
     await storySelect.selectOption("needs_review");
-    await page.getByRole("button", { name: "Analyze recommendations" }).click();
+    await page.getByRole("button", { name: "Run analyzer only" }).click();
     const blockedCard = page.getByLabel("Sounding candidate Norman, Oklahoma (USM00072357)");
     await expect(blockedCard).toBeVisible();
     await expect(blockedCard).toContainText("Blocked");
-    await expect(blockedCard.getByRole("button", { name: "Use this sounding" })).toBeDisabled();
+    await expect(blockedCard.getByRole("button", { name: "Add to run plan" })).toBeDisabled();
 
     await storySelect.selectOption("all");
-    await page.getByRole("button", { name: "Analyze recommendations" }).click();
-    await valleyCard.getByRole("button", { name: "Save candidate" }).click();
+    await page.getByText("Advanced filters").click();
+    await page.getByRole("button", { name: "Run analyzer only" }).click();
+    const refreshedValleyCard = page.getByLabel("Sounding candidate Valley, Nebraska (USM00072558)");
+    await refreshedValleyCard.getByRole("button", { name: "Save candidate" }).click();
     await expect(page.getByText("Sounding candidate saved")).toBeVisible();
+    await page.getByRole("tab", { name: /Saved candidates/ }).click();
+    const savedCard = page.getByLabel("Saved sounding candidate Valley, Nebraska (USM00072558)");
     await expect(
-      page.getByLabel("Saved sounding candidate Valley, Nebraska (USM00072558)"),
+      savedCard,
     ).toBeVisible();
 
-    await valleyCard.getByRole("button", { name: "Use this sounding" }).click();
-    await expect(page.getByText("Candidate selected for package review")).toBeVisible();
-    await expect(page.getByText("Candidate loaded into observed-sounding package review")).toBeVisible();
-    await expect(page.getByText("USM00072558 · Valley, Nebraska")).toBeVisible();
-    await expect(page.getByText(/Screened as Cloud-forming shallow cumulus/i)).toBeVisible();
+    await savedCard.getByRole("button", { name: "Add to run plan" }).click();
+    await expect(page.getByText("Valley, Nebraska (USM00072558) added to the run plan")).toBeVisible();
+    await expect(
+      page.getByLabel("Run plan").getByLabel("Recipe", { exact: true }).first(),
+    ).toHaveValue("untriggered_observed_evolution");
+    await page.getByRole("button", { name: "Duplicate variant" }).click();
+    await expect(page.getByText("Run-plan variant duplicated")).toBeVisible();
 
-    await page.getByTestId("create-package-btn").scrollIntoViewIfNeeded();
-    await page.getByTestId("create-package-btn").click();
-    await expect(page.getByText("Package ready").first()).toBeVisible();
+    await page.getByRole("button", { name: "Create packages and queue selected runs" }).click();
+    await expect(page.getByText("2 queued locally")).toBeVisible();
+    await expect(page.getByText("Queued for local serial CM1 run.").first()).toBeVisible();
   });
 
   test("Results notebook renders with mocked data", async ({ page }) => {
@@ -226,6 +241,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByLabel("Results list").getByText("Baseline Shallow Cumulus — Quick Look")).toHaveCount(0);
 
     await gotoBuild(page);
+    await page.getByText("Run monitor").click();
     const pipelineRuns = page.getByLabel("Local packages and runs");
     const ingestReadyRun = pipelineRuns.locator("article", { hasText: "dry-run-disposable" });
     await expect(ingestReadyRun.getByText("Ready to ingest")).toBeVisible();

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -15,12 +15,16 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await gotoBuild(page);
 
     await expect(page.locator("select").first()).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Upload a Sounding" })).toBeVisible();
+    await page.getByLabel("Experiment", { exact: true }).selectOption("baseline-shallow-cumulus");
     await expect(page.getByText(/physical question/i).first()).toBeVisible();
     await expect(page.getByText(/how do low-level moisture/i).first()).toBeVisible();
     await expect(page.getByText("Run monitor")).toBeVisible();
     await page.getByText("Run monitor").click();
     await expect(page.getByRole("heading", { name: "Local run launchpad" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Packages and runs needing action" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Packages and runs needing action" }),
+    ).toBeVisible();
     await expect(
       page.getByTestId("package-review-panel").getByText("Not packaged yet").first(),
     ).toBeVisible();
@@ -58,12 +62,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
   });
 
-  test("Build can review an observed IGRA sounding before package creation", async ({
-    page,
-  }) => {
+  test("Build can review an observed IGRA sounding before package creation", async ({ page }) => {
     await gotoBuild(page);
 
-    await page.getByLabel("Experiment", { exact: true }).selectOption("__observed_sounding_upload__");
+    await page
+      .getByLabel("Experiment", { exact: true })
+      .selectOption("__observed_sounding_upload__");
     await expect(page.getByRole("heading", { name: "Upload a Sounding" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Find interesting soundings" })).toBeVisible();
     await expect(page.getByRole("tab", { name: "Cached recommendations" })).toHaveAttribute(
@@ -85,13 +89,18 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("Observed sounding validated for package review")).toBeVisible();
     await expect(page.getByText("Valley, Nebraska (USM00072558)").first()).toBeVisible();
     await expect(page.locator("#observed-sounding-time")).toHaveValue("2025-01-02T00:00:00Z");
-    await page.getByText("Uploaded-sounding review").click();
-    await expect(page.getByText("USM00072558 · Valley, Nebraska")).toBeVisible();
-    await expect(page.getByText(/CM1 z=0 is station surface at 351.5 m MSL/i)).toBeVisible();
-    await expect(page.getByText(/generated CM1 namelist uses isnd=7/i).first()).toBeVisible();
+    const observedReview = page.getByLabel("Observed sounding review");
+    await observedReview.getByText("Uploaded-sounding review").click();
+    await expect(observedReview.getByText("USM00072558 · Valley, Nebraska")).toBeVisible();
+    await expect(
+      observedReview.getByText(/CM1 z=0 is station surface at 351.5 m MSL/i),
+    ).toBeVisible();
+    await expect(observedReview.getByText(/generated CM1 namelist uses isnd=7/i)).toBeVisible();
 
-    await page.getByText("Observed-sounding caveats").click();
-    await expect(page.getByText("Station elevation joined from igra station fixture")).toBeVisible();
+    await observedReview.getByText("Observed-sounding caveats").click();
+    await expect(
+      observedReview.getByText("Station elevation joined from igra station fixture"),
+    ).toBeVisible();
 
     await page.getByRole("button", { name: "Add to run plan" }).click();
     await expect(
@@ -109,7 +118,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
   test("Build can screen, save, and use observed sounding candidates", async ({ page }) => {
     await gotoBuild(page);
 
-    await page.getByLabel("Experiment", { exact: true }).selectOption("__observed_sounding_upload__");
+    await page
+      .getByLabel("Experiment", { exact: true })
+      .selectOption("__observed_sounding_upload__");
     await expect(page.getByRole("heading", { name: "Find interesting soundings" })).toBeVisible();
     await expect(page.getByText(/Screening guidance only/i).first()).toBeVisible();
     await expect(page.getByText("IGRA cache not checked yet")).toBeVisible();
@@ -149,7 +160,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await storySelect.selectOption("all");
     await page.getByText("Advanced filters").click();
     await page.getByRole("button", { name: "Run analyzer only" }).click();
-    const refreshedValleyCard = page.getByLabel("Sounding candidate Valley, Nebraska (USM00072558)");
+    const refreshedValleyCard = page.getByLabel(
+      "Sounding candidate Valley, Nebraska (USM00072558)",
+    );
     await refreshedValleyCard.getByRole("button", { name: "Save candidate" }).click();
     await expect(page.getByText("Sounding candidate saved")).toBeVisible();
     await page.getByRole("tab", { name: /Saved candidates/ }).click();
@@ -208,7 +221,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
 
     await filterBar.getByLabel("Search").fill("Valley");
     await expect(resultsList.getByText("Uploaded Sounding — Valley, Nebraska")).toBeVisible();
-    await expect(resultsList.getByText("Observed sounding: USM00072558 · Valley, Nebraska")).toBeVisible();
+    await expect(
+      resultsList.getByText("Observed sounding: USM00072558 · Valley, Nebraska"),
+    ).toBeVisible();
     await expect(resultsList.getByText("Baseline Shallow Cumulus — Quick Look")).toHaveCount(0);
 
     await filterBar.getByLabel("Search").fill("");
@@ -228,22 +243,34 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     );
   });
 
-  test("Results deletes ingested results and Build keeps non-ingested cleanup", async ({ page }) => {
+  test("Results deletes ingested results and Build keeps non-ingested cleanup", async ({
+    page,
+  }) => {
     await gotoResults(page);
 
     const resultDetail = page.getByLabel("Result detail");
-    await resultDetail.getByRole("button", { name: "Preview delete result and local run data" }).click();
-    await expect(page.getByRole("heading", { name: "Delete result and local run data preview" })).toBeVisible();
-    await expect(page.getByText(/result will disappear from Results, Explore, and local inventory/)).toBeVisible();
+    await resultDetail
+      .getByRole("button", { name: "Preview delete result and local run data" })
+      .click();
+    await expect(
+      page.getByRole("heading", { name: "Delete result and local run data preview" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/result will disappear from Results, Explore, and local inventory/),
+    ).toBeVisible();
     await expect(page.getByText("Result metadata and notebook edits")).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Delete result and local run data", exact: true }),
     ).toBeVisible();
-    await page.getByRole("button", { name: "Delete result and local run data", exact: true }).click();
+    await page
+      .getByRole("button", { name: "Delete result and local run data", exact: true })
+      .click();
     await expect(
       page.getByRole("status").filter({ hasText: /Result and local run data deleted/ }),
     ).toBeVisible();
-    await expect(page.getByLabel("Results list").getByText("Baseline Shallow Cumulus — Quick Look")).toHaveCount(0);
+    await expect(
+      page.getByLabel("Results list").getByText("Baseline Shallow Cumulus — Quick Look"),
+    ).toHaveCount(0);
 
     await gotoBuild(page);
     await page.getByText("Run monitor").click();
@@ -252,7 +279,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(ingestReadyRun.getByText("Ready to ingest")).toBeVisible();
     await expect(ingestReadyRun.getByRole("button", { name: "Preview cleanup" })).toBeEnabled();
     await ingestReadyRun.getByRole("button", { name: "Preview cleanup" }).click();
-    await expect(page.getByRole("heading", { name: "Delete local package/run data preview" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Delete local package/run data preview" }),
+    ).toBeVisible();
     await expect(page.getByText(/does not touch Results entries/)).toBeVisible();
     await expect(page.getByRole("button", { name: "Confirm delete local run data" })).toBeVisible();
 
@@ -283,7 +312,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("button", { name: "Open in Explore" }).first()).toBeVisible();
   });
 
-  test("Unified Explore renders cloud context, slice inspector, and explanation", async ({ page }) => {
+  test("Unified Explore renders cloud context, slice inspector, and explanation", async ({
+    page,
+  }) => {
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
@@ -311,7 +342,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       const fieldControl = document.querySelector("#explore-slice-field");
       return Boolean(
         fieldControl &&
-          (fieldControl.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING),
+        fieldControl.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING,
       );
     });
     expect(fieldControlsPrecedeHeatmap).toBe(true);
@@ -355,7 +386,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       page.getByText("Pause playback to select a cell and explain this time step."),
     ).toBeVisible();
     await expect(
-      page.getByText(/Animating 3-D scene at .*; slice and evidence remain at .* until playback is paused\./),
+      page.getByText(
+        /Animating 3-D scene at .*; slice and evidence remain at .* until playback is paused\./,
+      ),
     ).toBeVisible();
     await expect(page.locator("#explore-time")).toHaveValue("2", { timeout: 2_000 });
 
@@ -388,9 +421,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
 
     const processMode = page.getByLabel("Process mode");
     await expect(processMode).toBeVisible();
-    await expect(processMode.locator("option", { hasText: "Thermal Fate summary" })).toHaveCount(
-      1,
-    );
+    await expect(processMode.locator("option", { hasText: "Thermal Fate summary" })).toHaveCount(1);
     await expect(processMode.locator("option", { hasText: "Cloud Water" })).toHaveCount(1);
     await expect(processMode.locator("option", { hasText: "Updrafts" })).toHaveCount(1);
     await expect(processMode.locator("option", { hasText: "Moisture" })).toHaveCount(0);
@@ -412,11 +443,13 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
 
     await expect(page.getByText(/slice synced/i).first()).toBeVisible({ timeout: 10_000 });
     await expect(page.locator("#explore-slice-field")).toHaveValue("qc");
-    await expect(page.locator("#explore-slice-field option", { hasText: "qc - Cloud water" })).toHaveCount(
-      1,
-    );
     await expect(
-      page.locator("#explore-slice-field option", { hasText: "w - Vertical velocity (slice only)" }),
+      page.locator("#explore-slice-field option", { hasText: "qc - Cloud water" }),
+    ).toHaveCount(1);
+    await expect(
+      page.locator("#explore-slice-field option", {
+        hasText: "w - Vertical velocity (slice only)",
+      }),
     ).toHaveCount(1);
     await expect(page.getByText(/loading fields/i)).not.toBeVisible();
 
@@ -492,7 +525,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/slice synced/i).first()).toBeVisible({ timeout: 10_000 });
     await expect(page.locator("#explore-slice-field")).toHaveValue("w");
     await expect(
-      page.locator("#explore-slice-field option", { hasText: "w - Vertical velocity (slice only)" }),
+      page.locator("#explore-slice-field option", {
+        hasText: "w - Vertical velocity (slice only)",
+      }),
     ).toHaveCount(1);
   });
 
@@ -510,9 +545,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
-    await expect(page.getByRole("alert")).toContainText(
-      "Visualization fields temporarily failed.",
-    );
+    await expect(page.getByRole("alert")).toContainText("Visualization fields temporarily failed.");
     await expect(page.getByRole("button", { name: "Retry loading fields" })).toBeVisible();
     await expect(page.getByText("Loading fields...", { exact: true })).not.toBeVisible();
   });
@@ -537,7 +570,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       );
       return Boolean(
         technicalSummary &&
-          (element.compareDocumentPosition(technicalSummary) & Node.DOCUMENT_POSITION_FOLLOWING),
+        element.compareDocumentPosition(technicalSummary) & Node.DOCUMENT_POSITION_FOLLOWING,
       );
     });
     expect(heatmapPrecedesTechnicalDetails).toBe(true);

--- a/app/frontend/e2e/mocked-smoke/navigation.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/navigation.spec.ts
@@ -56,6 +56,8 @@ test.describe("mocked smoke: app shell", () => {
     await gotoApp(page);
 
     await gotoBuild(page);
+    await expect(page.getByText("Run monitor")).toBeVisible();
+    await page.getByText("Run monitor").click();
     await expect(page.getByRole("heading", { name: "Local run launchpad" })).toBeVisible();
 
     await gotoResults(page);
@@ -117,6 +119,8 @@ test.describe("mocked smoke: app shell", () => {
       }
 
       await gotoBuild(page);
+      await expect(page.getByText("Run monitor")).toBeVisible();
+      await page.getByText("Run monitor").click();
       await expect(page.getByRole("heading", { name: "Local run launchpad" })).toBeVisible();
       await gotoResults(page);
       await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -279,8 +279,13 @@ small {
 .run-configuration-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
-  gap: 0.65rem;
+  gap: 0.7rem;
   margin: 0.75rem 0;
+  align-items: start;
+}
+
+.embedded-run-configuration-panel .run-configuration-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .run-configuration-control {
@@ -295,6 +300,7 @@ small {
   display: block;
   margin-top: 0.2rem;
   color: var(--color-text-muted);
+  font-size: 0.82rem;
   font-weight: 500;
   line-height: 1.35;
 }
@@ -335,8 +341,8 @@ small {
 
 .selected-run-builder > * + * {
   border-top: 1px solid rgba(188, 211, 224, 0.72);
-  padding-top: 0.85rem;
-  margin-top: 0.85rem;
+  padding-top: 0.8rem;
+  margin-top: 0.8rem;
 }
 
 .selected-sounding-strip {
@@ -359,13 +365,63 @@ small {
   gap: 0.85rem;
 }
 
-.selected-sounding-add-panel {
-  display: grid;
-  gap: 0.75rem;
+.run-configuration-summary {
+  grid-template-columns: repeat(auto-fit, minmax(11.5rem, 1fr));
+  gap: 0.6rem;
+  border: 1px solid rgba(188, 211, 224, 0.68);
+  border-radius: 8px;
+  padding: 0.7rem 0.75rem;
+  background: rgba(247, 251, 253, 0.72);
 }
 
-.selected-sounding-add-panel button {
-  justify-self: start;
+.run-configuration-summary dt {
+  color: var(--color-text-primary);
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.run-configuration-summary dd {
+  margin: 0.16rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.run-configuration-notes .compact-list {
+  margin-top: 0.55rem;
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
+}
+
+.hypothesis-details-panel {
+  border-top: 1px solid rgba(188, 211, 224, 0.66);
+  padding-top: 0.65rem;
+}
+
+.hypothesis-details-panel .compact-metrics + .compact-metrics,
+.hypothesis-details-panel .compact-metrics + div {
+  margin-top: 0.7rem;
+}
+
+.run-configuration-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  align-items: end;
+  justify-content: space-between;
+  border-top: 1px solid rgba(188, 211, 224, 0.72);
+  padding-top: 0.8rem;
+}
+
+.run-configuration-action-row h4,
+.run-configuration-action-row p {
+  margin-bottom: 0;
+}
+
+.run-configuration-action-row button {
+  white-space: nowrap;
 }
 
 .summary-note {
@@ -587,24 +643,20 @@ small {
 
 .saved-candidate-card {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(13rem, 18rem) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.75rem;
-  align-items: center;
+  align-items: start;
 }
 
-.saved-candidate-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: end;
+.saved-candidate-notes-drawer {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.65rem;
 }
 
-.saved-candidate-controls label {
-  display: grid;
-  gap: 0.25rem;
-  min-width: 12rem;
-  color: var(--color-text-primary);
-  font-weight: 800;
+.saved-candidate-notes-drawer .candidate-notes-form {
+  border-top: 0;
+  padding-top: 0.55rem;
 }
 
 .run-plan-list {
@@ -1155,6 +1207,10 @@ button:disabled {
   color: var(--color-text-muted);
   cursor: pointer;
   font-weight: 800;
+}
+
+.technical-details[open] > summary {
+  margin-bottom: 0.65rem;
 }
 
 .table-panel {
@@ -2669,7 +2725,8 @@ details[open] > summary {
   .control-row,
   .candidate-toolbar,
   .candidate-workspace,
-  .explore-result-summary {
+  .explore-result-summary,
+  .embedded-run-configuration-panel .run-configuration-grid {
     grid-template-columns: 1fr;
   }
 

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -316,16 +316,53 @@ small {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(247, 251, 253, 0.86));
 }
 
+.atmosphere-source-panel,
+.candidate-search-controls,
+.upload-source-stack,
+.run-plan-panel {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.source-path-tabs {
+  align-items: stretch;
+}
+
+.source-path-tabs button {
+  min-height: 2.55rem;
+}
+
+.candidate-search-controls label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.candidate-search-controls small {
+  color: var(--color-text-muted);
+  font-weight: 500;
+  line-height: 1.35;
+}
+
 .candidate-cache-summary {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
   gap: 0.6rem;
   margin: 0;
 }
 
-.candidate-cache-summary > div,
+.candidate-cache-summary h4 {
+  margin: 0;
+}
+
+.candidate-cache-summary .compact-metrics,
+.run-plan-panel .compact-metrics {
+  margin: 0;
+}
+
 .candidate-detail-panel,
-.saved-candidate-card {
+.saved-candidate-card,
+.run-plan-card {
   border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 0.75rem;
@@ -400,10 +437,10 @@ small {
 
 .candidate-card {
   display: grid;
-  gap: 0.65rem;
+  gap: 0.5rem;
   border: 1px solid var(--color-border);
   border-radius: 8px;
-  padding: 0.75rem;
+  padding: 0.65rem 0.7rem;
   background: var(--color-surface);
 }
 
@@ -495,8 +532,6 @@ small {
 .saved-candidates-panel {
   display: grid;
   gap: 0.7rem;
-  border-top: 1px solid var(--color-border);
-  padding-top: 0.9rem;
 }
 
 .saved-candidate-card {
@@ -519,6 +554,119 @@ small {
   min-width: 12rem;
   color: var(--color-text-primary);
   font-weight: 800;
+}
+
+.run-plan-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.run-plan-card {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.run-plan-select {
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.run-plan-select input {
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0.15rem;
+}
+
+.run-plan-select small {
+  display: block;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.run-plan-config-primary {
+  display: grid;
+  gap: 0.65rem;
+  border: 1px solid rgba(46, 126, 178, 0.16);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: rgba(247, 251, 253, 0.74);
+}
+
+.run-plan-config-heading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  align-items: end;
+  justify-content: space-between;
+}
+
+.run-plan-config-heading h4 {
+  margin: 0;
+}
+
+.run-plan-config-heading span {
+  color: var(--color-text-muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+
+.run-plan-configuration-grid {
+  grid-template-columns: repeat(auto-fit, minmax(13.5rem, 1fr));
+  margin: 0;
+}
+
+.run-plan-config-summary {
+  grid-column: 1 / -1;
+  max-width: 62rem;
+  margin: 0;
+  padding-top: 0.15rem;
+  font-size: 0.92rem;
+}
+
+.run-plan-recipe-details {
+  padding-top: 0.1rem;
+}
+
+.run-plan-metadata-grid {
+  margin-top: 0.65rem;
+}
+
+.run-monitor-panel {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: var(--shadow-subtle);
+}
+
+.run-monitor-panel > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.9rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.run-monitor-panel > summary::-webkit-details-marker {
+  display: none;
+}
+
+.run-monitor-panel > summary small {
+  display: block;
+  color: var(--color-text-muted);
+  font-weight: 650;
+}
+
+.run-monitor-panel[open] > summary {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.run-monitor-panel .local-run-panel {
+  padding: 0.9rem;
 }
 
 .screening-guidance-note {

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -319,9 +319,20 @@ small {
 .atmosphere-source-panel,
 .candidate-search-controls,
 .upload-source-stack,
+.selected-sounding-setup,
 .run-plan-panel {
   display: grid;
   gap: 0.85rem;
+}
+
+.selected-sounding-setup {
+  border-top: 1px solid rgba(188, 211, 224, 0.86);
+  padding-top: 1rem;
+}
+
+.selected-sounding-summary,
+.selected-sounding-add-panel {
+  background: rgba(255, 255, 255, 0.78);
 }
 
 .source-path-tabs {
@@ -2653,6 +2664,7 @@ details[open] > summary {
   }
 
   .section-heading,
+  .panel-heading-row,
   .notebook-title {
     display: grid;
   }

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -278,7 +278,7 @@ small {
 
 .run-configuration-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
   gap: 0.65rem;
   margin: 0.75rem 0;
 }
@@ -319,20 +319,60 @@ small {
 .atmosphere-source-panel,
 .candidate-search-controls,
 .upload-source-stack,
-.selected-sounding-setup,
 .run-plan-panel {
   display: grid;
   gap: 0.85rem;
 }
 
 .selected-sounding-setup {
-  border-top: 1px solid rgba(188, 211, 224, 0.86);
-  padding-top: 1rem;
+  display: grid;
+  gap: 0;
 }
 
-.selected-sounding-summary,
+.selected-run-builder {
+  background: rgba(255, 255, 255, 0.86);
+}
+
+.selected-run-builder > * + * {
+  border-top: 1px solid rgba(188, 211, 224, 0.72);
+  padding-top: 0.85rem;
+  margin-top: 0.85rem;
+}
+
+.selected-sounding-strip {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.selected-sounding-context {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-weight: 650;
+}
+
+.selected-sounding-metrics {
+  grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+}
+
+.run-configuration-panel {
+  display: grid;
+  gap: 0.85rem;
+}
+
 .selected-sounding-add-panel {
-  background: rgba(255, 255, 255, 0.78);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.selected-sounding-add-panel button {
+  justify-self: start;
+}
+
+.summary-note {
+  display: inline-block;
+  margin-left: 0.45rem;
+  color: var(--color-text-muted);
+  font-weight: 600;
 }
 
 .source-path-tabs {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3053,6 +3053,12 @@ describe("App", () => {
         dryRunBody = String(init?.body ?? "");
         return Promise.resolve(new Response(JSON.stringify(dryRunResponse), { status: 200 }));
       }
+      if (url === "/api/runs/queue" && init?.method === "POST") {
+        return Promise.resolve(new Response(JSON.stringify(emptyRunQueue), { status: 200 }));
+      }
+      if (url === "/api/runs/queue") {
+        return Promise.resolve(new Response(JSON.stringify(emptyRunQueue), { status: 200 }));
+      }
       if (url === "/api/results") {
         return Promise.resolve(new Response(JSON.stringify(resultsResponse), { status: 200 }));
       }
@@ -3075,9 +3081,14 @@ describe("App", () => {
     });
 
     expect(await screen.findByRole("heading", { name: "Upload a Sounding" })).toBeInTheDocument();
-    expect(screen.getByText("Observed sounding profile, Surface heating")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Cached recommendations" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.queryByLabelText("IGRA station sounding-data file")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "Upload IGRA station text" }));
+    expect(screen.getByLabelText("IGRA station sounding-data file")).toBeInTheDocument();
     expect(screen.queryByLabelText("Low-level humidity")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Surface heating")).not.toBeDisabled();
     expect(screen.queryByLabelText("Use uploaded sounding")).not.toBeInTheDocument();
 
     const file = new File(["#USM00072558 2025 01 02 00"], "USM00072558-data-beg2025.txt", {
@@ -3111,7 +3122,13 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/This is not normal atmospheric evolution/i)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId("create-package-btn"));
+    fireEvent.click(screen.getByRole("button", { name: "Add uploaded sounding to run plan" }));
+    expect(screen.getByRole("heading", { name: "Plan multiple CM1 runs" })).toBeInTheDocument();
+    expect(within(screen.getByLabelText("Run plan")).getByLabelText("Recipe")).toHaveValue(
+      "triggered_deep_potential",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
 
     await waitFor(() => {
       expect(dryRunBody).toContain('"run_recipe":"triggered_deep_potential"');
@@ -3133,6 +3150,9 @@ describe("App", () => {
       if (url === "/api/dry-run-package") {
         dryRunBody = String(init?.body ?? "");
       }
+      if (url === "/api/runs/queue" && init?.method === "POST") {
+        return Promise.resolve(new Response(JSON.stringify(emptyRunQueue), { status: 200 }));
+      }
       return (
         defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
       );
@@ -3150,36 +3170,31 @@ describe("App", () => {
     fireEvent.change(storyFilter, {
       target: { value: "deep_convection_trial" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
 
     expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
     expect(screenBody).toContain('"story_filter":"deep_convection_trial"');
     const deepCard = screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)");
     expect(deepCard).toHaveTextContent("Supercell-like environment");
 
-    fireEvent.click(within(deepCard).getByRole("button", { name: "Use this sounding" }));
+    fireEvent.click(within(deepCard).getByRole("button", { name: "Add to run plan" }));
 
-    expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Triggered deep potential" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
+    expect(await screen.findByText("Norman, Oklahoma (USM00072357) added to the run plan")).toBeInTheDocument();
+    expect(within(screen.getByLabelText("Run plan")).getByLabelText("Recipe")).toHaveValue(
+      "triggered_deep_potential",
     );
-    expect(screen.getByText("Idealized three warm bubbles")).toBeInTheDocument();
+    expect(screen.getByText("triggered_deep_potential_v1")).toBeInTheDocument();
     expect(
-      screen.getByText(/The candidate story is the atmospheric hypothesis/),
+      screen.getByText("Warm-bubble trigger · triggered potential, not normal evolution"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Deep cloud")).toBeInTheDocument();
-    expect(screen.getByText("Strong updraft")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Surface heating: Baseline; plus idealized warm-bubble initiation/i),
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Untriggered observed evolution" }));
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Untriggered observed evolution does not test that hypothesis",
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Triggered deep potential" }));
+    expect(screen.getByText("triggered_deep_potential_warm_bubble_v1")).toBeInTheDocument();
+    expect(screen.getAllByLabelText(/^Run plan item /)).toHaveLength(1);
 
-    fireEvent.click(screen.getByTestId("create-package-btn"));
+    fireEvent.click(screen.getByRole("button", { name: "Duplicate variant" }));
+    expect(await screen.findByText("Run-plan variant duplicated")).toBeInTheDocument();
+    expect(screen.getAllByLabelText(/^Run plan item /)).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
 
     await waitFor(() => {
       expect(dryRunBody).toContain('"run_recipe":"triggered_deep_potential"');
@@ -3197,6 +3212,9 @@ describe("App", () => {
       if (url === "/api/dry-run-package") {
         dryRunBody = String(init?.body ?? "");
       }
+      if (url === "/api/runs/queue" && init?.method === "POST") {
+        return Promise.resolve(new Response(JSON.stringify(emptyRunQueue), { status: 200 }));
+      }
       return (
         defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
       );
@@ -3212,26 +3230,23 @@ describe("App", () => {
     fireEvent.change(await screen.findByLabelText("Story"), {
       target: { value: "humid_rainy_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
 
     expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
     const humidCard = screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)");
     expect(humidCard).toHaveTextContent("Humid / rainy");
 
-    fireEvent.click(within(humidCard).getByRole("button", { name: "Use this sounding" }));
+    fireEvent.click(within(humidCard).getByRole("button", { name: "Add to run plan" }));
 
-    expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Untriggered observed evolution" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
     expect(
-      screen.getByText(
-        /Predicted rain behavior needs rain-water, surface-rain, and\/or reflectivity outputs/,
-      ),
+      await screen.findByText("Wilmington, Ohio (USM00072426) added to the run plan"),
     ).toBeInTheDocument();
+    expect(within(screen.getByLabelText("Run plan")).getByLabelText("Recipe")).toHaveValue(
+      "untriggered_observed_evolution",
+    );
+    expect(screen.getByText("untriggered_observed_sounding_evolution_v0")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId("create-package-btn"));
+    fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
 
     await waitFor(() => {
       expect(dryRunBody).toContain('"run_recipe":"untriggered_observed_evolution"');
@@ -3258,6 +3273,9 @@ describe("App", () => {
       if (url === "/api/dry-run-package") {
         dryRunBody = String(init?.body ?? "");
       }
+      if (url === "/api/runs/queue" && init?.method === "POST") {
+        return Promise.resolve(new Response(JSON.stringify(emptyRunQueue), { status: 200 }));
+      }
       return (
         defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
       );
@@ -3276,25 +3294,13 @@ describe("App", () => {
     expect(screen.getByText(/Screening guidance only/)).toBeInTheDocument();
     expect(screen.getByText("IGRA cache not checked yet")).toBeInTheDocument();
     expect(screen.queryByLabelText("Save into")).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Refresh IGRA catalog" }));
-
-    expect(await screen.findByText("IGRA station catalog refreshed")).toBeInTheDocument();
-    expect(screen.getByText("Cached sounding inventory").nextElementSibling).toHaveTextContent(
-      "2 cached soundings",
-    );
-    expect(screen.getByText("Planned analysis slice").nextElementSibling).toHaveTextContent(
-      "Up to 2 soundings (5 per cached file)",
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Cache station files" }));
-    expect(await screen.findByText("Cached 1 station file")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Prepare & search local soundings" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Advanced filters"));
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "shallow_cumulus_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
 
     expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
     expect(screenBody).toContain('"story_filter":"shallow_cumulus_candidate"');
@@ -3303,8 +3309,6 @@ describe("App", () => {
     const valleyCard = screen.getByLabelText("Sounding candidate Valley, Nebraska (USM00072558)");
     expect(valleyCard).toHaveTextContent("Cloud-forming shallow cumulus");
     expect(valleyCard).toHaveTextContent("Package-ready");
-    expect(valleyCard).toHaveTextContent("Low estimated LCL makes cloud formation easier to test.");
-    expect(valleyCard).toHaveTextContent("Low-level moisture: 10.2 g/kg");
     fireEvent.click(within(valleyCard).getByRole("button", { name: /Valley, Nebraska/ }));
     expect(
       screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
@@ -3328,31 +3332,23 @@ describe("App", () => {
     expect(await screen.findByText("Sounding candidate saved")).toBeInTheDocument();
     expect(saveBody).toContain('"tags":["compare","rerun"]');
     expect(saveBody).toContain('"notes":"Compare this against the humid case."');
+    fireEvent.click(screen.getByRole("tab", { name: /Saved candidates/ }));
     const savedCard = await screen.findByLabelText(
       "Saved sounding candidate Valley, Nebraska (USM00072558)",
     );
     expect(savedCard).toHaveTextContent("Tags: compare, rerun");
     expect(savedCard).toHaveTextContent("Notes: Compare this against the humid case.");
 
-    fireEvent.click(within(savedCard).getByRole("button", { name: "Use to create package" }));
+    fireEvent.click(within(savedCard).getByRole("button", { name: "Add to run plan" }));
 
-    expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
-    expect(
-      screen.getByText("Candidate loaded into observed-sounding package review"),
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("create-package-btn"));
+    expect(await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
 
     await waitFor(() => {
       expect(dryRunBody).toContain('"user_tags":["compare","rerun"]');
       expect(dryRunBody).toContain('"user_notes":"Compare this against the humid case."');
       expect(dryRunBody).toContain('"saved_notes":"Compare this against the humid case."');
     });
-    expect(screen.getByText("Package notes").nextElementSibling).toHaveTextContent(
-      "Compare this against the humid case.",
-    );
-    expect(screen.getByText("Sounding").nextElementSibling).toHaveTextContent(
-      "Valley, Nebraska (USM00072558)",
-    );
 
     fireEvent.click(within(savedCard).getByRole("button", { name: "Remove saved" }));
     expect(await screen.findByText("Saved sounding candidate removed")).toBeInTheDocument();
@@ -3360,20 +3356,21 @@ describe("App", () => {
       screen.queryByLabelText("Saved sounding candidate Valley, Nebraska (USM00072558)"),
     ).not.toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("tab", { name: "Cached recommendations" }));
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "needs_review" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
     const normanCard = await screen.findByLabelText(
       "Sounding candidate Norman, Oklahoma (USM00072357)",
     );
     expect(normanCard).toHaveTextContent("Blocked");
-    expect(within(normanCard).getByRole("button", { name: "Use this sounding" })).toBeDisabled();
+    expect(within(normanCard).getByRole("button", { name: "Add to run plan" })).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "all" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
     const selectedValleyCard = await screen.findByLabelText(
       "Sounding candidate Valley, Nebraska (USM00072558)",
     );
@@ -3381,16 +3378,10 @@ describe("App", () => {
       screen.getByRole("heading", { name: "Recommended cached soundings" }),
     ).toBeInTheDocument();
 
-    fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Use this sounding" }));
+    fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Add to run plan" }));
+    expect(await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan")).toBeInTheDocument();
 
-    expect(await screen.findByText("Candidate selected for package review")).toBeInTheDocument();
-    expect(
-      screen.getByText("Candidate loaded into observed-sounding package review"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("USM00072558 · Valley, Nebraska")).toBeInTheDocument();
-    expect(screen.getByText(/Screened as Cloud-forming shallow cumulus/)).toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("create-package-btn"));
+    fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
 
     await waitFor(() => {
       expect(dryRunBody).toContain('"observed_sounding"');
@@ -3421,6 +3412,14 @@ describe("App", () => {
       target: { value: "__observed_sounding_upload__" },
     });
 
+    expect(await screen.findByRole("tab", { name: "Cached recommendations" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(
+      screen.queryByLabelText("Saved sounding candidate Valley, Nebraska (USM00072558)"),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: /Saved candidates/ }));
     expect(
       await screen.findByLabelText("Saved sounding candidate Valley, Nebraska (USM00072558)"),
     ).toBeInTheDocument();
@@ -3494,7 +3493,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "shallow_cumulus_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
 
     const valleyCard = await screen.findByLabelText(
       "Sounding candidate Valley, Nebraska (USM00072558)",
@@ -3509,6 +3508,7 @@ describe("App", () => {
     });
     fireEvent.click(within(candidateDetails).getByRole("button", { name: "Save candidate" }));
 
+    fireEvent.click(screen.getByRole("tab", { name: /Saved candidates/ }));
     const savedCard = await screen.findByLabelText(
       "Saved sounding candidate Valley, Nebraska (USM00072558)",
     );
@@ -3527,6 +3527,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Experiment"), {
       target: { value: "__observed_sounding_upload__" },
     });
+    fireEvent.click(screen.getByRole("tab", { name: /Saved candidates/ }));
 
     const reloadedSavedCard = await screen.findByLabelText(
       "Saved sounding candidate Valley, Nebraska (USM00072558)",
@@ -3550,7 +3551,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Support"), {
       target: { value: "weak" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
 
     const wilmingtonCard = await screen.findByLabelText(
       "Sounding candidate Wilmington, Ohio (USM00072426)",
@@ -3581,14 +3582,14 @@ describe("App", () => {
       target: { value: "__observed_sounding_upload__" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
-    expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Prepare & search local soundings" }));
+    expect(await screen.findByText("Recommendation run complete")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Advanced filters"));
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "shallow_cumulus_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
     expect(
       screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
     ).toBeInTheDocument();
@@ -3596,7 +3597,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Sort"), {
       target: { value: "estimated_lcl_height_m_agl" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Analyze recommendations" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
     await waitFor(() => {
       const candidateCards = screen.getAllByLabelText(/^Sounding candidate /);
       const visibleOrder = candidateCards.map((card) => card.textContent ?? "");
@@ -3847,6 +3848,10 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    const runMonitor = screen.getByText("Run monitor").closest("details");
+    expect(runMonitor).not.toHaveAttribute("open");
+    fireEvent.click(screen.getByText("Run monitor"));
+    expect(runMonitor).toHaveAttribute("open");
     expect(await screen.findByRole("heading", { name: "Local run launchpad" })).toBeInTheDocument();
     expect(screen.queryByText("Local experiment loop")).not.toBeInTheDocument();
     expect(screen.getByText("Build pipeline")).toBeInTheDocument();

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -469,7 +469,11 @@ function preRunValidationReportForRequest(body: {
         : observed
           ? "untriggered_observed_sounding_evolution_v0_assumptions"
           : "generated_reference_lower_atmosphere_v1",
-      assumption_mode: deep ? "triggered_deep_potential" : observed ? "normal_evolution" : "generated_reference",
+      assumption_mode: deep
+        ? "triggered_deep_potential"
+        : observed
+          ? "normal_evolution"
+          : "generated_reference",
     },
   };
 }
@@ -2999,6 +3003,13 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { name: "Build and run a CM1 experiment" }),
     ).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Upload a Sounding" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Experiment")).toHaveValue("__observed_sounding_upload__");
+    expect(screen.queryByLabelText("Low-level humidity")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     expect(
       (await screen.findAllByRole("heading", { name: "Baseline Shallow Cumulus" })).length,
     ).toBeGreaterThan(0);
@@ -3015,12 +3026,11 @@ describe("App", () => {
     expect(screen.getByLabelText("Low-level humidity")).toBeInTheDocument();
     expect(screen.getByLabelText("Surface heating")).toBeInTheDocument();
     expect(screen.getAllByText(/Selected: Baseline/).length).toBeGreaterThan(0);
+    expect(screen.getByRole("heading", { name: "Configure this CM1 run" })).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Configure this CM1 run" }),
+      screen.getByText("360 min runtime; 900 s output; 25 saved frames; 3 s timestep"),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText("Short evolution; Local 6 km; Scout 64 x 64; 100 m dx/dy; Standard 15 min"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("64 x 64 x 75; dx/dy 100 m, dz 40 m")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Local run launchpad" })).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Packages and runs needing action" }),
@@ -3031,7 +3041,6 @@ describe("App", () => {
         "No package has been created from the current setup in this browser session.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText("Experiment")).toHaveTextContent("Upload a Sounding");
     expect(screen.getByText("Build pipeline")).toBeInTheDocument();
     expect(screen.queryByText("Local experiment loop")).not.toBeInTheDocument();
     expect(screen.queryByText("namelist.input")).not.toBeInTheDocument();
@@ -3073,12 +3082,6 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
-    expect(
-      await screen.findByRole("heading", { name: "Experiment setup summary" }),
-    ).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText("Experiment"), {
-      target: { value: "__observed_sounding_upload__" },
-    });
 
     expect(await screen.findByRole("heading", { name: "Upload a Sounding" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Cached recommendations" })).toHaveAttribute(
@@ -3101,15 +3104,13 @@ describe("App", () => {
     expect(
       await screen.findByText("Observed sounding validated for package review"),
     ).toBeInTheDocument();
+    expect(screen.getByText("Valley, Nebraska (USM00072558)")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Uploaded-sounding review"));
     expect(screen.getByText("USM00072558 · Valley, Nebraska")).toBeInTheDocument();
     expect(screen.getByText(/CM1 z=0 is station surface at 351.5 m MSL/)).toBeInTheDocument();
     expect(screen.getAllByText(/observed sounding winds/).length).toBeGreaterThan(0);
-    expect(
-      screen.getByRole("heading", { name: "Configure this CM1 run" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Surface heating: Baseline; no added deep-initiation trigger/i),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Configure this CM1 run" })).toBeInTheDocument();
+    expect(screen.getByText(/Baseline surface heating; no deep trigger/i)).toBeInTheDocument();
     expect(screen.getByLabelText("Experiment recipe")).toHaveValue(
       "untriggered_observed_evolution",
     );
@@ -3117,12 +3118,9 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Experiment recipe"), {
       target: { value: "triggered_deep_potential" },
     });
-    expect(screen.getByText("Idealized warm-bubble trigger")).toBeInTheDocument();
+    expect(screen.getByText(/Baseline surface heating; warm-bubble trigger/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/Surface heating: Baseline; plus idealized warm-bubble initiation/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Triggered deep potential is not normal atmospheric evolution/i),
+      screen.getByText(/Triggered deep potential adds a warm-bubble trigger/i),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
@@ -3131,7 +3129,9 @@ describe("App", () => {
       "triggered_deep_potential",
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create packages and queue selected runs" }),
+    );
 
     await waitFor(() => {
       expect(dryRunBody).toContain('"run_recipe":"triggered_deep_potential"');
@@ -3200,7 +3200,9 @@ describe("App", () => {
     expect(await screen.findByText("Run-plan variant duplicated")).toBeInTheDocument();
     expect(screen.getAllByLabelText(/^Run plan item /)).toHaveLength(2);
 
-    fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create packages and queue selected runs" }),
+    );
 
     await waitFor(() => {
       expect(dryRunBody).toContain('"run_recipe":"triggered_deep_potential"');
@@ -3253,7 +3255,9 @@ describe("App", () => {
     );
     expect(screen.getByText("untriggered_observed_sounding_evolution_v0")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create packages and queue selected runs" }),
+    );
 
     await waitFor(() => {
       expect(dryRunBody).toContain('"run_recipe":"untriggered_observed_evolution"');
@@ -3301,7 +3305,9 @@ describe("App", () => {
     expect(screen.getByText(/Screening guidance only/)).toBeInTheDocument();
     expect(screen.getByText("IGRA cache not checked yet")).toBeInTheDocument();
     expect(screen.queryByLabelText("Save into")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Prepare & search local soundings" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Prepare & search local soundings" }),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Advanced filters"));
     fireEvent.change(screen.getByLabelText("Story"), {
@@ -3343,8 +3349,13 @@ describe("App", () => {
     const savedCard = await screen.findByLabelText(
       "Saved sounding candidate Valley, Nebraska (USM00072558)",
     );
-    expect(savedCard).toHaveTextContent("Tags: compare, rerun");
-    expect(savedCard).toHaveTextContent("Notes: Compare this against the humid case.");
+    expect(savedCard).toHaveTextContent("2 tags");
+    expect(savedCard).toHaveTextContent("notes saved");
+    fireEvent.click(within(savedCard).getByText("Tags and notes"));
+    expect(within(savedCard).getByLabelText("Tags")).toHaveValue("compare, rerun");
+    expect(within(savedCard).getByLabelText("Notes")).toHaveValue(
+      "Compare this against the humid case.",
+    );
 
     fireEvent.click(within(savedCard).getByRole("button", { name: "Select for run setup" }));
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
@@ -3352,7 +3363,9 @@ describe("App", () => {
     expect(
       await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan"),
     ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create packages and queue selected runs" }),
+    );
 
     await waitFor(() => {
       expect(dryRunBody).toContain('"user_tags":["compare","rerun"]');
@@ -3396,7 +3409,9 @@ describe("App", () => {
       await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan"),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create packages and queue selected runs" }),
+    );
 
     await waitFor(() => {
       expect(dryRunBody).toContain('"observed_sounding"');
@@ -3443,7 +3458,7 @@ describe("App", () => {
     expect(fetch).not.toHaveBeenCalledWith("/api/sounding-candidates/analyze", expect.anything());
   });
 
-  it("updates saved candidate working sets and preserves tags through reload", async () => {
+  it("updates saved candidate tags and notes through the metadata drawer", async () => {
     const defaultFetch = vi.mocked(fetch).getMockImplementation();
     let savedStore: Array<(typeof savedCandidatesResponse.saved_candidates)[number]> = [];
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -3527,12 +3542,16 @@ describe("App", () => {
     const savedCard = await screen.findByLabelText(
       "Saved sounding candidate Valley, Nebraska (USM00072558)",
     );
-    expect(savedCard).toHaveTextContent("Tags: Maybe rerun");
-    fireEvent.change(
-      within(savedCard).getByLabelText("Working set for Valley, Nebraska (USM00072558)"),
-      { target: { value: "Deep convection candidates" } },
+    expect(savedCard).toHaveTextContent("1 tag");
+    expect(savedCard).toHaveTextContent("notes saved");
+    expect(within(savedCard).queryByText("Working set")).not.toBeInTheDocument();
+    fireEvent.click(within(savedCard).getByText("Tags and notes"));
+    expect(within(savedCard).getByLabelText("Tags")).toHaveValue("Maybe rerun");
+    expect(within(savedCard).getByLabelText("Notes")).toHaveValue(
+      "Keep this one in the candidate notebook.",
     );
-    fireEvent.click(within(savedCard).getByRole("button", { name: "Update working set" }));
+    fireEvent.click(within(savedCard).getByRole("button", { name: "Deep convection candidates" }));
+    fireEvent.click(within(savedCard).getByRole("button", { name: "Save tags and notes" }));
 
     expect(await screen.findByText("Saved sounding candidate updated")).toBeInTheDocument();
 
@@ -3547,8 +3566,13 @@ describe("App", () => {
     const reloadedSavedCard = await screen.findByLabelText(
       "Saved sounding candidate Valley, Nebraska (USM00072558)",
     );
-    expect(reloadedSavedCard).toHaveTextContent("Tags: Deep convection candidates");
-    expect(reloadedSavedCard).toHaveTextContent("Notes: Keep this one in the candidate notebook.");
+    fireEvent.click(within(reloadedSavedCard).getByText("Tags and notes"));
+    expect(within(reloadedSavedCard).getByLabelText("Tags")).toHaveValue(
+      "Maybe rerun, Deep convection candidates",
+    );
+    expect(within(reloadedSavedCard).getByLabelText("Notes")).toHaveValue(
+      "Keep this one in the candidate notebook.",
+    );
   });
 
   it("shows secondary family candidates with the scoped story ingredient score", async () => {
@@ -3653,6 +3677,9 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     fireEvent.change(await screen.findByLabelText("Domain size"), {
       target: { value: "wide_12km" },
     });
@@ -3744,6 +3771,9 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     fireEvent.click(await screen.findByTestId("create-package-btn"));
 
     expect(
@@ -3815,6 +3845,10 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Retry scenarios" }));
 
+    expect(await screen.findByRole("heading", { name: "Upload a Sounding" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     expect(
       (await screen.findAllByRole("heading", { name: "Baseline Shallow Cumulus" })).length,
     ).toBeGreaterThan(0);
@@ -3863,6 +3897,9 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     const runMonitor = screen.getByText("Run monitor").closest("details");
     expect(runMonitor).not.toHaveAttribute("open");
     fireEvent.click(screen.getByText("Run monitor"));
@@ -4248,6 +4285,9 @@ describe("App", () => {
 
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     fireEvent.click(await screen.findByTestId("create-package-btn"));
 
     await screen.findByRole("heading", { name: "Package ready for CM1" });
@@ -4325,6 +4365,9 @@ describe("App", () => {
 
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     fireEvent.click(await screen.findByTestId("create-package-btn"));
 
     await screen.findByRole("heading", { name: "Package ready for CM1" });
@@ -4345,6 +4388,9 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     const humidityControl = await screen.findByLabelText("Low-level humidity");
     await waitFor(() => {
       expect(humidityControl).toHaveValue("baseline");
@@ -4408,6 +4454,9 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     fireEvent.click(await screen.findByTestId("create-package-btn"));
 
     expect(await screen.findByText("dry-run-001")).toBeInTheDocument();
@@ -4507,6 +4556,9 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     fireEvent.click(await screen.findByTestId("create-package-btn"));
     fireEvent.click(await screen.findByTestId("launch-cm1-btn"));
 
@@ -5065,6 +5117,9 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(screen.getByLabelText("Experiment"), {
+      target: { value: "baseline-shallow-cumulus" },
+    });
     fireEvent.click((await screen.findAllByRole("button", { name: "Preview cleanup" }))[0]);
 
     expect(await screen.findByRole("alert")).toHaveTextContent(

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -4661,11 +4661,13 @@ describe("App", () => {
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.getByLabelText("Time")).toHaveValue("2");
     expect(screen.getByText(/Supercell-like environment · Matched/)).toBeInTheDocument();
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "/api/results/result-deep-convection/visualization/slice?field=w&time_index=2",
-      ),
-    );
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "/api/results/result-deep-convection/visualization/slice?field=w&time_index=2",
+        ),
+      );
+    });
   });
 
   it("filters Results by search text and cloud/rain outcomes", async () => {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3016,7 +3016,7 @@ describe("App", () => {
     expect(screen.getByLabelText("Surface heating")).toBeInTheDocument();
     expect(screen.getAllByText(/Selected: Baseline/).length).toBeGreaterThan(0);
     expect(
-      screen.getByRole("heading", { name: "Choose what CM1 will actually run" }),
+      screen.getByRole("heading", { name: "Configure this CM1 run" }),
     ).toBeInTheDocument();
     expect(
       screen.getByText("Short evolution; Local 6 km; Scout 64 x 64; 100 m dx/dy; Standard 15 min"),
@@ -3105,24 +3105,27 @@ describe("App", () => {
     expect(screen.getByText(/CM1 z=0 is station surface at 351.5 m MSL/)).toBeInTheDocument();
     expect(screen.getAllByText(/observed sounding winds/).length).toBeGreaterThan(0);
     expect(
-      screen.getByRole("heading", { name: "What atmospheric outcome are we checking?" }),
+      screen.getByRole("heading", { name: "Configure this CM1 run" }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/Surface heating: Baseline; no added deep-initiation trigger/i),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Untriggered observed evolution" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
+    expect(screen.getByLabelText("Experiment recipe")).toHaveValue(
+      "untriggered_observed_evolution",
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Triggered deep potential" }));
-    expect(screen.getByText("Idealized three warm bubbles")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Experiment recipe"), {
+      target: { value: "triggered_deep_potential" },
+    });
+    expect(screen.getByText("Idealized warm-bubble trigger")).toBeInTheDocument();
     expect(
       screen.getByText(/Surface heating: Baseline; plus idealized warm-bubble initiation/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/This is not normal atmospheric evolution/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Triggered deep potential is not normal atmospheric evolution/i),
+    ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Add selected sounding to run plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
     expect(screen.getByRole("heading", { name: "Plan multiple CM1 runs" })).toBeInTheDocument();
     expect(within(screen.getByLabelText("Run plan")).getByLabelText("Recipe")).toHaveValue(
       "triggered_deep_potential",
@@ -3178,7 +3181,7 @@ describe("App", () => {
     expect(deepCard).toHaveTextContent("Supercell-like environment");
 
     fireEvent.click(within(deepCard).getByRole("button", { name: "Select for run setup" }));
-    fireEvent.click(screen.getByRole("button", { name: "Add selected sounding to run plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
 
     expect(
       await screen.findByText("Norman, Oklahoma (USM00072357) added to the run plan"),
@@ -3240,7 +3243,7 @@ describe("App", () => {
     expect(humidCard).toHaveTextContent("Humid / rainy");
 
     fireEvent.click(within(humidCard).getByRole("button", { name: "Select for run setup" }));
-    fireEvent.click(screen.getByRole("button", { name: "Add selected sounding to run plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
 
     expect(
       await screen.findByText("Wilmington, Ohio (USM00072426) added to the run plan"),
@@ -3344,7 +3347,7 @@ describe("App", () => {
     expect(savedCard).toHaveTextContent("Notes: Compare this against the humid case.");
 
     fireEvent.click(within(savedCard).getByRole("button", { name: "Select for run setup" }));
-    fireEvent.click(screen.getByRole("button", { name: "Add selected sounding to run plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
 
     expect(
       await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan"),
@@ -3388,7 +3391,7 @@ describe("App", () => {
     fireEvent.click(
       within(selectedValleyCard).getByRole("button", { name: "Select for run setup" }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Add selected sounding to run plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
     expect(
       await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan"),
     ).toBeInTheDocument();

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3103,7 +3103,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("USM00072558 · Valley, Nebraska")).toBeInTheDocument();
     expect(screen.getByText(/CM1 z=0 is station surface at 351.5 m MSL/)).toBeInTheDocument();
-    expect(screen.getByText(/observed sounding winds/)).toBeInTheDocument();
+    expect(screen.getAllByText(/observed sounding winds/).length).toBeGreaterThan(0);
     expect(
       screen.getByRole("heading", { name: "What atmospheric outcome are we checking?" }),
     ).toBeInTheDocument();
@@ -3122,7 +3122,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/This is not normal atmospheric evolution/i)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Add uploaded sounding to run plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add selected sounding to run plan" }));
     expect(screen.getByRole("heading", { name: "Plan multiple CM1 runs" })).toBeInTheDocument();
     expect(within(screen.getByLabelText("Run plan")).getByLabelText("Recipe")).toHaveValue(
       "triggered_deep_potential",
@@ -3177,9 +3177,12 @@ describe("App", () => {
     const deepCard = screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)");
     expect(deepCard).toHaveTextContent("Supercell-like environment");
 
-    fireEvent.click(within(deepCard).getByRole("button", { name: "Add to run plan" }));
+    fireEvent.click(within(deepCard).getByRole("button", { name: "Select for run setup" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add selected sounding to run plan" }));
 
-    expect(await screen.findByText("Norman, Oklahoma (USM00072357) added to the run plan")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Norman, Oklahoma (USM00072357) added to the run plan"),
+    ).toBeInTheDocument();
     expect(within(screen.getByLabelText("Run plan")).getByLabelText("Recipe")).toHaveValue(
       "triggered_deep_potential",
     );
@@ -3236,7 +3239,8 @@ describe("App", () => {
     const humidCard = screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)");
     expect(humidCard).toHaveTextContent("Humid / rainy");
 
-    fireEvent.click(within(humidCard).getByRole("button", { name: "Add to run plan" }));
+    fireEvent.click(within(humidCard).getByRole("button", { name: "Select for run setup" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add selected sounding to run plan" }));
 
     expect(
       await screen.findByText("Wilmington, Ohio (USM00072426) added to the run plan"),
@@ -3339,9 +3343,12 @@ describe("App", () => {
     expect(savedCard).toHaveTextContent("Tags: compare, rerun");
     expect(savedCard).toHaveTextContent("Notes: Compare this against the humid case.");
 
-    fireEvent.click(within(savedCard).getByRole("button", { name: "Add to run plan" }));
+    fireEvent.click(within(savedCard).getByRole("button", { name: "Select for run setup" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add selected sounding to run plan" }));
 
-    expect(await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan"),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
 
     await waitFor(() => {
@@ -3365,7 +3372,7 @@ describe("App", () => {
       "Sounding candidate Norman, Oklahoma (USM00072357)",
     );
     expect(normanCard).toHaveTextContent("Blocked");
-    expect(within(normanCard).getByRole("button", { name: "Add to run plan" })).toBeDisabled();
+    expect(within(normanCard).getByRole("button", { name: "Select for run setup" })).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "all" },
@@ -3378,8 +3385,13 @@ describe("App", () => {
       screen.getByRole("heading", { name: "Recommended cached soundings" }),
     ).toBeInTheDocument();
 
-    fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Add to run plan" }));
-    expect(await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan")).toBeInTheDocument();
+    fireEvent.click(
+      within(selectedValleyCard).getByRole("button", { name: "Select for run setup" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Add selected sounding to run plan" }));
+    expect(
+      await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan"),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Create packages and queue selected runs" }));
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -344,6 +344,42 @@ type RunRecipe =
   | "triggered_deep_potential";
 
 type ObservedRunRecipe = "untriggered_observed_evolution" | "triggered_deep_potential";
+type AtmosphereSourcePath = "cached_recommendations" | "saved_candidates" | "upload_igra_text";
+type SearchIntent =
+  | "best_overall"
+  | "deep_convection"
+  | "humid_rainy"
+  | "dry_microburst"
+  | "shallow_boundary_layer";
+type SearchDepth = "quick_scan" | "deeper_scan" | "broad_historical_sweep";
+type TimeScope = "recent_latest";
+type RunPlanQueueTarget = "local" | "lan";
+type RunPlanItemStatus =
+  | "planned"
+  | "packaging"
+  | "queued"
+  | "lan_started"
+  | "package_failed"
+  | "skipped";
+
+type RunPlanItem = {
+  id: string;
+  selected: boolean;
+  source: AtmosphereSourcePath;
+  candidate: SoundingCandidate | null;
+  savedCandidate?: SavedSoundingCandidate | null;
+  observedSounding: ObservedSoundingRecord | null;
+  candidateScreening: Record<string, unknown> | null;
+  activeStory: CandidateStoryId | null;
+  runRecipe: ObservedRunRecipe;
+  runConfiguration: RunConfigurationInput;
+  controls: Record<string, string | number | boolean>;
+  queueTarget: RunPlanQueueTarget;
+  status: RunPlanItemStatus;
+  message: string | null;
+  dryRun: DryRunResponse | null;
+  blockedPreRunValidationReport: PreRunValidationReport | null;
+};
 
 type StoryScore = {
   story: CandidateStoryId;
@@ -1134,7 +1170,6 @@ type SceneSlicePlane = "horizontal" | "vertical_x" | "vertical_y";
 const FIELD_LOAD_TIMEOUT_MS = 30000;
 const OBSERVED_SOUNDING_EXPERIMENT_ID = "__observed_sounding_upload__";
 const OBSERVED_SOUNDING_BASE_SCENARIO_ID = "baseline-shallow-cumulus";
-const OBSERVED_SOUNDING_VISIBLE_CONTROLS = new Set(["surface_heating"]);
 const candidateStoryIdValues = new Set<string>([
   "shallow_cumulus_candidate",
   "dry_failed_candidate",
@@ -1188,6 +1223,49 @@ const DEFAULT_TRIGGERED_DEEP_POTENTIAL_RUN_CONFIGURATION: RunConfigurationInput 
   domain_size: "storm_120km",
   output_cadence: "standard_15min",
   diagnostic_set: "full",
+};
+
+const SEARCH_INTENT_OPTIONS: Array<{ value: SearchIntent; label: string }> = [
+  { value: "best_overall", label: "Best overall recommendations" },
+  { value: "deep_convection", label: "Deep convection potential" },
+  { value: "humid_rainy", label: "Humid/rainy evolution" },
+  { value: "dry_microburst", label: "Dry microburst / inverted-V" },
+  { value: "shallow_boundary_layer", label: "Shallow cumulus / boundary layer" },
+];
+
+const SEARCH_DEPTH_OPTIONS: Array<{ value: SearchDepth; label: string; description: string }> = [
+  {
+    value: "quick_scan",
+    label: "Quick scan",
+    description: "Small latest-sounding slice; fastest recommendation pass.",
+  },
+  {
+    value: "deeper_scan",
+    label: "Deeper scan",
+    description: "Default bounded slice for useful local recommendations.",
+  },
+  {
+    value: "broad_historical_sweep",
+    label: "Broad historical sweep",
+    description: "Larger bounded local slice; may take longer and need more cached data.",
+  },
+];
+
+const TIME_SCOPE_OPTIONS: Array<{ value: TimeScope; label: string; description: string }> = [
+  {
+    value: "recent_latest",
+    label: "Recent/latest",
+    description: "Current backend support: latest soundings from cached station files.",
+  },
+];
+
+const SEARCH_DEPTH_LIMITS: Record<
+  SearchDepth,
+  { cacheLimit: string; latestPerStation: string; resultLimit: string }
+> = {
+  quick_scan: { cacheLimit: "5", latestPerStation: "2", resultLimit: "25" },
+  deeper_scan: { cacheLimit: "10", latestPerStation: "5", resultLimit: "50" },
+  broad_historical_sweep: { cacheLimit: "25", latestPerStation: "10", resultLimit: "100" },
 };
 
 class DryRunRequestError extends Error {
@@ -1767,6 +1845,11 @@ export function App() {
     string,
     unknown
   > | null>(null);
+  const [atmosphereSourcePath, setAtmosphereSourcePath] =
+    useState<AtmosphereSourcePath>("cached_recommendations");
+  const [searchIntent, setSearchIntent] = useState<SearchIntent>("best_overall");
+  const [searchDepth, setSearchDepth] = useState<SearchDepth>("deeper_scan");
+  const [timeScope, setTimeScope] = useState<TimeScope>("recent_latest");
   const [igraCatalog, setIgraCatalog] = useState<IGRACatalogResponse["catalog"] | null>(null);
   const [igraCache, setIgraCache] = useState<IGRACacheResponse | null>(null);
   const [screeningInputs, setScreeningInputs] = useState<ScreeningInput[]>([]);
@@ -1787,6 +1870,8 @@ export function App() {
   const [candidateScreening, setCandidateScreening] = useState<ScreeningResult | null>(null);
   const [savedCandidates, setSavedCandidates] = useState<SavedSoundingCandidate[]>([]);
   const [candidateDetailId, setCandidateDetailId] = useState<string | null>(null);
+  const [runPlanItems, setRunPlanItems] = useState<RunPlanItem[]>([]);
+  const [batchQueueStatus, setBatchQueueStatus] = useState<string | null>(null);
   const [dryRun, setDryRun] = useState<DryRunResponse | null>(null);
   const [blockedPreRunValidationReport, setBlockedPreRunValidationReport] =
     useState<PreRunValidationReport | null>(null);
@@ -2151,6 +2236,39 @@ export function App() {
     setIngestedResultId(null);
   }
 
+  function handleAtmosphereSourcePathChange(sourcePath: AtmosphereSourcePath) {
+    setAtmosphereSourcePath(sourcePath);
+    if (selectedScenarioId !== OBSERVED_SOUNDING_EXPERIMENT_ID) {
+      handleSelectScenario(OBSERVED_SOUNDING_EXPERIMENT_ID);
+    }
+    if (sourcePath === "cached_recommendations") {
+      setCandidateStatus("Cached recommendations selected");
+    } else if (sourcePath === "saved_candidates") {
+      setCandidateStatus("Saved candidates selected");
+    } else {
+      setObservedSoundingStatus((current) => current ?? "Upload an IGRA station text file");
+    }
+  }
+
+  function handleSearchIntentChange(intent: SearchIntent) {
+    setSearchIntent(intent);
+    const filters = searchIntentFilters(intent);
+    setCandidateStoryFilter(filters.story);
+    setCandidateStoryFamilyFilter(filters.storyFamily);
+    setCandidateSupportFilter(filters.support);
+    setCandidateReadinessFilter("all");
+    setCandidateSort("best_match");
+    setCandidateStationSearch("");
+  }
+
+  function handleSearchDepthChange(depth: SearchDepth) {
+    setSearchDepth(depth);
+    const limits = SEARCH_DEPTH_LIMITS[depth];
+    setCandidateCacheLimit(limits.cacheLimit);
+    setCandidateLatestPerStation(limits.latestPerStation);
+    setCandidateResultLimit(limits.resultLimit);
+  }
+
   async function refreshSoundingCandidateState(statusWhenLoaded?: string) {
     setCandidateError(null);
     setCandidateStatus("Checking local IGRA cache");
@@ -2176,6 +2294,60 @@ export function App() {
         caught instanceof Error ? caught.message : "Unable to load sounding candidate state.",
       );
       setCandidateStatus("Sounding candidate state unavailable");
+    }
+  }
+
+  async function handlePrepareAndSearchLocalSoundings() {
+    const limits = SEARCH_DEPTH_LIMITS[searchDepth];
+    const cacheLimit = boundedInteger(limits.cacheLimit, 1, 100, 10);
+    const latestPerStation = boundedInteger(limits.latestPerStation, 1, 50, 5);
+    const resultLimit = boundedInteger(limits.resultLimit, 1, 200, 50);
+    setCandidateError(null);
+    setCandidateStatus("Preparing local sounding data");
+    try {
+      let [catalogPayload, cachePayload, inputsPayload, savedPayload] = await Promise.all([
+        fetchIGRARecentCatalog(),
+        fetchIGRARecentCache(),
+        fetchScreeningInputs(),
+        fetchSavedSoundingCandidates(),
+      ]);
+      if (inputsPayload.inputs.length === 0) {
+        setCandidateStatus(`Caching up to ${cacheLimit} local station file${cacheLimit === 1 ? "" : "s"}`);
+        await cacheIGRARecentBatch(cacheLimit);
+        [catalogPayload, cachePayload, inputsPayload, savedPayload] = await Promise.all([
+          fetchIGRARecentCatalog(),
+          fetchIGRARecentCache(),
+          fetchScreeningInputs(),
+          fetchSavedSoundingCandidates(),
+        ]);
+      }
+      setIgraCatalog(catalogPayload.catalog);
+      setIgraCache(cachePayload);
+      setScreeningInputs(inputsPayload.inputs);
+      setSavedCandidates(savedPayload.saved_candidates);
+      setCandidateStatus("Searching cached soundings");
+      const result = await screenSoundingCandidates({
+        story: candidateStoryFilter,
+        storyFamily: candidateStoryFamilyFilter,
+        support: candidateSupportFilter,
+        readiness: candidateReadinessFilter,
+        stationSearch: candidateStationSearch,
+        sort: candidateSort,
+        latestPerStation,
+        limit: resultLimit,
+      });
+      setCandidateScreening(result);
+      setCandidateDetailId(result.candidates[0]?.candidate_id ?? null);
+      setCandidateStatus(
+        result.candidates.length > 0
+          ? "Recommendation run complete"
+          : "Recommendation run found no matching candidates",
+      );
+    } catch (caught) {
+      setCandidateError(
+        caught instanceof Error ? caught.message : "Unable to prepare and search local soundings.",
+      );
+      setCandidateStatus("Prepare and search failed");
     }
   }
 
@@ -2333,7 +2505,7 @@ export function App() {
     setObservedSoundingFilename(candidate.source_file_name);
     setObservedSoundingText(null);
     setObservedSoundingParse(observedSoundingParseFromCandidate(candidate, selectedSounding));
-    setObservedSoundingStatus("Candidate loaded into observed-sounding package review");
+    setObservedSoundingStatus("Candidate loaded from recommendation");
     setObservedSoundingError(null);
     setSelectedCandidateScreening(
       candidateScreeningMetadata(candidate, savedCandidate, activeStory),
@@ -2351,7 +2523,227 @@ export function App() {
     setLanWorkerError(null);
     setLanWorkerActionStatus(null);
     setIngestedResultId(null);
-    setCandidateStatus("Candidate selected for package review");
+    setCandidateStatus("Candidate ready in run plan");
+  }
+
+  function handleAddCandidateToRunPlan(
+    candidate: SoundingCandidate,
+    savedCandidate?: SavedSoundingCandidate,
+    activeStory?: CandidateStoryId,
+  ) {
+    const item = runPlanItemFromCandidate(candidate, savedCandidate, activeStory, controls);
+    if (!item) {
+      setCandidateError(
+        "This candidate is not package-ready. Review its caveats before adding another sounding.",
+      );
+      return;
+    }
+    handleUseSoundingCandidate(candidate, savedCandidate, activeStory);
+    setRunPlanItems((current) => [...current, item]);
+    setBatchQueueStatus(`${candidateStationLabel(candidate)} added to the run plan`);
+  }
+
+  function handleAddUploadedSoundingToRunPlan() {
+    if (!observedSoundingParse?.selected_sounding) {
+      setObservedSoundingError("Upload and validate an IGRA sounding before adding it.");
+      return;
+    }
+    const item = runPlanItemFromUploadedSounding({
+      observedSounding: observedSoundingParse.selected_sounding,
+      observedRunRecipe,
+      runConfiguration,
+      controls,
+      selectedCandidateScreening,
+    });
+    setRunPlanItems((current) => [...current, item]);
+    setBatchQueueStatus("Uploaded sounding added to the run plan");
+  }
+
+  function handleDuplicateRunPlanItem(itemId: string) {
+    setRunPlanItems((current) => {
+      const item = current.find((entry) => entry.id === itemId);
+      if (!item) return current;
+      return [
+        ...current,
+        {
+          ...item,
+          id: createRunPlanItemId(),
+          selected: true,
+          status: "planned",
+          message: "Variant duplicated; edit recipe or configuration before queueing.",
+          dryRun: null,
+          blockedPreRunValidationReport: null,
+        },
+      ];
+    });
+    setBatchQueueStatus("Run-plan variant duplicated");
+  }
+
+  function handleRemoveRunPlanItem(itemId: string) {
+    setRunPlanItems((current) => current.filter((item) => item.id !== itemId));
+  }
+
+  function handleClearSelectedRunPlanItems() {
+    setRunPlanItems((current) => current.filter((item) => !item.selected));
+    setBatchQueueStatus("Selected run-plan items removed");
+  }
+
+  function handleClearRunPlan() {
+    setRunPlanItems([]);
+    setBatchQueueStatus("Run plan cleared");
+  }
+
+  function handleRunPlanItemSelectedChange(itemId: string, selected: boolean) {
+    updateRunPlanItem(itemId, (item) => ({ ...item, selected }));
+  }
+
+  function handleRunPlanItemQueueTargetChange(itemId: string, queueTarget: RunPlanQueueTarget) {
+    updateRunPlanItem(itemId, (item) => ({
+      ...item,
+      queueTarget,
+      status: "planned",
+      message: null,
+    }));
+  }
+
+  function handleRunPlanItemRecipeChange(itemId: string, runRecipe: ObservedRunRecipe) {
+    updateRunPlanItem(itemId, (item) => ({
+      ...item,
+      runRecipe,
+      runConfiguration: defaultRunConfigurationForSelection(
+        OBSERVED_SOUNDING_EXPERIMENT_ID,
+        runRecipe,
+      ),
+      status: "planned",
+      message: "Recipe changed; package not created yet.",
+      dryRun: null,
+      blockedPreRunValidationReport: null,
+    }));
+  }
+
+  function handleRunPlanItemConfigurationChange(
+    itemId: string,
+    runConfiguration: RunConfigurationInput,
+  ) {
+    updateRunPlanItem(itemId, (item) => ({
+      ...item,
+      runConfiguration,
+      status: "planned",
+      message: "Run configuration changed; package not created yet.",
+      dryRun: null,
+      blockedPreRunValidationReport: null,
+    }));
+  }
+
+  function updateRunPlanItem(itemId: string, update: (item: RunPlanItem) => RunPlanItem) {
+    setRunPlanItems((current) => current.map((item) => (item.id === itemId ? update(item) : item)));
+  }
+
+  async function handleCreateAndQueueRunPlan() {
+    const selectedItems = runPlanItems.filter((item) => item.selected);
+    if (selectedItems.length === 0) {
+      setBatchQueueStatus("Select at least one run-plan item before queueing.");
+      return;
+    }
+    setBatchQueueStatus(`Creating and queueing ${selectedItems.length} selected run${selectedItems.length === 1 ? "" : "s"}`);
+    setRunWorkflowError(null);
+    let queued = 0;
+    let lanStarted = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const item of selectedItems) {
+      if (!item.observedSounding) {
+        skipped += 1;
+        updateRunPlanItem(item.id, (current) => ({
+          ...current,
+          status: "skipped",
+          message: "Skipped because the selected sounding data is missing.",
+        }));
+        continue;
+      }
+      if (item.queueTarget === "lan" && !lanWorkerConfig?.configured) {
+        skipped += 1;
+        updateRunPlanItem(item.id, (current) => ({
+          ...current,
+          status: "skipped",
+          message: "Skipped because LAN worker execution is not configured.",
+        }));
+        continue;
+      }
+
+      updateRunPlanItem(item.id, (current) => ({
+        ...current,
+        status: "packaging",
+        message: "Creating package",
+        dryRun: null,
+        blockedPreRunValidationReport: null,
+      }));
+
+      try {
+        const packageUserMetadata = runUserMetadataFromCandidateScreening(item.candidateScreening);
+        const result = await requestDryRunPackage(
+          OBSERVED_SOUNDING_BASE_SCENARIO_ID,
+          item.controls,
+          item.runConfiguration,
+          item.runRecipe,
+          item.observedSounding,
+          item.candidateScreening,
+          packageUserMetadata,
+        );
+        setDryRun(result);
+        setBlockedPreRunValidationReport(null);
+
+        if (item.queueTarget === "lan") {
+          const launched = await startLanWorkerRun(result.manifest_path);
+          setLanWorkerStatus(launched);
+          setLanWorkerActionStatus(lanWorkerStatusLabel(launched));
+          lanStarted += 1;
+          updateRunPlanItem(item.id, (current) => ({
+            ...current,
+            status: "lan_started",
+            message: launched.message ?? "Package sent to LAN worker.",
+            dryRun: result,
+            blockedPreRunValidationReport: null,
+          }));
+        } else {
+          const queuedResponse = await enqueueLocalRun(result.manifest_path);
+          setRunQueue(queuedResponse);
+          setRunQueueStatus(runQueueSummary(queuedResponse));
+          await processAutoIngestedQueue(queuedResponse);
+          queued += 1;
+          updateRunPlanItem(item.id, (current) => ({
+            ...current,
+            status: "queued",
+            message: "Queued for local serial CM1 run.",
+            dryRun: result,
+            blockedPreRunValidationReport: null,
+          }));
+        }
+      } catch (caught) {
+        failed += 1;
+        const blockedReport =
+          caught instanceof DryRunRequestError ? caught.preRunValidationReport : null;
+        if (blockedReport) setBlockedPreRunValidationReport(blockedReport);
+        updateRunPlanItem(item.id, (current) => ({
+          ...current,
+          status: "package_failed",
+          message: caught instanceof Error ? caught.message : "Unable to create or queue package.",
+          blockedPreRunValidationReport: blockedReport,
+        }));
+      }
+    }
+
+    await refreshLocalRunQueue();
+    await refreshStorageAfterWorkflow("Local pipeline updated");
+    setBatchQueueStatus(
+      batchQueueSummary({
+        queued,
+        lanStarted,
+        failed,
+        skipped,
+      }),
+    );
   }
 
   async function handleDryRun(event: FormEvent<HTMLFormElement>) {
@@ -2898,6 +3290,10 @@ export function App() {
           observedSoundingStatus={observedSoundingStatus}
           observedSoundingError={observedSoundingError}
           selectedCandidateScreening={selectedCandidateScreening}
+          atmosphereSourcePath={atmosphereSourcePath}
+          searchIntent={searchIntent}
+          searchDepth={searchDepth}
+          timeScope={timeScope}
           igraCatalog={igraCatalog}
           igraCache={igraCache}
           screeningInputs={screeningInputs}
@@ -2915,6 +3311,8 @@ export function App() {
           candidateScreening={candidateScreening}
           savedCandidates={savedCandidates}
           candidateDetailId={candidateDetailId}
+          runPlanItems={runPlanItems}
+          batchQueueStatus={batchQueueStatus}
           validationMessages={validationMessages}
           dryRun={dryRun}
           blockedPreRunValidationReport={blockedPreRunValidationReport}
@@ -2946,6 +3344,10 @@ export function App() {
           onObservedRunRecipeChange={handleObservedRunRecipeChange}
           onObservedSoundingFile={handleObservedSoundingFile}
           onObservedSoundingTimeChange={handleObservedSoundingTimeChange}
+          onAtmosphereSourcePathChange={handleAtmosphereSourcePathChange}
+          onSearchIntentChange={handleSearchIntentChange}
+          onSearchDepthChange={handleSearchDepthChange}
+          onTimeScopeChange={setTimeScope}
           onCandidateStoryFilterChange={setCandidateStoryFilter}
           onCandidateStoryFamilyFilterChange={setCandidateStoryFamilyFilter}
           onCandidateSupportFilterChange={setCandidateSupportFilter}
@@ -2959,10 +3361,21 @@ export function App() {
           onCandidateDetailChange={setCandidateDetailId}
           onRefreshIGRAData={handleRefreshIGRAData}
           onCacheIGRAStationFiles={handleCacheIGRAStationFiles}
+          onPrepareAndSearchLocalSoundings={handlePrepareAndSearchLocalSoundings}
           onScreenSoundingCandidates={handleScreenSoundingCandidates}
           onSaveSoundingCandidate={handleSaveSoundingCandidate}
           onRemoveSavedSoundingCandidate={handleRemoveSavedSoundingCandidate}
-          onUseSoundingCandidate={handleUseSoundingCandidate}
+          onAddCandidateToRunPlan={handleAddCandidateToRunPlan}
+          onAddUploadedSoundingToRunPlan={handleAddUploadedSoundingToRunPlan}
+          onDuplicateRunPlanItem={handleDuplicateRunPlanItem}
+          onRemoveRunPlanItem={handleRemoveRunPlanItem}
+          onClearSelectedRunPlanItems={handleClearSelectedRunPlanItems}
+          onClearRunPlan={handleClearRunPlan}
+          onRunPlanItemSelectedChange={handleRunPlanItemSelectedChange}
+          onRunPlanItemQueueTargetChange={handleRunPlanItemQueueTargetChange}
+          onRunPlanItemRecipeChange={handleRunPlanItemRecipeChange}
+          onRunPlanItemConfigurationChange={handleRunPlanItemConfigurationChange}
+          onCreateAndQueueRunPlan={handleCreateAndQueueRunPlan}
           onDryRun={handleDryRun}
           onLaunchRun={handleLaunchRun}
           onRefreshRunStatus={handleRefreshRunStatus}
@@ -3046,6 +3459,10 @@ function BuildWorkspace({
   observedSoundingStatus,
   observedSoundingError,
   selectedCandidateScreening,
+  atmosphereSourcePath,
+  searchIntent,
+  searchDepth,
+  timeScope,
   igraCatalog,
   igraCache,
   screeningInputs,
@@ -3063,6 +3480,8 @@ function BuildWorkspace({
   candidateScreening,
   savedCandidates,
   candidateDetailId,
+  runPlanItems,
+  batchQueueStatus,
   validationMessages,
   dryRun,
   blockedPreRunValidationReport,
@@ -3089,6 +3508,10 @@ function BuildWorkspace({
   onObservedRunRecipeChange,
   onObservedSoundingFile,
   onObservedSoundingTimeChange,
+  onAtmosphereSourcePathChange,
+  onSearchIntentChange,
+  onSearchDepthChange,
+  onTimeScopeChange,
   onCandidateStoryFilterChange,
   onCandidateStoryFamilyFilterChange,
   onCandidateSupportFilterChange,
@@ -3102,10 +3525,21 @@ function BuildWorkspace({
   onCandidateDetailChange,
   onRefreshIGRAData,
   onCacheIGRAStationFiles,
+  onPrepareAndSearchLocalSoundings,
   onScreenSoundingCandidates,
   onSaveSoundingCandidate,
   onRemoveSavedSoundingCandidate,
-  onUseSoundingCandidate,
+  onAddCandidateToRunPlan,
+  onAddUploadedSoundingToRunPlan,
+  onDuplicateRunPlanItem,
+  onRemoveRunPlanItem,
+  onClearSelectedRunPlanItems,
+  onClearRunPlan,
+  onRunPlanItemSelectedChange,
+  onRunPlanItemQueueTargetChange,
+  onRunPlanItemRecipeChange,
+  onRunPlanItemConfigurationChange,
+  onCreateAndQueueRunPlan,
   onDryRun,
   onLaunchRun,
   onRefreshRunStatus,
@@ -3142,6 +3576,10 @@ function BuildWorkspace({
   observedSoundingStatus: string | null;
   observedSoundingError: string | null;
   selectedCandidateScreening: Record<string, unknown> | null;
+  atmosphereSourcePath: AtmosphereSourcePath;
+  searchIntent: SearchIntent;
+  searchDepth: SearchDepth;
+  timeScope: TimeScope;
   igraCatalog: IGRACatalogResponse["catalog"] | null;
   igraCache: IGRACacheResponse | null;
   screeningInputs: ScreeningInput[];
@@ -3159,6 +3597,8 @@ function BuildWorkspace({
   candidateScreening: ScreeningResult | null;
   savedCandidates: SavedSoundingCandidate[];
   candidateDetailId: string | null;
+  runPlanItems: RunPlanItem[];
+  batchQueueStatus: string | null;
   validationMessages: string[];
   dryRun: DryRunResponse | null;
   blockedPreRunValidationReport: PreRunValidationReport | null;
@@ -3185,6 +3625,10 @@ function BuildWorkspace({
   onObservedRunRecipeChange: (runRecipe: ObservedRunRecipe) => void;
   onObservedSoundingFile: (file: File) => void;
   onObservedSoundingTimeChange: (validTimeUtc: string) => void;
+  onAtmosphereSourcePathChange: (sourcePath: AtmosphereSourcePath) => void;
+  onSearchIntentChange: (intent: SearchIntent) => void;
+  onSearchDepthChange: (depth: SearchDepth) => void;
+  onTimeScopeChange: (timeScope: TimeScope) => void;
   onCandidateStoryFilterChange: (filter: CandidateStoryFilter) => void;
   onCandidateStoryFamilyFilterChange: (filter: CandidateStoryFamilyFilter) => void;
   onCandidateSupportFilterChange: (filter: CandidateSupportFilter) => void;
@@ -3198,13 +3642,28 @@ function BuildWorkspace({
   onCandidateDetailChange: (candidateId: string) => void;
   onRefreshIGRAData: () => void;
   onCacheIGRAStationFiles: () => void;
+  onPrepareAndSearchLocalSoundings: () => void;
   onScreenSoundingCandidates: () => void;
   onSaveSoundingCandidate: (candidate: SoundingCandidate) => void;
   onRemoveSavedSoundingCandidate: (savedCandidateId: string) => void;
-  onUseSoundingCandidate: (
+  onAddCandidateToRunPlan: (
     candidate: SoundingCandidate,
     savedCandidate?: SavedSoundingCandidate,
+    activeStory?: CandidateStoryId,
   ) => void;
+  onAddUploadedSoundingToRunPlan: () => void;
+  onDuplicateRunPlanItem: (itemId: string) => void;
+  onRemoveRunPlanItem: (itemId: string) => void;
+  onClearSelectedRunPlanItems: () => void;
+  onClearRunPlan: () => void;
+  onRunPlanItemSelectedChange: (itemId: string, selected: boolean) => void;
+  onRunPlanItemQueueTargetChange: (itemId: string, target: RunPlanQueueTarget) => void;
+  onRunPlanItemRecipeChange: (itemId: string, runRecipe: ObservedRunRecipe) => void;
+  onRunPlanItemConfigurationChange: (
+    itemId: string,
+    runConfiguration: RunConfigurationInput,
+  ) => void;
+  onCreateAndQueueRunPlan: () => void;
   onDryRun: (event: FormEvent<HTMLFormElement>) => void;
   onLaunchRun: () => void;
   onRefreshRunStatus: () => void;
@@ -3233,6 +3692,22 @@ function BuildWorkspace({
   const runConfigurationPreview = previewRunConfiguration(
     runConfiguration,
     observedSoundingExperimentSelected ? observedRunRecipe : "generated_reference_lower_atmosphere",
+  );
+  const runPlanPanel = (
+    <RunPlanPanel
+      items={runPlanItems}
+      batchStatus={batchQueueStatus}
+      lanWorkerConfigured={lanWorkerConfig?.configured ?? false}
+      onSelectedChange={onRunPlanItemSelectedChange}
+      onQueueTargetChange={onRunPlanItemQueueTargetChange}
+      onRecipeChange={onRunPlanItemRecipeChange}
+      onConfigurationChange={onRunPlanItemConfigurationChange}
+      onDuplicate={onDuplicateRunPlanItem}
+      onRemove={onRemoveRunPlanItem}
+      onClearSelected={onClearSelectedRunPlanItems}
+      onClearAll={onClearRunPlan}
+      onCreateAndQueue={onCreateAndQueueRunPlan}
+    />
   );
 
   return (
@@ -3304,7 +3779,7 @@ function BuildWorkspace({
                 </h2>
                 <p>
                   {observedSoundingExperimentSelected
-                    ? "Use an observed IGRA sounding as the atmosphere profile while keeping Cloud Chamber's local CM1 package path and surface-heating control."
+                    ? "Choose a local sounding source, review why an atmosphere looks interesting, then add one or more run variants to a batch plan."
                     : selectedScenario.description}
                 </p>
               </div>
@@ -3313,124 +3788,148 @@ function BuildWorkspace({
                 <h3 id="physical-question-title">Physical Question</h3>
                 <p>
                   {observedSoundingExperimentSelected
-                    ? "What does CM1 do when initialized from this observed atmosphere, with surface heating as the controlled experiment lever?"
+                    ? "Given this observed atmosphere, what can CM1 honestly test under the selected run recipe and explicit assumptions?"
                     : selectedScenario.physical_question}
                 </p>
               </section>
 
-              <section className="experiment-summary" aria-labelledby="experiment-summary-title">
-                <h3 id="experiment-summary-title">Experiment setup summary</h3>
-                <dl className="compact-metrics">
-                  <Metric label="Expected outcome" value={selectedScenario.expected_behavior} />
-                  <Metric
-                    label="Readiness"
-                    value="Supported local package template from the scenario catalog"
-                  />
-                  <Metric
-                    label="What changes"
-                    value={
-                      observedSoundingExperimentSelected
-                        ? "Observed sounding profile, Surface heating"
-                        : selectedScenario.controls.map((control) => control.label).join(", ")
-                    }
-                  />
-                  <Metric
-                    label="What stays controlled"
-                    value={
-                      observedSoundingExperimentSelected
-                        ? "CM1 remains the source of truth; non-heating atmospheric controls are supplied by the uploaded sounding."
-                        : "CM1 remains the source of truth; raw namelist details stay in technical review."
-                    }
-                  />
-                </dl>
-              </section>
-
-              <section aria-labelledby="controls-title">
-                <h3 id="controls-title">Curated Atmospheric Controls</h3>
-                {observedSoundingExperimentSelected && (
-                  <p className="field-help">
-                    The uploaded sounding supplies the temperature, moisture, cap, and wind profile.
-                    Surface heating remains editable so you can test how the observed atmosphere
-                    responds to boundary-layer forcing.
-                  </p>
-                )}
-                {selectedScenario.controls
-                  .filter(
-                    (control) =>
-                      !observedSoundingExperimentSelected ||
-                      OBSERVED_SOUNDING_VISIBLE_CONTROLS.has(control.id),
-                  )
-                  .map((control) => (
-                    <BuildControlRow
-                      key={control.id}
-                      control={control}
-                      value={controls[control.id] ?? control.default}
-                      onChange={(value) => onControlChange(control.id, value)}
-                    />
-                  ))}
-              </section>
-
-              {observedSoundingExperimentSelected && (
+              {!observedSoundingExperimentSelected && (
                 <>
-                  <ObservedAtmosphereCandidatesPanel
-                    catalog={igraCatalog}
-                    cache={igraCache}
-                    screeningInputs={screeningInputs}
-                    storyFilter={candidateStoryFilter}
-                    storyFamilyFilter={candidateStoryFamilyFilter}
-                    supportFilter={candidateSupportFilter}
-                    sort={candidateSort}
-                    stationSearch={candidateStationSearch}
-                    readinessFilter={candidateReadinessFilter}
-                    cacheLimit={candidateCacheLimit}
-                    latestPerStation={candidateLatestPerStation}
-                    resultLimit={candidateResultLimit}
-                    status={candidateStatus}
-                    error={candidateError}
-                    screening={candidateScreening}
-                    savedCandidates={savedCandidates}
-                    selectedCandidateId={candidateDetailId}
-                    onStoryFilterChange={onCandidateStoryFilterChange}
-                    onStoryFamilyFilterChange={onCandidateStoryFamilyFilterChange}
-                    onSupportFilterChange={onCandidateSupportFilterChange}
-                    onSortChange={onCandidateSortChange}
-                    onStationSearchChange={onCandidateStationSearchChange}
-                    onReadinessFilterChange={onCandidateReadinessFilterChange}
-                    onClearFilters={onClearCandidateAnalysisFilters}
-                    onCacheLimitChange={onCandidateCacheLimitChange}
-                    onLatestPerStationChange={onCandidateLatestPerStationChange}
-                    onResultLimitChange={onCandidateResultLimitChange}
-                    onCandidateDetailChange={onCandidateDetailChange}
-                    onRefreshIGRAData={onRefreshIGRAData}
-                    onCacheStationFiles={onCacheIGRAStationFiles}
-                    onScreen={onScreenSoundingCandidates}
-                    onSave={onSaveSoundingCandidate}
-                    onRemoveSaved={onRemoveSavedSoundingCandidate}
-                    onUse={onUseSoundingCandidate}
-                  />
-                  <ObservedSoundingInputPanel
-                    parsed={observedSoundingParse}
-                    status={observedSoundingStatus}
-                    error={observedSoundingError}
-                    selectedCandidateScreening={selectedCandidateScreening}
-                    onFile={onObservedSoundingFile}
-                    onTimeChange={onObservedSoundingTimeChange}
-                  />
-                  <ObservedRunRecipePanel
-                    runRecipe={observedRunRecipe}
-                    controls={controls}
-                    selectedCandidateScreening={selectedCandidateScreening}
-                    onChange={onObservedRunRecipeChange}
-                  />
+                  <section
+                    className="experiment-summary"
+                    aria-labelledby="experiment-summary-title"
+                  >
+                    <h3 id="experiment-summary-title">Experiment setup summary</h3>
+                    <dl className="compact-metrics">
+                      <Metric label="Expected outcome" value={selectedScenario.expected_behavior} />
+                      <Metric
+                        label="Readiness"
+                        value="Supported local package template from the scenario catalog"
+                      />
+                      <Metric
+                        label="What changes"
+                        value={selectedScenario.controls
+                          .map((control) => control.label)
+                          .join(", ")}
+                      />
+                      <Metric
+                        label="What stays controlled"
+                        value="CM1 remains the source of truth; raw namelist details stay in technical review."
+                      />
+                    </dl>
+                  </section>
+
+                  <section aria-labelledby="controls-title">
+                    <h3 id="controls-title">Curated Atmospheric Controls</h3>
+                    {selectedScenario.controls.map((control) => (
+                      <BuildControlRow
+                        key={control.id}
+                        control={control}
+                        value={controls[control.id] ?? control.default}
+                        onChange={(value) => onControlChange(control.id, value)}
+                      />
+                    ))}
+                  </section>
                 </>
               )}
 
-              <RunConfigurationPanel
-                configuration={runConfiguration}
-                preview={runConfigurationPreview}
-                triggeredDeepPotential={selectedTriggeredDeepPotential}
-                onChange={onRunConfigurationChange}
-              />
+              {observedSoundingExperimentSelected && (
+                <>
+                  <AtmosphereSourcePicker
+                    sourcePath={atmosphereSourcePath}
+                    savedCandidateCount={savedCandidates.length}
+                    onChange={onAtmosphereSourcePathChange}
+                  />
+
+                  {runPlanItems.length > 0 && runPlanPanel}
+
+                  {atmosphereSourcePath === "cached_recommendations" && (
+                    <ObservedAtmosphereCandidatesPanel
+                      catalog={igraCatalog}
+                      cache={igraCache}
+                      screeningInputs={screeningInputs}
+                      searchIntent={searchIntent}
+                      searchDepth={searchDepth}
+                      timeScope={timeScope}
+                      storyFilter={candidateStoryFilter}
+                      storyFamilyFilter={candidateStoryFamilyFilter}
+                      supportFilter={candidateSupportFilter}
+                      sort={candidateSort}
+                      stationSearch={candidateStationSearch}
+                      readinessFilter={candidateReadinessFilter}
+                      cacheLimit={candidateCacheLimit}
+                      latestPerStation={candidateLatestPerStation}
+                      resultLimit={candidateResultLimit}
+                      status={candidateStatus}
+                      error={candidateError}
+                      screening={candidateScreening}
+                      savedCandidates={savedCandidates}
+                      selectedCandidateId={candidateDetailId}
+                      onSearchIntentChange={onSearchIntentChange}
+                      onSearchDepthChange={onSearchDepthChange}
+                      onTimeScopeChange={onTimeScopeChange}
+                      onStoryFilterChange={onCandidateStoryFilterChange}
+                      onStoryFamilyFilterChange={onCandidateStoryFamilyFilterChange}
+                      onSupportFilterChange={onCandidateSupportFilterChange}
+                      onSortChange={onCandidateSortChange}
+                      onStationSearchChange={onCandidateStationSearchChange}
+                      onReadinessFilterChange={onCandidateReadinessFilterChange}
+                      onClearFilters={onClearCandidateAnalysisFilters}
+                      onCacheLimitChange={onCandidateCacheLimitChange}
+                      onLatestPerStationChange={onCandidateLatestPerStationChange}
+                      onResultLimitChange={onCandidateResultLimitChange}
+                      onCandidateDetailChange={onCandidateDetailChange}
+                      onRefreshIGRAData={onRefreshIGRAData}
+                      onCacheStationFiles={onCacheIGRAStationFiles}
+                      onPrepareAndSearch={onPrepareAndSearchLocalSoundings}
+                      onScreen={onScreenSoundingCandidates}
+                      onSave={onSaveSoundingCandidate}
+                      onAddToRunPlan={onAddCandidateToRunPlan}
+                    />
+                  )}
+
+                  {atmosphereSourcePath === "saved_candidates" && (
+                    <SavedCandidatesSourcePanel
+                      savedCandidates={savedCandidates}
+                      status={candidateStatus}
+                      error={candidateError}
+                      onSave={onSaveSoundingCandidate}
+                      onRemoveSaved={onRemoveSavedSoundingCandidate}
+                      onAddToRunPlan={onAddCandidateToRunPlan}
+                    />
+                  )}
+
+                  {atmosphereSourcePath === "upload_igra_text" && (
+                    <UploadSoundingSourcePanel
+                      observedSoundingParse={observedSoundingParse}
+                      observedSoundingStatus={observedSoundingStatus}
+                      observedSoundingError={observedSoundingError}
+                      selectedCandidateScreening={selectedCandidateScreening}
+                      observedRunRecipe={observedRunRecipe}
+                      controls={controls}
+                      runConfiguration={runConfiguration}
+                      runConfigurationPreview={runConfigurationPreview}
+                      selectedTriggeredDeepPotential={selectedTriggeredDeepPotential}
+                      onObservedSoundingFile={onObservedSoundingFile}
+                      onObservedSoundingTimeChange={onObservedSoundingTimeChange}
+                      onObservedRunRecipeChange={onObservedRunRecipeChange}
+                      onRunConfigurationChange={onRunConfigurationChange}
+                      onAddUploadedSoundingToRunPlan={onAddUploadedSoundingToRunPlan}
+                    />
+                  )}
+
+                  {runPlanItems.length === 0 && runPlanPanel}
+                </>
+              )}
+
+              {!observedSoundingExperimentSelected && (
+                <RunConfigurationPanel
+                  configuration={runConfiguration}
+                  preview={runConfigurationPreview}
+                  triggeredDeepPotential={selectedTriggeredDeepPotential}
+                  onChange={onRunConfigurationChange}
+                />
+              )}
 
               {validationMessages.length > 0 && (
                 <div className="validation" role="alert">
@@ -3450,25 +3949,23 @@ function BuildWorkspace({
                 <PreRunValidationReportPanel report={blockedPreRunValidationReport} />
               )}
 
-              <BuildRunActionPanel
-                dryRun={dryRun}
-                runStatus={runStatus}
-                lanWorkerStatus={lanWorkerStatus}
-                lanWorkerConfigured={lanWorkerConfig?.configured ?? false}
-                canCreatePackage={
-                  validationMessages.length === 0 &&
-                  (!observedSoundingExperimentSelected ||
-                    Boolean(observedSoundingParse?.selected_sounding))
-                }
-                onLaunchRun={onLaunchRun}
-                onLaunchLanWorkerRun={onLaunchLanWorkerRun}
-              />
+              {!observedSoundingExperimentSelected && (
+                <BuildRunActionPanel
+                  dryRun={dryRun}
+                  runStatus={runStatus}
+                  lanWorkerStatus={lanWorkerStatus}
+                  lanWorkerConfigured={lanWorkerConfig?.configured ?? false}
+                  canCreatePackage={validationMessages.length === 0}
+                  onLaunchRun={onLaunchRun}
+                  onLaunchLanWorkerRun={onLaunchLanWorkerRun}
+                />
+              )}
             </>
           )}
         </form>
 
         <aside className="side-stack">
-          <LocalRunWorkflowPanel
+          <RunMonitorPanel
             dryRun={dryRun}
             runStatus={runStatus}
             runQueue={runQueue}
@@ -3918,10 +4415,68 @@ function ScenarioStatePanel({
   );
 }
 
+function AtmosphereSourcePicker({
+  sourcePath,
+  savedCandidateCount,
+  onChange,
+}: {
+  sourcePath: AtmosphereSourcePath;
+  savedCandidateCount: number;
+  onChange: (sourcePath: AtmosphereSourcePath) => void;
+}) {
+  const options: Array<{ value: AtmosphereSourcePath; label: string; description: string }> = [
+    {
+      value: "cached_recommendations",
+      label: "Cached recommendations",
+      description: "Search local cached soundings and review recommendation evidence.",
+    },
+    {
+      value: "saved_candidates",
+      label: `Saved candidates${savedCandidateCount > 0 ? ` (${savedCandidateCount})` : ""}`,
+      description: "Use your saved shortlist as the atmosphere source.",
+    },
+    {
+      value: "upload_igra_text",
+      label: "Upload IGRA station text",
+      description: "Manually upload and validate a station text file.",
+    },
+  ];
+  const selected = options.find((option) => option.value === sourcePath) ?? options[0];
+  return (
+    <section className="experiment-summary atmosphere-source-panel" aria-label="Atmosphere source">
+      <div className="panel-heading-row">
+        <div>
+          <p className="eyebrow">Atmosphere source</p>
+          <h3>Choose one source path</h3>
+          <p className="field-help">{selected.description}</p>
+        </div>
+        <StatusBadge label={selected.label} tone="neutral" />
+      </div>
+      <div className="button-row source-path-tabs" role="tablist" aria-label="Atmosphere sources">
+        {options.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            role="tab"
+            aria-selected={sourcePath === option.value}
+            className={sourcePath === option.value ? "active-control" : "secondary-button"}
+            onClick={() => onChange(option.value)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function ObservedAtmosphereCandidatesPanel({
   catalog,
   cache,
   screeningInputs,
+  searchIntent,
+  searchDepth,
+  timeScope,
   storyFilter,
   storyFamilyFilter,
   supportFilter,
@@ -3936,6 +4491,9 @@ function ObservedAtmosphereCandidatesPanel({
   screening,
   savedCandidates,
   selectedCandidateId,
+  onSearchIntentChange,
+  onSearchDepthChange,
+  onTimeScopeChange,
   onStoryFilterChange,
   onStoryFamilyFilterChange,
   onSupportFilterChange,
@@ -3949,14 +4507,17 @@ function ObservedAtmosphereCandidatesPanel({
   onCandidateDetailChange,
   onRefreshIGRAData,
   onCacheStationFiles,
+  onPrepareAndSearch,
   onScreen,
   onSave,
-  onRemoveSaved,
-  onUse,
+  onAddToRunPlan,
 }: {
   catalog: IGRACatalogResponse["catalog"] | null;
   cache: IGRACacheResponse | null;
   screeningInputs: ScreeningInput[];
+  searchIntent: SearchIntent;
+  searchDepth: SearchDepth;
+  timeScope: TimeScope;
   storyFilter: CandidateStoryFilter;
   storyFamilyFilter: CandidateStoryFamilyFilter;
   supportFilter: CandidateSupportFilter;
@@ -3971,6 +4532,9 @@ function ObservedAtmosphereCandidatesPanel({
   screening: ScreeningResult | null;
   savedCandidates: SavedSoundingCandidate[];
   selectedCandidateId: string | null;
+  onSearchIntentChange: (intent: SearchIntent) => void;
+  onSearchDepthChange: (depth: SearchDepth) => void;
+  onTimeScopeChange: (timeScope: TimeScope) => void;
   onStoryFilterChange: (filter: CandidateStoryFilter) => void;
   onStoryFamilyFilterChange: (filter: CandidateStoryFamilyFilter) => void;
   onSupportFilterChange: (filter: CandidateSupportFilter) => void;
@@ -3984,10 +4548,10 @@ function ObservedAtmosphereCandidatesPanel({
   onCandidateDetailChange: (candidateId: string) => void;
   onRefreshIGRAData: () => void;
   onCacheStationFiles: () => void;
+  onPrepareAndSearch: () => void;
   onScreen: () => void;
   onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
-  onRemoveSaved: (savedCandidateId: string) => void;
-  onUse: (
+  onAddToRunPlan: (
     candidate: SoundingCandidate,
     savedCandidate?: SavedSoundingCandidate,
     activeStory?: CandidateStoryId,
@@ -4066,36 +4630,100 @@ function ObservedAtmosphereCandidatesPanel({
         </p>
       </div>
 
-      <dl className="candidate-cache-summary">
-        <Metric label="Region" value={catalog?.region.label ?? "Great Plains / Midwest"} />
-        <Metric
-          label="Last refreshed"
-          value={catalog?.refreshed_at ? formatDate(catalog.refreshed_at) : "Not refreshed here"}
-        />
-        <Metric label="Cached stations" value={cachedStations.toString()} />
-        <Metric label="Cached station files" value={cachedCatalogFiles.toString()} />
-        <Metric label="Cached sounding inventory" value={cachedInventorySummary} />
-        <Metric label="Planned analysis slice" value={plannedAnalysisSummary} />
-        <Metric label="Last analysis" value={lastAnalysisSummary} />
-      </dl>
+      <section className="candidate-search-controls" aria-label="Prepare and search local soundings">
+        <div className="run-configuration-grid">
+          <label>
+            <strong>Source region</strong>
+            <select value="great_plains_midwest" disabled>
+              <option value="great_plains_midwest">Great Plains / Midwest</option>
+            </select>
+            <small>Current local station catalog scope.</small>
+          </label>
+          <label>
+            <strong>Search intent</strong>
+            <select
+              value={searchIntent}
+              onChange={(event) => onSearchIntentChange(event.target.value as SearchIntent)}
+            >
+              {SEARCH_INTENT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+              <option value="winter_disabled" disabled>
+                Cold season / winter (not supported yet)
+              </option>
+            </select>
+            <small>Maps to the current backend-supported story filters.</small>
+          </label>
+          <label>
+            <strong>Search depth</strong>
+            <select
+              value={searchDepth}
+              onChange={(event) => onSearchDepthChange(event.target.value as SearchDepth)}
+            >
+              {SEARCH_DEPTH_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <small>{SEARCH_DEPTH_OPTIONS.find((option) => option.value === searchDepth)?.description}</small>
+          </label>
+          <label>
+            <strong>Time scope</strong>
+            <select
+              value={timeScope}
+              onChange={(event) => onTimeScopeChange(event.target.value as TimeScope)}
+            >
+              {TIME_SCOPE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+              <option value="seasonal_disabled" disabled>
+                Seasonal historical (not supported yet)
+              </option>
+              <option value="date_range_disabled" disabled>
+                Specific date range (not supported yet)
+              </option>
+              <option value="all_cached_disabled" disabled>
+                All cached (not supported yet)
+              </option>
+            </select>
+            <small>{TIME_SCOPE_OPTIONS.find((option) => option.value === timeScope)?.description}</small>
+          </label>
+        </div>
+        <div className="candidate-discovery-actions" aria-label="Sounding search action">
+          <button type="button" onClick={onPrepareAndSearch}>
+            Prepare & search local soundings
+          </button>
+        </div>
+      </section>
+
+      <section className="candidate-cache-summary" aria-label="Local sounding data">
+        <h4>Local sounding data</h4>
+        <dl className="compact-metrics">
+          <Metric label="Region" value={catalog?.region.label ?? "Great Plains / Midwest"} />
+          <Metric
+            label="Station catalog"
+            value={catalog?.refreshed_at ? `Last refreshed ${formatDate(catalog.refreshed_at)}` : "Not refreshed here"}
+          />
+          <Metric label="Local station files" value={cachedCatalogFiles.toString()} />
+          <Metric label="Parsed soundings" value={cachedInventorySummary} />
+          <Metric
+            label="Ready to search"
+            value={screeningInputs.length > 0 ? "Yes" : "No cached sounding files ready"}
+          />
+          <Metric label="Last recommendation run" value={lastAnalysisSummary} />
+        </dl>
+      </section>
 
       {error && (
         <div className="validation" role="alert">
           <p>{error}</p>
         </div>
       )}
-
-      <div className="candidate-discovery-actions" aria-label="Sounding candidate actions">
-        <button type="button" onClick={onScreen}>
-          Analyze recommendations
-        </button>
-        <button type="button" className="secondary-button" onClick={onRefreshIGRAData}>
-          Refresh IGRA catalog
-        </button>
-        <button type="button" className="secondary-button" onClick={onCacheStationFiles}>
-          Cache station files
-        </button>
-      </div>
 
       {activeRefinements.length > 0 && (
         <div className="screening-guidance-note">
@@ -4253,7 +4881,24 @@ function ObservedAtmosphereCandidatesPanel({
               onChange={(event) => onResultLimitChange(event.target.value)}
             />
           </label>
+          <div className="candidate-toolbar-actions">
+            <button type="button" className="secondary-button" onClick={onRefreshIGRAData}>
+              Refresh IGRA catalog
+            </button>
+            <button type="button" className="secondary-button" onClick={onCacheStationFiles}>
+              Cache station files
+            </button>
+            <button type="button" className="secondary-button" onClick={onScreen}>
+              Run analyzer only
+            </button>
+          </div>
         </div>
+        <dl className="compact-metrics">
+          <Metric label="Cached stations" value={cachedStations.toString()} />
+          <Metric label="Cached station files" value={cachedStationFiles.toString()} />
+          <Metric label="Planned backend slice" value={plannedAnalysisSummary} />
+          <Metric label="Returned candidate limit" value={resultLimit} />
+        </dl>
       </details>
 
       <div className="candidate-workspace">
@@ -4295,8 +4940,8 @@ function ObservedAtmosphereCandidatesPanel({
                   saved={savedCandidateIds.has(candidate.candidate_id)}
                   onSelect={() => onCandidateDetailChange(candidate.candidate_id)}
                   onSave={() => onSave(candidate)}
-                  onUse={(activeStory) =>
-                    onUse(
+                  onAddToRunPlan={(activeStory) =>
+                    onAddToRunPlan(
                       candidate,
                       savedCandidates.find(
                         (saved) => saved.candidate.candidate_id === candidate.candidate_id,
@@ -4316,35 +4961,72 @@ function ObservedAtmosphereCandidatesPanel({
           storyFamilyFilter={storyFamilyFilter}
           savedCandidate={selectedSavedCandidate}
           onSave={onSave}
+          onAddToRunPlan={(candidate, activeStory) =>
+            onAddToRunPlan(candidate, selectedSavedCandidate ?? undefined, activeStory)
+          }
         />
       </div>
+    </section>
+  );
+}
 
-      <section className="saved-candidates-panel" aria-labelledby="saved-candidates-title">
-        <div className="panel-heading-row">
-          <div>
-            <h4 id="saved-candidates-title">Saved sounding candidates</h4>
-            <p>
-              Saved candidates are pre-run hypotheses. They are not Results and they do not prove an
-              atmospheric outcome.
-            </p>
-          </div>
+function SavedCandidatesSourcePanel({
+  savedCandidates,
+  status,
+  error,
+  onSave,
+  onRemoveSaved,
+  onAddToRunPlan,
+}: {
+  savedCandidates: SavedSoundingCandidate[];
+  status: string;
+  error: string | null;
+  onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
+  onRemoveSaved: (savedCandidateId: string) => void;
+  onAddToRunPlan: (
+    candidate: SoundingCandidate,
+    savedCandidate?: SavedSoundingCandidate,
+    activeStory?: CandidateStoryId,
+  ) => void;
+}) {
+  return (
+    <section className="experiment-summary saved-candidates-panel" aria-labelledby="saved-candidates-title">
+      <div className="panel-heading-row">
+        <div>
+          <p className="eyebrow">Saved source</p>
+          <h3 id="saved-candidates-title">Saved candidate shortlist</h3>
+          <p className="field-help">
+            Saved candidates are atmosphere hypotheses you chose to keep. Add one or more to the run
+            plan, then duplicate variants if you want different recipes or configurations.
+          </p>
         </div>
-        {savedCandidates.length === 0 ? (
-          <p className="field-help">No saved candidates yet.</p>
-        ) : (
-          <div className="saved-candidate-list">
-            {savedCandidates.map((saved) => (
-              <SavedSoundingCandidateCard
-                key={saved.saved_candidate_id}
-                saved={saved}
-                onUpdateWorkingSet={(tags) => onSave(saved.candidate, tags, saved.notes ?? null)}
-                onUse={() => onUse(saved.candidate, saved)}
-                onRemove={() => onRemoveSaved(saved.saved_candidate_id)}
-              />
-            ))}
-          </div>
-        )}
-      </section>
+        <StatusBadge
+          label={`${savedCandidates.length.toLocaleString()} saved`}
+          tone={savedCandidates.length > 0 ? "good" : "warning"}
+        />
+      </div>
+      <p className="state-chip" role="status">
+        {status}
+      </p>
+      {error && <p className="error-text">{error}</p>}
+      {savedCandidates.length === 0 ? (
+        <div className="scenario-state-panel">
+          <h4>No saved candidates yet</h4>
+          <p>Switch to cached recommendations, select a candidate, and save it with tags or notes.</p>
+        </div>
+      ) : (
+        <div className="saved-candidate-list">
+          {savedCandidates.map((saved) => (
+            <SavedSoundingCandidateCard
+              key={saved.saved_candidate_id}
+              saved={saved}
+              onUpdateWorkingSet={(tags) => onSave(saved.candidate, tags, saved.notes ?? null)}
+              onUse={() => onAddToRunPlan(saved.candidate, saved, saved.primary_story)}
+              onRemove={() => onRemoveSaved(saved.saved_candidate_id)}
+            />
+          ))}
+        </div>
+      )}
     </section>
   );
 }
@@ -4416,7 +5098,7 @@ function SavedSoundingCandidateCard({
       </div>
       <div className="button-row">
         <button type="button" onClick={onUse}>
-          Use to create package
+          Add to run plan
         </button>
         <button type="button" className="secondary-button" onClick={onRemove}>
           Remove saved
@@ -4434,7 +5116,7 @@ function SoundingCandidateCard({
   saved,
   onSelect,
   onSave,
-  onUse,
+  onAddToRunPlan,
 }: {
   candidate: SoundingCandidate;
   storyFilter: CandidateStoryFilter;
@@ -4443,7 +5125,7 @@ function SoundingCandidateCard({
   saved: boolean;
   onSelect: () => void;
   onSave: () => void;
-  onUse: (activeStory: CandidateStoryId) => void;
+  onAddToRunPlan: (activeStory: CandidateStoryId) => void;
 }) {
   const activeScore = candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter);
   const story = activeScore?.story ?? candidate.primary_story;
@@ -4454,7 +5136,7 @@ function SoundingCandidateCard({
     activeScore?.score_0_to_100 ??
     candidateIngredientScore(candidate, storyFilter, storyFamilyFilter);
   const recipeFit = candidateRecipeFitForStory(candidate, story);
-  const reasons = candidateInterestReasons(candidate);
+  const firstCaveat = candidate.caveats[0];
   return (
     <article
       className={`candidate-card${selected ? " selected-candidate-card" : ""}`}
@@ -4492,29 +5174,19 @@ function SoundingCandidateCard({
           />
         </span>
       </button>
-      <p className="candidate-interest-summary">{reasons[0]}</p>
-      {reasons.length > 1 && (
-        <ul className="compact-list candidate-reason-list">
-          {reasons.slice(1, 3).map((reason) => (
-            <li key={`${candidate.candidate_id}-${reason}`}>{reason}</li>
-          ))}
-        </ul>
-      )}
-      <ul className="compact-list">
-        {candidate.evidence.slice(0, 3).map((item) => (
-          <li key={`${candidate.candidate_id}-${item.label}`}>
-            {item.label}: {candidateEvidenceValue(item)}
-          </li>
-        ))}
-      </ul>
       {candidate.caveats.length > 0 && (
         <p className="field-help">
-          {candidate.caveats.length} caveat{candidate.caveats.length === 1 ? "" : "s"}
+          Key caveat: {humanize(firstCaveat)}
+          {candidate.caveats.length > 1 ? ` + ${candidate.caveats.length - 1} more` : ""}
         </p>
       )}
       <div className="button-row">
-        <button type="button" disabled={!candidate.package_ready} onClick={() => onUse(story)}>
-          Use this sounding
+        <button
+          type="button"
+          disabled={!candidate.package_ready}
+          onClick={() => onAddToRunPlan(story)}
+        >
+          Add to run plan
         </button>
         <button type="button" className="secondary-button" disabled={saved} onClick={onSave}>
           {saved ? "Saved" : "Save candidate"}
@@ -4530,12 +5202,14 @@ function SoundingCandidateDetail({
   storyFamilyFilter,
   savedCandidate,
   onSave,
+  onAddToRunPlan,
 }: {
   candidate: SoundingCandidate | null;
   storyFilter: CandidateStoryFilter;
   storyFamilyFilter: CandidateStoryFamilyFilter;
   savedCandidate: SavedSoundingCandidate | null;
   onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
+  onAddToRunPlan: (candidate: SoundingCandidate, activeStory: CandidateStoryId) => void;
 }) {
   const [tagDraft, setTagDraft] = useState("");
   const [notesDraft, setNotesDraft] = useState("");
@@ -4614,6 +5288,15 @@ function SoundingCandidateDetail({
         produce. CM1 decides whether clouds, rain, or suppression actually happen.
       </p>
       <p className="field-help">Recipe fit: {recipeFit.summary}</p>
+      <div className="button-row">
+        <button
+          type="button"
+          disabled={!candidate.package_ready}
+          onClick={() => onAddToRunPlan(candidate, story)}
+        >
+          Add to run plan
+        </button>
+      </div>
       <section>
         <h5>Why this is interesting</h5>
         <ul className="compact-list candidate-reason-list">
@@ -4720,6 +5403,80 @@ function SoundingCandidateDetail({
         </button>
       </div>
     </aside>
+  );
+}
+
+function UploadSoundingSourcePanel({
+  observedSoundingParse,
+  observedSoundingStatus,
+  observedSoundingError,
+  selectedCandidateScreening,
+  observedRunRecipe,
+  controls,
+  runConfiguration,
+  runConfigurationPreview,
+  selectedTriggeredDeepPotential,
+  onObservedSoundingFile,
+  onObservedSoundingTimeChange,
+  onObservedRunRecipeChange,
+  onRunConfigurationChange,
+  onAddUploadedSoundingToRunPlan,
+}: {
+  observedSoundingParse: ObservedSoundingParseResponse | null;
+  observedSoundingStatus: string | null;
+  observedSoundingError: string | null;
+  selectedCandidateScreening: Record<string, unknown> | null;
+  observedRunRecipe: ObservedRunRecipe;
+  controls: Record<string, string | number | boolean>;
+  runConfiguration: RunConfigurationInput;
+  runConfigurationPreview: RunConfiguration;
+  selectedTriggeredDeepPotential: boolean;
+  onObservedSoundingFile: (file: File) => void;
+  onObservedSoundingTimeChange: (validTimeUtc: string) => void;
+  onObservedRunRecipeChange: (runRecipe: ObservedRunRecipe) => void;
+  onRunConfigurationChange: (configuration: RunConfigurationInput) => void;
+  onAddUploadedSoundingToRunPlan: () => void;
+}) {
+  const canAdd = Boolean(observedSoundingParse?.selected_sounding);
+  return (
+    <section className="upload-source-stack" aria-label="Upload IGRA station text source">
+      <ObservedSoundingInputPanel
+        parsed={observedSoundingParse}
+        status={observedSoundingStatus}
+        error={observedSoundingError}
+        selectedCandidateScreening={selectedCandidateScreening}
+        onFile={onObservedSoundingFile}
+        onTimeChange={onObservedSoundingTimeChange}
+      />
+      <ObservedRunRecipePanel
+        runRecipe={observedRunRecipe}
+        controls={controls}
+        selectedCandidateScreening={selectedCandidateScreening}
+        onChange={onObservedRunRecipeChange}
+      />
+      <RunConfigurationPanel
+        configuration={runConfiguration}
+        preview={runConfigurationPreview}
+        triggeredDeepPotential={selectedTriggeredDeepPotential}
+        onChange={onRunConfigurationChange}
+      />
+      <section className="experiment-summary">
+        <div className="panel-heading-row">
+          <div>
+            <p className="eyebrow">Run plan</p>
+            <h3>Add uploaded sounding</h3>
+            <p className="field-help">
+              This creates a planned run from the validated upload. You can edit or duplicate it in
+              the run plan before queueing.
+            </p>
+          </div>
+          <StatusBadge label={canAdd ? "Ready" : "Needs upload"} tone={canAdd ? "good" : "warning"} />
+        </div>
+        <button type="button" disabled={!canAdd} onClick={onAddUploadedSoundingToRunPlan}>
+          Add uploaded sounding to run plan
+        </button>
+      </section>
+    </section>
   );
 }
 
@@ -4984,6 +5741,306 @@ function ObservedRunRecipePanel({
   );
 }
 
+function RunPlanPanel({
+  items,
+  batchStatus,
+  lanWorkerConfigured,
+  onSelectedChange,
+  onQueueTargetChange,
+  onRecipeChange,
+  onConfigurationChange,
+  onDuplicate,
+  onRemove,
+  onClearSelected,
+  onClearAll,
+  onCreateAndQueue,
+}: {
+  items: RunPlanItem[];
+  batchStatus: string | null;
+  lanWorkerConfigured: boolean;
+  onSelectedChange: (itemId: string, selected: boolean) => void;
+  onQueueTargetChange: (itemId: string, target: RunPlanQueueTarget) => void;
+  onRecipeChange: (itemId: string, runRecipe: ObservedRunRecipe) => void;
+  onConfigurationChange: (itemId: string, configuration: RunConfigurationInput) => void;
+  onDuplicate: (itemId: string) => void;
+  onRemove: (itemId: string) => void;
+  onClearSelected: () => void;
+  onClearAll: () => void;
+  onCreateAndQueue: () => void;
+}) {
+  const selectedCount = items.filter((item) => item.selected).length;
+  const queuedCount = items.filter(
+    (item) => item.status === "queued" || item.status === "lan_started",
+  ).length;
+  const failedCount = items.filter(
+    (item) => item.status === "package_failed" || item.status === "skipped",
+  ).length;
+  return (
+    <section className="experiment-summary run-plan-panel" aria-label="Run plan">
+      <div className="panel-heading-row">
+        <div>
+          <p className="eyebrow">Run plan</p>
+          <h3>Plan multiple CM1 runs</h3>
+          <p className="field-help">
+            Add candidate atmospheres, duplicate variants, edit recipe and run configuration, then
+            queue selected items as a batch.
+          </p>
+        </div>
+        <StatusBadge
+          label={`${items.length.toLocaleString()} planned · ${selectedCount.toLocaleString()} selected`}
+          tone={items.length > 0 ? "good" : "warning"}
+        />
+      </div>
+
+      {items.length === 0 ? (
+        <div className="scenario-state-panel">
+          <h4>No planned runs yet</h4>
+          <p>Add a cached recommendation, saved candidate, or uploaded sounding to build a batch.</p>
+        </div>
+      ) : (
+        <>
+          <dl className="compact-metrics">
+            <Metric label="Selected for queue" value={selectedCount.toLocaleString()} />
+            <Metric label="Queued / launched" value={queuedCount.toLocaleString()} />
+            <Metric label="Needs attention" value={failedCount.toLocaleString()} />
+          </dl>
+          <div className="run-plan-list">
+            {items.map((item, index) => (
+              <RunPlanItemCard
+                key={item.id}
+                item={item}
+                index={index}
+                lanWorkerConfigured={lanWorkerConfigured}
+                onSelectedChange={onSelectedChange}
+                onQueueTargetChange={onQueueTargetChange}
+                onRecipeChange={onRecipeChange}
+                onConfigurationChange={onConfigurationChange}
+                onDuplicate={onDuplicate}
+                onRemove={onRemove}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      {batchStatus && <p className="inline-status">{batchStatus}</p>}
+
+      <div className="button-row">
+        <button type="button" disabled={selectedCount === 0} onClick={onCreateAndQueue}>
+          Create packages and queue selected runs
+        </button>
+        <button
+          type="button"
+          className="secondary-button"
+          disabled={selectedCount === 0}
+          onClick={onClearSelected}
+        >
+          Clear selected
+        </button>
+        <button
+          type="button"
+          className="secondary-button"
+          disabled={items.length === 0}
+          onClick={onClearAll}
+        >
+          Clear all
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function RunPlanItemCard({
+  item,
+  index,
+  lanWorkerConfigured,
+  onSelectedChange,
+  onQueueTargetChange,
+  onRecipeChange,
+  onConfigurationChange,
+  onDuplicate,
+  onRemove,
+}: {
+  item: RunPlanItem;
+  index: number;
+  lanWorkerConfigured: boolean;
+  onSelectedChange: (itemId: string, selected: boolean) => void;
+  onQueueTargetChange: (itemId: string, target: RunPlanQueueTarget) => void;
+  onRecipeChange: (itemId: string, runRecipe: ObservedRunRecipe) => void;
+  onConfigurationChange: (itemId: string, configuration: RunConfigurationInput) => void;
+  onDuplicate: (itemId: string) => void;
+  onRemove: (itemId: string) => void;
+}) {
+  const metadata = runPlanRecipeMetadata(item);
+  const activeStory = item.activeStory ?? observedRecipeStoryId(item.candidateScreening);
+  const preview = previewRunConfiguration(item.runConfiguration, item.runRecipe);
+  const sourceLabel =
+    item.candidate !== null
+      ? `${candidateStationLabel(item.candidate)} · ${formatDate(item.candidate.valid_time_utc)}`
+      : item.observedSounding
+        ? `${item.observedSounding.station_name ?? item.observedSounding.station_id} · ${formatDate(item.observedSounding.valid_time_utc)}`
+        : "Observed sounding";
+  return (
+    <article className="run-plan-card" aria-label={`Run plan item ${index + 1}`}>
+      <div className="panel-heading-row">
+        <label className="run-plan-select">
+          <input
+            type="checkbox"
+            checked={item.selected}
+            onChange={(event) => onSelectedChange(item.id, event.target.checked)}
+          />
+          <span>
+            <strong>{sourceLabel}</strong>
+            <small>{activeStory ? candidateStoryLabel(activeStory) : "Uploaded observed sounding"}</small>
+          </span>
+        </label>
+        <StatusBadge label={runPlanStatusLabel(item.status)} tone={runPlanStatusTone(item.status)} />
+      </div>
+
+      {item.message && <p className="state-note">{item.message}</p>}
+      {item.blockedPreRunValidationReport && (
+        <PreRunValidationReportPanel report={item.blockedPreRunValidationReport} />
+      )}
+
+      <section className="run-plan-config-primary" aria-label={`Run configuration for item ${index + 1}`}>
+        <div className="run-plan-config-heading">
+          <div>
+            <p className="eyebrow">Run configuration</p>
+            <h4>Choose what CM1 will run</h4>
+          </div>
+          <span>{runConfigurationTimingSummary(preview)}</span>
+        </div>
+        <div className="run-configuration-grid run-plan-configuration-grid">
+          <RunConfigurationSelect
+            id={`run-plan-recipe-${item.id}`}
+            label="Recipe"
+            description="Choose the CM1 assumption set for this run-plan item."
+            value={item.runRecipe}
+            options={[
+              { value: "untriggered_observed_evolution", label: "Untriggered observed-sounding evolution v0" },
+              { value: "triggered_deep_potential", label: "Triggered deep-potential experiment" },
+            ]}
+            onChange={(value) => onRecipeChange(item.id, value as ObservedRunRecipe)}
+          />
+          <RunConfigurationSelect
+            id={`run-plan-target-${item.id}`}
+            label="Queue target"
+            description="Choose where this package should run after creation."
+            value={item.queueTarget}
+            options={[
+              { value: "local", label: "Local serial queue" },
+              { value: "lan", label: lanWorkerConfigured ? "LAN worker" : "LAN worker unavailable" },
+            ]}
+            onChange={(value) => onQueueTargetChange(item.id, value as RunPlanQueueTarget)}
+          />
+          <RunPlanConfigurationFields
+            item={item}
+            preview={preview}
+            onConfigurationChange={onConfigurationChange}
+          />
+        </div>
+      </section>
+
+      <details className="technical-details run-plan-recipe-details">
+        <summary>Recipe assumptions, outputs, and caveats</summary>
+        <dl className="compact-metrics run-plan-metadata-grid">
+          <Metric label="Recipe ID" value={metadata.recipeId} />
+          <Metric label="Assumption set" value={metadata.assumptionSetId} />
+          <Metric label="Assumption mode" value={metadata.assumptionMode} />
+          <Metric label="Assumptions" value={metadata.assumptionsSummary} />
+          <Metric
+            label="Required outputs"
+            value={compactList(metadata.requiredOutputFields, "Not declared")}
+          />
+          <Metric
+            label="Missing outputs"
+            value={compactList(metadata.missingRequiredOutputFields, "None declared")}
+          />
+        </dl>
+        {metadata.recipeCaveats.length > 0 && (
+          <ul className="compact-list">
+            {metadata.recipeCaveats.map((caveat) => (
+              <li key={caveat}>{humanize(caveat)}</li>
+            ))}
+          </ul>
+        )}
+      </details>
+
+      <div className="button-row">
+        <button type="button" className="secondary-button" onClick={() => onDuplicate(item.id)}>
+          Duplicate variant
+        </button>
+        <button type="button" className="secondary-button" onClick={() => onRemove(item.id)}>
+          Remove
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function RunPlanConfigurationFields({
+  item,
+  preview,
+  onConfigurationChange,
+}: {
+  item: RunPlanItem;
+  preview: RunConfiguration;
+  onConfigurationChange: (itemId: string, configuration: RunConfigurationInput) => void;
+}) {
+  const triggeredDeepPotential = item.runRecipe === "triggered_deep_potential";
+  const domainOptions = triggeredDeepPotential ? DEEP_DOMAIN_OPTIONS : SHALLOW_DOMAIN_OPTIONS;
+  const update = (key: keyof RunConfigurationInput, value: string) => {
+    onConfigurationChange(item.id, { ...item.runConfiguration, [key]: value });
+  };
+  return (
+    <>
+      <RunConfigurationSelect
+        id={`run-plan-duration-${item.id}`}
+        label="Duration"
+        description="Model-time length for this variant."
+        value={item.runConfiguration.duration}
+        options={DURATION_OPTIONS}
+        onChange={(value) => update("duration", value)}
+      />
+      <RunConfigurationSelect
+        id={`run-plan-grid-${item.id}`}
+        label="Horizontal cells"
+        description="Cell count controls dx/dy and compute complexity."
+        value={item.runConfiguration.horizontal_cell_count}
+        options={HORIZONTAL_CELL_OPTIONS}
+        onChange={(value) => update("horizontal_cell_count", value)}
+      />
+      <RunConfigurationSelect
+        id={`run-plan-domain-${item.id}`}
+        label="Domain size"
+        description="Domain width and model top for this recipe."
+        value={item.runConfiguration.domain_size}
+        options={domainOptions}
+        onChange={(value) => update("domain_size", value)}
+      />
+      <RunConfigurationSelect
+        id={`run-plan-cadence-${item.id}`}
+        label="Output cadence"
+        description="Saved output interval for Results and Explore."
+        value={item.runConfiguration.output_cadence}
+        options={OUTPUT_CADENCE_OPTIONS}
+        onChange={(value) => update("output_cadence", value)}
+      />
+      <RunConfigurationSelect
+        id={`run-plan-fields-${item.id}`}
+        label="Diagnostic set"
+        description="Requested output field density."
+        value={item.runConfiguration.diagnostic_set}
+        options={DIAGNOSTIC_SET_OPTIONS}
+        onChange={(value) => update("diagnostic_set", value)}
+      />
+      <p className="field-help run-plan-config-summary">
+        {runConfigurationGridSummary(preview)} · {preview.output_volume_summary}
+      </p>
+    </>
+  );
+}
+
 function ResultsWorkspace({
   results,
   selectedResult,
@@ -5178,6 +6235,71 @@ function ExploreResultSummary({ result }: { result: ResultCard }) {
   );
 }
 
+type LocalRunWorkflowPanelProps = {
+  dryRun: DryRunResponse | null;
+  runStatus: RunStatusResponse | null;
+  runQueue: RunQueueResponse | null;
+  runQueueStatus: string;
+  error: string | null;
+  lanWorkerConfig: LanWorkerConfigResponse | null;
+  lanWorkerStatus: LanWorkerRunResponse | null;
+  lanWorkerError: string | null;
+  lanWorkerActionStatus: string | null;
+  ingestedResultId: string | null;
+  storageInventory: StorageInventoryResponse | null;
+  storageStatus: string;
+  storageError: string | null;
+  runDeletePreview: DeleteRunResponse | null;
+  runDeleteMessage: string | null;
+  results: ResultCard[];
+  autoFinalizingWorkerRunIds: Set<string>;
+  failedAutoFinalizingWorkerRunIds: Set<string>;
+  onRefreshRunStatus: () => void;
+  onLaunchLanWorkerRun: () => void;
+  onRefreshLanWorkerStatus: () => void;
+  onCollectLanWorkerRun: () => void;
+  onCleanupLanWorkerRun: () => void;
+  onIngestRun: () => void;
+  onLaunchStoredRun: (manifestPath: string) => void;
+  onLaunchStoredLanWorkerRun: (manifestPath: string) => void;
+  onRefreshStoredLanWorkerStatus: (manifestPath: string) => void;
+  onFinalizeStoredLanWorkerRun: (manifestPath: string) => void;
+  onIngestStoredRun: (manifestPath: string) => void;
+  onOpenInResults: () => void;
+  onInspectIngested: () => void;
+  onOpenStoredResult: (resultId: string) => void;
+  onExploreStoredResult: (resultId: string) => void;
+  onRefreshStorage: () => void;
+  onPreviewRunDelete: (runId: string) => void;
+  onConfirmRunDelete: (runId: string) => void;
+};
+
+function RunMonitorPanel(props: LocalRunWorkflowPanelProps) {
+  const activeCount =
+    (props.runQueue?.active_run_id ? 1 : 0) +
+    (props.lanWorkerStatus &&
+    ["submitted", "running", "copied_to_worker"].includes(props.lanWorkerStatus.state)
+      ? 1
+      : 0);
+  const queuedCount = props.runQueue?.queued_count ?? 0;
+  const completedCount =
+    props.storageInventory?.runs.filter((run) => run.lifecycle_state === "completed").length ?? 0;
+  return (
+    <details className="run-monitor-panel">
+      <summary>
+        <span>
+          <strong>Run monitor</strong>
+          <small>
+            {activeCount.toLocaleString()} active · {queuedCount.toLocaleString()} queued ·{" "}
+            {completedCount.toLocaleString()} completed
+          </small>
+        </span>
+      </summary>
+      <LocalRunWorkflowPanel {...props} />
+    </details>
+  );
+}
+
 function LocalRunWorkflowPanel({
   dryRun,
   runStatus,
@@ -5215,44 +6337,7 @@ function LocalRunWorkflowPanel({
   onRefreshStorage,
   onPreviewRunDelete,
   onConfirmRunDelete,
-}: {
-  dryRun: DryRunResponse | null;
-  runStatus: RunStatusResponse | null;
-  runQueue: RunQueueResponse | null;
-  runQueueStatus: string;
-  error: string | null;
-  lanWorkerConfig: LanWorkerConfigResponse | null;
-  lanWorkerStatus: LanWorkerRunResponse | null;
-  lanWorkerError: string | null;
-  lanWorkerActionStatus: string | null;
-  ingestedResultId: string | null;
-  storageInventory: StorageInventoryResponse | null;
-  storageStatus: string;
-  storageError: string | null;
-  runDeletePreview: DeleteRunResponse | null;
-  runDeleteMessage: string | null;
-  results: ResultCard[];
-  autoFinalizingWorkerRunIds: Set<string>;
-  failedAutoFinalizingWorkerRunIds: Set<string>;
-  onRefreshRunStatus: () => void;
-  onLaunchLanWorkerRun: () => void;
-  onRefreshLanWorkerStatus: () => void;
-  onCollectLanWorkerRun: () => void;
-  onCleanupLanWorkerRun: () => void;
-  onIngestRun: () => void;
-  onLaunchStoredRun: (manifestPath: string) => void;
-  onLaunchStoredLanWorkerRun: (manifestPath: string) => void;
-  onRefreshStoredLanWorkerStatus: (manifestPath: string) => void;
-  onFinalizeStoredLanWorkerRun: (manifestPath: string) => void;
-  onIngestStoredRun: (manifestPath: string) => void;
-  onOpenInResults: () => void;
-  onInspectIngested: () => void;
-  onOpenStoredResult: (resultId: string) => void;
-  onExploreStoredResult: (resultId: string) => void;
-  onRefreshStorage: () => void;
-  onPreviewRunDelete: (runId: string) => void;
-  onConfirmRunDelete: (runId: string) => void;
-}) {
+}: LocalRunWorkflowPanelProps) {
   const stage = buildRunStage(dryRun, runStatus, ingestedResultId, lanWorkerStatus);
   const canIngestLocal =
     runStatus?.lifecycle_state === "completed" &&
@@ -9581,6 +10666,239 @@ function runUserMetadataFromCandidateScreening(
       : null;
   if (tags.length === 0 && !notes) return null;
   return { tags, notes };
+}
+
+function createRunPlanItemId(): string {
+  const random =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `run-plan-${random}`;
+}
+
+function runPlanItemFromCandidate(
+  candidate: SoundingCandidate,
+  savedCandidate: SavedSoundingCandidate | undefined,
+  activeStory: CandidateStoryId | undefined,
+  controls: Record<string, string | number | boolean>,
+): RunPlanItem | null {
+  if (!candidate.package_ready || !candidate.selected_sounding_payload) return null;
+  const runRecipe = defaultRunRecipeForCandidate(candidate, activeStory);
+  return {
+    id: createRunPlanItemId(),
+    selected: true,
+    source: savedCandidate ? "saved_candidates" : "cached_recommendations",
+    candidate,
+    savedCandidate: savedCandidate ?? null,
+    observedSounding: candidate.selected_sounding_payload,
+    candidateScreening: candidateScreeningMetadata(candidate, savedCandidate, activeStory),
+    activeStory: activeStory ?? candidate.primary_story,
+    runRecipe,
+    runConfiguration: defaultRunConfigurationForSelection(
+      OBSERVED_SOUNDING_EXPERIMENT_ID,
+      runRecipe,
+    ),
+    controls,
+    queueTarget: "local",
+    status: "planned",
+    message: null,
+    dryRun: null,
+    blockedPreRunValidationReport: null,
+  };
+}
+
+function runPlanItemFromUploadedSounding({
+  observedSounding,
+  observedRunRecipe,
+  runConfiguration,
+  controls,
+  selectedCandidateScreening,
+}: {
+  observedSounding: ObservedSoundingRecord;
+  observedRunRecipe: ObservedRunRecipe;
+  runConfiguration: RunConfigurationInput;
+  controls: Record<string, string | number | boolean>;
+  selectedCandidateScreening: Record<string, unknown> | null;
+}): RunPlanItem {
+  return {
+    id: createRunPlanItemId(),
+    selected: true,
+    source: "upload_igra_text",
+    candidate: null,
+    savedCandidate: null,
+    observedSounding,
+    candidateScreening: selectedCandidateScreening,
+    activeStory: observedRecipeStoryId(selectedCandidateScreening),
+    runRecipe: observedRunRecipe,
+    runConfiguration,
+    controls,
+    queueTarget: "local",
+    status: "planned",
+    message: null,
+    dryRun: null,
+    blockedPreRunValidationReport: null,
+  };
+}
+
+function searchIntentFilters(intent: SearchIntent): {
+  story: CandidateStoryFilter;
+  storyFamily: CandidateStoryFamilyFilter;
+  support: CandidateSupportFilter;
+} {
+  switch (intent) {
+    case "deep_convection":
+      return {
+        story: "deep_convection_trial",
+        storyFamily: "deep_convection",
+        support: "supported",
+      };
+    case "humid_rainy":
+      return { story: "humid_rainy_candidate", storyFamily: "all", support: "all" };
+    case "dry_microburst":
+      return { story: "dry_microburst_inverted_v", storyFamily: "all", support: "all" };
+    case "shallow_boundary_layer":
+      return { story: "shallow_cumulus_candidate", storyFamily: "lower_atmosphere", support: "all" };
+    case "best_overall":
+      return { story: "all", storyFamily: "all", support: "all" };
+  }
+}
+
+function batchQueueSummary({
+  queued,
+  lanStarted,
+  failed,
+  skipped,
+}: {
+  queued: number;
+  lanStarted: number;
+  failed: number;
+  skipped: number;
+}): string {
+  const parts = [
+    queued > 0 ? `${queued.toLocaleString()} queued locally` : null,
+    lanStarted > 0 ? `${lanStarted.toLocaleString()} sent to LAN worker` : null,
+    failed > 0 ? `${failed.toLocaleString()} package failed validation or queueing` : null,
+    skipped > 0 ? `${skipped.toLocaleString()} skipped` : null,
+  ].filter((part): part is string => part !== null);
+  return parts.length > 0 ? parts.join(" · ") : "No run-plan items were queued.";
+}
+
+function runPlanStatusLabel(status: RunPlanItemStatus): string {
+  switch (status) {
+    case "planned":
+      return "Planned";
+    case "packaging":
+      return "Creating package";
+    case "queued":
+      return "Queued";
+    case "lan_started":
+      return "LAN worker started";
+    case "package_failed":
+      return "Package failed";
+    case "skipped":
+      return "Skipped";
+  }
+}
+
+function runPlanStatusTone(status: RunPlanItemStatus): "good" | "warning" | "neutral" {
+  if (status === "queued" || status === "lan_started") return "good";
+  if (status === "package_failed" || status === "skipped") return "warning";
+  return "neutral";
+}
+
+function runPlanRecipeMetadata(item: RunPlanItem): {
+  recipeId: string;
+  recipeDisplayName: string;
+  assumptionSetId: string;
+  assumptionMode: string;
+  assumptionsSummary: string;
+  requiredOutputFields: string[];
+  missingRequiredOutputFields: string[];
+  recipeCaveats: string[];
+} {
+  const report = item.dryRun?.report;
+  const staticMetadata = staticRecipeMetadata(item.runRecipe);
+  return {
+    recipeId: report?.recipe_id ?? staticMetadata.recipeId,
+    recipeDisplayName: report?.recipe_display_name ?? staticMetadata.recipeDisplayName,
+    assumptionSetId: report?.assumption_set_id ?? staticMetadata.assumptionSetId,
+    assumptionMode: report?.assumption_mode ?? staticMetadata.assumptionMode,
+    assumptionsSummary: compactRecipeAssumptions(report?.recipe_assumptions, item.runRecipe),
+    requiredOutputFields: report?.required_output_fields ?? staticMetadata.requiredOutputFields,
+    missingRequiredOutputFields: report?.missing_required_output_fields ?? [],
+    recipeCaveats: report?.recipe_caveats ?? staticMetadata.recipeCaveats,
+  };
+}
+
+function staticRecipeMetadata(runRecipe: ObservedRunRecipe): {
+  recipeId: string;
+  recipeDisplayName: string;
+  assumptionSetId: string;
+  assumptionMode: string;
+  requiredOutputFields: string[];
+  recipeCaveats: string[];
+} {
+  if (runRecipe === "triggered_deep_potential") {
+    return {
+      recipeId: "triggered_deep_potential_v1",
+      recipeDisplayName: "Triggered Deep-Potential Experiment",
+      assumptionSetId: "triggered_deep_potential_warm_bubble_v1",
+      assumptionMode: "triggered_deep_potential",
+      requiredOutputFields: ["qc", "w", "qr", "rain", "dbz", "updraft_helicity"],
+      recipeCaveats: [
+        "The recipe tests triggered potential, not normal atmospheric evolution.",
+        "The warm-bubble trigger must be preserved in provenance and Results comparison.",
+      ],
+    };
+  }
+  return {
+    recipeId: "untriggered_observed_sounding_evolution_v0",
+    recipeDisplayName: "Untriggered Observed-Sounding Evolution v0",
+    assumptionSetId: "untriggered_observed_sounding_evolution_v0_assumptions",
+    assumptionMode: "normal_evolution",
+    requiredOutputFields: ["qv", "qc", "w", "qr", "rain", "dbz"],
+    recipeCaveats: [
+      "No warm-bubble or artificial deep-convection trigger is applied.",
+      "Surface fluxes use current recipe defaults; they are not validated place/time surface-energy inputs.",
+      "Radiation, terrain, GIS surface initialization, and large-scale forcing are not part of v0.",
+    ],
+  };
+}
+
+function compactRecipeAssumptions(
+  assumptions: Record<string, unknown> | undefined,
+  runRecipe: ObservedRunRecipe,
+): string {
+  if (runRecipe === "triggered_deep_potential") {
+    return "Warm-bubble trigger · triggered potential, not normal evolution";
+  }
+  const trigger = assumptions?.trigger;
+  const surfaceFluxes = assumptions?.surface_fluxes;
+  const radiation = assumptions?.radiation;
+  const largeScaleForcing = assumptions?.large_scale_forcing;
+  const triggerLabel =
+    trigger && typeof trigger === "object" && "mode" in trigger && trigger.mode === "none"
+      ? "No warm-bubble trigger"
+      : "No warm-bubble trigger";
+  const fluxLabel =
+    surfaceFluxes &&
+    typeof surfaceFluxes === "object" &&
+    "mode" in surfaceFluxes &&
+    surfaceFluxes.mode === "current_recipe_default"
+      ? "current surface-flux defaults"
+      : "current surface-flux defaults";
+  const radiationLabel =
+    radiation && typeof radiation === "object" && "mode" in radiation && radiation.mode === "disabled"
+      ? "radiation disabled"
+      : "radiation disabled";
+  const forcingLabel =
+    largeScaleForcing &&
+    typeof largeScaleForcing === "object" &&
+    "mode" in largeScaleForcing &&
+    largeScaleForcing.mode === "none"
+      ? "no large-scale forcing"
+      : "no large-scale forcing";
+  return `${triggerLabel} · ${fluxLabel} · ${radiationLabel} · ${forcingLabel}`;
 }
 
 function preRunValidationStatusLabel(status: string): string {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -2312,7 +2312,9 @@ export function App() {
         fetchSavedSoundingCandidates(),
       ]);
       if (inputsPayload.inputs.length === 0) {
-        setCandidateStatus(`Caching up to ${cacheLimit} local station file${cacheLimit === 1 ? "" : "s"}`);
+        setCandidateStatus(
+          `Caching up to ${cacheLimit} local station file${cacheLimit === 1 ? "" : "s"}`,
+        );
         await cacheIGRARecentBatch(cacheLimit);
         [catalogPayload, cachePayload, inputsPayload, savedPayload] = await Promise.all([
           fetchIGRARecentCatalog(),
@@ -2523,40 +2525,41 @@ export function App() {
     setLanWorkerError(null);
     setLanWorkerActionStatus(null);
     setIngestedResultId(null);
-    setCandidateStatus("Candidate ready in run plan");
+    setCandidateStatus("Candidate selected for run setup");
   }
 
-  function handleAddCandidateToRunPlan(
+  function handleSelectCandidateForRunSetup(
     candidate: SoundingCandidate,
     savedCandidate?: SavedSoundingCandidate,
     activeStory?: CandidateStoryId,
   ) {
-    const item = runPlanItemFromCandidate(candidate, savedCandidate, activeStory, controls);
-    if (!item) {
+    if (!candidate.package_ready || !candidate.selected_sounding_payload) {
       setCandidateError(
-        "This candidate is not package-ready. Review its caveats before adding another sounding.",
+        "This candidate is not package-ready. Review its caveats before selecting it for setup.",
       );
       return;
     }
     handleUseSoundingCandidate(candidate, savedCandidate, activeStory);
-    setRunPlanItems((current) => [...current, item]);
-    setBatchQueueStatus(`${candidateStationLabel(candidate)} added to the run plan`);
+    setBatchQueueStatus(`${candidateStationLabel(candidate)} selected for run setup`);
   }
 
-  function handleAddUploadedSoundingToRunPlan() {
+  function handleAddSelectedSoundingToRunPlan() {
     if (!observedSoundingParse?.selected_sounding) {
       setObservedSoundingError("Upload and validate an IGRA sounding before adding it.");
       return;
     }
     const item = runPlanItemFromUploadedSounding({
       observedSounding: observedSoundingParse.selected_sounding,
+      source: runPlanSourceFromCandidateScreening(selectedCandidateScreening),
       observedRunRecipe,
       runConfiguration,
       controls,
       selectedCandidateScreening,
     });
     setRunPlanItems((current) => [...current, item]);
-    setBatchQueueStatus("Uploaded sounding added to the run plan");
+    const selected = observedSoundingParse.selected_sounding;
+    const label = selectedObservedSoundingStationLabel(selected, selectedCandidateScreening);
+    setBatchQueueStatus(`${label} added to the run plan`);
   }
 
   function handleDuplicateRunPlanItem(itemId: string) {
@@ -2645,7 +2648,9 @@ export function App() {
       setBatchQueueStatus("Select at least one run-plan item before queueing.");
       return;
     }
-    setBatchQueueStatus(`Creating and queueing ${selectedItems.length} selected run${selectedItems.length === 1 ? "" : "s"}`);
+    setBatchQueueStatus(
+      `Creating and queueing ${selectedItems.length} selected run${selectedItems.length === 1 ? "" : "s"}`,
+    );
     setRunWorkflowError(null);
     let queued = 0;
     let lanStarted = 0;
@@ -2796,6 +2801,12 @@ export function App() {
     setObservedSoundingParse(null);
     setSelectedCandidateScreening(null);
     setObservedRunRecipe("untriggered_observed_evolution");
+    setRunConfiguration(
+      defaultRunConfigurationForSelection(
+        OBSERVED_SOUNDING_EXPERIMENT_ID,
+        "untriggered_observed_evolution",
+      ),
+    );
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
     setRunStatus(null);
@@ -2808,6 +2819,12 @@ export function App() {
       setObservedSoundingParse(parsed);
       setSelectedCandidateScreening(null);
       setObservedRunRecipe("untriggered_observed_evolution");
+      setRunConfiguration(
+        defaultRunConfigurationForSelection(
+          OBSERVED_SOUNDING_EXPERIMENT_ID,
+          "untriggered_observed_evolution",
+        ),
+      );
       setObservedSoundingStatus("Observed sounding validated for package review");
     } catch (caught) {
       setObservedSoundingText(null);
@@ -2834,6 +2851,12 @@ export function App() {
       setObservedSoundingParse(parsed);
       setSelectedCandidateScreening(null);
       setObservedRunRecipe("untriggered_observed_evolution");
+      setRunConfiguration(
+        defaultRunConfigurationForSelection(
+          OBSERVED_SOUNDING_EXPERIMENT_ID,
+          "untriggered_observed_evolution",
+        ),
+      );
       setObservedSoundingStatus("Observed sounding validated for package review");
     } catch (caught) {
       setObservedSoundingError(
@@ -3365,8 +3388,8 @@ export function App() {
           onScreenSoundingCandidates={handleScreenSoundingCandidates}
           onSaveSoundingCandidate={handleSaveSoundingCandidate}
           onRemoveSavedSoundingCandidate={handleRemoveSavedSoundingCandidate}
-          onAddCandidateToRunPlan={handleAddCandidateToRunPlan}
-          onAddUploadedSoundingToRunPlan={handleAddUploadedSoundingToRunPlan}
+          onSelectCandidateForRunSetup={handleSelectCandidateForRunSetup}
+          onAddSelectedSoundingToRunPlan={handleAddSelectedSoundingToRunPlan}
           onDuplicateRunPlanItem={handleDuplicateRunPlanItem}
           onRemoveRunPlanItem={handleRemoveRunPlanItem}
           onClearSelectedRunPlanItems={handleClearSelectedRunPlanItems}
@@ -3529,8 +3552,8 @@ function BuildWorkspace({
   onScreenSoundingCandidates,
   onSaveSoundingCandidate,
   onRemoveSavedSoundingCandidate,
-  onAddCandidateToRunPlan,
-  onAddUploadedSoundingToRunPlan,
+  onSelectCandidateForRunSetup,
+  onAddSelectedSoundingToRunPlan,
   onDuplicateRunPlanItem,
   onRemoveRunPlanItem,
   onClearSelectedRunPlanItems,
@@ -3646,12 +3669,12 @@ function BuildWorkspace({
   onScreenSoundingCandidates: () => void;
   onSaveSoundingCandidate: (candidate: SoundingCandidate) => void;
   onRemoveSavedSoundingCandidate: (savedCandidateId: string) => void;
-  onAddCandidateToRunPlan: (
+  onSelectCandidateForRunSetup: (
     candidate: SoundingCandidate,
     savedCandidate?: SavedSoundingCandidate,
     activeStory?: CandidateStoryId,
   ) => void;
-  onAddUploadedSoundingToRunPlan: () => void;
+  onAddSelectedSoundingToRunPlan: () => void;
   onDuplicateRunPlanItem: (itemId: string) => void;
   onRemoveRunPlanItem: (itemId: string) => void;
   onClearSelectedRunPlanItems: () => void;
@@ -3808,9 +3831,7 @@ function BuildWorkspace({
                       />
                       <Metric
                         label="What changes"
-                        value={selectedScenario.controls
-                          .map((control) => control.label)
-                          .join(", ")}
+                        value={selectedScenario.controls.map((control) => control.label).join(", ")}
                       />
                       <Metric
                         label="What stays controlled"
@@ -3840,8 +3861,6 @@ function BuildWorkspace({
                     savedCandidateCount={savedCandidates.length}
                     onChange={onAtmosphereSourcePathChange}
                   />
-
-                  {runPlanItems.length > 0 && runPlanPanel}
 
                   {atmosphereSourcePath === "cached_recommendations" && (
                     <ObservedAtmosphereCandidatesPanel
@@ -3884,7 +3903,7 @@ function BuildWorkspace({
                       onPrepareAndSearch={onPrepareAndSearchLocalSoundings}
                       onScreen={onScreenSoundingCandidates}
                       onSave={onSaveSoundingCandidate}
-                      onAddToRunPlan={onAddCandidateToRunPlan}
+                      onSelectForRunSetup={onSelectCandidateForRunSetup}
                     />
                   )}
 
@@ -3895,7 +3914,7 @@ function BuildWorkspace({
                       error={candidateError}
                       onSave={onSaveSoundingCandidate}
                       onRemoveSaved={onRemoveSavedSoundingCandidate}
-                      onAddToRunPlan={onAddCandidateToRunPlan}
+                      onSelectForRunSetup={onSelectCandidateForRunSetup}
                     />
                   )}
 
@@ -3905,20 +3924,27 @@ function BuildWorkspace({
                       observedSoundingStatus={observedSoundingStatus}
                       observedSoundingError={observedSoundingError}
                       selectedCandidateScreening={selectedCandidateScreening}
+                      onObservedSoundingFile={onObservedSoundingFile}
+                      onObservedSoundingTimeChange={onObservedSoundingTimeChange}
+                    />
+                  )}
+
+                  {observedSoundingParse?.selected_sounding && (
+                    <SelectedSoundingRunSetupPanel
+                      observedSounding={observedSoundingParse.selected_sounding}
+                      selectedCandidateScreening={selectedCandidateScreening}
                       observedRunRecipe={observedRunRecipe}
                       controls={controls}
                       runConfiguration={runConfiguration}
                       runConfigurationPreview={runConfigurationPreview}
                       selectedTriggeredDeepPotential={selectedTriggeredDeepPotential}
-                      onObservedSoundingFile={onObservedSoundingFile}
-                      onObservedSoundingTimeChange={onObservedSoundingTimeChange}
                       onObservedRunRecipeChange={onObservedRunRecipeChange}
                       onRunConfigurationChange={onRunConfigurationChange}
-                      onAddUploadedSoundingToRunPlan={onAddUploadedSoundingToRunPlan}
+                      onAddSelectedSoundingToRunPlan={onAddSelectedSoundingToRunPlan}
                     />
                   )}
 
-                  {runPlanItems.length === 0 && runPlanPanel}
+                  {runPlanPanel}
                 </>
               )}
 
@@ -4510,7 +4536,7 @@ function ObservedAtmosphereCandidatesPanel({
   onPrepareAndSearch,
   onScreen,
   onSave,
-  onAddToRunPlan,
+  onSelectForRunSetup,
 }: {
   catalog: IGRACatalogResponse["catalog"] | null;
   cache: IGRACacheResponse | null;
@@ -4551,7 +4577,7 @@ function ObservedAtmosphereCandidatesPanel({
   onPrepareAndSearch: () => void;
   onScreen: () => void;
   onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
-  onAddToRunPlan: (
+  onSelectForRunSetup: (
     candidate: SoundingCandidate,
     savedCandidate?: SavedSoundingCandidate,
     activeStory?: CandidateStoryId,
@@ -4630,7 +4656,10 @@ function ObservedAtmosphereCandidatesPanel({
         </p>
       </div>
 
-      <section className="candidate-search-controls" aria-label="Prepare and search local soundings">
+      <section
+        className="candidate-search-controls"
+        aria-label="Prepare and search local soundings"
+      >
         <div className="run-configuration-grid">
           <label>
             <strong>Source region</strong>
@@ -4668,7 +4697,9 @@ function ObservedAtmosphereCandidatesPanel({
                 </option>
               ))}
             </select>
-            <small>{SEARCH_DEPTH_OPTIONS.find((option) => option.value === searchDepth)?.description}</small>
+            <small>
+              {SEARCH_DEPTH_OPTIONS.find((option) => option.value === searchDepth)?.description}
+            </small>
           </label>
           <label>
             <strong>Time scope</strong>
@@ -4691,7 +4722,9 @@ function ObservedAtmosphereCandidatesPanel({
                 All cached (not supported yet)
               </option>
             </select>
-            <small>{TIME_SCOPE_OPTIONS.find((option) => option.value === timeScope)?.description}</small>
+            <small>
+              {TIME_SCOPE_OPTIONS.find((option) => option.value === timeScope)?.description}
+            </small>
           </label>
         </div>
         <div className="candidate-discovery-actions" aria-label="Sounding search action">
@@ -4707,7 +4740,11 @@ function ObservedAtmosphereCandidatesPanel({
           <Metric label="Region" value={catalog?.region.label ?? "Great Plains / Midwest"} />
           <Metric
             label="Station catalog"
-            value={catalog?.refreshed_at ? `Last refreshed ${formatDate(catalog.refreshed_at)}` : "Not refreshed here"}
+            value={
+              catalog?.refreshed_at
+                ? `Last refreshed ${formatDate(catalog.refreshed_at)}`
+                : "Not refreshed here"
+            }
           />
           <Metric label="Local station files" value={cachedCatalogFiles.toString()} />
           <Metric label="Parsed soundings" value={cachedInventorySummary} />
@@ -4940,8 +4977,8 @@ function ObservedAtmosphereCandidatesPanel({
                   saved={savedCandidateIds.has(candidate.candidate_id)}
                   onSelect={() => onCandidateDetailChange(candidate.candidate_id)}
                   onSave={() => onSave(candidate)}
-                  onAddToRunPlan={(activeStory) =>
-                    onAddToRunPlan(
+                  onSelectForRunSetup={(activeStory) =>
+                    onSelectForRunSetup(
                       candidate,
                       savedCandidates.find(
                         (saved) => saved.candidate.candidate_id === candidate.candidate_id,
@@ -4961,8 +4998,8 @@ function ObservedAtmosphereCandidatesPanel({
           storyFamilyFilter={storyFamilyFilter}
           savedCandidate={selectedSavedCandidate}
           onSave={onSave}
-          onAddToRunPlan={(candidate, activeStory) =>
-            onAddToRunPlan(candidate, selectedSavedCandidate ?? undefined, activeStory)
+          onSelectForRunSetup={(candidate, activeStory) =>
+            onSelectForRunSetup(candidate, selectedSavedCandidate ?? undefined, activeStory)
           }
         />
       </div>
@@ -4976,21 +5013,24 @@ function SavedCandidatesSourcePanel({
   error,
   onSave,
   onRemoveSaved,
-  onAddToRunPlan,
+  onSelectForRunSetup,
 }: {
   savedCandidates: SavedSoundingCandidate[];
   status: string;
   error: string | null;
   onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
   onRemoveSaved: (savedCandidateId: string) => void;
-  onAddToRunPlan: (
+  onSelectForRunSetup: (
     candidate: SoundingCandidate,
     savedCandidate?: SavedSoundingCandidate,
     activeStory?: CandidateStoryId,
   ) => void;
 }) {
   return (
-    <section className="experiment-summary saved-candidates-panel" aria-labelledby="saved-candidates-title">
+    <section
+      className="experiment-summary saved-candidates-panel"
+      aria-labelledby="saved-candidates-title"
+    >
       <div className="panel-heading-row">
         <div>
           <p className="eyebrow">Saved source</p>
@@ -5012,7 +5052,9 @@ function SavedCandidatesSourcePanel({
       {savedCandidates.length === 0 ? (
         <div className="scenario-state-panel">
           <h4>No saved candidates yet</h4>
-          <p>Switch to cached recommendations, select a candidate, and save it with tags or notes.</p>
+          <p>
+            Switch to cached recommendations, select a candidate, and save it with tags or notes.
+          </p>
         </div>
       ) : (
         <div className="saved-candidate-list">
@@ -5021,7 +5063,7 @@ function SavedCandidatesSourcePanel({
               key={saved.saved_candidate_id}
               saved={saved}
               onUpdateWorkingSet={(tags) => onSave(saved.candidate, tags, saved.notes ?? null)}
-              onUse={() => onAddToRunPlan(saved.candidate, saved, saved.primary_story)}
+              onUse={() => onSelectForRunSetup(saved.candidate, saved, saved.primary_story)}
               onRemove={() => onRemoveSaved(saved.saved_candidate_id)}
             />
           ))}
@@ -5098,7 +5140,7 @@ function SavedSoundingCandidateCard({
       </div>
       <div className="button-row">
         <button type="button" onClick={onUse}>
-          Add to run plan
+          Select for run setup
         </button>
         <button type="button" className="secondary-button" onClick={onRemove}>
           Remove saved
@@ -5116,7 +5158,7 @@ function SoundingCandidateCard({
   saved,
   onSelect,
   onSave,
-  onAddToRunPlan,
+  onSelectForRunSetup,
 }: {
   candidate: SoundingCandidate;
   storyFilter: CandidateStoryFilter;
@@ -5125,7 +5167,7 @@ function SoundingCandidateCard({
   saved: boolean;
   onSelect: () => void;
   onSave: () => void;
-  onAddToRunPlan: (activeStory: CandidateStoryId) => void;
+  onSelectForRunSetup: (activeStory: CandidateStoryId) => void;
 }) {
   const activeScore = candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter);
   const story = activeScore?.story ?? candidate.primary_story;
@@ -5184,9 +5226,9 @@ function SoundingCandidateCard({
         <button
           type="button"
           disabled={!candidate.package_ready}
-          onClick={() => onAddToRunPlan(story)}
+          onClick={() => onSelectForRunSetup(story)}
         >
-          Add to run plan
+          Select for run setup
         </button>
         <button type="button" className="secondary-button" disabled={saved} onClick={onSave}>
           {saved ? "Saved" : "Save candidate"}
@@ -5202,14 +5244,14 @@ function SoundingCandidateDetail({
   storyFamilyFilter,
   savedCandidate,
   onSave,
-  onAddToRunPlan,
+  onSelectForRunSetup,
 }: {
   candidate: SoundingCandidate | null;
   storyFilter: CandidateStoryFilter;
   storyFamilyFilter: CandidateStoryFamilyFilter;
   savedCandidate: SavedSoundingCandidate | null;
   onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
-  onAddToRunPlan: (candidate: SoundingCandidate, activeStory: CandidateStoryId) => void;
+  onSelectForRunSetup: (candidate: SoundingCandidate, activeStory: CandidateStoryId) => void;
 }) {
   const [tagDraft, setTagDraft] = useState("");
   const [notesDraft, setNotesDraft] = useState("");
@@ -5292,9 +5334,9 @@ function SoundingCandidateDetail({
         <button
           type="button"
           disabled={!candidate.package_ready}
-          onClick={() => onAddToRunPlan(candidate, story)}
+          onClick={() => onSelectForRunSetup(candidate, story)}
         >
-          Add to run plan
+          Select for run setup
         </button>
       </div>
       <section>
@@ -5411,33 +5453,16 @@ function UploadSoundingSourcePanel({
   observedSoundingStatus,
   observedSoundingError,
   selectedCandidateScreening,
-  observedRunRecipe,
-  controls,
-  runConfiguration,
-  runConfigurationPreview,
-  selectedTriggeredDeepPotential,
   onObservedSoundingFile,
   onObservedSoundingTimeChange,
-  onObservedRunRecipeChange,
-  onRunConfigurationChange,
-  onAddUploadedSoundingToRunPlan,
 }: {
   observedSoundingParse: ObservedSoundingParseResponse | null;
   observedSoundingStatus: string | null;
   observedSoundingError: string | null;
   selectedCandidateScreening: Record<string, unknown> | null;
-  observedRunRecipe: ObservedRunRecipe;
-  controls: Record<string, string | number | boolean>;
-  runConfiguration: RunConfigurationInput;
-  runConfigurationPreview: RunConfiguration;
-  selectedTriggeredDeepPotential: boolean;
   onObservedSoundingFile: (file: File) => void;
   onObservedSoundingTimeChange: (validTimeUtc: string) => void;
-  onObservedRunRecipeChange: (runRecipe: ObservedRunRecipe) => void;
-  onRunConfigurationChange: (configuration: RunConfigurationInput) => void;
-  onAddUploadedSoundingToRunPlan: () => void;
 }) {
-  const canAdd = Boolean(observedSoundingParse?.selected_sounding);
   return (
     <section className="upload-source-stack" aria-label="Upload IGRA station text source">
       <ObservedSoundingInputPanel
@@ -5448,32 +5473,99 @@ function UploadSoundingSourcePanel({
         onFile={onObservedSoundingFile}
         onTimeChange={onObservedSoundingTimeChange}
       />
+    </section>
+  );
+}
+
+function SelectedSoundingRunSetupPanel({
+  observedSounding,
+  selectedCandidateScreening,
+  observedRunRecipe,
+  controls,
+  runConfiguration,
+  runConfigurationPreview,
+  selectedTriggeredDeepPotential,
+  onObservedRunRecipeChange,
+  onRunConfigurationChange,
+  onAddSelectedSoundingToRunPlan,
+}: {
+  observedSounding: ObservedSoundingRecord;
+  selectedCandidateScreening: Record<string, unknown> | null;
+  observedRunRecipe: ObservedRunRecipe;
+  controls: Record<string, string | number | boolean>;
+  runConfiguration: RunConfigurationInput;
+  runConfigurationPreview: RunConfiguration;
+  selectedTriggeredDeepPotential: boolean;
+  onObservedRunRecipeChange: (runRecipe: ObservedRunRecipe) => void;
+  onRunConfigurationChange: (configuration: RunConfigurationInput) => void;
+  onAddSelectedSoundingToRunPlan: () => void;
+}) {
+  const source = runPlanSourceFromCandidateScreening(selectedCandidateScreening);
+  const sourceLabel =
+    source === "saved_candidates"
+      ? "Saved candidate"
+      : source === "cached_recommendations"
+        ? "Cached recommendation"
+        : "Uploaded IGRA station text";
+  const stationLabel = selectedObservedSoundingStationLabel(
+    observedSounding,
+    selectedCandidateScreening,
+  );
+  const activeStoryLabel = observedRecipeStoryLabel(selectedCandidateScreening);
+  return (
+    <section className="selected-sounding-setup" aria-label="Selected sounding run setup">
+      <section className="experiment-summary selected-sounding-summary">
+        <div className="panel-heading-row">
+          <div>
+            <p className="eyebrow">Selected sounding</p>
+            <h3>{stationLabel}</h3>
+            <p className="field-help">
+              Configure this sounding here, then add it to the run plan at the bottom.
+            </p>
+          </div>
+          <StatusBadge label="Ready to configure" tone="good" />
+        </div>
+        <dl className="compact-metrics">
+          <Metric label="Source" value={sourceLabel} />
+          <Metric label="Selected time" value={formatDate(observedSounding.valid_time_utc)} />
+          <Metric label="Screened hypothesis" value={activeStoryLabel} />
+          <Metric label="Usable levels" value={observedSounding.levels.length.toString()} />
+          <Metric label="Wind handling" value={humanize(observedSounding.wind_handling)} />
+          <Metric label="Validation" value={humanize(observedSounding.validation.status)} />
+        </dl>
+      </section>
+
       <ObservedRunRecipePanel
         runRecipe={observedRunRecipe}
         controls={controls}
         selectedCandidateScreening={selectedCandidateScreening}
         onChange={onObservedRunRecipeChange}
       />
+
       <RunConfigurationPanel
         configuration={runConfiguration}
         preview={runConfigurationPreview}
         triggeredDeepPotential={selectedTriggeredDeepPotential}
         onChange={onRunConfigurationChange}
       />
-      <section className="experiment-summary">
+
+      <section className="experiment-summary selected-sounding-add-panel">
         <div className="panel-heading-row">
           <div>
-            <p className="eyebrow">Run plan</p>
-            <h3>Add uploaded sounding</h3>
+            <p className="eyebrow">Add to run plan</p>
+            <h3>Stage this configured run</h3>
             <p className="field-help">
-              This creates a planned run from the validated upload. You can edit or duplicate it in
-              the run plan before queueing.
+              Adding creates an editable planned run. Queue target, recipe, and run configuration
+              can still be changed on the run-plan item.
             </p>
           </div>
-          <StatusBadge label={canAdd ? "Ready" : "Needs upload"} tone={canAdd ? "good" : "warning"} />
+          <StatusBadge
+            label={runConfigurationTimingSummary(runConfigurationPreview)}
+            tone="neutral"
+          />
         </div>
-        <button type="button" disabled={!canAdd} onClick={onAddUploadedSoundingToRunPlan}>
-          Add uploaded sounding to run plan
+        <button type="button" onClick={onAddSelectedSoundingToRunPlan}>
+          Add selected sounding to run plan
         </button>
       </section>
     </section>
@@ -5795,7 +5887,9 @@ function RunPlanPanel({
       {items.length === 0 ? (
         <div className="scenario-state-panel">
           <h4>No planned runs yet</h4>
-          <p>Add a cached recommendation, saved candidate, or uploaded sounding to build a batch.</p>
+          <p>
+            Add a cached recommendation, saved candidate, or uploaded sounding to build a batch.
+          </p>
         </div>
       ) : (
         <>
@@ -5878,7 +5972,7 @@ function RunPlanItemCard({
     item.candidate !== null
       ? `${candidateStationLabel(item.candidate)} · ${formatDate(item.candidate.valid_time_utc)}`
       : item.observedSounding
-        ? `${item.observedSounding.station_name ?? item.observedSounding.station_id} · ${formatDate(item.observedSounding.valid_time_utc)}`
+        ? `${selectedObservedSoundingStationLabel(item.observedSounding, item.candidateScreening)} · ${formatDate(item.observedSounding.valid_time_utc)}`
         : "Observed sounding";
   return (
     <article className="run-plan-card" aria-label={`Run plan item ${index + 1}`}>
@@ -5891,10 +5985,15 @@ function RunPlanItemCard({
           />
           <span>
             <strong>{sourceLabel}</strong>
-            <small>{activeStory ? candidateStoryLabel(activeStory) : "Uploaded observed sounding"}</small>
+            <small>
+              {activeStory ? candidateStoryLabel(activeStory) : "Uploaded observed sounding"}
+            </small>
           </span>
         </label>
-        <StatusBadge label={runPlanStatusLabel(item.status)} tone={runPlanStatusTone(item.status)} />
+        <StatusBadge
+          label={runPlanStatusLabel(item.status)}
+          tone={runPlanStatusTone(item.status)}
+        />
       </div>
 
       {item.message && <p className="state-note">{item.message}</p>}
@@ -5902,7 +6001,10 @@ function RunPlanItemCard({
         <PreRunValidationReportPanel report={item.blockedPreRunValidationReport} />
       )}
 
-      <section className="run-plan-config-primary" aria-label={`Run configuration for item ${index + 1}`}>
+      <section
+        className="run-plan-config-primary"
+        aria-label={`Run configuration for item ${index + 1}`}
+      >
         <div className="run-plan-config-heading">
           <div>
             <p className="eyebrow">Run configuration</p>
@@ -5917,7 +6019,10 @@ function RunPlanItemCard({
             description="Choose the CM1 assumption set for this run-plan item."
             value={item.runRecipe}
             options={[
-              { value: "untriggered_observed_evolution", label: "Untriggered observed-sounding evolution v0" },
+              {
+                value: "untriggered_observed_evolution",
+                label: "Untriggered observed-sounding evolution v0",
+              },
               { value: "triggered_deep_potential", label: "Triggered deep-potential experiment" },
             ]}
             onChange={(value) => onRecipeChange(item.id, value as ObservedRunRecipe)}
@@ -5929,7 +6034,10 @@ function RunPlanItemCard({
             value={item.queueTarget}
             options={[
               { value: "local", label: "Local serial queue" },
-              { value: "lan", label: lanWorkerConfigured ? "LAN worker" : "LAN worker unavailable" },
+              {
+                value: "lan",
+                label: lanWorkerConfigured ? "LAN worker" : "LAN worker unavailable",
+              },
             ]}
             onChange={(value) => onQueueTargetChange(item.id, value as RunPlanQueueTarget)}
           />
@@ -10628,6 +10736,9 @@ function candidateScreeningMetadata(
     : null;
   return {
     candidate_id: candidate.candidate_id,
+    station_id: candidate.station_id,
+    station_name: candidate.station_name ?? null,
+    valid_time_utc: candidate.valid_time_utc,
     saved_candidate_id: savedCandidate?.saved_candidate_id ?? null,
     screening_version: candidate.screening_version,
     primary_story: candidate.primary_story,
@@ -10676,45 +10787,16 @@ function createRunPlanItemId(): string {
   return `run-plan-${random}`;
 }
 
-function runPlanItemFromCandidate(
-  candidate: SoundingCandidate,
-  savedCandidate: SavedSoundingCandidate | undefined,
-  activeStory: CandidateStoryId | undefined,
-  controls: Record<string, string | number | boolean>,
-): RunPlanItem | null {
-  if (!candidate.package_ready || !candidate.selected_sounding_payload) return null;
-  const runRecipe = defaultRunRecipeForCandidate(candidate, activeStory);
-  return {
-    id: createRunPlanItemId(),
-    selected: true,
-    source: savedCandidate ? "saved_candidates" : "cached_recommendations",
-    candidate,
-    savedCandidate: savedCandidate ?? null,
-    observedSounding: candidate.selected_sounding_payload,
-    candidateScreening: candidateScreeningMetadata(candidate, savedCandidate, activeStory),
-    activeStory: activeStory ?? candidate.primary_story,
-    runRecipe,
-    runConfiguration: defaultRunConfigurationForSelection(
-      OBSERVED_SOUNDING_EXPERIMENT_ID,
-      runRecipe,
-    ),
-    controls,
-    queueTarget: "local",
-    status: "planned",
-    message: null,
-    dryRun: null,
-    blockedPreRunValidationReport: null,
-  };
-}
-
 function runPlanItemFromUploadedSounding({
   observedSounding,
+  source,
   observedRunRecipe,
   runConfiguration,
   controls,
   selectedCandidateScreening,
 }: {
   observedSounding: ObservedSoundingRecord;
+  source: AtmosphereSourcePath;
   observedRunRecipe: ObservedRunRecipe;
   runConfiguration: RunConfigurationInput;
   controls: Record<string, string | number | boolean>;
@@ -10723,7 +10805,7 @@ function runPlanItemFromUploadedSounding({
   return {
     id: createRunPlanItemId(),
     selected: true,
-    source: "upload_igra_text",
+    source,
     candidate: null,
     savedCandidate: null,
     observedSounding,
@@ -10738,6 +10820,43 @@ function runPlanItemFromUploadedSounding({
     dryRun: null,
     blockedPreRunValidationReport: null,
   };
+}
+
+function runPlanSourceFromCandidateScreening(
+  selectedCandidateScreening: Record<string, unknown> | null,
+): AtmosphereSourcePath {
+  if (selectedCandidateScreening) {
+    return selectedCandidateScreening.saved_candidate_id
+      ? "saved_candidates"
+      : "cached_recommendations";
+  }
+  return "upload_igra_text";
+}
+
+function candidateScreeningStationLabel(
+  candidateScreening: Record<string, unknown> | null,
+): string | null {
+  if (!candidateScreening) return null;
+  const stationId =
+    typeof candidateScreening.station_id === "string" ? candidateScreening.station_id : null;
+  const stationName =
+    typeof candidateScreening.station_name === "string" && candidateScreening.station_name
+      ? candidateScreening.station_name
+      : null;
+  if (stationName && stationId) return `${stationName} (${stationId})`;
+  return stationName ?? stationId;
+}
+
+function selectedObservedSoundingStationLabel(
+  observedSounding: ObservedSoundingRecord,
+  candidateScreening: Record<string, unknown> | null,
+): string {
+  return (
+    candidateScreeningStationLabel(candidateScreening) ??
+    (observedSounding.station_name
+      ? `${observedSounding.station_name} (${observedSounding.station_id})`
+      : observedSounding.station_id)
+  );
 }
 
 function searchIntentFilters(intent: SearchIntent): {
@@ -10757,7 +10876,11 @@ function searchIntentFilters(intent: SearchIntent): {
     case "dry_microburst":
       return { story: "dry_microburst_inverted_v", storyFamily: "all", support: "all" };
     case "shallow_boundary_layer":
-      return { story: "shallow_cumulus_candidate", storyFamily: "lower_atmosphere", support: "all" };
+      return {
+        story: "shallow_cumulus_candidate",
+        storyFamily: "lower_atmosphere",
+        support: "all",
+      };
     case "best_overall":
       return { story: "all", storyFamily: "all", support: "all" };
   }
@@ -10888,7 +11011,10 @@ function compactRecipeAssumptions(
       ? "current surface-flux defaults"
       : "current surface-flux defaults";
   const radiationLabel =
-    radiation && typeof radiation === "object" && "mode" in radiation && radiation.mode === "disabled"
+    radiation &&
+    typeof radiation === "object" &&
+    "mode" in radiation &&
+    radiation.mode === "disabled"
       ? "radiation disabled"
       : "radiation disabled";
   const forcingLabel =

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -4251,26 +4251,47 @@ function RunConfigurationPanel({
   configuration,
   preview,
   triggeredDeepPotential,
+  runRecipe,
+  controls,
+  selectedCandidateScreening,
   onChange,
+  onRunRecipeChange,
+  embedded = false,
 }: {
   configuration: RunConfigurationInput;
   preview: RunConfiguration;
   triggeredDeepPotential: boolean;
+  runRecipe?: ObservedRunRecipe;
+  controls?: Record<string, string | number | boolean>;
+  selectedCandidateScreening?: Record<string, unknown> | null;
   onChange: (configuration: RunConfigurationInput) => void;
+  onRunRecipeChange?: (runRecipe: ObservedRunRecipe) => void;
+  embedded?: boolean;
 }) {
-  const domainOptions = triggeredDeepPotential ? DEEP_DOMAIN_OPTIONS : SHALLOW_DOMAIN_OPTIONS;
+  const observedRecipeSelected = runRecipe !== undefined && onRunRecipeChange !== undefined;
+  const selectedDeep = runRecipe ? runRecipe === "triggered_deep_potential" : triggeredDeepPotential;
+  const domainOptions = selectedDeep ? DEEP_DOMAIN_OPTIONS : SHALLOW_DOMAIN_OPTIONS;
+  const recipeMismatchWarning =
+    runRecipe && selectedCandidateScreening
+      ? candidateRecipeMismatchWarning(selectedCandidateScreening, runRecipe)
+      : null;
+  const appliedForcing =
+    runRecipe && controls ? observedRecipeAppliedForcing(controls, selectedDeep) : null;
   const update = (key: keyof RunConfigurationInput, value: string) => {
     onChange({ ...configuration, [key]: value });
   };
   return (
-    <section className="experiment-summary" aria-labelledby="run-configuration-title">
+    <section
+      className={embedded ? "run-configuration-panel" : "experiment-summary run-configuration-panel"}
+      aria-labelledby="run-configuration-title"
+    >
       <div className="panel-heading-row">
         <div>
           <p className="eyebrow">Run configuration</p>
-          <h3 id="run-configuration-title">Choose what CM1 will actually run</h3>
+          <h3 id="run-configuration-title">Configure this CM1 run</h3>
           <p className="field-help">
-            Smoke checks package health. Science configurations are long enough to inspect
-            evolution; cost is controlled by horizontal cells, domain, cadence, and diagnostics.
+            Set the experiment recipe, duration, grid, domain, cadence, and diagnostics before
+            staging this sounding into the run plan.
           </p>
         </div>
         <StatusBadge
@@ -4280,6 +4301,25 @@ function RunConfigurationPanel({
       </div>
 
       <div className="run-configuration-grid">
+        {observedRecipeSelected && (
+          <RunConfigurationSelect
+            id="run-recipe"
+            label="Experiment recipe"
+            description="Initiation and comparison context for this observed sounding."
+            value={runRecipe}
+            options={[
+              {
+                value: "untriggered_observed_evolution",
+                label: "Observed evolution",
+              },
+              {
+                value: "triggered_deep_potential",
+                label: "Triggered deep potential",
+              },
+            ]}
+            onChange={(value) => onRunRecipeChange(value as ObservedRunRecipe)}
+          />
+        )}
         <RunConfigurationSelect
           id="run-duration"
           label="Duration"
@@ -4292,7 +4332,7 @@ function RunConfigurationPanel({
           id="run-grid"
           label="Horizontal cells"
           description={
-            triggeredDeepPotential
+            selectedDeep
               ? "Storm-scale cell budget. CM1 spacing is derived from domain width divided by cells."
               : "Observed-evolution cell budget. More cells reduce dx/dy and increase compute and output volume."
           }
@@ -4304,7 +4344,7 @@ function RunConfigurationPanel({
           id="run-domain"
           label="Domain size"
           description={
-            triggeredDeepPotential
+            selectedDeep
               ? "Storm-growth domain for triggered-potential experiments."
               : "Observed soundings default wider so winds do not make the setup misleading."
           }
@@ -4330,7 +4370,20 @@ function RunConfigurationPanel({
         />
       </div>
 
+      {recipeMismatchWarning && (
+        <div className="validation" role="alert">
+          {recipeMismatchWarning}
+        </div>
+      )}
+
       <dl className="compact-metrics">
+        {runRecipe && (
+          <Metric
+            label="Initiation"
+            value={selectedDeep ? "Idealized warm-bubble trigger" : "No added deep trigger"}
+          />
+        )}
+        {appliedForcing && <Metric label="Forcing" value={appliedForcing} />}
         <Metric label="Selected setup" value={preview.label} />
         <Metric label="Runtime / saved frames" value={runConfigurationTimingSummary(preview)} />
         <Metric label="Grid" value={runConfigurationGridSummary(preview)} />
@@ -4347,6 +4400,12 @@ function RunConfigurationPanel({
         <p className="field-help">
           This configuration may be better suited to larger compute. Cloud Chamber will still show
           the CM1-facing values before launch.
+        </p>
+      )}
+      {selectedDeep && (
+        <p className="field-help">
+          Triggered deep potential is not normal atmospheric evolution; it adds an idealized trigger
+          to inspect whether this profile can support deeper convection.
         </p>
       )}
 
@@ -5513,61 +5572,70 @@ function SelectedSoundingRunSetupPanel({
   );
   const activeStoryLabel = observedRecipeStoryLabel(selectedCandidateScreening);
   return (
-    <section className="selected-sounding-setup" aria-label="Selected sounding run setup">
-      <section className="experiment-summary selected-sounding-summary">
+    <section
+      className="experiment-summary selected-sounding-setup selected-run-builder"
+      aria-label="Selected sounding run setup"
+    >
+      <div className="selected-sounding-strip">
         <div className="panel-heading-row">
           <div>
             <p className="eyebrow">Selected sounding</p>
             <h3>{stationLabel}</h3>
-            <p className="field-help">
-              Configure this sounding here, then add it to the run plan at the bottom.
-            </p>
           </div>
           <StatusBadge label="Ready to configure" tone="good" />
         </div>
-        <dl className="compact-metrics">
-          <Metric label="Source" value={sourceLabel} />
-          <Metric label="Selected time" value={formatDate(observedSounding.valid_time_utc)} />
-          <Metric label="Screened hypothesis" value={activeStoryLabel} />
-          <Metric label="Usable levels" value={observedSounding.levels.length.toString()} />
-          <Metric label="Wind handling" value={humanize(observedSounding.wind_handling)} />
-          <Metric label="Validation" value={humanize(observedSounding.validation.status)} />
-        </dl>
-      </section>
-
-      <ObservedRunRecipePanel
-        runRecipe={observedRunRecipe}
-        controls={controls}
-        selectedCandidateScreening={selectedCandidateScreening}
-        onChange={onObservedRunRecipeChange}
-      />
+        <p className="selected-sounding-context">
+          {formatDate(observedSounding.valid_time_utc)} · {sourceLabel} · {activeStoryLabel} ·{" "}
+          {humanize(observedSounding.validation.status)}
+        </p>
+        <details className="technical-details selected-sounding-details">
+          <summary>Source, validation, and sounding details</summary>
+          <dl className="compact-metrics selected-sounding-metrics">
+            <Metric label="Source" value={sourceLabel} />
+            <Metric label="Selected time" value={formatDate(observedSounding.valid_time_utc)} />
+            <Metric label="Screened hypothesis" value={activeStoryLabel} />
+            <Metric label="Validation" value={humanize(observedSounding.validation.status)} />
+            <Metric label="Usable levels" value={observedSounding.levels.length.toString()} />
+            <Metric label="Wind handling" value={humanize(observedSounding.wind_handling)} />
+            <Metric
+              label="Model bottom"
+              value={formatNumber(observedSounding.model_bottom_elevation_m_msl, "m MSL")}
+            />
+          </dl>
+        </details>
+      </div>
 
       <RunConfigurationPanel
         configuration={runConfiguration}
         preview={runConfigurationPreview}
         triggeredDeepPotential={selectedTriggeredDeepPotential}
+        runRecipe={observedRunRecipe}
+        controls={controls}
+        selectedCandidateScreening={selectedCandidateScreening}
         onChange={onRunConfigurationChange}
+        onRunRecipeChange={onObservedRunRecipeChange}
+        embedded
       />
 
-      <section className="experiment-summary selected-sounding-add-panel">
+      <ObservedRunRecipePanel
+        runRecipe={observedRunRecipe}
+        selectedCandidateScreening={selectedCandidateScreening}
+      />
+
+      <div className="selected-sounding-add-panel">
         <div className="panel-heading-row">
           <div>
             <p className="eyebrow">Add to run plan</p>
-            <h3>Stage this configured run</h3>
+            <h3>Add to plan</h3>
             <p className="field-help">
-              Adding creates an editable planned run. Queue target, recipe, and run configuration
-              can still be changed on the run-plan item.
+              Stage this setup as an editable row below; duplicate it there to compare variants.
             </p>
           </div>
-          <StatusBadge
-            label={runConfigurationTimingSummary(runConfigurationPreview)}
-            tone="neutral"
-          />
         </div>
         <button type="button" onClick={onAddSelectedSoundingToRunPlan}>
-          Add selected sounding to run plan
+          Add to run plan
         </button>
-      </section>
+      </div>
     </section>
   );
 }
@@ -5665,51 +5733,54 @@ function ObservedSoundingInputPanel({
             </select>
           </div>
 
-          <dl className="compact-metrics">
-            <Metric label="Source" value={`${parsed.source_provider} · ${parsed.source_format}`} />
-            <Metric label="Uploaded file" value={parsed.uploaded_filename} />
-            <Metric
-              label="Station"
-              value={`${selected.station_id}${selected.station_name ? ` · ${selected.station_name}` : ""}`}
-            />
-            <Metric
-              label="Location"
-              value={
-                selected.station_latitude !== null &&
-                selected.station_latitude !== undefined &&
-                selected.station_longitude !== null &&
-                selected.station_longitude !== undefined
-                  ? `${formatNumber(selected.station_latitude, "deg")}, ${formatNumber(selected.station_longitude, "deg")}`
-                  : "Not available"
-              }
-            />
-            <Metric
-              label="Model bottom / vertical datum"
-              value={`CM1 z=0 is station surface at ${formatNumber(selected.model_bottom_elevation_m_msl, "m MSL")}`}
-            />
-            <Metric
-              label="Source heights"
-              value={`${humanize(selected.source_vertical_coordinate_type)} converted to height above station surface`}
-            />
-            <Metric
-              label="Converted model z range"
-              value={`${formatNumber(selected.levels[0]?.model_z_m ?? null, "m")} to ${formatNumber(selected.levels.at(-1)?.model_z_m ?? null, "m")}`}
-            />
-            <Metric label="Usable levels" value={selected.levels.length.toString()} />
-            <Metric label="Wind handling" value={humanize(selected.wind_handling)} />
-            <Metric label="Validation" value={humanize(selected.validation.status)} />
-          </dl>
+          <details className="technical-details source-review-details">
+            <summary>Uploaded-sounding review</summary>
+            <dl className="compact-metrics">
+              <Metric label="Source" value={`${parsed.source_provider} · ${parsed.source_format}`} />
+              <Metric label="Uploaded file" value={parsed.uploaded_filename} />
+              <Metric
+                label="Station"
+                value={`${selected.station_id}${selected.station_name ? ` · ${selected.station_name}` : ""}`}
+              />
+              <Metric
+                label="Location"
+                value={
+                  selected.station_latitude !== null &&
+                  selected.station_latitude !== undefined &&
+                  selected.station_longitude !== null &&
+                  selected.station_longitude !== undefined
+                    ? `${formatNumber(selected.station_latitude, "deg")}, ${formatNumber(selected.station_longitude, "deg")}`
+                    : "Not available"
+                }
+              />
+              <Metric
+                label="Model bottom / vertical datum"
+                value={`CM1 z=0 is station surface at ${formatNumber(selected.model_bottom_elevation_m_msl, "m MSL")}`}
+              />
+              <Metric
+                label="Source heights"
+                value={`${humanize(selected.source_vertical_coordinate_type)} converted to height above station surface`}
+              />
+              <Metric
+                label="Converted model z range"
+                value={`${formatNumber(selected.levels[0]?.model_z_m ?? null, "m")} to ${formatNumber(selected.levels.at(-1)?.model_z_m ?? null, "m")}`}
+              />
+              <Metric label="Usable levels" value={selected.levels.length.toString()} />
+              <Metric label="Wind handling" value={humanize(selected.wind_handling)} />
+              <Metric label="Validation" value={humanize(selected.validation.status)} />
+            </dl>
 
-          {selected.validation.caveats.length > 0 && (
-            <details>
-              <summary>Observed-sounding caveats</summary>
-              <ul className="compact-list">
-                {selected.validation.caveats.map((caveat) => (
-                  <li key={caveat}>{humanize(caveat)}</li>
-                ))}
-              </ul>
-            </details>
-          )}
+            {selected.validation.caveats.length > 0 && (
+              <details>
+                <summary>Observed-sounding caveats</summary>
+                <ul className="compact-list">
+                  {selected.validation.caveats.map((caveat) => (
+                    <li key={caveat}>{humanize(caveat)}</li>
+                  ))}
+                </ul>
+              </details>
+            )}
+          </details>
         </section>
       )}
     </section>
@@ -5718,53 +5789,32 @@ function ObservedSoundingInputPanel({
 
 function ObservedRunRecipePanel({
   runRecipe,
-  controls,
   selectedCandidateScreening,
-  onChange,
 }: {
   runRecipe: ObservedRunRecipe;
-  controls: Record<string, string | number | boolean>;
   selectedCandidateScreening: Record<string, unknown> | null;
-  onChange: (runRecipe: ObservedRunRecipe) => void;
 }) {
   const selectedDeep = runRecipe === "triggered_deep_potential";
   const activeStory = observedRecipeStoryId(selectedCandidateScreening);
-  const recipeMismatchWarning = candidateRecipeMismatchWarning(
-    selectedCandidateScreening,
-    runRecipe,
-  );
   const activeStoryLabel = observedRecipeStoryLabel(selectedCandidateScreening);
   const expectedSignatures = observedRecipeSignatureLabels(activeStory);
   const hypothesisSummary = observedRecipeHypothesisSummary(activeStory);
   const evidenceSummary = observedRecipeEvidenceSummary(selectedCandidateScreening);
   const recipeFitSummary = observedRecipeFitSummary(selectedCandidateScreening, activeStory);
-  const appliedForcing = observedRecipeAppliedForcing(controls, selectedDeep);
-  const candidateGuidance = selectedCandidateScreening
-    ? "The candidate story is the atmospheric hypothesis. Surface heating and initiation choices are the forcing used to test it."
-    : "No screened candidate is selected yet. This run can still inspect the observed profile, but there is no saved atmospheric hypothesis to compare.";
   const methodScope = selectedDeep
     ? "Forced-initiation test of deep-convection potential; not normal atmospheric evolution."
     : "No added deep trigger; CM1 evolves the observed profile with the selected surface-heating forcing.";
 
   return (
-    <section className="experiment-summary" aria-labelledby="observed-run-recipe-title">
-      <div className="panel-heading-row">
-        <div>
-          <p className="eyebrow">Candidate hypothesis</p>
-          <h3 id="observed-run-recipe-title">What atmospheric outcome are we checking?</h3>
-          <p className="field-help">{candidateGuidance}</p>
-        </div>
-        <StatusBadge
-          label={activeStoryLabel}
-          tone={selectedCandidateScreening ? "neutral" : "warning"}
-        />
-      </div>
-
+    <details className="technical-details hypothesis-details-panel">
+      <summary>
+        Hypothesis, evidence, and expected outputs
+        <span className="summary-note">{activeStoryLabel}</span>
+      </summary>
       <dl className="compact-metrics">
         <Metric label="Atmospheric hypothesis" value={activeStoryLabel} />
         <Metric label="Expected evolution to check" value={hypothesisSummary} />
         <Metric label="Why this sounding looked interesting" value={evidenceSummary} />
-        <Metric label="Applied forcing" value={appliedForcing} />
         <Metric label="Can this run test it?" value={recipeFitSummary} />
       </dl>
 
@@ -5779,42 +5829,10 @@ function ObservedRunRecipePanel({
         </div>
       )}
 
-      <div>
-        <p className="eyebrow">Run method</p>
-        <p className="field-help">
-          Choose the CM1 assumption set. This changes initiation and comparison context; surface
-          heating remains its own forcing control.
-        </p>
-      </div>
-
-      <div className="button-row" role="group" aria-label="Run method">
-        <button
-          type="button"
-          className={!selectedDeep ? "active-control" : "secondary-button"}
-          aria-pressed={!selectedDeep}
-          onClick={() => onChange("untriggered_observed_evolution")}
-        >
-          Untriggered observed evolution
-        </button>
-        <button
-          type="button"
-          className={selectedDeep ? "active-control" : "secondary-button"}
-          aria-pressed={selectedDeep}
-          onClick={() => onChange("triggered_deep_potential")}
-        >
-          Triggered deep potential
-        </button>
-      </div>
-
-      {recipeMismatchWarning && (
-        <div className="validation" role="alert">
-          {recipeMismatchWarning}
-        </div>
-      )}
       <dl className="compact-metrics">
         <Metric
-          label="Selected run method"
-          value={selectedDeep ? "Triggered deep potential" : "Untriggered observed evolution"}
+          label="Experiment recipe"
+          value={selectedDeep ? "Triggered deep potential" : "Observed evolution"}
         />
         <Metric
           label="Initiation"
@@ -5822,14 +5840,7 @@ function ObservedRunRecipePanel({
         />
         <Metric label="Method scope" value={methodScope} />
       </dl>
-      {selectedDeep && (
-        <p className="field-help">
-          This is not normal atmospheric evolution. It adds an idealized trigger so you can inspect
-          whether this observed profile can support deeper convection under a deliberately forced
-          experiment.
-        </p>
-      )}
-    </section>
+    </details>
   );
 }
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1827,7 +1827,7 @@ async function responseError(response: Response, fallback: string): Promise<stri
 export function App() {
   const [activeSection, setActiveSection] = useState<WorkspaceSection>("results");
   const [scenarios, setScenarios] = useState<Scenario[]>([]);
-  const [selectedScenarioId, setSelectedScenarioId] = useState("baseline-shallow-cumulus");
+  const [selectedScenarioId, setSelectedScenarioId] = useState(OBSERVED_SOUNDING_EXPERIMENT_ID);
   const [controls, setControls] = useState<Record<string, string | number | boolean>>({});
   const [runConfiguration, setRunConfiguration] = useState<RunConfigurationInput>(
     DEFAULT_SHALLOW_RUN_CONFIGURATION,
@@ -1923,7 +1923,11 @@ export function App() {
       const catalog = await fetchScenarioCatalog();
       if (!active()) return;
       setScenarios(catalog.scenarios);
-      setSelectedScenarioId(catalog.golden_path_scenario_id);
+      setSelectedScenarioId(
+        catalog.scenarios.some((scenario) => scenario.id === OBSERVED_SOUNDING_BASE_SCENARIO_ID)
+          ? OBSERVED_SOUNDING_EXPERIMENT_ID
+          : catalog.golden_path_scenario_id,
+      );
       if (catalog.scenarios.length === 0) {
         setScenarioLoadState("empty");
         setStatus("No scenarios available");
@@ -3856,6 +3860,21 @@ function BuildWorkspace({
 
               {observedSoundingExperimentSelected && (
                 <>
+                  {observedSoundingParse?.selected_sounding && (
+                    <SelectedSoundingRunSetupPanel
+                      observedSounding={observedSoundingParse.selected_sounding}
+                      selectedCandidateScreening={selectedCandidateScreening}
+                      observedRunRecipe={observedRunRecipe}
+                      controls={controls}
+                      runConfiguration={runConfiguration}
+                      runConfigurationPreview={runConfigurationPreview}
+                      selectedTriggeredDeepPotential={selectedTriggeredDeepPotential}
+                      onObservedRunRecipeChange={onObservedRunRecipeChange}
+                      onRunConfigurationChange={onRunConfigurationChange}
+                      onAddSelectedSoundingToRunPlan={onAddSelectedSoundingToRunPlan}
+                    />
+                  )}
+
                   <AtmosphereSourcePicker
                     sourcePath={atmosphereSourcePath}
                     savedCandidateCount={savedCandidates.length}
@@ -3926,21 +3945,6 @@ function BuildWorkspace({
                       selectedCandidateScreening={selectedCandidateScreening}
                       onObservedSoundingFile={onObservedSoundingFile}
                       onObservedSoundingTimeChange={onObservedSoundingTimeChange}
-                    />
-                  )}
-
-                  {observedSoundingParse?.selected_sounding && (
-                    <SelectedSoundingRunSetupPanel
-                      observedSounding={observedSoundingParse.selected_sounding}
-                      selectedCandidateScreening={selectedCandidateScreening}
-                      observedRunRecipe={observedRunRecipe}
-                      controls={controls}
-                      runConfiguration={runConfiguration}
-                      runConfigurationPreview={runConfigurationPreview}
-                      selectedTriggeredDeepPotential={selectedTriggeredDeepPotential}
-                      onObservedRunRecipeChange={onObservedRunRecipeChange}
-                      onRunConfigurationChange={onRunConfigurationChange}
-                      onAddSelectedSoundingToRunPlan={onAddSelectedSoundingToRunPlan}
                     />
                   )}
 
@@ -4254,6 +4258,7 @@ function RunConfigurationPanel({
   runRecipe,
   controls,
   selectedCandidateScreening,
+  onAddToRunPlan,
   onChange,
   onRunRecipeChange,
   embedded = false,
@@ -4264,12 +4269,15 @@ function RunConfigurationPanel({
   runRecipe?: ObservedRunRecipe;
   controls?: Record<string, string | number | boolean>;
   selectedCandidateScreening?: Record<string, unknown> | null;
+  onAddToRunPlan?: () => void;
   onChange: (configuration: RunConfigurationInput) => void;
   onRunRecipeChange?: (runRecipe: ObservedRunRecipe) => void;
   embedded?: boolean;
 }) {
   const observedRecipeSelected = runRecipe !== undefined && onRunRecipeChange !== undefined;
-  const selectedDeep = runRecipe ? runRecipe === "triggered_deep_potential" : triggeredDeepPotential;
+  const selectedDeep = runRecipe
+    ? runRecipe === "triggered_deep_potential"
+    : triggeredDeepPotential;
   const domainOptions = selectedDeep ? DEEP_DOMAIN_OPTIONS : SHALLOW_DOMAIN_OPTIONS;
   const recipeMismatchWarning =
     runRecipe && selectedCandidateScreening
@@ -4277,22 +4285,38 @@ function RunConfigurationPanel({
       : null;
   const appliedForcing =
     runRecipe && controls ? observedRecipeAppliedForcing(controls, selectedDeep) : null;
+  const configurationHelp = observedRecipeSelected
+    ? "Choose the recipe, model time, grid, domain, cadence, and diagnostics for this observed atmosphere."
+    : "Choose duration, grid, domain, cadence, and diagnostics before creating the CM1 package.";
+  const configurationNotes: string[] = [];
+  if (preview.mode === "smoke") {
+    configurationNotes.push(
+      "Smoke mode is only for package health and CM1 startup behavior; it should not be used to judge atmospheric evolution.",
+    );
+  }
+  if (preview.caveats.includes("configuration_better_suited_to_larger_compute")) {
+    configurationNotes.push(
+      "This configuration may be better suited to larger compute. Cloud Chamber still shows the CM1-facing values before launch.",
+    );
+  }
+  if (selectedDeep) {
+    configurationNotes.push(
+      "Triggered deep potential adds a warm-bubble trigger. Treat it as a forced-potential experiment, not normal atmospheric evolution.",
+    );
+  }
   const update = (key: keyof RunConfigurationInput, value: string) => {
     onChange({ ...configuration, [key]: value });
   };
+  const panelClassName = embedded
+    ? "run-configuration-panel embedded-run-configuration-panel"
+    : "experiment-summary run-configuration-panel";
   return (
-    <section
-      className={embedded ? "run-configuration-panel" : "experiment-summary run-configuration-panel"}
-      aria-labelledby="run-configuration-title"
-    >
+    <section className={panelClassName} aria-labelledby="run-configuration-title">
       <div className="panel-heading-row">
         <div>
           <p className="eyebrow">Run configuration</p>
           <h3 id="run-configuration-title">Configure this CM1 run</h3>
-          <p className="field-help">
-            Set the experiment recipe, duration, grid, domain, cadence, and diagnostics before
-            staging this sounding into the run plan.
-          </p>
+          <p className="field-help">{configurationHelp}</p>
         </div>
         <StatusBadge
           label={preview.mode === "smoke" ? "Smoke check" : "Science run"}
@@ -4305,7 +4329,7 @@ function RunConfigurationPanel({
           <RunConfigurationSelect
             id="run-recipe"
             label="Experiment recipe"
-            description="Initiation and comparison context for this observed sounding."
+            description="Initiation and comparison context."
             value={runRecipe}
             options={[
               {
@@ -4323,7 +4347,7 @@ function RunConfigurationPanel({
         <RunConfigurationSelect
           id="run-duration"
           label="Duration"
-          description="Model-time length. Short evolution is the shortest normal science run."
+          description="Model-time length."
           value={configuration.duration}
           options={DURATION_OPTIONS}
           onChange={(value) => update("duration", value)}
@@ -4333,8 +4357,8 @@ function RunConfigurationPanel({
           label="Horizontal cells"
           description={
             selectedDeep
-              ? "Storm-scale cell budget. CM1 spacing is derived from domain width divided by cells."
-              : "Observed-evolution cell budget. More cells reduce dx/dy and increase compute and output volume."
+              ? "Storm-scale cell budget; spacing derives from domain width."
+              : "Cell budget; more cells reduce dx/dy and increase cost."
           }
           value={configuration.horizontal_cell_count}
           options={HORIZONTAL_CELL_OPTIONS}
@@ -4343,11 +4367,7 @@ function RunConfigurationPanel({
         <RunConfigurationSelect
           id="run-domain"
           label="Domain size"
-          description={
-            selectedDeep
-              ? "Storm-growth domain for triggered-potential experiments."
-              : "Observed soundings default wider so winds do not make the setup misleading."
-          }
+          description={selectedDeep ? "Storm-growth domain." : "Domain width and model top."}
           value={configuration.domain_size}
           options={domainOptions}
           onChange={(value) => update("domain_size", value)}
@@ -4363,7 +4383,7 @@ function RunConfigurationPanel({
         <RunConfigurationSelect
           id="run-fields"
           label="Diagnostic set"
-          description="Controls which CM1 variables are written for Results and Explore. More diagnostics mainly increase disk use and I/O, while enabling better explanations."
+          description="CM1 fields written for Results and Explore."
           value={configuration.diagnostic_set}
           options={DIAGNOSTIC_SET_OPTIONS}
           onChange={(value) => update("diagnostic_set", value)}
@@ -4376,37 +4396,29 @@ function RunConfigurationPanel({
         </div>
       )}
 
-      <dl className="compact-metrics">
-        {runRecipe && (
-          <Metric
-            label="Initiation"
-            value={selectedDeep ? "Idealized warm-bubble trigger" : "No added deep trigger"}
-          />
-        )}
+      <dl className="compact-metrics run-configuration-summary">
         {appliedForcing && <Metric label="Forcing" value={appliedForcing} />}
-        <Metric label="Selected setup" value={preview.label} />
-        <Metric label="Runtime / saved frames" value={runConfigurationTimingSummary(preview)} />
+        <Metric label="Runtime" value={runConfigurationTimingSummary(preview)} />
         <Metric label="Grid" value={runConfigurationGridSummary(preview)} />
-        <Metric label="Output volume" value={preview.output_volume_summary} />
+        <Metric label="Output" value={preview.output_volume_summary} />
       </dl>
 
-      {preview.mode === "smoke" && (
-        <p className="field-help">
-          Smoke mode is only for package health and CM1 startup behavior; it should not be used to
-          judge normal atmospheric evolution.
-        </p>
+      {configurationNotes.length > 0 && (
+        <details className="technical-details run-configuration-notes">
+          <summary>Configuration notes</summary>
+          <ul className="compact-list">
+            {configurationNotes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        </details>
       )}
-      {preview.caveats.includes("configuration_better_suited_to_larger_compute") && (
-        <p className="field-help">
-          This configuration may be better suited to larger compute. Cloud Chamber will still show
-          the CM1-facing values before launch.
-        </p>
-      )}
-      {selectedDeep && (
-        <p className="field-help">
-          Triggered deep potential is not normal atmospheric evolution; it adds an idealized trigger
-          to inspect whether this profile can support deeper convection.
-        </p>
+
+      {observedRecipeSelected && selectedCandidateScreening && (
+        <ObservedRunRecipePanel
+          runRecipe={runRecipe}
+          selectedCandidateScreening={selectedCandidateScreening}
+        />
       )}
 
       <details className="technical-details">
@@ -4432,6 +4444,21 @@ function RunConfigurationPanel({
           />
         </dl>
       </details>
+
+      {onAddToRunPlan && (
+        <div className="run-configuration-action-row">
+          <div>
+            <p className="eyebrow">Add to run plan</p>
+            <h4>Stage this configured run</h4>
+            <p className="field-help">
+              Adds an editable planned run below; duplicate it there to compare variants.
+            </p>
+          </div>
+          <button type="button" onClick={onAddToRunPlan}>
+            Add to run plan
+          </button>
+        </div>
+      )}
     </section>
   );
 }
@@ -5121,7 +5148,7 @@ function SavedCandidatesSourcePanel({
             <SavedSoundingCandidateCard
               key={saved.saved_candidate_id}
               saved={saved}
-              onUpdateWorkingSet={(tags) => onSave(saved.candidate, tags, saved.notes ?? null)}
+              onUpdateAnnotations={(tags, notes) => onSave(saved.candidate, tags, notes)}
               onUse={() => onSelectForRunSetup(saved.candidate, saved, saved.primary_story)}
               onRemove={() => onRemoveSaved(saved.saved_candidate_id)}
             />
@@ -5134,25 +5161,27 @@ function SavedCandidatesSourcePanel({
 
 function SavedSoundingCandidateCard({
   saved,
-  onUpdateWorkingSet,
+  onUpdateAnnotations,
   onUse,
   onRemove,
 }: {
   saved: SavedSoundingCandidate;
-  onUpdateWorkingSet: (tags: string[]) => void;
+  onUpdateAnnotations: (tags: string[], notes: string | null) => void;
   onUse: () => void;
   onRemove: () => void;
 }) {
-  const currentWorkingSet = saved.tags.find(isCandidateSuggestedTag) ?? "";
-  const [workingSetDraft, setWorkingSetDraft] = useState(currentWorkingSet);
-  const workingSetDraftRef = useRef(currentWorkingSet);
+  const [tagDraft, setTagDraft] = useState(saved.tags.join(", "));
+  const [notesDraft, setNotesDraft] = useState(saved.notes ?? "");
   useEffect(() => {
-    workingSetDraftRef.current = currentWorkingSet;
-    setWorkingSetDraft(currentWorkingSet);
-  }, [saved.saved_candidate_id, currentWorkingSet]);
-  const freeformTags = saved.tags.filter((tag) => !isCandidateSuggestedTag(tag));
-  const workingSetTags = (draft: string) =>
-    _dedupeStrings([draft, ...freeformTags].filter((tag): tag is string => Boolean(tag)));
+    setTagDraft(saved.tags.join(", "));
+    setNotesDraft(saved.notes ?? "");
+  }, [saved.saved_candidate_id, saved.tags, saved.notes]);
+  const handleTagSuggestion = (tag: string) => {
+    setTagDraft(_dedupeStrings([...parseTags(tagDraft), tag]).join(", "));
+  };
+  const handleSaveAnnotations = () => {
+    onUpdateAnnotations(parseTags(tagDraft), notesDraft.trim() || null);
+  };
   return (
     <article
       className="saved-candidate-card"
@@ -5163,40 +5192,56 @@ function SavedSoundingCandidateCard({
         <small>
           {formatDate(saved.candidate.valid_time_utc)} · {candidateStoryLabel(saved.primary_story)}
         </small>
-        {saved.tags.length > 0 && <small>Tags: {saved.tags.join(", ")}</small>}
-        {saved.notes && <small>Notes: {saved.notes}</small>}
+        {(saved.tags.length > 0 || saved.notes) && (
+          <small>
+            {saved.tags.length > 0
+              ? `${saved.tags.length} tag${saved.tags.length === 1 ? "" : "s"}`
+              : "No tags"}
+            {saved.notes ? " · notes saved" : ""}
+          </small>
+        )}
         {saved.linked_run_ids.length > 0 && (
           <small>Used in {saved.linked_run_ids.join(", ")}</small>
         )}
       </div>
-      <div className="saved-candidate-controls">
-        <label htmlFor={`saved-working-set-${saved.saved_candidate_id}`}>
-          Working set
-          <select
-            id={`saved-working-set-${saved.saved_candidate_id}`}
-            aria-label={`Working set for ${candidateStationLabel(saved.candidate)}`}
-            value={workingSetDraft}
-            onChange={(event) => {
-              workingSetDraftRef.current = event.target.value;
-              setWorkingSetDraft(event.target.value);
-            }}
-          >
-            <option value="">No working set</option>
+      <details className="saved-candidate-notes-drawer">
+        <summary>Tags and notes</summary>
+        <div className="candidate-notes-form">
+          <label htmlFor={`saved-tags-${saved.saved_candidate_id}`}>
+            Tags
+            <input
+              id={`saved-tags-${saved.saved_candidate_id}`}
+              value={tagDraft}
+              placeholder="deep convection, rerun, compare"
+              onChange={(event) => setTagDraft(event.target.value)}
+            />
+          </label>
+          <div className="candidate-tag-suggestions" aria-label="Suggested tags">
             {candidateSuggestedTags.map((tag) => (
-              <option key={tag} value={tag}>
+              <button
+                type="button"
+                className="secondary-button"
+                key={tag}
+                onClick={() => handleTagSuggestion(tag)}
+              >
                 {tag}
-              </option>
+              </button>
             ))}
-          </select>
-        </label>
-        <button
-          type="button"
-          className="secondary-button"
-          onClick={() => onUpdateWorkingSet(workingSetTags(workingSetDraftRef.current))}
-        >
-          Update working set
-        </button>
-      </div>
+          </div>
+          <label htmlFor={`saved-notes-${saved.saved_candidate_id}`}>
+            Notes
+            <textarea
+              id={`saved-notes-${saved.saved_candidate_id}`}
+              value={notesDraft}
+              placeholder="What makes this worth running or comparing?"
+              onChange={(event) => setNotesDraft(event.target.value)}
+            />
+          </label>
+          <button type="button" className="secondary-button" onClick={handleSaveAnnotations}>
+            Save tags and notes
+          </button>
+        </div>
+      </details>
       <div className="button-row">
         <button type="button" onClick={onUse}>
           Select for run setup
@@ -5571,8 +5616,13 @@ function SelectedSoundingRunSetupPanel({
     selectedCandidateScreening,
   );
   const activeStoryLabel = observedRecipeStoryLabel(selectedCandidateScreening);
+  const setupRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    setupRef.current?.scrollIntoView?.({ block: "start", behavior: "auto" });
+  }, [observedSounding.station_id, observedSounding.valid_time_utc]);
   return (
     <section
+      ref={setupRef}
       className="experiment-summary selected-sounding-setup selected-run-builder"
       aria-label="Selected sounding run setup"
     >
@@ -5612,30 +5662,11 @@ function SelectedSoundingRunSetupPanel({
         runRecipe={observedRunRecipe}
         controls={controls}
         selectedCandidateScreening={selectedCandidateScreening}
+        onAddToRunPlan={onAddSelectedSoundingToRunPlan}
         onChange={onRunConfigurationChange}
         onRunRecipeChange={onObservedRunRecipeChange}
         embedded
       />
-
-      <ObservedRunRecipePanel
-        runRecipe={observedRunRecipe}
-        selectedCandidateScreening={selectedCandidateScreening}
-      />
-
-      <div className="selected-sounding-add-panel">
-        <div className="panel-heading-row">
-          <div>
-            <p className="eyebrow">Add to run plan</p>
-            <h3>Add to plan</h3>
-            <p className="field-help">
-              Stage this setup as an editable row below; duplicate it there to compare variants.
-            </p>
-          </div>
-        </div>
-        <button type="button" onClick={onAddSelectedSoundingToRunPlan}>
-          Add to run plan
-        </button>
-      </div>
     </section>
   );
 }
@@ -5736,7 +5767,10 @@ function ObservedSoundingInputPanel({
           <details className="technical-details source-review-details">
             <summary>Uploaded-sounding review</summary>
             <dl className="compact-metrics">
-              <Metric label="Source" value={`${parsed.source_provider} · ${parsed.source_format}`} />
+              <Metric
+                label="Source"
+                value={`${parsed.source_provider} · ${parsed.source_format}`}
+              />
               <Metric label="Uploaded file" value={parsed.uploaded_filename} />
               <Metric
                 label="Station"
@@ -6027,14 +6061,14 @@ function RunPlanItemCard({
           <RunConfigurationSelect
             id={`run-plan-recipe-${item.id}`}
             label="Recipe"
-            description="Choose the CM1 assumption set for this run-plan item."
+            description="Initiation and comparison context."
             value={item.runRecipe}
             options={[
               {
                 value: "untriggered_observed_evolution",
-                label: "Untriggered observed-sounding evolution v0",
+                label: "Observed evolution",
               },
-              { value: "triggered_deep_potential", label: "Triggered deep-potential experiment" },
+              { value: "triggered_deep_potential", label: "Triggered deep potential" },
             ]}
             onChange={(value) => onRecipeChange(item.id, value as ObservedRunRecipe)}
           />
@@ -6116,7 +6150,7 @@ function RunPlanConfigurationFields({
       <RunConfigurationSelect
         id={`run-plan-duration-${item.id}`}
         label="Duration"
-        description="Model-time length for this variant."
+        description="Model-time length."
         value={item.runConfiguration.duration}
         options={DURATION_OPTIONS}
         onChange={(value) => update("duration", value)}
@@ -6124,7 +6158,7 @@ function RunPlanConfigurationFields({
       <RunConfigurationSelect
         id={`run-plan-grid-${item.id}`}
         label="Horizontal cells"
-        description="Cell count controls dx/dy and compute complexity."
+        description="Controls dx/dy and compute."
         value={item.runConfiguration.horizontal_cell_count}
         options={HORIZONTAL_CELL_OPTIONS}
         onChange={(value) => update("horizontal_cell_count", value)}
@@ -6132,7 +6166,7 @@ function RunPlanConfigurationFields({
       <RunConfigurationSelect
         id={`run-plan-domain-${item.id}`}
         label="Domain size"
-        description="Domain width and model top for this recipe."
+        description="Width and model top."
         value={item.runConfiguration.domain_size}
         options={domainOptions}
         onChange={(value) => update("domain_size", value)}
@@ -6140,7 +6174,7 @@ function RunPlanConfigurationFields({
       <RunConfigurationSelect
         id={`run-plan-cadence-${item.id}`}
         label="Output cadence"
-        description="Saved output interval for Results and Explore."
+        description="Saved-output interval."
         value={item.runConfiguration.output_cadence}
         options={OUTPUT_CADENCE_OPTIONS}
         onChange={(value) => update("output_cadence", value)}
@@ -6148,7 +6182,7 @@ function RunPlanConfigurationFields({
       <RunConfigurationSelect
         id={`run-plan-fields-${item.id}`}
         label="Diagnostic set"
-        description="Requested output field density."
+        description="Output field density."
         value={item.runConfiguration.diagnostic_set}
         options={DIAGNOSTIC_SET_OPTIONS}
         onChange={(value) => update("diagnostic_set", value)}
@@ -10399,10 +10433,6 @@ function candidateRecipeFitTone(status: CandidateRecipeFitStatus): "good" | "war
   return "warning";
 }
 
-function isCandidateSuggestedTag(tag: string): tag is (typeof candidateSuggestedTags)[number] {
-  return (candidateSuggestedTags as readonly string[]).includes(tag);
-}
-
 function observedRecipeStoryId(
   selectedCandidateScreening: Record<string, unknown> | null,
 ): CandidateStoryId | null {
@@ -10518,10 +10548,8 @@ function observedRecipeAppliedForcing(
     typeof surfaceHeating === "string" && surfaceHeating.length > 0
       ? humanize(surfaceHeating)
       : "Baseline";
-  const initiation = selectedDeep
-    ? "plus idealized warm-bubble initiation"
-    : "no added deep-initiation trigger";
-  return `Surface heating: ${surfaceHeatingLabel}; ${initiation}.`;
+  const initiation = selectedDeep ? "warm-bubble trigger" : "no deep trigger";
+  return `${surfaceHeatingLabel} surface heating; ${initiation}.`;
 }
 
 function candidateRecipeMismatchWarning(

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -181,8 +181,10 @@ candidate-analysis endpoints, display backend recommendations and advanced
 refinements, and save candidates with freeform tags/notes. Saved candidates are
 loaded as a shortlist source without requiring a catalog refresh, cache action,
 or analysis run. Manual upload remains hidden unless that source path is active.
-Package-ready candidates and uploaded soundings are added to a Build run plan
-rather than immediately becoming a single package-review state.
+Package-ready candidates, saved candidates, and uploaded soundings all flow into
+one selected-sounding setup surface for recipe and run-configuration choices.
+The configured selection is then added to the bottom Build run plan rather than
+immediately becoming a single package-review state.
 The frontend does not read cached station text directly, compute the story
 scores, or sort raw feature values itself. Candidate status is separate from
 run/result status: saved candidates are pre-run hypotheses, while generated

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -11,7 +11,7 @@ visualizer.
 The current user-facing architecture is:
 
 ```text
-Build = configure and launch one CM1 run
+Build = configure and launch one or more planned CM1 runs
 Results = notebook for completed/ingested runs
 Explore = inspect one result with CM1-derived evidence
 ```
@@ -28,7 +28,9 @@ pre-run validation are the run-builder contract.
 
 The first MVP target is a 2024 MacBook Air with 8GB RAM. Design for one local CM1 run at a time, conservative output handling, and backend-side processing/downsampling. Optional cloud compute can be researched later, but it is not part of the core architecture.
 
-Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later and should not drive the first result storage model.
+Replay / inspect / save is core MVP. Duplicate / tweak / rerun begins in the
+Build run plan as source-level package variants; it should not force Results
+storage to model a single active package or hide completed-result provenance.
 
 Active sequencing lives in [Current Roadmap](current-roadmap.md). Historical
 issue sequencing in the archived roadmap should not drive new architecture
@@ -172,16 +174,28 @@ triggered deep-potential run recipe, which treats selected observed soundings as
 pre-run hypotheses for an idealized triggered CM1 experiment.
 
 The Build UI consumes this layer through bounded JSON only. `Upload a Sounding`
-loads saved candidates immediately when that experiment is selected, before any
-catalog refresh or analysis action. It can also call the recent-catalog/cache
-and candidate-analysis endpoints, display backend recommendations and advanced
-refinements, save candidates with freeform tags/notes, and pass a selected
-candidate's `selected_sounding_payload` into the existing observed-sounding
-package review.
+is the observed-atmosphere entry point, but the user chooses exactly one source
+path at a time: cached recommendations, saved candidates, or manual IGRA station
+text upload. Cached recommendations call recent-catalog/cache and
+candidate-analysis endpoints, display backend recommendations and advanced
+refinements, and save candidates with freeform tags/notes. Saved candidates are
+loaded as a shortlist source without requiring a catalog refresh, cache action,
+or analysis run. Manual upload remains hidden unless that source path is active.
+Package-ready candidates and uploaded soundings are added to a Build run plan
+rather than immediately becoming a single package-review state.
 The frontend does not read cached station text directly, compute the story
 scores, or sort raw feature values itself. Candidate status is separate from
 run/result status: saved candidates are pre-run hypotheses, while generated
 packages, launched runs, and ingested results remain separate lifecycle objects.
+
+The observed-atmosphere run plan owns batch package creation. Each item stores
+its source payload, selected story/hypothesis metadata, selected run recipe,
+recipe metadata (`recipe_id`, display name, assumption set/mode, assumptions,
+required output fields, caveats, and missing required fields when known), run
+configuration, local/LAN queue target, current packaging/queue status, and any
+blocked pre-run validation report. The frontend may duplicate items to compare
+recipe or configuration variants, but package generation and pre-run validation
+remain backend-owned.
 
 Triggered deep-potential observed-sounding runs extend the same dry-run package
 contract rather than creating a separate workflow. The package records

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -157,17 +157,20 @@ panel. Selecting the saved source should load saved candidates without requiring
 a catalog refresh, cache action, or new analysis run. All candidate language
 must remain pre-run and provisional: a candidate is an observed atmosphere worth
 trying, not a prediction that clouds, rain, or suppression will occur. When a
-candidate is added to the run plan, its screening story, score, evidence,
-feature summary, saved tags/notes, and caveats should be copied into package
-metadata as provenance.
+candidate is selected for run setup, Build should use the same recipe and run
+configuration flow used for uploads. When that configured sounding is added to
+the run plan, its screening story, score, evidence, feature summary, saved
+tags/notes, and caveats should be copied into package metadata as provenance.
 
-When an uploaded, cached, or saved observed sounding is run-ready, Build should
-let the user add it to a run plan. The run plan should support multiple
-candidate atmospheres, duplicate variants, per-item run recipe and run
-configuration edits, local or LAN queue target selection, remove/clear actions,
-and a batch action to create packages and queue selected runs. Per-item
-packaging or queue failures should remain visible instead of clearing the
-failed item from the plan. The triggered deep-potential recipe is first-class for
+When an uploaded, cached, or saved observed sounding is selected, Build should
+show one shared selected-sounding setup flow above the run plan. The source path
+should determine where the selected atmosphere came from, not create a separate
+configuration workflow. The run plan should sit below the source/setup flow and
+support multiple candidate atmospheres, duplicate variants, per-item run recipe
+and run configuration edits, local or LAN queue target selection, remove/clear
+actions, and a batch action to create packages and queue selected runs. Per-item
+packaging or queue failures should remain visible instead of clearing the failed
+item from the plan. The triggered deep-potential recipe is first-class for
 severe/deep-convection observed-sounding experiments: it uses the observed
 temperature, moisture, and complete wind profile through CM1 `isnd = 7`, runs an
 idealized three-warm-bubble trigger (`iinit = 3`), uses a storm-scale model box

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -25,7 +25,7 @@ Cloud Chamber is a guided experiment notebook for understanding why clouds forme
 The current product model is:
 
 ```text
-Build = configure and launch one CM1 run
+Build = configure and launch one or more planned CM1 runs
 Results = notebook for completed/ingested runs
 Explore = inspect one result with CM1-derived evidence
 ```
@@ -138,28 +138,36 @@ pre-run evidence and context only. Parcel, storm-relative, wet-bulb, and
 winter-phase diagnostics must remain explicitly unavailable until their methods
 are implemented and tested.
 
-In Build, `Upload a Sounding` is the product-facing entry point for this
-candidate workflow. It should show a `Find interesting soundings` workbench
-beside the observed-sounding upload path. The workbench can refresh the bounded
-IGRA cache, analyze cached soundings into station-diverse recommendations, show
-why each candidate is interesting, expose story, story-family, support,
-readiness, station-search, and sort controls as advanced refinements, show
-package-ready and blocked candidates with evidence and caveats, save candidates
-with freeform tags and notes for later review, and load a selected package-ready
-candidate into the observed-sounding package review. Missing sounding-derived
-features must remain unavailable/caveated and must not sort as zero-valued
-evidence.
-Saved candidates should appear as soon as the user selects `Upload a Sounding`,
-without requiring a catalog refresh, cache action, or new analysis run. It must
-keep the language pre-run and provisional: a candidate is an observed atmosphere
-worth trying, not a prediction that clouds, rain, or suppression will occur.
-When a candidate is used, its screening story, score, evidence, feature summary,
-and caveats should be copied into package metadata as
-provenance.
+In Build, `Upload a Sounding` is the product-facing entry point for observed
+atmosphere work. It should offer one source path at a time: cached local
+recommendations, saved candidates, or manual IGRA station text upload. The
+cached-recommendation path should lead with product-level search controls such
+as source region, search intent, search depth, and time scope, with raw cache
+limits and backend filters kept in advanced refinements. The workbench can
+refresh the bounded IGRA cache, analyze cached soundings into station-diverse
+recommendations, show why each candidate is interesting, expose story,
+story-family, support, readiness, station-search, and sort controls as advanced
+refinements, show package-ready and blocked candidates with evidence and
+caveats, and save candidates with freeform tags and notes for later review.
+Manual upload should stay hidden while cached recommendations or saved
+candidates are the active source path.
 
-When an uploaded or saved observed sounding is run-ready, Build should let the
-user choose an observed-sounding run recipe and adjust the explicit CM1-facing
-run configuration. The triggered deep-potential recipe is first-class for
+Saved candidates are a source path and shortlist, not an always-visible side
+panel. Selecting the saved source should load saved candidates without requiring
+a catalog refresh, cache action, or new analysis run. All candidate language
+must remain pre-run and provisional: a candidate is an observed atmosphere worth
+trying, not a prediction that clouds, rain, or suppression will occur. When a
+candidate is added to the run plan, its screening story, score, evidence,
+feature summary, saved tags/notes, and caveats should be copied into package
+metadata as provenance.
+
+When an uploaded, cached, or saved observed sounding is run-ready, Build should
+let the user add it to a run plan. The run plan should support multiple
+candidate atmospheres, duplicate variants, per-item run recipe and run
+configuration edits, local or LAN queue target selection, remove/clear actions,
+and a batch action to create packages and queue selected runs. Per-item
+packaging or queue failures should remain visible instead of clearing the
+failed item from the plan. The triggered deep-potential recipe is first-class for
 severe/deep-convection observed-sounding experiments: it uses the observed
 temperature, moisture, and complete wind profile through CM1 `isnd = 7`, runs an
 idealized three-warm-bubble trigger (`iinit = 3`), uses a storm-scale model box
@@ -175,6 +183,12 @@ better suited to larger compute instead of making machine choice the primary
 product axis. Raw trigger parameters remain
 metadata-only in v1 and should not become user controls until useful ranges are
 validated.
+
+The run monitor should be compact by default. It should summarize active,
+queued, and completed runtime work while keeping detailed package, queue, LAN,
+ingest, and cleanup actions reachable on demand. The package/run status rail is
+supporting context for the run plan, not the primary place to continue after
+choosing a sounding.
 
 Explore should be a focused visualization plus explanation screen for one
 selected result. Its core interaction is `What happened here?`: select a cloud,

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -21,9 +21,9 @@ interpretations around that source data.
 
 ## Current Product Model
 
-- **Build** = configure and launch one CM1 run from a selected atmosphere,
-  starting preset, and guarded run settings. Build owns active, incomplete, and
-  non-ingested package/run work.
+- **Build** = choose observed or generated atmospheres, configure one or more
+  planned CM1 runs, and launch or queue selected variants. Build owns active,
+  incomplete, and non-ingested package/run work.
 - **Results** = experiment notebook for completed and ingested runs. Results owns
   ingested-result review, notes, and explicit ingested-result cleanup.
 - **Explore** = scientific inspection of one result using CM1-derived evidence.


### PR DESCRIPTION
## Summary

Closes #302.

This rationalizes Build around the observed-atmosphere workflow:

- defaults Build to **Upload a Sounding** instead of the old baseline scenario path;
- splits observed-sounding work into one active source path at a time: cached recommendations, saved candidates, or manual IGRA upload;
- routes cached, saved, and uploaded soundings through one shared selected-sounding run-builder before adding them to a plan;
- moves the selected-sounding setup above the source browser after a sounding is selected and scrolls it into view, so the next step is configuration rather than more discovery controls;
- makes run configuration the primary setup surface, with the experiment recipe inside the same configuration grid as duration, cells, domain, cadence, and diagnostics;
- folds hypothesis details, configuration notes, CM1-facing values, and **Add to run plan** into that run-configuration surface instead of separate visual boxes;
- replaces saved-candidate “Working set” controls with a **Tags and notes** drawer, including freeform notes and tag suggestions;
- keeps the run plan at the bottom as the batch/cart for configured runs;
- keeps per-item recipe/config edits, local/LAN queue target selection, batch package creation/queueing, and per-item status after a run is added;
- keeps the run monitor collapsed by default while preserving package, queue, LAN, ingest, and cleanup actions;
- updates product/architecture docs to reflect the source-path, selected-sounding setup, bottom run-plan, and batch-queue model.

## UI Notes

The source panels are now for finding or uploading a sounding. Once a sounding is selected from cached recommendations, saved candidates, or upload, Build shows one selected-sounding run-builder surface first: compact selected atmosphere context, run configuration, collapsed hypothesis/provenance details, and a single **Add to run plan** action. The source browser remains available below that setup if the user wants to pick a different sounding.

I verified the structure visually with temporary Playwright screenshots at desktop and mobile widths. The screenshots were not committed.

## Verification

- `cd app/frontend && npx tsc -b --pretty false && npm test -- App.test.tsx`
- `cd app/frontend && npx playwright test e2e/mocked-smoke/build-results-explore.spec.ts`
- temporary Playwright visual check for selected-sounding run-builder desktop/mobile layout, removed before commit
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Known Notes

`npm test` still prints the existing React `act(...)` warning in the scenario-loading test, and backend pytest still prints the existing NumPy binary warning. Both full check scripts pass.
