### PR TITLE
Implement numeric surface forcing controls

### DIFF
--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -175,9 +175,9 @@ def build_cm1_input_contract(
         resolved_run_configuration,
     )
     defaults = cloud_scale_defaults_for_configuration(resolved_run_configuration)
-    if observed_sounding is not None and not _has_observed_wind_profile(
+    if observed_sounding is not None and not has_complete_rendered_observed_wind_profile(
         observed_sounding,
-        required_model_top_m=_required_sounding_top_m(defaults),
+        defaults=defaults,
     ):
         raise ValueError(
             "Observed-sounding runs require a complete finite observed u/v wind profile "
@@ -549,14 +549,14 @@ def _output_switches(
     return switches
 
 
-def _has_observed_wind_profile(
+def has_complete_rendered_observed_wind_profile(
     record: ObservedSoundingRecord,
     *,
-    required_model_top_m: float,
+    defaults: CloudScaleDefaults,
 ) -> bool:
     levels = _rendered_observed_wind_levels(
         record,
-        required_model_top_m=required_model_top_m,
+        required_model_top_m=_required_sounding_top_m(defaults),
     )
     return bool(levels) and all(
         _finite_number(level.u_wind_m_s) and _finite_number(level.v_wind_m_s) for level in levels

--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -34,7 +34,9 @@ class GeneratedFileRole(StrEnum):
 class RunRecipe(StrEnum):
     GENERATED_REFERENCE_LOWER_ATMOSPHERE = "generated_reference_lower_atmosphere"
     UNTRIGGERED_OBSERVED_EVOLUTION = "untriggered_observed_evolution"
-    TRIGGERED_DEEP_POTENTIAL = "triggered_deep_potential"
+
+
+REMOVED_TRIGGERED_DEEP_POTENTIAL_RECIPE = "triggered_deep_potential"
 
 
 @dataclass(frozen=True)
@@ -173,17 +175,14 @@ def build_cm1_input_contract(
         resolved_run_configuration,
     )
     defaults = cloud_scale_defaults_for_configuration(resolved_run_configuration)
-    if resolved_run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-        if observed_sounding is None:
-            raise ValueError("Triggered deep-potential run requires a validated observed sounding.")
-        if not _has_observed_wind_profile(
-            observed_sounding,
-            required_model_top_m=_required_sounding_top_m(defaults),
-        ):
-            raise ValueError(
-                "Triggered deep-potential runs require a complete finite observed u/v wind "
-                "profile for every input_sounding level."
-            )
+    if observed_sounding is not None and not _has_observed_wind_profile(
+        observed_sounding,
+        required_model_top_m=_required_sounding_top_m(defaults),
+    ):
+        raise ValueError(
+            "Observed-sounding runs require a complete finite observed u/v wind profile "
+            "for every input_sounding level."
+        )
     control_fragments = tuple(
         ControlMappingFragment(
             control_id=control.id,
@@ -216,9 +215,7 @@ def build_cm1_input_contract(
         input_source="observed_sounding"
         if observed_sounding is not None
         else "generated_reference",
-        trigger_type=(
-            "warm_bubble" if resolved_run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL else None
-        ),
+        trigger_type=None,
         trigger_parameters=_trigger_parameters(resolved_run_recipe),
         scenario_id=scenario.id,
         physical_question=scenario.physical_question,
@@ -270,6 +267,12 @@ def _resolve_run_recipe(
     run_recipe: str | RunRecipe | None,
     observed_sounding: ObservedSoundingRecord | None,
 ) -> RunRecipe:
+    if run_recipe == REMOVED_TRIGGERED_DEEP_POTENTIAL_RECIPE:
+        raise ValueError(
+            "Triggered deep-potential package generation has been removed. "
+            "Use observed-sounding run configuration with numeric surface heat/moisture "
+            "forcing, or implement differential lower-boundary forcing from issue #307."
+        )
     if isinstance(run_recipe, RunRecipe):
         return run_recipe
     if run_recipe:
@@ -284,10 +287,8 @@ def _resolve_run_recipe(
 
 def _run_recipe_display_name(run_recipe: RunRecipe) -> str:
     match run_recipe:
-        case RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-            return "Triggered Deep-Potential Experiment"
         case RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
-            return "Untriggered Observed Evolution"
+            return "Observed Surface-Forced Evolution"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
             return "Generated Lower-Atmosphere Reference"
 
@@ -295,10 +296,8 @@ def _run_recipe_display_name(run_recipe: RunRecipe) -> str:
 def recipe_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
-        case RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-            return "triggered_deep_potential_v1"
         case RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
-            return "untriggered_observed_sounding_evolution_v0"
+            return "observed_surface_forced_evolution_v0"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
             return "generated_reference_lower_atmosphere_v1"
         case None:
@@ -308,10 +307,8 @@ def recipe_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
 def recipe_display_name_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
-        case RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-            return "Triggered Deep-Potential Experiment"
         case RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
-            return "Untriggered Observed-Sounding Evolution v0"
+            return "Observed Surface-Forced Evolution v0"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
             return "Generated Lower-Atmosphere Reference"
         case None:
@@ -321,10 +318,8 @@ def recipe_display_name_for_run_recipe(run_recipe: str | RunRecipe) -> str:
 def assumption_set_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
-        case RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-            return "triggered_deep_potential_warm_bubble_v1"
         case RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
-            return "untriggered_observed_sounding_evolution_v0_assumptions"
+            return "observed_surface_forced_evolution_v0_assumptions"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
             return "generated_reference_lower_atmosphere_v1"
         case None:
@@ -334,10 +329,8 @@ def assumption_set_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
 def assumption_mode_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
-        case RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-            return "triggered_deep_potential"
         case RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
-            return "normal_evolution"
+            return "surface_forced_observed_evolution"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
             return "generated_reference"
         case None:
@@ -347,12 +340,10 @@ def assumption_mode_for_run_recipe(run_recipe: str | RunRecipe) -> str:
 def required_output_fields_for_run_recipe(run_recipe: str | RunRecipe) -> tuple[str, ...]:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
-        case RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-            return ("qc", "w", "qr", "rain", "dbz", "updraft_helicity")
         case RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
-            return ("qv", "qc", "w", "qr", "rain", "dbz")
+            return ("qv", "qc", "w", "qr", "rain", "dbz", "hfx", "lhfx")
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
-            return ("qc", "w")
+            return ("qv", "qc", "w", "qr", "rain", "dbz", "hfx", "lhfx")
         case None:
             return ()
 
@@ -362,10 +353,11 @@ def recipe_caveats_for_run_recipe(run_recipe: str | RunRecipe) -> tuple[str, ...
     match resolved:
         case RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
             return (
-                "No warm-bubble or artificial deep-convection trigger is applied.",
+                "No artificial atmospheric trigger is applied.",
                 (
-                    "Surface fluxes use current recipe defaults; they are not validated "
-                    "place/time surface-energy inputs."
+                    "Surface heat/moisture fluxes are constant uniform lower-boundary "
+                    "proxy settings; they are not validated place/time surface-energy "
+                    "inputs."
                 ),
                 (
                     "Radiation, terrain, GIS surface initialization, and large-scale forcing "
@@ -375,11 +367,6 @@ def recipe_caveats_for_run_recipe(run_recipe: str | RunRecipe) -> tuple[str, ...
                     "Humid/rainy hypotheses remain partial until rain-water-aloft, "
                     "surface-rain, and reflectivity outputs are present and inspected."
                 ),
-            )
-        case RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-            return (
-                "The recipe tests triggered potential, not normal atmospheric evolution.",
-                "The warm-bubble trigger must be preserved in provenance and Results comparison.",
             )
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
             return ()
@@ -399,16 +386,7 @@ def _coerce_run_recipe(run_recipe: str | RunRecipe) -> RunRecipe | None:
 def _trigger_parameters(
     run_recipe: RunRecipe,
 ) -> dict[str, str | int | float | bool]:
-    if run_recipe != RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-        return {}
-    return {
-        "cm1_iinit": 3,
-        "cm1_trigger": (
-            "CM1 built-in three warm bubbles with 2 K maximum potential-temperature "
-            "perturbations in a line near 1.4 km AGL"
-        ),
-        "raw_controls_exposed": False,
-    }
+    return {}
 
 
 def _expected_outputs(
@@ -418,12 +396,6 @@ def _expected_outputs(
     base = ("qc", "qr", "qv", "th", "prs", "u", "v", "w", "rain", "dbz")
     analysis = (*base, "psfc", "hfx", "lhfx", "lwp")
     rich = (*analysis, "tke", "km", "kh", "vorticity", "updraft_helicity")
-    if diagnostic_set == "essential":
-        return base
-    if diagnostic_set == "process":
-        return analysis
-    if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-        return rich
     return rich
 
 
@@ -435,35 +407,12 @@ def _run_caveats(
     if run_recipe == RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
         caveats.extend(recipe_caveats_for_run_recipe(run_recipe))
         return tuple(caveats)
-    if run_recipe != RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-        return tuple(caveats)
-    caveats.extend(
-        [
-            "Triggered deep-potential runs use an idealized CM1 three-warm-bubble trigger.",
-            (
-                "Manual smoke evidence applies to the triggered deep-potential recipe; "
-                "each observed sounding remains an experiment to evaluate after CM1 completes."
-            ),
-            (
-                "Storm mode, rotation, rain, downdraft, and cold-pool behavior are outcomes "
-                "to inspect after the run."
-            ),
-            "Terrain, mesoscale lift, radiation, and map/GIS forcing are not part of v1.",
-        ]
-    )
-    if "configuration_better_suited_to_larger_compute" in run_configuration.caveats:
-        caveats.append(
-            "This configuration may be better suited to larger compute; cost/runtime/output "
-            "volume should be reviewed before launch."
-        )
     return tuple(caveats)
 
 
 def _manual_validation_status(run_recipe: RunRecipe) -> str:
-    if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-        return "triggered_deep_potential_recipe_smoke_validated"
     if run_recipe == RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
-        return "untriggered_observed_sounding_evolution_v0_metadata_only"
+        return "observed_surface_forced_evolution_v0_metadata_only"
     return "current_run_recipe_path"
 
 
@@ -494,7 +443,7 @@ def _recipe_assumptions(
             "seconds": values.output_cadence_seconds,
         },
         "diagnostic_set": {
-            "mode": "configured",
+            "mode": "full_outputs_always",
             "selection": run_configuration.diagnostic_set,
         },
     }
@@ -503,46 +452,49 @@ def _recipe_assumptions(
             **configured_shape,
             "trigger": {
                 "mode": "none",
-                "description": "No warm-bubble or artificial deep-convection trigger.",
+                "description": "No artificial atmospheric trigger.",
             },
             "observed_sounding": {
                 "temperature_profile": "required",
                 "moisture_profile": "required",
                 "wind_profile": "used_when_available",
             },
-            "surface_fluxes": {
-                "mode": "current_recipe_default",
-                "description": (
-                    "Uniform constant sensible/latent flux proxy inherited from the "
-                    "current observed-sounding LES path."
-                ),
-            },
-            "radiation": {"mode": "disabled", "cm1_radopt": 0},
-            "large_scale_forcing": {"mode": "none"},
-        }
-    if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-        return {
-            **configured_shape,
-            "trigger": {
-                "mode": "prescribed",
-                "type": "warm_bubble",
-                "description": "CM1 built-in three-warm-bubble line initiation.",
-            },
-            "observed_sounding": {
-                "temperature_profile": "required",
-                "moisture_profile": "required",
-                "wind_profile": "required_complete_finite_uv",
-            },
-            "surface_fluxes": {"mode": "disabled"},
+            "surface_fluxes": _surface_flux_assumption_payload(run_configuration),
             "radiation": {"mode": "disabled", "cm1_radopt": 0},
             "large_scale_forcing": {"mode": "none"},
         }
     return {
         **configured_shape,
         "trigger": {"mode": "generated_reference"},
-        "surface_fluxes": {"mode": "current_recipe_default"},
+        "surface_fluxes": _surface_flux_assumption_payload(run_configuration),
         "radiation": {"mode": "disabled", "cm1_radopt": 0},
         "large_scale_forcing": {"mode": "none"},
+    }
+
+
+def _surface_flux_assumption_payload(run_configuration: RunConfiguration) -> dict[str, object]:
+    values = run_configuration.surface_flux_cm1_values
+    if run_configuration.surface_flux_mode == "disabled":
+        return {
+            "mode": "disabled",
+            "cm1_values": values.model_dump(mode="json"),
+        }
+    return {
+        "mode": run_configuration.surface_flux_mode,
+        "description": (
+            "Uniform lower-boundary heat/moisture forcing, constant over the domain and model time."
+        ),
+        "translation_method": (
+            "Numeric product values map directly to CM1 constant-flux namelist "
+            "values. CM1 units are preserved and are not presented as W/m2."
+        ),
+        "product_selections": {
+            "surface_heat_flux_k_m_s": run_configuration.surface_heat_flux_k_m_s,
+            "surface_moisture_flux_g_g_m_s": run_configuration.surface_moisture_flux_g_g_m_s,
+            "summary": run_configuration.surface_flux_summary,
+        },
+        "cm1_values": values.model_dump(mode="json"),
+        "caveats": list(run_configuration.surface_flux_caveats),
     }
 
 
@@ -550,6 +502,7 @@ def _output_switches(
     diagnostic_set: str,
     *,
     deep_convection: bool,
+    surface_flux_outputs: bool,
 ) -> dict[str, int]:
     switches = {
         "sfcflx": 0,
@@ -564,6 +517,16 @@ def _output_switches(
         "lwp": 0,
     }
     if diagnostic_set in {"process", "full"}:
+        switches.update(
+            {
+                "sfcflx": 1,
+                "sfcparams": 1,
+                "sfcdiags": 1,
+                "psfc": 1,
+                "lwp": 1,
+            }
+        )
+    if surface_flux_outputs:
         switches.update(
             {
                 "sfcflx": 1,
@@ -639,7 +602,7 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
     Observed-sounding runs use ``isnd = 7`` so CM1 reads the thermodynamic
     and wind profile from ``input_sounding``. The resolved run configuration
     controls runtime, horizontal cells, domain size, saved-output cadence, and
-    diagnostic set before CM1 is launched. The intentional
+    full output field set before CM1 is launched. The intentional
     product-path change outside the sounding source is ``output_format = 2`` so
     Cloud Chamber can ingest NetCDF output when the local CM1 build supports it.
     """
@@ -647,33 +610,31 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
     defaults = contract.cloud_scale_defaults
     sounding_source_id = 7 if contract.observed_sounding is not None else 17
     wind_profile_id = 0 if contract.observed_sounding is not None else 9
-    deep_convection = contract.run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL
-    testcase = 0 if deep_convection else 3
-    adapt_dt = 0 if deep_convection else 1
+    testcase = 3
+    adapt_dt = 1
     ptype = 5
-    ihail = 1 if deep_convection else 0
-    iautoc = 1 if deep_convection else 0
-    icor = 0 if deep_convection else 1
-    lspgrad = 0 if deep_convection else 2
-    idiss = 1 if deep_convection else 0
-    wbc = ebc = sbc = nbc = 2 if deep_convection else 1
-    bbc = 1 if deep_convection else 3
-    iinit = 3 if deep_convection else 0
-    irandp = 0 if deep_convection else 1
-    imove = 1 if deep_convection else 0
+    ihail = 0
+    iautoc = 0
+    icor = 1
+    lspgrad = 2
+    idiss = 0
+    wbc = ebc = sbc = nbc = 1
+    bbc = 3
+    iinit = 0
+    irandp = 1
+    imove = 0
     output = _output_switches(
         contract.run_configuration.diagnostic_set,
-        deep_convection=deep_convection,
+        deep_convection=False,
+        surface_flux_outputs=(
+            contract.run_configuration.surface_flux_mode == "constant_uniform_surface_flux_proxy"
+        ),
     )
-    isfcflx = 0 if deep_convection else 1
-    sfcmodel = 0 if deep_convection else 1
-    oceanmodel = 0 if deep_convection else 1
-    set_flx = 0 if deep_convection else 1
-    set_ust = 0 if deep_convection else 1
-    l_h = 100.0 if deep_convection else 0.0
-    lhref1 = 100.0 if deep_convection else 0.0
-    lhref2 = 1000.0 if deep_convection else 0.0
-    ndcnst = 250.0 if deep_convection else 100.0
+    surface = contract.run_configuration.surface_flux_cm1_values
+    l_h = 0.0
+    lhref1 = 0.0
+    lhref2 = 0.0
+    ndcnst = 100.0
     return f"""
  &param0
  nx           =      {defaults.nx},
@@ -798,9 +759,9 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  /
 
  &param12
- isfcflx    =      {isfcflx},
- sfcmodel   =      {sfcmodel},
- oceanmodel =      {oceanmodel},
+ isfcflx    =      {surface.isfcflx},
+ sfcmodel   =      {surface.sfcmodel},
+ oceanmodel =      {surface.oceanmodel},
  initsfc    =      1,
  tsk0       = 299.28,
  tmn0       = 297.28,
@@ -815,13 +776,13 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  iz0tlnd    =      0,
  oml_hml0   =   50.0,
  oml_gamma  =   0.14,
- set_flx    =      {set_flx},
- cnst_shflx = 8.0e-3,
- cnst_lhflx = 5.2e-5,
- set_znt    =      0,
- cnst_znt   =   0.00,
- set_ust    =      {set_ust},
- cnst_ust   =   0.28,
+ set_flx    =      {surface.set_flx},
+ cnst_shflx = {_format_cm1_scientific(surface.cnst_shflx)},
+ cnst_lhflx = {_format_cm1_scientific(surface.cnst_lhflx)},
+ set_znt    =      {surface.set_znt},
+ cnst_znt   =   {surface.cnst_znt:.2f},
+ set_ust    =      {surface.set_ust},
+ cnst_ust   =   {surface.cnst_ust:.2f},
  ramp_sgs   =      1,
  ramp_time  = 1800.0,
  t2p_avg   =       1,
@@ -1000,6 +961,12 @@ def _format_cm1_float(value: float) -> str:
     if "." not in text:
         return f"{text}.0"
     return text
+
+
+def _format_cm1_scientific(value: float) -> str:
+    if value == 0:
+        return "0.0"
+    return f"{value:.1e}".replace("e-0", "e-").replace("e+0", "e+")
 
 
 def render_input_sounding_notes(contract: CM1InputContract) -> str:

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -263,7 +263,7 @@ def _user_facing_validation_error(message: str) -> str:
         "horizontal_cell_count": "horizontal cell count",
         "domain_size": "domain size",
         "output_cadence": "output cadence",
-        "diagnostic_set": "diagnostic set",
+        "diagnostic_set": "output field density",
     }
     for internal, label in replacements.items():
         message = message.replace(internal, label)
@@ -355,6 +355,8 @@ def _dry_run_report_payload(
         "variant_metadata": {
             "moisture_profile": contract.moisture_profile,
             "stability_profile": contract.stability_profile,
+            "surface_flux_mode": contract.run_configuration.surface_flux_mode,
+            "surface_flux_summary": contract.run_configuration.surface_flux_summary,
             "sounding_source": (
                 "observed_igra_station_text"
                 if contract.observed_sounding is not None
@@ -470,20 +472,15 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
     estimated_compute_multiplier = grid_multiplier * timestep_multiplier * runtime_multiplier
     estimated_output_volume_multiplier = grid_multiplier * output_frame_multiplier
     is_smoke = contract.run_configuration.mode == "smoke"
-    is_triggered_deep_potential = contract.run_recipe.value == "triggered_deep_potential"
     cost_warning = (
-        _triggered_deep_potential_cost_warning(contract.run_configuration)
-        if is_triggered_deep_potential
+        (
+            "Short smoke mode checks package health and CM1 startup behavior; "
+            "it is not long enough to evaluate normal atmospheric evolution."
+        )
+        if is_smoke
         else (
-            (
-                "Short smoke mode checks package health and CM1 startup behavior; "
-                "it is not long enough to evaluate normal atmospheric evolution."
-            )
-            if is_smoke
-            else (
-                "Configuration cost depends on duration, horizontal cells, domain, cadence, "
-                "and diagnostic set. Review the CM1-facing values before launch."
-            )
+            "Configuration cost depends on duration, horizontal cells, domain, cadence, "
+            "and full output volume. Review the CM1-facing values before launch."
         )
     )
     return {
@@ -495,6 +492,14 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
         "domain_size": contract.run_configuration.domain_size,
         "output_cadence": contract.run_configuration.output_cadence,
         "diagnostic_set": contract.run_configuration.diagnostic_set,
+        "surface_heat_flux_k_m_s": contract.run_configuration.surface_heat_flux_k_m_s,
+        "surface_moisture_flux_g_g_m_s": (contract.run_configuration.surface_moisture_flux_g_g_m_s),
+        "surface_flux_mode": contract.run_configuration.surface_flux_mode,
+        "surface_flux_summary": contract.run_configuration.surface_flux_summary,
+        "surface_flux_cm1_values": contract.run_configuration.surface_flux_cm1_values.model_dump(
+            mode="json"
+        ),
+        "surface_flux_caveats": list(contract.run_configuration.surface_flux_caveats),
         "runtime_seconds": defaults.runtime_seconds,
         "output_cadence_seconds": defaults.output_cadence_seconds,
         "expected_output_frames": output_frames,
@@ -506,12 +511,7 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
         "dz_m": defaults.vertical_spacing_m,
         "model_top_m": defaults.vertical_extent_km * 1000.0,
         "time_step_seconds": defaults.time_step_seconds,
-        "time_step_note": (
-            "Triggered deep-potential runs use a larger solver timestep for the storm-scale "
-            "idealized-trigger setup."
-            if is_triggered_deep_potential
-            else "CM1 solver timestep is resolved from the selected run configuration."
-        ),
+        "time_step_note": "CM1 solver timestep is resolved from the selected run configuration.",
         "grid_cell_count": grid_cells,
         "grid_cell_multiplier_vs_default": round(grid_multiplier, 2),
         "time_step_multiplier_vs_default": round(timestep_multiplier, 2),
@@ -522,41 +522,28 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
         ),
         "cost_warning": cost_warning,
         "validation_note": (
-            "Triggered deep-potential runs use a wider idealized domain, observed winds, "
-            "and a warm-bubble trigger. Manual CM1 smoke evidence applies to the recipe; "
-            "each observed sounding remains an experiment until CM1 output is inspected."
-            if is_triggered_deep_potential
+            "Short smoke mode is separated from science runs; use short evolution or longer "
+            "configurations for meteorological evolution."
+            if is_smoke
             else (
-                "Short smoke mode is separated from science runs; use short evolution or longer "
-                "configurations for meteorological evolution."
-                if is_smoke
-                else (
-                    "Run configuration preserves explicit duration, horizontal cell count, "
-                    "domain, cadence, and diagnostic-set choices."
-                )
+                "Run configuration preserves explicit duration, horizontal cell count, "
+                "domain, cadence, full-output requests, and numeric surface-forcing values."
             )
         ),
     }
 
 
 def _run_recipe_mapping_summary(contract: CM1InputContract) -> str:
-    if contract.run_recipe.value == "triggered_deep_potential":
-        return (
-            "observed IGRA external input_sounding profile with observed u/v winds; "
-            "triggered deep-potential recipe uses CM1 isnd=7, testcase=0, iinit=3 "
-            "three-warm-bubble line initiation, a storm-scale idealized domain, NetCDF "
-            "output, rain output, reflectivity output, vorticity output, and "
-            "updraft-helicity output"
-        )
     if contract.observed_sounding is not None:
         return (
-            "observed IGRA external input_sounding profile; untriggered observed-sounding "
-            "evolution v0 uses CM1 isnd=7, no warm-bubble trigger, configured duration, "
-            "configured domain and output cadence, current surface-flux defaults, disabled "
-            "radiation, no large-scale forcing, NetCDF output, cloud water, water vapor, "
-            "vertical velocity, rain-water-aloft, surface-rain, and reflectivity output "
-            "where available; observed wind direction/speed is converted to u/v and "
-            "applied through CM1 input_sounding handling"
+            "observed IGRA external input_sounding profile; the run uses CM1 isnd=7, "
+            "configured duration, configured domain and output cadence, numeric constant "
+            "uniform lower-boundary heat/moisture flux proxy settings, disabled radiation, "
+            "no large-scale forcing, NetCDF output, cloud water, water vapor, vertical "
+            "velocity, rain-water-aloft, surface-rain, reflectivity, vorticity, "
+            "updraft-helicity, and surface-flux output where available; observed "
+            "wind direction/speed is converted to u/v and applied through CM1 input_sounding "
+            "handling"
         )
     return (
         "external input_sounding profile; namelist settings remain inherited from "
@@ -566,36 +553,15 @@ def _run_recipe_mapping_summary(contract: CM1InputContract) -> str:
 
 
 def _cm1_mapping_status(contract: CM1InputContract) -> str:
-    if contract.run_recipe.value == "triggered_deep_potential":
-        return (
-            "CM1-ready triggered deep-potential run with manual CM1 smoke evidence "
-            "for the recipe; each observed sounding remains an experiment"
-        )
     if contract.observed_sounding is not None:
         return (
-            "CM1-ready untriggered observed-sounding evolution v0 run with explicit "
-            "normal-evolution assumptions; still pending case-specific local/manual "
-            "scientific interpretation"
+            "CM1-ready observed-sounding run with explicit uniform lower-boundary "
+            "heat/moisture forcing assumptions; still pending case-specific local/manual "
+            "scientific interpretation after CM1 output is inspected"
         )
     return (
         "CM1-ready generated-reference run; still pending local/manual smoke-run "
         "scientific validation"
-    )
-
-
-def _triggered_deep_potential_cost_warning(run_configuration: object) -> str:
-    mode = getattr(run_configuration, "mode", "")
-    domain = getattr(run_configuration, "domain_size", "storm_120km")
-    cadence = getattr(run_configuration, "output_cadence", "standard_15min")
-    if mode == "smoke":
-        return (
-            "Smoke mode checks run-input health with the triggered "
-            "storm-scale setup; it is not a science-duration result."
-        )
-    return (
-        "Triggered deep-potential runs use a storm-scale domain. Review expected "
-        f"cost/runtime/output volume for {domain} and {cadence}; larger configurations "
-        "may be better suited to larger compute."
     )
 
 

--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -449,7 +449,6 @@ def build_interesting_time_product(
         diagnostics=diagnostics,
         output_manifest=output_manifest,
         variables=set(variables),
-        run_recipe=run_recipe,
     )
     defaults = _field_defaults(records)
     summary = _science_summary(
@@ -458,7 +457,6 @@ def build_interesting_time_product(
         records,
         defaults,
         variables=set(variables),
-        run_recipe=run_recipe,
     )
     caveats = _dedupe(
         [
@@ -482,7 +480,6 @@ def _interesting_time_records(
     diagnostics: ResultDiagnostics | None,
     output_manifest: OutputProductManifest,
     variables: set[str],
-    run_recipe: str | None,
 ) -> list[InterestingTimeRecord]:
     latest = _latest_time_record(output_manifest)
     if diagnostics is None:
@@ -555,9 +552,7 @@ def _interesting_time_records(
             output_manifest=output_manifest,
             unavailable_caveat="no_deep_cloud_detected" if cloud.available else "missing_qc_field",
             support_state="unavailable" if cloud.available else "unsupported_missing_fields",
-        )
-        if run_recipe == "triggered_deep_potential"
-        else None,
+        ),
         _event_record(
             key="max_updraft_w",
             label="Max updraft",
@@ -667,7 +662,7 @@ def _interesting_time_records(
     compact_records = [record for record in records if record is not None]
     compact_records.append(
         _field_default_record(
-            _default_source_record(compact_records, run_recipe=run_recipe),
+            _default_source_record(compact_records),
             fallback_reason=None,
         )
     )
@@ -905,13 +900,11 @@ def _science_summary(
     defaults: dict[str, FieldDefaultTime],
     *,
     variables: set[str],
-    run_recipe: str | None,
 ) -> ScienceSummary:
     record_by_key = {record.key: record for record in records}
     default_record = record_by_key.get("field_default_time")
     latest = record_by_key.get("latest_output")
     qc_default = defaults.get("qc")
-    is_deep_convection = run_recipe == "triggered_deep_potential"
     if diagnostics is None:
         return ScienceSummary(
             latest_output_time_seconds=latest.time_seconds if latest else None,
@@ -922,6 +915,7 @@ def _science_summary(
         )
     supported_science_keys = {
         "first_cloud",
+        "first_deep_convection",
         "max_qc",
         "highest_cloud_top",
         "max_updraft_w",
@@ -941,7 +935,7 @@ def _science_summary(
     first_deep_convection = _record_time(record_by_key.get("first_deep_convection"))
     deep_cloud_formed = _deep_cloud_formed(diagnostics)
     strong_updraft_formed = _strong_updraft_formed(diagnostics)
-    default_source = default_record if is_deep_convection else qc_default or default_record
+    default_source = default_record if deep_cloud_formed else qc_default or default_record
     return ScienceSummary(
         cloud_formed=diagnostics.cloud.formed if diagnostics.cloud.available else None,
         deep_cloud_formed=deep_cloud_formed,
@@ -976,7 +970,7 @@ def _science_summary(
         else _latest_manifest_time(output_manifest),
         default_explore_time_index=default_source.time_index if default_source else None,
         default_explore_time_seconds=default_source.time_seconds if default_source else None,
-        cm1_outcome=_cm1_outcome(diagnostics) if is_deep_convection else None,
+        cm1_outcome=None,
         diagnostic_availability=_diagnostic_availability(variables, diagnostics),
         interesting_time_support_state=support_state,
     )
@@ -984,14 +978,14 @@ def _science_summary(
 
 def _default_source_record(
     records: list[InterestingTimeRecord],
-    *,
-    run_recipe: str | None,
 ) -> InterestingTimeRecord:
     by_key = {record.key: record for record in records}
     preferred_keys = (
-        ("first_deep_convection", "max_updraft_w", "rain_onset", "max_qc")
-        if run_recipe == "triggered_deep_potential"
-        else ("first_cloud", "max_qc", "max_updraft_w")
+        "first_deep_convection",
+        "first_cloud",
+        "max_qc",
+        "max_updraft_w",
+        "rain_onset",
     )
     for key in preferred_keys:
         record = by_key.get(key)

--- a/app/backend/cloud_chamber/pre_run_validation.py
+++ b/app/backend/cloud_chamber/pre_run_validation.py
@@ -9,6 +9,7 @@ from cloud_chamber.cm1_input_contract import (
     RunRecipe,
     assumption_mode_for_run_recipe,
     assumption_set_id_for_run_recipe,
+    has_complete_rendered_observed_wind_profile,
     recipe_caveats_for_run_recipe,
     recipe_display_name_for_run_recipe,
     recipe_id_for_run_recipe,
@@ -49,7 +50,13 @@ def build_pre_run_validation_report(
         field for field in required_outputs if field not in set(contract.expected_outputs)
     ]
     alignment = _hypothesis_recipe_alignment(story, contract.run_recipe)
+    input_validation = _input_validation_payload(contract.observed_sounding, contract)
     blocking_errors = list(alignment["blocking_errors"])
+    if input_validation["observed_wind_profile"] == "missing_required":
+        blocking_errors.append(
+            "Observed-sounding runs require a complete finite observed u/v wind profile "
+            "for every input_sounding level."
+        )
     caveats = _dedupe(
         [
             *contract.run_configuration.caveats,
@@ -76,7 +83,7 @@ def build_pre_run_validation_report(
             "missing_assumptions": alignment["missing_assumptions"],
             "missing_outputs": missing_outputs,
         },
-        "input_validation": _input_validation_payload(contract.observed_sounding, contract),
+        "input_validation": input_validation,
         "run_shape_validation": _run_shape_validation_payload(contract),
         "forcing_validation": _forcing_validation_payload(contract),
         "output_validation": {
@@ -272,12 +279,18 @@ def _input_validation_payload(
             "model_bottom_elevation": "generated_reference",
             "caveats": [],
         }
-    wind_required = False
-    wind_status = (
-        ("present_required" if wind_required else "present_optional")
-        if observed_sounding.wind_handling
-        else ("missing_required" if wind_required else "optional_missing")
+    wind_required = contract.run_recipe == RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION
+    complete_wind_profile = has_complete_rendered_observed_wind_profile(
+        observed_sounding,
+        defaults=contract.cloud_scale_defaults,
     )
+    if wind_required:
+        wind_status = "present_required" if complete_wind_profile else "missing_required"
+    else:
+        wind_status = "present_optional" if complete_wind_profile else "optional_missing"
+    caveats = list(observed_sounding.validation.caveats)
+    if wind_status == "missing_required":
+        caveats.append("complete_observed_wind_profile_required_for_input_sounding")
     return {
         "observed_temperature_profile": "present",
         "observed_moisture_profile": "present",
@@ -285,7 +298,7 @@ def _input_validation_payload(
         "model_bottom_elevation": (
             "present" if observed_sounding.model_bottom_elevation_m_msl is not None else "missing"
         ),
-        "caveats": list(observed_sounding.validation.caveats),
+        "caveats": _dedupe(caveats),
     }
 
 

--- a/app/backend/cloud_chamber/pre_run_validation.py
+++ b/app/backend/cloud_chamber/pre_run_validation.py
@@ -179,37 +179,18 @@ def _hypothesis_recipe_alignment(
             "caveats": [],
         }
     if story in DEEP_CONVECTION_STORIES:
-        if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-            return {
-                "status": "aligned",
-                "reasons": [
-                    "Deep-convection hypothesis is paired with the triggered deep-potential recipe."
-                ],
-                "missing_assumptions": [],
-                "blocking_errors": [],
-                "caveats": [],
-            }
         return {
-            "status": "blocked",
-            "reasons": ["Deep-convection hypothesis is paired with an untriggered/shallow recipe."],
-            "missing_assumptions": ["triggered_deep_potential_warm_bubble_v1"],
-            "blocking_errors": [
-                "Selected run recipe does not test this deep-convection hypothesis."
-            ],
-            "caveats": [],
-        }
-    if story in NORMAL_EVOLUTION_STORIES and run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-        return {
-            "status": "blocked",
+            "status": "partial",
             "reasons": [
-                "Normal-evolution hypothesis is paired with an explicitly triggered recipe."
+                "Deep-convection ingredients can be tested only as the selected run evolves "
+                "under the configured lower-boundary forcing."
             ],
-            "missing_assumptions": ["normal_evolution_without_explicit_trigger"],
-            "blocking_errors": [
-                "Selected triggered recipe would make comparison metadata misleading "
-                "for this hypothesis."
+            "missing_assumptions": [],
+            "blocking_errors": [],
+            "caveats": [
+                "deep_convection_outcome_depends_on_surface_forcing_duration_domain_and_resolution",
+                "differential_surface_initiation_is_tracked_in_issue_307",
             ],
-            "caveats": [],
         }
     if story == "humid_rainy_candidate":
         return {
@@ -291,7 +272,7 @@ def _input_validation_payload(
             "model_bottom_elevation": "generated_reference",
             "caveats": [],
         }
-    wind_required = contract.run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL
+    wind_required = False
     wind_status = (
         ("present_required" if wind_required else "present_optional")
         if observed_sounding.wind_handling
@@ -376,28 +357,28 @@ def _run_shape_from_payload(
     }
 
 
-def _forcing_validation_payload(contract: CM1InputContract) -> dict[str, str]:
-    return _forcing_validation_for_recipe(contract.run_recipe.value)
+def _forcing_validation_payload(contract: CM1InputContract) -> dict[str, Any]:
+    payload: dict[str, Any] = dict(_forcing_validation_for_recipe(contract.run_recipe.value))
+    surface_fluxes = contract.recipe_assumptions.get("surface_fluxes")
+    if isinstance(surface_fluxes, dict):
+        payload["surface_fluxes"] = surface_fluxes
+    return payload
 
 
-def _forcing_validation_for_recipe(run_recipe: str) -> dict[str, str]:
-    if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL.value:
-        return {
-            "trigger": "warm_bubble_required_for_triggered_deep_potential",
-            "surface_fluxes": "disabled",
-            "radiation": "disabled",
-            "large_scale_forcing": "none",
-        }
+def _forcing_validation_for_recipe(run_recipe: str) -> dict[str, Any]:
     if run_recipe == RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION.value:
         return {
             "trigger": "none",
-            "surface_fluxes": "current_recipe_default_caveated",
+            "surface_fluxes": {
+                "mode": "constant_uniform_surface_flux_proxy",
+                "status": "selected_values_unavailable_before_configuration_resolves",
+            },
             "radiation": "disabled",
             "large_scale_forcing": "none",
         }
     return {
         "trigger": "none",
-        "surface_fluxes": "current_recipe_default",
+        "surface_fluxes": {"mode": "current_recipe_default"},
         "radiation": "disabled",
         "large_scale_forcing": "not_supported_v1",
     }
@@ -407,12 +388,12 @@ def _required_outputs_for_story(
     story: str | None,
     run_recipe: RunRecipe,
 ) -> list[str]:
-    if story in DEEP_CONVECTION_STORIES or run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL:
-        return ["qc", "w", "qr", "rain", "dbz", "updraft_helicity"]
+    if story in DEEP_CONVECTION_STORIES:
+        return ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "lhfx", "updraft_helicity"]
     if story == "humid_rainy_candidate":
-        return ["qv", "qc", "w", "qr", "rain", "dbz"]
+        return ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "lhfx"]
     if run_recipe == RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION:
-        return ["qv", "qc", "w"]
+        return ["qv", "qc", "w", "hfx", "lhfx"]
     return ["qc", "w"]
 
 
@@ -485,10 +466,10 @@ def _run_recipe(value: str) -> RunRecipe:
 
 
 def _run_recipe_display_name(run_recipe: str) -> str:
-    if run_recipe == RunRecipe.TRIGGERED_DEEP_POTENTIAL.value:
-        return "Triggered Deep-Potential Experiment"
+    if run_recipe == "triggered_deep_potential":
+        return "Removed Triggered Deep-Potential Path"
     if run_recipe == RunRecipe.UNTRIGGERED_OBSERVED_EVOLUTION.value:
-        return "Untriggered Observed Evolution"
+        return "Observed Surface-Forced Evolution"
     return "Generated Lower-Atmosphere Reference"
 
 

--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -301,31 +301,21 @@ def _card_from_metadata(
 
 
 def _default_result_card_name(metadata: ResultMetadata) -> str:
-    if metadata.run_recipe == "triggered_deep_potential":
-        station_name = _observed_sounding_value(metadata.observed_sounding, "station_name")
-        station_id = _observed_sounding_value(metadata.observed_sounding, "station_id")
-        if station_name:
-            return f"Triggered Deep-Potential Experiment — {station_name}"
-        if station_id:
-            return f"Triggered Deep-Potential Experiment — {station_id}"
-        return "Triggered Deep-Potential Experiment"
     if metadata.input_source == "observed_sounding":
         recipe_name = metadata.recipe_display_name or metadata.run_recipe_display_name
         station_name = _observed_sounding_value(metadata.observed_sounding, "station_name")
         station_id = _observed_sounding_value(metadata.observed_sounding, "station_id")
         if station_name:
-            return f"{recipe_name or 'Untriggered Observed Evolution'} — {station_name}"
+            return f"{recipe_name or 'Observed Surface-Forced Evolution'} — {station_name}"
         if station_id:
-            return f"{recipe_name or 'Untriggered Observed Evolution'} — {station_id}"
-        return recipe_name or "Untriggered Observed Evolution"
+            return f"{recipe_name or 'Observed Surface-Forced Evolution'} — {station_id}"
+        return recipe_name or "Observed Surface-Forced Evolution"
     return metadata.scenario_name or metadata.scenario_id
 
 
 def _display_scenario_name(metadata: ResultMetadata) -> str | None:
-    if metadata.run_recipe == "triggered_deep_potential" and metadata.run_recipe_display_name:
-        return metadata.run_recipe_display_name
     if metadata.input_source == "observed_sounding":
-        return metadata.recipe_display_name or "Untriggered Observed Evolution"
+        return metadata.recipe_display_name or "Observed Surface-Forced Evolution"
     return metadata.scenario_name
 
 

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -1007,19 +1007,6 @@ def _candidate_hypothesis_comparison(
                 [*caveats, "candidate_story_not_in_deep_convection_v1_rule_set"]
             ),
         )
-    if result.run_recipe != "triggered_deep_potential":
-        return CandidateHypothesisComparison(
-            screened_as=screened_as,
-            ran_as=ran_as,
-            cm1_outcome=(
-                "Unable to evaluate candidate match because this was not a "
-                "triggered deep-potential run."
-            ),
-            match_status="unable_to_evaluate",
-            match_status_label="Unable to evaluate",
-            evidence=evidence,
-            caveats=_dedupe_strings([*caveats, "comparison_requires_triggered_deep_potential_run"]),
-        )
     if not diagnostics.cloud.available or not diagnostics.vertical_velocity.available:
         return CandidateHypothesisComparison(
             screened_as=screened_as,
@@ -1050,7 +1037,8 @@ def _candidate_hypothesis_comparison(
     return CandidateHypothesisComparison(
         screened_as=screened_as,
         ran_as=ran_as,
-        cm1_outcome=science_summary.cm1_outcome or "CM1 outcome unavailable.",
+        cm1_outcome=science_summary.cm1_outcome
+        or _deep_candidate_cm1_outcome(science_summary, diagnostics),
         match_status=match_status,
         match_status_label=_match_status_label(match_status),
         evidence=evidence,
@@ -1095,11 +1083,30 @@ def _candidate_story_label(story: str | None) -> str | None:
 
 
 def _display_run_recipe(run_recipe: str | None) -> str:
-    if run_recipe == "triggered_deep_potential":
-        return "Triggered Deep-Potential Experiment"
     if run_recipe == "untriggered_observed_evolution":
-        return "Untriggered Observed Evolution"
+        return "Observed Surface-Forced Evolution"
     return "CM1 run"
+
+
+def _deep_candidate_cm1_outcome(
+    science_summary: ScienceSummary,
+    diagnostics: ResultDiagnostics,
+) -> str:
+    deep_cloud = science_summary.deep_cloud_formed is True
+    strong_updraft = science_summary.strong_updraft_formed is True
+    rain_water_aloft = diagnostics.rain.available and diagnostics.rain.present
+    surface_rain = diagnostics.surface_rain.available and diagnostics.surface_rain.present is True
+    if deep_cloud and strong_updraft and rain_water_aloft and surface_rain:
+        return "Deep convection formed with strong updraft, rain water aloft, and surface rain."
+    if deep_cloud and strong_updraft and rain_water_aloft:
+        return "Deep convection formed with strong updraft and rain water aloft."
+    if deep_cloud and strong_updraft:
+        return "Deep convection formed with strong updraft."
+    if deep_cloud or strong_updraft or rain_water_aloft:
+        return (
+            "Some deep-candidate evidence appeared, but the full deep-convection signature did not."
+        )
+    return "Deep convection was not detected by current cloud-top and updraft thresholds."
 
 
 def _match_status_label(match_status: str) -> str:

--- a/app/backend/cloud_chamber/run_configuration.py
+++ b/app/backend/cloud_chamber/run_configuration.py
@@ -1,12 +1,13 @@
 """Run-configuration choices for CM1 run generation.
 
 The product model is intentionally explicit: duration, horizontal cell budget,
-domain size, output cadence, and diagnostic set are separate levers. The backend
-resolves those choices into CM1-facing values before package creation.
+domain size, output cadence, and lower-boundary forcing are separate levers. The
+backend resolves those choices into CM1-facing values before package creation.
 """
 
 from __future__ import annotations
 
+import math
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -35,6 +36,23 @@ class RunConfigurationCM1Values(BaseModel):
     grid_cell_count: int
 
 
+class RunConfigurationSurfaceFluxCM1Values(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    isfcflx: int
+    sfcmodel: int
+    oceanmodel: int
+    set_flx: int
+    cnst_shflx: float
+    cnst_shflx_units: str
+    cnst_lhflx: float
+    cnst_lhflx_units: str
+    set_znt: int
+    cnst_znt: float
+    set_ust: int
+    cnst_ust: float
+
+
 class RunConfiguration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -51,6 +69,14 @@ class RunConfiguration(BaseModel):
     cost_runtime_summary: str
     output_volume_summary: str
     cm1_values: RunConfigurationCM1Values
+    initiation_method: str
+    initiation_summary: str
+    surface_heat_flux_k_m_s: float
+    surface_moisture_flux_g_g_m_s: float
+    surface_flux_mode: str
+    surface_flux_summary: str
+    surface_flux_cm1_values: RunConfigurationSurfaceFluxCM1Values
+    surface_flux_caveats: list[str] = Field(default_factory=list)
     caveats: list[str] = Field(default_factory=list)
 
 
@@ -171,32 +197,31 @@ CADENCE_CHOICES: dict[str, _CadenceChoice] = {
     "detailed_5min": _CadenceChoice(seconds=300, label="Detailed 5 min"),
 }
 
-DIAGNOSTIC_SET_CHOICES = {"essential", "process", "full"}
+DEFAULT_SURFACE_HEAT_FLUX_K_M_S = 8.0e-3
+DEFAULT_SURFACE_MOISTURE_FLUX_G_G_M_S = 5.2e-5
+SURFACE_HEAT_FLUX_CONTEXT_RANGE_K_M_S = (0.0, 0.2)
+SURFACE_MOISTURE_FLUX_CONTEXT_RANGE_G_G_M_S = (0.0, 2.0e-4)
 
 
-def default_run_configuration_payload(run_recipe: str | None = None) -> dict[str, str]:
-    if run_recipe == "triggered_deep_potential":
-        return {
-            "duration": "short_6h",
-            "horizontal_cell_count": "cells_128",
-            "domain_size": "storm_120km",
-            "output_cadence": "standard_15min",
-            "diagnostic_set": "full",
-        }
+def default_run_configuration_payload(run_recipe: str | None = None) -> dict[str, str | float]:
     if run_recipe == "untriggered_observed_evolution":
         return {
             "duration": "short_6h",
             "horizontal_cell_count": "cells_128",
             "domain_size": "wide_12km",
             "output_cadence": "standard_15min",
-            "diagnostic_set": "process",
+            "diagnostic_set": "full",
+            "surface_heat_flux_k_m_s": DEFAULT_SURFACE_HEAT_FLUX_K_M_S,
+            "surface_moisture_flux_g_g_m_s": DEFAULT_SURFACE_MOISTURE_FLUX_G_G_M_S,
         }
     return {
         "duration": "short_6h",
         "horizontal_cell_count": "cells_64",
         "domain_size": "local_6km",
         "output_cadence": "standard_15min",
-        "diagnostic_set": "process",
+        "diagnostic_set": "full",
+        "surface_heat_flux_k_m_s": DEFAULT_SURFACE_HEAT_FLUX_K_M_S,
+        "surface_moisture_flux_g_g_m_s": DEFAULT_SURFACE_MOISTURE_FLUX_G_G_M_S,
     }
 
 
@@ -217,29 +242,45 @@ def resolve_run_configuration(
         **payload,
     }
 
-    if run_recipe == "triggered_deep_potential":
-        if payload.get("domain_size") in SHALLOW_DOMAIN_CHOICES:
-            payload["domain_size"] = "storm_120km"
-    elif payload.get("domain_size") in DEEP_DOMAIN_CHOICES:
+    initiation_method = "none"
+    if payload.get("domain_size") in DEEP_DOMAIN_CHOICES:
         payload["domain_size"] = "local_6km"
 
-    is_triggered_deep_potential = run_recipe == "triggered_deep_potential"
     duration = _choice(DURATION_CHOICES, payload.get("duration"), "duration")
     horizontal_cells = _choice(
         HORIZONTAL_CELL_CHOICES,
         payload.get("horizontal_cell_count"),
         "horizontal_cell_count",
     )
-    domains = DEEP_DOMAIN_CHOICES if is_triggered_deep_potential else SHALLOW_DOMAIN_CHOICES
-    domain = _choice(domains, payload.get("domain_size"), "domain_size")
+    domain = _choice(SHALLOW_DOMAIN_CHOICES, payload.get("domain_size"), "domain_size")
     cadence = _choice(
         CADENCE_CHOICES,
         payload.get("output_cadence"),
         "output_cadence",
     )
-    diagnostic_set = str(payload.get("diagnostic_set", "process"))
-    if diagnostic_set not in DIAGNOSTIC_SET_CHOICES:
-        raise ValueError(f"Unknown diagnostic_set: {diagnostic_set}")
+    diagnostic_set = "full"
+    heat_flux = _float_payload(
+        payload,
+        "surface_heat_flux_k_m_s",
+        "surface heat flux",
+    )
+    moisture_flux = _float_payload(
+        payload,
+        "surface_moisture_flux_g_g_m_s",
+        "surface moisture flux",
+    )
+    surface_flux_enabled = True
+    surface_flux_mode = "constant_uniform_surface_flux_proxy"
+    surface_flux_cm1_values = _surface_flux_cm1_values(
+        enabled=surface_flux_enabled,
+        heat_flux_k_m_s=heat_flux,
+        moisture_flux_g_g_m_s=moisture_flux,
+    )
+    surface_flux_caveats = _surface_flux_caveats(
+        surface_flux_mode,
+        heat_flux_k_m_s=heat_flux,
+        moisture_flux_g_g_m_s=moisture_flux,
+    )
 
     nx = horizontal_cells.cells
     ny = horizontal_cells.cells
@@ -254,13 +295,15 @@ def resolve_run_configuration(
         domain_size=str(payload["domain_size"]),
         output_cadence=str(payload["output_cadence"]),
         diagnostic_set=diagnostic_set,
+        surface_heat_flux_k_m_s=heat_flux,
+        surface_moisture_flux_g_g_m_s=moisture_flux,
+        surface_flux_mode=surface_flux_mode,
     )
     caveats = _configuration_caveats(
         mode=duration.mode,
-        run_recipe=run_recipe,
-        diagnostic_set=diagnostic_set,
         horizontal_cell_count=horizontal_cells.cells,
         domain_size=str(payload["domain_size"]),
+        surface_flux_caveats=surface_flux_caveats,
     )
     return RunConfiguration(
         configuration_id=configuration_id,
@@ -291,14 +334,26 @@ def resolve_run_configuration(
             model_top_m=domain.model_top_m,
             domain_x_km=domain.x_km,
             domain_y_km=domain.y_km,
-            time_step_seconds=_time_step_seconds(run_recipe),
+            time_step_seconds=_time_step_seconds(),
             runtime_seconds=duration.seconds,
             output_cadence_seconds=cadence.seconds,
             restart_cadence_seconds=restart_seconds,
-            rayleigh_damping_start_m=_rayleigh_damping_start_m(run_recipe),
+            rayleigh_damping_start_m=_rayleigh_damping_start_m(),
             expected_output_frames=frames,
             grid_cell_count=grid_cells,
         ),
+        initiation_method=initiation_method,
+        initiation_summary=_initiation_summary(initiation_method),
+        surface_heat_flux_k_m_s=heat_flux,
+        surface_moisture_flux_g_g_m_s=moisture_flux,
+        surface_flux_mode=surface_flux_mode,
+        surface_flux_summary=_surface_flux_summary(
+            surface_flux_mode,
+            heat_flux,
+            moisture_flux,
+        ),
+        surface_flux_cm1_values=surface_flux_cm1_values,
+        surface_flux_caveats=surface_flux_caveats,
         caveats=caveats,
     )
 
@@ -309,6 +364,22 @@ def _choice[T](choices: dict[str, T], value: object, label: str) -> T:
     return choices[value]
 
 
+def _float_payload(payload: dict[str, Any], key: str, label: str) -> float:
+    value = payload.get(key)
+    if isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError as exc:
+            raise ValueError(f"Unknown {label}: {value}") from exc
+    elif isinstance(value, int | float):
+        parsed = float(value)
+    else:
+        raise ValueError(f"Unknown {label}: {value}")
+    if not math.isfinite(parsed) or parsed < 0:
+        raise ValueError(f"Invalid {label}: must be a finite non-negative number")
+    return parsed
+
+
 def _configuration_id(
     *,
     duration: str,
@@ -316,8 +387,20 @@ def _configuration_id(
     domain_size: str,
     output_cadence: str,
     diagnostic_set: str,
+    surface_heat_flux_k_m_s: float,
+    surface_moisture_flux_g_g_m_s: float,
+    surface_flux_mode: str,
 ) -> str:
-    return f"{duration}__{horizontal_cell_count}__{domain_size}__{output_cadence}__{diagnostic_set}"
+    if surface_flux_mode == "disabled":
+        return (
+            f"{duration}__{horizontal_cell_count}__{domain_size}__{output_cadence}"
+            f"__{diagnostic_set}__surface_fluxes_disabled"
+        )
+    return (
+        f"{duration}__{horizontal_cell_count}__{domain_size}__{output_cadence}"
+        f"__{diagnostic_set}__shflx_{_flux_id(surface_heat_flux_k_m_s)}"
+        f"__qflx_{_flux_id(surface_moisture_flux_g_g_m_s)}"
+    )
 
 
 def _configuration_label(
@@ -341,42 +424,109 @@ def _runtime_summary(duration_seconds: int, grid_cells: int, cadence_seconds: in
 
 
 def _output_summary(frames: int, grid_cells: int, diagnostic_set: str) -> str:
-    return f"{frames:,} saved frames, {diagnostic_set} diagnostics, {grid_cells:,} cells per frame"
+    return f"{frames:,} saved frames, full output fields, {grid_cells:,} cells per frame"
 
 
 def _configuration_caveats(
     *,
     mode: RunMode,
-    run_recipe: str | None,
-    diagnostic_set: str,
     horizontal_cell_count: int,
     domain_size: str,
+    surface_flux_caveats: list[str],
 ) -> list[str]:
-    caveats: list[str] = []
+    caveats: list[str] = list(surface_flux_caveats)
     if mode == "smoke":
         caveats.append("short_smoke_mode_is_for_package_health_not_science_evolution")
     if mode == "science":
         caveats.append("science_run_configuration_minimum_duration_6h")
-    if run_recipe == "triggered_deep_potential":
-        caveats.append("triggered_deep_potential_is_not_normal_evolution")
-    if diagnostic_set == "essential":
-        caveats.append("essential_diagnostic_set_limits_later_diagnostics")
     if horizontal_cell_count >= 256 or domain_size in {
         "wide_12km",
         "regional_60km",
         "regional_120km",
-        "storm_240km",
     }:
         caveats.append("configuration_better_suited_to_larger_compute")
     return caveats
 
 
-def _time_step_seconds(run_recipe: str | None) -> float:
-    return 6.0 if run_recipe == "triggered_deep_potential" else 3.0
+def _initiation_summary(initiation_method: str) -> str:
+    return "No artificial initiation"
 
 
-def _rayleigh_damping_start_m(run_recipe: str | None) -> int:
-    return 15000 if run_recipe == "triggered_deep_potential" else 2500
+def _surface_flux_cm1_values(
+    *,
+    enabled: bool,
+    heat_flux_k_m_s: float,
+    moisture_flux_g_g_m_s: float,
+) -> RunConfigurationSurfaceFluxCM1Values:
+    return RunConfigurationSurfaceFluxCM1Values(
+        isfcflx=1 if enabled else 0,
+        sfcmodel=1 if enabled else 0,
+        oceanmodel=1 if enabled else 0,
+        set_flx=1 if enabled else 0,
+        cnst_shflx=heat_flux_k_m_s if enabled else 0.0,
+        cnst_shflx_units="K m/s",
+        cnst_lhflx=moisture_flux_g_g_m_s if enabled else 0.0,
+        cnst_lhflx_units="g/g m/s",
+        set_znt=0,
+        cnst_znt=0.0,
+        set_ust=1 if enabled else 0,
+        cnst_ust=0.28,
+    )
+
+
+def _surface_flux_summary(
+    surface_flux_mode: str,
+    heat_flux_k_m_s: float,
+    moisture_flux_g_g_m_s: float,
+) -> str:
+    if surface_flux_mode == "disabled":
+        return "Surface heat/moisture flux forcing disabled"
+    return (
+        f"Surface heat flux {_format_scientific(heat_flux_k_m_s)} K m/s; "
+        f"surface moisture flux {_format_scientific(moisture_flux_g_g_m_s)} g/g m/s; "
+        "constant uniform proxy"
+    )
+
+
+def _surface_flux_caveats(
+    surface_flux_mode: str,
+    *,
+    heat_flux_k_m_s: float,
+    moisture_flux_g_g_m_s: float,
+) -> list[str]:
+    if surface_flux_mode == "disabled":
+        return []
+    caveats = [
+        "surface_flux_proxy_constant_uniform_not_place_time_energy_budget",
+        "surface_flux_proxy_not_real_land_surface_or_evaporation_model",
+        "surface_flux_proxy_values_need_local_smoke_validation",
+    ]
+    if not _in_range(heat_flux_k_m_s, SURFACE_HEAT_FLUX_CONTEXT_RANGE_K_M_S):
+        caveats.append("surface_heat_flux_outside_daytime_context_range")
+    if not _in_range(moisture_flux_g_g_m_s, SURFACE_MOISTURE_FLUX_CONTEXT_RANGE_G_G_M_S):
+        caveats.append("surface_moisture_flux_outside_daytime_context_range")
+    return caveats
+
+
+def _in_range(value: float, bounds: tuple[float, float]) -> bool:
+    low, high = bounds
+    return low <= value <= high
+
+
+def _format_scientific(value: float) -> str:
+    return f"{value:.3g}"
+
+
+def _flux_id(value: float) -> str:
+    return f"{value:.3e}".replace("+", "").replace("-", "m").replace(".", "p")
+
+
+def _time_step_seconds() -> float:
+    return 3.0
+
+
+def _rayleigh_damping_start_m() -> int:
+    return 2500
 
 
 def _expected_output_frames(runtime_seconds: int, output_cadence_seconds: int) -> int:

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -67,7 +67,6 @@ CandidateStoryFamilyFilter = Literal["all", "lower_atmosphere", "deep_convection
 CandidateRecipeFitStatus = Literal[
     "testable_now",
     "partially_testable",
-    "requires_triggered_deep_potential",
     "requires_surface_forcing_recipe",
     "not_testable_with_current_recipes",
     "blocked_profile",
@@ -1161,15 +1160,19 @@ def _candidate_recipe_fit(
             "caveats": ["candidate_requires_manual_screening_review"],
         }
     if story in DEEP_CONVECTION_STORY_IDS:
-        caveats = ["untriggered_observed_evolution_does_not_test_deep_potential"]
+        caveats = [
+            "deep_convection_outcome_depends_on_surface_forcing_duration_domain_and_resolution",
+            "differential_surface_initiation_is_tracked_in_issue_307",
+        ]
         if features.get("observed_wind_available") is not True:
-            caveats.append("complete_observed_wind_profile_required_for_deep_potential")
+            caveats.append("complete_observed_wind_profile_required_for_input_sounding")
         return {
-            "status": "requires_triggered_deep_potential",
-            "label": "requires triggered deep-potential run",
+            "status": "partially_testable",
+            "label": "testable as forced observed evolution",
             "summary": (
-                "This story screens deep-convection ingredients. Untriggered observed evolution "
-                "does not test that hypothesis without the triggered deep-potential recipe."
+                "This story screens deep-convection ingredients. CM1 can evolve the observed "
+                "atmosphere under selected uniform lower-boundary forcing; differential "
+                "initiation is a follow-up."
             ),
             "caveats": caveats,
         }
@@ -1382,7 +1385,7 @@ def _score_features(
     ]
     deep_caveats = [f"missing_or_unavailable_feature:{name}" for name in missing_deep_features]
     if not observed_wind_available:
-        deep_caveats.append("observed_wind_required_for_triggered_deep_potential")
+        deep_caveats.append("complete_observed_wind_profile_required_for_input_sounding")
 
     moist = _score_high(qv, low=4.0, high=10.0)
     dry = _score_low(qv, low=3.0, high=8.0)
@@ -1432,7 +1435,7 @@ def _score_features(
         ]
     )
     if initiation_support < 45.0:
-        deep_caveats.append("weak_deep_initiation_screen_for_triggered_deep_potential")
+        deep_caveats.append("weak_deep_initiation_screen_for_uniform_surface_forcing")
     instability = _weighted_score(
         [
             (cape_score, 0.55),
@@ -1473,13 +1476,13 @@ def _score_features(
     surface_coverage_factor = 1.0
     if lowest_level is None:
         surface_coverage_factor = 0.5
-        deep_caveats.append("surface_level_unavailable_for_triggered_deep_potential")
+        deep_caveats.append("surface_level_unavailable_for_observed_surface_forcing")
     elif lowest_level > 250.0:
         surface_coverage_factor = 0.25
-        deep_caveats.append("lowest_usable_level_too_high_for_triggered_deep_potential")
+        deep_caveats.append("lowest_usable_level_too_high_for_observed_surface_forcing")
     elif lowest_level > 100.0:
         surface_coverage_factor = 0.65
-        deep_caveats.append("lowest_usable_level_caveat_for_triggered_deep_potential")
+        deep_caveats.append("lowest_usable_level_caveat_for_observed_surface_forcing")
 
     shallow = _weighted_score(
         [(moist, 0.28), (low_lcl, 0.22), (deep_moisture, 0.18), (weak_cap, 0.14), (thermal, 0.18)]
@@ -1569,7 +1572,7 @@ def _score_features(
         # The broad shallow/humid stories are easy to satisfy in moist warm-season
         # profiles. When the same sounding has meaningful CAPE, shear, and deep
         # lapse-rate support, keep those broad labels available but let the
-        # triggered deep-potential recommendation become the useful product path.
+        # deep-convection recommendation become the useful product path.
         shallow_score = min(shallow_score, 62.0)
         humid_score = min(humid_score, 62.0)
     elif observed_wind_available and effective_cape >= 250.0 and deep_environment >= 55.0:
@@ -1689,7 +1692,7 @@ def _score_features(
             ],
             caveats=[
                 "line/cold-pool-specific recipe support may come later; "
-                "v1 runs as triggered deep potential",
+                "v1 runs as observed surface-forced evolution",
                 *deep_caveats,
             ],
         ),
@@ -1979,7 +1982,7 @@ def _score_features(
             label="Observed wind availability",
             value=features.get("observed_wind_available"),
             interpretation=(
-                "Observed winds are required for trustworthy triggered deep-potential runs."
+                "Observed winds are required for trustworthy observed-sounding deep-candidate runs."
             ),
             supports_story=[
                 "severe_thunderstorm_environment",

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -26,6 +26,7 @@ from cloud_chamber.output_products import (
 )
 from cloud_chamber.result_diagnostics import QC_CLOUD_THRESHOLD_KG_KG
 from cloud_chamber.result_ingest import (
+    DEEP_CONVECTION_STORY_IDS,
     ResultMetadata,
     get_result_metadata,
 )
@@ -1694,9 +1695,24 @@ def _fallback_view_defaults(
 
 
 def _preferred_field(metadata: ResultMetadata, fields: Mapping[str, object]) -> str | None:
-    if metadata.run_recipe == "triggered_deep_potential" and "w" in fields:
+    if _metadata_is_deep_candidate(metadata) and "w" in fields:
         return "w"
     return "qc" if "qc" in fields else next(iter(fields), None)
+
+
+def _metadata_is_deep_candidate(metadata: ResultMetadata) -> bool:
+    screening = metadata.candidate_screening or {}
+    story_values = [
+        screening.get("active_story"),
+        screening.get("primary_story"),
+        screening.get("story"),
+    ]
+    story_scores = screening.get("story_scores")
+    if isinstance(story_scores, list):
+        for score in story_scores:
+            if isinstance(score, dict):
+                story_values.append(score.get("story"))
+    return any(story in DEEP_CONVECTION_STORY_IDS for story in story_values)
 
 
 def field_slice(

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -38,7 +38,7 @@ def test_cm1_contract_documents_expected_generated_files_and_default_run_configu
     assert contract.scenario_id == "baseline-shallow-cumulus"
     assert contract.run_configuration.duration == "short_6h"
     assert contract.run_configuration.domain_size == "local_6km"
-    assert contract.run_configuration.diagnostic_set == "process"
+    assert contract.run_configuration.diagnostic_set == "full"
     assert {file.role for file in contract.generated_files} == set(GeneratedFileRole)
     assert contract.cloud_scale_defaults.nx == 64
     assert contract.cloud_scale_defaults.ny == 64
@@ -203,11 +203,11 @@ def test_observed_contract_declares_untriggered_v0_recipe_assumptions() -> None:
     )
 
     assert contract.run_recipe.value == "untriggered_observed_evolution"
-    assert contract.recipe_id == "untriggered_observed_sounding_evolution_v0"
-    assert contract.recipe_display_name == "Untriggered Observed-Sounding Evolution v0"
-    assert contract.assumption_set_id == "untriggered_observed_sounding_evolution_v0_assumptions"
-    assert contract.assumption_mode == "normal_evolution"
-    assert contract.required_output_fields == ("qv", "qc", "w", "qr", "rain", "dbz")
+    assert contract.recipe_id == "observed_surface_forced_evolution_v0"
+    assert contract.recipe_display_name == "Observed Surface-Forced Evolution v0"
+    assert contract.assumption_set_id == "observed_surface_forced_evolution_v0_assumptions"
+    assert contract.assumption_mode == "surface_forced_observed_evolution"
+    assert contract.required_output_fields == ("qv", "qc", "w", "qr", "rain", "dbz", "hfx", "lhfx")
     trigger = cast(dict[str, Any], contract.recipe_assumptions["trigger"])
     radiation = cast(dict[str, Any], contract.recipe_assumptions["radiation"])
     forcing = cast(dict[str, Any], contract.recipe_assumptions["large_scale_forcing"])
@@ -215,10 +215,70 @@ def test_observed_contract_declares_untriggered_v0_recipe_assumptions() -> None:
     assert trigger["mode"] == "none"
     assert radiation["mode"] == "disabled"
     assert forcing["mode"] == "none"
-    assert surface_fluxes["mode"] == "current_recipe_default"
-    assert "No warm-bubble or artificial deep-convection trigger is applied." in (
-        contract.recipe_caveats
+    assert surface_fluxes["mode"] == "constant_uniform_surface_flux_proxy"
+    assert surface_fluxes["product_selections"] == {
+        "surface_heat_flux_k_m_s": 8.0e-3,
+        "surface_moisture_flux_g_g_m_s": 5.2e-5,
+        "summary": (
+            "Surface heat flux 0.008 K m/s; surface moisture flux 5.2e-05 g/g m/s; "
+            "constant uniform proxy"
+        ),
+    }
+    assert surface_fluxes["cm1_values"]["cnst_shflx"] == 8.0e-3
+    assert surface_fluxes["cm1_values"]["cnst_lhflx"] == 5.2e-5
+    assert "No artificial atmospheric trigger is applied." in contract.recipe_caveats
+
+
+def test_observed_surface_flux_proxy_choices_render_namelist_and_surface_outputs() -> None:
+    from igra_fixtures import IGRA_FIXTURE
+
+    from cloud_chamber.observed_sounding import parse_igra_station_text
+
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+
+    contract = build_cm1_input_contract(
+        baseline_scenario(),
+        observed_sounding=observed,
+        run_configuration={
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "wide_12km",
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "essential",
+            "surface_heat_flux_k_m_s": 4.0e-2,
+            "surface_moisture_flux_g_g_m_s": 1.0e-4,
+        },
     )
+    namelist = render_namelist_fragment(contract)
+    surface_fluxes = cast(dict[str, Any], contract.recipe_assumptions["surface_fluxes"])
+
+    assert contract.run_configuration.surface_heat_flux_k_m_s == 4.0e-2
+    assert contract.run_configuration.surface_moisture_flux_g_g_m_s == 1.0e-4
+    assert contract.run_configuration.surface_flux_mode == "constant_uniform_surface_flux_proxy"
+    assert contract.run_configuration.surface_flux_cm1_values.cnst_shflx == 4.0e-2
+    assert contract.run_configuration.surface_flux_cm1_values.cnst_lhflx == 1.0e-4
+    assert "surface_flux_proxy_values_need_local_smoke_validation" in (
+        contract.run_configuration.surface_flux_caveats
+    )
+    assert surface_fluxes["product_selections"]["surface_heat_flux_k_m_s"] == 4.0e-2
+    assert surface_fluxes["product_selections"]["surface_moisture_flux_g_g_m_s"] == 1.0e-4
+    assert surface_fluxes["cm1_values"]["isfcflx"] == 1
+    assert surface_fluxes["cm1_values"]["set_flx"] == 1
+    assert surface_fluxes["cm1_values"]["cnst_shflx"] == 4.0e-2
+    assert surface_fluxes["cm1_values"]["cnst_lhflx"] == 1.0e-4
+    for field in ("qc", "qr", "qv", "w", "rain", "dbz", "hfx", "lhfx", "updraft_helicity"):
+        assert field in contract.expected_outputs
+    assert "isfcflx    =      1," in namelist
+    assert "sfcmodel   =      1," in namelist
+    assert "set_flx    =      1," in namelist
+    assert "cnst_shflx = 4.0e-2," in namelist
+    assert "cnst_lhflx = 1.0e-4," in namelist
+    assert "output_sfcflx    = 1," in namelist
+    assert "output_sfcparams = 1," in namelist
+    assert "output_sfcdiags  = 1," in namelist
 
 
 def test_baseline_humidity_ladder_only_changes_low_level_moisture_profile() -> None:

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -76,7 +76,7 @@ def test_dry_run_manifest_and_report_include_golden_path_metadata(tmp_path: Path
     assert report["cm1_was_launched"] is False
     assert report["estimated_cost_or_size"] == (
         "Configuration cost depends on duration, horizontal cells, domain, cadence, "
-        "and diagnostic set. Review the CM1-facing values before launch."
+        "and full output volume. Review the CM1-facing values before launch."
     )
     assert report["physical_question"] == manifest.physical_question
     assert report["visualization_defaults"]["primary_field"] == "qc"
@@ -120,28 +120,28 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
     assert manifest.run_configuration["cm1_values"]["nx"] == 128
     assert manifest.run_configuration["cm1_values"]["runtime_seconds"] == 21600
     assert manifest.run_recipe == "untriggered_observed_evolution"
-    assert manifest.recipe_id == "untriggered_observed_sounding_evolution_v0"
-    assert manifest.recipe_display_name == "Untriggered Observed-Sounding Evolution v0"
-    assert manifest.assumption_set_id == "untriggered_observed_sounding_evolution_v0_assumptions"
-    assert manifest.assumption_mode == "normal_evolution"
-    assert manifest.required_output_fields == ["qv", "qc", "w", "qr", "rain", "dbz"]
+    assert manifest.recipe_id == "observed_surface_forced_evolution_v0"
+    assert manifest.recipe_display_name == "Observed Surface-Forced Evolution v0"
+    assert manifest.assumption_set_id == "observed_surface_forced_evolution_v0_assumptions"
+    assert manifest.assumption_mode == "surface_forced_observed_evolution"
+    assert manifest.required_output_fields == ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "lhfx"]
     assert manifest.recipe_assumptions["trigger"]["mode"] == "none"
     assert manifest.recipe_assumptions["radiation"]["mode"] == "disabled"
     assert manifest.recipe_assumptions["large_scale_forcing"]["mode"] == "none"
-    assert manifest.recipe_assumptions["surface_fluxes"]["mode"] == "current_recipe_default"
-    assert "No warm-bubble or artificial deep-convection trigger is applied." in (
-        manifest.recipe_caveats
+    assert manifest.recipe_assumptions["surface_fluxes"]["mode"] == (
+        "constant_uniform_surface_flux_proxy"
     )
-    assert "No warm-bubble or artificial deep-convection trigger is applied." in (
-        manifest.run_caveats
-    )
+    assert manifest.recipe_assumptions["surface_fluxes"]["cm1_values"]["cnst_shflx"] == 8.0e-3
+    assert manifest.recipe_assumptions["surface_fluxes"]["cm1_values"]["cnst_lhflx"] == 5.2e-5
+    assert "No artificial atmospheric trigger is applied." in manifest.recipe_caveats
+    assert "No artificial atmospheric trigger is applied." in manifest.run_caveats
     assert manifest.pre_run_validation_report is not None
     assert manifest.pre_run_validation_report["run_shape_validation"]["domain"] == "wide_12km"
     assert manifest.pre_run_validation_report["selected_run_recipe"]["run_recipe"] == (
         "untriggered_observed_evolution"
     )
     assert manifest.pre_run_validation_report["selected_run_recipe"]["recipe_id"] == (
-        "untriggered_observed_sounding_evolution_v0"
+        "observed_surface_forced_evolution_v0"
     )
     assert manifest.pre_run_validation_report["selected_run_recipe"]["required_fields"] == [
         "qv",
@@ -150,13 +150,26 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
         "qr",
         "rain",
         "dbz",
+        "hfx",
+        "lhfx",
     ]
     assert manifest.user.tags == ["compare", "candidate"]
     assert manifest.user.notes == "Compare against humid/rainy candidates."
-    assert report["recipe_id"] == "untriggered_observed_sounding_evolution_v0"
-    assert report["assumption_mode"] == "normal_evolution"
-    assert report["required_output_fields"] == ["qv", "qc", "w", "qr", "rain", "dbz"]
+    assert report["recipe_id"] == "observed_surface_forced_evolution_v0"
+    assert report["assumption_mode"] == "surface_forced_observed_evolution"
+    assert report["required_output_fields"] == ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "lhfx"]
     assert report["variant_metadata"]["sounding_source"] == "observed_igra_station_text"
+    assert report["variant_metadata"]["surface_flux_mode"] == (
+        "constant_uniform_surface_flux_proxy"
+    )
+    assert report["run_configuration_summary"]["surface_flux_summary"] == (
+        "Surface heat flux 0.008 K m/s; surface moisture flux 5.2e-05 g/g m/s; "
+        "constant uniform proxy"
+    )
+    assert (
+        report["pre_run_validation_report"]["forcing_validation"]["surface_fluxes"]["mode"]
+        == "constant_uniform_surface_flux_proxy"
+    )
     assert report["observed_sounding"]["station_name"] == "Valley, Nebraska"
     assert report["user"]["tags"] == ["compare", "candidate"]
     assert report["user"]["notes"] == "Compare against humid/rainy candidates."
@@ -164,11 +177,14 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
     assert report["observed_sounding"]["wind_source"] == "observed_igra_wind_profile"
     assert report["observed_sounding"]["wind_units"] == "m/s"
     assert "input_sounding" in report["observed_sounding"]["wind_conversion"]
-    assert case_manifest["recipe_id"] == "untriggered_observed_sounding_evolution_v0"
-    assert case_manifest["contract"]["recipe_id"] == "untriggered_observed_sounding_evolution_v0"
+    assert case_manifest["recipe_id"] == "observed_surface_forced_evolution_v0"
+    assert case_manifest["contract"]["recipe_id"] == "observed_surface_forced_evolution_v0"
     assert case_manifest["contract"]["observed_sounding"]["station_id"] == "USM00072558"
     assert "isnd      =  7," in namelist
     assert "iwnd      =  0," in namelist
+    assert "cnst_shflx = 8.0e-3," in namelist
+    assert "cnst_lhflx = 5.2e-5," in namelist
+    assert "output_sfcflx    = 1," in namelist
     assert "USM00072558" not in sounding
     assert float(sounding.splitlines()[1].split()[0]) == pytest.approx(observed.levels[0].model_z_m)
     first_body_z = float(sounding.splitlines()[1].split()[0])
@@ -184,151 +200,82 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
     assert float(sounding.splitlines()[-1].split()[0]) > 18000
 
 
-def test_deep_convection_trial_package_uses_observed_sounding_and_warm_bubble(
+def test_observed_dry_run_package_persists_surface_flux_proxy_choices(
     tmp_path: Path,
 ) -> None:
     observed = parse_igra_station_text(
         IGRA_FIXTURE,
         uploaded_filename="USM00072558-data-beg2025.txt",
     ).selected_sounding
-    candidate_screening = {
-        "candidate_id": "USM00072558-deep-test",
-        "primary_story": "supercell_environment",
-        "rank_score": 91.0,
-    }
 
     result = generate_dry_run_package(
         scenario_data=load_baseline_template(),
         runtime_home=tmp_path,
-        run_id="run-deep-convection-trial",
-        run_recipe="triggered_deep_potential",
+        run_id="run-observed-surface-flux",
         observed_sounding=observed,
-        candidate_screening=candidate_screening,
+        run_configuration={
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "wide_12km",
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "essential",
+            "surface_heat_flux_k_m_s": 4.0e-2,
+            "surface_moisture_flux_g_g_m_s": 1.0e-4,
+        },
     )
 
     manifest = load_run_manifest(result.manifest_path)
     report = json.loads(result.report_path.read_text())
-    case_manifest = json.loads((result.package_dir / "case_manifest.json").read_text())
     namelist = (result.package_dir / "namelist.input").read_text()
-    sounding = (result.package_dir / "input_sounding").read_text()
 
-    assert manifest.run_recipe == "triggered_deep_potential"
-    assert manifest.run_recipe_display_name == "Triggered Deep-Potential Experiment"
-    assert manifest.recipe_id == "triggered_deep_potential_v1"
-    assert manifest.assumption_set_id == "triggered_deep_potential_warm_bubble_v1"
-    assert manifest.assumption_mode == "triggered_deep_potential"
-    assert manifest.required_output_fields == [
-        "qc",
-        "w",
-        "qr",
-        "rain",
-        "dbz",
-        "updraft_helicity",
-    ]
-    assert manifest.input_source == "observed_sounding"
-    assert manifest.trigger_type == "warm_bubble"
-    assert manifest.trigger_parameters == {
-        "cm1_iinit": 3,
-        "cm1_trigger": (
-            "CM1 built-in three warm bubbles with 2 K maximum potential-temperature "
-            "perturbations in a line near 1.4 km AGL"
-        ),
-        "raw_controls_exposed": False,
-    }
-    assert "dbz" in manifest.expected_outputs
-    assert "updraft_helicity" in manifest.expected_outputs
-    assert manifest.manual_validation_status == "triggered_deep_potential_recipe_smoke_validated"
-    assert any(
-        "Manual smoke evidence applies to the triggered deep-potential recipe" in caveat
-        and "each observed sounding remains an experiment" in caveat
-        for caveat in manifest.run_caveats
-    )
-    assert manifest.candidate_screening == candidate_screening
-    assert manifest.pre_run_validation_report is not None
-    assert manifest.pre_run_validation_report["selected_hypothesis"]["story_id"] == (
-        "supercell_environment"
-    )
-    assert manifest.pre_run_validation_report["selected_run_recipe"]["recipe_id"] == (
-        "triggered_deep_potential_v1"
-    )
-    assert manifest.pre_run_validation_report["selected_run_recipe"]["assumption_set_id"] == (
-        "triggered_deep_potential_warm_bubble_v1"
-    )
-    assert manifest.pre_run_validation_report["hypothesis_recipe_alignment"]["status"] == (
-        "aligned"
-    )
-    assert manifest.run_configuration["duration"] == "short_6h"
-    assert manifest.run_configuration["domain_size"] == "storm_120km"
-    assert manifest.run_configuration["horizontal_cell_count"] == 128
-    assert manifest.run_configuration["diagnostic_set"] == "full"
-    assert report["run_recipe"] == "triggered_deep_potential"
-    assert report["run_recipe_display_name"] == "Triggered Deep-Potential Experiment"
-    assert report["recipe_id"] == "triggered_deep_potential_v1"
-    assert report["trigger_type"] == "warm_bubble"
-    assert report["candidate_screening"] == candidate_screening
-    assert report["pre_run_validation_report"] == manifest.pre_run_validation_report
-    assert "testcase=0" in report["variant_metadata"]["mapping"]
-    assert "iinit=3 three-warm-bubble" in report["variant_metadata"]["mapping"]
-    assert "reflectivity output" in report["variant_metadata"]["mapping"]
-    assert report["manual_validation_status"] == "triggered_deep_potential_recipe_smoke_validated"
-    assert "manual CM1 smoke evidence" in report["cm1_mapping_status"]
-    assert "each observed sounding remains an experiment" in report["cm1_mapping_status"]
-    assert case_manifest["run_recipe"] == "triggered_deep_potential"
-    assert case_manifest["recipe_id"] == "triggered_deep_potential_v1"
-    assert case_manifest["contract"]["run_recipe"] == "triggered_deep_potential"
-    assert case_manifest["contract"]["recipe_id"] == "triggered_deep_potential_v1"
+    assert manifest.run_configuration["surface_heat_flux_k_m_s"] == 4.0e-2
+    assert manifest.run_configuration["surface_moisture_flux_g_g_m_s"] == 1.0e-4
+    assert manifest.run_configuration["surface_flux_cm1_values"]["cnst_shflx"] == 4.0e-2
+    assert manifest.run_configuration["surface_flux_cm1_values"]["cnst_lhflx"] == 1.0e-4
     assert (
-        case_manifest["contract"]["manual_validation_status"]
-        == "triggered_deep_potential_recipe_smoke_validated"
+        manifest.recipe_assumptions["surface_fluxes"]["product_selections"][
+            "surface_heat_flux_k_m_s"
+        ]
+        == 4.0e-2
     )
-
-    assert "testcase  =  0," in namelist
-    assert "isnd      =  7," in namelist
-    assert "iwnd      =  0," in namelist
-    assert "iinit     =  3," in namelist
-    assert "irandp    =  0," in namelist
-    assert "imove     =  1," in namelist
-    assert "ptype     =  5," in namelist
-    assert "ihail     =  1," in namelist
-    assert "iautoc    =  1," in namelist
-    assert "output_rain      = 1," in namelist
-    assert "output_dbz       = 1," in namelist
-    assert "output_vort      = 1," in namelist
-    assert "output_uh        = 1," in namelist
-    assert "nx           =      128," in namelist
-    assert "ny           =      128," in namelist
-    assert "nz           =      40," in namelist
-    assert "dx     =   937.5," in namelist
-    assert "dy     =   937.5," in namelist
-    assert "dz     =   500.0," in namelist
-    assert "dtl    =   6.000," in namelist
-    assert "timax  = 21600.0," in namelist
-    assert "tapfrq =  900.0," in namelist
-    assert "zd      =  15000.0," in namelist
-    assert float(sounding.splitlines()[-1].split()[0]) >= 20000.0
-    first_body_z = float(sounding.splitlines()[1].split()[0])
-    first_body_level = _level_at_rendered_z(observed.levels, first_body_z)
-    assert float(sounding.splitlines()[1].split()[3]) == pytest.approx(
-        first_body_level.u_wind_m_s,
-        abs=0.01,
+    assert (
+        manifest.recipe_assumptions["surface_fluxes"]["product_selections"][
+            "surface_moisture_flux_g_g_m_s"
+        ]
+        == 1.0e-4
     )
-    assert float(sounding.splitlines()[1].split()[4]) == pytest.approx(
-        first_body_level.v_wind_m_s,
-        abs=0.01,
-    )
+    assert "surface_flux_proxy_not_real_land_surface_or_evaporation_model" in (manifest.run_caveats)
+    for field in ("qc", "qr", "qv", "w", "rain", "dbz", "hfx", "lhfx", "updraft_helicity"):
+        assert field in report["expected_outputs"]
+    assert report["run_configuration_summary"]["surface_flux_cm1_values"]["cnst_shflx"] == 4.0e-2
+    assert report["run_configuration_summary"]["surface_flux_cm1_values"]["cnst_lhflx"] == 1.0e-4
+    assert "cnst_shflx = 4.0e-2," in namelist
+    assert "cnst_lhflx = 1.0e-4," in namelist
+    assert "output_sfcflx    = 1," in namelist
+    assert "output_sfcparams = 1," in namelist
+    assert "output_sfcdiags  = 1," in namelist
 
 
-def test_deep_convection_trial_requires_observed_sounding(tmp_path: Path) -> None:
-    with pytest.raises(DryRunPackageError, match="requires a validated observed sounding"):
+def test_triggered_deep_potential_package_generation_is_removed(
+    tmp_path: Path,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+
+    with pytest.raises(DryRunPackageError, match="package generation has been removed"):
         generate_dry_run_package(
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
-            run_id="run-deep-no-sounding",
+            run_id="run-triggered-removed",
             run_recipe="triggered_deep_potential",
+            observed_sounding=observed,
         )
+    assert not (tmp_path / "runs" / "run-triggered-removed").exists()
 
 
-def test_pre_run_validation_blocks_deep_hypothesis_on_observed_quicklook(
+def test_pre_run_validation_caveats_deep_hypothesis_under_uniform_forcing(
     tmp_path: Path,
 ) -> None:
     observed = parse_igra_station_text(
@@ -343,30 +290,29 @@ def test_pre_run_validation_blocks_deep_hypothesis_on_observed_quicklook(
         "rank_score": 93.0,
     }
 
-    with pytest.raises(DryRunPackageError, match="does not test this deep-convection") as excinfo:
-        generate_dry_run_package(
-            scenario_data=load_baseline_template(),
-            runtime_home=tmp_path,
-            run_id="run-deep-hypothesis-quicklook",
-            run_recipe="untriggered_observed_evolution",
-            observed_sounding=observed,
-            candidate_screening=candidate_screening,
-        )
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-deep-hypothesis-uniform-forcing",
+        run_recipe="untriggered_observed_evolution",
+        observed_sounding=observed,
+        candidate_screening=candidate_screening,
+    )
 
-    report = excinfo.value.pre_run_validation_report
+    manifest = load_run_manifest(result.manifest_path)
+    report = manifest.pre_run_validation_report
     assert report is not None
-    assert report["status"] == "blocked"
+    assert report["status"] == "caveated"
     assert report["selected_hypothesis"]["story_id"] == "supercell_environment"
     assert report["selected_run_recipe"]["run_recipe"] == "untriggered_observed_evolution"
-    assert report["selected_run_recipe"]["recipe_id"] == (
-        "untriggered_observed_sounding_evolution_v0"
-    )
-    assert report["hypothesis_recipe_alignment"]["status"] == "blocked"
+    assert report["selected_run_recipe"]["recipe_id"] == ("observed_surface_forced_evolution_v0")
+    assert report["hypothesis_recipe_alignment"]["status"] == "partial"
+    assert "updraft_helicity" in report["output_validation"]["required_fields"]
     assert (
-        "triggered_deep_potential_warm_bubble_v1"
-        in report["hypothesis_recipe_alignment"]["missing_assumptions"]
+        "deep_convection_outcome_depends_on_surface_forcing_duration_domain_and_resolution"
+        in (report["caveats"])
     )
-    assert not (tmp_path / "runs" / "run-deep-hypothesis-quicklook").exists()
+    assert (tmp_path / "runs" / "run-deep-hypothesis-uniform-forcing").exists()
 
 
 def test_pre_run_validation_blocks_invalid_run_configuration(tmp_path: Path) -> None:
@@ -392,7 +338,7 @@ def test_pre_run_validation_blocks_invalid_run_configuration(tmp_path: Path) -> 
     assert not (tmp_path / "runs" / "run-invalid-domain").exists()
 
 
-def test_pre_run_validation_caveats_missing_deep_comparison_outputs(
+def test_pre_run_validation_requests_full_deep_comparison_outputs(
     tmp_path: Path,
 ) -> None:
     observed = parse_igra_station_text(
@@ -404,7 +350,7 @@ def test_pre_run_validation_caveats_missing_deep_comparison_outputs(
         scenario_data=load_baseline_template(),
         runtime_home=tmp_path,
         run_id="run-deep-core-output",
-        run_recipe="triggered_deep_potential",
+        run_recipe="untriggered_observed_evolution",
         observed_sounding=observed,
         candidate_screening={
             "candidate_id": "USM00072558-supercell",
@@ -414,7 +360,7 @@ def test_pre_run_validation_caveats_missing_deep_comparison_outputs(
         run_configuration={
             "duration": "short_6h",
             "horizontal_cell_count": "cells_64",
-            "domain_size": "storm_120km",
+            "domain_size": "local_6km",
             "output_cadence": "standard_15min",
             "diagnostic_set": "essential",
         },
@@ -424,11 +370,11 @@ def test_pre_run_validation_caveats_missing_deep_comparison_outputs(
     report = manifest.pre_run_validation_report
     assert report is not None
     assert report["status"] == "caveated"
-    assert "updraft_helicity" in report["output_validation"]["missing_fields"]
-    assert "missing_required_output_field:updraft_helicity" in report["caveats"]
+    assert "updraft_helicity" in report["output_validation"]["enabled_fields"]
+    assert report["output_validation"]["missing_fields"] == []
 
 
-def test_deep_convection_trial_requires_observed_wind_components(tmp_path: Path) -> None:
+def test_observed_runs_require_wind_before_input_sounding_render(tmp_path: Path) -> None:
     observed = parse_igra_station_text(
         IGRA_FIXTURE,
         uploaded_filename="USM00072558-data-beg2025.txt",
@@ -446,13 +392,13 @@ def test_deep_convection_trial_requires_observed_wind_components(tmp_path: Path)
         generate_dry_run_package(
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
-            run_id="run-deep-no-wind",
-            run_recipe="triggered_deep_potential",
+            run_id="run-observed-no-wind",
             observed_sounding=no_wind,
         )
+    assert not (tmp_path / "runs" / "run-observed-no-wind").exists()
 
 
-def test_deep_convection_trial_requires_complete_rendered_wind_profile(
+def test_observed_runs_require_complete_rendered_wind_profile(
     tmp_path: Path,
 ) -> None:
     observed = parse_igra_station_text(
@@ -474,12 +420,11 @@ def test_deep_convection_trial_requires_complete_rendered_wind_profile(
         generate_dry_run_package(
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
-            run_id="run-deep-partial-wind",
-            run_recipe="triggered_deep_potential",
+            run_id="run-observed-partial-wind",
             observed_sounding=missing_mid_profile_wind,
         )
 
-    assert not (tmp_path / "runs" / "run-deep-partial-wind").exists()
+    assert not (tmp_path / "runs" / "run-observed-partial-wind").exists()
 
 
 def test_dry_run_package_refuses_to_overwrite_existing_run_dir(tmp_path: Path) -> None:

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -136,6 +136,9 @@ def test_dry_run_package_can_use_observed_igra_sounding(tmp_path: Path) -> None:
     assert "No artificial atmospheric trigger is applied." in manifest.recipe_caveats
     assert "No artificial atmospheric trigger is applied." in manifest.run_caveats
     assert manifest.pre_run_validation_report is not None
+    assert manifest.pre_run_validation_report["input_validation"]["observed_wind_profile"] == (
+        "present_required"
+    )
     assert manifest.pre_run_validation_report["run_shape_validation"]["domain"] == "wide_12km"
     assert manifest.pre_run_validation_report["selected_run_recipe"]["run_recipe"] == (
         "untriggered_observed_evolution"
@@ -388,13 +391,20 @@ def test_observed_runs_require_wind_before_input_sounding_render(tmp_path: Path)
         }
     )
 
-    with pytest.raises(DryRunPackageError, match="complete finite observed u/v wind profile"):
+    with pytest.raises(
+        DryRunPackageError, match="complete finite observed u/v wind profile"
+    ) as excinfo:
         generate_dry_run_package(
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
             run_id="run-observed-no-wind",
             observed_sounding=no_wind,
         )
+    report = excinfo.value.pre_run_validation_report
+    assert report is not None
+    assert report["status"] == "blocked"
+    assert report["input_validation"]["observed_wind_profile"] == "blocked"
+    assert "complete finite observed u/v wind profile" in report["blocking_errors"][0]
     assert not (tmp_path / "runs" / "run-observed-no-wind").exists()
 
 
@@ -416,13 +426,20 @@ def test_observed_runs_require_complete_rendered_wind_profile(
         }
     )
 
-    with pytest.raises(DryRunPackageError, match="complete finite observed u/v wind profile"):
+    with pytest.raises(
+        DryRunPackageError, match="complete finite observed u/v wind profile"
+    ) as excinfo:
         generate_dry_run_package(
             scenario_data=load_baseline_template(),
             runtime_home=tmp_path,
             run_id="run-observed-partial-wind",
             observed_sounding=missing_mid_profile_wind,
         )
+    report = excinfo.value.pre_run_validation_report
+    assert report is not None
+    assert report["status"] == "blocked"
+    assert report["input_validation"]["observed_wind_profile"] == "blocked"
+    assert "complete finite observed u/v wind profile" in report["blocking_errors"][0]
 
     assert not (tmp_path / "runs" / "run-observed-partial-wind").exists()
 

--- a/app/backend/tests/test_output_products.py
+++ b/app/backend/tests/test_output_products.py
@@ -313,7 +313,6 @@ def test_deep_convection_interesting_times_and_unavailable_diagnostics(
         diagnostics=diagnostics,
         output_manifest=manifest,
         variables=["qc", "w", "qr"],
-        run_recipe="triggered_deep_potential",
     )
 
     records = {record.key: record for record in product.available_interesting_times}
@@ -326,10 +325,7 @@ def test_deep_convection_interesting_times_and_unavailable_diagnostics(
     assert product.science_summary.time_of_first_deep_convection_seconds == 1200.0
     assert product.science_summary.highest_cloud_top_m == 10200.0
     assert product.science_summary.default_explore_time_index == 2
-    assert (
-        product.science_summary.cm1_outcome
-        == "Deep convection formed with strong updraft and rain water aloft."
-    )
+    assert product.science_summary.cm1_outcome is None
     availability = {item.key: item for item in product.science_summary.diagnostic_availability}
     assert availability["max_dbz_or_reflectivity_proxy"].support_state == (
         "unsupported_missing_fields"
@@ -439,7 +435,7 @@ def test_non_deep_summary_does_not_emit_deep_convection_outcome(
     )
 
     records = {record.key: record for record in product.available_interesting_times}
-    assert "first_deep_convection" not in records
+    assert records["first_deep_convection"].support_state == "unavailable"
     assert product.science_summary.cm1_outcome is None
     assert product.science_summary.time_of_first_deep_convection_seconds is None
 
@@ -462,7 +458,6 @@ def test_deep_convection_present_but_unsupported_fields_are_caveated(
         diagnostics=diagnostics,
         output_manifest=manifest,
         variables=["qc", "w", "dbz", "th"],
-        run_recipe="triggered_deep_potential",
     )
 
     availability = {item.key: item for item in product.science_summary.diagnostic_availability}

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -191,34 +191,34 @@ def test_result_card_preserves_untriggered_observed_recipe_metadata(tmp_path: Pa
         },
         package_updates={
             "run_recipe": "untriggered_observed_evolution",
-            "run_recipe_display_name": "Untriggered Observed Evolution",
-            "recipe_id": "untriggered_observed_sounding_evolution_v0",
-            "recipe_display_name": "Untriggered Observed-Sounding Evolution v0",
-            "assumption_set_id": "untriggered_observed_sounding_evolution_v0_assumptions",
-            "assumption_mode": "normal_evolution",
+            "run_recipe_display_name": "Observed Surface-Forced Evolution",
+            "recipe_id": "observed_surface_forced_evolution_v0",
+            "recipe_display_name": "Observed Surface-Forced Evolution v0",
+            "assumption_set_id": "observed_surface_forced_evolution_v0_assumptions",
+            "assumption_mode": "surface_forced_observed_evolution",
             "recipe_assumptions": {
                 "trigger": {"mode": "none"},
                 "radiation": {"mode": "disabled"},
                 "large_scale_forcing": {"mode": "none"},
             },
             "required_output_fields": ["qv", "qc", "w", "qr", "rain", "dbz"],
-            "recipe_caveats": ["No warm-bubble or artificial deep-convection trigger is applied."],
+            "recipe_caveats": ["No artificial atmospheric trigger is applied."],
             "input_source": "observed_sounding",
         },
     )
 
     card = get_result_card(settings, result_id)
 
-    assert card.name == "Untriggered Observed-Sounding Evolution v0 — Valley, Nebraska"
-    assert card.scenario_name == "Untriggered Observed-Sounding Evolution v0"
-    assert card.recipe_id == "untriggered_observed_sounding_evolution_v0"
-    assert card.recipe_display_name == "Untriggered Observed-Sounding Evolution v0"
-    assert card.assumption_set_id == "untriggered_observed_sounding_evolution_v0_assumptions"
-    assert card.assumption_mode == "normal_evolution"
+    assert card.name == "Observed Surface-Forced Evolution v0 — Valley, Nebraska"
+    assert card.scenario_name == "Observed Surface-Forced Evolution v0"
+    assert card.recipe_id == "observed_surface_forced_evolution_v0"
+    assert card.recipe_display_name == "Observed Surface-Forced Evolution v0"
+    assert card.assumption_set_id == "observed_surface_forced_evolution_v0_assumptions"
+    assert card.assumption_mode == "surface_forced_observed_evolution"
     assert card.recipe_assumptions["trigger"]["mode"] == "none"
     assert card.required_output_fields == ["qv", "qc", "w", "qr", "rain", "dbz"]
     assert card.missing_required_output_fields == ["qv", "dbz"]
-    assert "recipe_id:untriggered_observed_sounding_evolution_v0" in card.provenance_labels
+    assert "recipe_id:observed_surface_forced_evolution_v0" in card.provenance_labels
     assert card.saved is False
     assert card.protected is False
     assert "source_model:CM1" in card.provenance_labels
@@ -240,11 +240,11 @@ def test_result_card_exposes_observed_sounding_source(tmp_path: Path) -> None:
         },
         package_updates={
             "run_recipe": "untriggered_observed_evolution",
-            "run_recipe_display_name": "Untriggered Observed Evolution",
-            "recipe_id": "untriggered_observed_sounding_evolution_v0",
-            "recipe_display_name": "Untriggered Observed-Sounding Evolution v0",
-            "assumption_set_id": "untriggered_observed_sounding_evolution_v0_assumptions",
-            "assumption_mode": "normal_evolution",
+            "run_recipe_display_name": "Observed Surface-Forced Evolution",
+            "recipe_id": "observed_surface_forced_evolution_v0",
+            "recipe_display_name": "Observed Surface-Forced Evolution v0",
+            "assumption_set_id": "observed_surface_forced_evolution_v0_assumptions",
+            "assumption_mode": "surface_forced_observed_evolution",
             "recipe_assumptions": {"trigger": {"mode": "none"}},
             "required_output_fields": ["qv", "qc", "w", "qr", "rain", "dbz"],
             "input_source": "observed_sounding",
@@ -253,16 +253,16 @@ def test_result_card_exposes_observed_sounding_source(tmp_path: Path) -> None:
 
     card = get_result_card(settings, result_id)
 
-    assert card.name == "Untriggered Observed-Sounding Evolution v0 — Valley, Nebraska"
+    assert card.name == "Observed Surface-Forced Evolution v0 — Valley, Nebraska"
     assert card.scenario_id == "baseline-shallow-cumulus"
-    assert card.scenario_name == "Untriggered Observed-Sounding Evolution v0"
+    assert card.scenario_name == "Observed Surface-Forced Evolution v0"
     assert card.input_source == "observed_sounding"
     assert card.input_source_label == "Observed sounding: USM00072558 · Valley, Nebraska"
     assert card.observed_sounding is not None
     assert card.observed_sounding["station_id"] == "USM00072558"
 
 
-def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: Path) -> None:
+def test_result_card_preserves_deep_candidate_surface_forced_identity(tmp_path: Path) -> None:
     settings, result_id, _run_dir = create_completed_result(
         tmp_path,
         run_id="run-deep-card",
@@ -280,57 +280,57 @@ def test_result_card_preserves_deep_convection_trial_package_identity(tmp_path: 
                 "primary_story": "supercell_environment",
                 "rank_score": 93.0,
             },
-            "run_recipe": "triggered_deep_potential",
-            "run_recipe_display_name": "Triggered Deep-Potential Experiment",
-            "recipe_id": "triggered_deep_potential_v1",
-            "recipe_display_name": "Triggered Deep-Potential Experiment",
-            "assumption_set_id": "triggered_deep_potential_warm_bubble_v1",
-            "assumption_mode": "triggered_deep_potential",
+            "run_recipe": "untriggered_observed_evolution",
+            "run_recipe_display_name": "Observed Surface-Forced Evolution",
+            "recipe_id": "observed_surface_forced_evolution_v0",
+            "recipe_display_name": "Observed Surface-Forced Evolution v0",
+            "assumption_set_id": "observed_surface_forced_evolution_v0_assumptions",
+            "assumption_mode": "surface_forced_observed_evolution",
             "recipe_assumptions": {
-                "trigger": {"mode": "prescribed", "type": "warm_bubble"},
+                "trigger": {"mode": "none"},
+                "surface_fluxes": {
+                    "mode": "constant_uniform",
+                    "sensible_heat_flux_k_m_s": 8.0e-3,
+                    "moisture_flux_g_g_m_s": 5.2e-5,
+                },
                 "radiation": {"mode": "disabled"},
             },
-            "required_output_fields": ["qc", "w", "qr", "rain", "dbz", "updraft_helicity"],
+            "required_output_fields": ["qc", "w", "qr", "rain", "dbz"],
             "input_source": "observed_sounding",
-            "trigger_type": "warm_bubble",
-            "trigger_parameters": {
-                "cm1_iinit": 3,
-                "cm1_trigger": "CM1 built-in three warm bubbles",
-                "raw_controls_exposed": False,
-            },
-            "expected_outputs": ["qc", "qr", "w", "dbz", "updraft_helicity"],
+            "trigger_type": None,
+            "trigger_parameters": {},
+            "expected_outputs": ["qc", "qr", "w", "rain", "dbz"],
             "run_caveats": [
-                (
-                    "Triggered Deep-Potential Experiment uses an idealized CM1 "
-                    "three-warm-bubble trigger."
-                )
+                "No artificial atmospheric trigger is applied.",
+                "Surface heat/moisture fluxes are constant uniform lower-boundary proxy settings.",
             ],
-            "manual_validation_status": "triggered_deep_potential_recipe_smoke_validated",
+            "manual_validation_status": "observed_surface_forced_evolution_v0_metadata_only",
         },
     )
 
     card = get_result_card(settings, result_id)
 
-    assert card.name == "Triggered Deep-Potential Experiment — Norman, Oklahoma"
-    assert card.scenario_name == "Triggered Deep-Potential Experiment"
-    assert card.run_recipe == "triggered_deep_potential"
-    assert card.run_recipe_display_name == "Triggered Deep-Potential Experiment"
-    assert card.recipe_id == "triggered_deep_potential_v1"
-    assert card.assumption_set_id == "triggered_deep_potential_warm_bubble_v1"
-    assert card.trigger_type == "warm_bubble"
+    assert card.name == "Observed Surface-Forced Evolution v0 — Norman, Oklahoma"
+    assert card.scenario_name == "Observed Surface-Forced Evolution v0"
+    assert card.run_recipe == "untriggered_observed_evolution"
+    assert card.run_recipe_display_name == "Observed Surface-Forced Evolution"
+    assert card.recipe_id == "observed_surface_forced_evolution_v0"
+    assert card.assumption_set_id == "observed_surface_forced_evolution_v0_assumptions"
+    assert card.trigger_type is None
     assert card.trigger_parameters is not None
-    assert card.trigger_parameters["cm1_iinit"] == 3
+    assert card.trigger_parameters == {}
     assert "dbz" in card.expected_outputs
     assert card.run_caveats == [
-        "Triggered Deep-Potential Experiment uses an idealized CM1 three-warm-bubble trigger."
+        "No artificial atmospheric trigger is applied.",
+        "Surface heat/moisture fluxes are constant uniform lower-boundary proxy settings.",
     ]
-    assert card.manual_validation_status == "triggered_deep_potential_recipe_smoke_validated"
-    assert "run_recipe:triggered_deep_potential" in card.provenance_labels
+    assert card.manual_validation_status == "observed_surface_forced_evolution_v0_metadata_only"
+    assert "run_recipe:untriggered_observed_evolution" in card.provenance_labels
     assert card.candidate_screening is not None
     assert card.candidate_screening["primary_story"] == "supercell_environment"
     assert card.candidate_hypothesis_comparison is not None
     assert card.candidate_hypothesis_comparison.screened_as == "Supercell-like environment"
-    assert card.candidate_hypothesis_comparison.ran_as == "Triggered Deep-Potential Experiment"
+    assert card.candidate_hypothesis_comparison.ran_as == "Observed Surface-Forced Evolution v0"
     assert card.candidate_hypothesis_comparison.match_status == "did_not_match"
 
 

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -213,8 +213,8 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
     assert result.coordinates == ["time", "z", "y", "x"]
     assert result.variables == ["qc", "w"]
     assert result.recipe_id == "generated_reference_lower_atmosphere_v1"
-    assert result.required_output_fields == ["qc", "w"]
-    assert result.missing_required_output_fields == []
+    assert result.required_output_fields == ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "lhfx"]
+    assert result.missing_required_output_fields == ["qv", "qr", "rain", "dbz", "hfx", "lhfx"]
     assert result.time_coordinate == "time"
     assert result.time_steps == 1
     assert result.grid_shape == [2, 2, 2]
@@ -237,7 +237,8 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
     assert result.process_diagnostics.interpretation_support.confidence == "supported"
     assert result.process_diagnostics.deep_breakthrough.status == "unsupported_missing_fields"
     assert result.warnings == [
-        "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"
+        "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG",
+        "Recipe required output fields missing from NetCDF metadata: qv, qr, rain, dbz, hfx, lhfx",
     ]
     assert (run_dir / RESULT_METADATA_FILENAME).exists()
     assert product_manifest_path.exists()
@@ -404,21 +405,25 @@ def test_ingests_deep_convection_candidate_outcome_comparison(tmp_path: Path) ->
         manifest.model_copy(
             update={
                 "candidate_screening": candidate_screening,
-                "run_recipe": "triggered_deep_potential",
-                "run_recipe_display_name": "Triggered Deep-Potential Experiment",
-                "recipe_id": "triggered_deep_potential_v1",
-                "recipe_display_name": "Triggered Deep-Potential Experiment",
-                "assumption_set_id": "triggered_deep_potential_warm_bubble_v1",
-                "assumption_mode": "triggered_deep_potential",
+                "run_recipe": "untriggered_observed_evolution",
+                "run_recipe_display_name": "Observed Surface-Forced Evolution",
+                "recipe_id": "observed_surface_forced_evolution_v0",
+                "recipe_display_name": "Observed Surface-Forced Evolution v0",
+                "assumption_set_id": "observed_surface_forced_evolution_v0_assumptions",
+                "assumption_mode": "surface_forced_observed_evolution",
                 "recipe_assumptions": {
-                    "trigger": {"mode": "prescribed", "type": "warm_bubble"},
+                    "trigger": {"mode": "none"},
+                    "surface_fluxes": {
+                        "mode": "constant_uniform",
+                        "sensible_heat_flux_k_m_s": 8.0e-3,
+                        "moisture_flux_g_g_m_s": 5.2e-5,
+                    },
                     "radiation": {"mode": "disabled"},
                 },
-                "required_output_fields": ["qc", "w", "qr", "rain", "dbz", "updraft_helicity"],
+                "required_output_fields": ["qc", "w", "qr", "rain", "dbz"],
                 "input_source": "observed_sounding",
-                "trigger_type": "warm_bubble",
-                "expected_outputs": ["qc", "qr", "w", "dbz", "updraft_helicity"],
-                "manual_validation_status": "triggered_deep_potential_recipe_smoke_validated",
+                "expected_outputs": ["qc", "qr", "w", "rain", "dbz"],
+                "manual_validation_status": "observed_surface_forced_evolution_v0_metadata_only",
             }
         ),
     )
@@ -433,7 +438,7 @@ def test_ingests_deep_convection_candidate_outcome_comparison(tmp_path: Path) ->
     assert result.science_summary.default_explore_time_seconds == 900.0
     assert result.candidate_hypothesis_comparison is not None
     assert result.candidate_hypothesis_comparison.screened_as == "Supercell-like environment"
-    assert result.candidate_hypothesis_comparison.ran_as == "Triggered Deep-Potential Experiment"
+    assert result.candidate_hypothesis_comparison.ran_as == "Observed Surface-Forced Evolution v0"
     assert result.candidate_hypothesis_comparison.match_status == "matched"
     assert result.candidate_hypothesis_comparison.cm1_outcome == (
         "Deep convection formed with strong updraft and rain water aloft."
@@ -446,7 +451,7 @@ def test_ingests_deep_convection_candidate_outcome_comparison(tmp_path: Path) ->
     )
 
 
-def test_non_deep_candidate_comparison_does_not_use_deep_outcome_language(
+def test_deep_candidate_comparison_uses_observed_surface_forced_outcome(
     tmp_path: Path,
 ) -> None:
     manifest_path = create_manifest(tmp_path, run_id="run-observed-quicklook-candidate")
@@ -472,20 +477,18 @@ def test_non_deep_candidate_comparison_does_not_use_deep_outcome_language(
             update={
                 "candidate_screening": candidate_screening,
                 "run_recipe": "untriggered_observed_evolution",
-                "run_recipe_display_name": "Untriggered Observed Evolution",
-                "recipe_id": "untriggered_observed_sounding_evolution_v0",
-                "recipe_display_name": "Untriggered Observed-Sounding Evolution v0",
-                "assumption_set_id": "untriggered_observed_sounding_evolution_v0_assumptions",
-                "assumption_mode": "normal_evolution",
+                "run_recipe_display_name": "Observed Surface-Forced Evolution",
+                "recipe_id": "observed_surface_forced_evolution_v0",
+                "recipe_display_name": "Observed Surface-Forced Evolution v0",
+                "assumption_set_id": "observed_surface_forced_evolution_v0_assumptions",
+                "assumption_mode": "surface_forced_observed_evolution",
                 "recipe_assumptions": {
                     "trigger": {"mode": "none"},
                     "radiation": {"mode": "disabled"},
                     "large_scale_forcing": {"mode": "none"},
                 },
                 "required_output_fields": ["qv", "qc", "w", "qr", "rain", "dbz"],
-                "recipe_caveats": [
-                    "No warm-bubble or artificial deep-convection trigger is applied."
-                ],
+                "recipe_caveats": ["No artificial atmospheric trigger is applied."],
                 "input_source": "observed_sounding",
             }
         ),
@@ -495,10 +498,10 @@ def test_non_deep_candidate_comparison_does_not_use_deep_outcome_language(
 
     assert result.science_summary is not None
     assert result.science_summary.cm1_outcome is None
-    assert result.recipe_id == "untriggered_observed_sounding_evolution_v0"
-    assert result.recipe_display_name == "Untriggered Observed-Sounding Evolution v0"
-    assert result.assumption_set_id == "untriggered_observed_sounding_evolution_v0_assumptions"
-    assert result.assumption_mode == "normal_evolution"
+    assert result.recipe_id == "observed_surface_forced_evolution_v0"
+    assert result.recipe_display_name == "Observed Surface-Forced Evolution v0"
+    assert result.assumption_set_id == "observed_surface_forced_evolution_v0_assumptions"
+    assert result.assumption_mode == "surface_forced_observed_evolution"
     assert result.recipe_assumptions["trigger"]["mode"] == "none"
     assert result.required_output_fields == ["qv", "qc", "w", "qr", "rain", "dbz"]
     assert result.missing_required_output_fields == ["qv", "rain", "dbz"]
@@ -506,12 +509,12 @@ def test_non_deep_candidate_comparison_does_not_use_deep_outcome_language(
         result.warnings
     )
     assert result.candidate_hypothesis_comparison is not None
-    assert result.candidate_hypothesis_comparison.match_status == "unable_to_evaluate"
+    assert result.candidate_hypothesis_comparison.match_status == "did_not_match"
     assert result.candidate_hypothesis_comparison.cm1_outcome == (
-        "Unable to evaluate candidate match because this was not a triggered deep-potential run."
+        "Deep convection was not detected by current cloud-top and updraft thresholds."
     )
-    assert "Trigger failed" not in result.candidate_hypothesis_comparison.cm1_outcome
-    assert "comparison_requires_triggered_deep_potential_run" in (
+    assert "trigger" not in result.candidate_hypothesis_comparison.cm1_outcome.lower()
+    assert "comparison_requires_triggered_deep_potential_run" not in (
         result.candidate_hypothesis_comparison.caveats
     )
 
@@ -690,5 +693,8 @@ def test_missing_expected_fields_are_warnings_not_claimed_diagnostics(tmp_path: 
     assert result.diagnostics.cloud.available is False
     assert result.warnings == [
         "Expected fields missing from NetCDF metadata: qc",
-        "Recipe required output fields missing from NetCDF metadata: qc",
+        (
+            "Recipe required output fields missing from NetCDF metadata: "
+            "qv, qc, qr, rain, dbz, hfx, lhfx"
+        ),
     ]

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -263,7 +263,7 @@ def test_observed_wind_available_requires_complete_finite_profile() -> None:
     assert features["observed_wind_available"] is False
     supercell = next(score for score in scores if score.story == "supercell_environment")
     assert supercell.support == "unavailable"
-    assert "observed_wind_required_for_triggered_deep_potential" in supercell.caveats
+    assert "complete_observed_wind_profile_required_for_input_sounding" in supercell.caveats
 
 
 def test_screen_cached_soundings_can_target_one_story(tmp_path: Path) -> None:
@@ -886,7 +886,7 @@ def test_deep_convection_scoring_penalizes_profiles_that_start_well_above_surfac
 
     severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
     assert severe.support == "unavailable"
-    assert "lowest_usable_level_too_high_for_triggered_deep_potential" in severe.caveats
+    assert "lowest_usable_level_too_high_for_observed_surface_forcing" in severe.caveats
 
 
 def test_deep_convection_scoring_requires_observed_wind_support() -> None:
@@ -930,7 +930,7 @@ def test_deep_convection_scoring_requires_observed_wind_support() -> None:
     severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
     assert supercell.support == "unavailable"
     assert severe.support == "unavailable"
-    assert "observed_wind_required_for_triggered_deep_potential" in supercell.caveats
+    assert "complete_observed_wind_profile_required_for_input_sounding" in supercell.caveats
 
 
 def test_story_scores_and_evidence_are_traceable_to_soundings() -> None:

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -1201,8 +1201,15 @@ def test_deep_convection_view_defaults_prefer_updraft_field(tmp_path: Path) -> N
         tmp_path,
         run_id="run-deep-visualization",
         package_updates={
-            "run_recipe": "triggered_deep_potential",
-            "run_recipe_display_name": "Triggered Deep-Potential Experiment",
+            "run_recipe": "untriggered_observed_evolution",
+            "run_recipe_display_name": "Observed Surface-Forced Evolution",
+            "candidate_screening": {
+                "primary_story": "supercell_environment",
+                "active_story": "supercell_environment",
+                "story_scores": [
+                    {"story": "supercell_environment", "support": "supported"},
+                ],
+            },
         },
     )
 

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -62,9 +62,9 @@ const defaultRunConfigurationSummary = {
   estimated_compute_multiplier_vs_default: 1,
   estimated_output_volume_multiplier_vs_default: 1,
   cost_warning:
-    "Configuration cost depends on duration, horizontal cell count, domain, cadence, and diagnostic set. Review the CM1-facing values before launch.",
+    "Configuration cost depends on duration, horizontal cell count, domain, cadence, and full output-field volume. Review the CM1-facing values before launch.",
   validation_note:
-    "Run configuration preserves explicit duration, horizontal cell count, domain, cadence, and diagnostic-set choices.",
+    "Run configuration preserves explicit duration, horizontal cell count, domain, cadence, and full output fields.",
 };
 
 const defaultPreRunValidationReport = {

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -106,9 +106,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(
       page.getByText("Valley, Nebraska (USM00072558) added to the run plan"),
     ).toBeVisible();
+    await expect(page.getByLabel("Run plan").getByLabel("Surface heat flux").first()).toHaveValue(
+      "8.0e-3",
+    );
     await expect(
-      page.getByLabel("Run plan").getByLabel("Recipe", { exact: true }).first(),
-    ).toHaveValue("untriggered_observed_evolution");
+      page.getByLabel("Run plan").getByLabel("Surface moisture flux").first(),
+    ).toHaveValue("5.2e-5");
 
     await page.getByRole("button", { name: "Create packages and queue selected runs" }).click();
     await expect(page.getByText("Queued for local serial CM1 run.")).toBeVisible();
@@ -174,9 +177,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(
       page.getByText("Valley, Nebraska (USM00072558) added to the run plan"),
     ).toBeVisible();
+    await expect(page.getByLabel("Run plan").getByLabel("Surface heat flux").first()).toHaveValue(
+      "8.0e-3",
+    );
     await expect(
-      page.getByLabel("Run plan").getByLabel("Recipe", { exact: true }).first(),
-    ).toHaveValue("untriggered_observed_evolution");
+      page.getByLabel("Run plan").getByLabel("Surface moisture flux").first(),
+    ).toHaveValue("5.2e-5");
     await page.getByRole("button", { name: "Duplicate variant" }).click();
     await expect(page.getByText("Run-plan variant duplicated")).toBeVisible();
 

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, VisualizerSceneShell } from "./App";
 
 const defaultRunConfiguration = {
-  configuration_id: "short_6h__cells_64__local_6km__standard_15min__process",
+  configuration_id: "short_6h__cells_64__local_6km__standard_15min__full",
   mode: "science",
   label: "Short evolution; Local 6 km; Scout 64 x 64; 100 m dx/dy; Standard 15 min",
   duration: "short_6h",
@@ -14,9 +14,27 @@ const defaultRunConfiguration = {
   domain_size: "local_6km",
   output_cadence: "standard_15min",
   output_cadence_seconds: 900,
-  diagnostic_set: "process",
+  diagnostic_set: "full",
+  surface_flux_mode: "constant_uniform_surface_flux_proxy",
+  surface_flux_summary:
+    "Surface heat flux 0.008 K m/s; surface moisture flux 5.2e-5 g/g m/s; constant uniform proxy",
+  surface_flux_cm1_values: {
+    isfcflx: 1,
+    sfcmodel: 1,
+    set_flx: 1,
+    set_ust: 1,
+    cnst_shflx: 0.008,
+    cnst_shflx_units: "K m/s",
+    cnst_lhflx: 5.2e-5,
+    cnst_lhflx_units: "g/g m/s",
+  },
+  surface_flux_caveats: [
+    "surface_flux_proxy_constant_uniform_not_place_time_energy_budget",
+    "surface_flux_proxy_not_real_land_surface_or_evaporation_model",
+    "surface_flux_proxy_values_need_local_smoke_validation",
+  ],
   cost_runtime_summary: "6 h model time, 307,200 cells, 15 min saved-output cadence",
-  output_volume_summary: "25 saved frames, process diagnostics, 307,200 cells per frame",
+  output_volume_summary: "25 saved frames, full output fields, 307,200 cells per frame",
   cm1_values: {
     nx: 64,
     ny: 64,
@@ -66,9 +84,13 @@ const defaultRunConfigurationSummary = {
   estimated_compute_multiplier_vs_default: 1,
   estimated_output_volume_multiplier_vs_default: 1,
   cost_warning:
-    "Configuration cost depends on duration, horizontal cell count, domain, cadence, and diagnostic set. Review the CM1-facing values before launch.",
+    "Configuration cost depends on duration, horizontal cells, domain, cadence, and full output volume. Review the CM1-facing values before launch.",
   validation_note:
-    "Run configuration preserves explicit duration, horizontal cell count, domain, cadence, and diagnostic-set choices.",
+    "Run configuration preserves explicit duration, horizontal cell count, domain, cadence, and full-output choices.",
+  surface_flux_mode: defaultRunConfiguration.surface_flux_mode,
+  surface_flux_summary: defaultRunConfiguration.surface_flux_summary,
+  surface_flux_cm1_values: defaultRunConfiguration.surface_flux_cm1_values,
+  surface_flux_caveats: defaultRunConfiguration.surface_flux_caveats,
 };
 
 const defaultPreRunValidationReport = {
@@ -111,13 +133,20 @@ const defaultPreRunValidationReport = {
     dy_m: 100,
     output_cadence: "standard_15min",
     output_cadence_seconds: 900,
-    diagnostic_set: "process",
+    diagnostic_set: "full",
     estimated_frames: 25,
-    estimated_output_volume: "25 saved frames, process diagnostics, 307,200 cells per frame",
+    estimated_output_volume: "25 saved frames, full output fields, 307,200 cells per frame",
   },
   forcing_validation: {
     trigger: "none",
-    surface_fluxes: "current_recipe_default",
+    surface_fluxes: {
+      mode: "constant_uniform_surface_flux_proxy",
+      product_selections: {
+        surface_heat_flux_k_m_s: 0.008,
+        surface_moisture_flux_g_g_m_s: 5.2e-5,
+      },
+      cm1_values: defaultRunConfiguration.surface_flux_cm1_values,
+    },
     radiation: "disabled_or_future",
     large_scale_forcing: "not_supported_v1",
   },
@@ -147,7 +176,7 @@ const highDetailRunConfiguration = {
   output_cadence_seconds: 300,
   diagnostic_set: "full",
   cost_runtime_summary: "12 h model time, 4,915,200 cells, 5 min saved-output cadence",
-  output_volume_summary: "145 saved frames, full diagnostics, 4,915,200 cells per frame",
+  output_volume_summary: "145 saved frames, full output fields, 4,915,200 cells per frame",
   cm1_values: {
     ...defaultRunConfiguration.cm1_values,
     nx: 256,
@@ -259,7 +288,7 @@ const deepDryRunResponse = {
     ...dryRunResponse.report,
     run_configuration: highDetailRunConfiguration,
     estimated_cost_or_size:
-      "Configuration cost depends on duration, horizontal cell count, domain, cadence, and diagnostic set. Review the CM1-facing values before launch.",
+      "Configuration cost depends on duration, horizontal cells, domain, cadence, and full output volume. Review the CM1-facing values before launch.",
     run_configuration_summary: {
       ...defaultRunConfigurationSummary,
       configuration_id: highDetailRunConfiguration.configuration_id,
@@ -405,17 +434,12 @@ function preRunValidationReportForRequest(body: {
     (body.observed_sounding
       ? "untriggered_observed_evolution"
       : "generated_reference_lower_atmosphere");
-  const deep = runRecipe === "triggered_deep_potential";
   const observed = runRecipe === "untriggered_observed_evolution";
-  const recipeId = deep
-    ? "triggered_deep_potential_v1"
-    : observed
-      ? "untriggered_observed_sounding_evolution_v0"
+  const recipeId = observed
+      ? "observed_surface_forced_evolution_v0"
       : "generated_reference_lower_atmosphere_v1";
-  const recipeDisplayName = deep
-    ? "Triggered Deep-Potential Experiment"
-    : observed
-      ? "Untriggered Observed-Sounding Evolution v0"
+  const recipeDisplayName = observed
+      ? "Observed Surface-Forced Evolution v0"
       : "Generated Lower-Atmosphere Reference";
   const activeStory =
     typeof body.candidate_screening?.active_story === "string"
@@ -453,26 +477,20 @@ function preRunValidationReportForRequest(body: {
         typeof body.candidate_screening?.rank_score === "number"
           ? body.candidate_screening.rank_score
           : null,
-      predicted_output_signature: deep ? ["deep_cloud", "strong_updraft"] : [],
+      predicted_output_signature: observed ? ["qv", "qc", "w", "qr", "rain", "dbz"] : [],
     },
     selected_run_recipe: {
       run_recipe: runRecipe,
       recipe_id: recipeId,
-      display_name: deep
-        ? "Triggered Deep-Potential Experiment"
-        : observed
-          ? "Untriggered Observed Evolution"
+      display_name: observed
+          ? "Observed Surface-Forced Evolution"
           : "Generated Lower-Atmosphere Reference",
       recipe_display_name: recipeDisplayName,
-      assumption_set_id: deep
-        ? "triggered_deep_potential_warm_bubble_v1"
-        : observed
-          ? "untriggered_observed_sounding_evolution_v0_assumptions"
+      assumption_set_id: observed
+          ? "observed_surface_forced_evolution_v0_assumptions"
           : "generated_reference_lower_atmosphere_v1",
-      assumption_mode: deep
-        ? "triggered_deep_potential"
-        : observed
-          ? "normal_evolution"
+      assumption_mode: observed
+          ? "surface_forced_observed_evolution"
           : "generated_reference",
     },
   };
@@ -1430,12 +1448,12 @@ const deepConvectionResultCard = {
   ...observedSoundingResultCard,
   result_id: "result-deep-convection",
   run_id: "dry-run-deep-convection",
-  name: "Triggered Deep-Potential Experiment — Norman, Oklahoma",
+  name: "Observed Surface-Forced Experiment — Norman, Oklahoma",
   tags: ["deep-convection", "candidate"],
-  scenario_name: "Triggered Deep-Potential Experiment",
-  run_recipe: "triggered_deep_potential",
-  run_recipe_display_name: "Triggered Deep-Potential Experiment",
-  trigger_type: "warm_bubble",
+  scenario_name: "Observed Surface-Forced Experiment",
+  run_recipe: "untriggered_observed_evolution",
+  run_recipe_display_name: "Observed Surface-Forced Evolution",
+  trigger_type: null,
   expected_outputs: ["qc", "qr", "w", "dbz", "updraft_helicity"],
   candidate_screening: {
     candidate_id: "USM00072357-2025052000-supercell",
@@ -1510,7 +1528,7 @@ const deepConvectionResultCard = {
   },
   candidate_hypothesis_comparison: {
     screened_as: "Supercell-like environment",
-    ran_as: "Triggered Deep-Potential Experiment",
+    ran_as: "Observed Surface-Forced Evolution",
     cm1_outcome: "Deep convection formed with strong updraft and rain water aloft.",
     match_status: "matched",
     match_status_label: "Matched",
@@ -3110,38 +3128,38 @@ describe("App", () => {
     expect(screen.getByText(/CM1 z=0 is station surface at 351.5 m MSL/)).toBeInTheDocument();
     expect(screen.getAllByText(/observed sounding winds/).length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Configure this CM1 run" })).toBeInTheDocument();
-    expect(screen.getByText(/Baseline surface heating; no deep trigger/i)).toBeInTheDocument();
-    expect(screen.getByLabelText("Experiment recipe")).toHaveValue(
-      "untriggered_observed_evolution",
-    );
-
-    fireEvent.change(screen.getByLabelText("Experiment recipe"), {
-      target: { value: "triggered_deep_potential" },
+    expect(screen.queryByLabelText("Experiment recipe")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Diagnostic set")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Surface heat flux")).toHaveValue("8.0e-3");
+    expect(screen.getByLabelText("Surface moisture flux")).toHaveValue("5.2e-5");
+    fireEvent.change(screen.getByLabelText("Surface heat flux"), {
+      target: { value: "0.037" },
     });
-    expect(screen.getByText(/Baseline surface heating; warm-bubble trigger/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Triggered deep potential adds a warm-bubble trigger/i),
-    ).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Surface moisture flux"), {
+      target: { value: "9.5e-5" },
+    });
+    expect(screen.getByText(/Surface heat flux 0.037 K m\/s/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
     expect(screen.getByRole("heading", { name: "Plan multiple CM1 runs" })).toBeInTheDocument();
-    expect(within(screen.getByLabelText("Run plan")).getByLabelText("Recipe")).toHaveValue(
-      "triggered_deep_potential",
-    );
+    expect(within(screen.getByLabelText("Run plan")).queryByLabelText("Recipe")).not.toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Create packages and queue selected runs" }),
     );
 
     await waitFor(() => {
-      expect(dryRunBody).toContain('"run_recipe":"triggered_deep_potential"');
+      expect(dryRunBody).toContain('"run_recipe":"untriggered_observed_evolution"');
+      expect(dryRunBody).toContain('"diagnostic_set":"full"');
+      expect(dryRunBody).toContain('"surface_heat_flux_k_m_s":"0.037"');
+      expect(dryRunBody).toContain('"surface_moisture_flux_g_g_m_s":"9.5e-5"');
       expect(dryRunBody).toContain('"observed_sounding"');
       expect(dryRunBody).toContain('"station_id":"USM00072558"');
       expect(dryRunBody).toContain('"model_bottom_elevation_m_msl":351.5');
     });
   });
 
-  it("defaults deep-convection candidates to the Triggered Deep-Potential Experiment package", async () => {
+  it("stages deep-convection candidates as observed forcing runs", async () => {
     const defaultFetch = vi.mocked(fetch).getMockImplementation();
     let dryRunBody = "";
     let screenBody = "";
@@ -3186,14 +3204,12 @@ describe("App", () => {
     expect(
       await screen.findByText("Norman, Oklahoma (USM00072357) added to the run plan"),
     ).toBeInTheDocument();
-    expect(within(screen.getByLabelText("Run plan")).getByLabelText("Recipe")).toHaveValue(
-      "triggered_deep_potential",
-    );
-    expect(screen.getByText("triggered_deep_potential_v1")).toBeInTheDocument();
-    expect(
-      screen.getByText("Warm-bubble trigger · triggered potential, not normal evolution"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("triggered_deep_potential_warm_bubble_v1")).toBeInTheDocument();
+    const runPlan = within(screen.getByLabelText("Run plan"));
+    expect(runPlan.queryByLabelText("Recipe")).not.toBeInTheDocument();
+    expect(runPlan.getByLabelText("Surface heat flux")).toHaveValue("8.0e-3");
+    expect(runPlan.getByLabelText("Surface moisture flux")).toHaveValue("5.2e-5");
+    expect(screen.getByText("observed_surface_forced_evolution_v0")).toBeInTheDocument();
+    expect(screen.getByText(/No artificial trigger/i)).toBeInTheDocument();
     expect(screen.getAllByLabelText(/^Run plan item /)).toHaveLength(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Duplicate variant" }));
@@ -3205,7 +3221,10 @@ describe("App", () => {
     );
 
     await waitFor(() => {
-      expect(dryRunBody).toContain('"run_recipe":"triggered_deep_potential"');
+      expect(dryRunBody).toContain('"run_recipe":"untriggered_observed_evolution"');
+      expect(dryRunBody).toContain('"diagnostic_set":"full"');
+      expect(dryRunBody).toContain('"surface_heat_flux_k_m_s":"8.0e-3"');
+      expect(dryRunBody).toContain('"surface_moisture_flux_g_g_m_s":"5.2e-5"');
       expect(dryRunBody).toContain('"candidate_screening"');
       expect(dryRunBody).toContain('"primary_story":"supercell_environment"');
       expect(dryRunBody).toContain('"candidate_id":"USM00072357-2025052000-supercell"');
@@ -3250,10 +3269,8 @@ describe("App", () => {
     expect(
       await screen.findByText("Wilmington, Ohio (USM00072426) added to the run plan"),
     ).toBeInTheDocument();
-    expect(within(screen.getByLabelText("Run plan")).getByLabelText("Recipe")).toHaveValue(
-      "untriggered_observed_evolution",
-    );
-    expect(screen.getByText("untriggered_observed_sounding_evolution_v0")).toBeInTheDocument();
+    expect(within(screen.getByLabelText("Run plan")).queryByLabelText("Recipe")).not.toBeInTheDocument();
+    expect(screen.getByText("observed_surface_forced_evolution_v0")).toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Create packages and queue selected runs" }),
@@ -3598,7 +3615,7 @@ describe("App", () => {
     expect(wilmingtonCard).toHaveTextContent("High-CAPE pulse storm");
     expect(wilmingtonCard).toHaveTextContent("Primary: Humid / rainy");
     expect(wilmingtonCard).toHaveTextContent("48.9 % ingredient score");
-    expect(wilmingtonCard).toHaveTextContent("Recipe fit: requires triggered deep-potential run");
+    expect(wilmingtonCard).toHaveTextContent("Recipe fit: testable as forced observed evolution");
     expect(
       screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
     ).not.toBeInTheDocument();
@@ -3661,6 +3678,12 @@ describe("App", () => {
         expect(init?.body).toEqual(expect.stringContaining('"domain_size":"wide_12km"'));
         expect(init?.body).toEqual(expect.stringContaining('"output_cadence":"detailed_5min"'));
         expect(init?.body).toEqual(expect.stringContaining('"diagnostic_set":"full"'));
+        expect(init?.body).toEqual(
+          expect.stringContaining('"surface_heat_flux_k_m_s":"0.04"'),
+        );
+        expect(init?.body).toEqual(
+          expect.stringContaining('"surface_moisture_flux_g_g_m_s":"1.1e-4"'),
+        );
         return Promise.resolve(new Response(JSON.stringify(deepDryRunResponse), { status: 200 }));
       }
       if (url === "/api/results") {
@@ -3694,7 +3717,13 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Output cadence"), {
       target: { value: "detailed_5min" },
     });
-    fireEvent.change(screen.getByLabelText("Diagnostic set"), { target: { value: "full" } });
+    expect(screen.queryByLabelText("Diagnostic set")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Surface heat flux"), {
+      target: { value: "0.04" },
+    });
+    fireEvent.change(screen.getByLabelText("Surface moisture flux"), {
+      target: { value: "1.1e-4" },
+    });
 
     fireEvent.click(screen.getByTestId("create-package-btn"));
 
@@ -3714,27 +3743,27 @@ describe("App", () => {
       ...defaultPreRunValidationReport,
       status: "blocked",
       selected_hypothesis: {
-        hypothesis_id: "supercell_environment",
-        story_id: "supercell_environment",
-        story_label: "Supercell-like environment",
-        ingredient_score: 93,
-        predicted_output_signature: ["deep_cloud", "strong_updraft"],
+        hypothesis_id: "humid_rainy_candidate",
+        story_id: "humid_rainy_candidate",
+        story_label: "Humid / rainy",
+        ingredient_score: 82,
+        predicted_output_signature: ["qc", "qr", "rain", "dbz"],
       },
       selected_run_recipe: {
         run_recipe: "untriggered_observed_evolution",
-        recipe_id: "untriggered_observed_sounding_evolution_v0",
-        display_name: "Untriggered Observed Evolution",
-        recipe_display_name: "Untriggered Observed-Sounding Evolution v0",
-        assumption_set_id: "untriggered_observed_sounding_evolution_v0_assumptions",
-        assumption_mode: "normal_evolution",
+        recipe_id: "observed_surface_forced_evolution_v0",
+        display_name: "Observed Surface-Forced Evolution",
+        recipe_display_name: "Observed Surface-Forced Evolution v0",
+        assumption_set_id: "observed_surface_forced_evolution_v0_assumptions",
+        assumption_mode: "surface_forced_observed_evolution",
       },
       hypothesis_recipe_alignment: {
         status: "blocked",
-        reasons: ["Deep-convection hypothesis is paired with an untriggered/shallow recipe."],
-        missing_assumptions: ["triggered_deep_potential_warm_bubble_v1"],
+        reasons: ["Surface-flux values must be reviewed before this package can be created."],
+        missing_assumptions: ["surface_flux_values_need_manual_review"],
         missing_outputs: [],
       },
-      blocking_errors: ["Selected run recipe does not test this deep-convection hypothesis."],
+      blocking_errors: ["Surface-flux values must be reviewed before this package can be created."],
       caveats: [],
     };
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -3749,7 +3778,7 @@ describe("App", () => {
             JSON.stringify({
               detail: {
                 message:
-                  "Pre-run validation blocked package creation: Selected run recipe does not test this deep-convection hypothesis.",
+                  "Pre-run validation blocked package creation: Surface-flux values must be reviewed before this package can be created.",
                 pre_run_validation_report: blockedReport,
               },
             }),
@@ -3781,10 +3810,10 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Pre-run validation report")).toHaveTextContent("Blocked");
     expect(screen.getByLabelText("Pre-run validation report")).toHaveTextContent(
-      "Selected run recipe does not test this deep-convection hypothesis.",
+      "Surface-flux values must be reviewed before this package can be created.",
     );
     expect(screen.getByLabelText("Pre-run validation report")).toHaveTextContent(
-      "triggered_deep_potential_warm_bubble_v1",
+      "surface_flux_values_need_manual_review",
     );
   });
 
@@ -4698,7 +4727,7 @@ describe("App", () => {
 
     const resultDetail = await screen.findByLabelText("Result detail");
     expect(resultDetail).toHaveTextContent(
-      "Triggered Deep-Potential Experiment — Norman, Oklahoma",
+      "Observed Surface-Forced Experiment — Norman, Oklahoma",
     );
     expect(resultDetail).toHaveTextContent("Deep convection formed");
     expect(resultDetail).toHaveTextContent("Screening vs CM1");

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -43,6 +43,8 @@ type RunConfigurationInput = {
   domain_size: string;
   output_cadence: string;
   diagnostic_set: string;
+  surface_heat_flux_k_m_s: string;
+  surface_moisture_flux_g_g_m_s: string;
 };
 
 type RunConfigurationCM1Values = {
@@ -64,16 +66,40 @@ type RunConfigurationCM1Values = {
   grid_cell_count: number;
 };
 
-type RunConfiguration = Omit<RunConfigurationInput, "horizontal_cell_count"> & {
+type RunConfigurationSurfaceFluxCM1Values = {
+  isfcflx: number;
+  sfcmodel: number;
+  oceanmodel: number;
+  set_flx: number;
+  cnst_shflx: number;
+  cnst_shflx_units: string;
+  cnst_lhflx: number;
+  cnst_lhflx_units: string;
+  set_znt: number;
+  cnst_znt: number;
+  set_ust: number;
+  cnst_ust: number;
+};
+
+type RunConfiguration = Omit<
+  RunConfigurationInput,
+  "horizontal_cell_count" | "surface_heat_flux_k_m_s" | "surface_moisture_flux_g_g_m_s"
+> & {
   configuration_id: string;
   mode: "smoke" | "science";
   label: string;
   horizontal_cell_count: string | number;
   duration_seconds: number;
   output_cadence_seconds: number;
+  surface_heat_flux_k_m_s: number;
+  surface_moisture_flux_g_g_m_s: number;
   cost_runtime_summary: string;
   output_volume_summary: string;
   cm1_values: RunConfigurationCM1Values;
+  surface_flux_mode: string;
+  surface_flux_summary: string;
+  surface_flux_cm1_values: RunConfigurationSurfaceFluxCM1Values;
+  surface_flux_caveats: string[];
   caveats: string[];
 };
 
@@ -86,6 +112,12 @@ type RunConfigurationSummary = {
   domain_size: string;
   output_cadence: string;
   diagnostic_set: string;
+  surface_heat_flux_k_m_s?: number;
+  surface_moisture_flux_g_g_m_s?: number;
+  surface_flux_mode?: string;
+  surface_flux_summary?: string;
+  surface_flux_cm1_values?: RunConfigurationSurfaceFluxCM1Values;
+  surface_flux_caveats?: string[];
   runtime_seconds: number;
   output_cadence_seconds: number;
   expected_output_frames: number;
@@ -327,7 +359,6 @@ type CandidateReadinessFilter = "all" | "package_ready" | "blocked";
 type CandidateRecipeFitStatus =
   | "testable_now"
   | "partially_testable"
-  | "requires_triggered_deep_potential"
   | "requires_surface_forcing_recipe"
   | "not_testable_with_current_recipes"
   | "blocked_profile";
@@ -340,10 +371,9 @@ type CandidateRecipeFitDisplay = {
 
 type RunRecipe =
   | "generated_reference_lower_atmosphere"
-  | "untriggered_observed_evolution"
-  | "triggered_deep_potential";
+  | "untriggered_observed_evolution";
 
-type ObservedRunRecipe = "untriggered_observed_evolution" | "triggered_deep_potential";
+type ObservedRunRecipe = "untriggered_observed_evolution";
 type AtmosphereSourcePath = "cached_recommendations" | "saved_candidates" | "upload_igra_text";
 type SearchIntent =
   | "best_overall"
@@ -354,6 +384,7 @@ type SearchIntent =
 type SearchDepth = "quick_scan" | "deeper_scan" | "broad_historical_sweep";
 type TimeScope = "recent_latest";
 type RunPlanQueueTarget = "local" | "lan";
+const CURRENT_OBSERVED_RUN_RECIPE: ObservedRunRecipe = "untriggered_observed_evolution";
 type RunPlanItemStatus =
   | "planned"
   | "packaging"
@@ -1206,7 +1237,9 @@ const DEFAULT_SHALLOW_RUN_CONFIGURATION: RunConfigurationInput = {
   horizontal_cell_count: "cells_64",
   domain_size: "local_6km",
   output_cadence: "standard_15min",
-  diagnostic_set: "process",
+  diagnostic_set: "full",
+  surface_heat_flux_k_m_s: "8.0e-3",
+  surface_moisture_flux_g_g_m_s: "5.2e-5",
 };
 
 const DEFAULT_OBSERVED_RUN_CONFIGURATION: RunConfigurationInput = {
@@ -1214,15 +1247,9 @@ const DEFAULT_OBSERVED_RUN_CONFIGURATION: RunConfigurationInput = {
   horizontal_cell_count: "cells_128",
   domain_size: "wide_12km",
   output_cadence: "standard_15min",
-  diagnostic_set: "process",
-};
-
-const DEFAULT_TRIGGERED_DEEP_POTENTIAL_RUN_CONFIGURATION: RunConfigurationInput = {
-  duration: "short_6h",
-  horizontal_cell_count: "cells_128",
-  domain_size: "storm_120km",
-  output_cadence: "standard_15min",
   diagnostic_set: "full",
+  surface_heat_flux_k_m_s: "8.0e-3",
+  surface_moisture_flux_g_g_m_s: "5.2e-5",
 };
 
 const SEARCH_INTENT_OPTIONS: Array<{ value: SearchIntent; label: string }> = [
@@ -1832,9 +1859,6 @@ export function App() {
   const [runConfiguration, setRunConfiguration] = useState<RunConfigurationInput>(
     DEFAULT_SHALLOW_RUN_CONFIGURATION,
   );
-  const [observedRunRecipe, setObservedRunRecipe] = useState<ObservedRunRecipe>(
-    "untriggered_observed_evolution",
-  );
   const [observedSoundingFilename, setObservedSoundingFilename] = useState<string | null>(null);
   const [observedSoundingText, setObservedSoundingText] = useState<string | null>(null);
   const [observedSoundingParse, setObservedSoundingParse] =
@@ -2058,15 +2082,12 @@ export function App() {
       selectedScenario.controls.map((control) => [control.id, control.default]),
     );
     setControls(defaults);
-    setRunConfiguration(
-      defaultRunConfigurationForSelection(selectedScenarioId, "untriggered_observed_evolution"),
-    );
+    setRunConfiguration(defaultRunConfigurationForSelection(selectedScenarioId));
     setObservedSoundingFilename(null);
     setObservedSoundingText(null);
     setObservedSoundingParse(null);
     setObservedSoundingStatus(null);
     setObservedSoundingError(null);
-    setObservedRunRecipe("untriggered_observed_evolution");
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
     setRunStatus(null);
@@ -2205,7 +2226,6 @@ export function App() {
   }
 
   function handleSelectScenario(scenarioId: string) {
-    const nextRunRecipe: ObservedRunRecipe = "untriggered_observed_evolution";
     setSelectedScenarioId(scenarioId);
     setObservedSoundingFilename(null);
     setObservedSoundingText(null);
@@ -2213,23 +2233,7 @@ export function App() {
     setObservedSoundingStatus(null);
     setObservedSoundingError(null);
     setSelectedCandidateScreening(null);
-    setObservedRunRecipe(nextRunRecipe);
-    setRunConfiguration(defaultRunConfigurationForSelection(scenarioId, nextRunRecipe));
-    setDryRun(null);
-    setBlockedPreRunValidationReport(null);
-    setRunStatus(null);
-    setRunWorkflowError(null);
-    setLanWorkerStatus(null);
-    setLanWorkerError(null);
-    setLanWorkerActionStatus(null);
-    setIngestedResultId(null);
-  }
-
-  function handleObservedRunRecipeChange(runRecipe: ObservedRunRecipe) {
-    setObservedRunRecipe(runRecipe);
-    setRunConfiguration(
-      defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID, runRecipe),
-    );
+    setRunConfiguration(defaultRunConfigurationForSelection(scenarioId));
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
     setRunStatus(null);
@@ -2516,10 +2520,8 @@ export function App() {
     setSelectedCandidateScreening(
       candidateScreeningMetadata(candidate, savedCandidate, activeStory),
     );
-    const nextRunRecipe = defaultRunRecipeForCandidate(candidate, activeStory);
-    setObservedRunRecipe(nextRunRecipe);
     setRunConfiguration(
-      defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID, nextRunRecipe),
+      defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID),
     );
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
@@ -2555,7 +2557,6 @@ export function App() {
     const item = runPlanItemFromUploadedSounding({
       observedSounding: observedSoundingParse.selected_sounding,
       source: runPlanSourceFromCandidateScreening(selectedCandidateScreening),
-      observedRunRecipe,
       runConfiguration,
       controls,
       selectedCandidateScreening,
@@ -2610,21 +2611,6 @@ export function App() {
       queueTarget,
       status: "planned",
       message: null,
-    }));
-  }
-
-  function handleRunPlanItemRecipeChange(itemId: string, runRecipe: ObservedRunRecipe) {
-    updateRunPlanItem(itemId, (item) => ({
-      ...item,
-      runRecipe,
-      runConfiguration: defaultRunConfigurationForSelection(
-        OBSERVED_SOUNDING_EXPERIMENT_ID,
-        runRecipe,
-      ),
-      status: "planned",
-      message: "Recipe changed; package not created yet.",
-      dryRun: null,
-      blockedPreRunValidationReport: null,
     }));
   }
 
@@ -2780,7 +2766,7 @@ export function App() {
         selectedScenario.id,
         controls,
         runConfiguration,
-        observedSoundingExperimentSelected ? observedRunRecipe : null,
+        observedSoundingExperimentSelected ? CURRENT_OBSERVED_RUN_RECIPE : null,
         observedSoundingExperimentSelected ? observedSoundingParse?.selected_sounding : null,
         observedSoundingExperimentSelected ? selectedCandidateScreening : null,
         packageUserMetadata,
@@ -2804,13 +2790,7 @@ export function App() {
     setObservedSoundingError(null);
     setObservedSoundingParse(null);
     setSelectedCandidateScreening(null);
-    setObservedRunRecipe("untriggered_observed_evolution");
-    setRunConfiguration(
-      defaultRunConfigurationForSelection(
-        OBSERVED_SOUNDING_EXPERIMENT_ID,
-        "untriggered_observed_evolution",
-      ),
-    );
+    setRunConfiguration(defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID));
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
     setRunStatus(null);
@@ -2822,13 +2802,7 @@ export function App() {
       const parsed = await parseObservedSoundingUpload(file.name, text);
       setObservedSoundingParse(parsed);
       setSelectedCandidateScreening(null);
-      setObservedRunRecipe("untriggered_observed_evolution");
-      setRunConfiguration(
-        defaultRunConfigurationForSelection(
-          OBSERVED_SOUNDING_EXPERIMENT_ID,
-          "untriggered_observed_evolution",
-        ),
-      );
+      setRunConfiguration(defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID));
       setObservedSoundingStatus("Observed sounding validated for package review");
     } catch (caught) {
       setObservedSoundingText(null);
@@ -2854,13 +2828,7 @@ export function App() {
       );
       setObservedSoundingParse(parsed);
       setSelectedCandidateScreening(null);
-      setObservedRunRecipe("untriggered_observed_evolution");
-      setRunConfiguration(
-        defaultRunConfigurationForSelection(
-          OBSERVED_SOUNDING_EXPERIMENT_ID,
-          "untriggered_observed_evolution",
-        ),
-      );
+      setRunConfiguration(defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID));
       setObservedSoundingStatus("Observed sounding validated for package review");
     } catch (caught) {
       setObservedSoundingError(
@@ -3312,7 +3280,6 @@ export function App() {
           observedSoundingExperimentSelected={observedSoundingExperimentSelected}
           controls={controls}
           runConfiguration={runConfiguration}
-          observedRunRecipe={observedRunRecipe}
           observedSoundingParse={observedSoundingParse}
           observedSoundingStatus={observedSoundingStatus}
           observedSoundingError={observedSoundingError}
@@ -3368,7 +3335,6 @@ export function App() {
             }))
           }
           onRunConfigurationChange={setRunConfiguration}
-          onObservedRunRecipeChange={handleObservedRunRecipeChange}
           onObservedSoundingFile={handleObservedSoundingFile}
           onObservedSoundingTimeChange={handleObservedSoundingTimeChange}
           onAtmosphereSourcePathChange={handleAtmosphereSourcePathChange}
@@ -3400,7 +3366,6 @@ export function App() {
           onClearRunPlan={handleClearRunPlan}
           onRunPlanItemSelectedChange={handleRunPlanItemSelectedChange}
           onRunPlanItemQueueTargetChange={handleRunPlanItemQueueTargetChange}
-          onRunPlanItemRecipeChange={handleRunPlanItemRecipeChange}
           onRunPlanItemConfigurationChange={handleRunPlanItemConfigurationChange}
           onCreateAndQueueRunPlan={handleCreateAndQueueRunPlan}
           onDryRun={handleDryRun}
@@ -3481,7 +3446,6 @@ function BuildWorkspace({
   observedSoundingExperimentSelected,
   controls,
   runConfiguration,
-  observedRunRecipe,
   observedSoundingParse,
   observedSoundingStatus,
   observedSoundingError,
@@ -3532,7 +3496,6 @@ function BuildWorkspace({
   onSelectScenario,
   onControlChange,
   onRunConfigurationChange,
-  onObservedRunRecipeChange,
   onObservedSoundingFile,
   onObservedSoundingTimeChange,
   onAtmosphereSourcePathChange,
@@ -3564,7 +3527,6 @@ function BuildWorkspace({
   onClearRunPlan,
   onRunPlanItemSelectedChange,
   onRunPlanItemQueueTargetChange,
-  onRunPlanItemRecipeChange,
   onRunPlanItemConfigurationChange,
   onCreateAndQueueRunPlan,
   onDryRun,
@@ -3598,7 +3560,6 @@ function BuildWorkspace({
   observedSoundingExperimentSelected: boolean;
   controls: Record<string, string | number | boolean>;
   runConfiguration: RunConfigurationInput;
-  observedRunRecipe: ObservedRunRecipe;
   observedSoundingParse: ObservedSoundingParseResponse | null;
   observedSoundingStatus: string | null;
   observedSoundingError: string | null;
@@ -3649,7 +3610,6 @@ function BuildWorkspace({
   onSelectScenario: (scenarioId: string) => void;
   onControlChange: (controlId: string, value: string) => void;
   onRunConfigurationChange: (configuration: RunConfigurationInput) => void;
-  onObservedRunRecipeChange: (runRecipe: ObservedRunRecipe) => void;
   onObservedSoundingFile: (file: File) => void;
   onObservedSoundingTimeChange: (validTimeUtc: string) => void;
   onAtmosphereSourcePathChange: (sourcePath: AtmosphereSourcePath) => void;
@@ -3685,7 +3645,6 @@ function BuildWorkspace({
   onClearRunPlan: () => void;
   onRunPlanItemSelectedChange: (itemId: string, selected: boolean) => void;
   onRunPlanItemQueueTargetChange: (itemId: string, target: RunPlanQueueTarget) => void;
-  onRunPlanItemRecipeChange: (itemId: string, runRecipe: ObservedRunRecipe) => void;
   onRunPlanItemConfigurationChange: (
     itemId: string,
     runConfiguration: RunConfigurationInput,
@@ -3714,12 +3673,7 @@ function BuildWorkspace({
   onRetryScenarios: () => void;
 }) {
   const scenarioControlsReady = scenarioLoadState === "loaded" && selectedScenario !== undefined;
-  const selectedTriggeredDeepPotential =
-    observedSoundingExperimentSelected && observedRunRecipe === "triggered_deep_potential";
-  const runConfigurationPreview = previewRunConfiguration(
-    runConfiguration,
-    observedSoundingExperimentSelected ? observedRunRecipe : "generated_reference_lower_atmosphere",
-  );
+  const runConfigurationPreview = previewRunConfiguration(runConfiguration);
   const runPlanPanel = (
     <RunPlanPanel
       items={runPlanItems}
@@ -3727,7 +3681,6 @@ function BuildWorkspace({
       lanWorkerConfigured={lanWorkerConfig?.configured ?? false}
       onSelectedChange={onRunPlanItemSelectedChange}
       onQueueTargetChange={onRunPlanItemQueueTargetChange}
-      onRecipeChange={onRunPlanItemRecipeChange}
       onConfigurationChange={onRunPlanItemConfigurationChange}
       onDuplicate={onDuplicateRunPlanItem}
       onRemove={onRemoveRunPlanItem}
@@ -3815,7 +3768,7 @@ function BuildWorkspace({
                 <h3 id="physical-question-title">Physical Question</h3>
                 <p>
                   {observedSoundingExperimentSelected
-                    ? "Given this observed atmosphere, what can CM1 honestly test under the selected run recipe and explicit assumptions?"
+                    ? "Given this observed atmosphere, what can CM1 honestly test under the selected surface forcing, run shape, and explicit assumptions?"
                     : selectedScenario.physical_question}
                 </p>
               </section>
@@ -3864,12 +3817,8 @@ function BuildWorkspace({
                     <SelectedSoundingRunSetupPanel
                       observedSounding={observedSoundingParse.selected_sounding}
                       selectedCandidateScreening={selectedCandidateScreening}
-                      observedRunRecipe={observedRunRecipe}
-                      controls={controls}
                       runConfiguration={runConfiguration}
                       runConfigurationPreview={runConfigurationPreview}
-                      selectedTriggeredDeepPotential={selectedTriggeredDeepPotential}
-                      onObservedRunRecipeChange={onObservedRunRecipeChange}
                       onRunConfigurationChange={onRunConfigurationChange}
                       onAddSelectedSoundingToRunPlan={onAddSelectedSoundingToRunPlan}
                     />
@@ -3956,7 +3905,6 @@ function BuildWorkspace({
                 <RunConfigurationPanel
                   configuration={runConfiguration}
                   preview={runConfigurationPreview}
-                  triggeredDeepPotential={selectedTriggeredDeepPotential}
                   onChange={onRunConfigurationChange}
                 />
               )}
@@ -4094,9 +4042,9 @@ function PreRunValidationReportPanel({ report }: { report: PreRunValidationRepor
       <div className="panel-heading-row">
         <div>
           <p className="eyebrow">Pre-run validation</p>
-          <h3>Hypothesis and run recipe check</h3>
+          <h3>Hypothesis and experiment setup check</h3>
           <p className="field-help">
-            Cloud Chamber checks whether the selected hypothesis, recipe, fields, and run shape can
+            Cloud Chamber checks whether the selected hypothesis, forcing, fields, and run shape can
             be compared honestly before CM1 is launched.
           </p>
         </div>
@@ -4254,40 +4202,24 @@ function BuildRunActionPanel({
 function RunConfigurationPanel({
   configuration,
   preview,
-  triggeredDeepPotential,
-  runRecipe,
-  controls,
   selectedCandidateScreening,
   onAddToRunPlan,
   onChange,
-  onRunRecipeChange,
   embedded = false,
 }: {
-  configuration: RunConfigurationInput;
-  preview: RunConfiguration;
-  triggeredDeepPotential: boolean;
-  runRecipe?: ObservedRunRecipe;
-  controls?: Record<string, string | number | boolean>;
-  selectedCandidateScreening?: Record<string, unknown> | null;
-  onAddToRunPlan?: () => void;
-  onChange: (configuration: RunConfigurationInput) => void;
-  onRunRecipeChange?: (runRecipe: ObservedRunRecipe) => void;
-  embedded?: boolean;
-}) {
-  const observedRecipeSelected = runRecipe !== undefined && onRunRecipeChange !== undefined;
-  const selectedDeep = runRecipe
-    ? runRecipe === "triggered_deep_potential"
-    : triggeredDeepPotential;
-  const domainOptions = selectedDeep ? DEEP_DOMAIN_OPTIONS : SHALLOW_DOMAIN_OPTIONS;
-  const recipeMismatchWarning =
-    runRecipe && selectedCandidateScreening
-      ? candidateRecipeMismatchWarning(selectedCandidateScreening, runRecipe)
-      : null;
-  const appliedForcing =
-    runRecipe && controls ? observedRecipeAppliedForcing(controls, selectedDeep) : null;
-  const configurationHelp = observedRecipeSelected
-    ? "Choose the recipe, model time, grid, domain, cadence, and diagnostics for this observed atmosphere."
-    : "Choose duration, grid, domain, cadence, and diagnostics before creating the CM1 package.";
+	  configuration: RunConfigurationInput;
+	  preview: RunConfiguration;
+	  selectedCandidateScreening?: Record<string, unknown> | null;
+	  onAddToRunPlan?: () => void;
+	  onChange: (configuration: RunConfigurationInput) => void;
+	  embedded?: boolean;
+	}) {
+  const recipeMismatchWarning = selectedCandidateScreening
+    ? candidateRecipeMismatchWarning(selectedCandidateScreening)
+    : null;
+  const appliedForcing = observedRecipeAppliedForcing(preview);
+  const configurationHelp =
+    "Choose lower-boundary forcing, model time, grid, domain, and cadence for this atmosphere.";
   const configurationNotes: string[] = [];
   if (preview.mode === "smoke") {
     configurationNotes.push(
@@ -4297,11 +4229,6 @@ function RunConfigurationPanel({
   if (preview.caveats.includes("configuration_better_suited_to_larger_compute")) {
     configurationNotes.push(
       "This configuration may be better suited to larger compute. Cloud Chamber still shows the CM1-facing values before launch.",
-    );
-  }
-  if (selectedDeep) {
-    configurationNotes.push(
-      "Triggered deep potential adds a warm-bubble trigger. Treat it as a forced-potential experiment, not normal atmospheric evolution.",
     );
   }
   const update = (key: keyof RunConfigurationInput, value: string) => {
@@ -4325,25 +4252,22 @@ function RunConfigurationPanel({
       </div>
 
       <div className="run-configuration-grid">
-        {observedRecipeSelected && (
-          <RunConfigurationSelect
-            id="run-recipe"
-            label="Experiment recipe"
-            description="Initiation and comparison context."
-            value={runRecipe}
-            options={[
-              {
-                value: "untriggered_observed_evolution",
-                label: "Observed evolution",
-              },
-              {
-                value: "triggered_deep_potential",
-                label: "Triggered deep potential",
-              },
-            ]}
-            onChange={(value) => onRunRecipeChange(value as ObservedRunRecipe)}
-          />
-        )}
+        <RunConfigurationTextInput
+          id="run-surface-heat-flux"
+          label="Surface heat flux"
+          units="K m/s"
+          description="CM1 cnst_shflx. Current baseline is 8.0e-3; 0.03-0.10 is a stronger daytime-heating sensitivity; values above about 0.2 are very aggressive."
+          value={configuration.surface_heat_flux_k_m_s}
+          onChange={(value) => update("surface_heat_flux_k_m_s", value)}
+        />
+        <RunConfigurationTextInput
+          id="run-surface-moisture-flux"
+          label="Surface moisture flux"
+          units="g/g m/s"
+          description="CM1 cnst_lhflx. Current baseline is 5.2e-5; 2e-5-1e-4 is a useful moisture-supply sensitivity; values above about 2e-4 are very aggressive."
+          value={configuration.surface_moisture_flux_g_g_m_s}
+          onChange={(value) => update("surface_moisture_flux_g_g_m_s", value)}
+        />
         <RunConfigurationSelect
           id="run-duration"
           label="Duration"
@@ -4355,11 +4279,7 @@ function RunConfigurationPanel({
         <RunConfigurationSelect
           id="run-grid"
           label="Horizontal cells"
-          description={
-            selectedDeep
-              ? "Storm-scale cell budget; spacing derives from domain width."
-              : "Cell budget; more cells reduce dx/dy and increase cost."
-          }
+          description="Cell budget; more cells reduce dx/dy and increase cost."
           value={configuration.horizontal_cell_count}
           options={HORIZONTAL_CELL_OPTIONS}
           onChange={(value) => update("horizontal_cell_count", value)}
@@ -4367,9 +4287,9 @@ function RunConfigurationPanel({
         <RunConfigurationSelect
           id="run-domain"
           label="Domain size"
-          description={selectedDeep ? "Storm-growth domain." : "Domain width and model top."}
+          description="Domain width and model top."
           value={configuration.domain_size}
-          options={domainOptions}
+          options={SHALLOW_DOMAIN_OPTIONS}
           onChange={(value) => update("domain_size", value)}
         />
         <RunConfigurationSelect
@@ -4380,14 +4300,6 @@ function RunConfigurationPanel({
           options={OUTPUT_CADENCE_OPTIONS}
           onChange={(value) => update("output_cadence", value)}
         />
-        <RunConfigurationSelect
-          id="run-fields"
-          label="Diagnostic set"
-          description="CM1 fields written for Results and Explore."
-          value={configuration.diagnostic_set}
-          options={DIAGNOSTIC_SET_OPTIONS}
-          onChange={(value) => update("diagnostic_set", value)}
-        />
       </div>
 
       {recipeMismatchWarning && (
@@ -4397,10 +4309,10 @@ function RunConfigurationPanel({
       )}
 
       <dl className="compact-metrics run-configuration-summary">
-        {appliedForcing && <Metric label="Forcing" value={appliedForcing} />}
+        <Metric label="Forcing" value={appliedForcing} />
         <Metric label="Runtime" value={runConfigurationTimingSummary(preview)} />
         <Metric label="Grid" value={runConfigurationGridSummary(preview)} />
-        <Metric label="Output" value={preview.output_volume_summary} />
+        <Metric label="Saved fields" value={runConfigurationFieldSummary(preview)} />
       </dl>
 
       {configurationNotes.length > 0 && (
@@ -4414,9 +4326,8 @@ function RunConfigurationPanel({
         </details>
       )}
 
-      {observedRecipeSelected && selectedCandidateScreening && (
+      {selectedCandidateScreening && (
         <ObservedRunRecipePanel
-          runRecipe={runRecipe}
           selectedCandidateScreening={selectedCandidateScreening}
         />
       )}
@@ -4441,6 +4352,25 @@ function RunConfigurationPanel({
           <Metric
             label="Rayleigh damping start"
             value={formatMeters(preview.cm1_values.rayleigh_damping_start_m)}
+          />
+          <Metric label="Surface flux mode" value={humanize(preview.surface_flux_mode)} />
+          <Metric
+            label="cnst_shflx"
+            value={formatScientific(
+              preview.surface_flux_cm1_values.cnst_shflx,
+              preview.surface_flux_cm1_values.cnst_shflx_units,
+            )}
+          />
+          <Metric
+            label="cnst_lhflx"
+            value={formatScientific(
+              preview.surface_flux_cm1_values.cnst_lhflx,
+              preview.surface_flux_cm1_values.cnst_lhflx_units,
+            )}
+          />
+          <Metric
+            label="Surface switches"
+            value={`isfcflx ${preview.surface_flux_cm1_values.isfcflx}; sfcmodel ${preview.surface_flux_cm1_values.sfcmodel}; set_flx ${preview.surface_flux_cm1_values.set_flx}; set_ust ${preview.surface_flux_cm1_values.set_ust}`}
           />
         </dl>
       </details>
@@ -4499,6 +4429,44 @@ function RunConfigurationSelect({
           </option>
         ))}
       </select>
+    </div>
+  );
+}
+
+function RunConfigurationTextInput({
+  id,
+  label,
+  units,
+  description,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  units: string;
+  description: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const descriptionId = `${id}-description`;
+  return (
+    <div className="run-configuration-control">
+      <span>
+        <label htmlFor={id}>
+          <strong>{label}</strong>
+        </label>
+        <small id={descriptionId}>
+          {units}; {description}
+        </small>
+      </span>
+      <input
+        id={id}
+        type="text"
+        inputMode="decimal"
+        value={value}
+        aria-describedby={descriptionId}
+        onChange={(event) => onChange(event.target.value)}
+      />
     </div>
   );
 }
@@ -5584,23 +5552,15 @@ function UploadSoundingSourcePanel({
 function SelectedSoundingRunSetupPanel({
   observedSounding,
   selectedCandidateScreening,
-  observedRunRecipe,
-  controls,
   runConfiguration,
   runConfigurationPreview,
-  selectedTriggeredDeepPotential,
-  onObservedRunRecipeChange,
   onRunConfigurationChange,
   onAddSelectedSoundingToRunPlan,
 }: {
   observedSounding: ObservedSoundingRecord;
   selectedCandidateScreening: Record<string, unknown> | null;
-  observedRunRecipe: ObservedRunRecipe;
-  controls: Record<string, string | number | boolean>;
   runConfiguration: RunConfigurationInput;
   runConfigurationPreview: RunConfiguration;
-  selectedTriggeredDeepPotential: boolean;
-  onObservedRunRecipeChange: (runRecipe: ObservedRunRecipe) => void;
   onRunConfigurationChange: (configuration: RunConfigurationInput) => void;
   onAddSelectedSoundingToRunPlan: () => void;
 }) {
@@ -5658,13 +5618,9 @@ function SelectedSoundingRunSetupPanel({
       <RunConfigurationPanel
         configuration={runConfiguration}
         preview={runConfigurationPreview}
-        triggeredDeepPotential={selectedTriggeredDeepPotential}
-        runRecipe={observedRunRecipe}
-        controls={controls}
         selectedCandidateScreening={selectedCandidateScreening}
         onAddToRunPlan={onAddSelectedSoundingToRunPlan}
         onChange={onRunConfigurationChange}
-        onRunRecipeChange={onObservedRunRecipeChange}
         embedded
       />
     </section>
@@ -5822,22 +5778,16 @@ function ObservedSoundingInputPanel({
 }
 
 function ObservedRunRecipePanel({
-  runRecipe,
   selectedCandidateScreening,
 }: {
-  runRecipe: ObservedRunRecipe;
   selectedCandidateScreening: Record<string, unknown> | null;
 }) {
-  const selectedDeep = runRecipe === "triggered_deep_potential";
   const activeStory = observedRecipeStoryId(selectedCandidateScreening);
   const activeStoryLabel = observedRecipeStoryLabel(selectedCandidateScreening);
   const expectedSignatures = observedRecipeSignatureLabels(activeStory);
   const hypothesisSummary = observedRecipeHypothesisSummary(activeStory);
   const evidenceSummary = observedRecipeEvidenceSummary(selectedCandidateScreening);
   const recipeFitSummary = observedRecipeFitSummary(selectedCandidateScreening, activeStory);
-  const methodScope = selectedDeep
-    ? "Forced-initiation test of deep-convection potential; not normal atmospheric evolution."
-    : "No added deep trigger; CM1 evolves the observed profile with the selected surface-heating forcing.";
 
   return (
     <details className="technical-details hypothesis-details-panel">
@@ -5865,14 +5815,9 @@ function ObservedRunRecipePanel({
 
       <dl className="compact-metrics">
         <Metric
-          label="Experiment recipe"
-          value={selectedDeep ? "Triggered deep potential" : "Observed evolution"}
+          label="Run scope"
+          value="CM1 evolves the observed profile with the selected uniform lower-boundary heat/moisture forcing."
         />
-        <Metric
-          label="Initiation"
-          value={selectedDeep ? "Idealized three warm bubbles" : "No added deep trigger"}
-        />
-        <Metric label="Method scope" value={methodScope} />
       </dl>
     </details>
   );
@@ -5884,7 +5829,6 @@ function RunPlanPanel({
   lanWorkerConfigured,
   onSelectedChange,
   onQueueTargetChange,
-  onRecipeChange,
   onConfigurationChange,
   onDuplicate,
   onRemove,
@@ -5897,7 +5841,6 @@ function RunPlanPanel({
   lanWorkerConfigured: boolean;
   onSelectedChange: (itemId: string, selected: boolean) => void;
   onQueueTargetChange: (itemId: string, target: RunPlanQueueTarget) => void;
-  onRecipeChange: (itemId: string, runRecipe: ObservedRunRecipe) => void;
   onConfigurationChange: (itemId: string, configuration: RunConfigurationInput) => void;
   onDuplicate: (itemId: string) => void;
   onRemove: (itemId: string) => void;
@@ -5919,8 +5862,8 @@ function RunPlanPanel({
           <p className="eyebrow">Run plan</p>
           <h3>Plan multiple CM1 runs</h3>
           <p className="field-help">
-            Add candidate atmospheres, duplicate variants, edit recipe and run configuration, then
-            queue selected items as a batch.
+            Add candidate atmospheres, duplicate variants, edit forcing and run shape, then queue
+            selected items as a batch.
           </p>
         </div>
         <StatusBadge
@@ -5952,7 +5895,6 @@ function RunPlanPanel({
                 lanWorkerConfigured={lanWorkerConfigured}
                 onSelectedChange={onSelectedChange}
                 onQueueTargetChange={onQueueTargetChange}
-                onRecipeChange={onRecipeChange}
                 onConfigurationChange={onConfigurationChange}
                 onDuplicate={onDuplicate}
                 onRemove={onRemove}
@@ -5995,7 +5937,6 @@ function RunPlanItemCard({
   lanWorkerConfigured,
   onSelectedChange,
   onQueueTargetChange,
-  onRecipeChange,
   onConfigurationChange,
   onDuplicate,
   onRemove,
@@ -6005,14 +5946,13 @@ function RunPlanItemCard({
   lanWorkerConfigured: boolean;
   onSelectedChange: (itemId: string, selected: boolean) => void;
   onQueueTargetChange: (itemId: string, target: RunPlanQueueTarget) => void;
-  onRecipeChange: (itemId: string, runRecipe: ObservedRunRecipe) => void;
   onConfigurationChange: (itemId: string, configuration: RunConfigurationInput) => void;
   onDuplicate: (itemId: string) => void;
   onRemove: (itemId: string) => void;
 }) {
   const metadata = runPlanRecipeMetadata(item);
   const activeStory = item.activeStory ?? observedRecipeStoryId(item.candidateScreening);
-  const preview = previewRunConfiguration(item.runConfiguration, item.runRecipe);
+  const preview = previewRunConfiguration(item.runConfiguration);
   const sourceLabel =
     item.candidate !== null
       ? `${candidateStationLabel(item.candidate)} · ${formatDate(item.candidate.valid_time_utc)}`
@@ -6058,20 +5998,6 @@ function RunPlanItemCard({
           <span>{runConfigurationTimingSummary(preview)}</span>
         </div>
         <div className="run-configuration-grid run-plan-configuration-grid">
-          <RunConfigurationSelect
-            id={`run-plan-recipe-${item.id}`}
-            label="Recipe"
-            description="Initiation and comparison context."
-            value={item.runRecipe}
-            options={[
-              {
-                value: "untriggered_observed_evolution",
-                label: "Observed evolution",
-              },
-              { value: "triggered_deep_potential", label: "Triggered deep potential" },
-            ]}
-            onChange={(value) => onRecipeChange(item.id, value as ObservedRunRecipe)}
-          />
           <RunConfigurationSelect
             id={`run-plan-target-${item.id}`}
             label="Queue target"
@@ -6140,13 +6066,27 @@ function RunPlanConfigurationFields({
   preview: RunConfiguration;
   onConfigurationChange: (itemId: string, configuration: RunConfigurationInput) => void;
 }) {
-  const triggeredDeepPotential = item.runRecipe === "triggered_deep_potential";
-  const domainOptions = triggeredDeepPotential ? DEEP_DOMAIN_OPTIONS : SHALLOW_DOMAIN_OPTIONS;
   const update = (key: keyof RunConfigurationInput, value: string) => {
     onConfigurationChange(item.id, { ...item.runConfiguration, [key]: value });
   };
   return (
     <>
+      <RunConfigurationTextInput
+        id={`run-plan-surface-heat-flux-${item.id}`}
+        label="Surface heat flux"
+        units="K m/s"
+        description="CM1 cnst_shflx; baseline 8.0e-3, stronger sensitivity about 0.03-0.10."
+        value={item.runConfiguration.surface_heat_flux_k_m_s}
+        onChange={(value) => update("surface_heat_flux_k_m_s", value)}
+      />
+      <RunConfigurationTextInput
+        id={`run-plan-surface-moisture-flux-${item.id}`}
+        label="Surface moisture flux"
+        units="g/g m/s"
+        description="CM1 cnst_lhflx; baseline 5.2e-5, useful sensitivity about 2e-5-1e-4."
+        value={item.runConfiguration.surface_moisture_flux_g_g_m_s}
+        onChange={(value) => update("surface_moisture_flux_g_g_m_s", value)}
+      />
       <RunConfigurationSelect
         id={`run-plan-duration-${item.id}`}
         label="Duration"
@@ -6168,7 +6108,7 @@ function RunPlanConfigurationFields({
         label="Domain size"
         description="Width and model top."
         value={item.runConfiguration.domain_size}
-        options={domainOptions}
+        options={SHALLOW_DOMAIN_OPTIONS}
         onChange={(value) => update("domain_size", value)}
       />
       <RunConfigurationSelect
@@ -6178,14 +6118,6 @@ function RunPlanConfigurationFields({
         value={item.runConfiguration.output_cadence}
         options={OUTPUT_CADENCE_OPTIONS}
         onChange={(value) => update("output_cadence", value)}
-      />
-      <RunConfigurationSelect
-        id={`run-plan-fields-${item.id}`}
-        label="Diagnostic set"
-        description="Output field density."
-        value={item.runConfiguration.diagnostic_set}
-        options={DIAGNOSTIC_SET_OPTIONS}
-        onChange={(value) => update("diagnostic_set", value)}
       />
       <p className="field-help run-plan-config-summary">
         {runConfigurationGridSummary(preview)} · {preview.output_volume_summary}
@@ -8045,7 +7977,7 @@ function ResultNotebookCard({
         <Metric label="Max updraft" value={formatNumber(resultMaxUpdraft(result), "m/s")} />
         <Metric label="Min downdraft" value={formatNumber(resultMinDowndraft(result), "m/s")} />
         <Metric label="Cloud top" value={formatNumber(resultCloudTopMeters(result), "m")} />
-        {isTriggeredDeepPotentialRun(result) && (
+        {hasDeepConvectionDiagnostics(result) && (
           <Metric label="Deep convection" value={deepConvectionOutcome(result)} />
         )}
         <Metric label="Latest output" value={formatSeconds(resultLatestOutputTime(result))} />
@@ -10338,22 +10270,6 @@ function candidateSortLabel(sort: CandidateSort): string {
   return labels[sort];
 }
 
-function defaultRunRecipeForCandidate(
-  candidate: SoundingCandidate,
-  activeStory?: CandidateStoryId,
-): ObservedRunRecipe {
-  if (activeStory && deepConvectionStoryIds.has(activeStory)) return "triggered_deep_potential";
-  if (deepConvectionStoryIds.has(candidate.primary_story)) return "triggered_deep_potential";
-  if (
-    candidate.story_scores.some(
-      (score) => deepConvectionStoryIds.has(score.story) && score.support === "supported",
-    )
-  ) {
-    return "triggered_deep_potential";
-  }
-  return "untriggered_observed_evolution";
-}
-
 function candidateRecipeFitForStory(
   candidate: SoundingCandidate,
   story: CandidateStoryId,
@@ -10382,21 +10298,24 @@ function candidateRecipeFitForStory(
   if (story === "needs_review") {
     return {
       status: "not_testable_with_current_recipes",
-      label: "not testable with current run recipe",
+      label: "not testable with current experiment setup",
       summary: "This candidate needs manual screening before it maps to a current run path.",
       caveats: ["candidate_requires_manual_screening_review"],
     };
   }
   if (deepConvectionStoryIds.has(story)) {
-    const caveats = ["untriggered_observed_evolution_does_not_test_deep_potential"];
+    const caveats = [
+      "deep_convection_outcome_depends_on_surface_forcing_duration_domain_and_resolution",
+      "differential_surface_initiation_is_tracked_in_issue_307",
+    ];
     if (candidate.features.observed_wind_available !== true) {
-      caveats.push("complete_observed_wind_profile_required_for_deep_potential");
+      caveats.push("complete_observed_wind_profile_required_for_input_sounding");
     }
     return {
-      status: "requires_triggered_deep_potential",
-      label: "requires triggered deep-potential run",
+      status: "partially_testable",
+      label: "testable as forced observed evolution",
       summary:
-        "This story screens deep-convection ingredients. An untriggered observed-evolution run does not test that hypothesis without the triggered deep-potential recipe.",
+        "This story screens deep-convection ingredients. CM1 can evolve the observed atmosphere under the selected lower-boundary forcing; differential initiation is a follow-up.",
       caveats,
     };
   }
@@ -10453,7 +10372,7 @@ function observedRecipeHypothesisSummary(story: CandidateStoryId | null): string
     return "Inspect cloud, updraft, moisture, and precipitation evolution without a saved pre-run story.";
   }
   if (deepConvectionStoryIds.has(story)) {
-    return "Deep-convection ingredients are present; check whether supplied initiation can produce deep cloud, strong updraft, and precipitation signatures.";
+    return "Deep-convection ingredients are present; check whether the selected lower-boundary forcing, duration, domain, and resolution produce deep cloud, strong updraft, and precipitation signatures.";
   }
   switch (story) {
     case "shallow_cumulus_candidate":
@@ -10475,7 +10394,7 @@ function observedRecipeHypothesisSummary(story: CandidateStoryId | null): string
 function observedRecipeSignatureLabels(story: CandidateStoryId | null): string[] {
   if (!story) return [];
   if (deepConvectionStoryIds.has(story)) {
-    return ["Deep cloud", "Strong updraft", "Rain water aloft", "Reflectivity if requested"];
+    return ["Deep cloud", "Strong updraft", "Rain water aloft", "Reflectivity"];
   }
   switch (story) {
     case "shallow_cumulus_candidate":
@@ -10489,7 +10408,7 @@ function observedRecipeSignatureLabels(story: CandidateStoryId | null): string[]
         "Cloud water",
         "Rain water aloft",
         "Surface rain or accumulated precipitation",
-        "Reflectivity if requested",
+        "Reflectivity",
       ];
     case "needs_review":
     case "poor_or_incomplete_candidate":
@@ -10534,27 +10453,17 @@ function observedRecipeFitSummary(
     return fitSummary;
   }
   if (story && deepConvectionStoryIds.has(story)) {
-    return "Needs the triggered deep-potential method to test the deep-convection hypothesis.";
+    return "Inspectable under the selected surface forcing; deep outcomes depend on duration, domain, resolution, and later differential-forcing support.";
   }
   return "The selected observed-sounding method can inspect this story when duration, cadence, and requested fields are adequate.";
 }
 
-function observedRecipeAppliedForcing(
-  controls: Record<string, string | number | boolean>,
-  selectedDeep: boolean,
-): string {
-  const surfaceHeating = controls.surface_heating;
-  const surfaceHeatingLabel =
-    typeof surfaceHeating === "string" && surfaceHeating.length > 0
-      ? humanize(surfaceHeating)
-      : "Baseline";
-  const initiation = selectedDeep ? "warm-bubble trigger" : "no deep trigger";
-  return `${surfaceHeatingLabel} surface heating; ${initiation}.`;
+function observedRecipeAppliedForcing(configuration: RunConfiguration): string {
+  return configuration.surface_flux_summary;
 }
 
 function candidateRecipeMismatchWarning(
   selectedCandidateScreening: Record<string, unknown> | null,
-  runRecipe: ObservedRunRecipe,
 ): string | null {
   if (!selectedCandidateScreening) return null;
   const activeStory =
@@ -10576,8 +10485,8 @@ function candidateRecipeMismatchWarning(
             score.score_0_to_100 > 0 &&
             score.support !== "unavailable",
         )));
-  if (runRecipe === "untriggered_observed_evolution" && hasMeaningfulDeepStory) {
-    return "This candidate was screened for deep-convection potential. Untriggered observed evolution does not test that hypothesis. Choose the triggered deep-potential recipe, or treat this as an untriggered evolution experiment.";
+  if (hasMeaningfulDeepStory) {
+    return "This candidate was screened for deep-convection potential. This run will test how it evolves under the selected uniform lower-boundary forcing; differential surface initiation is tracked separately.";
   }
   const hasHumidRainyStory =
     activeStory === "humid_rainy_candidate" ||
@@ -10829,14 +10738,12 @@ function createRunPlanItemId(): string {
 function runPlanItemFromUploadedSounding({
   observedSounding,
   source,
-  observedRunRecipe,
   runConfiguration,
   controls,
   selectedCandidateScreening,
 }: {
   observedSounding: ObservedSoundingRecord;
   source: AtmosphereSourcePath;
-  observedRunRecipe: ObservedRunRecipe;
   runConfiguration: RunConfigurationInput;
   controls: Record<string, string | number | boolean>;
   selectedCandidateScreening: Record<string, unknown> | null;
@@ -10850,7 +10757,7 @@ function runPlanItemFromUploadedSounding({
     observedSounding,
     candidateScreening: selectedCandidateScreening,
     activeStory: observedRecipeStoryId(selectedCandidateScreening),
-    runRecipe: observedRunRecipe,
+    runRecipe: CURRENT_OBSERVED_RUN_RECIPE,
     runConfiguration,
     controls,
     queueTarget: "local",
@@ -10979,20 +10886,20 @@ function runPlanRecipeMetadata(item: RunPlanItem): {
   recipeCaveats: string[];
 } {
   const report = item.dryRun?.report;
-  const staticMetadata = staticRecipeMetadata(item.runRecipe);
+  const staticMetadata = staticRecipeMetadata();
   return {
     recipeId: report?.recipe_id ?? staticMetadata.recipeId,
     recipeDisplayName: report?.recipe_display_name ?? staticMetadata.recipeDisplayName,
     assumptionSetId: report?.assumption_set_id ?? staticMetadata.assumptionSetId,
     assumptionMode: report?.assumption_mode ?? staticMetadata.assumptionMode,
-    assumptionsSummary: compactRecipeAssumptions(report?.recipe_assumptions, item.runRecipe),
+    assumptionsSummary: compactRecipeAssumptions(report?.recipe_assumptions),
     requiredOutputFields: report?.required_output_fields ?? staticMetadata.requiredOutputFields,
     missingRequiredOutputFields: report?.missing_required_output_fields ?? [],
     recipeCaveats: report?.recipe_caveats ?? staticMetadata.recipeCaveats,
   };
 }
 
-function staticRecipeMetadata(runRecipe: ObservedRunRecipe): {
+function staticRecipeMetadata(): {
   recipeId: string;
   recipeDisplayName: string;
   assumptionSetId: string;
@@ -11000,55 +10907,36 @@ function staticRecipeMetadata(runRecipe: ObservedRunRecipe): {
   requiredOutputFields: string[];
   recipeCaveats: string[];
 } {
-  if (runRecipe === "triggered_deep_potential") {
-    return {
-      recipeId: "triggered_deep_potential_v1",
-      recipeDisplayName: "Triggered Deep-Potential Experiment",
-      assumptionSetId: "triggered_deep_potential_warm_bubble_v1",
-      assumptionMode: "triggered_deep_potential",
-      requiredOutputFields: ["qc", "w", "qr", "rain", "dbz", "updraft_helicity"],
-      recipeCaveats: [
-        "The recipe tests triggered potential, not normal atmospheric evolution.",
-        "The warm-bubble trigger must be preserved in provenance and Results comparison.",
-      ],
-    };
-  }
   return {
-    recipeId: "untriggered_observed_sounding_evolution_v0",
-    recipeDisplayName: "Untriggered Observed-Sounding Evolution v0",
-    assumptionSetId: "untriggered_observed_sounding_evolution_v0_assumptions",
-    assumptionMode: "normal_evolution",
-    requiredOutputFields: ["qv", "qc", "w", "qr", "rain", "dbz"],
+    recipeId: "observed_surface_forced_evolution_v0",
+    recipeDisplayName: "Observed Surface-Forced Evolution v0",
+    assumptionSetId: "observed_surface_forced_evolution_v0_assumptions",
+    assumptionMode: "surface_forced_observed_evolution",
+    requiredOutputFields: ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "lhfx"],
     recipeCaveats: [
-      "No warm-bubble or artificial deep-convection trigger is applied.",
-      "Surface fluxes use current recipe defaults; they are not validated place/time surface-energy inputs.",
+      "No artificial atmospheric trigger is applied.",
+      "Surface fluxes use numeric constant uniform lower-boundary proxy values; they are not validated place/time surface-energy inputs.",
       "Radiation, terrain, GIS surface initialization, and large-scale forcing are not part of v0.",
     ],
   };
 }
 
-function compactRecipeAssumptions(
-  assumptions: Record<string, unknown> | undefined,
-  runRecipe: ObservedRunRecipe,
-): string {
-  if (runRecipe === "triggered_deep_potential") {
-    return "Warm-bubble trigger · triggered potential, not normal evolution";
-  }
+function compactRecipeAssumptions(assumptions: Record<string, unknown> | undefined): string {
   const trigger = assumptions?.trigger;
   const surfaceFluxes = assumptions?.surface_fluxes;
   const radiation = assumptions?.radiation;
   const largeScaleForcing = assumptions?.large_scale_forcing;
   const triggerLabel =
     trigger && typeof trigger === "object" && "mode" in trigger && trigger.mode === "none"
-      ? "No warm-bubble trigger"
-      : "No warm-bubble trigger";
+      ? "No artificial trigger"
+      : "No artificial trigger";
   const fluxLabel =
     surfaceFluxes &&
     typeof surfaceFluxes === "object" &&
     "mode" in surfaceFluxes &&
-    surfaceFluxes.mode === "current_recipe_default"
-      ? "current surface-flux defaults"
-      : "current surface-flux defaults";
+    surfaceFluxes.mode === "constant_uniform_surface_flux_proxy"
+      ? "numeric uniform surface fluxes"
+      : "numeric uniform surface fluxes";
   const radiationLabel =
     radiation &&
     typeof radiation === "object" &&
@@ -11570,47 +11458,30 @@ const SHALLOW_DOMAIN_OPTIONS = [
   { value: "regional_120km", label: "Regional 120 km" },
 ];
 
-const DEEP_DOMAIN_OPTIONS = [
-  { value: "storm_120km", label: "Storm 120 km" },
-  { value: "storm_160km", label: "Storm 160 km" },
-  { value: "storm_240km", label: "Storm 240 km" },
-];
-
 const OUTPUT_CADENCE_OPTIONS = [
   { value: "sparse_60min", label: "Sparse (60 min)" },
   { value: "standard_15min", label: "Standard (15 min)" },
   { value: "detailed_5min", label: "Detailed (5 min)" },
 ];
 
-const DIAGNOSTIC_SET_OPTIONS = [
-  { value: "essential", label: "Essential" },
-  { value: "process", label: "Process" },
-  { value: "full", label: "Full" },
-];
-
-function defaultRunConfigurationForSelection(
-  scenarioId: string,
-  runRecipe: RunRecipe,
-): RunConfigurationInput {
-  if (runRecipe === "triggered_deep_potential") {
-    return { ...DEFAULT_TRIGGERED_DEEP_POTENTIAL_RUN_CONFIGURATION };
-  }
+function defaultRunConfigurationForSelection(scenarioId: string): RunConfigurationInput {
   if (scenarioId === OBSERVED_SOUNDING_EXPERIMENT_ID) {
     return { ...DEFAULT_OBSERVED_RUN_CONFIGURATION };
   }
   return { ...DEFAULT_SHALLOW_RUN_CONFIGURATION };
 }
 
-function previewRunConfiguration(
-  configuration: RunConfigurationInput,
-  runRecipe: RunRecipe,
-): RunConfiguration {
-  const deep = runRecipe === "triggered_deep_potential";
+function previewRunConfiguration(configuration: RunConfigurationInput): RunConfiguration {
   const duration = durationValue(configuration.duration);
   const horizontalCells = horizontalCellValue(configuration.horizontal_cell_count);
-  const domain = domainValue(configuration.domain_size, deep);
+  const domain = domainValue(configuration.domain_size, false);
   const cadence = cadenceValue(configuration.output_cadence);
-  const diagnosticSet = diagnosticSetValue(configuration.diagnostic_set);
+  const diagnosticSet = { value: "full" };
+  const heatFlux = numericConfigurationValue(configuration.surface_heat_flux_k_m_s, 8.0e-3);
+  const moistureFlux = numericConfigurationValue(
+    configuration.surface_moisture_flux_g_g_m_s,
+    5.2e-5,
+  );
   const nx = horizontalCells.cells;
   const ny = horizontalCells.cells;
   const dxM = (domain.xKm * 1000) / nx;
@@ -11624,21 +11495,31 @@ function previewRunConfiguration(
   if (duration.mode === "science") {
     caveats.push("science_run_configuration_minimum_duration_6h");
   }
-  if (deep) {
-    caveats.push("triggered_deep_potential_is_not_normal_evolution");
-  }
-  if (diagnosticSet.value === "essential") {
-    caveats.push("essential_diagnostic_set_limits_later_diagnostics");
-  }
   if (
     horizontalCells.cells >= 256 ||
     domain.value === "wide_12km" ||
     domain.value === "regional_60km" ||
-    domain.value === "regional_120km" ||
-    domain.value === "storm_240km"
+    domain.value === "regional_120km"
   ) {
     caveats.push("configuration_better_suited_to_larger_compute");
   }
+  if (heatFlux < 0 || moistureFlux < 0) {
+    caveats.push("surface_flux_values_must_be_non_negative");
+  }
+  const surfaceFluxCm1Values: RunConfigurationSurfaceFluxCM1Values = {
+    isfcflx: 1,
+    sfcmodel: 1,
+    oceanmodel: 1,
+    set_flx: 1,
+    cnst_shflx: heatFlux,
+    cnst_shflx_units: "K m/s",
+    cnst_lhflx: moistureFlux,
+    cnst_lhflx_units: "g/g m/s",
+    set_znt: 0,
+    cnst_znt: 0,
+    set_ust: 1,
+    cnst_ust: 0.28,
+  };
   const cm1Values: RunConfigurationCM1Values = {
     nx,
     ny,
@@ -11649,11 +11530,11 @@ function previewRunConfiguration(
     model_top_m: domain.modelTopM,
     domain_x_km: domain.xKm,
     domain_y_km: domain.yKm,
-    time_step_seconds: deep ? 6 : 3,
+    time_step_seconds: 3,
     runtime_seconds: duration.seconds,
     output_cadence_seconds: cadence.seconds,
     restart_cadence_seconds: Math.max(cadence.seconds, Math.min(duration.seconds, 10800)),
-    rayleigh_damping_start_m: deep ? 15000 : 2500,
+    rayleigh_damping_start_m: 2500,
     expected_output_frames: expectedFrames,
     grid_cell_count: gridCellCount,
   };
@@ -11674,10 +11555,25 @@ function previewRunConfiguration(
     output_cadence_seconds: cadence.seconds,
     diagnostic_set: diagnosticSet.value,
     cost_runtime_summary: `${hours.toLocaleString()} h model time, ${gridCellCount.toLocaleString()} cells, ${cadenceMinutes.toLocaleString()} min saved-output cadence`,
-    output_volume_summary: `${expectedFrames.toLocaleString()} saved frames, ${diagnosticSet.value} diagnostics, ${gridCellCount.toLocaleString()} cells per frame`,
+    output_volume_summary: `${expectedFrames.toLocaleString()} saved frames, full output fields, ${gridCellCount.toLocaleString()} cells per frame`,
     cm1_values: cm1Values,
+    surface_heat_flux_k_m_s: heatFlux,
+    surface_moisture_flux_g_g_m_s: moistureFlux,
+    surface_flux_mode: "constant_uniform_surface_flux_proxy",
+    surface_flux_summary: `Surface heat flux ${formatCompactNumber(heatFlux)} K m/s; surface moisture flux ${formatCompactNumber(moistureFlux)} g/g m/s; constant uniform proxy`,
+    surface_flux_cm1_values: surfaceFluxCm1Values,
+    surface_flux_caveats: [
+      "surface_flux_proxy_constant_uniform_not_place_time_energy_budget",
+      "surface_flux_proxy_not_real_land_surface_or_evaporation_model",
+      "surface_flux_proxy_values_need_local_smoke_validation",
+    ],
     caveats,
   };
+}
+
+function numericConfigurationValue(value: string, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
 }
 
 function durationValue(value: string): {
@@ -11797,11 +11693,6 @@ function cadenceValue(value: string): { seconds: number; label: string } {
   return { seconds: 900, label: "Standard 15 min" };
 }
 
-function diagnosticSetValue(value: string): { value: string } {
-  if (value === "essential" || value === "full") return { value };
-  return { value: "process" };
-}
-
 function runConfigurationGridSummary(configuration: RunConfiguration): string {
   const values = configuration.cm1_values;
   return `${values.nx} x ${values.ny} x ${values.nz}; dx/dy ${formatMeters(values.dx_m)}, dz ${formatMeters(values.dz_m)}`;
@@ -11810,6 +11701,10 @@ function runConfigurationGridSummary(configuration: RunConfiguration): string {
 function runConfigurationTimingSummary(configuration: RunConfiguration): string {
   const values = configuration.cm1_values;
   return `${formatModelTime(values.runtime_seconds)} runtime; ${formatSeconds(values.output_cadence_seconds)} output; ${values.expected_output_frames.toLocaleString()} saved frames; ${formatSeconds(values.time_step_seconds)} timestep`;
+}
+
+function runConfigurationFieldSummary(configuration: RunConfiguration): string {
+  return `Full output fields; ${configuration.cm1_values.expected_output_frames.toLocaleString()} saved frames`;
 }
 
 function formatSeconds(value: number | null): string {
@@ -12293,15 +12188,12 @@ function isDryFailedContrast(result: ResultCard): boolean {
 }
 
 function resultStory(result: ResultCard): string {
-  if (isTriggeredDeepPotentialRun(result)) {
-    const comparison = result.candidate_hypothesis_comparison;
-    if (comparison) {
-      return `${comparison.cm1_outcome} Candidate hypothesis ${comparison.match_status_label.toLowerCase()}.`;
-    }
-    return (
-      result.science_summary?.cm1_outcome ??
-      "Triggered deep-potential result is ready for field inspection."
-    );
+  const comparison = result.candidate_hypothesis_comparison;
+  if (comparison) {
+    return `${comparison.cm1_outcome} Candidate hypothesis ${comparison.match_status_label.toLowerCase()}.`;
+  }
+  if (hasDeepConvectionDiagnostics(result) && result.science_summary?.cm1_outcome) {
+    return result.science_summary.cm1_outcome;
   }
   if (isDryFailedContrast(result)) {
     return "Thermals rose, but low-level moisture stayed too dry for meaningful cloud water or rain.";
@@ -12319,7 +12211,7 @@ function resultStory(result: ResultCard): string {
 }
 
 function compactScienceSummary(result: ResultCard): string {
-  if (isTriggeredDeepPotentialRun(result)) {
+  if (hasDeepConvectionDiagnostics(result)) {
     const parts = [
       deepConvectionOutcome(result),
       resultMaxUpdraft(result) !== null
@@ -12462,8 +12354,13 @@ function scienceSupportLabel(result: ResultCard): string {
   return "Interesting times limited";
 }
 
-function isTriggeredDeepPotentialRun(result: ResultCard): boolean {
-  return result.run_recipe === "triggered_deep_potential";
+function hasDeepConvectionDiagnostics(result: ResultCard): boolean {
+  return (
+    result.science_summary?.deep_cloud_formed !== undefined ||
+    result.science_summary?.strong_updraft_formed !== undefined ||
+    result.science_summary?.time_of_first_deep_convection_seconds !== undefined ||
+    (result.interesting_times ?? []).some((time) => time.key === "first_deep_convection")
+  );
 }
 
 function deepConvectionOutcome(result: ResultCard): string {
@@ -12495,7 +12392,7 @@ function caveatLabel(result: ResultCard): string {
 }
 
 function cloudOutcome(result: ResultCard): string {
-  if (isTriggeredDeepPotentialRun(result)) return deepConvectionOutcome(result);
+  if (hasDeepConvectionDiagnostics(result)) return deepConvectionOutcome(result);
   if (!result.diagnostics_summary) return "Unknown";
   return result.diagnostics_summary.includes("cloud formed") &&
     !result.diagnostics_summary.includes("no cloud formed")

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -23,7 +23,7 @@ notebook entries and explicit ingested-result cleanup.
 Observed-sounding run directions seed a CM1-facing configuration, but they
 should not be modeled as rigid product cages. The data model uses explicit
 `run_recipe` and `run_configuration` values: duration, horizontal cell budget,
-domain, cadence, diagnostic set, forcing assumptions, requested fields, and
+domain, cadence, forcing assumptions, full requested fields, and
 pre-run validation are the run-builder contract.
 
 The first MVP target is a 2024 MacBook Air with 8GB RAM. Design for one local CM1 run at a time, conservative output handling, and backend-side processing/downsampling. Optional cloud compute can be researched later, but it is not part of the core architecture.
@@ -115,7 +115,7 @@ story-specific candidate scores. Stable story identifiers are
 `shallow_cumulus_candidate`, `dry_failed_candidate`,
 `capped_suppressed_candidate`, `humid_rainy_candidate`, `needs_review`, and
 `poor_or_incomplete_candidate`; severe/deep-convection story identifiers remain
-pre-run hypotheses for triggered deep-potential recipe routing. The auditable scoring
+pre-run atmospheric hypotheses for observed-sounding run configuration. The auditable scoring
 contract lives in
 [contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
 Analysis has a default recommendation mode that answers which cached soundings
@@ -142,8 +142,8 @@ hypotheses only when explicit run assumptions, predicted CM1-observable output
 signatures, required output fields, and compatible run recipes are present.
 The compatible recipe layer is governed by
 [Run Recipe And Story-Mapping Contract](contracts/run-recipe-and-story-mapping.md),
-which maps current story IDs to untriggered normal-evolution, surface-forced,
-triggered deep-potential, blocked, or future run recipes. Build should use that
+which maps current story IDs to observed surface-forced, blocked, or future run
+recipes. Build should use that
 mapping to warn when a package can run but cannot test the selected hypothesis;
 Results should use the same recipe ID and required fields before comparing
 predicted and actual CM1 output.
@@ -169,9 +169,9 @@ defines readiness states for severe/deep-convection, boundary-layer, low-cloud,
 and winter/cold-season stories so APIs can distinguish screenable environments
 from runnable configuration paths. Until a story has backend features, scoring
 tests, evidence, caveats, and recipe-fit support, it must not be emitted as an
-enabled runnable label. The first implemented severe/deep-convection path is the
-triggered deep-potential run recipe, which treats selected observed soundings as
-pre-run hypotheses for an idealized triggered CM1 experiment.
+enabled runnable label. Severe/deep-convection candidates are currently
+inspectable only as observed-sounding experiments under selected numeric uniform
+surface forcing, with differential-forcing initiation tracked as future work.
 
 The Build UI consumes this layer through bounded JSON only. `Upload a Sounding`
 is the observed-atmosphere entry point, but the user chooses exactly one source
@@ -191,36 +191,30 @@ run/result status: saved candidates are pre-run hypotheses, while generated
 packages, launched runs, and ingested results remain separate lifecycle objects.
 
 The observed-atmosphere run plan owns batch package creation. Each item stores
-its source payload, selected story/hypothesis metadata, selected run recipe,
-recipe metadata (`recipe_id`, display name, assumption set/mode, assumptions,
-required output fields, caveats, and missing required fields when known), run
-configuration, local/LAN queue target, current packaging/queue status, and any
-blocked pre-run validation report. The frontend may duplicate items to compare
-recipe or configuration variants, but package generation and pre-run validation
-remain backend-owned.
+its source payload, selected story/hypothesis metadata, selected forcing values,
+run configuration, local/LAN queue target, current packaging/queue status, and
+any blocked pre-run validation report. The frontend may duplicate items to
+compare forcing or configuration variants, but package generation and pre-run
+validation remain backend-owned.
 
-Triggered deep-potential observed-sounding runs extend the same dry-run package
-contract rather than creating a separate workflow. The package records
-`run_recipe = triggered_deep_potential`, `input_source = observed_sounding`,
-`trigger_type = warm_bubble`, trigger metadata, expected output fields,
-recipe smoke-validation status, run caveats, and any candidate-screening payload
-on the run manifest, case manifest, and dry-run report. The generated namelist
-uses the observed `input_sounding` route (`isnd = 7`), requires complete usable
-observed u/v winds, selects CM1's built-in three-warm-bubble initialization
-(`iinit = 3`) with `testcase = 0`, uses a storm-scale idealized domain for storm
-growth, and enables rain-water-aloft, surface-rain, reflectivity, vorticity, and
-updraft-helicity output. Manual smoke evidence applies to the recipe path and
-basic run/ingest health; each observed sounding remains an experiment whose
-outcome must be inspected after CM1 completes. The trigger is described as fixed
-v1 recipe metadata rather than a primary product control. Ingest copies the run
-recipe and trigger metadata into result metadata and Result Cards so Results and
-Explore do not lose the distinction between untriggered observed evolution and a
-triggered deep-potential run.
+Observed-sounding packages extend the same dry-run package contract rather than
+creating separate workflows by story. The package records
+`run_recipe = untriggered_observed_evolution` as the current backend routing
+value, `input_source = observed_sounding`, numeric uniform surface heat/moisture
+flux selections, expected full output fields, run caveats, and any
+candidate-screening payload on the run manifest, case manifest, and dry-run
+report. The generated namelist uses the observed `input_sounding` route
+(`isnd = 7`), requires complete usable observed u/v winds, applies no artificial
+atmospheric trigger, and enables cloud, moisture, wind, rain-water-aloft,
+surface-rain, reflectivity, surface-flux, vorticity, and updraft-helicity output.
+Each observed sounding remains an experiment whose outcome must be inspected
+after CM1 completes. Differential surface heating/moisture or convergence-like
+initiation is future work rather than a hidden current trigger.
 
-Untriggered observed-sounding evolution v0 is the first concrete normal-evolution
-recipe for lower-atmosphere observed-sounding hypotheses. Package generation keeps
-the CM1 routing value `run_recipe = untriggered_observed_evolution`, but also
-persists `recipe_id = untriggered_observed_sounding_evolution_v0`,
+Observed surface-forced evolution v0 is the first concrete run configuration
+for lower-atmosphere observed-sounding hypotheses. Package generation keeps
+the current CM1 routing value `run_recipe = untriggered_observed_evolution`, but
+also persists `recipe_id = observed_surface_forced_evolution_v0`,
 `assumption_set_id`, `assumption_mode`, recipe assumptions, required output
 fields, and recipe caveats. Ingest copies the same fields into result metadata
 and computes `missing_required_output_fields` from the actual NetCDF variables
@@ -311,11 +305,11 @@ The earlier Cloud Chamber quick-look derivative is not scientifically accepted: 
 The first reference-derived validation run, `dry-run-les-shallowcu-20260522140642`, completed locally with NetCDF output and ingested 7 model-output time steps over 21600 seconds. It produced cloud water and vertical velocity diagnostics, so the architecture should treat the reference-derived package as the recovery baseline and the earlier compact derivative as invalid evidence rather than a tuning base.
 
 Run configuration uses guarded fields for duration, horizontal cell budget,
-domain size, output cadence, diagnostic set, forcing, requested fields, advanced
-CM1-facing values, and a pre-run validation report. Raw numerical timestep is
-not a normal v1 control. Defaults must expose their derived CM1-facing values in
-advanced metadata so dry-run reports and Build UI can show exactly what will be
-written without requiring raw namelist editing.
+domain size, output cadence, numeric surface forcing, full requested fields,
+advanced CM1-facing values, and a pre-run validation report. Raw numerical
+timestep is not a normal v1 control. Defaults must expose their derived
+CM1-facing values in advanced metadata so dry-run reports and Build UI can show
+exactly what will be written without requiring raw namelist editing.
 
 Current product defaults are deliberately different by run direction:
 lower-atmosphere scenarios use a six-hour local-domain science run, uploaded

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -33,8 +33,8 @@ Explore = inspect one result with CM1-derived evidence
 Build should be organized around configurable observed-sounding runs. Presets
 are useful starting points, not separate product cages: a user should be able to
 start from a sane preset, inspect the actual CM1-facing settings, and adjust
-duration, horizontal cell budget, domain size, output cadence, forcing, and
-diagnostic set within guarded bounds.
+numeric surface forcing, duration, horizontal cell budget, domain size, and
+output cadence within guarded bounds while requesting the full output field set.
 
 See [UX Reset: Guided Experiment Notebook](ux-reset-guided-experiment-notebook.md)
 for the PM/design source of truth for future UX work.
@@ -160,32 +160,31 @@ trying, not a prediction that clouds, rain, or suppression will occur. When a
 candidate is selected for run setup, Build should use the same recipe and run
 configuration flow used for uploads. When that configured sounding is added to
 the run plan, its screening story, score, evidence, feature summary, saved
-tags/notes, and caveats should be copied into package metadata as provenance.
+tags/notes, selected numeric surface-forcing values, and caveats should be
+copied into package metadata as provenance.
 
 When an uploaded, cached, or saved observed sounding is selected, Build should
 show one shared selected-sounding setup flow above the run plan. The source path
 should determine where the selected atmosphere came from, not create a separate
 configuration workflow. The run plan should sit below the source/setup flow and
-support multiple candidate atmospheres, duplicate variants, per-item run recipe
-and run configuration edits, local or LAN queue target selection, remove/clear
+support multiple candidate atmospheres, duplicate variants, per-item forcing and
+run-configuration edits, local or LAN queue target selection, remove/clear
 actions, and a batch action to create packages and queue selected runs. Per-item
 packaging or queue failures should remain visible instead of clearing the failed
-item from the plan. The triggered deep-potential recipe is first-class for
-severe/deep-convection observed-sounding experiments: it uses the observed
-temperature, moisture, and complete wind profile through CM1 `isnd = 7`, runs an
-idealized three-warm-bubble trigger (`iinit = 3`), uses a storm-scale model box
-suitable for storm growth and precipitation inspection, requests rain water
-aloft, surface rain, reflectivity, vorticity, and updraft-helicity output, and
-records `run_recipe = triggered_deep_potential` plus trigger, expected-output,
-caveat, and candidate-screening provenance in generated manifests. Product copy
-should describe the run as a triggered deep-potential experiment with explicit
-assumptions and output requirements. Short science configurations must still run
-long enough to be meteorologically useful. Build
-should show expected cost, runtime, and output volume, and note when a configuration is
-better suited to larger compute instead of making machine choice the primary
-product axis. Raw trigger parameters remain
-metadata-only in v1 and should not become user controls until useful ranges are
-validated.
+item from the plan.
+
+Observed-sounding experiments use the observed temperature, moisture, and
+complete wind profile through CM1 `isnd = 7`, apply numeric uniform lower-boundary
+heat/moisture flux controls, and request the full Results/Explore output field
+set. Severe/deep-convection candidates remain first-class atmospheric hypotheses,
+but current packages do not add an artificial deep-convection trigger. Product
+copy should describe these as observed-sounding experiments under explicit
+surface-forcing, duration, grid, domain, and cadence assumptions. Differential
+surface heating/moisture forcing for initiation or boundary experiments is future
+work tracked separately. Short science configurations must still run long enough
+to be meteorologically useful. Build should show expected cost, runtime, and
+output volume, and note when a configuration is better suited to larger compute
+instead of making machine choice the primary product axis.
 
 The run monitor should be compact by default. It should summarize active,
 queued, and completed runtime work while keeping detailed package, queue, LAN,
@@ -276,8 +275,8 @@ Exact morphology is not pass/fail. The acceptance question is whether the produc
 2. Choose scenario category.
 3. Select a starting scenario or observed-sounding run direction.
 4. See expected behavior, controls, run cost, and output fields.
-5. Adjust duration, horizontal cells, domain, output cadence, and diagnostic set
-   before package review.
+5. Adjust numeric surface heat/moisture fluxes, duration, horizontal cells,
+   domain, and output cadence before package review.
 
 The Scenario Builder flow is intentionally bounded: it loads
 validated scenario templates from the local backend, defaults to Baseline
@@ -617,16 +616,12 @@ of truth.
 Current defaults are product choices, not compatibility holdovers:
 
 - Baseline lower-atmosphere scenarios default to `short_6h`, `cells_64`,
-  `local_6km`, `standard_15min`, and `process` diagnostics. This keeps the
+  `local_6km`, `standard_15min`, and full output fields. This keeps the
   first run cheap enough to iterate while still giving six hours of model
   evolution and enough fields for Results/Explore diagnostics.
 - Uploaded observed-sounding normal-evolution runs default to the same duration,
-  cadence, and diagnostic set, but use `cells_128` and `wide_12km` so observed
+  cadence, and full output field set, but use `cells_128` and `wide_12km` so observed
   winds do not make the package misleadingly small by default.
-- Triggered deep-potential observed-sounding runs default to `short_6h`,
-  `cells_128`, `storm_120km`, `standard_15min`, and `full` diagnostics. That
-  setup is deliberately wider and better instrumented because it is asking a
-  storm-scale triggered-potential question.
 - `smoke_1h` is an explicit smoke-check mode for package health, CM1 startup,
   ingest, and basic visualization wiring. It is not evidence for normal
   atmospheric evolution.
@@ -1294,11 +1289,10 @@ metadata as provenance. Observed-sounding results should read as `Uploaded
 Sounding` or the active observed run recipe in notebook names, scenario labels,
 and scenario filtering while the underlying generated scenario ID remains
 available in technical details as lineage.
-Triggered deep-potential observed-sounding results should retain their run-recipe
-provenance after ingest: notebook names and scenario labels may identify the run
-as triggered deep potential, while the original observed station/time, generated
-scenario ID, `run_recipe`, trigger metadata, expected outputs, caveats, and
-candidate-screening hypothesis remain available as provenance.
+Observed-sounding results should retain their run provenance after ingest: the
+original observed station/time, generated scenario ID, numeric surface-forcing
+values, expected outputs, caveats, and candidate-screening hypothesis remain
+available as provenance.
 Technical metadata such as raw lifecycle/product states, run IDs, provenance
 labels, controls, and detailed caveats remain available under disclosure rather
 than dominating the first read. The layout should be mobile-first: cards stack

--- a/docs/contracts/analyzer-hypothesis-output-signature.md
+++ b/docs/contracts/analyzer-hypothesis-output-signature.md
@@ -81,7 +81,7 @@ assumption_set:
   assumption_set_id: string
   label: string
   trigger:
-    mode: none | warm_bubble | future_explicit_trigger | unavailable
+    mode: none | future_differential_surface_forcing | future_explicit_trigger | unavailable
     description: string
     caveats: [string]
   surface_fluxes:
@@ -108,18 +108,19 @@ assumption_set:
     reasons: [string]
 ```
 
-Assumption sets must distinguish normal evolution from triggered potential
-experiments:
+Assumption sets must distinguish observed evolution under explicit forcing from
+future forcing modes:
 
-- `normal_evolution`: no explicit deep-convection trigger; useful for asking
-  what the initialized atmosphere does under the selected surface/forcing
-  assumptions.
-- `triggered_deep_potential`: explicit warm-bubble or future trigger; useful for
-  asking whether instability, moisture, and wind support deep convection when
-  initiation is supplied.
+- `observed_surface_forced_evolution`: no artificial atmospheric trigger; useful
+  for asking what the initialized atmosphere does under the selected numeric
+  uniform lower-boundary heat/moisture forcing, duration, domain, grid, and
+  cadence.
 - `surface_forced_evolution`: explicit surface sensible/latent heat-flux
   assumptions; useful for boundary-layer growth, shallow cloud, drizzle, or
   suppression hypotheses.
+- `future_differential_surface_forcing`: spatially varying heating/moisture
+  forcing for initiation, boundaries, gradients, or patch experiments. This is
+  tracked separately from issue #305.
 - `place_time_radiative_evolution`: radiation/place-time assumptions; future
   contract for fog, nocturnal, winter, and diurnal hypotheses.
 
@@ -174,7 +175,7 @@ output or a clearly labeled supported diagnostic, not from cloud water alone.
 | Cloud depth/top | `qc`, vertical coordinate, time coordinate | Must report threshold and cloud-top method. |
 | Shallow cloud persistence | `qc`, time coordinate | Needs enough duration and cadence to distinguish transient noise from evolution. |
 | Updraft strength | `w`, time coordinate | May include height/region caveats when available. |
-| Deep breakthrough | `qc`, `w`, vertical coordinate, time coordinate | Triggered deep-potential recipe only until normal-evolution deep signatures are separately validated. |
+| Deep breakthrough | `qc`, `w`, vertical coordinate, time coordinate | Current observed-sounding runs can inspect deep-cloud/updraft evidence under uniform forcing, but broad deep-convection prediction remains caveated until differential forcing and comparison diagnostics are validated. |
 | Rain water aloft | `qr`, time coordinate | User-facing label should say rain water aloft. |
 | Surface rain | `rain` or supported surface precipitation field | Must preserve units and must not be inferred from `qr`. |
 | Reflectivity | `dbz` or supported reflectivity diagnostic | Unsupported reflectivity stays unavailable. |
@@ -198,7 +199,6 @@ recommended_run_recipes:
     run_recipe:
       generated_reference_lower_atmosphere
       | untriggered_observed_evolution
-      | triggered_deep_potential
       | future
     run_configuration:
       duration_seconds: number | null
@@ -207,8 +207,7 @@ recommended_run_recipes:
       dx_m: number | null
       model_top_m: number | null
       output_cadence_seconds: number | null
-      diagnostic_set: essential | process | full | null
-      requested_fields: [string]
+      requested_fields: [string] # current observed runs request the full field set
       forcing: string
     suitability:
       status: testable_now | partially_testable | requires_new_recipe | blocked
@@ -226,10 +225,10 @@ Examples:
 - A humid/rainy hypothesis is only testable for rain behavior when `qr`,
   surface `rain`, and/or `dbz` outputs are enabled according to the predicted
   signature.
-- A supercell or severe-thunderstorm hypothesis requires a triggered
-  deep-potential recipe; untriggered observed evolution can still be run
-  deliberately, but it tests untriggered evolution, not the deep-potential
-  hypothesis.
+- A supercell or severe-thunderstorm hypothesis may be inspected with the
+  observed-sounding run under selected uniform surface forcing, but deep
+  organization claims remain caveated until differential forcing and comparison
+  diagnostics exist.
 - A surface-flux or radiation/place-time hypothesis requires the matching
   forcing assumptions before predicted output signatures can be emitted.
 

--- a/docs/contracts/realistic-les-input-specification.md
+++ b/docs/contracts/realistic-les-input-specification.md
@@ -533,7 +533,7 @@ Capability distinctions:
 
 | Item | Status |
 | --- | --- |
-| Explicit run-configuration choices | Supported by Cloud Chamber package generation through duration, horizontal cell budget, domain, cadence, and diagnostic set. |
+| Explicit run-configuration choices | Supported by Cloud Chamber package generation through surface forcing, duration, horizontal cell budget, domain, cadence, and full output-field volume. |
 | Local Mac deep runs with larger grids and more output | Supported but expensive; estimates need validation per scenario. |
 | Additional output fields for realistic cases | Likely CM1 capability needing output/product validation. |
 | Workstation/remote/HPC tiers | Future / unsupported as local product flow. |

--- a/docs/contracts/run-recipe-and-story-mapping.md
+++ b/docs/contracts/run-recipe-and-story-mapping.md
@@ -61,9 +61,9 @@ run_recipe:
   compatible_story_ids: [string]
   assumption_set_id: string
   assumption_mode:
-    normal_evolution
+    surface_forced_observed_evolution
     | surface_forced_evolution
-    | triggered_deep_potential
+    | future_differential_surface_forcing
     | elevated_forced_evolution
     | future
   run_shape:
@@ -78,7 +78,7 @@ run_recipe:
     diagnostic_set: essential | process | full | null
   forcing:
     trigger:
-      mode: none | warm_bubble | future_explicit_trigger | unavailable
+      mode: none | future_explicit_trigger | future_differential_surface_forcing | unavailable
       description: string
     surface_sensible_heat_flux:
       mode: current_recipe_default | prescribed | disabled | future | unavailable
@@ -116,14 +116,13 @@ run_recipe:
     run_recipe:
       generated_reference_lower_atmosphere
       | untriggered_observed_evolution
-      | triggered_deep_potential
       | future
     run_configuration_defaults:
       duration: string | null
       horizontal_cell_count: string | null
       domain_size: string | null
       output_cadence: string | null
-      diagnostic_set: string | null
+      requested_fields: [string]
     namelist_summary: [string]
     runtime_files_needed: [string]
   comparison_contract:
@@ -137,7 +136,7 @@ advanced metadata under `cm1_mapping` or a later recipe-detail API.
 
 ## Assumption Modes
 
-### `normal_evolution`
+### `surface_forced_observed_evolution`
 
 An untriggered observed-sounding evolution recipe asks what the initialized
 atmosphere does under the selected recipe defaults. It must not imply a weather
@@ -152,41 +151,42 @@ latent heat flux assumptions are explicit. Humid, drizzle, warm-rain, fog,
 post-frontal, and boundary-layer hypotheses need this mode before product copy
 can claim normal-evolution precipitation or low-cloud signatures.
 
-### `triggered_deep_potential`
+### `future_differential_surface_forcing`
 
-A triggered deep-potential recipe asks whether the sounding supports deep
-convection when initiation is supplied. It is the right shape for current
-severe/deep-convection candidates, but it is not normal atmospheric evolution.
-The trigger must be copied into provenance and Results comparison.
+A future differential-forcing recipe asks whether localized or spatially varying
+surface heating/moisture gradients can initiate or organize convection. It is the
+right shape for future boundary, patch, dryline, or differential-heating
+experiments. It is not implemented by issue #305 and should not be implied by the
+current uniform surface-flux controls.
 
 ### `elevated_forced_evolution`
 
 An elevated recipe asks whether an above-surface source layer can sustain cloud
 or convection. It needs source-layer, forcing, and output assumptions that the
-current observed-sounding quick look does not supply.
+current observed-sounding run builder does not supply.
 
 ## Current Recipe Catalog
 
-### `untriggered_observed_sounding_evolution_v0`
+### `observed_surface_forced_evolution_v0`
 
 ```yaml
-recipe_id: untriggered_observed_sounding_evolution_v0
-display_name: Untriggered observed-sounding evolution v0
-product_question: What does this observed atmosphere do without an explicit
-  deep-convection trigger, under the current observed-sounding LES defaults?
-assumption_set_id: untriggered_observed_sounding_evolution_v0_assumptions
-assumption_mode: normal_evolution
+recipe_id: observed_surface_forced_evolution_v0
+display_name: Observed-sounding surface-forced evolution v0
+product_question: What does this observed atmosphere do under the selected
+  numeric uniform lower-boundary heat/moisture forcing?
+assumption_set_id: observed_surface_forced_evolution_v0_assumptions
+assumption_mode: surface_forced_evolution
 run_shape:
   duration_seconds: 21600 | configured
   horizontal_cell_count: 64 | 96 | 128 | 192 | 256 | 384 | configured
   domain_width_m: 6400 | 12800 | 60000 | 120000 | configured
   model_top_m: current observed-sounding LES model top
   output_cadence_seconds: 3600 | 900 | 300 | configured
-  diagnostic_set: essential | process | full
+  requested_fields: full_output_field_set
 forcing:
   trigger: {mode: none}
-  surface_sensible_heat_flux: {mode: current_recipe_default}
-  surface_latent_heat_flux: {mode: current_recipe_default}
+  surface_sensible_heat_flux: {mode: prescribed, units: K m/s, value: configured}
+  surface_latent_heat_flux: {mode: prescribed, units: g/g m/s, value: configured}
   radiation: {mode: disabled}
   large_scale_lift: {mode: none}
   convergence: {mode: none}
@@ -195,13 +195,13 @@ required_inputs:
   observed_moisture_profile: required
   observed_wind_profile: used_when_available
 required_outputs:
-  fields: [qv, qc, w, qr, rain, dbz]
+  fields: [qv, qc, w, qr, rain, dbz, u, v, th, prs, hfx, lhfx]
   diagnostics: [first_cloud, max_qc, cloud_top, max_updraft_w]
 current_support:
   status: supported
   caveats:
-    - Current recipe defaults are not a real place/time surface-energy budget.
-    - Surface fluxes use current recipe defaults and are not user-controlled yet.
+    - Numeric fluxes are uniform proxy controls, not a real place/time
+      surface-energy budget.
     - Radiation, terrain, GIS surface initialization, and large-scale forcing
       are not part of v0.
     - Scores remain ingredient guidance until a predicted signature exists.
@@ -212,14 +212,14 @@ cm1_mapping:
     horizontal_cell_count: cells_128
     domain_size: wide_12km
     output_cadence: standard_15min
-    diagnostic_set: process
+    requested_fields: full_output_field_set
 ```
 
-This v0 recipe can test shallow cloud and dry-failed signatures when the predicted
-signature only requires cloud water, vertical velocity, and enough duration and
-cadence. It is not enough for product claims about rain reaching the ground
-unless the active predicted signature explicitly requires and receives
-surface-rain output.
+This v0 recipe can inspect shallow cloud, humid/rainy, capped, and deep-candidate
+signals when the predicted signature can be evaluated from full CM1 output fields
+and enough duration/cadence. Deep organization, cold-pool, and storm-mode claims
+remain caveated until comparison diagnostics and differential forcing are
+validated.
 
 ### `observed_capped_evolution_v1`
 
@@ -228,8 +228,8 @@ recipe_id: observed_capped_evolution_v1
 display_name: Observed-sounding capped evolution
 product_question: Does the observed profile limit vertical growth under the
   current untriggered LES defaults?
-assumption_set_id: untriggered_observed_sounding_evolution_v0_assumptions
-assumption_mode: normal_evolution
+assumption_set_id: observed_surface_forced_evolution_v0_assumptions
+assumption_mode: surface_forced_observed_evolution
 required_outputs:
   fields: [qc, w, th, qv]
   diagnostics: [first_cloud, cloud_top, max_qc, max_updraft_w]
@@ -244,7 +244,7 @@ cm1_mapping:
   run_recipe: untriggered_observed_evolution
 ```
 
-This recipe is a specialized view of the current untriggered observed-sounding
+This recipe is a specialized view of the current observed-sounding
 path. It can support a capped/suppressed comparison only when the run is long
 enough and the signature does not require unsupported forcing.
 
@@ -270,8 +270,8 @@ required_outputs:
 current_support:
   status: caveated
   caveats:
-    - Current surface fluxes are recipe defaults, not validated place/time
-      surface-energy inputs.
+    - Current surface fluxes are numeric uniform proxy values, not validated
+      place/time surface-energy inputs.
     - `qr` is rain water aloft, `rain` is surface rain, and `dbz` is
       reflectivity; they must be evaluated separately.
 cm1_mapping:
@@ -282,65 +282,11 @@ This is the honest bridge for `humid_rainy_candidate`: Cloud Chamber may run a
 moist observed-sounding experiment now, but precipitation signatures are only
 testable when the required fields are requested, ingested, and clearly labeled.
 
-### `triggered_deep_potential_v1`
-
-```yaml
-recipe_id: triggered_deep_potential_v1
-display_name: Triggered deep-convection potential
-product_question: If initiation is supplied, does this sounding support deep
-  convection and storm-scale structure in CM1?
-assumption_set_id: triggered_deep_potential_warm_bubble_v1
-assumption_mode: triggered_deep_potential
-run_shape:
-  duration_seconds: 21600 | configured
-  horizontal_cell_count: 128 | configured
-  domain_width_m: 120000 | 160000 | 240000
-  model_top_m: 20000
-  output_cadence_seconds: 3600 | 900 | 300 | configured
-  diagnostic_set: full
-forcing:
-  trigger:
-    mode: warm_bubble
-    description: CM1 built-in three-warm-bubble line initiation.
-  surface_sensible_heat_flux: {mode: disabled}
-  surface_latent_heat_flux: {mode: disabled}
-  radiation: {mode: disabled}
-  large_scale_lift: {mode: none}
-  convergence: {mode: none}
-required_inputs:
-  observed_temperature_profile: required
-  observed_moisture_profile: required
-  observed_wind_profile: required
-required_outputs:
-  fields: [qc, w, qr, rain, dbz, u, v, th]
-  diagnostics:
-    - first_deep_convection
-    - max_updraft_w
-    - cloud_top
-    - rain_water_aloft_onset
-    - max_surface_rain
-    - max_dbz
-    - updraft_helicity
-current_support:
-  status: caveated
-  caveats:
-    - Package/run/ingest smoke evidence exists, but defaults are not broadly
-      characterized across selected candidates.
-    - The recipe tests triggered potential, not normal weather evolution.
-    - Storm mode, rotation, downdraft, cold pool, and surface rain are outcomes
-      to inspect after CM1 completes.
-cm1_mapping:
-  run_recipe: triggered_deep_potential
-  run_configuration_defaults:
-    duration: short_6h
-    horizontal_cell_count: cells_128
-    domain_size: storm_120km
-    output_cadence: standard_15min
-    diagnostic_set: full
-```
-
-This recipe is first-class. Its caveats are scientific trust boundaries, not a
-reason to fall back to shallow quick-look for severe/deep-convection stories.
+Deep-convection candidate stories currently use the same observed-sounding
+surface-forced run path with stronger caveats. The run can inspect whether deep
+cloud, strong updraft, rain-water aloft, surface rain, and reflectivity occur
+under selected uniform lower-boundary forcing. It does not claim to supply a
+localized storm trigger.
 
 ### `squall_line_cold_pool_future`
 
@@ -361,8 +307,9 @@ cm1_mapping:
   run_recipe: future
 ```
 
-The current triggered-deep recipe may be a caveated first experiment, but it
-does not contain line forcing or validated cold-pool diagnostics.
+The current observed-sounding surface-forced recipe may be a caveated first
+experiment, but it does not contain line forcing or validated cold-pool
+diagnostics.
 
 ### `elevated_forced_evolution_future`
 
@@ -389,24 +336,24 @@ source layer and forcing assumptions being tested.
 
 | Story ID | Primary recipe | Recipe fit | Required assumptions | Required outputs for comparison | Result comparison intent |
 | --- | --- | --- | --- | --- | --- |
-| `shallow_cumulus_candidate` | `untriggered_observed_sounding_evolution_v0` | `testable_now` when the run is long enough | no explicit trigger; current observed-sounding LES defaults; complete observed temperature/moisture profile; wind used when available | `qv`, `qc`, `w`, time and vertical coordinates | cloud formation, cloud top/depth, persistence, vertical velocity |
-| `dry_failed_candidate` | `untriggered_observed_sounding_evolution_v0` | `testable_now` when duration/cadence can support a no-cloud conclusion | no explicit trigger; current observed-sounding LES defaults; complete observed profile | `qv`, `qc`, `w`, time coordinate | weak/no cloud with meaningful vertical motion; moisture limitation remains caveated |
+| `shallow_cumulus_candidate` | `observed_surface_forced_evolution_v0` | `testable_now` when the run is long enough | no artificial trigger; numeric uniform surface heat/moisture fluxes; complete observed temperature/moisture profile; wind used when available | `qv`, `qc`, `w`, time and vertical coordinates | cloud formation, cloud top/depth, persistence, vertical velocity |
+| `dry_failed_candidate` | `observed_surface_forced_evolution_v0` | `testable_now` when duration/cadence can support a no-cloud conclusion | no artificial trigger; numeric uniform surface heat/moisture fluxes; complete observed profile | `qv`, `qc`, `w`, time coordinate | weak/no cloud with meaningful vertical motion; moisture limitation remains caveated |
 | `capped_suppressed_candidate` | `observed_capped_evolution_v1` | `partially_testable` | no explicit trigger; cap comes from observed profile; enough run time to observe delayed growth | `qc`, `w`, `th`, time and vertical coordinates | reduced cloud depth, delayed cloud, or capped vertical motion |
-| `humid_rainy_candidate` | `surface_forced_moist_evolution_v1` | `partially_testable` until surface flux controls are validated | explicit current or future surface-flux assumptions; no deep trigger; precipitation fields requested | `qc`, `w`, `qr`, `rain`, `dbz` when precipitation is predicted | cloud, rain water aloft, surface rain, and reflectivity evaluated separately |
-| `severe_thunderstorm_environment` | `triggered_deep_potential_v1` | `partially_testable` with current triggered deep-potential caveats | explicit warm-bubble trigger; complete observed wind profile; storm-scale domain | `qc`, `w`, `qr`, `rain`, `dbz`, updraft diagnostics | whether triggered initiation supports deep convection and precipitation signatures |
-| `supercell_environment` | `triggered_deep_potential_v1` | `partially_testable` | explicit warm-bubble trigger; complete observed wind profile; storm-scale domain; rotation diagnostics caveated | `qc`, `w`, `qr`, `rain`, `dbz`, `u`, `v`, updraft-helicity when available | deep convection and organization evidence; not a tornado or forecast product |
-| `high_cape_pulse_storm` | `triggered_deep_potential_v1` | `partially_testable` | explicit warm-bubble trigger; high-CAPE interpretation caveated until parcel diagnostics are implemented | `qc`, `w`, `qr`, `rain`, `dbz` | strong buoyant updraft and deep cloud under triggered initiation |
-| `dry_microburst_inverted_v` | `triggered_deep_potential_v1` | `partially_testable` only if precipitation/downdraft pathway develops | explicit trigger; precipitation aloft; subcloud dry-layer evidence; downdraft diagnostics caveated | `qr`, `rain`, `w`, `th`, near-surface wind fields when implemented | rain water aloft, downdraft/cooling/outflow evidence; not a wind-gust forecast |
-| `squall_line_cold_pool_candidate` | `triggered_deep_potential_v1` plus future `squall_line_cold_pool_future` | `partially_testable` for generic triggered deep convection; `requires_recipe` for line/cold-pool claims | explicit trigger now; future line forcing and cold-pool diagnostics for the full story | `qc`, `w`, `qr`, `rain`, `dbz`, `th`, `u`, `v` | current run can inspect storm/deep-cloud evidence; cold-pool/line match is future |
+| `humid_rainy_candidate` | `surface_forced_moist_evolution_v1` | `partially_testable` until surface-flux smoke evidence is broad | numeric uniform surface-flux assumptions; no artificial trigger; precipitation fields requested | `qc`, `w`, `qr`, `rain`, `dbz` when precipitation is predicted | cloud, rain water aloft, surface rain, and reflectivity evaluated separately |
+| `severe_thunderstorm_environment` | `observed_surface_forced_evolution_v0` plus future differential forcing | `partially_testable` | no artificial trigger; numeric uniform surface fluxes; complete observed wind profile; domain/duration/resolution caveats | `qc`, `w`, `qr`, `rain`, `dbz`, `u`, `v`, updraft diagnostics | whether deep cloud and strong updraft occur under the selected uniform forcing; not a storm-initiation guarantee |
+| `supercell_environment` | `observed_surface_forced_evolution_v0` plus future differential forcing | `partially_testable` | no artificial trigger; complete observed wind profile; rotation diagnostics caveated | `qc`, `w`, `qr`, `rain`, `dbz`, `u`, `v`, updraft-helicity when available | deep convection and organization evidence under uniform forcing; not a tornado or forecast product |
+| `high_cape_pulse_storm` | `observed_surface_forced_evolution_v0` plus future differential forcing | `partially_testable` | no artificial trigger; high-CAPE interpretation caveated until parcel diagnostics are implemented | `qc`, `w`, `qr`, `rain`, `dbz` | strong buoyant updraft and deep cloud if CM1 produces them under selected forcing |
+| `dry_microburst_inverted_v` | `observed_surface_forced_evolution_v0` plus future downdraft diagnostics | `partially_testable` only if precipitation/downdraft pathway develops | precipitation aloft; subcloud dry-layer evidence; downdraft diagnostics caveated | `qr`, `rain`, `w`, `th`, near-surface wind fields when implemented | rain water aloft, downdraft/cooling/outflow evidence; not a wind-gust forecast |
+| `squall_line_cold_pool_candidate` | `observed_surface_forced_evolution_v0` plus future `squall_line_cold_pool_future` | `partially_testable` for generic deep-cloud evidence; `requires_recipe` for line/cold-pool claims | no line trigger now; future line forcing and cold-pool diagnostics for the full story | `qc`, `w`, `qr`, `rain`, `dbz`, `th`, `u`, `v` | current run can inspect storm/deep-cloud evidence; cold-pool/line match is future |
 | `elevated_convection` | `elevated_forced_evolution_future` | `requires_recipe` unless a chosen recipe declares source-layer assumptions | elevated source layer, forcing, and surface-decoupling assumptions | `qc`, `w`, `qr`, `rain`, `dbz`, layer diagnostics | future elevated cloud/updraft source-layer comparison |
 | `needs_review` | none by default; user selects a concrete hypothesis first | `not_evaluated` | depends on selected hypothesis | depends on selected hypothesis | cannot compare until an active story and recipe are chosen |
 | `poor_or_incomplete_candidate` | none | `blocked` | package-readiness blockers must be resolved | none | no runnable recipe until profile/input safety passes |
 
-Deep-convection stories should not silently route to shallow quick-look as if
-that tested the deep hypothesis. The user may still deliberately run
-`untriggered_observed_sounding_evolution_v0`; Results must then mark the deep hypothesis as
-`not_comparable` or `inconclusive` rather than as a failed deep-convection
-prediction.
+Deep-convection stories should not silently promise initiation. The current
+observed-sounding run path can inspect deep-cloud/updraft evidence under selected
+uniform lower-boundary forcing; Results must keep differential-initiation,
+storm-mode, cold-pool, and severe-weather claims caveated unless the required
+fields and diagnostics exist.
 
 ## Pre-Run Validation Feed (#284)
 
@@ -421,9 +368,9 @@ together. It should fail, warn, or caveat before package generation when:
   request;
 - duration, model top, domain width, or output cadence are too weak for the
   selected signature;
-- a recipe assumption is missing, such as surface fluxes for drizzle/warm-rain
-  claims, warm-bubble trigger provenance for deep potential, or source-layer
-  assumptions for elevated convection;
+- a recipe assumption is missing, such as numeric surface fluxes for
+  drizzle/warm-rain claims, differential forcing for initiation claims, or
+  source-layer assumptions for elevated convection;
 - expected cost, runtime, or output volume should be surfaced before launch.
 
 Validation should distinguish:
@@ -467,8 +414,9 @@ Comparison rules:
 - Keep `qr` as rain water aloft, `rain` as surface rain or accumulated
   precipitation at ground, and `dbz` as reflectivity.
 
-Do not use triggered deep-potential trigger-failed language for non-deep recipes
-or for deliberate untriggered observed-evolution runs.
+Do not use trigger-failed language for observed-sounding runs. If deep cloud or
+strong updraft does not occur, describe the observed CM1 outcome under the saved
+forcing and run-shape assumptions.
 
 ## Product Copy Rules
 
@@ -479,6 +427,5 @@ or for deliberate untriggered observed-evolution runs.
   the selected hypothesis.
 - Say "partially testable" when the current recipe can inspect part of the
   hypothesis but lacks required forcing, diagnostics, or validation.
-- Say "triggered deep-convection potential" for warm-bubble deep recipes.
-- Say "normal evolution" only for untriggered recipes, and disclose any current
-  surface/radiation/forcing defaults.
+- Say "observed-sounding run" or "surface-forced observed evolution" for current
+  Build packages, and disclose the numeric surface/radiation/forcing assumptions.

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -287,10 +287,10 @@ deep-convection recommendation when a secondary deep-convection score has
 meaningful support. Missing feature values must remain unavailable/caveated and
 sort last instead of becoming zero-valued evidence. The UI must not show a
 confident story label without evidence, caveats, and package readiness.
-The workbench should also show a minimal recipe-fit status, such as
-`partially_testable`, `requires_triggered_deep_potential`, or `blocked_profile`,
-so candidate interest remains separate from what the current package path can
-actually test.
+The workbench should also show a minimal experiment-fit status, such as
+`testable_now`, `partially_testable`, `requires_surface_forcing_recipe`, or
+`blocked_profile`, so candidate interest remains separate from what the current
+run configuration can actually test.
 
 Saved candidates may carry freeform tags and notes such as `Deep convection
 candidates`, `Surface-forced candidates`, `Needs longer run`, `Needs finer

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -74,10 +74,12 @@ candidate stories. It does not make severe, winter, cold-pool, or specialized
 boundary-layer stories scientifically validated until their scoring, evidence,
 caveats, and package-readiness states are implemented and tested.
 
-The deep-convection package design now maps to the triggered deep-potential run
-recipe. User-facing docs should describe this as a configurable
-triggered-potential experiment, not as a separate half-state "Trial" product or
-package-family compatibility layer.
+The historical deep-convection package design is now evidence and background,
+not the active Build contract. User-facing docs should describe current
+observed-sounding packages as configurable experiments with numeric
+lower-boundary heat/moisture forcing, full output fields, and explicit caveats.
+Differential surface forcing for initiation or boundary experiments is future
+work.
 
 ## Current State
 
@@ -89,16 +91,14 @@ package-family compatibility layer.
   states exist. Candidate scores are pre-run selection aids, not CM1 outcome
   predictions.
 - The run-recipe contract now defines how current story IDs map to compatible,
-  caveated, blocked, or future CM1 run recipes. That mapping is the handoff from
+  caveated, blocked, or future CM1 run configurations. That mapping is the handoff from
   cached-sounding analysis to pre-run validation and predicted-vs-actual Results
   comparison.
-- The deep-convection observed-sounding package path exists and has
-  package/run/ingest smoke evidence. It can generate storm-scale CM1 packages
-  with fixed v1 warm-bubble trigger metadata and expected deep-output fields,
-  but it has not yet been characterized across a broad selected candidate set.
-  #285 is needed before treating its defaults as broadly validated. Each
-  observed sounding remains its own experiment whose result must be evaluated
-  after CM1 runs.
+- Observed-sounding package generation now uses numeric uniform surface
+  heat/moisture forcing and complete observed u/v wind profiles. Deep-convection
+  candidates remain important pre-run hypotheses, but current packages do not add
+  an artificial deep trigger; each observed sounding remains its own experiment
+  whose result must be evaluated after CM1 runs.
 - Build owns active package/run work, including generated packages, queued or
   running local CM1 work, failed or incomplete runs, completed-but-not-ingested
   output, serial local queue state, auto-ingest for completed usable output, and
@@ -135,17 +135,18 @@ compare input atmospheres before packaging.
 Goal: let Build start from a sane preset and then adjust run settings that map
 to real CM1 configuration.
 
-Scope: controls for model duration, horizontal cell budget, domain size, output
-cadence, forcing, and diagnostic set within guarded bounds. Starting points
-should remain available, and an advanced drawer should expose the actual
-CM1-facing values those choices imply.
+Scope: controls for numeric surface heat/moisture forcing, model duration,
+horizontal cell budget, domain size, and output cadence within guarded bounds.
+Starting points should remain available, and an advanced drawer should expose the
+actual CM1-facing values those choices imply. Current observed-sounding runs
+request the full output field set.
 
 Non-goals: raw numerical timestep as a normal v1 control, raw trigger controls,
 new trigger types, or a full Build redesign in one issue.
 
 Why now: the product direction is configurable runs, not rigid scenario or
-package-family cages. Horizontal cell budget, domain, diagnostic set, and
-output cadence are the main cost levers; duration controls must preserve enough
+package-family cages. Horizontal cell budget, domain, output cadence, and full
+output volume are the main cost levers; duration controls must preserve enough
 model time for meaningful evolution.
 
 ### Pre-Run Configuration Validation
@@ -165,24 +166,25 @@ or silently patching bad input into something packageable.
 Why now: configurable controls need trust boundaries before they become normal
 Build workflow.
 
-### Deep-Convection Configuration Validation Across Soundings
+### Deep-Convection Candidate Validation Across Soundings
 
-Goal: keep the triggered deep-potential observed-sounding recipe first-class
-while measuring where its current configuration is run-ready, caveated, or
+Goal: keep severe/deep-convection candidate stories first-class while measuring
+where current observed-sounding configurations are run-ready, caveated, or
 misleading.
 
-Scope: validate complete observed-wind requirements, storm-scale box choices,
-duration, horizontal cell budget, domain size, output cadence, diagnostic set,
-expected fields, expected cost/runtime/output volume, larger-compute suitability notes, and
-candidate-provenance copy across selected observed soundings. Separate
-package/run/ingest smoke checks from science outcomes.
+Scope: validate complete observed-wind requirements, duration, horizontal cell
+budget, domain size, output cadence, full expected fields,
+cost/runtime/output-volume notes, larger-compute suitability notes, numeric
+surface-forcing provenance, and candidate-provenance copy across selected
+observed soundings. Separate package/run/ingest smoke checks from science
+outcomes.
 
-Non-goals: removing the deep-convection path, exposing raw trigger controls,
-adding trigger types, or treating a smoke run as evidence that a specific
-observed sounding should produce deep convection.
+Non-goals: adding artificial atmospheric triggers, exposing raw trigger controls,
+or treating a smoke run as evidence that a specific observed sounding should
+produce deep convection.
 
-Why now: deep-convection packaging exists and is useful, but the trust language
-must stay honest while configuration coverage expands.
+Why now: deep-convection screening is useful, but the trust language must stay
+honest while observed-sounding configuration coverage expands.
 
 ### Surface Sensible/Latent Heat Flux Control Validation
 

--- a/docs/research/surface-flux-control-validation.md
+++ b/docs/research/surface-flux-control-validation.md
@@ -1,16 +1,16 @@
 # Surface Flux Control Validation
 
-Status: research validation for issue #286
+Status: implementation contract for issue #305
 
-PM recommendation: keep metadata-only / not exposed yet.
+PM recommendation: expose numeric constant lower-boundary heat/moisture forcing
+controls with explicit CM1 units, full output fields, and caveats.
 
-Cloud Chamber should not expose surface sensible and latent heat flux as normal
-Build controls yet. CM1 has the needed constant-flux namelist knobs, and Cloud
-Chamber already has a partial generation/output path for surface-flux fields.
-The missing trust layer is end-to-end evidence: package generation, CM1 run,
-ingest, result metadata, and output-product inspection must show that changed
-surface-flux assumptions are active, unit-safe, and understandable before these
-become user-facing controls.
+Cloud Chamber exposes surface sensible and latent heat flux as numeric Build
+controls for observed-sounding runs. CM1 has the needed constant-flux namelist
+knobs, and Cloud Chamber records the selected values, translated CM1 namelist
+values, caveats, and full output-field request in package metadata. The controls
+are intentionally raw numeric sensitivities in CM1 units, not reduced/baseline/
+enhanced presets.
 
 This is not a recommendation to drop surface forcing. It is a recommendation to
 treat surface forcing as an explicit, caveated lower-boundary proxy until smoke
@@ -74,10 +74,10 @@ and that arbitrary spatially varying surface temperature, land/water flag, and
 land-use values must be coded in `init_surface.F`. That keeps this validation in
 the uniform-proxy lane, not the realistic land-surface lane.
 
-Important unit decision: product controls should not expose `cnst_shflx` and
-`cnst_lhflx` as if they are already W/m2. A future UI may show W/m2 or
-human-readable strength levels, but the conversion to CM1 namelist values must
-be explicit, documented, copied into metadata, and verified against CM1 output.
+Important unit decision: product controls expose `cnst_shflx` in `K m/s` and
+`cnst_lhflx` in `g/g m/s`. They must not be described as W/m2. The UI may show
+reasonable examples and warnings, but users may enter any finite non-negative
+numeric value; backend validation records the exact CM1-facing values.
 
 ## Current Cloud Chamber State
 
@@ -97,9 +97,10 @@ surface-flux path:
 | `set_ust` | `1` |
 | `cnst_ust` | `0.28` |
 
-Triggered deep-potential runs currently turn this surface-flux path off and use
-the idealized warm-bubble trigger instead. That is appropriate for triggered
-potential, but it does not answer the surface-forced moist-evolution question.
+The former idealized deep-trigger path is no longer a current Build recipe.
+Deep-convection candidates can still be run as observed-sounding experiments
+under the selected uniform lower-boundary forcing, with caveats that differential
+heating or convergence-style initiation is future work tracked in issue #307.
 
 The current observed path is therefore best described as:
 
@@ -154,8 +155,7 @@ units for all real runs or that changed flux values produce expected responses.
 
 ## Smoke Validation Matrix
 
-The implementation should remain metadata-only until this matrix has local CM1
-evidence:
+The implementation remains caveated until this matrix has local CM1 evidence:
 
 | Run | Change | Required evidence |
 | --- | --- | --- |
@@ -171,7 +171,7 @@ Each smoke record should capture:
 - model duration
 - domain size, cell count, dx/dy, and model top
 - saved-output cadence
-- requested diagnostic set
+- full output-field request and saved-output cadence
 - exact CM1 namelist values for `isfcflx`, `sfcmodel`, `set_flx`,
   `cnst_shflx`, `cnst_lhflx`, `set_znt`, `cnst_znt`, `set_ust`, and `cnst_ust`
 - CM1 exit status

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -136,7 +136,8 @@ provenance, and that stale triggered-recipe requests fail clearly.
 Automated tests for observed-sounding runs must use tiny or mocked fixtures. They
 should verify that package generation:
 
-- requires an observed sounding and observed u/v wind components;
+- requires a complete finite observed u/v wind profile for every rendered
+  `input_sounding` level;
 - preserves candidate-screening metadata;
 - records run configuration, numeric surface forcing, expected outputs, caveats,
   and validation status on generated
@@ -145,7 +146,8 @@ should verify that package generation:
   numeric constant surface fluxes, full output fields, rain output, reflectivity
   output, vorticity output, and updraft-helicity output;
 - writes a numeric `input_sounding` with observed wind components; and
-- preserves package identity through ingest into Result Cards.
+- preserves observed surface-forced package identity, candidate-screening
+  provenance, numeric forcing, and notes/tags through ingest into Result Cards.
 
 Manual/local QA is required before treating the package as scientifically
 accepted for a selected real sounding. New soundings remain experiments whose
@@ -156,12 +158,16 @@ outcomes must be inspected after CM1 runs. The manual smoke loop should:
 3. generate a science package;
 4. inspect `run_manifest.json`, `dry_run_report.json`, `namelist.input`, and
    `input_sounding`;
-5. confirm `isnd = 7`, `iinit = 3`, `testcase = 0`, rain/reflectivity/vorticity/
-   updraft-helicity output, observed u/v winds, and the storm-scale model box;
+5. confirm `isnd = 7`, no artificial deep-trigger path, the selected
+   numeric constant surface-flux values, full output-field switches including
+   rain/reflectivity/vorticity/updraft-helicity support, complete observed u/v
+   wind columns, and domain/grid/runtime values that match the chosen run
+   configuration;
 6. run CM1 locally or on the LAN worker outside CI;
 7. ingest completed output;
-8. open Results and Explore to confirm the notebook keeps the Deep Convection
-   Trial identity and the result is interpretable; and
+8. open Results and Explore to confirm observed surface-forced identity,
+   candidate-screening provenance, numeric forcing, and interpretable CM1 output
+   products; and
 9. confirm no generated run folders, logs, NetCDF output, copied runtime files,
    screenshots, or videos are committed.
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -125,38 +125,35 @@ implemented. Tests must not expect winter/cold-season, cold-pool, fog/stratus,
 or other future taxonomy labels to appear as enabled Build filters before that
 support exists. The readiness taxonomy is documented in
 [research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md).
-The implemented severe/deep-convection exception is the triggered
-deep-potential run recipe. Unit/component tests should prove that
-deep-convection candidates can default to that recipe, that package requests
-include `run_recipe = triggered_deep_potential` and candidate-screening
-provenance, and that untriggered observed-evolution runs remain available.
+Deep-convection stories are now candidate hypotheses, not a separate artificial
+trigger recipe. Unit/component tests should prove that deep-convection candidates
+flow into the same observed-sounding run configuration surface, that package
+requests include numeric surface heat/moisture forcing and candidate-screening
+provenance, and that stale triggered-recipe requests fail clearly.
 
-### Triggered Deep-Potential Recipe Validation
+### Observed-Sounding Surface-Forced Validation
 
-Automated tests for triggered deep-potential runs must use tiny or mocked fixtures. They
+Automated tests for observed-sounding runs must use tiny or mocked fixtures. They
 should verify that package generation:
 
 - requires an observed sounding and observed u/v wind components;
 - preserves candidate-screening metadata;
-- records run recipe, display name, trigger type, trigger metadata,
-  expected outputs, caveats, and recipe smoke-validation status on generated
+- records run configuration, numeric surface forcing, expected outputs, caveats,
+  and validation status on generated
   manifests and reports;
 - writes CM1-facing `namelist.input` settings for the observed-sounding route,
-  three-warm-bubble trigger, storm-scale domain, rain output, reflectivity output,
-  vorticity output, and updraft-helicity output;
+  numeric constant surface fluxes, full output fields, rain output, reflectivity
+  output, vorticity output, and updraft-helicity output;
 - writes a numeric `input_sounding` with observed wind components; and
 - preserves package identity through ingest into Result Cards.
 
 Manual/local QA is required before treating the package as scientifically
-accepted for a selected real sounding. #261 established package-health evidence
-for the v1 three-warm-bubble trigger using a Fort Worth severe candidate that
-produced strong updraft, reflectivity, rain water, ice, graupel, surface rain,
-and updraft helicity; new soundings remain experiments whose outcomes must be
-inspected after CM1 runs. The manual smoke loop should:
+accepted for a selected real sounding. New soundings remain experiments whose
+outcomes must be inspected after CM1 runs. The manual smoke loop should:
 
 1. choose or upload a real observed sounding with usable winds;
-2. select `Triggered deep potential`;
-3. generate a short-evolution package;
+2. set numeric surface heat/moisture forcing values;
+3. generate a science package;
 4. inspect `run_manifest.json`, `dry_run_report.json`, `namelist.input`, and
    `input_sounding`;
 5. confirm `isnd = 7`, `iinit = 3`, `testcase = 0`, rain/reflectivity/vorticity/
@@ -605,7 +602,8 @@ Manual validation should record:
 - the CM1 version and local runtime path
 - the Cloud Chamber commit
 - the selected run configuration
-- the horizontal cell budget, domain, runtime, output cadence, and diagnostic set
+- the horizontal cell budget, domain, runtime, output cadence, full output-field
+  request, and numeric surface forcing
 - diagnostics such as cloud base, cloud top, first cloud time, rain onset, and updraft strength
 - cloud-water max or summary
 - log warnings/errors


### PR DESCRIPTION
## Summary

Closes #305.

This replaces the old observed/deep preset placeholder with an explicit observed surface-forced run-builder path:

- adds numeric surface heat flux and surface moisture flux controls with CM1-facing units and guidance text;
- removes the user-facing recipe/diagnostic-set selectors from the Build flow;
- forces observed-sounding packages onto full output fields internally;
- removes warm-bubble / triggered-deep-potential generation as an active path and fails stale requests clearly;
- lets deep-candidate comparison evaluate observed surface-forced runs from actual CM1 outputs instead of requiring a removed trigger path;
- updates result cards, output products, visualization defaults, screening caveats, and docs to match the surface-forced model.

## Product / Science Boundary

The current implemented forcing is constant uniform lower-boundary heat/moisture flux. It can test what the observed profile does under explicit selected surface forcing and run shape. It does not claim localized initiation, boundary convergence, dryline behavior, or differential-heating initiation.

Follow-up #307 tracks differential surface heating and moisture-forcing patterns.

## Verification

- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_cm1_input_contract.py app/backend/tests/test_dry_run_package.py app/backend/tests/test_sounding_candidates.py app/backend/tests/test_result_ingest.py app/backend/tests/test_result_cards.py app/backend/tests/test_output_products.py app/backend/tests/test_visualization_data.py -q`
- `cd app/frontend && npm test -- App.test.tsx`
- `scripts/check.sh`
- `scripts/check-e2e.sh`
- Manual Playwright live UI pass against `localhost:5173`: Build opens on Upload a Sounding, uploaded IGRA fixture validates, Configure panel shows numeric surface heat/moisture flux inputs, Add to run plan is visible, Diagnostic set is absent, and browser console errors are empty.

## Known Limits

- The backend still uses the existing `untriggered_observed_evolution` wire value for the current observed-sounding route, but product-facing names and persisted recipe IDs now use observed surface-forced language.
- Full differential forcing remains future work in #307.
