### PR TITLE
Add surface-forced campaign runner

### DIFF
--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import subprocess
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 
 import yaml  # type: ignore[import-untyped]
 from pydantic import BaseModel, ConfigDict, Field
@@ -24,6 +25,7 @@ from cloud_chamber.dry_run_package import DryRunPackageError, generate_dry_run_p
 from cloud_chamber.lan_worker import (
     LanWorkerApiError,
     collect_lan_worker_run,
+    lan_worker_run_status,
     start_lan_worker_run,
 )
 from cloud_chamber.local_run_manager import LocalRunManager
@@ -82,8 +84,140 @@ KNOWN_STATUS_VALUES = {
     "skipped",
     "blocked",
 }
+TERMINAL_OR_ACTIVE_STATUSES = {
+    "queued",
+    "running",
+    "completed_not_ingested",
+    "ingested",
+}
+RERUN_REQUIRED_STATUSES = {
+    "run_failed",
+    "ingest_failed",
+    "run_canceled",
+    "package_failed",
+    "blocked",
+}
+SUPPORTED_REQUIRED_SUMMARY_FIELDS = {
+    "campaign_id",
+    "schema_version",
+    "matrix_id",
+    "stable_resume_identity",
+    "run_id",
+    "result_id",
+    "package_status",
+    "run_status",
+    "ingest_status",
+    "queue_target",
+    "station_id",
+    "station_name",
+    "valid_time_utc",
+    "candidate_id",
+    "selection_source_type",
+    "selection_source_reference",
+    "candidate_story",
+    "candidate_score",
+    "candidate_evidence",
+    "candidate_caveats",
+    "surface_heat_flux_k_m_s",
+    "surface_heat_flux_units",
+    "surface_moisture_flux_g_g_m_s",
+    "surface_moisture_flux_units",
+    "cm1_cnst_shflx",
+    "cm1_cnst_shflx_units",
+    "cm1_cnst_lhflx",
+    "cm1_cnst_lhflx_units",
+    "duration",
+    "duration_seconds",
+    "domain_size",
+    "horizontal_cell_count",
+    "nx",
+    "ny",
+    "nz",
+    "dx_m",
+    "dy_m",
+    "dz_m",
+    "model_top_m",
+    "output_cadence",
+    "expected_output_volume",
+    "cloud_chamber_commit",
+    "cm1_version",
+    "cm1_build",
+    "required_output_fields",
+    "missing_output_fields",
+    "available_output_fields",
+    "diagnostic_support",
+    "interesting_time_support_state",
+    "source_manifest_lifecycle_state",
+    "source_manifest_product_state",
+    "warnings",
+    "caveats",
+    "hfx_present",
+    "hfx_units",
+    "hfx_min",
+    "hfx_max",
+    "hfx_mean",
+    "lhfx_present",
+    "lhfx_units",
+    "lhfx_min",
+    "lhfx_max",
+    "lhfx_mean",
+    "low_level_qv_response",
+    "low_level_qv_response_method",
+    "low_level_theta_or_temperature_response",
+    "low_level_theta_or_temperature_response_method",
+    "first_cloud_time",
+    "max_cloud_top_m",
+    "max_cloud_top_time",
+    "max_qc",
+    "max_qc_time",
+    "cloud_depth_or_classification",
+    "max_w_m_s",
+    "max_w_time",
+    "max_w_height_m",
+    "qr_present",
+    "surface_rain_present",
+    "surface_rain_max",
+    "surface_rain_units",
+    "dbz_present",
+    "max_dbz",
+    "first_deep_cloud_time",
+    "deep_cloud_formed",
+    "deep_cloud_flag",
+    "evidence_fields",
+    "forcing_path_not_verified",
+    "surface_outputs_missing",
+    "boundary_layer_response_verified",
+    "forcing_wiring_verified_but_response_not_verified",
+    "uniform_forcing_too_weak",
+    "uniform_forcing_physics_limited",
+    "run_duration_or_domain_limited",
+    "candidate_selection_limited",
+    "output_products_or_diagnostics_missing",
+    "valid_no_initiation_under_tested_assumptions",
+    "inconclusive_noncomparable_runs",
+    "inconclusive_missing_evidence",
+    "differential_forcing_followup_candidate",
+    "radiation_or_place_time_followup_candidate",
+}
+MATRIX_CONTEXT_FIELDS = {
+    "selection_id",
+    "cloud_chamber_commit",
+    "cm1_version",
+    "required_output_fields",
+    "surface_heat_flux_k_m_s",
+    "surface_moisture_flux_g_g_m_s",
+    "cm1_cnst_shflx",
+    "cm1_cnst_lhflx",
+    "runtime_seconds",
+    "expected_output_frames",
+    "expected_output_volume",
+}
 
 QueueTarget = Literal["local", "lan"]
+
+
+class LocalQueueLike(Protocol):
+    def enqueue(self, manifest_path: Path) -> Any: ...
 
 
 class CampaignError(RuntimeError):
@@ -102,6 +236,7 @@ class CampaignRunPlan(BaseModel):
     selection_role: str | None = None
     selection_source_type: str
     selection_source_reference: str
+    selection_payload_hash: str
     forcing_id: str | None = None
     comparison_type: str | None = None
     comparison_control_matrix_id: str | None = None
@@ -128,6 +263,9 @@ class CampaignPlan(BaseModel):
     protocol: str | None = None
     commit_report_path: str | None = None
     matrix_path: str | None = None
+    execution: dict[str, Any] = Field(default_factory=dict)
+    comparison_types: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    required_summary_fields: dict[str, list[str]] = Field(default_factory=dict)
     run_count: int
     runs: list[CampaignRunPlan]
     caveats: list[str] = Field(default_factory=list)
@@ -150,6 +288,7 @@ class CampaignStateRun(BaseModel):
     error: str | None = None
     message: str | None = None
     lan_worker_payload: dict[str, Any] | None = None
+    gate_override: dict[str, Any] | None = None
     updated_at: datetime
 
 
@@ -230,6 +369,10 @@ def build_campaign_plan(
     )
     run_defaults = _mapping(matrix.get("run_defaults", {}), "run_defaults", errors)
     runs = _list_of_mappings(matrix.get("runs"), "runs", errors)
+    required_summary_fields = _required_summary_fields(
+        matrix.get("required_summary_fields"), errors
+    )
+    _validate_execution(execution, errors)
 
     planned: list[CampaignRunPlan] = []
     matrix_ids: set[str] = set()
@@ -291,12 +434,14 @@ def build_campaign_plan(
 
         source_type = str(source.get("type", "unknown"))
         source_reference = _selection_source_reference(source)
+        selection_payload_hash = _selection_payload_hash(source, matrix_base)
         candidate_screening = _candidate_screening_from_matrix(selection, source)
         stable_identity = _stable_resume_identity(
             campaign_id=campaign_id,
             matrix_id=matrix_id,
             selection_id=selection_id,
             selection_source_reference=source_reference,
+            selection_payload_hash=selection_payload_hash,
             run_configuration=resolved_configuration.model_dump(mode="json"),
             forcing_id=forcing_id,
         )
@@ -310,6 +455,7 @@ def build_campaign_plan(
                 selection_role=_optional_string(selection.get("role")),
                 selection_source_type=source_type,
                 selection_source_reference=source_reference,
+                selection_payload_hash=selection_payload_hash,
                 forcing_id=forcing_id,
                 comparison_type=comparison_type,
                 comparison_control_matrix_id=(
@@ -345,6 +491,9 @@ def build_campaign_plan(
         protocol=_optional_string(campaign.get("protocol")),
         commit_report_path=_optional_string(campaign.get("commit_report_path")),
         matrix_path=str(matrix_path) if matrix_path is not None else None,
+        execution=execution,
+        comparison_types={key: dict(value) for key, value in comparison_types.items()},
+        required_summary_fields=required_summary_fields,
         run_count=len(planned),
         runs=planned,
         caveats=caveats,
@@ -396,6 +545,13 @@ def package_campaign(
             continue
 
         try:
+            package_dir = resolved_settings.runtime_home.expanduser() / "runs" / run.run_id
+            if force_rerun and _run_dir_has_runtime_artifacts(package_dir):
+                raise CampaignError(
+                    "Refusing --force-rerun because the existing run directory contains "
+                    "output, logs, or result artifacts. Delete it intentionally outside the "
+                    "campaign runner before rerunning."
+                )
             observed = _resolve_observed_sounding(
                 run, settings=resolved_settings, matrix_path=matrix_path
             )
@@ -416,6 +572,7 @@ def package_campaign(
                 run_recipe=OBSERVED_SURFACE_FORCED_RECIPE,
                 run_configuration=run.run_configuration,
                 allow_overwrite=force_rerun,
+                app_commit=_repo_commit(),
             )
         except (CampaignError, DryRunPackageError, ObservedSoundingError, OSError) as exc:
             _upsert_state_run(
@@ -460,25 +617,92 @@ def queue_campaign(
     runtime_home: Path | None = None,
     selected_matrix_ids: set[str] | None = None,
     resume: bool = True,
+    include_optional: bool = False,
+    override_phase_gate: bool = False,
+    override_reason: str | None = None,
     allow_absolute_local_paths: bool = False,
-    local_queue_factory: Callable[[CloudChamberSettings], LocalRunQueueManager] | None = None,
+    local_queue_factory: Callable[[CloudChamberSettings], LocalQueueLike] | None = None,
     lan_start: Callable[[CloudChamberSettings, Path], dict[str, object]] = start_lan_worker_run,
+    lan_status: Callable[[CloudChamberSettings, Path], dict[str, object]] = lan_worker_run_status,
 ) -> CampaignOperationResult:
     resolved_settings = settings or load_settings(home=runtime_home)
     plan = plan_campaign(matrix_path, allow_absolute_local_paths=allow_absolute_local_paths)
+    execution_runs = _selected_runs(
+        plan.runs,
+        selected_matrix_ids,
+        include_optional=include_optional,
+    )
     package_campaign(
         matrix_path,
         settings=resolved_settings,
-        selected_matrix_ids=selected_matrix_ids,
+        selected_matrix_ids={run.matrix_id for run in execution_runs},
         resume=resume,
         allow_absolute_local_paths=allow_absolute_local_paths,
     )
+    status_campaign(
+        matrix_path,
+        settings=resolved_settings,
+        allow_absolute_local_paths=allow_absolute_local_paths,
+        lan_status=lan_status,
+    )
     state = _load_or_create_state(plan, resolved_settings.runtime_home)
     queue_factory = local_queue_factory or _default_local_queue
+    summaries = [_summary_for_plan_run(run, state) for run in plan.runs]
+    gate_state = _phase_gate_state(summaries)
+    override = _gate_override_payload(
+        enabled=override_phase_gate,
+        reason=override_reason,
+        gate_state=gate_state,
+    )
+    max_lan = _max_concurrent_runs(plan)
+    lan_active = _active_lan_count(state)
 
-    for run in _selected_runs(plan.runs, selected_matrix_ids):
+    for run in execution_runs:
         state_run = _state_run_for_matrix(state, run.matrix_id)
         if state_run is None or not state_run.manifest_path:
+            continue
+        if state_run.status in TERMINAL_OR_ACTIVE_STATUSES:
+            _upsert_state_run(
+                state,
+                state_run.model_copy(
+                    update={
+                        "message": f"Skipped queue; campaign row is already {state_run.status}.",
+                        "updated_at": _now(),
+                    }
+                ),
+            )
+            continue
+        if state_run.status in RERUN_REQUIRED_STATUSES and not (
+            state_run.status == "blocked" and override_phase_gate
+        ):
+            _upsert_state_run(
+                state,
+                state_run.model_copy(
+                    update={
+                        "message": (
+                            f"Skipped queue; {state_run.status} rows require an explicit rerun."
+                        ),
+                        "updated_at": _now(),
+                    }
+                ),
+            )
+            continue
+        if not _phase_gate_allows_queue(run, gate_state, override_phase_gate):
+            _upsert_state_run(
+                state,
+                state_run.model_copy(
+                    update={
+                        "status": "blocked",
+                        "run_status": "blocked",
+                        "message": (
+                            f"Phase gate blocked queueing: {gate_state}. "
+                            "Queue Phase 1 first or provide an override reason."
+                        ),
+                        "gate_override": override,
+                        "updated_at": _now(),
+                    }
+                ),
+            )
             continue
         manifest_path = Path(state_run.manifest_path).expanduser()
         try:
@@ -501,13 +725,30 @@ def queue_campaign(
                             "run_status": status,
                             "message": entry.message if entry else "Queued for local CM1.",
                             "error": entry.error if entry else None,
+                            "gate_override": override,
                             "updated_at": _now(),
                         }
                     ),
                 )
             else:
+                if lan_active >= max_lan:
+                    _upsert_state_run(
+                        state,
+                        state_run.model_copy(
+                            update={
+                                "status": "blocked",
+                                "run_status": "blocked",
+                                "message": (f"LAN max_concurrent_runs={max_lan} already reached."),
+                                "gate_override": override,
+                                "updated_at": _now(),
+                            }
+                        ),
+                    )
+                    continue
                 payload = lan_start(resolved_settings, manifest_path)
                 status = _lan_payload_to_campaign_status(payload)
+                if status in {"queued", "running"}:
+                    lan_active += 1
                 _upsert_state_run(
                     state,
                     state_run.model_copy(
@@ -517,6 +758,7 @@ def queue_campaign(
                             "lan_worker_payload": dict(payload),
                             "message": _payload_message(payload, "LAN worker run started."),
                             "error": None,
+                            "gate_override": override,
                             "updated_at": _now(),
                         }
                     ),
@@ -548,6 +790,7 @@ def status_campaign(
     settings: CloudChamberSettings | None = None,
     runtime_home: Path | None = None,
     allow_absolute_local_paths: bool = False,
+    lan_status: Callable[[CloudChamberSettings, Path], dict[str, object]] = lan_worker_run_status,
 ) -> CampaignOperationResult:
     resolved_settings = settings or load_settings(home=runtime_home)
     plan = plan_campaign(matrix_path, allow_absolute_local_paths=allow_absolute_local_paths)
@@ -570,7 +813,13 @@ def status_campaign(
             continue
         _upsert_state_run(
             state,
-            _state_run_with_runtime_status(state_run, queue_entries=queue_entries),
+            _state_run_with_runtime_status(
+                state_run,
+                run,
+                settings=resolved_settings,
+                queue_entries=queue_entries,
+                lan_status=lan_status,
+            ),
         )
 
     _save_state(state, resolved_settings.runtime_home)
@@ -588,6 +837,7 @@ def ingest_campaign(
     runtime_home: Path | None = None,
     selected_matrix_ids: set[str] | None = None,
     allow_absolute_local_paths: bool = False,
+    lan_status: Callable[[CloudChamberSettings, Path], dict[str, object]] = lan_worker_run_status,
     lan_collect: Callable[[CloudChamberSettings, Path], dict[str, object]] = collect_lan_worker_run,
 ) -> CampaignOperationResult:
     resolved_settings = settings or load_settings(home=runtime_home)
@@ -595,6 +845,7 @@ def ingest_campaign(
         matrix_path,
         settings=resolved_settings,
         allow_absolute_local_paths=allow_absolute_local_paths,
+        lan_status=lan_status,
     )
     plan = plan_campaign(matrix_path, allow_absolute_local_paths=allow_absolute_local_paths)
     state = _load_or_create_state(plan, resolved_settings.runtime_home)
@@ -605,7 +856,18 @@ def ingest_campaign(
             continue
         manifest_path = Path(state_run.manifest_path).expanduser()
         try:
-            if run.queue_target == "lan" and state_run.status in {"running", "queued"}:
+            if run.queue_target == "lan" and state_run.status in {"queued", "running"}:
+                _upsert_state_run(
+                    state,
+                    state_run.model_copy(
+                        update={
+                            "message": "LAN worker output is not ready for collection.",
+                            "updated_at": _now(),
+                        }
+                    ),
+                )
+                continue
+            if run.queue_target == "lan" and state_run.status == "completed_not_ingested":
                 payload = lan_collect(resolved_settings, manifest_path)
                 state_run = state_run.model_copy(
                     update={
@@ -614,6 +876,31 @@ def ingest_campaign(
                         "updated_at": _now(),
                     }
                 )
+                if _lan_payload_to_campaign_status(payload) not in {
+                    "completed_not_ingested",
+                    "ingested",
+                }:
+                    _upsert_state_run(state, state_run)
+                    continue
+                manifest = load_run_manifest(manifest_path)
+                if (
+                    manifest.lifecycle_state != LifecycleState.COMPLETED
+                    or manifest.provenance.product_state != ProductState.COMPLETED_CM1_RESULT
+                    or not manifest.outputs.netcdf_paths
+                ):
+                    _upsert_state_run(
+                        state,
+                        state_run.model_copy(
+                            update={
+                                "message": (
+                                    "LAN worker reported completion, but collection has not "
+                                    "updated the local manifest with completed CM1 output."
+                                ),
+                                "updated_at": _now(),
+                            }
+                        ),
+                    )
+                    continue
             existing_result = _load_result_for_manifest_path(manifest_path)
             if existing_result is not None:
                 _upsert_state_run(
@@ -683,6 +970,7 @@ def report_campaign(
     plan = plan_campaign(matrix_path, allow_absolute_local_paths=allow_absolute_local_paths)
     state = _load_or_create_state(plan, resolved_settings.runtime_home)
     summaries = [_summary_for_plan_run(run, state) for run in plan.runs]
+    comparisons = _evaluate_comparisons(plan, summaries)
     summary = {
         "schema_version": CAMPAIGN_SUMMARY_SCHEMA_VERSION,
         "campaign_id": plan.campaign_id,
@@ -694,7 +982,9 @@ def report_campaign(
         "run_count": len(summaries),
         "status_counts": _status_counts(summaries),
         "phase_gate_state": _phase_gate_state(summaries),
+        "gate_overrides": _gate_overrides(summaries),
         "runs": summaries,
+        "comparisons": comparisons,
         "unavailable_diagnostics": _unavailable_diagnostics(summaries),
         "preliminary_diagnosis_categories": _preliminary_diagnosis_categories(summaries),
         "recommended_follow_ups": _recommended_follow_ups(summaries),
@@ -706,7 +996,7 @@ def report_campaign(
     json_path = summary_json_path or (
         resolved_settings.runtime_home.expanduser()
         / "campaigns"
-        / plan.campaign_id
+        / _safe_id(plan.campaign_id)
         / "campaign-summary.json"
     )
     markdown_path.parent.mkdir(parents=True, exist_ok=True)
@@ -780,6 +1070,7 @@ def _stable_resume_identity(
     matrix_id: str,
     selection_id: str,
     selection_source_reference: str,
+    selection_payload_hash: str,
     run_configuration: Mapping[str, Any],
     forcing_id: str | None,
 ) -> str:
@@ -788,6 +1079,7 @@ def _stable_resume_identity(
         "matrix_id": matrix_id,
         "selection_id": selection_id,
         "selection_source_reference": selection_source_reference,
+        "selection_payload_hash": selection_payload_hash,
         "forcing_id": forcing_id,
         "run_configuration": run_configuration,
     }
@@ -796,9 +1088,72 @@ def _stable_resume_identity(
 
 
 def _run_id(campaign_id: str, matrix_id: str, stable_identity: str) -> str:
-    raw = f"{campaign_id}-{matrix_id}-{stable_identity[:10]}"
-    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", raw).strip("-")
+    raw = f"{_safe_id(campaign_id)}-{matrix_id}-{stable_identity[:10]}"
+    cleaned = _safe_id(raw)
     return cleaned[:112] or f"campaign-run-{stable_identity[:10]}"
+
+
+def _safe_id(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-")
+    return cleaned or "campaign"
+
+
+def _required_summary_fields(data: Any, errors: list[str]) -> dict[str, list[str]]:
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        errors.append("required_summary_fields must be an object")
+        return {}
+    output: dict[str, list[str]] = {}
+    for group, values in data.items():
+        if not isinstance(group, str):
+            errors.append("required_summary_fields keys must be strings")
+            continue
+        if not isinstance(values, list):
+            errors.append(f"required_summary_fields.{group} must be a list")
+            continue
+        fields: list[str] = []
+        for value in values:
+            if not isinstance(value, str):
+                errors.append(f"required_summary_fields.{group} contains a non-string field")
+                continue
+            if value not in SUPPORTED_REQUIRED_SUMMARY_FIELDS:
+                errors.append(f"Unsupported required_summary_fields.{group} field: {value}")
+            fields.append(value)
+        output[group] = fields
+    return output
+
+
+def _validate_execution(execution: Mapping[str, Any], errors: list[str]) -> None:
+    max_concurrent = execution.get("max_concurrent_runs")
+    if max_concurrent is not None and (not isinstance(max_concurrent, int) or max_concurrent < 1):
+        errors.append("execution.max_concurrent_runs must be an integer >= 1")
+
+
+def _selection_payload_hash(source: Mapping[str, Any], matrix_base: Path) -> str:
+    source_type = source.get("type")
+    payload = source.get("selected_sounding_payload") or source.get("observed_sounding_payload")
+    if isinstance(payload, dict):
+        return _hash_json(payload)
+    if source_type == "uploaded_or_local_igra":
+        local_text_path = _optional_string(source.get("local_text_path"))
+        if local_text_path:
+            path = _resolve_matrix_path(local_text_path, matrix_base)
+            if path.exists():
+                selected_time = _optional_string(source.get("selected_valid_time_utc"))
+                return _hash_text(path.read_text() + f"\nselected_time={selected_time}")
+        runtime_ref = _optional_string(source.get("runtime_file_ref"))
+        if runtime_ref:
+            return _hash_text(f"runtime_file_ref:{runtime_ref}")
+    return _hash_text(_selection_source_reference(source))
+
+
+def _hash_json(payload: Mapping[str, Any]) -> str:
+    return _hash_text(json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str))
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
 def _selection_source_reference(source: Mapping[str, Any]) -> str:
@@ -1081,7 +1436,7 @@ def _save_state(state: CampaignState, runtime_home: Path) -> None:
 
 
 def _state_path(runtime_home: Path, campaign_id: str) -> Path:
-    return runtime_home.expanduser() / "campaigns" / campaign_id / "campaign-state.json"
+    return runtime_home.expanduser() / "campaigns" / _safe_id(campaign_id) / "campaign-state.json"
 
 
 def _new_state_run(
@@ -1130,10 +1485,67 @@ def _state_run_for_matrix(state: CampaignState, matrix_id: str) -> CampaignState
 def _selected_runs(
     runs: Sequence[CampaignRunPlan],
     selected_matrix_ids: set[str] | None,
+    *,
+    include_optional: bool = True,
 ) -> list[CampaignRunPlan]:
     if selected_matrix_ids is None:
-        return list(runs)
+        return [run for run in runs if include_optional or not run.optional]
+    available = {run.matrix_id for run in runs}
+    unknown = sorted(selected_matrix_ids - available)
+    if unknown:
+        raise CampaignError("Unknown matrix_id values: " + ", ".join(unknown))
     return [run for run in runs if run.matrix_id in selected_matrix_ids]
+
+
+def _phase_gate_allows_queue(
+    run: CampaignRunPlan,
+    gate_state: str,
+    override_phase_gate: bool,
+) -> bool:
+    if _is_phase_one_run(run):
+        return True
+    if gate_state == "forcing_path_verified_for_campaign":
+        return True
+    return override_phase_gate
+
+
+def _is_phase_one_run(run: CampaignRunPlan) -> bool:
+    if run.phase is not None:
+        return run.phase == "forcing_path_smoke_check"
+    return run.selection_role == "forcing_path_smoke_check"
+
+
+def _gate_override_payload(
+    *,
+    enabled: bool,
+    reason: str | None,
+    gate_state: str,
+) -> dict[str, Any] | None:
+    if not enabled:
+        return None
+    return {
+        "enabled": True,
+        "reason": reason or "operator_override_without_reason",
+        "gate_state_at_override": gate_state,
+        "recorded_at": _now().isoformat(),
+    }
+
+
+def _max_concurrent_runs(plan: CampaignPlan) -> int:
+    value = plan.execution.get("max_concurrent_runs")
+    if isinstance(value, int) and value >= 1:
+        return value
+    return 1
+
+
+def _active_lan_count(state: CampaignState) -> int:
+    return len(
+        [
+            run
+            for run in state.runs
+            if run.queue_target == "lan" and run.status in {"queued", "running"}
+        ]
+    )
 
 
 def _default_local_queue(settings: CloudChamberSettings) -> LocalRunQueueManager:
@@ -1145,8 +1557,11 @@ def _default_local_queue(settings: CloudChamberSettings) -> LocalRunQueueManager
 
 def _state_run_with_runtime_status(
     state_run: CampaignStateRun,
+    run: CampaignRunPlan,
     *,
+    settings: CloudChamberSettings,
     queue_entries: Mapping[str, Mapping[str, Any]],
+    lan_status: Callable[[CloudChamberSettings, Path], dict[str, object]],
 ) -> CampaignStateRun:
     if not state_run.manifest_path:
         return state_run
@@ -1161,6 +1576,44 @@ def _state_run_with_runtime_status(
             }
         )
     manifest = load_run_manifest(manifest_path)
+    if state_run.status == "blocked":
+        return state_run.model_copy(
+            update={
+                "package_status": "packaged"
+                if manifest.lifecycle_state != LifecycleState.CREATED
+                else state_run.package_status,
+                "updated_at": _now(),
+            }
+        )
+    if run.queue_target == "lan" and state_run.status in {
+        "queued",
+        "running",
+        "completed_not_ingested",
+    }:
+        try:
+            payload = lan_status(settings, manifest_path)
+        except LanWorkerApiError as exc:
+            return state_run.model_copy(
+                update={
+                    "message": "LAN worker status could not be refreshed.",
+                    "error": str(exc),
+                    "updated_at": _now(),
+                }
+            )
+        status = _lan_payload_to_campaign_status(payload)
+        return state_run.model_copy(
+            update={
+                "status": status,
+                "run_status": status,
+                "lan_worker_payload": dict(payload),
+                "message": _payload_message(payload, f"LAN worker status: {status}."),
+                "error": None
+                if status != "run_failed"
+                else _payload_message(payload, "LAN failed."),
+                "updated_at": _now(),
+            }
+        )
+
     queue_entry = queue_entries.get(str(manifest_path))
     status = _manifest_to_campaign_status(manifest)
     message = state_run.message
@@ -1267,6 +1720,41 @@ def _load_result_for_manifest_path(manifest_path: Path) -> ResultMetadata | None
         return None
 
 
+def _run_dir_has_runtime_artifacts(package_dir: Path) -> bool:
+    if not package_dir.exists():
+        return False
+    patterns = (
+        RESULT_METADATA_FILENAME,
+        "cm1out_*.nc",
+        "cm1out_*.nc4",
+        "cm1out_*.cdf",
+        "cm1out_*.netcdf",
+        "cm1out_*.dat",
+        "cm1out_*.ctl",
+        "logs/*.log",
+        "logs/*",
+    )
+    for pattern in patterns:
+        if list(package_dir.glob(pattern)):
+            return True
+    return False
+
+
+def _repo_commit() -> str | None:
+    try:
+        completed = subprocess.run(
+            ("git", "rev-parse", "HEAD"),
+            check=True,
+            cwd=Path(__file__).resolve().parents[3],
+            text=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    commit = completed.stdout.strip()
+    return commit or None
+
+
 def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[str, Any]:
     state_run = _state_run_for_matrix(state, run.matrix_id)
     manifest = None
@@ -1278,14 +1766,24 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
             result = _load_result_for_manifest_path(manifest_path)
     observed = manifest.observed_sounding if manifest is not None else None
     diagnostics = result.diagnostics if result is not None else None
+    science = result.science_summary if result is not None else None
     variables = set(result.variables) if result is not None else set()
     missing_fields = (
         result.missing_required_output_fields
         if result is not None
-        else ["unavailable_until_result_ingested"]
+        else ["unavailable:until_result_ingested"]
     )
     candidate = manifest.candidate_screening if manifest is not None else run.candidate_screening
+    cloud = diagnostics.cloud if diagnostics is not None else None
+    vertical_velocity = diagnostics.vertical_velocity if diagnostics is not None else None
+    rain = diagnostics.rain if diagnostics is not None else None
+    surface_rain = diagnostics.surface_rain if diagnostics is not None else None
+    reflectivity = diagnostics.reflectivity if diagnostics is not None else None
+    deep_cloud_formed = (
+        science.deep_cloud_formed if science is not None else "unavailable:not_ingested"
+    )
     return {
+        "schema_version": CAMPAIGN_SUMMARY_SCHEMA_VERSION,
         "campaign_id": run.campaign_id,
         "matrix_id": run.matrix_id,
         "phase": run.phase,
@@ -1299,6 +1797,12 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "run_status": state_run.run_status if state_run else "planned",
         "ingest_status": state_run.ingest_status if state_run else "not_started",
         "queue_target": run.queue_target,
+        "source_manifest_lifecycle_state": (
+            manifest.lifecycle_state.value if manifest is not None else None
+        ),
+        "source_manifest_product_state": (
+            manifest.provenance.product_state.value if manifest is not None else None
+        ),
         "station_id": _mapping_value(observed, "station_id"),
         "station_name": _mapping_value(observed, "station_name"),
         "valid_time_utc": _mapping_value(observed, "valid_time_utc"),
@@ -1332,46 +1836,85 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "output_cadence": run.run_configuration["output_cadence"],
         "expected_output_frames": run.cm1_values.get("expected_output_frames"),
         "expected_output_volume": run.resolved_run_configuration.get("output_volume_summary"),
+        "cloud_chamber_commit": manifest.app.commit if manifest is not None else None,
+        "cm1_version": "unavailable:cm1_version_not_recorded",
+        "cm1_build": "unavailable:cm1_build_not_recorded",
         "required_output_fields": manifest.required_output_fields if manifest is not None else [],
         "missing_output_fields": missing_fields,
+        "available_output_fields": sorted(variables),
+        "evidence_fields": sorted(variables),
         "diagnostic_support": _diagnostic_support(result),
+        "interesting_time_support_state": (
+            science.interesting_time_support_state
+            if science is not None
+            else "unavailable:not_ingested"
+        ),
         "hfx_present": "hfx" in variables,
         "hfx_units": _field_units(result, "hfx"),
+        "hfx_min": "unavailable:surface_flux_statistics_not_implemented",
+        "hfx_max": "unavailable:surface_flux_statistics_not_implemented",
+        "hfx_mean": "unavailable:surface_flux_statistics_not_implemented",
         "lhfx_present": "lhfx" in variables,
         "lhfx_units": _field_units(result, "lhfx"),
-        "low_level_qv_response": "unavailable",
+        "lhfx_min": "unavailable:surface_flux_statistics_not_implemented",
+        "lhfx_max": "unavailable:surface_flux_statistics_not_implemented",
+        "lhfx_mean": "unavailable:surface_flux_statistics_not_implemented",
+        "low_level_qv_response": ("unavailable:low_level_response_diagnostic_not_implemented"),
         "low_level_qv_response_method": "low_level_response_diagnostic_not_implemented",
-        "low_level_theta_or_temperature_response": "unavailable",
+        "low_level_theta_or_temperature_response": (
+            "unavailable:low_level_response_diagnostic_not_implemented"
+        ),
         "low_level_theta_or_temperature_response_method": (
             "low_level_response_diagnostic_not_implemented"
         ),
-        "first_cloud_time": (
-            diagnostics.cloud.first_cloud_time_seconds if diagnostics is not None else None
+        "first_cloud_time": _first_defined(
+            cloud.first_cloud_time_seconds if cloud is not None else None,
+            science.first_cloud_time_seconds if science is not None else None,
         ),
-        "max_cloud_top_m": diagnostics.cloud.cloud_top_m if diagnostics is not None else None,
-        "max_qc": diagnostics.cloud.max_qc_kg_kg if diagnostics is not None else None,
-        "max_qc_time": (
-            diagnostics.cloud.time_of_max_qc_seconds if diagnostics is not None else None
+        "max_cloud_top_m": _first_defined(
+            cloud.cloud_top_m if cloud is not None else None,
+            science.highest_cloud_top_m if science is not None else None,
         ),
-        "max_w_m_s": (diagnostics.vertical_velocity.max_w_m_s if diagnostics is not None else None),
-        "max_w_time": (
-            diagnostics.vertical_velocity.time_of_max_w_seconds if diagnostics is not None else None
+        "max_cloud_top_time": _time_of_max_time_value(
+            cloud.cloud_top_time_series if cloud is not None else []
         ),
-        "qr_present": diagnostics.rain.present if diagnostics is not None else None,
-        "surface_rain_present": (
-            diagnostics.surface_rain.present if diagnostics is not None else None
+        "max_qc": _first_defined(
+            cloud.max_qc_kg_kg if cloud is not None else None,
+            science.max_qc_kg_kg if science is not None else None,
         ),
-        "surface_rain_max": (
-            diagnostics.surface_rain.max_surface_rain if diagnostics is not None else None
+        "max_qc_time": _first_defined(
+            cloud.time_of_max_qc_seconds if cloud is not None else None,
+            science.max_qc_time_seconds if science is not None else None,
         ),
-        "surface_rain_units": (diagnostics.surface_rain.units if diagnostics is not None else None),
-        "dbz_present": (
-            diagnostics.reflectivity.max_dbz is not None if diagnostics is not None else None
+        "cloud_depth_or_classification": _cloud_depth_or_classification(result),
+        "max_w_m_s": _first_defined(
+            vertical_velocity.max_w_m_s if vertical_velocity is not None else None,
+            science.max_updraft_w_m_s if science is not None else None,
         ),
-        "max_dbz": diagnostics.reflectivity.max_dbz if diagnostics is not None else None,
-        "first_deep_cloud_time": "unavailable",
+        "max_w_time": _first_defined(
+            vertical_velocity.time_of_max_w_seconds if vertical_velocity is not None else None,
+            science.max_updraft_time_seconds if science is not None else None,
+        ),
+        "max_w_height_m": _time_value_at_time(
+            vertical_velocity.max_w_height_time_series if vertical_velocity is not None else [],
+            vertical_velocity.time_of_max_w_seconds if vertical_velocity is not None else None,
+        ),
+        "qr_present": rain.present if rain is not None else None,
+        "surface_rain_present": surface_rain.present if surface_rain is not None else None,
+        "surface_rain_max": (surface_rain.max_surface_rain if surface_rain is not None else None),
+        "surface_rain_units": surface_rain.units if surface_rain is not None else None,
+        "dbz_present": reflectivity.max_dbz is not None if reflectivity is not None else None,
+        "max_dbz": reflectivity.max_dbz if reflectivity is not None else None,
+        "deep_cloud_formed": deep_cloud_formed,
+        "deep_cloud_flag": deep_cloud_formed,
+        "first_deep_cloud_time": (
+            science.time_of_first_deep_convection_seconds
+            if science is not None
+            else "unavailable:not_ingested"
+        ),
         "warnings": result.warnings if result is not None else [],
         "caveats": _summary_caveats(run, state_run, result),
+        "gate_override": state_run.gate_override if state_run is not None else None,
         "error": state_run.error if state_run else None,
     }
 
@@ -1379,18 +1922,18 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
 def _diagnostic_support(result: ResultMetadata | None) -> dict[str, str]:
     if result is None or result.diagnostics is None:
         return {
-            "surface_fluxes": "unavailable_until_result_ingested",
-            "low_level_response": "unavailable",
-            "cloud": "unavailable",
-            "vertical_velocity": "unavailable",
-            "rain_water_aloft": "unavailable",
-            "surface_rain": "unavailable",
-            "reflectivity": "unavailable",
+            "surface_fluxes": "unavailable:until_result_ingested",
+            "low_level_response": "unavailable:until_result_ingested",
+            "cloud": "unavailable:until_result_ingested",
+            "vertical_velocity": "unavailable:until_result_ingested",
+            "rain_water_aloft": "unavailable:until_result_ingested",
+            "surface_rain": "unavailable:until_result_ingested",
+            "reflectivity": "unavailable:until_result_ingested",
         }
     diagnostics = result.diagnostics
     return {
         "surface_fluxes": "available" if {"hfx", "lhfx"} <= set(result.variables) else "missing",
-        "low_level_response": "unavailable",
+        "low_level_response": "unavailable:low_level_response_diagnostic_not_implemented",
         "cloud": "available" if diagnostics.cloud.available else "missing",
         "vertical_velocity": "available" if diagnostics.vertical_velocity.available else "missing",
         "rain_water_aloft": "available" if diagnostics.rain.available else "missing",
@@ -1403,6 +1946,58 @@ def _field_units(result: ResultMetadata | None, field_name: str) -> str | None:
     if result is None:
         return None
     return next((field.units for field in result.fields_detected if field.name == field_name), None)
+
+
+def _first_defined(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _time_of_max_time_value(values: Sequence[Any]) -> float | None:
+    best_time: float | None = None
+    best_value: float | None = None
+    for point in values:
+        value = getattr(point, "value", None)
+        time_seconds = getattr(point, "time_seconds", None)
+        if not isinstance(value, int | float):
+            continue
+        if best_value is None or float(value) > best_value:
+            best_value = float(value)
+            best_time = float(time_seconds) if isinstance(time_seconds, int | float) else None
+    return best_time
+
+
+def _time_value_at_time(values: Sequence[Any], target_time: float | None) -> float | None:
+    if target_time is None:
+        return None
+    for point in values:
+        time_seconds = getattr(point, "time_seconds", None)
+        value = getattr(point, "value", None)
+        if (
+            isinstance(time_seconds, int | float)
+            and abs(float(time_seconds) - target_time) < 1e-6
+            and isinstance(value, int | float)
+        ):
+            return float(value)
+    return None
+
+
+def _cloud_depth_or_classification(result: ResultMetadata | None) -> str:
+    if result is None or result.diagnostics is None:
+        return "unavailable:not_ingested"
+    cloud = result.diagnostics.cloud
+    if not cloud.available:
+        return "unavailable:missing_qc_field"
+    if not cloud.formed:
+        return "no_cloud_detected"
+    top = cloud.cloud_top_m
+    if top is None:
+        return "cloud_detected_depth_unavailable"
+    if top >= 8000.0:
+        return f"deep_cloud_top_{top:.0f}_m"
+    return f"shallow_or_midlevel_cloud_top_{top:.0f}_m"
 
 
 def _summary_caveats(
@@ -1445,11 +2040,26 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
         f"- Status counts: `{json.dumps(summary['status_counts'], sort_keys=True)}`",
         f"- Phase gate state: `{summary['phase_gate_state']}`",
         "",
-        "## Run Table",
+        "## Operator Overrides",
         "",
-        "| Matrix ID | Status | Station/time | Forcing | Grid/domain | Key result |",
-        "| --- | --- | --- | --- | --- | --- |",
     ]
+    if summary.get("gate_overrides"):
+        for override in summary["gate_overrides"]:
+            lines.append(
+                f"- {override['matrix_id']}: `{override['reason']}` "
+                f"(gate `{override['gate_state_at_override']}`)"
+            )
+    else:
+        lines.append("No operator phase-gate overrides were recorded.")
+    lines.extend(
+        [
+            "",
+            "## Run Table",
+            "",
+            "| Matrix ID | Status | Station/time | Forcing | Grid/domain | Key result |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
     for run in summary["runs"]:
         lines.append(
             "| "
@@ -1492,10 +2102,25 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                 "",
                 f"- Run ID: `{run['run_id']}`",
                 f"- Result ID: `{run['result_id'] or 'not ingested'}`",
+                (
+                    f"- Status: package `{run['package_status']}`, "
+                    f"run `{run['run_status']}`, ingest `{run['ingest_status']}`"
+                ),
+                (
+                    f"- Provenance: Cloud Chamber "
+                    f"`{run['cloud_chamber_commit'] or 'unavailable'}`, "
+                    f"CM1 `{run['cm1_version']}`"
+                ),
                 f"- Source: `{run['selection_source_type']}` `{run['selection_source_reference']}`",
                 f"- Candidate story: `{run['candidate_story'] or 'unavailable'}`",
                 f"- Required/missing fields: `{required_fields}` / `{missing_fields}`",
                 f"- Surface flux fields: hfx `{run['hfx_present']}`, lhfx `{run['lhfx_present']}`",
+                (
+                    f"- Surface flux stats: hfx `{run['hfx_min']}`/"
+                    f"`{run['hfx_max']}`/`{run['hfx_mean']}`, "
+                    f"lhfx `{run['lhfx_min']}`/`{run['lhfx_max']}`/"
+                    f"`{run['lhfx_mean']}`"
+                ),
                 f"- Cloud/updraft: {cloud_updraft}",
                 f"- Precipitation/reflectivity: {precipitation}",
                 f"- Low-level response: `{run['low_level_qv_response_method']}`",
@@ -1509,6 +2134,38 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
             "",
             _forcing_response_summary(summary),
             "",
+            "## Matched Comparisons",
+            "",
+        ]
+    )
+    if summary["comparisons"]:
+        for comparison in summary["comparisons"]:
+            lines.extend(
+                [
+                    (
+                        f"### {comparison['experiment_matrix_id']} vs "
+                        f"{comparison['control_matrix_id']}"
+                    ),
+                    "",
+                    f"- Type: `{comparison['comparison_type']}`",
+                    f"- Status: `{comparison['status']}`",
+                    f"- Varied fields: `{', '.join(comparison['fields_that_varied']) or 'none'}`",
+                    (
+                        f"- Equality failures: "
+                        f"`{json.dumps(comparison['equality_gate_failures'], sort_keys=True)}`"
+                    ),
+                    (
+                        f"- Unavailable evidence: "
+                        f"`{', '.join(comparison['unavailable_evidence']) or 'none'}`"
+                    ),
+                    f"- Interpretation: {comparison['interpretation']}",
+                    "",
+                ]
+            )
+    else:
+        lines.append("No comparison instances are defined in this matrix.")
+    lines.extend(
+        [
             "## Deepening And Class Differences",
             "",
             _deepening_summary(summary),
@@ -1548,13 +2205,193 @@ def _status_counts(summaries: Sequence[Mapping[str, Any]]) -> dict[str, int]:
     return counts
 
 
+def _gate_overrides(summaries: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    overrides: list[dict[str, Any]] = []
+    for summary in summaries:
+        payload = summary.get("gate_override")
+        if not isinstance(payload, dict):
+            continue
+        overrides.append(
+            {
+                "matrix_id": summary.get("matrix_id"),
+                "reason": payload.get("reason") or "operator_override_without_reason",
+                "gate_state_at_override": payload.get("gate_state_at_override"),
+                "recorded_at": payload.get("recorded_at"),
+            }
+        )
+    return overrides
+
+
+def _evaluate_comparisons(
+    plan: CampaignPlan,
+    summaries: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    by_matrix_id = {str(summary["matrix_id"]): summary for summary in summaries}
+    results: list[dict[str, Any]] = []
+    for run in plan.runs:
+        if not run.comparison_type or not run.comparison_control_matrix_id:
+            continue
+        definition = plan.comparison_types.get(run.comparison_type, {})
+        control = by_matrix_id.get(run.comparison_control_matrix_id)
+        experiment = by_matrix_id.get(run.matrix_id)
+        if control is None or experiment is None:
+            results.append(
+                {
+                    "comparison_type": run.comparison_type,
+                    "control_matrix_id": run.comparison_control_matrix_id,
+                    "experiment_matrix_id": run.matrix_id,
+                    "status": "inconclusive_missing_evidence",
+                    "interpretation": "Control or experiment summary is unavailable.",
+                    "equality_gate_failures": [],
+                    "unavailable_evidence": ["missing_control_or_experiment_summary"],
+                    "supported_differences": [],
+                }
+            )
+            continue
+        equality_failures = _comparison_equality_failures(control, experiment, definition)
+        unavailable = _comparison_unavailable_evidence(control, experiment, definition)
+        supported = _comparison_supported_differences(control, experiment, definition)
+        if equality_failures:
+            status = "inconclusive_noncomparable_runs"
+            interpretation = (
+                "Runs are not comparable because required-equal fields differ or are missing."
+            )
+        elif unavailable:
+            status = "inconclusive_missing_evidence"
+            interpretation = (
+                "Runs are structurally comparable, but required output fields or diagnostics "
+                "are unavailable."
+            )
+        else:
+            status = "comparable"
+            interpretation = (
+                "Required comparison gates passed; inspect supported differences without "
+                "treating them as predicted-vs-actual verdicts."
+            )
+        results.append(
+            {
+                "comparison_type": run.comparison_type,
+                "control_matrix_id": run.comparison_control_matrix_id,
+                "experiment_matrix_id": run.matrix_id,
+                "status": status,
+                "fields_that_varied": list(definition.get("varied_fields", [])),
+                "equality_gate_failures": equality_failures,
+                "unavailable_evidence": unavailable,
+                "supported_differences": supported,
+                "interpretation": interpretation,
+            }
+        )
+    return results
+
+
+def _comparison_equality_failures(
+    control: Mapping[str, Any],
+    experiment: Mapping[str, Any],
+    definition: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    for field in _string_list(definition.get("required_equal_fields")):
+        left = _comparison_field_value(control, field)
+        right = _comparison_field_value(experiment, field)
+        if left != right:
+            failures.append(
+                {
+                    "field": field,
+                    "control": left,
+                    "experiment": right,
+                }
+            )
+    return failures
+
+
+def _comparison_unavailable_evidence(
+    control: Mapping[str, Any],
+    experiment: Mapping[str, Any],
+    definition: Mapping[str, Any],
+) -> list[str]:
+    unavailable: list[str] = []
+    for summary, role in ((control, "control"), (experiment, "experiment")):
+        if summary.get("status") != "ingested":
+            unavailable.append(f"{role}:result_not_ingested")
+        fields = set(_string_list(summary.get("available_output_fields")))
+        for field in _string_list(definition.get("required_available_fields")):
+            if not _field_available(field, fields):
+                unavailable.append(f"{role}:missing_required_field:{field}")
+        support = summary.get("diagnostic_support")
+        diagnostic_support = support if isinstance(support, dict) else {}
+        for diagnostic in _string_list(definition.get("required_diagnostic_support")):
+            if diagnostic_support.get(diagnostic) != "available":
+                unavailable.append(f"{role}:diagnostic_unavailable:{diagnostic}")
+    return _dedupe(unavailable)
+
+
+def _comparison_supported_differences(
+    control: Mapping[str, Any],
+    experiment: Mapping[str, Any],
+    definition: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    differences: list[dict[str, Any]] = []
+    for field in _string_list(definition.get("varied_fields")):
+        left = _comparison_field_value(control, field)
+        right = _comparison_field_value(experiment, field)
+        if left != right:
+            differences.append({"field": field, "control": left, "experiment": right})
+    for field in (
+        "max_cloud_top_m",
+        "max_qc",
+        "max_w_m_s",
+        "qr_present",
+        "surface_rain_present",
+        "max_dbz",
+    ):
+        left = control.get(field)
+        right = experiment.get(field)
+        if left not in {None, "unavailable"} or right not in {None, "unavailable"}:
+            differences.append({"field": field, "control": left, "experiment": right})
+    return differences
+
+
+def _comparison_field_value(summary: Mapping[str, Any], field: str) -> Any:
+    if field in MATRIX_CONTEXT_FIELDS:
+        if field == "runtime_seconds":
+            return summary.get("duration_seconds")
+        return summary.get(field)
+    return summary.get(field)
+
+
+def _field_available(field: str, available_fields: set[str]) -> bool:
+    if field == "th_or_temperature":
+        return bool({"th", "theta", "theta_v", "temperature", "t"} & available_fields)
+    return field in available_fields
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _is_unavailable(value: Any) -> bool:
+    return isinstance(value, str) and value.startswith("unavailable")
+
+
 def _phase_gate_state(summaries: Sequence[Mapping[str, Any]]) -> str:
-    ingested = [summary for summary in summaries if summary.get("status") == "ingested"]
-    if not ingested:
+    phase1 = [
+        summary for summary in summaries if summary.get("phase") == "forcing_path_smoke_check"
+    ]
+    if not phase1:
         return "inconclusive_missing_evidence"
-    if not all(summary.get("hfx_present") and summary.get("lhfx_present") for summary in ingested):
+    if not all(summary.get("status") == "ingested" for summary in phase1):
+        return "inconclusive_missing_evidence"
+    if not all(summary.get("hfx_present") and summary.get("lhfx_present") for summary in phase1):
         return "forcing_wiring_not_verified"
-    return "forcing_wiring_verified_but_response_not_verified"
+    if not all(
+        not _is_unavailable(summary.get("low_level_qv_response"))
+        and not _is_unavailable(summary.get("low_level_theta_or_temperature_response"))
+        for summary in phase1
+    ):
+        return "forcing_wiring_verified_but_response_not_verified"
+    return "forcing_path_verified_for_campaign"
 
 
 def _unavailable_diagnostics(summaries: Sequence[Mapping[str, Any]]) -> list[str]:
@@ -1562,9 +2399,9 @@ def _unavailable_diagnostics(summaries: Sequence[Mapping[str, Any]]) -> list[str
     for summary in summaries:
         for field in summary.get("missing_output_fields", []):
             unavailable.add(f"missing_output_field:{field}")
-        if summary.get("low_level_qv_response") == "unavailable":
+        if _is_unavailable(summary.get("low_level_qv_response")):
             unavailable.add("low_level_qv_response")
-        if summary.get("low_level_theta_or_temperature_response") == "unavailable":
+        if _is_unavailable(summary.get("low_level_theta_or_temperature_response")):
             unavailable.add("low_level_theta_or_temperature_response")
     return sorted(unavailable)
 
@@ -1628,7 +2465,7 @@ def _deepening_summary(summary: Mapping[str, Any]) -> str:
 def _default_report_path(plan: CampaignPlan) -> Path:
     if plan.commit_report_path:
         return Path(plan.commit_report_path)
-    return DEFAULT_REPORT_ROOT / f"{plan.campaign_id}.md"
+    return DEFAULT_REPORT_ROOT / f"{_safe_id(plan.campaign_id)}.md"
 
 
 def _station_time_label(run: Mapping[str, Any]) -> str:

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -1,0 +1,1840 @@
+"""Surface-forced observed-sounding campaign planning and reporting.
+
+This module is intentionally orchestration-only. CM1 package generation,
+queueing, LAN worker execution, and result ingest remain owned by the existing
+backend paths; the campaign layer validates a matrix, keeps resumable state, and
+summarizes what those paths produced.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml  # type: ignore[import-untyped]
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.cm1_input_contract import RunRecipe
+from cloud_chamber.dry_run_package import DryRunPackageError, generate_dry_run_package
+from cloud_chamber.lan_worker import (
+    LanWorkerApiError,
+    collect_lan_worker_run,
+    start_lan_worker_run,
+)
+from cloud_chamber.local_run_manager import LocalRunManager
+from cloud_chamber.local_run_queue import LocalRunQueueError, LocalRunQueueManager
+from cloud_chamber.observed_sounding import (
+    ObservedSoundingError,
+    ObservedSoundingRecord,
+    observed_sounding_from_payload,
+    parse_igra_station_text,
+)
+from cloud_chamber.result_ingest import (
+    RESULT_METADATA_FILENAME,
+    ResultIngestError,
+    ResultMetadata,
+    ingest_completed_run,
+    result_metadata_from_json,
+)
+from cloud_chamber.run_configuration import resolve_run_configuration
+from cloud_chamber.run_manifest import LifecycleState, ProductState, load_run_manifest
+from cloud_chamber.scenario_catalog import load_scenario_template
+from cloud_chamber.settings import CloudChamberSettings, load_settings
+from cloud_chamber.sounding_candidates import (
+    SavedSoundingCandidate,
+    SoundingCandidate,
+    list_saved_candidates,
+    list_screening_inputs,
+    screen_cached_soundings,
+)
+
+MATRIX_SCHEMA_VERSION = "surface_forced_campaign_matrix_v1"
+CAMPAIGN_STATE_SCHEMA_VERSION = "surface_forced_campaign_state_v1"
+CAMPAIGN_SUMMARY_SCHEMA_VERSION = "surface_forced_campaign_summary_v1"
+OBSERVED_SURFACE_FORCED_RECIPE = RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION.value
+DEFAULT_SCENARIO_ID = "baseline-shallow-cumulus"
+DEFAULT_REPORT_ROOT = Path("docs/research/surface-forced-campaigns")
+RUN_CONFIGURATION_KEYS = {
+    "duration",
+    "horizontal_cell_count",
+    "domain_size",
+    "output_cadence",
+    "diagnostic_set",
+    "surface_heat_flux_k_m_s",
+    "surface_moisture_flux_g_g_m_s",
+}
+KNOWN_STATUS_VALUES = {
+    "planned",
+    "packaged",
+    "queued",
+    "running",
+    "completed_not_ingested",
+    "ingested",
+    "package_failed",
+    "run_failed",
+    "ingest_failed",
+    "run_canceled",
+    "skipped",
+    "blocked",
+}
+
+QueueTarget = Literal["local", "lan"]
+
+
+class CampaignError(RuntimeError):
+    """Raised when a campaign matrix or campaign operation is invalid."""
+
+
+class CampaignRunPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = MATRIX_SCHEMA_VERSION
+    campaign_id: str
+    matrix_id: str
+    phase: str | None = None
+    optional: bool = False
+    selection_id: str
+    selection_role: str | None = None
+    selection_source_type: str
+    selection_source_reference: str
+    forcing_id: str | None = None
+    comparison_type: str | None = None
+    comparison_control_matrix_id: str | None = None
+    comparison_role: str | None = None
+    queue_target: QueueTarget
+    run_configuration: dict[str, Any]
+    resolved_run_configuration: dict[str, Any]
+    cm1_values: dict[str, Any]
+    surface_flux_cm1_values: dict[str, Any]
+    tags: list[str] = Field(default_factory=list)
+    notes: str | None = None
+    stable_resume_identity: str
+    run_id: str
+    candidate_screening: dict[str, Any] | None = None
+
+
+class CampaignPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = MATRIX_SCHEMA_VERSION
+    campaign_id: str
+    title: str | None = None
+    objective: str | None = None
+    protocol: str | None = None
+    commit_report_path: str | None = None
+    matrix_path: str | None = None
+    run_count: int
+    runs: list[CampaignRunPlan]
+    caveats: list[str] = Field(default_factory=list)
+
+
+class CampaignStateRun(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    matrix_id: str
+    stable_resume_identity: str
+    run_id: str
+    queue_target: QueueTarget
+    status: str
+    package_status: str = "planned"
+    run_status: str = "planned"
+    ingest_status: str = "not_started"
+    manifest_path: str | None = None
+    package_dir: str | None = None
+    result_id: str | None = None
+    error: str | None = None
+    message: str | None = None
+    lan_worker_payload: dict[str, Any] | None = None
+    updated_at: datetime
+
+
+class CampaignState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = CAMPAIGN_STATE_SCHEMA_VERSION
+    campaign_id: str
+    matrix_path: str | None = None
+    updated_at: datetime
+    runs: list[CampaignStateRun] = Field(default_factory=list)
+
+
+class CampaignReportArtifacts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    markdown_path: str
+    summary_json_path: str
+    summary: dict[str, Any]
+
+
+class CampaignOperationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    campaign_id: str
+    state_path: str
+    runs: list[CampaignStateRun]
+
+
+def load_campaign_matrix(path: Path) -> dict[str, Any]:
+    """Load a campaign matrix from YAML or JSON."""
+
+    try:
+        loaded = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        raise CampaignError(f"Invalid campaign matrix YAML/JSON: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise CampaignError(f"Campaign matrix must be a YAML/JSON object: {path}")
+    return dict(loaded)
+
+
+def build_campaign_plan(
+    matrix: Mapping[str, Any],
+    *,
+    matrix_path: Path | None = None,
+    allow_absolute_local_paths: bool = False,
+) -> CampaignPlan:
+    """Validate a matrix and resolve each run to CM1-facing configuration values."""
+
+    errors: list[str] = []
+    caveats: list[str] = []
+    if matrix.get("schema_version") != MATRIX_SCHEMA_VERSION:
+        errors.append(
+            f"schema_version must be {MATRIX_SCHEMA_VERSION!r}; "
+            f"got {matrix.get('schema_version')!r}"
+        )
+
+    campaign = _mapping(matrix.get("campaign"), "campaign", errors)
+    campaign_id = _required_string(campaign, "campaign_id", "campaign", errors)
+    execution = _mapping(matrix.get("execution", {}), "execution", errors)
+    selection_sets = _indexed_mappings(
+        matrix.get("selection_sets"),
+        key="selection_id",
+        label="selection_sets",
+        errors=errors,
+    )
+    forcing_sets = _indexed_mappings(
+        matrix.get("forcing_sets", []),
+        key="forcing_id",
+        label="forcing_sets",
+        errors=errors,
+    )
+    comparison_types = _indexed_mappings(
+        matrix.get("comparison_types", []),
+        key="comparison_type",
+        label="comparison_types",
+        errors=errors,
+    )
+    run_defaults = _mapping(matrix.get("run_defaults", {}), "run_defaults", errors)
+    runs = _list_of_mappings(matrix.get("runs"), "runs", errors)
+
+    planned: list[CampaignRunPlan] = []
+    matrix_ids: set[str] = set()
+    default_queue_target = _queue_target(
+        run_defaults.get("queue_target") or execution.get("queue_target") or "local",
+        errors=errors,
+        context="execution.queue_target",
+    )
+    matrix_base = matrix_path.parent if matrix_path is not None else Path.cwd()
+
+    for index, run in enumerate(runs):
+        context = f"runs[{index}]"
+        matrix_id = _required_string(run, "matrix_id", context, errors)
+        if matrix_id in matrix_ids:
+            errors.append(f"Duplicate run matrix_id: {matrix_id}")
+        matrix_ids.add(matrix_id)
+
+        selection_id = _required_string(run, "selection_id", context, errors)
+        selection = selection_sets.get(selection_id)
+        if selection is None:
+            errors.append(f"{context}.selection_id references unknown selection: {selection_id}")
+            selection = {}
+
+        forcing_id = _optional_string(run.get("forcing_id"))
+        forcing = forcing_sets.get(forcing_id or "", {})
+        if forcing_id is not None and not forcing:
+            errors.append(f"{context}.forcing_id references unknown forcing set: {forcing_id}")
+
+        comparison = _optional_mapping(run.get("comparison"))
+        comparison_type = _optional_string(comparison.get("type")) if comparison else None
+        if comparison_type is not None and comparison_type not in comparison_types:
+            errors.append(f"{context}.comparison.type references unknown type: {comparison_type}")
+
+        source = _validate_selection_source(
+            selection,
+            context=f"selection_sets[{selection_id}].source",
+            matrix_base=matrix_base,
+            allow_absolute_local_paths=allow_absolute_local_paths,
+            errors=errors,
+        )
+        queue_target = _queue_target(
+            run.get("queue_target") or run_defaults.get("queue_target") or default_queue_target,
+            errors=errors,
+            context=f"{context}.queue_target",
+        )
+        run_configuration = _resolved_run_configuration_payload(
+            defaults=run_defaults,
+            forcing=forcing,
+            run=run,
+        )
+        try:
+            resolved_configuration = resolve_run_configuration(
+                run_configuration=run_configuration,
+                run_recipe=OBSERVED_SURFACE_FORCED_RECIPE,
+            )
+        except ValueError as exc:
+            errors.append(f"{context}.run_configuration invalid: {exc}")
+            continue
+
+        source_type = str(source.get("type", "unknown"))
+        source_reference = _selection_source_reference(source)
+        candidate_screening = _candidate_screening_from_matrix(selection, source)
+        stable_identity = _stable_resume_identity(
+            campaign_id=campaign_id,
+            matrix_id=matrix_id,
+            selection_id=selection_id,
+            selection_source_reference=source_reference,
+            run_configuration=resolved_configuration.model_dump(mode="json"),
+            forcing_id=forcing_id,
+        )
+        planned.append(
+            CampaignRunPlan(
+                campaign_id=campaign_id,
+                matrix_id=matrix_id,
+                phase=_optional_string(run.get("phase")),
+                optional=bool(run.get("optional", False)),
+                selection_id=selection_id,
+                selection_role=_optional_string(selection.get("role")),
+                selection_source_type=source_type,
+                selection_source_reference=source_reference,
+                forcing_id=forcing_id,
+                comparison_type=comparison_type,
+                comparison_control_matrix_id=(
+                    _optional_string(comparison.get("control_matrix_id")) if comparison else None
+                ),
+                comparison_role=_optional_string(run.get("comparison_role")),
+                queue_target=queue_target,
+                run_configuration=run_configuration,
+                resolved_run_configuration=resolved_configuration.model_dump(mode="json"),
+                cm1_values=resolved_configuration.cm1_values.model_dump(mode="json"),
+                surface_flux_cm1_values=(
+                    resolved_configuration.surface_flux_cm1_values.model_dump(mode="json")
+                ),
+                tags=_resolved_tags(run_defaults, selection, run, campaign_id, matrix_id),
+                notes=_resolved_notes(run_defaults, selection, run),
+                stable_resume_identity=stable_identity,
+                run_id=_run_id(campaign_id, matrix_id, stable_identity),
+                candidate_screening=candidate_screening,
+            )
+        )
+
+    _validate_comparison_control_refs(planned, errors)
+    if errors:
+        raise CampaignError("; ".join(errors))
+
+    if any(run.queue_target == "lan" for run in planned):
+        caveats.append("lan_queue_target_uses_existing_trusted_lan_worker_configuration")
+
+    return CampaignPlan(
+        campaign_id=campaign_id,
+        title=_optional_string(campaign.get("title")),
+        objective=_optional_string(campaign.get("objective")),
+        protocol=_optional_string(campaign.get("protocol")),
+        commit_report_path=_optional_string(campaign.get("commit_report_path")),
+        matrix_path=str(matrix_path) if matrix_path is not None else None,
+        run_count=len(planned),
+        runs=planned,
+        caveats=caveats,
+    )
+
+
+def plan_campaign(
+    matrix_path: Path,
+    *,
+    allow_absolute_local_paths: bool = False,
+) -> CampaignPlan:
+    matrix = load_campaign_matrix(matrix_path)
+    return build_campaign_plan(
+        matrix,
+        matrix_path=matrix_path,
+        allow_absolute_local_paths=allow_absolute_local_paths,
+    )
+
+
+def package_campaign(
+    matrix_path: Path,
+    *,
+    settings: CloudChamberSettings | None = None,
+    runtime_home: Path | None = None,
+    selected_matrix_ids: set[str] | None = None,
+    resume: bool = False,
+    force_rerun: bool = False,
+    allow_absolute_local_paths: bool = False,
+) -> CampaignOperationResult:
+    resolved_settings = settings or load_settings(home=runtime_home)
+    plan = plan_campaign(matrix_path, allow_absolute_local_paths=allow_absolute_local_paths)
+    state = _load_or_create_state(plan, resolved_settings.runtime_home)
+    scenario = load_scenario_template(DEFAULT_SCENARIO_ID).model_dump(mode="json")
+
+    for run in _selected_runs(plan.runs, selected_matrix_ids):
+        existing = _state_run_for_matrix(state, run.matrix_id)
+        if (
+            resume
+            and existing is not None
+            and existing.stable_resume_identity == run.stable_resume_identity
+            and existing.manifest_path
+            and Path(existing.manifest_path).expanduser().exists()
+            and not force_rerun
+        ):
+            _upsert_state_run(
+                state,
+                existing.model_copy(update={"message": "Resumed existing package."}),
+            )
+            continue
+
+        try:
+            observed = _resolve_observed_sounding(
+                run, settings=resolved_settings, matrix_path=matrix_path
+            )
+            candidate_screening = _candidate_screening_for_package(
+                run,
+                observed=observed,
+                settings=resolved_settings,
+                matrix_path=matrix_path,
+            )
+            result = generate_dry_run_package(
+                scenario_data=scenario,
+                runtime_home=resolved_settings.runtime_home,
+                run_id=run.run_id,
+                observed_sounding=observed,
+                candidate_screening=candidate_screening,
+                user_tags=run.tags,
+                user_notes=run.notes,
+                run_recipe=OBSERVED_SURFACE_FORCED_RECIPE,
+                run_configuration=run.run_configuration,
+                allow_overwrite=force_rerun,
+            )
+        except (CampaignError, DryRunPackageError, ObservedSoundingError, OSError) as exc:
+            _upsert_state_run(
+                state,
+                _new_state_run(
+                    run,
+                    status="package_failed",
+                    package_status="package_failed",
+                    run_status="not_started",
+                    ingest_status="not_started",
+                    error=str(exc),
+                ),
+            )
+            continue
+
+        _upsert_state_run(
+            state,
+            _new_state_run(
+                run,
+                status="packaged",
+                package_status="packaged",
+                run_status="not_started",
+                ingest_status="not_started",
+                manifest_path=str(result.manifest_path),
+                package_dir=str(result.package_dir),
+                message="Dry-run package created.",
+            ),
+        )
+
+    _save_state(state, resolved_settings.runtime_home)
+    return CampaignOperationResult(
+        campaign_id=state.campaign_id,
+        state_path=str(_state_path(resolved_settings.runtime_home, state.campaign_id)),
+        runs=state.runs,
+    )
+
+
+def queue_campaign(
+    matrix_path: Path,
+    *,
+    settings: CloudChamberSettings | None = None,
+    runtime_home: Path | None = None,
+    selected_matrix_ids: set[str] | None = None,
+    resume: bool = True,
+    allow_absolute_local_paths: bool = False,
+    local_queue_factory: Callable[[CloudChamberSettings], LocalRunQueueManager] | None = None,
+    lan_start: Callable[[CloudChamberSettings, Path], dict[str, object]] = start_lan_worker_run,
+) -> CampaignOperationResult:
+    resolved_settings = settings or load_settings(home=runtime_home)
+    plan = plan_campaign(matrix_path, allow_absolute_local_paths=allow_absolute_local_paths)
+    package_campaign(
+        matrix_path,
+        settings=resolved_settings,
+        selected_matrix_ids=selected_matrix_ids,
+        resume=resume,
+        allow_absolute_local_paths=allow_absolute_local_paths,
+    )
+    state = _load_or_create_state(plan, resolved_settings.runtime_home)
+    queue_factory = local_queue_factory or _default_local_queue
+
+    for run in _selected_runs(plan.runs, selected_matrix_ids):
+        state_run = _state_run_for_matrix(state, run.matrix_id)
+        if state_run is None or not state_run.manifest_path:
+            continue
+        manifest_path = Path(state_run.manifest_path).expanduser()
+        try:
+            if run.queue_target == "local":
+                queue_state = queue_factory(resolved_settings).enqueue(manifest_path)
+                entry = next(
+                    (
+                        candidate
+                        for candidate in queue_state.entries
+                        if Path(candidate.manifest_path).expanduser() == manifest_path
+                    ),
+                    None,
+                )
+                status = _queue_entry_to_campaign_status(entry.state if entry else "queued")
+                _upsert_state_run(
+                    state,
+                    state_run.model_copy(
+                        update={
+                            "status": status,
+                            "run_status": status,
+                            "message": entry.message if entry else "Queued for local CM1.",
+                            "error": entry.error if entry else None,
+                            "updated_at": _now(),
+                        }
+                    ),
+                )
+            else:
+                payload = lan_start(resolved_settings, manifest_path)
+                status = _lan_payload_to_campaign_status(payload)
+                _upsert_state_run(
+                    state,
+                    state_run.model_copy(
+                        update={
+                            "status": status,
+                            "run_status": status,
+                            "lan_worker_payload": dict(payload),
+                            "message": _payload_message(payload, "LAN worker run started."),
+                            "error": None,
+                            "updated_at": _now(),
+                        }
+                    ),
+                )
+        except (LocalRunQueueError, LanWorkerApiError, CampaignError) as exc:
+            _upsert_state_run(
+                state,
+                state_run.model_copy(
+                    update={
+                        "status": "run_failed",
+                        "run_status": "run_failed",
+                        "error": str(exc),
+                        "updated_at": _now(),
+                    }
+                ),
+            )
+
+    _save_state(state, resolved_settings.runtime_home)
+    return CampaignOperationResult(
+        campaign_id=state.campaign_id,
+        state_path=str(_state_path(resolved_settings.runtime_home, state.campaign_id)),
+        runs=state.runs,
+    )
+
+
+def status_campaign(
+    matrix_path: Path,
+    *,
+    settings: CloudChamberSettings | None = None,
+    runtime_home: Path | None = None,
+    allow_absolute_local_paths: bool = False,
+) -> CampaignOperationResult:
+    resolved_settings = settings or load_settings(home=runtime_home)
+    plan = plan_campaign(matrix_path, allow_absolute_local_paths=allow_absolute_local_paths)
+    state = _load_or_create_state(plan, resolved_settings.runtime_home)
+    queue_entries = _read_queue_entries(resolved_settings.runtime_home)
+
+    for run in plan.runs:
+        state_run = _state_run_for_matrix(state, run.matrix_id)
+        if state_run is None:
+            _upsert_state_run(
+                state,
+                _new_state_run(
+                    run,
+                    status="planned",
+                    package_status="planned",
+                    run_status="planned",
+                    ingest_status="not_started",
+                ),
+            )
+            continue
+        _upsert_state_run(
+            state,
+            _state_run_with_runtime_status(state_run, queue_entries=queue_entries),
+        )
+
+    _save_state(state, resolved_settings.runtime_home)
+    return CampaignOperationResult(
+        campaign_id=state.campaign_id,
+        state_path=str(_state_path(resolved_settings.runtime_home, state.campaign_id)),
+        runs=state.runs,
+    )
+
+
+def ingest_campaign(
+    matrix_path: Path,
+    *,
+    settings: CloudChamberSettings | None = None,
+    runtime_home: Path | None = None,
+    selected_matrix_ids: set[str] | None = None,
+    allow_absolute_local_paths: bool = False,
+    lan_collect: Callable[[CloudChamberSettings, Path], dict[str, object]] = collect_lan_worker_run,
+) -> CampaignOperationResult:
+    resolved_settings = settings or load_settings(home=runtime_home)
+    status_campaign(
+        matrix_path,
+        settings=resolved_settings,
+        allow_absolute_local_paths=allow_absolute_local_paths,
+    )
+    plan = plan_campaign(matrix_path, allow_absolute_local_paths=allow_absolute_local_paths)
+    state = _load_or_create_state(plan, resolved_settings.runtime_home)
+
+    for run in _selected_runs(plan.runs, selected_matrix_ids):
+        state_run = _state_run_for_matrix(state, run.matrix_id)
+        if state_run is None or not state_run.manifest_path:
+            continue
+        manifest_path = Path(state_run.manifest_path).expanduser()
+        try:
+            if run.queue_target == "lan" and state_run.status in {"running", "queued"}:
+                payload = lan_collect(resolved_settings, manifest_path)
+                state_run = state_run.model_copy(
+                    update={
+                        "lan_worker_payload": dict(payload),
+                        "message": _payload_message(payload, "LAN worker output collected."),
+                        "updated_at": _now(),
+                    }
+                )
+            existing_result = _load_result_for_manifest_path(manifest_path)
+            if existing_result is not None:
+                _upsert_state_run(
+                    state,
+                    state_run.model_copy(
+                        update={
+                            "status": "ingested",
+                            "ingest_status": "ingested",
+                            "result_id": existing_result.result_id,
+                            "error": None,
+                            "updated_at": _now(),
+                        }
+                    ),
+                )
+                continue
+            result = ingest_completed_run(manifest_path)
+        except (ResultIngestError, LanWorkerApiError, OSError) as exc:
+            _upsert_state_run(
+                state,
+                state_run.model_copy(
+                    update={
+                        "status": "ingest_failed",
+                        "ingest_status": "ingest_failed",
+                        "error": str(exc),
+                        "updated_at": _now(),
+                    }
+                ),
+            )
+            continue
+        _upsert_state_run(
+            state,
+            state_run.model_copy(
+                update={
+                    "status": "ingested",
+                    "ingest_status": "ingested",
+                    "result_id": result.result_id,
+                    "error": None,
+                    "message": "Completed CM1 output ingested.",
+                    "updated_at": _now(),
+                }
+            ),
+        )
+
+    _save_state(state, resolved_settings.runtime_home)
+    return CampaignOperationResult(
+        campaign_id=state.campaign_id,
+        state_path=str(_state_path(resolved_settings.runtime_home, state.campaign_id)),
+        runs=state.runs,
+    )
+
+
+def report_campaign(
+    matrix_path: Path,
+    *,
+    settings: CloudChamberSettings | None = None,
+    runtime_home: Path | None = None,
+    report_path: Path | None = None,
+    summary_json_path: Path | None = None,
+    allow_absolute_local_paths: bool = False,
+) -> CampaignReportArtifacts:
+    resolved_settings = settings or load_settings(home=runtime_home)
+    status_campaign(
+        matrix_path,
+        settings=resolved_settings,
+        allow_absolute_local_paths=allow_absolute_local_paths,
+    )
+    plan = plan_campaign(matrix_path, allow_absolute_local_paths=allow_absolute_local_paths)
+    state = _load_or_create_state(plan, resolved_settings.runtime_home)
+    summaries = [_summary_for_plan_run(run, state) for run in plan.runs]
+    summary = {
+        "schema_version": CAMPAIGN_SUMMARY_SCHEMA_VERSION,
+        "campaign_id": plan.campaign_id,
+        "title": plan.title,
+        "objective": plan.objective,
+        "protocol": plan.protocol,
+        "matrix_path": str(matrix_path),
+        "generated_at": _now().isoformat(),
+        "run_count": len(summaries),
+        "status_counts": _status_counts(summaries),
+        "phase_gate_state": _phase_gate_state(summaries),
+        "runs": summaries,
+        "unavailable_diagnostics": _unavailable_diagnostics(summaries),
+        "preliminary_diagnosis_categories": _preliminary_diagnosis_categories(summaries),
+        "recommended_follow_ups": _recommended_follow_ups(summaries),
+    }
+
+    markdown_path = report_path or _default_report_path(plan)
+    if not markdown_path.is_absolute():
+        markdown_path = Path.cwd() / markdown_path
+    json_path = summary_json_path or (
+        resolved_settings.runtime_home.expanduser()
+        / "campaigns"
+        / plan.campaign_id
+        / "campaign-summary.json"
+    )
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.write_text(_render_markdown_report(plan, summary))
+    json_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    return CampaignReportArtifacts(
+        markdown_path=str(markdown_path),
+        summary_json_path=str(json_path),
+        summary=summary,
+    )
+
+
+def _validate_selection_source(
+    selection: Mapping[str, Any],
+    *,
+    context: str,
+    matrix_base: Path,
+    allow_absolute_local_paths: bool,
+    errors: list[str],
+) -> dict[str, Any]:
+    source = _mapping(selection.get("source"), context, errors)
+    source_type = source.get("type")
+    if source_type not in {"saved_candidate", "cached_recommendation", "uploaded_or_local_igra"}:
+        errors.append(
+            f"{context}.type must be saved_candidate, cached_recommendation, "
+            "or uploaded_or_local_igra"
+        )
+        return dict(source)
+    if source_type == "saved_candidate" and not _optional_string(source.get("saved_candidate_id")):
+        errors.append(f"{context}.saved_candidate_id is required")
+    if source_type == "cached_recommendation" and not _optional_string(source.get("candidate_id")):
+        errors.append(f"{context}.candidate_id is required")
+    if source_type == "uploaded_or_local_igra":
+        local_text_path = _optional_string(source.get("local_text_path"))
+        runtime_file_ref = _optional_string(source.get("runtime_file_ref"))
+        if bool(local_text_path) == bool(runtime_file_ref):
+            errors.append(
+                f"{context} must specify exactly one of local_text_path or runtime_file_ref"
+            )
+        if not _optional_string(source.get("selected_valid_time_utc")):
+            errors.append(f"{context}.selected_valid_time_utc is required")
+        if local_text_path:
+            configured_path = Path(local_text_path).expanduser()
+            if configured_path.is_absolute() and not allow_absolute_local_paths:
+                errors.append(
+                    f"{context}.local_text_path is absolute; pass --allow-absolute-local-paths "
+                    "for local-only matrices and do not commit machine-private paths"
+                )
+    return dict(source)
+
+
+def _resolved_run_configuration_payload(
+    *,
+    defaults: Mapping[str, Any],
+    forcing: Mapping[str, Any],
+    run: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for source in (defaults, forcing, run):
+        for key in RUN_CONFIGURATION_KEYS:
+            if key in source:
+                payload[key] = source[key]
+    payload["diagnostic_set"] = "full"
+    return payload
+
+
+def _stable_resume_identity(
+    *,
+    campaign_id: str,
+    matrix_id: str,
+    selection_id: str,
+    selection_source_reference: str,
+    run_configuration: Mapping[str, Any],
+    forcing_id: str | None,
+) -> str:
+    payload = {
+        "campaign_id": campaign_id,
+        "matrix_id": matrix_id,
+        "selection_id": selection_id,
+        "selection_source_reference": selection_source_reference,
+        "forcing_id": forcing_id,
+        "run_configuration": run_configuration,
+    }
+    text = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _run_id(campaign_id: str, matrix_id: str, stable_identity: str) -> str:
+    raw = f"{campaign_id}-{matrix_id}-{stable_identity[:10]}"
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", raw).strip("-")
+    return cleaned[:112] or f"campaign-run-{stable_identity[:10]}"
+
+
+def _selection_source_reference(source: Mapping[str, Any]) -> str:
+    source_type = source.get("type")
+    if source_type == "saved_candidate":
+        return str(source.get("saved_candidate_id"))
+    if source_type == "cached_recommendation":
+        parts = [str(source.get("candidate_id"))]
+        if source.get("station_id"):
+            parts.append(str(source.get("station_id")))
+        if source.get("valid_time_utc"):
+            parts.append(str(source.get("valid_time_utc")))
+        return "|".join(parts)
+    if source_type == "uploaded_or_local_igra":
+        return str(source.get("local_text_path") or source.get("runtime_file_ref"))
+    return "unknown"
+
+
+def _candidate_screening_from_matrix(
+    selection: Mapping[str, Any],
+    source: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    payload = selection.get("candidate_screening")
+    if isinstance(payload, dict):
+        return dict(payload)
+    criteria = selection.get("selection_criteria")
+    if not isinstance(criteria, dict):
+        return None
+    preferred_story = _optional_string(criteria.get("preferred_story"))
+    if preferred_story is None:
+        return None
+    return {
+        "candidate_id": source.get("candidate_id"),
+        "primary_story": preferred_story,
+        "primary_story_label": preferred_story.replace("_", " ").title(),
+        "story_family": "deep_convection"
+        if preferred_story
+        in {
+            "severe_thunderstorm_environment",
+            "supercell_environment",
+            "high_cape_pulse_storm",
+            "dry_microburst_inverted_v",
+            "squall_line_cold_pool_candidate",
+            "elevated_convection",
+        }
+        else "lower_atmosphere",
+        "rank_score": criteria.get("score_0_to_100"),
+        "evidence": criteria.get("desired_properties") or [],
+        "caveats": ["campaign_matrix_selection_criteria_not_recomputed"],
+    }
+
+
+def _candidate_screening_for_package(
+    run: CampaignRunPlan,
+    *,
+    observed: ObservedSoundingRecord,
+    settings: CloudChamberSettings,
+    matrix_path: Path,
+) -> dict[str, Any] | None:
+    if run.candidate_screening is not None:
+        return run.candidate_screening
+    candidate = _candidate_for_source(run, settings=settings, matrix_path=matrix_path)
+    if candidate is not None:
+        return candidate.model_dump(mode="json")
+    return {
+        "candidate_id": run.selection_source_reference,
+        "station_id": observed.station_id,
+        "station_name": observed.station_name,
+        "valid_time_utc": observed.valid_time_utc.isoformat(),
+        "primary_story": "needs_review",
+        "primary_story_label": "Campaign-selected observed sounding",
+        "story_family": "review",
+        "rank_score": None,
+        "evidence": [],
+        "caveats": ["campaign_source_has_no_cached_screening_payload"],
+    }
+
+
+def _resolve_observed_sounding(
+    run: CampaignRunPlan,
+    *,
+    settings: CloudChamberSettings,
+    matrix_path: Path,
+) -> ObservedSoundingRecord:
+    source = _source_from_plan(run, matrix_path)
+    source_type = source.get("type")
+    if source_type == "saved_candidate":
+        saved = _saved_candidate(settings, str(source.get("saved_candidate_id")))
+        if saved.selected_sounding_payload is None:
+            raise CampaignError(
+                f"Saved candidate {saved.saved_candidate_id} has no selected sounding payload"
+            )
+        return observed_sounding_from_payload(saved.selected_sounding_payload)
+    if source_type == "cached_recommendation":
+        candidate = _candidate_for_source(run, settings=settings, matrix_path=matrix_path)
+        if candidate is None or candidate.selected_sounding_payload is None:
+            raise CampaignError(
+                f"Cached recommendation {source.get('candidate_id')} could not be resolved "
+                "to a package-ready observed sounding"
+            )
+        return observed_sounding_from_payload(candidate.selected_sounding_payload)
+    if source_type == "uploaded_or_local_igra":
+        text_path = _local_igra_text_path(source, matrix_path)
+        selected_time = _parse_utc_datetime(str(source.get("selected_valid_time_utc")))
+        return parse_igra_station_text(
+            text_path.read_text(),
+            uploaded_filename=text_path.name,
+            selected_time_utc=selected_time,
+        ).selected_sounding
+    raise CampaignError(f"Unsupported selection source type: {source_type}")
+
+
+def _candidate_for_source(
+    run: CampaignRunPlan,
+    *,
+    settings: CloudChamberSettings,
+    matrix_path: Path,
+) -> SoundingCandidate | None:
+    source = _source_from_plan(run, matrix_path)
+    if source.get("type") == "saved_candidate":
+        saved = _saved_candidate(settings, str(source.get("saved_candidate_id")))
+        return saved.candidate
+    if source.get("type") != "cached_recommendation":
+        return None
+
+    payload = source.get("selected_sounding_payload") or source.get("observed_sounding_payload")
+    if isinstance(payload, dict):
+        observed = observed_sounding_from_payload(payload)
+        return SoundingCandidate(
+            candidate_id=str(source.get("candidate_id")),
+            station_id=observed.station_id,
+            station_name=observed.station_name,
+            station_latitude=observed.station_latitude,
+            station_longitude=observed.station_longitude,
+            station_elevation_m_msl=observed.station_elevation_m_msl,
+            valid_time_utc=observed.valid_time_utc,
+            source_time_text=observed.source_time_text,
+            source_file_name=observed.uploaded_filename,
+            source_file_hash="campaign-matrix-payload",
+            primary_story="needs_review",
+            primary_story_label="Campaign-supplied cached recommendation",
+            story_family="review",
+            story_scores=[],
+            rank_score=0.0,
+            confidence="low",
+            package_ready=True,
+            features={},
+            evidence=[],
+            caveats=["campaign_matrix_embedded_selected_sounding_payload"],
+            selected_sounding_payload=observed.model_dump(mode="json"),
+            created_at=_now(),
+        )
+
+    station_id = _optional_string(source.get("station_id"))
+    valid_time = _optional_string(source.get("valid_time_utc"))
+    if station_id and valid_time:
+        selected_time = _parse_utc_datetime(valid_time)
+        for screening_input in list_screening_inputs(settings):
+            if screening_input.station_id != station_id:
+                continue
+            text_path = Path(screening_input.cached_text_path).expanduser()
+            observed = parse_igra_station_text(
+                text_path.read_text(),
+                uploaded_filename=text_path.name,
+                selected_time_utc=selected_time,
+            ).selected_sounding
+            screened = screen_cached_soundings(
+                settings,
+                station_id=station_id,
+                latest_per_station=int(source.get("latest_per_station", 50)),
+                limit=10_000,
+            )
+            matching = next(
+                (
+                    candidate
+                    for candidate in screened.candidates
+                    if candidate.valid_time_utc == selected_time
+                ),
+                None,
+            )
+            if matching is not None:
+                return matching
+            return SoundingCandidate(
+                candidate_id=str(source.get("candidate_id")),
+                station_id=observed.station_id,
+                station_name=observed.station_name,
+                station_latitude=observed.station_latitude,
+                station_longitude=observed.station_longitude,
+                station_elevation_m_msl=observed.station_elevation_m_msl,
+                valid_time_utc=observed.valid_time_utc,
+                source_time_text=observed.source_time_text,
+                source_file_name=observed.uploaded_filename,
+                source_file_hash="campaign-cache-resolution",
+                primary_story="needs_review",
+                primary_story_label="Campaign-selected cached sounding",
+                story_family="review",
+                story_scores=[],
+                rank_score=0.0,
+                confidence="low",
+                package_ready=True,
+                features={},
+                evidence=[],
+                caveats=["cached_recommendation_resolved_by_station_time_without_screening_match"],
+                selected_sounding_payload=observed.model_dump(mode="json"),
+                created_at=_now(),
+            )
+
+    screened = screen_cached_soundings(
+        settings,
+        latest_per_station=int(source.get("latest_per_station", 50)),
+        limit=10_000,
+    )
+    candidate_id = str(source.get("candidate_id"))
+    return next(
+        (candidate for candidate in screened.candidates if candidate.candidate_id == candidate_id),
+        None,
+    )
+
+
+def _source_from_plan(run: CampaignRunPlan, matrix_path: Path) -> dict[str, Any]:
+    matrix = load_campaign_matrix(matrix_path)
+    selection_sets = _indexed_mappings(
+        matrix.get("selection_sets", []),
+        key="selection_id",
+        label="selection_sets",
+        errors=[],
+    )
+    selection = selection_sets.get(run.selection_id)
+    if selection is None or not isinstance(selection.get("source"), dict):
+        raise CampaignError(f"Selection not found in matrix: {run.selection_id}")
+    return dict(selection["source"])
+
+
+def _saved_candidate(
+    settings: CloudChamberSettings, saved_candidate_id: str
+) -> SavedSoundingCandidate:
+    for candidate in list_saved_candidates(settings):
+        if candidate.saved_candidate_id == saved_candidate_id:
+            return candidate
+    raise CampaignError(f"Saved candidate not found: {saved_candidate_id}")
+
+
+def _local_igra_text_path(source: Mapping[str, Any], matrix_path: Path) -> Path:
+    configured = _optional_string(source.get("local_text_path")) or _optional_string(
+        source.get("runtime_file_ref")
+    )
+    if configured is None:
+        raise CampaignError("uploaded_or_local_igra source is missing a text path")
+    return _resolve_matrix_path(configured, matrix_path.parent)
+
+
+def _resolve_matrix_path(value: str, matrix_base: Path) -> Path:
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return path
+    return (matrix_base / path).resolve()
+
+
+def _load_or_create_state(plan: CampaignPlan, runtime_home: Path) -> CampaignState:
+    path = _state_path(runtime_home, plan.campaign_id)
+    if path.exists():
+        try:
+            return CampaignState.model_validate_json(path.read_text())
+        except ValueError as exc:
+            raise CampaignError(f"Campaign state is unreadable: {path}: {exc}") from exc
+    return CampaignState(
+        schema_version=CAMPAIGN_STATE_SCHEMA_VERSION,
+        campaign_id=plan.campaign_id,
+        matrix_path=plan.matrix_path,
+        updated_at=_now(),
+        runs=[],
+    )
+
+
+def _save_state(state: CampaignState, runtime_home: Path) -> None:
+    updated = state.model_copy(update={"updated_at": _now()})
+    path = _state_path(runtime_home, updated.campaign_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(updated.model_dump_json(indent=2) + "\n")
+
+
+def _state_path(runtime_home: Path, campaign_id: str) -> Path:
+    return runtime_home.expanduser() / "campaigns" / campaign_id / "campaign-state.json"
+
+
+def _new_state_run(
+    run: CampaignRunPlan,
+    *,
+    status: str,
+    package_status: str,
+    run_status: str,
+    ingest_status: str,
+    manifest_path: str | None = None,
+    package_dir: str | None = None,
+    result_id: str | None = None,
+    error: str | None = None,
+    message: str | None = None,
+) -> CampaignStateRun:
+    if status not in KNOWN_STATUS_VALUES:
+        raise CampaignError(f"Unknown campaign status: {status}")
+    return CampaignStateRun(
+        matrix_id=run.matrix_id,
+        stable_resume_identity=run.stable_resume_identity,
+        run_id=run.run_id,
+        queue_target=run.queue_target,
+        status=status,
+        package_status=package_status,
+        run_status=run_status,
+        ingest_status=ingest_status,
+        manifest_path=manifest_path,
+        package_dir=package_dir,
+        result_id=result_id,
+        error=error,
+        message=message,
+        updated_at=_now(),
+    )
+
+
+def _upsert_state_run(state: CampaignState, run: CampaignStateRun) -> None:
+    state.runs = [existing for existing in state.runs if existing.matrix_id != run.matrix_id]
+    state.runs.append(run)
+    state.runs.sort(key=lambda item: item.matrix_id)
+
+
+def _state_run_for_matrix(state: CampaignState, matrix_id: str) -> CampaignStateRun | None:
+    return next((run for run in state.runs if run.matrix_id == matrix_id), None)
+
+
+def _selected_runs(
+    runs: Sequence[CampaignRunPlan],
+    selected_matrix_ids: set[str] | None,
+) -> list[CampaignRunPlan]:
+    if selected_matrix_ids is None:
+        return list(runs)
+    return [run for run in runs if run.matrix_id in selected_matrix_ids]
+
+
+def _default_local_queue(settings: CloudChamberSettings) -> LocalRunQueueManager:
+    return LocalRunQueueManager(
+        settings=settings,
+        run_manager=LocalRunManager(settings=settings),
+    )
+
+
+def _state_run_with_runtime_status(
+    state_run: CampaignStateRun,
+    *,
+    queue_entries: Mapping[str, Mapping[str, Any]],
+) -> CampaignStateRun:
+    if not state_run.manifest_path:
+        return state_run
+    manifest_path = Path(state_run.manifest_path).expanduser()
+    if not manifest_path.exists():
+        return state_run.model_copy(
+            update={
+                "status": "blocked",
+                "run_status": "blocked",
+                "error": f"Manifest path no longer exists: {manifest_path}",
+                "updated_at": _now(),
+            }
+        )
+    manifest = load_run_manifest(manifest_path)
+    queue_entry = queue_entries.get(str(manifest_path))
+    status = _manifest_to_campaign_status(manifest)
+    message = state_run.message
+    error = state_run.error
+    result_id = state_run.result_id
+    if queue_entry is not None:
+        status = _queue_entry_to_campaign_status(str(queue_entry.get("state")))
+        message = _optional_string(queue_entry.get("message")) or message
+        error = _optional_string(queue_entry.get("error")) or error
+        result_id = _optional_string(queue_entry.get("result_id")) or result_id
+    result = _load_result_for_manifest_path(manifest_path)
+    if result is not None:
+        status = "ingested"
+        result_id = result.result_id
+    return state_run.model_copy(
+        update={
+            "status": status,
+            "package_status": "packaged",
+            "run_status": status if status not in {"ingested"} else "completed_not_ingested",
+            "ingest_status": "ingested" if status == "ingested" else state_run.ingest_status,
+            "result_id": result_id,
+            "message": message,
+            "error": error,
+            "updated_at": _now(),
+        }
+    )
+
+
+def _manifest_to_campaign_status(manifest: Any) -> str:
+    if manifest.lifecycle_state == LifecycleState.PACKAGED:
+        return "packaged"
+    if manifest.lifecycle_state == LifecycleState.QUEUED:
+        return "queued"
+    if manifest.lifecycle_state == LifecycleState.RUNNING:
+        return "running"
+    if manifest.lifecycle_state == LifecycleState.COMPLETED:
+        if manifest.provenance.product_state == ProductState.COMPLETED_CM1_RESULT:
+            return "completed_not_ingested"
+        return "run_failed"
+    if manifest.lifecycle_state == LifecycleState.FAILED:
+        return "run_failed"
+    if manifest.lifecycle_state == LifecycleState.CANCELED:
+        return "run_canceled"
+    if manifest.lifecycle_state == LifecycleState.INGESTED:
+        return "ingested"
+    return "blocked"
+
+
+def _queue_entry_to_campaign_status(state: str) -> str:
+    mapping = {
+        "queued": "queued",
+        "running": "running",
+        "ingested": "ingested",
+        "ingest_failed": "ingest_failed",
+        "completed_no_output": "run_failed",
+        "failed": "run_failed",
+        "canceled": "run_canceled",
+        "launch_failed": "run_failed",
+    }
+    return mapping.get(state, "blocked")
+
+
+def _lan_payload_to_campaign_status(payload: Mapping[str, Any]) -> str:
+    state = str(payload.get("state", "running"))
+    if state in {"running", "started"}:
+        return "running"
+    if state in {"queued"}:
+        return "queued"
+    if state in {"ready_for_local_ingest", "completed", "complete"}:
+        return "completed_not_ingested"
+    if state in {"failed", "error"}:
+        return "run_failed"
+    return "running"
+
+
+def _read_queue_entries(runtime_home: Path) -> dict[str, dict[str, Any]]:
+    path = runtime_home.expanduser() / "run-queue.json"
+    if not path.exists():
+        return {}
+    try:
+        loaded = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    entries = loaded.get("entries") if isinstance(loaded, dict) else None
+    if not isinstance(entries, list):
+        return {}
+    indexed: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        manifest_path = _optional_string(entry.get("manifest_path"))
+        if manifest_path:
+            indexed[manifest_path] = dict(entry)
+    return indexed
+
+
+def _load_result_for_manifest_path(manifest_path: Path) -> ResultMetadata | None:
+    path = manifest_path.parent / RESULT_METADATA_FILENAME
+    if not path.exists():
+        return None
+    try:
+        return result_metadata_from_json(path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[str, Any]:
+    state_run = _state_run_for_matrix(state, run.matrix_id)
+    manifest = None
+    result = None
+    if state_run is not None and state_run.manifest_path:
+        manifest_path = Path(state_run.manifest_path).expanduser()
+        if manifest_path.exists():
+            manifest = load_run_manifest(manifest_path)
+            result = _load_result_for_manifest_path(manifest_path)
+    observed = manifest.observed_sounding if manifest is not None else None
+    diagnostics = result.diagnostics if result is not None else None
+    variables = set(result.variables) if result is not None else set()
+    missing_fields = (
+        result.missing_required_output_fields
+        if result is not None
+        else ["unavailable_until_result_ingested"]
+    )
+    candidate = manifest.candidate_screening if manifest is not None else run.candidate_screening
+    return {
+        "campaign_id": run.campaign_id,
+        "matrix_id": run.matrix_id,
+        "phase": run.phase,
+        "stable_resume_identity": run.stable_resume_identity,
+        "run_id": state_run.run_id if state_run else run.run_id,
+        "result_id": (
+            result.result_id if result is not None else state_run.result_id if state_run else None
+        ),
+        "status": state_run.status if state_run else "planned",
+        "package_status": state_run.package_status if state_run else "planned",
+        "run_status": state_run.run_status if state_run else "planned",
+        "ingest_status": state_run.ingest_status if state_run else "not_started",
+        "queue_target": run.queue_target,
+        "station_id": _mapping_value(observed, "station_id"),
+        "station_name": _mapping_value(observed, "station_name"),
+        "valid_time_utc": _mapping_value(observed, "valid_time_utc"),
+        "selection_id": run.selection_id,
+        "selection_source_type": run.selection_source_type,
+        "selection_source_reference": run.selection_source_reference,
+        "candidate_id": _mapping_value(candidate, "candidate_id"),
+        "candidate_story": _mapping_value(candidate, "primary_story"),
+        "candidate_score": _mapping_value(candidate, "rank_score"),
+        "candidate_evidence": _candidate_evidence(candidate),
+        "candidate_caveats": _list_from_mapping(candidate, "caveats"),
+        "surface_heat_flux_k_m_s": run.run_configuration["surface_heat_flux_k_m_s"],
+        "surface_heat_flux_units": "K m/s",
+        "surface_moisture_flux_g_g_m_s": run.run_configuration["surface_moisture_flux_g_g_m_s"],
+        "surface_moisture_flux_units": "g/g m/s",
+        "cm1_cnst_shflx": run.surface_flux_cm1_values.get("cnst_shflx"),
+        "cm1_cnst_shflx_units": run.surface_flux_cm1_values.get("cnst_shflx_units"),
+        "cm1_cnst_lhflx": run.surface_flux_cm1_values.get("cnst_lhflx"),
+        "cm1_cnst_lhflx_units": run.surface_flux_cm1_values.get("cnst_lhflx_units"),
+        "duration": run.run_configuration["duration"],
+        "duration_seconds": run.resolved_run_configuration["duration_seconds"],
+        "domain_size": run.run_configuration["domain_size"],
+        "horizontal_cell_count": run.resolved_run_configuration["horizontal_cell_count"],
+        "nx": run.cm1_values.get("nx"),
+        "ny": run.cm1_values.get("ny"),
+        "nz": run.cm1_values.get("nz"),
+        "dx_m": run.cm1_values.get("dx_m"),
+        "dy_m": run.cm1_values.get("dy_m"),
+        "dz_m": run.cm1_values.get("dz_m"),
+        "model_top_m": run.cm1_values.get("model_top_m"),
+        "output_cadence": run.run_configuration["output_cadence"],
+        "expected_output_frames": run.cm1_values.get("expected_output_frames"),
+        "expected_output_volume": run.resolved_run_configuration.get("output_volume_summary"),
+        "required_output_fields": manifest.required_output_fields if manifest is not None else [],
+        "missing_output_fields": missing_fields,
+        "diagnostic_support": _diagnostic_support(result),
+        "hfx_present": "hfx" in variables,
+        "hfx_units": _field_units(result, "hfx"),
+        "lhfx_present": "lhfx" in variables,
+        "lhfx_units": _field_units(result, "lhfx"),
+        "low_level_qv_response": "unavailable",
+        "low_level_qv_response_method": "low_level_response_diagnostic_not_implemented",
+        "low_level_theta_or_temperature_response": "unavailable",
+        "low_level_theta_or_temperature_response_method": (
+            "low_level_response_diagnostic_not_implemented"
+        ),
+        "first_cloud_time": (
+            diagnostics.cloud.first_cloud_time_seconds if diagnostics is not None else None
+        ),
+        "max_cloud_top_m": diagnostics.cloud.cloud_top_m if diagnostics is not None else None,
+        "max_qc": diagnostics.cloud.max_qc_kg_kg if diagnostics is not None else None,
+        "max_qc_time": (
+            diagnostics.cloud.time_of_max_qc_seconds if diagnostics is not None else None
+        ),
+        "max_w_m_s": (diagnostics.vertical_velocity.max_w_m_s if diagnostics is not None else None),
+        "max_w_time": (
+            diagnostics.vertical_velocity.time_of_max_w_seconds if diagnostics is not None else None
+        ),
+        "qr_present": diagnostics.rain.present if diagnostics is not None else None,
+        "surface_rain_present": (
+            diagnostics.surface_rain.present if diagnostics is not None else None
+        ),
+        "surface_rain_max": (
+            diagnostics.surface_rain.max_surface_rain if diagnostics is not None else None
+        ),
+        "surface_rain_units": (diagnostics.surface_rain.units if diagnostics is not None else None),
+        "dbz_present": (
+            diagnostics.reflectivity.max_dbz is not None if diagnostics is not None else None
+        ),
+        "max_dbz": diagnostics.reflectivity.max_dbz if diagnostics is not None else None,
+        "first_deep_cloud_time": "unavailable",
+        "warnings": result.warnings if result is not None else [],
+        "caveats": _summary_caveats(run, state_run, result),
+        "error": state_run.error if state_run else None,
+    }
+
+
+def _diagnostic_support(result: ResultMetadata | None) -> dict[str, str]:
+    if result is None or result.diagnostics is None:
+        return {
+            "surface_fluxes": "unavailable_until_result_ingested",
+            "low_level_response": "unavailable",
+            "cloud": "unavailable",
+            "vertical_velocity": "unavailable",
+            "rain_water_aloft": "unavailable",
+            "surface_rain": "unavailable",
+            "reflectivity": "unavailable",
+        }
+    diagnostics = result.diagnostics
+    return {
+        "surface_fluxes": "available" if {"hfx", "lhfx"} <= set(result.variables) else "missing",
+        "low_level_response": "unavailable",
+        "cloud": "available" if diagnostics.cloud.available else "missing",
+        "vertical_velocity": "available" if diagnostics.vertical_velocity.available else "missing",
+        "rain_water_aloft": "available" if diagnostics.rain.available else "missing",
+        "surface_rain": "available" if diagnostics.surface_rain.available else "missing",
+        "reflectivity": "available" if diagnostics.reflectivity.available else "missing",
+    }
+
+
+def _field_units(result: ResultMetadata | None, field_name: str) -> str | None:
+    if result is None:
+        return None
+    return next((field.units for field in result.fields_detected if field.name == field_name), None)
+
+
+def _summary_caveats(
+    run: CampaignRunPlan,
+    state_run: CampaignStateRun | None,
+    result: ResultMetadata | None,
+) -> list[str]:
+    caveats = [
+        "surface_forcing_is_constant_uniform_proxy",
+        "low_level_response_diagnostic_not_implemented",
+    ]
+    if run.optional:
+        caveats.append("optional_campaign_run")
+    if state_run is not None and state_run.error:
+        caveats.append("campaign_run_has_error")
+    if result is None:
+        caveats.append("result_not_ingested")
+    else:
+        caveats.extend(result.run_caveats)
+        caveats.extend(result.interesting_time_caveats)
+    return _dedupe(caveats)
+
+
+def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> str:
+    lines = [
+        f"# Surface-Forced Campaign Report: {plan.campaign_id}",
+        "",
+        f"Campaign ID: `{plan.campaign_id}`",
+        f"Protocol: `{plan.protocol or 'not specified'}`",
+        f"Matrix: `{summary['matrix_path']}`",
+        f"Generated: `{summary['generated_at']}`",
+        "",
+        "## Objective",
+        "",
+        plan.objective or "No objective supplied in the campaign matrix.",
+        "",
+        "## Matrix Summary",
+        "",
+        f"- Runs planned: {summary['run_count']}",
+        f"- Status counts: `{json.dumps(summary['status_counts'], sort_keys=True)}`",
+        f"- Phase gate state: `{summary['phase_gate_state']}`",
+        "",
+        "## Run Table",
+        "",
+        "| Matrix ID | Status | Station/time | Forcing | Grid/domain | Key result |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for run in summary["runs"]:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(run["matrix_id"]),
+                    str(run["status"]),
+                    _station_time_label(run),
+                    _forcing_label(run),
+                    _grid_label(run),
+                    _key_result_label(run),
+                ]
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Per-Run Evidence",
+            "",
+        ]
+    )
+    for run in summary["runs"]:
+        required_fields = ", ".join(run["required_output_fields"]) or "unavailable"
+        missing_fields = ", ".join(run["missing_output_fields"]) or "none"
+        cloud_updraft = (
+            f"first cloud `{_fmt(run['first_cloud_time'])}`, "
+            f"max cloud top `{_fmt(run['max_cloud_top_m'])}`, "
+            f"max qc `{_fmt(run['max_qc'])}`, "
+            f"max w `{_fmt(run['max_w_m_s'])}`"
+        )
+        precipitation = (
+            f"qr `{run['qr_present']}`, "
+            f"surface rain `{run['surface_rain_present']}`, "
+            f"max dBZ `{_fmt(run['max_dbz'])}`"
+        )
+        lines.extend(
+            [
+                f"### {run['matrix_id']}",
+                "",
+                f"- Run ID: `{run['run_id']}`",
+                f"- Result ID: `{run['result_id'] or 'not ingested'}`",
+                f"- Source: `{run['selection_source_type']}` `{run['selection_source_reference']}`",
+                f"- Candidate story: `{run['candidate_story'] or 'unavailable'}`",
+                f"- Required/missing fields: `{required_fields}` / `{missing_fields}`",
+                f"- Surface flux fields: hfx `{run['hfx_present']}`, lhfx `{run['lhfx_present']}`",
+                f"- Cloud/updraft: {cloud_updraft}",
+                f"- Precipitation/reflectivity: {precipitation}",
+                f"- Low-level response: `{run['low_level_qv_response_method']}`",
+                f"- Caveats: `{', '.join(run['caveats']) or 'none'}`",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "## Forcing Response",
+            "",
+            _forcing_response_summary(summary),
+            "",
+            "## Deepening And Class Differences",
+            "",
+            _deepening_summary(summary),
+            "",
+            "## Unavailable Or Missing Diagnostics",
+            "",
+        ]
+    )
+    for item in summary["unavailable_diagnostics"]:
+        lines.append(f"- {item}")
+    lines.extend(
+        [
+            "",
+            "## Preliminary Diagnosis Categories",
+            "",
+        ]
+    )
+    for item in summary["preliminary_diagnosis_categories"]:
+        lines.append(f"- {item}")
+    lines.extend(
+        [
+            "",
+            "## Recommended Follow-Up Issues",
+            "",
+        ]
+    )
+    for item in summary["recommended_follow_ups"]:
+        lines.append(f"- {item}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _status_counts(summaries: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for summary in summaries:
+        status = str(summary.get("status") or "planned")
+        counts[status] = counts.get(status, 0) + 1
+    return counts
+
+
+def _phase_gate_state(summaries: Sequence[Mapping[str, Any]]) -> str:
+    ingested = [summary for summary in summaries if summary.get("status") == "ingested"]
+    if not ingested:
+        return "inconclusive_missing_evidence"
+    if not all(summary.get("hfx_present") and summary.get("lhfx_present") for summary in ingested):
+        return "forcing_wiring_not_verified"
+    return "forcing_wiring_verified_but_response_not_verified"
+
+
+def _unavailable_diagnostics(summaries: Sequence[Mapping[str, Any]]) -> list[str]:
+    unavailable: set[str] = set()
+    for summary in summaries:
+        for field in summary.get("missing_output_fields", []):
+            unavailable.add(f"missing_output_field:{field}")
+        if summary.get("low_level_qv_response") == "unavailable":
+            unavailable.add("low_level_qv_response")
+        if summary.get("low_level_theta_or_temperature_response") == "unavailable":
+            unavailable.add("low_level_theta_or_temperature_response")
+    return sorted(unavailable)
+
+
+def _preliminary_diagnosis_categories(summaries: Sequence[Mapping[str, Any]]) -> list[str]:
+    categories: set[str] = set()
+    if not summaries:
+        return ["no_runs_available"]
+    if any(summary.get("status") in {"package_failed", "blocked"} for summary in summaries):
+        categories.add("implementation_or_validation_blocked_some_runs")
+    if any(summary.get("status") == "ingested" for summary in summaries):
+        categories.add("ingested_results_available_for_review")
+    if any(summary.get("hfx_present") and summary.get("lhfx_present") for summary in summaries):
+        categories.add("surface_flux_outputs_present_in_at_least_one_result")
+    if any(summary.get("max_cloud_top_m") not in {None, "unavailable"} for summary in summaries):
+        categories.add("cloud_depth_evidence_available")
+    if not categories:
+        categories.add("campaign_not_far_enough_for_science_diagnosis")
+    return sorted(categories)
+
+
+def _recommended_follow_ups(summaries: Sequence[Mapping[str, Any]]) -> list[str]:
+    followups = [
+        "Implement standardized low-level qv/theta/temperature response diagnostics.",
+        (
+            "Review campaign rows with unavailable required output fields before "
+            "scientific conclusions."
+        ),
+    ]
+    if any(summary.get("status") == "package_failed" for summary in summaries):
+        followups.append("Fix package-generation blockers before queueing the full campaign.")
+    if any(summary.get("status") == "run_failed" for summary in summaries):
+        followups.append(
+            "Inspect CM1 runtime logs for failed campaign runs outside the repository."
+        )
+    return _dedupe(followups)
+
+
+def _forcing_response_summary(summary: Mapping[str, Any]) -> str:
+    state = summary.get("phase_gate_state")
+    if state == "forcing_wiring_verified_but_response_not_verified":
+        return (
+            "Surface-flux output fields are present in at least one ingested result, but "
+            "standardized low-level response diagnostics are not implemented yet."
+        )
+    if state == "forcing_wiring_not_verified":
+        return "Surface-flux output fields are missing from ingested results."
+    return "No ingested result evidence is available yet."
+
+
+def _deepening_summary(summary: Mapping[str, Any]) -> str:
+    ingested = [run for run in summary["runs"] if run.get("status") == "ingested"]
+    if not ingested:
+        return "No ingested results are available to compare deepening or sounding-class response."
+    return (
+        "Deepening and class-difference evidence is listed per run above. This report does "
+        "not convert those diagnostics into predicted-vs-actual verdicts."
+    )
+
+
+def _default_report_path(plan: CampaignPlan) -> Path:
+    if plan.commit_report_path:
+        return Path(plan.commit_report_path)
+    return DEFAULT_REPORT_ROOT / f"{plan.campaign_id}.md"
+
+
+def _station_time_label(run: Mapping[str, Any]) -> str:
+    station = run.get("station_name") or run.get("station_id") or "unavailable"
+    valid_time = run.get("valid_time_utc") or "time unavailable"
+    return f"{station} {valid_time}"
+
+
+def _forcing_label(run: Mapping[str, Any]) -> str:
+    return (
+        f"H {run.get('surface_heat_flux_k_m_s')} K m/s; "
+        f"M {run.get('surface_moisture_flux_g_g_m_s')} g/g m/s"
+    )
+
+
+def _grid_label(run: Mapping[str, Any]) -> str:
+    return f"{run.get('domain_size')} {run.get('horizontal_cell_count')} dx {run.get('dx_m')} m"
+
+
+def _key_result_label(run: Mapping[str, Any]) -> str:
+    if run.get("status") != "ingested":
+        return str(run.get("status"))
+    return (
+        f"cloud top {_fmt(run.get('max_cloud_top_m'))}; "
+        f"max w {_fmt(run.get('max_w_m_s'))}; "
+        f"surface rain {run.get('surface_rain_present')}"
+    )
+
+
+def _mapping(data: Any, label: str, errors: list[str]) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        errors.append(f"{label} must be an object")
+        return {}
+    return dict(data)
+
+
+def _optional_mapping(data: Any) -> dict[str, Any] | None:
+    return dict(data) if isinstance(data, dict) else None
+
+
+def _list_of_mappings(data: Any, label: str, errors: list[str]) -> list[dict[str, Any]]:
+    if not isinstance(data, list):
+        errors.append(f"{label} must be a list")
+        return []
+    rows: list[dict[str, Any]] = []
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            errors.append(f"{label}[{index}] must be an object")
+            continue
+        rows.append(dict(item))
+    return rows
+
+
+def _indexed_mappings(
+    data: Any,
+    *,
+    key: str,
+    label: str,
+    errors: list[str],
+) -> dict[str, dict[str, Any]]:
+    rows = _list_of_mappings(data, label, errors)
+    indexed: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        identifier = _optional_string(row.get(key))
+        if identifier is None:
+            errors.append(f"{label} item missing {key}")
+            continue
+        if identifier in indexed:
+            errors.append(f"Duplicate {label}.{key}: {identifier}")
+            continue
+        indexed[identifier] = row
+    return indexed
+
+
+def _required_string(
+    data: Mapping[str, Any],
+    key: str,
+    context: str,
+    errors: list[str],
+) -> str:
+    value = _optional_string(data.get(key))
+    if value is None:
+        errors.append(f"{context}.{key} is required")
+        return ""
+    return value
+
+
+def _optional_string(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _queue_target(value: Any, *, errors: list[str], context: str) -> QueueTarget:
+    if value == "local":
+        return "local"
+    if value == "lan":
+        return "lan"
+    errors.append(f"{context} must be local or lan")
+    return "local"
+
+
+def _resolved_tags(
+    defaults: Mapping[str, Any],
+    selection: Mapping[str, Any],
+    run: Mapping[str, Any],
+    campaign_id: str,
+    matrix_id: str,
+) -> list[str]:
+    tags: list[str] = [f"campaign:{campaign_id}", f"matrix:{matrix_id}"]
+    for source in (defaults, selection, run):
+        value = source.get("tags")
+        if isinstance(value, list):
+            tags.extend(str(item).strip() for item in value if str(item).strip())
+    return _dedupe(tags)
+
+
+def _resolved_notes(
+    defaults: Mapping[str, Any],
+    selection: Mapping[str, Any],
+    run: Mapping[str, Any],
+) -> str | None:
+    notes = [
+        text
+        for text in (
+            _optional_string(defaults.get("notes")),
+            _optional_string(selection.get("selection_notes")),
+            _optional_string(run.get("notes")),
+        )
+        if text
+    ]
+    return "\n\n".join(notes) if notes else None
+
+
+def _validate_comparison_control_refs(
+    planned: Sequence[CampaignRunPlan], errors: list[str]
+) -> None:
+    matrix_ids = {run.matrix_id for run in planned}
+    for run in planned:
+        if run.comparison_control_matrix_id and run.comparison_control_matrix_id not in matrix_ids:
+            errors.append(
+                f"{run.matrix_id}.comparison.control_matrix_id references unknown run: "
+                f"{run.comparison_control_matrix_id}"
+            )
+
+
+def _parse_utc_datetime(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise CampaignError(f"Invalid UTC datetime: {value}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _mapping_value(mapping: Mapping[str, Any] | None, key: str) -> Any:
+    if mapping is None:
+        return None
+    value = mapping.get(key)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _list_from_mapping(mapping: Mapping[str, Any] | None, key: str) -> list[Any]:
+    if mapping is None:
+        return []
+    value = mapping.get(key)
+    return list(value) if isinstance(value, list) else []
+
+
+def _candidate_evidence(candidate: Mapping[str, Any] | None) -> list[Any]:
+    if candidate is None:
+        return []
+    evidence = candidate.get("evidence")
+    if isinstance(evidence, list):
+        return evidence
+    reasons = candidate.get("interest_reasons")
+    return list(reasons) if isinstance(reasons, list) else []
+
+
+def _payload_message(payload: Mapping[str, object], fallback: str) -> str:
+    message = payload.get("message")
+    return str(message) if isinstance(message, str) and message else fallback
+
+
+def _dedupe(values: Iterable[str]) -> list[str]:
+    output: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        output.append(value)
+    return output
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return "unavailable"
+    if isinstance(value, float):
+        return f"{value:.4g}"
+    return str(value)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -9,6 +9,7 @@ description = "Local backend tooling for Cloud Chamber CM1 experiments."
 requires-python = ">=3.12"
 dependencies = [
   "fastapi>=0.115",
+  "pyyaml>=6.0",
   "scipy>=1.14",
   "xarray>=2024.7",
 ]
@@ -18,7 +19,6 @@ dev = [
   "httpx>=0.27",
   "mypy>=1.10",
   "pytest>=8.2",
-  "pyyaml>=6.0",
   "ruff>=0.5",
   "uvicorn>=0.30",
 ]

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 import yaml  # type: ignore[import-untyped]
 from igra_fixtures import IGRA_FIXTURE
 
+from cloud_chamber.output_products import ScienceSummary
 from cloud_chamber.result_diagnostics import (
     CloudDiagnostics,
     RainDiagnostics,
@@ -16,6 +18,7 @@ from cloud_chamber.result_diagnostics import (
     ResultDiagnostics,
     SurfaceRainDiagnostics,
     TimeDiagnostics,
+    TimeValue,
     VerticalVelocityDiagnostics,
 )
 from cloud_chamber.result_ingest import RESULT_METADATA_FILENAME, FieldMetadata, ResultMetadata
@@ -31,10 +34,15 @@ from cloud_chamber.settings import CloudChamberSettings
 from cloud_chamber.surface_forced_campaign import (
     CampaignError,
     build_campaign_plan,
+    ingest_campaign,
     package_campaign,
+    plan_campaign,
     queue_campaign,
     report_campaign,
+    status_campaign,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def fake_settings(tmp_path: Path) -> CloudChamberSettings:
@@ -48,11 +56,17 @@ def fake_settings(tmp_path: Path) -> CloudChamberSettings:
     )
 
 
-def write_matrix(tmp_path: Path, *, queue_target: str = "local") -> Path:
+def write_matrix(
+    tmp_path: Path,
+    *,
+    queue_target: str = "local",
+    include_followups: bool = False,
+    include_comparison: bool = False,
+) -> Path:
     fixture_dir = tmp_path / "fixtures"
     fixture_dir.mkdir()
     (fixture_dir / "valley.txt").write_text(IGRA_FIXTURE)
-    matrix = {
+    matrix: dict[str, Any] = {
         "schema_version": "surface_forced_campaign_matrix_v1",
         "campaign": {
             "campaign_id": "surface_forced_test",
@@ -107,6 +121,7 @@ def write_matrix(tmp_path: Path, *, queue_target: str = "local") -> Path:
                 "varied_fields": ["surface_heat_flux_k_m_s"],
                 "required_equal_fields": ["duration"],
                 "required_available_fields": ["hfx", "lhfx", "qv", "qc", "w"],
+                "required_diagnostic_support": ["surface_fluxes", "low_level_response"],
             }
         ],
         "runs": [
@@ -120,6 +135,39 @@ def write_matrix(tmp_path: Path, *, queue_target: str = "local") -> Path:
         ],
         "required_summary_fields": {"metadata": ["campaign_id"], "evidence": ["hfx_present"]},
     }
+    if include_followups:
+        matrix["runs"].extend(
+            [
+                {
+                    "matrix_id": "phase2_followup",
+                    "phase": "easy_sounding_response_check",
+                    "selection_id": "control_sounding",
+                    "forcing_id": "stronger_flux",
+                },
+                {
+                    "matrix_id": "phase2_optional_120km",
+                    "phase": "easy_sounding_response_check",
+                    "optional": True,
+                    "selection_id": "control_sounding",
+                    "forcing_id": "stronger_flux",
+                    "domain_size": "regional_120km",
+                },
+            ]
+        )
+    if include_comparison:
+        matrix["runs"].append(
+            {
+                "matrix_id": "phase1_experiment_high_flux",
+                "phase": "forcing_path_smoke_check",
+                "selection_id": "control_sounding",
+                "forcing_id": "stronger_flux",
+                "surface_heat_flux_k_m_s": 5.0e-2,
+                "comparison": {
+                    "type": "forcing_sensitivity_same_duration",
+                    "control_matrix_id": "phase1_control_high_flux",
+                },
+            }
+        )
     matrix_path = tmp_path / "campaign.yaml"
     matrix_path.write_text(yaml.safe_dump(matrix, sort_keys=False))
     return matrix_path
@@ -144,6 +192,19 @@ def test_campaign_plan_validates_matrix_and_resolves_cm1_values(tmp_path: Path) 
     assert run.stable_resume_identity
 
 
+def test_campaign_plans_checked_in_example_matrix() -> None:
+    plan = plan_campaign(
+        REPO_ROOT / "docs/research/templates/surface-forced-campaign-matrix.example.yaml"
+    )
+
+    assert plan.campaign_id == "surface_forced_smoke_001"
+    assert plan.run_count == 10
+    assert plan.execution["max_concurrent_runs"] == 1
+    assert "forcing_sensitivity_same_duration" in plan.comparison_types
+    assert any(run.optional for run in plan.runs)
+    assert plan.required_summary_fields["evidence"]
+
+
 def test_campaign_plan_blocks_machine_private_absolute_igra_paths(tmp_path: Path) -> None:
     matrix_path = write_matrix(tmp_path)
     matrix = yaml.safe_load(matrix_path.read_text())
@@ -155,6 +216,15 @@ def test_campaign_plan_blocks_machine_private_absolute_igra_paths(tmp_path: Path
         assert "absolute" in str(exc)
     else:
         raise AssertionError("absolute local path should be blocked by default")
+
+
+def test_campaign_plan_rejects_unknown_required_summary_field(tmp_path: Path) -> None:
+    matrix_path = write_matrix(tmp_path)
+    matrix = yaml.safe_load(matrix_path.read_text())
+    matrix["required_summary_fields"]["evidence"].append("not_a_real_summary_field")
+
+    with pytest.raises(CampaignError, match="Unsupported required_summary_fields"):
+        build_campaign_plan(matrix, matrix_path=matrix_path)
 
 
 def test_campaign_package_creates_observed_surface_forced_package_and_resumes(
@@ -215,6 +285,224 @@ def test_campaign_queue_uses_existing_local_queue_path(
     assert enqueued == [Path(result.runs[0].manifest_path or "")]
 
 
+def test_campaign_queue_rejects_unknown_matrix_id(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path)
+
+    with pytest.raises(CampaignError, match="Unknown matrix_id"):
+        queue_campaign(
+            matrix_path,
+            settings=settings,
+            selected_matrix_ids={"missing-row"},
+        )
+
+
+def test_campaign_queue_blocks_followups_and_excludes_optional_by_default(
+    tmp_path: Path,
+) -> None:
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path, include_followups=True)
+    enqueued: list[str] = []
+
+    class FakeQueue:
+        def enqueue(self, manifest_path: Path) -> SimpleNamespace:
+            enqueued.append(manifest_path.name)
+            entry = SimpleNamespace(
+                manifest_path=str(manifest_path),
+                state="queued",
+                message="Queued by fake local queue.",
+                error=None,
+                result_id=None,
+            )
+            return SimpleNamespace(entries=[entry])
+
+    result = queue_campaign(
+        matrix_path,
+        settings=settings,
+        local_queue_factory=lambda _settings: FakeQueue(),
+    )
+    runs = {run.matrix_id: run for run in result.runs}
+
+    assert len(enqueued) == 1
+    assert runs["phase1_control_high_flux"].status == "queued"
+    assert runs["phase2_followup"].status == "blocked"
+    assert runs["phase2_optional_120km"].status == "planned"
+
+    override = queue_campaign(
+        matrix_path,
+        settings=settings,
+        selected_matrix_ids={"phase2_followup"},
+        override_phase_gate=True,
+        override_reason="manual smoke evidence reviewed",
+        local_queue_factory=lambda _settings: FakeQueue(),
+    )
+    followup = next(run for run in override.runs if run.matrix_id == "phase2_followup")
+    assert followup.status == "queued"
+    assert followup.gate_override is not None
+    assert followup.gate_override["reason"] == "manual smoke evidence reviewed"
+
+
+@pytest.mark.parametrize(
+    ("lifecycle", "product_state", "expected_status"),
+    [
+        (
+            LifecycleState.QUEUED,
+            ProductState.QUEUED_RUNNING_CM1_PROCESS,
+            "queued",
+        ),
+        (
+            LifecycleState.RUNNING,
+            ProductState.QUEUED_RUNNING_CM1_PROCESS,
+            "running",
+        ),
+        (
+            LifecycleState.COMPLETED,
+            ProductState.COMPLETED_CM1_RESULT,
+            "completed_not_ingested",
+        ),
+        (
+            LifecycleState.INGESTED,
+            ProductState.INGESTED_RESULT_METADATA,
+            "ingested",
+        ),
+        (
+            LifecycleState.FAILED,
+            ProductState.FAILED_CANCELED_CM1_RUN,
+            "run_failed",
+        ),
+        (
+            LifecycleState.CANCELED,
+            ProductState.FAILED_CANCELED_CM1_RUN,
+            "run_canceled",
+        ),
+    ],
+)
+def test_campaign_queue_is_idempotent_for_existing_lifecycle_states(
+    tmp_path: Path,
+    lifecycle: LifecycleState,
+    product_state: ProductState,
+    expected_status: str,
+) -> None:
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path)
+    packaged = package_campaign(matrix_path, settings=settings, resume=True)
+    manifest_path = Path(packaged.runs[0].manifest_path or "")
+    _set_manifest_lifecycle(manifest_path, lifecycle, product_state)
+
+    class FailingQueue:
+        def enqueue(self, _manifest_path: Path) -> SimpleNamespace:
+            raise AssertionError("queue should not be called for existing lifecycle state")
+
+    result = queue_campaign(
+        matrix_path,
+        settings=settings,
+        local_queue_factory=lambda _settings: FailingQueue(),
+    )
+
+    assert result.runs[0].status == expected_status
+    assert "Skipped queue" in (result.runs[0].message or "")
+
+
+def test_campaign_lan_queue_status_collect_and_ingest_flow(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    from cloud_chamber import surface_forced_campaign
+
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path, queue_target="lan")
+    started: list[Path] = []
+
+    def fake_start(_settings: CloudChamberSettings, manifest_path: Path) -> dict[str, object]:
+        started.append(manifest_path)
+        return {"state": "running", "message": "LAN worker started"}
+
+    def fake_running(_settings: CloudChamberSettings, _manifest_path: Path) -> dict[str, object]:
+        return {"state": "running", "message": "LAN worker still running"}
+
+    def fake_complete(_settings: CloudChamberSettings, _manifest_path: Path) -> dict[str, object]:
+        return {"state": "ready_for_local_ingest", "message": "LAN output is ready"}
+
+    def fake_collect(_settings: CloudChamberSettings, manifest_path: Path) -> dict[str, object]:
+        netcdf_path = manifest_path.parent / "cm1out_000001.nc"
+        netcdf_path.write_text("fake netcdf placeholder")
+        _set_manifest_lifecycle(
+            manifest_path,
+            LifecycleState.COMPLETED,
+            ProductState.COMPLETED_CM1_RESULT,
+            netcdf_path=netcdf_path,
+        )
+        return {"state": "ready_for_local_ingest", "message": "LAN output collected"}
+
+    queued = queue_campaign(
+        matrix_path,
+        settings=settings,
+        lan_start=fake_start,
+        lan_status=fake_running,
+    )
+    assert queued.runs[0].status == "running"
+    assert len(started) == 1
+
+    def duplicate_start(_settings: CloudChamberSettings, _manifest_path: Path) -> dict[str, object]:
+        raise AssertionError("LAN start should not run twice")
+
+    repeated = queue_campaign(
+        matrix_path,
+        settings=settings,
+        lan_start=duplicate_start,
+        lan_status=fake_running,
+    )
+    assert repeated.runs[0].status == "running"
+    assert len(started) == 1
+
+    running = status_campaign(matrix_path, settings=settings, lan_status=fake_running)
+    assert running.runs[0].status == "running"
+
+    not_ready = ingest_campaign(matrix_path, settings=settings, lan_status=fake_running)
+    assert not_ready.runs[0].status == "running"
+    assert not_ready.runs[0].ingest_status == "not_started"
+
+    complete = status_campaign(matrix_path, settings=settings, lan_status=fake_complete)
+    assert complete.runs[0].status == "completed_not_ingested"
+
+    monkeypatch.setattr(
+        surface_forced_campaign,
+        "ingest_completed_run",
+        lambda _manifest_path: SimpleNamespace(result_id="result-lan-campaign"),
+    )
+    ingested = ingest_campaign(
+        matrix_path,
+        settings=settings,
+        lan_status=fake_complete,
+        lan_collect=fake_collect,
+    )
+
+    assert ingested.runs[0].status == "ingested"
+    assert ingested.runs[0].result_id == "result-lan-campaign"
+
+
+def test_campaign_lan_queue_enforces_max_concurrent_runs(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path, queue_target="lan", include_comparison=True)
+    started: list[Path] = []
+
+    def fake_start(_settings: CloudChamberSettings, manifest_path: Path) -> dict[str, object]:
+        started.append(manifest_path)
+        return {"state": "running", "message": "LAN worker started"}
+
+    result = queue_campaign(
+        matrix_path,
+        settings=settings,
+        lan_start=fake_start,
+    )
+    runs = {run.matrix_id: run for run in result.runs}
+
+    assert len(started) == 1
+    assert runs["phase1_control_high_flux"].status == "running"
+    assert runs["phase1_experiment_high_flux"].status == "blocked"
+    assert "max_concurrent_runs=1" in (runs["phase1_experiment_high_flux"].message or "")
+
+
 def test_campaign_report_summarizes_ingested_result_without_fabricating_bl_response(
     tmp_path: Path,
 ) -> None:
@@ -241,10 +529,43 @@ def test_campaign_report_summarizes_ingested_result_without_fabricating_bl_respo
     run = summary["runs"][0]
     assert run["hfx_present"] is True
     assert run["lhfx_present"] is True
-    assert run["low_level_qv_response"] == "unavailable"
+    assert run["low_level_qv_response"] == (
+        "unavailable:low_level_response_diagnostic_not_implemented"
+    )
     assert run["low_level_qv_response_method"] == "low_level_response_diagnostic_not_implemented"
     assert "low_level_qv_response" in summary["unavailable_diagnostics"]
     assert "max w `2.5`" in report_path.read_text()
+
+
+def test_campaign_report_evaluates_comparison_contract(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path, include_comparison=True)
+    packaged = package_campaign(matrix_path, settings=settings, resume=True)
+    for state_run in packaged.runs:
+        _write_fake_result_metadata(Path(state_run.manifest_path or ""))
+
+    artifacts = report_campaign(
+        matrix_path,
+        settings=settings,
+        report_path=tmp_path / "report.md",
+        summary_json_path=tmp_path / "summary.json",
+    )
+
+    comparisons = artifacts.summary["comparisons"]
+    assert len(comparisons) == 1
+    comparison = comparisons[0]
+    assert comparison["comparison_type"] == "forcing_sensitivity_same_duration"
+    assert comparison["control_matrix_id"] == "phase1_control_high_flux"
+    assert comparison["experiment_matrix_id"] == "phase1_experiment_high_flux"
+    assert comparison["status"] == "inconclusive_missing_evidence"
+    assert comparison["equality_gate_failures"] == []
+    assert "control:diagnostic_unavailable:low_level_response" in comparison["unavailable_evidence"]
+    assert {
+        "field": "surface_heat_flux_k_m_s",
+        "control": 0.04,
+        "experiment": 0.05,
+    } in comparison["supported_differences"]
+    assert "## Matched Comparisons" in Path(artifacts.markdown_path).read_text()
 
 
 def test_campaign_ingest_updates_state_with_existing_completed_output(
@@ -284,6 +605,28 @@ def test_campaign_ingest_updates_state_with_existing_completed_output(
     assert result.runs[0].result_id == "result-surface-forced-test"
 
 
+def _set_manifest_lifecycle(
+    manifest_path: Path,
+    lifecycle: LifecycleState,
+    product_state: ProductState,
+    *,
+    netcdf_path: Path | None = None,
+) -> None:
+    manifest = load_run_manifest(manifest_path)
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": lifecycle,
+                "provenance": ProvenanceMetadata(product_state=product_state),
+                "outputs": OutputMetadata(
+                    netcdf_paths=[str(netcdf_path)] if netcdf_path is not None else []
+                ),
+            }
+        ),
+    )
+
+
 def _write_fake_result_metadata(manifest_path: Path) -> None:
     manifest = load_run_manifest(manifest_path)
     now = datetime.now(UTC)
@@ -310,7 +653,7 @@ def _write_fake_result_metadata(manifest_path: Path) -> None:
         required_output_fields=manifest.required_output_fields,
         missing_required_output_fields=[],
         candidate_screening=manifest.candidate_screening,
-        variables=["qc", "w", "qr", "rain", "dbz", "hfx", "lhfx"],
+        variables=["qc", "w", "qr", "rain", "dbz", "hfx", "lhfx", "qv", "th"],
         fields_detected=[
             FieldMetadata(
                 name="hfx", dimensions=["time", "y", "x"], shape=[2, 2, 2], units="K m/s"
@@ -318,18 +661,31 @@ def _write_fake_result_metadata(manifest_path: Path) -> None:
             FieldMetadata(
                 name="lhfx", dimensions=["time", "y", "x"], shape=[2, 2, 2], units="g/g m/s"
             ),
+            FieldMetadata(
+                name="qv", dimensions=["time", "z", "y", "x"], shape=[2, 2, 2, 2], units="kg/kg"
+            ),
+            FieldMetadata(
+                name="th", dimensions=["time", "z", "y", "x"], shape=[2, 2, 2, 2], units="K"
+            ),
         ],
         diagnostics=ResultDiagnostics(
             cloud=CloudDiagnostics(
                 formed=True,
                 first_cloud_time_seconds=900.0,
                 cloud_top_m=1800.0,
+                cloud_top_time_series=[
+                    TimeValue(time_seconds=900.0, value=900.0),
+                    TimeValue(time_seconds=1800.0, value=1800.0),
+                ],
                 max_qc_kg_kg=2.0e-5,
                 time_of_max_qc_seconds=1800.0,
             ),
             vertical_velocity=VerticalVelocityDiagnostics(
                 max_w_m_s=2.5,
                 time_of_max_w_seconds=1800.0,
+                max_w_height_time_series=[
+                    TimeValue(time_seconds=1800.0, value=2400.0),
+                ],
                 units="m/s",
             ),
             rain=RainDiagnostics(
@@ -352,6 +708,27 @@ def _write_fake_result_metadata(manifest_path: Path) -> None:
                 field_absent=False,
             ),
             time=TimeDiagnostics(source="time", fallback_used=False, coordinate_name="time"),
+        ),
+        science_summary=ScienceSummary(
+            cloud_formed=True,
+            deep_cloud_formed=False,
+            strong_updraft_formed=False,
+            first_cloud_time_seconds=900.0,
+            first_cloud_time_label="900 s",
+            time_of_first_deep_convection_seconds=None,
+            max_qc_kg_kg=2.0e-5,
+            max_qc_time_seconds=1800.0,
+            max_updraft_w_m_s=2.5,
+            max_updraft_time_seconds=1800.0,
+            highest_cloud_top_m=1800.0,
+            rain_onset_time_seconds=2700.0,
+            max_qr_kg_kg=1.0e-6,
+            max_rain_or_surface_precip=0.0,
+            max_dbz_or_reflectivity_proxy=32.0,
+            latest_output_time_seconds=3600.0,
+            default_explore_time_index=1,
+            default_explore_time_seconds=1800.0,
+            interesting_time_support_state="supported",
         ),
         warnings=[],
         created_at=now,

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+from igra_fixtures import IGRA_FIXTURE
+
+from cloud_chamber.result_diagnostics import (
+    CloudDiagnostics,
+    RainDiagnostics,
+    ReflectivityDiagnostics,
+    ResultDiagnostics,
+    SurfaceRainDiagnostics,
+    TimeDiagnostics,
+    VerticalVelocityDiagnostics,
+)
+from cloud_chamber.result_ingest import RESULT_METADATA_FILENAME, FieldMetadata, ResultMetadata
+from cloud_chamber.run_manifest import (
+    LifecycleState,
+    OutputMetadata,
+    ProductState,
+    ProvenanceMetadata,
+    load_run_manifest,
+    write_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.surface_forced_campaign import (
+    CampaignError,
+    build_campaign_plan,
+    package_campaign,
+    queue_campaign,
+    report_campaign,
+)
+
+
+def fake_settings(tmp_path: Path) -> CloudChamberSettings:
+    runtime_home = tmp_path / "CloudChamber"
+    return CloudChamberSettings(
+        runtime_home=runtime_home,
+        cm1_root=tmp_path / "cm1r21.1",
+        cm1_run_dir=tmp_path / "cm1r21.1" / "run",
+        cache_dir=runtime_home / "cache",
+        log_dir=runtime_home / "logs",
+    )
+
+
+def write_matrix(tmp_path: Path, *, queue_target: str = "local") -> Path:
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+    (fixture_dir / "valley.txt").write_text(IGRA_FIXTURE)
+    matrix = {
+        "schema_version": "surface_forced_campaign_matrix_v1",
+        "campaign": {
+            "campaign_id": "surface_forced_test",
+            "title": "Surface forced test",
+            "objective": "Verify campaign runner plumbing.",
+            "protocol": "docs/research/surface-forced-sounding-verification-protocol.md",
+            "commit_report_path": str(tmp_path / "reports" / "surface_forced_test.md"),
+        },
+        "execution": {"queue_target": queue_target, "resume_existing": True},
+        "selection_sets": [
+            {
+                "selection_id": "control_sounding",
+                "role": "forcing_path_smoke_check",
+                "source": {
+                    "type": "uploaded_or_local_igra",
+                    "local_text_path": "fixtures/valley.txt",
+                    "selected_valid_time_utc": "2025-01-02T00:00:00Z",
+                },
+                "selection_notes": "Tiny test IGRA fixture.",
+                "candidate_screening": {
+                    "candidate_id": "fixture-candidate",
+                    "primary_story": "humid_rainy_candidate",
+                    "primary_story_label": "Humid / rainy candidate",
+                    "story_family": "lower_atmosphere",
+                    "rank_score": 72.0,
+                    "evidence": [{"label": "low-level moisture", "value": "high"}],
+                    "caveats": ["fixture_screening"],
+                },
+            }
+        ],
+        "run_defaults": {
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "wide_12km",
+            "output_cadence": "standard_15min",
+            "surface_heat_flux_k_m_s": 8.0e-3,
+            "surface_moisture_flux_g_g_m_s": 5.2e-5,
+            "queue_target": queue_target,
+            "tags": ["campaign-test"],
+            "notes": "Campaign default note.",
+        },
+        "forcing_sets": [
+            {
+                "forcing_id": "stronger_flux",
+                "surface_heat_flux_k_m_s": 4.0e-2,
+                "surface_moisture_flux_g_g_m_s": 1.0e-4,
+            }
+        ],
+        "comparison_types": [
+            {
+                "comparison_type": "forcing_sensitivity_same_duration",
+                "varied_fields": ["surface_heat_flux_k_m_s"],
+                "required_equal_fields": ["duration"],
+                "required_available_fields": ["hfx", "lhfx", "qv", "qc", "w"],
+            }
+        ],
+        "runs": [
+            {
+                "matrix_id": "phase1_control_high_flux",
+                "phase": "forcing_path_smoke_check",
+                "selection_id": "control_sounding",
+                "forcing_id": "stronger_flux",
+                "comparison_role": "phase1_control",
+            }
+        ],
+        "required_summary_fields": {"metadata": ["campaign_id"], "evidence": ["hfx_present"]},
+    }
+    matrix_path = tmp_path / "campaign.yaml"
+    matrix_path.write_text(yaml.safe_dump(matrix, sort_keys=False))
+    return matrix_path
+
+
+def test_campaign_plan_validates_matrix_and_resolves_cm1_values(tmp_path: Path) -> None:
+    matrix_path = write_matrix(tmp_path)
+    plan = build_campaign_plan(yaml.safe_load(matrix_path.read_text()), matrix_path=matrix_path)
+
+    assert plan.campaign_id == "surface_forced_test"
+    assert plan.run_count == 1
+    run = plan.runs[0]
+    assert run.matrix_id == "phase1_control_high_flux"
+    assert run.queue_target == "local"
+    assert run.run_configuration["surface_heat_flux_k_m_s"] == 4.0e-2
+    assert run.run_configuration["surface_moisture_flux_g_g_m_s"] == 1.0e-4
+    assert run.surface_flux_cm1_values["cnst_shflx"] == 4.0e-2
+    assert run.surface_flux_cm1_values["cnst_lhflx"] == 1.0e-4
+    assert run.cm1_values["nx"] == 128
+    assert run.cm1_values["domain_x_km"] == 12.8
+    assert "campaign:surface_forced_test" in run.tags
+    assert run.stable_resume_identity
+
+
+def test_campaign_plan_blocks_machine_private_absolute_igra_paths(tmp_path: Path) -> None:
+    matrix_path = write_matrix(tmp_path)
+    matrix = yaml.safe_load(matrix_path.read_text())
+    matrix["selection_sets"][0]["source"]["local_text_path"] = str(tmp_path / "valley.txt")
+
+    try:
+        build_campaign_plan(matrix, matrix_path=matrix_path)
+    except CampaignError as exc:
+        assert "absolute" in str(exc)
+    else:
+        raise AssertionError("absolute local path should be blocked by default")
+
+
+def test_campaign_package_creates_observed_surface_forced_package_and_resumes(
+    tmp_path: Path,
+) -> None:
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path)
+
+    first = package_campaign(matrix_path, settings=settings, resume=True)
+    second = package_campaign(matrix_path, settings=settings, resume=True)
+
+    assert first.runs[0].status == "packaged"
+    assert second.runs[0].message == "Resumed existing package."
+    assert len(list((settings.runtime_home / "runs").iterdir())) == 1
+    manifest = load_run_manifest(Path(first.runs[0].manifest_path or ""))
+    assert manifest.run_recipe == "observed_surface_forced_evolution"
+    assert manifest.observed_sounding is not None
+    assert manifest.observed_sounding["station_id"] == "USM00072558"
+    assert manifest.candidate_screening is not None
+    assert manifest.candidate_screening["primary_story"] == "humid_rainy_candidate"
+    assert manifest.run_configuration["surface_heat_flux_k_m_s"] == 4.0e-2
+    assert manifest.run_configuration["surface_moisture_flux_g_g_m_s"] == 1.0e-4
+    assert "campaign:surface_forced_test" in manifest.user.tags
+    assert "Campaign default note." in (manifest.user.notes or "")
+
+
+def test_campaign_queue_uses_existing_local_queue_path(
+    tmp_path: Path,
+) -> None:
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path)
+    enqueued: list[Path] = []
+
+    class FakeQueue:
+        def enqueue(self, manifest_path: Path) -> SimpleNamespace:
+            enqueued.append(manifest_path)
+            entry = SimpleNamespace(
+                manifest_path=str(manifest_path),
+                state="queued",
+                message="Queued by fake local queue.",
+                error=None,
+                result_id=None,
+            )
+            return SimpleNamespace(entries=[entry])
+
+    def fake_queue_factory(_settings: CloudChamberSettings) -> Any:
+        return FakeQueue()
+
+    result = queue_campaign(
+        matrix_path,
+        settings=settings,
+        local_queue_factory=fake_queue_factory,
+    )
+
+    assert result.runs[0].status == "queued"
+    assert result.runs[0].run_status == "queued"
+    assert result.runs[0].message == "Queued by fake local queue."
+    assert enqueued == [Path(result.runs[0].manifest_path or "")]
+
+
+def test_campaign_report_summarizes_ingested_result_without_fabricating_bl_response(
+    tmp_path: Path,
+) -> None:
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path)
+    packaged = package_campaign(matrix_path, settings=settings, resume=True)
+    manifest_path = Path(packaged.runs[0].manifest_path or "")
+    _write_fake_result_metadata(manifest_path)
+
+    report_path = tmp_path / "report.md"
+    summary_path = tmp_path / "summary.json"
+    artifacts = report_campaign(
+        matrix_path,
+        settings=settings,
+        report_path=report_path,
+        summary_json_path=summary_path,
+    )
+
+    summary = artifacts.summary
+    assert Path(artifacts.markdown_path) == report_path
+    assert Path(artifacts.summary_json_path) == summary_path
+    assert summary["status_counts"] == {"ingested": 1}
+    assert summary["phase_gate_state"] == "forcing_wiring_verified_but_response_not_verified"
+    run = summary["runs"][0]
+    assert run["hfx_present"] is True
+    assert run["lhfx_present"] is True
+    assert run["low_level_qv_response"] == "unavailable"
+    assert run["low_level_qv_response_method"] == "low_level_response_diagnostic_not_implemented"
+    assert "low_level_qv_response" in summary["unavailable_diagnostics"]
+    assert "max w `2.5`" in report_path.read_text()
+
+
+def test_campaign_ingest_updates_state_with_existing_completed_output(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    from cloud_chamber import surface_forced_campaign
+
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path)
+    packaged = package_campaign(matrix_path, settings=settings, resume=True)
+    manifest_path = Path(packaged.runs[0].manifest_path or "")
+    manifest = load_run_manifest(manifest_path)
+    netcdf_path = manifest_path.parent / "cm1out_000001.nc"
+    netcdf_path.write_text("fake netcdf placeholder")
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(
+            update={
+                "lifecycle_state": LifecycleState.COMPLETED,
+                "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+                "outputs": OutputMetadata(netcdf_paths=[str(netcdf_path)]),
+            }
+        ),
+    )
+
+    monkeypatch.setattr(
+        surface_forced_campaign,
+        "ingest_completed_run",
+        lambda _manifest_path: SimpleNamespace(result_id="result-surface-forced-test"),
+    )
+
+    result = surface_forced_campaign.ingest_campaign(matrix_path, settings=settings)
+
+    assert result.runs[0].status == "ingested"
+    assert result.runs[0].ingest_status == "ingested"
+    assert result.runs[0].result_id == "result-surface-forced-test"
+
+
+def _write_fake_result_metadata(manifest_path: Path) -> None:
+    manifest = load_run_manifest(manifest_path)
+    now = datetime.now(UTC)
+    result = ResultMetadata(
+        result_id=f"result-{manifest.run_id}",
+        run_id=manifest.run_id,
+        scenario_id=manifest.scenario.id,
+        physical_question=manifest.physical_question,
+        controls=manifest.controls,
+        run_configuration=manifest.run_configuration,
+        source_lifecycle_state="completed",
+        source_product_state="completed_cm1_result",
+        source_model="CM1",
+        input_source=manifest.input_source or "observed_sounding",
+        input_source_label="Observed sounding",
+        observed_sounding=manifest.observed_sounding,
+        run_recipe=manifest.run_recipe,
+        run_recipe_display_name=manifest.run_recipe_display_name,
+        recipe_id=manifest.recipe_id,
+        recipe_display_name=manifest.recipe_display_name,
+        assumption_set_id=manifest.assumption_set_id,
+        assumption_mode=manifest.assumption_mode,
+        recipe_assumptions=manifest.recipe_assumptions,
+        required_output_fields=manifest.required_output_fields,
+        missing_required_output_fields=[],
+        candidate_screening=manifest.candidate_screening,
+        variables=["qc", "w", "qr", "rain", "dbz", "hfx", "lhfx"],
+        fields_detected=[
+            FieldMetadata(
+                name="hfx", dimensions=["time", "y", "x"], shape=[2, 2, 2], units="K m/s"
+            ),
+            FieldMetadata(
+                name="lhfx", dimensions=["time", "y", "x"], shape=[2, 2, 2], units="g/g m/s"
+            ),
+        ],
+        diagnostics=ResultDiagnostics(
+            cloud=CloudDiagnostics(
+                formed=True,
+                first_cloud_time_seconds=900.0,
+                cloud_top_m=1800.0,
+                max_qc_kg_kg=2.0e-5,
+                time_of_max_qc_seconds=1800.0,
+            ),
+            vertical_velocity=VerticalVelocityDiagnostics(
+                max_w_m_s=2.5,
+                time_of_max_w_seconds=1800.0,
+                units="m/s",
+            ),
+            rain=RainDiagnostics(
+                present=True,
+                first_rain_time_seconds=2700.0,
+                max_qr_kg_kg=1.0e-6,
+                available=True,
+            ),
+            surface_rain=SurfaceRainDiagnostics(
+                present=False,
+                max_surface_rain=0.0,
+                units="mm",
+                available=True,
+                field_absent=False,
+            ),
+            reflectivity=ReflectivityDiagnostics(
+                max_dbz=32.0,
+                units="dBZ",
+                available=True,
+                field_absent=False,
+            ),
+            time=TimeDiagnostics(source="time", fallback_used=False, coordinate_name="time"),
+        ),
+        warnings=[],
+        created_at=now,
+        updated_at=now,
+    )
+    (manifest_path.parent / RESULT_METADATA_FILENAME).write_text(result.to_json_text())
+
+
+def test_campaign_summary_json_is_plain_json(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    matrix_path = write_matrix(tmp_path)
+    package_campaign(matrix_path, settings=settings, resume=True)
+    summary_path = tmp_path / "summary.json"
+
+    report_campaign(
+        matrix_path,
+        settings=settings,
+        report_path=tmp_path / "report.md",
+        summary_json_path=summary_path,
+    )
+
+    loaded = json.loads(summary_path.read_text())
+    assert loaded["campaign_id"] == "surface_forced_test"

--- a/docs/research/surface-forced-sounding-verification-protocol.md
+++ b/docs/research/surface-forced-sounding-verification-protocol.md
@@ -170,6 +170,7 @@ missing fields.
 Supported modes:
 
 ```bash
+scripts/run_surface_forced_campaign.py --matrix <campaign.yaml>
 scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --plan
 scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --package --resume
 scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --queue
@@ -177,6 +178,26 @@ scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --status
 scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --ingest
 scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --report
 ```
+
+If no mode flag is supplied, the runner defaults to `--plan`. `--queue` is the
+first mode that can start CM1 execution and is deliberately staged:
+
+- optional matrix rows are excluded unless the operator passes `--include-optional`
+  or explicitly selects the optional row with `--matrix-id`;
+- Phase 1 rows may queue before evidence exists;
+- Phase 2 and later rows remain `blocked` until the Phase 1 gate returns
+  `forcing_path_verified_for_campaign`;
+- an operator may continue after an inconclusive gate with
+  `--override-phase-gate --override-reason <reason>`, and the override must be
+  preserved in campaign state and reports;
+- LAN queueing honors `execution.max_concurrent_runs` and leaves excess rows
+  blocked rather than launching multiple remote runs.
+
+`--status` refreshes trusted LAN worker state for LAN rows without overwriting
+the remote state with an unchanged local packaged manifest. `--ingest` collects
+LAN output only after the worker reports the result is ready, then waits for
+collection to update the local manifest with completed CM1 output before calling
+result ingest.
 
 The runner writes resumable campaign state under the configured runtime home:
 

--- a/docs/research/surface-forced-sounding-verification-protocol.md
+++ b/docs/research/surface-forced-sounding-verification-protocol.md
@@ -159,6 +159,36 @@ blocked
 
 The report should preserve the source manifest state when available.
 
+### Runner implementation
+
+The checked-in runner is `scripts/run_surface_forced_campaign.py`. It is a thin
+orchestration layer over existing backend package generation, local serial
+queueing, trusted LAN worker execution, result ingest, and result metadata
+summaries. It does not run CM1 in tests and does not invent diagnostics from
+missing fields.
+
+Supported modes:
+
+```bash
+scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --plan
+scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --package --resume
+scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --queue
+scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --status
+scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --ingest
+scripts/run_surface_forced_campaign.py --matrix <campaign.yaml> --report
+```
+
+The runner writes resumable campaign state under the configured runtime home:
+
+```text
+<runtime-home>/campaigns/<campaign_id>/campaign-state.json
+```
+
+Generated packages, NetCDF outputs, logs, worker settings, and runtime folders
+remain runtime artifacts and must not be committed. Markdown reports may be
+written to `docs/research/surface-forced-campaigns/` when the campaign matrix
+explicitly names that committed report path.
+
 ## Comparison contract
 
 The schema distinguishes **comparison type definitions** from **comparison instances**.

--- a/scripts/run_surface_forced_campaign.py
+++ b/scripts/run_surface_forced_campaign.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Plan, package, queue, ingest, and report a surface-forced sounding campaign."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_ROOT = REPO_ROOT / "app" / "backend"
+BACKEND_VENV_PYTHON = BACKEND_ROOT / ".venv" / "bin" / "python"
+
+if sys.version_info < (3, 12):
+    if BACKEND_VENV_PYTHON.exists() and Path(sys.executable) != BACKEND_VENV_PYTHON:
+        os.execv(
+            str(BACKEND_VENV_PYTHON),
+            [str(BACKEND_VENV_PYTHON), str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    raise SystemExit("run_surface_forced_campaign.py requires Python 3.12 or newer.")
+
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from cloud_chamber.surface_forced_campaign import (  # noqa: E402
+    CampaignError,
+    ingest_campaign,
+    package_campaign,
+    plan_campaign,
+    queue_campaign,
+    report_campaign,
+    status_campaign,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    selected = set(args.matrix_id) if args.matrix_id else None
+    runtime_home = Path(args.runtime_home).expanduser() if args.runtime_home else None
+    ran = False
+    try:
+        if args.plan:
+            plan = plan_campaign(
+                Path(args.matrix),
+                allow_absolute_local_paths=args.allow_absolute_local_paths,
+            )
+            print(plan.model_dump_json(indent=2))
+            ran = True
+        if args.package:
+            result = package_campaign(
+                Path(args.matrix),
+                runtime_home=runtime_home,
+                selected_matrix_ids=selected,
+                resume=args.resume,
+                force_rerun=args.force_rerun,
+                allow_absolute_local_paths=args.allow_absolute_local_paths,
+            )
+            print(result.model_dump_json(indent=2))
+            ran = True
+        if args.queue:
+            result = queue_campaign(
+                Path(args.matrix),
+                runtime_home=runtime_home,
+                selected_matrix_ids=selected,
+                resume=True,
+                allow_absolute_local_paths=args.allow_absolute_local_paths,
+            )
+            print(result.model_dump_json(indent=2))
+            ran = True
+        if args.status:
+            result = status_campaign(
+                Path(args.matrix),
+                runtime_home=runtime_home,
+                allow_absolute_local_paths=args.allow_absolute_local_paths,
+            )
+            print(result.model_dump_json(indent=2))
+            ran = True
+        if args.ingest:
+            result = ingest_campaign(
+                Path(args.matrix),
+                runtime_home=runtime_home,
+                selected_matrix_ids=selected,
+                allow_absolute_local_paths=args.allow_absolute_local_paths,
+            )
+            print(result.model_dump_json(indent=2))
+            ran = True
+        if args.report:
+            artifacts = report_campaign(
+                Path(args.matrix),
+                runtime_home=runtime_home,
+                report_path=Path(args.report_path).expanduser()
+                if args.report_path
+                else None,
+                summary_json_path=(
+                    Path(args.summary_json_path).expanduser()
+                    if args.summary_json_path
+                    else None
+                ),
+                allow_absolute_local_paths=args.allow_absolute_local_paths,
+            )
+            print(json.dumps(artifacts.model_dump(mode="json"), indent=2))
+            ran = True
+    except CampaignError as exc:
+        print(f"surface-forced-campaign: {exc}", file=sys.stderr)
+        return 2
+
+    if not ran:
+        parser.error("select at least one mode")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a checked-in surface-forced observed-sounding campaign matrix."
+    )
+    parser.add_argument(
+        "--matrix", required=True, help="Campaign matrix YAML/JSON path."
+    )
+    parser.add_argument(
+        "--runtime-home",
+        help="Cloud Chamber runtime home. Defaults to settings/CLOUD_CHAMBER_RUNTIME_HOME.",
+    )
+    parser.add_argument(
+        "--matrix-id",
+        action="append",
+        default=[],
+        help="Limit package/queue/ingest operations to one matrix_id. Repeatable.",
+    )
+    parser.add_argument(
+        "--allow-absolute-local-paths",
+        action="store_true",
+        help=(
+            "Allow absolute local IGRA source paths for local-only matrices. Do not commit "
+            "matrices containing machine-private paths."
+        ),
+    )
+    parser.add_argument(
+        "--plan", action="store_true", help="Validate and print planned runs."
+    )
+    parser.add_argument(
+        "--package", action="store_true", help="Create dry-run packages."
+    )
+    parser.add_argument(
+        "--queue",
+        action="store_true",
+        help="Create packages if needed and queue selected runs locally or on LAN.",
+    )
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Summarize campaign state from manifests, queue state, and runtime files.",
+    )
+    parser.add_argument(
+        "--ingest", action="store_true", help="Ingest completed run outputs."
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Write markdown and JSON campaign summary artifacts.",
+    )
+    parser.add_argument(
+        "--report-path",
+        help="Override markdown report path. Defaults to the matrix commit_report_path.",
+    )
+    parser.add_argument(
+        "--summary-json-path",
+        help="Override JSON summary path. Defaults to runtime campaigns/<id>/campaign-summary.json.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Reuse existing campaign packages with the same stable resume identity.",
+    )
+    parser.add_argument(
+        "--force-rerun",
+        action="store_true",
+        help="Overwrite an existing generated package for selected rows.",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_surface_forced_campaign.py
+++ b/scripts/run_surface_forced_campaign.py
@@ -40,7 +40,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     selected = set(args.matrix_id) if args.matrix_id else None
     runtime_home = Path(args.runtime_home).expanduser() if args.runtime_home else None
-    ran = False
+    if not any(
+        (args.plan, args.package, args.queue, args.status, args.ingest, args.report)
+    ):
+        args.plan = True
     try:
         if args.plan:
             plan = plan_campaign(
@@ -48,7 +51,6 @@ def main(argv: list[str] | None = None) -> int:
                 allow_absolute_local_paths=args.allow_absolute_local_paths,
             )
             print(plan.model_dump_json(indent=2))
-            ran = True
         if args.package:
             result = package_campaign(
                 Path(args.matrix),
@@ -59,17 +61,18 @@ def main(argv: list[str] | None = None) -> int:
                 allow_absolute_local_paths=args.allow_absolute_local_paths,
             )
             print(result.model_dump_json(indent=2))
-            ran = True
         if args.queue:
             result = queue_campaign(
                 Path(args.matrix),
                 runtime_home=runtime_home,
                 selected_matrix_ids=selected,
                 resume=True,
+                include_optional=args.include_optional,
+                override_phase_gate=args.override_phase_gate,
+                override_reason=args.override_reason,
                 allow_absolute_local_paths=args.allow_absolute_local_paths,
             )
             print(result.model_dump_json(indent=2))
-            ran = True
         if args.status:
             result = status_campaign(
                 Path(args.matrix),
@@ -77,7 +80,6 @@ def main(argv: list[str] | None = None) -> int:
                 allow_absolute_local_paths=args.allow_absolute_local_paths,
             )
             print(result.model_dump_json(indent=2))
-            ran = True
         if args.ingest:
             result = ingest_campaign(
                 Path(args.matrix),
@@ -86,7 +88,6 @@ def main(argv: list[str] | None = None) -> int:
                 allow_absolute_local_paths=args.allow_absolute_local_paths,
             )
             print(result.model_dump_json(indent=2))
-            ran = True
         if args.report:
             artifacts = report_campaign(
                 Path(args.matrix),
@@ -102,13 +103,10 @@ def main(argv: list[str] | None = None) -> int:
                 allow_absolute_local_paths=args.allow_absolute_local_paths,
             )
             print(json.dumps(artifacts.model_dump(mode="json"), indent=2))
-            ran = True
     except CampaignError as exc:
         print(f"surface-forced-campaign: {exc}", file=sys.stderr)
         return 2
 
-    if not ran:
-        parser.error("select at least one mode")
     return 0
 
 
@@ -147,6 +145,20 @@ def _build_parser() -> argparse.ArgumentParser:
         "--queue",
         action="store_true",
         help="Create packages if needed and queue selected runs locally or on LAN.",
+    )
+    parser.add_argument(
+        "--include-optional",
+        action="store_true",
+        help="Include optional matrix rows when queueing without explicit --matrix-id.",
+    )
+    parser.add_argument(
+        "--override-phase-gate",
+        action="store_true",
+        help="Allow queueing post-Phase-1 rows before the automatic phase gate passes.",
+    )
+    parser.add_argument(
+        "--override-reason",
+        help="Reason persisted when --override-phase-gate is used.",
     )
     parser.add_argument(
         "--status",


### PR DESCRIPTION
## Summary
- Adds a backend-owned surface-forced campaign runner for checked-in YAML/JSON matrices.
- Supports `--plan`, `--package`, `--queue`, `--status`, `--ingest`, `--report`, and resumable campaign state under the configured runtime home.
- Generates markdown/JSON campaign summaries from manifests and ingested result metadata while preserving unavailable diagnostics instead of fabricating boundary-layer response evidence.
- Documents runner usage in the surface-forced verification protocol.

Closes #311.

## Verification
- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_surface_forced_campaign.py`
- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_surface_forced_campaign.py app/backend/tests/test_dry_run_package.py app/backend/tests/test_local_run_queue.py app/backend/tests/test_result_ingest.py`
- `scripts/run_surface_forced_campaign.py --matrix docs/research/templates/surface-forced-campaign-matrix.example.yaml --plan`
- `scripts/check.sh`

## Notes
- No generated packages, NetCDF, logs, runtime folders, screenshots, traces, videos, SSH config, or local settings are committed.
- `scripts/check-e2e.sh` was not run because this PR does not change frontend or API behavior.
