### PR TITLE
Fix observed-sounding candidate recommendation trace

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -66,6 +66,7 @@ from cloud_chamber.selected_region_diagnostics import (
 )
 from cloud_chamber.settings import load_settings
 from cloud_chamber.sounding_candidates import (
+    CandidateHistoryScope,
     CandidateReadinessFilter,
     CandidateSortDirection,
     CandidateSortKey,
@@ -167,19 +168,24 @@ class IGRACacheRequest(BaseModel):
 
 class IGRABatchCacheRequest(BaseModel):
     station_id: str | None = None
+    station_ids: list[str] = Field(default_factory=list)
     limit: int = 10
 
 
 class SoundingCandidateScreenRequest(BaseModel):
     station_id: str | None = None
-    latest_per_station: int = 5
+    station_ids: list[str] = Field(default_factory=list)
+    history_scope: CandidateHistoryScope = "latest_per_station"
+    latest_per_station: int | None = 5
     limit: int = 50
     target_story: TargetStoryId | None = None
 
 
 class SoundingCandidateAnalysisRequest(BaseModel):
     station_id: str | None = None
-    latest_per_station: int = 5
+    station_ids: list[str] = Field(default_factory=list)
+    history_scope: CandidateHistoryScope = "all_cached"
+    latest_per_station: int | None = None
     limit: int = 50
     story_filter: CandidateStoryFilter = "all"
     story_family: CandidateStoryFamilyFilter = "all"
@@ -291,7 +297,7 @@ def cache_igra_recent_file(request: IGRACacheRequest) -> dict[str, object]:
 
 @app.post("/api/igra/recent/cache-batch")
 def cache_igra_recent_files(request: IGRABatchCacheRequest) -> dict[str, object]:
-    if request.limit < 1:
+    if request.limit < 1 and not request.station_ids:
         raise HTTPException(status_code=400, detail="limit must be at least 1")
     settings = load_settings()
     catalog = read_igra_recent_catalog(settings)
@@ -300,13 +306,29 @@ def cache_igra_recent_files(request: IGRABatchCacheRequest) -> dict[str, object]
             status_code=400,
             detail="Refresh IGRA recent catalog before caching station files.",
         )
+    selected_station_ids = [
+        station.strip()
+        for station in ([request.station_id] if request.station_id else []) + request.station_ids
+        if station and station.strip()
+    ]
+    selected_station_set = set(selected_station_ids)
     uncached = [
         reference
         for reference in catalog.zip_references
         if reference.cached_status == "not_cached"
-        and (request.station_id is None or reference.station_id == request.station_id)
+        and (not selected_station_set or reference.station_id in selected_station_set)
     ]
-    selected = uncached[: request.limit]
+    if selected_station_set:
+        station_order = {station: index for index, station in enumerate(selected_station_ids)}
+        selected = sorted(
+            uncached,
+            key=lambda reference: (
+                station_order.get(reference.station_id, len(station_order)),
+                reference.filename,
+            ),
+        )
+    else:
+        selected = uncached[: request.limit]
     cached_entries: list[dict[str, object]] = []
     failed: list[dict[str, str]] = []
     for reference in selected:
@@ -327,6 +349,7 @@ def cache_igra_recent_files(request: IGRABatchCacheRequest) -> dict[str, object]
             )
     return {
         "requested_limit": request.limit,
+        "requested_station_ids": selected_station_ids,
         "selected_count": len(selected),
         "cached_entries": cached_entries,
         "failed": failed,
@@ -346,6 +369,8 @@ def screen_sounding_candidates(request: SoundingCandidateScreenRequest) -> dict[
         result = screen_cached_soundings(
             load_settings(),
             station_id=request.station_id,
+            station_ids=request.station_ids,
+            history_scope=request.history_scope,
             latest_per_station=request.latest_per_station,
             limit=request.limit,
             target_story=request.target_story,
@@ -361,6 +386,8 @@ def analyze_sounding_candidates(request: SoundingCandidateAnalysisRequest) -> di
         result = analyze_cached_soundings(
             load_settings(),
             station_id=request.station_id,
+            station_ids=request.station_ids,
+            history_scope=request.history_scope,
             latest_per_station=request.latest_per_station,
             limit=request.limit,
             story_filter=request.story_filter,

--- a/app/backend/cloud_chamber/observed_sounding.py
+++ b/app/backend/cloud_chamber/observed_sounding.py
@@ -90,6 +90,14 @@ class ObservedSoundingRecord(BaseModel):
         return self
 
 
+class ParsedIgraSounding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    summary: SoundingTimeSummary
+    record: ObservedSoundingRecord | None = None
+    error: str | None = None
+
+
 class ObservedSoundingUploadResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -147,17 +155,7 @@ def parse_igra_station_text(
     if not headers:
         raise ObservedSoundingError("No IGRA sounding headers were found in the uploaded file.")
 
-    available = [
-        SoundingTimeSummary(
-            station_id=header["station_id"],
-            valid_time_utc=header["valid_time_utc"],
-            source_time_text=header["source_time_text"],
-            num_levels=header["num_levels"],
-            pressure_source=header["pressure_source"],
-            non_pressure_source=header["non_pressure_source"],
-        )
-        for header in headers
-    ]
+    available = [_summary_from_header(header) for header in headers]
     selected = _select_header(headers, selected_time_utc)
     raw_levels = lines[
         selected["line_index"] + 1 : selected["line_index"] + 1 + selected["num_levels"]
@@ -184,17 +182,47 @@ def summarize_igra_station_text(text: str) -> list[SoundingTimeSummary]:
     headers = _scan_headers(lines)
     if not headers:
         raise ObservedSoundingError("No IGRA sounding headers were found in the station file.")
-    return [
-        SoundingTimeSummary(
-            station_id=header["station_id"],
-            valid_time_utc=header["valid_time_utc"],
-            source_time_text=header["source_time_text"],
-            num_levels=header["num_levels"],
-            pressure_source=header["pressure_source"],
-            non_pressure_source=header["non_pressure_source"],
-        )
-        for header in headers
-    ]
+    return [_summary_from_header(header) for header in headers]
+
+
+def parse_igra_station_soundings(
+    text: str,
+    *,
+    uploaded_filename: str,
+    selected_times_utc: set[datetime] | None = None,
+    station_metadata: StationMetadata | None = None,
+) -> list[ParsedIgraSounding]:
+    """Parse selected IGRA sounding records from one station text scan."""
+
+    lines = text.splitlines()
+    headers = _scan_headers(lines)
+    if not headers:
+        raise ObservedSoundingError("No IGRA sounding headers were found in the station file.")
+
+    normalized_times = (
+        {selected_time.astimezone(UTC) for selected_time in selected_times_utc}
+        if selected_times_utc is not None
+        else None
+    )
+    parsed: list[ParsedIgraSounding] = []
+    for header in headers:
+        summary = _summary_from_header(header)
+        if normalized_times is not None and summary.valid_time_utc not in normalized_times:
+            continue
+        raw_levels = lines[
+            header["line_index"] + 1 : header["line_index"] + 1 + header["num_levels"]
+        ]
+        try:
+            record = _normalize_sounding(
+                header=header,
+                raw_levels=raw_levels,
+                uploaded_filename=uploaded_filename,
+                station_metadata=station_metadata,
+            )
+            parsed.append(ParsedIgraSounding(summary=summary, record=record))
+        except ObservedSoundingError as exc:
+            parsed.append(ParsedIgraSounding(summary=summary, error=str(exc)))
+    return parsed
 
 
 def observed_sounding_from_payload(payload: object) -> ObservedSoundingRecord:
@@ -314,6 +342,17 @@ def _select_header(headers: list[_IgraHeader], selected_time_utc: datetime | Non
         if header["valid_time_utc"] == normalized:
             return header
     raise ObservedSoundingError("Selected sounding time was not found in the uploaded file.")
+
+
+def _summary_from_header(header: _IgraHeader) -> SoundingTimeSummary:
+    return SoundingTimeSummary(
+        station_id=header["station_id"],
+        valid_time_utc=header["valid_time_utc"],
+        source_time_text=header["source_time_text"],
+        num_levels=header["num_levels"],
+        pressure_source=header["pressure_source"],
+        non_pressure_source=header["non_pressure_source"],
+    )
 
 
 def _normalize_sounding(

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -23,7 +23,10 @@ from cloud_chamber.observed_sounding import (
     ObservedSoundingError,
     ObservedSoundingLevel,
     ObservedSoundingRecord,
+    ParsedIgraSounding,
+    SoundingTimeSummary,
     StationMetadata,
+    parse_igra_station_soundings,
     parse_igra_station_text,
     summarize_igra_station_text,
 )
@@ -90,6 +93,7 @@ CandidateStoryFilter = Literal[
 ]
 CandidateSupportFilter = Literal["all", "supported", "weak", "unavailable"]
 CandidateReadinessFilter = Literal["all", "package_ready", "blocked"]
+CandidateHistoryScope = Literal["latest_per_station", "all_cached"]
 CandidateSortDirection = Literal["asc", "desc"]
 CandidateSortKey = Literal[
     "best_match",
@@ -320,6 +324,9 @@ class CandidateAnalysisFilterSummary(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     station_id: str | None = None
+    station_ids: list[str] = Field(default_factory=list)
+    history_scope: CandidateHistoryScope = "latest_per_station"
+    latest_per_station: int | None = 5
     story_filter: CandidateStoryFilter = "all"
     story_family: CandidateStoryFamilyFilter = "all"
     support: CandidateSupportFilter = "all"
@@ -354,6 +361,10 @@ class CandidateExcludedReason(BaseModel):
 class CandidateFilterTrace(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    selected_station_count: int
+    selected_cached_soundings: int
+    history_scope: CandidateHistoryScope
+    latest_per_station: int | None = None
     analyzed_soundings: int
     story_score_records: int
     stage_counts: dict[str, int]
@@ -428,7 +439,7 @@ SORT_OPTIONS: tuple[CandidateSortOption, ...] = (
         key="rank_score", label="Rank score", units="0-100", default_direction="desc"
     ),
     CandidateSortOption(key="confidence", label="Confidence", default_direction="desc"),
-    CandidateSortOption(key="support", label="Support state", default_direction="desc"),
+    CandidateSortOption(key="support", label="Evidence tier", default_direction="desc"),
     CandidateSortOption(
         key="package_readiness", label="Package readiness", default_direction="desc"
     ),
@@ -564,20 +575,26 @@ def screen_cached_soundings(
     settings: CloudChamberSettings,
     *,
     station_id: str | None = None,
-    latest_per_station: int = 5,
-    limit: int = 50,
+    station_ids: list[str] | None = None,
+    history_scope: CandidateHistoryScope = "latest_per_station",
+    latest_per_station: int | None = 5,
+    limit: int | None = 50,
     target_story: TargetStoryId | None = None,
 ) -> ScreeningResult:
     """Screen cached IGRA soundings and return story-matched hypotheses."""
 
-    if latest_per_station < 1:
-        raise ValueError("latest_per_station must be at least 1")
-    if limit < 1:
+    selected_station_ids = _normalize_station_selection(station_id, station_ids)
+    if history_scope == "latest_per_station":
+        if latest_per_station is None or latest_per_station < 1:
+            raise ValueError("latest_per_station must be at least 1 for latest-per-station history")
+    elif history_scope != "all_cached":
+        raise ValueError(f"Unsupported history_scope: {history_scope}")
+    if limit is not None and limit < 1:
         raise ValueError("limit must be at least 1")
     candidates: list[SoundingCandidate] = []
     caveats: list[str] = []
     for entry in _cached_text_entries(settings):
-        if station_id is not None and entry.station_id != station_id:
+        if selected_station_ids and entry.station_id not in selected_station_ids:
             continue
         if entry.cached_text_path is None:
             continue
@@ -589,13 +606,32 @@ def screen_cached_soundings(
             caveats.append(f"{entry.station_id}:{path.name}:{exc}")
             continue
         summaries = sorted(summaries, key=lambda summary: summary.valid_time_utc, reverse=True)
-        for summary in summaries[:latest_per_station]:
+        selected_summaries = (
+            summaries[:latest_per_station] if history_scope == "latest_per_station" else summaries
+        )
+        selected_times = {summary.valid_time_utc for summary in selected_summaries}
+        try:
+            parsed_soundings = parse_igra_station_soundings(
+                text,
+                uploaded_filename=path.name,
+                selected_times_utc=selected_times,
+                station_metadata=_station_metadata_from_cache_entry(entry),
+            )
+        except ObservedSoundingError as exc:
+            caveats.append(f"{entry.station_id}:{path.name}:{exc}")
+            continue
+        parsed_by_time = {parsed.summary.valid_time_utc: parsed for parsed in parsed_soundings}
+        for summary in selected_summaries:
+            parsed = parsed_by_time.get(summary.valid_time_utc)
+            if parsed is None:
+                caveats.append(f"{entry.station_id}:{path.name}:missing_selected_time")
+                continue
             candidates.append(
-                _candidate_from_cached_sounding(
+                _candidate_from_parsed_sounding(
                     entry=entry,
                     source_text=text,
                     source_path=path,
-                    selected_time=summary.valid_time_utc,
+                    parsed=parsed,
                 )
             )
     ranked = sorted(
@@ -614,7 +650,7 @@ def screen_cached_soundings(
     )
     return ScreeningResult(
         generated_at=datetime.now(UTC),
-        candidates=ranked[:limit],
+        candidates=ranked if limit is None else ranked[:limit],
         caveats=caveats,
     )
 
@@ -623,7 +659,9 @@ def analyze_cached_soundings(
     settings: CloudChamberSettings,
     *,
     station_id: str | None = None,
-    latest_per_station: int = 5,
+    station_ids: list[str] | None = None,
+    history_scope: CandidateHistoryScope = "all_cached",
+    latest_per_station: int | None = None,
     limit: int = 50,
     story_filter: CandidateStoryFilter = "all",
     story_family: CandidateStoryFamilyFilter = "all",
@@ -635,18 +673,23 @@ def analyze_cached_soundings(
 ) -> CandidateAnalysisResult:
     """Analyze cached sounding candidates with backend-owned filters and sorts."""
 
-    if latest_per_station < 1:
-        raise ValueError("latest_per_station must be at least 1")
+    selected_station_ids = _normalize_station_selection(station_id, station_ids)
+    if history_scope == "latest_per_station":
+        if latest_per_station is None or latest_per_station < 1:
+            raise ValueError("latest_per_station must be at least 1 for latest-per-station history")
+    elif history_scope != "all_cached":
+        raise ValueError(f"Unsupported history_scope: {history_scope}")
     if limit < 1:
         raise ValueError("limit must be at least 1")
     selected_direction = sort_direction or _DEFAULT_SORT_DIRECTIONS[sort_by]
     target_story = _target_story_for_filter(story_filter, story_family)
-    pool_limit = max(limit, 10_000)
     screened = screen_cached_soundings(
         settings,
         station_id=station_id,
+        station_ids=list(selected_station_ids),
+        history_scope=history_scope,
         latest_per_station=latest_per_station,
-        limit=pool_limit,
+        limit=None,
         target_story=target_story,
     )
     normalized_search = station_search.strip()
@@ -697,6 +740,11 @@ def analyze_cached_soundings(
         sort_direction=selected_direction,
         filters=CandidateAnalysisFilterSummary(
             station_id=station_id,
+            station_ids=list(selected_station_ids),
+            history_scope=history_scope,
+            latest_per_station=latest_per_station
+            if history_scope == "latest_per_station"
+            else None,
             story_filter=story_filter,
             story_family=story_family,
             support=support,
@@ -713,6 +761,10 @@ def analyze_cached_soundings(
             readiness=readiness,
             station_search=normalized_search,
             limit=limit,
+            history_scope=history_scope,
+            latest_per_station=latest_per_station
+            if history_scope == "latest_per_station"
+            else None,
         ),
         sort_options=list(SORT_OPTIONS),
         caveats=screened.caveats,
@@ -810,6 +862,23 @@ def _dedupe_nonempty_strings(values: list[str]) -> list[str]:
         seen.add(cleaned)
         deduped.append(cleaned)
     return deduped
+
+
+def _normalize_station_selection(
+    station_id: str | None, station_ids: list[str] | None
+) -> tuple[str, ...]:
+    selected: list[str] = []
+    if station_id:
+        selected.append(station_id.strip())
+    selected.extend(station.strip() for station in (station_ids or []) if station.strip())
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for station in selected:
+        if station in seen:
+            continue
+        seen.add(station)
+        deduped.append(station)
+    return tuple(deduped)
 
 
 def _candidate_story_score(candidate: SoundingCandidate, story: TargetStoryId | None) -> float:
@@ -964,7 +1033,10 @@ def _candidate_filter_trace(
     readiness: CandidateReadinessFilter,
     station_search: str,
     limit: int,
+    history_scope: CandidateHistoryScope,
+    latest_per_station: int | None,
 ) -> CandidateFilterTrace:
+    selected_station_count = len({candidate.station_id for candidate in candidates})
     stages: list[CandidateFilterStage] = [
         CandidateFilterStage(
             key="analyzed_soundings",
@@ -1013,7 +1085,7 @@ def _candidate_filter_trace(
     )
     apply_stage(
         key="support",
-        label="Support",
+        label="Evidence tier",
         active=support != "all",
         keep=lambda candidate: _candidate_matches_support_filter(
             candidate,
@@ -1021,7 +1093,7 @@ def _candidate_filter_trace(
             story_family=story_family,
             support=support,
         ),
-        excluded_reason=f"Support: {support}",
+        excluded_reason=f"Evidence tier: {_support_label(support)}",
     )
     apply_stage(
         key="readiness",
@@ -1056,6 +1128,10 @@ def _candidate_filter_trace(
     stage_counts = {stage.key: stage.count for stage in stages}
     station_distribution = _station_distribution(rendered_candidates)
     return CandidateFilterTrace(
+        selected_station_count=selected_station_count,
+        selected_cached_soundings=len(candidates),
+        history_scope=history_scope,
+        latest_per_station=latest_per_station,
         analyzed_soundings=len(candidates),
         story_score_records=sum(len(candidate.story_scores) for candidate in candidates),
         stage_counts=stage_counts,
@@ -1182,6 +1258,16 @@ def _story_family_label(story_family: CandidateStoryFamilyFilter) -> str:
     if story_family == "lower_atmosphere":
         return "lower-atmosphere stories"
     return "review / incomplete"
+
+
+def _support_label(support: CandidateSupportFilter) -> str:
+    if support == "all":
+        return "all evidence tiers"
+    if support == "supported":
+        return "strong signal"
+    if support == "weak":
+        return "plausible / caveated"
+    return "little or no signal"
 
 
 def _candidate_matches_analysis_filters(
@@ -1429,20 +1515,57 @@ def _candidate_from_cached_sounding(
     source_path: Path,
     selected_time: datetime,
 ) -> SoundingCandidate:
-    source_hash = hashlib.sha256(source_text.encode("utf-8")).hexdigest()
-    created_at = datetime.now(UTC)
     station_metadata = _station_metadata_from_cache_entry(entry)
-    station_latitude: float | None
-    station_longitude: float | None
-    station_elevation: float | None
     try:
-        parsed = parse_igra_station_text(
+        response = parse_igra_station_text(
             source_text,
             uploaded_filename=source_path.name,
             selected_time_utc=selected_time,
             station_metadata=station_metadata,
         )
-        record = parsed.selected_sounding
+        parsed = ParsedIgraSounding(
+            summary=next(
+                summary
+                for summary in response.available_soundings
+                if summary.valid_time_utc == response.selected_sounding.valid_time_utc
+            ),
+            record=response.selected_sounding,
+        )
+    except ObservedSoundingError as exc:
+        parsed = ParsedIgraSounding(
+            summary=SoundingTimeSummary(
+                station_id=entry.station_id,
+                valid_time_utc=selected_time,
+                source_time_text=selected_time.isoformat().replace("+00:00", "Z"),
+                num_levels=0,
+                pressure_source="",
+                non_pressure_source="",
+            ),
+            error=str(exc),
+        )
+    return _candidate_from_parsed_sounding(
+        entry=entry,
+        source_text=source_text,
+        source_path=source_path,
+        parsed=parsed,
+    )
+
+
+def _candidate_from_parsed_sounding(
+    *,
+    entry: IGRACacheEntry,
+    source_text: str,
+    source_path: Path,
+    parsed: ParsedIgraSounding,
+) -> SoundingCandidate:
+    source_hash = hashlib.sha256(source_text.encode("utf-8")).hexdigest()
+    created_at = datetime.now(UTC)
+    selected_time = parsed.summary.valid_time_utc
+    station_latitude: float | None
+    station_longitude: float | None
+    station_elevation: float | None
+    if parsed.record is not None:
+        record = parsed.record
         features = _features_from_record(record)
         story_scores, evidence = _score_features(features, package_ready=True)
         caveats = list(record.validation.caveats)
@@ -1454,15 +1577,16 @@ def _candidate_from_cached_sounding(
         station_longitude = record.station_longitude
         station_elevation = record.station_elevation_m_msl
         package_ready = True
-    except ObservedSoundingError as exc:
+    else:
+        error = parsed.error or "Observed sounding could not be parsed."
         features = {
             "data_completeness_score": 0.0,
-            "package_error": str(exc),
+            "package_error": error,
         }
-        story_scores, evidence = _poor_candidate_scores(str(exc))
-        caveats = [str(exc)]
+        story_scores, evidence = _poor_candidate_scores(error)
+        caveats = [error]
         selected_payload = None
-        source_time_text = selected_time.isoformat().replace("+00:00", "Z")
+        source_time_text = parsed.summary.source_time_text
         station_latitude = entry.latitude
         station_longitude = entry.longitude
         station_elevation = entry.elevation_m_msl

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+from collections.abc import Callable
 from datetime import UTC, datetime
 from functools import cmp_to_key
 from pathlib import Path
@@ -267,6 +268,18 @@ class SoundingCandidate(BaseModel):
         "CM1 package will produce."
     )
     recipe_fit_caveats: list[str] = Field(default_factory=list)
+    active_story: StoryId | None = None
+    active_story_label: str | None = None
+    display_story: str | None = None
+    matched_story_ids: list[StoryId] = Field(default_factory=list)
+    active_story_score: float | None = None
+    ingredient_score: float | None = None
+    active_story_support: Support | None = None
+    package_readiness: str | None = None
+    recipe_fit: str | None = None
+    top_reasons: list[str] = Field(default_factory=list)
+    top_caveats: list[str] = Field(default_factory=list)
+    evidence_summary: list[str] = Field(default_factory=list)
     screening_version: str = SCREENING_VERSION
     created_at: datetime
 
@@ -314,6 +327,42 @@ class CandidateAnalysisFilterSummary(BaseModel):
     station_search: str = ""
 
 
+class CandidateFilterStage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    label: str
+    count: int
+    active: bool = False
+
+
+class CandidateStationDistribution(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    station_id: str
+    station_name: str | None = None
+    count: int
+
+
+class CandidateExcludedReason(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    reason: str
+    count: int
+
+
+class CandidateFilterTrace(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    analyzed_soundings: int
+    story_score_records: int
+    stage_counts: dict[str, int]
+    stages: list[CandidateFilterStage]
+    station_distribution: list[CandidateStationDistribution]
+    top_excluded_reasons: list[CandidateExcludedReason]
+    applied_limit: int
+
+
 class CandidateAnalysisResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -325,6 +374,7 @@ class CandidateAnalysisResult(BaseModel):
     sort_by: CandidateSortKey
     sort_direction: CandidateSortDirection
     filters: CandidateAnalysisFilterSummary
+    filter_trace: CandidateFilterTrace
     sort_options: list[CandidateSortOption]
     caveats: list[str] = Field(default_factory=list)
 
@@ -612,6 +662,14 @@ def analyze_cached_soundings(
             station_search=normalized_search,
         )
     ]
+    contextual_filtered = [
+        _candidate_with_analysis_context(
+            candidate,
+            story_filter=story_filter,
+            story_family=story_family,
+        )
+        for candidate in filtered
+    ]
     if _uses_default_discovery_view(
         story_filter=story_filter,
         story_family=story_family,
@@ -620,18 +678,19 @@ def analyze_cached_soundings(
         station_search=normalized_search,
         sort_by=sort_by,
     ):
-        sorted_candidates = _diverse_recommendations(filtered)
+        sorted_candidates = _diverse_recommendations(contextual_filtered)
     else:
         sorted_candidates = _sort_analysis_candidates(
-            filtered,
+            contextual_filtered,
             sort_by=sort_by,
             sort_direction=selected_direction,
             story_filter=story_filter,
             story_family=story_family,
         )
+    limited_candidates = sorted_candidates[:limit]
     return CandidateAnalysisResult(
         generated_at=datetime.now(UTC),
-        candidates=sorted_candidates[:limit],
+        candidates=limited_candidates,
         total_candidate_count=len(screened.candidates),
         filtered_candidate_count=len(filtered),
         sort_by=sort_by,
@@ -644,9 +703,113 @@ def analyze_cached_soundings(
             readiness=readiness,
             station_search=normalized_search,
         ),
+        filter_trace=_candidate_filter_trace(
+            screened.candidates,
+            sorted_candidates=sorted_candidates,
+            rendered_candidates=limited_candidates,
+            story_filter=story_filter,
+            story_family=story_family,
+            support=support,
+            readiness=readiness,
+            station_search=normalized_search,
+            limit=limit,
+        ),
         sort_options=list(SORT_OPTIONS),
         caveats=screened.caveats,
     )
+
+
+def _candidate_with_analysis_context(
+    candidate: SoundingCandidate,
+    *,
+    story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter,
+) -> SoundingCandidate:
+    scoped_scores = _candidate_story_scores_for_scope(
+        candidate,
+        story_filter=story_filter,
+        story_family=story_family,
+    )
+    meaningful_scores = [score for score in scoped_scores if _meaningful_story_score(score)]
+    active_score = max(
+        meaningful_scores or scoped_scores,
+        key=lambda score: score.score_0_to_100,
+        default=None,
+    )
+    if active_score is None:
+        active_score = next(
+            (score for score in candidate.story_scores if score.story == candidate.primary_story),
+            None,
+        )
+    active_story = active_score.story if active_score else candidate.primary_story
+    active_label = active_score.label if active_score else candidate.primary_story_label
+    active_support = active_score.support if active_score else None
+    active_score_value = active_score.score_0_to_100 if active_score else candidate.rank_score
+    recipe_fit = _candidate_recipe_fit(
+        active_story,
+        features=candidate.features,
+        package_ready=candidate.package_ready,
+    )
+    matched_scores = sorted(
+        meaningful_scores,
+        key=lambda score: score.score_0_to_100,
+        reverse=True,
+    )
+    evidence_summary = _candidate_evidence_summary(candidate, active_story)
+    top_reasons = _dedupe_nonempty_strings(
+        [
+            *(active_score.reasons if active_score else []),
+            *candidate.interest_reasons,
+            *(evidence_summary[:2]),
+            candidate.interest_summary or "",
+        ]
+    )[:4]
+    top_caveats = _dedupe_nonempty_strings(
+        [
+            *(active_score.caveats if active_score else []),
+            *recipe_fit["caveats"],
+            *candidate.caveats,
+        ]
+    )[:3]
+    return candidate.model_copy(
+        update={
+            "active_story": active_story,
+            "active_story_label": active_label,
+            "display_story": active_label,
+            "matched_story_ids": [score.story for score in matched_scores],
+            "active_story_score": round(active_score_value, 2),
+            "ingredient_score": round(active_score_value, 2),
+            "active_story_support": active_support,
+            "package_readiness": "package_ready" if candidate.package_ready else "blocked",
+            "recipe_fit": recipe_fit["status"],
+            "top_reasons": top_reasons,
+            "top_caveats": top_caveats,
+            "evidence_summary": evidence_summary,
+        }
+    )
+
+
+def _candidate_evidence_summary(candidate: SoundingCandidate, active_story: StoryId) -> list[str]:
+    scoped = [
+        item.interpretation
+        for item in candidate.evidence
+        if active_story in item.supports_story and item.interpretation
+    ]
+    if scoped:
+        return scoped[:3]
+    return [item.interpretation for item in candidate.evidence if item.interpretation][:3]
+
+
+def _dedupe_nonempty_strings(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        cleaned = value.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        deduped.append(cleaned)
+    return deduped
 
 
 def _candidate_story_score(candidate: SoundingCandidate, story: TargetStoryId | None) -> float:
@@ -790,6 +953,237 @@ def _target_story_for_filter(
     return None
 
 
+def _candidate_filter_trace(
+    candidates: list[SoundingCandidate],
+    *,
+    sorted_candidates: list[SoundingCandidate],
+    rendered_candidates: list[SoundingCandidate],
+    story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter,
+    support: CandidateSupportFilter,
+    readiness: CandidateReadinessFilter,
+    station_search: str,
+    limit: int,
+) -> CandidateFilterTrace:
+    stages: list[CandidateFilterStage] = [
+        CandidateFilterStage(
+            key="analyzed_soundings",
+            label="Analyzed cached soundings",
+            count=len(candidates),
+            active=True,
+        )
+    ]
+    top_excluded_reasons: list[CandidateExcludedReason] = []
+    current = candidates
+
+    def apply_stage(
+        *,
+        key: str,
+        label: str,
+        active: bool,
+        keep: Callable[[SoundingCandidate], bool],
+        excluded_reason: str,
+    ) -> None:
+        nonlocal current
+        before = len(current)
+        if active:
+            current = [candidate for candidate in current if keep(candidate)]
+        stages.append(CandidateFilterStage(key=key, label=label, count=len(current), active=active))
+        excluded = before - len(current)
+        if active and excluded > 0:
+            top_excluded_reasons.append(
+                CandidateExcludedReason(reason=excluded_reason, count=excluded)
+            )
+
+    apply_stage(
+        key="story_filter",
+        label="Story filter",
+        active=story_filter != "all",
+        keep=lambda candidate: _candidate_matches_story_filter(candidate, story_filter),
+        excluded_reason=f"Story filter: {_story_filter_label(story_filter)}",
+    )
+    apply_stage(
+        key="story_family",
+        label="Story family",
+        active=story_family != "all",
+        keep=lambda candidate: _candidate_matches_story_family(
+            candidate, story_filter, story_family
+        ),
+        excluded_reason=f"Story family: {_story_family_label(story_family)}",
+    )
+    apply_stage(
+        key="support",
+        label="Support",
+        active=support != "all",
+        keep=lambda candidate: _candidate_matches_support_filter(
+            candidate,
+            story_filter=story_filter,
+            story_family=story_family,
+            support=support,
+        ),
+        excluded_reason=f"Support: {support}",
+    )
+    apply_stage(
+        key="readiness",
+        label="Package readiness",
+        active=readiness != "all",
+        keep=lambda candidate: _candidate_matches_readiness(candidate, readiness),
+        excluded_reason=f"Readiness: {readiness}",
+    )
+    apply_stage(
+        key="station_search",
+        label="Station search",
+        active=bool(station_search),
+        keep=lambda candidate: _candidate_matches_station_search(candidate, station_search),
+        excluded_reason=f"Station search: {station_search}",
+    )
+    stages.append(
+        CandidateFilterStage(
+            key="sorted_or_recommended",
+            label="Sorted recommendation set",
+            count=len(sorted_candidates),
+            active=True,
+        )
+    )
+    stages.append(
+        CandidateFilterStage(
+            key="limited",
+            label="Returned candidate limit",
+            count=len(rendered_candidates),
+            active=len(sorted_candidates) > len(rendered_candidates),
+        )
+    )
+    stage_counts = {stage.key: stage.count for stage in stages}
+    station_distribution = _station_distribution(rendered_candidates)
+    return CandidateFilterTrace(
+        analyzed_soundings=len(candidates),
+        story_score_records=sum(len(candidate.story_scores) for candidate in candidates),
+        stage_counts=stage_counts,
+        stages=stages,
+        station_distribution=station_distribution,
+        top_excluded_reasons=sorted(
+            top_excluded_reasons,
+            key=lambda reason: reason.count,
+            reverse=True,
+        )[:4],
+        applied_limit=limit,
+    )
+
+
+def _candidate_matches_story_filter(
+    candidate: SoundingCandidate,
+    story_filter: CandidateStoryFilter,
+) -> bool:
+    if story_filter == "all":
+        return True
+    scoped_scores = _candidate_story_scores_for_scope(
+        candidate,
+        story_filter=story_filter,
+        story_family="all",
+    )
+    return any(_meaningful_story_score(score) for score in scoped_scores)
+
+
+def _candidate_matches_story_family(
+    candidate: SoundingCandidate,
+    story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter,
+) -> bool:
+    if story_family == "all":
+        return True
+    scoped_scores = _candidate_story_scores_for_scope(
+        candidate,
+        story_filter=story_filter,
+        story_family=story_family,
+    )
+    return any(_meaningful_story_score(score) for score in scoped_scores)
+
+
+def _candidate_matches_support_filter(
+    candidate: SoundingCandidate,
+    *,
+    story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter,
+    support: CandidateSupportFilter,
+) -> bool:
+    if support == "all":
+        return True
+    scoped_scores = _candidate_story_scores_for_scope(
+        candidate,
+        story_filter=story_filter,
+        story_family=story_family,
+    )
+    if story_filter == "all" and story_family == "all":
+        score = max(scoped_scores, key=lambda item: item.score_0_to_100, default=None)
+        return score is not None and score.support == support
+    return any(score.support == support for score in scoped_scores)
+
+
+def _candidate_matches_readiness(
+    candidate: SoundingCandidate, readiness: CandidateReadinessFilter
+) -> bool:
+    if readiness == "package_ready":
+        return candidate.package_ready
+    if readiness == "blocked":
+        return not candidate.package_ready
+    return True
+
+
+def _candidate_matches_station_search(candidate: SoundingCandidate, station_search: str) -> bool:
+    if not station_search:
+        return True
+    normalized = station_search.lower()
+    searchable = " ".join(
+        str(value)
+        for value in (
+            candidate.station_id,
+            candidate.station_name,
+            candidate.source_file_name,
+            candidate.primary_story_label,
+            candidate.story_family,
+            *(score.label for score in candidate.story_scores),
+            *(score.story for score in candidate.story_scores),
+        )
+        if value
+    ).lower()
+    return normalized in searchable
+
+
+def _station_distribution(
+    candidates: list[SoundingCandidate],
+) -> list[CandidateStationDistribution]:
+    counts: dict[str, CandidateStationDistribution] = {}
+    for candidate in candidates:
+        current = counts.get(candidate.station_id)
+        if current is None:
+            counts[candidate.station_id] = CandidateStationDistribution(
+                station_id=candidate.station_id,
+                station_name=candidate.station_name,
+                count=1,
+            )
+        else:
+            counts[candidate.station_id] = current.model_copy(update={"count": current.count + 1})
+    return sorted(counts.values(), key=lambda item: (-item.count, item.station_id))
+
+
+def _story_filter_label(story_filter: CandidateStoryFilter) -> str:
+    if story_filter == "all":
+        return "all stories"
+    if story_filter == "deep_convection_trial":
+        return "deep-convection stories"
+    return STORY_LABELS[story_filter]
+
+
+def _story_family_label(story_family: CandidateStoryFamilyFilter) -> str:
+    if story_family == "all":
+        return "all families"
+    if story_family == "deep_convection":
+        return "deep-convection stories"
+    if story_family == "lower_atmosphere":
+        return "lower-atmosphere stories"
+    return "review / incomplete"
+
+
 def _candidate_matches_analysis_filters(
     candidate: SoundingCandidate,
     *,
@@ -799,9 +1193,7 @@ def _candidate_matches_analysis_filters(
     readiness: CandidateReadinessFilter,
     station_search: str,
 ) -> bool:
-    if readiness == "package_ready" and not candidate.package_ready:
-        return False
-    if readiness == "blocked" and candidate.package_ready:
+    if not _candidate_matches_readiness(candidate, readiness):
         return False
     scoped_scores = _candidate_story_scores_for_scope(
         candidate,
@@ -820,21 +1212,8 @@ def _candidate_matches_analysis_filters(
                 return False
         elif not any(score.support == support for score in scoped_scores):
             return False
-    if station_search:
-        normalized = station_search.lower()
-        searchable = " ".join(
-            str(value)
-            for value in (
-                candidate.station_id,
-                candidate.station_name,
-                candidate.source_file_name,
-                candidate.primary_story_label,
-                candidate.story_family,
-            )
-            if value
-        ).lower()
-        if normalized not in searchable:
-            return False
+    if not _candidate_matches_station_search(candidate, station_search):
+        return False
     return True
 
 

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -610,6 +610,7 @@ def screen_cached_soundings(
             summaries[:latest_per_station] if history_scope == "latest_per_station" else summaries
         )
         selected_times = {summary.valid_time_utc for summary in selected_summaries}
+        source_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
         try:
             parsed_soundings = parse_igra_station_soundings(
                 text,
@@ -629,8 +630,8 @@ def screen_cached_soundings(
             candidates.append(
                 _candidate_from_parsed_sounding(
                     entry=entry,
-                    source_text=text,
                     source_path=path,
+                    source_hash=source_hash,
                     parsed=parsed,
                 )
             )
@@ -1545,8 +1546,8 @@ def _candidate_from_cached_sounding(
         )
     return _candidate_from_parsed_sounding(
         entry=entry,
-        source_text=source_text,
         source_path=source_path,
+        source_hash=hashlib.sha256(source_text.encode("utf-8")).hexdigest(),
         parsed=parsed,
     )
 
@@ -1554,11 +1555,10 @@ def _candidate_from_cached_sounding(
 def _candidate_from_parsed_sounding(
     *,
     entry: IGRACacheEntry,
-    source_text: str,
     source_path: Path,
+    source_hash: str,
     parsed: ParsedIgraSounding,
 ) -> SoundingCandidate:
-    source_hash = hashlib.sha256(source_text.encode("utf-8")).hexdigest()
     created_at = datetime.now(UTC)
     selected_time = parsed.summary.valid_time_utc
     station_latitude: float | None

--- a/app/backend/cloud_chamber/sounding_diagnostics.py
+++ b/app/backend/cloud_chamber/sounding_diagnostics.py
@@ -20,6 +20,47 @@ DIAGNOSTIC_VERSION = "sounding-diagnostics-v1"
 SupportState = Literal["supported", "weak", "unavailable"]
 
 
+class _HeightInterpolator:
+    def __init__(self, levels: list[ObservedSoundingLevel]) -> None:
+        self._levels = levels
+        self._cache: dict[str, tuple[list[float], list[float]]] = {}
+
+    def interpolate(self, height_m: float, field: str) -> float | None:
+        heights, values = self._values(field)
+        if not heights:
+            return None
+        if height_m < heights[0]:
+            return values[0] if height_m <= 0.0 and heights[0] <= 100.0 else None
+        if height_m > heights[-1]:
+            return None
+        index = bisect_left(heights, height_m)
+        if index < len(heights) and math.isclose(heights[index], height_m, abs_tol=1e-6):
+            return values[index]
+        if index == 0 or index >= len(heights):
+            return None
+        lower_height = heights[index - 1]
+        upper_height = heights[index]
+        if math.isclose(lower_height, upper_height):
+            return None
+        fraction = (height_m - lower_height) / (upper_height - lower_height)
+        return values[index - 1] + fraction * (values[index] - values[index - 1])
+
+    def _values(self, field: str) -> tuple[list[float], list[float]]:
+        cached = self._cache.get(field)
+        if cached is not None:
+            return cached
+        heights: list[float] = []
+        values: list[float] = []
+        for level in self._levels:
+            value = getattr(level, field)
+            if _finite(level.model_z_m, value):
+                heights.append(float(level.model_z_m))
+                values.append(float(value))
+        cached = (heights, values)
+        self._cache[field] = cached
+        return cached
+
+
 class SoundingDiagnosticFeature(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -63,6 +104,7 @@ def compute_sounding_diagnostics(record: ObservedSoundingRecord) -> SoundingDiag
     """Compute bounded, caveated diagnostics from an observed sounding record."""
 
     levels = sorted(record.levels, key=lambda level: float(level.model_z_m))
+    height_interpolator = _HeightInterpolator(levels)
     assumptions = [
         "Diagnostics are computed from the observed sounding profile before a CM1 run.",
         "Candidate diagnostics are pre-run evidence, not forecasts or CM1 outcomes.",
@@ -303,7 +345,7 @@ def compute_sounding_diagnostics(record: ObservedSoundingRecord) -> SoundingDiag
         _feature(
             "lapse_rate_0_1000m_c_per_km",
             "Lapse rate 0-1000 m",
-            _lapse_rate(levels, 0.0, 1000.0),
+            _lapse_rate(levels, 0.0, 1000.0, height_interpolator),
             "C/km",
             "linear interpolation in height between 0 and 1000 m AGL",
         )
@@ -312,7 +354,7 @@ def compute_sounding_diagnostics(record: ObservedSoundingRecord) -> SoundingDiag
         _feature(
             "lapse_rate_0_3000m_c_per_km",
             "Lapse rate 0-3000 m",
-            _lapse_rate(levels, 0.0, 3000.0),
+            _lapse_rate(levels, 0.0, 3000.0, height_interpolator),
             "C/km",
             "linear interpolation in height between 0 and 3000 m AGL",
         )
@@ -494,7 +536,7 @@ def compute_sounding_diagnostics(record: ObservedSoundingRecord) -> SoundingDiag
         _feature(
             "bulk_shear_0_1km_m_s",
             "Bulk shear 0-1 km",
-            _bulk_shear(levels, 0.0, 1000.0),
+            _bulk_shear(levels, 0.0, 1000.0, height_interpolator),
             "m/s",
             "vector wind difference between interpolated 0 and 1000 m winds",
         )
@@ -503,7 +545,7 @@ def compute_sounding_diagnostics(record: ObservedSoundingRecord) -> SoundingDiag
         _feature(
             "bulk_shear_0_3km_m_s",
             "Bulk shear 0-3 km",
-            _bulk_shear(levels, 0.0, 3000.0),
+            _bulk_shear(levels, 0.0, 3000.0, height_interpolator),
             "m/s",
             "vector wind difference between interpolated 0 and 3000 m winds",
         )
@@ -512,7 +554,7 @@ def compute_sounding_diagnostics(record: ObservedSoundingRecord) -> SoundingDiag
         _feature(
             "bulk_shear_0_6km_m_s",
             "Bulk shear 0-6 km",
-            _bulk_shear(levels, 0.0, 6000.0),
+            _bulk_shear(levels, 0.0, 6000.0, height_interpolator),
             "m/s",
             "vector wind difference between interpolated 0 and 6000 m winds",
         )
@@ -704,7 +746,8 @@ def _data_quality(levels: list[ObservedSoundingLevel]) -> SoundingDataQuality:
     below_6 = _count_levels(usable, 6000.0)
     top = _top(usable) or 0.0
     lowest = _lowest(usable) or 9999.0
-    wind_bonus = 20.0 if _has_wind(usable) else 0.0
+    has_wind = _has_wind(usable)
+    wind_bonus = 20.0 if has_wind else 0.0
     score = min(
         100.0,
         min(25.0, len(usable) * 2.5)
@@ -714,7 +757,7 @@ def _data_quality(levels: list[ObservedSoundingLevel]) -> SoundingDataQuality:
         + wind_bonus,
     )
     caveats: list[str] = []
-    if not _has_wind(usable):
+    if not has_wind:
         caveats.append("observed_wind_profile_missing_or_incomplete")
     if below_1 < 2:
         caveats.append("sparse_low_level_profile_below_1km")
@@ -794,9 +837,15 @@ def _moisture_depth(levels: list[ObservedSoundingLevel], *, min_qv_g_kg: float) 
     return _round(max(moist), 1) if moist else None
 
 
-def _lapse_rate(levels: list[ObservedSoundingLevel], bottom_m: float, top_m: float) -> float | None:
-    bottom = _interpolate_by_height(levels, bottom_m, "temperature_c")
-    top = _interpolate_by_height(levels, top_m, "temperature_c")
+def _lapse_rate(
+    levels: list[ObservedSoundingLevel],
+    bottom_m: float,
+    top_m: float,
+    height_interpolator: _HeightInterpolator | None = None,
+) -> float | None:
+    interpolator = height_interpolator or _HeightInterpolator(levels)
+    bottom = interpolator.interpolate(bottom_m, "temperature_c")
+    top = interpolator.interpolate(top_m, "temperature_c")
     if bottom is None or top is None or math.isclose(bottom_m, top_m):
         return None
     return _round((bottom - top) / ((top_m - bottom_m) / 1000.0), 2)
@@ -870,9 +919,15 @@ def _wind_profile_depth(levels: list[ObservedSoundingLevel]) -> float | None:
     return _round(max(wind_levels) - min(wind_levels), 1)
 
 
-def _bulk_shear(levels: list[ObservedSoundingLevel], bottom_m: float, top_m: float) -> float | None:
-    bottom = _interpolate_wind(levels, bottom_m)
-    top = _interpolate_wind(levels, top_m)
+def _bulk_shear(
+    levels: list[ObservedSoundingLevel],
+    bottom_m: float,
+    top_m: float,
+    height_interpolator: _HeightInterpolator | None = None,
+) -> float | None:
+    interpolator = height_interpolator or _HeightInterpolator(levels)
+    bottom = _interpolate_wind(levels, bottom_m, interpolator)
+    top = _interpolate_wind(levels, top_m, interpolator)
     if bottom is None or top is None:
         return None
     return _round(math.hypot(top[0] - bottom[0], top[1] - bottom[1]), 2)
@@ -1169,10 +1224,13 @@ def _interpolate_by_pressure(
 
 
 def _interpolate_wind(
-    levels: list[ObservedSoundingLevel], height_m: float
+    levels: list[ObservedSoundingLevel],
+    height_m: float,
+    height_interpolator: _HeightInterpolator | None = None,
 ) -> tuple[float, float] | None:
-    u = _interpolate_by_height(levels, height_m, "u_wind_m_s")
-    v = _interpolate_by_height(levels, height_m, "v_wind_m_s")
+    interpolator = height_interpolator or _HeightInterpolator(levels)
+    u = interpolator.interpolate(height_m, "u_wind_m_s")
+    v = interpolator.interpolate(height_m, "v_wind_m_s")
     if u is None or v is None:
         return None
     return u, v
@@ -1202,7 +1260,12 @@ def _numeric(value: float | int | str | bool | None) -> float | None:
 
 
 def _finite(*values: object) -> bool:
-    return all(isinstance(value, int | float) and math.isfinite(float(value)) for value in values)
+    for value in values:
+        if not isinstance(value, int | float):
+            return False
+        if not math.isfinite(float(value)):
+            return False
+    return True
 
 
 def _round(value: float | int | None, digits: int) -> float | None:

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -431,6 +431,12 @@ def test_analysis_family_filter_includes_supported_secondary_deep_story(
         "primary-humid-supported-secondary-supercell"
     ]
     assert result.filtered_candidate_count == 1
+    assert result.candidates[0].primary_story == "humid_rainy_candidate"
+    assert result.candidates[0].active_story == "supercell_environment"
+    assert result.candidates[0].display_story == "Supercell-like environment"
+    assert result.candidates[0].matched_story_ids == ["supercell_environment"]
+    assert result.candidates[0].active_story_score == 74.0
+    assert result.candidates[0].active_story_support == "supported"
 
 
 def test_analysis_family_support_filter_uses_deep_family_scores(
@@ -458,6 +464,11 @@ def test_analysis_family_support_filter_uses_deep_family_scores(
 
     assert [item.candidate_id for item in result.candidates] == ["secondary-deep-supported"]
     assert result.filtered_candidate_count == 1
+    assert result.candidates[0].active_story == "supercell_environment"
+    assert result.filter_trace.stage_counts["story_family"] == 2
+    assert result.filter_trace.stage_counts["support"] == 1
+    assert result.filter_trace.top_excluded_reasons[0].reason == "Support: supported"
+    assert result.filter_trace.top_excluded_reasons[0].count == 1
 
 
 def test_analysis_deep_family_best_match_sort_uses_best_deep_score(
@@ -487,6 +498,48 @@ def test_analysis_deep_family_best_match_sort_uses_best_deep_score(
         "humid-lower-better-deep",
         "humid-high-weaker-deep",
     ]
+    assert [item.active_story_score for item in result.candidates] == [91.0, 67.0]
+
+
+def test_analysis_filter_trace_preserves_distinct_candidate_rows_after_grouping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    station_a = _analysis_candidate(
+        "station-a-secondary-deep",
+        primary_score=91.0,
+        deep_score=75.0,
+    ).model_copy(update={"station_id": "USM00070001", "station_name": "Station A"})
+    station_b = _analysis_candidate(
+        "station-b-secondary-deep",
+        primary_score=89.0,
+        deep_score=72.0,
+    ).model_copy(update={"station_id": "USM00070002", "station_name": "Station B"})
+    no_deep_match = _analysis_candidate(
+        "station-c-no-deep-match",
+        primary_score=95.0,
+        deep_score=0.0,
+        deep_support="unavailable",
+    ).model_copy(update={"station_id": "USM00070003", "station_name": "Station C"})
+    _patch_screened_candidates(monkeypatch, [station_a, station_b, no_deep_match])
+
+    result = analyze_cached_soundings(
+        _settings(tmp_path),
+        story_family="deep_convection",
+        limit=10,
+    )
+
+    assert [item.station_id for item in result.candidates] == ["USM00070001", "USM00070002"]
+    assert result.filter_trace.analyzed_soundings == 3
+    assert result.filter_trace.story_score_records == 6
+    assert result.filter_trace.stage_counts["story_family"] == 2
+    assert result.filter_trace.stage_counts["limited"] == 2
+    assert [(item.station_id, item.count) for item in result.filter_trace.station_distribution] == [
+        ("USM00070001", 1),
+        ("USM00070002", 1),
+    ]
+    assert result.filter_trace.top_excluded_reasons[0].reason == (
+        "Story family: deep-convection stories"
+    )
 
 
 def test_screen_cached_soundings_caveats_unreadable_files(tmp_path: Path) -> None:
@@ -1081,6 +1134,11 @@ def test_sounding_candidate_api_screen_save_and_delete(
     assert analyzed_payload["filters"]["story_filter"] == "shallow_cumulus_candidate"
     assert analyzed_payload["sort_by"] == "mean_qv_0_1000m_g_kg"
     assert analyzed_payload["sort_options"]
+    assert analyzed_payload["filter_trace"]["analyzed_soundings"] >= 1
+    assert analyzed_payload["filter_trace"]["stage_counts"]["limited"] == len(
+        analyzed_payload["candidates"]
+    )
+    assert analyzed_payload["candidates"][0]["active_story"] == "shallow_cumulus_candidate"
 
     saved = client.post(
         "/api/sounding-candidates/saved",

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -147,13 +147,16 @@ def _patch_screened_candidates(
         settings: CloudChamberSettings,
         *,
         station_id: str | None = None,
-        latest_per_station: int = 5,
-        limit: int = 50,
+        station_ids: list[str] | None = None,
+        history_scope: str = "latest_per_station",
+        latest_per_station: int | None = 5,
+        limit: int | None = 50,
         target_story: TargetStoryId | None = None,
     ) -> ScreeningResult:
+        _ = settings, station_id, station_ids, history_scope, latest_per_station, target_story
         return ScreeningResult(
             generated_at=datetime(2026, 7, 1, tzinfo=UTC),
-            candidates=candidates[:limit],
+            candidates=candidates if limit is None else candidates[:limit],
             caveats=[],
         )
 
@@ -303,7 +306,12 @@ def test_analyze_cached_soundings_filters_and_sorts_multiple_cached_blocks(
         station_id="USM00072426",
         station_name="Wilmington, Ohio",
     )
-    seed = analyze_cached_soundings(settings, latest_per_station=1, limit=10)
+    seed = analyze_cached_soundings(
+        settings,
+        history_scope="latest_per_station",
+        latest_per_station=1,
+        limit=10,
+    )
     target_story = seed.candidates[0].primary_story
     target_support = next(
         score.support for score in seed.candidates[0].story_scores if score.story == target_story
@@ -311,6 +319,7 @@ def test_analyze_cached_soundings_filters_and_sorts_multiple_cached_blocks(
 
     result = analyze_cached_soundings(
         settings,
+        history_scope="latest_per_station",
         latest_per_station=1,
         limit=10,
         story_filter=target_story,
@@ -361,10 +370,92 @@ def test_analyze_cached_soundings_default_recommendations_are_explained_and_dive
     assert all(candidate.discovery_bucket for candidate in result.candidates)
 
 
+def test_analyze_cached_soundings_all_cached_uses_exact_selected_soundings(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_cached_igra_station(
+        settings,
+        station_id="USM00072558",
+        station_name="Valley, Nebraska",
+    )
+    _write_cached_igra_station(
+        settings,
+        station_id="USM00072426",
+        station_name="Wilmington, Ohio",
+    )
+
+    all_selected = analyze_cached_soundings(
+        settings,
+        history_scope="all_cached",
+        latest_per_station=None,
+        limit=1,
+    )
+
+    assert all_selected.total_candidate_count == 4
+    assert len(all_selected.candidates) == 1
+    assert all_selected.filter_trace.selected_station_count == 2
+    assert all_selected.filter_trace.selected_cached_soundings == 4
+    assert all_selected.filter_trace.history_scope == "all_cached"
+    assert all_selected.filter_trace.latest_per_station is None
+    assert all_selected.filter_trace.stage_counts["limited"] == 1
+
+    wilmington_only = analyze_cached_soundings(
+        settings,
+        station_ids=["USM00072426"],
+        history_scope="all_cached",
+        latest_per_station=None,
+        limit=10,
+    )
+
+    assert wilmington_only.total_candidate_count == 2
+    assert {candidate.station_id for candidate in wilmington_only.candidates} == {"USM00072426"}
+    assert wilmington_only.filters.station_ids == ["USM00072426"]
+    assert wilmington_only.filter_trace.selected_station_count == 1
+    assert wilmington_only.filter_trace.selected_cached_soundings == 2
+
+
+def test_analyze_cached_soundings_latest_scope_is_explicit_per_selected_station(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_cached_igra_station(
+        settings,
+        station_id="USM00072558",
+        station_name="Valley, Nebraska",
+    )
+    _write_cached_igra_station(
+        settings,
+        station_id="USM00072426",
+        station_name="Wilmington, Ohio",
+    )
+
+    result = analyze_cached_soundings(
+        settings,
+        station_ids=["USM00072558", "USM00072426"],
+        history_scope="latest_per_station",
+        latest_per_station=1,
+        limit=10,
+    )
+
+    assert result.total_candidate_count == 2
+    assert result.filters.station_ids == ["USM00072558", "USM00072426"]
+    assert result.filters.history_scope == "latest_per_station"
+    assert result.filters.latest_per_station == 1
+    assert result.filter_trace.selected_station_count == 2
+    assert result.filter_trace.selected_cached_soundings == 2
+    assert result.filter_trace.history_scope == "latest_per_station"
+    assert result.filter_trace.latest_per_station == 1
+
+
 def test_analysis_sorts_physical_fields_with_missing_values_last(tmp_path: Path) -> None:
     settings = _settings(tmp_path)
     _write_cached_igra_station(settings)
-    parsed_candidate = analyze_cached_soundings(settings, latest_per_station=1).candidates[0]
+    parsed_candidate = analyze_cached_soundings(
+        settings,
+        history_scope="latest_per_station",
+        latest_per_station=1,
+    ).candidates[0]
     low_lcl = parsed_candidate.model_copy(
         update={
             "candidate_id": "low-lcl",
@@ -467,7 +558,7 @@ def test_analysis_family_support_filter_uses_deep_family_scores(
     assert result.candidates[0].active_story == "supercell_environment"
     assert result.filter_trace.stage_counts["story_family"] == 2
     assert result.filter_trace.stage_counts["support"] == 1
-    assert result.filter_trace.top_excluded_reasons[0].reason == "Support: supported"
+    assert result.filter_trace.top_excluded_reasons[0].reason == "Evidence tier: strong signal"
     assert result.filter_trace.top_excluded_reasons[0].count == 1
 
 

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -15,7 +15,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await gotoBuild(page);
 
     await expect(page.locator("select").first()).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Upload a Sounding" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Observed Soundings" })).toBeVisible();
     await page.getByLabel("Experiment", { exact: true }).selectOption("baseline-shallow-cumulus");
     await expect(page.getByText(/physical question/i).first()).toBeVisible();
     await expect(page.getByText(/how do low-level moisture/i).first()).toBeVisible();
@@ -68,7 +68,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await page
       .getByLabel("Experiment", { exact: true })
       .selectOption("__observed_sounding_upload__");
-    await expect(page.getByRole("heading", { name: "Upload a Sounding" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Observed Soundings" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Find interesting soundings" })).toBeVisible();
     await expect(page.getByRole("tab", { name: "Cached recommendations" })).toHaveAttribute(
       "aria-selected",
@@ -128,7 +128,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/Screening guidance only/i).first()).toBeVisible();
     await expect(page.getByText("IGRA cache not checked yet")).toBeVisible();
 
-    await page.getByText("Advanced filters").click();
+    await page.getByText("Advanced filters", { exact: true }).click();
     await page.getByRole("button", { name: "Refresh IGRA catalog" }).click();
     await expect(page.getByText("IGRA station catalog refreshed")).toBeVisible();
     await expect(page.getByText("Parsed soundings")).toBeVisible();
@@ -141,7 +141,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     const candidateControls = page.getByLabel("Advanced sounding candidate controls");
     const storySelect = candidateControls.getByRole("combobox").first();
     await storySelect.selectOption("shallow_cumulus_candidate");
-    await page.getByRole("button", { name: "Run analyzer only" }).click();
+    await page.getByRole("button", { name: "Apply advanced filters" }).click();
 
     await expect(page.getByText("Cached sounding analysis loaded")).toBeVisible();
     const valleyCard = page.getByLabel("Sounding candidate Valley, Nebraska (USM00072558)");
@@ -154,25 +154,24 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     );
 
     await storySelect.selectOption("needs_review");
-    await page.getByRole("button", { name: "Run analyzer only" }).click();
+    await page.getByRole("button", { name: "Apply advanced filters" }).click();
     const blockedCard = page.getByLabel("Sounding candidate Norman, Oklahoma (USM00072357)");
     await expect(blockedCard).toBeVisible();
     await expect(blockedCard).toContainText("Blocked");
-    await expect(blockedCard.getByRole("button", { name: "Select for run setup" })).toBeDisabled();
+    await expect(blockedCard.getByRole("button", { name: "Configure run" })).toBeDisabled();
 
     await storySelect.selectOption("all");
-    await page.getByText("Advanced filters").click();
-    await page.getByRole("button", { name: "Run analyzer only" }).click();
+    await page.getByRole("button", { name: "Apply advanced filters" }).click();
     const refreshedValleyCard = page.getByLabel(
       "Sounding candidate Valley, Nebraska (USM00072558)",
     );
-    await refreshedValleyCard.getByRole("button", { name: "Save candidate" }).click();
+    await refreshedValleyCard.getByRole("button", { name: "Save" }).click();
     await expect(page.getByText("Sounding candidate saved")).toBeVisible();
     await page.getByRole("tab", { name: /Saved candidates/ }).click();
     const savedCard = page.getByLabel("Saved sounding candidate Valley, Nebraska (USM00072558)");
     await expect(savedCard).toBeVisible();
 
-    await savedCard.getByRole("button", { name: "Select for run setup" }).click();
+    await savedCard.getByRole("button", { name: "Configure run" }).click();
     await page.getByRole("button", { name: "Add to run plan" }).click();
     await expect(
       page.getByText("Valley, Nebraska (USM00072558) added to the run plan"),

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -125,18 +125,20 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       .getByLabel("Experiment", { exact: true })
       .selectOption("__observed_sounding_upload__");
     await expect(page.getByRole("heading", { name: "Find interesting soundings" })).toBeVisible();
-    await expect(page.getByText(/Screening guidance only/i).first()).toBeVisible();
-    await expect(page.getByText("IGRA cache not checked yet")).toBeVisible();
+    await expect(page.getByText("Cached soundings ready to search")).toBeVisible();
+    await expect(page.getByLabel("Prepare and search local soundings")).toContainText(
+      "Selected soundings",
+    );
+    await expect(page.getByLabel("Station picker")).toContainText("All cached stations");
+    await expect(page.getByLabel("Local sounding data")).toContainText("2 cached soundings");
+    await expect(page.getByLabel("Advanced sounding candidate controls")).not.toBeVisible();
 
     await page.getByText("Advanced filters", { exact: true }).click();
-    await page.getByRole("button", { name: "Refresh IGRA catalog" }).click();
+    await page.getByRole("button", { name: "Refresh catalog" }).click();
     await expect(page.getByText("IGRA station catalog refreshed")).toBeVisible();
     await expect(page.getByText("Parsed soundings")).toBeVisible();
-    await expect(page.getByText("2 cached soundings")).toBeVisible();
+    await expect(page.getByLabel("Local sounding data")).toContainText("2 cached soundings");
     await expect(page.getByText("Ready to search")).toBeVisible();
-
-    await page.getByRole("button", { name: "Cache station files" }).click();
-    await expect(page.getByText("Cached 1 station file")).toBeVisible();
 
     const candidateControls = page.getByLabel("Advanced sounding candidate controls");
     const storySelect = candidateControls.getByRole("combobox").first();

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -542,6 +542,10 @@ small {
   margin-bottom: 0;
 }
 
+.candidate-filter-detail {
+  font-weight: 650;
+}
+
 .candidate-card {
   display: grid;
   gap: 0.5rem;

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -454,8 +454,10 @@ small {
 
 .candidate-cache-summary {
   display: grid;
-  gap: 0.6rem;
+  gap: 0.45rem;
   margin: 0;
+  border-top: 1px solid rgba(215, 226, 232, 0.72);
+  padding-top: 0.6rem;
 }
 
 .candidate-cache-summary h4 {
@@ -465,6 +467,20 @@ small {
 .candidate-cache-summary .compact-metrics,
 .run-plan-panel .compact-metrics {
   margin: 0;
+}
+
+.candidate-cache-metrics {
+  grid-template-columns: repeat(auto-fit, minmax(10.5rem, 1fr));
+  gap: 0.45rem 0.7rem;
+}
+
+.candidate-cache-metrics dt {
+  font-size: 0.72rem;
+}
+
+.candidate-cache-metrics dd {
+  font-size: 0.85rem;
+  line-height: 1.25;
 }
 
 .candidate-detail-panel,
@@ -481,6 +497,63 @@ small {
   flex-wrap: wrap;
   gap: 0.55rem;
   align-items: center;
+}
+
+.candidate-search-set-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.55rem;
+  margin: 0;
+  border: 1px solid rgba(188, 211, 224, 0.66);
+  border-radius: 8px;
+  padding: 0.65rem 0.7rem;
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.candidate-search-set-summary div,
+.station-picklist-row span {
+  min-width: 0;
+}
+
+.candidate-station-picker {
+  display: grid;
+  gap: 0.7rem;
+  border: 1px solid rgba(188, 211, 224, 0.66);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.station-picklist {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+  gap: 0.5rem;
+  max-height: 18rem;
+  overflow: auto;
+  padding-right: 0.15rem;
+}
+
+.station-picklist-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.55rem;
+  align-items: center;
+  border: 1px solid rgba(215, 226, 232, 0.9);
+  border-radius: 7px;
+  padding: 0.55rem;
+  background: rgba(247, 251, 253, 0.9);
+}
+
+.station-picklist-row input {
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+}
+
+.station-picklist-row strong,
+.station-picklist-row small {
+  display: block;
+  overflow-wrap: anywhere;
 }
 
 .candidate-advanced-filters {
@@ -850,6 +923,13 @@ button:hover:not(:disabled) {
 .button-row button + button:not(.danger-button):hover:not(:disabled) {
   background: var(--color-accent-soft);
   color: #245f8d;
+}
+
+.active-secondary-button {
+  border: 1px solid #9bc4dc;
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+  box-shadow: none;
 }
 
 .danger-button {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -712,12 +712,51 @@ const screeningInputsResponse = {
   inputs: [
     {
       station_id: "USM00072558",
+      station_name: "Valley, Nebraska",
+      cached_text_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072558-data.txt",
       source_file_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072558-data.txt",
       source_file_name: "USM00072558-data.txt",
+      cached_status: "cached_extracted",
       sounding_count: 2,
       package_ready_count: 1,
       blocked_count: 1,
       latest_valid_time_utc: "2025-01-02T00:00:00Z",
+    },
+    {
+      station_id: "USM00072357",
+      station_name: "Norman, Oklahoma",
+      cached_text_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072357-data.txt",
+      source_file_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072357-data.txt",
+      source_file_name: "USM00072357-data.txt",
+      cached_status: "cached_extracted",
+      sounding_count: 2,
+      package_ready_count: 1,
+      blocked_count: 1,
+      latest_valid_time_utc: "2025-05-20T00:00:00Z",
+    },
+    {
+      station_id: "USM00072426",
+      station_name: "Wilmington, Ohio",
+      cached_text_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072426-data.txt",
+      source_file_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072426-data.txt",
+      source_file_name: "USM00072426-data.txt",
+      cached_status: "cached_extracted",
+      sounding_count: 1,
+      package_ready_count: 1,
+      blocked_count: 0,
+      latest_valid_time_utc: "2025-01-03T00:00:00Z",
+    },
+    {
+      station_id: "USM00072440",
+      station_name: "Springfield, Missouri",
+      cached_text_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072440-data.txt",
+      source_file_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072440-data.txt",
+      source_file_name: "USM00072440-data.txt",
+      cached_status: "cached_extracted",
+      sounding_count: 1,
+      package_ready_count: 1,
+      blocked_count: 0,
+      latest_valid_time_utc: "2025-01-04T00:00:00Z",
     },
   ],
 };
@@ -739,6 +778,9 @@ const screeningResponse = {
   sort_direction: "desc",
   filters: {
     station_id: null,
+    station_ids: [],
+    history_scope: "all_cached",
+    latest_per_station: null,
     story_filter: "all",
     story_family: "all",
     support: "all",
@@ -746,6 +788,10 @@ const screeningResponse = {
     station_search: "",
   },
   filter_trace: {
+    selected_station_count: 4,
+    selected_cached_soundings: 5,
+    history_scope: "all_cached",
+    latest_per_station: null,
     analyzed_soundings: 5,
     story_score_records: 8,
     stage_counts: {
@@ -780,6 +826,8 @@ const testDeepConvectionStoryIds = new Set([
 
 function screeningResponseForRequest(init?: RequestInit) {
   const request = JSON.parse(String(init?.body ?? "{}")) as {
+    station_ids?: string[];
+    history_scope?: "all_cached" | "latest_per_station";
     story_filter?: string;
     story_family?: string;
     support?: string;
@@ -789,13 +837,19 @@ function screeningResponseForRequest(init?: RequestInit) {
     latest_per_station?: number;
     limit?: number;
   };
+  const stationIds = new Set(request.station_ids ?? []);
+  const historyScope = request.history_scope ?? "all_cached";
   const storyFilter = request.story_filter ?? "all";
   const storyFamily = request.story_family ?? "all";
   const support = request.support ?? "all";
   const readiness = request.readiness ?? "all";
   const stationSearch = (request.station_search ?? "").trim().toLowerCase();
   const sortBy = request.sort_by ?? "best_match";
-  const baseCandidates = [...screeningResponse.candidates];
+  const limit = Number(request.limit ?? 100);
+  const baseCandidates =
+    stationIds.size > 0
+      ? screeningResponse.candidates.filter((candidate) => stationIds.has(candidate.station_id))
+      : [...screeningResponse.candidates];
   const storyFiltered = baseCandidates.filter((candidate) => {
     const score = storyScoreForTest(candidate, storyFilter, storyFamily);
     if (storyFilter !== "all" && (!score || !meaningfulStoryScoreForTest(score))) {
@@ -839,8 +893,9 @@ function screeningResponseForRequest(init?: RequestInit) {
       return Boolean(candidate);
     })
     .sort((left, right) => compareCandidateFixtures(left, right, storyFilter, storyFamily, sortBy));
+  const limitedCandidates = candidates.slice(0, limit);
   const stationDistribution = Array.from(
-    candidates.reduce((counts, candidate) => {
+    limitedCandidates.reduce((counts, candidate) => {
       const current = counts.get(candidate.station_id) ?? {
         station_id: candidate.station_id,
         station_name: candidate.station_name,
@@ -853,12 +908,16 @@ function screeningResponseForRequest(init?: RequestInit) {
   );
   return {
     ...screeningResponse,
-    candidates,
-    total_candidate_count: screeningResponse.candidates.length,
+    candidates: limitedCandidates,
+    total_candidate_count: baseCandidates.length,
     filtered_candidate_count: candidates.length,
     sort_by: sortBy,
     filters: {
       station_id: null,
+      station_ids: request.station_ids ?? [],
+      history_scope: historyScope,
+      latest_per_station:
+        historyScope === "latest_per_station" ? (request.latest_per_station ?? 20) : null,
       story_filter: storyFilter,
       story_family: storyFamily,
       support,
@@ -866,6 +925,11 @@ function screeningResponseForRequest(init?: RequestInit) {
       station_search: request.station_search ?? "",
     },
     filter_trace: {
+      selected_station_count: new Set(baseCandidates.map((candidate) => candidate.station_id)).size,
+      selected_cached_soundings: baseCandidates.length,
+      history_scope: historyScope,
+      latest_per_station:
+        historyScope === "latest_per_station" ? (request.latest_per_station ?? 20) : null,
       analyzed_soundings: baseCandidates.length,
       story_score_records: baseCandidates.reduce(
         (total, candidate) => total + candidate.story_scores.length,
@@ -879,7 +943,7 @@ function screeningResponseForRequest(init?: RequestInit) {
         readiness: readinessFiltered.length,
         station_search: searchFiltered.length,
         sorted_or_recommended: candidates.length,
-        limited: candidates.length,
+        limited: limitedCandidates.length,
       },
       stages: [],
       station_distribution: stationDistribution,
@@ -895,7 +959,7 @@ function screeningResponseForRequest(init?: RequestInit) {
               },
             ]
           : [],
-      applied_limit: Number(request.limit ?? 50),
+      applied_limit: limit,
     },
   };
 }
@@ -1042,9 +1106,53 @@ const igraCatalogResponse = {
     zip_references: [
       {
         station_id: "USM00072558",
-        station_name: "VALLEY",
-        cached_status: "cached",
+        station_name: "Valley, Nebraska",
+        latitude: 41.32,
+        longitude: -96.3669,
+        elevation_m_msl: 351.5,
+        filename: "USM00072558-data-beg2025.txt.zip",
+        cached_status: "cached_extracted",
         url: "https://example.test/USM00072558-data-beg2025.txt.zip",
+      },
+      {
+        station_id: "USM00072357",
+        station_name: "Norman, Oklahoma",
+        latitude: 35.22,
+        longitude: -97.44,
+        elevation_m_msl: 357,
+        filename: "USM00072357-data-beg2025.txt.zip",
+        cached_status: "cached_extracted",
+        url: "https://example.test/USM00072357-data-beg2025.txt.zip",
+      },
+      {
+        station_id: "USM00072426",
+        station_name: "Wilmington, Ohio",
+        latitude: 39.42,
+        longitude: -83.82,
+        elevation_m_msl: 317,
+        filename: "USM00072426-data-beg2025.txt.zip",
+        cached_status: "cached_extracted",
+        url: "https://example.test/USM00072426-data-beg2025.txt.zip",
+      },
+      {
+        station_id: "USM00072440",
+        station_name: "Springfield, Missouri",
+        latitude: 37.23,
+        longitude: -93.38,
+        elevation_m_msl: 387,
+        filename: "USM00072440-data-beg2025.txt.zip",
+        cached_status: "cached_extracted",
+        url: "https://example.test/USM00072440-data-beg2025.txt.zip",
+      },
+      {
+        station_id: "USM00072562",
+        station_name: "North Platte, Nebraska",
+        latitude: 41.13,
+        longitude: -100.68,
+        elevation_m_msl: 847,
+        filename: "USM00072562-data-beg2025.txt.zip",
+        cached_status: "not_cached",
+        url: "https://example.test/USM00072562-data-beg2025.txt.zip",
       },
     ],
   },
@@ -1054,11 +1162,38 @@ const igraCacheResponse = {
   entries: [
     {
       station_id: "USM00072558",
-      station_name: "VALLEY",
+      station_name: "Valley, Nebraska",
       data_txt_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072558-data.txt",
       zip_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072558-data-beg2025.txt.zip",
       sounding_count: 2,
       latest_valid_time_utc: "2025-01-02T00:00:00Z",
+      size_bytes: 1234,
+    },
+    {
+      station_id: "USM00072357",
+      station_name: "Norman, Oklahoma",
+      data_txt_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072357-data.txt",
+      zip_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072357-data-beg2025.txt.zip",
+      sounding_count: 2,
+      latest_valid_time_utc: "2025-05-20T00:00:00Z",
+      size_bytes: 1234,
+    },
+    {
+      station_id: "USM00072426",
+      station_name: "Wilmington, Ohio",
+      data_txt_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072426-data.txt",
+      zip_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072426-data-beg2025.txt.zip",
+      sounding_count: 1,
+      latest_valid_time_utc: "2025-01-03T00:00:00Z",
+      size_bytes: 1234,
+    },
+    {
+      station_id: "USM00072440",
+      station_name: "Springfield, Missouri",
+      data_txt_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072440-data.txt",
+      zip_path: "/tmp/CloudChamber/cache/igra/recent/stations/USM00072440-data-beg2025.txt.zip",
+      sounding_count: 1,
+      latest_valid_time_utc: "2025-01-04T00:00:00Z",
       size_bytes: 1234,
     },
   ],
@@ -2775,11 +2910,13 @@ beforeEach(() => {
         return Promise.resolve(new Response(JSON.stringify(igraCacheResponse), { status: 200 }));
       }
       if (url === "/api/igra/recent/cache-batch" && init?.method === "POST") {
+        const body = JSON.parse(String(init.body ?? "{}")) as { station_ids?: string[] };
         return Promise.resolve(
           new Response(
             JSON.stringify({
               requested_limit: 10,
-              selected_count: 1,
+              requested_station_ids: body.station_ids ?? [],
+              selected_count: body.station_ids?.length ?? 1,
               cached_entries: [igraCacheResponse.entries[0]],
               failed: [],
               remaining_uncached_count: 0,
@@ -3433,11 +3570,11 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { name: "Find interesting soundings" }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Screening guidance only/)).toBeInTheDocument();
-    expect(screen.getByText("IGRA cache not checked yet")).toBeInTheDocument();
+    expect(screen.getByText(/Choose the stations and history/)).toBeInTheDocument();
+    expect(screen.getByText("Cached soundings ready to search")).toBeInTheDocument();
     expect(screen.queryByLabelText("Save into")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Analyze cached soundings" }),
+      screen.getByRole("button", { name: "Search selected soundings" }),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Advanced filters"));
@@ -3682,6 +3819,9 @@ describe("App", () => {
       "Keep this one in the candidate notebook.",
     );
     fireEvent.click(within(savedCard).getByRole("button", { name: "Deep convection candidates" }));
+    expect(within(savedCard).getByLabelText("Tags")).toHaveValue(
+      "Maybe rerun, Deep convection candidates",
+    );
     fireEvent.click(within(savedCard).getByRole("button", { name: "Save tags and notes" }));
 
     expect(await screen.findByText("Saved sounding candidate updated")).toBeInTheDocument();
@@ -3706,7 +3846,7 @@ describe("App", () => {
     );
   });
 
-  it("uses credible deep-convection defaults and the station-history sweep", async () => {
+  it("uses family-scoped deep-convection defaults across the selected cached soundings", async () => {
     const defaultFetch = vi.mocked(fetch).getMockImplementation();
     let analyzeBody = "";
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -3729,24 +3869,83 @@ describe("App", () => {
       target: { value: "deep_convection" },
     });
     expect(screen.getByText("Advanced filters").closest("details")).not.toHaveAttribute("open");
-    expect(screen.getByText("Search intent changed; analyze cached soundings")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+    expect(screen.getByText("Search intent changed; search selected soundings")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Search selected soundings" }));
 
     expect(await screen.findByText("Recommendation run complete")).toBeInTheDocument();
-    expect(analyzeBody).toContain('"story_filter":"deep_convection_trial"');
+    expect(analyzeBody).toContain('"story_filter":"all"');
     expect(analyzeBody).toContain('"story_family":"deep_convection"');
-    expect(analyzeBody).toContain('"support":"supported"');
-    expect(analyzeBody).toContain('"latest_per_station":20');
-    expect(analyzeBody).toContain('"limit":75');
+    expect(analyzeBody).toContain('"support":"all"');
+    expect(analyzeBody).toContain('"history_scope":"all_cached"');
+    expect(analyzeBody).toContain('"latest_per_station":null');
+    expect(analyzeBody).toContain('"limit":100');
     expect(
-      screen.getByText(/5 analyzed · 2 matched deep-convection stories · 1 supported · 1 shown/),
+      screen.getByText((content) =>
+        content.includes("5 analyzed from 5 selected cached soundings") &&
+        content.includes("4 stations") &&
+        content.includes("all cached history") &&
+        content.includes("2 matched deep convection stories") &&
+        content.includes("2 shown"),
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
     ).toBeInTheDocument();
     expect(
-      screen.queryByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
-    ).not.toBeInTheDocument();
+      screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
+    ).toBeInTheDocument();
+  });
+
+  it("searches and caches explicitly selected stations", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let analyzeBody = "";
+    let cacheBody = "";
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/sounding-candidates/analyze") {
+        analyzeBody = String(init?.body ?? "");
+      }
+      if (url === "/api/igra/recent/cache-batch" && init?.method === "POST") {
+        cacheBody = String(init.body ?? "");
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Choose stations" }));
+    fireEvent.click(await screen.findByLabelText(/Norman, Oklahoma/));
+    fireEvent.click(await screen.findByLabelText(/North Platte, Nebraska/));
+
+    fireEvent.click(screen.getByRole("button", { name: "Cache selected stations" }));
+    await waitFor(() => {
+      expect(cacheBody).toContain('"station_ids":["USM00072357","USM00072562"]');
+    });
+
+    fireEvent.change(screen.getByLabelText("History scope"), {
+      target: { value: "latest_per_station" },
+    });
+    fireEvent.change(screen.getByLabelText("Latest soundings per station"), {
+      target: { value: "3" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Search selected soundings" }));
+
+    await waitFor(() => {
+      expect(analyzeBody).toContain('"station_ids":["USM00072357","USM00072562"]');
+      expect(analyzeBody).toContain('"history_scope":"latest_per_station"');
+      expect(analyzeBody).toContain('"latest_per_station":3');
+    });
+    expect(
+      (await screen.findAllByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"))
+        .length,
+    ).toBeGreaterThan(0);
   });
 
   it("shows secondary family candidates with the scoped story ingredient score", async () => {
@@ -3761,7 +3960,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Story family"), {
       target: { value: "deep_convection" },
     });
-    fireEvent.change(screen.getByLabelText("Support"), {
+    fireEvent.change(screen.getByLabelText("Evidence tier"), {
       target: { value: "weak" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
@@ -3770,7 +3969,7 @@ describe("App", () => {
       "Sounding candidate Wilmington, Ohio (USM00072426)",
     );
     expect(wilmingtonCard).toHaveTextContent("High-CAPE pulse storm");
-    expect(wilmingtonCard).toHaveTextContent("Primary: Humid / rainy");
+    expect(wilmingtonCard).not.toHaveTextContent("Primary: Humid / rainy");
     expect(wilmingtonCard).toHaveTextContent("48.9 % ingredient score");
     expect(wilmingtonCard).toHaveTextContent("Recipe fit: testable as forced observed evolution");
     expect(
@@ -3795,7 +3994,7 @@ describe("App", () => {
       target: { value: "__observed_sounding_upload__" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Search selected soundings" }));
     expect(await screen.findByText("Recommendation run complete")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Advanced filters"));

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -745,6 +745,27 @@ const screeningResponse = {
     readiness: "all",
     station_search: "",
   },
+  filter_trace: {
+    analyzed_soundings: 5,
+    story_score_records: 8,
+    stage_counts: {
+      analyzed_soundings: 5,
+      story_filter: 5,
+      story_family: 5,
+      support: 5,
+      readiness: 5,
+      station_search: 5,
+      sorted_or_recommended: 5,
+      limited: 5,
+    },
+    stages: [],
+    station_distribution: [
+      { station_id: "USM00072558", station_name: "Valley, Nebraska", count: 1 },
+      { station_id: "USM00072357", station_name: "Norman, Oklahoma", count: 1 },
+    ],
+    top_excluded_reasons: [],
+    applied_limit: 50,
+  },
   caveats: ["screening_guidance_only"],
 };
 
@@ -765,6 +786,8 @@ function screeningResponseForRequest(init?: RequestInit) {
     readiness?: string;
     station_search?: string;
     sort_by?: string;
+    latest_per_station?: number;
+    limit?: number;
   };
   const storyFilter = request.story_filter ?? "all";
   const storyFamily = request.story_family ?? "all";
@@ -772,36 +795,62 @@ function screeningResponseForRequest(init?: RequestInit) {
   const readiness = request.readiness ?? "all";
   const stationSearch = (request.station_search ?? "").trim().toLowerCase();
   const sortBy = request.sort_by ?? "best_match";
-  const candidates = [...screeningResponse.candidates]
-    .filter((candidate) => {
-      if (readiness === "package_ready" && !candidate.package_ready) return false;
-      if (readiness === "blocked" && candidate.package_ready) return false;
-      const scopedScores = storyScoresForTest(candidate, storyFilter, storyFamily);
-      if (
-        storyFamily !== "all" &&
-        !scopedScores.some((score) => meaningfulStoryScoreForTest(score))
-      ) {
-        return false;
-      }
+  const baseCandidates = [...screeningResponse.candidates];
+  const storyFiltered = baseCandidates.filter((candidate) => {
+    const score = storyScoreForTest(candidate, storyFilter, storyFamily);
+    if (storyFilter !== "all" && (!score || !meaningfulStoryScoreForTest(score))) {
+      return false;
+    }
+    if (
+      storyFamily !== "all" &&
+      !storyScoresForTest(candidate, storyFilter, storyFamily).some((scopeScore) =>
+        meaningfulStoryScoreForTest(scopeScore),
+      )
+    ) {
+      return false;
+    }
+    return true;
+  });
+  const supportFiltered = storyFiltered.filter((candidate) => {
+    if (support === "all") return true;
+    const scopedScores = storyScoresForTest(candidate, storyFilter, storyFamily);
+    if (storyFilter === "all" && storyFamily === "all") {
       const score = storyScoreForTest(candidate, storyFilter, storyFamily);
-      if (storyFilter !== "all" && (!score || !meaningfulStoryScoreForTest(score))) {
-        return false;
-      }
-      if (support !== "all") {
-        if (storyFilter === "all" && storyFamily === "all") {
-          if (!score || score.support !== support) return false;
-        } else if (!scopedScores.some((scopeScore) => scopeScore.support === support)) {
-          return false;
-        }
-      }
-      if (!stationSearch) return true;
-      return [candidate.station_id, candidate.station_name, candidate.primary_story_label]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase()
-        .includes(stationSearch);
+      return Boolean(score && score.support === support);
+    }
+    return scopedScores.some((scopeScore) => scopeScore.support === support);
+  });
+  const readinessFiltered = supportFiltered.filter((candidate) => {
+    if (readiness === "package_ready" && !candidate.package_ready) return false;
+    if (readiness === "blocked" && candidate.package_ready) return false;
+    return true;
+  });
+  const searchFiltered = readinessFiltered.filter((candidate) => {
+    if (!stationSearch) return true;
+    return [candidate.station_id, candidate.station_name, candidate.primary_story_label]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase()
+      .includes(stationSearch);
+  });
+  const candidates = searchFiltered
+    .map((candidate) => candidateWithActiveFieldsForTest(candidate, storyFilter, storyFamily))
+    .filter((candidate) => {
+      return Boolean(candidate);
     })
     .sort((left, right) => compareCandidateFixtures(left, right, storyFilter, storyFamily, sortBy));
+  const stationDistribution = Array.from(
+    candidates.reduce((counts, candidate) => {
+      const current = counts.get(candidate.station_id) ?? {
+        station_id: candidate.station_id,
+        station_name: candidate.station_name,
+        count: 0,
+      };
+      counts.set(candidate.station_id, { ...current, count: current.count + 1 });
+      return counts;
+    }, new Map<string, { station_id: string; station_name?: string | null; count: number }>())
+      .values(),
+  );
   return {
     ...screeningResponse,
     candidates,
@@ -816,6 +865,38 @@ function screeningResponseForRequest(init?: RequestInit) {
       readiness,
       station_search: request.station_search ?? "",
     },
+    filter_trace: {
+      analyzed_soundings: baseCandidates.length,
+      story_score_records: baseCandidates.reduce(
+        (total, candidate) => total + candidate.story_scores.length,
+        0,
+      ),
+      stage_counts: {
+        analyzed_soundings: baseCandidates.length,
+        story_filter: storyFiltered.length,
+        story_family: storyFiltered.length,
+        support: supportFiltered.length,
+        readiness: readinessFiltered.length,
+        station_search: searchFiltered.length,
+        sorted_or_recommended: candidates.length,
+        limited: candidates.length,
+      },
+      stages: [],
+      station_distribution: stationDistribution,
+      top_excluded_reasons:
+        storyFiltered.length < baseCandidates.length
+          ? [
+              {
+                reason:
+                  storyFamily !== "all"
+                    ? `Story family: ${storyFamily}`
+                    : `Story filter: ${storyFilter}`,
+                count: baseCandidates.length - storyFiltered.length,
+              },
+            ]
+          : [],
+      applied_limit: Number(request.limit ?? 50),
+    },
   };
 }
 
@@ -829,6 +910,39 @@ function storyScoreForTest(
       (left, right) => right.score_0_to_100 - left.score_0_to_100,
     )[0] ?? null
   );
+}
+
+function candidateWithActiveFieldsForTest(
+  candidate: (typeof screeningResponse.candidates)[number],
+  storyFilter: string,
+  storyFamily: string,
+) {
+  const scopedScores = storyScoresForTest(candidate, storyFilter, storyFamily);
+  const meaningfulScores = scopedScores.filter((score) => meaningfulStoryScoreForTest(score));
+  const activeScore =
+    [...(meaningfulScores.length > 0 ? meaningfulScores : scopedScores)].sort(
+      (left, right) => right.score_0_to_100 - left.score_0_to_100,
+    )[0] ?? null;
+  const activeStory = activeScore?.story ?? candidate.primary_story;
+  const activeLabel = activeScore?.label ?? candidate.primary_story_label;
+  return {
+    ...candidate,
+    active_story: activeStory,
+    active_story_label: activeLabel,
+    display_story: activeLabel,
+    matched_story_ids: meaningfulScores
+      .sort((left, right) => right.score_0_to_100 - left.score_0_to_100)
+      .map((score) => score.story),
+    active_story_score: activeScore?.score_0_to_100 ?? candidate.rank_score,
+    ingredient_score: activeScore?.score_0_to_100 ?? candidate.rank_score,
+    active_story_support: activeScore?.support ?? null,
+    package_readiness: candidate.package_ready ? "package_ready" : "blocked",
+    recipe_fit:
+      "recipe_fit_status" in candidate ? candidate.recipe_fit_status : "partially_testable",
+    top_reasons: candidate.interest_reasons ?? [],
+    top_caveats: candidate.caveats.slice(0, 2),
+    evidence_summary: candidate.evidence.map((item) => item.interpretation).slice(0, 3),
+  };
 }
 
 function storyScoresForTest(
@@ -3021,7 +3135,7 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { name: "Build and run a CM1 experiment" }),
     ).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { name: "Upload a Sounding" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Observed Soundings" })).toBeInTheDocument();
     expect(screen.getByLabelText("Experiment")).toHaveValue("__observed_sounding_upload__");
     expect(screen.queryByLabelText("Low-level humidity")).not.toBeInTheDocument();
 
@@ -3101,7 +3215,7 @@ describe("App", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
 
-    expect(await screen.findByRole("heading", { name: "Upload a Sounding" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Observed Soundings" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Cached recommendations" })).toHaveAttribute(
       "aria-selected",
       "true",
@@ -3191,14 +3305,14 @@ describe("App", () => {
     fireEvent.change(storyFilter, {
       target: { value: "deep_convection_trial" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
 
     expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
     expect(screenBody).toContain('"story_filter":"deep_convection_trial"');
     const deepCard = screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)");
     expect(deepCard).toHaveTextContent("Supercell-like environment");
 
-    fireEvent.click(within(deepCard).getByRole("button", { name: "Select for run setup" }));
+    fireEvent.click(within(deepCard).getByRole("button", { name: "Configure run" }));
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
 
     expect(
@@ -3257,13 +3371,13 @@ describe("App", () => {
     fireEvent.change(await screen.findByLabelText("Story"), {
       target: { value: "humid_rainy_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
 
     expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
     const humidCard = screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)");
     expect(humidCard).toHaveTextContent("Humid / rainy");
 
-    fireEvent.click(within(humidCard).getByRole("button", { name: "Select for run setup" }));
+    fireEvent.click(within(humidCard).getByRole("button", { name: "Configure run" }));
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
 
     expect(
@@ -3323,19 +3437,19 @@ describe("App", () => {
     expect(screen.getByText("IGRA cache not checked yet")).toBeInTheDocument();
     expect(screen.queryByLabelText("Save into")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Prepare & search local soundings" }),
+      screen.getByRole("button", { name: "Analyze cached soundings" }),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Advanced filters"));
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "shallow_cumulus_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
 
     expect(await screen.findByText("Cached sounding analysis loaded")).toBeInTheDocument();
     expect(screenBody).toContain('"story_filter":"shallow_cumulus_candidate"');
     expect(screen.getByRole("heading", { name: "Refined candidates" })).toBeInTheDocument();
-    expect(screen.getByText(/Refined view/)).toBeInTheDocument();
+    expect(screen.getByText(/Search filters applied/)).toBeInTheDocument();
     const valleyCard = screen.getByLabelText("Sounding candidate Valley, Nebraska (USM00072558)");
     expect(valleyCard).toHaveTextContent("Cloud-forming shallow cumulus");
     expect(valleyCard).toHaveTextContent("Package-ready");
@@ -3374,7 +3488,7 @@ describe("App", () => {
       "Compare this against the humid case.",
     );
 
-    fireEvent.click(within(savedCard).getByRole("button", { name: "Select for run setup" }));
+    fireEvent.click(within(savedCard).getByRole("button", { name: "Configure run" }));
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
 
     expect(
@@ -3400,17 +3514,17 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "needs_review" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
     const normanCard = await screen.findByLabelText(
       "Sounding candidate Norman, Oklahoma (USM00072357)",
     );
     expect(normanCard).toHaveTextContent("Blocked");
-    expect(within(normanCard).getByRole("button", { name: "Select for run setup" })).toBeDisabled();
+    expect(within(normanCard).getByRole("button", { name: "Configure run" })).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "all" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
     const selectedValleyCard = await screen.findByLabelText(
       "Sounding candidate Valley, Nebraska (USM00072558)",
     );
@@ -3419,7 +3533,7 @@ describe("App", () => {
     ).toBeInTheDocument();
 
     fireEvent.click(
-      within(selectedValleyCard).getByRole("button", { name: "Select for run setup" }),
+      within(selectedValleyCard).getByRole("button", { name: "Configure run" }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
     expect(
@@ -3438,7 +3552,7 @@ describe("App", () => {
     });
   });
 
-  it("loads saved sounding candidates as soon as Upload a Sounding is selected", async () => {
+  it("loads saved sounding candidates as soon as Observed Soundings is selected", async () => {
     const defaultFetch = vi.mocked(fetch).getMockImplementation();
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -3540,7 +3654,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "shallow_cumulus_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
 
     const valleyCard = await screen.findByLabelText(
       "Sounding candidate Valley, Nebraska (USM00072558)",
@@ -3592,6 +3706,49 @@ describe("App", () => {
     );
   });
 
+  it("uses credible deep-convection defaults and the station-history sweep", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let analyzeBody = "";
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/sounding-candidates/analyze") {
+        analyzeBody = String(init?.body ?? "");
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+    fireEvent.change(await screen.findByDisplayValue("Best overall recommendations"), {
+      target: { value: "deep_convection" },
+    });
+    expect(screen.getByText("Advanced filters").closest("details")).not.toHaveAttribute("open");
+    expect(screen.getByText("Search intent changed; analyze cached soundings")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
+
+    expect(await screen.findByText("Recommendation run complete")).toBeInTheDocument();
+    expect(analyzeBody).toContain('"story_filter":"deep_convection_trial"');
+    expect(analyzeBody).toContain('"story_family":"deep_convection"');
+    expect(analyzeBody).toContain('"support":"supported"');
+    expect(analyzeBody).toContain('"latest_per_station":20');
+    expect(analyzeBody).toContain('"limit":75');
+    expect(
+      screen.getByText(/5 analyzed · 2 matched deep-convection stories · 1 supported · 1 shown/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows secondary family candidates with the scoped story ingredient score", async () => {
     render(<App />);
 
@@ -3607,7 +3764,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Support"), {
       target: { value: "weak" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
 
     const wilmingtonCard = await screen.findByLabelText(
       "Sounding candidate Wilmington, Ohio (USM00072426)",
@@ -3638,22 +3795,24 @@ describe("App", () => {
       target: { value: "__observed_sounding_upload__" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Prepare & search local soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Analyze cached soundings" }));
     expect(await screen.findByText("Recommendation run complete")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Advanced filters"));
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "shallow_cumulus_candidate" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
+    expect(screen.getByText("Story filter changed; apply advanced filters")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
     expect(
-      screen.getByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
+      await screen.findByLabelText("Sounding candidate Wilmington, Ohio (USM00072426)"),
     ).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Sort"), {
       target: { value: "estimated_lcl_height_m_agl" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Run analyzer only" }));
+    expect(screen.getByText("Sort changed; apply advanced filters")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
     await waitFor(() => {
       const candidateCards = screen.getAllByLabelText(/^Sounding candidate /);
       const visibleOrder = candidateCards.map((card) => card.textContent ?? "");
@@ -3874,7 +4033,7 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Retry scenarios" }));
 
-    expect(await screen.findByRole("heading", { name: "Upload a Sounding" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Observed Soundings" })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Experiment"), {
       target: { value: "baseline-shallow-cumulus" },
     });

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -2429,6 +2429,34 @@ export function App() {
       : null;
   }
 
+  function candidateSearchStatus(
+    action: "Searching" | "Analyzing",
+    inputs: ScreeningInput[] = screeningInputs,
+  ): string {
+    const stationIds = selectedStationIdsForCandidateRequest();
+    const selectedStationSet = new Set(stationIds);
+    const selectedInputs =
+      stationSelectionMode === "selected"
+        ? inputs.filter((input) => selectedStationSet.has(input.station_id))
+        : inputs;
+    const latestPerStation = selectedHistoryLatestPerStation();
+    const soundingCount =
+      candidateHistoryScope === "all_cached"
+        ? selectedInputs.reduce((total, input) => total + (input.sounding_count ?? 0), 0)
+        : selectedInputs.reduce(
+            (total, input) => total + Math.min(input.sounding_count ?? 0, latestPerStation ?? 0),
+            0,
+          );
+    const stationCount = selectedInputs.length;
+    if (soundingCount >= 1000) {
+      return `${action} ${soundingCount.toLocaleString()} cached soundings from ${stationCount.toLocaleString()} station${stationCount === 1 ? "" : "s"}; this can take a minute or two`;
+    }
+    if (soundingCount > 0) {
+      return `${action} ${soundingCount.toLocaleString()} selected sounding${soundingCount === 1 ? "" : "s"}`;
+    }
+    return `${action} selected soundings`;
+  }
+
   async function refreshSoundingCandidateState(statusWhenLoaded?: string) {
     setCandidateError(null);
     setCandidateStatus("Checking local IGRA cache");
@@ -2480,7 +2508,7 @@ export function App() {
       setIgraCache(cachePayload);
       setScreeningInputs(inputsPayload.inputs);
       setSavedCandidates(savedPayload.saved_candidates);
-      setCandidateStatus("Searching selected soundings");
+      setCandidateStatus(candidateSearchStatus("Searching", inputsPayload.inputs));
       const result = await screenSoundingCandidates({
         stationIds,
         historyScope: candidateHistoryScope,
@@ -2568,7 +2596,7 @@ export function App() {
     setCandidateError(null);
     setCandidateScreening(null);
     setCandidateDetailId(null);
-    setCandidateStatus("Analyzing selected soundings");
+    setCandidateStatus(candidateSearchStatus("Analyzing"));
     try {
       const result = await screenSoundingCandidates({
         stationIds,
@@ -4830,11 +4858,12 @@ function ObservedAtmosphereCandidatesPanel({
       : (savedCandidates.find(
           (saved) => saved.candidate.candidate_id === selectedCandidate.candidate_id,
         ) ?? null);
-  const cachedStations = new Set((cache?.entries ?? []).map((entry) => entry.station_id)).size;
-  const cachedStationFiles = cache?.entries.length ?? 0;
-  const cachedCatalogFiles =
-    catalog?.zip_references.filter((reference) => reference.cached_status !== "not_cached")
-      .length ?? cachedStationFiles;
+  const cachedStations =
+    screeningInputs.length > 0
+      ? new Set(screeningInputs.map((input) => input.station_id)).size
+      : new Set((cache?.entries ?? []).map((entry) => entry.station_id)).size;
+  const cachedStationFiles =
+    screeningInputs.length > 0 ? screeningInputs.length : (cache?.entries.length ?? 0);
   const stationOptions = useMemo(() => {
     const inputByStation = new Map(screeningInputs.map((input) => [input.station_id, input]));
     const optionByStation = new Map<
@@ -5139,7 +5168,7 @@ function ObservedAtmosphereCandidatesPanel({
                 : "Not refreshed here"
             }
           />
-          <Metric label="Station files" value={cachedCatalogFiles.toString()} />
+          <Metric label="Station files" value={cachedStationFiles.toLocaleString()} />
           <Metric label="Parsed soundings" value={cachedInventorySummary} />
           <Metric label="Last search" value={lastAnalysisSummary} />
         </dl>

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -461,8 +461,42 @@ type SoundingCandidate = {
   recipe_fit_label?: string;
   recipe_fit_summary?: string;
   recipe_fit_caveats?: string[];
+  active_story?: CandidateStoryId | null;
+  active_story_label?: string | null;
+  display_story?: string | null;
+  matched_story_ids?: CandidateStoryId[];
+  active_story_score?: number | null;
+  ingredient_score?: number | null;
+  active_story_support?: "supported" | "weak" | "unavailable" | null;
+  package_readiness?: string | null;
+  recipe_fit?: CandidateRecipeFitStatus | string | null;
+  top_reasons?: string[];
+  top_caveats?: string[];
+  evidence_summary?: string[];
   screening_version: string;
   created_at: string;
+};
+
+type CandidateFilterTrace = {
+  analyzed_soundings: number;
+  story_score_records: number;
+  stage_counts: Record<string, number>;
+  stages: Array<{
+    key: string;
+    label: string;
+    count: number;
+    active: boolean;
+  }>;
+  station_distribution: Array<{
+    station_id: string;
+    station_name?: string | null;
+    count: number;
+  }>;
+  top_excluded_reasons: Array<{
+    reason: string;
+    count: number;
+  }>;
+  applied_limit: number;
 };
 
 type ScreeningInput = {
@@ -497,6 +531,7 @@ type ScreeningResult = {
     readiness: CandidateReadinessFilter;
     station_search: string;
   };
+  filter_trace?: CandidateFilterTrace;
 };
 
 type UserRunMetadata = {
@@ -1254,7 +1289,7 @@ const DEFAULT_OBSERVED_RUN_CONFIGURATION: RunConfigurationInput = {
 
 const SEARCH_INTENT_OPTIONS: Array<{ value: SearchIntent; label: string }> = [
   { value: "best_overall", label: "Best overall recommendations" },
-  { value: "deep_convection", label: "Deep convection potential" },
+  { value: "deep_convection", label: "Credible deep-convection potential" },
   { value: "humid_rainy", label: "Humid/rainy evolution" },
   { value: "dry_microburst", label: "Dry microburst / inverted-V" },
   { value: "shallow_boundary_layer", label: "Shallow cumulus / boundary layer" },
@@ -1263,18 +1298,18 @@ const SEARCH_INTENT_OPTIONS: Array<{ value: SearchIntent; label: string }> = [
 const SEARCH_DEPTH_OPTIONS: Array<{ value: SearchDepth; label: string; description: string }> = [
   {
     value: "quick_scan",
-    label: "Quick scan",
-    description: "Small latest-sounding slice; fastest recommendation pass.",
+    label: "Latest sample",
+    description: "Latest 2 soundings per cached station file; fastest sanity check.",
   },
   {
     value: "deeper_scan",
-    label: "Deeper scan",
-    description: "Default bounded slice for useful local recommendations.",
+    label: "Station-history sweep",
+    description: "Latest 20 soundings per cached station file; default recommendation pass.",
   },
   {
     value: "broad_historical_sweep",
-    label: "Broad historical sweep",
-    description: "Larger bounded local slice; may take longer and need more cached data.",
+    label: "Broad cached history",
+    description: "Latest 50 soundings per cached station file; larger local sweep.",
   },
 ];
 
@@ -1290,9 +1325,9 @@ const SEARCH_DEPTH_LIMITS: Record<
   SearchDepth,
   { cacheLimit: string; latestPerStation: string; resultLimit: string }
 > = {
-  quick_scan: { cacheLimit: "5", latestPerStation: "2", resultLimit: "25" },
-  deeper_scan: { cacheLimit: "10", latestPerStation: "5", resultLimit: "50" },
-  broad_historical_sweep: { cacheLimit: "25", latestPerStation: "10", resultLimit: "100" },
+  quick_scan: { cacheLimit: "10", latestPerStation: "2", resultLimit: "25" },
+  deeper_scan: { cacheLimit: "25", latestPerStation: "20", resultLimit: "75" },
+  broad_historical_sweep: { cacheLimit: "50", latestPerStation: "50", resultLimit: "150" },
 };
 
 class DryRunRequestError extends Error {
@@ -1886,9 +1921,15 @@ export function App() {
   const [candidateStationSearch, setCandidateStationSearch] = useState("");
   const [candidateReadinessFilter, setCandidateReadinessFilter] =
     useState<CandidateReadinessFilter>("all");
-  const [candidateCacheLimit, setCandidateCacheLimit] = useState("10");
-  const [candidateLatestPerStation, setCandidateLatestPerStation] = useState("5");
-  const [candidateResultLimit, setCandidateResultLimit] = useState("50");
+  const [candidateCacheLimit, setCandidateCacheLimit] = useState(
+    SEARCH_DEPTH_LIMITS.deeper_scan.cacheLimit,
+  );
+  const [candidateLatestPerStation, setCandidateLatestPerStation] = useState(
+    SEARCH_DEPTH_LIMITS.deeper_scan.latestPerStation,
+  );
+  const [candidateResultLimit, setCandidateResultLimit] = useState(
+    SEARCH_DEPTH_LIMITS.deeper_scan.resultLimit,
+  );
   const [candidateStatus, setCandidateStatus] = useState("IGRA cache not checked yet");
   const [candidateError, setCandidateError] = useState<string | null>(null);
   const [candidateScreening, setCandidateScreening] = useState<ScreeningResult | null>(null);
@@ -2258,6 +2299,13 @@ export function App() {
     }
   }
 
+  function markCandidateSearchSettingsChanged(status: string) {
+    setCandidateScreening(null);
+    setCandidateDetailId(null);
+    setCandidateError(null);
+    setCandidateStatus(status);
+  }
+
   function handleSearchIntentChange(intent: SearchIntent) {
     setSearchIntent(intent);
     const filters = searchIntentFilters(intent);
@@ -2267,6 +2315,7 @@ export function App() {
     setCandidateReadinessFilter("all");
     setCandidateSort("best_match");
     setCandidateStationSearch("");
+    markCandidateSearchSettingsChanged("Search intent changed; analyze cached soundings");
   }
 
   function handleSearchDepthChange(depth: SearchDepth) {
@@ -2275,6 +2324,52 @@ export function App() {
     setCandidateCacheLimit(limits.cacheLimit);
     setCandidateLatestPerStation(limits.latestPerStation);
     setCandidateResultLimit(limits.resultLimit);
+    markCandidateSearchSettingsChanged("Search depth changed; analyze cached soundings");
+  }
+
+  function handleCandidateStoryFilterChange(filter: CandidateStoryFilter) {
+    setCandidateStoryFilter(filter);
+    markCandidateSearchSettingsChanged("Story filter changed; apply advanced filters");
+  }
+
+  function handleCandidateStoryFamilyFilterChange(filter: CandidateStoryFamilyFilter) {
+    setCandidateStoryFamilyFilter(filter);
+    markCandidateSearchSettingsChanged("Story family changed; apply advanced filters");
+  }
+
+  function handleCandidateSupportFilterChange(filter: CandidateSupportFilter) {
+    setCandidateSupportFilter(filter);
+    markCandidateSearchSettingsChanged("Support filter changed; apply advanced filters");
+  }
+
+  function handleCandidateSortChange(sort: CandidateSort) {
+    setCandidateSort(sort);
+    markCandidateSearchSettingsChanged("Sort changed; apply advanced filters");
+  }
+
+  function handleCandidateStationSearchChange(search: string) {
+    setCandidateStationSearch(search);
+    markCandidateSearchSettingsChanged("Station search changed; apply advanced filters");
+  }
+
+  function handleCandidateReadinessFilterChange(filter: CandidateReadinessFilter) {
+    setCandidateReadinessFilter(filter);
+    markCandidateSearchSettingsChanged("Readiness filter changed; apply advanced filters");
+  }
+
+  function handleCandidateCacheLimitChange(limit: string) {
+    setCandidateCacheLimit(limit);
+    markCandidateSearchSettingsChanged("Cache limit changed; analyze cached soundings");
+  }
+
+  function handleCandidateLatestPerStationChange(limit: string) {
+    setCandidateLatestPerStation(limit);
+    markCandidateSearchSettingsChanged("Analysis slice changed; apply advanced filters");
+  }
+
+  function handleCandidateResultLimitChange(limit: string) {
+    setCandidateResultLimit(limit);
+    markCandidateSearchSettingsChanged("Returned candidate limit changed; apply advanced filters");
   }
 
   async function refreshSoundingCandidateState(statusWhenLoaded?: string) {
@@ -2308,9 +2403,11 @@ export function App() {
   async function handlePrepareAndSearchLocalSoundings() {
     const limits = SEARCH_DEPTH_LIMITS[searchDepth];
     const cacheLimit = boundedInteger(limits.cacheLimit, 1, 100, 10);
-    const latestPerStation = boundedInteger(limits.latestPerStation, 1, 50, 5);
-    const resultLimit = boundedInteger(limits.resultLimit, 1, 200, 50);
+    const latestPerStation = boundedInteger(limits.latestPerStation, 1, 50, 20);
+    const resultLimit = boundedInteger(limits.resultLimit, 1, 200, 75);
     setCandidateError(null);
+    setCandidateScreening(null);
+    setCandidateDetailId(null);
     setCandidateStatus("Preparing local sounding data");
     try {
       let [catalogPayload, cachePayload, inputsPayload, savedPayload] = await Promise.all([
@@ -2406,6 +2503,8 @@ export function App() {
 
   async function handleScreenSoundingCandidates() {
     setCandidateError(null);
+    setCandidateScreening(null);
+    setCandidateDetailId(null);
     setCandidateStatus("Analyzing cached soundings");
     try {
       const result = await screenSoundingCandidates({
@@ -2415,8 +2514,8 @@ export function App() {
         readiness: candidateReadinessFilter,
         stationSearch: candidateStationSearch,
         sort: candidateSort,
-        latestPerStation: boundedInteger(candidateLatestPerStation, 1, 50, 5),
-        limit: boundedInteger(candidateResultLimit, 1, 200, 50),
+        latestPerStation: boundedInteger(candidateLatestPerStation, 1, 50, 20),
+        limit: boundedInteger(candidateResultLimit, 1, 200, 75),
       });
       setCandidateScreening(result);
       setCandidateDetailId(result.candidates[0]?.candidate_id ?? null);
@@ -2442,7 +2541,9 @@ export function App() {
     setCandidateStationSearch("");
     setCandidateReadinessFilter("all");
     setCandidateSort("best_match");
-    setCandidateStatus("Showing default discovery settings; run Analyze recommendations");
+    markCandidateSearchSettingsChanged(
+      "Showing default recommendation settings; analyze cached soundings",
+    );
   }
 
   async function handleSaveSoundingCandidate(
@@ -3341,16 +3442,16 @@ export function App() {
           onSearchIntentChange={handleSearchIntentChange}
           onSearchDepthChange={handleSearchDepthChange}
           onTimeScopeChange={setTimeScope}
-          onCandidateStoryFilterChange={setCandidateStoryFilter}
-          onCandidateStoryFamilyFilterChange={setCandidateStoryFamilyFilter}
-          onCandidateSupportFilterChange={setCandidateSupportFilter}
-          onCandidateSortChange={setCandidateSort}
-          onCandidateStationSearchChange={setCandidateStationSearch}
-          onCandidateReadinessFilterChange={setCandidateReadinessFilter}
+          onCandidateStoryFilterChange={handleCandidateStoryFilterChange}
+          onCandidateStoryFamilyFilterChange={handleCandidateStoryFamilyFilterChange}
+          onCandidateSupportFilterChange={handleCandidateSupportFilterChange}
+          onCandidateSortChange={handleCandidateSortChange}
+          onCandidateStationSearchChange={handleCandidateStationSearchChange}
+          onCandidateReadinessFilterChange={handleCandidateReadinessFilterChange}
           onClearCandidateAnalysisFilters={handleClearCandidateAnalysisFilters}
-          onCandidateCacheLimitChange={setCandidateCacheLimit}
-          onCandidateLatestPerStationChange={setCandidateLatestPerStation}
-          onCandidateResultLimitChange={setCandidateResultLimit}
+          onCandidateCacheLimitChange={handleCandidateCacheLimitChange}
+          onCandidateLatestPerStationChange={handleCandidateLatestPerStationChange}
+          onCandidateResultLimitChange={handleCandidateResultLimitChange}
           onCandidateDetailChange={setCandidateDetailId}
           onRefreshIGRAData={handleRefreshIGRAData}
           onCacheIGRAStationFiles={handleCacheIGRAStationFiles}
@@ -3717,7 +3818,7 @@ function BuildWorkspace({
               </option>
             ))}
             {scenarios.some((scenario) => scenario.id === OBSERVED_SOUNDING_BASE_SCENARIO_ID) && (
-              <option value={OBSERVED_SOUNDING_EXPERIMENT_ID}>Upload a Sounding</option>
+              <option value={OBSERVED_SOUNDING_EXPERIMENT_ID}>Observed Soundings</option>
             )}
           </select>
 
@@ -3754,7 +3855,7 @@ function BuildWorkspace({
                 <p className="eyebrow">Guided local CM1 experiment</p>
                 <h2>
                   {observedSoundingExperimentSelected
-                    ? "Upload a Sounding"
+                    ? "Observed Soundings"
                     : selectedScenario.display_name}
                 </h2>
                 <p>
@@ -4680,8 +4781,14 @@ function ObservedAtmosphereCandidatesPanel({
   const lastAnalysisSummary = screening
     ? `${visibleCandidates.length.toLocaleString()} shown from ${(
         screening.filtered_candidate_count ?? visibleCandidates.length
-      ).toLocaleString()} selected / ${(screening.total_candidate_count ?? visibleCandidates.length).toLocaleString()} analyzed`
+      ).toLocaleString()} matching / ${(screening.total_candidate_count ?? visibleCandidates.length).toLocaleString()} analyzed`
     : "Not run yet";
+  const filterTraceSummary = candidateFilterTraceSummary(screening, {
+    storyFilter,
+    storyFamilyFilter,
+    supportFilter,
+    readinessFilter,
+  });
   const activeRefinements = [
     storyFilter !== "all" ? `Story: ${candidateStoryLabel(storyFilter)}` : null,
     storyFamilyFilter !== "all" ? `Family: ${candidateStoryFamilyLabel(storyFamilyFilter)}` : null,
@@ -4783,7 +4890,7 @@ function ObservedAtmosphereCandidatesPanel({
         </div>
         <div className="candidate-discovery-actions" aria-label="Sounding search action">
           <button type="button" onClick={onPrepareAndSearch}>
-            Prepare & search local soundings
+            Analyze cached soundings
           </button>
         </div>
       </section>
@@ -4818,7 +4925,7 @@ function ObservedAtmosphereCandidatesPanel({
 
       {activeRefinements.length > 0 && (
         <div className="screening-guidance-note">
-          <strong>Refined view</strong>
+          <strong>Search filters applied</strong>
           <span>{activeRefinements.join(" · ")}</span>
           <button type="button" className="link-button" onClick={onClearFilters}>
             Clear refinements
@@ -4826,7 +4933,7 @@ function ObservedAtmosphereCandidatesPanel({
         </div>
       )}
 
-      <details className="candidate-advanced-filters" open={activeRefinements.length > 0}>
+      <details className="candidate-advanced-filters">
         <summary>Advanced filters</summary>
         <div className="candidate-toolbar" aria-label="Advanced sounding candidate controls">
           <label>
@@ -4980,7 +5087,7 @@ function ObservedAtmosphereCandidatesPanel({
               Cache station files
             </button>
             <button type="button" className="secondary-button" onClick={onScreen}>
-              Run analyzer only
+              Apply advanced filters
             </button>
           </div>
         </div>
@@ -5002,13 +5109,13 @@ function ObservedAtmosphereCandidatesPanel({
                   : "Recommended cached soundings"}
               </h4>
               <p className="field-help">
-                Showing {visibleCandidates.length.toLocaleString()} candidates
-                {screening.total_candidate_count !== undefined
-                  ? ` from ${screening.total_candidate_count.toLocaleString()} analyzed cached soundings`
-                  : ""}
-                . Scores rank sounding ingredients only. They do not predict what the current CM1
-                package will produce.
+                {filterTraceSummary.summary}
               </p>
+              {filterTraceSummary.detail && (
+                <p className="field-help candidate-filter-detail">
+                  {filterTraceSummary.detail}
+                </p>
+              )}
             </div>
           )}
           {visibleCandidates.length === 0 ? (
@@ -5117,7 +5224,13 @@ function SavedCandidatesSourcePanel({
               key={saved.saved_candidate_id}
               saved={saved}
               onUpdateAnnotations={(tags, notes) => onSave(saved.candidate, tags, notes)}
-              onUse={() => onSelectForRunSetup(saved.candidate, saved, saved.primary_story)}
+              onUse={() =>
+                onSelectForRunSetup(
+                  saved.candidate,
+                  saved,
+                  saved.candidate.active_story ?? saved.primary_story,
+                )
+              }
               onRemove={() => onRemoveSaved(saved.saved_candidate_id)}
             />
           ))}
@@ -5212,7 +5325,7 @@ function SavedSoundingCandidateCard({
       </details>
       <div className="button-row">
         <button type="button" onClick={onUse}>
-          Select for run setup
+          Configure run
         </button>
         <button type="button" className="secondary-button" onClick={onRemove}>
           Remove saved
@@ -5242,15 +5355,13 @@ function SoundingCandidateCard({
   onSelectForRunSetup: (activeStory: CandidateStoryId) => void;
 }) {
   const activeScore = candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter);
-  const story = activeScore?.story ?? candidate.primary_story;
-  const activeFamily = activeScore
-    ? candidateStoryFamilyForStory(activeScore.story)
-    : candidate.story_family;
-  const ingredientScore =
-    activeScore?.score_0_to_100 ??
-    candidateIngredientScore(candidate, storyFilter, storyFamilyFilter);
+  const story = candidateActiveStoryId(candidate, storyFilter, storyFamilyFilter);
+  const activeFamily = story ? candidateStoryFamilyForStory(story) : candidate.story_family;
+  const ingredientScore = candidateIngredientScore(candidate, storyFilter, storyFamilyFilter);
   const recipeFit = candidateRecipeFitForStory(candidate, story);
-  const firstCaveat = candidate.caveats[0];
+  const reasons = candidateInterestReasons(candidate).slice(0, 3);
+  const caveats = candidateDisplayCaveats(candidate);
+  const firstCaveat = caveats[0];
   return (
     <article
       className={`candidate-card${selected ? " selected-candidate-card" : ""}`}
@@ -5269,7 +5380,10 @@ function SoundingCandidateCard({
           {candidate.discovery_bucket && (
             <StatusBadge label={candidate.discovery_bucket} tone="neutral" />
           )}
-          <StatusBadge label={candidateStoryLabel(story)} tone="neutral" />
+          <StatusBadge
+            label={candidateDisplayStoryLabel(candidate, storyFilter, storyFamilyFilter)}
+            tone="neutral"
+          />
           {activeScore && activeScore.story !== candidate.primary_story && (
             <StatusBadge label={`Primary: ${candidate.primary_story_label}`} tone="neutral" />
           )}
@@ -5288,10 +5402,17 @@ function SoundingCandidateCard({
           />
         </span>
       </button>
-      {candidate.caveats.length > 0 && (
+      {reasons.length > 0 && (
+        <ul className="compact-list candidate-reason-list">
+          {reasons.map((reason) => (
+            <li key={`${candidate.candidate_id}-card-${reason}`}>{reason}</li>
+          ))}
+        </ul>
+      )}
+      {firstCaveat && (
         <p className="field-help">
           Key caveat: {humanize(firstCaveat)}
-          {candidate.caveats.length > 1 ? ` + ${candidate.caveats.length - 1} more` : ""}
+          {caveats.length > 1 ? ` + ${caveats.length - 1} more` : ""}
         </p>
       )}
       <div className="button-row">
@@ -5300,10 +5421,10 @@ function SoundingCandidateCard({
           disabled={!candidate.package_ready}
           onClick={() => onSelectForRunSetup(story)}
         >
-          Select for run setup
+          Configure run
         </button>
         <button type="button" className="secondary-button" disabled={saved} onClick={onSave}>
-          {saved ? "Saved" : "Save candidate"}
+          {saved ? "Saved" : "Save"}
         </button>
       </div>
     </article>
@@ -5345,13 +5466,9 @@ function SoundingCandidateDetail({
   }
   const activeCandidate = candidate;
   const activeScore = candidateActiveStoryScore(activeCandidate, storyFilter, storyFamilyFilter);
-  const story = activeScore?.story ?? activeCandidate.primary_story;
-  const activeFamily = activeScore
-    ? candidateStoryFamilyForStory(activeScore.story)
-    : activeCandidate.story_family;
-  const ingredientScore =
-    activeScore?.score_0_to_100 ??
-    candidateIngredientScore(activeCandidate, storyFilter, storyFamilyFilter);
+  const story = candidateActiveStoryId(activeCandidate, storyFilter, storyFamilyFilter);
+  const activeFamily = story ? candidateStoryFamilyForStory(story) : activeCandidate.story_family;
+  const ingredientScore = candidateIngredientScore(activeCandidate, storyFilter, storyFamilyFilter);
   const recipeFit = candidateRecipeFitForStory(activeCandidate, story);
   const reasons = candidateInterestReasons(activeCandidate);
   const savedTagValues = parseTags(tagDraft);
@@ -5389,7 +5506,8 @@ function SoundingCandidateDetail({
         <div>
           <h4>{candidateStationLabel(candidate)}</h4>
           <p>
-            {formatDate(candidate.valid_time_utc)} · {candidateStoryLabel(story)}
+            {formatDate(candidate.valid_time_utc)} ·{" "}
+            {candidateDisplayStoryLabel(candidate, storyFilter, storyFamilyFilter)}
           </p>
         </div>
         <StatusBadge
@@ -5408,7 +5526,7 @@ function SoundingCandidateDetail({
           disabled={!candidate.package_ready}
           onClick={() => onSelectForRunSetup(candidate, story)}
         >
-          Select for run setup
+          Configure run
         </button>
       </div>
       <section>
@@ -10576,11 +10694,47 @@ function observedSoundingLocationLabel(observed: ObservedSoundingSummary): strin
   return "Not available";
 }
 
+function candidateActiveStoryId(
+  candidate: SoundingCandidate,
+  storyFilter: CandidateStoryFilter,
+  storyFamilyFilter: CandidateStoryFamilyFilter,
+): CandidateStoryId {
+  const scopedStories = new Set(
+    candidateStoryScoresForScope(candidate, storyFilter, storyFamilyFilter).map(
+      (score) => score.story,
+    ),
+  );
+  if (candidate.active_story && scopedStories.has(candidate.active_story)) {
+    return candidate.active_story;
+  }
+  return candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter)?.story ?? candidate.primary_story;
+}
+
+function candidateDisplayStoryLabel(
+  candidate: SoundingCandidate,
+  storyFilter: CandidateStoryFilter,
+  storyFamilyFilter: CandidateStoryFamilyFilter,
+): string {
+  const activeStory = candidateActiveStoryId(candidate, storyFilter, storyFamilyFilter);
+  if (candidate.active_story === activeStory) {
+    return candidate.display_story ?? candidate.active_story_label ?? candidateStoryLabel(activeStory);
+  }
+  return candidateStoryLabel(activeStory);
+}
+
 function candidateIngredientScore(
   candidate: SoundingCandidate,
   storyFilter: CandidateStoryFilter,
   storyFamilyFilter: CandidateStoryFamilyFilter = "all",
 ): number {
+  const activeStory = candidateActiveStoryId(candidate, storyFilter, storyFamilyFilter);
+  if (
+    candidate.active_story === activeStory &&
+    typeof candidate.ingredient_score === "number" &&
+    Number.isFinite(candidate.ingredient_score)
+  ) {
+    return candidate.ingredient_score;
+  }
   return (
     candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter)?.score_0_to_100 ??
     candidate.rank_score
@@ -10623,6 +10777,8 @@ function candidateStoryScoresForScope(
 }
 
 function candidateInterestReasons(candidate: SoundingCandidate): string[] {
+  const topReasons = candidate.top_reasons?.filter(Boolean) ?? [];
+  if (topReasons.length > 0) return topReasons;
   const explicitReasons = candidate.interest_reasons?.filter(Boolean) ?? [];
   if (explicitReasons.length > 0) return explicitReasons;
   if (candidate.interest_summary) return [candidate.interest_summary];
@@ -10631,6 +10787,79 @@ function candidateInterestReasons(candidate: SoundingCandidate): string[] {
     .filter((reason): reason is string => Boolean(reason));
   if (evidenceReasons.length > 0) return evidenceReasons.slice(0, 3);
   return [candidate.primary_story_label];
+}
+
+function candidateDisplayCaveats(candidate: SoundingCandidate): string[] {
+  const topCaveats = candidate.top_caveats?.filter(Boolean) ?? [];
+  return topCaveats.length > 0 ? topCaveats : candidate.caveats;
+}
+
+function candidateFilterTraceSummary(
+  screening: ScreeningResult | null,
+  filters: {
+    storyFilter: CandidateStoryFilter;
+    storyFamilyFilter: CandidateStoryFamilyFilter;
+    supportFilter: CandidateSupportFilter;
+    readinessFilter: CandidateReadinessFilter;
+  },
+): { summary: string; detail: string | null } {
+  if (!screening) {
+    return { summary: "No recommendation run loaded.", detail: null };
+  }
+  const trace = screening.filter_trace;
+  const shown = screening.candidates.length;
+  if (!trace) {
+    return {
+      summary: `${shown.toLocaleString()} shown from ${(
+        screening.filtered_candidate_count ?? shown
+      ).toLocaleString()} matching / ${(screening.total_candidate_count ?? shown).toLocaleString()} analyzed.`,
+      detail: "Scores rank sounding ingredients only; CM1 results remain the source of truth.",
+    };
+  }
+  const storyStage =
+    filters.storyFilter !== "all"
+      ? trace.stage_counts.story_filter
+      : filters.storyFamilyFilter !== "all"
+        ? trace.stage_counts.story_family
+        : undefined;
+  const supportStage =
+    filters.supportFilter !== "all" ? trace.stage_counts.support : undefined;
+  const readinessStage =
+    filters.readinessFilter !== "all" ? trace.stage_counts.readiness : undefined;
+  const parts = [
+    `${trace.analyzed_soundings.toLocaleString()} analyzed`,
+    storyStage !== undefined
+      ? `${storyStage.toLocaleString()} matched ${candidateTraceScopeLabel(
+          filters.storyFilter,
+          filters.storyFamilyFilter,
+        )}`
+      : null,
+    supportStage !== undefined
+      ? `${supportStage.toLocaleString()} ${humanize(filters.supportFilter)}`
+      : null,
+    readinessStage !== undefined
+      ? `${readinessStage.toLocaleString()} ${humanize(filters.readinessFilter)}`
+      : null,
+    `${shown.toLocaleString()} shown`,
+  ].filter((part): part is string => part !== null);
+  const mainExclusion = trace.top_excluded_reasons[0];
+  const detail =
+    shown === 1 && mainExclusion
+      ? `Only one candidate remains; the largest filter impact was ${mainExclusion.reason} (${mainExclusion.count.toLocaleString()} removed).`
+      : `Trace includes ${trace.story_score_records.toLocaleString()} story-score records across ${trace.station_distribution.length.toLocaleString()} shown station${trace.station_distribution.length === 1 ? "" : "s"}.`;
+  return {
+    summary: parts.join(" · "),
+    detail,
+  };
+}
+
+function candidateTraceScopeLabel(
+  storyFilter: CandidateStoryFilter,
+  storyFamilyFilter: CandidateStoryFamilyFilter,
+): string {
+  if (storyFilter !== "all") return candidateStoryLabel(storyFilter).toLowerCase();
+  if (storyFamilyFilter !== "all") return candidateStoryFamilyLabel(storyFamilyFilter).toLowerCase();
+  return "selected intent";
 }
 
 function boundedInteger(value: string, min: number, max: number, fallback: number): number {
@@ -10679,9 +10908,8 @@ function candidateScreeningMetadata(
   savedCandidate?: SavedSoundingCandidate,
   activeStory?: CandidateStoryId,
 ): Record<string, unknown> {
-  const activeScore = activeStory
-    ? candidate.story_scores.find((score) => score.story === activeStory)
-    : null;
+  const selectedActiveStory = activeStory ?? candidate.active_story ?? candidate.primary_story;
+  const activeScore = candidate.story_scores.find((score) => score.story === selectedActiveStory);
   return {
     candidate_id: candidate.candidate_id,
     station_id: candidate.station_id,
@@ -10690,14 +10918,27 @@ function candidateScreeningMetadata(
     saved_candidate_id: savedCandidate?.saved_candidate_id ?? null,
     screening_version: candidate.screening_version,
     primary_story: candidate.primary_story,
-    active_story: activeStory ?? candidate.primary_story,
-    active_story_label: activeScore?.label ?? candidate.primary_story_label,
+    active_story: selectedActiveStory,
+    active_story_label:
+      activeScore?.label ??
+      (candidate.active_story === selectedActiveStory
+        ? (candidate.active_story_label ?? candidate.display_story)
+        : null) ??
+      candidate.primary_story_label,
+    display_story: candidate.display_story ?? null,
+    matched_story_ids: candidate.matched_story_ids ?? [],
     story_scores: candidate.story_scores,
     rank_score: candidate.rank_score,
+    active_story_score: candidate.active_story_score ?? null,
+    ingredient_score: candidate.ingredient_score ?? null,
+    active_story_support: candidate.active_story_support ?? null,
     confidence: candidate.confidence,
     features: candidate.features,
     evidence: candidate.evidence,
     caveats: candidate.caveats,
+    top_reasons: candidate.top_reasons ?? [],
+    top_caveats: candidate.top_caveats ?? [],
+    evidence_summary: candidate.evidence_summary ?? [],
     interest_summary: candidate.interest_summary ?? null,
     interest_reasons: candidate.interest_reasons ?? [],
     discovery_bucket: candidate.discovery_bucket ?? null,

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -381,8 +381,8 @@ type SearchIntent =
   | "humid_rainy"
   | "dry_microburst"
   | "shallow_boundary_layer";
-type SearchDepth = "quick_scan" | "deeper_scan" | "broad_historical_sweep";
-type TimeScope = "recent_latest";
+type StationSelectionMode = "all_cached" | "selected";
+type CandidateHistoryScope = "all_cached" | "latest_per_station";
 type RunPlanQueueTarget = "local" | "lan";
 const CURRENT_OBSERVED_RUN_RECIPE: ObservedRunRecipe = "observed_surface_forced_evolution";
 type RunPlanItemStatus =
@@ -478,6 +478,10 @@ type SoundingCandidate = {
 };
 
 type CandidateFilterTrace = {
+  selected_station_count?: number;
+  selected_cached_soundings?: number;
+  history_scope?: CandidateHistoryScope;
+  latest_per_station?: number | null;
   analyzed_soundings: number;
   story_score_records: number;
   stage_counts: Record<string, number>;
@@ -525,6 +529,9 @@ type ScreeningResult = {
   sort_direction?: "asc" | "desc";
   filters?: {
     station_id?: string | null;
+    station_ids?: string[];
+    history_scope?: CandidateHistoryScope;
+    latest_per_station?: number | null;
     story_filter: CandidateStoryFilter;
     story_family: CandidateStoryFamilyFilter;
     support: CandidateSupportFilter;
@@ -568,7 +575,14 @@ type IGRACatalogResponse = {
     refreshed_at: string;
     region: { label: string; tag: string };
     stations: unknown[];
-    zip_references: { cached_status: string }[];
+    zip_references: Array<{
+      station_id: string;
+      station_name?: string | null;
+      latitude?: number | null;
+      longitude?: number | null;
+      filename: string;
+      cached_status: string;
+    }>;
   } | null;
 };
 
@@ -583,6 +597,7 @@ type IGRACacheResponse = {
 
 type IGRABatchCacheResponse = {
   requested_limit: number;
+  requested_station_ids?: string[];
   selected_count: number;
   cached_entries: unknown[];
   failed: Array<{ station_id: string; filename: string; error: string }>;
@@ -1289,46 +1304,31 @@ const DEFAULT_OBSERVED_RUN_CONFIGURATION: RunConfigurationInput = {
 
 const SEARCH_INTENT_OPTIONS: Array<{ value: SearchIntent; label: string }> = [
   { value: "best_overall", label: "Best overall recommendations" },
-  { value: "deep_convection", label: "Credible deep-convection potential" },
+  { value: "deep_convection", label: "Deep-convection ingredients" },
   { value: "humid_rainy", label: "Humid/rainy evolution" },
   { value: "dry_microburst", label: "Dry microburst / inverted-V" },
   { value: "shallow_boundary_layer", label: "Shallow cumulus / boundary layer" },
 ];
 
-const SEARCH_DEPTH_OPTIONS: Array<{ value: SearchDepth; label: string; description: string }> = [
+const HISTORY_SCOPE_OPTIONS: Array<{
+  value: CandidateHistoryScope;
+  label: string;
+  description: string;
+}> = [
   {
-    value: "quick_scan",
-    label: "Latest sample",
-    description: "Latest 2 soundings per cached station file; fastest sanity check.",
+    value: "all_cached",
+    label: "All cached history",
+    description: "Analyze every cached sounding for the selected stations.",
   },
   {
-    value: "deeper_scan",
-    label: "Station-history sweep",
-    description: "Latest 20 soundings per cached station file; default recommendation pass.",
-  },
-  {
-    value: "broad_historical_sweep",
-    label: "Broad cached history",
-    description: "Latest 50 soundings per cached station file; larger local sweep.",
-  },
-];
-
-const TIME_SCOPE_OPTIONS: Array<{ value: TimeScope; label: string; description: string }> = [
-  {
-    value: "recent_latest",
-    label: "Recent/latest",
-    description: "Current backend support: latest soundings from cached station files.",
+    value: "latest_per_station",
+    label: "Latest N per station",
+    description: "Analyze an explicit recent-history set for the selected stations.",
   },
 ];
 
-const SEARCH_DEPTH_LIMITS: Record<
-  SearchDepth,
-  { cacheLimit: string; latestPerStation: string; resultLimit: string }
-> = {
-  quick_scan: { cacheLimit: "10", latestPerStation: "2", resultLimit: "25" },
-  deeper_scan: { cacheLimit: "25", latestPerStation: "20", resultLimit: "75" },
-  broad_historical_sweep: { cacheLimit: "50", latestPerStation: "50", resultLimit: "150" },
-};
+const DEFAULT_LATEST_PER_STATION = "20";
+const DEFAULT_CANDIDATE_RESULT_LIMIT = "100";
 
 class DryRunRequestError extends Error {
   preRunValidationReport: PreRunValidationReport | null;
@@ -1460,11 +1460,17 @@ async function fetchIGRARecentCache(): Promise<IGRACacheResponse> {
   return response.json() as Promise<IGRACacheResponse>;
 }
 
-async function cacheIGRARecentBatch(limit: number): Promise<IGRABatchCacheResponse> {
+async function cacheIGRARecentBatch(options: {
+  limit?: number;
+  stationIds?: string[];
+}): Promise<IGRABatchCacheResponse> {
   const response = await fetch("/api/igra/recent/cache-batch", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ limit }),
+    body: JSON.stringify({
+      limit: options.limit ?? 10,
+      station_ids: options.stationIds ?? [],
+    }),
   });
   if (!response.ok) {
     throw new Error(await responseError(response, "Unable to cache IGRA station files."));
@@ -1481,19 +1487,23 @@ async function fetchScreeningInputs(): Promise<ScreeningInputsResponse> {
 }
 
 async function screenSoundingCandidates(options: {
+  stationIds: string[];
+  historyScope: CandidateHistoryScope;
   story: CandidateStoryFilter;
   storyFamily: CandidateStoryFamilyFilter;
   support: CandidateSupportFilter;
   readiness: CandidateReadinessFilter;
   stationSearch: string;
   sort: CandidateSort;
-  latestPerStation: number;
+  latestPerStation: number | null;
   limit: number;
 }): Promise<ScreeningResult> {
   const response = await fetch("/api/sounding-candidates/analyze", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
+      station_ids: options.stationIds,
+      history_scope: options.historyScope,
       latest_per_station: options.latestPerStation,
       limit: options.limit,
       story_filter: options.story,
@@ -1505,7 +1515,7 @@ async function screenSoundingCandidates(options: {
     }),
   });
   if (!response.ok) {
-    throw new Error(await responseError(response, "Unable to analyze cached soundings."));
+    throw new Error(await responseError(response, "Unable to search selected soundings."));
   }
   return response.json() as Promise<ScreeningResult>;
 }
@@ -1907,8 +1917,11 @@ export function App() {
   const [atmosphereSourcePath, setAtmosphereSourcePath] =
     useState<AtmosphereSourcePath>("cached_recommendations");
   const [searchIntent, setSearchIntent] = useState<SearchIntent>("best_overall");
-  const [searchDepth, setSearchDepth] = useState<SearchDepth>("deeper_scan");
-  const [timeScope, setTimeScope] = useState<TimeScope>("recent_latest");
+  const [stationSelectionMode, setStationSelectionMode] =
+    useState<StationSelectionMode>("all_cached");
+  const [selectedStationIds, setSelectedStationIds] = useState<string[]>([]);
+  const [candidateHistoryScope, setCandidateHistoryScope] =
+    useState<CandidateHistoryScope>("all_cached");
   const [igraCatalog, setIgraCatalog] = useState<IGRACatalogResponse["catalog"] | null>(null);
   const [igraCache, setIgraCache] = useState<IGRACacheResponse | null>(null);
   const [screeningInputs, setScreeningInputs] = useState<ScreeningInput[]>([]);
@@ -1921,14 +1934,11 @@ export function App() {
   const [candidateStationSearch, setCandidateStationSearch] = useState("");
   const [candidateReadinessFilter, setCandidateReadinessFilter] =
     useState<CandidateReadinessFilter>("all");
-  const [candidateCacheLimit, setCandidateCacheLimit] = useState(
-    SEARCH_DEPTH_LIMITS.deeper_scan.cacheLimit,
-  );
   const [candidateLatestPerStation, setCandidateLatestPerStation] = useState(
-    SEARCH_DEPTH_LIMITS.deeper_scan.latestPerStation,
+    DEFAULT_LATEST_PER_STATION,
   );
   const [candidateResultLimit, setCandidateResultLimit] = useState(
-    SEARCH_DEPTH_LIMITS.deeper_scan.resultLimit,
+    DEFAULT_CANDIDATE_RESULT_LIMIT,
   );
   const [candidateStatus, setCandidateStatus] = useState("IGRA cache not checked yet");
   const [candidateError, setCandidateError] = useState<string | null>(null);
@@ -2142,16 +2152,35 @@ export function App() {
   useEffect(() => {
     if (!observedSoundingExperimentSelected) return;
     let active = true;
-    fetchSavedSoundingCandidates()
-      .then((payload) => {
+    setCandidateStatus("Loading local sounding data");
+    setCandidateError(null);
+    Promise.all([
+      fetchIGRARecentCatalog(),
+      fetchIGRARecentCache(),
+      fetchScreeningInputs(),
+      fetchSavedSoundingCandidates(),
+    ])
+      .then(([catalogPayload, cachePayload, inputsPayload, savedPayload]) => {
         if (!active) return;
-        setSavedCandidates(payload.saved_candidates);
+        setIgraCatalog(catalogPayload.catalog);
+        setIgraCache(cachePayload);
+        setScreeningInputs(inputsPayload.inputs);
+        setSavedCandidates(savedPayload.saved_candidates);
+        setCandidateStatus(
+          inputsPayload.inputs.length > 0
+            ? "Cached soundings ready to search"
+            : "No cached sounding files ready",
+        );
       })
       .catch((caught: unknown) => {
         if (!active) return;
+        setIgraCatalog(null);
+        setIgraCache(null);
+        setScreeningInputs([]);
         setCandidateError(
-          caught instanceof Error ? caught.message : "Unable to load saved sounding candidates.",
+          caught instanceof Error ? caught.message : "Unable to load local sounding data.",
         );
+        setCandidateStatus("Local sounding data unavailable");
       });
     return () => {
       active = false;
@@ -2315,16 +2344,39 @@ export function App() {
     setCandidateReadinessFilter("all");
     setCandidateSort("best_match");
     setCandidateStationSearch("");
-    markCandidateSearchSettingsChanged("Search intent changed; analyze cached soundings");
+    markCandidateSearchSettingsChanged("Search intent changed; search selected soundings");
   }
 
-  function handleSearchDepthChange(depth: SearchDepth) {
-    setSearchDepth(depth);
-    const limits = SEARCH_DEPTH_LIMITS[depth];
-    setCandidateCacheLimit(limits.cacheLimit);
-    setCandidateLatestPerStation(limits.latestPerStation);
-    setCandidateResultLimit(limits.resultLimit);
-    markCandidateSearchSettingsChanged("Search depth changed; analyze cached soundings");
+  function handleStationSelectionModeChange(mode: StationSelectionMode) {
+    setStationSelectionMode(mode);
+    markCandidateSearchSettingsChanged("Station set changed; search selected soundings");
+  }
+
+  function handleSelectedStationToggle(stationId: string) {
+    setSelectedStationIds((current) =>
+      current.includes(stationId)
+        ? current.filter((selected) => selected !== stationId)
+        : [...current, stationId],
+    );
+    setStationSelectionMode("selected");
+    markCandidateSearchSettingsChanged("Station selection changed; search selected soundings");
+  }
+
+  function handleSelectAllCachedStations() {
+    setSelectedStationIds([]);
+    setStationSelectionMode("all_cached");
+    markCandidateSearchSettingsChanged("All cached stations selected; search selected soundings");
+  }
+
+  function handleClearSelectedStations() {
+    setSelectedStationIds([]);
+    setStationSelectionMode("selected");
+    markCandidateSearchSettingsChanged("Station selection cleared");
+  }
+
+  function handleCandidateHistoryScopeChange(scope: CandidateHistoryScope) {
+    setCandidateHistoryScope(scope);
+    markCandidateSearchSettingsChanged("History scope changed; search selected soundings");
   }
 
   function handleCandidateStoryFilterChange(filter: CandidateStoryFilter) {
@@ -2357,19 +2409,24 @@ export function App() {
     markCandidateSearchSettingsChanged("Readiness filter changed; apply advanced filters");
   }
 
-  function handleCandidateCacheLimitChange(limit: string) {
-    setCandidateCacheLimit(limit);
-    markCandidateSearchSettingsChanged("Cache limit changed; analyze cached soundings");
-  }
-
   function handleCandidateLatestPerStationChange(limit: string) {
     setCandidateLatestPerStation(limit);
-    markCandidateSearchSettingsChanged("Analysis slice changed; apply advanced filters");
+    markCandidateSearchSettingsChanged("History scope changed; search selected soundings");
   }
 
   function handleCandidateResultLimitChange(limit: string) {
     setCandidateResultLimit(limit);
     markCandidateSearchSettingsChanged("Returned candidate limit changed; apply advanced filters");
+  }
+
+  function selectedStationIdsForCandidateRequest(): string[] {
+    return stationSelectionMode === "selected" ? selectedStationIds : [];
+  }
+
+  function selectedHistoryLatestPerStation(): number | null {
+    return candidateHistoryScope === "latest_per_station"
+      ? boundedInteger(candidateLatestPerStation, 1, 2000, 20)
+      : null;
   }
 
   async function refreshSoundingCandidateState(statusWhenLoaded?: string) {
@@ -2401,46 +2458,39 @@ export function App() {
   }
 
   async function handlePrepareAndSearchLocalSoundings() {
-    const limits = SEARCH_DEPTH_LIMITS[searchDepth];
-    const cacheLimit = boundedInteger(limits.cacheLimit, 1, 100, 10);
-    const latestPerStation = boundedInteger(limits.latestPerStation, 1, 50, 20);
-    const resultLimit = boundedInteger(limits.resultLimit, 1, 200, 75);
+    const stationIds = selectedStationIdsForCandidateRequest();
+    if (stationSelectionMode === "selected" && stationIds.length === 0) {
+      setCandidateError("Select at least one station, or switch to all cached stations.");
+      setCandidateStatus("Station selection required");
+      return;
+    }
+    const resultLimit = boundedInteger(candidateResultLimit, 1, 500, 100);
     setCandidateError(null);
     setCandidateScreening(null);
     setCandidateDetailId(null);
-    setCandidateStatus("Preparing local sounding data");
+    setCandidateStatus("Preparing selected soundings");
     try {
-      let [catalogPayload, cachePayload, inputsPayload, savedPayload] = await Promise.all([
+      const [catalogPayload, cachePayload, inputsPayload, savedPayload] = await Promise.all([
         fetchIGRARecentCatalog(),
         fetchIGRARecentCache(),
         fetchScreeningInputs(),
         fetchSavedSoundingCandidates(),
       ]);
-      if (inputsPayload.inputs.length === 0) {
-        setCandidateStatus(
-          `Caching up to ${cacheLimit} local station file${cacheLimit === 1 ? "" : "s"}`,
-        );
-        await cacheIGRARecentBatch(cacheLimit);
-        [catalogPayload, cachePayload, inputsPayload, savedPayload] = await Promise.all([
-          fetchIGRARecentCatalog(),
-          fetchIGRARecentCache(),
-          fetchScreeningInputs(),
-          fetchSavedSoundingCandidates(),
-        ]);
-      }
       setIgraCatalog(catalogPayload.catalog);
       setIgraCache(cachePayload);
       setScreeningInputs(inputsPayload.inputs);
       setSavedCandidates(savedPayload.saved_candidates);
-      setCandidateStatus("Searching cached soundings");
+      setCandidateStatus("Searching selected soundings");
       const result = await screenSoundingCandidates({
+        stationIds,
+        historyScope: candidateHistoryScope,
         story: candidateStoryFilter,
         storyFamily: candidateStoryFamilyFilter,
         support: candidateSupportFilter,
         readiness: candidateReadinessFilter,
         stationSearch: candidateStationSearch,
         sort: candidateSort,
-        latestPerStation,
+        latestPerStation: selectedHistoryLatestPerStation(),
         limit: resultLimit,
       });
       setCandidateScreening(result);
@@ -2452,9 +2502,9 @@ export function App() {
       );
     } catch (caught) {
       setCandidateError(
-        caught instanceof Error ? caught.message : "Unable to prepare and search local soundings.",
+        caught instanceof Error ? caught.message : "Unable to search selected soundings.",
       );
-      setCandidateStatus("Prepare and search failed");
+      setCandidateStatus("Selected sounding search failed");
     }
   }
 
@@ -2474,11 +2524,18 @@ export function App() {
   }
 
   async function handleCacheIGRAStationFiles() {
-    const limit = boundedInteger(candidateCacheLimit, 1, 100, 10);
+    const stationIds = selectedStationIdsForCandidateRequest();
+    if (stationIds.length === 0) {
+      setCandidateError("Select one or more catalog stations to cache.");
+      setCandidateStatus("Station selection required");
+      return;
+    }
     setCandidateError(null);
-    setCandidateStatus(`Caching up to ${limit} IGRA station file${limit === 1 ? "" : "s"}`);
+    setCandidateStatus(
+      `Caching ${stationIds.length} selected station${stationIds.length === 1 ? "" : "s"}`,
+    );
     try {
-      const result = await cacheIGRARecentBatch(limit);
+      const result = await cacheIGRARecentBatch({ stationIds });
       await refreshSoundingCandidateState(
         result.cached_entries.length > 0
           ? `Cached ${result.cached_entries.length} station file${
@@ -2502,20 +2559,28 @@ export function App() {
   }
 
   async function handleScreenSoundingCandidates() {
+    const stationIds = selectedStationIdsForCandidateRequest();
+    if (stationSelectionMode === "selected" && stationIds.length === 0) {
+      setCandidateError("Select at least one station, or switch to all cached stations.");
+      setCandidateStatus("Station selection required");
+      return;
+    }
     setCandidateError(null);
     setCandidateScreening(null);
     setCandidateDetailId(null);
-    setCandidateStatus("Analyzing cached soundings");
+    setCandidateStatus("Analyzing selected soundings");
     try {
       const result = await screenSoundingCandidates({
+        stationIds,
+        historyScope: candidateHistoryScope,
         story: candidateStoryFilter,
         storyFamily: candidateStoryFamilyFilter,
         support: candidateSupportFilter,
         readiness: candidateReadinessFilter,
         stationSearch: candidateStationSearch,
         sort: candidateSort,
-        latestPerStation: boundedInteger(candidateLatestPerStation, 1, 50, 20),
-        limit: boundedInteger(candidateResultLimit, 1, 200, 75),
+        latestPerStation: selectedHistoryLatestPerStation(),
+        limit: boundedInteger(candidateResultLimit, 1, 500, 100),
       });
       setCandidateScreening(result);
       setCandidateDetailId(result.candidates[0]?.candidate_id ?? null);
@@ -2528,9 +2593,9 @@ export function App() {
       setSavedCandidates(savedPayload.saved_candidates);
     } catch (caught) {
       setCandidateError(
-        caught instanceof Error ? caught.message : "Unable to analyze cached soundings.",
+        caught instanceof Error ? caught.message : "Unable to search selected soundings.",
       );
-      setCandidateStatus("Candidate analysis failed");
+      setCandidateStatus("Candidate search failed");
     }
   }
 
@@ -2542,7 +2607,7 @@ export function App() {
     setCandidateReadinessFilter("all");
     setCandidateSort("best_match");
     markCandidateSearchSettingsChanged(
-      "Showing default recommendation settings; analyze cached soundings",
+      "Showing default recommendation settings; search selected soundings",
     );
   }
 
@@ -3387,8 +3452,9 @@ export function App() {
           selectedCandidateScreening={selectedCandidateScreening}
           atmosphereSourcePath={atmosphereSourcePath}
           searchIntent={searchIntent}
-          searchDepth={searchDepth}
-          timeScope={timeScope}
+          stationSelectionMode={stationSelectionMode}
+          selectedStationIds={selectedStationIds}
+          candidateHistoryScope={candidateHistoryScope}
           igraCatalog={igraCatalog}
           igraCache={igraCache}
           screeningInputs={screeningInputs}
@@ -3398,7 +3464,6 @@ export function App() {
           candidateSort={candidateSort}
           candidateStationSearch={candidateStationSearch}
           candidateReadinessFilter={candidateReadinessFilter}
-          candidateCacheLimit={candidateCacheLimit}
           candidateLatestPerStation={candidateLatestPerStation}
           candidateResultLimit={candidateResultLimit}
           candidateStatus={candidateStatus}
@@ -3440,8 +3505,11 @@ export function App() {
           onObservedSoundingTimeChange={handleObservedSoundingTimeChange}
           onAtmosphereSourcePathChange={handleAtmosphereSourcePathChange}
           onSearchIntentChange={handleSearchIntentChange}
-          onSearchDepthChange={handleSearchDepthChange}
-          onTimeScopeChange={setTimeScope}
+          onStationSelectionModeChange={handleStationSelectionModeChange}
+          onSelectedStationToggle={handleSelectedStationToggle}
+          onSelectAllCachedStations={handleSelectAllCachedStations}
+          onClearSelectedStations={handleClearSelectedStations}
+          onCandidateHistoryScopeChange={handleCandidateHistoryScopeChange}
           onCandidateStoryFilterChange={handleCandidateStoryFilterChange}
           onCandidateStoryFamilyFilterChange={handleCandidateStoryFamilyFilterChange}
           onCandidateSupportFilterChange={handleCandidateSupportFilterChange}
@@ -3449,7 +3517,6 @@ export function App() {
           onCandidateStationSearchChange={handleCandidateStationSearchChange}
           onCandidateReadinessFilterChange={handleCandidateReadinessFilterChange}
           onClearCandidateAnalysisFilters={handleClearCandidateAnalysisFilters}
-          onCandidateCacheLimitChange={handleCandidateCacheLimitChange}
           onCandidateLatestPerStationChange={handleCandidateLatestPerStationChange}
           onCandidateResultLimitChange={handleCandidateResultLimitChange}
           onCandidateDetailChange={setCandidateDetailId}
@@ -3553,8 +3620,9 @@ function BuildWorkspace({
   selectedCandidateScreening,
   atmosphereSourcePath,
   searchIntent,
-  searchDepth,
-  timeScope,
+  stationSelectionMode,
+  selectedStationIds,
+  candidateHistoryScope,
   igraCatalog,
   igraCache,
   screeningInputs,
@@ -3564,7 +3632,6 @@ function BuildWorkspace({
   candidateSort,
   candidateStationSearch,
   candidateReadinessFilter,
-  candidateCacheLimit,
   candidateLatestPerStation,
   candidateResultLimit,
   candidateStatus,
@@ -3601,8 +3668,11 @@ function BuildWorkspace({
   onObservedSoundingTimeChange,
   onAtmosphereSourcePathChange,
   onSearchIntentChange,
-  onSearchDepthChange,
-  onTimeScopeChange,
+  onStationSelectionModeChange,
+  onSelectedStationToggle,
+  onSelectAllCachedStations,
+  onClearSelectedStations,
+  onCandidateHistoryScopeChange,
   onCandidateStoryFilterChange,
   onCandidateStoryFamilyFilterChange,
   onCandidateSupportFilterChange,
@@ -3610,7 +3680,6 @@ function BuildWorkspace({
   onCandidateStationSearchChange,
   onCandidateReadinessFilterChange,
   onClearCandidateAnalysisFilters,
-  onCandidateCacheLimitChange,
   onCandidateLatestPerStationChange,
   onCandidateResultLimitChange,
   onCandidateDetailChange,
@@ -3667,8 +3736,9 @@ function BuildWorkspace({
   selectedCandidateScreening: Record<string, unknown> | null;
   atmosphereSourcePath: AtmosphereSourcePath;
   searchIntent: SearchIntent;
-  searchDepth: SearchDepth;
-  timeScope: TimeScope;
+  stationSelectionMode: StationSelectionMode;
+  selectedStationIds: string[];
+  candidateHistoryScope: CandidateHistoryScope;
   igraCatalog: IGRACatalogResponse["catalog"] | null;
   igraCache: IGRACacheResponse | null;
   screeningInputs: ScreeningInput[];
@@ -3678,7 +3748,6 @@ function BuildWorkspace({
   candidateSort: CandidateSort;
   candidateStationSearch: string;
   candidateReadinessFilter: CandidateReadinessFilter;
-  candidateCacheLimit: string;
   candidateLatestPerStation: string;
   candidateResultLimit: string;
   candidateStatus: string;
@@ -3715,8 +3784,11 @@ function BuildWorkspace({
   onObservedSoundingTimeChange: (validTimeUtc: string) => void;
   onAtmosphereSourcePathChange: (sourcePath: AtmosphereSourcePath) => void;
   onSearchIntentChange: (intent: SearchIntent) => void;
-  onSearchDepthChange: (depth: SearchDepth) => void;
-  onTimeScopeChange: (timeScope: TimeScope) => void;
+  onStationSelectionModeChange: (mode: StationSelectionMode) => void;
+  onSelectedStationToggle: (stationId: string) => void;
+  onSelectAllCachedStations: () => void;
+  onClearSelectedStations: () => void;
+  onCandidateHistoryScopeChange: (scope: CandidateHistoryScope) => void;
   onCandidateStoryFilterChange: (filter: CandidateStoryFilter) => void;
   onCandidateStoryFamilyFilterChange: (filter: CandidateStoryFamilyFilter) => void;
   onCandidateSupportFilterChange: (filter: CandidateSupportFilter) => void;
@@ -3724,7 +3796,6 @@ function BuildWorkspace({
   onCandidateStationSearchChange: (value: string) => void;
   onCandidateReadinessFilterChange: (filter: CandidateReadinessFilter) => void;
   onClearCandidateAnalysisFilters: () => void;
-  onCandidateCacheLimitChange: (value: string) => void;
   onCandidateLatestPerStationChange: (value: string) => void;
   onCandidateResultLimitChange: (value: string) => void;
   onCandidateDetailChange: (candidateId: string) => void;
@@ -3937,15 +4008,15 @@ function BuildWorkspace({
                       cache={igraCache}
                       screeningInputs={screeningInputs}
                       searchIntent={searchIntent}
-                      searchDepth={searchDepth}
-                      timeScope={timeScope}
+                      stationSelectionMode={stationSelectionMode}
+                      selectedStationIds={selectedStationIds}
+                      historyScope={candidateHistoryScope}
                       storyFilter={candidateStoryFilter}
                       storyFamilyFilter={candidateStoryFamilyFilter}
                       supportFilter={candidateSupportFilter}
                       sort={candidateSort}
                       stationSearch={candidateStationSearch}
                       readinessFilter={candidateReadinessFilter}
-                      cacheLimit={candidateCacheLimit}
                       latestPerStation={candidateLatestPerStation}
                       resultLimit={candidateResultLimit}
                       status={candidateStatus}
@@ -3954,8 +4025,11 @@ function BuildWorkspace({
                       savedCandidates={savedCandidates}
                       selectedCandidateId={candidateDetailId}
                       onSearchIntentChange={onSearchIntentChange}
-                      onSearchDepthChange={onSearchDepthChange}
-                      onTimeScopeChange={onTimeScopeChange}
+                      onStationSelectionModeChange={onStationSelectionModeChange}
+                      onSelectedStationToggle={onSelectedStationToggle}
+                      onSelectAllCachedStations={onSelectAllCachedStations}
+                      onClearSelectedStations={onClearSelectedStations}
+                      onHistoryScopeChange={onCandidateHistoryScopeChange}
                       onStoryFilterChange={onCandidateStoryFilterChange}
                       onStoryFamilyFilterChange={onCandidateStoryFamilyFilterChange}
                       onSupportFilterChange={onCandidateSupportFilterChange}
@@ -3963,7 +4037,6 @@ function BuildWorkspace({
                       onStationSearchChange={onCandidateStationSearchChange}
                       onReadinessFilterChange={onCandidateReadinessFilterChange}
                       onClearFilters={onClearCandidateAnalysisFilters}
-                      onCacheLimitChange={onCandidateCacheLimitChange}
                       onLatestPerStationChange={onCandidateLatestPerStationChange}
                       onResultLimitChange={onCandidateResultLimitChange}
                       onCandidateDetailChange={onCandidateDetailChange}
@@ -4656,15 +4729,15 @@ function ObservedAtmosphereCandidatesPanel({
   cache,
   screeningInputs,
   searchIntent,
-  searchDepth,
-  timeScope,
+  stationSelectionMode,
+  selectedStationIds,
+  historyScope,
   storyFilter,
   storyFamilyFilter,
   supportFilter,
   sort,
   stationSearch,
   readinessFilter,
-  cacheLimit,
   latestPerStation,
   resultLimit,
   status,
@@ -4673,8 +4746,11 @@ function ObservedAtmosphereCandidatesPanel({
   savedCandidates,
   selectedCandidateId,
   onSearchIntentChange,
-  onSearchDepthChange,
-  onTimeScopeChange,
+  onStationSelectionModeChange,
+  onSelectedStationToggle,
+  onSelectAllCachedStations,
+  onClearSelectedStations,
+  onHistoryScopeChange,
   onStoryFilterChange,
   onStoryFamilyFilterChange,
   onSupportFilterChange,
@@ -4682,7 +4758,6 @@ function ObservedAtmosphereCandidatesPanel({
   onStationSearchChange,
   onReadinessFilterChange,
   onClearFilters,
-  onCacheLimitChange,
   onLatestPerStationChange,
   onResultLimitChange,
   onCandidateDetailChange,
@@ -4697,15 +4772,15 @@ function ObservedAtmosphereCandidatesPanel({
   cache: IGRACacheResponse | null;
   screeningInputs: ScreeningInput[];
   searchIntent: SearchIntent;
-  searchDepth: SearchDepth;
-  timeScope: TimeScope;
+  stationSelectionMode: StationSelectionMode;
+  selectedStationIds: string[];
+  historyScope: CandidateHistoryScope;
   storyFilter: CandidateStoryFilter;
   storyFamilyFilter: CandidateStoryFamilyFilter;
   supportFilter: CandidateSupportFilter;
   sort: CandidateSort;
   stationSearch: string;
   readinessFilter: CandidateReadinessFilter;
-  cacheLimit: string;
   latestPerStation: string;
   resultLimit: string;
   status: string;
@@ -4714,8 +4789,11 @@ function ObservedAtmosphereCandidatesPanel({
   savedCandidates: SavedSoundingCandidate[];
   selectedCandidateId: string | null;
   onSearchIntentChange: (intent: SearchIntent) => void;
-  onSearchDepthChange: (depth: SearchDepth) => void;
-  onTimeScopeChange: (timeScope: TimeScope) => void;
+  onStationSelectionModeChange: (mode: StationSelectionMode) => void;
+  onSelectedStationToggle: (stationId: string) => void;
+  onSelectAllCachedStations: () => void;
+  onClearSelectedStations: () => void;
+  onHistoryScopeChange: (scope: CandidateHistoryScope) => void;
   onStoryFilterChange: (filter: CandidateStoryFilter) => void;
   onStoryFamilyFilterChange: (filter: CandidateStoryFamilyFilter) => void;
   onSupportFilterChange: (filter: CandidateSupportFilter) => void;
@@ -4723,7 +4801,6 @@ function ObservedAtmosphereCandidatesPanel({
   onStationSearchChange: (value: string) => void;
   onReadinessFilterChange: (filter: CandidateReadinessFilter) => void;
   onClearFilters: () => void;
-  onCacheLimitChange: (value: string) => void;
   onLatestPerStationChange: (value: string) => void;
   onResultLimitChange: (value: string) => void;
   onCandidateDetailChange: (candidateId: string) => void;
@@ -4758,6 +4835,57 @@ function ObservedAtmosphereCandidatesPanel({
   const cachedCatalogFiles =
     catalog?.zip_references.filter((reference) => reference.cached_status !== "not_cached")
       .length ?? cachedStationFiles;
+  const stationOptions = useMemo(() => {
+    const inputByStation = new Map(screeningInputs.map((input) => [input.station_id, input]));
+    const optionByStation = new Map<
+      string,
+      {
+        station_id: string;
+        station_name?: string | null;
+        cached: boolean;
+        cached_status?: string | null;
+        sounding_count: number;
+        latest_valid_time_utc?: string | null;
+      }
+    >();
+    for (const reference of catalog?.zip_references ?? []) {
+      const input = inputByStation.get(reference.station_id);
+      optionByStation.set(reference.station_id, {
+        station_id: reference.station_id,
+        station_name: reference.station_name,
+        cached: Boolean(input) || reference.cached_status !== "not_cached",
+        cached_status: reference.cached_status,
+        sounding_count: input?.sounding_count ?? 0,
+        latest_valid_time_utc: input?.latest_valid_time_utc ?? null,
+      });
+    }
+    for (const input of screeningInputs) {
+      const current = optionByStation.get(input.station_id);
+      optionByStation.set(input.station_id, {
+        station_id: input.station_id,
+        station_name: input.station_name ?? current?.station_name ?? null,
+        cached: true,
+        cached_status: input.cached_status,
+        sounding_count: input.sounding_count ?? 0,
+        latest_valid_time_utc: input.latest_valid_time_utc ?? null,
+      });
+    }
+    return [...optionByStation.values()].sort((left, right) =>
+      (left.station_name ?? left.station_id).localeCompare(right.station_name ?? right.station_id),
+    );
+  }, [catalog?.zip_references, screeningInputs]);
+  const selectedStationIdSet = useMemo(() => new Set(selectedStationIds), [selectedStationIds]);
+  const cachedStationOptions = stationOptions.filter((option) => option.cached);
+  const activeStationOptions =
+    stationSelectionMode === "selected"
+      ? stationOptions.filter((option) => selectedStationIdSet.has(option.station_id))
+      : cachedStationOptions;
+  const selectedCachedStationOptions = activeStationOptions.filter((option) => option.cached);
+  const selectedUncachedStationOptions = activeStationOptions.filter((option) => !option.cached);
+  const selectedCachedSoundingCount = selectedCachedStationOptions.reduce(
+    (total, option) => total + option.sounding_count,
+    0,
+  );
   const screenableSoundingCount = screeningInputs.reduce(
     (total, input) => total + (input.sounding_count ?? 0),
     0,
@@ -4766,18 +4894,22 @@ function ObservedAtmosphereCandidatesPanel({
     screenableSoundingCount > 0
       ? `${screenableSoundingCount.toLocaleString()} cached soundings`
       : `${screeningInputs.length.toLocaleString()} cached files`;
-  const latestPerCachedFile = boundedInteger(latestPerStation, 1, 50, 5);
-  const plannedAnalysisCount = screeningInputs.reduce((total, input) => {
-    const count = input.sounding_count;
-    if (typeof count === "number" && Number.isFinite(count)) {
-      return total + Math.min(count, latestPerCachedFile);
-    }
-    return total + latestPerCachedFile;
-  }, 0);
+  const latestPerCachedFile = boundedInteger(latestPerStation, 1, 2000, 20);
+  const plannedAnalysisCount =
+    historyScope === "all_cached"
+      ? selectedCachedSoundingCount
+      : selectedCachedStationOptions.reduce(
+          (total, option) => total + Math.min(option.sounding_count, latestPerCachedFile),
+          0,
+        );
   const plannedAnalysisSummary =
-    screeningInputs.length > 0
-      ? `Up to ${plannedAnalysisCount.toLocaleString()} soundings (${latestPerCachedFile.toLocaleString()} per cached file)`
-      : "No cached files";
+    selectedCachedStationOptions.length > 0
+      ? `${plannedAnalysisCount.toLocaleString()} sounding${plannedAnalysisCount === 1 ? "" : "s"} from ${selectedCachedStationOptions.length.toLocaleString()} cached station${selectedCachedStationOptions.length === 1 ? "" : "s"}`
+      : "No cached stations selected";
+  const stationSelectionSummary =
+    stationSelectionMode === "all_cached"
+      ? `All ${cachedStationOptions.length.toLocaleString()} cached station${cachedStationOptions.length === 1 ? "" : "s"}`
+      : `${selectedStationIds.length.toLocaleString()} selected station${selectedStationIds.length === 1 ? "" : "s"}`;
   const lastAnalysisSummary = screening
     ? `${visibleCandidates.length.toLocaleString()} shown from ${(
         screening.filtered_candidate_count ?? visibleCandidates.length
@@ -4792,7 +4924,7 @@ function ObservedAtmosphereCandidatesPanel({
   const activeRefinements = [
     storyFilter !== "all" ? `Story: ${candidateStoryLabel(storyFilter)}` : null,
     storyFamilyFilter !== "all" ? `Family: ${candidateStoryFamilyLabel(storyFamilyFilter)}` : null,
-    supportFilter !== "all" ? `Support: ${humanize(supportFilter)}` : null,
+    supportFilter !== "all" ? `Evidence tier: ${supportTierLabel(supportFilter)}` : null,
     readinessFilter !== "all" ? `Readiness: ${humanize(readinessFilter)}` : null,
     stationSearch.trim() ? `Station search: ${stationSearch.trim()}` : null,
     sort !== "best_match" ? `Sort: ${candidateSortLabel(sort)}` : null,
@@ -4808,8 +4940,8 @@ function ObservedAtmosphereCandidatesPanel({
           <p className="eyebrow">Observed atmosphere</p>
           <h3 id="sounding-candidates-title">Find interesting soundings</h3>
           <p className="field-help">
-            Screening guidance only. The cache inventory is local data; recommendations analyze the
-            latest bounded slice from those cached files.
+            Choose the stations and history to search, then review the matching candidate
+            evidence.
           </p>
         </div>
         <p className="state-chip" role="status">
@@ -4823,15 +4955,16 @@ function ObservedAtmosphereCandidatesPanel({
       >
         <div className="run-configuration-grid">
           <label>
-            <strong>Source region</strong>
-            <select value="great_plains_midwest" disabled>
+            <span>Source region</span>
+            <select aria-label="Source region" value="great_plains_midwest" disabled>
               <option value="great_plains_midwest">Great Plains / Midwest</option>
             </select>
             <small>Current local station catalog scope.</small>
           </label>
           <label>
-            <strong>Search intent</strong>
+            <span>Search intent</span>
             <select
+              aria-label="Search intent"
               value={searchIntent}
               onChange={(event) => onSearchIntentChange(event.target.value as SearchIntent)}
             >
@@ -4844,76 +4977,171 @@ function ObservedAtmosphereCandidatesPanel({
                 Cold season / winter (not supported yet)
               </option>
             </select>
-            <small>Maps to the current backend-supported story filters.</small>
+            <small>Sets the recommendation category and explanation focus.</small>
           </label>
           <label>
-            <strong>Search depth</strong>
+            <span>History scope</span>
             <select
-              value={searchDepth}
-              onChange={(event) => onSearchDepthChange(event.target.value as SearchDepth)}
+              aria-label="History scope"
+              value={historyScope}
+              onChange={(event) =>
+                onHistoryScopeChange(event.target.value as CandidateHistoryScope)
+              }
             >
-              {SEARCH_DEPTH_OPTIONS.map((option) => (
+              {HISTORY_SCOPE_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>
                   {option.label}
                 </option>
               ))}
             </select>
             <small>
-              {SEARCH_DEPTH_OPTIONS.find((option) => option.value === searchDepth)?.description}
+              {HISTORY_SCOPE_OPTIONS.find((option) => option.value === historyScope)?.description}
             </small>
           </label>
+          {historyScope === "latest_per_station" && (
+            <label>
+              <span>Latest soundings per station</span>
+              <input
+                aria-label="Latest soundings per station"
+                type="number"
+                min="1"
+                max="2000"
+                value={latestPerStation}
+                onChange={(event) => onLatestPerStationChange(event.target.value)}
+              />
+              <small>Applied to each selected cached station.</small>
+            </label>
+          )}
           <label>
-            <strong>Time scope</strong>
-            <select
-              value={timeScope}
-              onChange={(event) => onTimeScopeChange(event.target.value as TimeScope)}
-            >
-              {TIME_SCOPE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-              <option value="seasonal_disabled" disabled>
-                Seasonal historical (not supported yet)
-              </option>
-              <option value="date_range_disabled" disabled>
-                Specific date range (not supported yet)
-              </option>
-              <option value="all_cached_disabled" disabled>
-                All cached (not supported yet)
-              </option>
-            </select>
-            <small>
-              {TIME_SCOPE_OPTIONS.find((option) => option.value === timeScope)?.description}
-            </small>
+            <span>Returned candidate limit</span>
+            <input
+              aria-label="Returned candidate limit"
+              type="number"
+              min="1"
+              max="500"
+              value={resultLimit}
+              onChange={(event) => onResultLimitChange(event.target.value)}
+            />
+            <small>Limit is applied after the selected soundings are analyzed.</small>
           </label>
+        </div>
+        <div className="candidate-search-set-summary" aria-label="Selected soundings">
+          <Metric label="Selected soundings" value={plannedAnalysisSummary} />
+          <Metric label="Station set" value={stationSelectionSummary} />
+          <Metric label="Cached inventory" value={cachedInventorySummary} />
+          <Metric
+            label="Uncached selected"
+            value={`${selectedUncachedStationOptions.length.toLocaleString()} station${selectedUncachedStationOptions.length === 1 ? "" : "s"}`}
+          />
         </div>
         <div className="candidate-discovery-actions" aria-label="Sounding search action">
           <button type="button" onClick={onPrepareAndSearch}>
-            Analyze cached soundings
+            Search selected soundings
+          </button>
+          <button type="button" className="secondary-button" onClick={onRefreshIGRAData}>
+            Refresh catalog
+          </button>
+          <button
+            type="button"
+            className="secondary-button"
+            disabled={selectedUncachedStationOptions.length === 0}
+            onClick={onCacheStationFiles}
+          >
+            Cache selected stations
           </button>
         </div>
       </section>
 
+      <section className="candidate-station-picker" aria-label="Station picker">
+        <div className="panel-heading-row">
+          <div>
+            <h4>Station set</h4>
+            <p className="field-help">
+              Search all cached stations, or choose specific stations to cache or analyze.
+            </p>
+          </div>
+          <div className="button-row">
+            <button
+              type="button"
+              className={
+                stationSelectionMode === "all_cached" ? "active-secondary-button" : "secondary-button"
+              }
+              onClick={onSelectAllCachedStations}
+            >
+              All cached stations
+            </button>
+            <button
+              type="button"
+              className={
+                stationSelectionMode === "selected" ? "active-secondary-button" : "secondary-button"
+              }
+              onClick={() => onStationSelectionModeChange("selected")}
+            >
+              Choose stations
+            </button>
+            <button type="button" className="secondary-button" onClick={onClearSelectedStations}>
+              Clear selected
+            </button>
+          </div>
+        </div>
+        {stationSelectionMode === "selected" ? (
+          <div className="station-picklist">
+            {stationOptions.length === 0 ? (
+              <p className="field-help">Refresh the IGRA catalog to load station choices.</p>
+            ) : (
+              stationOptions.map((station) => (
+                <label key={station.station_id} className="station-picklist-row">
+                  <input
+                    type="checkbox"
+                    checked={selectedStationIdSet.has(station.station_id)}
+                    onChange={() => onSelectedStationToggle(station.station_id)}
+                  />
+                  <span>
+                    <strong>{station.station_name ?? station.station_id}</strong>
+                    <small>
+                      {station.station_id} ·{" "}
+                      {station.cached
+                        ? `${station.sounding_count.toLocaleString()} cached sounding${station.sounding_count === 1 ? "" : "s"}`
+                        : "not cached"}
+                    </small>
+                  </span>
+                  <StatusBadge
+                    label={station.cached ? "Cached" : "Available to cache"}
+                    tone={station.cached ? "good" : "neutral"}
+                  />
+                </label>
+              ))
+            )}
+          </div>
+        ) : (
+          <p className="field-help">
+            Using all cached stations. Click Choose stations to pick specific stations or cache
+            uncached catalog stations.
+          </p>
+        )}
+      </section>
+
       <section className="candidate-cache-summary" aria-label="Local sounding data">
-        <h4>Local sounding data</h4>
-        <dl className="compact-metrics">
+        <div className="panel-heading-row">
+          <h4>Local sounding data</h4>
+          <StatusBadge
+            label={screeningInputs.length > 0 ? "Ready to search" : "No cached soundings"}
+            tone={screeningInputs.length > 0 ? "good" : "neutral"}
+          />
+        </div>
+        <dl className="compact-metrics candidate-cache-metrics">
           <Metric label="Region" value={catalog?.region.label ?? "Great Plains / Midwest"} />
           <Metric
-            label="Station catalog"
+            label="Catalog"
             value={
               catalog?.refreshed_at
-                ? `Last refreshed ${formatDate(catalog.refreshed_at)}`
+                ? formatDate(catalog.refreshed_at)
                 : "Not refreshed here"
             }
           />
-          <Metric label="Local station files" value={cachedCatalogFiles.toString()} />
+          <Metric label="Station files" value={cachedCatalogFiles.toString()} />
           <Metric label="Parsed soundings" value={cachedInventorySummary} />
-          <Metric
-            label="Ready to search"
-            value={screeningInputs.length > 0 ? "Yes" : "No cached sounding files ready"}
-          />
-          <Metric label="Last recommendation run" value={lastAnalysisSummary} />
+          <Metric label="Last search" value={lastAnalysisSummary} />
         </dl>
       </section>
 
@@ -4977,17 +5205,17 @@ function ObservedAtmosphereCandidatesPanel({
             </select>
           </label>
           <label>
-            Support
+            Evidence tier
             <select
               value={supportFilter}
               onChange={(event) =>
                 onSupportFilterChange(event.target.value as CandidateSupportFilter)
               }
             >
-              <option value="all">All support states</option>
-              <option value="supported">Supported</option>
-              <option value="weak">Weak support</option>
-              <option value="unavailable">Unavailable</option>
+              <option value="all">All evidence tiers</option>
+              <option value="supported">Strong signal</option>
+              <option value="weak">Plausible / caveated</option>
+              <option value="unavailable">Little or no signal</option>
             </select>
           </label>
           <label>
@@ -5004,7 +5232,7 @@ function ObservedAtmosphereCandidatesPanel({
               <option value="story_family">Story family</option>
               <option value="rank_score">Rank score</option>
               <option value="confidence">Confidence</option>
-              <option value="support">Support state</option>
+              <option value="support">Evidence tier</option>
               <option value="package_readiness">Package readiness</option>
               <option value="observed_wind_available">Observed wind availability</option>
               <option value="profile_top_m_agl">Profile top</option>
@@ -5028,11 +5256,11 @@ function ObservedAtmosphereCandidatesPanel({
             </select>
           </label>
           <label>
-            Station search
+            Result text search
             <input
               type="search"
               value={stationSearch}
-              placeholder="Station name, ID, or state"
+              placeholder="Station name, ID, or story"
               onChange={(event) => onStationSearchChange(event.target.value)}
             />
           </label>
@@ -5049,43 +5277,7 @@ function ObservedAtmosphereCandidatesPanel({
               <option value="blocked">Blocked / needs review</option>
             </select>
           </label>
-          <label>
-            Cache station files up to
-            <input
-              type="number"
-              min="1"
-              max="100"
-              value={cacheLimit}
-              onChange={(event) => onCacheLimitChange(event.target.value)}
-            />
-          </label>
-          <label>
-            Latest per cached file
-            <input
-              type="number"
-              min="1"
-              max="50"
-              value={latestPerStation}
-              onChange={(event) => onLatestPerStationChange(event.target.value)}
-            />
-          </label>
-          <label>
-            Returned candidate limit
-            <input
-              type="number"
-              min="1"
-              max="200"
-              value={resultLimit}
-              onChange={(event) => onResultLimitChange(event.target.value)}
-            />
-          </label>
           <div className="candidate-toolbar-actions">
-            <button type="button" className="secondary-button" onClick={onRefreshIGRAData}>
-              Refresh IGRA catalog
-            </button>
-            <button type="button" className="secondary-button" onClick={onCacheStationFiles}>
-              Cache station files
-            </button>
             <button type="button" className="secondary-button" onClick={onScreen}>
               Apply advanced filters
             </button>
@@ -5094,7 +5286,7 @@ function ObservedAtmosphereCandidatesPanel({
         <dl className="compact-metrics">
           <Metric label="Cached stations" value={cachedStations.toString()} />
           <Metric label="Cached station files" value={cachedStationFiles.toString()} />
-          <Metric label="Planned backend slice" value={plannedAnalysisSummary} />
+          <Metric label="Selected soundings" value={plannedAnalysisSummary} />
           <Metric label="Returned candidate limit" value={resultLimit} />
         </dl>
       </details>
@@ -5354,7 +5546,6 @@ function SoundingCandidateCard({
   onSave: () => void;
   onSelectForRunSetup: (activeStory: CandidateStoryId) => void;
 }) {
-  const activeScore = candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter);
   const story = candidateActiveStoryId(candidate, storyFilter, storyFamilyFilter);
   const activeFamily = story ? candidateStoryFamilyForStory(story) : candidate.story_family;
   const ingredientScore = candidateIngredientScore(candidate, storyFilter, storyFamilyFilter);
@@ -5384,9 +5575,6 @@ function SoundingCandidateCard({
             label={candidateDisplayStoryLabel(candidate, storyFilter, storyFamilyFilter)}
             tone="neutral"
           />
-          {activeScore && activeScore.story !== candidate.primary_story && (
-            <StatusBadge label={`Primary: ${candidate.primary_story_label}`} tone="neutral" />
-          )}
           <StatusBadge label={candidateStoryFamilyLabel(activeFamily)} tone="neutral" />
           <StatusBadge
             label={`${formatNumber(ingredientScore, "%")} ingredient score`}
@@ -10363,7 +10551,7 @@ function candidateSortLabel(sort: CandidateSort): string {
     story_family: "Story family",
     rank_score: "Rank score",
     confidence: "Confidence",
-    support: "Support state",
+    support: "Evidence tier",
     package_readiness: "Package readiness",
     observed_wind_available: "Observed wind availability",
     profile_top_m_agl: "Profile top",
@@ -10386,6 +10574,16 @@ function candidateSortLabel(sort: CandidateSort): string {
     freezing_level_m_agl: "Freezing level",
   };
   return labels[sort];
+}
+
+function supportTierLabel(support: CandidateSupportFilter): string {
+  const labels: Record<CandidateSupportFilter, string> = {
+    all: "All evidence tiers",
+    supported: "Strong signal",
+    weak: "Plausible / caveated",
+    unavailable: "Little or no signal",
+  };
+  return labels[support];
 }
 
 function candidateRecipeFitForStory(
@@ -10826,8 +11024,19 @@ function candidateFilterTraceSummary(
     filters.supportFilter !== "all" ? trace.stage_counts.support : undefined;
   const readinessStage =
     filters.readinessFilter !== "all" ? trace.stage_counts.readiness : undefined;
+  const stationDistribution = trace.station_distribution ?? [];
+  const topExcludedReasons = trace.top_excluded_reasons ?? [];
+  const historyScope =
+    trace.history_scope === "latest_per_station" && trace.latest_per_station
+      ? `latest ${trace.latest_per_station.toLocaleString()} per station`
+      : "all cached history";
+  const selectedStations =
+    trace.selected_station_count ?? stationDistribution.length;
+  const selectedSoundings = trace.selected_cached_soundings ?? trace.analyzed_soundings;
   const parts = [
-    `${trace.analyzed_soundings.toLocaleString()} analyzed`,
+    `${trace.analyzed_soundings.toLocaleString()} analyzed from ${selectedSoundings.toLocaleString()} selected cached sounding${selectedSoundings === 1 ? "" : "s"}`,
+    `${selectedStations.toLocaleString()} station${selectedStations === 1 ? "" : "s"}`,
+    historyScope,
     storyStage !== undefined
       ? `${storyStage.toLocaleString()} matched ${candidateTraceScopeLabel(
           filters.storyFilter,
@@ -10835,18 +11044,18 @@ function candidateFilterTraceSummary(
         )}`
       : null,
     supportStage !== undefined
-      ? `${supportStage.toLocaleString()} ${humanize(filters.supportFilter)}`
+      ? `${supportStage.toLocaleString()} ${supportTierLabel(filters.supportFilter).toLowerCase()}`
       : null,
     readinessStage !== undefined
       ? `${readinessStage.toLocaleString()} ${humanize(filters.readinessFilter)}`
       : null,
     `${shown.toLocaleString()} shown`,
   ].filter((part): part is string => part !== null);
-  const mainExclusion = trace.top_excluded_reasons[0];
+  const mainExclusion = topExcludedReasons[0];
   const detail =
     shown === 1 && mainExclusion
       ? `Only one candidate remains; the largest filter impact was ${mainExclusion.reason} (${mainExclusion.count.toLocaleString()} removed).`
-      : `Trace includes ${trace.story_score_records.toLocaleString()} story-score records across ${trace.station_distribution.length.toLocaleString()} shown station${trace.station_distribution.length === 1 ? "" : "s"}.`;
+      : `Trace includes ${trace.story_score_records.toLocaleString()} story-score records across ${stationDistribution.length.toLocaleString()} shown station${stationDistribution.length === 1 ? "" : "s"}.`;
   return {
     summary: parts.join(" · "),
     detail,
@@ -11054,9 +11263,9 @@ function searchIntentFilters(intent: SearchIntent): {
   switch (intent) {
     case "deep_convection":
       return {
-        story: "deep_convection_trial",
+        story: "all",
         storyFamily: "deep_convection",
-        support: "supported",
+        support: "all",
       };
     case "humid_rainy":
       return { story: "humid_rainy_candidate", storyFamily: "all", support: "all" };

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -173,14 +173,18 @@ enabled runnable label. Severe/deep-convection candidates are currently
 inspectable only as observed-sounding experiments under selected numeric uniform
 surface forcing, with differential-forcing initiation tracked as future work.
 
-The Build UI consumes this layer through bounded JSON only. `Upload a Sounding`
+The Build UI consumes this layer through bounded JSON only. `Observed Soundings`
 is the observed-atmosphere entry point, but the user chooses exactly one source
 path at a time: cached recommendations, saved candidates, or manual IGRA station
 text upload. Cached recommendations call recent-catalog/cache and
 candidate-analysis endpoints, display backend recommendations and advanced
-refinements, and save candidates with freeform tags/notes. Saved candidates are
-loaded as a shortlist source without requiring a catalog refresh, cache action,
-or analysis run. Manual upload remains hidden unless that source path is active.
+refinements, and save candidates with freeform tags/notes. Candidate-analysis
+responses include the active story that matched the current search intent,
+matched story IDs, ingredient score, top reasons/caveats, and a filter trace
+with analyzed-sounding counts, stage counts, station distribution, and top
+exclusion reasons. Saved candidates are loaded as a shortlist source without
+requiring a catalog refresh, cache action, or analysis run. Manual upload
+remains hidden unless that source path is active.
 Package-ready candidates, saved candidates, and uploaded soundings all flow into
 one selected-sounding setup surface for recipe and run-configuration choices.
 The configured selection is then added to the bottom Build run plan rather than

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -120,10 +120,12 @@ contract lives in
 [contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
 Analysis has a default recommendation mode that answers which cached soundings
 look interesting and why, using backend-owned interest reasons and station
-diversity before exposing refinements. It can also target story, story family,
-support state, recipe readiness, station search, and backend-owned sort keys
-because the useful sounding depends on the experiment question; shallow-cumulus
-and humid/rainy searches should not imply the same ranked list.
+diversity before exposing refinements. It analyzes the selected station set and
+selected history scope exactly, with the returned-candidate limit applied after
+analysis. It can also target story, story family, evidence tier, recipe
+readiness, station search, and backend-owned sort keys because the useful
+sounding depends on the experiment question; shallow-cumulus and humid/rainy
+searches should not imply the same ranked list.
 Missing feature values stay unavailable and sort last instead of being treated
 as zero. Saved candidates, freeform tags, and notes are runtime-local cache state
 under
@@ -152,7 +154,7 @@ The sounding-diagnostics layer is a backend-only feature extractor for observed
 soundings. It produces bounded `SoundingDiagnostics` payloads with
 `diagnostic_version`, station/time provenance, `feature_values`,
 `unavailable_features`, data-quality summaries, assumptions, and caveats. Each
-feature records its key, label, value, units, support state, method,
+feature records its key, label, value, units, evidence state, method,
 assumptions, and caveats so missing data weakens or blocks evidence instead of
 being treated as physically meaningful. V1 supports profile quality,
 cloud-base/moisture proxies, low-level and midlevel lapse-rate proxies,

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -139,17 +139,22 @@ pre-run evidence and context only. Parcel, storm-relative, wet-bulb, and
 winter-phase diagnostics must remain explicitly unavailable until their methods
 are implemented and tested.
 
-In Build, `Upload a Sounding` is the product-facing entry point for observed
+In Build, `Observed Soundings` is the product-facing entry point for observed
 atmosphere work. It should offer one source path at a time: cached local
 recommendations, saved candidates, or manual IGRA station text upload. The
 cached-recommendation path should lead with product-level search controls such
 as source region, search intent, search depth, and time scope, with raw cache
 limits and backend filters kept in advanced refinements. The workbench can
 refresh the bounded IGRA cache, analyze cached soundings into station-diverse
-recommendations, show why each candidate is interesting, expose story,
-story-family, support, readiness, station-search, and sort controls as advanced
-refinements, show package-ready and blocked candidates with evidence and
-caveats, and save candidates with freeform tags and notes for later review.
+recommendations, show the exact analyzed slice and filter trace, show why each
+candidate is interesting, expose story, story-family, support, readiness,
+station-search, and sort controls as advanced refinements, show package-ready
+and blocked candidates with evidence and caveats, and save candidates with
+freeform tags and notes for later review. Search-depth labels must describe the
+actual slice being analyzed. The default station-history sweep analyzes the
+latest 20 soundings per cached station file; credible deep-convection intent
+defaults to supported deep-convection story scores, while weak or unavailable
+deep-adjacent matches require explicit advanced refinement.
 Manual upload should stay hidden while cached recommendations or saved
 candidates are the active source path.
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -108,7 +108,7 @@ transparent candidate-selection aids that rank sounding ingredients only; they
 are not CM1 outcome predictions. Saved candidates live in the runtime cache and
 may be handed into package metadata as provenance for why a sounding was tried.
 The browser never parses remote directory listings, ZIP files, or station text
-files. The current story identifiers, feature inputs, score support states,
+files. The current story identifiers, feature inputs, evidence-tier states,
 evidence requirements, and caveat rules are defined in
 [contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
 The forward analyzer contract for testable hypotheses, explicit run
@@ -143,18 +143,21 @@ In Build, `Observed Soundings` is the product-facing entry point for observed
 atmosphere work. It should offer one source path at a time: cached local
 recommendations, saved candidates, or manual IGRA station text upload. The
 cached-recommendation path should lead with product-level search controls such
-as source region, search intent, search depth, and time scope, with raw cache
-limits and backend filters kept in advanced refinements. The workbench can
-refresh the bounded IGRA cache, analyze cached soundings into station-diverse
-recommendations, show the exact analyzed slice and filter trace, show why each
-candidate is interesting, expose story, story-family, support, readiness,
+as source region, search intent, station set, history scope, and returned
+candidate limit, with secondary backend filters kept in advanced refinements.
+The workbench can refresh the IGRA catalog, cache selected station files,
+analyze the selected station/history set into station-diverse recommendations,
+show the exact analyzed set and filter trace, show why each candidate is
+interesting, expose story, story-family, evidence-tier, readiness,
 station-search, and sort controls as advanced refinements, show package-ready
 and blocked candidates with evidence and caveats, and save candidates with
-freeform tags and notes for later review. Search-depth labels must describe the
-actual slice being analyzed. The default station-history sweep analyzes the
-latest 20 soundings per cached station file; credible deep-convection intent
-defaults to supported deep-convection story scores, while weak or unavailable
-deep-adjacent matches require explicit advanced refinement.
+freeform tags and notes for later review. History-scope labels must describe
+the actual set being analyzed. The default recommendation pass analyzes all
+cached history for all cached stations. `Latest N per station` is an explicit
+user selection, and the returned-candidate limit is applied only after the
+selected soundings have been analyzed. A deep-convection search intent scopes
+recommendations to deep-convection ingredient stories; it must not silently
+mean "supported-only" evidence or primary-story-only membership.
 Manual upload should stay hidden while cached recommendations or saved
 candidates are the active source path.
 
@@ -1287,7 +1290,7 @@ cloud time, max `qc`, max/min `w`, caveats, output summary, and editable name/ta
 edits use `Save changes`; ingested results already appear in Results.
 The notebook also exposes backend-derived science summary fields such as
 first-cloud time, max `qc`, max updraft, rain onset, latest output time, and
-interesting-time support state so the user can search, filter, and sort the
+interesting-time evidence state so the user can search, filter, and sort the
 experiment list by meaningful scientific evidence rather than raw file order.
 Result Cards must also distinguish generated-reference runs from runs
 created from an uploaded observed sounding, preserving station/time/source

--- a/docs/development.md
+++ b/docs/development.md
@@ -204,19 +204,21 @@ to test. CM1 output remains the source of truth.
 
 The same workflow is available in the app from Build -> `Observed Soundings` ->
 `Find interesting soundings`. Use `Refresh IGRA catalog` to update station
-metadata, `Cache station files` to download a bounded batch of station-period
-files, then `Analyze cached soundings`. The default search depth analyzes
-the latest 20 soundings per cached station file and reports the exact analyzed
-slice before showing recommendations. The default view asks the backend which
-cached soundings look interesting and why, with station-diverse recommendations,
+metadata, choose the station set, `Cache selected stations` when uncached
+station files are needed, then `Search selected soundings`. The default search
+uses all cached history for all cached stations; if `Latest N per station` is
+selected, the per-station history limit is explicit and reported before
+recommendations. The returned-candidate limit is applied after the selected
+soundings are analyzed. The default view asks the backend which selected
+soundings look interesting and why, with station-diverse recommendations,
 filter-trace counts, and explanation fields. Advanced refinements can narrow by
-story, story family, support, readiness, station search, and sounding-derived
-sort keys; missing feature values remain unavailable rather than becoming
-zero-valued evidence. `Configure run` loads a package-ready candidate into the
-observed-sounding package review; it does not launch CM1 and it does not claim
-the candidate will produce the screened outcome. Blocked candidates remain
-reviewable but cannot be used for package generation until their caveats are
-resolved. Saved candidates can carry freeform tags and notes such as
+story, story family, evidence tier, readiness, station search, and
+sounding-derived sort keys; missing feature values remain unavailable rather
+than becoming zero-valued evidence. `Configure run` loads a package-ready
+candidate into the observed-sounding package review; it does not launch CM1 and
+it does not claim the candidate will produce the screened outcome. Blocked
+candidates remain reviewable but cannot be used for package generation until
+their caveats are resolved. Saved candidates can carry freeform tags and notes such as
 `Deep convection candidates`, `Needs longer run`, or `Needs review`; when a saved
 candidate is used to create a
 package, those annotations are copied into package provenance and run-status

--- a/docs/development.md
+++ b/docs/development.md
@@ -202,20 +202,23 @@ use `--story deep-convection`, `--story shallow-cumulus`, `--story dry-failed`,
 `--story capped-suppressed`, or `--story humid-rainy` depending on what you want
 to test. CM1 output remains the source of truth.
 
-The same workflow is available in the app from Build -> `Upload a Sounding` ->
+The same workflow is available in the app from Build -> `Observed Soundings` ->
 `Find interesting soundings`. Use `Refresh IGRA catalog` to update station
 metadata, `Cache station files` to download a bounded batch of station-period
-files, then `Analyze recommendations`. The default view asks the backend which
-cached soundings look interesting and why, with station-diverse recommendations
-and explanation fields. Advanced refinements can narrow by story, story family,
-support, readiness, station search, and sounding-derived sort keys; missing
-feature values remain unavailable rather than becoming zero-valued evidence.
-`Use this sounding` loads a package-ready candidate into the observed-sounding
-package review; it does not launch CM1 and it does not claim the candidate will
-produce the screened outcome. Blocked candidates remain reviewable but cannot be
-used for package generation until their caveats are resolved. Saved candidates
-can carry freeform tags and notes such as `Deep convection candidates`,
-`Needs longer run`, or `Needs review`; when a saved candidate is used to create a
+files, then `Analyze cached soundings`. The default search depth analyzes
+the latest 20 soundings per cached station file and reports the exact analyzed
+slice before showing recommendations. The default view asks the backend which
+cached soundings look interesting and why, with station-diverse recommendations,
+filter-trace counts, and explanation fields. Advanced refinements can narrow by
+story, story family, support, readiness, station search, and sounding-derived
+sort keys; missing feature values remain unavailable rather than becoming
+zero-valued evidence. `Configure run` loads a package-ready candidate into the
+observed-sounding package review; it does not launch CM1 and it does not claim
+the candidate will produce the screened outcome. Blocked candidates remain
+reviewable but cannot be used for package generation until their caveats are
+resolved. Saved candidates can carry freeform tags and notes such as
+`Deep convection candidates`, `Needs longer run`, or `Needs review`; when a saved
+candidate is used to create a
 package, those annotations are copied into package provenance and run-status
 payloads.
 

--- a/docs/research/expanded-sounding-candidate-taxonomy.md
+++ b/docs/research/expanded-sounding-candidate-taxonomy.md
@@ -34,7 +34,7 @@ Every story in this taxonomy declares these fields:
 | `specialized_package_recommended` | `yes`, `no` | Whether a future package should better represent the story physics. |
 | `future_package_required` | `yes`, `no` | Whether the story should be blocked from package generation until a new package family exists. |
 | `candidate_can_be_saved` | `yes`, `no` | Whether the UI may save this candidate as a pre-run hypothesis. |
-| `candidate_can_generate_current_package` | `yes`, `caveated`, `no` | Whether `Use this sounding` may generate the current observed-sounding package. |
+| `candidate_can_generate_current_package` | `yes`, `caveated`, `no` | Whether `Configure run` may use this candidate for the current observed-sounding package path. |
 
 The UI should map these fields to simple readiness states:
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -111,14 +111,16 @@ boundary. Component tests and mocked Playwright smoke tests should verify that
 saved candidates load immediately when `Observed Soundings` is selected; the
 candidate workbench can refresh IGRA catalog metadata, cache a bounded batch of
 station files through mocked APIs, show station-diverse backend recommendations
-with why-interesting reasons and filter-trace counts, refine by story, story
-family, support, readiness, station search, and backend-owned sort keys when
-requested, include secondary story-score matches in explicit refined results,
-exclude weak deep-convection matches from the default credible deep-convection
-intent, sort missing metrics last, show blocked candidates as unusable, save
-candidates with freeform tags and notes, load a package-ready candidate into the
-observed-sounding package review, and include candidate-screening provenance in
-the generated package request. Browser tests must mock the backend APIs and must
+with why-interesting reasons and filter-trace counts, analyze the exact selected
+station set and history scope, apply the returned-candidate limit only after
+analysis, refine by story, story family, evidence tier, readiness, station
+search, and backend-owned sort keys when requested, include secondary
+story-score matches in explicit refined results, avoid silently converting
+deep-convection intent into a supported-only evidence filter, sort missing
+metrics last, show blocked candidates as unusable, save candidates with freeform
+tags and notes, load a package-ready candidate into the observed-sounding
+package review, and include candidate-screening provenance in the generated
+package request. Browser tests must mock the backend APIs and must
 not fetch NOAA/NCEI, parse raw station text,
 compute story scores, or imply that a candidate score predicts the CM1 outcome.
 
@@ -516,7 +518,7 @@ Output-product tests should cover interesting-time metadata without using real
 CM1 output. Tiny synthetic NetCDF fixtures and fake diagnostics should verify
 supported landmarks such as first cloud, max `qc`, max/min `w`, rain onset, and
 latest output; honest no-event behavior for no-cloud results; missing-field and
-missing-diagnostic support states; inferred-time caveats; per-field default
+missing-diagnostic evidence states; inferred-time caveats; per-field default
 time choices; and Result Card propagation of the compact `science_summary`.
 
 Viewport-stability tests should verify that the domain box, floor/grid, active

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -106,18 +106,20 @@ evidence; missing wind must not produce fake shear, storm-motion, or SRH
 values. Browser/UI tests must not parse sounding text or compute these
 diagnostics client-side.
 
-Frontend tests for the `Upload a Sounding` Build workflow should cover the same
+Frontend tests for the `Observed Soundings` Build workflow should cover the same
 boundary. Component tests and mocked Playwright smoke tests should verify that
-saved candidates load immediately when `Upload a Sounding` is selected; the
+saved candidates load immediately when `Observed Soundings` is selected; the
 candidate workbench can refresh IGRA catalog metadata, cache a bounded batch of
 station files through mocked APIs, show station-diverse backend recommendations
-with why-interesting reasons, refine by story, story family, support, readiness,
-station search, and backend-owned sort keys when requested, include secondary
-story-score matches in refined results, sort missing metrics last, show blocked
-candidates as unusable, save candidates with freeform tags and notes, load a
-package-ready candidate into the observed-sounding package review, and include
-candidate-screening provenance in the generated package request. Browser tests
-must mock the backend APIs and must not fetch NOAA/NCEI, parse raw station text,
+with why-interesting reasons and filter-trace counts, refine by story, story
+family, support, readiness, station search, and backend-owned sort keys when
+requested, include secondary story-score matches in explicit refined results,
+exclude weak deep-convection matches from the default credible deep-convection
+intent, sort missing metrics last, show blocked candidates as unusable, save
+candidates with freeform tags and notes, load a package-ready candidate into the
+observed-sounding package review, and include candidate-screening provenance in
+the generated package request. Browser tests must mock the backend APIs and must
+not fetch NOAA/NCEI, parse raw station text,
 compute story scores, or imply that a candidate score predicts the CM1 outcome.
 
 Most expanded real-sounding story families are spec-only until backend feature


### PR DESCRIPTION
## Summary

Closes #315.

This reworks the cached observed-sounding recommendation workflow so the UI answers: which selected soundings are interesting, why they matched, and exactly what station/history set was searched.

- Replaces hidden search-depth/sampling behavior with explicit station-set and history-scope controls: all cached history by default, or an explicit latest-N-per-station search.
- Adds backend support for exact selected-station analysis, all-cached history scans, parse-once station-file screening, and filter traces that report selected stations/soundings.
- Keeps deep-convection search family-scoped without silently applying a supported-only evidence filter or primary-story-only membership.
- Makes station selection visible in the main observed-sounding workflow, removes “corpus” language, tightens the local sounding data summary, and uses “evidence tier” in user-facing copy.
- Keeps the all-history path on the full diagnostic scorer, while removing repeated source hashing and repeated height interpolation work so the long search eventually returns without changing candidate evidence.
- Makes the live UI explicit when it is searching thousands of cached soundings, and fixes the local data panel so station-file counts come from screenable cached files instead of stale catalog status.
- Updates frontend/backend tests, mocked E2E coverage, and docs so the product contract matches the new station/history search behavior.

## Verification

- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_sounding_diagnostics.py app/backend/tests/test_sounding_candidates.py -q`
- `cd app/frontend && npm test -- App.test.tsx`
- Direct backend all-history search: shallow/boundary-layer intent over all cached history completed with 100 returned, 10,030 matching, and 22,029 analyzed across 22 stations.
- Manual live Playwright browser smoke against the actual frontend/backend: all cached history + shallow/boundary-layer completed with 100 shown from 10,030 matching / 22,029 analyzed and no failed browser requests.
- Manual live Playwright browser smoke against the actual frontend/backend: selected 2 stations, latest 3 per station, deep-convection ingredients completed with 6 analyzed / 3 shown; advanced filters stayed collapsed after intent changes; local data showed 22 station files and 22,029 cached soundings.
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Notes

Draft PR because this was requested as do-not-merge work.

Known existing warnings during verification:

- React `act(...)` warnings in one frontend loading-state test.
- Vite chunk-size warning during frontend build.
- Existing numpy runtime warning in backend result-ingest tests.
