### PR TITLE
Stage observed run setup above run plan

### DIFF
--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -191,6 +191,22 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(savedCard).toBeVisible();
 
     await savedCard.getByRole("button", { name: "Configure run" }).click();
+    await expect(page.getByLabel("Selected sounding run setup")).toBeVisible();
+    const selectedSetupOrderIsCorrect = await page.evaluate(() => {
+      const saved = document.querySelector(
+        '[aria-label="Saved sounding candidate Valley, Nebraska (USM00072558)"]',
+      );
+      const setup = document.querySelector('[aria-label="Selected sounding run setup"]');
+      const runPlan = document.querySelector('[aria-label="Run plan"]');
+      return Boolean(
+        saved &&
+          setup &&
+          runPlan &&
+          (saved.compareDocumentPosition(setup) & Node.DOCUMENT_POSITION_FOLLOWING) &&
+          (setup.compareDocumentPosition(runPlan) & Node.DOCUMENT_POSITION_FOLLOWING),
+      );
+    });
+    expect(selectedSetupOrderIsCorrect).toBe(true);
     await page.getByRole("button", { name: "Add to run plan" }).click();
     await expect(
       page.getByText("Valley, Nebraska (USM00072558) added to the run plan"),

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3636,6 +3636,14 @@ describe("App", () => {
     );
 
     fireEvent.click(within(savedCard).getByRole("button", { name: "Configure run" }));
+    const selectedRunSetup = screen.getByLabelText("Selected sounding run setup");
+    const runPlanSection = screen.getByLabelText("Run plan");
+    expect(
+      savedCard.compareDocumentPosition(selectedRunSetup) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      selectedRunSetup.compareDocumentPosition(runPlanSection) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
 
     expect(

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -4013,17 +4013,6 @@ function BuildWorkspace({
 
               {observedSoundingExperimentSelected && (
                 <>
-                  {observedSoundingParse?.selected_sounding && (
-                    <SelectedSoundingRunSetupPanel
-                      observedSounding={observedSoundingParse.selected_sounding}
-                      selectedCandidateScreening={selectedCandidateScreening}
-                      runConfiguration={runConfiguration}
-                      runConfigurationPreview={runConfigurationPreview}
-                      onRunConfigurationChange={onRunConfigurationChange}
-                      onAddSelectedSoundingToRunPlan={onAddSelectedSoundingToRunPlan}
-                    />
-                  )}
-
                   <AtmosphereSourcePicker
                     sourcePath={atmosphereSourcePath}
                     savedCandidateCount={savedCandidates.length}
@@ -4096,6 +4085,17 @@ function BuildWorkspace({
                       selectedCandidateScreening={selectedCandidateScreening}
                       onObservedSoundingFile={onObservedSoundingFile}
                       onObservedSoundingTimeChange={onObservedSoundingTimeChange}
+                    />
+                  )}
+
+                  {observedSoundingParse?.selected_sounding && (
+                    <SelectedSoundingRunSetupPanel
+                      observedSounding={observedSoundingParse.selected_sounding}
+                      selectedCandidateScreening={selectedCandidateScreening}
+                      runConfiguration={runConfiguration}
+                      runConfigurationPreview={runConfigurationPreview}
+                      onRunConfigurationChange={onRunConfigurationChange}
+                      onAddSelectedSoundingToRunPlan={onAddSelectedSoundingToRunPlan}
                     />
                   )}
 


### PR DESCRIPTION
## Summary
- Move the selected-sounding run setup below the active observed-sounding source browser and directly above the run plan.
- Preserve the existing Configure run behavior, but make the scroll target a forward staging step instead of a panel that appears above the source browser.
- Add unit and mocked E2E order assertions so the setup stays between the selected source row and the run plan.

## Verification
- `cd app/frontend && npm test -- App.test.tsx`
- `cd app/frontend && npx playwright test e2e/mocked-smoke/build-results-explore.spec.ts -g "Build can screen, save, and use observed sounding candidates"`
- Live Playwright pass against `localhost:5173`, confirming candidate source -> selected run setup -> run plan order and no console errors. Screenshot: `/tmp/cloud-chamber-run-config-placement.png`
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Notes
- Existing check noise remains: React `act(...)` warning, Vite chunk-size warning, backend numpy warning, and Playwright `NO_COLOR` warning.
