### PR TITLE
Fix non-finite diagnostic trust handling

### DIFF
--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -170,6 +170,7 @@ class ScienceSummary(BaseModel):
     default_explore_time_index: int | None = None
     default_explore_time_seconds: float | None = None
     cm1_outcome: str | None = None
+    field_quality_assessed: bool = False
     field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
     diagnostic_availability: list[ScienceDiagnosticAvailability] = Field(default_factory=list)
     interesting_time_caveats: list[str] = Field(default_factory=list)
@@ -454,7 +455,7 @@ def build_interesting_time_product(
         output_manifest=output_manifest,
         variables=set(variables),
     )
-    if diagnostics is not None:
+    if diagnostics is not None and diagnostics.field_quality_assessed:
         records = _records_with_field_quality(records, diagnostics.field_quality)
     defaults = _field_defaults(records)
     summary = _science_summary(
@@ -1026,7 +1027,8 @@ def _science_summary(
         default_explore_time_index=default_source.time_index if default_source else None,
         default_explore_time_seconds=default_source.time_seconds if default_source else None,
         cm1_outcome=None,
-        field_quality=diagnostics.field_quality,
+        field_quality_assessed=diagnostics.field_quality_assessed,
+        field_quality=diagnostics.field_quality if diagnostics.field_quality_assessed else {},
         diagnostic_availability=_diagnostic_availability(variables, diagnostics),
         interesting_time_support_state=support_state,
     )
@@ -1246,7 +1248,7 @@ def _availability_field_quality(
     diagnostics: ResultDiagnostics | None,
     field: str,
 ) -> FieldQuality | None:
-    if diagnostics is None:
+    if diagnostics is None or not diagnostics.field_quality_assessed:
         return None
     return diagnostics.field_quality.get(field)
 

--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -17,7 +17,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from cloud_chamber.result_diagnostics import ResultDiagnostics, TimeValue
+from cloud_chamber.result_diagnostics import FieldQuality, ResultDiagnostics, TimeValue
 
 OUTPUT_PRODUCT_MANIFEST_VERSION = 1
 DERIVED_PRODUCTS_DIRNAME = "derived-products"
@@ -109,6 +109,7 @@ class InterestingTimeRecord(BaseModel):
     value: float | bool | None = None
     units: str | None = None
     support_state: InterestingTimeSupportState
+    field_quality: FieldQuality | None = None
     provenance: InterestingTimeProvenance = Field(default_factory=InterestingTimeProvenance)
     caveats: list[str] = Field(default_factory=list)
     fallback_reason: str | None = None
@@ -122,6 +123,7 @@ class FieldDefaultTime(BaseModel):
     time_seconds: float | None = None
     source_interesting_time_key: str
     support_state: InterestingTimeSupportState
+    field_quality: FieldQuality | None = None
     fallback_reason: str | None = None
     caveats: list[str] = Field(default_factory=list)
 
@@ -133,6 +135,7 @@ class ScienceDiagnosticAvailability(BaseModel):
     label: str
     support_state: InterestingTimeSupportState
     source_field: str | None = None
+    field_quality: FieldQuality | None = None
     value: float | bool | None = None
     units: str | None = None
     caveats: list[str] = Field(default_factory=list)
@@ -167,6 +170,7 @@ class ScienceSummary(BaseModel):
     default_explore_time_index: int | None = None
     default_explore_time_seconds: float | None = None
     cm1_outcome: str | None = None
+    field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
     diagnostic_availability: list[ScienceDiagnosticAvailability] = Field(default_factory=list)
     interesting_time_caveats: list[str] = Field(default_factory=list)
     interesting_time_support_state: str = "unavailable"
@@ -450,6 +454,8 @@ def build_interesting_time_product(
         output_manifest=output_manifest,
         variables=set(variables),
     )
+    if diagnostics is not None:
+        records = _records_with_field_quality(records, diagnostics.field_quality)
     defaults = _field_defaults(records)
     summary = _science_summary(
         diagnostics,
@@ -801,6 +807,7 @@ def _field_default_record(
         value=source_record.value,
         units=source_record.units,
         support_state="supported" if fallback is None else "fallback",
+        field_quality=source_record.field_quality,
         caveats=list(source_record.caveats),
         fallback_reason=fallback,
     )
@@ -887,10 +894,58 @@ def _field_defaults(
             time_seconds=source.time_seconds,
             source_interesting_time_key=source.key,
             support_state="supported" if fallback_reason is None else "fallback",
+            field_quality=source.field_quality,
             fallback_reason=fallback_reason,
             caveats=list(source.caveats),
         )
     return defaults
+
+
+def _records_with_field_quality(
+    records: list[InterestingTimeRecord],
+    field_quality: dict[str, FieldQuality],
+) -> list[InterestingTimeRecord]:
+    return [_record_with_field_quality(record, field_quality) for record in records]
+
+
+def _record_with_field_quality(
+    record: InterestingTimeRecord,
+    field_quality: dict[str, FieldQuality],
+) -> InterestingTimeRecord:
+    quality = _quality_for_source_field(record.source_field, field_quality)
+    if quality is None:
+        return record
+    caveats = _dedupe([*record.caveats, *quality.caveats])
+    support_state = record.support_state
+    if quality.quality_state == "untrusted" and support_state == "supported":
+        support_state = "unavailable"
+        caveats = _dedupe([*caveats, "interesting_time_source_field_untrusted"])
+    return record.model_copy(
+        update={
+            "field_quality": quality,
+            "support_state": support_state,
+            "caveats": caveats,
+        }
+    )
+
+
+def _quality_for_source_field(
+    source_field: str | None,
+    field_quality: dict[str, FieldQuality],
+) -> FieldQuality | None:
+    if source_field is None:
+        return None
+    if source_field in {"qc", "qc+qr+qi+qs+qg when available"}:
+        return field_quality.get("qc")
+    if source_field == "w":
+        return field_quality.get("w")
+    if source_field == "qr":
+        return field_quality.get("qr")
+    if source_field == "rain":
+        return field_quality.get("surface_rain")
+    if source_field == "dbz":
+        return field_quality.get("dbz")
+    return None
 
 
 def _science_summary(
@@ -971,6 +1026,7 @@ def _science_summary(
         default_explore_time_index=default_source.time_index if default_source else None,
         default_explore_time_seconds=default_source.time_seconds if default_source else None,
         cm1_outcome=None,
+        field_quality=diagnostics.field_quality,
         diagnostic_availability=_diagnostic_availability(variables, diagnostics),
         interesting_time_support_state=support_state,
     )
@@ -1105,6 +1161,7 @@ def _diagnostic_availability(
             source_field="dbz",
             field_present="dbz" in variables,
             implemented=reflectivity_supported,
+            field_quality=_availability_field_quality(diagnostics, "dbz"),
         ),
         _availability_record(
             key="max_rain_or_surface_precip",
@@ -1112,6 +1169,7 @@ def _diagnostic_availability(
             source_field="rain",
             field_present="rain" in variables,
             implemented=surface_rain_supported,
+            field_quality=_availability_field_quality(diagnostics, "surface_rain"),
         ),
         _availability_record(
             key="updraft_depth_proxy",
@@ -1119,6 +1177,7 @@ def _diagnostic_availability(
             source_field="w",
             field_present="w" in variables,
             implemented=False,
+            field_quality=_availability_field_quality(diagnostics, "w"),
         ),
         _availability_record(
             key="cold_pool_proxy",
@@ -1126,6 +1185,7 @@ def _diagnostic_availability(
             source_field="th",
             field_present=bool({"th", "theta", "theta_v"} & variables),
             implemented=False,
+            field_quality=None,
         ),
         _availability_record(
             key="near_surface_theta_perturbation_proxy",
@@ -1133,6 +1193,7 @@ def _diagnostic_availability(
             source_field="th",
             field_present=bool({"th", "theta", "theta_v"} & variables),
             implemented=False,
+            field_quality=None,
         ),
     ]
 
@@ -1144,13 +1205,27 @@ def _availability_record(
     source_field: str,
     field_present: bool,
     implemented: bool,
+    field_quality: FieldQuality | None = None,
 ) -> ScienceDiagnosticAvailability:
+    if field_quality is not None and field_quality.quality_state == "untrusted":
+        return ScienceDiagnosticAvailability(
+            key=key,
+            label=label,
+            source_field=source_field,
+            field_quality=field_quality,
+            support_state="unavailable",
+            caveats=_dedupe([*field_quality.caveats, "diagnostic_source_field_untrusted"]),
+        )
     if implemented:
         return ScienceDiagnosticAvailability(
             key=key,
             label=label,
             source_field=source_field,
+            field_quality=field_quality,
             support_state="supported",
+            caveats=field_quality.caveats
+            if field_quality is not None and field_quality.quality_state == "caveated"
+            else [],
         )
     caveat = (
         f"{key}_diagnostic_not_implemented" if field_present else f"missing_{source_field}_field"
@@ -1159,11 +1234,21 @@ def _availability_record(
         key=key,
         label=label,
         source_field=source_field,
+        field_quality=field_quality,
         support_state="unsupported_missing_diagnostic"
         if field_present
         else "unsupported_missing_fields",
         caveats=[caveat],
     )
+
+
+def _availability_field_quality(
+    diagnostics: ResultDiagnostics | None,
+    field: str,
+) -> FieldQuality | None:
+    if diagnostics is None:
+        return None
+    return diagnostics.field_quality.get(field)
 
 
 def _positive(value: float | None) -> bool:

--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -17,6 +17,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.output_products import FieldDefaultTime, InterestingTimeRecord, ScienceSummary
+from cloud_chamber.result_diagnostics import FieldQuality
 from cloud_chamber.result_ingest import (
     RESULT_METADATA_FILENAME,
     CandidateHypothesisComparison,
@@ -126,6 +127,7 @@ class ResultCard(BaseModel):
     surface_rain_units: str | None = None
     max_dbz: float | None = None
     reflectivity_available: bool | None = None
+    field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
     interesting_times: list[InterestingTimeRecord] = Field(default_factory=list)
     default_time_by_field: dict[str, FieldDefaultTime] = Field(default_factory=dict)
     science_summary: ScienceSummary | None = None
@@ -269,24 +271,41 @@ def _card_from_metadata(
         thermal_fate_label=interpretation.thermal_fate_label if interpretation else None,
         thermal_fate_confidence=interpretation.confidence if interpretation else None,
         main_limiting_factor=interpretation.main_limiting_factor if interpretation else None,
-        first_cloud_time_seconds=cloud.first_cloud_time_seconds if cloud else None,
-        max_qc_kg_kg=cloud.max_qc_kg_kg if cloud else None,
-        time_of_max_qc_seconds=cloud.time_of_max_qc_seconds if cloud else None,
-        max_w_m_s=vertical_velocity.max_w_m_s if vertical_velocity else None,
+        first_cloud_time_seconds=(
+            cloud.first_cloud_time_seconds if cloud and cloud.available else None
+        ),
+        max_qc_kg_kg=cloud.max_qc_kg_kg if cloud and cloud.available else None,
+        time_of_max_qc_seconds=(
+            cloud.time_of_max_qc_seconds if cloud and cloud.available else None
+        ),
+        max_w_m_s=(
+            vertical_velocity.max_w_m_s
+            if vertical_velocity and vertical_velocity.available
+            else None
+        ),
         time_of_max_w_seconds=vertical_velocity.time_of_max_w_seconds
-        if vertical_velocity
+        if vertical_velocity and vertical_velocity.available
         else None,
-        min_w_m_s=vertical_velocity.min_w_m_s if vertical_velocity else None,
+        min_w_m_s=(
+            vertical_velocity.min_w_m_s
+            if vertical_velocity and vertical_velocity.available
+            else None
+        ),
         time_of_min_w_seconds=vertical_velocity.time_of_min_w_seconds
-        if vertical_velocity
+        if vertical_velocity and vertical_velocity.available
         else None,
-        rain_present=rain.present if rain else None,
-        first_rain_time_seconds=rain.first_rain_time_seconds if rain else None,
-        surface_rain_present=surface_rain.present if surface_rain else None,
-        max_surface_rain=surface_rain.max_surface_rain if surface_rain else None,
+        rain_present=rain.present if rain and rain.available else None,
+        first_rain_time_seconds=rain.first_rain_time_seconds if rain and rain.available else None,
+        surface_rain_present=(
+            surface_rain.present if surface_rain and surface_rain.available else None
+        ),
+        max_surface_rain=(
+            surface_rain.max_surface_rain if surface_rain and surface_rain.available else None
+        ),
         surface_rain_units=surface_rain.units if surface_rain else None,
-        max_dbz=reflectivity.max_dbz if reflectivity else None,
+        max_dbz=reflectivity.max_dbz if reflectivity and reflectivity.available else None,
         reflectivity_available=reflectivity.available if reflectivity else None,
+        field_quality=diagnostics.field_quality if diagnostics else {},
         interesting_times=metadata.interesting_times,
         default_time_by_field=metadata.default_time_by_field,
         science_summary=metadata.science_summary,

--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -127,6 +127,7 @@ class ResultCard(BaseModel):
     surface_rain_units: str | None = None
     max_dbz: float | None = None
     reflectivity_available: bool | None = None
+    field_quality_assessed: bool = False
     field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
     interesting_times: list[InterestingTimeRecord] = Field(default_factory=list)
     default_time_by_field: dict[str, FieldDefaultTime] = Field(default_factory=dict)
@@ -305,7 +306,10 @@ def _card_from_metadata(
         surface_rain_units=surface_rain.units if surface_rain else None,
         max_dbz=reflectivity.max_dbz if reflectivity and reflectivity.available else None,
         reflectivity_available=reflectivity.available if reflectivity else None,
-        field_quality=diagnostics.field_quality if diagnostics else {},
+        field_quality_assessed=diagnostics.field_quality_assessed if diagnostics else False,
+        field_quality=diagnostics.field_quality
+        if diagnostics is not None and diagnostics.field_quality_assessed
+        else {},
         interesting_times=metadata.interesting_times,
         default_time_by_field=metadata.default_time_by_field,
         science_summary=metadata.science_summary,

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import isfinite
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -21,6 +21,21 @@ THERMAL_FATE_CONFIDENCE_VALUES = (
     "insufficient_evidence",
     "unsupported_missing_fields",
 )
+
+FieldQualityState = Literal["trusted", "caveated", "untrusted", "unavailable"]
+
+
+class FieldQuality(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    source_field: str
+    quality_state: FieldQualityState
+    reason: str | None = None
+    finite_count: int = 0
+    non_finite_count: int = 0
+    total_count: int = 0
+    caveats: list[str] = Field(default_factory=list)
 
 
 class TimeValue(BaseModel):
@@ -120,6 +135,7 @@ class ResultDiagnostics(BaseModel):
     surface_rain: SurfaceRainDiagnostics = Field(default_factory=SurfaceRainDiagnostics)
     reflectivity: ReflectivityDiagnostics = Field(default_factory=ReflectivityDiagnostics)
     time: TimeDiagnostics
+    field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
     caveats: list[str] = Field(default_factory=list)
 
 
@@ -348,6 +364,7 @@ def compute_baseline_diagnostics(dataset: Any, inherited_caveats: list[str]) -> 
     rain = _rain_diagnostics(dataset, time_context, caveats)
     surface_rain = _surface_rain_diagnostics(dataset, time_context, caveats)
     reflectivity = _reflectivity_diagnostics(dataset, time_context, caveats)
+    field_quality = _field_quality_map(dataset)
     return ResultDiagnostics(
         cloud=cloud,
         vertical_velocity=vertical_velocity,
@@ -355,7 +372,95 @@ def compute_baseline_diagnostics(dataset: Any, inherited_caveats: list[str]) -> 
         surface_rain=surface_rain,
         reflectivity=reflectivity,
         time=time_context.diagnostics,
+        field_quality=field_quality,
         caveats=_dedupe(caveats),
+    )
+
+
+FIELD_QUALITY_SOURCES = {
+    "qc": {
+        "source_field": "qc",
+        "missing": "missing_qc_field",
+        "partial": "non_finite_values_detected_in_qc",
+        "entire": "qc_field_entirely_non_finite",
+    },
+    "w": {
+        "source_field": "w",
+        "missing": "missing_w_field",
+        "partial": "non_finite_values_detected_in_w",
+        "entire": "w_field_entirely_non_finite",
+    },
+    "qr": {
+        "source_field": "qr",
+        "missing": "qr_field_absent",
+        "partial": "non_finite_values_detected_in_qr",
+        "entire": "qr_field_entirely_non_finite",
+    },
+    "surface_rain": {
+        "source_field": "rain",
+        "missing": "surface_rain_field_absent",
+        "partial": "non_finite_values_detected_in_surface_rain",
+        "entire": "surface_rain_field_entirely_non_finite",
+    },
+    "dbz": {
+        "source_field": "dbz",
+        "missing": "dbz_field_absent",
+        "partial": "non_finite_values_detected_in_dbz",
+        "entire": "dbz_field_entirely_non_finite",
+    },
+}
+
+
+def _field_quality_map(dataset: Any) -> dict[str, FieldQuality]:
+    return {
+        field: _field_quality(dataset, field, config)
+        for field, config in FIELD_QUALITY_SOURCES.items()
+    }
+
+
+def _field_quality(dataset: Any, field: str, config: dict[str, str]) -> FieldQuality:
+    source_field = config["source_field"]
+    if source_field not in dataset.data_vars:
+        return FieldQuality(
+            field=field,
+            source_field=source_field,
+            quality_state="unavailable",
+            reason=config["missing"],
+            caveats=[config["missing"]],
+        )
+    data_array = dataset[source_field]
+    finite_count = _finite_count(data_array)
+    non_finite_count = _non_finite_count(data_array)
+    total_count = _total_count(data_array)
+    if finite_count == 0:
+        return FieldQuality(
+            field=field,
+            source_field=source_field,
+            quality_state="untrusted",
+            reason=config["entire"],
+            finite_count=finite_count,
+            non_finite_count=non_finite_count,
+            total_count=total_count,
+            caveats=[config["partial"], config["entire"]],
+        )
+    if non_finite_count > 0:
+        return FieldQuality(
+            field=field,
+            source_field=source_field,
+            quality_state="caveated",
+            reason=config["partial"],
+            finite_count=finite_count,
+            non_finite_count=non_finite_count,
+            total_count=total_count,
+            caveats=[config["partial"]],
+        )
+    return FieldQuality(
+        field=field,
+        source_field=source_field,
+        quality_state="trusted",
+        finite_count=finite_count,
+        non_finite_count=non_finite_count,
+        total_count=total_count,
     )
 
 
@@ -833,6 +938,10 @@ def _non_finite_count(data_array: Any) -> int:
         if parsed is None or not isfinite(parsed):
             count += 1
     return count
+
+
+def _total_count(data_array: Any) -> int:
+    return int(data_array.values.size)
 
 
 def _has_finite_values(data_array: Any) -> bool:

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -135,6 +135,7 @@ class ResultDiagnostics(BaseModel):
     surface_rain: SurfaceRainDiagnostics = Field(default_factory=SurfaceRainDiagnostics)
     reflectivity: ReflectivityDiagnostics = Field(default_factory=ReflectivityDiagnostics)
     time: TimeDiagnostics
+    field_quality_assessed: bool = False
     field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
     caveats: list[str] = Field(default_factory=list)
 
@@ -372,6 +373,7 @@ def compute_baseline_diagnostics(dataset: Any, inherited_caveats: list[str]) -> 
         surface_rain=surface_rain,
         reflectivity=reflectivity,
         time=time_context.diagnostics,
+        field_quality_assessed=True,
         field_quality=field_quality,
         caveats=_dedupe(caveats),
     )

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -555,6 +555,9 @@ def _merge_diagnostics(
         [diagnostics.reflectivity for diagnostics in diagnostics_parts]
     )
     field_quality = _merge_field_quality_maps(diagnostics_parts)
+    field_quality_assessed = any(
+        diagnostics.field_quality_assessed for diagnostics in diagnostics_parts
+    )
     caveats = _dedupe_strings(
         [
             *inherited_caveats,
@@ -568,6 +571,7 @@ def _merge_diagnostics(
         surface_rain=surface_rain,
         reflectivity=reflectivity,
         time=time,
+        field_quality_assessed=field_quality_assessed,
         field_quality=field_quality,
         caveats=caveats,
     )
@@ -1182,6 +1186,8 @@ def _candidate_outcome_evidence(science_summary: ScienceSummary) -> list[str]:
 
 
 def _field_quality_comparison_caveats(diagnostics: ResultDiagnostics) -> list[str]:
+    if not diagnostics.field_quality_assessed:
+        return ["field_quality_not_assessed"]
     caveats: list[str] = []
     for field in FIELD_QUALITY_ORDER:
         quality = diagnostics.field_quality.get(field)

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -22,6 +22,7 @@ from cloud_chamber.output_products import (
 )
 from cloud_chamber.result_diagnostics import (
     CloudDiagnostics,
+    FieldQuality,
     ProcessDiagnostics,
     RainDiagnostics,
     ReflectivityDiagnostics,
@@ -553,6 +554,7 @@ def _merge_diagnostics(
     reflectivity = _merge_reflectivity_diagnostics(
         [diagnostics.reflectivity for diagnostics in diagnostics_parts]
     )
+    field_quality = _merge_field_quality_maps(diagnostics_parts)
     caveats = _dedupe_strings(
         [
             *inherited_caveats,
@@ -566,6 +568,7 @@ def _merge_diagnostics(
         surface_rain=surface_rain,
         reflectivity=reflectivity,
         time=time,
+        field_quality=field_quality,
         caveats=caveats,
     )
 
@@ -747,6 +750,87 @@ def _merge_reflectivity_diagnostics(
         ),
         available=True,
         field_absent=all(part.field_absent for part in parts),
+    )
+
+
+FIELD_QUALITY_ORDER = ("qc", "w", "qr", "surface_rain", "dbz")
+
+
+def _merge_field_quality_maps(
+    diagnostics_parts: list[ResultDiagnostics],
+) -> dict[str, FieldQuality]:
+    field_names = [
+        field
+        for field in FIELD_QUALITY_ORDER
+        if any(field in diagnostics.field_quality for diagnostics in diagnostics_parts)
+    ]
+    return {
+        field: _merge_field_quality(
+            field,
+            [
+                diagnostics.field_quality[field]
+                for diagnostics in diagnostics_parts
+                if field in diagnostics.field_quality
+            ],
+        )
+        for field in field_names
+    }
+
+
+def _merge_field_quality(field: str, qualities: list[FieldQuality]) -> FieldQuality:
+    source_field = next((quality.source_field for quality in qualities), field)
+    finite_count = sum(quality.finite_count for quality in qualities)
+    non_finite_count = sum(quality.non_finite_count for quality in qualities)
+    total_count = sum(quality.total_count for quality in qualities)
+    caveats = _dedupe_strings([caveat for quality in qualities for caveat in quality.caveats])
+    reason = next(
+        (
+            quality.reason
+            for quality in qualities
+            if quality.quality_state != "trusted" and quality.reason is not None
+        ),
+        None,
+    )
+
+    if total_count == 0 and finite_count == 0:
+        return FieldQuality(
+            field=field,
+            source_field=source_field,
+            quality_state="unavailable",
+            reason=reason,
+            caveats=caveats,
+        )
+    if finite_count == 0:
+        return FieldQuality(
+            field=field,
+            source_field=source_field,
+            quality_state="untrusted",
+            reason=reason,
+            finite_count=finite_count,
+            non_finite_count=non_finite_count,
+            total_count=total_count,
+            caveats=caveats,
+        )
+    if non_finite_count > 0 or any(
+        quality.quality_state in {"caveated", "untrusted", "unavailable"} for quality in qualities
+    ):
+        return FieldQuality(
+            field=field,
+            source_field=source_field,
+            quality_state="caveated",
+            reason=reason,
+            finite_count=finite_count,
+            non_finite_count=non_finite_count,
+            total_count=total_count,
+            caveats=caveats,
+        )
+    return FieldQuality(
+        field=field,
+        source_field=source_field,
+        quality_state="trusted",
+        finite_count=finite_count,
+        non_finite_count=non_finite_count,
+        total_count=total_count,
     )
 
 
@@ -998,9 +1082,11 @@ def _candidate_hypothesis_comparison(
         )
 
     evidence = _candidate_outcome_evidence(science_summary)
+    field_quality_caveats = _field_quality_comparison_caveats(diagnostics)
     caveats = [
         "candidate_screening_is_a_pre_run_hypothesis",
         "candidate_match_uses_simple_v1_deep_convection_rules",
+        *field_quality_caveats,
     ]
     if primary_story not in DEEP_CONVECTION_STORY_IDS:
         return CandidateHypothesisComparison(
@@ -1095,6 +1181,24 @@ def _candidate_outcome_evidence(science_summary: ScienceSummary) -> list[str]:
     return evidence
 
 
+def _field_quality_comparison_caveats(diagnostics: ResultDiagnostics) -> list[str]:
+    caveats: list[str] = []
+    for field in FIELD_QUALITY_ORDER:
+        quality = diagnostics.field_quality.get(field)
+        if quality is None or quality.quality_state == "trusted":
+            continue
+        caveat = f"field_quality_{quality.quality_state}:{field}"
+        if quality.reason:
+            caveat = f"{caveat}:{quality.reason}"
+        if quality.total_count > 0:
+            caveat = (
+                f"{caveat}:finite={quality.finite_count}:"
+                f"non_finite={quality.non_finite_count}:total={quality.total_count}"
+            )
+        caveats.append(caveat)
+    return caveats
+
+
 def _screening_string(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
 
@@ -1175,9 +1279,19 @@ def _input_source_label(manifest: RunManifest) -> str:
 
 
 def _diagnostics_summary(diagnostics: ResultDiagnostics) -> str:
-    cloud_status = "cloud formed" if diagnostics.cloud.formed else "no cloud formed"
+    cloud_status = (
+        "cloud formed"
+        if diagnostics.cloud.available and diagnostics.cloud.formed
+        else "no cloud formed"
+        if diagnostics.cloud.available
+        else "cloud unavailable"
+    )
     rain_water_status = (
-        "rain water aloft detected" if diagnostics.rain.present else "no rain water aloft detected"
+        "rain water aloft detected"
+        if diagnostics.rain.available and diagnostics.rain.present
+        else "no rain water aloft detected"
+        if diagnostics.rain.available
+        else "rain water aloft unavailable"
     )
     if diagnostics.surface_rain.available:
         surface_status = (

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -36,6 +36,7 @@ from cloud_chamber.observed_sounding import (
     observed_sounding_from_payload,
     parse_igra_station_text,
 )
+from cloud_chamber.result_diagnostics import FieldQuality
 from cloud_chamber.result_ingest import (
     RESULT_METADATA_FILENAME,
     ResultIngestError,
@@ -1794,8 +1795,9 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         result.warnings if result is not None else [], variables
     )
     caveats = _normalize_campaign_messages(_summary_caveats(run, state_run, result), variables)
-    diagnostic_trust = _diagnostic_trust(caveats)
-    diagnostic_quality_warnings = _diagnostic_quality_warnings(caveats)
+    field_quality = diagnostics.field_quality if diagnostics is not None else None
+    diagnostic_trust = _diagnostic_trust(caveats, field_quality)
+    diagnostic_quality_warnings = _diagnostic_quality_warnings(caveats, field_quality)
     candidate = manifest.candidate_screening if manifest is not None else run.candidate_screening
     cloud = diagnostics.cloud if diagnostics is not None else None
     vertical_velocity = diagnostics.vertical_velocity if diagnostics is not None else None
@@ -2119,10 +2121,30 @@ FIELD_TRUST_CAVEATS = {
 }
 
 
-def _diagnostic_trust(caveats: Iterable[str]) -> dict[str, str]:
+def _diagnostic_trust(
+    caveats: Iterable[str],
+    field_quality: Mapping[str, FieldQuality] | None = None,
+) -> dict[str, str]:
     caveat_set = set(caveats)
     if "result_not_ingested" in caveat_set:
         return {field: "unavailable_until_result_ingested" for field in FIELD_TRUST_CAVEATS}
+    if field_quality:
+        quality_trust: dict[str, str] = {}
+        for field, codes in FIELD_TRUST_CAVEATS.items():
+            quality = field_quality.get(field)
+            if quality is None:
+                quality_trust[field] = "trusted"
+            elif quality.quality_state == "untrusted":
+                quality_trust[field] = "untrusted_entirely_non_finite"
+            elif quality.quality_state == "unavailable":
+                quality_trust[field] = "unavailable_field_missing"
+            elif quality.quality_state == "caveated":
+                quality_trust[field] = "caveated_non_finite_values_detected"
+            else:
+                quality_trust[field] = "trusted"
+            if quality is not None and quality.reason == codes["entire"]:
+                quality_trust[field] = "untrusted_entirely_non_finite"
+        return quality_trust
     trust: dict[str, str] = {}
     for field, codes in FIELD_TRUST_CAVEATS.items():
         if codes["entire"] in caveat_set:
@@ -2136,11 +2158,24 @@ def _diagnostic_trust(caveats: Iterable[str]) -> dict[str, str]:
     return trust
 
 
-def _diagnostic_quality_warnings(caveats: Iterable[str]) -> list[str]:
+def _diagnostic_quality_warnings(
+    caveats: Iterable[str],
+    field_quality: Mapping[str, FieldQuality] | None = None,
+) -> list[str]:
     return _dedupe(
-        caveat
-        for caveat in caveats
-        if "non_finite" in caveat or caveat.endswith("_field_entirely_non_finite")
+        [
+            *(
+                caveat
+                for caveat in caveats
+                if "non_finite" in caveat or caveat.endswith("_field_entirely_non_finite")
+            ),
+            *(
+                caveat
+                for quality in (field_quality or {}).values()
+                for caveat in quality.caveats
+                if "non_finite" in caveat or caveat.endswith("_field_entirely_non_finite")
+            ),
+        ]
     )
 
 
@@ -2269,6 +2304,8 @@ def _summary_caveats(
     else:
         caveats.extend(result.run_caveats)
         caveats.extend(result.interesting_time_caveats)
+        if result.diagnostics is not None:
+            caveats.extend(result.diagnostics.caveats)
     return _dedupe(caveats)
 
 
@@ -2720,8 +2757,9 @@ def _recommended_follow_ups(summaries: Sequence[Mapping[str, Any]]) -> list[str]
     ]
     if any(summary.get("diagnostic_quality_warnings") for summary in summaries):
         followups.append(
-            "Standardize non-finite field trust handling across result cards, output "
-            "products, campaign reports, and comparisons."
+            "Review caveated or untrusted non-finite fields before using cloud, "
+            "updraft, rain-water, surface-rain, or reflectivity outcomes as "
+            "scientific evidence."
         )
     if any(summary.get("status") == "package_failed" for summary in summaries):
         followups.append("Fix package-generation blockers before queueing the full campaign.")

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -1796,7 +1796,14 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
     )
     caveats = _normalize_campaign_messages(_summary_caveats(run, state_run, result), variables)
     field_quality = diagnostics.field_quality if diagnostics is not None else None
-    diagnostic_trust = _diagnostic_trust(caveats, field_quality)
+    field_quality_assessed = (
+        diagnostics.field_quality_assessed if diagnostics is not None else False
+    )
+    diagnostic_trust = _diagnostic_trust(
+        caveats,
+        field_quality,
+        field_quality_assessed=field_quality_assessed,
+    )
     diagnostic_quality_warnings = _diagnostic_quality_warnings(caveats, field_quality)
     candidate = manifest.candidate_screening if manifest is not None else run.candidate_screening
     cloud = diagnostics.cloud if diagnostics is not None else None
@@ -2124,16 +2131,18 @@ FIELD_TRUST_CAVEATS = {
 def _diagnostic_trust(
     caveats: Iterable[str],
     field_quality: Mapping[str, FieldQuality] | None = None,
+    *,
+    field_quality_assessed: bool = False,
 ) -> dict[str, str]:
     caveat_set = set(caveats)
     if "result_not_ingested" in caveat_set:
         return {field: "unavailable_until_result_ingested" for field in FIELD_TRUST_CAVEATS}
-    if field_quality:
+    if field_quality_assessed:
         quality_trust: dict[str, str] = {}
         for field, codes in FIELD_TRUST_CAVEATS.items():
-            quality = field_quality.get(field)
+            quality = (field_quality or {}).get(field)
             if quality is None:
-                quality_trust[field] = "trusted"
+                quality_trust[field] = "not_assessed"
             elif quality.quality_state == "untrusted":
                 quality_trust[field] = "untrusted_entirely_non_finite"
             elif quality.quality_state == "unavailable":
@@ -2154,7 +2163,7 @@ def _diagnostic_trust(
         elif codes["partial"] in caveat_set:
             trust[field] = "caveated_non_finite_values_detected"
         else:
-            trust[field] = "trusted"
+            trust[field] = "not_assessed"
     return trust
 
 
@@ -2194,6 +2203,8 @@ def _field_trust_label(status: str | None) -> str:
         return "unavailable"
     if status == "unavailable_until_result_ingested":
         return "unavailable"
+    if status == "not_assessed":
+        return "not assessed"
     return "trusted"
 
 
@@ -2203,7 +2214,7 @@ def _trusted_metric_label(label: str, value: Any, trust_status: str | None) -> s
         return f"{label} unavailable (untrusted)"
     if trust_label == "unavailable":
         return f"{label} unavailable"
-    suffix = f" ({trust_label})" if trust_label == "caveated" else ""
+    suffix = f" ({trust_label})" if trust_label in {"caveated", "not assessed"} else ""
     return f"{label} {_fmt(value)}{suffix}"
 
 
@@ -2213,7 +2224,7 @@ def _trusted_bool_label(label: str, value: Any, trust_status: str | None) -> str
         return f"{label} unavailable (untrusted)"
     if trust_label == "unavailable":
         return f"{label} unavailable"
-    suffix = f" ({trust_label})" if trust_label == "caveated" else ""
+    suffix = f" ({trust_label})" if trust_label in {"caveated", "not assessed"} else ""
     return f"{label} {_bool_or_fmt(value)}{suffix}"
 
 

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -24,7 +24,11 @@ from cloud_chamber.output_products import (
     output_product_manifest_from_json,
     resolve_time_index,
 )
-from cloud_chamber.result_diagnostics import QC_CLOUD_THRESHOLD_KG_KG
+from cloud_chamber.result_diagnostics import (
+    QC_CLOUD_THRESHOLD_KG_KG,
+    FieldQuality,
+    FieldQualityState,
+)
 from cloud_chamber.result_ingest import (
     DEEP_CONVECTION_STORY_IDS,
     ResultMetadata,
@@ -39,6 +43,14 @@ OutputProductStatus = Literal["available", "unavailable"]
 ProfileAggregationMethod = Literal["domain_mean", "domain_min", "domain_max", "selected_column"]
 TimeHeightAggregationMethod = Literal["cloud_fraction", "domain_mean", "domain_min", "domain_max"]
 TimeSeriesAggregationMethod = Literal["cloud_fraction", "domain_mean", "domain_min", "domain_max"]
+
+FIELD_QUALITY_KEY_BY_RAW_FIELD = {
+    "qc": "qc",
+    "w": "w",
+    "qr": "qr",
+    "rain": "surface_rain",
+    "dbz": "dbz",
+}
 
 
 @dataclass(frozen=True)
@@ -431,6 +443,20 @@ class FieldCatalogResponse(BaseModel):
     caveats: list[str] = Field(default_factory=list)
 
 
+class OutputProductFieldQuality(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str | None = None
+    source_field: str | None = None
+    assessed: bool = False
+    quality_state: FieldQualityState | None = None
+    reason: str | None = None
+    finite_count: int | None = None
+    non_finite_count: int | None = None
+    total_count: int | None = None
+    quality_caveats: list[str] = Field(default_factory=list)
+
+
 class OutputProductDescriptor(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -444,6 +470,7 @@ class OutputProductDescriptor(BaseModel):
     aggregation_methods: list[str] = Field(default_factory=list)
     required_fields: list[str] = Field(default_factory=list)
     reason: str | None = None
+    field_quality: OutputProductFieldQuality | None = None
     caveats: list[str] = Field(default_factory=list)
 
 
@@ -504,6 +531,7 @@ class VerticalProfileResponse(BaseModel):
     finite_counts: list[int]
     non_finite_counts: list[int]
     aggregation_method: ProfileAggregationMethod
+    field_quality: OutputProductFieldQuality | None = None
     provenance: ProvenancePayload
     caveats: list[str] = Field(default_factory=list)
 
@@ -534,6 +562,7 @@ class TimeHeightResponse(BaseModel):
     finite_counts: list[list[int]]
     non_finite_counts: list[list[int]]
     aggregation_method: TimeHeightAggregationMethod
+    field_quality: OutputProductFieldQuality | None = None
     provenance: ProvenancePayload
     caveats: list[str] = Field(default_factory=list)
 
@@ -560,6 +589,7 @@ class TimeSeriesResponse(BaseModel):
     finite_counts: list[int]
     non_finite_counts: list[int]
     aggregation_method: TimeSeriesAggregationMethod
+    field_quality: OutputProductFieldQuality | None = None
     provenance: ProvenancePayload
     caveats: list[str] = Field(default_factory=list)
 
@@ -602,6 +632,7 @@ class SliceResponse(BaseModel):
     data_encoding: VisualizationEncoding
     values: list[list[float | None]]
     stats: SliceStats
+    field_quality: OutputProductFieldQuality | None = None
     provenance: ProvenancePayload
     caveats: list[str] = Field(default_factory=list)
 
@@ -656,6 +687,7 @@ class PointCloudResponse(BaseModel):
     point_order: list[str]
     points: list[list[float]]
     stats: PointCloudStats
+    field_quality: OutputProductFieldQuality | None = None
     provenance: ProvenancePayload
     caveats: list[str] = Field(default_factory=list)
 
@@ -1063,11 +1095,11 @@ def output_product_catalog(
     time_series_products: list[OutputProductDescriptor] = []
     for field in catalog.available_fields:
         if field.capabilities.profile_candidate:
-            profile_products.append(_profile_product_descriptor(field))
+            profile_products.append(_profile_product_descriptor(metadata, field))
         if field.capabilities.time_height_candidate:
-            time_height_products.append(_time_height_product_descriptor(field))
+            time_height_products.append(_time_height_product_descriptor(metadata, field))
         if _time_series_methods_for_field(field):
-            time_series_products.append(_time_series_product_descriptor(field))
+            time_series_products.append(_time_series_product_descriptor(metadata, field))
 
     unavailable = [
         OutputProductDescriptor(
@@ -1078,15 +1110,18 @@ def output_product_catalog(
             aggregation_methods=[],
             required_fields=["theta", "qv", "surface_fluxes"],
             reason="future_diagnostic_method_not_validated",
+            field_quality=_output_field_quality(metadata, "boundary_layer_depth"),
             caveats=[
                 "boundary_layer_depth_proxy_not_implemented",
                 "method_must_be_documented_and_tested_before_science_use",
             ],
         )
     ]
-    unavailable.extend(_near_surface_wind_unavailable_descriptors(catalog.available_fields))
     unavailable.extend(
-        _unavailable_product_descriptor(field) for field in catalog.unavailable_fields
+        _near_surface_wind_unavailable_descriptors(metadata, catalog.available_fields)
+    )
+    unavailable.extend(
+        _unavailable_product_descriptor(metadata, field) for field in catalog.unavailable_fields
     )
     return OutputProductCatalogResponse(
         result_id=metadata.result_id,
@@ -1153,9 +1188,11 @@ def vertical_profile(
             y_index=y_index,
         )
         resolved_time = _resolved_output_time(metadata, dataset, dims.time, time_index)
+        field_quality = _output_field_quality(metadata, field)
         caveats = _dedupe(
             [
                 *_field_caveats(field, visual_field.coordinate_names),
+                *_output_field_quality_caveats(field_quality),
                 "json_profile_product_mvp",
                 "native_grid_profile_no_interpolation",
                 *resolved_time.time_caveats,
@@ -1194,6 +1231,7 @@ def vertical_profile(
             finite_counts=finite_counts,
             non_finite_counts=non_finite_counts,
             aggregation_method=aggregation_method,
+            field_quality=field_quality,
             provenance=_provenance(
                 metadata,
                 processing_method="backend_xarray_vertical_profile_product",
@@ -1255,9 +1293,11 @@ def time_height_product(
             dims.time,
             time_size=int(data_array.sizes[dims.time]),
         )
+        field_quality = _output_field_quality(metadata, field)
         caveats = _dedupe(
             [
                 *_field_caveats(field, visual_field.coordinate_names),
+                *_output_field_quality_caveats(field_quality),
                 "json_time_height_product_mvp",
                 "native_grid_time_height_no_interpolation",
                 *time_axis.time_caveats,
@@ -1288,6 +1328,7 @@ def time_height_product(
             finite_counts=finite_counts,
             non_finite_counts=non_finite_counts,
             aggregation_method=aggregation_method,
+            field_quality=field_quality,
             provenance=_provenance(
                 metadata,
                 processing_method="backend_xarray_time_height_product",
@@ -1347,9 +1388,11 @@ def time_series_product(
             dims.time,
             time_size=int(data_array.sizes[dims.time]),
         )
+        field_quality = _output_field_quality(metadata, field)
         caveats = _dedupe(
             [
                 *_field_caveats(field, visual_field.coordinate_names),
+                *_output_field_quality_caveats(field_quality),
                 "json_time_series_product_mvp",
                 "native_grid_time_series_no_interpolation",
                 *time_axis.time_caveats,
@@ -1376,6 +1419,7 @@ def time_series_product(
             finite_counts=finite_counts,
             non_finite_counts=non_finite_counts,
             aggregation_method=aggregation_method,
+            field_quality=field_quality,
             provenance=_provenance(
                 metadata,
                 processing_method="backend_xarray_time_series_product",
@@ -1520,9 +1564,11 @@ def point_cloud(
         active_z_values = [point[2] for point in source_points]
         max_location = _max_point_location(source_points)
         visual_field = _visualizable_field(metadata, dataset, field)
+        field_quality = _output_field_quality(metadata, field)
         caveats = _dedupe(
             [
                 *_field_caveats(field, visual_field.coordinate_names),
+                *_output_field_quality_caveats(field_quality),
                 "native_grid_thresholded_point_cloud",
                 f"visualizer_interpretation_of_cm1_{field}",
                 *(["surface_field_rendered_on_domain_floor"] if is_surface_field else []),
@@ -1572,6 +1618,7 @@ def point_cloud(
                 downsampled=source_count > max_points,
                 downsample_stride=stride,
             ),
+            field_quality=field_quality,
             provenance=_provenance(
                 metadata,
                 processing_method="backend_xarray_native_grid_threshold",
@@ -1774,9 +1821,11 @@ def field_slice(
             surface_extent = _surface_vertical_extent(dataset)
             selected_value = surface_extent.min if surface_extent else 0.0
             level_units = surface_extent.units if surface_extent else None
+            field_quality = _output_field_quality(metadata, field)
             caveats = _dedupe(
                 [
                     *_field_caveats(field, visual_field.coordinate_names),
+                    *_output_field_quality_caveats(field_quality),
                     "surface_field_no_vertical_dimension",
                     "surface_field_rendered_on_domain_floor",
                     "native_grid_view_no_interpolation",
@@ -1808,6 +1857,7 @@ def field_slice(
                 data_encoding=encoding,
                 values=values,
                 stats=stats,
+                field_quality=field_quality,
                 provenance=_provenance(metadata),
                 caveats=caveats,
             )
@@ -1829,9 +1879,11 @@ def field_slice(
         vertical_dim = dims.vertical
         vertical_units = _coordinate_units(dataset, vertical_dim)
         level_units = _coordinate_units(dataset, selected_dimension)
+        field_quality = _output_field_quality(metadata, field)
         caveats = _dedupe(
             [
                 *_field_caveats(field, visual_field.coordinate_names),
+                *_output_field_quality_caveats(field_quality),
                 "native_grid_view_no_interpolation",
                 "json_numeric_slice_mvp",
             ]
@@ -1869,6 +1921,7 @@ def field_slice(
             data_encoding=encoding,
             values=values,
             stats=stats,
+            field_quality=field_quality,
             provenance=_provenance(metadata),
             caveats=caveats,
         )
@@ -2225,10 +2278,71 @@ def _field_capabilities(
     )
 
 
-def _profile_product_descriptor(field: VisualizableField) -> OutputProductDescriptor:
+def _output_field_quality(
+    metadata: ResultMetadata,
+    raw_field_name: str,
+) -> OutputProductFieldQuality:
+    diagnostics = metadata.diagnostics
+    quality_key = FIELD_QUALITY_KEY_BY_RAW_FIELD.get(raw_field_name)
+    if diagnostics is None or not diagnostics.field_quality_assessed:
+        return OutputProductFieldQuality(
+            field=quality_key,
+            source_field=raw_field_name,
+            assessed=False,
+            reason="field_quality_not_assessed",
+            quality_caveats=["field_quality_not_assessed"],
+        )
+    if quality_key is None:
+        return OutputProductFieldQuality(
+            source_field=raw_field_name,
+            assessed=False,
+            reason="field_quality_not_tracked_for_field",
+            quality_caveats=["field_quality_not_tracked_for_field"],
+        )
+    quality = diagnostics.field_quality.get(quality_key)
+    if quality is None:
+        return OutputProductFieldQuality(
+            field=quality_key,
+            source_field=raw_field_name,
+            assessed=False,
+            reason="field_quality_missing_for_tracked_field",
+            quality_caveats=["field_quality_missing_for_tracked_field"],
+        )
+    return _output_field_quality_from_diagnostic(quality)
+
+
+def _output_field_quality_from_diagnostic(quality: FieldQuality) -> OutputProductFieldQuality:
+    return OutputProductFieldQuality(
+        field=quality.field,
+        source_field=quality.source_field,
+        assessed=True,
+        quality_state=quality.quality_state,
+        reason=quality.reason,
+        finite_count=quality.finite_count,
+        non_finite_count=quality.non_finite_count,
+        total_count=quality.total_count,
+        quality_caveats=quality.caveats,
+    )
+
+
+def _output_field_quality_caveats(
+    field_quality: OutputProductFieldQuality | None,
+) -> list[str]:
+    if field_quality is None:
+        return []
+    if not field_quality.assessed:
+        return field_quality.quality_caveats
+    return field_quality.quality_caveats if field_quality.quality_state != "trusted" else []
+
+
+def _profile_product_descriptor(
+    metadata: ResultMetadata,
+    field: VisualizableField,
+) -> OutputProductDescriptor:
     methods: list[str] = ["domain_mean", "domain_min", "domain_max"]
     if field.capabilities.selected_column:
         methods.append("selected_column")
+    field_quality = _output_field_quality(metadata, field.raw_field_name)
     return OutputProductDescriptor(
         product_key=f"profile:{field.raw_field_name}",
         product_kind="vertical_profile",
@@ -2239,14 +2353,21 @@ def _profile_product_descriptor(field: VisualizableField) -> OutputProductDescri
         units=field.units,
         aggregation_methods=methods,
         required_fields=[field.raw_field_name],
-        caveats=_dedupe(["bounded_json_profile", *field.caveats]),
+        field_quality=field_quality,
+        caveats=_dedupe(
+            ["bounded_json_profile", *field.caveats, *_output_field_quality_caveats(field_quality)]
+        ),
     )
 
 
-def _time_height_product_descriptor(field: VisualizableField) -> OutputProductDescriptor:
+def _time_height_product_descriptor(
+    metadata: ResultMetadata,
+    field: VisualizableField,
+) -> OutputProductDescriptor:
     methods: list[str] = ["domain_mean", "domain_min", "domain_max"]
     if field.canonical_field_name == "cloud_water":
         methods.insert(0, "cloud_fraction")
+    field_quality = _output_field_quality(metadata, field.raw_field_name)
     return OutputProductDescriptor(
         product_key=f"time_height:{field.raw_field_name}",
         product_kind="time_height",
@@ -2257,12 +2378,23 @@ def _time_height_product_descriptor(field: VisualizableField) -> OutputProductDe
         units=field.units,
         aggregation_methods=methods,
         required_fields=[field.raw_field_name],
-        caveats=_dedupe(["bounded_json_time_height", *field.caveats]),
+        field_quality=field_quality,
+        caveats=_dedupe(
+            [
+                "bounded_json_time_height",
+                *field.caveats,
+                *_output_field_quality_caveats(field_quality),
+            ]
+        ),
     )
 
 
-def _time_series_product_descriptor(field: VisualizableField) -> OutputProductDescriptor:
+def _time_series_product_descriptor(
+    metadata: ResultMetadata,
+    field: VisualizableField,
+) -> OutputProductDescriptor:
     methods = _time_series_methods_for_field(field)
+    field_quality = _output_field_quality(metadata, field.raw_field_name)
     return OutputProductDescriptor(
         product_key=f"time_series:{field.raw_field_name}",
         product_kind="time_series",
@@ -2273,11 +2405,22 @@ def _time_series_product_descriptor(field: VisualizableField) -> OutputProductDe
         units=field.units,
         aggregation_methods=list(methods),
         required_fields=[field.raw_field_name],
-        caveats=_dedupe(["bounded_json_time_series", *field.caveats]),
+        field_quality=field_quality,
+        caveats=_dedupe(
+            [
+                "bounded_json_time_series",
+                *field.caveats,
+                *_output_field_quality_caveats(field_quality),
+            ]
+        ),
     )
 
 
-def _unavailable_product_descriptor(field: UnavailableField) -> OutputProductDescriptor:
+def _unavailable_product_descriptor(
+    metadata: ResultMetadata,
+    field: UnavailableField,
+) -> OutputProductDescriptor:
+    field_quality = _output_field_quality(metadata, field.raw_field_name)
     return OutputProductDescriptor(
         product_key=f"unavailable:{field.raw_field_name}",
         product_kind="future_diagnostic",
@@ -2287,17 +2430,20 @@ def _unavailable_product_descriptor(field: UnavailableField) -> OutputProductDes
         display_name=field.display_name,
         required_fields=[field.raw_field_name],
         reason=field.reason,
-        caveats=field.caveats,
+        field_quality=field_quality,
+        caveats=_dedupe([*field.caveats, *_output_field_quality_caveats(field_quality)]),
     )
 
 
 def _near_surface_wind_unavailable_descriptors(
+    metadata: ResultMetadata,
     fields: list[VisualizableField],
 ) -> list[OutputProductDescriptor]:
     descriptors: list[OutputProductDescriptor] = []
     for field in fields:
         if field.canonical_field_name not in {"east_west_wind", "north_south_wind"}:
             continue
+        field_quality = _output_field_quality(metadata, field.raw_field_name)
         descriptors.append(
             OutputProductDescriptor(
                 product_key=f"near_surface_wind_time_series:{field.raw_field_name}",
@@ -2308,12 +2454,16 @@ def _near_surface_wind_unavailable_descriptors(
                 display_name=f"Near-surface {field.display_name.lower()} time series",
                 required_fields=[field.raw_field_name],
                 reason="near_surface_wind_diagnostic_not_implemented",
-                caveats=[
-                    "lowest_level_wind_selection_method_not_finalized",
-                    "native_staggered_wind_component",
-                    "no_vector_interpolation",
-                    "wind_component_not_wind_gust_outflow_or_rotation_diagnostic",
-                ],
+                field_quality=field_quality,
+                caveats=_dedupe(
+                    [
+                        "lowest_level_wind_selection_method_not_finalized",
+                        "native_staggered_wind_component",
+                        "no_vector_interpolation",
+                        "wind_component_not_wind_gust_outflow_or_rotation_diagnostic",
+                        *_output_field_quality_caveats(field_quality),
+                    ]
+                ),
             )
         )
     return descriptors

--- a/app/backend/tests/test_output_products.py
+++ b/app/backend/tests/test_output_products.py
@@ -16,6 +16,7 @@ from cloud_chamber.output_products import (
 )
 from cloud_chamber.result_diagnostics import (
     CloudDiagnostics,
+    FieldQuality,
     RainDiagnostics,
     ReflectivityDiagnostics,
     ResultDiagnostics,
@@ -468,3 +469,49 @@ def test_deep_convection_present_but_unsupported_fields_are_caveated(
     assert "max_dbz_or_reflectivity_proxy_diagnostic_not_implemented" in (
         availability["max_dbz_or_reflectivity_proxy"].caveats
     )
+
+
+def test_interesting_times_expose_untrusted_field_quality(tmp_path: Path) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=[0.0], values=[2e-6])
+    manifest = build_manifest(tmp_path, [model])
+    diagnostics = ResultDiagnostics(
+        cloud=CloudDiagnostics(
+            formed=True,
+            first_cloud_time_seconds=0.0,
+            max_qc_kg_kg=2e-6,
+            time_of_max_qc_seconds=0.0,
+        ),
+        vertical_velocity=VerticalVelocityDiagnostics(max_w_m_s=1.0, units="m/s"),
+        rain=RainDiagnostics(available=False, field_absent=True),
+        time=TimeDiagnostics(source="netcdf_time_coordinate", fallback_used=False),
+        field_quality={
+            "qc": FieldQuality(
+                field="qc",
+                source_field="qc",
+                quality_state="untrusted",
+                reason="qc_field_entirely_non_finite",
+                finite_count=0,
+                non_finite_count=1,
+                total_count=1,
+                caveats=[
+                    "non_finite_values_detected_in_qc",
+                    "qc_field_entirely_non_finite",
+                ],
+            )
+        },
+    )
+
+    product = build_interesting_time_product(
+        result_id="result-field-quality",
+        diagnostics=diagnostics,
+        output_manifest=manifest,
+        variables=["qc", "w"],
+    )
+
+    records = {record.key: record for record in product.available_interesting_times}
+    assert records["first_cloud"].support_state == "unavailable"
+    assert records["first_cloud"].field_quality is not None
+    assert records["first_cloud"].field_quality.quality_state == "untrusted"
+    assert "interesting_time_source_field_untrusted" in records["first_cloud"].caveats
+    assert product.science_summary.field_quality["qc"].quality_state == "untrusted"

--- a/app/backend/tests/test_output_products.py
+++ b/app/backend/tests/test_output_products.py
@@ -485,6 +485,7 @@ def test_interesting_times_expose_untrusted_field_quality(tmp_path: Path) -> Non
         vertical_velocity=VerticalVelocityDiagnostics(max_w_m_s=1.0, units="m/s"),
         rain=RainDiagnostics(available=False, field_absent=True),
         time=TimeDiagnostics(source="netcdf_time_coordinate", fallback_used=False),
+        field_quality_assessed=True,
         field_quality={
             "qc": FieldQuality(
                 field="qc",
@@ -514,4 +515,5 @@ def test_interesting_times_expose_untrusted_field_quality(tmp_path: Path) -> Non
     assert records["first_cloud"].field_quality is not None
     assert records["first_cloud"].field_quality.quality_state == "untrusted"
     assert "interesting_time_source_field_untrusted" in records["first_cloud"].caveats
+    assert product.science_summary.field_quality_assessed is True
     assert product.science_summary.field_quality["qc"].quality_state == "untrusted"

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -156,10 +156,12 @@ def test_result_card_created_from_ingested_metadata(tmp_path: Path) -> None:
     assert card.surface_rain_units == "mm"
     assert card.reflectivity_available is False
     assert card.max_dbz is None
+    assert card.field_quality_assessed is True
     assert card.field_quality["qc"].quality_state == "trusted"
     assert card.field_quality["qr"].quality_state == "trusted"
     assert card.field_quality["dbz"].quality_state == "unavailable"
     assert card.science_summary is not None
+    assert card.science_summary.field_quality_assessed is True
     assert card.science_summary.first_cloud_time_seconds == 1800.0
     assert card.science_summary.max_qc_kg_kg == 2e-6
     assert card.science_summary.max_updraft_w_m_s == 4.0
@@ -410,6 +412,7 @@ def test_result_card_handles_missing_diagnostics_gracefully(tmp_path: Path) -> N
     assert card.field_quality["surface_rain"].quality_state == "unavailable"
     assert card.field_quality["dbz"].quality_state == "unavailable"
     assert card.science_summary is not None
+    assert card.science_summary.field_quality_assessed is True
     assert card.science_summary.interesting_time_support_state == "fallback"
     assert card.default_time_by_field["qc"].support_state == "fallback"
     assert any(

--- a/app/backend/tests/test_result_cards.py
+++ b/app/backend/tests/test_result_cards.py
@@ -156,6 +156,9 @@ def test_result_card_created_from_ingested_metadata(tmp_path: Path) -> None:
     assert card.surface_rain_units == "mm"
     assert card.reflectivity_available is False
     assert card.max_dbz is None
+    assert card.field_quality["qc"].quality_state == "trusted"
+    assert card.field_quality["qr"].quality_state == "trusted"
+    assert card.field_quality["dbz"].quality_state == "unavailable"
     assert card.science_summary is not None
     assert card.science_summary.first_cloud_time_seconds == 1800.0
     assert card.science_summary.max_qc_kg_kg == 2e-6
@@ -389,7 +392,7 @@ def test_result_card_handles_missing_diagnostics_gracefully(tmp_path: Path) -> N
     card = get_result_card(settings, result_id)
 
     assert card.diagnostics_summary == (
-        "no cloud formed; no rain water aloft detected; surface rain unavailable; "
+        "cloud unavailable; rain water aloft unavailable; surface rain unavailable; "
         "reflectivity unavailable"
     )
     assert card.first_cloud_time_seconds is None
@@ -399,8 +402,13 @@ def test_result_card_handles_missing_diagnostics_gracefully(tmp_path: Path) -> N
     assert card.time_of_max_w_seconds is None
     assert card.min_w_m_s is None
     assert card.time_of_min_w_seconds is None
-    assert card.rain_present is False
+    assert card.rain_present is None
     assert card.first_rain_time_seconds is None
+    assert card.field_quality["qc"].quality_state == "unavailable"
+    assert card.field_quality["w"].quality_state == "unavailable"
+    assert card.field_quality["qr"].quality_state == "unavailable"
+    assert card.field_quality["surface_rain"].quality_state == "unavailable"
+    assert card.field_quality["dbz"].quality_state == "unavailable"
     assert card.science_summary is not None
     assert card.science_summary.interesting_time_support_state == "fallback"
     assert card.default_time_by_field["qc"].support_state == "fallback"

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -379,6 +379,16 @@ def test_non_finite_values_are_ignored_and_recorded(tmp_path: Path) -> None:
     assert diagnostics.vertical_velocity.max_w_m_s == 4.0
     assert "non_finite_values_detected_in_qc" in diagnostics.caveats
     assert "non_finite_values_detected_in_w" in diagnostics.caveats
+    qc_quality = diagnostics.field_quality["qc"]
+    w_quality = diagnostics.field_quality["w"]
+    assert qc_quality.quality_state == "caveated"
+    assert qc_quality.finite_count == 47
+    assert qc_quality.non_finite_count == 1
+    assert qc_quality.total_count == 48
+    assert w_quality.quality_state == "caveated"
+    assert w_quality.finite_count == 47
+    assert w_quality.non_finite_count == 1
+    assert w_quality.total_count == 48
 
 
 def test_entirely_non_finite_target_field_fails_gracefully(tmp_path: Path) -> None:
@@ -396,6 +406,53 @@ def test_entirely_non_finite_target_field_fails_gracefully(tmp_path: Path) -> No
     assert diagnostics.cloud.available is False
     assert diagnostics.cloud.max_qc_kg_kg is None
     assert "qc_field_entirely_non_finite" in diagnostics.caveats
+    qc_quality = diagnostics.field_quality["qc"]
+    assert qc_quality.quality_state == "untrusted"
+    assert qc_quality.reason == "qc_field_entirely_non_finite"
+    assert qc_quality.finite_count == 0
+    assert qc_quality.non_finite_count == 48
+    assert qc_quality.total_count == 48
+
+
+def test_field_quality_marks_all_non_finite_core_result_fields_untrusted(
+    tmp_path: Path,
+) -> None:
+    all_nan_field = [
+        [[[float("nan") for _x in range(4)] for _y in range(3)] for _z in range(2)]
+        for _time in range(2)
+    ]
+    all_nan_surface = [[[float("nan") for _x in range(4)] for _y in range(3)] for _time in range(2)]
+    dataset = write_dataset(
+        tmp_path / "all_core_fields_nan.nc",
+        base_dataset(
+            qc_values=all_nan_field,
+            w_values=all_nan_field,
+            qr_values=all_nan_field,
+            rain_values=all_nan_surface,
+            dbz_values=all_nan_field,
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    expected_totals = {
+        "qc": 48,
+        "w": 48,
+        "qr": 48,
+        "surface_rain": 24,
+        "dbz": 48,
+    }
+    for field, total in expected_totals.items():
+        quality = diagnostics.field_quality[field]
+        assert quality.quality_state == "untrusted"
+        assert quality.finite_count == 0
+        assert quality.non_finite_count == total
+        assert quality.total_count == total
+    assert diagnostics.cloud.available is False
+    assert diagnostics.vertical_velocity.available is False
+    assert diagnostics.rain.available is False
+    assert diagnostics.surface_rain.available is False
+    assert diagnostics.reflectivity.available is False
 
 
 def test_netcdf_time_coordinate_and_inferred_fallback(tmp_path: Path) -> None:

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -245,6 +245,7 @@ def test_qc_max_time_and_cloud_fraction_series(tmp_path: Path) -> None:
 
     diagnostics = compute_baseline_diagnostics(dataset, [])
 
+    assert diagnostics.field_quality_assessed is True
     assert diagnostics.cloud.max_qc_kg_kg == 1.3e-5
     assert diagnostics.cloud.time_of_max_qc_seconds == 300.0
     assert [point.time_seconds for point in diagnostics.cloud.qc_max_time_series] == [0.0, 300.0]
@@ -357,6 +358,7 @@ def test_missing_qc_and_missing_w_are_graceful(tmp_path: Path) -> None:
 
     diagnostics = compute_baseline_diagnostics(dataset, [])
 
+    assert diagnostics.field_quality_assessed is True
     assert diagnostics.cloud.available is False
     assert diagnostics.vertical_velocity.available is False
     assert "missing_qc_field" in diagnostics.caveats
@@ -435,6 +437,7 @@ def test_field_quality_marks_all_non_finite_core_result_fields_untrusted(
 
     diagnostics = compute_baseline_diagnostics(dataset, [])
 
+    assert diagnostics.field_quality_assessed is True
     expected_totals = {
         "qc": 48,
         "w": 48,

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -229,6 +229,7 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
     assert result.diagnostics is not None
     assert result.diagnostics.cloud.formed is False
     assert result.diagnostics.rain.field_absent is True
+    assert result.diagnostics.field_quality_assessed is True
     assert result.diagnostics.field_quality["qc"].quality_state == "trusted"
     assert result.diagnostics.field_quality["w"].quality_state == "trusted"
     assert result.diagnostics.field_quality["qr"].quality_state == "unavailable"

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -223,12 +223,15 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
         ("w", "m/s"),
     ]
     assert result.diagnostics_summary == (
-        "no cloud formed; no rain water aloft detected; surface rain unavailable; "
+        "no cloud formed; rain water aloft unavailable; surface rain unavailable; "
         "reflectivity unavailable"
     )
     assert result.diagnostics is not None
     assert result.diagnostics.cloud.formed is False
     assert result.diagnostics.rain.field_absent is True
+    assert result.diagnostics.field_quality["qc"].quality_state == "trusted"
+    assert result.diagnostics.field_quality["w"].quality_state == "trusted"
+    assert result.diagnostics.field_quality["qr"].quality_state == "unavailable"
     assert result.process_diagnostics is not None
     assert (
         result.process_diagnostics.interpretation_support.thermal_fate_label
@@ -569,6 +572,53 @@ def test_deep_candidate_comparison_uses_observed_surface_forced_outcome(
     )
 
 
+def test_deep_candidate_comparison_caveats_untrusted_rain_water_field(
+    tmp_path: Path,
+) -> None:
+    manifest_path = create_manifest(tmp_path, run_id="run-untrusted-rain-water")
+    run_dir = manifest_path.parent
+    netcdf_path = run_dir / "cm1out_000001.nc"
+    write_model_netcdf(
+        netcdf_path,
+        times=[900.0],
+        qc_values=[2e-5],
+        w_values=[15.0],
+        qr_values=[float("nan")],
+        z_values=[500.0, 10500.0],
+    )
+    complete_manifest(manifest_path, OutputMetadata(netcdf_paths=[str(netcdf_path)]))
+    manifest = load_run_manifest(manifest_path)
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(
+            update={
+                "candidate_screening": {
+                    "candidate_id": "USM00072357-2025052000-supercell",
+                    "primary_story": "supercell_environment",
+                    "rank_score": 93.0,
+                },
+                "run_recipe": "observed_surface_forced_evolution",
+                "recipe_display_name": "Observed Surface-Forced Evolution v0",
+                "required_output_fields": ["qc", "w", "qr"],
+                "input_source": "observed_sounding",
+            }
+        ),
+    )
+
+    result = ingest_completed_run(manifest_path)
+
+    assert result.diagnostics is not None
+    assert result.diagnostics.field_quality["qr"].quality_state == "untrusted"
+    comparison = result.candidate_hypothesis_comparison
+    assert comparison is not None
+    assert comparison.match_status == "partially_supported"
+    assert not any("rain-water-aloft onset" in item for item in comparison.evidence)
+    assert any(
+        caveat.startswith("field_quality_untrusted:qr:qr_field_entirely_non_finite")
+        for caveat in comparison.caveats
+    )
+
+
 def test_no_cloud_result_keeps_interesting_times_honest(tmp_path: Path) -> None:
     manifest_path = create_manifest(tmp_path, run_id="run-no-cloud-interesting-times")
     run_dir = manifest_path.parent
@@ -736,11 +786,13 @@ def test_missing_expected_fields_are_warnings_not_claimed_diagnostics(tmp_path: 
 
     assert result.variables == ["w"]
     assert result.diagnostics_summary == (
-        "no cloud formed; no rain water aloft detected; surface rain unavailable; "
+        "cloud unavailable; rain water aloft unavailable; surface rain unavailable; "
         "reflectivity unavailable"
     )
     assert result.diagnostics is not None
     assert result.diagnostics.cloud.available is False
+    assert result.diagnostics.field_quality["qc"].quality_state == "unavailable"
+    assert result.diagnostics.field_quality["w"].quality_state == "trusted"
     assert result.warnings == [
         "Expected fields missing from NetCDF metadata: qc",
         (

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -599,6 +599,9 @@ def test_output_product_catalog_advertises_bounded_products_and_unavailable_diag
     assert unavailable["unavailable:dbz"].reason == (
         "expected_known_field_missing_from_result_metadata"
     )
+    assert unavailable["unavailable:dbz"].field_quality is not None
+    assert unavailable["unavailable:dbz"].field_quality.assessed is True
+    assert unavailable["unavailable:dbz"].field_quality.quality_state == "unavailable"
     assert unavailable["near_surface_wind_time_series:u"].reason == (
         "near_surface_wind_diagnostic_not_implemented"
     )
@@ -634,6 +637,9 @@ def test_vertical_profile_domain_mean_preserves_units_coordinates_and_time_index
     assert profile.finite_counts == [12, 12]
     assert profile.non_finite_counts == [0, 0]
     assert profile.aggregation_method == "domain_mean"
+    assert profile.field_quality is not None
+    assert profile.field_quality.assessed is False
+    assert profile.field_quality.reason == "field_quality_not_tracked_for_field"
     assert "native_grid_profile_no_interpolation" in profile.caveats
 
 
@@ -728,6 +734,12 @@ def test_time_height_products_compute_cloud_fraction_and_w_extrema(
     assert cloud_fraction.values[1] == pytest.approx([1.0, 1.0])
     assert cloud_fraction.finite_counts == [[11, 12], [12, 11]]
     assert cloud_fraction.non_finite_counts == [[1, 0], [0, 1]]
+    assert cloud_fraction.field_quality is not None
+    assert cloud_fraction.field_quality.assessed is True
+    assert cloud_fraction.field_quality.quality_state == "caveated"
+    assert cloud_fraction.field_quality.finite_count == 46
+    assert cloud_fraction.field_quality.non_finite_count == 2
+    assert "non_finite_values_detected_in_qc" in cloud_fraction.field_quality.quality_caveats
     assert "cloud_fraction_threshold_kg_kg:1e-06" in cloud_fraction.caveats
 
     assert max_w.field.canonical_field_name == "vertical_velocity"
@@ -827,10 +839,20 @@ def test_time_series_products_cover_surface_rain_reflectivity_and_fluxes(
     assert surface_rain.units == "mm"
     assert surface_rain.values == pytest.approx([2.75, 5.75])
     assert surface_rain.finite_counts == [12, 12]
+    assert surface_rain.field_quality is not None
+    assert surface_rain.field_quality.assessed is True
+    assert surface_rain.field_quality.source_field == "rain"
+    assert surface_rain.field_quality.quality_state == "trusted"
     assert reflectivity.field.canonical_field_name == "reflectivity"
     assert reflectivity.values == pytest.approx([13.0, 37.0])
+    assert reflectivity.field_quality is not None
+    assert reflectivity.field_quality.assessed is True
+    assert reflectivity.field_quality.quality_state == "trusted"
     assert surface_flux.field.canonical_field_name == "surface_sensible_heat_flux"
     assert surface_flux.values == pytest.approx([5.5, 17.5])
+    assert surface_flux.field_quality is not None
+    assert surface_flux.field_quality.assessed is False
+    assert surface_flux.field_quality.reason == "field_quality_not_tracked_for_field"
     assert "native_grid_time_series_no_interpolation" in surface_flux.caveats
 
 
@@ -1478,11 +1500,17 @@ def test_output_product_api_returns_profile_time_height_and_time_series(
     )
     assert profile.status_code == 200
     assert profile.json()["values"] == pytest.approx([0.010055, 0.010175])
+    assert profile.json()["field_quality"]["assessed"] is False
+    assert profile.json()["field_quality"]["reason"] == "field_quality_not_tracked_for_field"
     assert time_height.status_code == 200
     assert time_height.json()["shape"] == [2, 3]
     assert time_height.json()["values"][0] == pytest.approx([11.0, 23.0, 35.0])
     assert time_height.json()["values"][1] == pytest.approx([47.0, 59.0, 71.0])
+    assert time_height.json()["field_quality"]["assessed"] is True
+    assert time_height.json()["field_quality"]["quality_state"] == "trusted"
     assert time_series.status_code == 200
     assert time_series.json()["values"] == pytest.approx([2.75, 5.75])
+    assert time_series.json()["field_quality"]["assessed"] is True
+    assert time_series.json()["field_quality"]["quality_state"] == "trusted"
     assert bad_profile.status_code == 400
     assert "not profile-capable" in bad_profile.json()["detail"]

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1639,13 +1639,45 @@ const missingDiagnosticsCard = {
   time_of_max_w_seconds: null,
   min_w_m_s: null,
   time_of_min_w_seconds: null,
-  rain_present: false,
+  rain_present: null,
   first_rain_time_seconds: null,
   surface_rain_present: null,
   max_surface_rain: null,
   surface_rain_units: null,
   reflectivity_available: null,
   max_dbz: null,
+  field_quality: {
+    qc: {
+      field: "qc",
+      source_field: "qc",
+      quality_state: "unavailable",
+      reason: "missing_qc_field",
+      finite_count: 0,
+      non_finite_count: 0,
+      total_count: 0,
+      caveats: ["missing_qc_field"],
+    },
+    w: {
+      field: "w",
+      source_field: "w",
+      quality_state: "unavailable",
+      reason: "missing_w_field",
+      finite_count: 0,
+      non_finite_count: 0,
+      total_count: 0,
+      caveats: ["missing_w_field"],
+    },
+    qr: {
+      field: "qr",
+      source_field: "qr",
+      quality_state: "unavailable",
+      reason: "qr_field_absent",
+      finite_count: 0,
+      non_finite_count: 0,
+      total_count: 0,
+      caveats: ["qr_field_absent"],
+    },
+  },
   caveats: ["missing_qc_field", "missing_w_field"],
   output_file_summary: {
     ...resultCard.output_file_summary,
@@ -5415,12 +5447,15 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "No diagnostics yet" }));
+    const resultDetail = screen.getByLabelText("Result detail");
 
     expect(screen.getAllByText("Diagnostics unavailable").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Unknown").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("No rain water aloft detected").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Cloud unavailable").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Rain water aloft unavailable").length).toBeGreaterThan(0);
     expect(screen.getByText("missing_qc_field")).toBeInTheDocument();
     expect(screen.getByText("missing_w_field")).toBeInTheDocument();
+    fireEvent.click(within(resultDetail).getByText("Technical details"));
+    expect(screen.getByText(/Cloud water \(qc\) is unavailable/)).toBeInTheDocument();
     expect(screen.queryByText(/horizontal slice/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/vertical slice/i)).not.toBeInTheDocument();
   });

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1324,6 +1324,59 @@ const autoIngestedRunQueue = {
   updated_at: new Date().toISOString(),
 };
 
+const trustedFieldQuality = {
+  qc: {
+    field: "qc",
+    source_field: "qc",
+    quality_state: "trusted",
+    reason: null,
+    finite_count: 100,
+    non_finite_count: 0,
+    total_count: 100,
+    caveats: [],
+  },
+  w: {
+    field: "w",
+    source_field: "w",
+    quality_state: "trusted",
+    reason: null,
+    finite_count: 100,
+    non_finite_count: 0,
+    total_count: 100,
+    caveats: [],
+  },
+  qr: {
+    field: "qr",
+    source_field: "qr",
+    quality_state: "trusted",
+    reason: null,
+    finite_count: 100,
+    non_finite_count: 0,
+    total_count: 100,
+    caveats: [],
+  },
+  surface_rain: {
+    field: "surface_rain",
+    source_field: "rain",
+    quality_state: "trusted",
+    reason: null,
+    finite_count: 100,
+    non_finite_count: 0,
+    total_count: 100,
+    caveats: [],
+  },
+  dbz: {
+    field: "dbz",
+    source_field: "dbz",
+    quality_state: "trusted",
+    reason: null,
+    finite_count: 100,
+    non_finite_count: 0,
+    total_count: 100,
+    caveats: [],
+  },
+};
+
 const resultCard = {
   result_id: "result-dry-run-quicklook",
   run_id: "dry-run-quicklook",
@@ -1371,6 +1424,8 @@ const resultCard = {
   surface_rain_units: "mm",
   reflectivity_available: true,
   max_dbz: 30,
+  field_quality_assessed: true,
+  field_quality: trustedFieldQuality,
   science_summary: {
     first_cloud_time_seconds: 1800,
     first_cloud_time_label: "1,800 s",
@@ -1388,6 +1443,8 @@ const resultCard = {
     latest_output_time_seconds: 10800,
     default_explore_time_index: 3,
     default_explore_time_seconds: 2700,
+    field_quality_assessed: true,
+    field_quality: trustedFieldQuality,
     interesting_time_caveats: [],
     interesting_time_support_state: "supported",
   },
@@ -1646,6 +1703,7 @@ const missingDiagnosticsCard = {
   surface_rain_units: null,
   reflectivity_available: null,
   max_dbz: null,
+  field_quality_assessed: true,
   field_quality: {
     qc: {
       field: "qc",
@@ -5456,8 +5514,53 @@ describe("App", () => {
     expect(screen.getByText("missing_w_field")).toBeInTheDocument();
     fireEvent.click(within(resultDetail).getByText("Technical details"));
     expect(screen.getByText(/Cloud water \(qc\) is unavailable/)).toBeInTheDocument();
+    expect(screen.getByText("Surface rain was not assessed.")).toBeInTheDocument();
     expect(screen.queryByText(/horizontal slice/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/vertical slice/i)).not.toBeInTheDocument();
+  });
+
+  it("does not treat legacy missing field-quality assessment as trusted", async () => {
+    const legacyQualityCard = {
+      ...resultCard,
+      result_id: "result-legacy-quality",
+      run_id: "dry-run-legacy-quality",
+      name: "Legacy quality result",
+      field_quality_assessed: false,
+      field_quality: {},
+      science_summary: {
+        ...resultCard.science_summary,
+        field_quality_assessed: false,
+        field_quality: {},
+      },
+    };
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/scenarios") {
+        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
+      }
+      if (url === "/api/results") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ results: [legacyQualityCard] }), { status: 200 }),
+        );
+      }
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Legacy quality result" }));
+    const resultDetail = screen.getByLabelText("Result detail");
+    fireEvent.click(within(resultDetail).getByText("Technical details"));
+
+    expect(screen.getByText("Field quality not assessed for this result.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("All tracked field-quality checks are trusted."),
+    ).not.toBeInTheDocument();
   });
 
   it("shows result delete preview and confirm inside Results", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -835,6 +835,7 @@ type ScienceSummary = {
   default_explore_time_index?: number | null;
   default_explore_time_seconds?: number | null;
   cm1_outcome?: string | null;
+  field_quality_assessed?: boolean;
   field_quality?: Record<string, FieldQuality>;
   diagnostic_availability?: ScienceDiagnosticAvailability[];
   interesting_time_caveats: string[];
@@ -919,6 +920,7 @@ type ResultCard = {
   surface_rain_units?: string | null;
   max_dbz?: number | null;
   reflectivity_available?: boolean | null;
+  field_quality_assessed?: boolean;
   field_quality?: Record<string, FieldQuality>;
   interesting_times?: InterestingTimeRecord[];
   default_time_by_field?: Record<string, FieldDefaultTime>;
@@ -13131,21 +13133,46 @@ const FIELD_QUALITY_LABELS: Record<string, string> = {
 const FIELD_QUALITY_ORDER = ["qc", "w", "qr", "surface_rain", "dbz"];
 
 function resultFieldQuality(result: ResultCard, field: string): FieldQuality | null {
-  return result.field_quality?.[field] ?? result.science_summary?.field_quality?.[field] ?? null;
+  if (result.field_quality_assessed !== undefined) {
+    return result.field_quality?.[field] ?? null;
+  }
+  return result.science_summary?.field_quality?.[field] ?? null;
+}
+
+function resultFieldQualityAssessed(result: ResultCard): boolean {
+  if (result.field_quality_assessed !== undefined) return result.field_quality_assessed;
+  return result.science_summary?.field_quality_assessed ?? false;
 }
 
 function fieldQualityBlocksEvidence(result: ResultCard, field: string): boolean {
+  if (!resultFieldQualityAssessed(result)) return false;
   const quality = resultFieldQuality(result, field);
+  if (!quality) return true;
   return quality?.quality_state === "untrusted" || quality?.quality_state === "unavailable";
 }
 
-function nonTrustedFieldQuality(result: ResultCard): FieldQuality[] {
-  const byField = new Map<string, FieldQuality>();
+type FieldQualityDisplayRow = {
+  key: string;
+  description: string;
+};
+
+function nonTrustedFieldQuality(result: ResultCard): FieldQualityDisplayRow[] {
+  const rows = new Map<string, FieldQualityDisplayRow>();
   for (const field of FIELD_QUALITY_ORDER) {
     const quality = resultFieldQuality(result, field);
-    if (quality && quality.quality_state !== "trusted") byField.set(field, quality);
+    if (!quality) {
+      rows.set(field, {
+        key: field,
+        description: `${FIELD_QUALITY_LABELS[field] ?? humanize(field)} was not assessed.`,
+      });
+    } else if (quality.quality_state !== "trusted") {
+      rows.set(field, {
+        key: field,
+        description: fieldQualityDescription(quality),
+      });
+    }
   }
-  return [...byField.values()];
+  return [...rows.values()];
 }
 
 function fieldQualityCounts(quality: FieldQuality): string {
@@ -13162,18 +13189,21 @@ function fieldQualityDescription(quality: FieldQuality): string {
 }
 
 function FieldQualitySummary({ result }: { result: ResultCard }) {
+  const assessed = resultFieldQualityAssessed(result);
   const rows = nonTrustedFieldQuality(result);
   return (
     <section aria-labelledby="field-quality-title">
       <h4 id="field-quality-title">Field quality</h4>
-      {rows.length > 0 ? (
+      {!assessed ? (
+        <p>Field quality not assessed for this result.</p>
+      ) : rows.length > 0 ? (
         <ul className="compact-list">
-          {rows.map((quality) => (
-            <li key={quality.field}>{fieldQualityDescription(quality)}</li>
+          {rows.map((row) => (
+            <li key={row.key}>{row.description}</li>
           ))}
         </ul>
       ) : (
-        <p>No non-finite field-quality caveats recorded.</p>
+        <p>All tracked field-quality checks are trusted.</p>
       )}
     </section>
   );

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -768,6 +768,19 @@ type InterestingTimeSupportState =
   | "unsupported_missing_fields"
   | "unsupported_missing_diagnostic";
 
+type FieldQualityState = "trusted" | "caveated" | "untrusted" | "unavailable";
+
+type FieldQuality = {
+  field: string;
+  source_field: string;
+  quality_state: FieldQualityState;
+  reason?: string | null;
+  finite_count: number;
+  non_finite_count: number;
+  total_count: number;
+  caveats: string[];
+};
+
 type InterestingTimeRecord = {
   key: string;
   label: string;
@@ -779,6 +792,7 @@ type InterestingTimeRecord = {
   value?: number | boolean | null;
   units?: string | null;
   support_state: InterestingTimeSupportState;
+  field_quality?: FieldQuality | null;
   caveats: string[];
   fallback_reason?: string | null;
 };
@@ -789,6 +803,7 @@ type FieldDefaultTime = {
   time_seconds?: number | null;
   source_interesting_time_key: string;
   support_state: InterestingTimeSupportState;
+  field_quality?: FieldQuality | null;
   fallback_reason?: string | null;
   caveats: string[];
 };
@@ -820,6 +835,7 @@ type ScienceSummary = {
   default_explore_time_index?: number | null;
   default_explore_time_seconds?: number | null;
   cm1_outcome?: string | null;
+  field_quality?: Record<string, FieldQuality>;
   diagnostic_availability?: ScienceDiagnosticAvailability[];
   interesting_time_caveats: string[];
   interesting_time_support_state: string;
@@ -830,6 +846,7 @@ type ScienceDiagnosticAvailability = {
   label: string;
   support_state: string;
   source_field?: string | null;
+  field_quality?: FieldQuality | null;
   value?: number | boolean | null;
   units?: string | null;
   caveats: string[];
@@ -902,6 +919,7 @@ type ResultCard = {
   surface_rain_units?: string | null;
   max_dbz?: number | null;
   reflectivity_available?: boolean | null;
+  field_quality?: Record<string, FieldQuality>;
   interesting_times?: InterestingTimeRecord[];
   default_time_by_field?: Record<string, FieldDefaultTime>;
   science_summary?: ScienceSummary | null;
@@ -6693,7 +6711,7 @@ function ExploreResultSummary({ result }: { result: ResultCard }) {
       </div>
       <div className="badge-row">
         <OutcomeBadge result={result} />
-        <StatusBadge label={rainOutcome(result.rain_present)} tone="neutral" />
+        <StatusBadge label={rainWaterOutcome(result)} tone="neutral" />
         <StatusBadge label={resultInputSourceLabel(result)} tone="neutral" />
         <StatusBadge label={scienceSupportLabel(result)} tone="neutral" />
       </div>
@@ -8318,7 +8336,7 @@ function ExperimentNotebookList({
                 </p>
                 <div className="badge-row">
                   <OutcomeBadge result={result} />
-                  <StatusBadge label={rainOutcome(result.rain_present)} tone="neutral" />
+                  <StatusBadge label={rainWaterOutcome(result)} tone="neutral" />
                   <StatusBadge label={resultInputSourceLabel(result)} tone="neutral" />
                 </div>
                 <p className="science-card-summary">{compactScienceSummary(result)}</p>
@@ -8392,7 +8410,7 @@ function ResultNotebookCard({
 
       <div className="badge-row">
         <OutcomeBadge result={result} />
-        <StatusBadge label={rainOutcome(result.rain_present)} tone="neutral" />
+        <StatusBadge label={rainWaterOutcome(result)} tone="neutral" />
       </div>
 
       <p className="result-story">{resultStory(result)}</p>
@@ -8411,7 +8429,7 @@ function ResultNotebookCard({
 
       <dl className="metric-grid key-result-values">
         <Metric label="Cloud" value={cloudOutcome(result)} />
-        <Metric label="Rain water aloft" value={rainOutcome(result.rain_present)} />
+        <Metric label="Rain water aloft" value={rainWaterOutcome(result)} />
         <Metric label="Surface rain" value={surfaceRainOutcome(result)} />
         <Metric label="Reflectivity" value={reflectivityOutcome(result)} />
         <Metric label="First cloud time" value={formatSeconds(resultFirstCloudTime(result))} />
@@ -8523,6 +8541,8 @@ function ResultNotebookCard({
             ))}
           </ul>
         </section>
+
+        <FieldQualitySummary result={result} />
 
         <section aria-labelledby="caveats-title">
           <h4 id="caveats-title">Caveats / warnings</h4>
@@ -9838,6 +9858,7 @@ function ResultExplanationPanel({
   result: ResultCard;
   isNoCloudWithUpdraft: boolean;
 }) {
+  const cloudLabel = cloudOutcome(result);
   return (
     <section className="selected-region-inspector" aria-label="Result-level explanation panel">
       <div className="section-heading compact-heading">
@@ -9847,11 +9868,13 @@ function ResultExplanationPanel({
         </div>
         <StatusBadge
           label={
-            cloudOutcome(result) === "Cloud formed"
+            cloudLabel === "Cloud formed"
               ? "Cloud formed in this result"
-              : "No cloud formed in this result"
+              : cloudLabel === "No cloud formed"
+                ? "No cloud formed in this result"
+                : cloudLabel
           }
-          tone={cloudOutcome(result) === "Cloud formed" ? "good" : "warning"}
+          tone={cloudLabel === "Cloud formed" ? "good" : "warning"}
         />
       </div>
       <p>{resultStory(result)}</p>
@@ -9861,7 +9884,7 @@ function ResultExplanationPanel({
           <Metric label="First cloud time" value={formatSeconds(result.first_cloud_time_seconds)} />
           <Metric label="Max qc" value={formatScientific(result.max_qc_kg_kg, "kg/kg")} />
           <Metric label="Max w" value={formatNumber(result.max_w_m_s, "m/s")} />
-          <Metric label="Rain water aloft" value={rainOutcome(result.rain_present)} />
+          <Metric label="Rain water aloft" value={rainWaterOutcome(result)} />
           <Metric label="Surface rain" value={surfaceRainOutcome(result)} />
           <Metric label="Reflectivity" value={reflectivityOutcome(result)} />
         </dl>
@@ -11756,7 +11779,7 @@ function processModeSummary(
       }`,
       annotations: [
         `Diagnostics summary: ${result.diagnostics_summary ?? "Unavailable"}`,
-        `Cloud: ${cloudOutcome(result)}; rain water aloft: ${rainOutcome(result.rain_present)}`,
+        `Cloud: ${cloudOutcome(result)}; rain water aloft: ${rainWaterOutcome(result)}`,
       ],
       caveats,
     };
@@ -11859,17 +11882,18 @@ function processModeSummary(
   }
 
   if (mode === "precipitation_feedback") {
+    const rainWaterDetected = rainWaterOutcome(result) === "Rain water aloft detected";
     return {
       support: "future",
       evidenceType: "qr/rain and downdraft proxy diagnostics",
-      source: result.rain_present
+      source: rainWaterDetected
         ? "Rain-water aloft summary exists, but cold-pool/outflow evidence is not available"
         : "Required rain, downdraft, cold-pool, and outflow evidence is not available",
-      description: result.rain_present
+      description: rainWaterDetected
         ? "Rain water aloft is present, but precipitation-feedback needs downdraft/cold-pool evidence before it can be selected as a normal focus."
         : "Precipitation feedback is future work for this result because rain-water, cold-pool, and outflow diagnostics are not available.",
       annotations: [
-        `Rain water aloft: ${rainOutcome(result.rain_present)}`,
+        `Rain water aloft: ${rainWaterOutcome(result)}`,
         `Min w: ${formatNumber(result.min_w_m_s, "m/s")}`,
       ],
       caveats: [...caveats, "precipitation_feedback_requires_downdraft_and_cold_pool_diagnostics"],
@@ -12758,7 +12782,7 @@ function filterAndSortResults(results: ResultCard[], filters: ResultsFilterState
     )
     .filter((result) =>
       matchesBooleanFilter(
-        rainOutcome(result.rain_present),
+        rainWaterOutcome(result),
         filters.rain,
         "Rain water aloft detected",
         "No rain water aloft detected",
@@ -12822,7 +12846,7 @@ function matchesBooleanFilter(
   if (filter === "all") return true;
   if (filter === "yes") return value === yesValue;
   if (filter === "no") return value === noValue;
-  return value === "Unknown";
+  return value === "Unknown" || value.endsWith(" unavailable");
 }
 
 function compareResults(left: ResultCard, right: ResultCard, sort: ResultsSortKey): number {
@@ -12884,7 +12908,7 @@ function isDryFailedContrast(result: ResultCard): boolean {
     result.scenario_id === "dry-failed-cumulus" &&
     result.source_lifecycle_state === "completed" &&
     cloudOutcome(result) === "No cloud formed" &&
-    result.rain_present === false &&
+    rainWaterOutcome(result) === "No rain water aloft detected" &&
     (result.max_w_m_s ?? 0) > 0
   );
 }
@@ -13066,6 +13090,9 @@ function hasDeepConvectionDiagnostics(result: ResultCard): boolean {
 }
 
 function deepConvectionOutcome(result: ResultCard): string {
+  if (fieldQualityBlocksEvidence(result, "qc") || fieldQualityBlocksEvidence(result, "w")) {
+    return "Deep convection unavailable";
+  }
   const formed = result.science_summary?.deep_cloud_formed;
   if (formed === true) return "Deep convection formed";
   if (formed === false) return "Deep convection not detected";
@@ -13093,7 +13120,67 @@ function caveatLabel(result: ResultCard): string {
     : "Needs review";
 }
 
+const FIELD_QUALITY_LABELS: Record<string, string> = {
+  qc: "Cloud water",
+  w: "Vertical velocity",
+  qr: "Rain water aloft",
+  surface_rain: "Surface rain",
+  dbz: "Reflectivity",
+};
+
+const FIELD_QUALITY_ORDER = ["qc", "w", "qr", "surface_rain", "dbz"];
+
+function resultFieldQuality(result: ResultCard, field: string): FieldQuality | null {
+  return result.field_quality?.[field] ?? result.science_summary?.field_quality?.[field] ?? null;
+}
+
+function fieldQualityBlocksEvidence(result: ResultCard, field: string): boolean {
+  const quality = resultFieldQuality(result, field);
+  return quality?.quality_state === "untrusted" || quality?.quality_state === "unavailable";
+}
+
+function nonTrustedFieldQuality(result: ResultCard): FieldQuality[] {
+  const byField = new Map<string, FieldQuality>();
+  for (const field of FIELD_QUALITY_ORDER) {
+    const quality = resultFieldQuality(result, field);
+    if (quality && quality.quality_state !== "trusted") byField.set(field, quality);
+  }
+  return [...byField.values()];
+}
+
+function fieldQualityCounts(quality: FieldQuality): string {
+  if (quality.total_count <= 0) return "no sampled values";
+  return `${quality.finite_count} finite / ${quality.non_finite_count} non-finite / ${quality.total_count} total`;
+}
+
+function fieldQualityDescription(quality: FieldQuality): string {
+  const label = FIELD_QUALITY_LABELS[quality.field] ?? humanize(quality.field);
+  const reason = quality.reason ? `; ${quality.reason}` : "";
+  return `${label} (${quality.source_field}) is ${quality.quality_state}; ${fieldQualityCounts(
+    quality,
+  )}${reason}`;
+}
+
+function FieldQualitySummary({ result }: { result: ResultCard }) {
+  const rows = nonTrustedFieldQuality(result);
+  return (
+    <section aria-labelledby="field-quality-title">
+      <h4 id="field-quality-title">Field quality</h4>
+      {rows.length > 0 ? (
+        <ul className="compact-list">
+          {rows.map((quality) => (
+            <li key={quality.field}>{fieldQualityDescription(quality)}</li>
+          ))}
+        </ul>
+      ) : (
+        <p>No non-finite field-quality caveats recorded.</p>
+      )}
+    </section>
+  );
+}
+
 function cloudOutcome(result: ResultCard): string {
+  if (fieldQualityBlocksEvidence(result, "qc")) return "Cloud unavailable";
   if (hasDeepConvectionDiagnostics(result)) return deepConvectionOutcome(result);
   if (!result.diagnostics_summary) return "Unknown";
   return result.diagnostics_summary.includes("cloud formed") &&
@@ -13107,7 +13194,13 @@ function rainOutcome(value: boolean | null): string {
   return value ? "Rain water aloft detected" : "No rain water aloft detected";
 }
 
+function rainWaterOutcome(result: ResultCard): string {
+  if (fieldQualityBlocksEvidence(result, "qr")) return "Rain water aloft unavailable";
+  return rainOutcome(result.rain_present);
+}
+
 function surfaceRainOutcome(result: ResultCard): string {
+  if (fieldQualityBlocksEvidence(result, "surface_rain")) return "Unavailable";
   if (result.surface_rain_present === true) {
     return result.max_surface_rain !== null && result.max_surface_rain !== undefined
       ? `Reached ground; max ${formatNumber(result.max_surface_rain, result.surface_rain_units ?? "")}`
@@ -13118,6 +13211,7 @@ function surfaceRainOutcome(result: ResultCard): string {
 }
 
 function reflectivityOutcome(result: ResultCard): string {
+  if (fieldQualityBlocksEvidence(result, "dbz")) return "Unavailable";
   if (!result.reflectivity_available) return "Unavailable";
   return result.max_dbz !== null && result.max_dbz !== undefined
     ? `Max ${formatNumber(result.max_dbz, "dBZ")}`

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -681,7 +681,17 @@ Current diagnostics compute:
 - optional surface-rain summary from the CM1 `rain` field;
 - optional reflectivity summary from the CM1 `dbz` field.
 
-Diagnostics preserve runtime warnings from the run manifest/result metadata. CM1 floating-point exception flags are caveats, not automatic failure. The diagnostics also count non-finite values in target fields where practical, ignore NaN/infinity for finite summaries, and record field-specific caveats if `qc`, `w`, `qr`, surface `rain`, or `dbz` are missing or entirely non-finite. Result metadata exposes a `field_quality` map for those fields with `trusted`, `caveated`, `untrusted`, or `unavailable` state plus finite/non-finite counts. Result cards, output products, campaign reports, and candidate comparisons must use that state so missing or entirely non-finite fields are not presented as clean negative or positive outcomes.
+Diagnostics preserve runtime warnings from the run manifest/result metadata. CM1
+floating-point exception flags are caveats, not automatic failure. The
+diagnostics also count non-finite values in target fields where practical,
+ignore NaN/infinity for finite summaries, and record field-specific caveats if
+`qc`, `w`, `qr`, surface `rain`, or `dbz` are missing or entirely non-finite.
+Result metadata exposes `field_quality_assessed` plus a `field_quality` map for
+those fields with `trusted`, `caveated`, `untrusted`, or `unavailable` state and
+finite/non-finite counts. Missing assessment is not equivalent to trusted.
+Result cards, output products, campaign reports, and candidate comparisons must
+use explicit assessed quality state so missing, unassessed, or entirely
+non-finite fields are not presented as clean negative or positive outcomes.
 
 This result metadata is not a Result Card UI and not visualization-ready data. It is the backend bridge that later result cards and inspectors can consume.
 

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -681,7 +681,7 @@ Current diagnostics compute:
 - optional surface-rain summary from the CM1 `rain` field;
 - optional reflectivity summary from the CM1 `dbz` field.
 
-Diagnostics preserve runtime warnings from the run manifest/result metadata. CM1 floating-point exception flags are caveats, not automatic failure. The diagnostics also count non-finite values in target fields where practical, ignore NaN/infinity for finite summaries, and record field-specific caveats if `qc`, `w`, `qr`, surface `rain`, or `dbz` are missing or entirely non-finite.
+Diagnostics preserve runtime warnings from the run manifest/result metadata. CM1 floating-point exception flags are caveats, not automatic failure. The diagnostics also count non-finite values in target fields where practical, ignore NaN/infinity for finite summaries, and record field-specific caveats if `qc`, `w`, `qr`, surface `rain`, or `dbz` are missing or entirely non-finite. Result metadata exposes a `field_quality` map for those fields with `trusted`, `caveated`, `untrusted`, or `unavailable` state plus finite/non-finite counts. Result cards, output products, campaign reports, and candidate comparisons must use that state so missing or entirely non-finite fields are not presented as clean negative or positive outcomes.
 
 This result metadata is not a Result Card UI and not visualization-ready data. It is the backend bridge that later result cards and inspectors can consume.
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -1118,9 +1118,9 @@ Rain diagnostics use `qr` when present:
 qr_rain_threshold_kg_kg = 1e-7
 ```
 
-If `qr` is absent, the user-facing result says `No rain detected.` and the metadata records that the `qr` field was absent. Missing `qr` does not fail the diagnostics.
+If `qr` is absent, the user-facing result must say that rain-water-aloft diagnostics are unavailable, not that rain water aloft was absent. The metadata records that the `qr` field was absent. Missing `qr` does not fail the diagnostics, but it cannot support a clean rain-water outcome.
 
-NaN and infinity values are ignored for finite min/max and fraction summaries. Field-specific caveats record non-finite values or entirely non-finite target fields. CM1 runtime floating-point exception flags are preserved as caveats and evaluated against the target diagnostic fields rather than treated as automatic run failure.
+NaN and infinity values are ignored for finite min/max and fraction summaries. Field-specific caveats record non-finite values or entirely non-finite target fields. Target fields also carry field-quality state: `trusted`, `caveated`, `untrusted`, or `unavailable`. Entirely non-finite `qc`, `w`, `qr`, surface `rain`, or `dbz` fields are untrusted and must not be summarized as clean cloud, updraft, rain-water, surface-rain, or reflectivity evidence. CM1 runtime floating-point exception flags are preserved as caveats and evaluated against the target diagnostic fields rather than treated as automatic run failure.
 
 Shared controls are controls that can be compared across multiple lower-atmosphere scenarios, such as low-level humidity, surface heating, cap strength, cap height, dry air aloft, and mixing/entrainment. Scenario-specific controls should be introduced only when a scenario needs them to answer its physical question.
 

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -261,6 +261,13 @@ support states such as `unavailable`, `unsupported_missing_fields`, and
 `unsupported_missing_diagnostic` rather than silently falling back to a
 misleading cloud/rain-water landmark.
 
+Interesting-time records, field defaults, diagnostic availability records, and
+science summaries may carry target-field `field_quality` metadata for `qc`, `w`,
+`qr`, surface `rain`, and `dbz`. Entirely non-finite source fields are
+`untrusted` and must not produce supported landmarks or clean comparison
+evidence. Partially non-finite fields may remain usable only with visible
+caveats and finite/non-finite counts.
+
 Triggered deep-potential results extend the same product with backend-owned
 summary fields for deep-cloud formation, first deep-convection time, strong
 updraft detection, cloud top, rain-water onset, max `qr`, and the default Explore

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -402,9 +402,9 @@ the result output-products API. Supported MVP aggregations are domain mean,
 domain min, domain max, and selected column for profile-capable 3-D fields.
 Payloads include the global output `time_index`, resolved local source-file
 index when the output product manifest is available, vertical coordinate values,
-finite/non-finite counts, provenance, and caveats. Surface-only fields such as
-surface rain and surface fluxes remain unavailable for vertical profiles rather
-than being reshaped into misleading columns.
+finite/non-finite counts, field-quality metadata, provenance, and caveats.
+Surface-only fields such as surface rain and surface fluxes remain unavailable
+for vertical profiles rather than being reshaped into misleading columns.
 
 ## Time-Height Products
 
@@ -435,8 +435,8 @@ The current backend skeleton exposes time-height products for time-height-capabl
 and cloud fraction for `qc` using the documented cloud-water threshold. Payloads
 include global output time indices, source-file/local-time mappings when
 available, vertical coordinates, shape and size class, finite/non-finite counts,
-provenance, and caveats. The browser consumes the bounded payload only; it does
-not parse raw NetCDF.
+field-quality metadata, provenance, and caveats. The browser consumes the
+bounded payload only; it does not parse raw NetCDF.
 
 ## Evolved-Run Time-Series Products
 
@@ -451,6 +451,18 @@ Missing fields must return an unavailable/caveated catalog state or a clear
 product error, not a guessed scientific result. Boundary-layer-depth and
 mixed-layer-depth style products remain future diagnostics until a defensible
 method is documented and tested.
+
+Field-product payloads must be self-describing. Vertical profile, time-height,
+time-series, native slice, and point-cloud payloads carry a `field_quality`
+object for the requested raw field when diagnostics can evaluate it. The object
+records whether quality was assessed, the source field, quality state, finite
+count, non-finite count, total count, reason, and quality caveats. Tracked fields
+use the current `qc`, `w`, `qr`, surface `rain`, and `dbz` diagnostic quality
+records. Untracked fields such as `qv`, `hfx`, or `qfx` must explicitly report
+that field quality is not tracked rather than implying trusted status. Older
+results or partial metadata with no assessment signal must report
+`assessed = false`; only an explicit assessed `trusted` field-quality record is
+trusted evidence.
 
 Wind-component products are scalar summaries of native-grid CM1 `u` and `v`
 components. They may support vertical profiles and time-height products when
@@ -692,6 +704,8 @@ Minimum provenance:
 - product version;
 - rendering method when visual;
 - source warnings/caveats.
+- field-quality assessment state for each field product, including explicit
+  not-assessed/not-tracked states when no trusted quality record exists.
 
 Common caveats:
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -328,13 +328,14 @@ NetCDF ingest tests use tiny synthetic NetCDF files in temporary run directories
 
 Multi-file NetCDF ingest tests should use tiny generated fixtures under temporary run directories. They should cover CM1-style sequences such as `cm1out_000001.nc`, `cm1out_000002.nc`, and `cm1out_stats.nc`; verify model-field files are sorted by output index; exclude or separately classify stats NetCDF files; count total model output files and time steps; preserve first/last output time; record direct-vs-inferred time handling; tolerate corrupt individual output files with caveats when enough valid files remain; and ensure diagnostics time series span the full model-field sequence. A full-run no-cloud result is meaningful only after all usable model-output files have been evaluated.
 
-Baseline Shallow Cumulus diagnostics tests use tiny synthetic NetCDF fixtures only. They cover no-cloud and cloud-formed cases, the `qc >= 1e-6 kg/kg` threshold, the minimum 10 cloudy grid-cell rule, first cloud time, cloud base/top from vertical coordinates, max `qc`, `qc` max time series, cloud fraction time series, max/min `w`, optional `qr` rain detection with `qr >= 1e-7 kg/kg`, missing `qc`/`w`/`qr`, NaN/infinity handling, entirely non-finite fields, NetCDF time-coordinate use, and inferred output-index fallback. These diagnostics are learning summaries, not morphology validation.
+Baseline Shallow Cumulus diagnostics tests use tiny synthetic NetCDF fixtures only. They cover no-cloud and cloud-formed cases, the `qc >= 1e-6 kg/kg` threshold, the minimum 10 cloudy grid-cell rule, first cloud time, cloud base/top from vertical coordinates, max `qc`, `qc` max time series, cloud fraction time series, max/min `w`, optional `qr` rain detection with `qr >= 1e-7 kg/kg`, missing `qc`/`w`/`qr`, NaN/infinity handling, entirely non-finite fields, NetCDF time-coordinate use, and inferred output-index fallback. They should assert field-quality states and finite/non-finite counts for `qc`, `w`, `qr`, surface `rain`, and `dbz` so unavailable or untrusted fields do not appear as clean scientific outcomes. These diagnostics are learning summaries, not morphology validation.
 
 Result Card / Experiment Notebook tests should use tiny synthetic NetCDF
 fixtures and temporary runtime homes. They should cover creating a card from
 ingested metadata, listing/getting cards, updating name/tags/notes, saving and
-protecting cards, missing diagnostics, provenance labels, output file summary,
-and serialization round trips. They must not use real CM1 output.
+protecting cards, missing diagnostics, field-quality propagation, provenance
+labels, output file summary, and serialization round trips. They must not use
+real CM1 output.
 
 Visualization-ready data contract tests should use tiny synthetic NetCDF
 fixtures and temporary runtime homes only. They should cover the fields endpoint,

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -328,7 +328,20 @@ NetCDF ingest tests use tiny synthetic NetCDF files in temporary run directories
 
 Multi-file NetCDF ingest tests should use tiny generated fixtures under temporary run directories. They should cover CM1-style sequences such as `cm1out_000001.nc`, `cm1out_000002.nc`, and `cm1out_stats.nc`; verify model-field files are sorted by output index; exclude or separately classify stats NetCDF files; count total model output files and time steps; preserve first/last output time; record direct-vs-inferred time handling; tolerate corrupt individual output files with caveats when enough valid files remain; and ensure diagnostics time series span the full model-field sequence. A full-run no-cloud result is meaningful only after all usable model-output files have been evaluated.
 
-Baseline Shallow Cumulus diagnostics tests use tiny synthetic NetCDF fixtures only. They cover no-cloud and cloud-formed cases, the `qc >= 1e-6 kg/kg` threshold, the minimum 10 cloudy grid-cell rule, first cloud time, cloud base/top from vertical coordinates, max `qc`, `qc` max time series, cloud fraction time series, max/min `w`, optional `qr` rain detection with `qr >= 1e-7 kg/kg`, missing `qc`/`w`/`qr`, NaN/infinity handling, entirely non-finite fields, NetCDF time-coordinate use, and inferred output-index fallback. They should assert field-quality states and finite/non-finite counts for `qc`, `w`, `qr`, surface `rain`, and `dbz` so unavailable or untrusted fields do not appear as clean scientific outcomes. These diagnostics are learning summaries, not morphology validation.
+Baseline Shallow Cumulus diagnostics tests use tiny synthetic NetCDF fixtures
+only. They cover no-cloud and cloud-formed cases, the `qc >= 1e-6 kg/kg`
+threshold, the minimum 10 cloudy grid-cell rule, first cloud time, cloud
+base/top from vertical coordinates, max `qc`, `qc` max time series, cloud
+fraction time series, max/min `w`, optional `qr` rain detection with
+`qr >= 1e-7 kg/kg`, missing `qc`/`w`/`qr`, NaN/infinity handling, entirely
+non-finite fields, NetCDF time-coordinate use, and inferred output-index
+fallback. They should assert field-quality assessment presence, field-quality
+states, and finite/non-finite counts for `qc`, `w`, `qr`, surface `rain`, and
+`dbz` so unavailable, unassessed, or untrusted fields do not appear as clean
+scientific outcomes. Output-product tests should assert that profile,
+time-height, time-series, slice, and point-cloud payloads carry local
+field-quality metadata instead of making consumers infer trust from a separate
+summary. These diagnostics are learning summaries, not morphology validation.
 
 Result Card / Experiment Notebook tests should use tiny synthetic NetCDF
 fixtures and temporary runtime homes. They should cover creating a card from


### PR DESCRIPTION
## Summary
- add field-quality state for qc, w, qr, surface rain, and dbz with finite/non-finite counts
- propagate field quality through result metadata, result cards, output products, campaign reports, and candidate comparisons
- update Results UI labels so missing/untrusted fields show as unavailable instead of clean no-rain/no-cloud outcomes
- update docs to make field quality part of the diagnostic/output-product contract

Closes #325.

## Verification
- app/backend/.venv/bin/python -m pytest app/backend/tests/test_result_diagnostics.py app/backend/tests/test_result_ingest.py app/backend/tests/test_result_cards.py app/backend/tests/test_output_products.py app/backend/tests/test_surface_forced_campaign.py
- cd app/frontend && npm test -- App.test.tsx
- scripts/check.sh
- scripts/check-e2e.sh
- live browser check of Results detail field-quality section on http://localhost:5173

## Notes
- PR intentionally does not merge per request.
- Existing Vitest act warnings are still emitted by the pre-existing loading-state test; tests pass.