### PR TITLE
Add hfx/qfx surface flux statistics

### DIFF
--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -17,7 +17,12 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from cloud_chamber.result_diagnostics import FieldQuality, ResultDiagnostics, TimeValue
+from cloud_chamber.result_diagnostics import (
+    FieldQuality,
+    ResultDiagnostics,
+    SurfaceFluxDiagnostics,
+    TimeValue,
+)
 
 OUTPUT_PRODUCT_MANIFEST_VERSION = 1
 DERIVED_PRODUCTS_DIRNAME = "derived-products"
@@ -170,6 +175,7 @@ class ScienceSummary(BaseModel):
     default_explore_time_index: int | None = None
     default_explore_time_seconds: float | None = None
     cm1_outcome: str | None = None
+    surface_fluxes: SurfaceFluxDiagnostics = Field(default_factory=SurfaceFluxDiagnostics)
     field_quality_assessed: bool = False
     field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
     diagnostic_availability: list[ScienceDiagnosticAvailability] = Field(default_factory=list)
@@ -1027,6 +1033,7 @@ def _science_summary(
         default_explore_time_index=default_source.time_index if default_source else None,
         default_explore_time_seconds=default_source.time_seconds if default_source else None,
         cm1_outcome=None,
+        surface_fluxes=diagnostics.surface_fluxes,
         field_quality_assessed=diagnostics.field_quality_assessed,
         field_quality=diagnostics.field_quality if diagnostics.field_quality_assessed else {},
         diagnostic_availability=_diagnostic_availability(variables, diagnostics),

--- a/app/backend/cloud_chamber/result_cards.py
+++ b/app/backend/cloud_chamber/result_cards.py
@@ -17,7 +17,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.output_products import FieldDefaultTime, InterestingTimeRecord, ScienceSummary
-from cloud_chamber.result_diagnostics import FieldQuality
+from cloud_chamber.result_diagnostics import FieldQuality, SurfaceFluxDiagnostics
 from cloud_chamber.result_ingest import (
     RESULT_METADATA_FILENAME,
     CandidateHypothesisComparison,
@@ -127,6 +127,7 @@ class ResultCard(BaseModel):
     surface_rain_units: str | None = None
     max_dbz: float | None = None
     reflectivity_available: bool | None = None
+    surface_fluxes: SurfaceFluxDiagnostics | None = None
     field_quality_assessed: bool = False
     field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
     interesting_times: list[InterestingTimeRecord] = Field(default_factory=list)
@@ -306,6 +307,7 @@ def _card_from_metadata(
         surface_rain_units=surface_rain.units if surface_rain else None,
         max_dbz=reflectivity.max_dbz if reflectivity and reflectivity.available else None,
         reflectivity_available=reflectivity.available if reflectivity else None,
+        surface_fluxes=diagnostics.surface_fluxes if diagnostics else None,
         field_quality_assessed=diagnostics.field_quality_assessed if diagnostics else False,
         field_quality=diagnostics.field_quality
         if diagnostics is not None and diagnostics.field_quality_assessed

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -126,6 +126,33 @@ class ReflectivityDiagnostics(BaseModel):
     field_absent: bool = True
 
 
+class SurfaceFluxFieldDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_field: str
+    available: bool = False
+    field_absent: bool = True
+    min_value: float | None = None
+    max_value: float | None = None
+    mean_value: float | None = None
+    units: str | None = None
+    finite_count: int = 0
+    non_finite_count: int = 0
+    total_count: int = 0
+    caveats: list[str] = Field(default_factory=list)
+
+
+class SurfaceFluxDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    hfx: SurfaceFluxFieldDiagnostics = Field(
+        default_factory=lambda: SurfaceFluxFieldDiagnostics(source_field="hfx")
+    )
+    qfx: SurfaceFluxFieldDiagnostics = Field(
+        default_factory=lambda: SurfaceFluxFieldDiagnostics(source_field="qfx")
+    )
+
+
 class ResultDiagnostics(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -134,6 +161,7 @@ class ResultDiagnostics(BaseModel):
     rain: RainDiagnostics
     surface_rain: SurfaceRainDiagnostics = Field(default_factory=SurfaceRainDiagnostics)
     reflectivity: ReflectivityDiagnostics = Field(default_factory=ReflectivityDiagnostics)
+    surface_fluxes: SurfaceFluxDiagnostics = Field(default_factory=SurfaceFluxDiagnostics)
     time: TimeDiagnostics
     field_quality_assessed: bool = False
     field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
@@ -365,6 +393,7 @@ def compute_baseline_diagnostics(dataset: Any, inherited_caveats: list[str]) -> 
     rain = _rain_diagnostics(dataset, time_context, caveats)
     surface_rain = _surface_rain_diagnostics(dataset, time_context, caveats)
     reflectivity = _reflectivity_diagnostics(dataset, time_context, caveats)
+    surface_fluxes = _surface_flux_diagnostics(dataset, caveats)
     field_quality = _field_quality_map(dataset)
     return ResultDiagnostics(
         cloud=cloud,
@@ -372,6 +401,7 @@ def compute_baseline_diagnostics(dataset: Any, inherited_caveats: list[str]) -> 
         rain=rain,
         surface_rain=surface_rain,
         reflectivity=reflectivity,
+        surface_fluxes=surface_fluxes,
         time=time_context.diagnostics,
         field_quality_assessed=True,
         field_quality=field_quality,
@@ -409,6 +439,18 @@ FIELD_QUALITY_SOURCES = {
         "missing": "dbz_field_absent",
         "partial": "non_finite_values_detected_in_dbz",
         "entire": "dbz_field_entirely_non_finite",
+    },
+    "hfx": {
+        "source_field": "hfx",
+        "missing": "hfx_field_absent",
+        "partial": "non_finite_values_detected_in_hfx",
+        "entire": "hfx_field_entirely_non_finite",
+    },
+    "qfx": {
+        "source_field": "qfx",
+        "missing": "qfx_field_absent",
+        "partial": "non_finite_values_detected_in_qfx",
+        "entire": "qfx_field_entirely_non_finite",
     },
 }
 
@@ -722,6 +764,65 @@ def _reflectivity_diagnostics(
     )
 
 
+def _surface_flux_diagnostics(dataset: Any, caveats: list[str]) -> SurfaceFluxDiagnostics:
+    return SurfaceFluxDiagnostics(
+        hfx=_surface_flux_field_diagnostics(dataset, "hfx", caveats),
+        qfx=_surface_flux_field_diagnostics(dataset, "qfx", caveats),
+    )
+
+
+def _surface_flux_field_diagnostics(
+    dataset: Any,
+    field: str,
+    caveats: list[str],
+) -> SurfaceFluxFieldDiagnostics:
+    if field not in dataset.data_vars:
+        return SurfaceFluxFieldDiagnostics(
+            source_field=field,
+            field_absent=True,
+            caveats=[f"{field}_field_absent"],
+        )
+
+    data_array = dataset[field]
+    units = _attr_string(data_array, "units")
+    finite_count = _finite_count(data_array)
+    non_finite_count = _non_finite_count(data_array)
+    total_count = _total_count(data_array)
+    field_caveats: list[str] = []
+    if non_finite_count > 0:
+        field_caveat = f"non_finite_values_detected_in_{field}"
+        field_caveats.append(field_caveat)
+        caveats.append(field_caveat)
+    if finite_count == 0:
+        field_caveat = f"{field}_field_entirely_non_finite"
+        field_caveats.append(field_caveat)
+        caveats.append(field_caveat)
+        return SurfaceFluxFieldDiagnostics(
+            source_field=field,
+            available=False,
+            field_absent=False,
+            units=units,
+            finite_count=finite_count,
+            non_finite_count=non_finite_count,
+            total_count=total_count,
+            caveats=_dedupe(field_caveats),
+        )
+
+    return SurfaceFluxFieldDiagnostics(
+        source_field=field,
+        available=True,
+        field_absent=False,
+        min_value=_finite_min(data_array),
+        max_value=_finite_max(data_array),
+        mean_value=_finite_mean(data_array),
+        units=units,
+        finite_count=finite_count,
+        non_finite_count=non_finite_count,
+        total_count=total_count,
+        caveats=_dedupe(field_caveats),
+    )
+
+
 def _cloud_extent_array(dataset: Any, qc: Any, caveats: list[str]) -> Any:
     """Return the field used for cloud base/top diagnostics.
 
@@ -927,6 +1028,11 @@ def _finite_max(data_array: Any) -> float | None:
 def _finite_min(data_array: Any) -> float | None:
     values = _finite_values(data_array)
     return min(values) if values else None
+
+
+def _finite_mean(data_array: Any) -> float | None:
+    values = _finite_values(data_array)
+    return sum(values) / len(values) if values else None
 
 
 def _threshold_count(data_array: Any, threshold: float) -> int:

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -27,6 +27,8 @@ from cloud_chamber.result_diagnostics import (
     RainDiagnostics,
     ReflectivityDiagnostics,
     ResultDiagnostics,
+    SurfaceFluxDiagnostics,
+    SurfaceFluxFieldDiagnostics,
     SurfaceRainDiagnostics,
     TimeDiagnostics,
     TimeValue,
@@ -554,6 +556,9 @@ def _merge_diagnostics(
     reflectivity = _merge_reflectivity_diagnostics(
         [diagnostics.reflectivity for diagnostics in diagnostics_parts]
     )
+    surface_fluxes = _merge_surface_flux_diagnostics(
+        [diagnostics.surface_fluxes for diagnostics in diagnostics_parts]
+    )
     field_quality = _merge_field_quality_maps(diagnostics_parts)
     field_quality_assessed = any(
         diagnostics.field_quality_assessed for diagnostics in diagnostics_parts
@@ -570,6 +575,7 @@ def _merge_diagnostics(
         rain=rain,
         surface_rain=surface_rain,
         reflectivity=reflectivity,
+        surface_fluxes=surface_fluxes,
         time=time,
         field_quality_assessed=field_quality_assessed,
         field_quality=field_quality,
@@ -757,7 +763,61 @@ def _merge_reflectivity_diagnostics(
     )
 
 
-FIELD_QUALITY_ORDER = ("qc", "w", "qr", "surface_rain", "dbz")
+def _merge_surface_flux_diagnostics(
+    parts: list[SurfaceFluxDiagnostics],
+) -> SurfaceFluxDiagnostics:
+    return SurfaceFluxDiagnostics(
+        hfx=_merge_surface_flux_field_diagnostics("hfx", [part.hfx for part in parts]),
+        qfx=_merge_surface_flux_field_diagnostics("qfx", [part.qfx for part in parts]),
+    )
+
+
+def _merge_surface_flux_field_diagnostics(
+    source_field: str,
+    parts: list[SurfaceFluxFieldDiagnostics],
+) -> SurfaceFluxFieldDiagnostics:
+    if not parts:
+        return SurfaceFluxFieldDiagnostics(source_field=source_field)
+    available_parts = [part for part in parts if part.available]
+    finite_count = sum(part.finite_count for part in parts)
+    non_finite_count = sum(part.non_finite_count for part in parts)
+    total_count = sum(part.total_count for part in parts)
+    units = next((part.units for part in parts if part.units is not None), None)
+    caveats = _dedupe_strings([caveat for part in parts for caveat in part.caveats])
+    if not available_parts:
+        return SurfaceFluxFieldDiagnostics(
+            source_field=source_field,
+            available=False,
+            field_absent=all(part.field_absent for part in parts),
+            units=units,
+            finite_count=finite_count,
+            non_finite_count=non_finite_count,
+            total_count=total_count,
+            caveats=caveats,
+        )
+
+    weighted_total = sum(
+        (part.mean_value or 0.0) * part.finite_count
+        for part in available_parts
+        if part.mean_value is not None
+    )
+    return SurfaceFluxFieldDiagnostics(
+        source_field=source_field,
+        available=True,
+        field_absent=False,
+        min_value=_min_optional([part.min_value for part in available_parts]),
+        max_value=_max_optional([part.max_value for part in available_parts]),
+        mean_value=weighted_total / finite_count if finite_count > 0 else None,
+        units=units,
+        finite_count=finite_count,
+        non_finite_count=non_finite_count,
+        total_count=total_count,
+        caveats=caveats,
+    )
+
+
+FIELD_QUALITY_MERGE_ORDER = ("qc", "w", "qr", "surface_rain", "dbz", "hfx", "qfx")
+FIELD_QUALITY_COMPARISON_ORDER = ("qc", "w", "qr", "surface_rain", "dbz")
 
 
 def _merge_field_quality_maps(
@@ -765,7 +825,7 @@ def _merge_field_quality_maps(
 ) -> dict[str, FieldQuality]:
     field_names = [
         field
-        for field in FIELD_QUALITY_ORDER
+        for field in FIELD_QUALITY_MERGE_ORDER
         if any(field in diagnostics.field_quality for diagnostics in diagnostics_parts)
     ]
     return {
@@ -1189,7 +1249,7 @@ def _field_quality_comparison_caveats(diagnostics: ResultDiagnostics) -> list[st
     if not diagnostics.field_quality_assessed:
         return ["field_quality_not_assessed"]
     caveats: list[str] = []
-    for field in FIELD_QUALITY_ORDER:
+    for field in FIELD_QUALITY_COMPARISON_ORDER:
         quality = diagnostics.field_quality.get(field)
         if quality is None or quality.quality_state == "trusted":
             continue

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -66,6 +66,11 @@ CAMPAIGN_SUMMARY_SCHEMA_VERSION = "surface_forced_campaign_summary_v1"
 OBSERVED_SURFACE_FORCED_RECIPE = RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION.value
 DEFAULT_SCENARIO_ID = "baseline-shallow-cumulus"
 DEFAULT_REPORT_ROOT = Path("docs/research/surface-forced-campaigns")
+DEFAULT_PHASE1_REQUIRED_COMPARISON_TYPES = (
+    "heat_flux_sensitivity",
+    "moisture_flux_sensitivity",
+    "combined_flux_sensitivity",
+)
 RUN_CONFIGURATION_KEYS = {
     "duration",
     "horizontal_cell_count",
@@ -289,6 +294,7 @@ class CampaignPlan(BaseModel):
     matrix_path: str | None = None
     execution: dict[str, Any] = Field(default_factory=dict)
     comparison_types: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    phase1_required_comparison_types: list[str] = Field(default_factory=list)
     required_summary_fields: dict[str, list[str]] = Field(default_factory=dict)
     run_count: int
     runs: list[CampaignRunPlan]
@@ -391,6 +397,13 @@ def build_campaign_plan(
         label="comparison_types",
         errors=errors,
     )
+    phase1_required_comparison_types = _string_list(matrix.get("phase1_required_comparison_types"))
+    for required_comparison_type in phase1_required_comparison_types:
+        if required_comparison_type not in comparison_types:
+            errors.append(
+                "phase1_required_comparison_types references unknown comparison_type: "
+                f"{required_comparison_type}"
+            )
     run_defaults = _mapping(matrix.get("run_defaults", {}), "run_defaults", errors)
     runs = _list_of_mappings(matrix.get("runs"), "runs", errors)
     required_summary_fields = _required_summary_fields(
@@ -517,6 +530,7 @@ def build_campaign_plan(
         matrix_path=str(matrix_path) if matrix_path is not None else None,
         execution=execution,
         comparison_types={key: dict(value) for key, value in comparison_types.items()},
+        phase1_required_comparison_types=phase1_required_comparison_types,
         required_summary_fields=required_summary_fields,
         run_count=len(planned),
         runs=planned,
@@ -2560,6 +2574,15 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
     )
     surface_flux_response = summary.get("surface_flux_response", {})
     response_evaluations = surface_flux_response.get("evaluations", [])
+    missing_required_comparison_types = surface_flux_response.get(
+        "missing_required_comparison_types",
+        [],
+    )
+    if missing_required_comparison_types:
+        lines.append(
+            "- Missing required Phase 1 comparison types: "
+            f"`{', '.join(missing_required_comparison_types)}`"
+        )
     if response_evaluations:
         for evaluation in response_evaluations:
             lines.append(
@@ -2567,9 +2590,11 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                 f"`{evaluation['control_matrix_id']}`: `{evaluation['status']}`"
             )
             for expectation in evaluation.get("expectations", []):
+                role = "required" if expectation.get("required") else "informational"
                 lines.append(
-                    f"  - {expectation['field']}: expected "
-                    f"`{expectation['expected']}`, observed `{expectation['observed']}`"
+                    f"  - {expectation['field']}: {role}; expected "
+                    f"`{expectation['expected']}`, observed `{expectation['observed']}`; "
+                    f"`{expectation['status']}`"
                 )
     else:
         lines.append("No Phase 1 surface-flux response comparisons are available.")
@@ -2818,6 +2843,9 @@ def _surface_flux_response_evaluation(
     summaries: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any]:
     by_matrix_id = {str(summary["matrix_id"]): summary for summary in summaries}
+    required_comparison_types = list(
+        plan.phase1_required_comparison_types or DEFAULT_PHASE1_REQUIRED_COMPARISON_TYPES
+    )
     evaluations: list[dict[str, Any]] = []
     for run in plan.runs:
         if not _is_phase_one_run(run):
@@ -2838,7 +2866,19 @@ def _surface_flux_response_evaluation(
             )
         )
 
-    if not evaluations:
+    evaluated_comparison_types = {str(evaluation["comparison_type"]) for evaluation in evaluations}
+    missing_required_comparison_types = [
+        comparison_type
+        for comparison_type in required_comparison_types
+        if comparison_type not in evaluated_comparison_types
+    ]
+    unavailable_evidence = [
+        f"missing_phase1_required_comparison_type:{comparison_type}"
+        for comparison_type in missing_required_comparison_types
+    ]
+    if missing_required_comparison_types:
+        state = SURFACE_FLUX_RESPONSE_MISSING
+    elif not evaluations:
         state = SURFACE_FLUX_RESPONSE_MISSING
     elif any(
         evaluation["status"] == SURFACE_FLUX_RESPONSE_NONCOMPARABLE for evaluation in evaluations
@@ -2854,6 +2894,9 @@ def _surface_flux_response_evaluation(
         state = SURFACE_FLUX_RESPONSE_VERIFIED
     return {
         "state": state,
+        "required_comparison_types": required_comparison_types,
+        "missing_required_comparison_types": missing_required_comparison_types,
+        "unavailable_evidence": unavailable_evidence,
         "evaluations": evaluations,
     }
 
@@ -2917,12 +2960,13 @@ def _surface_flux_response_for_pair(
             selected_control_field="surface_moisture_flux_g_g_m_s",
         ),
     ]
+    required_expectations = [expectation for expectation in expectations if expectation["required"]]
     status = (
         SURFACE_FLUX_RESPONSE_VERIFIED
-        if all(expectation["status"] == "verified" for expectation in expectations)
+        if all(expectation["status"] == "verified" for expectation in required_expectations)
         else SURFACE_FLUX_RESPONSE_NOT_VERIFIED
     )
-    if all(expectation["expected"] == "comparable" for expectation in expectations):
+    if not required_expectations:
         status = SURFACE_FLUX_RESPONSE_NONCOMPARABLE
     return {
         **base,
@@ -2993,12 +3037,19 @@ def _surface_flux_field_expectation(
     experiment_mean = _float_or_none(experiment.get(f"{field}_mean"))
     expected = _expected_direction(control_selected, experiment_selected)
     observed = _expected_direction(control_mean, experiment_mean)
-    status = "verified" if expected == observed else "not_verified"
+    required = expected in {"increase", "decrease"}
+    if required:
+        status = "verified" if expected == observed else "not_verified"
+    elif expected == "comparable":
+        status = "informational"
+    else:
+        status = "not_evaluated"
     return {
         "field": field,
         "selected_control_field": selected_control_field,
         "expected": expected,
         "observed": observed,
+        "required": required,
         "status": status,
         "control_selected": control_selected,
         "experiment_selected": experiment_selected,

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -672,7 +672,8 @@ def queue_campaign(
     state = _load_or_create_state(plan, resolved_settings.runtime_home)
     queue_factory = local_queue_factory or _default_local_queue
     summaries = [_summary_for_plan_run(run, state) for run in plan.runs]
-    gate_state = _phase_gate_state(summaries)
+    surface_flux_response = _surface_flux_response_evaluation(plan, summaries)
+    gate_state = _phase_gate_state(summaries, surface_flux_response)
     override = _gate_override_payload(
         enabled=override_phase_gate,
         reason=override_reason,
@@ -995,6 +996,7 @@ def report_campaign(
     state = _load_or_create_state(plan, resolved_settings.runtime_home)
     summaries = [_summary_for_plan_run(run, state) for run in plan.runs]
     comparisons = _evaluate_comparisons(plan, summaries)
+    surface_flux_response = _surface_flux_response_evaluation(plan, summaries)
     summary = {
         "schema_version": CAMPAIGN_SUMMARY_SCHEMA_VERSION,
         "campaign_id": plan.campaign_id,
@@ -1005,13 +1007,14 @@ def report_campaign(
         "generated_at": _now().isoformat(),
         "run_count": len(summaries),
         "status_counts": _status_counts(summaries),
-        "phase_gate_state": _phase_gate_state(summaries),
+        "phase_gate_state": _phase_gate_state(summaries, surface_flux_response),
+        "surface_flux_response": surface_flux_response,
         "gate_overrides": _gate_overrides(summaries),
         "runs": summaries,
         "comparisons": comparisons,
         "unavailable_diagnostics": _unavailable_diagnostics(summaries),
         "preliminary_diagnosis_categories": _preliminary_diagnosis_categories(summaries),
-        "recommended_follow_ups": _recommended_follow_ups(summaries),
+        "recommended_follow_ups": _recommended_follow_ups(summaries, surface_flux_response),
     }
 
     markdown_path = report_path or _default_report_path(plan)
@@ -2427,6 +2430,10 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
         f"- Runs planned: {summary['run_count']}",
         f"- Status counts: `{json.dumps(summary['status_counts'], sort_keys=True)}`",
         f"- Phase gate state: `{summary['phase_gate_state']}`",
+        (
+            f"- Surface flux response: "
+            f"`{summary.get('surface_flux_response', {}).get('state', 'unavailable')}`"
+        ),
         "",
         "## Operator Overrides",
         "",
@@ -2546,6 +2553,28 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
             "## Forcing Response",
             "",
             _forcing_response_summary(summary),
+            "",
+            "## Surface Flux Response",
+            "",
+        ]
+    )
+    surface_flux_response = summary.get("surface_flux_response", {})
+    response_evaluations = surface_flux_response.get("evaluations", [])
+    if response_evaluations:
+        for evaluation in response_evaluations:
+            lines.append(
+                f"- `{evaluation['experiment_matrix_id']}` vs "
+                f"`{evaluation['control_matrix_id']}`: `{evaluation['status']}`"
+            )
+            for expectation in evaluation.get("expectations", []):
+                lines.append(
+                    f"  - {expectation['field']}: expected "
+                    f"`{expectation['expected']}`, observed `{expectation['observed']}`"
+                )
+    else:
+        lines.append("No Phase 1 surface-flux response comparisons are available.")
+    lines.extend(
+        [
             "",
             "## Matched Comparisons",
             "",
@@ -2778,6 +2807,238 @@ def _comparison_field_value(summary: Mapping[str, Any], field: str) -> Any:
     return summary.get(field)
 
 
+SURFACE_FLUX_RESPONSE_VERIFIED = "surface_flux_response_verified"
+SURFACE_FLUX_RESPONSE_NOT_VERIFIED = "surface_flux_response_not_verified"
+SURFACE_FLUX_RESPONSE_MISSING = "surface_flux_response_inconclusive_missing_evidence"
+SURFACE_FLUX_RESPONSE_NONCOMPARABLE = "surface_flux_response_inconclusive_noncomparable"
+
+
+def _surface_flux_response_evaluation(
+    plan: CampaignPlan,
+    summaries: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    by_matrix_id = {str(summary["matrix_id"]): summary for summary in summaries}
+    evaluations: list[dict[str, Any]] = []
+    for run in plan.runs:
+        if not _is_phase_one_run(run):
+            continue
+        if not run.comparison_type or not run.comparison_control_matrix_id:
+            continue
+        definition = plan.comparison_types.get(run.comparison_type, {})
+        control = by_matrix_id.get(run.comparison_control_matrix_id)
+        experiment = by_matrix_id.get(run.matrix_id)
+        evaluations.append(
+            _surface_flux_response_for_pair(
+                comparison_type=run.comparison_type,
+                control_matrix_id=run.comparison_control_matrix_id,
+                experiment_matrix_id=run.matrix_id,
+                definition=definition,
+                control=control,
+                experiment=experiment,
+            )
+        )
+
+    if not evaluations:
+        state = SURFACE_FLUX_RESPONSE_MISSING
+    elif any(
+        evaluation["status"] == SURFACE_FLUX_RESPONSE_NONCOMPARABLE for evaluation in evaluations
+    ):
+        state = SURFACE_FLUX_RESPONSE_NONCOMPARABLE
+    elif any(evaluation["status"] == SURFACE_FLUX_RESPONSE_MISSING for evaluation in evaluations):
+        state = SURFACE_FLUX_RESPONSE_MISSING
+    elif any(
+        evaluation["status"] == SURFACE_FLUX_RESPONSE_NOT_VERIFIED for evaluation in evaluations
+    ):
+        state = SURFACE_FLUX_RESPONSE_NOT_VERIFIED
+    else:
+        state = SURFACE_FLUX_RESPONSE_VERIFIED
+    return {
+        "state": state,
+        "evaluations": evaluations,
+    }
+
+
+def _surface_flux_response_for_pair(
+    *,
+    comparison_type: str,
+    control_matrix_id: str,
+    experiment_matrix_id: str,
+    definition: Mapping[str, Any],
+    control: Mapping[str, Any] | None,
+    experiment: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    base = {
+        "comparison_type": comparison_type,
+        "control_matrix_id": control_matrix_id,
+        "experiment_matrix_id": experiment_matrix_id,
+        "expectations": [],
+        "equality_gate_failures": [],
+        "unavailable_evidence": [],
+    }
+    if control is None or experiment is None:
+        return {
+            **base,
+            "status": SURFACE_FLUX_RESPONSE_MISSING,
+            "unavailable_evidence": ["missing_control_or_experiment_summary"],
+        }
+
+    equality_failures = _comparison_equality_failures(control, experiment, definition)
+    if equality_failures:
+        return {
+            **base,
+            "status": SURFACE_FLUX_RESPONSE_NONCOMPARABLE,
+            "equality_gate_failures": equality_failures,
+        }
+
+    unavailable = _surface_flux_pair_unavailable_evidence(control, experiment)
+    if unavailable:
+        status = (
+            SURFACE_FLUX_RESPONSE_NONCOMPARABLE
+            if any("noncomparable_units" in item for item in unavailable)
+            else SURFACE_FLUX_RESPONSE_MISSING
+        )
+        return {
+            **base,
+            "status": status,
+            "unavailable_evidence": unavailable,
+        }
+
+    expectations = [
+        _surface_flux_field_expectation(
+            field="hfx",
+            control=control,
+            experiment=experiment,
+            selected_control_field="surface_heat_flux_k_m_s",
+        ),
+        _surface_flux_field_expectation(
+            field="qfx",
+            control=control,
+            experiment=experiment,
+            selected_control_field="surface_moisture_flux_g_g_m_s",
+        ),
+    ]
+    status = (
+        SURFACE_FLUX_RESPONSE_VERIFIED
+        if all(expectation["status"] == "verified" for expectation in expectations)
+        else SURFACE_FLUX_RESPONSE_NOT_VERIFIED
+    )
+    if all(expectation["expected"] == "comparable" for expectation in expectations):
+        status = SURFACE_FLUX_RESPONSE_NONCOMPARABLE
+    return {
+        **base,
+        "status": status,
+        "expectations": expectations,
+    }
+
+
+def _surface_flux_pair_unavailable_evidence(
+    control: Mapping[str, Any],
+    experiment: Mapping[str, Any],
+) -> list[str]:
+    unavailable: list[str] = []
+    for summary, role in ((control, "control"), (experiment, "experiment")):
+        if summary.get("status") != "ingested":
+            unavailable.append(f"{role}:result_not_ingested")
+        for field in ("hfx", "qfx"):
+            unavailable.extend(_surface_flux_stat_unavailable_reasons(summary, role, field))
+    for field in ("hfx", "qfx"):
+        control_units = control.get(f"{field}_units")
+        experiment_units = experiment.get(f"{field}_units")
+        if control_units is None or experiment_units is None:
+            continue
+        if control_units != experiment_units:
+            unavailable.append(f"{field}:noncomparable_units:{control_units}:vs:{experiment_units}")
+    noncomparable = [item for item in unavailable if "noncomparable_units" in item]
+    if noncomparable:
+        return noncomparable
+    return _dedupe(unavailable)
+
+
+def _surface_flux_stat_unavailable_reasons(
+    summary: Mapping[str, Any],
+    role: str,
+    field: str,
+) -> list[str]:
+    value = summary.get(f"{field}_mean")
+    finite_count = _int_or_none(summary.get(f"{field}_finite_count"))
+    non_finite_count = _int_or_none(summary.get(f"{field}_non_finite_count"))
+    total_count = _int_or_none(summary.get(f"{field}_total_count"))
+    units = summary.get(f"{field}_units")
+    reasons: list[str] = []
+    if not isinstance(value, int | float) or _is_unavailable(value):
+        reasons.append(f"{role}:{field}_mean_unavailable")
+    if finite_count is None or finite_count <= 0:
+        reasons.append(f"{role}:{field}_finite_count_unavailable")
+    if total_count is None or total_count <= 0:
+        reasons.append(f"{role}:{field}_total_count_unavailable")
+    if non_finite_count is None:
+        reasons.append(f"{role}:{field}_non_finite_count_unavailable")
+    elif non_finite_count > 0:
+        reasons.append(f"{role}:{field}_stats_not_trusted_non_finite")
+    if not isinstance(units, str) or not units:
+        reasons.append(f"{role}:{field}_units_unavailable")
+    return reasons
+
+
+def _surface_flux_field_expectation(
+    *,
+    field: str,
+    control: Mapping[str, Any],
+    experiment: Mapping[str, Any],
+    selected_control_field: str,
+) -> dict[str, Any]:
+    control_selected = _float_or_none(control.get(selected_control_field))
+    experiment_selected = _float_or_none(experiment.get(selected_control_field))
+    control_mean = _float_or_none(control.get(f"{field}_mean"))
+    experiment_mean = _float_or_none(experiment.get(f"{field}_mean"))
+    expected = _expected_direction(control_selected, experiment_selected)
+    observed = _expected_direction(control_mean, experiment_mean)
+    status = "verified" if expected == observed else "not_verified"
+    return {
+        "field": field,
+        "selected_control_field": selected_control_field,
+        "expected": expected,
+        "observed": observed,
+        "status": status,
+        "control_selected": control_selected,
+        "experiment_selected": experiment_selected,
+        "control_mean": control_mean,
+        "experiment_mean": experiment_mean,
+        "units": control.get(f"{field}_units"),
+    }
+
+
+def _expected_direction(left: float | None, right: float | None) -> str:
+    if left is None or right is None:
+        return "unknown"
+    tolerance = _comparison_numeric_tolerance(left, right)
+    if right > left + tolerance:
+        return "increase"
+    if right < left - tolerance:
+        return "decrease"
+    return "comparable"
+
+
+def _comparison_numeric_tolerance(left: float, right: float) -> float:
+    return max(abs(left), abs(right), 1.0) * 1e-9
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
 def _field_available(field: str, available_fields: set[str]) -> bool:
     if field in {"qfx", "lhfx"}:
         return bool({"qfx", "lhfx"} & available_fields)
@@ -2796,7 +3057,10 @@ def _is_unavailable(value: Any) -> bool:
     return isinstance(value, str) and value.startswith("unavailable")
 
 
-def _phase_gate_state(summaries: Sequence[Mapping[str, Any]]) -> str:
+def _phase_gate_state(
+    summaries: Sequence[Mapping[str, Any]],
+    surface_flux_response: Mapping[str, Any],
+) -> str:
     phase1 = [
         summary for summary in summaries if summary.get("phase") == "forcing_path_smoke_check"
     ]
@@ -2804,8 +3068,11 @@ def _phase_gate_state(summaries: Sequence[Mapping[str, Any]]) -> str:
         return "inconclusive_missing_evidence"
     if not all(summary.get("status") == "ingested" for summary in phase1):
         return "inconclusive_missing_evidence"
-    if not all(summary.get("hfx_present") and summary.get("lhfx_present") for summary in phase1):
+    if not all(summary.get("hfx_present") and summary.get("qfx_present") for summary in phase1):
         return "forcing_wiring_not_verified"
+    response_state = surface_flux_response.get("state")
+    if response_state != SURFACE_FLUX_RESPONSE_VERIFIED:
+        return str(response_state or SURFACE_FLUX_RESPONSE_MISSING)
     if not all(
         not _is_unavailable(summary.get("low_level_qv_response"))
         and not _is_unavailable(summary.get("low_level_theta_or_temperature_response"))
@@ -2850,15 +3117,22 @@ def _preliminary_diagnosis_categories(summaries: Sequence[Mapping[str, Any]]) ->
     return sorted(categories)
 
 
-def _recommended_follow_ups(summaries: Sequence[Mapping[str, Any]]) -> list[str]:
+def _recommended_follow_ups(
+    summaries: Sequence[Mapping[str, Any]],
+    surface_flux_response: Mapping[str, Any],
+) -> list[str]:
     followups = [
         "Implement standardized low-level qv/theta/temperature response diagnostics.",
-        "Add hfx/qfx surface-flux statistics before claiming emitted flux magnitudes.",
         (
             "Review campaign rows with unavailable required output fields before "
             "scientific conclusions."
         ),
     ]
+    if surface_flux_response.get("state") != SURFACE_FLUX_RESPONSE_VERIFIED:
+        followups.append(
+            "Resolve Phase 1 surface-flux response comparisons before treating "
+            "selected forcing changes as verified in CM1 output."
+        )
     if any(summary.get("diagnostic_quality_warnings") for summary in summaries):
         followups.append(
             "Review caveated or untrusted non-finite fields before using cloud, "
@@ -2878,16 +3152,34 @@ def _forcing_response_summary(summary: Mapping[str, Any]) -> str:
     state = summary.get("phase_gate_state")
     if state == "forcing_path_verified_for_campaign":
         return (
-            "Phase 1 has ingested comparable surface-forced runs with required surface-flux "
-            "outputs and low-level response diagnostics available. Later phases may be queued "
-            "without an operator override, subject to campaign cost/runtime judgment."
+            "Phase 1 has ingested comparable surface-forced runs, verified matched "
+            "hfx/qfx output response to selected forcing changes, and has low-level "
+            "response diagnostics available. Later phases may be queued without an "
+            "operator override, subject to campaign cost/runtime judgment."
         )
     if state == "forcing_wiring_verified_but_response_not_verified":
         return (
             "Phase 1 confirmed selected forcing metadata, CM1-facing forcing controls, "
-            "and hfx/qfx output-field presence. It did not verify emitted flux magnitudes "
-            "or boundary-layer thermodynamic response because surface-flux statistics and "
-            "low-level qv/theta response diagnostics are not implemented yet."
+            "hfx/qfx output-field presence, and matched emitted surface-flux response. "
+            "It did not verify boundary-layer thermodynamic response because low-level "
+            "qv/theta response diagnostics are not implemented yet."
+        )
+    if state == SURFACE_FLUX_RESPONSE_NOT_VERIFIED:
+        return (
+            "Phase 1 produced hfx/qfx statistics, but matched emitted surface-flux "
+            "means did not move in the expected direction for the selected forcing "
+            "changes."
+        )
+    if state == SURFACE_FLUX_RESPONSE_MISSING:
+        return (
+            "Phase 1 cannot verify emitted surface-flux response because one or more "
+            "matched hfx/qfx statistics are missing, untrusted, or not ingested."
+        )
+    if state == SURFACE_FLUX_RESPONSE_NONCOMPARABLE:
+        return (
+            "Phase 1 cannot verify emitted surface-flux response because one or more "
+            "matched runs are structurally non-comparable or use non-comparable hfx/qfx "
+            "units."
         )
     if state == "forcing_wiring_not_verified":
         return "Surface-flux output fields are missing from ingested results."

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -36,7 +36,11 @@ from cloud_chamber.observed_sounding import (
     observed_sounding_from_payload,
     parse_igra_station_text,
 )
-from cloud_chamber.result_diagnostics import FieldQuality
+from cloud_chamber.result_diagnostics import (
+    FieldQuality,
+    SurfaceFluxDiagnostics,
+    SurfaceFluxFieldDiagnostics,
+)
 from cloud_chamber.result_ingest import (
     RESULT_METADATA_FILENAME,
     ResultIngestError,
@@ -165,6 +169,17 @@ SUPPORTED_REQUIRED_SUMMARY_FIELDS = {
     "hfx_min",
     "hfx_max",
     "hfx_mean",
+    "hfx_finite_count",
+    "hfx_non_finite_count",
+    "hfx_total_count",
+    "qfx_present",
+    "qfx_units",
+    "qfx_min",
+    "qfx_max",
+    "qfx_mean",
+    "qfx_finite_count",
+    "qfx_non_finite_count",
+    "qfx_total_count",
     "lhfx_present",
     "lhfx_units",
     "lhfx_min",
@@ -1811,6 +1826,17 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
     rain = diagnostics.rain if diagnostics is not None else None
     surface_rain = diagnostics.surface_rain if diagnostics is not None else None
     reflectivity = diagnostics.reflectivity if diagnostics is not None else None
+    surface_fluxes = diagnostics.surface_fluxes if diagnostics is not None else None
+    hfx_stats = _surface_flux_summary_values(
+        surface_fluxes.hfx if surface_fluxes is not None else None,
+        source_field="hfx",
+        fallback_units=_field_units(result, "hfx"),
+    )
+    qfx_stats = _surface_flux_summary_values(
+        surface_fluxes.qfx if surface_fluxes is not None else None,
+        source_field="qfx",
+        fallback_units=_field_units(result, "qfx"),
+    )
     deep_cloud_formed = (
         science.deep_cloud_formed if science is not None else "unavailable:not_ingested"
     )
@@ -1973,18 +1999,27 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
             else "unavailable:not_ingested"
         ),
         "hfx_present": "hfx" in variables,
-        "hfx_units": _field_units(result, "hfx"),
-        "hfx_min": "unavailable:surface_flux_statistics_not_implemented",
-        "hfx_max": "unavailable:surface_flux_statistics_not_implemented",
-        "hfx_mean": "unavailable:surface_flux_statistics_not_implemented",
+        "hfx_units": hfx_stats["units"],
+        "hfx_min": hfx_stats["min"],
+        "hfx_max": hfx_stats["max"],
+        "hfx_mean": hfx_stats["mean"],
+        "hfx_finite_count": hfx_stats["finite_count"],
+        "hfx_non_finite_count": hfx_stats["non_finite_count"],
+        "hfx_total_count": hfx_stats["total_count"],
         "qfx_present": "qfx" in variables,
-        "qfx_units": _field_units(result, "qfx"),
+        "qfx_units": qfx_stats["units"],
+        "qfx_min": qfx_stats["min"],
+        "qfx_max": qfx_stats["max"],
+        "qfx_mean": qfx_stats["mean"],
+        "qfx_finite_count": qfx_stats["finite_count"],
+        "qfx_non_finite_count": qfx_stats["non_finite_count"],
+        "qfx_total_count": qfx_stats["total_count"],
         "surface_moisture_flux_output_field": _surface_moisture_flux_field(variables),
         "lhfx_present": _surface_moisture_flux_field(variables) is not None,
-        "lhfx_units": _field_units(result, _surface_moisture_flux_field(variables)),
-        "lhfx_min": "unavailable:surface_flux_statistics_not_implemented",
-        "lhfx_max": "unavailable:surface_flux_statistics_not_implemented",
-        "lhfx_mean": "unavailable:surface_flux_statistics_not_implemented",
+        "lhfx_units": qfx_stats["units"],
+        "lhfx_min": qfx_stats["min"],
+        "lhfx_max": qfx_stats["max"],
+        "lhfx_mean": qfx_stats["mean"],
         "low_level_qv_response": ("unavailable:low_level_response_diagnostic_not_implemented"),
         "low_level_qv_response_method": "low_level_response_diagnostic_not_implemented",
         "low_level_theta_or_temperature_response": (
@@ -2040,9 +2075,7 @@ def _diagnostic_support(result: ResultMetadata | None) -> dict[str, str]:
     diagnostics = result.diagnostics
     variables = set(result.variables)
     return {
-        "surface_fluxes": "available"
-        if "hfx" in variables and _surface_moisture_flux_field(variables) is not None
-        else "missing",
+        "surface_fluxes": _surface_flux_support(diagnostics.surface_fluxes, variables),
         "low_level_response": "unavailable:low_level_response_diagnostic_not_implemented",
         "cloud": "available" if diagnostics.cloud.available else "missing",
         "vertical_velocity": "available" if diagnostics.vertical_velocity.available else "missing",
@@ -2052,10 +2085,66 @@ def _diagnostic_support(result: ResultMetadata | None) -> dict[str, str]:
     }
 
 
+def _surface_flux_support(
+    diagnostics: SurfaceFluxDiagnostics,
+    variables: set[str],
+) -> str:
+    field_presence = "hfx" in variables and _surface_moisture_flux_field(variables) is not None
+    if diagnostics.hfx.available and diagnostics.qfx.available:
+        return "available"
+    if field_presence:
+        return "unavailable:surface_flux_statistics_unavailable"
+    return "missing"
+
+
 def _field_units(result: ResultMetadata | None, field_name: str | None) -> str | None:
     if result is None or field_name is None:
         return None
     return next((field.units for field in result.fields_detected if field.name == field_name), None)
+
+
+def _surface_flux_summary_values(
+    diagnostics: SurfaceFluxFieldDiagnostics | None,
+    *,
+    source_field: str,
+    fallback_units: str | None,
+) -> dict[str, Any]:
+    if diagnostics is None:
+        unavailable = "unavailable:until_result_ingested"
+        return {
+            "units": fallback_units,
+            "min": unavailable,
+            "max": unavailable,
+            "mean": unavailable,
+            "finite_count": 0,
+            "non_finite_count": 0,
+            "total_count": 0,
+        }
+    if diagnostics.available:
+        return {
+            "units": diagnostics.units or fallback_units,
+            "min": diagnostics.min_value,
+            "max": diagnostics.max_value,
+            "mean": diagnostics.mean_value,
+            "finite_count": diagnostics.finite_count,
+            "non_finite_count": diagnostics.non_finite_count,
+            "total_count": diagnostics.total_count,
+        }
+    if diagnostics.field_absent:
+        reason = f"unavailable:{source_field}_field_absent"
+    elif diagnostics.total_count > 0 and diagnostics.finite_count == 0:
+        reason = f"unavailable:{source_field}_field_entirely_non_finite"
+    else:
+        reason = f"unavailable:{source_field}_statistics_unavailable"
+    return {
+        "units": diagnostics.units or fallback_units,
+        "min": reason,
+        "max": reason,
+        "mean": reason,
+        "finite_count": diagnostics.finite_count,
+        "non_finite_count": diagnostics.non_finite_count,
+        "total_count": diagnostics.total_count,
+    }
 
 
 def _surface_moisture_flux_field(fields: Iterable[str]) -> str | None:
@@ -2436,8 +2525,12 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                 (
                     f"- Surface flux stats: hfx `{run['hfx_min']}`/"
                     f"`{run['hfx_max']}`/`{run['hfx_mean']}`, "
-                    f"moisture `{run['lhfx_min']}`/`{run['lhfx_max']}`/"
-                    f"`{run['lhfx_mean']}`"
+                    f"qfx `{run['qfx_min']}`/`{run['qfx_max']}`/"
+                    f"`{run['qfx_mean']}`; counts hfx "
+                    f"`{run['hfx_finite_count']}`/`{run['hfx_non_finite_count']}`/"
+                    f"`{run['hfx_total_count']}`, qfx "
+                    f"`{run['qfx_finite_count']}`/`{run['qfx_non_finite_count']}`/"
+                    f"`{run['qfx_total_count']}`"
                 ),
                 f"- Cloud/updraft: {cloud_updraft}",
                 f"- Precipitation/reflectivity: {precipitation}",

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -50,6 +50,8 @@ FIELD_QUALITY_KEY_BY_RAW_FIELD = {
     "qr": "qr",
     "rain": "surface_rain",
     "dbz": "dbz",
+    "hfx": "hfx",
+    "qfx": "qfx",
 }
 
 

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any
 
+import pytest
 import xarray as xr
 
 from cloud_chamber.result_diagnostics import (
@@ -21,6 +22,8 @@ def base_dataset(
     qr_values: list[list[list[list[float]]]] | None = None,
     rain_values: list[list[list[float]]] | None = None,
     dbz_values: list[list[list[list[float]]]] | None = None,
+    hfx_values: list[list[list[float]]] | None = None,
+    qfx_values: list[list[list[float]]] | None = None,
     qi_values: list[list[list[list[float]]]] | None = None,
     qs_values: list[list[list[list[float]]]] | None = None,
     qg_values: list[list[list[list[float]]]] | None = None,
@@ -68,6 +71,18 @@ def base_dataset(
             dbz_values,
             {"units": "dBZ"},
         )
+    if hfx_values is not None:
+        data_vars["hfx"] = (
+            ("time", "y", "x"),
+            hfx_values,
+            {"units": "K m/s"},
+        )
+    if qfx_values is not None:
+        data_vars["qfx"] = (
+            ("time", "y", "x"),
+            qfx_values,
+            {"units": "kg/m^2/s"},
+        )
     if qi_values is not None:
         data_vars["qi"] = (
             ("time", "z", "y", "x"),
@@ -103,6 +118,21 @@ def zeros(z_count: int = 2) -> list[list[list[list[float]]]]:
         [[[0.0 for _x in range(4)] for _y in range(3)] for _z in range(z_count)]
         for _time in range(2)
     ]
+
+
+def surface_values(start: float = 0.0, step: float = 1.0) -> list[list[list[float]]]:
+    value = start
+    values = []
+    for _time in range(2):
+        time_values = []
+        for _y in range(3):
+            row = []
+            for _x in range(4):
+                row.append(value)
+                value += step
+            time_values.append(row)
+        values.append(time_values)
+    return values
 
 
 def with_cloud(cloudy_cells: int = 12) -> list[list[list[list[float]]]]:
@@ -351,6 +381,132 @@ def test_surface_rain_and_reflectivity_are_distinct_outputs(tmp_path: Path) -> N
     assert diagnostics.reflectivity.max_dbz == 32.0
     assert diagnostics.reflectivity.time_of_max_dbz_seconds == 300.0
     assert diagnostics.reflectivity.units == "dBZ"
+
+
+def test_surface_flux_statistics_preserve_units_and_counts(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "surface_fluxes.nc",
+        base_dataset(
+            qc_values=zeros(),
+            w_values=w_field(),
+            hfx_values=surface_values(start=1.0, step=1.0),
+            qfx_values=surface_values(start=0.0, step=0.5),
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    hfx = diagnostics.surface_fluxes.hfx
+    qfx = diagnostics.surface_fluxes.qfx
+    assert hfx.available is True
+    assert hfx.field_absent is False
+    assert hfx.units == "K m/s"
+    assert hfx.min_value == pytest.approx(1.0)
+    assert hfx.max_value == pytest.approx(24.0)
+    assert hfx.mean_value == pytest.approx(12.5)
+    assert hfx.finite_count == 24
+    assert hfx.non_finite_count == 0
+    assert hfx.total_count == 24
+    assert diagnostics.field_quality["hfx"].quality_state == "trusted"
+    assert diagnostics.field_quality["hfx"].source_field == "hfx"
+
+    assert qfx.available is True
+    assert qfx.field_absent is False
+    assert qfx.units == "kg/m^2/s"
+    assert qfx.min_value == pytest.approx(0.0)
+    assert qfx.max_value == pytest.approx(11.5)
+    assert qfx.mean_value == pytest.approx(5.75)
+    assert qfx.finite_count == 24
+    assert qfx.non_finite_count == 0
+    assert qfx.total_count == 24
+    assert diagnostics.field_quality["qfx"].quality_state == "trusted"
+    assert diagnostics.field_quality["qfx"].source_field == "qfx"
+
+
+def test_surface_flux_statistics_report_missing_fields_without_global_caveats(
+    tmp_path: Path,
+) -> None:
+    dataset = write_dataset(
+        tmp_path / "surface_fluxes_missing.nc",
+        base_dataset(qc_values=zeros(), w_values=w_field()),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.surface_fluxes.hfx.available is False
+    assert diagnostics.surface_fluxes.hfx.field_absent is True
+    assert diagnostics.surface_fluxes.hfx.caveats == ["hfx_field_absent"]
+    assert diagnostics.surface_fluxes.qfx.available is False
+    assert diagnostics.surface_fluxes.qfx.field_absent is True
+    assert diagnostics.surface_fluxes.qfx.caveats == ["qfx_field_absent"]
+    assert diagnostics.field_quality["hfx"].quality_state == "unavailable"
+    assert diagnostics.field_quality["qfx"].quality_state == "unavailable"
+    assert "hfx_field_absent" not in diagnostics.caveats
+    assert "qfx_field_absent" not in diagnostics.caveats
+
+
+def test_surface_flux_statistics_caveat_partially_non_finite_fields(
+    tmp_path: Path,
+) -> None:
+    hfx = surface_values(start=1.0, step=1.0)
+    hfx[0][0][0] = float("nan")
+    qfx = surface_values(start=0.0, step=0.5)
+    qfx[1][2][3] = float("inf")
+    dataset = write_dataset(
+        tmp_path / "surface_fluxes_partially_non_finite.nc",
+        base_dataset(qc_values=zeros(), w_values=w_field(), hfx_values=hfx, qfx_values=qfx),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.surface_fluxes.hfx.available is True
+    assert diagnostics.surface_fluxes.hfx.min_value == pytest.approx(2.0)
+    assert diagnostics.surface_fluxes.hfx.max_value == pytest.approx(24.0)
+    assert diagnostics.surface_fluxes.hfx.finite_count == 23
+    assert diagnostics.surface_fluxes.hfx.non_finite_count == 1
+    assert diagnostics.field_quality["hfx"].quality_state == "caveated"
+    assert "non_finite_values_detected_in_hfx" in diagnostics.caveats
+
+    assert diagnostics.surface_fluxes.qfx.available is True
+    assert diagnostics.surface_fluxes.qfx.min_value == pytest.approx(0.0)
+    assert diagnostics.surface_fluxes.qfx.max_value == pytest.approx(11.0)
+    assert diagnostics.surface_fluxes.qfx.finite_count == 23
+    assert diagnostics.surface_fluxes.qfx.non_finite_count == 1
+    assert diagnostics.field_quality["qfx"].quality_state == "caveated"
+    assert "non_finite_values_detected_in_qfx" in diagnostics.caveats
+
+
+def test_surface_flux_statistics_mark_all_non_finite_fields_unavailable(
+    tmp_path: Path,
+) -> None:
+    all_nan_surface = [[[float("nan") for _x in range(4)] for _y in range(3)] for _time in range(2)]
+    dataset = write_dataset(
+        tmp_path / "surface_fluxes_all_nan.nc",
+        base_dataset(
+            qc_values=zeros(),
+            w_values=w_field(),
+            hfx_values=all_nan_surface,
+            qfx_values=all_nan_surface,
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.surface_fluxes.hfx.available is False
+    assert diagnostics.surface_fluxes.hfx.field_absent is False
+    assert diagnostics.surface_fluxes.hfx.finite_count == 0
+    assert diagnostics.surface_fluxes.hfx.non_finite_count == 24
+    assert diagnostics.surface_fluxes.hfx.total_count == 24
+    assert diagnostics.field_quality["hfx"].quality_state == "untrusted"
+    assert "hfx_field_entirely_non_finite" in diagnostics.caveats
+
+    assert diagnostics.surface_fluxes.qfx.available is False
+    assert diagnostics.surface_fluxes.qfx.field_absent is False
+    assert diagnostics.surface_fluxes.qfx.finite_count == 0
+    assert diagnostics.surface_fluxes.qfx.non_finite_count == 24
+    assert diagnostics.surface_fluxes.qfx.total_count == 24
+    assert diagnostics.field_quality["qfx"].quality_state == "untrusted"
+    assert "qfx_field_entirely_non_finite" in diagnostics.caveats
 
 
 def test_missing_qc_and_missing_w_are_graceful(tmp_path: Path) -> None:

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -107,6 +107,8 @@ def write_model_netcdf(
     qr_values: list[float] | None = None,
     rain_values: list[float] | None = None,
     dbz_values: list[float] | None = None,
+    hfx_values: list[float] | None = None,
+    qfx_values: list[float] | None = None,
     z_values: list[float] | None = None,
     include_qc: bool = True,
     include_w: bool = True,
@@ -154,6 +156,18 @@ def write_model_netcdf(
                 for dbz_value in dbz_values
             ],
             {"units": "dBZ"},
+        )
+    if hfx_values is not None:
+        data_vars["hfx"] = (
+            ("time", "y", "x"),
+            [[[hfx_value for _x in range(4)] for _y in range(3)] for hfx_value in hfx_values],
+            {"units": "K m/s"},
+        )
+    if qfx_values is not None:
+        data_vars["qfx"] = (
+            ("time", "y", "x"),
+            [[[qfx_value for _x in range(4)] for _y in range(3)] for qfx_value in qfx_values],
+            {"units": "kg/m^2/s"},
         )
     xr.Dataset(
         data_vars=data_vars,
@@ -229,10 +243,16 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
     assert result.diagnostics is not None
     assert result.diagnostics.cloud.formed is False
     assert result.diagnostics.rain.field_absent is True
+    assert result.diagnostics.surface_fluxes.hfx.available is False
+    assert result.diagnostics.surface_fluxes.hfx.field_absent is True
+    assert result.diagnostics.surface_fluxes.qfx.available is False
+    assert result.diagnostics.surface_fluxes.qfx.field_absent is True
     assert result.diagnostics.field_quality_assessed is True
     assert result.diagnostics.field_quality["qc"].quality_state == "trusted"
     assert result.diagnostics.field_quality["w"].quality_state == "trusted"
     assert result.diagnostics.field_quality["qr"].quality_state == "unavailable"
+    assert result.diagnostics.field_quality["hfx"].quality_state == "unavailable"
+    assert result.diagnostics.field_quality["qfx"].quality_state == "unavailable"
     assert result.process_diagnostics is not None
     assert (
         result.process_diagnostics.interpretation_support.thermal_fate_label
@@ -279,8 +299,22 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     first = run_dir / "cm1out_000001.nc"
     second = run_dir / "cm1out_000002.nc"
     stats = run_dir / "cm1out_stats.nc"
-    write_model_netcdf(first, times=[300.0], qc_values=[0.0], w_values=[-5.0])
-    write_model_netcdf(second, times=[600.0], qc_values=[2e-6], w_values=[7.0])
+    write_model_netcdf(
+        first,
+        times=[300.0],
+        qc_values=[0.0],
+        w_values=[-5.0],
+        hfx_values=[1.0],
+        qfx_values=[1.0e-5],
+    )
+    write_model_netcdf(
+        second,
+        times=[600.0],
+        qc_values=[2e-6],
+        w_values=[7.0],
+        hfx_values=[3.0],
+        qfx_values=[3.0e-5],
+    )
     write_stats_netcdf(stats)
     complete_manifest(
         manifest_path,
@@ -305,6 +339,22 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     assert result.diagnostics.cloud.time_of_max_qc_seconds == 600.0
     assert result.diagnostics.vertical_velocity.min_w_m_s == -5.0
     assert result.diagnostics.vertical_velocity.max_w_m_s == 7.0
+    assert result.diagnostics.surface_fluxes.hfx.available is True
+    assert result.diagnostics.surface_fluxes.hfx.units == "K m/s"
+    assert result.diagnostics.surface_fluxes.hfx.min_value == pytest.approx(1.0)
+    assert result.diagnostics.surface_fluxes.hfx.max_value == pytest.approx(3.0)
+    assert result.diagnostics.surface_fluxes.hfx.mean_value == pytest.approx(2.0)
+    assert result.diagnostics.surface_fluxes.hfx.finite_count == 24
+    assert result.diagnostics.surface_fluxes.hfx.total_count == 24
+    assert result.diagnostics.surface_fluxes.qfx.available is True
+    assert result.diagnostics.surface_fluxes.qfx.units == "kg/m^2/s"
+    assert result.diagnostics.surface_fluxes.qfx.min_value == pytest.approx(1.0e-5)
+    assert result.diagnostics.surface_fluxes.qfx.max_value == pytest.approx(3.0e-5)
+    assert result.diagnostics.surface_fluxes.qfx.mean_value == pytest.approx(2.0e-5)
+    assert result.diagnostics.surface_fluxes.qfx.finite_count == 24
+    assert result.diagnostics.surface_fluxes.qfx.total_count == 24
+    assert result.diagnostics.field_quality["hfx"].quality_state == "trusted"
+    assert result.diagnostics.field_quality["qfx"].quality_state == "trusted"
     interesting = {record.key: record for record in result.interesting_times}
     assert interesting["first_cloud"].support_state == "supported"
     assert interesting["first_cloud"].time_index == 1

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -176,6 +176,108 @@ def write_matrix(
     return matrix_path
 
 
+def write_phase1_surface_flux_matrix(tmp_path: Path) -> Path:
+    matrix_path = write_matrix(tmp_path)
+    matrix = yaml.safe_load(matrix_path.read_text())
+    matrix["comparison_types"] = [
+        {
+            "comparison_type": "heat_flux_sensitivity",
+            "varied_fields": ["surface_heat_flux_k_m_s", "cm1_cnst_shflx"],
+            "required_equal_fields": [
+                "selection_id",
+                "surface_moisture_flux_g_g_m_s",
+                "duration",
+                "domain_size",
+                "horizontal_cell_count",
+                "output_cadence",
+                "required_output_fields",
+            ],
+            "required_available_fields": ["hfx", "qfx"],
+            "required_diagnostic_support": ["surface_fluxes"],
+        },
+        {
+            "comparison_type": "moisture_flux_sensitivity",
+            "varied_fields": ["surface_moisture_flux_g_g_m_s", "cm1_cnst_lhflx"],
+            "required_equal_fields": [
+                "selection_id",
+                "surface_heat_flux_k_m_s",
+                "duration",
+                "domain_size",
+                "horizontal_cell_count",
+                "output_cadence",
+                "required_output_fields",
+            ],
+            "required_available_fields": ["hfx", "qfx"],
+            "required_diagnostic_support": ["surface_fluxes"],
+        },
+        {
+            "comparison_type": "combined_flux_sensitivity",
+            "varied_fields": [
+                "surface_heat_flux_k_m_s",
+                "surface_moisture_flux_g_g_m_s",
+                "cm1_cnst_shflx",
+                "cm1_cnst_lhflx",
+            ],
+            "required_equal_fields": [
+                "selection_id",
+                "duration",
+                "domain_size",
+                "horizontal_cell_count",
+                "output_cadence",
+                "required_output_fields",
+            ],
+            "required_available_fields": ["hfx", "qfx"],
+            "required_diagnostic_support": ["surface_fluxes"],
+        },
+    ]
+    matrix["runs"] = [
+        {
+            "matrix_id": "phase1_control_default_flux",
+            "phase": "forcing_path_smoke_check",
+            "selection_id": "control_sounding",
+            "comparison_role": "phase1_control",
+        },
+        {
+            "matrix_id": "phase1_control_high_sensible",
+            "phase": "forcing_path_smoke_check",
+            "selection_id": "control_sounding",
+            "surface_heat_flux_k_m_s": 4.0e-2,
+            "surface_moisture_flux_g_g_m_s": 5.2e-5,
+            "comparison": {
+                "type": "heat_flux_sensitivity",
+                "control_matrix_id": "phase1_control_default_flux",
+            },
+            "comparison_role": "heat_flux_sensitivity",
+        },
+        {
+            "matrix_id": "phase1_control_high_moisture",
+            "phase": "forcing_path_smoke_check",
+            "selection_id": "control_sounding",
+            "surface_heat_flux_k_m_s": 8.0e-3,
+            "surface_moisture_flux_g_g_m_s": 1.0e-4,
+            "comparison": {
+                "type": "moisture_flux_sensitivity",
+                "control_matrix_id": "phase1_control_default_flux",
+            },
+            "comparison_role": "moisture_flux_sensitivity",
+        },
+        {
+            "matrix_id": "phase1_control_high_both",
+            "phase": "forcing_path_smoke_check",
+            "selection_id": "control_sounding",
+            "surface_heat_flux_k_m_s": 4.0e-2,
+            "surface_moisture_flux_g_g_m_s": 1.0e-4,
+            "comparison": {
+                "type": "combined_flux_sensitivity",
+                "control_matrix_id": "phase1_control_default_flux",
+            },
+            "comparison_role": "combined_flux_sensitivity",
+        },
+    ]
+    matrix_path.write_text(yaml.safe_dump(matrix, sort_keys=False))
+    return matrix_path
+
+
 def test_campaign_plan_validates_matrix_and_resolves_cm1_values(tmp_path: Path) -> None:
     matrix_path = write_matrix(tmp_path)
     plan = build_campaign_plan(yaml.safe_load(matrix_path.read_text()), matrix_path=matrix_path)
@@ -674,12 +776,15 @@ def test_campaign_report_summarizes_ingested_result_without_fabricating_bl_respo
     assert Path(artifacts.markdown_path) == report_path
     assert Path(artifacts.summary_json_path) == summary_path
     assert summary["status_counts"] == {"ingested": 1}
-    assert summary["phase_gate_state"] == "forcing_wiring_verified_but_response_not_verified"
+    assert summary["phase_gate_state"] == "surface_flux_response_inconclusive_missing_evidence"
+    assert summary["surface_flux_response"]["state"] == (
+        "surface_flux_response_inconclusive_missing_evidence"
+    )
     run = summary["runs"][0]
     assert run["hfx_present"] is True
     assert run["hfx_units"] == "K m/s"
-    assert run["hfx_min"] == 1.0
-    assert run["hfx_max"] == 3.0
+    assert run["hfx_min"] == 2.0
+    assert run["hfx_max"] == 2.0
     assert run["hfx_mean"] == 2.0
     assert run["hfx_finite_count"] == 8
     assert run["hfx_non_finite_count"] == 0
@@ -687,8 +792,8 @@ def test_campaign_report_summarizes_ingested_result_without_fabricating_bl_respo
     assert run["qfx_present"] is True
     assert run["surface_moisture_flux_output_field"] == "qfx"
     assert run["qfx_units"] == "kg/m^2/s"
-    assert run["qfx_min"] == 1.0e-5
-    assert run["qfx_max"] == 3.0e-5
+    assert run["qfx_min"] == 2.0e-5
+    assert run["qfx_max"] == 2.0e-5
     assert run["qfx_mean"] == 2.0e-5
     assert run["qfx_finite_count"] == 8
     assert run["qfx_non_finite_count"] == 0
@@ -701,6 +806,171 @@ def test_campaign_report_summarizes_ingested_result_without_fabricating_bl_respo
     assert run["low_level_qv_response_method"] == "low_level_response_diagnostic_not_implemented"
     assert "low_level_qv_response" in summary["unavailable_diagnostics"]
     assert "max w 2.5" in report_path.read_text()
+
+
+def test_campaign_report_verifies_matched_phase1_surface_flux_response(
+    tmp_path: Path,
+) -> None:
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.0e-5),
+            "phase1_control_high_moisture": (2.0, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+    )
+
+    assert artifacts.summary["surface_flux_response"]["state"] == "surface_flux_response_verified"
+    assert artifacts.summary["phase_gate_state"] == (
+        "forcing_wiring_verified_but_response_not_verified"
+    )
+    evaluations = artifacts.summary["surface_flux_response"]["evaluations"]
+    assert {evaluation["status"] for evaluation in evaluations} == {
+        "surface_flux_response_verified"
+    }
+    heat = next(
+        evaluation
+        for evaluation in evaluations
+        if evaluation["comparison_type"] == "heat_flux_sensitivity"
+    )
+    assert heat["expectations"] == [
+        {
+            "field": "hfx",
+            "selected_control_field": "surface_heat_flux_k_m_s",
+            "expected": "increase",
+            "observed": "increase",
+            "status": "verified",
+            "control_selected": 0.008,
+            "experiment_selected": 0.04,
+            "control_mean": 2.0,
+            "experiment_mean": 4.0,
+            "units": "K m/s",
+        },
+        {
+            "field": "qfx",
+            "selected_control_field": "surface_moisture_flux_g_g_m_s",
+            "expected": "comparable",
+            "observed": "comparable",
+            "status": "verified",
+            "control_selected": 5.2e-05,
+            "experiment_selected": 5.2e-05,
+            "control_mean": 2.0e-05,
+            "experiment_mean": 2.0e-05,
+            "units": "kg/m^2/s",
+        },
+    ]
+    report = Path(artifacts.markdown_path).read_text()
+    assert "Surface flux response: `surface_flux_response_verified`" in report
+    assert "`phase1_control_high_sensible` vs `phase1_control_default_flux`" in report
+
+
+def test_campaign_report_rejects_unchanged_emitted_flux_response(
+    tmp_path: Path,
+) -> None:
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (2.0, 2.0e-5),
+            "phase1_control_high_moisture": (2.0, 2.0e-5),
+            "phase1_control_high_both": (2.0, 2.0e-5),
+        },
+    )
+
+    assert artifacts.summary["surface_flux_response"]["state"] == (
+        "surface_flux_response_not_verified"
+    )
+    assert artifacts.summary["phase_gate_state"] == "surface_flux_response_not_verified"
+    expectations = artifacts.summary["surface_flux_response"]["evaluations"][0]["expectations"]
+    assert expectations[0]["expected"] == "increase"
+    assert expectations[0]["observed"] == "comparable"
+    assert expectations[0]["status"] == "not_verified"
+
+
+def test_campaign_report_rejects_reversed_emitted_flux_response(tmp_path: Path) -> None:
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (1.0, 2.0e-5),
+            "phase1_control_high_moisture": (2.0, 1.0e-5),
+            "phase1_control_high_both": (1.0, 1.0e-5),
+        },
+    )
+
+    assert artifacts.summary["surface_flux_response"]["state"] == (
+        "surface_flux_response_not_verified"
+    )
+    heat = artifacts.summary["surface_flux_response"]["evaluations"][0]
+    assert heat["expectations"][0]["expected"] == "increase"
+    assert heat["expectations"][0]["observed"] == "decrease"
+
+
+def test_campaign_report_requires_trusted_surface_flux_stats(tmp_path: Path) -> None:
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.0e-5),
+            "phase1_control_high_moisture": (2.0, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+        non_finite_counts={"phase1_control_high_sensible": (1, 0)},
+    )
+
+    assert artifacts.summary["surface_flux_response"]["state"] == (
+        "surface_flux_response_inconclusive_missing_evidence"
+    )
+    heat = artifacts.summary["surface_flux_response"]["evaluations"][0]
+    assert "experiment:hfx_stats_not_trusted_non_finite" in heat["unavailable_evidence"]
+
+
+def test_campaign_report_rejects_mismatched_surface_flux_units(tmp_path: Path) -> None:
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.0e-5),
+            "phase1_control_high_moisture": (2.0, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+        unit_overrides={"phase1_control_high_sensible": ("W m-2", "kg/m^2/s")},
+    )
+
+    assert artifacts.summary["surface_flux_response"]["state"] == (
+        "surface_flux_response_inconclusive_noncomparable"
+    )
+    heat = artifacts.summary["surface_flux_response"]["evaluations"][0]
+    assert "hfx:noncomparable_units:K m/s:vs:W m-2" in heat["unavailable_evidence"]
+
+
+def test_campaign_report_rejects_structurally_noncomparable_surface_flux_runs(
+    tmp_path: Path,
+) -> None:
+    def mutate(matrix: dict[str, Any]) -> None:
+        for run in matrix["runs"]:
+            if run["matrix_id"] == "phase1_control_high_sensible":
+                run["domain_size"] = "local_6km"
+
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.0e-5),
+            "phase1_control_high_moisture": (2.0, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+        mutate_matrix=mutate,
+    )
+
+    assert artifacts.summary["surface_flux_response"]["state"] == (
+        "surface_flux_response_inconclusive_noncomparable"
+    )
+    heat = artifacts.summary["surface_flux_response"]["evaluations"][0]
+    assert {"field": "domain_size", "control": "wide_12km", "experiment": "local_6km"} in (
+        heat["equality_gate_failures"]
+    )
 
 
 def test_campaign_report_marks_non_finite_outcomes_as_untrusted(
@@ -888,6 +1158,49 @@ def test_campaign_ingest_updates_state_with_existing_completed_output(
     assert result.runs[0].result_id == "result-surface-forced-test"
 
 
+def _report_phase1_surface_flux_matrix(
+    tmp_path: Path,
+    *,
+    flux_means: dict[str, tuple[float, float]],
+    non_finite_counts: dict[str, tuple[int, int]] | None = None,
+    unit_overrides: dict[str, tuple[str, str]] | None = None,
+    mutate_matrix: Any | None = None,
+) -> Any:
+    settings = fake_settings(tmp_path)
+    matrix_path = write_phase1_surface_flux_matrix(tmp_path)
+    if mutate_matrix is not None:
+        matrix = yaml.safe_load(matrix_path.read_text())
+        mutate_matrix(matrix)
+        matrix_path.write_text(yaml.safe_dump(matrix, sort_keys=False))
+    packaged = package_campaign(matrix_path, settings=settings, resume=True)
+    for state_run in packaged.runs:
+        hfx_mean, qfx_mean = flux_means[state_run.matrix_id]
+        hfx_non_finite, qfx_non_finite = (non_finite_counts or {}).get(
+            state_run.matrix_id,
+            (0, 0),
+        )
+        hfx_units, qfx_units = (unit_overrides or {}).get(
+            state_run.matrix_id,
+            ("K m/s", "kg/m^2/s"),
+        )
+        _write_fake_result_metadata(
+            Path(state_run.manifest_path or ""),
+            hfx_mean=hfx_mean,
+            qfx_mean=qfx_mean,
+            hfx_units=hfx_units,
+            qfx_units=qfx_units,
+            hfx_non_finite_count=hfx_non_finite,
+            qfx_non_finite_count=qfx_non_finite,
+        )
+
+    return report_campaign(
+        matrix_path,
+        settings=settings,
+        report_path=tmp_path / "report.md",
+        summary_json_path=tmp_path / "summary.json",
+    )
+
+
 def _set_manifest_lifecycle(
     manifest_path: Path,
     lifecycle: LifecycleState,
@@ -918,6 +1231,12 @@ def _write_fake_result_metadata(
     run_caveats: list[str] | None = None,
     interesting_time_caveats: list[str] | None = None,
     surface_rain_present: bool = False,
+    hfx_mean: float = 2.0,
+    qfx_mean: float = 2.0e-5,
+    hfx_units: str = "K m/s",
+    qfx_units: str = "kg/m^2/s",
+    hfx_non_finite_count: int = 0,
+    qfx_non_finite_count: int = 0,
 ) -> None:
     manifest = load_run_manifest(manifest_path)
     now = datetime.now(UTC)
@@ -947,10 +1266,10 @@ def _write_fake_result_metadata(
         variables=["qc", "w", "qr", "rain", "dbz", "hfx", "qfx", "qv", "th"],
         fields_detected=[
             FieldMetadata(
-                name="hfx", dimensions=["time", "y", "x"], shape=[2, 2, 2], units="K m/s"
+                name="hfx", dimensions=["time", "y", "x"], shape=[2, 2, 2], units=hfx_units
             ),
             FieldMetadata(
-                name="qfx", dimensions=["time", "y", "x"], shape=[2, 2, 2], units="kg/m^2/s"
+                name="qfx", dimensions=["time", "y", "x"], shape=[2, 2, 2], units=qfx_units
             ),
             FieldMetadata(
                 name="qv", dimensions=["time", "z", "y", "x"], shape=[2, 2, 2, 2], units="kg/kg"
@@ -1003,25 +1322,25 @@ def _write_fake_result_metadata(
                     source_field="hfx",
                     available=True,
                     field_absent=False,
-                    min_value=1.0,
-                    max_value=3.0,
-                    mean_value=2.0,
-                    units="K m/s",
+                    min_value=hfx_mean,
+                    max_value=hfx_mean,
+                    mean_value=hfx_mean,
+                    units=hfx_units,
                     finite_count=8,
-                    non_finite_count=0,
-                    total_count=8,
+                    non_finite_count=hfx_non_finite_count,
+                    total_count=8 + hfx_non_finite_count,
                 ),
                 qfx=SurfaceFluxFieldDiagnostics(
                     source_field="qfx",
                     available=True,
                     field_absent=False,
-                    min_value=1.0e-5,
-                    max_value=3.0e-5,
-                    mean_value=2.0e-5,
-                    units="kg/m^2/s",
+                    min_value=qfx_mean,
+                    max_value=qfx_mean,
+                    mean_value=qfx_mean,
+                    units=qfx_units,
                     finite_count=8,
-                    non_finite_count=0,
-                    total_count=8,
+                    non_finite_count=qfx_non_finite_count,
+                    total_count=8 + qfx_non_finite_count,
                 ),
             ),
             time=TimeDiagnostics(source="time", fallback_used=False, coordinate_name="time"),

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -230,6 +230,11 @@ def write_phase1_surface_flux_matrix(tmp_path: Path) -> Path:
             "required_diagnostic_support": ["surface_fluxes"],
         },
     ]
+    matrix["phase1_required_comparison_types"] = [
+        "heat_flux_sensitivity",
+        "moisture_flux_sensitivity",
+        "combined_flux_sensitivity",
+    ]
     matrix["runs"] = [
         {
             "matrix_id": "phase1_control_default_flux",
@@ -306,6 +311,11 @@ def test_campaign_plans_checked_in_example_matrix() -> None:
     assert plan.run_count == 10
     assert plan.execution["max_concurrent_runs"] == 1
     assert "forcing_sensitivity_same_duration" in plan.comparison_types
+    assert plan.phase1_required_comparison_types == [
+        "heat_flux_sensitivity",
+        "moisture_flux_sensitivity",
+        "combined_flux_sensitivity",
+    ]
     assert any(run.optional for run in plan.runs)
     assert plan.required_summary_fields["evidence"]
 
@@ -815,8 +825,8 @@ def test_campaign_report_verifies_matched_phase1_surface_flux_response(
         tmp_path,
         flux_means={
             "phase1_control_default_flux": (2.0, 2.0e-5),
-            "phase1_control_high_sensible": (4.0, 2.0e-5),
-            "phase1_control_high_moisture": (2.0, 4.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.5e-5),
+            "phase1_control_high_moisture": (2.2, 4.0e-5),
             "phase1_control_high_both": (4.0, 4.0e-5),
         },
     )
@@ -840,6 +850,7 @@ def test_campaign_report_verifies_matched_phase1_surface_flux_response(
             "selected_control_field": "surface_heat_flux_k_m_s",
             "expected": "increase",
             "observed": "increase",
+            "required": True,
             "status": "verified",
             "control_selected": 0.008,
             "experiment_selected": 0.04,
@@ -851,18 +862,63 @@ def test_campaign_report_verifies_matched_phase1_surface_flux_response(
             "field": "qfx",
             "selected_control_field": "surface_moisture_flux_g_g_m_s",
             "expected": "comparable",
-            "observed": "comparable",
-            "status": "verified",
+            "observed": "increase",
+            "required": False,
+            "status": "informational",
             "control_selected": 5.2e-05,
             "experiment_selected": 5.2e-05,
             "control_mean": 2.0e-05,
-            "experiment_mean": 2.0e-05,
+            "experiment_mean": 2.5e-05,
             "units": "kg/m^2/s",
         },
     ]
+    moisture = next(
+        evaluation
+        for evaluation in evaluations
+        if evaluation["comparison_type"] == "moisture_flux_sensitivity"
+    )
+    assert moisture["expectations"][0]["required"] is False
+    assert moisture["expectations"][0]["status"] == "informational"
+    assert moisture["expectations"][1]["required"] is True
+    assert moisture["expectations"][1]["status"] == "verified"
     report = Path(artifacts.markdown_path).read_text()
     assert "Surface flux response: `surface_flux_response_verified`" in report
+    assert "qfx: informational; expected `comparable`, observed `increase`" in report
     assert "`phase1_control_high_sensible` vs `phase1_control_default_flux`" in report
+
+
+def test_campaign_report_requires_complete_phase1_surface_flux_response_matrix(
+    tmp_path: Path,
+) -> None:
+    def mutate(matrix: dict[str, Any]) -> None:
+        matrix["runs"] = [
+            run
+            for run in matrix["runs"]
+            if run["matrix_id"] in {"phase1_control_default_flux", "phase1_control_high_sensible"}
+        ]
+
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.0e-5),
+        },
+        mutate_matrix=mutate,
+    )
+
+    response = artifacts.summary["surface_flux_response"]
+    assert response["state"] == "surface_flux_response_inconclusive_missing_evidence"
+    assert response["missing_required_comparison_types"] == [
+        "moisture_flux_sensitivity",
+        "combined_flux_sensitivity",
+    ]
+    assert response["unavailable_evidence"] == [
+        "missing_phase1_required_comparison_type:moisture_flux_sensitivity",
+        "missing_phase1_required_comparison_type:combined_flux_sensitivity",
+    ]
+    assert artifacts.summary["phase_gate_state"] == (
+        "surface_flux_response_inconclusive_missing_evidence"
+    )
 
 
 def test_campaign_report_rejects_unchanged_emitted_flux_response(

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -17,6 +17,8 @@ from cloud_chamber.result_diagnostics import (
     RainDiagnostics,
     ReflectivityDiagnostics,
     ResultDiagnostics,
+    SurfaceFluxDiagnostics,
+    SurfaceFluxFieldDiagnostics,
     SurfaceRainDiagnostics,
     TimeDiagnostics,
     TimeValue,
@@ -675,10 +677,24 @@ def test_campaign_report_summarizes_ingested_result_without_fabricating_bl_respo
     assert summary["phase_gate_state"] == "forcing_wiring_verified_but_response_not_verified"
     run = summary["runs"][0]
     assert run["hfx_present"] is True
+    assert run["hfx_units"] == "K m/s"
+    assert run["hfx_min"] == 1.0
+    assert run["hfx_max"] == 3.0
+    assert run["hfx_mean"] == 2.0
+    assert run["hfx_finite_count"] == 8
+    assert run["hfx_non_finite_count"] == 0
+    assert run["hfx_total_count"] == 8
     assert run["qfx_present"] is True
     assert run["surface_moisture_flux_output_field"] == "qfx"
     assert run["qfx_units"] == "kg/m^2/s"
+    assert run["qfx_min"] == 1.0e-5
+    assert run["qfx_max"] == 3.0e-5
+    assert run["qfx_mean"] == 2.0e-5
+    assert run["qfx_finite_count"] == 8
+    assert run["qfx_non_finite_count"] == 0
+    assert run["qfx_total_count"] == 8
     assert run["lhfx_present"] is True
+    assert run["diagnostic_support"]["surface_fluxes"] == "available"
     assert run["low_level_qv_response"] == (
         "unavailable:low_level_response_diagnostic_not_implemented"
     )
@@ -981,6 +997,32 @@ def _write_fake_result_metadata(
                 units="dBZ",
                 available=True,
                 field_absent=False,
+            ),
+            surface_fluxes=SurfaceFluxDiagnostics(
+                hfx=SurfaceFluxFieldDiagnostics(
+                    source_field="hfx",
+                    available=True,
+                    field_absent=False,
+                    min_value=1.0,
+                    max_value=3.0,
+                    mean_value=2.0,
+                    units="K m/s",
+                    finite_count=8,
+                    non_finite_count=0,
+                    total_count=8,
+                ),
+                qfx=SurfaceFluxFieldDiagnostics(
+                    source_field="qfx",
+                    available=True,
+                    field_absent=False,
+                    min_value=1.0e-5,
+                    max_value=3.0e-5,
+                    mean_value=2.0e-5,
+                    units="kg/m^2/s",
+                    finite_count=8,
+                    non_finite_count=0,
+                    total_count=8,
+                ),
             ),
             time=TimeDiagnostics(source="time", fallback_used=False, coordinate_name="time"),
         ),

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -851,8 +851,11 @@ def test_time_series_products_cover_surface_rain_reflectivity_and_fluxes(
     assert surface_flux.field.canonical_field_name == "surface_sensible_heat_flux"
     assert surface_flux.values == pytest.approx([5.5, 17.5])
     assert surface_flux.field_quality is not None
-    assert surface_flux.field_quality.assessed is False
-    assert surface_flux.field_quality.reason == "field_quality_not_tracked_for_field"
+    assert surface_flux.field_quality.assessed is True
+    assert surface_flux.field_quality.source_field == "hfx"
+    assert surface_flux.field_quality.quality_state == "trusted"
+    assert surface_flux.field_quality.finite_count == 24
+    assert surface_flux.field_quality.non_finite_count == 0
     assert "native_grid_time_series_no_interpolation" in surface_flux.caveats
 
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -781,6 +781,25 @@ type FieldQuality = {
   caveats: string[];
 };
 
+type SurfaceFluxFieldDiagnostics = {
+  source_field: string;
+  available: boolean;
+  field_absent: boolean;
+  min_value?: number | null;
+  max_value?: number | null;
+  mean_value?: number | null;
+  units?: string | null;
+  finite_count: number;
+  non_finite_count: number;
+  total_count: number;
+  caveats: string[];
+};
+
+type SurfaceFluxDiagnostics = {
+  hfx: SurfaceFluxFieldDiagnostics;
+  qfx: SurfaceFluxFieldDiagnostics;
+};
+
 type InterestingTimeRecord = {
   key: string;
   label: string;
@@ -837,6 +856,7 @@ type ScienceSummary = {
   cm1_outcome?: string | null;
   field_quality_assessed?: boolean;
   field_quality?: Record<string, FieldQuality>;
+  surface_fluxes?: SurfaceFluxDiagnostics | null;
   diagnostic_availability?: ScienceDiagnosticAvailability[];
   interesting_time_caveats: string[];
   interesting_time_support_state: string;
@@ -920,6 +940,7 @@ type ResultCard = {
   surface_rain_units?: string | null;
   max_dbz?: number | null;
   reflectivity_available?: boolean | null;
+  surface_fluxes?: SurfaceFluxDiagnostics | null;
   field_quality_assessed?: boolean;
   field_quality?: Record<string, FieldQuality>;
   interesting_times?: InterestingTimeRecord[];

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -679,19 +679,26 @@ Current diagnostics compute:
 - max/min `w`, time of max/min `w`, and `w` max/min time series;
 - optional rain-water-aloft summary from `qr >= 1e-7 kg/kg`;
 - optional surface-rain summary from the CM1 `rain` field;
-- optional reflectivity summary from the CM1 `dbz` field.
+- optional reflectivity summary from the CM1 `dbz` field;
+- optional surface-flux summaries from CM1 `hfx` and `qfx`, including
+  min/max/mean, units, and finite/non-finite counts.
 
 Diagnostics preserve runtime warnings from the run manifest/result metadata. CM1
 floating-point exception flags are caveats, not automatic failure. The
 diagnostics also count non-finite values in target fields where practical,
 ignore NaN/infinity for finite summaries, and record field-specific caveats if
-`qc`, `w`, `qr`, surface `rain`, or `dbz` are missing or entirely non-finite.
+`qc`, `w`, `qr`, surface `rain`, `dbz`, `hfx`, or `qfx` are missing or entirely
+non-finite.
 Result metadata exposes `field_quality_assessed` plus a `field_quality` map for
 those fields with `trusted`, `caveated`, `untrusted`, or `unavailable` state and
 finite/non-finite counts. Missing assessment is not equivalent to trusted.
 Result cards, output products, campaign reports, and candidate comparisons must
 use explicit assessed quality state so missing, unassessed, or entirely
 non-finite fields are not presented as clean negative or positive outcomes.
+Surface-flux statistics preserve CM1 output units separately from the selected
+namelist controls. In particular, `qfx` evidence is reported as emitted CM1
+moisture-flux output and must not be equated to `cnst_lhflx` without a
+documented interpretation.
 
 This result metadata is not a Result Card UI and not visualization-ready data. It is the backend bridge that later result cards and inspectors can consume.
 

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -263,7 +263,7 @@ misleading cloud/rain-water landmark.
 
 Interesting-time records, field defaults, diagnostic availability records, and
 science summaries may carry target-field `field_quality` metadata for `qc`, `w`,
-`qr`, surface `rain`, and `dbz`. Entirely non-finite source fields are
+`qr`, surface `rain`, `dbz`, `hfx`, and `qfx`. Entirely non-finite source fields are
 `untrusted` and must not produce supported landmarks or clean comparison
 evidence. Partially non-finite fields may remain usable only with visible
 caveats and finite/non-finite counts.
@@ -457,10 +457,10 @@ time-series, native slice, and point-cloud payloads carry a `field_quality`
 object for the requested raw field when diagnostics can evaluate it. The object
 records whether quality was assessed, the source field, quality state, finite
 count, non-finite count, total count, reason, and quality caveats. Tracked fields
-use the current `qc`, `w`, `qr`, surface `rain`, and `dbz` diagnostic quality
-records. Untracked fields such as `qv`, `hfx`, or `qfx` must explicitly report
-that field quality is not tracked rather than implying trusted status. Older
-results or partial metadata with no assessment signal must report
+use the current `qc`, `w`, `qr`, surface `rain`, `dbz`, `hfx`, and `qfx`
+diagnostic quality records. Untracked fields such as `qv` must
+explicitly report that field quality is not tracked rather than implying trusted
+status. Older results or partial metadata with no assessment signal must report
 `assessed = false`; only an explicit assessed `trusted` field-quality record is
 trusted evidence.
 

--- a/docs/research/surface-forced-sounding-verification-protocol.md
+++ b/docs/research/surface-forced-sounding-verification-protocol.md
@@ -257,6 +257,10 @@ Phase 1 must be allowed to stop the campaign before expensive later phases. The 
 
 ```text
 forcing_wiring_not_verified
+surface_flux_response_verified
+surface_flux_response_not_verified
+surface_flux_response_inconclusive_missing_evidence
+surface_flux_response_inconclusive_noncomparable
 forcing_wiring_verified_but_response_not_verified
 forcing_path_verified_for_campaign
 inconclusive_missing_evidence
@@ -269,7 +273,10 @@ operator_override_continue
 - Missing CM1-facing `cnst_shflx` or `cnst_lhflx`: `forcing_wiring_not_verified`; block automatic continuation.
 - Missing `hfx` or `qfx` when requested: `inconclusive_missing_evidence`; block automatic continuation.
 - Missing standardized low-level response diagnostic: `inconclusive_missing_evidence`; block automatic continuation.
-- Emitted `hfx`/`qfx` values do not reflect the prescribed run-to-run forcing changes: `forcing_wiring_not_verified`; block automatic continuation.
+- Matched Phase 1 emitted `hfx`/`qfx` values are present, trusted, unit-comparable, and reflect the prescribed run-to-run forcing changes: `surface_flux_response_verified`; continue to low-level response checks.
+- Missing, untrusted, or not-ingested matched Phase 1 `hfx`/`qfx` statistics: `surface_flux_response_inconclusive_missing_evidence`; block automatic continuation.
+- Mismatched `hfx`/`qfx` units or structurally non-comparable Phase 1 runs: `surface_flux_response_inconclusive_noncomparable`; block automatic continuation.
+- Emitted `hfx`/`qfx` means do not move in the expected direction for the prescribed run-to-run forcing changes: `surface_flux_response_not_verified`; block automatic continuation.
 - Heat-only run does not show a directionally consistent theta/temperature response when the diagnostic is available: `forcing_wiring_verified_but_response_not_verified`; block automatic continuation by default.
 - Moisture-only run does not show a directionally consistent `qv` response when the diagnostic is available: `forcing_wiring_verified_but_response_not_verified`; block automatic continuation by default.
 

--- a/docs/research/surface-forced-sounding-verification-protocol.md
+++ b/docs/research/surface-forced-sounding-verification-protocol.md
@@ -76,6 +76,7 @@ selection_sets
 run_defaults
 forcing_sets
 comparison_types
+phase1_required_comparison_types
 runs
 required_summary_fields
 ```
@@ -90,6 +91,10 @@ required_summary_fields
 - Each `comparison_types[].comparison_type` must be unique.
 - Each `runs[].matrix_id` must be unique.
 - Each run must reference an existing `selection_id` and `forcing_id`.
+- `phase1_required_comparison_types` must name the Phase 1 comparison types
+  required before surface-flux response can be considered verified. For the
+  current protocol those are `heat_flux_sensitivity`,
+  `moisture_flux_sensitivity`, and `combined_flux_sensitivity`.
 - Use `matrix_id` as the canonical run-matrix identifier. Do not introduce `run_matrix_id` in the same schema.
 
 ### Source union
@@ -273,10 +278,11 @@ operator_override_continue
 - Missing CM1-facing `cnst_shflx` or `cnst_lhflx`: `forcing_wiring_not_verified`; block automatic continuation.
 - Missing `hfx` or `qfx` when requested: `inconclusive_missing_evidence`; block automatic continuation.
 - Missing standardized low-level response diagnostic: `inconclusive_missing_evidence`; block automatic continuation.
-- Matched Phase 1 emitted `hfx`/`qfx` values are present, trusted, unit-comparable, and reflect the prescribed run-to-run forcing changes: `surface_flux_response_verified`; continue to low-level response checks.
+- Matched Phase 1 emitted `hfx`/`qfx` values are present, trusted, unit-comparable, and every required Phase 1 comparison type is present: `surface_flux_response_verified`; continue to low-level response checks.
+- Missing one of the required `heat_flux_sensitivity`, `moisture_flux_sensitivity`, or `combined_flux_sensitivity` comparisons: `surface_flux_response_inconclusive_missing_evidence`; block automatic continuation.
 - Missing, untrusted, or not-ingested matched Phase 1 `hfx`/`qfx` statistics: `surface_flux_response_inconclusive_missing_evidence`; block automatic continuation.
 - Mismatched `hfx`/`qfx` units or structurally non-comparable Phase 1 runs: `surface_flux_response_inconclusive_noncomparable`; block automatic continuation.
-- Emitted `hfx`/`qfx` means do not move in the expected direction for the prescribed run-to-run forcing changes: `surface_flux_response_not_verified`; block automatic continuation.
+- Emitted means for intentionally varied fluxes do not move in the expected direction for the prescribed run-to-run forcing changes: `surface_flux_response_not_verified`; block automatic continuation. In the heat-only comparison, `hfx` increase is required and `qfx` change is informational. In the moisture-only comparison, `qfx` increase is required and `hfx` change is informational. In the combined comparison, both `hfx` and `qfx` increases are required.
 - Heat-only run does not show a directionally consistent theta/temperature response when the diagnostic is available: `forcing_wiring_verified_but_response_not_verified`; block automatic continuation by default.
 - Moisture-only run does not show a directionally consistent `qv` response when the diagnostic is available: `forcing_wiring_verified_but_response_not_verified`; block automatic continuation by default.
 

--- a/docs/research/surface-forced-sounding-verification-protocol.md
+++ b/docs/research/surface-forced-sounding-verification-protocol.md
@@ -555,9 +555,12 @@ The report should extract these from ingested metadata/output products when avai
 hfx_present
 hfx_units
 hfx_min / hfx_max / hfx_mean when derivable
-lhfx_present
-lhfx_units
-lhfx_min / lhfx_max / lhfx_mean when derivable
+hfx_finite_count / hfx_non_finite_count / hfx_total_count
+qfx_present
+qfx_units
+qfx_min / qfx_max / qfx_mean when derivable
+qfx_finite_count / qfx_non_finite_count / qfx_total_count
+surface_moisture_flux_output_field
 low_level_qv_response with method or unavailable reason
 low_level_qv_response_method
 low_level_theta_or_temperature_response with method or unavailable reason

--- a/docs/research/templates/surface-forced-campaign-matrix.example.yaml
+++ b/docs/research/templates/surface-forced-campaign-matrix.example.yaml
@@ -49,7 +49,7 @@ execution:
     minimum_to_continue_automatically:
       - selected_values_preserved
       - cm1_facing_values_preserved
-      - emitted_hfx_lhfx_reflect_prescribed_changes
+      - emitted_hfx_qfx_reflect_prescribed_changes
       - heat_only_theta_or_temperature_response_directionally_consistent
       - moisture_only_qv_response_directionally_consistent
   lifecycle_status_values:
@@ -536,11 +536,17 @@ required_summary_fields:
     - hfx_min
     - hfx_max
     - hfx_mean
-    - lhfx_present
-    - lhfx_units
-    - lhfx_min
-    - lhfx_max
-    - lhfx_mean
+    - hfx_finite_count
+    - hfx_non_finite_count
+    - hfx_total_count
+    - qfx_present
+    - qfx_units
+    - qfx_min
+    - qfx_max
+    - qfx_mean
+    - qfx_finite_count
+    - qfx_non_finite_count
+    - qfx_total_count
     - low_level_qv_response
     - low_level_qv_response_method
     - low_level_theta_or_temperature_response

--- a/docs/research/templates/surface-forced-campaign-matrix.example.yaml
+++ b/docs/research/templates/surface-forced-campaign-matrix.example.yaml
@@ -70,6 +70,11 @@ execution:
     - skipped
     - blocked
 
+phase1_required_comparison_types:
+  - heat_flux_sensitivity
+  - moisture_flux_sensitivity
+  - combined_flux_sensitivity
+
 selection_sets:
   - selection_id: control_sounding
     role: forcing_path_smoke_check

--- a/docs/research/templates/surface-forced-campaign-matrix.example.yaml
+++ b/docs/research/templates/surface-forced-campaign-matrix.example.yaml
@@ -44,6 +44,10 @@ execution:
     force_gate_states:
       verified: forcing_path_verified_for_campaign
       wiring_failed: forcing_wiring_not_verified
+      surface_flux_response_verified: surface_flux_response_verified
+      surface_flux_response_not_verified: surface_flux_response_not_verified
+      surface_flux_response_missing: surface_flux_response_inconclusive_missing_evidence
+      surface_flux_response_noncomparable: surface_flux_response_inconclusive_noncomparable
       wiring_only: forcing_wiring_verified_but_response_not_verified
       missing_evidence: inconclusive_missing_evidence
     minimum_to_continue_automatically:

--- a/docs/research/templates/surface-forced-campaign-report-template.md
+++ b/docs/research/templates/surface-forced-campaign-report-template.md
@@ -80,6 +80,7 @@ unavailable: low_level_response_diagnostic_not_implemented
 | selected values appear in CM1-facing namelist fields | `<pass/warn/fail/unavailable>` | `<cnst_shflx/cnst_lhflx>` | `<notes>` |
 | `hfx` emitted/ingested | `<pass/warn/fail/unavailable>` | `<field/units/min/max/mean/counts>` | Preserve output units separately from selected namelist controls. |
 | `qfx` emitted/ingested | `<pass/warn/fail/unavailable>` | `<field/units/min/max/mean/counts>` | Preserve output units separately from selected namelist controls; do not assume `qfx` equals `cnst_lhflx`. |
+| matched emitted surface-flux response | `<surface_flux_response_verified/not_verified/inconclusive>` | `<matched hfx/qfx means and units>` | Compare emitted `hfx` to emitted `hfx`, and emitted `qfx` to emitted `qfx`, across matched runs. |
 
 ### Atmospheric response checks
 

--- a/docs/research/templates/surface-forced-campaign-report-template.md
+++ b/docs/research/templates/surface-forced-campaign-report-template.md
@@ -78,8 +78,8 @@ unavailable: low_level_response_diagnostic_not_implemented
 | --- | --- | --- | --- |
 | selected forcing values preserved in package metadata | `<pass/warn/fail/unavailable>` | `<run ids / fields>` | `<notes>` |
 | selected values appear in CM1-facing namelist fields | `<pass/warn/fail/unavailable>` | `<cnst_shflx/cnst_lhflx>` | `<notes>` |
-| `hfx` emitted/ingested | `<pass/warn/fail/unavailable>` | `<field/units>` | Do not claim it reflects prescribed changes until hfx statistics exist. |
-| `qfx` emitted/ingested | `<pass/warn/fail/unavailable>` | `<field/units>` | Do not claim it reflects prescribed changes until qfx statistics exist. |
+| `hfx` emitted/ingested | `<pass/warn/fail/unavailable>` | `<field/units/min/max/mean/counts>` | Preserve output units separately from selected namelist controls. |
+| `qfx` emitted/ingested | `<pass/warn/fail/unavailable>` | `<field/units/min/max/mean/counts>` | Preserve output units separately from selected namelist controls; do not assume `qfx` equals `cnst_lhflx`. |
 
 ### Atmospheric response checks
 

--- a/docs/research/templates/surface-forced-campaign-report-template.md
+++ b/docs/research/templates/surface-forced-campaign-report-template.md
@@ -80,7 +80,7 @@ unavailable: low_level_response_diagnostic_not_implemented
 | selected values appear in CM1-facing namelist fields | `<pass/warn/fail/unavailable>` | `<cnst_shflx/cnst_lhflx>` | `<notes>` |
 | `hfx` emitted/ingested | `<pass/warn/fail/unavailable>` | `<field/units/min/max/mean/counts>` | Preserve output units separately from selected namelist controls. |
 | `qfx` emitted/ingested | `<pass/warn/fail/unavailable>` | `<field/units/min/max/mean/counts>` | Preserve output units separately from selected namelist controls; do not assume `qfx` equals `cnst_lhflx`. |
-| matched emitted surface-flux response | `<surface_flux_response_verified/not_verified/inconclusive>` | `<matched hfx/qfx means and units>` | Compare emitted `hfx` to emitted `hfx`, and emitted `qfx` to emitted `qfx`, across matched runs. |
+| matched emitted surface-flux response | `<surface_flux_response_verified/not_verified/inconclusive>` | `<required comparison types; matched hfx/qfx means and units>` | Require heat-only, moisture-only, and combined comparisons. Compare emitted `hfx` to emitted `hfx`, and emitted `qfx` to emitted `qfx`; non-varied flux changes are informational unless a protocol-specific tolerance makes them required. |
 
 ### Atmospheric response checks
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -198,6 +198,11 @@ surface-flux statistics: present fields preserve units and min/max/mean/counts,
 missing fields become explicit unavailable quality states, partially non-finite
 fields become caveated, entirely non-finite fields become untrusted/unavailable,
 and product payloads carry field quality for the requested flux field.
+Surface-forced campaign tests should verify that matched Phase 1 runs compare
+emitted `hfx` against emitted `hfx` and emitted `qfx` against emitted `qfx`;
+expected directional changes must pass before the automatic phase gate can move
+past surface-flux response verification, while unchanged, reversed, missing,
+untrusted, mismatched-unit, or structurally non-comparable cases remain blocked.
 
 Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
 They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, `.dat/.ctl` and NetCDF output artifacts are cataloged separately in the manifest, stderr floating-point flags are surfaced as runtime warnings, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -200,9 +200,13 @@ fields become caveated, entirely non-finite fields become untrusted/unavailable,
 and product payloads carry field quality for the requested flux field.
 Surface-forced campaign tests should verify that matched Phase 1 runs compare
 emitted `hfx` against emitted `hfx` and emitted `qfx` against emitted `qfx`;
-expected directional changes must pass before the automatic phase gate can move
-past surface-flux response verification, while unchanged, reversed, missing,
-untrusted, mismatched-unit, or structurally non-comparable cases remain blocked.
+the heat-only, moisture-only, and combined comparison types must all be present;
+and expected directional changes for intentionally varied fluxes must pass
+before the automatic phase gate can move past surface-flux response
+verification. Non-varied flux changes remain informational unless the protocol
+defines field-specific stability tolerances. Unchanged, reversed, incomplete,
+missing, untrusted, mismatched-unit, or structurally non-comparable cases remain
+blocked.
 
 Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
 They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, `.dat/.ctl` and NetCDF output artifacts are cataloged separately in the manifest, stderr floating-point flags are surfaced as runtime warnings, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -193,6 +193,11 @@ file/time mapping, and browser/UI tests should never parse raw NetCDF. The
 output product manifest tests should cover single-file, multi-time,
 multi-file, stats-exclusion, inferred-time, duplicate/non-monotonic-time, and
 missing/corrupt-file cases using temp runtime homes only.
+Result-diagnostic and output-product tests should also cover `hfx` and `qfx`
+surface-flux statistics: present fields preserve units and min/max/mean/counts,
+missing fields become explicit unavailable quality states, partially non-finite
+fields become caveated, entirely non-finite fields become untrusted/unavailable,
+and product payloads carry field quality for the requested flux field.
 
 Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
 They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, `.dat/.ctl` and NetCDF output artifacts are cataloged separately in the manifest, stderr floating-point flags are surfaced as runtime warnings, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.


### PR DESCRIPTION
## Summary
- compute backend-owned hfx/qfx surface-flux min/max/mean, units, finite/non-finite counts, and trust state during result diagnostics
- merge surface-flux stats across multi-file ingests and expose them through result cards, science summaries, and field-product quality metadata
- feed campaign summaries/reports with actual hfx/qfx stats while preserving qfx output units separately from selected cnst_lhflx controls
- verify matched Phase 1 emitted surface-flux response against the explicit required comparison set: heat_flux_sensitivity, moisture_flux_sensitivity, and combined_flux_sensitivity
- require the intentionally varied emitted flux to move in the expected direction; keep the non-varied flux change informational instead of treating near-identical output as a hard gate
- return explicit surface-flux response states for verified, not verified, missing/untrusted evidence, missing required comparison coverage, and non-comparable runs/units
- update output-product, architecture, testing, and surface-forced campaign docs/templates for the new diagnostic and campaign-gate contract

Closes #324

## Verification
- app/backend/.venv/bin/python -m pytest app/backend/tests/test_surface_forced_campaign.py
- scripts/check.sh
- scripts/check-e2e.sh

## Notes
- I did not rewrite the historical surface_forced_tall_001 campaign report; its unavailable surface-flux-stat lines remain a true snapshot of the diagnostics available when that report was generated.
- Auto-merge is not enabled because this is science-facing diagnostic trust work.
