### PR TITLE
Implement low-level qv/theta response diagnostics

### DIFF
--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -1207,7 +1207,7 @@ def _diagnostic_availability(
             key="near_surface_theta_perturbation_proxy",
             label="Near-surface theta perturbation",
             source_field="th",
-            field_present=bool({"th", "theta", "theta_v"} & variables),
+            field_present=bool({"th", "theta"} & variables),
             implemented=False,
             field_quality=None,
         ),
@@ -1230,7 +1230,7 @@ def _diagnostic_availability(
             diagnostics=low_level_response.theta_or_temperature
             if low_level_response is not None
             else None,
-            field_present=bool({"th", "theta", "theta_v", "temperature", "t"} & variables),
+            field_present=bool({"th", "theta", "temperature", "t"} & variables),
         ),
     ]
 
@@ -1249,7 +1249,7 @@ def _low_level_response_availability_record(
             label=label,
             source_field=diagnostics.source_field or source_field,
             support_state="supported",
-            value=diagnostics.delta_value,
+            value=diagnostics.early_response_delta,
             units=diagnostics.units,
             caveats=diagnostics.caveats,
         )

--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -19,6 +19,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.result_diagnostics import (
     FieldQuality,
+    LowLevelResponseDiagnostics,
+    LowLevelResponseFieldDiagnostics,
     ResultDiagnostics,
     SurfaceFluxDiagnostics,
     TimeValue,
@@ -176,6 +178,9 @@ class ScienceSummary(BaseModel):
     default_explore_time_seconds: float | None = None
     cm1_outcome: str | None = None
     surface_fluxes: SurfaceFluxDiagnostics = Field(default_factory=SurfaceFluxDiagnostics)
+    low_level_response: LowLevelResponseDiagnostics = Field(
+        default_factory=LowLevelResponseDiagnostics
+    )
     field_quality_assessed: bool = False
     field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
     diagnostic_availability: list[ScienceDiagnosticAvailability] = Field(default_factory=list)
@@ -1034,6 +1039,7 @@ def _science_summary(
         default_explore_time_seconds=default_source.time_seconds if default_source else None,
         cm1_outcome=None,
         surface_fluxes=diagnostics.surface_fluxes,
+        low_level_response=diagnostics.low_level_response,
         field_quality_assessed=diagnostics.field_quality_assessed,
         field_quality=diagnostics.field_quality if diagnostics.field_quality_assessed else {},
         diagnostic_availability=_diagnostic_availability(variables, diagnostics),
@@ -1163,6 +1169,7 @@ def _diagnostic_availability(
 ) -> list[ScienceDiagnosticAvailability]:
     reflectivity_supported = bool(diagnostics and diagnostics.reflectivity.available)
     surface_rain_supported = bool(diagnostics and diagnostics.surface_rain.available)
+    low_level_response = diagnostics.low_level_response if diagnostics is not None else None
     return [
         _availability_record(
             key="max_dbz_or_reflectivity_proxy",
@@ -1204,7 +1211,71 @@ def _diagnostic_availability(
             implemented=False,
             field_quality=None,
         ),
+        _low_level_response_availability_record(
+            key="low_level_qv_response",
+            label="Low-level qv response",
+            source_field="qv",
+            diagnostics=low_level_response.qv if low_level_response is not None else None,
+            field_present="qv" in variables,
+        ),
+        _low_level_response_availability_record(
+            key="low_level_theta_or_temperature_response",
+            label="Low-level theta/temperature response",
+            source_field=(
+                low_level_response.theta_or_temperature.source_field
+                if low_level_response is not None
+                and low_level_response.theta_or_temperature.source_field is not None
+                else "th"
+            ),
+            diagnostics=low_level_response.theta_or_temperature
+            if low_level_response is not None
+            else None,
+            field_present=bool({"th", "theta", "theta_v", "temperature", "t"} & variables),
+        ),
     ]
+
+
+def _low_level_response_availability_record(
+    *,
+    key: str,
+    label: str,
+    source_field: str,
+    diagnostics: LowLevelResponseFieldDiagnostics | None,
+    field_present: bool,
+) -> ScienceDiagnosticAvailability:
+    if diagnostics is not None and diagnostics.available:
+        return ScienceDiagnosticAvailability(
+            key=key,
+            label=label,
+            source_field=diagnostics.source_field or source_field,
+            support_state="supported",
+            value=diagnostics.delta_value,
+            units=diagnostics.units,
+            caveats=diagnostics.caveats,
+        )
+    if not field_present or (diagnostics is not None and diagnostics.field_absent):
+        caveat = (
+            diagnostics.caveats[0]
+            if diagnostics is not None and diagnostics.caveats
+            else f"missing_{source_field}_field"
+        )
+        return ScienceDiagnosticAvailability(
+            key=key,
+            label=label,
+            source_field=source_field,
+            support_state="unsupported_missing_fields",
+            caveats=[caveat],
+        )
+    return ScienceDiagnosticAvailability(
+        key=key,
+        label=label,
+        source_field=diagnostics.source_field if diagnostics is not None else source_field,
+        support_state="unavailable",
+        units=diagnostics.units if diagnostics is not None else None,
+        caveats=diagnostics.caveats
+        if diagnostics is not None and diagnostics.caveats
+        else [f"{key}_unavailable"],
+    )
 
 
 def _availability_record(

--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -1243,7 +1243,7 @@ def _low_level_response_availability_record(
     diagnostics: LowLevelResponseFieldDiagnostics | None,
     field_present: bool,
 ) -> ScienceDiagnosticAvailability:
-    if diagnostics is not None and diagnostics.available:
+    if diagnostics is not None and diagnostics.early_response_available:
         return ScienceDiagnosticAvailability(
             key=key,
             label=label,

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -15,6 +15,15 @@ HYDROMETEOR_CLOUD_TOP_FIELDS = ("qr", "qi", "qs", "qg")
 
 TIME_DIMENSION_CANDIDATES = ("time", "mtime", "t")
 VERTICAL_COORDINATE_CANDIDATES = ("z", "zh", "height", "height_m")
+LOW_LEVEL_RESPONSE_LAYER_BOTTOM_M = 0.0
+LOW_LEVEL_RESPONSE_LAYER_TOP_M = 1000.0
+LOW_LEVEL_THERMODYNAMIC_FIELD_CANDIDATES = (
+    "th",
+    "theta",
+    "theta_v",
+    "temperature",
+    "t",
+)
 THERMAL_FATE_CONFIDENCE_VALUES = (
     "supported",
     "candidate",
@@ -153,6 +162,46 @@ class SurfaceFluxDiagnostics(BaseModel):
     )
 
 
+class LowLevelResponseFieldDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_field: str | None = None
+    available: bool = False
+    field_absent: bool = True
+    layer_bottom_m: float = LOW_LEVEL_RESPONSE_LAYER_BOTTOM_M
+    layer_top_m: float = LOW_LEVEL_RESPONSE_LAYER_TOP_M
+    vertical_coordinate_name: str | None = None
+    vertical_coordinate_units: str | None = None
+    vertical_coordinate_method: str | None = None
+    time_dimension: str | None = None
+    first_time_index: int | None = None
+    final_time_index: int | None = None
+    first_time_seconds: float | None = None
+    final_time_seconds: float | None = None
+    first_mean_value: float | None = None
+    final_mean_value: float | None = None
+    delta_value: float | None = None
+    units: str | None = None
+    first_finite_count: int = 0
+    first_non_finite_count: int = 0
+    first_total_count: int = 0
+    final_finite_count: int = 0
+    final_non_finite_count: int = 0
+    final_total_count: int = 0
+    caveats: list[str] = Field(default_factory=list)
+
+
+class LowLevelResponseDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    qv: LowLevelResponseFieldDiagnostics = Field(
+        default_factory=lambda: LowLevelResponseFieldDiagnostics(source_field="qv")
+    )
+    theta_or_temperature: LowLevelResponseFieldDiagnostics = Field(
+        default_factory=LowLevelResponseFieldDiagnostics
+    )
+
+
 class ResultDiagnostics(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -162,6 +211,9 @@ class ResultDiagnostics(BaseModel):
     surface_rain: SurfaceRainDiagnostics = Field(default_factory=SurfaceRainDiagnostics)
     reflectivity: ReflectivityDiagnostics = Field(default_factory=ReflectivityDiagnostics)
     surface_fluxes: SurfaceFluxDiagnostics = Field(default_factory=SurfaceFluxDiagnostics)
+    low_level_response: LowLevelResponseDiagnostics = Field(
+        default_factory=LowLevelResponseDiagnostics
+    )
     time: TimeDiagnostics
     field_quality_assessed: bool = False
     field_quality: dict[str, FieldQuality] = Field(default_factory=dict)
@@ -394,6 +446,7 @@ def compute_baseline_diagnostics(dataset: Any, inherited_caveats: list[str]) -> 
     surface_rain = _surface_rain_diagnostics(dataset, time_context, caveats)
     reflectivity = _reflectivity_diagnostics(dataset, time_context, caveats)
     surface_fluxes = _surface_flux_diagnostics(dataset, caveats)
+    low_level_response = _low_level_response_diagnostics(dataset, time_context, caveats)
     field_quality = _field_quality_map(dataset)
     return ResultDiagnostics(
         cloud=cloud,
@@ -402,6 +455,7 @@ def compute_baseline_diagnostics(dataset: Any, inherited_caveats: list[str]) -> 
         surface_rain=surface_rain,
         reflectivity=reflectivity,
         surface_fluxes=surface_fluxes,
+        low_level_response=low_level_response,
         time=time_context.diagnostics,
         field_quality_assessed=True,
         field_quality=field_quality,
@@ -819,6 +873,236 @@ def _surface_flux_field_diagnostics(
         finite_count=finite_count,
         non_finite_count=non_finite_count,
         total_count=total_count,
+        caveats=_dedupe(field_caveats),
+    )
+
+
+def _low_level_response_diagnostics(
+    dataset: Any,
+    time: _TimeContext,
+    caveats: list[str],
+) -> LowLevelResponseDiagnostics:
+    return LowLevelResponseDiagnostics(
+        qv=_low_level_response_field_diagnostics(
+            dataset,
+            source_field="qv",
+            time=time,
+            caveats=caveats,
+        ),
+        theta_or_temperature=_low_level_response_field_diagnostics(
+            dataset,
+            source_field=_first_present(
+                LOW_LEVEL_THERMODYNAMIC_FIELD_CANDIDATES, list(dataset.data_vars)
+            ),
+            time=time,
+            caveats=caveats,
+            missing_reason="theta_or_temperature_field_absent",
+        ),
+    )
+
+
+def _low_level_response_field_diagnostics(
+    dataset: Any,
+    *,
+    source_field: str | None,
+    time: _TimeContext,
+    caveats: list[str],
+    missing_reason: str | None = None,
+) -> LowLevelResponseFieldDiagnostics:
+    if source_field is None or source_field not in dataset.data_vars:
+        reason = missing_reason or f"{source_field or 'unknown'}_field_absent"
+        return LowLevelResponseFieldDiagnostics(
+            source_field=source_field,
+            field_absent=True,
+            caveats=[reason],
+        )
+
+    data_array = dataset[source_field]
+    units = _attr_string(data_array, "units")
+    field_caveats: list[str] = []
+    vertical_name = _first_present(VERTICAL_COORDINATE_CANDIDATES, list(data_array.dims))
+    if vertical_name is None:
+        reason = f"{source_field}_low_level_response_missing_vertical_dimension"
+        caveats.append(reason)
+        return LowLevelResponseFieldDiagnostics(
+            source_field=source_field,
+            field_absent=False,
+            units=units,
+            caveats=[reason],
+        )
+    if vertical_name not in data_array.coords:
+        reason = f"{source_field}_low_level_response_missing_vertical_coordinate"
+        caveats.append(reason)
+        return LowLevelResponseFieldDiagnostics(
+            source_field=source_field,
+            field_absent=False,
+            vertical_coordinate_name=vertical_name,
+            units=units,
+            caveats=[reason],
+        )
+    vertical_coord = data_array.coords[vertical_name]
+    vertical_units = _attr_string(vertical_coord, "units")
+    normalized_units = _normalized_height_units(vertical_units)
+    if normalized_units is None:
+        reason = f"{source_field}_low_level_response_vertical_units_not_supported:{vertical_units}"
+        caveats.append(reason)
+        return LowLevelResponseFieldDiagnostics(
+            source_field=source_field,
+            field_absent=False,
+            vertical_coordinate_name=vertical_name,
+            vertical_coordinate_units=vertical_units,
+            units=units,
+            caveats=[reason],
+        )
+    if vertical_units is None:
+        field_caveats.append(
+            f"{source_field}_low_level_response_vertical_units_missing_assumed_meters"
+        )
+
+    vertical_values = [
+        _height_in_meters(_to_float_or_none(value), vertical_units)
+        for value in vertical_coord.values.tolist()
+    ]
+    low_level_indices = [
+        index
+        for index, value in enumerate(vertical_values)
+        if value is not None
+        and LOW_LEVEL_RESPONSE_LAYER_BOTTOM_M <= value <= LOW_LEVEL_RESPONSE_LAYER_TOP_M
+    ]
+    if not low_level_indices:
+        reason = f"{source_field}_low_level_response_no_levels_in_0_1_km"
+        caveats.append(reason)
+        return LowLevelResponseFieldDiagnostics(
+            source_field=source_field,
+            field_absent=False,
+            vertical_coordinate_name=vertical_name,
+            vertical_coordinate_units=vertical_units,
+            vertical_coordinate_method="coordinate_values_0_1_km_agl",
+            units=units,
+            caveats=_dedupe([*field_caveats, reason]),
+        )
+    if time.dimension is None or time.dimension not in data_array.dims:
+        reason = f"{source_field}_low_level_response_requires_time_dimension"
+        caveats.append(reason)
+        return LowLevelResponseFieldDiagnostics(
+            source_field=source_field,
+            field_absent=False,
+            vertical_coordinate_name=vertical_name,
+            vertical_coordinate_units=vertical_units,
+            vertical_coordinate_method="coordinate_values_0_1_km_agl",
+            units=units,
+            caveats=_dedupe([*field_caveats, reason]),
+        )
+    time_size = int(data_array.sizes[time.dimension])
+    if time_size < 2:
+        reason = f"{source_field}_low_level_response_requires_at_least_two_time_steps"
+        caveats.append(reason)
+        time_index = 0 if time_size else None
+        layer = (
+            data_array.isel({time.dimension: 0, vertical_name: low_level_indices})
+            if time_size
+            else None
+        )
+        layer_mean = _finite_mean(layer) if layer is not None else None
+        finite_count = _finite_count(layer) if layer is not None else 0
+        non_finite_count = _non_finite_count(layer) if layer is not None else 0
+        total_count = _total_count(layer) if layer is not None else 0
+        return LowLevelResponseFieldDiagnostics(
+            source_field=source_field,
+            field_absent=False,
+            vertical_coordinate_name=vertical_name,
+            vertical_coordinate_units=vertical_units,
+            vertical_coordinate_method="coordinate_values_0_1_km_agl",
+            time_dimension=time.dimension,
+            first_time_index=time_index,
+            final_time_index=time_index,
+            first_time_seconds=time.at(0) if time_size else None,
+            final_time_seconds=time.at(time_size - 1) if time_size else None,
+            first_mean_value=layer_mean,
+            final_mean_value=layer_mean,
+            units=units,
+            first_finite_count=finite_count,
+            first_non_finite_count=non_finite_count,
+            first_total_count=total_count,
+            final_finite_count=finite_count,
+            final_non_finite_count=non_finite_count,
+            final_total_count=total_count,
+            caveats=_dedupe([*field_caveats, reason]),
+        )
+
+    first_time_index = 0
+    final_time_index = time_size - 1
+    first_layer = data_array.isel(
+        {
+            time.dimension: first_time_index,
+            vertical_name: low_level_indices,
+        }
+    )
+    final_layer = data_array.isel(
+        {
+            time.dimension: final_time_index,
+            vertical_name: low_level_indices,
+        }
+    )
+    first_finite_count = _finite_count(first_layer)
+    final_finite_count = _finite_count(final_layer)
+    first_non_finite_count = _non_finite_count(first_layer)
+    final_non_finite_count = _non_finite_count(final_layer)
+    if first_non_finite_count > 0 or final_non_finite_count > 0:
+        field_caveat = f"non_finite_values_detected_in_{source_field}_low_level_response"
+        field_caveats.append(field_caveat)
+        caveats.append(field_caveat)
+    if first_finite_count == 0 or final_finite_count == 0:
+        reason = f"{source_field}_low_level_response_endpoint_entirely_non_finite"
+        field_caveats.append(reason)
+        caveats.append(reason)
+        return LowLevelResponseFieldDiagnostics(
+            source_field=source_field,
+            field_absent=False,
+            vertical_coordinate_name=vertical_name,
+            vertical_coordinate_units=vertical_units,
+            vertical_coordinate_method="coordinate_values_0_1_km_agl",
+            time_dimension=time.dimension,
+            first_time_index=first_time_index,
+            final_time_index=final_time_index,
+            first_time_seconds=time.at(first_time_index),
+            final_time_seconds=time.at(final_time_index),
+            units=units,
+            first_finite_count=first_finite_count,
+            first_non_finite_count=first_non_finite_count,
+            first_total_count=_total_count(first_layer),
+            final_finite_count=final_finite_count,
+            final_non_finite_count=final_non_finite_count,
+            final_total_count=_total_count(final_layer),
+            caveats=_dedupe(field_caveats),
+        )
+
+    first_mean = _finite_mean(first_layer)
+    final_mean = _finite_mean(final_layer)
+    return LowLevelResponseFieldDiagnostics(
+        source_field=source_field,
+        available=True,
+        field_absent=False,
+        vertical_coordinate_name=vertical_name,
+        vertical_coordinate_units=vertical_units,
+        vertical_coordinate_method="coordinate_values_0_1_km_agl",
+        time_dimension=time.dimension,
+        first_time_index=first_time_index,
+        final_time_index=final_time_index,
+        first_time_seconds=time.at(first_time_index),
+        final_time_seconds=time.at(final_time_index),
+        first_mean_value=first_mean,
+        final_mean_value=final_mean,
+        delta_value=(final_mean - first_mean)
+        if first_mean is not None and final_mean is not None
+        else None,
+        units=units,
+        first_finite_count=first_finite_count,
+        first_non_finite_count=first_non_finite_count,
+        first_total_count=_total_count(first_layer),
+        final_finite_count=final_finite_count,
+        final_non_finite_count=final_non_finite_count,
+        final_total_count=_total_count(final_layer),
         caveats=_dedupe(field_caveats),
     )
 

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import isfinite
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -17,10 +17,13 @@ TIME_DIMENSION_CANDIDATES = ("time", "mtime", "t")
 VERTICAL_COORDINATE_CANDIDATES = ("z", "zh", "height", "height_m")
 LOW_LEVEL_RESPONSE_LAYER_BOTTOM_M = 0.0
 LOW_LEVEL_RESPONSE_LAYER_TOP_M = 1000.0
+LOW_LEVEL_RESPONSE_EARLY_TARGET_SECONDS = 3600.0
+LOW_LEVEL_RESPONSE_EARLY_MIN_SECONDS = 1800.0
+LOW_LEVEL_RESPONSE_EARLY_MAX_SECONDS = 5400.0
+LOW_LEVEL_RESPONSE_METHOD = "0_1km_thickness_weighted_domain_mean_early_30_90min"
 LOW_LEVEL_THERMODYNAMIC_FIELD_CANDIDATES = (
     "th",
     "theta",
-    "theta_v",
     "temperature",
     "t",
 )
@@ -32,6 +35,13 @@ THERMAL_FATE_CONFIDENCE_VALUES = (
 )
 
 FieldQualityState = Literal["trusted", "caveated", "untrusted", "unavailable"]
+
+
+class _LowLevelLayerStats(TypedDict):
+    mean: float | None
+    finite_count: int
+    non_finite_count: int
+    total_count: int
 
 
 class FieldQuality(BaseModel):
@@ -181,6 +191,20 @@ class LowLevelResponseFieldDiagnostics(BaseModel):
     first_mean_value: float | None = None
     final_mean_value: float | None = None
     delta_value: float | None = None
+    early_response_start_time_index: int | None = None
+    early_response_end_time_index: int | None = None
+    early_response_start_time_seconds: float | None = None
+    early_response_end_time_seconds: float | None = None
+    early_response_start_mean_value: float | None = None
+    early_response_end_mean_value: float | None = None
+    early_response_delta: float | None = None
+    early_response_start_finite_count: int = 0
+    early_response_start_non_finite_count: int = 0
+    early_response_start_total_count: int = 0
+    early_response_end_finite_count: int = 0
+    early_response_end_non_finite_count: int = 0
+    early_response_end_total_count: int = 0
+    full_run_delta: float | None = None
     units: str | None = None
     first_finite_count: int = 0
     first_non_finite_count: int = 0
@@ -963,13 +987,8 @@ def _low_level_response_field_diagnostics(
         _height_in_meters(_to_float_or_none(value), vertical_units)
         for value in vertical_coord.values.tolist()
     ]
-    low_level_indices = [
-        index
-        for index, value in enumerate(vertical_values)
-        if value is not None
-        and LOW_LEVEL_RESPONSE_LAYER_BOTTOM_M <= value <= LOW_LEVEL_RESPONSE_LAYER_TOP_M
-    ]
-    if not low_level_indices:
+    weighted_levels = _low_level_weighted_levels(vertical_values)
+    if not weighted_levels:
         reason = f"{source_field}_low_level_response_no_levels_in_0_1_km"
         caveats.append(reason)
         return LowLevelResponseFieldDiagnostics(
@@ -977,7 +996,7 @@ def _low_level_response_field_diagnostics(
             field_absent=False,
             vertical_coordinate_name=vertical_name,
             vertical_coordinate_units=vertical_units,
-            vertical_coordinate_method="coordinate_values_0_1_km_agl",
+            vertical_coordinate_method=LOW_LEVEL_RESPONSE_METHOD,
             units=units,
             caveats=_dedupe([*field_caveats, reason]),
         )
@@ -989,7 +1008,7 @@ def _low_level_response_field_diagnostics(
             field_absent=False,
             vertical_coordinate_name=vertical_name,
             vertical_coordinate_units=vertical_units,
-            vertical_coordinate_method="coordinate_values_0_1_km_agl",
+            vertical_coordinate_method=LOW_LEVEL_RESPONSE_METHOD,
             units=units,
             caveats=_dedupe([*field_caveats, reason]),
         )
@@ -998,61 +1017,73 @@ def _low_level_response_field_diagnostics(
         reason = f"{source_field}_low_level_response_requires_at_least_two_time_steps"
         caveats.append(reason)
         time_index = 0 if time_size else None
-        layer = (
-            data_array.isel({time.dimension: 0, vertical_name: low_level_indices})
+        layer_stats = (
+            _low_level_layer_stats(
+                data_array.isel({time.dimension: 0}),
+                vertical_name=vertical_name,
+                weighted_levels=weighted_levels,
+            )
             if time_size
-            else None
+            else _empty_low_level_layer_stats()
         )
-        layer_mean = _finite_mean(layer) if layer is not None else None
-        finite_count = _finite_count(layer) if layer is not None else 0
-        non_finite_count = _non_finite_count(layer) if layer is not None else 0
-        total_count = _total_count(layer) if layer is not None else 0
         return LowLevelResponseFieldDiagnostics(
             source_field=source_field,
             field_absent=False,
             vertical_coordinate_name=vertical_name,
             vertical_coordinate_units=vertical_units,
-            vertical_coordinate_method="coordinate_values_0_1_km_agl",
+            vertical_coordinate_method=LOW_LEVEL_RESPONSE_METHOD,
             time_dimension=time.dimension,
             first_time_index=time_index,
             final_time_index=time_index,
             first_time_seconds=time.at(0) if time_size else None,
             final_time_seconds=time.at(time_size - 1) if time_size else None,
-            first_mean_value=layer_mean,
-            final_mean_value=layer_mean,
+            first_mean_value=layer_stats["mean"],
+            final_mean_value=layer_stats["mean"],
             units=units,
-            first_finite_count=finite_count,
-            first_non_finite_count=non_finite_count,
-            first_total_count=total_count,
-            final_finite_count=finite_count,
-            final_non_finite_count=non_finite_count,
-            final_total_count=total_count,
+            first_finite_count=layer_stats["finite_count"],
+            first_non_finite_count=layer_stats["non_finite_count"],
+            first_total_count=layer_stats["total_count"],
+            final_finite_count=layer_stats["finite_count"],
+            final_non_finite_count=layer_stats["non_finite_count"],
+            final_total_count=layer_stats["total_count"],
             caveats=_dedupe([*field_caveats, reason]),
         )
 
     first_time_index = 0
     final_time_index = time_size - 1
-    first_layer = data_array.isel(
-        {
-            time.dimension: first_time_index,
-            vertical_name: low_level_indices,
-        }
+    early_time_index = _low_level_early_response_end_index(time, time_size)
+    first_stats = _low_level_layer_stats(
+        data_array.isel({time.dimension: first_time_index}),
+        vertical_name=vertical_name,
+        weighted_levels=weighted_levels,
     )
-    final_layer = data_array.isel(
-        {
-            time.dimension: final_time_index,
-            vertical_name: low_level_indices,
-        }
+    final_stats = _low_level_layer_stats(
+        data_array.isel({time.dimension: final_time_index}),
+        vertical_name=vertical_name,
+        weighted_levels=weighted_levels,
     )
-    first_finite_count = _finite_count(first_layer)
-    final_finite_count = _finite_count(final_layer)
-    first_non_finite_count = _non_finite_count(first_layer)
-    final_non_finite_count = _non_finite_count(final_layer)
-    if first_non_finite_count > 0 or final_non_finite_count > 0:
+    early_stats = (
+        _low_level_layer_stats(
+            data_array.isel({time.dimension: early_time_index}),
+            vertical_name=vertical_name,
+            weighted_levels=weighted_levels,
+        )
+        if early_time_index is not None
+        else None
+    )
+    if (
+        first_stats["non_finite_count"] > 0
+        or final_stats["non_finite_count"] > 0
+        or (early_stats is not None and early_stats["non_finite_count"] > 0)
+    ):
         field_caveat = f"non_finite_values_detected_in_{source_field}_low_level_response"
         field_caveats.append(field_caveat)
         caveats.append(field_caveat)
-    if first_finite_count == 0 or final_finite_count == 0:
+    if (
+        first_stats["finite_count"] == 0
+        or final_stats["finite_count"] == 0
+        or (early_stats is not None and early_stats["finite_count"] == 0)
+    ):
         reason = f"{source_field}_low_level_response_endpoint_entirely_non_finite"
         field_caveats.append(reason)
         caveats.append(reason)
@@ -1061,31 +1092,45 @@ def _low_level_response_field_diagnostics(
             field_absent=False,
             vertical_coordinate_name=vertical_name,
             vertical_coordinate_units=vertical_units,
-            vertical_coordinate_method="coordinate_values_0_1_km_agl",
+            vertical_coordinate_method=LOW_LEVEL_RESPONSE_METHOD,
             time_dimension=time.dimension,
             first_time_index=first_time_index,
             final_time_index=final_time_index,
             first_time_seconds=time.at(first_time_index),
             final_time_seconds=time.at(final_time_index),
             units=units,
-            first_finite_count=first_finite_count,
-            first_non_finite_count=first_non_finite_count,
-            first_total_count=_total_count(first_layer),
-            final_finite_count=final_finite_count,
-            final_non_finite_count=final_non_finite_count,
-            final_total_count=_total_count(final_layer),
+            first_finite_count=first_stats["finite_count"],
+            first_non_finite_count=first_stats["non_finite_count"],
+            first_total_count=first_stats["total_count"],
+            final_finite_count=final_stats["finite_count"],
+            final_non_finite_count=final_stats["non_finite_count"],
+            final_total_count=final_stats["total_count"],
             caveats=_dedupe(field_caveats),
         )
 
-    first_mean = _finite_mean(first_layer)
-    final_mean = _finite_mean(final_layer)
+    if early_time_index is None:
+        reason = f"{source_field}_low_level_response_missing_early_output_30_90min"
+        field_caveats.append(reason)
+        caveats.append(reason)
+
+    first_mean = first_stats["mean"]
+    final_mean = final_stats["mean"]
+    early_mean = early_stats["mean"] if early_stats is not None else None
+    early_delta = (
+        early_mean - first_mean
+        if early_mean is not None and first_mean is not None and early_time_index is not None
+        else None
+    )
+    full_run_delta = (
+        final_mean - first_mean if first_mean is not None and final_mean is not None else None
+    )
     return LowLevelResponseFieldDiagnostics(
         source_field=source_field,
-        available=True,
+        available=early_delta is not None and full_run_delta is not None,
         field_absent=False,
         vertical_coordinate_name=vertical_name,
         vertical_coordinate_units=vertical_units,
-        vertical_coordinate_method="coordinate_values_0_1_km_agl",
+        vertical_coordinate_method=LOW_LEVEL_RESPONSE_METHOD,
         time_dimension=time.dimension,
         first_time_index=first_time_index,
         final_time_index=final_time_index,
@@ -1093,18 +1138,139 @@ def _low_level_response_field_diagnostics(
         final_time_seconds=time.at(final_time_index),
         first_mean_value=first_mean,
         final_mean_value=final_mean,
-        delta_value=(final_mean - first_mean)
-        if first_mean is not None and final_mean is not None
-        else None,
+        delta_value=early_delta,
+        early_response_start_time_index=first_time_index if early_delta is not None else None,
+        early_response_end_time_index=early_time_index if early_delta is not None else None,
+        early_response_start_time_seconds=(
+            time.at(first_time_index) if early_delta is not None else None
+        ),
+        early_response_end_time_seconds=(
+            time.at(early_time_index)
+            if early_delta is not None and early_time_index is not None
+            else None
+        ),
+        early_response_start_mean_value=first_mean if early_delta is not None else None,
+        early_response_end_mean_value=early_mean if early_delta is not None else None,
+        early_response_delta=early_delta,
+        early_response_start_finite_count=(
+            first_stats["finite_count"] if early_delta is not None else 0
+        ),
+        early_response_start_non_finite_count=(
+            first_stats["non_finite_count"] if early_delta is not None else 0
+        ),
+        early_response_start_total_count=(
+            first_stats["total_count"] if early_delta is not None else 0
+        ),
+        early_response_end_finite_count=(
+            early_stats["finite_count"]
+            if early_stats is not None and early_delta is not None
+            else 0
+        ),
+        early_response_end_non_finite_count=(
+            early_stats["non_finite_count"]
+            if early_stats is not None and early_delta is not None
+            else 0
+        ),
+        early_response_end_total_count=(
+            early_stats["total_count"] if early_stats is not None and early_delta is not None else 0
+        ),
+        full_run_delta=full_run_delta,
         units=units,
-        first_finite_count=first_finite_count,
-        first_non_finite_count=first_non_finite_count,
-        first_total_count=_total_count(first_layer),
-        final_finite_count=final_finite_count,
-        final_non_finite_count=final_non_finite_count,
-        final_total_count=_total_count(final_layer),
+        first_finite_count=first_stats["finite_count"],
+        first_non_finite_count=first_stats["non_finite_count"],
+        first_total_count=first_stats["total_count"],
+        final_finite_count=final_stats["finite_count"],
+        final_non_finite_count=final_stats["non_finite_count"],
+        final_total_count=final_stats["total_count"],
         caveats=_dedupe(field_caveats),
     )
+
+
+def _low_level_weighted_levels(
+    vertical_values: list[float | None],
+) -> list[tuple[int, float]]:
+    valid_levels = sorted(
+        (index, value) for index, value in enumerate(vertical_values) if value is not None
+    )
+    if not valid_levels:
+        return []
+    if len(valid_levels) == 1:
+        index, value = valid_levels[0]
+        if LOW_LEVEL_RESPONSE_LAYER_BOTTOM_M <= value <= LOW_LEVEL_RESPONSE_LAYER_TOP_M:
+            return [(index, LOW_LEVEL_RESPONSE_LAYER_TOP_M - LOW_LEVEL_RESPONSE_LAYER_BOTTOM_M)]
+        return []
+
+    weighted: list[tuple[int, float]] = []
+    for position, (index, value) in enumerate(valid_levels):
+        if position == 0:
+            next_value = valid_levels[position + 1][1]
+            lower = value - (next_value - value) / 2.0
+        else:
+            previous_value = valid_levels[position - 1][1]
+            lower = (previous_value + value) / 2.0
+        if position == len(valid_levels) - 1:
+            previous_value = valid_levels[position - 1][1]
+            upper = value + (value - previous_value) / 2.0
+        else:
+            next_value = valid_levels[position + 1][1]
+            upper = (value + next_value) / 2.0
+        clipped_lower = max(lower, LOW_LEVEL_RESPONSE_LAYER_BOTTOM_M)
+        clipped_upper = min(upper, LOW_LEVEL_RESPONSE_LAYER_TOP_M)
+        thickness = clipped_upper - clipped_lower
+        if thickness > 0:
+            weighted.append((index, thickness))
+    return weighted
+
+
+def _low_level_early_response_end_index(time: _TimeContext, time_size: int) -> int | None:
+    start_time = time.at(0)
+    if start_time is None:
+        return None
+    candidates: list[tuple[float, int]] = []
+    for index in range(1, time_size):
+        end_time = time.at(index)
+        if end_time is None:
+            continue
+        elapsed = end_time - start_time
+        if LOW_LEVEL_RESPONSE_EARLY_MIN_SECONDS <= elapsed <= LOW_LEVEL_RESPONSE_EARLY_MAX_SECONDS:
+            candidates.append((abs(elapsed - LOW_LEVEL_RESPONSE_EARLY_TARGET_SECONDS), index))
+    if not candidates:
+        return None
+    return min(candidates)[1]
+
+
+def _empty_low_level_layer_stats() -> _LowLevelLayerStats:
+    return {"mean": None, "finite_count": 0, "non_finite_count": 0, "total_count": 0}
+
+
+def _low_level_layer_stats(
+    data_array: Any,
+    *,
+    vertical_name: str,
+    weighted_levels: list[tuple[int, float]],
+) -> _LowLevelLayerStats:
+    weighted_sum = 0.0
+    total_weight = 0.0
+    finite_count = 0
+    non_finite_count = 0
+    total_count = 0
+    for vertical_index, thickness_m in weighted_levels:
+        layer = data_array.isel({vertical_name: vertical_index})
+        for value in layer.values.reshape(-1).tolist():
+            total_count += 1
+            parsed = _to_float_or_none(value)
+            if parsed is None or not isfinite(parsed):
+                non_finite_count += 1
+                continue
+            finite_count += 1
+            weighted_sum += parsed * thickness_m
+            total_weight += thickness_m
+    return {
+        "mean": weighted_sum / total_weight if total_weight else None,
+        "finite_count": finite_count,
+        "non_finite_count": non_finite_count,
+        "total_count": total_count,
+    }
 
 
 def _cloud_extent_array(dataset: Any, qc: Any, caveats: list[str]) -> Any:

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -177,6 +177,8 @@ class LowLevelResponseFieldDiagnostics(BaseModel):
 
     source_field: str | None = None
     available: bool = False
+    early_response_available: bool = False
+    full_run_response_available: bool = False
     field_absent: bool = True
     layer_bottom_m: float = LOW_LEVEL_RESPONSE_LAYER_BOTTOM_M
     layer_top_m: float = LOW_LEVEL_RESPONSE_LAYER_TOP_M
@@ -1079,14 +1081,22 @@ def _low_level_response_field_diagnostics(
         field_caveat = f"non_finite_values_detected_in_{source_field}_low_level_response"
         field_caveats.append(field_caveat)
         caveats.append(field_caveat)
-    if (
-        first_stats["finite_count"] == 0
-        or final_stats["finite_count"] == 0
-        or (early_stats is not None and early_stats["finite_count"] == 0)
-    ):
-        reason = f"{source_field}_low_level_response_endpoint_entirely_non_finite"
-        field_caveats.append(reason)
-        caveats.append(reason)
+
+    first_mean = first_stats["mean"]
+    final_mean = final_stats["mean"]
+    early_mean = early_stats["mean"] if early_stats is not None else None
+    first_endpoint_available = first_stats["finite_count"] > 0 and first_mean is not None
+    early_endpoint_available = (
+        early_stats is not None and early_stats["finite_count"] > 0 and early_mean is not None
+    )
+    final_endpoint_available = final_stats["finite_count"] > 0 and final_mean is not None
+
+    if not first_endpoint_available:
+        reason = f"{source_field}_low_level_response_start_endpoint_entirely_non_finite"
+        field_caveats.extend(
+            [reason, f"{source_field}_low_level_response_endpoint_entirely_non_finite"]
+        )
+        caveats.extend([reason, f"{source_field}_low_level_response_endpoint_entirely_non_finite"])
         return LowLevelResponseFieldDiagnostics(
             source_field=source_field,
             field_absent=False,
@@ -1112,21 +1122,40 @@ def _low_level_response_field_diagnostics(
         reason = f"{source_field}_low_level_response_missing_early_output_30_90min"
         field_caveats.append(reason)
         caveats.append(reason)
+    elif not early_endpoint_available:
+        reason = f"{source_field}_low_level_response_early_endpoint_entirely_non_finite"
+        field_caveats.append(reason)
+        caveats.append(reason)
+    if not final_endpoint_available:
+        reason = f"{source_field}_low_level_response_final_endpoint_entirely_non_finite"
+        field_caveats.append(reason)
+        caveats.append(reason)
 
-    first_mean = first_stats["mean"]
-    final_mean = final_stats["mean"]
-    early_mean = early_stats["mean"] if early_stats is not None else None
     early_delta = (
         early_mean - first_mean
-        if early_mean is not None and first_mean is not None and early_time_index is not None
+        if early_endpoint_available
+        and early_mean is not None
+        and first_mean is not None
+        and early_time_index is not None
         else None
     )
-    full_run_delta = (
-        final_mean - first_mean if first_mean is not None and final_mean is not None else None
+    full_run_has_distinct_endpoint = (
+        final_time_index != early_time_index
+        if early_time_index is not None
+        else final_time_index != 0
     )
+    full_run_delta = (
+        final_mean - first_mean
+        if final_endpoint_available and first_mean is not None and final_mean is not None
+        else None
+    )
+    early_response_available = early_delta is not None
+    full_run_response_available = full_run_delta is not None and full_run_has_distinct_endpoint
     return LowLevelResponseFieldDiagnostics(
         source_field=source_field,
-        available=early_delta is not None and full_run_delta is not None,
+        available=early_response_available,
+        early_response_available=early_response_available,
+        full_run_response_available=full_run_response_available,
         field_absent=False,
         vertical_coordinate_name=vertical_name,
         vertical_coordinate_units=vertical_units,
@@ -1174,7 +1203,7 @@ def _low_level_response_field_diagnostics(
         early_response_end_total_count=(
             early_stats["total_count"] if early_stats is not None and early_delta is not None else 0
         ),
-        full_run_delta=full_run_delta,
+        full_run_delta=full_run_delta if full_run_response_available else None,
         units=units,
         first_finite_count=first_stats["finite_count"],
         first_non_finite_count=first_stats["non_finite_count"],

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -859,14 +859,15 @@ def _merge_low_level_response_field_diagnostics(
 ) -> LowLevelResponseFieldDiagnostics:
     if not parts:
         return LowLevelResponseFieldDiagnostics(source_field=fallback_source_field)
-    available_parts = [part for part in parts if part.available]
-    endpoint_parts = [
+    available_parts = [part for part in parts if part.early_response_available or part.available]
+    time_parts = sorted(
+        [part for part in parts if part.first_time_seconds is not None],
+        key=_low_level_response_endpoint_sort_key,
+    )
+    finite_point_parts = [
         part
-        for part in parts
-        if part.first_mean_value is not None
-        and part.final_mean_value is not None
-        and part.first_finite_count > 0
-        and part.final_finite_count > 0
+        for part in time_parts
+        if part.first_mean_value is not None and part.first_finite_count > 0
     ]
     source_field = next(
         (part.source_field for part in parts if part.source_field is not None),
@@ -887,19 +888,21 @@ def _merge_low_level_response_field_diagnostics(
         None,
     )
     time_dimension = next((part.time_dimension for part in parts if part.time_dimension), None)
-    if not available_parts and len(endpoint_parts) >= 2 and source_field:
+    if not available_parts and len(finite_point_parts) >= 2 and source_field:
         caveats = [
             caveat
             for caveat in caveats
             if caveat != f"{source_field}_low_level_response_requires_at_least_two_time_steps"
         ]
-    if available_parts and len(endpoint_parts) < 2:
+    if available_parts and len(finite_point_parts) < 2:
         part = available_parts[0]
         return part.model_copy(update={"caveats": caveats})
-    if not available_parts and len(endpoint_parts) < 2:
+    if not available_parts and len(finite_point_parts) < 2:
         return LowLevelResponseFieldDiagnostics(
             source_field=source_field,
             available=False,
+            early_response_available=False,
+            full_run_response_available=False,
             field_absent=all(part.field_absent for part in parts),
             vertical_coordinate_name=vertical_coordinate_name,
             vertical_coordinate_units=vertical_coordinate_units,
@@ -915,11 +918,11 @@ def _merge_low_level_response_field_diagnostics(
             caveats=caveats,
         )
 
-    endpoint_source = sorted(endpoint_parts, key=_low_level_response_endpoint_sort_key)
+    endpoint_source = finite_point_parts
     first = endpoint_source[0]
-    final = endpoint_source[-1]
+    final = time_parts[-1] if time_parts else endpoint_source[-1]
     first_mean = first.first_mean_value
-    final_mean = final.final_mean_value
+    final_mean = final.first_mean_value
     early_end = _low_level_response_early_endpoint(endpoint_source, first.first_time_seconds)
     early_mean = early_end.first_mean_value if early_end is not None else None
     early_delta = (
@@ -927,25 +930,41 @@ def _merge_low_level_response_field_diagnostics(
         if early_mean is not None and first_mean is not None and early_end is not None
         else None
     )
+    final_endpoint_available = final_mean is not None and final.first_finite_count > 0
+    full_run_has_distinct_endpoint = (
+        final.first_time_seconds != early_end.first_time_seconds
+        if early_end is not None
+        else final.first_time_seconds != first.first_time_seconds
+    )
     full_run_delta = (
-        final_mean - first_mean if first_mean is not None and final_mean is not None else None
+        final_mean - first_mean
+        if final_endpoint_available and first_mean is not None and final_mean is not None
+        else None
     )
     if early_end is None and source_field:
         caveats = _dedupe_strings(
             [*caveats, f"{source_field}_low_level_response_missing_early_output_30_90min"]
         )
+    if not final_endpoint_available and source_field:
+        caveats = _dedupe_strings(
+            [*caveats, f"{source_field}_low_level_response_final_endpoint_entirely_non_finite"]
+        )
+    early_response_available = early_delta is not None
+    full_run_response_available = full_run_delta is not None and full_run_has_distinct_endpoint
     return LowLevelResponseFieldDiagnostics(
         source_field=source_field,
-        available=early_delta is not None and full_run_delta is not None,
+        available=early_response_available,
+        early_response_available=early_response_available,
+        full_run_response_available=full_run_response_available,
         field_absent=False,
         vertical_coordinate_name=vertical_coordinate_name,
         vertical_coordinate_units=vertical_coordinate_units,
         vertical_coordinate_method=vertical_coordinate_method,
         time_dimension=time_dimension,
         first_time_index=first.first_time_index,
-        final_time_index=final.final_time_index,
+        final_time_index=final.first_time_index,
         first_time_seconds=first.first_time_seconds,
-        final_time_seconds=final.final_time_seconds,
+        final_time_seconds=final.first_time_seconds,
         first_mean_value=first_mean,
         final_mean_value=final_mean,
         delta_value=early_delta,
@@ -980,14 +999,14 @@ def _merge_low_level_response_field_diagnostics(
         early_response_end_total_count=early_end.first_total_count
         if early_end is not None and early_delta is not None
         else 0,
-        full_run_delta=full_run_delta,
+        full_run_delta=full_run_delta if full_run_response_available else None,
         units=units,
         first_finite_count=first.first_finite_count,
         first_non_finite_count=first.first_non_finite_count,
         first_total_count=first.first_total_count,
-        final_finite_count=final.final_finite_count,
-        final_non_finite_count=final.final_non_finite_count,
-        final_total_count=final.final_total_count,
+        final_finite_count=final.first_finite_count,
+        final_non_finite_count=final.first_non_finite_count,
+        final_total_count=final.first_total_count,
         caveats=caveats,
     )
 

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -23,6 +23,8 @@ from cloud_chamber.output_products import (
 from cloud_chamber.result_diagnostics import (
     CloudDiagnostics,
     FieldQuality,
+    LowLevelResponseDiagnostics,
+    LowLevelResponseFieldDiagnostics,
     ProcessDiagnostics,
     RainDiagnostics,
     ReflectivityDiagnostics,
@@ -559,6 +561,9 @@ def _merge_diagnostics(
     surface_fluxes = _merge_surface_flux_diagnostics(
         [diagnostics.surface_fluxes for diagnostics in diagnostics_parts]
     )
+    low_level_response = _merge_low_level_response_diagnostics(
+        [diagnostics.low_level_response for diagnostics in diagnostics_parts]
+    )
     field_quality = _merge_field_quality_maps(diagnostics_parts)
     field_quality_assessed = any(
         diagnostics.field_quality_assessed for diagnostics in diagnostics_parts
@@ -569,6 +574,19 @@ def _merge_diagnostics(
             *(caveat for diagnostics in diagnostics_parts for caveat in diagnostics.caveats),
         ]
     )
+    if low_level_response.qv.available:
+        caveats = [
+            caveat
+            for caveat in caveats
+            if caveat != "qv_low_level_response_requires_at_least_two_time_steps"
+        ]
+    thermal_source = low_level_response.theta_or_temperature.source_field
+    if low_level_response.theta_or_temperature.available and thermal_source:
+        caveats = [
+            caveat
+            for caveat in caveats
+            if caveat != f"{thermal_source}_low_level_response_requires_at_least_two_time_steps"
+        ]
     return ResultDiagnostics(
         cloud=cloud,
         vertical_velocity=vertical,
@@ -576,6 +594,7 @@ def _merge_diagnostics(
         surface_rain=surface_rain,
         reflectivity=reflectivity,
         surface_fluxes=surface_fluxes,
+        low_level_response=low_level_response,
         time=time,
         field_quality_assessed=field_quality_assessed,
         field_quality=field_quality,
@@ -812,6 +831,113 @@ def _merge_surface_flux_field_diagnostics(
         finite_count=finite_count,
         non_finite_count=non_finite_count,
         total_count=total_count,
+        caveats=caveats,
+    )
+
+
+def _merge_low_level_response_diagnostics(
+    parts: list[LowLevelResponseDiagnostics],
+) -> LowLevelResponseDiagnostics:
+    return LowLevelResponseDiagnostics(
+        qv=_merge_low_level_response_field_diagnostics(
+            "qv",
+            [part.qv for part in parts],
+        ),
+        theta_or_temperature=_merge_low_level_response_field_diagnostics(
+            None,
+            [part.theta_or_temperature for part in parts],
+        ),
+    )
+
+
+def _merge_low_level_response_field_diagnostics(
+    fallback_source_field: str | None,
+    parts: list[LowLevelResponseFieldDiagnostics],
+) -> LowLevelResponseFieldDiagnostics:
+    if not parts:
+        return LowLevelResponseFieldDiagnostics(source_field=fallback_source_field)
+    available_parts = [part for part in parts if part.available]
+    endpoint_parts = [
+        part
+        for part in parts
+        if part.first_mean_value is not None
+        and part.final_mean_value is not None
+        and part.first_finite_count > 0
+        and part.final_finite_count > 0
+    ]
+    source_field = next(
+        (part.source_field for part in parts if part.source_field is not None),
+        fallback_source_field,
+    )
+    units = next((part.units for part in parts if part.units is not None), None)
+    caveats = _dedupe_strings([caveat for part in parts for caveat in part.caveats])
+    vertical_coordinate_name = next(
+        (part.vertical_coordinate_name for part in parts if part.vertical_coordinate_name),
+        None,
+    )
+    vertical_coordinate_units = next(
+        (part.vertical_coordinate_units for part in parts if part.vertical_coordinate_units),
+        None,
+    )
+    vertical_coordinate_method = next(
+        (part.vertical_coordinate_method for part in parts if part.vertical_coordinate_method),
+        None,
+    )
+    time_dimension = next((part.time_dimension for part in parts if part.time_dimension), None)
+    if not available_parts and len(endpoint_parts) >= 2 and source_field:
+        caveats = [
+            caveat
+            for caveat in caveats
+            if caveat != f"{source_field}_low_level_response_requires_at_least_two_time_steps"
+        ]
+    if not available_parts and len(endpoint_parts) < 2:
+        return LowLevelResponseFieldDiagnostics(
+            source_field=source_field,
+            available=False,
+            field_absent=all(part.field_absent for part in parts),
+            vertical_coordinate_name=vertical_coordinate_name,
+            vertical_coordinate_units=vertical_coordinate_units,
+            vertical_coordinate_method=vertical_coordinate_method,
+            time_dimension=time_dimension,
+            units=units,
+            first_finite_count=sum(part.first_finite_count for part in parts),
+            first_non_finite_count=sum(part.first_non_finite_count for part in parts),
+            first_total_count=sum(part.first_total_count for part in parts),
+            final_finite_count=sum(part.final_finite_count for part in parts),
+            final_non_finite_count=sum(part.final_non_finite_count for part in parts),
+            final_total_count=sum(part.final_total_count for part in parts),
+            caveats=caveats,
+        )
+
+    endpoint_source = available_parts or endpoint_parts
+    first = endpoint_source[0]
+    final = endpoint_source[-1]
+    first_mean = first.first_mean_value
+    final_mean = final.final_mean_value
+    return LowLevelResponseFieldDiagnostics(
+        source_field=source_field,
+        available=True,
+        field_absent=False,
+        vertical_coordinate_name=vertical_coordinate_name,
+        vertical_coordinate_units=vertical_coordinate_units,
+        vertical_coordinate_method=vertical_coordinate_method,
+        time_dimension=time_dimension,
+        first_time_index=first.first_time_index,
+        final_time_index=final.final_time_index,
+        first_time_seconds=first.first_time_seconds,
+        final_time_seconds=final.final_time_seconds,
+        first_mean_value=first_mean,
+        final_mean_value=final_mean,
+        delta_value=(final_mean - first_mean)
+        if first_mean is not None and final_mean is not None
+        else None,
+        units=units,
+        first_finite_count=first.first_finite_count,
+        first_non_finite_count=first.first_non_finite_count,
+        first_total_count=first.first_total_count,
+        final_finite_count=final.final_finite_count,
+        final_non_finite_count=final.final_non_finite_count,
+        final_total_count=final.final_total_count,
         caveats=caveats,
     )
 

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -21,6 +21,9 @@ from cloud_chamber.output_products import (
     write_output_product_manifest,
 )
 from cloud_chamber.result_diagnostics import (
+    LOW_LEVEL_RESPONSE_EARLY_MAX_SECONDS,
+    LOW_LEVEL_RESPONSE_EARLY_MIN_SECONDS,
+    LOW_LEVEL_RESPONSE_EARLY_TARGET_SECONDS,
     CloudDiagnostics,
     FieldQuality,
     LowLevelResponseDiagnostics,
@@ -890,6 +893,9 @@ def _merge_low_level_response_field_diagnostics(
             for caveat in caveats
             if caveat != f"{source_field}_low_level_response_requires_at_least_two_time_steps"
         ]
+    if available_parts and len(endpoint_parts) < 2:
+        part = available_parts[0]
+        return part.model_copy(update={"caveats": caveats})
     if not available_parts and len(endpoint_parts) < 2:
         return LowLevelResponseFieldDiagnostics(
             source_field=source_field,
@@ -909,14 +915,28 @@ def _merge_low_level_response_field_diagnostics(
             caveats=caveats,
         )
 
-    endpoint_source = available_parts or endpoint_parts
+    endpoint_source = sorted(endpoint_parts, key=_low_level_response_endpoint_sort_key)
     first = endpoint_source[0]
     final = endpoint_source[-1]
     first_mean = first.first_mean_value
     final_mean = final.final_mean_value
+    early_end = _low_level_response_early_endpoint(endpoint_source, first.first_time_seconds)
+    early_mean = early_end.first_mean_value if early_end is not None else None
+    early_delta = (
+        early_mean - first_mean
+        if early_mean is not None and first_mean is not None and early_end is not None
+        else None
+    )
+    full_run_delta = (
+        final_mean - first_mean if first_mean is not None and final_mean is not None else None
+    )
+    if early_end is None and source_field:
+        caveats = _dedupe_strings(
+            [*caveats, f"{source_field}_low_level_response_missing_early_output_30_90min"]
+        )
     return LowLevelResponseFieldDiagnostics(
         source_field=source_field,
-        available=True,
+        available=early_delta is not None and full_run_delta is not None,
         field_absent=False,
         vertical_coordinate_name=vertical_coordinate_name,
         vertical_coordinate_units=vertical_coordinate_units,
@@ -928,9 +948,39 @@ def _merge_low_level_response_field_diagnostics(
         final_time_seconds=final.final_time_seconds,
         first_mean_value=first_mean,
         final_mean_value=final_mean,
-        delta_value=(final_mean - first_mean)
-        if first_mean is not None and final_mean is not None
+        delta_value=early_delta,
+        early_response_start_time_index=first.first_time_index if early_delta is not None else None,
+        early_response_end_time_index=early_end.first_time_index
+        if early_end is not None and early_delta is not None
         else None,
+        early_response_start_time_seconds=(
+            first.first_time_seconds if early_delta is not None else None
+        ),
+        early_response_end_time_seconds=(
+            early_end.first_time_seconds
+            if early_end is not None and early_delta is not None
+            else None
+        ),
+        early_response_start_mean_value=first_mean if early_delta is not None else None,
+        early_response_end_mean_value=early_mean if early_delta is not None else None,
+        early_response_delta=early_delta,
+        early_response_start_finite_count=first.first_finite_count
+        if early_delta is not None
+        else 0,
+        early_response_start_non_finite_count=first.first_non_finite_count
+        if early_delta is not None
+        else 0,
+        early_response_start_total_count=first.first_total_count if early_delta is not None else 0,
+        early_response_end_finite_count=early_end.first_finite_count
+        if early_end is not None and early_delta is not None
+        else 0,
+        early_response_end_non_finite_count=early_end.first_non_finite_count
+        if early_end is not None and early_delta is not None
+        else 0,
+        early_response_end_total_count=early_end.first_total_count
+        if early_end is not None and early_delta is not None
+        else 0,
+        full_run_delta=full_run_delta,
         units=units,
         first_finite_count=first.first_finite_count,
         first_non_finite_count=first.first_non_finite_count,
@@ -940,6 +990,30 @@ def _merge_low_level_response_field_diagnostics(
         final_total_count=final.final_total_count,
         caveats=caveats,
     )
+
+
+def _low_level_response_endpoint_sort_key(
+    part: LowLevelResponseFieldDiagnostics,
+) -> float:
+    return part.first_time_seconds if part.first_time_seconds is not None else float("inf")
+
+
+def _low_level_response_early_endpoint(
+    parts: list[LowLevelResponseFieldDiagnostics],
+    start_time: float | None,
+) -> LowLevelResponseFieldDiagnostics | None:
+    if start_time is None:
+        return None
+    candidates: list[tuple[float, LowLevelResponseFieldDiagnostics]] = []
+    for part in parts[1:]:
+        if part.first_time_seconds is None:
+            continue
+        elapsed = part.first_time_seconds - start_time
+        if LOW_LEVEL_RESPONSE_EARLY_MIN_SECONDS <= elapsed <= LOW_LEVEL_RESPONSE_EARLY_MAX_SECONDS:
+            candidates.append((abs(elapsed - LOW_LEVEL_RESPONSE_EARLY_TARGET_SECONDS), part))
+    if not candidates:
+        return None
+    return min(candidates, key=lambda item: item[0])[1]
 
 
 FIELD_QUALITY_MERGE_ORDER = ("qc", "w", "qr", "surface_rain", "dbz", "hfx", "qfx")

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -38,6 +38,7 @@ from cloud_chamber.observed_sounding import (
 )
 from cloud_chamber.result_diagnostics import (
     FieldQuality,
+    LowLevelResponseFieldDiagnostics,
     SurfaceFluxDiagnostics,
     SurfaceFluxFieldDiagnostics,
 )
@@ -687,7 +688,8 @@ def queue_campaign(
     queue_factory = local_queue_factory or _default_local_queue
     summaries = [_summary_for_plan_run(run, state) for run in plan.runs]
     surface_flux_response = _surface_flux_response_evaluation(plan, summaries)
-    gate_state = _phase_gate_state(summaries, surface_flux_response)
+    low_level_response = _low_level_response_evaluation(plan, summaries)
+    gate_state = _phase_gate_state(summaries, surface_flux_response, low_level_response)
     override = _gate_override_payload(
         enabled=override_phase_gate,
         reason=override_reason,
@@ -1011,6 +1013,7 @@ def report_campaign(
     summaries = [_summary_for_plan_run(run, state) for run in plan.runs]
     comparisons = _evaluate_comparisons(plan, summaries)
     surface_flux_response = _surface_flux_response_evaluation(plan, summaries)
+    low_level_response = _low_level_response_evaluation(plan, summaries)
     summary = {
         "schema_version": CAMPAIGN_SUMMARY_SCHEMA_VERSION,
         "campaign_id": plan.campaign_id,
@@ -1021,14 +1024,23 @@ def report_campaign(
         "generated_at": _now().isoformat(),
         "run_count": len(summaries),
         "status_counts": _status_counts(summaries),
-        "phase_gate_state": _phase_gate_state(summaries, surface_flux_response),
+        "phase_gate_state": _phase_gate_state(
+            summaries,
+            surface_flux_response,
+            low_level_response,
+        ),
         "surface_flux_response": surface_flux_response,
+        "low_level_response": low_level_response,
         "gate_overrides": _gate_overrides(summaries),
         "runs": summaries,
         "comparisons": comparisons,
         "unavailable_diagnostics": _unavailable_diagnostics(summaries),
         "preliminary_diagnosis_categories": _preliminary_diagnosis_categories(summaries),
-        "recommended_follow_ups": _recommended_follow_ups(summaries, surface_flux_response),
+        "recommended_follow_ups": _recommended_follow_ups(
+            summaries,
+            surface_flux_response,
+            low_level_response,
+        ),
     }
 
     markdown_path = report_path or _default_report_path(plan)
@@ -1844,6 +1856,7 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
     surface_rain = diagnostics.surface_rain if diagnostics is not None else None
     reflectivity = diagnostics.reflectivity if diagnostics is not None else None
     surface_fluxes = diagnostics.surface_fluxes if diagnostics is not None else None
+    low_level_response = diagnostics.low_level_response if diagnostics is not None else None
     hfx_stats = _surface_flux_summary_values(
         surface_fluxes.hfx if surface_fluxes is not None else None,
         source_field="hfx",
@@ -1853,6 +1866,22 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         surface_fluxes.qfx if surface_fluxes is not None else None,
         source_field="qfx",
         fallback_units=_field_units(result, "qfx"),
+    )
+    low_level_qv = _low_level_response_summary_values(
+        low_level_response.qv if low_level_response is not None else None,
+        fallback_source_field="qv",
+        fallback_units=_field_units(result, "qv"),
+    )
+    low_level_thermal = _low_level_response_summary_values(
+        low_level_response.theta_or_temperature if low_level_response is not None else None,
+        fallback_source_field=_first_available_field(
+            result,
+            ["th", "theta", "theta_v", "temperature", "t"],
+        ),
+        fallback_units=_field_units(
+            result,
+            _first_available_field(result, ["th", "theta", "theta_v", "temperature", "t"]),
+        ),
     )
     deep_cloud_formed = (
         science.deep_cloud_formed if science is not None else "unavailable:not_ingested"
@@ -2037,14 +2066,34 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "lhfx_min": qfx_stats["min"],
         "lhfx_max": qfx_stats["max"],
         "lhfx_mean": qfx_stats["mean"],
-        "low_level_qv_response": ("unavailable:low_level_response_diagnostic_not_implemented"),
-        "low_level_qv_response_method": "low_level_response_diagnostic_not_implemented",
-        "low_level_theta_or_temperature_response": (
-            "unavailable:low_level_response_diagnostic_not_implemented"
-        ),
-        "low_level_theta_or_temperature_response_method": (
-            "low_level_response_diagnostic_not_implemented"
-        ),
+        "low_level_qv_response": low_level_qv["delta"],
+        "low_level_qv_response_method": low_level_qv["method"],
+        "low_level_qv_response_source_field": low_level_qv["source_field"],
+        "low_level_qv_response_units": low_level_qv["units"],
+        "low_level_qv_response_first_mean": low_level_qv["first_mean"],
+        "low_level_qv_response_final_mean": low_level_qv["final_mean"],
+        "low_level_qv_response_first_time_seconds": low_level_qv["first_time_seconds"],
+        "low_level_qv_response_final_time_seconds": low_level_qv["final_time_seconds"],
+        "low_level_qv_response_first_finite_count": low_level_qv["first_finite_count"],
+        "low_level_qv_response_final_finite_count": low_level_qv["final_finite_count"],
+        "low_level_theta_or_temperature_response": low_level_thermal["delta"],
+        "low_level_theta_or_temperature_response_method": low_level_thermal["method"],
+        "low_level_theta_or_temperature_response_source_field": low_level_thermal["source_field"],
+        "low_level_theta_or_temperature_response_units": low_level_thermal["units"],
+        "low_level_theta_or_temperature_response_first_mean": low_level_thermal["first_mean"],
+        "low_level_theta_or_temperature_response_final_mean": low_level_thermal["final_mean"],
+        "low_level_theta_or_temperature_response_first_time_seconds": low_level_thermal[
+            "first_time_seconds"
+        ],
+        "low_level_theta_or_temperature_response_final_time_seconds": low_level_thermal[
+            "final_time_seconds"
+        ],
+        "low_level_theta_or_temperature_response_first_finite_count": low_level_thermal[
+            "first_finite_count"
+        ],
+        "low_level_theta_or_temperature_response_final_finite_count": low_level_thermal[
+            "final_finite_count"
+        ],
         "first_cloud_time": first_cloud_time,
         "max_cloud_top_m": max_cloud_top_m,
         "max_cloud_top_time": max_cloud_top_time,
@@ -2093,7 +2142,7 @@ def _diagnostic_support(result: ResultMetadata | None) -> dict[str, str]:
     variables = set(result.variables)
     return {
         "surface_fluxes": _surface_flux_support(diagnostics.surface_fluxes, variables),
-        "low_level_response": "unavailable:low_level_response_diagnostic_not_implemented",
+        "low_level_response": _low_level_response_support(diagnostics.low_level_response),
         "cloud": "available" if diagnostics.cloud.available else "missing",
         "vertical_velocity": "available" if diagnostics.vertical_velocity.available else "missing",
         "rain_water_aloft": "available" if diagnostics.rain.available else "missing",
@@ -2112,6 +2161,21 @@ def _surface_flux_support(
     if field_presence:
         return "unavailable:surface_flux_statistics_unavailable"
     return "missing"
+
+
+def _low_level_response_support(response: Any) -> str:
+    qv = response.qv
+    thermal = response.theta_or_temperature
+    if qv.available and thermal.available:
+        return "available"
+    if qv.field_absent or thermal.field_absent:
+        return "missing"
+    reasons = [
+        _low_level_response_unavailable_reason(field)
+        for field in (qv, thermal)
+        if not field.available
+    ]
+    return "unavailable:" + ",".join(_dedupe([reason for reason in reasons if reason]))
 
 
 def _field_units(result: ResultMetadata | None, field_name: str | None) -> str | None:
@@ -2162,6 +2226,72 @@ def _surface_flux_summary_values(
         "non_finite_count": diagnostics.non_finite_count,
         "total_count": diagnostics.total_count,
     }
+
+
+def _low_level_response_summary_values(
+    diagnostics: LowLevelResponseFieldDiagnostics | None,
+    *,
+    fallback_source_field: str | None,
+    fallback_units: str | None,
+) -> dict[str, Any]:
+    unavailable = "unavailable:until_result_ingested"
+    if diagnostics is None:
+        return {
+            "source_field": fallback_source_field,
+            "units": fallback_units,
+            "delta": unavailable,
+            "first_mean": unavailable,
+            "final_mean": unavailable,
+            "first_time_seconds": unavailable,
+            "final_time_seconds": unavailable,
+            "first_finite_count": 0,
+            "final_finite_count": 0,
+            "method": unavailable,
+        }
+    reason = _low_level_response_unavailable_reason(diagnostics)
+    method = (
+        diagnostics.vertical_coordinate_method if diagnostics.available else f"unavailable:{reason}"
+    )
+    return {
+        "source_field": diagnostics.source_field or fallback_source_field,
+        "units": diagnostics.units or fallback_units,
+        "delta": diagnostics.delta_value if diagnostics.available else f"unavailable:{reason}",
+        "first_mean": (
+            diagnostics.first_mean_value if diagnostics.available else f"unavailable:{reason}"
+        ),
+        "final_mean": (
+            diagnostics.final_mean_value if diagnostics.available else f"unavailable:{reason}"
+        ),
+        "first_time_seconds": (
+            diagnostics.first_time_seconds if diagnostics.available else f"unavailable:{reason}"
+        ),
+        "final_time_seconds": (
+            diagnostics.final_time_seconds if diagnostics.available else f"unavailable:{reason}"
+        ),
+        "first_finite_count": diagnostics.first_finite_count,
+        "final_finite_count": diagnostics.final_finite_count,
+        "method": method,
+    }
+
+
+def _low_level_response_unavailable_reason(
+    diagnostics: LowLevelResponseFieldDiagnostics,
+) -> str:
+    if diagnostics.available:
+        return "available"
+    if diagnostics.caveats:
+        return diagnostics.caveats[0]
+    if diagnostics.field_absent:
+        source_field = diagnostics.source_field or "theta_or_temperature"
+        return f"{source_field}_field_absent"
+    return "low_level_response_unavailable"
+
+
+def _first_available_field(result: ResultMetadata | None, fields: Sequence[str]) -> str | None:
+    if result is None:
+        return None
+    variables = set(result.variables)
+    return next((field for field in fields if field in variables), None)
 
 
 def _surface_moisture_flux_field(fields: Iterable[str]) -> str | None:
@@ -2410,7 +2540,6 @@ def _summary_caveats(
 ) -> list[str]:
     caveats = [
         "surface_forcing_is_constant_uniform_proxy",
-        "low_level_response_diagnostic_not_implemented",
     ]
     if run.optional:
         caveats.append("optional_campaign_run")
@@ -2423,6 +2552,11 @@ def _summary_caveats(
         caveats.extend(result.interesting_time_caveats)
         if result.diagnostics is not None:
             caveats.extend(result.diagnostics.caveats)
+            if not (
+                result.diagnostics.low_level_response.qv.available
+                and result.diagnostics.low_level_response.theta_or_temperature.available
+            ):
+                caveats.append("low_level_response_unavailable")
     return _dedupe(caveats)
 
 
@@ -2557,7 +2691,21 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                 f"- Precipitation/reflectivity: {precipitation}",
                 f"- Diagnostic trust: `{_diagnostic_trust_summary(diagnostic_trust)}`",
                 f"- Field-quality warnings: `{quality_warnings}`",
-                f"- Low-level response: `{run['low_level_qv_response_method']}`",
+                (
+                    f"- Low-level qv response: `{run['low_level_qv_response']}` "
+                    f"`{run['low_level_qv_response_units'] or ''}` via "
+                    f"`{run['low_level_qv_response_method']}` "
+                    f"({run['low_level_qv_response_first_mean']} -> "
+                    f"{run['low_level_qv_response_final_mean']})"
+                ),
+                (
+                    f"- Low-level theta/temperature response: "
+                    f"`{run['low_level_theta_or_temperature_response']}` "
+                    f"`{run['low_level_theta_or_temperature_response_units'] or ''}` via "
+                    f"`{run['low_level_theta_or_temperature_response_method']}` "
+                    f"({run['low_level_theta_or_temperature_response_first_mean']} -> "
+                    f"{run['low_level_theta_or_temperature_response_final_mean']})"
+                ),
                 f"- Caveats: `{', '.join(run['caveats']) or 'none'}`",
                 "",
             ]
@@ -2598,6 +2746,39 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                 )
     else:
         lines.append("No Phase 1 surface-flux response comparisons are available.")
+    lines.extend(
+        [
+            "",
+            "## Low-Level Response",
+            "",
+        ]
+    )
+    low_level_response = summary.get("low_level_response", {})
+    low_level_evaluations = low_level_response.get("evaluations", [])
+    missing_low_level_comparison_types = low_level_response.get(
+        "missing_required_comparison_types",
+        [],
+    )
+    if missing_low_level_comparison_types:
+        lines.append(
+            "- Missing required Phase 1 comparison types: "
+            f"`{', '.join(missing_low_level_comparison_types)}`"
+        )
+    if low_level_evaluations:
+        for evaluation in low_level_evaluations:
+            lines.append(
+                f"- `{evaluation['experiment_matrix_id']}` vs "
+                f"`{evaluation['control_matrix_id']}`: `{evaluation['status']}`"
+            )
+            for expectation in evaluation.get("expectations", []):
+                role = "required" if expectation.get("required") else "informational"
+                lines.append(
+                    f"  - {expectation['field']}: {role}; expected "
+                    f"`{expectation['expected']}`, observed `{expectation['observed']}`; "
+                    f"`{expectation['status']}`"
+                )
+    else:
+        lines.append("No Phase 1 low-level response comparisons are available.")
     lines.extend(
         [
             "",
@@ -2811,6 +2992,8 @@ def _comparison_supported_differences(
         "qr_present",
         "surface_rain_present",
         "max_dbz",
+        "low_level_qv_response",
+        "low_level_theta_or_temperature_response",
     ):
         left = control.get(field)
         right = experiment.get(field)
@@ -2836,6 +3019,10 @@ SURFACE_FLUX_RESPONSE_VERIFIED = "surface_flux_response_verified"
 SURFACE_FLUX_RESPONSE_NOT_VERIFIED = "surface_flux_response_not_verified"
 SURFACE_FLUX_RESPONSE_MISSING = "surface_flux_response_inconclusive_missing_evidence"
 SURFACE_FLUX_RESPONSE_NONCOMPARABLE = "surface_flux_response_inconclusive_noncomparable"
+LOW_LEVEL_RESPONSE_VERIFIED = "low_level_response_verified"
+LOW_LEVEL_RESPONSE_NOT_VERIFIED = "low_level_response_not_verified"
+LOW_LEVEL_RESPONSE_MISSING = "low_level_response_inconclusive_missing_evidence"
+LOW_LEVEL_RESPONSE_NONCOMPARABLE = "low_level_response_inconclusive_noncomparable"
 
 
 def _surface_flux_response_evaluation(
@@ -2898,6 +3085,214 @@ def _surface_flux_response_evaluation(
         "missing_required_comparison_types": missing_required_comparison_types,
         "unavailable_evidence": unavailable_evidence,
         "evaluations": evaluations,
+    }
+
+
+def _low_level_response_evaluation(
+    plan: CampaignPlan,
+    summaries: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    by_matrix_id = {str(summary["matrix_id"]): summary for summary in summaries}
+    required_comparison_types = list(
+        plan.phase1_required_comparison_types or DEFAULT_PHASE1_REQUIRED_COMPARISON_TYPES
+    )
+    evaluations: list[dict[str, Any]] = []
+    for run in plan.runs:
+        if not _is_phase_one_run(run):
+            continue
+        if not run.comparison_type or not run.comparison_control_matrix_id:
+            continue
+        definition = plan.comparison_types.get(run.comparison_type, {})
+        control = by_matrix_id.get(run.comparison_control_matrix_id)
+        experiment = by_matrix_id.get(run.matrix_id)
+        evaluations.append(
+            _low_level_response_for_pair(
+                comparison_type=run.comparison_type,
+                control_matrix_id=run.comparison_control_matrix_id,
+                experiment_matrix_id=run.matrix_id,
+                definition=definition,
+                control=control,
+                experiment=experiment,
+            )
+        )
+
+    evaluated_comparison_types = {str(evaluation["comparison_type"]) for evaluation in evaluations}
+    missing_required_comparison_types = [
+        comparison_type
+        for comparison_type in required_comparison_types
+        if comparison_type not in evaluated_comparison_types
+    ]
+    unavailable_evidence = [
+        f"missing_phase1_required_comparison_type:{comparison_type}"
+        for comparison_type in missing_required_comparison_types
+    ]
+    if missing_required_comparison_types:
+        state = LOW_LEVEL_RESPONSE_MISSING
+    elif not evaluations:
+        state = LOW_LEVEL_RESPONSE_MISSING
+    elif any(
+        evaluation["status"] == LOW_LEVEL_RESPONSE_NONCOMPARABLE for evaluation in evaluations
+    ):
+        state = LOW_LEVEL_RESPONSE_NONCOMPARABLE
+    elif any(evaluation["status"] == LOW_LEVEL_RESPONSE_MISSING for evaluation in evaluations):
+        state = LOW_LEVEL_RESPONSE_MISSING
+    elif any(evaluation["status"] == LOW_LEVEL_RESPONSE_NOT_VERIFIED for evaluation in evaluations):
+        state = LOW_LEVEL_RESPONSE_NOT_VERIFIED
+    else:
+        state = LOW_LEVEL_RESPONSE_VERIFIED
+    return {
+        "state": state,
+        "required_comparison_types": required_comparison_types,
+        "missing_required_comparison_types": missing_required_comparison_types,
+        "unavailable_evidence": unavailable_evidence,
+        "evaluations": evaluations,
+    }
+
+
+def _low_level_response_for_pair(
+    *,
+    comparison_type: str,
+    control_matrix_id: str,
+    experiment_matrix_id: str,
+    definition: Mapping[str, Any],
+    control: Mapping[str, Any] | None,
+    experiment: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    base = {
+        "comparison_type": comparison_type,
+        "control_matrix_id": control_matrix_id,
+        "experiment_matrix_id": experiment_matrix_id,
+        "expectations": [],
+        "equality_gate_failures": [],
+        "unavailable_evidence": [],
+    }
+    if control is None or experiment is None:
+        return {
+            **base,
+            "status": LOW_LEVEL_RESPONSE_MISSING,
+            "unavailable_evidence": ["missing_control_or_experiment_summary"],
+        }
+
+    equality_failures = _comparison_equality_failures(control, experiment, definition)
+    if equality_failures:
+        return {
+            **base,
+            "status": LOW_LEVEL_RESPONSE_NONCOMPARABLE,
+            "equality_gate_failures": equality_failures,
+        }
+
+    unavailable = _low_level_pair_unavailable_evidence(control, experiment)
+    if unavailable:
+        status = (
+            LOW_LEVEL_RESPONSE_NONCOMPARABLE
+            if any("noncomparable_units" in item for item in unavailable)
+            else LOW_LEVEL_RESPONSE_MISSING
+        )
+        return {
+            **base,
+            "status": status,
+            "unavailable_evidence": unavailable,
+        }
+
+    expectations = [
+        _low_level_response_expectation(
+            field="low_level_theta_or_temperature_response",
+            selected_control_field="surface_heat_flux_k_m_s",
+            control=control,
+            experiment=experiment,
+        ),
+        _low_level_response_expectation(
+            field="low_level_qv_response",
+            selected_control_field="surface_moisture_flux_g_g_m_s",
+            control=control,
+            experiment=experiment,
+        ),
+    ]
+    required_expectations = [expectation for expectation in expectations if expectation["required"]]
+    status = (
+        LOW_LEVEL_RESPONSE_VERIFIED
+        if all(expectation["status"] == "verified" for expectation in required_expectations)
+        else LOW_LEVEL_RESPONSE_NOT_VERIFIED
+    )
+    if not required_expectations:
+        status = LOW_LEVEL_RESPONSE_NONCOMPARABLE
+    return {
+        **base,
+        "status": status,
+        "expectations": expectations,
+    }
+
+
+def _low_level_pair_unavailable_evidence(
+    control: Mapping[str, Any],
+    experiment: Mapping[str, Any],
+) -> list[str]:
+    unavailable: list[str] = []
+    for summary, role in ((control, "control"), (experiment, "experiment")):
+        if summary.get("status") != "ingested":
+            unavailable.append(f"{role}:result_not_ingested")
+        support = summary.get("diagnostic_support")
+        diagnostic_support = support if isinstance(support, dict) else {}
+        if diagnostic_support.get("low_level_response") != "available":
+            unavailable.append(f"{role}:diagnostic_unavailable:low_level_response")
+        for field in (
+            "low_level_qv_response",
+            "low_level_theta_or_temperature_response",
+        ):
+            value = summary.get(field)
+            if not isinstance(value, int | float) or _is_unavailable(value):
+                unavailable.append(f"{role}:{field}_unavailable:{value}")
+            units = summary.get(f"{field}_units")
+            if not isinstance(units, str) or not units:
+                unavailable.append(f"{role}:{field}_units_unavailable")
+    for field in (
+        "low_level_qv_response",
+        "low_level_theta_or_temperature_response",
+    ):
+        control_units = control.get(f"{field}_units")
+        experiment_units = experiment.get(f"{field}_units")
+        if control_units is None or experiment_units is None:
+            continue
+        if control_units != experiment_units:
+            unavailable.append(f"{field}:noncomparable_units:{control_units}:vs:{experiment_units}")
+    noncomparable = [item for item in unavailable if "noncomparable_units" in item]
+    if noncomparable:
+        return noncomparable
+    return _dedupe(unavailable)
+
+
+def _low_level_response_expectation(
+    *,
+    field: str,
+    selected_control_field: str,
+    control: Mapping[str, Any],
+    experiment: Mapping[str, Any],
+) -> dict[str, Any]:
+    control_selected = _float_or_none(control.get(selected_control_field))
+    experiment_selected = _float_or_none(experiment.get(selected_control_field))
+    control_delta = _float_or_none(control.get(field))
+    experiment_delta = _float_or_none(experiment.get(field))
+    expected = _expected_direction(control_selected, experiment_selected)
+    observed = _expected_direction(control_delta, experiment_delta)
+    required = expected in {"increase", "decrease"}
+    if required:
+        status = "verified" if expected == observed else "not_verified"
+    elif expected == "comparable":
+        status = "informational"
+    else:
+        status = "not_evaluated"
+    return {
+        "field": field,
+        "selected_control_field": selected_control_field,
+        "expected": expected,
+        "observed": observed,
+        "required": required,
+        "status": status,
+        "control_selected": control_selected,
+        "experiment_selected": experiment_selected,
+        "control_delta": control_delta,
+        "experiment_delta": experiment_delta,
+        "units": control.get(f"{field}_units"),
     }
 
 
@@ -3111,6 +3506,7 @@ def _is_unavailable(value: Any) -> bool:
 def _phase_gate_state(
     summaries: Sequence[Mapping[str, Any]],
     surface_flux_response: Mapping[str, Any],
+    low_level_response: Mapping[str, Any],
 ) -> str:
     phase1 = [
         summary for summary in summaries if summary.get("phase") == "forcing_path_smoke_check"
@@ -3124,11 +3520,8 @@ def _phase_gate_state(
     response_state = surface_flux_response.get("state")
     if response_state != SURFACE_FLUX_RESPONSE_VERIFIED:
         return str(response_state or SURFACE_FLUX_RESPONSE_MISSING)
-    if not all(
-        not _is_unavailable(summary.get("low_level_qv_response"))
-        and not _is_unavailable(summary.get("low_level_theta_or_temperature_response"))
-        for summary in phase1
-    ):
+    low_level_state = low_level_response.get("state")
+    if low_level_state != LOW_LEVEL_RESPONSE_VERIFIED:
         return "forcing_wiring_verified_but_response_not_verified"
     return "forcing_path_verified_for_campaign"
 
@@ -3171,9 +3564,9 @@ def _preliminary_diagnosis_categories(summaries: Sequence[Mapping[str, Any]]) ->
 def _recommended_follow_ups(
     summaries: Sequence[Mapping[str, Any]],
     surface_flux_response: Mapping[str, Any],
+    low_level_response: Mapping[str, Any],
 ) -> list[str]:
     followups = [
-        "Implement standardized low-level qv/theta/temperature response diagnostics.",
         (
             "Review campaign rows with unavailable required output fields before "
             "scientific conclusions."
@@ -3183,6 +3576,22 @@ def _recommended_follow_ups(
         followups.append(
             "Resolve Phase 1 surface-flux response comparisons before treating "
             "selected forcing changes as verified in CM1 output."
+        )
+    low_level_state = low_level_response.get("state")
+    if low_level_state == LOW_LEVEL_RESPONSE_MISSING:
+        followups.append(
+            "Resolve missing or unavailable low-level qv/theta response evidence before "
+            "continuing the campaign automatically."
+        )
+    elif low_level_state == LOW_LEVEL_RESPONSE_NOT_VERIFIED:
+        followups.append(
+            "Review Phase 1 low-level response comparisons; emitted surface fluxes changed, "
+            "but boundary-layer qv/theta deltas did not move in the expected direction."
+        )
+    elif low_level_state == LOW_LEVEL_RESPONSE_NONCOMPARABLE:
+        followups.append(
+            "Fix non-comparable Phase 1 low-level response runs or units before "
+            "treating boundary-layer response as verified."
         )
     if any(summary.get("diagnostic_quality_warnings") for summary in summaries):
         followups.append(
@@ -3209,11 +3618,32 @@ def _forcing_response_summary(summary: Mapping[str, Any]) -> str:
             "operator override, subject to campaign cost/runtime judgment."
         )
     if state == "forcing_wiring_verified_but_response_not_verified":
+        low_level_state = (summary.get("low_level_response") or {}).get("state")
+        if low_level_state == LOW_LEVEL_RESPONSE_NOT_VERIFIED:
+            return (
+                "Phase 1 confirmed selected forcing metadata, CM1-facing forcing controls, "
+                "hfx/qfx output-field presence, and matched emitted surface-flux response. "
+                "However, matched low-level qv/theta response did not move in the expected "
+                "direction, so automatic continuation remains blocked."
+            )
+        if low_level_state == LOW_LEVEL_RESPONSE_MISSING:
+            return (
+                "Phase 1 confirmed selected forcing metadata, CM1-facing forcing controls, "
+                "hfx/qfx output-field presence, and matched emitted surface-flux response. "
+                "It did not verify boundary-layer thermodynamic response because low-level "
+                "qv/theta evidence is missing or unavailable."
+            )
+        if low_level_state == LOW_LEVEL_RESPONSE_NONCOMPARABLE:
+            return (
+                "Phase 1 confirmed selected forcing metadata, CM1-facing forcing controls, "
+                "hfx/qfx output-field presence, and matched emitted surface-flux response. "
+                "It did not verify boundary-layer thermodynamic response because the "
+                "low-level response comparisons are not structurally comparable."
+            )
         return (
             "Phase 1 confirmed selected forcing metadata, CM1-facing forcing controls, "
             "hfx/qfx output-field presence, and matched emitted surface-flux response. "
-            "It did not verify boundary-layer thermodynamic response because low-level "
-            "qv/theta response diagnostics are not implemented yet."
+            "It did not verify boundary-layer thermodynamic response."
         )
     if state == SURFACE_FLUX_RESPONSE_NOT_VERIFIED:
         return (

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -193,13 +193,21 @@ SUPPORTED_REQUIRED_SUMMARY_FIELDS = {
     "lhfx_mean",
     "low_level_qv_response",
     "low_level_qv_response_method",
+    "low_level_qv_early_response_available",
     "low_level_qv_early_response_delta",
     "low_level_qv_early_response_delta_units",
+    "low_level_qv_early_response_min_finite_fraction",
+    "low_level_qv_early_response_quality_state",
+    "low_level_qv_full_run_response_available",
     "low_level_qv_full_run_delta",
     "low_level_theta_or_temperature_response",
     "low_level_theta_or_temperature_response_method",
+    "low_level_theta_or_temperature_early_response_available",
     "low_level_theta_or_temperature_early_response_delta",
     "low_level_theta_or_temperature_early_response_delta_units",
+    "low_level_theta_or_temperature_early_response_min_finite_fraction",
+    "low_level_theta_or_temperature_early_response_quality_state",
+    "low_level_theta_or_temperature_full_run_response_available",
     "low_level_theta_or_temperature_full_run_delta",
     "first_cloud_time",
     "max_cloud_top_m",
@@ -2073,12 +2081,24 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "lhfx_max": qfx_stats["max"],
         "lhfx_mean": qfx_stats["mean"],
         "low_level_qv_response": low_level_qv["early_delta"],
+        "low_level_qv_early_response_available": low_level_qv["early_response_available"],
+        "low_level_qv_full_run_response_available": low_level_qv["full_run_response_available"],
         "low_level_qv_early_response_delta": low_level_qv["early_delta"],
         "low_level_qv_early_response_delta_units": low_level_qv["units"],
         "low_level_qv_early_response_start_mean": low_level_qv["early_start_mean"],
         "low_level_qv_early_response_end_mean": low_level_qv["early_end_mean"],
         "low_level_qv_early_response_start_time_seconds": low_level_qv["early_start_time_seconds"],
         "low_level_qv_early_response_end_time_seconds": low_level_qv["early_end_time_seconds"],
+        "low_level_qv_early_response_start_finite_fraction": low_level_qv[
+            "early_start_finite_fraction"
+        ],
+        "low_level_qv_early_response_end_finite_fraction": low_level_qv[
+            "early_end_finite_fraction"
+        ],
+        "low_level_qv_early_response_min_finite_fraction": low_level_qv[
+            "early_min_finite_fraction"
+        ],
+        "low_level_qv_early_response_quality_state": low_level_qv["early_quality_state"],
         "low_level_qv_full_run_delta": low_level_qv["full_delta"],
         "low_level_qv_response_method": low_level_qv["method"],
         "low_level_qv_response_source_field": low_level_qv["source_field"],
@@ -2090,6 +2110,12 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "low_level_qv_response_first_finite_count": low_level_qv["first_finite_count"],
         "low_level_qv_response_final_finite_count": low_level_qv["final_finite_count"],
         "low_level_theta_or_temperature_response": low_level_thermal["early_delta"],
+        "low_level_theta_or_temperature_early_response_available": low_level_thermal[
+            "early_response_available"
+        ],
+        "low_level_theta_or_temperature_full_run_response_available": low_level_thermal[
+            "full_run_response_available"
+        ],
         "low_level_theta_or_temperature_early_response_delta": low_level_thermal["early_delta"],
         "low_level_theta_or_temperature_early_response_delta_units": low_level_thermal["units"],
         "low_level_theta_or_temperature_early_response_start_mean": low_level_thermal[
@@ -2103,6 +2129,18 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         ],
         "low_level_theta_or_temperature_early_response_end_time_seconds": low_level_thermal[
             "early_end_time_seconds"
+        ],
+        "low_level_theta_or_temperature_early_response_start_finite_fraction": low_level_thermal[
+            "early_start_finite_fraction"
+        ],
+        "low_level_theta_or_temperature_early_response_end_finite_fraction": low_level_thermal[
+            "early_end_finite_fraction"
+        ],
+        "low_level_theta_or_temperature_early_response_min_finite_fraction": low_level_thermal[
+            "early_min_finite_fraction"
+        ],
+        "low_level_theta_or_temperature_early_response_quality_state": low_level_thermal[
+            "early_quality_state"
         ],
         "low_level_theta_or_temperature_full_run_delta": low_level_thermal["full_delta"],
         "low_level_theta_or_temperature_response_method": low_level_thermal["method"],
@@ -2194,14 +2232,14 @@ def _surface_flux_support(
 def _low_level_response_support(response: Any) -> str:
     qv = response.qv
     thermal = response.theta_or_temperature
-    if qv.available and thermal.available:
+    if qv.early_response_available and thermal.early_response_available:
         return "available"
     if qv.field_absent or thermal.field_absent:
         return "missing"
     reasons = [
-        _low_level_response_unavailable_reason(field)
+        _low_level_response_early_unavailable_reason(field)
         for field in (qv, thermal)
-        if not field.available
+        if not field.early_response_available
     ]
     return "unavailable:" + ",".join(_dedupe([reason for reason in reasons if reason]))
 
@@ -2267,13 +2305,21 @@ def _low_level_response_summary_values(
         return {
             "source_field": fallback_source_field,
             "units": fallback_units,
+            "early_response_available": False,
+            "full_run_response_available": False,
             "early_delta": unavailable,
             "early_start_mean": unavailable,
             "early_end_mean": unavailable,
             "early_start_time_seconds": unavailable,
             "early_end_time_seconds": unavailable,
             "early_start_finite_count": 0,
+            "early_start_total_count": 0,
+            "early_start_finite_fraction": None,
             "early_end_finite_count": 0,
+            "early_end_total_count": 0,
+            "early_end_finite_fraction": None,
+            "early_min_finite_fraction": None,
+            "early_quality_state": "unavailable",
             "full_delta": unavailable,
             "first_mean": unavailable,
             "final_mean": unavailable,
@@ -2283,67 +2329,87 @@ def _low_level_response_summary_values(
             "final_finite_count": 0,
             "method": unavailable,
         }
-    reason = _low_level_response_unavailable_reason(diagnostics)
+    early_reason = _low_level_response_early_unavailable_reason(diagnostics)
+    full_reason = _low_level_response_full_run_unavailable_reason(diagnostics)
     method = (
         diagnostics.vertical_coordinate_method
         if diagnostics.vertical_coordinate_method is not None
-        else f"unavailable:{reason}"
+        else f"unavailable:{early_reason}"
     )
-    early_unavailable = f"unavailable:{reason}"
+    early_unavailable = f"unavailable:{early_reason}"
+    full_unavailable = f"unavailable:{full_reason}"
+    early_start_fraction = _finite_fraction(
+        diagnostics.early_response_start_finite_count,
+        diagnostics.early_response_start_total_count,
+    )
+    early_end_fraction = _finite_fraction(
+        diagnostics.early_response_end_finite_count,
+        diagnostics.early_response_end_total_count,
+    )
+    early_min_fraction = _min_defined([early_start_fraction, early_end_fraction])
+    early_quality_state = _low_level_early_quality_state(diagnostics, early_min_fraction)
     return {
         "source_field": diagnostics.source_field or fallback_source_field,
         "units": diagnostics.units or fallback_units,
+        "early_response_available": diagnostics.early_response_available,
+        "full_run_response_available": diagnostics.full_run_response_available,
         "early_delta": (
             diagnostics.early_response_delta
-            if diagnostics.early_response_delta is not None
+            if diagnostics.early_response_available
             else early_unavailable
         ),
         "early_start_mean": (
             diagnostics.early_response_start_mean_value
-            if diagnostics.early_response_delta is not None
+            if diagnostics.early_response_available
             else early_unavailable
         ),
         "early_end_mean": (
             diagnostics.early_response_end_mean_value
-            if diagnostics.early_response_delta is not None
+            if diagnostics.early_response_available
             else early_unavailable
         ),
         "early_start_time_seconds": (
             diagnostics.early_response_start_time_seconds
-            if diagnostics.early_response_delta is not None
+            if diagnostics.early_response_available
             else early_unavailable
         ),
         "early_end_time_seconds": (
             diagnostics.early_response_end_time_seconds
-            if diagnostics.early_response_delta is not None
+            if diagnostics.early_response_available
             else early_unavailable
         ),
         "early_start_finite_count": diagnostics.early_response_start_finite_count,
+        "early_start_total_count": diagnostics.early_response_start_total_count,
+        "early_start_finite_fraction": early_start_fraction,
         "early_end_finite_count": diagnostics.early_response_end_finite_count,
+        "early_end_total_count": diagnostics.early_response_end_total_count,
+        "early_end_finite_fraction": early_end_fraction,
+        "early_min_finite_fraction": early_min_fraction,
+        "early_quality_state": early_quality_state,
         "full_delta": (
             diagnostics.full_run_delta
-            if diagnostics.full_run_delta is not None
-            else f"unavailable:{reason}"
+            if diagnostics.full_run_response_available
+            else full_unavailable
         ),
         "first_mean": (
             diagnostics.first_mean_value
             if diagnostics.first_mean_value is not None
-            else f"unavailable:{reason}"
+            else full_unavailable
         ),
         "final_mean": (
             diagnostics.final_mean_value
             if diagnostics.final_mean_value is not None
-            else f"unavailable:{reason}"
+            else full_unavailable
         ),
         "first_time_seconds": (
             diagnostics.first_time_seconds
             if diagnostics.first_time_seconds is not None
-            else f"unavailable:{reason}"
+            else full_unavailable
         ),
         "final_time_seconds": (
             diagnostics.final_time_seconds
             if diagnostics.final_time_seconds is not None
-            else f"unavailable:{reason}"
+            else full_unavailable
         ),
         "first_finite_count": diagnostics.first_finite_count,
         "final_finite_count": diagnostics.final_finite_count,
@@ -2362,6 +2428,79 @@ def _low_level_response_unavailable_reason(
         source_field = diagnostics.source_field or "theta_or_temperature"
         return f"{source_field}_field_absent"
     return "low_level_response_unavailable"
+
+
+def _low_level_response_early_unavailable_reason(
+    diagnostics: LowLevelResponseFieldDiagnostics,
+) -> str:
+    if diagnostics.early_response_available:
+        return "available"
+    if diagnostics.field_absent:
+        source_field = diagnostics.source_field or "theta_or_temperature"
+        return f"{source_field}_field_absent"
+    for caveat in diagnostics.caveats:
+        if (
+            "missing_early_output" in caveat
+            or "early_endpoint_entirely_non_finite" in caveat
+            or "start_endpoint_entirely_non_finite" in caveat
+            or "requires_at_least_two_time_steps" in caveat
+            or "missing_vertical" in caveat
+            or "vertical_units_not_supported" in caveat
+            or "unavailable" in caveat
+        ):
+            return caveat
+    return "low_level_early_response_unavailable"
+
+
+def _low_level_response_full_run_unavailable_reason(
+    diagnostics: LowLevelResponseFieldDiagnostics,
+) -> str:
+    if diagnostics.full_run_response_available:
+        return "available"
+    if diagnostics.field_absent:
+        source_field = diagnostics.source_field or "theta_or_temperature"
+        return f"{source_field}_field_absent"
+    for caveat in diagnostics.caveats:
+        if (
+            "final_endpoint_entirely_non_finite" in caveat
+            or "start_endpoint_entirely_non_finite" in caveat
+            or "requires_at_least_two_time_steps" in caveat
+            or "missing_vertical" in caveat
+            or "vertical_units_not_supported" in caveat
+            or "unavailable" in caveat
+        ):
+            return caveat
+    return "low_level_full_run_response_unavailable"
+
+
+def _finite_fraction(finite_count: int, total_count: int) -> float | None:
+    if total_count <= 0:
+        return None
+    return finite_count / total_count
+
+
+def _min_defined(values: Sequence[float | None]) -> float | None:
+    defined = [value for value in values if value is not None]
+    return min(defined) if defined else None
+
+
+def _low_level_early_quality_state(
+    diagnostics: LowLevelResponseFieldDiagnostics,
+    finite_fraction: float | None,
+) -> str:
+    if not diagnostics.early_response_available:
+        return "unavailable"
+    if (
+        finite_fraction is not None
+        and finite_fraction < LOW_LEVEL_RESPONSE_MIN_EARLY_FINITE_FRACTION
+    ):
+        return "caveated_below_minimum_finite_fraction"
+    if (
+        diagnostics.early_response_start_non_finite_count > 0
+        or diagnostics.early_response_end_non_finite_count > 0
+    ):
+        return "caveated"
+    return "trusted"
 
 
 def _first_available_field(result: ResultMetadata | None, fields: Sequence[str]) -> str | None:
@@ -2775,6 +2914,7 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                     f"`{run['low_level_qv_response_method']}` "
                     f"({run['low_level_qv_early_response_start_mean']} -> "
                     f"{run['low_level_qv_early_response_end_mean']}); "
+                    f"quality `{run['low_level_qv_early_response_quality_state']}`; "
                     f"full-run delta `{run['low_level_qv_full_run_delta']}`"
                 ),
                 (
@@ -2784,6 +2924,8 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                     f"`{run['low_level_theta_or_temperature_response_method']}` "
                     f"({run['low_level_theta_or_temperature_early_response_start_mean']} -> "
                     f"{run['low_level_theta_or_temperature_early_response_end_mean']}); "
+                    f"quality "
+                    f"`{run['low_level_theta_or_temperature_early_response_quality_state']}`; "
                     f"full-run delta "
                     f"`{run['low_level_theta_or_temperature_full_run_delta']}`"
                 ),
@@ -2856,7 +2998,8 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                 lines.append(
                     f"  - {expectation['field']}: {role}; expected "
                     f"`{expectation['expected']}`, observed `{expectation['observed']}`; "
-                    f"`{expectation['status']}`"
+                    f"`{expectation['status']}`; quality "
+                    f"`{expectation.get('quality_state', 'unknown')}`"
                 )
     else:
         lines.append("No Phase 1 low-level response comparisons are available.")
@@ -3108,6 +3251,7 @@ LOW_LEVEL_RESPONSE_VERIFIED = "low_level_response_verified"
 LOW_LEVEL_RESPONSE_NOT_VERIFIED = "low_level_response_not_verified"
 LOW_LEVEL_RESPONSE_MISSING = "low_level_response_inconclusive_missing_evidence"
 LOW_LEVEL_RESPONSE_NONCOMPARABLE = "low_level_response_inconclusive_noncomparable"
+LOW_LEVEL_RESPONSE_MIN_EARLY_FINITE_FRACTION = 0.95
 
 
 def _surface_flux_response_evaluation(
@@ -3330,6 +3474,17 @@ def _low_level_pair_unavailable_evidence(
             units = summary.get(f"{field}_units")
             if not isinstance(units, str) or not units:
                 unavailable.append(f"{role}:{field}_units_unavailable")
+            finite_fraction = _float_or_none(
+                summary.get(field.replace("_delta", "_min_finite_fraction"))
+            )
+            if finite_fraction is None:
+                unavailable.append(f"{role}:{field}_finite_fraction_unavailable")
+            elif finite_fraction < LOW_LEVEL_RESPONSE_MIN_EARLY_FINITE_FRACTION:
+                unavailable.append(
+                    f"{role}:{field}_finite_fraction_below_threshold:"
+                    f"{finite_fraction:.3f}<"
+                    f"{LOW_LEVEL_RESPONSE_MIN_EARLY_FINITE_FRACTION:.3f}"
+                )
     for field in (
         "low_level_qv_early_response_delta",
         "low_level_theta_or_temperature_early_response_delta",
@@ -3357,6 +3512,14 @@ def _low_level_response_expectation(
     experiment_selected = _float_or_none(experiment.get(selected_control_field))
     control_delta = _float_or_none(control.get(field))
     experiment_delta = _float_or_none(experiment.get(field))
+    control_finite_fraction = _float_or_none(
+        control.get(field.replace("_delta", "_min_finite_fraction"))
+    )
+    experiment_finite_fraction = _float_or_none(
+        experiment.get(field.replace("_delta", "_min_finite_fraction"))
+    )
+    control_quality_state = control.get(field.replace("_delta", "_quality_state"))
+    experiment_quality_state = experiment.get(field.replace("_delta", "_quality_state"))
     expected = _expected_direction(control_selected, experiment_selected)
     observed = _expected_direction(control_delta, experiment_delta)
     required = expected in {"increase", "decrease"}
@@ -3378,6 +3541,15 @@ def _low_level_response_expectation(
         "control_delta": control_delta,
         "experiment_delta": experiment_delta,
         "units": control.get(f"{field}_units"),
+        "control_finite_fraction": control_finite_fraction,
+        "experiment_finite_fraction": experiment_finite_fraction,
+        "control_quality_state": control_quality_state,
+        "experiment_quality_state": experiment_quality_state,
+        "quality_state": (
+            "caveated"
+            if "caveated" in {control_quality_state, experiment_quality_state}
+            else "trusted"
+        ),
     }
 
 

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -193,8 +193,14 @@ SUPPORTED_REQUIRED_SUMMARY_FIELDS = {
     "lhfx_mean",
     "low_level_qv_response",
     "low_level_qv_response_method",
+    "low_level_qv_early_response_delta",
+    "low_level_qv_early_response_delta_units",
+    "low_level_qv_full_run_delta",
     "low_level_theta_or_temperature_response",
     "low_level_theta_or_temperature_response_method",
+    "low_level_theta_or_temperature_early_response_delta",
+    "low_level_theta_or_temperature_early_response_delta_units",
+    "low_level_theta_or_temperature_full_run_delta",
     "first_cloud_time",
     "max_cloud_top_m",
     "max_cloud_top_time",
@@ -1876,11 +1882,11 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         low_level_response.theta_or_temperature if low_level_response is not None else None,
         fallback_source_field=_first_available_field(
             result,
-            ["th", "theta", "theta_v", "temperature", "t"],
+            ["th", "theta", "temperature", "t"],
         ),
         fallback_units=_field_units(
             result,
-            _first_available_field(result, ["th", "theta", "theta_v", "temperature", "t"]),
+            _first_available_field(result, ["th", "theta", "temperature", "t"]),
         ),
     )
     deep_cloud_formed = (
@@ -2066,7 +2072,14 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "lhfx_min": qfx_stats["min"],
         "lhfx_max": qfx_stats["max"],
         "lhfx_mean": qfx_stats["mean"],
-        "low_level_qv_response": low_level_qv["delta"],
+        "low_level_qv_response": low_level_qv["early_delta"],
+        "low_level_qv_early_response_delta": low_level_qv["early_delta"],
+        "low_level_qv_early_response_delta_units": low_level_qv["units"],
+        "low_level_qv_early_response_start_mean": low_level_qv["early_start_mean"],
+        "low_level_qv_early_response_end_mean": low_level_qv["early_end_mean"],
+        "low_level_qv_early_response_start_time_seconds": low_level_qv["early_start_time_seconds"],
+        "low_level_qv_early_response_end_time_seconds": low_level_qv["early_end_time_seconds"],
+        "low_level_qv_full_run_delta": low_level_qv["full_delta"],
         "low_level_qv_response_method": low_level_qv["method"],
         "low_level_qv_response_source_field": low_level_qv["source_field"],
         "low_level_qv_response_units": low_level_qv["units"],
@@ -2076,7 +2089,22 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "low_level_qv_response_final_time_seconds": low_level_qv["final_time_seconds"],
         "low_level_qv_response_first_finite_count": low_level_qv["first_finite_count"],
         "low_level_qv_response_final_finite_count": low_level_qv["final_finite_count"],
-        "low_level_theta_or_temperature_response": low_level_thermal["delta"],
+        "low_level_theta_or_temperature_response": low_level_thermal["early_delta"],
+        "low_level_theta_or_temperature_early_response_delta": low_level_thermal["early_delta"],
+        "low_level_theta_or_temperature_early_response_delta_units": low_level_thermal["units"],
+        "low_level_theta_or_temperature_early_response_start_mean": low_level_thermal[
+            "early_start_mean"
+        ],
+        "low_level_theta_or_temperature_early_response_end_mean": low_level_thermal[
+            "early_end_mean"
+        ],
+        "low_level_theta_or_temperature_early_response_start_time_seconds": low_level_thermal[
+            "early_start_time_seconds"
+        ],
+        "low_level_theta_or_temperature_early_response_end_time_seconds": low_level_thermal[
+            "early_end_time_seconds"
+        ],
+        "low_level_theta_or_temperature_full_run_delta": low_level_thermal["full_delta"],
         "low_level_theta_or_temperature_response_method": low_level_thermal["method"],
         "low_level_theta_or_temperature_response_source_field": low_level_thermal["source_field"],
         "low_level_theta_or_temperature_response_units": low_level_thermal["units"],
@@ -2239,7 +2267,14 @@ def _low_level_response_summary_values(
         return {
             "source_field": fallback_source_field,
             "units": fallback_units,
-            "delta": unavailable,
+            "early_delta": unavailable,
+            "early_start_mean": unavailable,
+            "early_end_mean": unavailable,
+            "early_start_time_seconds": unavailable,
+            "early_end_time_seconds": unavailable,
+            "early_start_finite_count": 0,
+            "early_end_finite_count": 0,
+            "full_delta": unavailable,
             "first_mean": unavailable,
             "final_mean": unavailable,
             "first_time_seconds": unavailable,
@@ -2250,23 +2285,65 @@ def _low_level_response_summary_values(
         }
     reason = _low_level_response_unavailable_reason(diagnostics)
     method = (
-        diagnostics.vertical_coordinate_method if diagnostics.available else f"unavailable:{reason}"
+        diagnostics.vertical_coordinate_method
+        if diagnostics.vertical_coordinate_method is not None
+        else f"unavailable:{reason}"
     )
+    early_unavailable = f"unavailable:{reason}"
     return {
         "source_field": diagnostics.source_field or fallback_source_field,
         "units": diagnostics.units or fallback_units,
-        "delta": diagnostics.delta_value if diagnostics.available else f"unavailable:{reason}",
+        "early_delta": (
+            diagnostics.early_response_delta
+            if diagnostics.early_response_delta is not None
+            else early_unavailable
+        ),
+        "early_start_mean": (
+            diagnostics.early_response_start_mean_value
+            if diagnostics.early_response_delta is not None
+            else early_unavailable
+        ),
+        "early_end_mean": (
+            diagnostics.early_response_end_mean_value
+            if diagnostics.early_response_delta is not None
+            else early_unavailable
+        ),
+        "early_start_time_seconds": (
+            diagnostics.early_response_start_time_seconds
+            if diagnostics.early_response_delta is not None
+            else early_unavailable
+        ),
+        "early_end_time_seconds": (
+            diagnostics.early_response_end_time_seconds
+            if diagnostics.early_response_delta is not None
+            else early_unavailable
+        ),
+        "early_start_finite_count": diagnostics.early_response_start_finite_count,
+        "early_end_finite_count": diagnostics.early_response_end_finite_count,
+        "full_delta": (
+            diagnostics.full_run_delta
+            if diagnostics.full_run_delta is not None
+            else f"unavailable:{reason}"
+        ),
         "first_mean": (
-            diagnostics.first_mean_value if diagnostics.available else f"unavailable:{reason}"
+            diagnostics.first_mean_value
+            if diagnostics.first_mean_value is not None
+            else f"unavailable:{reason}"
         ),
         "final_mean": (
-            diagnostics.final_mean_value if diagnostics.available else f"unavailable:{reason}"
+            diagnostics.final_mean_value
+            if diagnostics.final_mean_value is not None
+            else f"unavailable:{reason}"
         ),
         "first_time_seconds": (
-            diagnostics.first_time_seconds if diagnostics.available else f"unavailable:{reason}"
+            diagnostics.first_time_seconds
+            if diagnostics.first_time_seconds is not None
+            else f"unavailable:{reason}"
         ),
         "final_time_seconds": (
-            diagnostics.final_time_seconds if diagnostics.available else f"unavailable:{reason}"
+            diagnostics.final_time_seconds
+            if diagnostics.final_time_seconds is not None
+            else f"unavailable:{reason}"
         ),
         "first_finite_count": diagnostics.first_finite_count,
         "final_finite_count": diagnostics.final_finite_count,
@@ -2692,19 +2769,23 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                 f"- Diagnostic trust: `{_diagnostic_trust_summary(diagnostic_trust)}`",
                 f"- Field-quality warnings: `{quality_warnings}`",
                 (
-                    f"- Low-level qv response: `{run['low_level_qv_response']}` "
+                    f"- Low-level qv early response: "
+                    f"`{run['low_level_qv_early_response_delta']}` "
                     f"`{run['low_level_qv_response_units'] or ''}` via "
                     f"`{run['low_level_qv_response_method']}` "
-                    f"({run['low_level_qv_response_first_mean']} -> "
-                    f"{run['low_level_qv_response_final_mean']})"
+                    f"({run['low_level_qv_early_response_start_mean']} -> "
+                    f"{run['low_level_qv_early_response_end_mean']}); "
+                    f"full-run delta `{run['low_level_qv_full_run_delta']}`"
                 ),
                 (
-                    f"- Low-level theta/temperature response: "
-                    f"`{run['low_level_theta_or_temperature_response']}` "
+                    f"- Low-level theta/temperature early response: "
+                    f"`{run['low_level_theta_or_temperature_early_response_delta']}` "
                     f"`{run['low_level_theta_or_temperature_response_units'] or ''}` via "
                     f"`{run['low_level_theta_or_temperature_response_method']}` "
-                    f"({run['low_level_theta_or_temperature_response_first_mean']} -> "
-                    f"{run['low_level_theta_or_temperature_response_final_mean']})"
+                    f"({run['low_level_theta_or_temperature_early_response_start_mean']} -> "
+                    f"{run['low_level_theta_or_temperature_early_response_end_mean']}); "
+                    f"full-run delta "
+                    f"`{run['low_level_theta_or_temperature_full_run_delta']}`"
                 ),
                 f"- Caveats: `{', '.join(run['caveats']) or 'none'}`",
                 "",
@@ -2993,7 +3074,11 @@ def _comparison_supported_differences(
         "surface_rain_present",
         "max_dbz",
         "low_level_qv_response",
+        "low_level_qv_early_response_delta",
+        "low_level_qv_full_run_delta",
         "low_level_theta_or_temperature_response",
+        "low_level_theta_or_temperature_early_response_delta",
+        "low_level_theta_or_temperature_full_run_delta",
     ):
         left = control.get(field)
         right = experiment.get(field)
@@ -3196,13 +3281,13 @@ def _low_level_response_for_pair(
 
     expectations = [
         _low_level_response_expectation(
-            field="low_level_theta_or_temperature_response",
+            field="low_level_theta_or_temperature_early_response_delta",
             selected_control_field="surface_heat_flux_k_m_s",
             control=control,
             experiment=experiment,
         ),
         _low_level_response_expectation(
-            field="low_level_qv_response",
+            field="low_level_qv_early_response_delta",
             selected_control_field="surface_moisture_flux_g_g_m_s",
             control=control,
             experiment=experiment,
@@ -3236,8 +3321,8 @@ def _low_level_pair_unavailable_evidence(
         if diagnostic_support.get("low_level_response") != "available":
             unavailable.append(f"{role}:diagnostic_unavailable:low_level_response")
         for field in (
-            "low_level_qv_response",
-            "low_level_theta_or_temperature_response",
+            "low_level_qv_early_response_delta",
+            "low_level_theta_or_temperature_early_response_delta",
         ):
             value = summary.get(field)
             if not isinstance(value, int | float) or _is_unavailable(value):
@@ -3246,8 +3331,8 @@ def _low_level_pair_unavailable_evidence(
             if not isinstance(units, str) or not units:
                 unavailable.append(f"{role}:{field}_units_unavailable")
     for field in (
-        "low_level_qv_response",
-        "low_level_theta_or_temperature_response",
+        "low_level_qv_early_response_delta",
+        "low_level_theta_or_temperature_early_response_delta",
     ):
         control_units = control.get(f"{field}_units")
         experiment_units = experiment.get(f"{field}_units")
@@ -3489,7 +3574,7 @@ def _field_available(field: str, available_fields: set[str]) -> bool:
     if field in {"qfx", "lhfx"}:
         return bool({"qfx", "lhfx"} & available_fields)
     if field == "th_or_temperature":
-        return bool({"th", "theta", "theta_v", "temperature", "t"} & available_fields)
+        return bool({"th", "theta", "temperature", "t"} & available_fields)
     return field in available_fields
 
 

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -24,6 +24,9 @@ def base_dataset(
     dbz_values: list[list[list[list[float]]]] | None = None,
     hfx_values: list[list[list[float]]] | None = None,
     qfx_values: list[list[list[float]]] | None = None,
+    qv_values: list[list[list[list[float]]]] | None = None,
+    th_values: list[list[list[list[float]]]] | None = None,
+    temperature_values: list[list[list[list[float]]]] | None = None,
     qi_values: list[list[list[list[float]]]] | None = None,
     qs_values: list[list[list[list[float]]]] | None = None,
     qg_values: list[list[list[list[float]]]] | None = None,
@@ -83,6 +86,24 @@ def base_dataset(
             qfx_values,
             {"units": "kg/m^2/s"},
         )
+    if qv_values is not None:
+        data_vars["qv"] = (
+            ("time", "z", "y", "x"),
+            qv_values,
+            {"units": "kg/kg"},
+        )
+    if th_values is not None:
+        data_vars["th"] = (
+            ("time", "z", "y", "x"),
+            th_values,
+            {"units": "K"},
+        )
+    if temperature_values is not None:
+        data_vars["temperature"] = (
+            ("time", "z", "y", "x"),
+            temperature_values,
+            {"units": "K"},
+        )
     if qi_values is not None:
         data_vars["qi"] = (
             ("time", "z", "y", "x"),
@@ -135,6 +156,13 @@ def surface_values(start: float = 0.0, step: float = 1.0) -> list[list[list[floa
     return values
 
 
+def time_z_values(values_by_time_z: list[list[float]]) -> list[list[list[list[float]]]]:
+    return [
+        [[[value for _x in range(4)] for _y in range(3)] for value in time_values]
+        for time_values in values_by_time_z
+    ]
+
+
 def with_cloud(cloudy_cells: int = 12) -> list[list[list[list[float]]]]:
     values = zeros()
     filled = 0
@@ -147,12 +175,12 @@ def with_cloud(cloudy_cells: int = 12) -> list[list[list[list[float]]]]:
     return values
 
 
-def w_field() -> list[list[list[list[float]]]]:
-    values = zeros()
+def w_field(z_count: int = 2) -> list[list[list[list[float]]]]:
+    values = zeros(z_count=z_count)
     values[0][0][0][0] = -1.5
-    values[0][1][2][3] = 2.5
+    values[0][min(1, z_count - 1)][2][3] = 2.5
     values[1][0][0][0] = -3.0
-    values[1][1][2][3] = 4.0
+    values[1][min(1, z_count - 1)][2][3] = 4.0
     return values
 
 
@@ -507,6 +535,131 @@ def test_surface_flux_statistics_mark_all_non_finite_fields_unavailable(
     assert diagnostics.surface_fluxes.qfx.total_count == 24
     assert diagnostics.field_quality["qfx"].quality_state == "untrusted"
     assert "qfx_field_entirely_non_finite" in diagnostics.caveats
+
+
+def test_low_level_response_computes_0_1km_first_final_deltas(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "low_level_response.nc",
+        base_dataset(
+            qc_values=zeros(z_count=3),
+            w_values=w_field(z_count=3),
+            qv_values=time_z_values(
+                [
+                    [0.010, 0.012, 0.080],
+                    [0.014, 0.018, 0.090],
+                ]
+            ),
+            th_values=time_z_values(
+                [
+                    [299.0, 301.0, 315.0],
+                    [302.0, 306.0, 318.0],
+                ]
+            ),
+            z_values=[250.0, 750.0, 1500.0],
+            z_units="m",
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    qv = diagnostics.low_level_response.qv
+    thermal = diagnostics.low_level_response.theta_or_temperature
+    assert qv.available is True
+    assert qv.source_field == "qv"
+    assert qv.vertical_coordinate_name == "z"
+    assert qv.vertical_coordinate_units == "m"
+    assert qv.vertical_coordinate_method == "coordinate_values_0_1_km_agl"
+    assert qv.first_time_seconds == 0.0
+    assert qv.final_time_seconds == 300.0
+    assert qv.first_mean_value == pytest.approx(0.011)
+    assert qv.final_mean_value == pytest.approx(0.016)
+    assert qv.delta_value == pytest.approx(0.005)
+    assert qv.units == "kg/kg"
+    assert qv.first_finite_count == 24
+    assert qv.final_finite_count == 24
+
+    assert thermal.available is True
+    assert thermal.source_field == "th"
+    assert thermal.first_mean_value == pytest.approx(300.0)
+    assert thermal.final_mean_value == pytest.approx(304.0)
+    assert thermal.delta_value == pytest.approx(4.0)
+    assert thermal.units == "K"
+
+
+def test_low_level_response_marks_missing_fields_unavailable(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "low_level_response_missing.nc",
+        base_dataset(qc_values=zeros(), w_values=w_field()),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.low_level_response.qv.available is False
+    assert diagnostics.low_level_response.qv.field_absent is True
+    assert diagnostics.low_level_response.qv.caveats == ["qv_field_absent"]
+    thermal = diagnostics.low_level_response.theta_or_temperature
+    assert thermal.available is False
+    assert thermal.field_absent is True
+    assert thermal.caveats == ["theta_or_temperature_field_absent"]
+
+
+def test_low_level_response_requires_vertical_coordinate(tmp_path: Path) -> None:
+    dataset = xr.Dataset(
+        data_vars={
+            "qv": (
+                ("time", "z", "y", "x"),
+                time_z_values([[0.010, 0.012], [0.014, 0.018]]),
+                {"units": "kg/kg"},
+            ),
+            "th": (
+                ("time", "z", "y", "x"),
+                time_z_values([[299.0, 301.0], [302.0, 306.0]]),
+                {"units": "K"},
+            ),
+            "qc": (("time", "z", "y", "x"), zeros(), {"units": "kg/kg"}),
+            "w": (("time", "z", "y", "x"), w_field(), {"units": "m/s"}),
+        },
+        coords={
+            "time": [0.0, 300.0],
+            "y": [0.0, 200.0, 400.0],
+            "x": [0.0, 200.0, 400.0, 600.0],
+        },
+    )
+    dataset = write_dataset(tmp_path / "low_level_response_missing_z_coord.nc", dataset)
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.low_level_response.qv.available is False
+    assert diagnostics.low_level_response.qv.caveats == [
+        "qv_low_level_response_missing_vertical_coordinate"
+    ]
+    assert "qv_low_level_response_missing_vertical_coordinate" in diagnostics.caveats
+
+
+def test_low_level_response_caveats_partially_non_finite_endpoints(tmp_path: Path) -> None:
+    qv_values = time_z_values([[0.010, 0.012], [0.014, 0.018]])
+    qv_values[1][0][0][0] = float("nan")
+    dataset = write_dataset(
+        tmp_path / "low_level_response_partially_nan.nc",
+        base_dataset(
+            qc_values=zeros(),
+            w_values=w_field(),
+            qv_values=qv_values,
+            temperature_values=time_z_values([[289.0, 291.0], [292.0, 296.0]]),
+            z_values=[250.0, 750.0],
+            z_units="m",
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    qv = diagnostics.low_level_response.qv
+    assert qv.available is True
+    assert qv.final_finite_count == 23
+    assert qv.final_non_finite_count == 1
+    assert qv.delta_value == pytest.approx(((0.014 * 11 + 0.018 * 12) / 23) - 0.011)
+    assert "non_finite_values_detected_in_qv_low_level_response" in diagnostics.caveats
+    assert diagnostics.low_level_response.theta_or_temperature.source_field == "temperature"
 
 
 def test_missing_qc_and_missing_w_are_graceful(tmp_path: Path) -> None:

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -31,6 +31,7 @@ def base_dataset(
     qs_values: list[list[list[list[float]]]] | None = None,
     qg_values: list[list[list[list[float]]]] | None = None,
     include_time_coord: bool = True,
+    time_values: list[float] | None = None,
     z_values: list[float] | None = None,
     z_units: str | None = None,
 ) -> xr.Dataset:
@@ -40,7 +41,7 @@ def base_dataset(
         "x": [0.0, 200.0, 400.0, 600.0],
     }
     if include_time_coord:
-        coords["time"] = [0.0, 300.0]
+        coords["time"] = time_values or [0.0, 300.0]
     else:
         coords["time"] = []
     data_vars: dict[str, Any] = {}
@@ -134,10 +135,10 @@ def base_dataset(
     return dataset
 
 
-def zeros(z_count: int = 2) -> list[list[list[list[float]]]]:
+def zeros(time_count: int = 2, z_count: int = 2) -> list[list[list[list[float]]]]:
     return [
         [[[0.0 for _x in range(4)] for _y in range(3)] for _z in range(z_count)]
-        for _time in range(2)
+        for _time in range(time_count)
     ]
 
 
@@ -175,8 +176,8 @@ def with_cloud(cloudy_cells: int = 12) -> list[list[list[list[float]]]]:
     return values
 
 
-def w_field(z_count: int = 2) -> list[list[list[list[float]]]]:
-    values = zeros(z_count=z_count)
+def w_field(time_count: int = 2, z_count: int = 2) -> list[list[list[list[float]]]]:
+    values = zeros(time_count=time_count, z_count=z_count)
     values[0][0][0][0] = -1.5
     values[0][min(1, z_count - 1)][2][3] = 2.5
     values[1][0][0][0] = -3.0
@@ -537,25 +538,30 @@ def test_surface_flux_statistics_mark_all_non_finite_fields_unavailable(
     assert "qfx_field_entirely_non_finite" in diagnostics.caveats
 
 
-def test_low_level_response_computes_0_1km_first_final_deltas(tmp_path: Path) -> None:
+def test_low_level_response_computes_weighted_early_and_full_run_deltas(
+    tmp_path: Path,
+) -> None:
     dataset = write_dataset(
         tmp_path / "low_level_response.nc",
         base_dataset(
-            qc_values=zeros(z_count=3),
-            w_values=w_field(z_count=3),
+            qc_values=zeros(time_count=3, z_count=3),
+            w_values=w_field(time_count=3, z_count=3),
             qv_values=time_z_values(
                 [
-                    [0.010, 0.012, 0.080],
-                    [0.014, 0.018, 0.090],
+                    [0.010, 0.012, 0.020],
+                    [0.011, 0.014, 0.028],
+                    [0.012, 0.013, 0.030],
                 ]
             ),
             th_values=time_z_values(
                 [
-                    [299.0, 301.0, 315.0],
-                    [302.0, 306.0, 318.0],
+                    [300.0, 310.0, 330.0],
+                    [302.0, 313.0, 336.0],
+                    [303.0, 312.0, 340.0],
                 ]
             ),
-            z_values=[250.0, 750.0, 1500.0],
+            time_values=[0.0, 3600.0, 21600.0],
+            z_values=[50.0, 250.0, 900.0],
             z_units="m",
         ),
     )
@@ -568,21 +574,30 @@ def test_low_level_response_computes_0_1km_first_final_deltas(tmp_path: Path) ->
     assert qv.source_field == "qv"
     assert qv.vertical_coordinate_name == "z"
     assert qv.vertical_coordinate_units == "m"
-    assert qv.vertical_coordinate_method == "coordinate_values_0_1_km_agl"
+    assert qv.vertical_coordinate_method == ("0_1km_thickness_weighted_domain_mean_early_30_90min")
     assert qv.first_time_seconds == 0.0
-    assert qv.final_time_seconds == 300.0
-    assert qv.first_mean_value == pytest.approx(0.011)
-    assert qv.final_mean_value == pytest.approx(0.016)
-    assert qv.delta_value == pytest.approx(0.005)
+    assert qv.final_time_seconds == 21600.0
+    assert qv.early_response_start_time_seconds == 0.0
+    assert qv.early_response_end_time_seconds == 3600.0
+    assert qv.first_mean_value == pytest.approx(0.0151)
+    assert qv.early_response_end_mean_value == pytest.approx(0.0195)
+    assert qv.final_mean_value == pytest.approx(0.020075)
+    assert qv.delta_value == pytest.approx(0.0044)
+    assert qv.early_response_delta == pytest.approx(0.0044)
+    assert qv.full_run_delta == pytest.approx(0.004975)
     assert qv.units == "kg/kg"
-    assert qv.first_finite_count == 24
-    assert qv.final_finite_count == 24
+    assert qv.first_finite_count == 36
+    assert qv.early_response_end_finite_count == 36
+    assert qv.final_finite_count == 36
 
     assert thermal.available is True
     assert thermal.source_field == "th"
-    assert thermal.first_mean_value == pytest.approx(300.0)
-    assert thermal.final_mean_value == pytest.approx(304.0)
-    assert thermal.delta_value == pytest.approx(4.0)
+    assert thermal.first_mean_value == pytest.approx(317.0)
+    assert thermal.early_response_end_mean_value == pytest.approx(321.125)
+    assert thermal.final_mean_value == pytest.approx(322.55)
+    assert thermal.delta_value == pytest.approx(4.125)
+    assert thermal.early_response_delta == pytest.approx(4.125)
+    assert thermal.full_run_delta == pytest.approx(5.55)
     assert thermal.units == "K"
 
 
@@ -646,6 +661,7 @@ def test_low_level_response_caveats_partially_non_finite_endpoints(tmp_path: Pat
             w_values=w_field(),
             qv_values=qv_values,
             temperature_values=time_z_values([[289.0, 291.0], [292.0, 296.0]]),
+            time_values=[0.0, 3600.0],
             z_values=[250.0, 750.0],
             z_units="m",
         ),
@@ -658,8 +674,46 @@ def test_low_level_response_caveats_partially_non_finite_endpoints(tmp_path: Pat
     assert qv.final_finite_count == 23
     assert qv.final_non_finite_count == 1
     assert qv.delta_value == pytest.approx(((0.014 * 11 + 0.018 * 12) / 23) - 0.011)
+    assert qv.full_run_delta == qv.delta_value
     assert "non_finite_values_detected_in_qv_low_level_response" in diagnostics.caveats
     assert diagnostics.low_level_response.theta_or_temperature.source_field == "temperature"
+
+
+def test_low_level_response_does_not_use_theta_v_for_heat_gate(tmp_path: Path) -> None:
+    dataset = write_dataset(
+        tmp_path / "low_level_response_theta_v_only.nc",
+        xr.Dataset(
+            data_vars={
+                "qv": (
+                    ("time", "z", "y", "x"),
+                    time_z_values([[0.010, 0.012], [0.014, 0.018]]),
+                    {"units": "kg/kg"},
+                ),
+                "theta_v": (
+                    ("time", "z", "y", "x"),
+                    time_z_values([[299.0, 301.0], [302.0, 306.0]]),
+                    {"units": "K"},
+                ),
+                "qc": (("time", "z", "y", "x"), zeros(), {"units": "kg/kg"}),
+                "w": (("time", "z", "y", "x"), w_field(), {"units": "m/s"}),
+            },
+            coords={
+                "time": [0.0, 3600.0],
+                "z": [250.0, 750.0],
+                "y": [0.0, 200.0, 400.0],
+                "x": [0.0, 200.0, 400.0, 600.0],
+            },
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.low_level_response.qv.available is True
+    thermal = diagnostics.low_level_response.theta_or_temperature
+    assert thermal.available is False
+    assert thermal.source_field is None
+    assert thermal.field_absent is True
+    assert thermal.caveats == ["theta_or_temperature_field_absent"]
 
 
 def test_missing_qc_and_missing_w_are_graceful(tmp_path: Path) -> None:

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -571,6 +571,8 @@ def test_low_level_response_computes_weighted_early_and_full_run_deltas(
     qv = diagnostics.low_level_response.qv
     thermal = diagnostics.low_level_response.theta_or_temperature
     assert qv.available is True
+    assert qv.early_response_available is True
+    assert qv.full_run_response_available is True
     assert qv.source_field == "qv"
     assert qv.vertical_coordinate_name == "z"
     assert qv.vertical_coordinate_units == "m"
@@ -591,6 +593,8 @@ def test_low_level_response_computes_weighted_early_and_full_run_deltas(
     assert qv.final_finite_count == 36
 
     assert thermal.available is True
+    assert thermal.early_response_available is True
+    assert thermal.full_run_response_available is True
     assert thermal.source_field == "th"
     assert thermal.first_mean_value == pytest.approx(317.0)
     assert thermal.early_response_end_mean_value == pytest.approx(321.125)
@@ -599,6 +603,100 @@ def test_low_level_response_computes_weighted_early_and_full_run_deltas(
     assert thermal.early_response_delta == pytest.approx(4.125)
     assert thermal.full_run_delta == pytest.approx(5.55)
     assert thermal.units == "K"
+
+
+def test_low_level_response_keeps_early_when_final_endpoint_non_finite(
+    tmp_path: Path,
+) -> None:
+    qv_values = time_z_values(
+        [
+            [0.010, 0.012],
+            [0.014, 0.018],
+            [float("nan"), float("nan")],
+        ]
+    )
+    dataset = write_dataset(
+        tmp_path / "low_level_response_bad_final.nc",
+        base_dataset(
+            qc_values=zeros(time_count=3),
+            w_values=w_field(time_count=3),
+            qv_values=qv_values,
+            th_values=time_z_values(
+                [
+                    [299.0, 301.0],
+                    [302.0, 306.0],
+                    [float("nan"), float("nan")],
+                ]
+            ),
+            time_values=[0.0, 3600.0, 21600.0],
+            z_values=[250.0, 750.0],
+            z_units="m",
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    qv = diagnostics.low_level_response.qv
+    assert qv.available is True
+    assert qv.early_response_available is True
+    assert qv.full_run_response_available is False
+    assert qv.early_response_delta == pytest.approx(0.005)
+    assert qv.full_run_delta is None
+    assert qv.final_finite_count == 0
+    assert "qv_low_level_response_final_endpoint_entirely_non_finite" in qv.caveats
+
+
+def test_low_level_response_keeps_early_when_no_distinct_final_endpoint(
+    tmp_path: Path,
+) -> None:
+    dataset = write_dataset(
+        tmp_path / "low_level_response_no_distinct_final.nc",
+        base_dataset(
+            qc_values=zeros(),
+            w_values=w_field(),
+            qv_values=time_z_values([[0.010, 0.012], [0.014, 0.018]]),
+            th_values=time_z_values([[299.0, 301.0], [302.0, 306.0]]),
+            time_values=[0.0, 3600.0],
+            z_values=[250.0, 750.0],
+            z_units="m",
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    qv = diagnostics.low_level_response.qv
+    assert qv.available is True
+    assert qv.early_response_available is True
+    assert qv.full_run_response_available is False
+    assert qv.early_response_delta == pytest.approx(0.005)
+    assert qv.full_run_delta is None
+
+
+def test_low_level_response_reports_full_run_when_early_endpoint_missing(
+    tmp_path: Path,
+) -> None:
+    dataset = write_dataset(
+        tmp_path / "low_level_response_missing_early.nc",
+        base_dataset(
+            qc_values=zeros(),
+            w_values=w_field(),
+            qv_values=time_z_values([[0.010, 0.012], [0.020, 0.024]]),
+            th_values=time_z_values([[299.0, 301.0], [306.0, 310.0]]),
+            time_values=[0.0, 21600.0],
+            z_values=[250.0, 750.0],
+            z_units="m",
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    qv = diagnostics.low_level_response.qv
+    assert qv.available is False
+    assert qv.early_response_available is False
+    assert qv.full_run_response_available is True
+    assert qv.early_response_delta is None
+    assert qv.full_run_delta == pytest.approx(0.011)
+    assert "qv_low_level_response_missing_early_output_30_90min" in qv.caveats
 
 
 def test_low_level_response_marks_missing_fields_unavailable(tmp_path: Path) -> None:
@@ -674,7 +772,9 @@ def test_low_level_response_caveats_partially_non_finite_endpoints(tmp_path: Pat
     assert qv.final_finite_count == 23
     assert qv.final_non_finite_count == 1
     assert qv.delta_value == pytest.approx(((0.014 * 11 + 0.018 * 12) / 23) - 0.011)
-    assert qv.full_run_delta == qv.delta_value
+    assert qv.early_response_available is True
+    assert qv.full_run_response_available is False
+    assert qv.full_run_delta is None
     assert "non_finite_values_detected_in_qv_low_level_response" in diagnostics.caveats
     assert diagnostics.low_level_response.theta_or_temperature.source_field == "temperature"
 

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -109,6 +109,8 @@ def write_model_netcdf(
     dbz_values: list[float] | None = None,
     hfx_values: list[float] | None = None,
     qfx_values: list[float] | None = None,
+    qv_values: list[float] | None = None,
+    th_values: list[float] | None = None,
     z_values: list[float] | None = None,
     include_qc: bool = True,
     include_w: bool = True,
@@ -168,6 +170,24 @@ def write_model_netcdf(
             ("time", "y", "x"),
             [[[qfx_value for _x in range(4)] for _y in range(3)] for qfx_value in qfx_values],
             {"units": "kg/m^2/s"},
+        )
+    if qv_values is not None:
+        data_vars["qv"] = (
+            ("time", "z", "y", "x"),
+            [
+                [[[qv_value for _x in range(4)] for _y in range(3)] for _z in z_values]
+                for qv_value in qv_values
+            ],
+            {"units": "kg/kg"},
+        )
+    if th_values is not None:
+        data_vars["th"] = (
+            ("time", "z", "y", "x"),
+            [
+                [[[th_value for _x in range(4)] for _y in range(3)] for _z in z_values]
+                for th_value in th_values
+            ],
+            {"units": "K"},
         )
     xr.Dataset(
         data_vars=data_vars,
@@ -306,6 +326,8 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
         w_values=[-5.0],
         hfx_values=[1.0],
         qfx_values=[1.0e-5],
+        qv_values=[0.010],
+        th_values=[300.0],
     )
     write_model_netcdf(
         second,
@@ -314,6 +336,8 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
         w_values=[7.0],
         hfx_values=[3.0],
         qfx_values=[3.0e-5],
+        qv_values=[0.016],
+        th_values=[304.0],
     )
     write_stats_netcdf(stats)
     complete_manifest(
@@ -355,6 +379,17 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     assert result.diagnostics.surface_fluxes.qfx.total_count == 24
     assert result.diagnostics.field_quality["hfx"].quality_state == "trusted"
     assert result.diagnostics.field_quality["qfx"].quality_state == "trusted"
+    assert result.diagnostics.low_level_response.qv.available is True
+    assert result.diagnostics.low_level_response.qv.first_time_seconds == 300.0
+    assert result.diagnostics.low_level_response.qv.final_time_seconds == 600.0
+    assert result.diagnostics.low_level_response.qv.delta_value == pytest.approx(0.006)
+    assert result.diagnostics.low_level_response.theta_or_temperature.available is True
+    assert result.diagnostics.low_level_response.theta_or_temperature.delta_value == pytest.approx(
+        4.0
+    )
+    assert (
+        "qv_low_level_response_requires_at_least_two_time_steps" not in result.diagnostics.caveats
+    )
     interesting = {record.key: record for record in result.interesting_times}
     assert interesting["first_cloud"].support_state == "supported"
     assert interesting["first_cloud"].time_index == 1
@@ -377,6 +412,10 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     assert result.science_summary.max_updraft_w_m_s == 7.0
     assert result.science_summary.min_downdraft_w_m_s == -5.0
     assert result.science_summary.latest_output_time_seconds == 600.0
+    assert result.science_summary.low_level_response.qv.delta_value == pytest.approx(0.006)
+    availability = {item.key: item for item in result.science_summary.diagnostic_availability}
+    assert availability["low_level_qv_response"].support_state == "supported"
+    assert availability["low_level_qv_response"].value == pytest.approx(0.006)
 
 
 def test_ingest_keeps_rain_water_surface_rain_and_reflectivity_distinct(

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -331,7 +331,7 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     )
     write_model_netcdf(
         second,
-        times=[600.0],
+        times=[3900.0],
         qc_values=[2e-6],
         w_values=[7.0],
         hfx_values=[3.0],
@@ -352,15 +352,15 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     assert result.model_output_file_count == 2
     assert result.time_steps == 2
     assert result.first_output_time_seconds == 300.0
-    assert result.last_output_time_seconds == 600.0
+    assert result.last_output_time_seconds == 3900.0
     assert result.time_coordinate_source == "netcdf_time_coordinate"
     assert result.time_coordinate_fallback_used is False
     assert result.diagnostics is not None
     assert result.diagnostics.cloud.formed is True
-    assert result.diagnostics.cloud.first_cloud_time_seconds == 600.0
+    assert result.diagnostics.cloud.first_cloud_time_seconds == 3900.0
     assert len(result.diagnostics.cloud.qc_max_time_series) == 2
     assert result.diagnostics.cloud.max_qc_kg_kg == 2e-6
-    assert result.diagnostics.cloud.time_of_max_qc_seconds == 600.0
+    assert result.diagnostics.cloud.time_of_max_qc_seconds == 3900.0
     assert result.diagnostics.vertical_velocity.min_w_m_s == -5.0
     assert result.diagnostics.vertical_velocity.max_w_m_s == 7.0
     assert result.diagnostics.surface_fluxes.hfx.available is True
@@ -381,8 +381,10 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     assert result.diagnostics.field_quality["qfx"].quality_state == "trusted"
     assert result.diagnostics.low_level_response.qv.available is True
     assert result.diagnostics.low_level_response.qv.first_time_seconds == 300.0
-    assert result.diagnostics.low_level_response.qv.final_time_seconds == 600.0
+    assert result.diagnostics.low_level_response.qv.final_time_seconds == 3900.0
+    assert result.diagnostics.low_level_response.qv.early_response_end_time_seconds == 3900.0
     assert result.diagnostics.low_level_response.qv.delta_value == pytest.approx(0.006)
+    assert result.diagnostics.low_level_response.qv.full_run_delta == pytest.approx(0.006)
     assert result.diagnostics.low_level_response.theta_or_temperature.available is True
     assert result.diagnostics.low_level_response.theta_or_temperature.delta_value == pytest.approx(
         4.0
@@ -393,7 +395,7 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     interesting = {record.key: record for record in result.interesting_times}
     assert interesting["first_cloud"].support_state == "supported"
     assert interesting["first_cloud"].time_index == 1
-    assert interesting["first_cloud"].time_seconds == 600.0
+    assert interesting["first_cloud"].time_seconds == 3900.0
     assert interesting["max_qc"].support_state == "supported"
     assert interesting["max_qc"].time_index == 1
     assert interesting["max_updraft_w"].time_index == 1
@@ -406,12 +408,12 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     assert result.default_time_by_field["w"].time_index == 1
     assert result.default_time_by_field["qr"].support_state == "fallback"
     assert result.science_summary is not None
-    assert result.science_summary.first_cloud_time_seconds == 600.0
+    assert result.science_summary.first_cloud_time_seconds == 3900.0
     assert result.science_summary.max_qc_kg_kg == 2e-6
-    assert result.science_summary.max_qc_time_seconds == 600.0
+    assert result.science_summary.max_qc_time_seconds == 3900.0
     assert result.science_summary.max_updraft_w_m_s == 7.0
     assert result.science_summary.min_downdraft_w_m_s == -5.0
-    assert result.science_summary.latest_output_time_seconds == 600.0
+    assert result.science_summary.latest_output_time_seconds == 3900.0
     assert result.science_summary.low_level_response.qv.delta_value == pytest.approx(0.006)
     availability = {item.key: item for item in result.science_summary.diagnostic_availability}
     assert availability["low_level_qv_response"].support_state == "supported"

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -384,7 +384,9 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     assert result.diagnostics.low_level_response.qv.final_time_seconds == 3900.0
     assert result.diagnostics.low_level_response.qv.early_response_end_time_seconds == 3900.0
     assert result.diagnostics.low_level_response.qv.delta_value == pytest.approx(0.006)
-    assert result.diagnostics.low_level_response.qv.full_run_delta == pytest.approx(0.006)
+    assert result.diagnostics.low_level_response.qv.early_response_available is True
+    assert result.diagnostics.low_level_response.qv.full_run_response_available is False
+    assert result.diagnostics.low_level_response.qv.full_run_delta is None
     assert result.diagnostics.low_level_response.theta_or_temperature.available is True
     assert result.diagnostics.low_level_response.theta_or_temperature.delta_value == pytest.approx(
         4.0

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -919,8 +919,13 @@ def test_campaign_report_verifies_matched_phase1_low_level_response(
         if row["matrix_id"] == "phase1_control_high_moisture"
     )
     assert run["low_level_qv_response"] == pytest.approx(0.004)
-    assert run["low_level_qv_response_method"] == "coordinate_values_0_1_km_agl"
+    assert run["low_level_qv_early_response_delta"] == pytest.approx(0.004)
+    assert run["low_level_qv_response_method"] == (
+        "0_1km_thickness_weighted_domain_mean_early_30_90min"
+    )
+    assert run["low_level_qv_full_run_delta"] == pytest.approx(0.004)
     assert run["low_level_theta_or_temperature_response"] == pytest.approx(1.1)
+    assert run["low_level_theta_or_temperature_early_response_delta"] == pytest.approx(1.1)
 
     moisture = next(
         evaluation
@@ -929,11 +934,49 @@ def test_campaign_report_verifies_matched_phase1_low_level_response(
     )
     assert moisture["expectations"][0]["required"] is False
     assert moisture["expectations"][1]["required"] is True
-    assert moisture["expectations"][1]["field"] == "low_level_qv_response"
+    assert moisture["expectations"][1]["field"] == "low_level_qv_early_response_delta"
     assert moisture["expectations"][1]["status"] == "verified"
     report = Path(artifacts.markdown_path).read_text()
     assert "## Low-Level Response" in report
-    assert "low_level_qv_response: required; expected `increase`, observed `increase`" in report
+    assert (
+        "low_level_qv_early_response_delta: required; expected `increase`, observed `increase`"
+    ) in report
+
+
+def test_campaign_gate_uses_early_response_not_full_run_delta(
+    tmp_path: Path,
+) -> None:
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.5e-5),
+            "phase1_control_high_moisture": (2.2, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+        low_level_deltas={
+            "phase1_control_default_flux": (0.001, 1.0),
+            "phase1_control_high_sensible": (0.0012, 3.0),
+            "phase1_control_high_moisture": (0.004, 1.1),
+            "phase1_control_high_both": (0.004, 3.2),
+        },
+        low_level_full_run_deltas={
+            "phase1_control_default_flux": (0.003, 3.0),
+            "phase1_control_high_sensible": (0.001, 2.0),
+            "phase1_control_high_moisture": (0.002, 1.0),
+            "phase1_control_high_both": (0.002, 2.0),
+        },
+    )
+
+    assert artifacts.summary["low_level_response"]["state"] == "low_level_response_verified"
+    assert artifacts.summary["phase_gate_state"] == "forcing_path_verified_for_campaign"
+    high_moisture = next(
+        row
+        for row in artifacts.summary["runs"]
+        if row["matrix_id"] == "phase1_control_high_moisture"
+    )
+    assert high_moisture["low_level_qv_early_response_delta"] == pytest.approx(0.004)
+    assert high_moisture["low_level_qv_full_run_delta"] == pytest.approx(0.002)
 
 
 def test_campaign_report_blocks_phase_gate_when_low_level_response_not_verified(
@@ -1302,6 +1345,7 @@ def _report_phase1_surface_flux_matrix(
     *,
     flux_means: dict[str, tuple[float, float]],
     low_level_deltas: dict[str, tuple[float, float]] | None = None,
+    low_level_full_run_deltas: dict[str, tuple[float, float]] | None = None,
     non_finite_counts: dict[str, tuple[int, int]] | None = None,
     unit_overrides: dict[str, tuple[str, str]] | None = None,
     mutate_matrix: Any | None = None,
@@ -1332,6 +1376,16 @@ def _report_phase1_surface_flux_matrix(
             ),
             low_level_theta_delta=(
                 low_level_deltas[state_run.matrix_id][1] if low_level_deltas is not None else None
+            ),
+            low_level_qv_full_run_delta=(
+                low_level_full_run_deltas[state_run.matrix_id][0]
+                if low_level_full_run_deltas is not None
+                else None
+            ),
+            low_level_theta_full_run_delta=(
+                low_level_full_run_deltas[state_run.matrix_id][1]
+                if low_level_full_run_deltas is not None
+                else None
             ),
             hfx_units=hfx_units,
             qfx_units=qfx_units,
@@ -1373,6 +1427,7 @@ def _fake_low_level_response_field(
     *,
     source_field: str,
     delta: float | None,
+    full_run_delta: float | None = None,
     units: str,
 ) -> LowLevelResponseFieldDiagnostics:
     if delta is None:
@@ -1384,7 +1439,9 @@ def _fake_low_level_response_field(
             caveats=[f"{source_field}_low_level_response_unavailable_in_fixture"],
         )
     first_mean = 0.010 if source_field == "qv" else 300.0
-    final_mean = first_mean + delta
+    full_delta = delta if full_run_delta is None else full_run_delta
+    early_mean = first_mean + delta
+    final_mean = first_mean + full_delta
     return LowLevelResponseFieldDiagnostics(
         source_field=source_field,
         available=True,
@@ -1393,15 +1450,29 @@ def _fake_low_level_response_field(
         layer_top_m=1000.0,
         vertical_coordinate_name="z",
         vertical_coordinate_units="m",
-        vertical_coordinate_method="coordinate_values_0_1_km_agl",
+        vertical_coordinate_method="0_1km_thickness_weighted_domain_mean_early_30_90min",
         time_dimension="time",
         first_time_index=0,
-        final_time_index=1,
+        final_time_index=2,
         first_time_seconds=0.0,
-        final_time_seconds=3600.0,
+        final_time_seconds=21600.0,
         first_mean_value=first_mean,
         final_mean_value=final_mean,
         delta_value=delta,
+        early_response_start_time_index=0,
+        early_response_end_time_index=1,
+        early_response_start_time_seconds=0.0,
+        early_response_end_time_seconds=3600.0,
+        early_response_start_mean_value=first_mean,
+        early_response_end_mean_value=early_mean,
+        early_response_delta=delta,
+        early_response_start_finite_count=8,
+        early_response_start_non_finite_count=0,
+        early_response_start_total_count=8,
+        early_response_end_finite_count=8,
+        early_response_end_non_finite_count=0,
+        early_response_end_total_count=8,
+        full_run_delta=full_delta,
         units=units,
         first_finite_count=8,
         first_non_finite_count=0,
@@ -1428,6 +1499,8 @@ def _write_fake_result_metadata(
     qfx_non_finite_count: int = 0,
     low_level_qv_delta: float | None = None,
     low_level_theta_delta: float | None = None,
+    low_level_qv_full_run_delta: float | None = None,
+    low_level_theta_full_run_delta: float | None = None,
 ) -> None:
     manifest = load_run_manifest(manifest_path)
     now = datetime.now(UTC)
@@ -1538,11 +1611,13 @@ def _write_fake_result_metadata(
                 qv=_fake_low_level_response_field(
                     source_field="qv",
                     delta=low_level_qv_delta,
+                    full_run_delta=low_level_qv_full_run_delta,
                     units="kg/kg",
                 ),
                 theta_or_temperature=_fake_low_level_response_field(
                     source_field="th",
                     delta=low_level_theta_delta,
+                    full_run_delta=low_level_theta_full_run_delta,
                     units="K",
                 ),
             ),

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -14,6 +14,8 @@ from igra_fixtures import IGRA_FIXTURE
 from cloud_chamber.output_products import ScienceSummary
 from cloud_chamber.result_diagnostics import (
     CloudDiagnostics,
+    LowLevelResponseDiagnostics,
+    LowLevelResponseFieldDiagnostics,
     RainDiagnostics,
     ReflectivityDiagnostics,
     ResultDiagnostics,
@@ -811,9 +813,11 @@ def test_campaign_report_summarizes_ingested_result_without_fabricating_bl_respo
     assert run["lhfx_present"] is True
     assert run["diagnostic_support"]["surface_fluxes"] == "available"
     assert run["low_level_qv_response"] == (
-        "unavailable:low_level_response_diagnostic_not_implemented"
+        "unavailable:qv_low_level_response_unavailable_in_fixture"
     )
-    assert run["low_level_qv_response_method"] == "low_level_response_diagnostic_not_implemented"
+    assert run["low_level_qv_response_method"] == (
+        "unavailable:qv_low_level_response_unavailable_in_fixture"
+    )
     assert "low_level_qv_response" in summary["unavailable_diagnostics"]
     assert "max w 2.5" in report_path.read_text()
 
@@ -885,6 +889,85 @@ def test_campaign_report_verifies_matched_phase1_surface_flux_response(
     assert "Surface flux response: `surface_flux_response_verified`" in report
     assert "qfx: informational; expected `comparable`, observed `increase`" in report
     assert "`phase1_control_high_sensible` vs `phase1_control_default_flux`" in report
+
+
+def test_campaign_report_verifies_matched_phase1_low_level_response(
+    tmp_path: Path,
+) -> None:
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.5e-5),
+            "phase1_control_high_moisture": (2.2, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+        low_level_deltas={
+            "phase1_control_default_flux": (0.001, 1.0),
+            "phase1_control_high_sensible": (0.0012, 3.0),
+            "phase1_control_high_moisture": (0.004, 1.1),
+            "phase1_control_high_both": (0.004, 3.2),
+        },
+    )
+
+    assert artifacts.summary["surface_flux_response"]["state"] == "surface_flux_response_verified"
+    assert artifacts.summary["low_level_response"]["state"] == "low_level_response_verified"
+    assert artifacts.summary["phase_gate_state"] == "forcing_path_verified_for_campaign"
+    run = next(
+        row
+        for row in artifacts.summary["runs"]
+        if row["matrix_id"] == "phase1_control_high_moisture"
+    )
+    assert run["low_level_qv_response"] == pytest.approx(0.004)
+    assert run["low_level_qv_response_method"] == "coordinate_values_0_1_km_agl"
+    assert run["low_level_theta_or_temperature_response"] == pytest.approx(1.1)
+
+    moisture = next(
+        evaluation
+        for evaluation in artifacts.summary["low_level_response"]["evaluations"]
+        if evaluation["comparison_type"] == "moisture_flux_sensitivity"
+    )
+    assert moisture["expectations"][0]["required"] is False
+    assert moisture["expectations"][1]["required"] is True
+    assert moisture["expectations"][1]["field"] == "low_level_qv_response"
+    assert moisture["expectations"][1]["status"] == "verified"
+    report = Path(artifacts.markdown_path).read_text()
+    assert "## Low-Level Response" in report
+    assert "low_level_qv_response: required; expected `increase`, observed `increase`" in report
+
+
+def test_campaign_report_blocks_phase_gate_when_low_level_response_not_verified(
+    tmp_path: Path,
+) -> None:
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.0e-5),
+            "phase1_control_high_moisture": (2.0, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+        low_level_deltas={
+            "phase1_control_default_flux": (0.001, 1.0),
+            "phase1_control_high_sensible": (0.001, 3.0),
+            "phase1_control_high_moisture": (0.001, 1.0),
+            "phase1_control_high_both": (0.004, 3.2),
+        },
+    )
+
+    assert artifacts.summary["surface_flux_response"]["state"] == "surface_flux_response_verified"
+    assert artifacts.summary["low_level_response"]["state"] == "low_level_response_not_verified"
+    assert artifacts.summary["phase_gate_state"] == (
+        "forcing_wiring_verified_but_response_not_verified"
+    )
+    moisture = next(
+        evaluation
+        for evaluation in artifacts.summary["low_level_response"]["evaluations"]
+        if evaluation["comparison_type"] == "moisture_flux_sensitivity"
+    )
+    assert moisture["expectations"][1]["expected"] == "increase"
+    assert moisture["expectations"][1]["observed"] == "comparable"
+    assert moisture["expectations"][1]["status"] == "not_verified"
 
 
 def test_campaign_report_requires_complete_phase1_surface_flux_response_matrix(
@@ -1218,6 +1301,7 @@ def _report_phase1_surface_flux_matrix(
     tmp_path: Path,
     *,
     flux_means: dict[str, tuple[float, float]],
+    low_level_deltas: dict[str, tuple[float, float]] | None = None,
     non_finite_counts: dict[str, tuple[int, int]] | None = None,
     unit_overrides: dict[str, tuple[str, str]] | None = None,
     mutate_matrix: Any | None = None,
@@ -1243,6 +1327,12 @@ def _report_phase1_surface_flux_matrix(
             Path(state_run.manifest_path or ""),
             hfx_mean=hfx_mean,
             qfx_mean=qfx_mean,
+            low_level_qv_delta=(
+                low_level_deltas[state_run.matrix_id][0] if low_level_deltas is not None else None
+            ),
+            low_level_theta_delta=(
+                low_level_deltas[state_run.matrix_id][1] if low_level_deltas is not None else None
+            ),
             hfx_units=hfx_units,
             qfx_units=qfx_units,
             hfx_non_finite_count=hfx_non_finite,
@@ -1279,6 +1369,49 @@ def _set_manifest_lifecycle(
     )
 
 
+def _fake_low_level_response_field(
+    *,
+    source_field: str,
+    delta: float | None,
+    units: str,
+) -> LowLevelResponseFieldDiagnostics:
+    if delta is None:
+        return LowLevelResponseFieldDiagnostics(
+            source_field=source_field,
+            available=False,
+            field_absent=False,
+            units=units,
+            caveats=[f"{source_field}_low_level_response_unavailable_in_fixture"],
+        )
+    first_mean = 0.010 if source_field == "qv" else 300.0
+    final_mean = first_mean + delta
+    return LowLevelResponseFieldDiagnostics(
+        source_field=source_field,
+        available=True,
+        field_absent=False,
+        layer_bottom_m=0.0,
+        layer_top_m=1000.0,
+        vertical_coordinate_name="z",
+        vertical_coordinate_units="m",
+        vertical_coordinate_method="coordinate_values_0_1_km_agl",
+        time_dimension="time",
+        first_time_index=0,
+        final_time_index=1,
+        first_time_seconds=0.0,
+        final_time_seconds=3600.0,
+        first_mean_value=first_mean,
+        final_mean_value=final_mean,
+        delta_value=delta,
+        units=units,
+        first_finite_count=8,
+        first_non_finite_count=0,
+        first_total_count=8,
+        final_finite_count=8,
+        final_non_finite_count=0,
+        final_total_count=8,
+    )
+
+
 def _write_fake_result_metadata(
     manifest_path: Path,
     *,
@@ -1293,6 +1426,8 @@ def _write_fake_result_metadata(
     qfx_units: str = "kg/m^2/s",
     hfx_non_finite_count: int = 0,
     qfx_non_finite_count: int = 0,
+    low_level_qv_delta: float | None = None,
+    low_level_theta_delta: float | None = None,
 ) -> None:
     manifest = load_run_manifest(manifest_path)
     now = datetime.now(UTC)
@@ -1397,6 +1532,18 @@ def _write_fake_result_metadata(
                     finite_count=8,
                     non_finite_count=qfx_non_finite_count,
                     total_count=8 + qfx_non_finite_count,
+                ),
+            ),
+            low_level_response=LowLevelResponseDiagnostics(
+                qv=_fake_low_level_response_field(
+                    source_field="qv",
+                    delta=low_level_qv_delta,
+                    units="kg/kg",
+                ),
+                theta_or_temperature=_fake_low_level_response_field(
+                    source_field="th",
+                    delta=low_level_theta_delta,
+                    units="K",
                 ),
             ),
             time=TimeDiagnostics(source="time", fallback_used=False, coordinate_name="time"),

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -979,6 +979,88 @@ def test_campaign_gate_uses_early_response_not_full_run_delta(
     assert high_moisture["low_level_qv_full_run_delta"] == pytest.approx(0.002)
 
 
+def test_campaign_gate_blocks_when_early_response_missing_even_with_full_run_delta(
+    tmp_path: Path,
+) -> None:
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.5e-5),
+            "phase1_control_high_moisture": (2.2, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+        low_level_full_run_deltas={
+            "phase1_control_default_flux": (0.001, 1.0),
+            "phase1_control_high_sensible": (0.0012, 3.0),
+            "phase1_control_high_moisture": (0.004, 1.1),
+            "phase1_control_high_both": (0.004, 3.2),
+        },
+    )
+
+    assert artifacts.summary["low_level_response"]["state"] == (
+        "low_level_response_inconclusive_missing_evidence"
+    )
+    assert artifacts.summary["phase_gate_state"] == (
+        "forcing_wiring_verified_but_response_not_verified"
+    )
+    high_moisture = next(
+        row
+        for row in artifacts.summary["runs"]
+        if row["matrix_id"] == "phase1_control_high_moisture"
+    )
+    assert high_moisture["low_level_qv_early_response_available"] is False
+    assert high_moisture["low_level_qv_full_run_response_available"] is True
+    assert high_moisture["low_level_qv_early_response_delta"] == (
+        "unavailable:low_level_early_response_unavailable"
+    )
+    assert high_moisture["low_level_qv_full_run_delta"] == pytest.approx(0.004)
+
+
+def test_campaign_gate_blocks_caveated_early_response_below_finite_threshold(
+    tmp_path: Path,
+) -> None:
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.5e-5),
+            "phase1_control_high_moisture": (2.2, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+        low_level_deltas={
+            "phase1_control_default_flux": (0.001, 1.0),
+            "phase1_control_high_sensible": (0.0012, 3.0),
+            "phase1_control_high_moisture": (0.004, 1.1),
+            "phase1_control_high_both": (0.004, 3.2),
+        },
+        low_level_qv_early_end_counts={
+            "phase1_control_high_moisture": (7, 8),
+        },
+    )
+
+    assert artifacts.summary["low_level_response"]["state"] == (
+        "low_level_response_inconclusive_missing_evidence"
+    )
+    moisture = next(
+        evaluation
+        for evaluation in artifacts.summary["low_level_response"]["evaluations"]
+        if evaluation["comparison_type"] == "moisture_flux_sensitivity"
+    )
+    assert any(
+        "experiment:low_level_qv_early_response_delta_finite_fraction_below_threshold" in item
+        for item in moisture["unavailable_evidence"]
+    )
+    high_moisture = next(
+        row
+        for row in artifacts.summary["runs"]
+        if row["matrix_id"] == "phase1_control_high_moisture"
+    )
+    assert high_moisture["low_level_qv_early_response_quality_state"] == (
+        "caveated_below_minimum_finite_fraction"
+    )
+
+
 def test_campaign_report_blocks_phase_gate_when_low_level_response_not_verified(
     tmp_path: Path,
 ) -> None:
@@ -1346,6 +1428,7 @@ def _report_phase1_surface_flux_matrix(
     flux_means: dict[str, tuple[float, float]],
     low_level_deltas: dict[str, tuple[float, float]] | None = None,
     low_level_full_run_deltas: dict[str, tuple[float, float]] | None = None,
+    low_level_qv_early_end_counts: dict[str, tuple[int, int]] | None = None,
     non_finite_counts: dict[str, tuple[int, int]] | None = None,
     unit_overrides: dict[str, tuple[str, str]] | None = None,
     mutate_matrix: Any | None = None,
@@ -1367,6 +1450,9 @@ def _report_phase1_surface_flux_matrix(
             state_run.matrix_id,
             ("K m/s", "kg/m^2/s"),
         )
+        qv_early_end_finite, qv_early_end_total = (low_level_qv_early_end_counts or {}).get(
+            state_run.matrix_id, (8, 8)
+        )
         _write_fake_result_metadata(
             Path(state_run.manifest_path or ""),
             hfx_mean=hfx_mean,
@@ -1382,6 +1468,8 @@ def _report_phase1_surface_flux_matrix(
                 if low_level_full_run_deltas is not None
                 else None
             ),
+            low_level_qv_early_end_finite_count=qv_early_end_finite,
+            low_level_qv_early_end_total_count=qv_early_end_total,
             low_level_theta_full_run_delta=(
                 low_level_full_run_deltas[state_run.matrix_id][1]
                 if low_level_full_run_deltas is not None
@@ -1429,22 +1517,30 @@ def _fake_low_level_response_field(
     delta: float | None,
     full_run_delta: float | None = None,
     units: str,
+    early_end_finite_count: int = 8,
+    early_end_total_count: int = 8,
 ) -> LowLevelResponseFieldDiagnostics:
-    if delta is None:
+    if delta is None and full_run_delta is None:
         return LowLevelResponseFieldDiagnostics(
             source_field=source_field,
             available=False,
+            early_response_available=False,
+            full_run_response_available=False,
             field_absent=False,
             units=units,
             caveats=[f"{source_field}_low_level_response_unavailable_in_fixture"],
         )
     first_mean = 0.010 if source_field == "qv" else 300.0
     full_delta = delta if full_run_delta is None else full_run_delta
-    early_mean = first_mean + delta
-    final_mean = first_mean + full_delta
+    early_mean = first_mean + delta if delta is not None else None
+    final_mean = first_mean + full_delta if full_delta is not None else None
+    early_available = delta is not None
+    full_available = full_run_delta is not None or (delta is not None and full_delta is not None)
     return LowLevelResponseFieldDiagnostics(
         source_field=source_field,
-        available=True,
+        available=early_available,
+        early_response_available=early_available,
+        full_run_response_available=full_available,
         field_absent=False,
         layer_bottom_m=0.0,
         layer_top_m=1000.0,
@@ -1459,20 +1555,22 @@ def _fake_low_level_response_field(
         first_mean_value=first_mean,
         final_mean_value=final_mean,
         delta_value=delta,
-        early_response_start_time_index=0,
-        early_response_end_time_index=1,
-        early_response_start_time_seconds=0.0,
-        early_response_end_time_seconds=3600.0,
-        early_response_start_mean_value=first_mean,
-        early_response_end_mean_value=early_mean,
+        early_response_start_time_index=0 if early_available else None,
+        early_response_end_time_index=1 if early_available else None,
+        early_response_start_time_seconds=0.0 if early_available else None,
+        early_response_end_time_seconds=3600.0 if early_available else None,
+        early_response_start_mean_value=first_mean if early_available else None,
+        early_response_end_mean_value=early_mean if early_available else None,
         early_response_delta=delta,
-        early_response_start_finite_count=8,
+        early_response_start_finite_count=8 if early_available else 0,
         early_response_start_non_finite_count=0,
-        early_response_start_total_count=8,
-        early_response_end_finite_count=8,
-        early_response_end_non_finite_count=0,
-        early_response_end_total_count=8,
-        full_run_delta=full_delta,
+        early_response_start_total_count=8 if early_available else 0,
+        early_response_end_finite_count=early_end_finite_count if early_available else 0,
+        early_response_end_non_finite_count=(
+            max(early_end_total_count - early_end_finite_count, 0) if early_available else 0
+        ),
+        early_response_end_total_count=early_end_total_count if early_available else 0,
+        full_run_delta=full_delta if full_available else None,
         units=units,
         first_finite_count=8,
         first_non_finite_count=0,
@@ -1501,6 +1599,8 @@ def _write_fake_result_metadata(
     low_level_theta_delta: float | None = None,
     low_level_qv_full_run_delta: float | None = None,
     low_level_theta_full_run_delta: float | None = None,
+    low_level_qv_early_end_finite_count: int = 8,
+    low_level_qv_early_end_total_count: int = 8,
 ) -> None:
     manifest = load_run_manifest(manifest_path)
     now = datetime.now(UTC)
@@ -1613,6 +1713,8 @@ def _write_fake_result_metadata(
                     delta=low_level_qv_delta,
                     full_run_delta=low_level_qv_full_run_delta,
                     units="kg/kg",
+                    early_end_finite_count=low_level_qv_early_end_finite_count,
+                    early_end_total_count=low_level_qv_early_end_total_count,
                 ),
                 theta_or_temperature=_fake_low_level_response_field(
                     source_field="th",

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -682,10 +682,12 @@ Current diagnostics compute:
 - optional reflectivity summary from the CM1 `dbz` field;
 - optional surface-flux summaries from CM1 `hfx` and `qfx`, including
   min/max/mean, units, and finite/non-finite counts.
-- optional low-level response summaries from 0-1 km AGL domain-mean `qv` and
-  theta/temperature at the first and final output time, including source field,
-  units, vertical-coordinate method, endpoint means, deltas, and finite/non-finite
-  endpoint counts.
+- optional low-level response summaries from 0-1 km AGL thickness-weighted
+  domain-mean `qv` and theta/temperature. These carry early-response evidence
+  from the output closest to 60 minutes after the first output, bounded to a
+  30-90 minute window, plus full-run first/final evidence. They include source
+  field, units, vertical-coordinate method, endpoint means, deltas, and
+  finite/non-finite endpoint counts.
 
 Diagnostics preserve runtime warnings from the run manifest/result metadata. CM1
 floating-point exception flags are caveats, not automatic failure. The

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -687,7 +687,9 @@ Current diagnostics compute:
   from the output closest to 60 minutes after the first output, bounded to a
   30-90 minute window, plus full-run first/final evidence. They include source
   field, units, vertical-coordinate method, endpoint means, deltas, and
-  finite/non-finite endpoint counts.
+  finite/non-finite endpoint counts. Early forcing-response support and full-run
+  evolution support are independent states; a bad or absent final endpoint must
+  not invalidate an otherwise usable early response.
 
 Diagnostics preserve runtime warnings from the run manifest/result metadata. CM1
 floating-point exception flags are caveats, not automatic failure. The

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -682,6 +682,10 @@ Current diagnostics compute:
 - optional reflectivity summary from the CM1 `dbz` field;
 - optional surface-flux summaries from CM1 `hfx` and `qfx`, including
   min/max/mean, units, and finite/non-finite counts.
+- optional low-level response summaries from 0-1 km AGL domain-mean `qv` and
+  theta/temperature at the first and final output time, including source field,
+  units, vertical-coordinate method, endpoint means, deltas, and finite/non-finite
+  endpoint counts.
 
 Diagnostics preserve runtime warnings from the run manifest/result metadata. CM1
 floating-point exception flags are caveats, not automatic failure. The
@@ -698,7 +702,9 @@ non-finite fields are not presented as clean negative or positive outcomes.
 Surface-flux statistics preserve CM1 output units separately from the selected
 namelist controls. In particular, `qfx` evidence is reported as emitted CM1
 moisture-flux output and must not be equated to `cnst_lhflx` without a
-documented interpretation.
+documented interpretation. Low-level response diagnostics require actual
+vertical-coordinate evidence; they do not infer the 0-1 km layer from raw array
+index.
 
 This result metadata is not a Result Card UI and not visualization-ready data. It is the backend bridge that later result cards and inspectors can consume.
 

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -257,8 +257,10 @@ output product manifest and mirrors compact fields into `result_metadata.json`:
 existing CM1-derived diagnostics; it does not build a second time index and it
 does not ask the browser to parse NetCDF. The science summary also carries the
 backend-owned low-level `qv` and theta/temperature response diagnostics when
-available. Missing fields, no-event outcomes, and diagnostics that are not
-implemented yet are represented explicitly with support states such as
+available, including early 30-90 minute forcing-response deltas and separate
+full-run deltas from 0-1 km AGL thickness-weighted domain means. Missing fields,
+no-event outcomes, and diagnostics that are not implemented yet are represented
+explicitly with support states such as
 `unavailable`, `unsupported_missing_fields`, and
 `unsupported_missing_diagnostic` rather than silently falling back to a
 misleading cloud/rain-water landmark.

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -255,9 +255,11 @@ output product manifest and mirrors compact fields into `result_metadata.json`:
 `interesting_times`, `default_time_by_field`, `science_summary`, and
 `interesting_time_caveats`. It uses the output-product manifest time index plus
 existing CM1-derived diagnostics; it does not build a second time index and it
-does not ask the browser to parse NetCDF. Missing fields, no-event outcomes,
-and diagnostics that are not implemented yet are represented explicitly with
-support states such as `unavailable`, `unsupported_missing_fields`, and
+does not ask the browser to parse NetCDF. The science summary also carries the
+backend-owned low-level `qv` and theta/temperature response diagnostics when
+available. Missing fields, no-event outcomes, and diagnostics that are not
+implemented yet are represented explicitly with support states such as
+`unavailable`, `unsupported_missing_fields`, and
 `unsupported_missing_diagnostic` rather than silently falling back to a
 misleading cloud/rain-water landmark.
 

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -258,9 +258,11 @@ existing CM1-derived diagnostics; it does not build a second time index and it
 does not ask the browser to parse NetCDF. The science summary also carries the
 backend-owned low-level `qv` and theta/temperature response diagnostics when
 available, including early 30-90 minute forcing-response deltas and separate
-full-run deltas from 0-1 km AGL thickness-weighted domain means. Missing fields,
-no-event outcomes, and diagnostics that are not implemented yet are represented
-explicitly with support states such as
+full-run deltas from 0-1 km AGL thickness-weighted domain means. Early and
+full-run response availability are exposed separately so consumers do not treat
+bad final-output evolution evidence as a missing early forcing response. Missing
+fields, no-event outcomes, and diagnostics that are not implemented yet are
+represented explicitly with support states such as
 `unavailable`, `unsupported_missing_fields`, and
 `unsupported_missing_diagnostic` rather than silently falling back to a
 misleading cloud/rain-water landmark.

--- a/docs/research/surface-forced-sounding-verification-protocol.md
+++ b/docs/research/surface-forced-sounding-verification-protocol.md
@@ -321,26 +321,32 @@ browser-side or report-local calculation.
 
 ```text
 vertical layer: 0-1000 m AGL, using available model vertical coordinate
-spatial statistic: domain mean unless a later issue adds selected-column context
+spatial statistic: thickness-weighted domain mean from vertical cell centers
 reference time: first output time, preferably model time 0 or earliest available output
-evaluation time: final output time for the run unless the report explicitly names another time
-per-run response: evaluation_time_mean - reference_time_mean
+early evaluation time: output closest to 60 minutes after reference, bounded to 30-90 minutes
+full-run evaluation time: final output time for the run
+early response: early_evaluation_time_mean - reference_time_mean
+full-run response: final_time_mean - reference_time_mean
 forcing sensitivity: response difference against the paired control run with same sounding, duration, domain, grid, and cadence
 units: preserve source field units; convert only if the backend has a documented conversion
 ```
 
 The result metadata and science-summary payload preserve source field, units,
-vertical-coordinate method, first/final time indices, first/final means, delta,
-and finite/non-finite endpoint counts. Missing `qv`, missing theta/temperature,
-missing vertical coordinates, unsupported vertical units, insufficient output
-times, or entirely non-finite endpoints produce explicit unavailable states.
+vertical-coordinate method, early-response endpoint indices/times/means/delta,
+full-run endpoint indices/times/means/delta, and finite/non-finite endpoint
+counts. Missing `qv`, missing theta/temperature, missing vertical coordinates,
+unsupported vertical units, insufficient output times in the 30-90 minute early
+window, or entirely non-finite endpoints produce explicit unavailable states.
 
 For Phase 1 gate evaluation, heat-only comparisons require the
-theta/temperature response delta to increase against the matched control;
-moisture-only comparisons require the `qv` response delta to increase against
-the matched control; combined comparisons require both. Non-varied low-level
-response changes are informational unless a later protocol defines a
-field-specific stability tolerance.
+early theta/temperature response delta to increase against the matched control;
+moisture-only comparisons require the early `qv` response delta to increase
+against the matched control; combined comparisons require both. Full-run deltas
+remain experiment evidence but must not be the only Phase 1 forcing-path gate.
+Non-varied low-level response changes are informational unless a later protocol
+defines a field-specific stability tolerance. `theta_v` is moisture-coupled and
+must not silently substitute for the thermal response gate unless a future
+protocol explicitly requests virtual-potential-temperature response.
 
 ## Phase 1 — Forcing-path smoke check
 
@@ -581,17 +587,25 @@ qfx_units
 qfx_min / qfx_max / qfx_mean when derivable
 qfx_finite_count / qfx_non_finite_count / qfx_total_count
 surface_moisture_flux_output_field
-low_level_qv_response with method or unavailable reason
+low_level_qv_response with early delta, method, or unavailable reason
+low_level_qv_early_response_delta
+low_level_qv_full_run_delta
 low_level_qv_response_method
 low_level_qv_response_source_field
 low_level_qv_response_units
+low_level_qv_early_response_start_mean / low_level_qv_early_response_end_mean
+low_level_qv_early_response_start_time_seconds / low_level_qv_early_response_end_time_seconds
 low_level_qv_response_first_mean / low_level_qv_response_final_mean
 low_level_qv_response_first_time_seconds / low_level_qv_response_final_time_seconds
 low_level_qv_response_first_finite_count / low_level_qv_response_final_finite_count
-low_level_theta_or_temperature_response with method or unavailable reason
+low_level_theta_or_temperature_response with early delta, method, or unavailable reason
+low_level_theta_or_temperature_early_response_delta
+low_level_theta_or_temperature_full_run_delta
 low_level_theta_or_temperature_response_method
 low_level_theta_or_temperature_response_source_field
 low_level_theta_or_temperature_response_units
+low_level_theta_or_temperature_early_response_start_mean / low_level_theta_or_temperature_early_response_end_mean
+low_level_theta_or_temperature_early_response_start_time_seconds / low_level_theta_or_temperature_early_response_end_time_seconds
 low_level_theta_or_temperature_response_first_mean / low_level_theta_or_temperature_response_final_mean
 low_level_theta_or_temperature_response_first_time_seconds / low_level_theta_or_temperature_response_final_time_seconds
 low_level_theta_or_temperature_response_first_finite_count / low_level_theta_or_temperature_response_final_finite_count

--- a/docs/research/surface-forced-sounding-verification-protocol.md
+++ b/docs/research/surface-forced-sounding-verification-protocol.md
@@ -337,12 +337,21 @@ full-run endpoint indices/times/means/delta, and finite/non-finite endpoint
 counts. Missing `qv`, missing theta/temperature, missing vertical coordinates,
 unsupported vertical units, insufficient output times in the 30-90 minute early
 window, or entirely non-finite endpoints produce explicit unavailable states.
+Early-response availability and full-run-response availability are independent:
+a valid early forcing response can remain available when the final endpoint is
+missing, not distinct from the early endpoint, or entirely non-finite. Likewise,
+a full-run delta can be reported as atmospheric-evolution evidence when the
+early response window is missing, but it must not satisfy the Phase 1 gate.
 
 For Phase 1 gate evaluation, heat-only comparisons require the
 early theta/temperature response delta to increase against the matched control;
 moisture-only comparisons require the early `qv` response delta to increase
 against the matched control; combined comparisons require both. Full-run deltas
 remain experiment evidence but must not be the only Phase 1 forcing-path gate.
+Early endpoints must have at least 95% finite coverage at both the reference
+and early evaluation time. Partially non-finite endpoints above that threshold
+are reported as caveated; below that threshold they are missing evidence for the
+gate, not a scientific non-response.
 Non-varied low-level response changes are informational unless a later protocol
 defines a field-specific stability tolerance. `theta_v` is moisture-coupled and
 must not silently substitute for the thermal response gate unless a future

--- a/docs/research/surface-forced-sounding-verification-protocol.md
+++ b/docs/research/surface-forced-sounding-verification-protocol.md
@@ -277,7 +277,9 @@ operator_override_continue
 - Missing selected/product forcing metadata: `forcing_wiring_not_verified`; block automatic continuation.
 - Missing CM1-facing `cnst_shflx` or `cnst_lhflx`: `forcing_wiring_not_verified`; block automatic continuation.
 - Missing `hfx` or `qfx` when requested: `inconclusive_missing_evidence`; block automatic continuation.
-- Missing standardized low-level response diagnostic: `inconclusive_missing_evidence`; block automatic continuation.
+- Missing or unavailable standardized low-level response diagnostic:
+  `forcing_wiring_verified_but_response_not_verified`; block automatic continuation
+  after surface-flux response is verified.
 - Matched Phase 1 emitted `hfx`/`qfx` values are present, trusted, unit-comparable, and every required Phase 1 comparison type is present: `surface_flux_response_verified`; continue to low-level response checks.
 - Missing one of the required `heat_flux_sensitivity`, `moisture_flux_sensitivity`, or `combined_flux_sensitivity` comparisons: `surface_flux_response_inconclusive_missing_evidence`; block automatic continuation.
 - Missing, untrusted, or not-ingested matched Phase 1 `hfx`/`qfx` statistics: `surface_flux_response_inconclusive_missing_evidence`; block automatic continuation.
@@ -313,9 +315,9 @@ Cloud Chamber commit and CM1 version/build are required per run in the summary c
 
 ## Low-level response diagnostic contract
 
-Low-level `qv` and theta/temperature response must be standardized before the campaign runner summarizes them.
-
-Preferred method for #311:
+Low-level `qv` and theta/temperature response is a backend-owned diagnostic.
+The campaign runner must use this standardized output rather than improvising a
+browser-side or report-local calculation.
 
 ```text
 vertical layer: 0-1000 m AGL, using available model vertical coordinate
@@ -327,13 +329,18 @@ forcing sensitivity: response difference against the paired control run with sam
 units: preserve source field units; convert only if the backend has a documented conversion
 ```
 
-If a standardized backend diagnostic is not implemented, report these fields as:
+The result metadata and science-summary payload preserve source field, units,
+vertical-coordinate method, first/final time indices, first/final means, delta,
+and finite/non-finite endpoint counts. Missing `qv`, missing theta/temperature,
+missing vertical coordinates, unsupported vertical units, insufficient output
+times, or entirely non-finite endpoints produce explicit unavailable states.
 
-```text
-unavailable: low_level_response_diagnostic_not_implemented
-```
-
-The campaign runner must not improvise a browser-side or ad hoc calculation without documenting the layer, statistic, reference time, paired control, units, and source fields.
+For Phase 1 gate evaluation, heat-only comparisons require the
+theta/temperature response delta to increase against the matched control;
+moisture-only comparisons require the `qv` response delta to increase against
+the matched control; combined comparisons require both. Non-varied low-level
+response changes are informational unless a later protocol defines a
+field-specific stability tolerance.
 
 ## Phase 1 — Forcing-path smoke check
 
@@ -576,8 +583,18 @@ qfx_finite_count / qfx_non_finite_count / qfx_total_count
 surface_moisture_flux_output_field
 low_level_qv_response with method or unavailable reason
 low_level_qv_response_method
+low_level_qv_response_source_field
+low_level_qv_response_units
+low_level_qv_response_first_mean / low_level_qv_response_final_mean
+low_level_qv_response_first_time_seconds / low_level_qv_response_final_time_seconds
+low_level_qv_response_first_finite_count / low_level_qv_response_final_finite_count
 low_level_theta_or_temperature_response with method or unavailable reason
 low_level_theta_or_temperature_response_method
+low_level_theta_or_temperature_response_source_field
+low_level_theta_or_temperature_response_units
+low_level_theta_or_temperature_response_first_mean / low_level_theta_or_temperature_response_final_mean
+low_level_theta_or_temperature_response_first_time_seconds / low_level_theta_or_temperature_response_final_time_seconds
+low_level_theta_or_temperature_response_first_finite_count / low_level_theta_or_temperature_response_final_finite_count
 first_cloud_time
 max_cloud_top_m and time
 max_qc and time

--- a/docs/research/templates/surface-forced-campaign-report-template.md
+++ b/docs/research/templates/surface-forced-campaign-report-template.md
@@ -42,9 +42,9 @@ Can an easy deep-candidate sounding deepen past shallow cumulus under uniform lo
 
 ## Per-run evidence table
 
-| Matrix ID | hfx | qfx | low_level_qv_response | low_level_theta_or_temperature_response | first_cloud_time | max_cloud_top_m | max_qc | max_w_m_s | cloud_depth_or_classification | qr | surface rain | dbz | Diagnostic trust | Field-quality warnings | Evidence fields | Initial diagnosis |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `<matrix_id>` | `<present; units; min/max/mean>` | `<present; units; min/max/mean>` | `<value/method/unavailable>` | `<value/method/unavailable>` | `<time/unavailable>` | `<m at time>` | `<kg/kg at time>` | `<m/s at time/height>` | `<class/depth/unavailable>` | `<present/absent/unavailable>` | `<present/absent/unavailable>` | `<present/absent/unavailable>` | `<trusted/caveated/untrusted/unavailable by field>` | `<non-finite or other severe field-quality warnings>` | `<fields/diagnostics>` | `<category>` |
+| Matrix ID | hfx | qfx | low_level_qv_early_response_delta | low_level_qv_full_run_delta | low_level_theta_or_temperature_early_response_delta | low_level_theta_or_temperature_full_run_delta | first_cloud_time | max_cloud_top_m | max_qc | max_w_m_s | cloud_depth_or_classification | qr | surface rain | dbz | Diagnostic trust | Field-quality warnings | Evidence fields | Initial diagnosis |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `<matrix_id>` | `<present; units; min/max/mean>` | `<present; units; min/max/mean>` | `<early value/method/unavailable>` | `<full-run value/unavailable>` | `<early value/method/unavailable>` | `<full-run value/unavailable>` | `<time/unavailable>` | `<m at time>` | `<kg/kg at time>` | `<m/s at time/height>` | `<class/depth/unavailable>` | `<present/absent/unavailable>` | `<present/absent/unavailable>` | `<present/absent/unavailable>` | `<trusted/caveated/untrusted/unavailable by field>` | `<non-finite or other severe field-quality warnings>` | `<fields/diagnostics>` | `<category>` |
 
 If `qc`, `w`, `qr`, surface `rain`, or `dbz` is entirely non-finite or materially contaminated by non-finite values, the run summary must mark the affected diagnostic as untrusted or caveated. Do not present surface rain, cloud top, updraft, rain-water-aloft, or reflectivity as clean evidence when the source field quality does not support that conclusion.
 
@@ -59,12 +59,18 @@ Required method fields:
 vertical layer:
 spatial statistic:
 reference time:
-evaluation time:
+early response window:
+full-run response:
 paired control run:
 source fields:
 units:
 finite/non-finite endpoint counts:
 ```
+
+Phase 1 gate checks use the early response window. Full-run deltas remain useful
+atmospheric-evolution evidence, but they are not clean forcing-path verification
+after cloud, precipitation, entrainment, and downdraft feedbacks may have
+developed.
 
 ## Phase 1 — forcing-path smoke check
 
@@ -82,8 +88,8 @@ finite/non-finite endpoint counts:
 
 | Check | Result | Evidence | Notes |
 | --- | --- | --- | --- |
-| heat-only run shows directionally consistent theta/temp response | `<pass/warn/fail/unavailable>` | `<summary>` | `<notes>` |
-| moisture-only run shows directionally consistent qv response | `<pass/warn/fail/unavailable>` | `<summary>` | `<notes>` |
+| heat-only run shows directionally consistent early theta/temp response | `<pass/warn/fail/unavailable>` | `<summary>` | `<notes>` |
+| moisture-only run shows directionally consistent early qv response | `<pass/warn/fail/unavailable>` | `<summary>` | `<notes>` |
 
 ### Phase 1 gate result
 

--- a/docs/research/templates/surface-forced-campaign-report-template.md
+++ b/docs/research/templates/surface-forced-campaign-report-template.md
@@ -50,7 +50,8 @@ If `qc`, `w`, `qr`, surface `rain`, or `dbz` is entirely non-finite or materiall
 
 ## Low-level response method
 
-State exactly how low-level `qv` and theta/temperature response were computed, or mark them unavailable.
+State exactly how backend-owned low-level `qv` and theta/temperature response
+were computed, or mark them unavailable.
 
 Required method fields:
 
@@ -62,12 +63,7 @@ evaluation time:
 paired control run:
 source fields:
 units:
-```
-
-If the standardized diagnostic is not implemented, write:
-
-```text
-unavailable: low_level_response_diagnostic_not_implemented
+finite/non-finite endpoint counts:
 ```
 
 ## Phase 1 — forcing-path smoke check
@@ -170,7 +166,8 @@ Examples:
 
 ```text
 - Fix package/output wiring before running more cases.
-- Add standardized low-level qv/theta response diagnostics before next campaign.
+- Resolve missing or not-verified low-level qv/theta response evidence before
+  continuing the campaign automatically.
 - Adjust default flux values or add stronger labeled examples.
 - Prefer Regional 60 km / 12 h for first deep-candidate checks.
 - Proceed to differential forcing (#307) as a follow-up candidate because uniform forcing responds but does not focus ascent.

--- a/docs/research/templates/surface-forced-campaign-report-template.md
+++ b/docs/research/templates/surface-forced-campaign-report-template.md
@@ -42,9 +42,9 @@ Can an easy deep-candidate sounding deepen past shallow cumulus under uniform lo
 
 ## Per-run evidence table
 
-| Matrix ID | hfx | qfx | low_level_qv_early_response_delta | low_level_qv_full_run_delta | low_level_theta_or_temperature_early_response_delta | low_level_theta_or_temperature_full_run_delta | first_cloud_time | max_cloud_top_m | max_qc | max_w_m_s | cloud_depth_or_classification | qr | surface rain | dbz | Diagnostic trust | Field-quality warnings | Evidence fields | Initial diagnosis |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `<matrix_id>` | `<present; units; min/max/mean>` | `<present; units; min/max/mean>` | `<early value/method/unavailable>` | `<full-run value/unavailable>` | `<early value/method/unavailable>` | `<full-run value/unavailable>` | `<time/unavailable>` | `<m at time>` | `<kg/kg at time>` | `<m/s at time/height>` | `<class/depth/unavailable>` | `<present/absent/unavailable>` | `<present/absent/unavailable>` | `<present/absent/unavailable>` | `<trusted/caveated/untrusted/unavailable by field>` | `<non-finite or other severe field-quality warnings>` | `<fields/diagnostics>` | `<category>` |
+| Matrix ID | hfx | qfx | low_level_qv_early_response_delta | low_level_qv_early_quality | low_level_qv_full_run_delta | low_level_theta_or_temperature_early_response_delta | low_level_theta_or_temperature_early_quality | low_level_theta_or_temperature_full_run_delta | first_cloud_time | max_cloud_top_m | max_qc | max_w_m_s | cloud_depth_or_classification | qr | surface rain | dbz | Diagnostic trust | Field-quality warnings | Evidence fields | Initial diagnosis |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `<matrix_id>` | `<present; units; min/max/mean>` | `<present; units; min/max/mean>` | `<early value/method/unavailable>` | `<trusted/caveated/unavailable plus finite fraction>` | `<full-run value/unavailable>` | `<early value/method/unavailable>` | `<trusted/caveated/unavailable plus finite fraction>` | `<full-run value/unavailable>` | `<time/unavailable>` | `<m at time>` | `<kg/kg at time>` | `<m/s at time/height>` | `<class/depth/unavailable>` | `<present/absent/unavailable>` | `<present/absent/unavailable>` | `<present/absent/unavailable>` | `<trusted/caveated/untrusted/unavailable by field>` | `<non-finite or other severe field-quality warnings>` | `<fields/diagnostics>` | `<category>` |
 
 If `qc`, `w`, `qr`, surface `rain`, or `dbz` is entirely non-finite or materially contaminated by non-finite values, the run summary must mark the affected diagnostic as untrusted or caveated. Do not present surface rain, cloud top, updraft, rain-water-aloft, or reflectivity as clean evidence when the source field quality does not support that conclusion.
 
@@ -65,12 +65,16 @@ paired control run:
 source fields:
 units:
 finite/non-finite endpoint counts:
+early/full-run availability:
+early finite-coverage threshold:
 ```
 
 Phase 1 gate checks use the early response window. Full-run deltas remain useful
 atmospheric-evolution evidence, but they are not clean forcing-path verification
 after cloud, precipitation, entrainment, and downdraft feedbacks may have
-developed.
+developed. Early and full-run response availability must be reported
+independently; a missing or bad final endpoint must not erase valid early
+forcing-response evidence.
 
 ## Phase 1 — forcing-path smoke check
 

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -213,12 +213,15 @@ preserve source field names, units, vertical-coordinate method, early-response
 endpoint times/means/deltas, full-run endpoint times/means/deltas, and
 finite/non-finite endpoint counts. Missing fields, missing vertical
 coordinates, unsupported vertical units, insufficient 30-90 minute early output,
-and entirely non-finite endpoints must be unavailable. Campaign tests should
-compare heat-only early theta/temperature response and moisture-only early `qv`
-response against matched controls, keep full-run deltas informational for the
-Phase 1 gate, and keep non-varied low-level response changes informational
-unless the protocol defines a field-specific tolerance. `theta_v` must not be a
-silent thermal-response fallback for the sensible-heat gate.
+and entirely non-finite endpoints must be unavailable for the affected response
+only. Campaign tests should cover early-only, full-run-only, both-available, and
+bad-final-endpoint cases. Campaign tests should compare heat-only early
+theta/temperature response and moisture-only early `qv` response against matched
+controls, keep full-run deltas informational for the Phase 1 gate, block early
+evidence below the documented finite-coverage threshold, and keep non-varied
+low-level response changes informational unless the protocol defines a
+field-specific tolerance. `theta_v` must not be a silent thermal-response
+fallback for the sensible-heat gate.
 
 Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
 They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, `.dat/.ctl` and NetCDF output artifacts are cataloged separately in the manifest, stderr floating-point flags are surfaced as runtime warnings, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -207,15 +207,18 @@ verification. Non-varied flux changes remain informational unless the protocol
 defines field-specific stability tolerances. Unchanged, reversed, incomplete,
 missing, untrusted, mismatched-unit, or structurally non-comparable cases remain
 blocked.
-Low-level response tests should compute backend-owned 0-1 km AGL domain-mean
-`qv` and theta/temperature first/final means and deltas, preserve source field
-names, units, vertical-coordinate method, time indices, and finite/non-finite
-endpoint counts, and mark missing fields, missing vertical coordinates,
-unsupported vertical units, insufficient output times, and entirely non-finite
-endpoints unavailable. Campaign tests should compare heat-only theta/temperature
-and moisture-only `qv` deltas against matched controls and keep non-varied
-low-level response changes informational unless the protocol defines a
-field-specific tolerance.
+Low-level response tests should compute backend-owned 0-1 km AGL
+thickness-weighted domain means for `qv` and theta/temperature. They must
+preserve source field names, units, vertical-coordinate method, early-response
+endpoint times/means/deltas, full-run endpoint times/means/deltas, and
+finite/non-finite endpoint counts. Missing fields, missing vertical
+coordinates, unsupported vertical units, insufficient 30-90 minute early output,
+and entirely non-finite endpoints must be unavailable. Campaign tests should
+compare heat-only early theta/temperature response and moisture-only early `qv`
+response against matched controls, keep full-run deltas informational for the
+Phase 1 gate, and keep non-varied low-level response changes informational
+unless the protocol defines a field-specific tolerance. `theta_v` must not be a
+silent thermal-response fallback for the sensible-heat gate.
 
 Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
 They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, `.dat/.ctl` and NetCDF output artifacts are cataloged separately in the manifest, stderr floating-point flags are surfaced as runtime warnings, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -207,6 +207,15 @@ verification. Non-varied flux changes remain informational unless the protocol
 defines field-specific stability tolerances. Unchanged, reversed, incomplete,
 missing, untrusted, mismatched-unit, or structurally non-comparable cases remain
 blocked.
+Low-level response tests should compute backend-owned 0-1 km AGL domain-mean
+`qv` and theta/temperature first/final means and deltas, preserve source field
+names, units, vertical-coordinate method, time indices, and finite/non-finite
+endpoint counts, and mark missing fields, missing vertical coordinates,
+unsupported vertical units, insufficient output times, and entirely non-finite
+endpoints unavailable. Campaign tests should compare heat-only theta/temperature
+and moisture-only `qv` deltas against matched controls and keep non-varied
+low-level response changes informational unless the protocol defines a
+field-specific tolerance.
 
 Local launcher tests must inject fake subprocess handles. They should assert command construction, stdout/stderr log capture, one-active-run refusal, queued/running/completed/failed/canceled state transitions, missing-settings failure, and protection against pre-existing output-like files. They must not launch real CM1 or require local runtime files in CI.
 They should also assert placeholder-only packages are rejected before launch, Rayleigh damping/domain checks catch damping over more than half the domain, required runtime files such as `LANDUSE.TBL` are staged from temp CM1 run directories, `.dat/.ctl` and NetCDF output artifacts are cataloged separately in the manifest, stderr floating-point flags are surfaced as runtime warnings, and exit code 0 without output becomes `needs_review` rather than `completed_cm1_result`.


### PR DESCRIPTION
## Summary
- compute backend-owned 0-1 km AGL thickness-weighted low-level `qv` and theta/temperature response diagnostics from CM1 output
- preserve source field, units, vertical-coordinate method, early-response endpoint times/means/deltas, full-run endpoint times/means/deltas, and finite/non-finite endpoint counts in result metadata and science-summary payloads
- gate Phase 1 campaign low-level response on the early forcing-response window: output closest to 60 minutes after reference, bounded to 30-90 minutes
- expose early-response availability and full-run-response availability independently, so bad or missing final output does not erase valid early forcing-response evidence
- keep full-run deltas as atmospheric-evolution evidence, not as the forcing-path verification gate
- require at least 95% finite coverage at the early response start/end endpoints before Phase 1 can treat the response as verification evidence
- merge one-time CM1 output files into run-level early and full-run response deltas without asking the browser to parse NetCDF
- exclude `theta_v` as a silent sensible-heat response fallback because it is moisture-coupled
- feed campaign summaries/reports with low-level response evidence, quality state, finite fraction, and matched-control response comparisons
- update architecture, output-product, campaign protocol, report template, and testing docs for the new diagnostic contract

Closes #323

## Verification
- app/backend/.venv/bin/python -m pytest app/backend/tests/test_result_diagnostics.py app/backend/tests/test_result_ingest.py app/backend/tests/test_surface_forced_campaign.py
- scripts/check.sh
- scripts/check-e2e.sh

## Notes
- Low-level response uses actual vertical-coordinate evidence for the 0-1 km layer; it does not infer height from raw array index.
- The early response window is unavailable when the output sequence lacks an output 30-90 minutes after the reference time.
- A valid full-run delta can still be reported when the early response window is unavailable, but it cannot satisfy the Phase 1 gate.
- Auto-merge is not enabled because this changes science-facing diagnostic and campaign-gate behavior.
