### PR TITLE
Fix frame-aware field quality for campaign gates

### DIFF
--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -60,17 +60,20 @@ class FieldFrameQualityRecord(BaseModel):
 class FieldFrameQualitySummary(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    frame_times_seconds: list[float | None] = Field(default_factory=list)
     affected_frames: list[FieldFrameQualityRecord] = Field(default_factory=list)
     affected_frame_indices: list[int] = Field(default_factory=list)
     affected_frame_times_seconds: list[float | None] = Field(default_factory=list)
     initial_frame_affected: bool = False
     terminal_frame_affected: bool = False
+    affected_frame_count: int = 0
     entirely_non_finite_frame_count: int = 0
     partially_non_finite_frame_count: int = 0
     finite_frame_count: int = 0
-    non_finite_frame_count: int = 0
     total_frame_count: int = 0
     finite_point_fraction: float | None = None
+    chronology_available: bool = True
+    chronology_caveats: list[str] = Field(default_factory=list)
     first_finite_frame_time_seconds: float | None = None
     last_finite_frame_time_seconds: float | None = None
 
@@ -669,6 +672,8 @@ def _field_quality_reason(
         return config["entire"]
     if non_finite_count <= 0:
         return None
+    if not frame_quality.chronology_available:
+        return f"{source_field}_frame_chronology_unavailable"
     terminal_entire = any(
         frame.position == "terminal" and frame.entirely_non_finite
         for frame in frame_quality.affected_frames
@@ -706,6 +711,8 @@ def _field_quality_caveats(
 def _field_frame_quality(data_array: Any, time: _TimeContext) -> FieldFrameQualitySummary:
     slices = _time_slices(data_array, time.dimension)
     total_frame_count = len(slices)
+    frame_times_seconds = [time.at(index) for index in range(total_frame_count)]
+    frame_positions, chronology_caveats = _frame_positions_from_times(frame_times_seconds)
     affected_frames: list[FieldFrameQualityRecord] = []
     finite_frame_count = 0
     first_finite_time: float | None = None
@@ -730,7 +737,7 @@ def _field_frame_quality(data_array: Any, time: _TimeContext) -> FieldFrameQuali
                 FieldFrameQualityRecord(
                     frame_index=index,
                     time_seconds=time_seconds,
-                    position=_frame_position(index, total_frame_count),
+                    position=frame_positions[index],
                     finite_count=finite_count,
                     non_finite_count=non_finite_count,
                     total_count=total_count,
@@ -740,10 +747,12 @@ def _field_frame_quality(data_array: Any, time: _TimeContext) -> FieldFrameQuali
 
     return _frame_quality_summary_from_records(
         affected_frames,
+        frame_times_seconds=frame_times_seconds,
         finite_frame_count=finite_frame_count,
         total_frame_count=total_frame_count,
         finite_point_count=finite_point_count,
         total_point_count=total_point_count,
+        chronology_caveats=chronology_caveats,
         first_finite_frame_time_seconds=first_finite_time,
         last_finite_frame_time_seconds=last_finite_time,
     )
@@ -752,14 +761,17 @@ def _field_frame_quality(data_array: Any, time: _TimeContext) -> FieldFrameQuali
 def _frame_quality_summary_from_records(
     affected_frames: list[FieldFrameQualityRecord],
     *,
+    frame_times_seconds: list[float | None],
     finite_frame_count: int,
     total_frame_count: int,
     finite_point_count: int,
     total_point_count: int,
+    chronology_caveats: list[str],
     first_finite_frame_time_seconds: float | None,
     last_finite_frame_time_seconds: float | None,
 ) -> FieldFrameQualitySummary:
     return FieldFrameQualitySummary(
+        frame_times_seconds=frame_times_seconds,
         affected_frames=affected_frames,
         affected_frame_indices=[frame.frame_index for frame in affected_frames],
         affected_frame_times_seconds=[frame.time_seconds for frame in affected_frames],
@@ -775,16 +787,53 @@ def _frame_quality_summary_from_records(
         partially_non_finite_frame_count=sum(
             1 for frame in affected_frames if not frame.entirely_non_finite
         ),
+        affected_frame_count=len(affected_frames),
         finite_frame_count=finite_frame_count,
-        non_finite_frame_count=len(affected_frames),
         total_frame_count=total_frame_count,
         finite_point_fraction=_finite_fraction(finite_point_count, total_point_count),
+        chronology_available=not chronology_caveats,
+        chronology_caveats=chronology_caveats,
         first_finite_frame_time_seconds=first_finite_frame_time_seconds,
         last_finite_frame_time_seconds=last_finite_frame_time_seconds,
     )
 
 
-def _frame_position(index: int, total_frame_count: int) -> FramePosition:
+def _frame_positions_from_times(
+    frame_times_seconds: list[float | None],
+) -> tuple[list[FramePosition], list[str]]:
+    total_frame_count = len(frame_times_seconds)
+    if total_frame_count <= 1:
+        return (["single"], [])
+
+    finite_times = [
+        (index, time_seconds)
+        for index, time_seconds in enumerate(frame_times_seconds)
+        if time_seconds is not None and isfinite(time_seconds)
+    ]
+    chronology_caveats: list[str] = []
+    if len(finite_times) != total_frame_count:
+        chronology_caveats.append("frame_chronology_unavailable_missing_time")
+    else:
+        seen_times = {time_seconds for _, time_seconds in finite_times}
+        if len(seen_times) != total_frame_count:
+            chronology_caveats.append("frame_chronology_unavailable_duplicate_time")
+
+    if chronology_caveats:
+        return (
+            [
+                _frame_position_from_index(index, total_frame_count)
+                for index in range(total_frame_count)
+            ],
+            chronology_caveats,
+        )
+
+    positions: list[FramePosition] = ["intermediate"] * total_frame_count
+    for rank, (index, _) in enumerate(sorted(finite_times, key=lambda item: item[1])):
+        positions[index] = _frame_position_from_index(rank, total_frame_count)
+    return positions, []
+
+
+def _frame_position_from_index(index: int, total_frame_count: int) -> FramePosition:
     if total_frame_count <= 1:
         return "single"
     if index == 0:

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -35,6 +35,7 @@ THERMAL_FATE_CONFIDENCE_VALUES = (
 )
 
 FieldQualityState = Literal["trusted", "caveated", "untrusted", "unavailable"]
+FramePosition = Literal["single", "initial", "intermediate", "terminal"]
 
 
 class _LowLevelLayerStats(TypedDict):
@@ -42,6 +43,36 @@ class _LowLevelLayerStats(TypedDict):
     finite_count: int
     non_finite_count: int
     total_count: int
+
+
+class FieldFrameQualityRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    frame_index: int
+    time_seconds: float | None = None
+    position: FramePosition
+    finite_count: int = 0
+    non_finite_count: int = 0
+    total_count: int = 0
+    entirely_non_finite: bool = False
+
+
+class FieldFrameQualitySummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    affected_frames: list[FieldFrameQualityRecord] = Field(default_factory=list)
+    affected_frame_indices: list[int] = Field(default_factory=list)
+    affected_frame_times_seconds: list[float | None] = Field(default_factory=list)
+    initial_frame_affected: bool = False
+    terminal_frame_affected: bool = False
+    entirely_non_finite_frame_count: int = 0
+    partially_non_finite_frame_count: int = 0
+    finite_frame_count: int = 0
+    non_finite_frame_count: int = 0
+    total_frame_count: int = 0
+    finite_point_fraction: float | None = None
+    first_finite_frame_time_seconds: float | None = None
+    last_finite_frame_time_seconds: float | None = None
 
 
 class FieldQuality(BaseModel):
@@ -54,6 +85,8 @@ class FieldQuality(BaseModel):
     finite_count: int = 0
     non_finite_count: int = 0
     total_count: int = 0
+    finite_fraction: float | None = None
+    frame_quality: FieldFrameQualitySummary | None = None
     caveats: list[str] = Field(default_factory=list)
 
 
@@ -158,6 +191,8 @@ class SurfaceFluxFieldDiagnostics(BaseModel):
     finite_count: int = 0
     non_finite_count: int = 0
     total_count: int = 0
+    finite_fraction: float | None = None
+    frame_quality: FieldFrameQualitySummary | None = None
     caveats: list[str] = Field(default_factory=list)
 
 
@@ -471,9 +506,9 @@ def compute_baseline_diagnostics(dataset: Any, inherited_caveats: list[str]) -> 
     rain = _rain_diagnostics(dataset, time_context, caveats)
     surface_rain = _surface_rain_diagnostics(dataset, time_context, caveats)
     reflectivity = _reflectivity_diagnostics(dataset, time_context, caveats)
-    surface_fluxes = _surface_flux_diagnostics(dataset, caveats)
+    surface_fluxes = _surface_flux_diagnostics(dataset, time_context, caveats)
     low_level_response = _low_level_response_diagnostics(dataset, time_context, caveats)
-    field_quality = _field_quality_map(dataset)
+    field_quality = _field_quality_map(dataset, time_context)
     return ResultDiagnostics(
         cloud=cloud,
         vertical_velocity=vertical_velocity,
@@ -535,14 +570,19 @@ FIELD_QUALITY_SOURCES = {
 }
 
 
-def _field_quality_map(dataset: Any) -> dict[str, FieldQuality]:
+def _field_quality_map(dataset: Any, time: _TimeContext) -> dict[str, FieldQuality]:
     return {
-        field: _field_quality(dataset, field, config)
+        field: _field_quality(dataset, field, config, time)
         for field, config in FIELD_QUALITY_SOURCES.items()
     }
 
 
-def _field_quality(dataset: Any, field: str, config: dict[str, str]) -> FieldQuality:
+def _field_quality(
+    dataset: Any,
+    field: str,
+    config: dict[str, str],
+    time: _TimeContext,
+) -> FieldQuality:
     source_field = config["source_field"]
     if source_field not in dataset.data_vars:
         return FieldQuality(
@@ -556,6 +596,16 @@ def _field_quality(dataset: Any, field: str, config: dict[str, str]) -> FieldQua
     finite_count = _finite_count(data_array)
     non_finite_count = _non_finite_count(data_array)
     total_count = _total_count(data_array)
+    finite_fraction = _finite_fraction(finite_count, total_count)
+    frame_quality = _field_frame_quality(data_array, time)
+    reason = _field_quality_reason(
+        field,
+        config,
+        finite_count=finite_count,
+        non_finite_count=non_finite_count,
+        frame_quality=frame_quality,
+    )
+    caveats = _field_quality_caveats(config, reason, non_finite_count)
     if finite_count == 0:
         return FieldQuality(
             field=field,
@@ -565,18 +615,35 @@ def _field_quality(dataset: Any, field: str, config: dict[str, str]) -> FieldQua
             finite_count=finite_count,
             non_finite_count=non_finite_count,
             total_count=total_count,
-            caveats=[config["partial"], config["entire"]],
+            finite_fraction=finite_fraction,
+            frame_quality=frame_quality,
+            caveats=caveats,
+        )
+    if reason is not None and "_terminal_output_frame_entirely_non_finite" in reason:
+        return FieldQuality(
+            field=field,
+            source_field=source_field,
+            quality_state="untrusted",
+            reason=reason,
+            finite_count=finite_count,
+            non_finite_count=non_finite_count,
+            total_count=total_count,
+            finite_fraction=finite_fraction,
+            frame_quality=frame_quality,
+            caveats=caveats,
         )
     if non_finite_count > 0:
         return FieldQuality(
             field=field,
             source_field=source_field,
             quality_state="caveated",
-            reason=config["partial"],
+            reason=reason or config["partial"],
             finite_count=finite_count,
             non_finite_count=non_finite_count,
             total_count=total_count,
-            caveats=[config["partial"]],
+            finite_fraction=finite_fraction,
+            frame_quality=frame_quality,
+            caveats=caveats,
         )
     return FieldQuality(
         field=field,
@@ -585,7 +652,146 @@ def _field_quality(dataset: Any, field: str, config: dict[str, str]) -> FieldQua
         finite_count=finite_count,
         non_finite_count=non_finite_count,
         total_count=total_count,
+        finite_fraction=finite_fraction,
+        frame_quality=frame_quality,
     )
+
+
+def _field_quality_reason(
+    source_field: str,
+    config: dict[str, str],
+    *,
+    finite_count: int,
+    non_finite_count: int,
+    frame_quality: FieldFrameQualitySummary,
+) -> str | None:
+    if finite_count == 0:
+        return config["entire"]
+    if non_finite_count <= 0:
+        return None
+    terminal_entire = any(
+        frame.position == "terminal" and frame.entirely_non_finite
+        for frame in frame_quality.affected_frames
+    )
+    if terminal_entire:
+        return f"{source_field}_terminal_output_frame_entirely_non_finite"
+    initial_entire = any(
+        frame.position == "initial" and frame.entirely_non_finite
+        for frame in frame_quality.affected_frames
+    )
+    non_initial_entire = any(
+        frame.position in {"intermediate", "single"} and frame.entirely_non_finite
+        for frame in frame_quality.affected_frames
+    )
+    if non_initial_entire:
+        return f"{source_field}_intermediate_output_frame_entirely_non_finite"
+    if initial_entire and frame_quality.entirely_non_finite_frame_count == 1:
+        return f"{source_field}_initial_output_frame_entirely_non_finite"
+    return config["partial"]
+
+
+def _field_quality_caveats(
+    config: dict[str, str],
+    reason: str | None,
+    non_finite_count: int,
+) -> list[str]:
+    caveats: list[str] = []
+    if non_finite_count > 0:
+        caveats.append(config["partial"])
+    if reason is not None and reason != config["partial"]:
+        caveats.append(reason)
+    return _dedupe(caveats)
+
+
+def _field_frame_quality(data_array: Any, time: _TimeContext) -> FieldFrameQualitySummary:
+    slices = _time_slices(data_array, time.dimension)
+    total_frame_count = len(slices)
+    affected_frames: list[FieldFrameQualityRecord] = []
+    finite_frame_count = 0
+    first_finite_time: float | None = None
+    last_finite_time: float | None = None
+    finite_point_count = 0
+    total_point_count = 0
+
+    for index, frame in enumerate(slices):
+        finite_count = _finite_count(frame)
+        total_count = _total_count(frame)
+        non_finite_count = total_count - finite_count
+        finite_point_count += finite_count
+        total_point_count += total_count
+        time_seconds = time.at(index)
+        if finite_count > 0:
+            finite_frame_count += 1
+            if first_finite_time is None:
+                first_finite_time = time_seconds
+            last_finite_time = time_seconds
+        if non_finite_count > 0:
+            affected_frames.append(
+                FieldFrameQualityRecord(
+                    frame_index=index,
+                    time_seconds=time_seconds,
+                    position=_frame_position(index, total_frame_count),
+                    finite_count=finite_count,
+                    non_finite_count=non_finite_count,
+                    total_count=total_count,
+                    entirely_non_finite=finite_count == 0,
+                )
+            )
+
+    return _frame_quality_summary_from_records(
+        affected_frames,
+        finite_frame_count=finite_frame_count,
+        total_frame_count=total_frame_count,
+        finite_point_count=finite_point_count,
+        total_point_count=total_point_count,
+        first_finite_frame_time_seconds=first_finite_time,
+        last_finite_frame_time_seconds=last_finite_time,
+    )
+
+
+def _frame_quality_summary_from_records(
+    affected_frames: list[FieldFrameQualityRecord],
+    *,
+    finite_frame_count: int,
+    total_frame_count: int,
+    finite_point_count: int,
+    total_point_count: int,
+    first_finite_frame_time_seconds: float | None,
+    last_finite_frame_time_seconds: float | None,
+) -> FieldFrameQualitySummary:
+    return FieldFrameQualitySummary(
+        affected_frames=affected_frames,
+        affected_frame_indices=[frame.frame_index for frame in affected_frames],
+        affected_frame_times_seconds=[frame.time_seconds for frame in affected_frames],
+        initial_frame_affected=any(
+            frame.position in {"initial", "single"} for frame in affected_frames
+        ),
+        terminal_frame_affected=any(
+            frame.position in {"terminal", "single"} for frame in affected_frames
+        ),
+        entirely_non_finite_frame_count=sum(
+            1 for frame in affected_frames if frame.entirely_non_finite
+        ),
+        partially_non_finite_frame_count=sum(
+            1 for frame in affected_frames if not frame.entirely_non_finite
+        ),
+        finite_frame_count=finite_frame_count,
+        non_finite_frame_count=len(affected_frames),
+        total_frame_count=total_frame_count,
+        finite_point_fraction=_finite_fraction(finite_point_count, total_point_count),
+        first_finite_frame_time_seconds=first_finite_frame_time_seconds,
+        last_finite_frame_time_seconds=last_finite_frame_time_seconds,
+    )
+
+
+def _frame_position(index: int, total_frame_count: int) -> FramePosition:
+    if total_frame_count <= 1:
+        return "single"
+    if index == 0:
+        return "initial"
+    if index == total_frame_count - 1:
+        return "terminal"
+    return "intermediate"
 
 
 class _TimeContext(BaseModel):
@@ -844,16 +1050,21 @@ def _reflectivity_diagnostics(
     )
 
 
-def _surface_flux_diagnostics(dataset: Any, caveats: list[str]) -> SurfaceFluxDiagnostics:
+def _surface_flux_diagnostics(
+    dataset: Any,
+    time: _TimeContext,
+    caveats: list[str],
+) -> SurfaceFluxDiagnostics:
     return SurfaceFluxDiagnostics(
-        hfx=_surface_flux_field_diagnostics(dataset, "hfx", caveats),
-        qfx=_surface_flux_field_diagnostics(dataset, "qfx", caveats),
+        hfx=_surface_flux_field_diagnostics(dataset, "hfx", time, caveats),
+        qfx=_surface_flux_field_diagnostics(dataset, "qfx", time, caveats),
     )
 
 
 def _surface_flux_field_diagnostics(
     dataset: Any,
     field: str,
+    time: _TimeContext,
     caveats: list[str],
 ) -> SurfaceFluxFieldDiagnostics:
     if field not in dataset.data_vars:
@@ -868,15 +1079,19 @@ def _surface_flux_field_diagnostics(
     finite_count = _finite_count(data_array)
     non_finite_count = _non_finite_count(data_array)
     total_count = _total_count(data_array)
-    field_caveats: list[str] = []
-    if non_finite_count > 0:
-        field_caveat = f"non_finite_values_detected_in_{field}"
-        field_caveats.append(field_caveat)
-        caveats.append(field_caveat)
+    finite_fraction = _finite_fraction(finite_count, total_count)
+    frame_quality = _field_frame_quality(data_array, time)
+    config = FIELD_QUALITY_SOURCES[field]
+    reason = _field_quality_reason(
+        field,
+        config,
+        finite_count=finite_count,
+        non_finite_count=non_finite_count,
+        frame_quality=frame_quality,
+    )
+    field_caveats = _field_quality_caveats(config, reason, non_finite_count)
+    caveats.extend(field_caveats)
     if finite_count == 0:
-        field_caveat = f"{field}_field_entirely_non_finite"
-        field_caveats.append(field_caveat)
-        caveats.append(field_caveat)
         return SurfaceFluxFieldDiagnostics(
             source_field=field,
             available=False,
@@ -885,6 +1100,8 @@ def _surface_flux_field_diagnostics(
             finite_count=finite_count,
             non_finite_count=non_finite_count,
             total_count=total_count,
+            finite_fraction=finite_fraction,
+            frame_quality=frame_quality,
             caveats=_dedupe(field_caveats),
         )
 
@@ -899,6 +1116,8 @@ def _surface_flux_field_diagnostics(
         finite_count=finite_count,
         non_finite_count=non_finite_count,
         total_count=total_count,
+        finite_fraction=finite_fraction,
+        frame_quality=frame_quality,
         caveats=_dedupe(field_caveats),
     )
 
@@ -1529,6 +1748,12 @@ def _non_finite_count(data_array: Any) -> int:
 
 def _total_count(data_array: Any) -> int:
     return int(data_array.values.size)
+
+
+def _finite_fraction(finite_count: int, total_count: int) -> float | None:
+    if total_count <= 0:
+        return None
+    return finite_count / total_count
 
 
 def _has_finite_values(data_array: Any) -> bool:

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -7,6 +7,7 @@ import json
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from math import isfinite
 from pathlib import Path
 from typing import Any, cast
 
@@ -826,32 +827,92 @@ def _merge_frame_quality_summaries(
     present = [summary for summary in summaries if summary is not None]
     if not present:
         return None
-    total_frame_count = sum(summary.total_frame_count for summary in present)
+    frame_records: list[tuple[int, int, float | None, int]] = []
+    chronology_caveats: list[str] = []
+    sequence_index = 0
+    for part_index, summary in enumerate(present):
+        frame_times = list(summary.frame_times_seconds)
+        if len(frame_times) != summary.total_frame_count:
+            chronology_caveats.append("frame_chronology_unavailable_missing_time")
+            frame_times = [None] * summary.total_frame_count
+        chronology_caveats.extend(summary.chronology_caveats)
+        for local_index in range(summary.total_frame_count):
+            frame_records.append(
+                (
+                    part_index,
+                    local_index,
+                    frame_times[local_index] if local_index < len(frame_times) else None,
+                    sequence_index,
+                )
+            )
+            sequence_index += 1
+
+    total_frame_count = len(frame_records)
     finite_frame_count = sum(summary.finite_frame_count for summary in present)
+    finite_time_values = [
+        time_seconds
+        for _, _, time_seconds, _ in frame_records
+        if time_seconds is not None and isfinite(time_seconds)
+    ]
+    if len(finite_time_values) != total_frame_count:
+        chronology_caveats.append("frame_chronology_unavailable_missing_time")
+    elif len(set(finite_time_values)) != total_frame_count:
+        chronology_caveats.append("frame_chronology_unavailable_duplicate_time")
+    chronology_caveats = _dedupe_strings(chronology_caveats)
+
+    if chronology_caveats:
+        ordered_frame_records = sorted(frame_records, key=lambda record: record[3])
+    else:
+        ordered_frame_records = sorted(
+            frame_records,
+            key=lambda record: cast(float, record[2]),
+        )
+    frame_order: dict[tuple[int, int], tuple[int, FramePosition, float | None]] = {}
+    frame_times_seconds: list[float | None] = []
+    for rank, (part_index, local_index, time_seconds, _) in enumerate(ordered_frame_records):
+        frame_order[(part_index, local_index)] = (
+            rank,
+            _merged_frame_position(rank, total_frame_count),
+            time_seconds,
+        )
+        frame_times_seconds.append(time_seconds)
+
     affected_frames: list[FieldFrameQualityRecord] = []
-    first_finite_time: float | None = None
-    last_finite_time: float | None = None
-    offset = 0
-    for summary in present:
-        if first_finite_time is None and summary.first_finite_frame_time_seconds is not None:
-            first_finite_time = summary.first_finite_frame_time_seconds
-        if summary.last_finite_frame_time_seconds is not None:
-            last_finite_time = summary.last_finite_frame_time_seconds
+    first_finite_candidates = [
+        summary.first_finite_frame_time_seconds
+        for summary in present
+        if summary.first_finite_frame_time_seconds is not None
+        and isfinite(summary.first_finite_frame_time_seconds)
+    ]
+    last_finite_candidates = [
+        summary.last_finite_frame_time_seconds
+        for summary in present
+        if summary.last_finite_frame_time_seconds is not None
+        and isfinite(summary.last_finite_frame_time_seconds)
+    ]
+    first_finite_time = min(first_finite_candidates) if first_finite_candidates else None
+    last_finite_time = max(last_finite_candidates) if last_finite_candidates else None
+    for part_index, summary in enumerate(present):
         for frame in summary.affected_frames:
-            frame_index = frame.frame_index + offset
+            if (part_index, frame.frame_index) not in frame_order:
+                chronology_caveats.append("frame_chronology_unavailable_missing_time")
+                continue
+            frame_index, position, time_seconds = frame_order[(part_index, frame.frame_index)]
             affected_frames.append(
                 FieldFrameQualityRecord(
                     frame_index=frame_index,
-                    time_seconds=frame.time_seconds,
-                    position=_merged_frame_position(frame_index, total_frame_count),
+                    time_seconds=time_seconds,
+                    position=position,
                     finite_count=frame.finite_count,
                     non_finite_count=frame.non_finite_count,
                     total_count=frame.total_count,
                     entirely_non_finite=frame.entirely_non_finite,
                 )
             )
-        offset += summary.total_frame_count
+    affected_frames = sorted(affected_frames, key=lambda frame: frame.frame_index)
+    chronology_caveats = _dedupe_strings(chronology_caveats)
     return FieldFrameQualitySummary(
+        frame_times_seconds=frame_times_seconds,
         affected_frames=affected_frames,
         affected_frame_indices=[frame.frame_index for frame in affected_frames],
         affected_frame_times_seconds=[frame.time_seconds for frame in affected_frames],
@@ -867,10 +928,12 @@ def _merge_frame_quality_summaries(
         partially_non_finite_frame_count=sum(
             1 for frame in affected_frames if not frame.entirely_non_finite
         ),
+        affected_frame_count=len(affected_frames),
         finite_frame_count=finite_frame_count,
-        non_finite_frame_count=len(affected_frames),
         total_frame_count=total_frame_count,
         finite_point_fraction=_finite_fraction(finite_count, total_count),
+        chronology_available=not chronology_caveats,
+        chronology_caveats=chronology_caveats,
         first_finite_frame_time_seconds=first_finite_time,
         last_finite_frame_time_seconds=last_finite_time,
     )
@@ -907,6 +970,8 @@ def _frame_quality_reason(
         return None
     if frame_quality is None:
         return partial_reason
+    if not frame_quality.chronology_available:
+        return f"{field}_frame_chronology_unavailable"
     terminal_entire = any(
         frame.position == "terminal" and frame.entirely_non_finite
         for frame in frame_quality.affected_frames

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import json
 import re
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -25,7 +26,10 @@ from cloud_chamber.result_diagnostics import (
     LOW_LEVEL_RESPONSE_EARLY_MIN_SECONDS,
     LOW_LEVEL_RESPONSE_EARLY_TARGET_SECONDS,
     CloudDiagnostics,
+    FieldFrameQualityRecord,
+    FieldFrameQualitySummary,
     FieldQuality,
+    FramePosition,
     LowLevelResponseDiagnostics,
     LowLevelResponseFieldDiagnostics,
     ProcessDiagnostics,
@@ -577,6 +581,7 @@ def _merge_diagnostics(
             *(caveat for diagnostics in diagnostics_parts for caveat in diagnostics.caveats),
         ]
     )
+    caveats = _sanitize_merged_field_quality_caveats(caveats, field_quality)
     if low_level_response.qv.available:
         caveats = [
             caveat
@@ -603,6 +608,24 @@ def _merge_diagnostics(
         field_quality=field_quality,
         caveats=caveats,
     )
+
+
+def _sanitize_merged_field_quality_caveats(
+    caveats: list[str],
+    field_quality: Mapping[str, FieldQuality],
+) -> list[str]:
+    cleaned = list(caveats)
+    for field, quality in field_quality.items():
+        entire_reason = f"{field}_field_entirely_non_finite"
+        if quality.finite_count > 0:
+            cleaned = [caveat for caveat in cleaned if caveat != entire_reason]
+        if (
+            quality.reason is not None
+            and "_output_frame_entirely_non_finite" in quality.reason
+            and quality.reason not in cleaned
+        ):
+            cleaned.append(quality.reason)
+    return _dedupe_strings(cleaned)
 
 
 def _merge_time_diagnostics(diagnostics_parts: list[ResultDiagnostics]) -> TimeDiagnostics:
@@ -794,6 +817,138 @@ def _merge_surface_flux_diagnostics(
     )
 
 
+def _merge_frame_quality_summaries(
+    summaries: list[FieldFrameQualitySummary | None],
+    *,
+    finite_count: int,
+    total_count: int,
+) -> FieldFrameQualitySummary | None:
+    present = [summary for summary in summaries if summary is not None]
+    if not present:
+        return None
+    total_frame_count = sum(summary.total_frame_count for summary in present)
+    finite_frame_count = sum(summary.finite_frame_count for summary in present)
+    affected_frames: list[FieldFrameQualityRecord] = []
+    first_finite_time: float | None = None
+    last_finite_time: float | None = None
+    offset = 0
+    for summary in present:
+        if first_finite_time is None and summary.first_finite_frame_time_seconds is not None:
+            first_finite_time = summary.first_finite_frame_time_seconds
+        if summary.last_finite_frame_time_seconds is not None:
+            last_finite_time = summary.last_finite_frame_time_seconds
+        for frame in summary.affected_frames:
+            frame_index = frame.frame_index + offset
+            affected_frames.append(
+                FieldFrameQualityRecord(
+                    frame_index=frame_index,
+                    time_seconds=frame.time_seconds,
+                    position=_merged_frame_position(frame_index, total_frame_count),
+                    finite_count=frame.finite_count,
+                    non_finite_count=frame.non_finite_count,
+                    total_count=frame.total_count,
+                    entirely_non_finite=frame.entirely_non_finite,
+                )
+            )
+        offset += summary.total_frame_count
+    return FieldFrameQualitySummary(
+        affected_frames=affected_frames,
+        affected_frame_indices=[frame.frame_index for frame in affected_frames],
+        affected_frame_times_seconds=[frame.time_seconds for frame in affected_frames],
+        initial_frame_affected=any(
+            frame.position in {"initial", "single"} for frame in affected_frames
+        ),
+        terminal_frame_affected=any(
+            frame.position in {"terminal", "single"} for frame in affected_frames
+        ),
+        entirely_non_finite_frame_count=sum(
+            1 for frame in affected_frames if frame.entirely_non_finite
+        ),
+        partially_non_finite_frame_count=sum(
+            1 for frame in affected_frames if not frame.entirely_non_finite
+        ),
+        finite_frame_count=finite_frame_count,
+        non_finite_frame_count=len(affected_frames),
+        total_frame_count=total_frame_count,
+        finite_point_fraction=_finite_fraction(finite_count, total_count),
+        first_finite_frame_time_seconds=first_finite_time,
+        last_finite_frame_time_seconds=last_finite_time,
+    )
+
+
+def _merged_frame_position(index: int, total_frame_count: int) -> FramePosition:
+    if total_frame_count <= 1:
+        return "single"
+    if index == 0:
+        return "initial"
+    if index == total_frame_count - 1:
+        return "terminal"
+    return "intermediate"
+
+
+def _finite_fraction(finite_count: int, total_count: int) -> float | None:
+    if total_count <= 0:
+        return None
+    return finite_count / total_count
+
+
+def _frame_quality_reason(
+    field: str,
+    *,
+    finite_count: int,
+    non_finite_count: int,
+    frame_quality: FieldFrameQualitySummary | None,
+    entire_reason: str,
+    partial_reason: str,
+) -> str | None:
+    if finite_count == 0:
+        return entire_reason
+    if non_finite_count <= 0:
+        return None
+    if frame_quality is None:
+        return partial_reason
+    terminal_entire = any(
+        frame.position == "terminal" and frame.entirely_non_finite
+        for frame in frame_quality.affected_frames
+    )
+    if terminal_entire:
+        return f"{field}_terminal_output_frame_entirely_non_finite"
+    intermediate_entire = any(
+        frame.position in {"intermediate", "single"} and frame.entirely_non_finite
+        for frame in frame_quality.affected_frames
+    )
+    if intermediate_entire:
+        return f"{field}_intermediate_output_frame_entirely_non_finite"
+    initial_entire = any(
+        frame.position == "initial" and frame.entirely_non_finite
+        for frame in frame_quality.affected_frames
+    )
+    if initial_entire and frame_quality.entirely_non_finite_frame_count == 1:
+        return f"{field}_initial_output_frame_entirely_non_finite"
+    return partial_reason
+
+
+def _merged_frame_quality_caveats(
+    *,
+    caveats: list[str],
+    finite_count: int,
+    non_finite_count: int,
+    reason: str | None,
+    entire_reason: str,
+    partial_reason: str,
+) -> list[str]:
+    cleaned = list(caveats)
+    if finite_count > 0:
+        cleaned = [caveat for caveat in cleaned if caveat != entire_reason]
+    if non_finite_count > 0 and partial_reason not in cleaned:
+        cleaned.append(partial_reason)
+    if reason is not None and reason not in {partial_reason, entire_reason}:
+        cleaned.append(reason)
+    if finite_count == 0 and entire_reason not in cleaned:
+        cleaned.append(entire_reason)
+    return _dedupe_strings([caveat for caveat in cleaned if caveat])
+
+
 def _merge_surface_flux_field_diagnostics(
     source_field: str,
     parts: list[SurfaceFluxFieldDiagnostics],
@@ -804,8 +959,31 @@ def _merge_surface_flux_field_diagnostics(
     finite_count = sum(part.finite_count for part in parts)
     non_finite_count = sum(part.non_finite_count for part in parts)
     total_count = sum(part.total_count for part in parts)
+    finite_fraction = _finite_fraction(finite_count, total_count)
     units = next((part.units for part in parts if part.units is not None), None)
-    caveats = _dedupe_strings([caveat for part in parts for caveat in part.caveats])
+    frame_quality = _merge_frame_quality_summaries(
+        [part.frame_quality for part in parts],
+        finite_count=finite_count,
+        total_count=total_count,
+    )
+    entire_reason = f"{source_field}_field_entirely_non_finite"
+    partial_reason = f"non_finite_values_detected_in_{source_field}"
+    reason = _frame_quality_reason(
+        source_field,
+        finite_count=finite_count,
+        non_finite_count=non_finite_count,
+        frame_quality=frame_quality,
+        entire_reason=entire_reason,
+        partial_reason=partial_reason,
+    )
+    caveats = _merged_frame_quality_caveats(
+        caveats=[caveat for part in parts for caveat in part.caveats],
+        finite_count=finite_count,
+        non_finite_count=non_finite_count,
+        reason=reason,
+        entire_reason=entire_reason,
+        partial_reason=partial_reason,
+    )
     if not available_parts:
         return SurfaceFluxFieldDiagnostics(
             source_field=source_field,
@@ -815,6 +993,8 @@ def _merge_surface_flux_field_diagnostics(
             finite_count=finite_count,
             non_finite_count=non_finite_count,
             total_count=total_count,
+            finite_fraction=finite_fraction,
+            frame_quality=frame_quality,
             caveats=caveats,
         )
 
@@ -834,6 +1014,8 @@ def _merge_surface_flux_field_diagnostics(
         finite_count=finite_count,
         non_finite_count=non_finite_count,
         total_count=total_count,
+        finite_fraction=finite_fraction,
+        frame_quality=frame_quality,
         caveats=caveats,
     )
 
@@ -1065,14 +1247,39 @@ def _merge_field_quality(field: str, qualities: list[FieldQuality]) -> FieldQual
     finite_count = sum(quality.finite_count for quality in qualities)
     non_finite_count = sum(quality.non_finite_count for quality in qualities)
     total_count = sum(quality.total_count for quality in qualities)
-    caveats = _dedupe_strings([caveat for quality in qualities for caveat in quality.caveats])
-    reason = next(
+    finite_fraction = _finite_fraction(finite_count, total_count)
+    frame_quality = _merge_frame_quality_summaries(
+        [quality.frame_quality for quality in qualities],
+        finite_count=finite_count,
+        total_count=total_count,
+    )
+    fallback_reason = next(
         (
             quality.reason
             for quality in qualities
             if quality.quality_state != "trusted" and quality.reason is not None
         ),
         None,
+    )
+    entire_reason = f"{field}_field_entirely_non_finite"
+    partial_reason = f"non_finite_values_detected_in_{field}"
+    reason = _frame_quality_reason(
+        field,
+        finite_count=finite_count,
+        non_finite_count=non_finite_count,
+        frame_quality=frame_quality,
+        entire_reason=entire_reason,
+        partial_reason=partial_reason,
+    )
+    if reason is None:
+        reason = fallback_reason
+    caveats = _merged_frame_quality_caveats(
+        caveats=[caveat for quality in qualities for caveat in quality.caveats],
+        finite_count=finite_count,
+        non_finite_count=non_finite_count,
+        reason=reason,
+        entire_reason=entire_reason,
+        partial_reason=partial_reason,
     )
 
     if total_count == 0 and finite_count == 0:
@@ -1092,6 +1299,21 @@ def _merge_field_quality(field: str, qualities: list[FieldQuality]) -> FieldQual
             finite_count=finite_count,
             non_finite_count=non_finite_count,
             total_count=total_count,
+            finite_fraction=finite_fraction,
+            frame_quality=frame_quality,
+            caveats=caveats,
+        )
+    if reason is not None and "_terminal_output_frame_entirely_non_finite" in reason:
+        return FieldQuality(
+            field=field,
+            source_field=source_field,
+            quality_state="untrusted",
+            reason=reason,
+            finite_count=finite_count,
+            non_finite_count=non_finite_count,
+            total_count=total_count,
+            finite_fraction=finite_fraction,
+            frame_quality=frame_quality,
             caveats=caveats,
         )
     if non_finite_count > 0 or any(
@@ -1105,6 +1327,8 @@ def _merge_field_quality(field: str, qualities: list[FieldQuality]) -> FieldQual
             finite_count=finite_count,
             non_finite_count=non_finite_count,
             total_count=total_count,
+            finite_fraction=finite_fraction,
+            frame_quality=frame_quality,
             caveats=caveats,
         )
     return FieldQuality(
@@ -1114,6 +1338,8 @@ def _merge_field_quality(field: str, qualities: list[FieldQuality]) -> FieldQual
         finite_count=finite_count,
         non_finite_count=non_finite_count,
         total_count=total_count,
+        finite_fraction=finite_fraction,
+        frame_quality=frame_quality,
     )
 
 

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -37,6 +37,7 @@ from cloud_chamber.observed_sounding import (
     parse_igra_station_text,
 )
 from cloud_chamber.result_diagnostics import (
+    FieldFrameQualitySummary,
     FieldQuality,
     LowLevelResponseFieldDiagnostics,
     SurfaceFluxDiagnostics,
@@ -178,6 +179,8 @@ SUPPORTED_REQUIRED_SUMMARY_FIELDS = {
     "hfx_finite_count",
     "hfx_non_finite_count",
     "hfx_total_count",
+    "hfx_finite_fraction",
+    "hfx_frame_quality",
     "qfx_present",
     "qfx_units",
     "qfx_min",
@@ -186,6 +189,11 @@ SUPPORTED_REQUIRED_SUMMARY_FIELDS = {
     "qfx_finite_count",
     "qfx_non_finite_count",
     "qfx_total_count",
+    "qfx_finite_fraction",
+    "qfx_frame_quality",
+    "terminal_output_contamination",
+    "terminal_output_contamination_fields",
+    "terminal_output_contamination_warnings",
     "lhfx_present",
     "lhfx_units",
     "lhfx_min",
@@ -1984,6 +1992,7 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         diagnostic_trust,
         "dbz",
     )
+    terminal_contamination = _terminal_output_contamination_summary(field_quality, warnings)
     summary = {
         "schema_version": CAMPAIGN_SUMMARY_SCHEMA_VERSION,
         "campaign_id": run.campaign_id,
@@ -2066,6 +2075,8 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "hfx_finite_count": hfx_stats["finite_count"],
         "hfx_non_finite_count": hfx_stats["non_finite_count"],
         "hfx_total_count": hfx_stats["total_count"],
+        "hfx_finite_fraction": hfx_stats["finite_fraction"],
+        "hfx_frame_quality": hfx_stats["frame_quality"],
         "qfx_present": "qfx" in variables,
         "qfx_units": qfx_stats["units"],
         "qfx_min": qfx_stats["min"],
@@ -2074,6 +2085,11 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "qfx_finite_count": qfx_stats["finite_count"],
         "qfx_non_finite_count": qfx_stats["non_finite_count"],
         "qfx_total_count": qfx_stats["total_count"],
+        "qfx_finite_fraction": qfx_stats["finite_fraction"],
+        "qfx_frame_quality": qfx_stats["frame_quality"],
+        "terminal_output_contamination": terminal_contamination["present"],
+        "terminal_output_contamination_fields": terminal_contamination["fields"],
+        "terminal_output_contamination_warnings": terminal_contamination["warnings"],
         "surface_moisture_flux_output_field": _surface_moisture_flux_field(variables),
         "lhfx_present": _surface_moisture_flux_field(variables) is not None,
         "lhfx_units": qfx_stats["units"],
@@ -2266,6 +2282,8 @@ def _surface_flux_summary_values(
             "finite_count": 0,
             "non_finite_count": 0,
             "total_count": 0,
+            "finite_fraction": None,
+            "frame_quality": None,
         }
     if diagnostics.available:
         return {
@@ -2276,6 +2294,8 @@ def _surface_flux_summary_values(
             "finite_count": diagnostics.finite_count,
             "non_finite_count": diagnostics.non_finite_count,
             "total_count": diagnostics.total_count,
+            "finite_fraction": diagnostics.finite_fraction,
+            "frame_quality": _frame_quality_summary_values(diagnostics.frame_quality),
         }
     if diagnostics.field_absent:
         reason = f"unavailable:{source_field}_field_absent"
@@ -2291,6 +2311,41 @@ def _surface_flux_summary_values(
         "finite_count": diagnostics.finite_count,
         "non_finite_count": diagnostics.non_finite_count,
         "total_count": diagnostics.total_count,
+        "finite_fraction": diagnostics.finite_fraction,
+        "frame_quality": _frame_quality_summary_values(diagnostics.frame_quality),
+    }
+
+
+def _frame_quality_summary_values(
+    frame_quality: FieldFrameQualitySummary | None,
+) -> dict[str, Any] | None:
+    if frame_quality is None:
+        return None
+    return {
+        "affected_frame_indices": frame_quality.affected_frame_indices,
+        "affected_frame_times_seconds": frame_quality.affected_frame_times_seconds,
+        "initial_frame_affected": frame_quality.initial_frame_affected,
+        "terminal_frame_affected": frame_quality.terminal_frame_affected,
+        "entirely_non_finite_frame_count": frame_quality.entirely_non_finite_frame_count,
+        "partially_non_finite_frame_count": frame_quality.partially_non_finite_frame_count,
+        "finite_frame_count": frame_quality.finite_frame_count,
+        "non_finite_frame_count": frame_quality.non_finite_frame_count,
+        "total_frame_count": frame_quality.total_frame_count,
+        "finite_point_fraction": frame_quality.finite_point_fraction,
+        "first_finite_frame_time_seconds": frame_quality.first_finite_frame_time_seconds,
+        "last_finite_frame_time_seconds": frame_quality.last_finite_frame_time_seconds,
+        "affected_frames": [
+            {
+                "frame_index": frame.frame_index,
+                "time_seconds": frame.time_seconds,
+                "position": frame.position,
+                "finite_count": frame.finite_count,
+                "non_finite_count": frame.non_finite_count,
+                "total_count": frame.total_count,
+                "entirely_non_finite": frame.entirely_non_finite,
+            }
+            for frame in frame_quality.affected_frames
+        ],
     }
 
 
@@ -2596,7 +2651,18 @@ def _diagnostic_trust(
             if quality is None:
                 quality_trust[field] = "not_assessed"
             elif quality.quality_state == "untrusted":
-                quality_trust[field] = "untrusted_entirely_non_finite"
+                if (
+                    quality.reason is not None
+                    and "_terminal_output_frame_entirely_non_finite" in quality.reason
+                ):
+                    quality_trust[field] = "untrusted_terminal_non_finite_frame"
+                elif (
+                    quality.reason is not None
+                    and "_intermediate_output_frame_entirely_non_finite" in quality.reason
+                ):
+                    quality_trust[field] = "untrusted_intermediate_non_finite_frame"
+                else:
+                    quality_trust[field] = "untrusted_entirely_non_finite"
             elif quality.quality_state == "unavailable":
                 quality_trust[field] = "unavailable_field_missing"
             elif quality.quality_state == "caveated":
@@ -2640,14 +2706,39 @@ def _diagnostic_quality_warnings(
     )
 
 
+def _terminal_output_contamination_summary(
+    field_quality: Mapping[str, FieldQuality] | None,
+    warnings: Iterable[str],
+) -> dict[str, Any]:
+    fields: list[str] = []
+    for field, quality in (field_quality or {}).items():
+        if _frame_quality_has_terminal_entirely_non_finite(
+            _frame_quality_summary_values(quality.frame_quality)
+        ):
+            fields.append(field)
+    warning_list = [
+        warning
+        for warning in warnings
+        if "IEEE_" in warning or "floating-point exception" in warning
+    ]
+    return {
+        "present": bool(fields),
+        "fields": sorted(fields),
+        "warnings": _dedupe(warning_list),
+    }
+
+
 def _trusted_outcome(value: Any, diagnostic_trust: Mapping[str, str], field: str) -> Any:
-    if diagnostic_trust.get(field) == "untrusted_entirely_non_finite":
+    status = diagnostic_trust.get(field)
+    if status is not None and status.startswith("untrusted"):
+        if status == "untrusted_terminal_non_finite_frame":
+            return f"unavailable:untrusted_{field}_terminal_output_frame_entirely_non_finite"
         return f"unavailable:untrusted_{field}_field_entirely_non_finite"
     return value
 
 
 def _field_trust_label(status: str | None) -> str:
-    if status == "untrusted_entirely_non_finite":
+    if status is not None and status.startswith("untrusted"):
         return "untrusted"
     if status == "caveated_non_finite_values_detected":
         return "caveated"
@@ -2683,6 +2774,44 @@ def _trusted_bool_label(label: str, value: Any, trust_status: str | None) -> str
 def _diagnostic_trust_summary(trust: Mapping[str, Any]) -> str:
     fields = ("qc", "w", "qr", "surface_rain", "dbz")
     return ", ".join(f"{field} {_field_trust_label(str(trust.get(field)))}" for field in fields)
+
+
+def _frame_quality_report_label(frame_quality: Any) -> str:
+    if not isinstance(frame_quality, Mapping):
+        return "not assessed"
+    indices = frame_quality.get("affected_frame_indices")
+    times = frame_quality.get("affected_frame_times_seconds")
+    if not isinstance(indices, list) or not indices:
+        total = frame_quality.get("total_frame_count")
+        finite = frame_quality.get("finite_frame_count")
+        if isinstance(total, int) and isinstance(finite, int):
+            return f"all {finite}/{total} frames finite"
+        return "no affected frames"
+    time_labels = (
+        [_time_seconds_report_label(time_seconds) for time_seconds in times]
+        if isinstance(times, list)
+        else []
+    )
+    terminal = (
+        "terminal affected" if frame_quality.get("terminal_frame_affected") else "terminal ok"
+    )
+    initial = "initial affected" if frame_quality.get("initial_frame_affected") else "initial ok"
+    entirely = frame_quality.get("entirely_non_finite_frame_count")
+    return (
+        f"affected frames {indices}"
+        + (f" at {', '.join(time_labels)}" if time_labels else "")
+        + f"; {initial}; {terminal}; entirely non-finite frames {entirely}"
+    )
+
+
+def _time_seconds_report_label(value: Any) -> str:
+    if isinstance(value, int):
+        return f"{value} s"
+    if isinstance(value, float):
+        if value.is_integer():
+            return f"{int(value)} s"
+        return f"{value:.3f} s"
+    return "time unavailable"
 
 
 def _stale_lhfx_missing_message(message: str, available_fields: set[str]) -> bool:
@@ -2732,8 +2861,8 @@ def _cloud_depth_or_classification(
     result: ResultMetadata | None,
     diagnostic_trust: Mapping[str, str],
 ) -> str:
-    if diagnostic_trust.get("qc") == "untrusted_entirely_non_finite":
-        return "unavailable:untrusted_qc_field_entirely_non_finite"
+    if str(diagnostic_trust.get("qc", "")).startswith("untrusted"):
+        return "unavailable:untrusted_qc_field"
     if result is None or result.diagnostics is None:
         return "unavailable:not_ingested"
     cloud = result.diagnostics.cloud
@@ -2847,6 +2976,10 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
         trust = run.get("diagnostic_trust")
         diagnostic_trust = trust if isinstance(trust, dict) else {}
         quality_warnings = ", ".join(run["diagnostic_quality_warnings"]) or "none"
+        terminal_fields = ", ".join(run.get("terminal_output_contamination_fields") or []) or "none"
+        terminal_warnings = (
+            ", ".join(run.get("terminal_output_contamination_warnings") or []) or "none"
+        )
         cloud_updraft = ", ".join(
             [
                 _trusted_metric_label(
@@ -2902,6 +3035,15 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                     f"`{run['hfx_total_count']}`, qfx "
                     f"`{run['qfx_finite_count']}`/`{run['qfx_non_finite_count']}`/"
                     f"`{run['qfx_total_count']}`"
+                ),
+                (
+                    f"- Surface flux frame quality: hfx "
+                    f"`{_frame_quality_report_label(run.get('hfx_frame_quality'))}`, "
+                    f"qfx `{_frame_quality_report_label(run.get('qfx_frame_quality'))}`"
+                ),
+                (
+                    f"- Terminal output contamination: "
+                    f"`{terminal_fields}`; warnings `{terminal_warnings}`"
                 ),
                 f"- Cloud/updraft: {cloud_updraft}",
                 f"- Precipitation/reflectivity: {precipitation}",
@@ -2966,6 +3108,10 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                     f"  - {expectation['field']}: {role}; expected "
                     f"`{expectation['expected']}`, observed `{expectation['observed']}`; "
                     f"`{expectation['status']}`"
+                )
+            if evaluation.get("unavailable_evidence"):
+                lines.append(
+                    f"  - Unavailable evidence: `{', '.join(evaluation['unavailable_evidence'])}`"
                 )
     else:
         lines.append("No Phase 1 surface-flux response comparisons are available.")
@@ -3292,6 +3438,13 @@ def _surface_flux_response_evaluation(
         f"missing_phase1_required_comparison_type:{comparison_type}"
         for comparison_type in missing_required_comparison_types
     ]
+    unavailable_evidence.extend(
+        evidence
+        for evaluation in evaluations
+        for evidence in evaluation.get("unavailable_evidence", [])
+        if isinstance(evidence, str)
+    )
+    unavailable_evidence = _dedupe(unavailable_evidence)
     if missing_required_comparison_types:
         state = SURFACE_FLUX_RESPONSE_MISSING
     elif not evaluations:
@@ -3660,6 +3813,7 @@ def _surface_flux_stat_unavailable_reasons(
     non_finite_count = _int_or_none(summary.get(f"{field}_non_finite_count"))
     total_count = _int_or_none(summary.get(f"{field}_total_count"))
     units = summary.get(f"{field}_units")
+    frame_quality = _frame_quality_mapping(summary.get(f"{field}_frame_quality"))
     reasons: list[str] = []
     if not isinstance(value, int | float) or _is_unavailable(value):
         reasons.append(f"{role}:{field}_mean_unavailable")
@@ -3670,10 +3824,68 @@ def _surface_flux_stat_unavailable_reasons(
     if non_finite_count is None:
         reasons.append(f"{role}:{field}_non_finite_count_unavailable")
     elif non_finite_count > 0:
-        reasons.append(f"{role}:{field}_stats_not_trusted_non_finite")
+        if _frame_quality_has_terminal_entirely_non_finite(frame_quality):
+            reasons.append(f"{role}:{field}_terminal_output_frame_entirely_non_finite")
+        elif _frame_quality_has_intermediate_entirely_non_finite(frame_quality):
+            reasons.append(f"{role}:{field}_intermediate_output_frame_entirely_non_finite")
+        elif _frame_quality_is_initial_only_entirely_non_finite(frame_quality):
+            pass
+        else:
+            reasons.append(f"{role}:{field}_stats_not_trusted_non_finite")
     if not isinstance(units, str) or not units:
         reasons.append(f"{role}:{field}_units_unavailable")
     return reasons
+
+
+def _frame_quality_mapping(value: Any) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _frame_quality_has_terminal_entirely_non_finite(
+    frame_quality: Mapping[str, Any] | None,
+) -> bool:
+    if frame_quality is None:
+        return False
+    return any(
+        isinstance(frame, Mapping)
+        and frame.get("position") in {"terminal", "single"}
+        and frame.get("entirely_non_finite") is True
+        for frame in _frame_quality_affected_frames(frame_quality)
+    )
+
+
+def _frame_quality_has_intermediate_entirely_non_finite(
+    frame_quality: Mapping[str, Any] | None,
+) -> bool:
+    if frame_quality is None:
+        return False
+    return any(
+        isinstance(frame, Mapping)
+        and frame.get("position") == "intermediate"
+        and frame.get("entirely_non_finite") is True
+        for frame in _frame_quality_affected_frames(frame_quality)
+    )
+
+
+def _frame_quality_is_initial_only_entirely_non_finite(
+    frame_quality: Mapping[str, Any] | None,
+) -> bool:
+    if frame_quality is None:
+        return False
+    affected_frames = [
+        frame
+        for frame in _frame_quality_affected_frames(frame_quality)
+        if isinstance(frame, Mapping)
+    ]
+    return bool(affected_frames) and all(
+        frame.get("position") == "initial" and frame.get("entirely_non_finite") is True
+        for frame in affected_frames
+    )
+
+
+def _frame_quality_affected_frames(frame_quality: Mapping[str, Any]) -> Sequence[Any]:
+    frames = frame_quality.get("affected_frames")
+    return frames if isinstance(frames, list) else []
 
 
 def _surface_flux_field_expectation(
@@ -3909,6 +4121,13 @@ def _forcing_response_summary(summary: Mapping[str, Any]) -> str:
             "changes."
         )
     if state == SURFACE_FLUX_RESPONSE_MISSING:
+        if _surface_flux_response_has_terminal_contamination(summary):
+            return (
+                "Phase 1 produced finite hfx/qfx means that can be directionally "
+                "reviewed, but emitted surface-flux verification remains blocked "
+                "because terminal output-frame contamination makes at least one "
+                "matched run untrusted."
+            )
         return (
             "Phase 1 cannot verify emitted surface-flux response because one or more "
             "matched hfx/qfx statistics are missing, untrusted, or not ingested."
@@ -3922,6 +4141,23 @@ def _forcing_response_summary(summary: Mapping[str, Any]) -> str:
     if state == "forcing_wiring_not_verified":
         return "Surface-flux output fields are missing from ingested results."
     return "No ingested result evidence is available yet."
+
+
+def _surface_flux_response_has_terminal_contamination(summary: Mapping[str, Any]) -> bool:
+    surface_flux_response = summary.get("surface_flux_response")
+    if not isinstance(surface_flux_response, Mapping):
+        return False
+    evaluations = surface_flux_response.get("evaluations")
+    if not isinstance(evaluations, list):
+        return False
+    return any(
+        isinstance(evaluation, Mapping)
+        and any(
+            isinstance(item, str) and "terminal_output_frame_entirely_non_finite" in item
+            for item in evaluation.get("unavailable_evidence", [])
+        )
+        for evaluation in evaluations
+    )
 
 
 def _deepening_summary(summary: Mapping[str, Any]) -> str:

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -193,7 +193,7 @@ SUPPORTED_REQUIRED_SUMMARY_FIELDS = {
     "qfx_frame_quality",
     "terminal_output_contamination",
     "terminal_output_contamination_fields",
-    "terminal_output_contamination_warnings",
+    "runtime_floating_point_warnings",
     "lhfx_present",
     "lhfx_units",
     "lhfx_min",
@@ -2089,7 +2089,7 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "qfx_frame_quality": qfx_stats["frame_quality"],
         "terminal_output_contamination": terminal_contamination["present"],
         "terminal_output_contamination_fields": terminal_contamination["fields"],
-        "terminal_output_contamination_warnings": terminal_contamination["warnings"],
+        "runtime_floating_point_warnings": terminal_contamination["warnings"],
         "surface_moisture_flux_output_field": _surface_moisture_flux_field(variables),
         "lhfx_present": _surface_moisture_flux_field(variables) is not None,
         "lhfx_units": qfx_stats["units"],
@@ -2322,16 +2322,19 @@ def _frame_quality_summary_values(
     if frame_quality is None:
         return None
     return {
+        "frame_times_seconds": frame_quality.frame_times_seconds,
         "affected_frame_indices": frame_quality.affected_frame_indices,
         "affected_frame_times_seconds": frame_quality.affected_frame_times_seconds,
         "initial_frame_affected": frame_quality.initial_frame_affected,
         "terminal_frame_affected": frame_quality.terminal_frame_affected,
+        "affected_frame_count": frame_quality.affected_frame_count,
         "entirely_non_finite_frame_count": frame_quality.entirely_non_finite_frame_count,
         "partially_non_finite_frame_count": frame_quality.partially_non_finite_frame_count,
         "finite_frame_count": frame_quality.finite_frame_count,
-        "non_finite_frame_count": frame_quality.non_finite_frame_count,
         "total_frame_count": frame_quality.total_frame_count,
         "finite_point_fraction": frame_quality.finite_point_fraction,
+        "chronology_available": frame_quality.chronology_available,
+        "chronology_caveats": frame_quality.chronology_caveats,
         "first_finite_frame_time_seconds": frame_quality.first_finite_frame_time_seconds,
         "last_finite_frame_time_seconds": frame_quality.last_finite_frame_time_seconds,
         "affected_frames": [
@@ -2966,6 +2969,15 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
     lines.extend(
         [
             "",
+            (
+                "Cloud-top values currently use the total hydrometeor envelope and may "
+                "exceed the coherent liquid/ice cloud-object top. See #330."
+            ),
+        ]
+    )
+    lines.extend(
+        [
+            "",
             "## Per-Run Evidence",
             "",
         ]
@@ -2977,9 +2989,7 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
         diagnostic_trust = trust if isinstance(trust, dict) else {}
         quality_warnings = ", ".join(run["diagnostic_quality_warnings"]) or "none"
         terminal_fields = ", ".join(run.get("terminal_output_contamination_fields") or []) or "none"
-        terminal_warnings = (
-            ", ".join(run.get("terminal_output_contamination_warnings") or []) or "none"
-        )
+        runtime_warnings = ", ".join(run.get("runtime_floating_point_warnings") or []) or "none"
         cloud_updraft = ", ".join(
             [
                 _trusted_metric_label(
@@ -3041,10 +3051,8 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                     f"`{_frame_quality_report_label(run.get('hfx_frame_quality'))}`, "
                     f"qfx `{_frame_quality_report_label(run.get('qfx_frame_quality'))}`"
                 ),
-                (
-                    f"- Terminal output contamination: "
-                    f"`{terminal_fields}`; warnings `{terminal_warnings}`"
-                ),
+                (f"- Terminal field contamination: `{terminal_fields}`"),
+                f"- Runtime floating-point warnings: `{runtime_warnings}`",
                 f"- Cloud/updraft: {cloud_updraft}",
                 f"- Precipitation/reflectivity: {precipitation}",
                 f"- Diagnostic trust: `{_diagnostic_trust_summary(diagnostic_trust)}`",
@@ -3824,12 +3832,14 @@ def _surface_flux_stat_unavailable_reasons(
     if non_finite_count is None:
         reasons.append(f"{role}:{field}_non_finite_count_unavailable")
     elif non_finite_count > 0:
-        if _frame_quality_has_terminal_entirely_non_finite(frame_quality):
+        if frame_quality is not None and not frame_quality.get("chronology_available", True):
+            reasons.append(f"{role}:{field}_frame_chronology_unavailable")
+        elif _frame_quality_has_terminal_entirely_non_finite(frame_quality):
             reasons.append(f"{role}:{field}_terminal_output_frame_entirely_non_finite")
         elif _frame_quality_has_intermediate_entirely_non_finite(frame_quality):
             reasons.append(f"{role}:{field}_intermediate_output_frame_entirely_non_finite")
         elif _frame_quality_is_initial_only_entirely_non_finite(frame_quality):
-            pass
+            reasons.append(f"{role}:{field}_initial_output_frame_entirely_non_finite")
         else:
             reasons.append(f"{role}:{field}_stats_not_trusted_non_finite")
     if not isinstance(units, str) or not units:

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -157,6 +157,14 @@ def surface_values(start: float = 0.0, step: float = 1.0) -> list[list[list[floa
     return values
 
 
+def constant_surface_frames(frame_values: list[float]) -> list[list[list[float]]]:
+    return [[[value for _x in range(4)] for _y in range(3)] for value in frame_values]
+
+
+def entirely_non_finite_surface_frame() -> list[list[float]]:
+    return [[float("nan") for _x in range(4)] for _y in range(3)]
+
+
 def time_z_values(values_by_time_z: list[list[float]]) -> list[list[list[list[float]]]]:
     return [
         [[[value for _x in range(4)] for _y in range(3)] for value in time_values]
@@ -493,6 +501,11 @@ def test_surface_flux_statistics_caveat_partially_non_finite_fields(
     assert diagnostics.surface_fluxes.hfx.max_value == pytest.approx(24.0)
     assert diagnostics.surface_fluxes.hfx.finite_count == 23
     assert diagnostics.surface_fluxes.hfx.non_finite_count == 1
+    hfx_frame_quality = diagnostics.surface_fluxes.hfx.frame_quality
+    assert hfx_frame_quality is not None
+    assert hfx_frame_quality.affected_frame_indices == [0]
+    assert hfx_frame_quality.partially_non_finite_frame_count == 1
+    assert hfx_frame_quality.entirely_non_finite_frame_count == 0
     assert diagnostics.field_quality["hfx"].quality_state == "caveated"
     assert "non_finite_values_detected_in_hfx" in diagnostics.caveats
 
@@ -505,10 +518,93 @@ def test_surface_flux_statistics_caveat_partially_non_finite_fields(
     assert "non_finite_values_detected_in_qfx" in diagnostics.caveats
 
 
+@pytest.mark.parametrize(
+    ("bad_index", "expected_reason", "expected_state", "initial", "terminal"),
+    [
+        (0, "hfx_initial_output_frame_entirely_non_finite", "caveated", True, False),
+        (
+            1,
+            "hfx_intermediate_output_frame_entirely_non_finite",
+            "caveated",
+            False,
+            False,
+        ),
+        (2, "hfx_terminal_output_frame_entirely_non_finite", "untrusted", False, True),
+    ],
+)
+def test_surface_flux_quality_identifies_entirely_non_finite_frame_position(
+    tmp_path: Path,
+    bad_index: int,
+    expected_reason: str,
+    expected_state: str,
+    initial: bool,
+    terminal: bool,
+) -> None:
+    hfx = constant_surface_frames([1.0, 2.0, 3.0])
+    hfx[bad_index] = entirely_non_finite_surface_frame()
+    dataset = write_dataset(
+        tmp_path / f"surface_flux_bad_frame_{bad_index}.nc",
+        base_dataset(
+            qc_values=zeros(time_count=3),
+            w_values=w_field(time_count=3),
+            hfx_values=hfx,
+            qfx_values=constant_surface_frames([1.0e-5, 2.0e-5, 3.0e-5]),
+            time_values=[0.0, 3600.0, 21600.0],
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    hfx_stats = diagnostics.surface_fluxes.hfx
+    assert hfx_stats.available is True
+    assert hfx_stats.finite_count == 24
+    assert hfx_stats.non_finite_count == 12
+    assert hfx_stats.frame_quality is not None
+    assert hfx_stats.frame_quality.affected_frame_indices == [bad_index]
+    assert hfx_stats.frame_quality.affected_frame_times_seconds == [
+        [0.0, 3600.0, 21600.0][bad_index]
+    ]
+    assert hfx_stats.frame_quality.initial_frame_affected is initial
+    assert hfx_stats.frame_quality.terminal_frame_affected is terminal
+    assert hfx_stats.frame_quality.entirely_non_finite_frame_count == 1
+    hfx_quality = diagnostics.field_quality["hfx"]
+    assert hfx_quality.quality_state == expected_state
+    assert hfx_quality.reason == expected_reason
+    assert expected_reason in hfx_quality.caveats
+
+
+def test_surface_flux_quality_records_multiple_entirely_non_finite_frames(
+    tmp_path: Path,
+) -> None:
+    hfx = constant_surface_frames([1.0, 2.0, 3.0, 4.0])
+    hfx[0] = entirely_non_finite_surface_frame()
+    hfx[3] = entirely_non_finite_surface_frame()
+    dataset = write_dataset(
+        tmp_path / "surface_flux_multiple_bad_frames.nc",
+        base_dataset(
+            qc_values=zeros(time_count=4),
+            w_values=w_field(time_count=4),
+            hfx_values=hfx,
+            time_values=[0.0, 3600.0, 7200.0, 21600.0],
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    hfx_quality = diagnostics.field_quality["hfx"]
+    assert hfx_quality.quality_state == "untrusted"
+    assert hfx_quality.reason == "hfx_terminal_output_frame_entirely_non_finite"
+    assert hfx_quality.frame_quality is not None
+    assert hfx_quality.frame_quality.affected_frame_indices == [0, 3]
+    assert hfx_quality.frame_quality.initial_frame_affected is True
+    assert hfx_quality.frame_quality.terminal_frame_affected is True
+    assert hfx_quality.frame_quality.finite_frame_count == 2
+
+
 def test_surface_flux_statistics_mark_all_non_finite_fields_unavailable(
     tmp_path: Path,
 ) -> None:
-    all_nan_surface = [[[float("nan") for _x in range(4)] for _y in range(3)] for _time in range(2)]
+    all_nan_surface = [entirely_non_finite_surface_frame() for _time in range(2)]
     dataset = write_dataset(
         tmp_path / "surface_fluxes_all_nan.nc",
         base_dataset(
@@ -527,6 +623,9 @@ def test_surface_flux_statistics_mark_all_non_finite_fields_unavailable(
     assert diagnostics.surface_fluxes.hfx.non_finite_count == 24
     assert diagnostics.surface_fluxes.hfx.total_count == 24
     assert diagnostics.field_quality["hfx"].quality_state == "untrusted"
+    assert diagnostics.field_quality["hfx"].reason == "hfx_field_entirely_non_finite"
+    assert diagnostics.field_quality["hfx"].frame_quality is not None
+    assert diagnostics.field_quality["hfx"].frame_quality.affected_frame_indices == [0, 1]
     assert "hfx_field_entirely_non_finite" in diagnostics.caveats
 
     assert diagnostics.surface_fluxes.qfx.available is False

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -523,6 +523,101 @@ def test_ingests_multifile_terminal_non_finite_frame_quality(
     assert result.diagnostics.low_level_response.qv.full_run_response_available is False
 
 
+def test_ingests_multifile_frame_quality_uses_model_time_chronology(
+    tmp_path: Path,
+) -> None:
+    manifest_path = create_manifest(tmp_path, run_id="run-time-sorted-frame-quality")
+    run_dir = manifest_path.parent
+    late_named_first = run_dir / "cm1out_000001.nc"
+    early_named_second = run_dir / "cm1out_000002.nc"
+    bad = float("nan")
+    write_model_netcdf(
+        late_named_first,
+        times=[21600.0],
+        qc_values=[bad],
+        w_values=[bad],
+        qr_values=[bad],
+        rain_values=[bad],
+        hfx_values=[bad],
+        qfx_values=[bad],
+        qv_values=[bad],
+        th_values=[bad],
+    )
+    write_model_netcdf(
+        early_named_second,
+        times=[0.0, 3600.0],
+        qc_values=[0.0, 2e-6],
+        w_values=[0.5, 3.0],
+        qr_values=[0.0, 1.0e-7],
+        rain_values=[0.0, 0.0],
+        hfx_values=[8.0, 8.0],
+        qfx_values=[5.0e-5, 5.0e-5],
+        qv_values=[0.010, 0.012],
+        th_values=[300.0, 302.0],
+    )
+    complete_manifest(
+        manifest_path,
+        OutputMetadata(netcdf_paths=[str(late_named_first), str(early_named_second)]),
+    )
+
+    result = ingest_completed_run(manifest_path)
+
+    assert result.diagnostics is not None
+    hfx = result.diagnostics.surface_fluxes.hfx
+    assert hfx.frame_quality is not None
+    assert hfx.frame_quality.chronology_available is True
+    assert hfx.frame_quality.frame_times_seconds == [0.0, 3600.0, 21600.0]
+    assert hfx.frame_quality.affected_frame_indices == [2]
+    assert hfx.frame_quality.affected_frame_times_seconds == [21600.0]
+    assert hfx.frame_quality.terminal_frame_affected is True
+    assert result.diagnostics.field_quality["hfx"].reason == (
+        "hfx_terminal_output_frame_entirely_non_finite"
+    )
+
+
+@pytest.mark.parametrize(
+    ("times", "expected_caveat"),
+    [
+        ([0.0, 0.0], "frame_chronology_unavailable_duplicate_time"),
+        ([0.0, float("nan")], "frame_chronology_unavailable_missing_time"),
+    ],
+)
+def test_ingests_frame_quality_caveats_unreliable_time_chronology(
+    tmp_path: Path,
+    times: list[float],
+    expected_caveat: str,
+) -> None:
+    manifest_path = create_manifest(tmp_path, run_id="run-unreliable-frame-chronology")
+    run_dir = manifest_path.parent
+    output = run_dir / "cm1out_000001.nc"
+    write_model_netcdf(
+        output,
+        times=times,
+        qc_values=[0.0, float("nan")],
+        w_values=[0.5, float("nan")],
+        qr_values=[0.0, float("nan")],
+        rain_values=[0.0, float("nan")],
+        hfx_values=[8.0, float("nan")],
+        qfx_values=[5.0e-5, float("nan")],
+        qv_values=[0.010, float("nan")],
+        th_values=[300.0, float("nan")],
+    )
+    complete_manifest(
+        manifest_path,
+        OutputMetadata(netcdf_paths=[str(output)]),
+    )
+
+    result = ingest_completed_run(manifest_path)
+
+    assert result.diagnostics is not None
+    hfx_quality = result.diagnostics.field_quality["hfx"]
+    assert hfx_quality.reason == "hfx_frame_chronology_unavailable"
+    assert hfx_quality.frame_quality is not None
+    assert hfx_quality.frame_quality.chronology_available is False
+    assert expected_caveat in hfx_quality.frame_quality.chronology_caveats
+    assert "hfx_frame_chronology_unavailable" in hfx_quality.caveats
+
+
 def test_ingest_keeps_rain_water_surface_rain_and_reflectivity_distinct(
     tmp_path: Path,
 ) -> None:

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -422,6 +422,107 @@ def test_ingests_multifile_model_output_sequence_and_excludes_stats(tmp_path: Pa
     assert availability["low_level_qv_response"].value == pytest.approx(0.006)
 
 
+def test_ingests_multifile_terminal_non_finite_frame_quality(
+    tmp_path: Path,
+) -> None:
+    manifest_path = create_manifest(tmp_path, run_id="run-terminal-nonfinite")
+    run_dir = manifest_path.parent
+    first = run_dir / "cm1out_000001.nc"
+    second = run_dir / "cm1out_000002.nc"
+    third = run_dir / "cm1out_000003.nc"
+    bad = float("nan")
+    write_model_netcdf(
+        first,
+        times=[0.0],
+        qc_values=[0.0],
+        w_values=[0.5],
+        qr_values=[0.0],
+        rain_values=[0.0],
+        hfx_values=[8.0],
+        qfx_values=[5.0e-5],
+        qv_values=[0.010],
+        th_values=[300.0],
+    )
+    write_model_netcdf(
+        second,
+        times=[3600.0],
+        qc_values=[2e-6],
+        w_values=[3.0],
+        qr_values=[1.0e-7],
+        rain_values=[0.0],
+        hfx_values=[8.0],
+        qfx_values=[5.0e-5],
+        qv_values=[0.012],
+        th_values=[302.0],
+    )
+    write_model_netcdf(
+        third,
+        times=[21600.0],
+        qc_values=[bad],
+        w_values=[bad],
+        qr_values=[bad],
+        rain_values=[bad],
+        hfx_values=[bad],
+        qfx_values=[bad],
+        qv_values=[bad],
+        th_values=[bad],
+    )
+    complete_manifest(
+        manifest_path,
+        OutputMetadata(
+            netcdf_paths=[str(third), str(first), str(second)],
+            runtime_warnings=[
+                "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG "
+                "IEEE_DIVIDE_BY_ZERO IEEE_OVERFLOW_FLAG IEEE_UNDERFLOW_FLAG"
+            ],
+        ),
+    )
+
+    result = ingest_completed_run(manifest_path)
+
+    assert result.model_output_paths == [str(first), str(second), str(third)]
+    assert result.diagnostics is not None
+    hfx = result.diagnostics.surface_fluxes.hfx
+    qfx = result.diagnostics.surface_fluxes.qfx
+    assert hfx.available is True
+    assert hfx.mean_value == pytest.approx(8.0)
+    assert hfx.finite_count == 24
+    assert hfx.non_finite_count == 12
+    assert hfx.frame_quality is not None
+    assert hfx.frame_quality.affected_frame_indices == [2]
+    assert hfx.frame_quality.affected_frame_times_seconds == [21600.0]
+    assert hfx.frame_quality.terminal_frame_affected is True
+    assert "hfx_field_entirely_non_finite" not in hfx.caveats
+    assert "hfx_terminal_output_frame_entirely_non_finite" in hfx.caveats
+    assert "hfx_field_entirely_non_finite" not in result.diagnostics.caveats
+    assert "qfx_field_entirely_non_finite" not in result.diagnostics.caveats
+    assert "hfx_terminal_output_frame_entirely_non_finite" in result.diagnostics.caveats
+    assert "qfx_terminal_output_frame_entirely_non_finite" in result.diagnostics.caveats
+    assert qfx.frame_quality is not None
+    assert qfx.frame_quality.affected_frame_indices == [2]
+    assert qfx.frame_quality.affected_frame_times_seconds == [21600.0]
+    hfx_quality = result.diagnostics.field_quality["hfx"]
+    assert hfx_quality.quality_state == "untrusted"
+    assert hfx_quality.reason == "hfx_terminal_output_frame_entirely_non_finite"
+    assert hfx_quality.frame_quality is not None
+    assert hfx_quality.frame_quality.last_finite_frame_time_seconds == 3600.0
+    assert result.diagnostics.field_quality["qc"].reason == (
+        "qc_terminal_output_frame_entirely_non_finite"
+    )
+    assert result.diagnostics.field_quality["qr"].reason == (
+        "qr_terminal_output_frame_entirely_non_finite"
+    )
+    assert result.diagnostics.field_quality["surface_rain"].reason == (
+        "surface_rain_terminal_output_frame_entirely_non_finite"
+    )
+    assert (
+        "qv_low_level_response_final_endpoint_entirely_non_finite"
+        in result.diagnostics.low_level_response.qv.caveats
+    )
+    assert result.diagnostics.low_level_response.qv.early_response_available is True
+    assert result.diagnostics.low_level_response.qv.full_run_response_available is False
+
+
 def test_ingest_keeps_rain_water_surface_rain_and_reflectivity_distinct(
     tmp_path: Path,
 ) -> None:

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -1193,7 +1193,7 @@ def test_campaign_report_requires_trusted_surface_flux_stats(tmp_path: Path) -> 
     assert "experiment:hfx_stats_not_trusted_non_finite" in heat["unavailable_evidence"]
 
 
-def test_campaign_report_allows_documented_initial_surface_flux_frame_contamination(
+def test_campaign_report_blocks_initial_surface_flux_frame_contamination_without_policy(
     tmp_path: Path,
 ) -> None:
     initial_frame = _fake_frame_quality(
@@ -1215,9 +1215,12 @@ def test_campaign_report_allows_documented_initial_surface_flux_frame_contaminat
         },
     )
 
-    assert artifacts.summary["surface_flux_response"]["state"] == "surface_flux_response_verified"
+    assert artifacts.summary["surface_flux_response"]["state"] == (
+        "surface_flux_response_inconclusive_missing_evidence"
+    )
     heat = artifacts.summary["surface_flux_response"]["evaluations"][0]
-    assert heat["unavailable_evidence"] == []
+    assert "control:hfx_initial_output_frame_entirely_non_finite" in heat["unavailable_evidence"]
+    assert "control:qfx_initial_output_frame_entirely_non_finite" in heat["unavailable_evidence"]
     control = next(
         run
         for run in artifacts.summary["runs"]
@@ -1291,9 +1294,13 @@ def test_campaign_report_blocks_terminal_surface_flux_frame_contamination(
     ]
     assert control["diagnostic_trust"]["qc"] == "untrusted_terminal_non_finite_frame"
     report = Path(artifacts.markdown_path).read_text()
+    assert "Terminal field contamination" in report
+    assert "Runtime floating-point warnings" in report
     assert "terminal output-frame contamination" in report
     assert "control:hfx_terminal_output_frame_entirely_non_finite" in report
     assert "21600 s" in report
+    assert "Cloud-top values currently use the total hydrometeor envelope" in report
+    assert "See #330" in report
     assert "hfx_field_entirely_non_finite" not in report
 
 
@@ -1713,6 +1720,14 @@ def _fake_frame_quality(
     total_frame_count: int = 3,
     finite_frame_count: int = 2,
 ) -> FieldFrameQualitySummary:
+    frame_times_seconds: list[float | None]
+    if total_frame_count <= 1:
+        frame_times_seconds = [time_seconds]
+    else:
+        frame_times_seconds = [
+            21600.0 * index / (total_frame_count - 1) for index in range(total_frame_count)
+        ]
+        frame_times_seconds[frame_index] = time_seconds
     return FieldFrameQualitySummary(
         affected_frames=[
             FieldFrameQualityRecord(
@@ -1725,16 +1740,19 @@ def _fake_frame_quality(
                 entirely_non_finite=finite_count == 0,
             )
         ],
+        frame_times_seconds=frame_times_seconds,
         affected_frame_indices=[frame_index],
         affected_frame_times_seconds=[time_seconds],
         initial_frame_affected=position == "initial",
         terminal_frame_affected=position == "terminal",
+        affected_frame_count=1,
         entirely_non_finite_frame_count=1 if finite_count == 0 else 0,
         partially_non_finite_frame_count=0 if finite_count == 0 else 1,
         finite_frame_count=finite_frame_count,
-        non_finite_frame_count=1,
         total_frame_count=total_frame_count,
         finite_point_fraction=finite_frame_count / total_frame_count,
+        chronology_available=True,
+        chronology_caveats=[],
         first_finite_frame_time_seconds=0.0,
         last_finite_frame_time_seconds=3600.0 if position == "terminal" else time_seconds,
     )

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -14,6 +14,9 @@ from igra_fixtures import IGRA_FIXTURE
 from cloud_chamber.output_products import ScienceSummary
 from cloud_chamber.result_diagnostics import (
     CloudDiagnostics,
+    FieldFrameQualityRecord,
+    FieldFrameQualitySummary,
+    FieldQuality,
     LowLevelResponseDiagnostics,
     LowLevelResponseFieldDiagnostics,
     RainDiagnostics,
@@ -1190,6 +1193,110 @@ def test_campaign_report_requires_trusted_surface_flux_stats(tmp_path: Path) -> 
     assert "experiment:hfx_stats_not_trusted_non_finite" in heat["unavailable_evidence"]
 
 
+def test_campaign_report_allows_documented_initial_surface_flux_frame_contamination(
+    tmp_path: Path,
+) -> None:
+    initial_frame = _fake_frame_quality(
+        frame_index=0,
+        time_seconds=0.0,
+        position="initial",
+    )
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.0e-5),
+            "phase1_control_high_moisture": (2.0, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+        non_finite_counts={"phase1_control_default_flux": (8, 8)},
+        frame_quality_overrides={
+            "phase1_control_default_flux": (initial_frame, initial_frame),
+        },
+    )
+
+    assert artifacts.summary["surface_flux_response"]["state"] == "surface_flux_response_verified"
+    heat = artifacts.summary["surface_flux_response"]["evaluations"][0]
+    assert heat["unavailable_evidence"] == []
+    control = next(
+        run
+        for run in artifacts.summary["runs"]
+        if run["matrix_id"] == "phase1_control_default_flux"
+    )
+    assert control["hfx_frame_quality"]["initial_frame_affected"] is True
+    assert control["hfx_frame_quality"]["terminal_frame_affected"] is False
+
+
+def test_campaign_report_blocks_terminal_surface_flux_frame_contamination(
+    tmp_path: Path,
+) -> None:
+    terminal_frame = _fake_frame_quality(
+        frame_index=24,
+        time_seconds=21600.0,
+        position="terminal",
+        total_frame_count=25,
+        finite_frame_count=24,
+    )
+    terminal_field_overrides = {
+        "qc": _fake_field_quality("qc", "qc", non_finite_count=8, frame_quality=terminal_frame),
+        "qr": _fake_field_quality("qr", "qr", non_finite_count=8, frame_quality=terminal_frame),
+        "surface_rain": _fake_field_quality(
+            "surface_rain", "rain", non_finite_count=8, frame_quality=terminal_frame
+        ),
+    }
+    artifacts = _report_phase1_surface_flux_matrix(
+        tmp_path,
+        flux_means={
+            "phase1_control_default_flux": (2.0, 2.0e-5),
+            "phase1_control_high_sensible": (4.0, 2.0e-5),
+            "phase1_control_high_moisture": (2.0, 4.0e-5),
+            "phase1_control_high_both": (4.0, 4.0e-5),
+        },
+        non_finite_counts={"phase1_control_default_flux": (8, 8)},
+        frame_quality_overrides={
+            "phase1_control_default_flux": (terminal_frame, terminal_frame),
+        },
+        field_quality_overrides_by_run={
+            "phase1_control_default_flux": terminal_field_overrides,
+        },
+        warnings_by_run={
+            "phase1_control_default_flux": [
+                "CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG "
+                "IEEE_DIVIDE_BY_ZERO IEEE_OVERFLOW_FLAG IEEE_UNDERFLOW_FLAG"
+            ]
+        },
+    )
+
+    assert artifacts.summary["surface_flux_response"]["state"] == (
+        "surface_flux_response_inconclusive_missing_evidence"
+    )
+    assert artifacts.summary["phase_gate_state"] == (
+        "surface_flux_response_inconclusive_missing_evidence"
+    )
+    heat = artifacts.summary["surface_flux_response"]["evaluations"][0]
+    assert "control:hfx_terminal_output_frame_entirely_non_finite" in heat["unavailable_evidence"]
+    assert "control:qfx_terminal_output_frame_entirely_non_finite" in heat["unavailable_evidence"]
+    control = next(
+        run
+        for run in artifacts.summary["runs"]
+        if run["matrix_id"] == "phase1_control_default_flux"
+    )
+    assert control["terminal_output_contamination"] is True
+    assert control["terminal_output_contamination_fields"] == [
+        "hfx",
+        "qc",
+        "qfx",
+        "qr",
+        "surface_rain",
+    ]
+    assert control["diagnostic_trust"]["qc"] == "untrusted_terminal_non_finite_frame"
+    report = Path(artifacts.markdown_path).read_text()
+    assert "terminal output-frame contamination" in report
+    assert "control:hfx_terminal_output_frame_entirely_non_finite" in report
+    assert "21600 s" in report
+    assert "hfx_field_entirely_non_finite" not in report
+
+
 def test_campaign_report_rejects_mismatched_surface_flux_units(tmp_path: Path) -> None:
     artifacts = _report_phase1_surface_flux_matrix(
         tmp_path,
@@ -1430,6 +1537,12 @@ def _report_phase1_surface_flux_matrix(
     low_level_full_run_deltas: dict[str, tuple[float, float]] | None = None,
     low_level_qv_early_end_counts: dict[str, tuple[int, int]] | None = None,
     non_finite_counts: dict[str, tuple[int, int]] | None = None,
+    frame_quality_overrides: dict[
+        str, tuple[FieldFrameQualitySummary | None, FieldFrameQualitySummary | None]
+    ]
+    | None = None,
+    field_quality_overrides_by_run: dict[str, dict[str, FieldQuality]] | None = None,
+    warnings_by_run: dict[str, list[str]] | None = None,
     unit_overrides: dict[str, tuple[str, str]] | None = None,
     mutate_matrix: Any | None = None,
 ) -> Any:
@@ -1449,6 +1562,10 @@ def _report_phase1_surface_flux_matrix(
         hfx_units, qfx_units = (unit_overrides or {}).get(
             state_run.matrix_id,
             ("K m/s", "kg/m^2/s"),
+        )
+        hfx_frame_quality, qfx_frame_quality = (frame_quality_overrides or {}).get(
+            state_run.matrix_id,
+            (None, None),
         )
         qv_early_end_finite, qv_early_end_total = (low_level_qv_early_end_counts or {}).get(
             state_run.matrix_id, (8, 8)
@@ -1479,6 +1596,10 @@ def _report_phase1_surface_flux_matrix(
             qfx_units=qfx_units,
             hfx_non_finite_count=hfx_non_finite,
             qfx_non_finite_count=qfx_non_finite,
+            hfx_frame_quality=hfx_frame_quality,
+            qfx_frame_quality=qfx_frame_quality,
+            field_quality_overrides=(field_quality_overrides_by_run or {}).get(state_run.matrix_id),
+            warnings=(warnings_by_run or {}).get(state_run.matrix_id),
         )
 
     return report_campaign(
@@ -1581,6 +1702,190 @@ def _fake_low_level_response_field(
     )
 
 
+def _fake_frame_quality(
+    *,
+    frame_index: int = 2,
+    time_seconds: float = 21600.0,
+    position: str = "terminal",
+    finite_count: int = 0,
+    non_finite_count: int = 8,
+    total_count: int = 8,
+    total_frame_count: int = 3,
+    finite_frame_count: int = 2,
+) -> FieldFrameQualitySummary:
+    return FieldFrameQualitySummary(
+        affected_frames=[
+            FieldFrameQualityRecord(
+                frame_index=frame_index,
+                time_seconds=time_seconds,
+                position=position,  # type: ignore[arg-type]
+                finite_count=finite_count,
+                non_finite_count=non_finite_count,
+                total_count=total_count,
+                entirely_non_finite=finite_count == 0,
+            )
+        ],
+        affected_frame_indices=[frame_index],
+        affected_frame_times_seconds=[time_seconds],
+        initial_frame_affected=position == "initial",
+        terminal_frame_affected=position == "terminal",
+        entirely_non_finite_frame_count=1 if finite_count == 0 else 0,
+        partially_non_finite_frame_count=0 if finite_count == 0 else 1,
+        finite_frame_count=finite_frame_count,
+        non_finite_frame_count=1,
+        total_frame_count=total_frame_count,
+        finite_point_fraction=finite_frame_count / total_frame_count,
+        first_finite_frame_time_seconds=0.0,
+        last_finite_frame_time_seconds=3600.0 if position == "terminal" else time_seconds,
+    )
+
+
+def _fake_flux_caveats(
+    field: str,
+    non_finite_count: int,
+    frame_quality: FieldFrameQualitySummary | None,
+) -> list[str]:
+    caveats: list[str] = []
+    if non_finite_count > 0:
+        caveats.append(f"non_finite_values_detected_in_{field}")
+    if frame_quality is not None and frame_quality.terminal_frame_affected:
+        caveats.append(f"{field}_terminal_output_frame_entirely_non_finite")
+    elif frame_quality is not None and frame_quality.initial_frame_affected:
+        caveats.append(f"{field}_initial_output_frame_entirely_non_finite")
+    elif frame_quality is not None and frame_quality.entirely_non_finite_frame_count > 0:
+        caveats.append(f"{field}_intermediate_output_frame_entirely_non_finite")
+    return caveats
+
+
+def _fake_field_quality_map(
+    *,
+    hfx_non_finite_count: int,
+    qfx_non_finite_count: int,
+    hfx_frame_quality: FieldFrameQualitySummary | None,
+    qfx_frame_quality: FieldFrameQualitySummary | None,
+) -> dict[str, FieldQuality]:
+    fields = {
+        "qc": "qc",
+        "w": "w",
+        "qr": "qr",
+        "surface_rain": "rain",
+        "dbz": "dbz",
+        "hfx": "hfx",
+        "qfx": "qfx",
+    }
+    qualities = {
+        field: FieldQuality(
+            field=field,
+            source_field=source_field,
+            quality_state="trusted",
+            finite_count=8,
+            non_finite_count=0,
+            total_count=8,
+            finite_fraction=1.0,
+        )
+        for field, source_field in fields.items()
+    }
+    qualities["hfx"] = _fake_field_quality(
+        "hfx",
+        "hfx",
+        non_finite_count=hfx_non_finite_count,
+        frame_quality=hfx_frame_quality,
+    )
+    qualities["qfx"] = _fake_field_quality(
+        "qfx",
+        "qfx",
+        non_finite_count=qfx_non_finite_count,
+        frame_quality=qfx_frame_quality,
+    )
+    return qualities
+
+
+def _fake_field_quality_from_caveats(caveats: list[str]) -> dict[str, FieldQuality]:
+    fields = {
+        "qc": ("qc", "non_finite_values_detected_in_qc", "qc_field_entirely_non_finite"),
+        "w": ("w", "non_finite_values_detected_in_w", "w_field_entirely_non_finite"),
+        "qr": ("qr", "non_finite_values_detected_in_qr", "qr_field_entirely_non_finite"),
+        "surface_rain": (
+            "rain",
+            "non_finite_values_detected_in_surface_rain",
+            "surface_rain_field_entirely_non_finite",
+        ),
+        "dbz": ("dbz", "non_finite_values_detected_in_dbz", "dbz_field_entirely_non_finite"),
+    }
+    overrides: dict[str, FieldQuality] = {}
+    caveat_set = set(caveats)
+    for field, (source_field, partial, entire) in fields.items():
+        if entire in caveat_set:
+            overrides[field] = FieldQuality(
+                field=field,
+                source_field=source_field,
+                quality_state="untrusted",
+                reason=entire,
+                finite_count=0,
+                non_finite_count=8,
+                total_count=8,
+                finite_fraction=0.0,
+                caveats=[partial, entire],
+            )
+        elif partial in caveat_set:
+            overrides[field] = FieldQuality(
+                field=field,
+                source_field=source_field,
+                quality_state="caveated",
+                reason=partial,
+                finite_count=7,
+                non_finite_count=1,
+                total_count=8,
+                finite_fraction=7 / 8,
+                caveats=[partial],
+            )
+    return overrides
+
+
+def _fake_field_quality(
+    field: str,
+    source_field: str,
+    *,
+    non_finite_count: int,
+    frame_quality: FieldFrameQualitySummary | None,
+) -> FieldQuality:
+    if non_finite_count <= 0:
+        return FieldQuality(
+            field=field,
+            source_field=source_field,
+            quality_state="trusted",
+            finite_count=8,
+            non_finite_count=0,
+            total_count=8,
+            finite_fraction=1.0,
+            frame_quality=frame_quality,
+        )
+    if frame_quality is not None and frame_quality.terminal_frame_affected:
+        reason = f"{field}_terminal_output_frame_entirely_non_finite"
+        quality_state = "untrusted"
+    elif frame_quality is not None and frame_quality.initial_frame_affected:
+        reason = f"{field}_initial_output_frame_entirely_non_finite"
+        quality_state = "caveated"
+    elif frame_quality is not None and frame_quality.entirely_non_finite_frame_count > 0:
+        reason = f"{field}_intermediate_output_frame_entirely_non_finite"
+        quality_state = "caveated"
+    else:
+        reason = f"non_finite_values_detected_in_{field}"
+        quality_state = "caveated"
+    return FieldQuality(
+        field=field,
+        source_field=source_field,
+        quality_state=quality_state,  # type: ignore[arg-type]
+        reason=reason,
+        finite_count=8,
+        non_finite_count=non_finite_count,
+        total_count=8 + non_finite_count,
+        finite_fraction=8 / (8 + non_finite_count),
+        frame_quality=frame_quality,
+        caveats=_fake_flux_caveats(field, non_finite_count, frame_quality),
+    )
+
+
 def _write_fake_result_metadata(
     manifest_path: Path,
     *,
@@ -1595,6 +1900,9 @@ def _write_fake_result_metadata(
     qfx_units: str = "kg/m^2/s",
     hfx_non_finite_count: int = 0,
     qfx_non_finite_count: int = 0,
+    hfx_frame_quality: FieldFrameQualitySummary | None = None,
+    qfx_frame_quality: FieldFrameQualitySummary | None = None,
+    field_quality_overrides: dict[str, FieldQuality] | None = None,
     low_level_qv_delta: float | None = None,
     low_level_theta_delta: float | None = None,
     low_level_qv_full_run_delta: float | None = None,
@@ -1604,6 +1912,14 @@ def _write_fake_result_metadata(
 ) -> None:
     manifest = load_run_manifest(manifest_path)
     now = datetime.now(UTC)
+    field_quality = _fake_field_quality_map(
+        hfx_non_finite_count=hfx_non_finite_count,
+        qfx_non_finite_count=qfx_non_finite_count,
+        hfx_frame_quality=hfx_frame_quality,
+        qfx_frame_quality=qfx_frame_quality,
+    )
+    field_quality.update(_fake_field_quality_from_caveats(run_caveats or []))
+    field_quality.update(field_quality_overrides or {})
     result = ResultMetadata(
         result_id=f"result-{manifest.run_id}",
         run_id=manifest.run_id,
@@ -1693,6 +2009,11 @@ def _write_fake_result_metadata(
                     finite_count=8,
                     non_finite_count=hfx_non_finite_count,
                     total_count=8 + hfx_non_finite_count,
+                    finite_fraction=8 / (8 + hfx_non_finite_count)
+                    if (8 + hfx_non_finite_count) > 0
+                    else None,
+                    frame_quality=hfx_frame_quality,
+                    caveats=_fake_flux_caveats("hfx", hfx_non_finite_count, hfx_frame_quality),
                 ),
                 qfx=SurfaceFluxFieldDiagnostics(
                     source_field="qfx",
@@ -1705,6 +2026,11 @@ def _write_fake_result_metadata(
                     finite_count=8,
                     non_finite_count=qfx_non_finite_count,
                     total_count=8 + qfx_non_finite_count,
+                    finite_fraction=8 / (8 + qfx_non_finite_count)
+                    if (8 + qfx_non_finite_count) > 0
+                    else None,
+                    frame_quality=qfx_frame_quality,
+                    caveats=_fake_flux_caveats("qfx", qfx_non_finite_count, qfx_frame_quality),
                 ),
             ),
             low_level_response=LowLevelResponseDiagnostics(
@@ -1724,6 +2050,8 @@ def _write_fake_result_metadata(
                 ),
             ),
             time=TimeDiagnostics(source="time", fallback_used=False, coordinate_name="time"),
+            field_quality_assessed=True,
+            field_quality=field_quality,
         ),
         run_caveats=run_caveats or [],
         science_summary=ScienceSummary(

--- a/docs/research/surface-forced-campaigns/surface_forced_tall_002.md
+++ b/docs/research/surface-forced-campaigns/surface_forced_tall_002.md
@@ -3,7 +3,7 @@
 Campaign ID: `surface_forced_tall_002`
 Protocol: `docs/research/surface-forced-sounding-verification-protocol.md`
 Matrix file: `surface_forced_tall_002.yaml` (runtime-local path omitted)
-Generated: `2026-07-14T14:43:04.705347+00:00`
+Generated: `2026-07-14T15:18:38.363023+00:00`
 
 ## Objective
 
@@ -35,6 +35,8 @@ No operator phase-gate overrides were recorded.
 | phase2_easy_deep_strong_120km_12h_optional | planned | unavailable time unavailable | H 0.04 K m/s; M 0.0001 g/g m/s | regional_120km 128 dx 937.5 m | planned |
 | phase3_weak_control_strong_60km_12h | planned | unavailable time unavailable | H 0.04 K m/s; M 0.0001 g/g m/s | regional_60km 128 dx 468.75 m | planned |
 
+Cloud-top values currently use the total hydrometeor envelope and may exceed the coherent liquid/ice cloud-object top. See #330.
+
 ## Per-Run Evidence
 
 ### phase1_control_default_flux
@@ -49,7 +51,8 @@ No operator phase-gate overrides were recorded.
 - Surface flux fields: hfx `True`, moisture flux `True` via `qfx`
 - Surface flux stats: hfx `7.944224834442139`/`9.5802640914917`/`8.904636484635072`, qfx `5.134478851687163e-05`/`6.191877037053928e-05`/`5.7552083215108483e-05`; counts hfx `393216`/`16384`/`409600`, qfx `393216`/`16384`/`409600`
 - Surface flux frame quality: hfx `affected frames [24] at 21600 s; initial ok; terminal affected; entirely non-finite frames 1`, qfx `affected frames [24] at 21600 s; initial ok; terminal affected; entirely non-finite frames 1`
-- Terminal output contamination: `hfx, qc, qfx, qr, surface_rain`; warnings `CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG, IEEE_DIVIDE_BY_ZERO, IEEE_OVERFLOW_FLAG, IEEE_UNDERFLOW_FLAG`
+- Terminal field contamination: `hfx, qc, qfx, qr, surface_rain`
+- Runtime floating-point warnings: `CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG, IEEE_DIVIDE_BY_ZERO, IEEE_OVERFLOW_FLAG, IEEE_UNDERFLOW_FLAG`
 - Cloud/updraft: first cloud unavailable (untrusted), max cloud top unavailable (untrusted), max qc unavailable (untrusted), max w 4.209 (caveated)
 - Precipitation/reflectivity: qr unavailable (untrusted), surface rain unavailable (untrusted), max dBZ 29.5
 - Diagnostic trust: `qc untrusted, w caveated, qr untrusted, surface_rain untrusted, dbz trusted`
@@ -70,7 +73,8 @@ No operator phase-gate overrides were recorded.
 - Surface flux fields: hfx `True`, moisture flux `True` via `qfx`
 - Surface flux stats: hfx `44.11780548095703`/`44.81328582763672`/`44.4474029038474`, qfx `5.70280863030348e-05`/`5.7927085435949266e-05`/`5.745413364151908e-05`; counts hfx `409600`/`0`/`409600`, qfx `409600`/`0`/`409600`
 - Surface flux frame quality: hfx `all 25/25 frames finite`, qfx `all 25/25 frames finite`
-- Terminal output contamination: `none`; warnings `CM1 stderr reported floating-point exception flags: IEEE_UNDERFLOW_FLAG`
+- Terminal field contamination: `none`
+- Runtime floating-point warnings: `CM1 stderr reported floating-point exception flags: IEEE_UNDERFLOW_FLAG`
 - Cloud/updraft: first cloud 1800, max cloud top 4591, max qc 0.002924, max w 9.897
 - Precipitation/reflectivity: qr yes, surface rain yes, max dBZ 56.08
 - Diagnostic trust: `qc trusted, w trusted, qr trusted, surface_rain trusted, dbz trusted`
@@ -91,7 +95,8 @@ No operator phase-gate overrides were recorded.
 - Surface flux fields: hfx `True`, moisture flux `True` via `qfx`
 - Surface flux stats: hfx `8.318500518798828`/`9.38566780090332`/`8.891412899023853`, qfx `0.00010339190339436755`/`0.00011665589408949018`/`0.00011051272358503895`; counts hfx `409600`/`0`/`409600`, qfx `409600`/`0`/`409600`
 - Surface flux frame quality: hfx `all 25/25 frames finite`, qfx `all 25/25 frames finite`
-- Terminal output contamination: `none`; warnings `CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG, IEEE_UNDERFLOW_FLAG`
+- Terminal field contamination: `none`
+- Runtime floating-point warnings: `CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG, IEEE_UNDERFLOW_FLAG`
 - Cloud/updraft: first cloud 2700, max cloud top 1.087e+04, max qc 0.008663, max w 9.921
 - Precipitation/reflectivity: qr yes, surface rain yes, max dBZ 57.01
 - Diagnostic trust: `qc trusted, w trusted, qr trusted, surface_rain trusted, dbz trusted`
@@ -112,7 +117,8 @@ No operator phase-gate overrides were recorded.
 - Surface flux fields: hfx `True`, moisture flux `True` via `qfx`
 - Surface flux stats: hfx `43.95238494873047`/`44.59759521484375`/`44.39683862362988`, qfx `0.000109258180600591`/`0.00011086207086918876`/`0.00011036302276258069`; counts hfx `409600`/`0`/`409600`, qfx `409600`/`0`/`409600`
 - Surface flux frame quality: hfx `all 25/25 frames finite`, qfx `all 25/25 frames finite`
-- Terminal output contamination: `none`; warnings `CM1 stderr reported floating-point exception flags: IEEE_UNDERFLOW_FLAG`
+- Terminal field contamination: `none`
+- Runtime floating-point warnings: `CM1 stderr reported floating-point exception flags: IEEE_UNDERFLOW_FLAG`
 - Cloud/updraft: first cloud 1800, max cloud top 5666, max qc 0.003865, max w 12.34
 - Precipitation/reflectivity: qr yes, surface rain yes, max dBZ 58.39
 - Diagnostic trust: `qc trusted, w trusted, qr trusted, surface_rain trusted, dbz trusted`
@@ -133,7 +139,8 @@ No operator phase-gate overrides were recorded.
 - Surface flux fields: hfx `False`, moisture flux `False` via `missing`
 - Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
 - Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
-- Terminal output contamination: `none`; warnings `none`
+- Terminal field contamination: `none`
+- Runtime floating-point warnings: `none`
 - Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
 - Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
 - Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
@@ -154,7 +161,8 @@ No operator phase-gate overrides were recorded.
 - Surface flux fields: hfx `False`, moisture flux `False` via `missing`
 - Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
 - Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
-- Terminal output contamination: `none`; warnings `none`
+- Terminal field contamination: `none`
+- Runtime floating-point warnings: `none`
 - Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
 - Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
 - Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
@@ -175,7 +183,8 @@ No operator phase-gate overrides were recorded.
 - Surface flux fields: hfx `False`, moisture flux `False` via `missing`
 - Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
 - Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
-- Terminal output contamination: `none`; warnings `none`
+- Terminal field contamination: `none`
+- Runtime floating-point warnings: `none`
 - Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
 - Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
 - Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
@@ -196,7 +205,8 @@ No operator phase-gate overrides were recorded.
 - Surface flux fields: hfx `False`, moisture flux `False` via `missing`
 - Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
 - Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
-- Terminal output contamination: `none`; warnings `none`
+- Terminal field contamination: `none`
+- Runtime floating-point warnings: `none`
 - Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
 - Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
 - Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
@@ -217,7 +227,8 @@ No operator phase-gate overrides were recorded.
 - Surface flux fields: hfx `False`, moisture flux `False` via `missing`
 - Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
 - Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
-- Terminal output contamination: `none`; warnings `none`
+- Terminal field contamination: `none`
+- Runtime floating-point warnings: `none`
 - Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
 - Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
 - Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
@@ -238,7 +249,8 @@ No operator phase-gate overrides were recorded.
 - Surface flux fields: hfx `False`, moisture flux `False` via `missing`
 - Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
 - Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
-- Terminal output contamination: `none`; warnings `none`
+- Terminal field contamination: `none`
+- Runtime floating-point warnings: `none`
 - Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
 - Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
 - Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`

--- a/docs/research/surface-forced-campaigns/surface_forced_tall_002.md
+++ b/docs/research/surface-forced-campaigns/surface_forced_tall_002.md
@@ -1,0 +1,368 @@
+# Surface-Forced Campaign Report: surface_forced_tall_002
+
+Campaign ID: `surface_forced_tall_002`
+Protocol: `docs/research/surface-forced-sounding-verification-protocol.md`
+Matrix file: `surface_forced_tall_002.yaml` (runtime-local path omitted)
+Generated: `2026-07-14T14:43:04.705347+00:00`
+
+## Objective
+
+Verify that numeric uniform lower-boundary heat/moisture forcing is preserved through package generation, CM1 execution, ingest, hfx/qfx statistics, early low-level qv/theta response diagnostics, and reporting on the corrected 18 km stretched domain; then gate deeper sounding-response checks on the Phase 1 evidence.
+
+## Matrix Summary
+
+- Runs planned: 10
+- Status counts: `{"ingested": 4, "planned": 6}`
+- Phase gate state: `surface_flux_response_inconclusive_missing_evidence`
+- Surface flux response: `surface_flux_response_inconclusive_missing_evidence`
+
+## Operator Overrides
+
+No operator phase-gate overrides were recorded.
+
+## Run Table
+
+| Matrix ID | Status | Station/time | Forcing | Grid/domain | Key result |
+| --- | --- | --- | --- | --- | --- |
+| phase1_control_default_flux | ingested | VALLEY; NE. 2026-06-07T18:00:00Z | H 0.008 K m/s; M 5.2e-05 g/g m/s | wide_12km 128 dx 100.0 m | cloud top unavailable (untrusted); max w 4.209 (caveated); surface rain unavailable (untrusted) |
+| phase1_control_high_sensible | ingested | VALLEY; NE. 2026-06-07T18:00:00Z | H 0.04 K m/s; M 5.2e-05 g/g m/s | wide_12km 128 dx 100.0 m | cloud top 4591; max w 9.897; surface rain yes |
+| phase1_control_high_moisture | ingested | VALLEY; NE. 2026-06-07T18:00:00Z | H 0.008 K m/s; M 0.0001 g/g m/s | wide_12km 128 dx 100.0 m | cloud top 1.087e+04; max w 9.921; surface rain yes |
+| phase1_control_high_both | ingested | VALLEY; NE. 2026-06-07T18:00:00Z | H 0.04 K m/s; M 0.0001 g/g m/s | wide_12km 128 dx 100.0 m | cloud top 5666; max w 12.34; surface rain yes |
+| phase2_easy_deep_default_12km_6h | planned | unavailable time unavailable | H 0.008 K m/s; M 5.2e-05 g/g m/s | wide_12km 128 dx 100.0 m | planned |
+| phase2_easy_deep_strong_12km_6h | planned | unavailable time unavailable | H 0.04 K m/s; M 0.0001 g/g m/s | wide_12km 128 dx 100.0 m | planned |
+| phase2_easy_deep_strong_12km_12h | planned | unavailable time unavailable | H 0.04 K m/s; M 0.0001 g/g m/s | wide_12km 128 dx 100.0 m | planned |
+| phase2_easy_deep_strong_60km_12h | planned | unavailable time unavailable | H 0.04 K m/s; M 0.0001 g/g m/s | regional_60km 128 dx 468.75 m | planned |
+| phase2_easy_deep_strong_120km_12h_optional | planned | unavailable time unavailable | H 0.04 K m/s; M 0.0001 g/g m/s | regional_120km 128 dx 937.5 m | planned |
+| phase3_weak_control_strong_60km_12h | planned | unavailable time unavailable | H 0.04 K m/s; M 0.0001 g/g m/s | regional_60km 128 dx 468.75 m | planned |
+
+## Per-Run Evidence
+
+### phase1_control_default_flux
+
+- Run ID: `surface_forced_tall_002-phase1_control_default_flux-4b99360e46`
+- Result ID: `result-surface_forced_tall_002-phase1_control_default_flux-4b99360e46`
+- Status: package `packaged`, run `completed_not_ingested`, ingest `ingested`
+- Provenance: Cloud Chamber `c94520049bdb7e3c396dc9a26f33037c4a2762d8`, CM1 `unavailable:cm1_version_not_recorded`
+- Source: `cached_recommendation` `sounding-candidate-f4fa3d80f08f03a8|USM00072558|2026-06-07T18:00:00Z`
+- Candidate story: `shallow_cumulus_candidate`
+- Required/missing fields: `qv, qc, w, qr, rain, dbz, hfx, qfx` / `none`
+- Surface flux fields: hfx `True`, moisture flux `True` via `qfx`
+- Surface flux stats: hfx `7.944224834442139`/`9.5802640914917`/`8.904636484635072`, qfx `5.134478851687163e-05`/`6.191877037053928e-05`/`5.7552083215108483e-05`; counts hfx `393216`/`16384`/`409600`, qfx `393216`/`16384`/`409600`
+- Surface flux frame quality: hfx `affected frames [24] at 21600 s; initial ok; terminal affected; entirely non-finite frames 1`, qfx `affected frames [24] at 21600 s; initial ok; terminal affected; entirely non-finite frames 1`
+- Terminal output contamination: `hfx, qc, qfx, qr, surface_rain`; warnings `CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG, IEEE_DIVIDE_BY_ZERO, IEEE_OVERFLOW_FLAG, IEEE_UNDERFLOW_FLAG`
+- Cloud/updraft: first cloud unavailable (untrusted), max cloud top unavailable (untrusted), max qc unavailable (untrusted), max w 4.209 (caveated)
+- Precipitation/reflectivity: qr unavailable (untrusted), surface rain unavailable (untrusted), max dBZ 29.5
+- Diagnostic trust: `qc untrusted, w caveated, qr untrusted, surface_rain untrusted, dbz trusted`
+- Field-quality warnings: `non_finite_values_detected_in_qc, non_finite_values_detected_in_w, non_finite_values_detected_in_qr, non_finite_values_detected_in_surface_rain, non_finite_values_detected_in_hfx, non_finite_values_detected_in_qfx, qc_terminal_output_frame_entirely_non_finite, qr_terminal_output_frame_entirely_non_finite, surface_rain_terminal_output_frame_entirely_non_finite, hfx_terminal_output_frame_entirely_non_finite, qfx_terminal_output_frame_entirely_non_finite`
+- Low-level qv early response: `0.00014980878158591532` `kg/kg` via `0_1km_thickness_weighted_domain_mean_early_30_90min` (0.013558389163419874 -> 0.013708197945005789); quality `trusted`; full-run delta `unavailable:qv_low_level_response_final_endpoint_entirely_non_finite`
+- Low-level theta/temperature early response: `-0.027736507558586254` `K` via `0_1km_thickness_weighted_domain_mean_early_30_90min` (300.6119450520672 -> 300.5842085445086); quality `trusted`; full-run delta `unavailable:th_low_level_response_final_endpoint_entirely_non_finite`
+- Caveats: `surface_forcing_is_constant_uniform_proxy, surface_flux_proxy_constant_uniform_not_place_time_energy_budget, surface_flux_proxy_not_real_land_surface_or_evaporation_model, surface_flux_proxy_values_need_local_smoke_validation, science_run_configuration_minimum_duration_6h, configuration_better_suited_to_larger_compute, No artificial atmospheric trigger is applied., Surface heat/moisture fluxes are constant uniform lower-boundary proxy settings; they are not validated place/time surface-energy inputs., Radiation, terrain, GIS surface initialization, and large-scale forcing are not part of v0., Humid/rainy hypotheses remain partial until rain-water-aloft, surface-rain, and reflectivity outputs are present and inspected., CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG, IEEE_DIVIDE_BY_ZERO, IEEE_OVERFLOW_FLAG, IEEE_UNDERFLOW_FLAG, cloud_top_uses_total_hydrometeor_fields:qc,qr,qi,qs,qg, max_height_unavailable_missing_vertical_coordinate, non_finite_values_detected_in_qc, non_finite_values_detected_in_w, non_finite_values_detected_in_qr, non_finite_values_detected_in_surface_rain, non_finite_values_detected_in_hfx, non_finite_values_detected_in_qfx, qc_terminal_output_frame_entirely_non_finite, qr_terminal_output_frame_entirely_non_finite, surface_rain_terminal_output_frame_entirely_non_finite, hfx_terminal_output_frame_entirely_non_finite, qfx_terminal_output_frame_entirely_non_finite, interesting_time_source_field_untrusted`
+
+### phase1_control_high_sensible
+
+- Run ID: `surface_forced_tall_002-phase1_control_high_sensible-56821294e3`
+- Result ID: `result-surface_forced_tall_002-phase1_control_high_sensible-56821294e3`
+- Status: package `packaged`, run `completed_not_ingested`, ingest `ingested`
+- Provenance: Cloud Chamber `c94520049bdb7e3c396dc9a26f33037c4a2762d8`, CM1 `unavailable:cm1_version_not_recorded`
+- Source: `cached_recommendation` `sounding-candidate-f4fa3d80f08f03a8|USM00072558|2026-06-07T18:00:00Z`
+- Candidate story: `shallow_cumulus_candidate`
+- Required/missing fields: `qv, qc, w, qr, rain, dbz, hfx, qfx` / `none`
+- Surface flux fields: hfx `True`, moisture flux `True` via `qfx`
+- Surface flux stats: hfx `44.11780548095703`/`44.81328582763672`/`44.4474029038474`, qfx `5.70280863030348e-05`/`5.7927085435949266e-05`/`5.745413364151908e-05`; counts hfx `409600`/`0`/`409600`, qfx `409600`/`0`/`409600`
+- Surface flux frame quality: hfx `all 25/25 frames finite`, qfx `all 25/25 frames finite`
+- Terminal output contamination: `none`; warnings `CM1 stderr reported floating-point exception flags: IEEE_UNDERFLOW_FLAG`
+- Cloud/updraft: first cloud 1800, max cloud top 4591, max qc 0.002924, max w 9.897
+- Precipitation/reflectivity: qr yes, surface rain yes, max dBZ 56.08
+- Diagnostic trust: `qc trusted, w trusted, qr trusted, surface_rain trusted, dbz trusted`
+- Field-quality warnings: `none`
+- Low-level qv early response: `0.00015244290594485996` `kg/kg` via `0_1km_thickness_weighted_domain_mean_early_30_90min` (0.013558389163419874 -> 0.013710832069364734); quality `trusted`; full-run delta `0.000244519849981549`
+- Low-level theta/temperature early response: `0.0878617688522354` `K` via `0_1km_thickness_weighted_domain_mean_early_30_90min` (300.6119450520672 -> 300.69980682091943); quality `trusted`; full-run delta `0.846182611699362`
+- Caveats: `surface_forcing_is_constant_uniform_proxy, surface_flux_proxy_constant_uniform_not_place_time_energy_budget, surface_flux_proxy_not_real_land_surface_or_evaporation_model, surface_flux_proxy_values_need_local_smoke_validation, science_run_configuration_minimum_duration_6h, configuration_better_suited_to_larger_compute, No artificial atmospheric trigger is applied., Surface heat/moisture fluxes are constant uniform lower-boundary proxy settings; they are not validated place/time surface-energy inputs., Radiation, terrain, GIS surface initialization, and large-scale forcing are not part of v0., Humid/rainy hypotheses remain partial until rain-water-aloft, surface-rain, and reflectivity outputs are present and inspected., CM1 stderr reported floating-point exception flags: IEEE_UNDERFLOW_FLAG, cloud_top_uses_total_hydrometeor_fields:qc,qr,qi,qs,qg, max_height_unavailable_missing_vertical_coordinate, no_deep_cloud_detected`
+
+### phase1_control_high_moisture
+
+- Run ID: `surface_forced_tall_002-phase1_control_high_moisture-6d46cf11d1`
+- Result ID: `result-surface_forced_tall_002-phase1_control_high_moisture-6d46cf11d1`
+- Status: package `packaged`, run `completed_not_ingested`, ingest `ingested`
+- Provenance: Cloud Chamber `c94520049bdb7e3c396dc9a26f33037c4a2762d8`, CM1 `unavailable:cm1_version_not_recorded`
+- Source: `cached_recommendation` `sounding-candidate-f4fa3d80f08f03a8|USM00072558|2026-06-07T18:00:00Z`
+- Candidate story: `shallow_cumulus_candidate`
+- Required/missing fields: `qv, qc, w, qr, rain, dbz, hfx, qfx` / `none`
+- Surface flux fields: hfx `True`, moisture flux `True` via `qfx`
+- Surface flux stats: hfx `8.318500518798828`/`9.38566780090332`/`8.891412899023853`, qfx `0.00010339190339436755`/`0.00011665589408949018`/`0.00011051272358503895`; counts hfx `409600`/`0`/`409600`, qfx `409600`/`0`/`409600`
+- Surface flux frame quality: hfx `all 25/25 frames finite`, qfx `all 25/25 frames finite`
+- Terminal output contamination: `none`; warnings `CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG, IEEE_UNDERFLOW_FLAG`
+- Cloud/updraft: first cloud 2700, max cloud top 1.087e+04, max qc 0.008663, max w 9.921
+- Precipitation/reflectivity: qr yes, surface rain yes, max dBZ 57.01
+- Diagnostic trust: `qc trusted, w trusted, qr trusted, surface_rain trusted, dbz trusted`
+- Field-quality warnings: `none`
+- Low-level qv early response: `0.00032528001756211566` `kg/kg` via `0_1km_thickness_weighted_domain_mean_early_30_90min` (0.013558389163419874 -> 0.01388366918098199); quality `trusted`; full-run delta `0.0009690320854314344`
+- Low-level theta/temperature early response: `-0.028184155874384942` `K` via `0_1km_thickness_weighted_domain_mean_early_30_90min` (300.6119450520672 -> 300.5837608961928); quality `trusted`; full-run delta `0.31267307259588506`
+- Caveats: `surface_forcing_is_constant_uniform_proxy, surface_flux_proxy_constant_uniform_not_place_time_energy_budget, surface_flux_proxy_not_real_land_surface_or_evaporation_model, surface_flux_proxy_values_need_local_smoke_validation, science_run_configuration_minimum_duration_6h, configuration_better_suited_to_larger_compute, No artificial atmospheric trigger is applied., Surface heat/moisture fluxes are constant uniform lower-boundary proxy settings; they are not validated place/time surface-energy inputs., Radiation, terrain, GIS surface initialization, and large-scale forcing are not part of v0., Humid/rainy hypotheses remain partial until rain-water-aloft, surface-rain, and reflectivity outputs are present and inspected., CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG, IEEE_UNDERFLOW_FLAG, cloud_top_uses_total_hydrometeor_fields:qc,qr,qi,qs,qg, max_height_unavailable_missing_vertical_coordinate`
+
+### phase1_control_high_both
+
+- Run ID: `surface_forced_tall_002-phase1_control_high_both-1c5b253ffb`
+- Result ID: `result-surface_forced_tall_002-phase1_control_high_both-1c5b253ffb`
+- Status: package `packaged`, run `completed_not_ingested`, ingest `ingested`
+- Provenance: Cloud Chamber `c94520049bdb7e3c396dc9a26f33037c4a2762d8`, CM1 `unavailable:cm1_version_not_recorded`
+- Source: `cached_recommendation` `sounding-candidate-f4fa3d80f08f03a8|USM00072558|2026-06-07T18:00:00Z`
+- Candidate story: `shallow_cumulus_candidate`
+- Required/missing fields: `qv, qc, w, qr, rain, dbz, hfx, qfx` / `none`
+- Surface flux fields: hfx `True`, moisture flux `True` via `qfx`
+- Surface flux stats: hfx `43.95238494873047`/`44.59759521484375`/`44.39683862362988`, qfx `0.000109258180600591`/`0.00011086207086918876`/`0.00011036302276258069`; counts hfx `409600`/`0`/`409600`, qfx `409600`/`0`/`409600`
+- Surface flux frame quality: hfx `all 25/25 frames finite`, qfx `all 25/25 frames finite`
+- Terminal output contamination: `none`; warnings `CM1 stderr reported floating-point exception flags: IEEE_UNDERFLOW_FLAG`
+- Cloud/updraft: first cloud 1800, max cloud top 5666, max qc 0.003865, max w 12.34
+- Precipitation/reflectivity: qr yes, surface rain yes, max dBZ 58.39
+- Diagnostic trust: `qc trusted, w trusted, qr trusted, surface_rain trusted, dbz trusted`
+- Field-quality warnings: `none`
+- Low-level qv early response: `0.00032863593977465813` `kg/kg` via `0_1km_thickness_weighted_domain_mean_early_30_90min` (0.013558389163419874 -> 0.013887025103194532); quality `trusted`; full-run delta `0.0006861705547625309`
+- Low-level theta/temperature early response: `0.08773937005958032` `K` via `0_1km_thickness_weighted_domain_mean_early_30_90min` (300.6119450520672 -> 300.6996844221268); quality `trusted`; full-run delta `1.0857133591252364`
+- Caveats: `surface_forcing_is_constant_uniform_proxy, surface_flux_proxy_constant_uniform_not_place_time_energy_budget, surface_flux_proxy_not_real_land_surface_or_evaporation_model, surface_flux_proxy_values_need_local_smoke_validation, science_run_configuration_minimum_duration_6h, configuration_better_suited_to_larger_compute, No artificial atmospheric trigger is applied., Surface heat/moisture fluxes are constant uniform lower-boundary proxy settings; they are not validated place/time surface-energy inputs., Radiation, terrain, GIS surface initialization, and large-scale forcing are not part of v0., Humid/rainy hypotheses remain partial until rain-water-aloft, surface-rain, and reflectivity outputs are present and inspected., CM1 stderr reported floating-point exception flags: IEEE_UNDERFLOW_FLAG, cloud_top_uses_total_hydrometeor_fields:qc,qr,qi,qs,qg, max_height_unavailable_missing_vertical_coordinate, no_deep_cloud_detected`
+
+### phase2_easy_deep_default_12km_6h
+
+- Run ID: `surface_forced_tall_002-phase2_easy_deep_default_12km_6h-8bf3806780`
+- Result ID: `not ingested`
+- Status: package `planned`, run `planned`, ingest `not_started`
+- Provenance: Cloud Chamber `unavailable`, CM1 `unavailable:cm1_version_not_recorded`
+- Source: `cached_recommendation` `sounding-candidate-369ae4c88bb32672|USM00072357|2025-05-20T00:00:00Z`
+- Candidate story: `supercell_environment`
+- Required/missing fields: `unavailable` / `unavailable:until_result_ingested`
+- Surface flux fields: hfx `False`, moisture flux `False` via `missing`
+- Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
+- Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
+- Terminal output contamination: `none`; warnings `none`
+- Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
+- Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
+- Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
+- Field-quality warnings: `none`
+- Low-level qv early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Low-level theta/temperature early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Caveats: `surface_forcing_is_constant_uniform_proxy, result_not_ingested`
+
+### phase2_easy_deep_strong_12km_6h
+
+- Run ID: `surface_forced_tall_002-phase2_easy_deep_strong_12km_6h-5ad9bcd1fd`
+- Result ID: `not ingested`
+- Status: package `planned`, run `planned`, ingest `not_started`
+- Provenance: Cloud Chamber `unavailable`, CM1 `unavailable:cm1_version_not_recorded`
+- Source: `cached_recommendation` `sounding-candidate-369ae4c88bb32672|USM00072357|2025-05-20T00:00:00Z`
+- Candidate story: `supercell_environment`
+- Required/missing fields: `unavailable` / `unavailable:until_result_ingested`
+- Surface flux fields: hfx `False`, moisture flux `False` via `missing`
+- Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
+- Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
+- Terminal output contamination: `none`; warnings `none`
+- Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
+- Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
+- Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
+- Field-quality warnings: `none`
+- Low-level qv early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Low-level theta/temperature early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Caveats: `surface_forcing_is_constant_uniform_proxy, result_not_ingested`
+
+### phase2_easy_deep_strong_12km_12h
+
+- Run ID: `surface_forced_tall_002-phase2_easy_deep_strong_12km_12h-4afcd6e8d8`
+- Result ID: `not ingested`
+- Status: package `planned`, run `planned`, ingest `not_started`
+- Provenance: Cloud Chamber `unavailable`, CM1 `unavailable:cm1_version_not_recorded`
+- Source: `cached_recommendation` `sounding-candidate-369ae4c88bb32672|USM00072357|2025-05-20T00:00:00Z`
+- Candidate story: `supercell_environment`
+- Required/missing fields: `unavailable` / `unavailable:until_result_ingested`
+- Surface flux fields: hfx `False`, moisture flux `False` via `missing`
+- Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
+- Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
+- Terminal output contamination: `none`; warnings `none`
+- Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
+- Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
+- Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
+- Field-quality warnings: `none`
+- Low-level qv early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Low-level theta/temperature early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Caveats: `surface_forcing_is_constant_uniform_proxy, result_not_ingested`
+
+### phase2_easy_deep_strong_60km_12h
+
+- Run ID: `surface_forced_tall_002-phase2_easy_deep_strong_60km_12h-aaa54b1010`
+- Result ID: `not ingested`
+- Status: package `planned`, run `planned`, ingest `not_started`
+- Provenance: Cloud Chamber `unavailable`, CM1 `unavailable:cm1_version_not_recorded`
+- Source: `cached_recommendation` `sounding-candidate-369ae4c88bb32672|USM00072357|2025-05-20T00:00:00Z`
+- Candidate story: `supercell_environment`
+- Required/missing fields: `unavailable` / `unavailable:until_result_ingested`
+- Surface flux fields: hfx `False`, moisture flux `False` via `missing`
+- Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
+- Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
+- Terminal output contamination: `none`; warnings `none`
+- Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
+- Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
+- Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
+- Field-quality warnings: `none`
+- Low-level qv early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Low-level theta/temperature early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Caveats: `surface_forcing_is_constant_uniform_proxy, result_not_ingested`
+
+### phase2_easy_deep_strong_120km_12h_optional
+
+- Run ID: `surface_forced_tall_002-phase2_easy_deep_strong_120km_12h_optional-477214201d`
+- Result ID: `not ingested`
+- Status: package `planned`, run `planned`, ingest `not_started`
+- Provenance: Cloud Chamber `unavailable`, CM1 `unavailable:cm1_version_not_recorded`
+- Source: `cached_recommendation` `sounding-candidate-369ae4c88bb32672|USM00072357|2025-05-20T00:00:00Z`
+- Candidate story: `supercell_environment`
+- Required/missing fields: `unavailable` / `unavailable:until_result_ingested`
+- Surface flux fields: hfx `False`, moisture flux `False` via `missing`
+- Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
+- Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
+- Terminal output contamination: `none`; warnings `none`
+- Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
+- Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
+- Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
+- Field-quality warnings: `none`
+- Low-level qv early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Low-level theta/temperature early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Caveats: `surface_forcing_is_constant_uniform_proxy, optional_campaign_run, result_not_ingested`
+
+### phase3_weak_control_strong_60km_12h
+
+- Run ID: `surface_forced_tall_002-phase3_weak_control_strong_60km_12h-96fe6460b1`
+- Result ID: `not ingested`
+- Status: package `planned`, run `planned`, ingest `not_started`
+- Provenance: Cloud Chamber `unavailable`, CM1 `unavailable:cm1_version_not_recorded`
+- Source: `cached_recommendation` `sounding-candidate-05af14d176e118b8|USM00072662|2025-07-09T18:00:00Z`
+- Candidate story: `dry_failed_candidate`
+- Required/missing fields: `unavailable` / `unavailable:until_result_ingested`
+- Surface flux fields: hfx `False`, moisture flux `False` via `missing`
+- Surface flux stats: hfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`, qfx `unavailable:until_result_ingested`/`unavailable:until_result_ingested`/`unavailable:until_result_ingested`; counts hfx `0`/`0`/`0`, qfx `0`/`0`/`0`
+- Surface flux frame quality: hfx `not assessed`, qfx `not assessed`
+- Terminal output contamination: `none`; warnings `none`
+- Cloud/updraft: first cloud unavailable, max cloud top unavailable, max qc unavailable, max w unavailable
+- Precipitation/reflectivity: qr unavailable, surface rain unavailable, max dBZ unavailable
+- Diagnostic trust: `qc unavailable, w unavailable, qr unavailable, surface_rain unavailable, dbz unavailable`
+- Field-quality warnings: `none`
+- Low-level qv early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Low-level theta/temperature early response: `unavailable:until_result_ingested` `` via `unavailable:until_result_ingested` (unavailable:until_result_ingested -> unavailable:until_result_ingested); quality `unavailable`; full-run delta `unavailable:until_result_ingested`
+- Caveats: `surface_forcing_is_constant_uniform_proxy, result_not_ingested`
+
+## Forcing Response
+
+Phase 1 produced finite hfx/qfx means that can be directionally reviewed, but emitted surface-flux verification remains blocked because terminal output-frame contamination makes at least one matched run untrusted.
+
+## Surface Flux Response
+
+- `phase1_control_high_sensible` vs `phase1_control_default_flux`: `surface_flux_response_inconclusive_missing_evidence`
+  - Unavailable evidence: `control:hfx_terminal_output_frame_entirely_non_finite, control:qfx_terminal_output_frame_entirely_non_finite`
+- `phase1_control_high_moisture` vs `phase1_control_default_flux`: `surface_flux_response_inconclusive_missing_evidence`
+  - Unavailable evidence: `control:hfx_terminal_output_frame_entirely_non_finite, control:qfx_terminal_output_frame_entirely_non_finite`
+- `phase1_control_high_both` vs `phase1_control_default_flux`: `surface_flux_response_inconclusive_missing_evidence`
+  - Unavailable evidence: `control:hfx_terminal_output_frame_entirely_non_finite, control:qfx_terminal_output_frame_entirely_non_finite`
+
+## Low-Level Response
+
+- `phase1_control_high_sensible` vs `phase1_control_default_flux`: `low_level_response_verified`
+  - low_level_theta_or_temperature_early_response_delta: required; expected `increase`, observed `increase`; `verified`; quality `trusted`
+  - low_level_qv_early_response_delta: informational; expected `comparable`, observed `increase`; `informational`; quality `trusted`
+- `phase1_control_high_moisture` vs `phase1_control_default_flux`: `low_level_response_verified`
+  - low_level_theta_or_temperature_early_response_delta: informational; expected `comparable`, observed `decrease`; `informational`; quality `trusted`
+  - low_level_qv_early_response_delta: required; expected `increase`, observed `increase`; `verified`; quality `trusted`
+- `phase1_control_high_both` vs `phase1_control_default_flux`: `low_level_response_verified`
+  - low_level_theta_or_temperature_early_response_delta: required; expected `increase`, observed `increase`; `verified`; quality `trusted`
+  - low_level_qv_early_response_delta: required; expected `increase`, observed `increase`; `verified`; quality `trusted`
+
+## Matched Comparisons
+
+### phase1_control_high_sensible vs phase1_control_default_flux
+
+- Type: `heat_flux_sensitivity`
+- Status: `comparable`
+- Varied fields: `surface_heat_flux_k_m_s, cm1_cnst_shflx`
+- Equality failures: `[]`
+- Unavailable evidence: `none`
+- Interpretation: Required comparison gates passed; inspect supported differences without treating them as predicted-vs-actual verdicts.
+
+### phase1_control_high_moisture vs phase1_control_default_flux
+
+- Type: `moisture_flux_sensitivity`
+- Status: `comparable`
+- Varied fields: `surface_moisture_flux_g_g_m_s, cm1_cnst_lhflx`
+- Equality failures: `[]`
+- Unavailable evidence: `none`
+- Interpretation: Required comparison gates passed; inspect supported differences without treating them as predicted-vs-actual verdicts.
+
+### phase1_control_high_both vs phase1_control_default_flux
+
+- Type: `combined_flux_sensitivity`
+- Status: `comparable`
+- Varied fields: `surface_heat_flux_k_m_s, surface_moisture_flux_g_g_m_s, cm1_cnst_shflx, cm1_cnst_lhflx`
+- Equality failures: `[]`
+- Unavailable evidence: `none`
+- Interpretation: Required comparison gates passed; inspect supported differences without treating them as predicted-vs-actual verdicts.
+
+### phase2_easy_deep_strong_12km_6h vs phase2_easy_deep_default_12km_6h
+
+- Type: `forcing_sensitivity_same_duration`
+- Status: `inconclusive_missing_evidence`
+- Varied fields: `surface_heat_flux_k_m_s, surface_moisture_flux_g_g_m_s, cm1_cnst_shflx, cm1_cnst_lhflx`
+- Equality failures: `[]`
+- Unavailable evidence: `control:result_not_ingested, control:missing_required_field:hfx, control:missing_required_field:qfx, control:missing_required_field:qv, control:missing_required_field:th_or_temperature, control:missing_required_field:qc, control:missing_required_field:w, control:diagnostic_unavailable:surface_fluxes, control:diagnostic_unavailable:low_level_response, control:diagnostic_unavailable:cloud, control:diagnostic_unavailable:vertical_velocity, experiment:result_not_ingested, experiment:missing_required_field:hfx, experiment:missing_required_field:qfx, experiment:missing_required_field:qv, experiment:missing_required_field:th_or_temperature, experiment:missing_required_field:qc, experiment:missing_required_field:w, experiment:diagnostic_unavailable:surface_fluxes, experiment:diagnostic_unavailable:low_level_response, experiment:diagnostic_unavailable:cloud, experiment:diagnostic_unavailable:vertical_velocity`
+- Interpretation: Runs are structurally comparable, but required output fields or diagnostics are unavailable.
+
+### phase2_easy_deep_strong_12km_12h vs phase2_easy_deep_strong_12km_6h
+
+- Type: `duration_sensitivity_same_forcing`
+- Status: `inconclusive_missing_evidence`
+- Varied fields: `duration, runtime_seconds, expected_output_frames, expected_output_volume`
+- Equality failures: `[]`
+- Unavailable evidence: `control:result_not_ingested, control:missing_required_field:hfx, control:missing_required_field:qfx, control:missing_required_field:qv, control:missing_required_field:th_or_temperature, control:missing_required_field:qc, control:missing_required_field:w, control:diagnostic_unavailable:surface_fluxes, control:diagnostic_unavailable:low_level_response, control:diagnostic_unavailable:cloud, control:diagnostic_unavailable:vertical_velocity, experiment:result_not_ingested, experiment:missing_required_field:hfx, experiment:missing_required_field:qfx, experiment:missing_required_field:qv, experiment:missing_required_field:th_or_temperature, experiment:missing_required_field:qc, experiment:missing_required_field:w, experiment:diagnostic_unavailable:surface_fluxes, experiment:diagnostic_unavailable:low_level_response, experiment:diagnostic_unavailable:cloud, experiment:diagnostic_unavailable:vertical_velocity`
+- Interpretation: Runs are structurally comparable, but required output fields or diagnostics are unavailable.
+
+### phase2_easy_deep_strong_60km_12h vs phase2_easy_deep_strong_12km_12h
+
+- Type: `domain_grid_bundle_sensitivity`
+- Status: `inconclusive_missing_evidence`
+- Varied fields: `domain_size, nx, ny, nz, dx_m, dy_m, dz_m, stretch_z, str_bot_m, str_top_m, dz_bot_m, dz_top_m, model_top_m, expected_output_volume`
+- Equality failures: `[]`
+- Unavailable evidence: `control:result_not_ingested, control:missing_required_field:hfx, control:missing_required_field:qfx, control:missing_required_field:qv, control:missing_required_field:th_or_temperature, control:missing_required_field:qc, control:missing_required_field:w, control:diagnostic_unavailable:surface_fluxes, control:diagnostic_unavailable:low_level_response, control:diagnostic_unavailable:cloud, control:diagnostic_unavailable:vertical_velocity, experiment:result_not_ingested, experiment:missing_required_field:hfx, experiment:missing_required_field:qfx, experiment:missing_required_field:qv, experiment:missing_required_field:th_or_temperature, experiment:missing_required_field:qc, experiment:missing_required_field:w, experiment:diagnostic_unavailable:surface_fluxes, experiment:diagnostic_unavailable:low_level_response, experiment:diagnostic_unavailable:cloud, experiment:diagnostic_unavailable:vertical_velocity`
+- Interpretation: Runs are structurally comparable, but required output fields or diagnostics are unavailable.
+
+### phase2_easy_deep_strong_120km_12h_optional vs phase2_easy_deep_strong_60km_12h
+
+- Type: `domain_grid_bundle_sensitivity`
+- Status: `inconclusive_missing_evidence`
+- Varied fields: `domain_size, nx, ny, nz, dx_m, dy_m, dz_m, stretch_z, str_bot_m, str_top_m, dz_bot_m, dz_top_m, model_top_m, expected_output_volume`
+- Equality failures: `[]`
+- Unavailable evidence: `control:result_not_ingested, control:missing_required_field:hfx, control:missing_required_field:qfx, control:missing_required_field:qv, control:missing_required_field:th_or_temperature, control:missing_required_field:qc, control:missing_required_field:w, control:diagnostic_unavailable:surface_fluxes, control:diagnostic_unavailable:low_level_response, control:diagnostic_unavailable:cloud, control:diagnostic_unavailable:vertical_velocity, experiment:result_not_ingested, experiment:missing_required_field:hfx, experiment:missing_required_field:qfx, experiment:missing_required_field:qv, experiment:missing_required_field:th_or_temperature, experiment:missing_required_field:qc, experiment:missing_required_field:w, experiment:diagnostic_unavailable:surface_fluxes, experiment:diagnostic_unavailable:low_level_response, experiment:diagnostic_unavailable:cloud, experiment:diagnostic_unavailable:vertical_velocity`
+- Interpretation: Runs are structurally comparable, but required output fields or diagnostics are unavailable.
+
+### phase3_weak_control_strong_60km_12h vs phase2_easy_deep_strong_60km_12h
+
+- Type: `cross_sounding_discrimination`
+- Status: `inconclusive_missing_evidence`
+- Varied fields: `selection_id, station_id, valid_time_utc, candidate_id, candidate_story, candidate_score, candidate_evidence, candidate_caveats`
+- Equality failures: `[]`
+- Unavailable evidence: `control:result_not_ingested, control:missing_required_field:hfx, control:missing_required_field:qfx, control:missing_required_field:qv, control:missing_required_field:th_or_temperature, control:missing_required_field:qc, control:missing_required_field:w, control:diagnostic_unavailable:surface_fluxes, control:diagnostic_unavailable:low_level_response, control:diagnostic_unavailable:cloud, control:diagnostic_unavailable:vertical_velocity, experiment:result_not_ingested, experiment:missing_required_field:hfx, experiment:missing_required_field:qfx, experiment:missing_required_field:qv, experiment:missing_required_field:th_or_temperature, experiment:missing_required_field:qc, experiment:missing_required_field:w, experiment:diagnostic_unavailable:surface_fluxes, experiment:diagnostic_unavailable:low_level_response, experiment:diagnostic_unavailable:cloud, experiment:diagnostic_unavailable:vertical_velocity`
+- Interpretation: Runs are structurally comparable, but required output fields or diagnostics are unavailable.
+
+## Deepening And Class Differences
+
+Deepening and class-difference evidence is listed per run above. This report does not convert those diagnostics into predicted-vs-actual verdicts.
+
+## Unavailable Or Missing Diagnostics
+
+- low_level_qv_response
+- low_level_theta_or_temperature_response
+
+## Preliminary Diagnosis Categories
+
+- cloud_depth_evidence_available
+- ingested_results_available_for_review
+- surface_flux_outputs_present_in_at_least_one_result
+
+## Recommended Follow-Up Issues
+
+- Review campaign rows with unavailable required output fields before scientific conclusions.
+- Resolve Phase 1 surface-flux response comparisons before treating selected forcing changes as verified in CM1 output.
+- Review caveated or untrusted non-finite fields before using cloud, updraft, rain-water, surface-rain, or reflectivity outcomes as scientific evidence.


### PR DESCRIPTION
## Summary
- add frame-level field quality for diagnostics and surface-flux stats, including affected frame indices/times and initial/intermediate/terminal classification
- derive merged frame position from chronological model time rather than NetCDF filename/file order; missing or duplicate timestamps become chronology-caveated gate blockers
- preserve finite hfx/qfx means while marking terminal all-non-finite frames as untrusted gate blockers
- keep initial-only contamination caveated and gate-blocking until a separate documented initialization-frame exclusion policy exists
- separate terminal field contamination from run-level runtime floating-point warnings in campaign reports
- regenerate surface_forced_tall_002 from existing runtime artifacts so Phase 1 remains blocked with explicit terminal-frame evidence and a visible #330 cloud-top caveat

## Verification
- app/backend/.venv/bin/python -m pytest app/backend/tests/test_result_diagnostics.py app/backend/tests/test_result_ingest.py app/backend/tests/test_surface_forced_campaign.py -q
- scripts/check.sh

## Notes
- Refs #329
- no CM1 rerun; Phase 1 metadata/report were regenerated from existing local NetCDF artifacts
- Phase 2/3 remain planned and blocked
- runtime result metadata/output manifests remain outside the repo; only the markdown campaign report is committed