### PR TITLE
Clarify liquid cloud vs hydrometeor-envelope cloud top

### DIFF
--- a/app/backend/cloud_chamber/output_products.py
+++ b/app/backend/cloud_chamber/output_products.py
@@ -18,6 +18,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.result_diagnostics import (
+    CloudDiagnostics,
     FieldQuality,
     LowLevelResponseDiagnostics,
     LowLevelResponseFieldDiagnostics,
@@ -166,6 +167,12 @@ class ScienceSummary(BaseModel):
     min_downdraft_w_m_s: float | None = None
     min_downdraft_time_seconds: float | None = None
     highest_cloud_top_m: float | None = None
+    highest_liquid_cloud_top_m: float | None = None
+    highest_coherent_cloud_object_top_m: float | None = None
+    coherent_cloud_object_source_fields: list[str] = Field(default_factory=list)
+    highest_raw_hydrometeor_envelope_top_m: float | None = None
+    highest_hydrometeor_envelope_top_m: float | None = None
+    hydrometeor_envelope_source_fields: list[str] = Field(default_factory=list)
     rain_onset_time_seconds: float | None = None
     max_qr_kg_kg: float | None = None
     max_rain_or_surface_precip: float | None = None
@@ -549,22 +556,59 @@ def _interesting_time_records(
             support_state="unavailable" if cloud.available else "unsupported_missing_fields",
         ),
         _series_max_record(
-            key="highest_cloud_top",
-            label="Highest cloud top",
-            series=cloud.cloud_top_time_series if cloud.available else [],
-            source_field="qc+qr+qi+qs+qg when available",
-            source_diagnostic="diagnostics.cloud.cloud_top_time_series",
+            key="highest_liquid_cloud_top",
+            label="Highest liquid cloud-water top",
+            series=cloud.liquid_cloud_top_time_series if cloud.available else [],
+            source_field="qc",
+            source_diagnostic="diagnostics.cloud.liquid_cloud_top_time_series",
             units="m",
             output_manifest=output_manifest,
-            unavailable_caveat="no_cloud_top_detected" if cloud.available else "missing_qc_field",
+            unavailable_caveat="no_liquid_cloud_top_detected"
+            if cloud.available
+            else "missing_qc_field",
+            support_state="unavailable" if cloud.available else "unsupported_missing_fields",
+        ),
+        _series_max_record(
+            key="highest_cloud_top",
+            label="Highest coherent cloud-object top",
+            series=_coherent_cloud_object_top_time_series(cloud) if cloud.available else [],
+            source_field=_cloud_top_source_field(
+                "coherent_cloud_object",
+                cloud.coherent_cloud_object_source_fields,
+            ),
+            source_diagnostic="diagnostics.cloud.coherent_cloud_object_top_time_series",
+            units="m",
+            output_manifest=output_manifest,
+            unavailable_caveat="no_coherent_cloud_object_top_detected"
+            if cloud.available
+            else "missing_qc_field",
+            support_state="unavailable" if cloud.available else "unsupported_missing_fields",
+        ),
+        _series_max_record(
+            key="highest_raw_hydrometeor_envelope_top",
+            label="Highest raw hydrometeor trace top",
+            series=_raw_hydrometeor_envelope_top_time_series(cloud) if cloud.available else [],
+            source_field=_cloud_top_source_field(
+                "raw_hydrometeor_envelope",
+                cloud.hydrometeor_envelope_source_fields,
+            ),
+            source_diagnostic="diagnostics.cloud.raw_hydrometeor_envelope_top_time_series",
+            units="m",
+            output_manifest=output_manifest,
+            unavailable_caveat="no_raw_hydrometeor_trace_top_detected"
+            if cloud.available
+            else "missing_qc_field",
             support_state="unavailable" if cloud.available else "unsupported_missing_fields",
         ),
         _event_record(
             key="first_deep_convection",
             label="First deep convection",
             time_seconds=_first_deep_convection_time(diagnostics) if cloud.available else None,
-            source_field="qc+qr+qi+qs+qg when available",
-            source_diagnostic="diagnostics.cloud.cloud_top_time_series",
+            source_field=_cloud_top_source_field(
+                "coherent_cloud_object",
+                cloud.coherent_cloud_object_source_fields,
+            ),
+            source_diagnostic="diagnostics.cloud.coherent_cloud_object_top_time_series",
             value=_deep_cloud_formed(diagnostics) if cloud.available else None,
             units=None,
             output_manifest=output_manifest,
@@ -924,14 +968,18 @@ def _record_with_field_quality(
     record: InterestingTimeRecord,
     field_quality: dict[str, FieldQuality],
 ) -> InterestingTimeRecord:
-    quality = _quality_for_source_field(record.source_field, field_quality)
-    if quality is None:
-        return record
-    caveats = _dedupe([*record.caveats, *quality.caveats])
+    qualities, quality_caveats = _qualities_for_source_field(record.source_field, field_quality)
+    quality = qualities[0] if len(qualities) == 1 else None
+    caveats = _dedupe([*record.caveats, *quality_caveats])
     support_state = record.support_state
-    if quality.quality_state == "untrusted" and support_state == "supported":
+    if (
+        any(item.quality_state == "untrusted" for item in qualities)
+        and support_state == "supported"
+    ):
         support_state = "unavailable"
         caveats = _dedupe([*caveats, "interesting_time_source_field_untrusted"])
+    elif any(item.quality_state == "caveated" for item in qualities):
+        caveats = _dedupe([*caveats, "interesting_time_source_field_caveated"])
     return record.model_copy(
         update={
             "field_quality": quality,
@@ -941,23 +989,62 @@ def _record_with_field_quality(
     )
 
 
-def _quality_for_source_field(
+def _qualities_for_source_field(
     source_field: str | None,
     field_quality: dict[str, FieldQuality],
-) -> FieldQuality | None:
+) -> tuple[list[FieldQuality], list[str]]:
     if source_field is None:
-        return None
-    if source_field in {"qc", "qc+qr+qi+qs+qg when available"}:
-        return field_quality.get("qc")
+        return [], []
+    source_fields = _source_field_components(source_field)
+    if source_fields:
+        qualities: list[FieldQuality] = []
+        caveats: list[str] = []
+        for field in source_fields:
+            quality = field_quality.get(field)
+            if quality is None:
+                caveats.append(f"field_quality_not_assessed:{field}")
+            else:
+                qualities.append(quality)
+                caveats.extend(quality.caveats)
+        return qualities, _dedupe(caveats)
     if source_field == "w":
-        return field_quality.get("w")
+        return _single_quality("w", field_quality)
     if source_field == "qr":
-        return field_quality.get("qr")
+        return _single_quality("qr", field_quality)
     if source_field == "rain":
-        return field_quality.get("surface_rain")
+        return _single_quality("surface_rain", field_quality)
     if source_field == "dbz":
-        return field_quality.get("dbz")
-    return None
+        return _single_quality("dbz", field_quality)
+    return [], []
+
+
+def _single_quality(
+    field: str,
+    field_quality: dict[str, FieldQuality],
+) -> tuple[list[FieldQuality], list[str]]:
+    quality = field_quality.get(field)
+    if quality is None:
+        return [], [f"field_quality_not_assessed:{field}"]
+    return [quality], list(quality.caveats)
+
+
+def _source_field_components(source_field: str) -> list[str]:
+    prefixes = (
+        "coherent_cloud_object:",
+        "raw_hydrometeor_envelope:",
+        "hydrometeor_envelope:",
+    )
+    for prefix in prefixes:
+        if source_field.startswith(prefix):
+            fields = source_field.removeprefix(prefix).replace(" when available", "")
+            return [
+                field
+                for field in fields.split("+")
+                if field and field not in {"when available", "none"}
+            ]
+    if source_field == "qc":
+        return ["qc"]
+    return []
 
 
 def _science_summary(
@@ -984,7 +1071,9 @@ def _science_summary(
         "first_cloud",
         "first_deep_convection",
         "max_qc",
+        "highest_liquid_cloud_top",
         "highest_cloud_top",
+        "highest_raw_hydrometeor_envelope_top",
         "max_updraft_w",
         "min_downdraft_w",
         "rain_onset",
@@ -998,9 +1087,23 @@ def _science_summary(
         if record.key in supported_science_keys and record.support_state == "supported"
     )
     support_state = "supported" if supported_count > 0 else "fallback"
-    highest_cloud_top = _record_value(record_by_key.get("highest_cloud_top"))
-    first_deep_convection = _record_time(record_by_key.get("first_deep_convection"))
-    deep_cloud_formed = _deep_cloud_formed(diagnostics)
+    highest_liquid_cloud_top = _record_value(record_by_key.get("highest_liquid_cloud_top"))
+    highest_coherent_cloud_top = _record_value(record_by_key.get("highest_cloud_top"))
+    highest_raw_hydrometeor_envelope_top = _record_value(
+        record_by_key.get("highest_raw_hydrometeor_envelope_top")
+    )
+    first_deep_record = record_by_key.get("first_deep_convection")
+    first_deep_convection = _record_time(first_deep_record)
+    raw_deep_cloud_formed = _deep_cloud_formed(diagnostics)
+    deep_cloud_formed = (
+        True
+        if raw_deep_cloud_formed is True
+        and first_deep_record is not None
+        and first_deep_record.support_state == "supported"
+        else raw_deep_cloud_formed
+        if raw_deep_cloud_formed is not True
+        else None
+    )
     strong_updraft_formed = _strong_updraft_formed(diagnostics)
     default_source = default_record if deep_cloud_formed else qc_default or default_record
     return ScienceSummary(
@@ -1023,7 +1126,13 @@ def _science_summary(
         if diagnostics.vertical_velocity.available
         else None,
         min_downdraft_time_seconds=diagnostics.vertical_velocity.time_of_min_w_seconds,
-        highest_cloud_top_m=highest_cloud_top,
+        highest_cloud_top_m=highest_coherent_cloud_top,
+        highest_liquid_cloud_top_m=highest_liquid_cloud_top,
+        highest_coherent_cloud_object_top_m=highest_coherent_cloud_top,
+        coherent_cloud_object_source_fields=diagnostics.cloud.coherent_cloud_object_source_fields,
+        highest_raw_hydrometeor_envelope_top_m=highest_raw_hydrometeor_envelope_top,
+        highest_hydrometeor_envelope_top_m=highest_raw_hydrometeor_envelope_top,
+        hydrometeor_envelope_source_fields=diagnostics.cloud.hydrometeor_envelope_source_fields,
         rain_onset_time_seconds=diagnostics.rain.first_rain_time_seconds,
         max_qr_kg_kg=diagnostics.rain.max_qr_kg_kg if diagnostics.rain.available else None,
         max_rain_or_surface_precip=diagnostics.surface_rain.max_surface_rain
@@ -1107,7 +1216,7 @@ def _record_time(record: InterestingTimeRecord | None) -> float | None:
 
 
 def _first_deep_convection_time(diagnostics: ResultDiagnostics) -> float | None:
-    for point in diagnostics.cloud.cloud_top_time_series:
+    for point in _coherent_cloud_object_top_time_series(diagnostics.cloud):
         if point.value is not None and point.value >= DEEP_CLOUD_TOP_THRESHOLD_M:
             return point.time_seconds
     return None
@@ -1118,8 +1227,22 @@ def _deep_cloud_formed(diagnostics: ResultDiagnostics) -> bool | None:
         return None
     return any(
         point.value is not None and point.value >= DEEP_CLOUD_TOP_THRESHOLD_M
-        for point in diagnostics.cloud.cloud_top_time_series
+        for point in _coherent_cloud_object_top_time_series(diagnostics.cloud)
     )
+
+
+def _coherent_cloud_object_top_time_series(cloud: CloudDiagnostics) -> list[TimeValue]:
+    return cloud.coherent_cloud_object_top_time_series or cloud.cloud_top_time_series
+
+
+def _raw_hydrometeor_envelope_top_time_series(cloud: CloudDiagnostics) -> list[TimeValue]:
+    return (
+        cloud.raw_hydrometeor_envelope_top_time_series or cloud.hydrometeor_envelope_top_time_series
+    )
+
+
+def _cloud_top_source_field(prefix: str, fields: list[str]) -> str:
+    return f"{prefix}:{'+'.join(fields) if fields else 'none'}"
 
 
 def _strong_updraft_formed(diagnostics: ResultDiagnostics) -> bool | None:
@@ -1161,7 +1284,10 @@ def _cm1_outcome(diagnostics: ResultDiagnostics) -> str:
         return "Deep cloud formed, but the updraft-strength threshold was not met."
     if strong_updraft:
         return "Strong updraft formed, but deep cloud did not reach the threshold."
-    return "Trigger failed to produce deep convection by current cloud-top and updraft thresholds."
+    return (
+        "Deep-convection criteria were not met by current coherent cloud-object "
+        "top and updraft thresholds."
+    )
 
 
 def _diagnostic_availability(

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -100,6 +100,19 @@ class TimeValue(BaseModel):
     value: float | None
 
 
+class CloudTopSupportRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time_seconds: float | None
+    top_m: float | None = None
+    top_defining_species: list[str] = Field(default_factory=list)
+    supporting_species: list[str] = Field(default_factory=list)
+    threshold_kg_kg: float = QC_CLOUD_THRESHOLD_KG_KG
+    qualifying_cell_count: int = 0
+    continuity_supported: bool = False
+    support_rule: str = "minimum_10_cells_per_level_connected_to_lowest_supported_hydrometeor_level"
+
+
 class TimeDiagnostics(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -119,6 +132,27 @@ class CloudDiagnostics(BaseModel):
     cloud_top_m: float | None = None
     cloud_base_time_series: list[TimeValue] = Field(default_factory=list)
     cloud_top_time_series: list[TimeValue] = Field(default_factory=list)
+    liquid_cloud_base_m: float | None = None
+    liquid_cloud_top_m: float | None = None
+    liquid_cloud_base_time_series: list[TimeValue] = Field(default_factory=list)
+    liquid_cloud_top_time_series: list[TimeValue] = Field(default_factory=list)
+    hydrometeor_envelope_base_m: float | None = None
+    hydrometeor_envelope_top_m: float | None = None
+    hydrometeor_envelope_top_time_series: list[TimeValue] = Field(default_factory=list)
+    hydrometeor_envelope_source_fields: list[str] = Field(default_factory=list)
+    raw_hydrometeor_envelope_base_m: float | None = None
+    raw_hydrometeor_envelope_top_m: float | None = None
+    raw_hydrometeor_envelope_top_time_series: list[TimeValue] = Field(default_factory=list)
+    raw_hydrometeor_envelope_top_support_time_series: list[CloudTopSupportRecord] = Field(
+        default_factory=list
+    )
+    coherent_cloud_object_base_m: float | None = None
+    coherent_cloud_object_top_m: float | None = None
+    coherent_cloud_object_top_time_series: list[TimeValue] = Field(default_factory=list)
+    coherent_cloud_object_top_support_time_series: list[CloudTopSupportRecord] = Field(
+        default_factory=list
+    )
+    coherent_cloud_object_source_fields: list[str] = Field(default_factory=list)
     max_qc_kg_kg: float | None = None
     time_of_max_qc_seconds: float | None = None
     max_qc_height_time_series: list[TimeValue] = Field(default_factory=list)
@@ -378,7 +412,9 @@ def compute_process_diagnostics(
     elif has_cloud and _cloud_top_increases(diagnostics.cloud.cloud_top_time_series):
         label = "Growing cumulus"
         confidence = "candidate"
-        summary = "Cloud formed and cloud top increased over available output times."
+        summary = (
+            "Cloud formed and coherent cloud-object top increased over available output times."
+        )
     elif has_cloud:
         label = "Fair-weather cumulus"
         confidence = "candidate"
@@ -574,9 +610,18 @@ FIELD_QUALITY_SOURCES = {
 
 
 def _field_quality_map(dataset: Any, time: _TimeContext) -> dict[str, FieldQuality]:
+    quality_sources = dict(FIELD_QUALITY_SOURCES)
+    for field in HYDROMETEOR_CLOUD_TOP_FIELDS:
+        if field in dataset.data_vars:
+            quality_sources[field] = {
+                "source_field": field,
+                "missing": f"{field}_field_absent",
+                "partial": f"non_finite_values_detected_in_{field}",
+                "entire": f"{field}_field_entirely_non_finite",
+            }
     return {
         field: _field_quality(dataset, field, config, time)
-        for field, config in FIELD_QUALITY_SOURCES.items()
+        for field, config in quality_sources.items()
     }
 
 
@@ -869,13 +914,24 @@ def _cloud_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> 
         caveats.append("qc_field_entirely_non_finite")
         return CloudDiagnostics(available=False)
 
-    cloud_extent = _cloud_extent_array(dataset, qc, caveats)
+    cloud_extent, envelope_source_fields = _cloud_extent_array(dataset, qc, caveats)
+    envelope_source_arrays = _hydrometeor_source_arrays(dataset, qc, envelope_source_fields)
     series_arrays = _time_slices(qc, time.dimension)
     cloud_extent_series_arrays = _time_slices(cloud_extent, time.dimension)
+    envelope_source_series_arrays = {
+        field: _time_slices(array, time.dimension)
+        for field, array in envelope_source_arrays.items()
+    }
     qc_max_series: list[TimeValue] = []
     cloud_fraction_series: list[TimeValue] = []
     cloud_base_series: list[TimeValue] = []
     cloud_top_series: list[TimeValue] = []
+    liquid_cloud_base_series: list[TimeValue] = []
+    liquid_cloud_top_series: list[TimeValue] = []
+    raw_envelope_top_series: list[TimeValue] = []
+    raw_envelope_support_series: list[CloudTopSupportRecord] = []
+    coherent_cloud_top_series: list[TimeValue] = []
+    coherent_cloud_support_series: list[CloudTopSupportRecord] = []
     max_qc_height_series: list[TimeValue] = []
     cloud_present_steps: list[float | None] = []
     first_cloud_time: float | None = None
@@ -891,11 +947,39 @@ def _cloud_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> 
         extent_array = (
             cloud_extent_series_arrays[index] if index < len(cloud_extent_series_arrays) else array
         )
-        cloud_base, cloud_top = _cloud_base_top(extent_array, caveats)
+        extent_source_arrays = {
+            field: slices[index] if index < len(slices) else array
+            for field, slices in envelope_source_series_arrays.items()
+        }
+        liquid_cloud_base, liquid_cloud_top = _cloud_base_top(array, caveats)
+        raw_base, raw_top, raw_support = _cloud_top_with_level_support(
+            extent_array,
+            source_arrays=extent_source_arrays,
+            caveats=caveats,
+            time_seconds=time_seconds,
+            minimum_cells=1,
+            require_connected_levels=False,
+        )
+        coherent_base, coherent_top, coherent_support = _cloud_top_with_level_support(
+            extent_array,
+            source_arrays=extent_source_arrays,
+            caveats=caveats,
+            time_seconds=time_seconds,
+            minimum_cells=MINIMUM_CLOUD_GRID_CELLS,
+            require_connected_levels=True,
+        )
         qc_max_series.append(TimeValue(time_seconds=time_seconds, value=slice_max))
         cloud_fraction_series.append(TimeValue(time_seconds=time_seconds, value=cloud_fraction))
-        cloud_base_series.append(TimeValue(time_seconds=time_seconds, value=cloud_base))
-        cloud_top_series.append(TimeValue(time_seconds=time_seconds, value=cloud_top))
+        cloud_base_series.append(TimeValue(time_seconds=time_seconds, value=coherent_base))
+        cloud_top_series.append(TimeValue(time_seconds=time_seconds, value=coherent_top))
+        liquid_cloud_base_series.append(
+            TimeValue(time_seconds=time_seconds, value=liquid_cloud_base)
+        )
+        liquid_cloud_top_series.append(TimeValue(time_seconds=time_seconds, value=liquid_cloud_top))
+        raw_envelope_top_series.append(TimeValue(time_seconds=time_seconds, value=raw_top))
+        raw_envelope_support_series.append(raw_support)
+        coherent_cloud_top_series.append(TimeValue(time_seconds=time_seconds, value=coherent_top))
+        coherent_cloud_support_series.append(coherent_support)
         max_qc_height_series.append(
             TimeValue(time_seconds=time_seconds, value=_height_of_level_max(array, caveats))
         )
@@ -907,14 +991,47 @@ def _cloud_diagnostics(dataset: Any, time: _TimeContext, caveats: list[str]) -> 
             max_qc = slice_max
             time_of_max_qc = time_seconds
 
-    cloud_base, cloud_top = _cloud_base_top(cloud_extent, caveats)
+    liquid_cloud_base, liquid_cloud_top = _cloud_base_top(qc, caveats)
+    raw_base, raw_top, raw_support = _cloud_top_with_level_support(
+        cloud_extent,
+        source_arrays=envelope_source_arrays,
+        caveats=caveats,
+        time_seconds=None,
+        minimum_cells=1,
+        require_connected_levels=False,
+    )
+    coherent_base, coherent_top, coherent_support = _cloud_top_with_level_support(
+        cloud_extent,
+        source_arrays=envelope_source_arrays,
+        caveats=caveats,
+        time_seconds=None,
+        minimum_cells=MINIMUM_CLOUD_GRID_CELLS,
+        require_connected_levels=True,
+    )
     return CloudDiagnostics(
         formed=first_cloud_time is not None,
         first_cloud_time_seconds=first_cloud_time,
-        cloud_base_m=cloud_base,
-        cloud_top_m=cloud_top,
+        cloud_base_m=coherent_base,
+        cloud_top_m=coherent_top,
         cloud_base_time_series=cloud_base_series,
         cloud_top_time_series=cloud_top_series,
+        liquid_cloud_base_m=liquid_cloud_base,
+        liquid_cloud_top_m=liquid_cloud_top,
+        liquid_cloud_base_time_series=liquid_cloud_base_series,
+        liquid_cloud_top_time_series=liquid_cloud_top_series,
+        hydrometeor_envelope_base_m=raw_base,
+        hydrometeor_envelope_top_m=raw_top,
+        hydrometeor_envelope_top_time_series=raw_envelope_top_series,
+        hydrometeor_envelope_source_fields=envelope_source_fields,
+        raw_hydrometeor_envelope_base_m=raw_base,
+        raw_hydrometeor_envelope_top_m=raw_top,
+        raw_hydrometeor_envelope_top_time_series=raw_envelope_top_series,
+        raw_hydrometeor_envelope_top_support_time_series=raw_envelope_support_series,
+        coherent_cloud_object_base_m=coherent_base,
+        coherent_cloud_object_top_m=coherent_top,
+        coherent_cloud_object_top_time_series=coherent_cloud_top_series,
+        coherent_cloud_object_top_support_time_series=coherent_cloud_support_series,
+        coherent_cloud_object_source_fields=coherent_support.supporting_species,
         max_qc_kg_kg=max_qc,
         time_of_max_qc_seconds=time_of_max_qc,
         max_qc_height_time_series=max_qc_height_series,
@@ -1570,17 +1687,17 @@ def _low_level_layer_stats(
     }
 
 
-def _cloud_extent_array(dataset: Any, qc: Any, caveats: list[str]) -> Any:
+def _cloud_extent_array(dataset: Any, qc: Any, caveats: list[str]) -> tuple[Any, list[str]]:
     """Return the field used for cloud base/top diagnostics.
 
     Liquid cloud water remains the source of truth for cloud formation and max-qc
-    diagnostics. For cloud top, deep-convection output can put the upper cloud in
-    ice/snow/graupel fields, so the vertical envelope should include compatible
-    hydrometeor mixing-ratio fields when they are present.
+    diagnostics. For top diagnostics, deep-convection output can put the upper
+    cloud in ice/snow/graupel fields, so the raw trace envelope should include
+    compatible hydrometeor mixing-ratio fields when they are present.
     """
 
     extent = qc
-    included_fields: list[str] = []
+    included_fields: list[str] = ["qc"]
     for field_name in HYDROMETEOR_CLOUD_TOP_FIELDS:
         if field_name not in dataset.data_vars:
             continue
@@ -1590,11 +1707,160 @@ def _cloud_extent_array(dataset: Any, qc: Any, caveats: list[str]) -> Any:
             continue
         extent = extent + field
         included_fields.append(field_name)
-    if included_fields:
-        caveat = "cloud_top_uses_total_hydrometeor_fields:qc," + ",".join(included_fields)
+    if len(included_fields) > 1:
+        caveat = "cloud_top_uses_total_hydrometeor_fields:" + ",".join(included_fields)
         if caveat not in caveats:
             caveats.append(caveat)
-    return extent
+    return extent, included_fields
+
+
+def _hydrometeor_source_arrays(dataset: Any, qc: Any, source_fields: list[str]) -> dict[str, Any]:
+    arrays: dict[str, Any] = {}
+    for field in source_fields:
+        if field == "qc":
+            arrays[field] = qc
+        elif field in dataset.data_vars:
+            arrays[field] = dataset[field]
+    return arrays
+
+
+def _cloud_top_with_level_support(
+    data_array: Any,
+    *,
+    source_arrays: dict[str, Any],
+    caveats: list[str],
+    time_seconds: float | None,
+    minimum_cells: int,
+    require_connected_levels: bool,
+) -> tuple[float | None, float | None, CloudTopSupportRecord]:
+    vertical_name = _first_present(VERTICAL_COORDINATE_CANDIDATES, list(data_array.dims))
+    if vertical_name is None:
+        caveats.append("cloud_object_top_unavailable_missing_vertical_coordinate")
+        return None, None, CloudTopSupportRecord(time_seconds=time_seconds)
+    if require_connected_levels:
+        caveat = "coherent_cloud_object_support_uses_grid_cell_count_not_physical_area"
+        if caveat not in caveats:
+            caveats.append(caveat)
+
+    vertical_values = _vertical_values(data_array, vertical_name, caveats)
+    supported_levels: list[int] = []
+    level_counts: dict[int, int] = {}
+    for index in range(int(data_array.sizes[vertical_name])):
+        count = _threshold_count(
+            data_array.isel({vertical_name: index}),
+            QC_CLOUD_THRESHOLD_KG_KG,
+        )
+        level_counts[index] = count
+        if count >= minimum_cells:
+            supported_levels.append(index)
+
+    if not supported_levels:
+        return None, None, CloudTopSupportRecord(time_seconds=time_seconds)
+
+    connected_levels = (
+        _lowest_connected_level_block(supported_levels)
+        if require_connected_levels
+        else supported_levels
+    )
+    detached_levels = [level for level in supported_levels if level not in connected_levels]
+    if detached_levels and require_connected_levels:
+        caveat = "detached_hydrometeor_layer_not_counted_as_coherent_cloud_object"
+        if caveat not in caveats:
+            caveats.append(caveat)
+
+    level_entries: list[tuple[int, float]] = []
+    for index in connected_levels:
+        if index >= len(vertical_values):
+            continue
+        vertical_value = vertical_values[index]
+        if vertical_value is not None:
+            level_entries.append((index, vertical_value))
+    if not level_entries:
+        return None, None, CloudTopSupportRecord(time_seconds=time_seconds)
+
+    top_index, top_value = max(level_entries, key=lambda entry: entry[1])
+    level_values = [value for _index, value in level_entries]
+    top_defining_species = _top_defining_species(
+        source_arrays,
+        vertical_name=vertical_name,
+        vertical_index=top_index,
+    )
+    supporting_species = _supporting_species(
+        source_arrays,
+        vertical_name=vertical_name,
+        vertical_indices=connected_levels,
+    )
+    if require_connected_levels and "qc" not in supporting_species:
+        caveat = "coherent_cloud_object_without_liquid_cloud_water_support"
+        if caveat not in caveats:
+            caveats.append(caveat)
+
+    return (
+        min(level_values),
+        max(level_values),
+        CloudTopSupportRecord(
+            time_seconds=time_seconds,
+            top_m=top_value,
+            top_defining_species=top_defining_species,
+            supporting_species=supporting_species,
+            threshold_kg_kg=QC_CLOUD_THRESHOLD_KG_KG,
+            qualifying_cell_count=level_counts.get(top_index, 0),
+            continuity_supported=bool(connected_levels),
+        ),
+    )
+
+
+def _lowest_connected_level_block(supported_levels: list[int]) -> list[int]:
+    sorted_levels = sorted(supported_levels)
+    connected = [sorted_levels[0]]
+    for level in sorted_levels[1:]:
+        if level == connected[-1] + 1:
+            connected.append(level)
+        else:
+            break
+    return connected
+
+
+def _top_defining_species(
+    source_arrays: dict[str, Any],
+    *,
+    vertical_name: str,
+    vertical_index: int,
+) -> list[str]:
+    species: list[str] = []
+    for field, array in source_arrays.items():
+        if vertical_name not in array.dims or vertical_index >= int(array.sizes[vertical_name]):
+            continue
+        count = _threshold_count(
+            array.isel({vertical_name: vertical_index}),
+            QC_CLOUD_THRESHOLD_KG_KG,
+        )
+        if count > 0:
+            species.append(field)
+    return species
+
+
+def _supporting_species(
+    source_arrays: dict[str, Any],
+    *,
+    vertical_name: str,
+    vertical_indices: list[int],
+) -> list[str]:
+    species: list[str] = []
+    for field, array in source_arrays.items():
+        if vertical_name not in array.dims:
+            continue
+        for vertical_index in vertical_indices:
+            if vertical_index >= int(array.sizes[vertical_name]):
+                continue
+            count = _threshold_count(
+                array.isel({vertical_name: vertical_index}),
+                QC_CLOUD_THRESHOLD_KG_KG,
+            )
+            if count > 0:
+                species.append(field)
+                break
+    return species
 
 
 def _cloud_base_top(qc: Any, caveats: list[str]) -> tuple[float | None, float | None]:

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -668,6 +668,65 @@ def _merge_cloud_diagnostics(parts: list[CloudDiagnostics]) -> CloudDiagnostics:
         cloud_top_time_series=[
             point for part in available_parts for point in part.cloud_top_time_series
         ],
+        liquid_cloud_base_m=_min_optional([part.liquid_cloud_base_m for part in available_parts]),
+        liquid_cloud_top_m=_max_optional([part.liquid_cloud_top_m for part in available_parts]),
+        liquid_cloud_base_time_series=[
+            point for part in available_parts for point in part.liquid_cloud_base_time_series
+        ],
+        liquid_cloud_top_time_series=[
+            point for part in available_parts for point in part.liquid_cloud_top_time_series
+        ],
+        hydrometeor_envelope_base_m=_min_optional(
+            [part.hydrometeor_envelope_base_m for part in available_parts]
+        ),
+        hydrometeor_envelope_top_m=_max_optional(
+            [part.hydrometeor_envelope_top_m for part in available_parts]
+        ),
+        hydrometeor_envelope_top_time_series=[
+            point for part in available_parts for point in part.hydrometeor_envelope_top_time_series
+        ],
+        hydrometeor_envelope_source_fields=_dedupe_strings(
+            [field for part in available_parts for field in part.hydrometeor_envelope_source_fields]
+        ),
+        raw_hydrometeor_envelope_base_m=_min_optional(
+            [part.raw_hydrometeor_envelope_base_m for part in available_parts]
+        ),
+        raw_hydrometeor_envelope_top_m=_max_optional(
+            [part.raw_hydrometeor_envelope_top_m for part in available_parts]
+        ),
+        raw_hydrometeor_envelope_top_time_series=[
+            point
+            for part in available_parts
+            for point in part.raw_hydrometeor_envelope_top_time_series
+        ],
+        raw_hydrometeor_envelope_top_support_time_series=[
+            point
+            for part in available_parts
+            for point in part.raw_hydrometeor_envelope_top_support_time_series
+        ],
+        coherent_cloud_object_base_m=_min_optional(
+            [part.coherent_cloud_object_base_m for part in available_parts]
+        ),
+        coherent_cloud_object_top_m=_max_optional(
+            [part.coherent_cloud_object_top_m for part in available_parts]
+        ),
+        coherent_cloud_object_top_time_series=[
+            point
+            for part in available_parts
+            for point in part.coherent_cloud_object_top_time_series
+        ],
+        coherent_cloud_object_top_support_time_series=[
+            point
+            for part in available_parts
+            for point in part.coherent_cloud_object_top_support_time_series
+        ],
+        coherent_cloud_object_source_fields=_dedupe_strings(
+            [
+                field
+                for part in available_parts
+                for field in part.coherent_cloud_object_source_fields
+            ]
+        ),
         max_qc_kg_kg=max_qc_time.value,
         time_of_max_qc_seconds=max_qc_time.time_seconds,
         max_qc_height_time_series=[
@@ -1735,8 +1794,25 @@ def _candidate_outcome_evidence(science_summary: ScienceSummary) -> list[str]:
         evidence.append(
             "deep cloud formed" if science_summary.deep_cloud_formed else "no deep cloud detected"
         )
-    if science_summary.highest_cloud_top_m is not None:
-        evidence.append(f"cloud top {_format_metric(science_summary.highest_cloud_top_m, 'm')}")
+    coherent_top = (
+        science_summary.highest_coherent_cloud_object_top_m
+        if science_summary.highest_coherent_cloud_object_top_m is not None
+        else science_summary.highest_cloud_top_m
+    )
+    if coherent_top is not None:
+        evidence.append(f"coherent cloud-object top {_format_metric(coherent_top, 'm')}")
+    raw_envelope_top = (
+        science_summary.highest_raw_hydrometeor_envelope_top_m
+        if science_summary.highest_raw_hydrometeor_envelope_top_m is not None
+        else science_summary.highest_hydrometeor_envelope_top_m
+    )
+    if raw_envelope_top is not None and raw_envelope_top != coherent_top:
+        evidence.append(f"raw hydrometeor trace top {_format_metric(raw_envelope_top, 'm')}")
+    if science_summary.highest_liquid_cloud_top_m is not None:
+        evidence.append(
+            f"liquid cloud-water top "
+            f"{_format_metric(science_summary.highest_liquid_cloud_top_m, 'm')}"
+        )
     if science_summary.max_updraft_w_m_s is not None:
         evidence.append(f"max updraft {_format_metric(science_summary.max_updraft_w_m_s, 'm/s')}")
     if science_summary.rain_onset_time_seconds is not None:
@@ -1811,8 +1887,8 @@ def _deep_candidate_cm1_outcome(
         )
     return (
         "Deep convection did not occur under this run configuration by current "
-        "cloud-top and updraft thresholds; this does not disprove the sounding's "
-        "deep-convection potential."
+        "coherent cloud-object top and updraft thresholds; this does not disprove "
+        "the sounding's deep-convection potential."
     )
 
 
@@ -1826,7 +1902,11 @@ def _match_status_label(match_status: str) -> str:
 
 
 def _format_metric(value: float, units: str) -> str:
-    return f"{value:g} {units}"
+    if abs(value) >= 1000:
+        formatted = f"{value:,.3f}".rstrip("0").rstrip(".")
+    else:
+        formatted = f"{value:g}"
+    return f"{formatted} {units}"
 
 
 def _format_seconds(value: float) -> str:

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -1918,7 +1918,8 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
     )
     max_cloud_top_m = _trusted_outcome(
         _first_defined(
-            cloud.cloud_top_m if cloud is not None else None,
+            cloud.coherent_cloud_object_top_m if cloud is not None else None,
+            science.highest_coherent_cloud_object_top_m if science is not None else None,
             science.highest_cloud_top_m if science is not None else None,
         ),
         diagnostic_trust,
@@ -2969,10 +2970,8 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
     lines.extend(
         [
             "",
-            (
-                "Cloud-top values currently use the total hydrometeor envelope and may "
-                "exceed the coherent liquid/ice cloud-object top. See #330."
-            ),
+            "Cloud-top summaries use the coherent cloud-object top. Raw sparse "
+            "hydrometeor trace tops are secondary evidence, not the deep-cloud classifier.",
         ]
     )
     lines.extend(
@@ -2996,7 +2995,9 @@ def _render_markdown_report(plan: CampaignPlan, summary: Mapping[str, Any]) -> s
                     "first cloud", run["first_cloud_time"], diagnostic_trust.get("qc")
                 ),
                 _trusted_metric_label(
-                    "max cloud top", run["max_cloud_top_m"], diagnostic_trust.get("qc")
+                    "max coherent cloud-object top",
+                    run["max_cloud_top_m"],
+                    diagnostic_trust.get("qc"),
                 ),
                 _trusted_metric_label("max qc", run["max_qc"], diagnostic_trust.get("qc")),
                 _trusted_metric_label("max w", run["max_w_m_s"], diagnostic_trust.get("w")),
@@ -4211,7 +4212,7 @@ def _key_result_label(run: Mapping[str, Any]) -> str:
     return "; ".join(
         [
             _trusted_metric_label(
-                "cloud top",
+                "coherent cloud-object top",
                 run.get("max_cloud_top_m"),
                 diagnostic_trust.get("qc"),
             ),

--- a/app/backend/tests/test_output_products.py
+++ b/app/backend/tests/test_output_products.py
@@ -290,6 +290,28 @@ def test_deep_convection_interesting_times_and_unavailable_diagnostics(
                 TimeValue(time_seconds=600.0, value=3500.0),
                 TimeValue(time_seconds=1200.0, value=10200.0),
             ],
+            liquid_cloud_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=2500.0),
+                TimeValue(time_seconds=1200.0, value=6200.0),
+            ],
+            hydrometeor_envelope_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=3500.0),
+                TimeValue(time_seconds=1200.0, value=10200.0),
+            ],
+            hydrometeor_envelope_source_fields=["qc", "qi", "qs"],
+            raw_hydrometeor_envelope_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=3500.0),
+                TimeValue(time_seconds=1200.0, value=10200.0),
+            ],
+            coherent_cloud_object_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=3500.0),
+                TimeValue(time_seconds=1200.0, value=10200.0),
+            ],
+            coherent_cloud_object_source_fields=["qc", "qi", "qs"],
             max_qc_kg_kg=2e-5,
             time_of_max_qc_seconds=1200.0,
         ),
@@ -319,12 +341,28 @@ def test_deep_convection_interesting_times_and_unavailable_diagnostics(
     records = {record.key: record for record in product.available_interesting_times}
     assert records["first_deep_convection"].support_state == "supported"
     assert records["first_deep_convection"].time_index == 2
+    assert records["first_deep_convection"].source_field is not None
+    assert records["first_deep_convection"].source_field.startswith("coherent_cloud_object:")
+    assert records["highest_liquid_cloud_top"].label == "Highest liquid cloud-water top"
+    assert records["highest_liquid_cloud_top"].value == 6200.0
+    assert records["highest_cloud_top"].label == "Highest coherent cloud-object top"
+    assert records["highest_cloud_top"].value == 10200.0
+    assert records["highest_raw_hydrometeor_envelope_top"].label == (
+        "Highest raw hydrometeor trace top"
+    )
+    assert records["highest_raw_hydrometeor_envelope_top"].value == 10200.0
     assert records["max_updraft_w"].time_index == 1
     assert product.science_summary.cloud_formed is True
     assert product.science_summary.deep_cloud_formed is True
     assert product.science_summary.strong_updraft_formed is True
     assert product.science_summary.time_of_first_deep_convection_seconds == 1200.0
     assert product.science_summary.highest_cloud_top_m == 10200.0
+    assert product.science_summary.highest_liquid_cloud_top_m == 6200.0
+    assert product.science_summary.highest_coherent_cloud_object_top_m == 10200.0
+    assert product.science_summary.highest_raw_hydrometeor_envelope_top_m == 10200.0
+    assert product.science_summary.highest_hydrometeor_envelope_top_m == 10200.0
+    assert product.science_summary.coherent_cloud_object_source_fields == ["qc", "qi", "qs"]
+    assert product.science_summary.hydrometeor_envelope_source_fields == ["qc", "qi", "qs"]
     assert product.science_summary.default_explore_time_index == 2
     assert product.science_summary.cm1_outcome is None
     availability = {item.key: item for item in product.science_summary.diagnostic_availability}
@@ -332,6 +370,133 @@ def test_deep_convection_interesting_times_and_unavailable_diagnostics(
         "unsupported_missing_fields"
     )
     assert availability["cold_pool_proxy"].support_state == "unsupported_missing_fields"
+
+
+def test_sparse_raw_hydrometeor_trace_does_not_support_deep_convection(
+    tmp_path: Path,
+) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=[0.0, 600.0, 1200.0], values=[0.0, 1.0, 2.0])
+    manifest = build_manifest(tmp_path, [model])
+    diagnostics = ResultDiagnostics(
+        cloud=CloudDiagnostics(
+            formed=True,
+            first_cloud_time_seconds=600.0,
+            cloud_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=2500.0),
+                TimeValue(time_seconds=1200.0, value=6200.0),
+            ],
+            liquid_cloud_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=2500.0),
+                TimeValue(time_seconds=1200.0, value=6200.0),
+            ],
+            raw_hydrometeor_envelope_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=2500.0),
+                TimeValue(time_seconds=1200.0, value=10200.0),
+            ],
+            hydrometeor_envelope_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=2500.0),
+                TimeValue(time_seconds=1200.0, value=10200.0),
+            ],
+            hydrometeor_envelope_source_fields=["qc", "qs"],
+            coherent_cloud_object_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=2500.0),
+                TimeValue(time_seconds=1200.0, value=6200.0),
+            ],
+            coherent_cloud_object_source_fields=["qc"],
+            max_qc_kg_kg=2e-5,
+            time_of_max_qc_seconds=1200.0,
+        ),
+        vertical_velocity=VerticalVelocityDiagnostics(
+            max_w_m_s=14.0,
+            time_of_max_w_seconds=600.0,
+            min_w_m_s=-6.0,
+            time_of_min_w_seconds=1200.0,
+            units="m/s",
+        ),
+        rain=RainDiagnostics(
+            present=True,
+            first_rain_time_seconds=1200.0,
+            max_qr_kg_kg=3e-7,
+            time_of_max_qr_seconds=1200.0,
+        ),
+        time=TimeDiagnostics(source="netcdf_time_coordinate", fallback_used=False),
+    )
+
+    product = build_interesting_time_product(
+        result_id="result-sparse-trace",
+        diagnostics=diagnostics,
+        output_manifest=manifest,
+        variables=["qc", "w", "qr"],
+    )
+
+    records = {record.key: record for record in product.available_interesting_times}
+    assert records["highest_cloud_top"].value == 6200.0
+    assert records["highest_raw_hydrometeor_envelope_top"].value == 10200.0
+    assert records["first_deep_convection"].support_state == "unavailable"
+    assert product.science_summary.deep_cloud_formed is False
+    assert product.science_summary.time_of_first_deep_convection_seconds is None
+    assert product.science_summary.highest_cloud_top_m == 6200.0
+    assert product.science_summary.highest_raw_hydrometeor_envelope_top_m == 10200.0
+
+
+def test_composite_cloud_top_uses_contributing_field_quality(tmp_path: Path) -> None:
+    model = tmp_path / "cm1out_000001.nc"
+    write_model_netcdf(model, times=[0.0, 600.0], values=[0.0, 1.0])
+    manifest = build_manifest(tmp_path, [model])
+    diagnostics = ResultDiagnostics(
+        cloud=CloudDiagnostics(
+            formed=True,
+            first_cloud_time_seconds=600.0,
+            cloud_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=9500.0),
+            ],
+            coherent_cloud_object_top_time_series=[
+                TimeValue(time_seconds=0.0, value=None),
+                TimeValue(time_seconds=600.0, value=9500.0),
+            ],
+            coherent_cloud_object_source_fields=["qc", "qi"],
+            max_qc_kg_kg=2e-5,
+            time_of_max_qc_seconds=600.0,
+        ),
+        vertical_velocity=VerticalVelocityDiagnostics(
+            max_w_m_s=14.0,
+            time_of_max_w_seconds=600.0,
+            units="m/s",
+        ),
+        rain=RainDiagnostics(available=False, field_absent=True),
+        time=TimeDiagnostics(source="netcdf_time_coordinate", fallback_used=False),
+        field_quality_assessed=True,
+        field_quality={
+            "qc": FieldQuality(field="qc", source_field="qc", quality_state="trusted"),
+            "qi": FieldQuality(
+                field="qi",
+                source_field="qi",
+                quality_state="untrusted",
+                reason="qi_field_entirely_non_finite",
+                caveats=["qi_field_entirely_non_finite"],
+            ),
+        },
+    )
+
+    product = build_interesting_time_product(
+        result_id="result-untrusted-ice-top",
+        diagnostics=diagnostics,
+        output_manifest=manifest,
+        variables=["qc", "w"],
+    )
+
+    records = {record.key: record for record in product.available_interesting_times}
+    assert records["highest_cloud_top"].support_state == "unavailable"
+    assert "interesting_time_source_field_untrusted" in records["highest_cloud_top"].caveats
+    assert product.science_summary.deep_cloud_formed is None
+    assert product.science_summary.highest_cloud_top_m is None
 
 
 def test_precipitation_and_reflectivity_outputs_are_supported_when_diagnosed(

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -216,14 +216,98 @@ def test_cloud_top_uses_ice_and_snow_hydrometeor_envelope(tmp_path: Path) -> Non
     diagnostics = compute_baseline_diagnostics(dataset, caveats)
 
     assert diagnostics.cloud.formed is True
+    assert diagnostics.cloud.liquid_cloud_base_m == 1500.0
+    assert diagnostics.cloud.liquid_cloud_top_m == 1500.0
+    assert diagnostics.cloud.hydrometeor_envelope_base_m == 1500.0
+    assert diagnostics.cloud.hydrometeor_envelope_top_m == 10500.0
+    assert diagnostics.cloud.hydrometeor_envelope_source_fields == ["qc", "qi", "qs"]
+    assert diagnostics.cloud.raw_hydrometeor_envelope_top_m == 10500.0
+    assert diagnostics.cloud.coherent_cloud_object_base_m == 1500.0
+    assert diagnostics.cloud.coherent_cloud_object_top_m == 10500.0
+    assert diagnostics.cloud.coherent_cloud_object_source_fields == ["qc", "qi", "qs"]
     assert diagnostics.cloud.cloud_base_m == 1500.0
     assert diagnostics.cloud.cloud_top_m == 10500.0
+    assert [point.value for point in diagnostics.cloud.liquid_cloud_top_time_series] == [
+        None,
+        1500.0,
+    ]
     assert [point.value for point in diagnostics.cloud.cloud_top_time_series] == [
         None,
         10500.0,
     ]
     assert diagnostics.cloud.max_qc_kg_kg == 2e-6
     assert "cloud_top_uses_total_hydrometeor_fields:qc,qi,qs" in diagnostics.caveats
+
+
+def test_sparse_high_hydrometeor_trace_does_not_define_coherent_cloud_top(
+    tmp_path: Path,
+) -> None:
+    qc_values = zeros(z_count=4)
+    qs_values = zeros(z_count=4)
+    for y_index in range(3):
+        for x_index in range(4):
+            qc_values[1][1][y_index][x_index] = 2e-6
+    qs_values[1][3][0][0] = 4e-6
+    dataset = write_dataset(
+        tmp_path / "sparse_trace.nc",
+        base_dataset(
+            qc_values=qc_values,
+            qs_values=qs_values,
+            z_values=[500.0, 1500.0, 7500.0, 10500.0],
+        ),
+    )
+    caveats: list[str] = []
+
+    diagnostics = compute_baseline_diagnostics(dataset, caveats)
+
+    assert diagnostics.cloud.formed is True
+    assert diagnostics.cloud.liquid_cloud_top_m == 1500.0
+    assert diagnostics.cloud.raw_hydrometeor_envelope_top_m == 10500.0
+    assert diagnostics.cloud.hydrometeor_envelope_top_m == 10500.0
+    assert diagnostics.cloud.coherent_cloud_object_top_m == 1500.0
+    assert diagnostics.cloud.cloud_top_m == 1500.0
+    assert [point.value for point in diagnostics.cloud.cloud_top_time_series] == [
+        None,
+        1500.0,
+    ]
+    assert [
+        point.value for point in diagnostics.cloud.raw_hydrometeor_envelope_top_time_series
+    ] == [None, 10500.0]
+    assert diagnostics.cloud.raw_hydrometeor_envelope_top_support_time_series[
+        -1
+    ].top_defining_species == ["qs"]
+    assert (
+        "coherent_cloud_object_support_uses_grid_cell_count_not_physical_area"
+        in diagnostics.caveats
+    )
+
+
+def test_substantial_detached_ice_cloud_is_defined_as_coherent_without_qc_support(
+    tmp_path: Path,
+) -> None:
+    qc_values = zeros(z_count=4)
+    qi_values = zeros(z_count=4)
+    for y_index in range(3):
+        for x_index in range(4):
+            qi_values[1][2][y_index][x_index] = 3e-6
+            qi_values[1][3][y_index][x_index] = 4e-6
+    dataset = write_dataset(
+        tmp_path / "detached_ice_cloud.nc",
+        base_dataset(
+            qc_values=qc_values,
+            qi_values=qi_values,
+            z_values=[500.0, 1500.0, 7500.0, 10500.0],
+        ),
+    )
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+
+    assert diagnostics.cloud.formed is False
+    assert diagnostics.cloud.liquid_cloud_top_m is None
+    assert diagnostics.cloud.raw_hydrometeor_envelope_top_m == 10500.0
+    assert diagnostics.cloud.coherent_cloud_object_top_m == 10500.0
+    assert diagnostics.cloud.coherent_cloud_object_source_fields == ["qi"]
+    assert "coherent_cloud_object_without_liquid_cloud_water_support" in diagnostics.caveats
 
 
 def test_no_cloud_case(tmp_path: Path) -> None:
@@ -242,7 +326,7 @@ def test_no_cloud_case(tmp_path: Path) -> None:
 def test_cloud_formed_requires_ten_grid_cells_and_reports_base_top(tmp_path: Path) -> None:
     dataset = write_dataset(
         tmp_path / "cloud.nc",
-        base_dataset(qc_values=with_cloud(12), w_values=w_field()),
+        base_dataset(qc_values=with_cloud(24), w_values=w_field()),
     )
 
     diagnostics = compute_baseline_diagnostics(dataset, [])
@@ -251,6 +335,8 @@ def test_cloud_formed_requires_ten_grid_cells_and_reports_base_top(tmp_path: Pat
     assert diagnostics.cloud.first_cloud_time_seconds == 300.0
     assert diagnostics.cloud.cloud_base_m == 500.0
     assert diagnostics.cloud.cloud_top_m == 1500.0
+    assert diagnostics.cloud.liquid_cloud_top_m == 1500.0
+    assert diagnostics.cloud.hydrometeor_envelope_top_m == 1500.0
     assert [point.value for point in diagnostics.cloud.cloud_base_time_series] == [None, 500.0]
     assert [point.value for point in diagnostics.cloud.cloud_top_time_series] == [None, 1500.0]
     assert [point.value for point in diagnostics.cloud.max_qc_height_time_series] == [
@@ -268,7 +354,7 @@ def test_cloud_base_top_converts_km_vertical_coordinate_to_meters(tmp_path: Path
     dataset = write_dataset(
         tmp_path / "cloud_km.nc",
         base_dataset(
-            qc_values=with_cloud(12),
+            qc_values=with_cloud(24),
             w_values=w_field(),
             z_values=[0.5, 1.5],
             z_units="km",

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -849,8 +849,8 @@ def test_deep_candidate_comparison_uses_observed_surface_forced_outcome(
     assert result.candidate_hypothesis_comparison.match_status == "inconclusive"
     assert result.candidate_hypothesis_comparison.cm1_outcome == (
         "Deep convection did not occur under this run configuration by current "
-        "cloud-top and updraft thresholds; this does not disprove the sounding's "
-        "deep-convection potential."
+        "coherent cloud-object top and updraft thresholds; this does not disprove "
+        "the sounding's deep-convection potential."
     )
     assert "trigger" not in result.candidate_hypothesis_comparison.cm1_outcome.lower()
     assert "failed" not in result.candidate_hypothesis_comparison.cm1_outcome.lower()

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -1299,8 +1299,7 @@ def test_campaign_report_blocks_terminal_surface_flux_frame_contamination(
     assert "terminal output-frame contamination" in report
     assert "control:hfx_terminal_output_frame_entirely_non_finite" in report
     assert "21600 s" in report
-    assert "Cloud-top values currently use the total hydrometeor envelope" in report
-    assert "See #330" in report
+    assert "Cloud-top summaries use the coherent cloud-object top" in report
     assert "hfx_field_entirely_non_finite" not in report
 
 

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1436,6 +1436,12 @@ const resultCard = {
     min_downdraft_w_m_s: -4.21529483795166,
     min_downdraft_time_seconds: 4500,
     highest_cloud_top_m: 1940,
+    highest_liquid_cloud_top_m: 1940,
+    highest_coherent_cloud_object_top_m: 1940,
+    coherent_cloud_object_source_fields: ["qc"],
+    highest_raw_hydrometeor_envelope_top_m: 1940,
+    highest_hydrometeor_envelope_top_m: 1940,
+    hydrometeor_envelope_source_fields: ["qc"],
     rain_onset_time_seconds: 5400,
     max_qr_kg_kg: 2e-7,
     max_rain_or_surface_precip: 4.2,
@@ -1475,11 +1481,11 @@ const resultCard = {
     },
     {
       key: "highest_cloud_top",
-      label: "Highest cloud top",
+      label: "Highest coherent cloud-object top",
       time_index: 3,
       time_seconds: 2700,
-      source_field: "qc",
-      source_diagnostic: "diagnostics.cloud.cloud_top_time_series",
+      source_field: "coherent_cloud_object:qc",
+      source_diagnostic: "diagnostics.cloud.coherent_cloud_object_top_time_series",
       value: 1940,
       units: "m",
       support_state: "supported",
@@ -1831,6 +1837,12 @@ const deepConvectionResultCard = {
     min_downdraft_w_m_s: -7,
     min_downdraft_time_seconds: 1800,
     highest_cloud_top_m: 10200,
+    highest_liquid_cloud_top_m: 6200,
+    highest_coherent_cloud_object_top_m: 10200,
+    coherent_cloud_object_source_fields: ["qc", "qi", "qs"],
+    highest_raw_hydrometeor_envelope_top_m: 10200,
+    highest_hydrometeor_envelope_top_m: 10200,
+    hydrometeor_envelope_source_fields: ["qc", "qi", "qs"],
     rain_onset_time_seconds: 1800,
     max_qr_kg_kg: 4e-7,
     latest_output_time_seconds: 2700,
@@ -1855,8 +1867,8 @@ const deepConvectionResultCard = {
       label: "First deep convection",
       time_index: 2,
       time_seconds: 1800,
-      source_field: "qc+qr+qi+qs+qg when available",
-      source_diagnostic: "diagnostics.cloud.cloud_top_time_series",
+      source_field: "coherent_cloud_object:qc+qi+qs",
+      source_diagnostic: "diagnostics.cloud.coherent_cloud_object_top_time_series",
       value: true,
       units: null,
       support_state: "supported",
@@ -1881,7 +1893,12 @@ const deepConvectionResultCard = {
     cm1_outcome: "Deep convection formed with strong updraft and rain water aloft.",
     match_status: "supported",
     match_status_label: "Supported",
-    evidence: ["deep cloud formed", "cloud top 10200 m", "max updraft 15 m/s"],
+    evidence: [
+      "deep cloud formed",
+      "coherent cloud-object top 10,200 m",
+      "liquid cloud-water top 6,200 m",
+      "max updraft 15 m/s",
+    ],
     caveats: [
       "candidate_screening_is_a_pre_run_hypothesis",
       "candidate_match_uses_simple_v1_deep_convection_rules",
@@ -5238,7 +5255,7 @@ describe("App", () => {
     expect(screen.getAllByText("-4.215 m/s").length).toBeGreaterThan(0);
     expect(resultDetail).toHaveTextContent("Science landmarks");
     expect(resultDetail).toHaveTextContent("Interesting times");
-    expect(resultDetail).toHaveTextContent("Highest cloud top");
+    expect(resultDetail).toHaveTextContent("Highest coherent cloud-object top");
     expect(resultDetail).toHaveTextContent("1,940 m");
     expect(resultDetail).toHaveTextContent("Rain-water onset");
     expect(resultDetail).toHaveTextContent("Default Explore time");
@@ -6349,6 +6366,84 @@ describe("App", () => {
     expect(
       screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length,
     ).toBeGreaterThan(0);
+  });
+
+  it("explains when liquid cloud water is shallower than the hydrometeor envelope", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/results") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ results: [deepConvectionResultCard] }), { status: 200 }),
+        );
+      }
+      if (url === "/api/results/result-deep-convection/visualization/fields") {
+        return Promise.resolve(new Response(JSON.stringify(fieldCatalogResponse), { status: 200 }));
+      }
+      if (url.startsWith("/api/results/result-deep-convection/visualization/defaults")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ...selectedTimeDefaultsResponse(url),
+              result_id: "result-deep-convection",
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.includes("/api/results/result-deep-convection/visualization/point-cloud")) {
+        const parsed = new URL(url, "http://localhost");
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              pointCloudResponse({
+                field: mockPointFieldFromParam(parsed.searchParams.get("field")),
+                threshold: Number(parsed.searchParams.get("threshold") ?? 0.000001),
+                timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
+              }),
+            ),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.includes("/api/results/result-deep-convection/visualization/slice")) {
+        const parsed = new URL(url, "http://localhost");
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              sliceResponse({
+                field: mockFieldFromParam(parsed.searchParams.get("field")),
+                orientation:
+                  parsed.searchParams.get("orientation") === "vertical_y"
+                    ? "vertical_y"
+                    : parsed.searchParams.get("orientation") === "vertical_x"
+                      ? "vertical_x"
+                      : "horizontal",
+                timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
+                levelIndex: Number(parsed.searchParams.get("level_index") ?? 0),
+              }),
+            ),
+            { status: 200 },
+          ),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+    render(<App />);
+
+    const resultDetail = await screen.findByLabelText("Result detail");
+    expect(resultDetail).toHaveTextContent("coherent cloud-object top 10,200 m");
+    expect(resultDetail).toHaveTextContent(/Liquid cloud top\s*6,200 m/);
+    expect(resultDetail).toHaveTextContent(/Coherent cloud top\s*10,200 m/);
+    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
+
+    expect(
+      await screen.findByText(
+        /Viewing liquid cloud water only: qc tops near 6,200 m, while the coherent cloud object reaches 10,200 m from qc\+qi\+qs\./,
+      ),
+    ).toBeInTheDocument();
   });
 
   it("separates 3-D scalar fields from slice-only fields", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -843,6 +843,12 @@ type ScienceSummary = {
   min_downdraft_w_m_s?: number | null;
   min_downdraft_time_seconds?: number | null;
   highest_cloud_top_m?: number | null;
+  highest_liquid_cloud_top_m?: number | null;
+  highest_coherent_cloud_object_top_m?: number | null;
+  coherent_cloud_object_source_fields?: string[];
+  highest_raw_hydrometeor_envelope_top_m?: number | null;
+  highest_hydrometeor_envelope_top_m?: number | null;
+  hydrometeor_envelope_source_fields?: string[];
   rain_onset_time_seconds?: number | null;
   max_qr_kg_kg?: number | null;
   max_rain_or_surface_precip?: number | null;
@@ -8459,7 +8465,23 @@ function ResultNotebookCard({
         <Metric label="Max qc" value={formatScientific(resultMaxQc(result), "kg/kg")} />
         <Metric label="Max updraft" value={formatNumber(resultMaxUpdraft(result), "m/s")} />
         <Metric label="Min downdraft" value={formatNumber(resultMinDowndraft(result), "m/s")} />
-        <Metric label="Cloud top" value={formatNumber(resultCloudTopMeters(result), "m")} />
+        {resultLiquidCloudTopMeters(result) !== null && (
+          <Metric
+            label="Liquid cloud top"
+            value={formatNumber(resultLiquidCloudTopMeters(result), "m")}
+          />
+        )}
+        <Metric
+          label="Coherent cloud top"
+          value={formatNumber(resultCloudTopMeters(result), "m")}
+        />
+        {resultRawHydrometeorEnvelopeTopMeters(result) !== null &&
+          resultRawHydrometeorEnvelopeTopMeters(result) !== resultCloudTopMeters(result) && (
+            <Metric
+              label="Raw hydrometeor trace top"
+              value={formatNumber(resultRawHydrometeorEnvelopeTopMeters(result), "m")}
+            />
+          )}
         {hasDeepConvectionDiagnostics(result) && (
           <Metric label="Deep convection" value={deepConvectionOutcome(result)} />
         )}
@@ -9626,6 +9648,10 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
                       : ""}
                   </p>
                 )}
+                {selectedEncoding?.field.raw_field_name === "qc" &&
+                  cloudTopMismatchNotice(result) && (
+                    <p className="control-help">{cloudTopMismatchNotice(result)}</p>
+                  )}
                 <label htmlFor="cloud-threshold">
                   {selectedEncoding?.thresholdLabel ?? "Visible minimum"}
                   <input
@@ -10900,7 +10926,7 @@ function observedRecipeSignatureLabels(story: CandidateStoryId | null): string[]
     case "dry_failed_candidate":
       return ["Vertical motion without meaningful cloud water"];
     case "capped_suppressed_candidate":
-      return ["Suppressed or shallow cloud", "Limited cloud top"];
+      return ["Suppressed or shallow cloud", "Limited cloud depth"];
     case "humid_rainy_candidate":
       return [
         "Cloud water",
@@ -12970,7 +12996,7 @@ function compactScienceSummary(result: ResultCard): string {
         ? `rain-water onset ${formatSeconds(resultRainOnsetTime(result))}`
         : null,
       resultCloudTopMeters(result) !== null
-        ? `cloud top ${formatNumber(resultCloudTopMeters(result), "m")}`
+        ? `coherent cloud top ${formatNumber(resultCloudTopMeters(result), "m")}`
         : null,
     ].filter(Boolean);
     return parts.join(" · ");
@@ -13020,10 +13046,57 @@ function resultLatestOutputTime(result: ResultCard): number | null {
 }
 
 function resultCloudTopMeters(result: ResultCard): number | null {
-  const value = result.science_summary?.highest_cloud_top_m ?? null;
+  const value =
+    result.science_summary?.highest_coherent_cloud_object_top_m ??
+    result.science_summary?.highest_cloud_top_m ??
+    null;
   if (value === null || value === undefined) return null;
   if (legacyCloudTopWasStoredInKilometers(result)) return value * 1000;
   return value;
+}
+
+function resultRawHydrometeorEnvelopeTopMeters(result: ResultCard): number | null {
+  const value =
+    result.science_summary?.highest_raw_hydrometeor_envelope_top_m ??
+    result.science_summary?.highest_hydrometeor_envelope_top_m ??
+    null;
+  if (value === null || value === undefined) return null;
+  if (legacyCloudTopWasStoredInKilometers(result)) return value * 1000;
+  return value;
+}
+
+function resultLiquidCloudTopMeters(result: ResultCard): number | null {
+  const value = result.science_summary?.highest_liquid_cloud_top_m ?? null;
+  if (value === null || value === undefined) return null;
+  if (legacyCloudTopWasStoredInKilometers(result)) return value * 1000;
+  return value;
+}
+
+function cloudTopMismatchNotice(result: ResultCard): string | null {
+  const liquidTop = resultLiquidCloudTopMeters(result);
+  const coherentTop = resultCloudTopMeters(result);
+  const rawTraceTop = resultRawHydrometeorEnvelopeTopMeters(result);
+  if (liquidTop === null) {
+    return null;
+  }
+  if (coherentTop !== null && coherentTop > liquidTop + 500) {
+    const fields = result.science_summary?.coherent_cloud_object_source_fields;
+    const fieldLabel = fields && fields.length > 1 ? fields.join("+") : "qc plus hydrometeors";
+    return (
+      `Viewing liquid cloud water only: qc tops near ${formatNumber(liquidTop, "m")}, ` +
+      `while the coherent cloud object reaches ${formatNumber(coherentTop, "m")} from ${fieldLabel}.`
+    );
+  }
+  if (rawTraceTop !== null && rawTraceTop > liquidTop + 500) {
+    const fields = result.science_summary?.hydrometeor_envelope_source_fields;
+    const fieldLabel = fields && fields.length > 1 ? fields.join("+") : "qc plus hydrometeors";
+    return (
+      `Viewing liquid cloud water only: qc tops near ${formatNumber(liquidTop, "m")}; ` +
+      `a sparse hydrometeor trace reaches ${formatNumber(rawTraceTop, "m")} from ${fieldLabel}, ` +
+      "but deep-cloud classification uses coherent cloud-object top."
+    );
+  }
+  return null;
 }
 
 function legacyCloudTopWasStoredInKilometers(result: ResultCard): boolean {
@@ -13040,7 +13113,9 @@ function visibleInterestingTimes(result: ResultCard): InterestingTimeRecord[] {
     "first_deep_convection",
     "first_cloud",
     "max_qc",
+    "highest_liquid_cloud_top",
     "highest_cloud_top",
+    "highest_raw_hydrometeor_envelope_top",
     "max_updraft_w",
     "min_downdraft_w",
     "rain_onset",
@@ -13060,6 +13135,14 @@ function visibleInterestingTimes(result: ResultCard): InterestingTimeRecord[] {
 function interestingTimePrimaryValue(record: InterestingTimeRecord, result: ResultCard): string {
   if (record.key === "highest_cloud_top") {
     const cloudTop = resultCloudTopMeters(result);
+    return cloudTop === null ? "Unavailable" : formatNumber(cloudTop, "m");
+  }
+  if (record.key === "highest_liquid_cloud_top") {
+    const cloudTop = resultLiquidCloudTopMeters(result);
+    return cloudTop === null ? "Unavailable" : formatNumber(cloudTop, "m");
+  }
+  if (record.key === "highest_raw_hydrometeor_envelope_top") {
+    const cloudTop = resultRawHydrometeorEnvelopeTopMeters(result);
     return cloudTop === null ? "Unavailable" : formatNumber(cloudTop, "m");
   }
   if (record.key === "latest_output" || record.key === "field_default_time") {

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -222,7 +222,9 @@ Near-term interesting times:
 - max `qc`;
 - max updraft `w`;
 - min downdraft `w`;
-- highest cloud top;
+- highest liquid cloud-water top from `qc`;
+- highest coherent cloud-object top from supported, vertically connected `qc`, `qr`, `qi`, `qs`, and `qg` levels when present;
+- highest raw hydrometeor trace top from any `qc`, `qr`, `qi`, `qs`, or `qg` threshold crossing;
 - rain-water onset from `qr`;
 - max rain water aloft from `qr`;
 - max `dbz`;
@@ -269,18 +271,24 @@ misleading cloud/rain-water landmark.
 
 Interesting-time records, field defaults, diagnostic availability records, and
 science summaries may carry target-field `field_quality` metadata for `qc`, `w`,
-`qr`, surface `rain`, `dbz`, `hfx`, and `qfx`. Entirely non-finite source fields are
-`untrusted` and must not produce supported landmarks or clean comparison
-evidence. Partially non-finite fields may remain usable only with visible
-caveats and finite/non-finite counts.
+`qr`, surface `rain`, `dbz`, `hfx`, and `qfx`, plus present ice/snow/graupel
+fields when they contribute to cloud-top diagnostics. Entirely non-finite source
+fields are `untrusted` and must not produce supported landmarks or clean
+comparison evidence. Partially non-finite fields may remain usable only with
+visible caveats and finite/non-finite counts.
 
 Triggered deep-potential results extend the same product with backend-owned
 summary fields for deep-cloud formation, first deep-convection time, strong
-updraft detection, cloud top, rain-water onset, max `qr`, and the default Explore
-time. Unsupported severe-storm diagnostics such as reflectivity maxima,
-surface-rain maxima, updraft-depth proxy, cold-pool proxy, and near-surface
-theta perturbation proxy must be recorded as unavailable or caveated until a
-supported backend diagnostic exists. When candidate-screening metadata is
+updraft detection, liquid cloud-water top, coherent cloud-object top, raw
+hydrometeor trace top, rain-water onset, max `qr`, and the default Explore time.
+The deep-cloud classifier must use coherent cloud-object top, not an isolated raw
+hydrometeor trace. The product must not use a generic "cloud top" label when the
+value comes from the broader trace envelope rather than visible `qc` alone.
+
+Unsupported severe-storm diagnostics such as reflectivity maxima, surface-rain
+maxima, updraft-depth proxy, cold-pool proxy, and near-surface theta
+perturbation proxy must be recorded as unavailable or caveated until a supported
+backend diagnostic exists. When candidate-screening metadata is
 present, result metadata may include a compact `candidate_hypothesis_comparison`
 with `Screened as`, `Ran as`, `CM1 outcome`, match state, evidence, and caveats.
 The comparison uses simple v1 rules and remains a post-run interpretation of

--- a/docs/research/output-and-visualization-architecture.md
+++ b/docs/research/output-and-visualization-architecture.md
@@ -294,7 +294,7 @@ CM1 documents a broad output field surface:
 | Surface/forcing | sensible/latent flux | `output_sfcflx` | not productized | raw | near-term for realistic inputs |
 | Surface/forcing | 2 m temp/moisture, 10 m winds, roughness | `output_sfcdiags`, `output_sfcparams` | not productized | raw | near-term for land/diurnal |
 | Surface/forcing | radiation terms / OLR | `output_radten`, `output_sfcparams` when radiation enabled | not productized | raw | medium with radiation runs |
-| Time evolution | interesting times | derived from `qc`, `w`, `qr`, cloud top/base | partial defaults | derived | near-term |
+| Time evolution | interesting times | derived from `qc`, `w`, `qr`, coherent cloud-object top/base, and raw hydrometeor trace top | partial defaults | derived | near-term |
 | Time evolution | time-height cloud fraction/max `w` | derive from full sequence | not productized | derived | near-term |
 | Time evolution | domain-mean profiles | domain diagnostics or derive from fields | not productized | raw/derived | near-term / medium |
 | Budgets | `th/qv/u/v/w` budgets | CM1 budget outputs | not productized | raw | future |
@@ -322,7 +322,8 @@ For those runs, #210's output implication is:
 - surface/wetness proxy needs surface fluxes, 2 m temp/moisture, and proxy
   caveats;
 - land/diurnal needs diurnal timing, boundary-layer growth, cloud onset,
-  cloud top/base, and surface flux evolution.
+  coherent cloud-object top/base, raw hydrometeor trace top, and surface flux
+  evolution.
 
 ## Backend Derived Output Products
 
@@ -570,7 +571,9 @@ Near-term interesting times:
 - max `qc`;
 - max updraft;
 - min downdraft;
-- highest cloud top;
+- highest liquid cloud-water top from `qc`;
+- highest coherent cloud-object top from supported, vertically connected hydrometeor levels;
+- highest raw hydrometeor trace top from any hydrometeor threshold crossing;
 - rain onset;
 - max `qr`;
 - max reflectivity;
@@ -741,7 +744,8 @@ Scope:
 
 - Record file/time mapping.
 - Compute interesting times: first cloud, max `qc`, max `w`, min `w`, rain
-  onset, max `qr`, max `dbz`, highest cloud top.
+  onset, max `qr`, max `dbz`, highest coherent cloud-object top, and highest
+  raw hydrometeor trace top.
 - Expose a small API payload for Explore and Results.
 - Preserve direct vs inferred time caveats.
 

--- a/docs/research/surface-forced-sounding-verification-protocol.md
+++ b/docs/research/surface-forced-sounding-verification-protocol.md
@@ -306,7 +306,7 @@ An operator override may continue the campaign, but the report must preserve the
 Where possible, #311 should map report fields to existing backend structures instead of inventing names:
 
 - `ResultMetadata`: result ID, run ID, scenario/recipe IDs, observed sounding, run configuration, expected/required/missing fields, warnings, caveats, candidate screening, result state.
-- `ScienceSummary`: first cloud time, cloud top/deep-cloud state, max `qc`, max `w`, rain-water timing, default interesting time, support state where available.
+- `ScienceSummary`: first cloud time, liquid cloud-water top, coherent cloud-object top, raw hydrometeor trace top, deep-cloud state, max `qc`, max `w`, rain-water timing, default interesting time, support state where available.
 - `ResultDiagnostics` and output-product payloads: field availability, units, min/max/mean when derivable, missing-field support states.
 
 If the backend cannot provide a field, the report must say `unavailable` and identify the missing diagnostic rather than inventing a value.
@@ -378,7 +378,7 @@ Required evidence:
 - Ingested metadata reports `hfx` and `qfx` separately when present.
 - Heat/moisture changes produce directionally consistent `hfx`/`qfx` changes where derivable.
 - Low-level thermal/moisture fields respond in the expected direction if derivable by the standardized low-level response diagnostic.
-- Cloud timing, cloud top, `qc`, or `w` response is summarized, even if weak.
+- Cloud timing, coherent cloud-object top, raw hydrometeor trace top, `qc`, or `w` response is summarized, even if weak.
 
 Interpretation:
 
@@ -424,7 +424,7 @@ The 12 km to 60 km step is not a pure domain-size test when `horizontal_cell_cou
 Required evidence:
 
 - Boundary-layer response compared with the matched Phase 2 control and Phase 1 behavior.
-- Max cloud top and time of max cloud top.
+- Max coherent cloud-object top, raw hydrometeor trace top, and the time of each maximum.
 - Max `w`, plus time and height of max `w` if available.
 - Max `qc` and time of max `qc`.
 - Cloud depth or classification when supported.


### PR DESCRIPTION
## Summary

- Adds a coherent cloud-object top diagnostic that can include legitimate connected ice/snow/graupel aloft, but requires documented support instead of accepting a single isolated threshold crossing.
- Keeps the unrestricted hydrometeor envelope as a raw trace metric, so reports can say both: coherent cloud top stayed lower, while sparse hydrometeor trace reached higher.
- Switches deep/tall-cloud classification, first-deep-convection timing, CM1 outcome language, campaign summaries, and compatibility `highest_cloud_top_m` handling to the coherent cloud-object top.
- Preserves source-field support for top diagnostics: top-defining species, supporting species, thresholds, qualifying cell counts, grid-count caveats, and field-quality checks for contributing species such as `qi`, `qs`, and `qg` when present.
- Updates Results/Explore copy, frontend tests, output-product docs, and campaign contracts so liquid `qc`, coherent cloud object, and raw hydrometeor trace are visibly separate.

Closes #330.

## Verification

- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_result_diagnostics.py app/backend/tests/test_output_products.py app/backend/tests/test_result_ingest.py app/backend/tests/test_result_cards.py app/backend/tests/test_surface_forced_campaign.py -q`
- `cd app/frontend && npm test -- App.test.tsx`
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Notes

- `highest_cloud_top_m` remains as a compatibility field, but now follows the coherent cloud-object top rather than the raw hydrometeor trace.
- The v1 coherent-top support rule is intentionally explicit and conservative: minimum qualifying cells per level plus vertical continuity from the lowest supported hydrometeor level. It records a caveat that this is grid-cell support rather than a physical-area/connected-component object analysis.
- Raw sparse hydrometeor trace remains available as secondary evidence and is not allowed to satisfy the deep-cloud criterion by itself.
