### PR TITLE
docs: record lower-timestep default-control probe

### DIFF
--- a/docs/research/surface-forced-campaigns/surface_forced_tall_002_default_control_stability.md
+++ b/docs/research/surface-forced-campaigns/surface_forced_tall_002_default_control_stability.md
@@ -8,6 +8,8 @@ Primary report: `docs/research/surface-forced-campaigns/surface_forced_tall_002.
 
 Prior investigation: `docs/research/surface-forced-campaigns/surface_forced_tall_002_terminal_failure.md`
 
+Follow-up probe: `docs/research/surface-forced-campaigns/surface_forced_tall_002_lower_timestep_restart_probe.md`
+
 ## Summary
 
 The existing artifacts are sufficient to choose the next rerun path, but they
@@ -20,10 +22,11 @@ statistics record is `21480 s`; stdout narrows the visible collapse to between
 `357.182 min` and `357.234 min`; the final `21600 s` output frame contains
 terminal multi-field non-finite contamination.
 
-The most defensible next action is a targeted default-control numerical
-diagnosis, not Phase 2/3 and not differential forcing. If any material numerical
-setting is changed to stabilize the default control, the campaign evidence must
-come from a new four-row Phase 1 matrix, `surface_forced_tall_003`.
+The completed lower-timestep restart probe supports the targeted numerical
+diagnosis path. It crossed the old failure interval and finished cleanly, but it
+changed a material numerical setting and used a restart shortcut. Therefore the
+campaign evidence must come from a new four-row Phase 1 matrix,
+`surface_forced_tall_003`, not from patching `surface_forced_tall_002`.
 
 ## Artifact Scope
 
@@ -239,22 +242,23 @@ numerical configuration.
 
 ### Step 1: Targeted default-control numerical diagnosis
 
-Run only the default-control member while varying the smallest number of
-numerical assumptions needed to test stability. The preferred first probe is a
-timestep-focused variant:
+Completed as a diagnostic restart probe. The lower adaptive timestep-target
+variant used:
 
 ```text
 same sounding
 same forcing values
 same domain/grid/output fields
 same microphysics/turbulence/surface model
-lower dtl target, for example 1.0 s
+dtl target lowered from 3.0 s to 1.0 s
 adaptive timestep still enabled
 ```
 
-If a restart-from-`10800 s` path is operationally safe, it can be used as a
-diagnostic shortcut. The result should not be treated as campaign evidence until
-it is rerun from the same initial conditions used by the matrix.
+It restarted from `10800 s`, crossed the previous `357.182-357.234 min` collapse
+window with finite CFL/ks diagnostics, wrote finite saved output through
+`21600 s`, and produced no invalid/divide-by-zero/overflow stderr flags. It
+should not be treated as campaign evidence until it is rerun from the same
+initial conditions used by the matrix.
 
 If the lower-timestep default control still fails, the next diagnostic probes
 should be considered in this order:
@@ -268,22 +272,18 @@ Each probe must record exactly which numerical settings changed and must keep
 surface forcing, sounding, domain, grid, output cadence, and required fields
 fixed.
 
-### Step 2: Decide campaign rerun scope
+### Step 2: Campaign rerun scope
 
-If the default control is fixed without changing material numerical settings,
-regenerate or rerun only the default-control row and reevaluate the existing
-Phase 1 gate.
-
-If any material numerical setting changes, including `dtl`, `idiff`, diffusion
-coefficient, turbulence configuration, solver, damping, or microphysics, do not
-compare the stabilized default control against the old comparator rows as
-campaign evidence. Create:
+The probe changed `dtl`, a material numerical setting. Do not compare the
+stabilized default-control probe against the old comparator rows as campaign
+evidence. Create:
 
 ```text
 surface_forced_tall_003
 ```
 
-and rerun the four Phase 1 rows under the same updated assumptions:
+and rerun the four Phase 1 rows from cold start under the same updated
+assumptions:
 
 ```text
 default
@@ -307,14 +307,15 @@ no terminal multi-field contamination
 ## #318 Update
 
 #318 should continue to classify the current campaign as blocked. The update
-from this diagnosis is:
+from this diagnosis and the follow-up lower-timestep restart probe is:
 
 ```text
 The default-control failure is reproducible in existing _001 and _002 artifacts,
 is upstream of ingest, and is most consistent with a localized late-run CM1
 runtime-integrity failure around the surface-layer/moisture/turbulence path.
-The next action is a targeted default-control numerical diagnosis, beginning
-with a lower-timestep probe. Any material numerical-setting change requires a
-new four-row surface_forced_tall_003 Phase 1 matrix before Phase 2 evidence is
-trusted.
+The lower-timestep restart probe crossed the old failure interval and completed
+with finite saved output and no stats sentinels, which strongly implicates the
+timestep/numerical path. Because the probe changed dtl and used a restart, the
+next campaign action is a cold-start four-row surface_forced_tall_003 Phase 1
+matrix before Phase 2 evidence is trusted.
 ```

--- a/docs/research/surface-forced-campaigns/surface_forced_tall_002_lower_timestep_restart_probe.md
+++ b/docs/research/surface-forced-campaigns/surface_forced_tall_002_lower_timestep_restart_probe.md
@@ -1,0 +1,184 @@
+# Surface-Forced Tall 002 Lower-Timestep Restart Probe
+
+Related issues: `#336`, `#318`
+
+Campaign ID: `surface_forced_tall_002`
+
+Probe run ID:
+
+```text
+surface_forced_tall_002-phase1_control_default_flux-dtl1_restart_probe
+```
+
+This note records a local diagnostic probe. It is not campaign evidence and it
+does not make `surface_forced_tall_002` pass Phase 1.
+
+## Summary
+
+A lower-timestep restart probe carried the failed default-control state from the
+`10800 s` restart checkpoint through `21600 s` without reproducing the terminal
+multi-field numerical failure.
+
+The original default-control run collapsed between `357.182 min` and
+`357.234 min`. In the lower-timestep restart probe, the same model-time window
+remained finite:
+
+```text
+357.166656 min: cflmax 0.4886, ksmax 0.0083, dt 2.0000
+357.200012 min: cflmax 0.4886, ksmax 0.0083, dt 2.0000
+357.233337 min: cflmax 0.4887, ksmax 0.0084, dt 2.0000
+```
+
+The probe finished with a normal stdout termination marker. Stderr reported
+only `IEEE_UNDERFLOW_FLAG`, not invalid, divide-by-zero, or overflow flags.
+All saved model-output frames from `11700 s` through `21600 s` were finite for
+the tracked fields:
+
+```text
+qv, qc, qr, th, w, hfx, qfx, rain, dbz
+```
+
+`cm1out_stats.nc` contained `181` records from `10800 s` through `21600 s` and
+no non-finite or sentinel statistics entries.
+
+## Probe Setup
+
+The probe used the existing default-control restart set:
+
+```text
+cm1rst_000001_*.dat
+```
+
+Copied inputs:
+
+```text
+namelist.input
+input_sounding
+LANDUSE.TBL
+cm1_config.txt
+cm1rst_000001_*.dat
+```
+
+Namelist changes:
+
+```text
+dtl      3.000    -> 1.000
+irst     0        -> 1
+rstnum   1        -> 1
+run_time -999.9   -> 10800.0
+```
+
+Held fixed:
+
+```text
+sounding
+surface heat flux
+surface moisture flux
+domain
+grid
+vertical stretching
+model top
+Rayleigh damping
+microphysics
+turbulence settings
+surface model
+output fields
+output cadence
+adaptive timestep enabled
+```
+
+Because `adapt_dt = 1`, this was not a fixed one-second timestep run. CM1
+adapted to about `2.0 s` through the probe. The result should therefore be
+described as a lower adaptive timestep-target probe, not a fixed timestep run.
+
+## Output Evidence
+
+The probe wrote normal-sized output files:
+
+```text
+cm1out_000014.nc through cm1out_000025.nc
+cm1out_stats.nc
+```
+
+The final model-output frame was `cm1out_000025.nc` at `21600 s`. It was finite
+for all tracked fields:
+
+| Field | Finite count | Total count | Final-frame max |
+| --- | ---: | ---: | ---: |
+| `qv` | `1,638,400` | `1,638,400` | `0.0190186 kg/kg` |
+| `qc` | `1,638,400` | `1,638,400` | `0.00226064 kg/kg` |
+| `qr` | `1,638,400` | `1,638,400` | `0.0012692 kg/kg` |
+| `th` | `1,638,400` | `1,638,400` | `430.29 K` |
+| `w` | `1,654,784` | `1,654,784` | `6.04097 m/s` |
+| `hfx` | `16,384` | `16,384` | `8.96993` |
+| `qfx` | `16,384` | `16,384` | `5.79741e-5` |
+| `rain` | `16,384` | `16,384` | `0.0503309` |
+| `dbz` | `1,638,400` | `1,638,400` | `45.4486 dBZ` |
+
+The final frame was not dynamically inert. It included finite rain water aloft,
+finite surface rain, finite reflectivity, and a finite updraft maximum above
+`6 m/s`.
+
+The saved-output sequence also crossed several cloud/rain-active checkpoints
+cleanly:
+
+| Time | `max_qv` | `max_qc` | `max_qr` | `max_w` | `max_dbz` |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| `18900 s` | `0.0330145` | `0.00804449` | `0.000130872` | `3.97059` | `7.26053` |
+| `19800 s` | `0.0183238` | `0.00202592` | `0.000180616` | `5.55417` | `33.4126` |
+| `20700 s` | `0.0190468` | `0.00128255` | `0.00159798` | `3.63463` | `37.1338` |
+| `21600 s` | `0.0190186` | `0.00226064` | `0.0012692` | `6.04097` | `45.4486` |
+
+This matters because the successful probe was not merely a quiet no-weather
+case. It carried a cloud/rain/reflectivity-active state through the previous
+failure window.
+
+## Interpretation
+
+The probe strongly suggests that the original terminal failure is sensitive to
+the CM1 timestep path. It does not prove that `dtl` is the only required
+stabilization, and it does not prove that a cold-start lower-timestep run will
+always complete.
+
+The probe is nevertheless enough to choose the next defensible campaign path:
+
+```text
+do not patch surface_forced_tall_002 into a passing campaign
+do not queue Phase 2/3 yet
+do not start differential forcing from this evidence
+create surface_forced_tall_003 with a lower timestep target
+rerun all four Phase 1 rows from cold start under the same numerical settings
+```
+
+Because `dtl` is a material numerical setting, a stabilized default-control row
+cannot be compared as campaign evidence against the old high-sensible,
+high-moisture, or high-both rows. The comparison matrix must be rerun
+like-with-like.
+
+## Recommended Next Step
+
+Create and run `surface_forced_tall_003` Phase 1 with the same physical matrix
+and a lower adaptive timestep target:
+
+```text
+default
+high sensible only
+high moisture only
+high sensible + high moisture
+```
+
+The report should explicitly preserve:
+
+```text
+dtl target
+adaptive timestep setting
+runtime floating-point warnings
+runtime-integrity state
+surface-flux response state
+low-level early-response state
+field-quality state
+```
+
+Phase 2 remains blocked until the new four-row Phase 1 passes runtime-integrity,
+surface-flux response, and low-level early-response gates.
+


### PR DESCRIPTION
## Summary
- document the lower-timestep restart probe for the `surface_forced_tall_002` default-control failure
- record that the probe crossed the old `357.182-357.234 min` collapse window and wrote finite saved output through `21600 s`
- update the stability diagnosis to require a cold-start four-row `surface_forced_tall_003` Phase 1 matrix before Phase 2/3 evidence is trusted

## Why
The probe strongly implicates the timestep/numerical path, but it changed `dtl` and used a restart shortcut. This keeps the campaign record honest: `_002` remains blocked, and any stabilized evidence needs a like-for-like `_003` matrix.

## Verification
- `scripts/check.sh`

## Notes
- Refs #336
- no generated CM1 outputs, NetCDF files, runtime logs, or run directories are committed
- Phase 2/3 remain blocked; #307 differential forcing remains out of scope for this evidence
