### PR TITLE
feat: make timestep target explicit for campaigns

### DIFF
--- a/app/backend/cloud_chamber/run_configuration.py
+++ b/app/backend/cloud_chamber/run_configuration.py
@@ -196,6 +196,7 @@ CADENCE_CHOICES: dict[str, _CadenceChoice] = {
 
 DEFAULT_SURFACE_HEAT_FLUX_K_M_S = 8.0e-3
 DEFAULT_SURFACE_MOISTURE_FLUX_G_G_M_S = 5.2e-5
+DEFAULT_TIME_STEP_SECONDS = 3.0
 SURFACE_HEAT_FLUX_CONTEXT_RANGE_K_M_S = (0.0, 0.2)
 SURFACE_MOISTURE_FLUX_CONTEXT_RANGE_G_G_M_S = (0.0, 2.0e-4)
 
@@ -264,6 +265,12 @@ def resolve_run_configuration(
         "surface_moisture_flux_g_g_m_s",
         "surface moisture flux",
     )
+    time_step_seconds = _positive_float_payload(
+        payload,
+        "time_step_seconds",
+        "time step seconds",
+        default=DEFAULT_TIME_STEP_SECONDS,
+    )
     surface_flux_enabled = True
     surface_flux_mode = "constant_uniform_surface_flux_proxy"
     surface_flux_cm1_values = _surface_flux_cm1_values(
@@ -293,12 +300,14 @@ def resolve_run_configuration(
         surface_heat_flux_k_m_s=heat_flux,
         surface_moisture_flux_g_g_m_s=moisture_flux,
         surface_flux_mode=surface_flux_mode,
+        time_step_seconds=time_step_seconds,
     )
     caveats = _configuration_caveats(
         mode=duration.mode,
         horizontal_cell_count=horizontal_cells.cells,
         domain_size=str(payload["domain_size"]),
         surface_flux_caveats=surface_flux_caveats,
+        time_step_seconds=time_step_seconds,
     )
     return RunConfiguration(
         configuration_id=configuration_id,
@@ -334,7 +343,7 @@ def resolve_run_configuration(
             dz_top_m=domain.dz_top_m,
             domain_x_km=domain.x_km,
             domain_y_km=domain.y_km,
-            time_step_seconds=_time_step_seconds(),
+            time_step_seconds=time_step_seconds,
             runtime_seconds=duration.seconds,
             output_cadence_seconds=cadence.seconds,
             restart_cadence_seconds=restart_seconds,
@@ -385,6 +394,21 @@ def _float_payload(payload: dict[str, Any], key: str, label: str) -> float:
     return parsed
 
 
+def _positive_float_payload(
+    payload: dict[str, Any],
+    key: str,
+    label: str,
+    *,
+    default: float,
+) -> float:
+    if key not in payload:
+        return default
+    parsed = _float_payload(payload, key, label)
+    if parsed <= 0:
+        raise ValueError(f"Invalid {label}: must be greater than zero")
+    return parsed
+
+
 def _configuration_id(
     *,
     duration: str,
@@ -395,16 +419,20 @@ def _configuration_id(
     surface_heat_flux_k_m_s: float,
     surface_moisture_flux_g_g_m_s: float,
     surface_flux_mode: str,
+    time_step_seconds: float,
 ) -> str:
+    timestep_suffix = ""
+    if not math.isclose(time_step_seconds, DEFAULT_TIME_STEP_SECONDS):
+        timestep_suffix = f"__dtl_{_flux_id(time_step_seconds)}s"
     if surface_flux_mode == "disabled":
         return (
             f"{duration}__{horizontal_cell_count}__{domain_size}__{output_cadence}"
-            f"__{diagnostic_set}__surface_fluxes_disabled"
+            f"__{diagnostic_set}__surface_fluxes_disabled{timestep_suffix}"
         )
     return (
         f"{duration}__{horizontal_cell_count}__{domain_size}__{output_cadence}"
         f"__{diagnostic_set}__shflx_{_flux_id(surface_heat_flux_k_m_s)}"
-        f"__qflx_{_flux_id(surface_moisture_flux_g_g_m_s)}"
+        f"__qflx_{_flux_id(surface_moisture_flux_g_g_m_s)}{timestep_suffix}"
     )
 
 
@@ -438,6 +466,7 @@ def _configuration_caveats(
     horizontal_cell_count: int,
     domain_size: str,
     surface_flux_caveats: list[str],
+    time_step_seconds: float,
 ) -> list[str]:
     caveats: list[str] = list(surface_flux_caveats)
     if mode == "smoke":
@@ -450,6 +479,8 @@ def _configuration_caveats(
         "regional_120km",
     }:
         caveats.append("configuration_better_suited_to_larger_compute")
+    if not math.isclose(time_step_seconds, DEFAULT_TIME_STEP_SECONDS):
+        caveats.append("non_default_timestep_target_requires_like_for_like_campaign_evidence")
     return caveats
 
 
@@ -524,10 +555,6 @@ def _format_scientific(value: float) -> str:
 
 def _flux_id(value: float) -> str:
     return f"{value:.3e}".replace("+", "").replace("-", "m").replace(".", "p")
-
-
-def _time_step_seconds() -> float:
-    return 3.0
 
 
 def _rayleigh_damping_start_m() -> int:

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -81,6 +81,7 @@ RUN_CONFIGURATION_KEYS = {
     "diagnostic_set",
     "surface_heat_flux_k_m_s",
     "surface_moisture_flux_g_g_m_s",
+    "time_step_seconds",
 }
 KNOWN_STATUS_VALUES = {
     "planned",
@@ -154,6 +155,7 @@ SUPPORTED_REQUIRED_SUMMARY_FIELDS = {
     "dz_bot_m",
     "dz_top_m",
     "model_top_m",
+    "time_step_seconds",
     "output_cadence",
     "expected_output_volume",
     "cloud_chamber_commit",
@@ -261,6 +263,7 @@ MATRIX_CONTEXT_FIELDS = {
     "cm1_cnst_shflx",
     "cm1_cnst_lhflx",
     "runtime_seconds",
+    "time_step_seconds",
     "expected_output_frames",
     "expected_output_volume",
 }
@@ -2051,6 +2054,7 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "dz_bot_m": run.cm1_values.get("dz_bot_m"),
         "dz_top_m": run.cm1_values.get("dz_top_m"),
         "model_top_m": run.cm1_values.get("model_top_m"),
+        "time_step_seconds": run.cm1_values.get("time_step_seconds"),
         "output_cadence": run.run_configuration["output_cadence"],
         "expected_output_frames": run.cm1_values.get("expected_output_frames"),
         "expected_output_volume": run.resolved_run_configuration.get("output_volume_summary"),
@@ -4246,7 +4250,10 @@ def _forcing_label(run: Mapping[str, Any]) -> str:
 
 
 def _grid_label(run: Mapping[str, Any]) -> str:
-    return f"{run.get('domain_size')} {run.get('horizontal_cell_count')} dx {run.get('dx_m')} m"
+    return (
+        f"{run.get('domain_size')} {run.get('horizontal_cell_count')} "
+        f"dx {run.get('dx_m')} m; dtl {run.get('time_step_seconds')} s"
+    )
 
 
 def _key_result_label(run: Mapping[str, Any]) -> str:

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -187,6 +187,28 @@ def test_rendered_namelist_explicit_configuration_changes_domain_detail_and_cade
     assert "output_format    = 2," in namelist
 
 
+def test_rendered_namelist_preserves_explicit_timestep_target() -> None:
+    contract = build_cm1_input_contract(
+        baseline_scenario(),
+        run_configuration={
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "wide_12km",
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "full",
+            "time_step_seconds": 1.0,
+        },
+    )
+    namelist = render_namelist_fragment(contract)
+
+    assert contract.run_configuration.cm1_values.time_step_seconds == 1.0
+    assert "dtl_1p000e00s" in contract.run_configuration.configuration_id
+    assert "non_default_timestep_target_requires_like_for_like_campaign_evidence" in (
+        contract.run_configuration.caveats
+    )
+    assert "dtl    =   1.000," in namelist
+
+
 def test_rendered_input_sounding_is_external_baseline_profile() -> None:
     contract = build_cm1_input_contract(baseline_scenario())
     sounding = render_input_sounding_notes(contract)

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -667,6 +667,32 @@ def test_dry_run_package_explicit_high_detail_configuration_reports_cost(
     assert "tapfrq =  300.0," in namelist
 
 
+def test_dry_run_package_reports_explicit_timestep_target(tmp_path: Path) -> None:
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-dtl-001",
+        run_configuration={
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "wide_12km",
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "full",
+            "time_step_seconds": 1.0,
+        },
+    )
+    namelist = (result.package_dir / "namelist.input").read_text()
+    report = json.loads(result.report_path.read_text())
+    details = report["run_configuration_summary"]
+
+    assert report["run_configuration"]["cm1_values"]["time_step_seconds"] == 1.0
+    assert details["time_step_seconds"] == 1.0
+    assert details["time_step_multiplier_vs_default"] == 3.0
+    assert details["estimated_compute_multiplier_vs_default"] == 12.0
+    assert "dtl_1p000e00s" in report["run_configuration"]["configuration_id"]
+    assert "dtl    =   1.000," in namelist
+
+
 def test_baseline_humidity_ladder_packages_change_only_sounding_moisture(
     tmp_path: Path,
 ) -> None:

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -308,6 +308,22 @@ def test_campaign_plan_validates_matrix_and_resolves_cm1_values(tmp_path: Path) 
     assert run.stable_resume_identity
 
 
+def test_campaign_plan_preserves_explicit_timestep_target(tmp_path: Path) -> None:
+    matrix_path = write_matrix(tmp_path)
+    matrix = yaml.safe_load(matrix_path.read_text())
+    matrix["run_defaults"]["time_step_seconds"] = 1.0
+    matrix["comparison_types"][0]["required_equal_fields"].append("time_step_seconds")
+    matrix_path.write_text(yaml.safe_dump(matrix, sort_keys=False))
+
+    plan = build_campaign_plan(yaml.safe_load(matrix_path.read_text()), matrix_path=matrix_path)
+    run = plan.runs[0]
+
+    assert run.run_configuration["time_step_seconds"] == 1.0
+    assert run.cm1_values["time_step_seconds"] == 1.0
+    assert run.resolved_run_configuration["cm1_values"]["time_step_seconds"] == 1.0
+    assert "dtl_1p000e00s" in run.resolved_run_configuration["configuration_id"]
+
+
 def test_campaign_plans_checked_in_example_matrix() -> None:
     plan = plan_campaign(
         REPO_ROOT / "docs/research/templates/surface-forced-campaign-matrix.example.yaml"

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -313,9 +313,11 @@ The first reference-derived validation run, `dry-run-les-shallowcu-2026052214064
 Run configuration uses guarded fields for duration, horizontal cell budget,
 domain size, output cadence, numeric surface forcing, full requested fields,
 advanced CM1-facing values, and a pre-run validation report. Raw numerical
-timestep is not a normal v1 control. Defaults must expose their derived
-CM1-facing values in advanced metadata so dry-run reports and Build UI can show
-exactly what will be written without requiring raw namelist editing.
+timestep is not a normal v1 control, but campaign matrices may set an explicit
+advanced timestep target when numerical stability is the evidence under test.
+Defaults must expose their derived CM1-facing values in advanced metadata so
+dry-run reports and Build UI can show exactly what will be written without
+requiring raw namelist editing.
 
 Current product defaults are deliberately different by source path:
 generated lower-atmosphere references use a six-hour local-domain science run,
@@ -1136,9 +1138,9 @@ scenario + controls
 Run-configuration metadata should flow through this path: scenario templates
 define editable configuration defaults, generated run packages record the
 selected duration, horizontal cell budget, domain, output cadence, diagnostic
-set, forcing, requested fields, advanced CM1-facing values, and validation
-report, run manifests preserve them during execution, and result metadata keeps
-them available for later inspection.
+set, forcing, requested fields, advanced CM1-facing values such as timestep
+target, and validation report, run manifests preserve them during execution, and
+result metadata keeps them available for later inspection.
 
 If size/runtime estimates are not validated yet, manifests and reports should record that explicitly rather than presenting guessed precision.
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -558,10 +558,12 @@ sounding validates a science hypothesis. Science runs should use enough model
 time, domain, and output cadence for the atmospheric question being asked.
 
 Grid/detail and output cadence are the main user-facing cost levers. Raw
-numerical timestep is not a normal v1 user control. Cloud Chamber should warn or
-caveat unvalidated control combinations when they can be safely generated,
-block configurations that cannot be rendered or launched honestly, and avoid
-silently replacing bad observed-sounding input with reference defaults.
+numerical timestep is not a normal v1 user control, but campaign and numerical
+validation matrices may set an explicit advanced timestep target when that value
+is part of the evidence being tested. Cloud Chamber should warn or caveat
+unvalidated control combinations when they can be safely generated, block
+configurations that cannot be rendered or launched honestly, and avoid silently
+replacing bad observed-sounding input with reference defaults.
 
 Generated packages include a backend-owned pre-run validation report. The
 report records the selected candidate/hypothesis, selected run recipe and
@@ -604,6 +606,7 @@ run_configuration:
     radiation_mode
     place_time_context
   advanced_cm1_values:
+    timestep_target_seconds
     namelist_summary
     input_sounding_summary
     runtime_files_needed
@@ -693,6 +696,7 @@ run_configuration:
     radiation_mode
     place_time_context
   advanced_cm1_values:
+    timestep_target_seconds
     namelist_summary
     input_sounding_summary
     runtime_files_needed
@@ -1149,6 +1153,7 @@ configuration:
     output_field_density:
     forcing:
     advanced_cm1_values:
+      timestep_target_seconds:
     pre_run_validation_report:
   namelist_parameters:
   input_sounding:

--- a/docs/research/templates/surface-forced-campaign-matrix.example.yaml
+++ b/docs/research/templates/surface-forced-campaign-matrix.example.yaml
@@ -116,6 +116,9 @@ run_defaults:
   horizontal_cell_count: cells_128
   domain_size: wide_12km
   output_cadence: standard_15min
+  # Advanced CM1-facing timestep target. Keep matched campaign comparisons
+  # like-for-like when this differs from the default 3.0 s target.
+  time_step_seconds: 3.0
   surface_heat_flux_k_m_s: 8.0e-3
   surface_moisture_flux_g_g_m_s: 5.2e-5
   queue_target: local
@@ -176,6 +179,7 @@ comparison_types:
       - dz_top_m
       - model_top_m
       - output_cadence
+      - time_step_seconds
       - cloud_chamber_commit
       - cm1_version
       - required_output_fields
@@ -206,6 +210,7 @@ comparison_types:
       - dz_top_m
       - model_top_m
       - output_cadence
+      - time_step_seconds
       - cloud_chamber_commit
       - cm1_version
       - required_output_fields
@@ -237,6 +242,7 @@ comparison_types:
       - dz_top_m
       - model_top_m
       - output_cadence
+      - time_step_seconds
       - cloud_chamber_commit
       - cm1_version
       - required_output_fields
@@ -268,6 +274,7 @@ comparison_types:
       - dz_top_m
       - model_top_m
       - output_cadence
+      - time_step_seconds
       - cloud_chamber_commit
       - cm1_version
       - required_output_fields
@@ -302,6 +309,7 @@ comparison_types:
       - dz_top_m
       - model_top_m
       - output_cadence
+      - time_step_seconds
       - cloud_chamber_commit
       - cm1_version
       - required_output_fields
@@ -333,6 +341,7 @@ comparison_types:
       - cm1_cnst_lhflx
       - duration
       - output_cadence
+      - time_step_seconds
       - cloud_chamber_commit
       - cm1_version
       - required_output_fields
@@ -371,6 +380,7 @@ comparison_types:
       - dz_top_m
       - model_top_m
       - output_cadence
+      - time_step_seconds
       - cloud_chamber_commit
       - cm1_version
       - required_output_fields
@@ -530,6 +540,7 @@ required_summary_fields:
     - dz_top_m
     - model_top_m
     - output_cadence
+    - time_step_seconds
     - expected_output_volume
     - cloud_chamber_commit
     - cm1_version

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -203,10 +203,12 @@ emitted `hfx` against emitted `hfx` and emitted `qfx` against emitted `qfx`;
 the heat-only, moisture-only, and combined comparison types must all be present;
 and expected directional changes for intentionally varied fluxes must pass
 before the automatic phase gate can move past surface-flux response
-verification. Non-varied flux changes remain informational unless the protocol
-defines field-specific stability tolerances. Unchanged, reversed, incomplete,
-missing, untrusted, mismatched-unit, or structurally non-comparable cases remain
-blocked.
+verification. Matched campaign rows must also keep CM1-facing numerical settings
+such as `time_step_seconds` like-for-like unless timestep is the explicit
+comparison variable. Non-varied flux changes remain informational unless the
+protocol defines field-specific stability tolerances. Unchanged, reversed,
+incomplete, missing, untrusted, mismatched-unit, or structurally non-comparable
+cases remain blocked.
 Low-level response tests should compute backend-owned 0-1 km AGL
 thickness-weighted domain means for `qv` and theta/temperature. They must
 preserve source field names, units, vertical-coordinate method, early-response


### PR DESCRIPTION
## Summary
- allow `time_step_seconds` as an explicit advanced run-configuration value
- carry timestep through campaign matrix planning, summaries, comparison fields, and reports
- document that timestep remains an advanced/campaign value, not a normal v1 user control

## Why
The lower-timestep probe showed that numerical stability evidence depends on `dtl`. Exploratory scouts and future campaign reruns need that setting recorded in metadata and run identity instead of relying on hand-edited namelists.

## Verification
- `scripts/check.sh`

## Notes
- Refs #336
- no generated CM1 outputs, NetCDF files, runtime logs, or run directories are committed
