### PR TITLE
fix: join station metadata for local IGRA campaigns

### DIFF
--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.cm1_input_contract import RunRecipe
 from cloud_chamber.dry_run_package import DryRunPackageError, generate_dry_run_package
+from cloud_chamber.igra_catalog import parse_station_metadata
 from cloud_chamber.lan_worker import (
     LanWorkerApiError,
     collect_lan_worker_run,
@@ -33,8 +34,10 @@ from cloud_chamber.local_run_queue import LocalRunQueueError, LocalRunQueueManag
 from cloud_chamber.observed_sounding import (
     ObservedSoundingError,
     ObservedSoundingRecord,
+    StationMetadata,
     observed_sounding_from_payload,
     parse_igra_station_text,
+    summarize_igra_station_text,
 )
 from cloud_chamber.result_diagnostics import (
     FieldFrameQualitySummary,
@@ -1336,10 +1339,12 @@ def _resolve_observed_sounding(
     if source_type == "uploaded_or_local_igra":
         text_path = _local_igra_text_path(source, matrix_path)
         selected_time = _parse_utc_datetime(str(source.get("selected_valid_time_utc")))
+        text = text_path.read_text()
         return parse_igra_station_text(
-            text_path.read_text(),
+            text,
             uploaded_filename=text_path.name,
             selected_time_utc=selected_time,
+            station_metadata=_station_metadata_for_local_igra(settings, text),
         ).selected_sounding
     raise CampaignError(f"Unsupported selection source type: {source_type}")
 
@@ -1481,6 +1486,35 @@ def _local_igra_text_path(source: Mapping[str, Any], matrix_path: Path) -> Path:
     if configured is None:
         raise CampaignError("uploaded_or_local_igra source is missing a text path")
     return _resolve_matrix_path(configured, matrix_path.parent)
+
+
+def _station_metadata_for_local_igra(
+    settings: CloudChamberSettings,
+    station_text: str,
+) -> StationMetadata | None:
+    summaries = summarize_igra_station_text(station_text)
+    if not summaries:
+        return None
+    station_id = summaries[0].station_id
+    station_list_path = (
+        settings.cache_dir.expanduser() / "igra" / "reference" / "igra2-station-list.txt"
+    )
+    if not station_list_path.exists():
+        return None
+    station = parse_station_metadata(
+        station_list_path.read_text(),
+        source=str(station_list_path),
+    ).get(station_id)
+    if station is None:
+        return None
+    return StationMetadata(
+        station_id=station.station_id,
+        station_name=station.station_name,
+        latitude=station.latitude,
+        longitude=station.longitude,
+        elevation_m_msl=station.elevation_m_msl,
+        source=station.source,
+    )
 
 
 def _resolve_matrix_path(value: str, matrix_base: Path) -> Path:

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -388,6 +388,29 @@ def test_campaign_package_creates_observed_surface_forced_package_and_resumes(
     assert "Campaign default note." in (manifest.user.notes or "")
 
 
+def test_campaign_package_joins_local_igra_station_metadata_from_cache(
+    tmp_path: Path,
+) -> None:
+    settings = fake_settings(tmp_path)
+    station_list = settings.cache_dir / "igra" / "reference" / "igra2-station-list.txt"
+    station_list.parent.mkdir(parents=True)
+    station_list.write_text(
+        "USM00072357  35.1808  -97.4378  344.9 OK NORMAN/MAX WESTHEIMER A; OK.   1974 2026  28084\n"
+    )
+    matrix_path = write_matrix(tmp_path)
+    fixture_path = tmp_path / "fixtures" / "valley.txt"
+    fixture_path.write_text(IGRA_FIXTURE.replace("USM00072558", "USM00072357"))
+
+    packaged = package_campaign(matrix_path, settings=settings, resume=True)
+    manifest = load_run_manifest(Path(packaged.runs[0].manifest_path or ""))
+
+    assert manifest.observed_sounding is not None
+    assert manifest.observed_sounding["station_id"] == "USM00072357"
+    assert manifest.observed_sounding["station_elevation_m_msl"] == pytest.approx(344.9)
+    assert manifest.observed_sounding["model_bottom_elevation_m_msl"] == pytest.approx(344.9)
+    assert manifest.observed_sounding["provenance"]["station_metadata_source"] == str(station_list)
+
+
 def test_campaign_queue_uses_existing_local_queue_path(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- join local IGRA campaign sources to the cached IGRA station-list metadata before parsing selected soundings
- preserve station elevation/site metadata for direct local IGRA campaign packaging
- add a regression test for a local IGRA source whose station metadata is supplied by the cache station list

## Why
The exploratory Norman scout exposed that direct `uploaded_or_local_igra` campaign sources could block on `station_site_elevation_missing` even when the local IGRA station list had the elevation. The cached recommendation path already had this metadata; the local source path should too.

## Verification
- `scripts/check.sh`

## Notes
- Refs #336
- no generated CM1 outputs, NetCDF files, runtime logs, or run directories are committed
