### PR TITLE
Add v0 differential surface-forcing patch experiment

### DIFF
--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -522,7 +522,7 @@ def _manual_validation_status(run_recipe: RunRecipe) -> str:
     if run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
         return "observed_surface_forced_evolution_v0_metadata_only"
     if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
-        return "differential_surface_forced_evolution_v0_runtime_unvalidated"
+        return "differential_surface_forced_evolution_v0_forcing_footprint_validated"
     return "current_run_recipe_path"
 
 

--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -20,6 +20,12 @@ from cloud_chamber.run_configuration import (
     resolve_run_configuration,
 )
 from cloud_chamber.scenario_schema import ControlAudience, ScenarioTemplate
+from cloud_chamber.surface_forcing import (
+    CM1_SOURCE_CUSTOMIZATION_FILENAME,
+    DIFFERENTIAL_SURFACE_FORCING_MODE,
+    SURFACE_FORCING_PATCH_FILENAME,
+    SURFACE_FORCING_PATCH_JSON_FILENAME,
+)
 
 
 class GeneratedFileRole(StrEnum):
@@ -29,11 +35,14 @@ class GeneratedFileRole(StrEnum):
     INPUT_SOUNDING = "input_sounding"
     DRY_RUN_REPORT = "dry_run_report"
     RUNTIME_FILE_CHECKLIST = "runtime_file_checklist"
+    SURFACE_FORCING_PATCH = "surface_forcing_patch"
+    CM1_SOURCE_CUSTOMIZATION = "cm1_source_customization"
 
 
 class RunRecipe(StrEnum):
     GENERATED_REFERENCE_LOWER_ATMOSPHERE = "generated_reference_lower_atmosphere"
     OBSERVED_SURFACE_FORCED_EVOLUTION = "observed_surface_forced_evolution"
+    DIFFERENTIAL_SURFACE_FORCED_EVOLUTION = "differential_surface_forced_evolution"
 
 
 REMOVED_TRIGGERED_DEEP_POTENTIAL_RECIPE = "triggered_deep_potential"
@@ -110,7 +119,7 @@ class CM1InputContract:
     observed_sounding: ObservedSoundingRecord | None = None
 
 
-GENERATED_FILE_SPECS = (
+BASE_GENERATED_FILE_SPECS = (
     GeneratedFileSpec(
         role=GeneratedFileRole.RUN_MANIFEST,
         relative_path="run_manifest.json",
@@ -162,6 +171,28 @@ GENERATED_FILE_SPECS = (
 )
 
 
+DIFFERENTIAL_SURFACE_GENERATED_FILE_SPECS = (
+    GeneratedFileSpec(
+        role=GeneratedFileRole.SURFACE_FORCING_PATCH,
+        relative_path=SURFACE_FORCING_PATCH_JSON_FILENAME,
+        description=(
+            "Declarative lower-boundary heat/moisture forcing patch, plus the small CM1 "
+            f"runtime patch file {SURFACE_FORCING_PATCH_FILENAME}."
+        ),
+        scientific_status="CM1-facing differential surface-forcing input and provenance",
+    ),
+    GeneratedFileSpec(
+        role=GeneratedFileRole.CM1_SOURCE_CUSTOMIZATION,
+        relative_path=CM1_SOURCE_CUSTOMIZATION_FILENAME,
+        description=(
+            "Manifest describing the external CM1 source customization required to apply "
+            "the differential surface-forcing patch at launch."
+        ),
+        scientific_status="runtime source-customization provenance",
+    ),
+)
+
+
 def build_cm1_input_contract(
     scenario: ScenarioTemplate,
     selected_controls: dict[str, str | float | bool] | None = None,
@@ -174,6 +205,10 @@ def build_cm1_input_contract(
     resolved_run_configuration = resolve_run_configuration(
         run_configuration=run_configuration,
         run_recipe=resolved_run_recipe.value,
+    )
+    resolved_run_recipe = _run_recipe_for_configuration(
+        resolved_run_recipe,
+        resolved_run_configuration,
     )
     recipe_assumptions = _recipe_assumptions(
         resolved_run_recipe,
@@ -228,7 +263,7 @@ def build_cm1_input_contract(
         moisture_profile=moisture_profile,
         stability_profile=stability_profile,
         cloud_scale_defaults=defaults,
-        generated_files=GENERATED_FILE_SPECS,
+        generated_files=generated_file_specs_for_configuration(resolved_run_configuration),
         control_fragments=control_fragments,
         expected_diagnostics=_diagnostic_names(scenario),
         expected_outputs=_expected_outputs(
@@ -280,8 +315,8 @@ def _resolve_run_recipe(
     if run_recipe == REMOVED_TRIGGERED_DEEP_POTENTIAL_RECIPE:
         raise ValueError(
             "Triggered deep-potential package generation has been removed. "
-            "Use observed-sounding run configuration with numeric surface heat/moisture "
-            "forcing, or implement differential lower-boundary forcing from issue #307."
+            "Use observed-sounding run configuration with numeric uniform or differential "
+            "lower-boundary heat/moisture forcing."
         )
     if isinstance(run_recipe, RunRecipe):
         return run_recipe
@@ -295,8 +330,28 @@ def _resolve_run_recipe(
     return RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE
 
 
+def _run_recipe_for_configuration(
+    run_recipe: RunRecipe,
+    run_configuration: RunConfiguration,
+) -> RunRecipe:
+    if run_configuration.surface_flux_mode == DIFFERENTIAL_SURFACE_FORCING_MODE:
+        if run_recipe == RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
+            raise ValueError(
+                "Differential surface forcing requires an observed-sounding run recipe."
+            )
+        return RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION
+    if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
+        raise ValueError(
+            "Differential surface-forced evolution requires "
+            "surface_forcing_mode=differential_surface_forcing_patch_v0."
+        )
+    return run_recipe
+
+
 def _run_recipe_display_name(run_recipe: RunRecipe) -> str:
     match run_recipe:
+        case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
+            return "Differential Surface-Forced Evolution"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "Observed Surface-Forced Evolution"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -306,6 +361,8 @@ def _run_recipe_display_name(run_recipe: RunRecipe) -> str:
 def recipe_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
+        case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
+            return "differential_surface_forced_evolution_v0"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "observed_surface_forced_evolution_v0"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -317,6 +374,8 @@ def recipe_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
 def recipe_display_name_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
+        case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
+            return "Differential Surface-Forced Evolution v0"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "Observed Surface-Forced Evolution v0"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -328,6 +387,8 @@ def recipe_display_name_for_run_recipe(run_recipe: str | RunRecipe) -> str:
 def assumption_set_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
+        case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
+            return "differential_surface_forced_evolution_v0_assumptions"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "observed_surface_forced_evolution_v0_assumptions"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -339,6 +400,8 @@ def assumption_set_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
 def assumption_mode_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
+        case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
+            return "differential_surface_forced_evolution"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "observed_surface_forced_evolution"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -350,6 +413,21 @@ def assumption_mode_for_run_recipe(run_recipe: str | RunRecipe) -> str:
 def required_output_fields_for_run_recipe(run_recipe: str | RunRecipe) -> tuple[str, ...]:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
+        case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
+            return (
+                "qv",
+                "qc",
+                "w",
+                "qr",
+                "rain",
+                "dbz",
+                "hfx",
+                "qfx",
+                "u",
+                "v",
+                "th",
+                "updraft_helicity",
+            )
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return ("qv", "qc", "w", "qr", "rain", "dbz", "hfx", "qfx")
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -361,6 +439,23 @@ def required_output_fields_for_run_recipe(run_recipe: str | RunRecipe) -> tuple[
 def recipe_caveats_for_run_recipe(run_recipe: str | RunRecipe) -> tuple[str, ...]:
     resolved = _coerce_run_recipe(run_recipe)
     match resolved:
+        case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
+            return (
+                "No artificial atmospheric trigger is applied.",
+                (
+                    "A centered lower-boundary heat/moisture forcing patch is applied "
+                    "through Cloud Chamber's external CM1 source customization."
+                ),
+                (
+                    "The patch is an idealized surface contrast, not a real land-surface, "
+                    "soil-moisture, vegetation, radiation, terrain, GIS, front, or dryline model."
+                ),
+                (
+                    "Surface-driven convergence, localized updraft, coherent cloud growth, "
+                    "rain-water, surface-rain, and reflectivity remain diagnostics to inspect, "
+                    "not guaranteed outcomes."
+                ),
+            )
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return (
                 "No artificial atmospheric trigger is applied.",
@@ -414,7 +509,10 @@ def _run_caveats(
     run_configuration: RunConfiguration,
 ) -> tuple[str, ...]:
     caveats = list(run_configuration.caveats)
-    if run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
+    if run_recipe in {
+        RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION,
+        RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION,
+    }:
         caveats.extend(recipe_caveats_for_run_recipe(run_recipe))
         return tuple(caveats)
     return tuple(caveats)
@@ -423,6 +521,8 @@ def _run_caveats(
 def _manual_validation_status(run_recipe: RunRecipe) -> str:
     if run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
         return "observed_surface_forced_evolution_v0_metadata_only"
+    if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
+        return "differential_surface_forced_evolution_v0_runtime_unvalidated"
     return "current_run_recipe_path"
 
 
@@ -457,12 +557,21 @@ def _recipe_assumptions(
             "selection": run_configuration.diagnostic_set,
         },
     }
-    if run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
+    if run_recipe in {
+        RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION,
+        RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION,
+    }:
+        trigger_description = "No artificial atmospheric trigger."
+        if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
+            trigger_description = (
+                "No artificial atmospheric trigger; initiation is tested through the selected "
+                "lower-boundary differential surface-forcing patch."
+            )
         return {
             **configured_shape,
             "trigger": {
                 "mode": "none",
-                "description": "No artificial atmospheric trigger.",
+                "description": trigger_description,
             },
             "observed_sounding": {
                 "temperature_profile": "required",
@@ -489,6 +598,35 @@ def _surface_flux_assumption_payload(run_configuration: RunConfiguration) -> dic
             "mode": "disabled",
             "cm1_values": values.model_dump(mode="json"),
         }
+    if run_configuration.surface_flux_mode == DIFFERENTIAL_SURFACE_FORCING_MODE:
+        return {
+            "mode": run_configuration.surface_flux_mode,
+            "description": (
+                "Background uniform lower-boundary heat/moisture forcing plus one centered "
+                "raised-cosine perturbation patch."
+            ),
+            "translation_method": (
+                "Background numeric product values map to CM1 constant-flux namelist "
+                "values. The spatial perturbation is applied by Cloud Chamber's local CM1 "
+                "source customization in the prescribed-flux path."
+            ),
+            "product_selections": {
+                "surface_heat_flux_k_m_s": run_configuration.surface_heat_flux_k_m_s,
+                "surface_moisture_flux_g_g_m_s": (run_configuration.surface_moisture_flux_g_g_m_s),
+                "summary": run_configuration.surface_flux_summary,
+            },
+            "surface_forcing_patch": (
+                run_configuration.surface_forcing_patch.model_dump(mode="json")
+                if run_configuration.surface_forcing_patch is not None
+                else None
+            ),
+            "cm1_values": values.model_dump(mode="json"),
+            "cm1_runtime_files": {
+                "surface_forcing_patch": SURFACE_FORCING_PATCH_FILENAME,
+                "source_customization": CM1_SOURCE_CUSTOMIZATION_FILENAME,
+            },
+            "caveats": list(run_configuration.surface_flux_caveats),
+        }
     return {
         "mode": run_configuration.surface_flux_mode,
         "description": (
@@ -506,6 +644,14 @@ def _surface_flux_assumption_payload(run_configuration: RunConfiguration) -> dic
         "cm1_values": values.model_dump(mode="json"),
         "caveats": list(run_configuration.surface_flux_caveats),
     }
+
+
+def generated_file_specs_for_configuration(
+    run_configuration: RunConfiguration,
+) -> tuple[GeneratedFileSpec, ...]:
+    if run_configuration.surface_flux_mode == DIFFERENTIAL_SURFACE_FORCING_MODE:
+        return (*BASE_GENERATED_FILE_SPECS, *DIFFERENTIAL_SURFACE_GENERATED_FILE_SPECS)
+    return BASE_GENERATED_FILE_SPECS
 
 
 def _output_switches(
@@ -557,6 +703,10 @@ def _output_switches(
             }
         )
     return switches
+
+
+def _initsfc_value(contract: CM1InputContract) -> int:
+    return 1
 
 
 def has_complete_rendered_observed_wind_profile(
@@ -636,9 +786,8 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
     output = _output_switches(
         contract.run_configuration.diagnostic_set,
         deep_convection=False,
-        surface_flux_outputs=(
-            contract.run_configuration.surface_flux_mode == "constant_uniform_surface_flux_proxy"
-        ),
+        surface_flux_outputs=contract.run_configuration.surface_flux_mode
+        in {"constant_uniform_surface_flux_proxy", DIFFERENTIAL_SURFACE_FORCING_MODE},
     )
     surface = contract.run_configuration.surface_flux_cm1_values
     l_h = 0.0
@@ -772,7 +921,7 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
  isfcflx    =      {surface.isfcflx},
  sfcmodel   =      {surface.sfcmodel},
  oceanmodel =      {surface.oceanmodel},
- initsfc    =      1,
+ initsfc    =      {_initsfc_value(contract)},
  tsk0       = 299.28,
  tmn0       = 297.28,
  xland0     =    2.0,

--- a/app/backend/cloud_chamber/cm1_source_customization.py
+++ b/app/backend/cloud_chamber/cm1_source_customization.py
@@ -1,0 +1,411 @@
+"""Apply Cloud Chamber CM1 source customizations outside the repo.
+
+CM1 remains an external dependency. Differential surface forcing needs a small
+source customization because the stock ``set_flx=1`` path writes uniform
+``thflux``/``qvflux`` fields from namelist constants. This module copies the
+configured external CM1 tree into an isolated runtime build tree, patches that
+copy, rebuilds ``cm1.exe``, copies the exact customized executable into the run
+directory, and records the operation beside the generated package.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import shutil
+import subprocess
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cloud_chamber.run_manifest import RunManifest
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.surface_forcing import (
+    CM1_SOURCE_CUSTOMIZATION_FILENAME,
+    DIFFERENTIAL_SURFACE_FORCING_MODE,
+    SURFACE_FORCING_PATCH_FILENAME,
+)
+
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+SOURCE_CUSTOMIZATION_STATUS_FILENAME = "cm1_source_customization_applied.json"
+SFCPHYS_MARKER = "CLOUD_CHAMBER_SURFACE_FORCING_PATCH_V0_SFCPHYS"
+
+SFCPHYS_TARGET = Path("src/sfcphys.F")
+CUSTOM_EXECUTABLE_FILENAME = "cm1_cloud_chamber_custom.exe"
+
+
+class CM1SourceCustomizationError(RuntimeError):
+    """Raised when differential surface forcing cannot customize local CM1."""
+
+
+@dataclass(frozen=True)
+class CM1SourceCustomizationResult:
+    status_path: Path
+    build_root: Path
+    executable_path: Path
+    source_hash: str
+    executable_sha256: str
+    patched_files: tuple[str, ...]
+    build_command: tuple[str, ...]
+
+
+def manifest_requires_cm1_source_customization(manifest: RunManifest) -> bool:
+    return manifest.run_configuration.get("surface_flux_mode") == DIFFERENTIAL_SURFACE_FORCING_MODE
+
+
+def prepare_cm1_source_customization(
+    *,
+    settings: CloudChamberSettings,
+    manifest: RunManifest,
+    command_runner: CommandRunner = subprocess.run,
+) -> CM1SourceCustomizationResult | None:
+    """Patch and rebuild the external CM1 tree for differential surface forcing."""
+
+    if not manifest_requires_cm1_source_customization(manifest):
+        return None
+
+    if settings.cm1_root is None:
+        raise CM1SourceCustomizationError(
+            "Differential surface forcing requires a configured CM1 root with source files."
+        )
+    if settings.cm1_run_dir is None:
+        raise CM1SourceCustomizationError(
+            "Differential surface forcing requires a configured CM1 run directory."
+        )
+
+    run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
+    patch_path = _required_generated_path(
+        manifest.generated_inputs.surface_forcing_patch,
+        run_dir / SURFACE_FORCING_PATCH_FILENAME,
+        "surface forcing patch file",
+    )
+    customization_path = _required_generated_path(
+        manifest.generated_inputs.cm1_source_customization,
+        run_dir / CM1_SOURCE_CUSTOMIZATION_FILENAME,
+        "CM1 source customization manifest",
+    )
+    _validate_patch_provenance(
+        manifest=manifest,
+        patch_path=patch_path,
+        customization_path=customization_path,
+    )
+    src_dir = settings.cm1_root / "src"
+    if not src_dir.exists():
+        raise CM1SourceCustomizationError(f"CM1 source directory does not exist: {src_dir}")
+    makefile = src_dir / "Makefile"
+    if not makefile.exists():
+        raise CM1SourceCustomizationError(f"CM1 Makefile does not exist: {makefile}")
+
+    _fail_if_source_already_customized(settings.cm1_root)
+    source_hash = _source_tree_hash(src_dir)
+    build_root = (
+        settings.runtime_home / "cm1_source_builds" / f"{source_hash[:16]}-{manifest.run_id}"
+    )
+    patched_files: list[str] = []
+    with _cm1_build_lock(settings.runtime_home):
+        if build_root.exists():
+            shutil.rmtree(build_root)
+        shutil.copytree(settings.cm1_root, build_root, ignore=_copytree_ignore)
+        build_src_dir = build_root / "src"
+        target = build_root / SFCPHYS_TARGET
+        if not target.exists():
+            raise CM1SourceCustomizationError(f"CM1 source file does not exist: {target}")
+        target.write_text(_patch_sfcphys_text(target.read_text()))
+        patched_files.append(str(SFCPHYS_TARGET))
+        build_command = ("make",)
+        try:
+            command_runner(
+                list(build_command),
+                cwd=build_src_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise CM1SourceCustomizationError(
+                "Failed to rebuild CM1 after applying differential surface-forcing source "
+                f"customization in isolated build tree: {exc.stderr or exc.stdout or exc}"
+            ) from exc
+
+    built_executable = _built_executable_path(
+        original_cm1_root=settings.cm1_root,
+        original_cm1_run_dir=settings.cm1_run_dir,
+        build_root=build_root,
+    )
+    if not built_executable.exists():
+        raise CM1SourceCustomizationError(
+            "CM1 rebuild did not produce an executable in the isolated build tree: "
+            f"{built_executable}"
+        )
+    executable_path = run_dir / CUSTOM_EXECUTABLE_FILENAME
+    shutil.copy2(built_executable, executable_path)
+    executable_sha256 = _file_sha256(executable_path)
+
+    status_path = run_dir / SOURCE_CUSTOMIZATION_STATUS_FILENAME
+    status_payload = {
+        "schema_version": "cm1_source_customization_status_v0",
+        "surface_flux_mode": DIFFERENTIAL_SURFACE_FORCING_MODE,
+        "run_id": manifest.run_id,
+        "applied_at": datetime.now(UTC).isoformat(),
+        "cm1_root": str(settings.cm1_root),
+        "cm1_run_dir": str(settings.cm1_run_dir),
+        "source_hash": source_hash,
+        "build_root": str(build_root),
+        "patch_file": str(patch_path),
+        "customization_manifest": str(customization_path),
+        "patched_files": patched_files,
+        "source_restored_after_build": "not_modified_isolated_build_tree",
+        "build_command": ["make"],
+        "custom_executable": str(executable_path),
+        "custom_executable_sha256": executable_sha256,
+        "no_silent_uniform_fallback": True,
+    }
+    status_path.write_text(json.dumps(status_payload, indent=2, sort_keys=True) + "\n")
+    return CM1SourceCustomizationResult(
+        status_path=status_path,
+        build_root=build_root,
+        executable_path=executable_path,
+        source_hash=source_hash,
+        executable_sha256=executable_sha256,
+        patched_files=tuple(patched_files),
+        build_command=("make",),
+    )
+
+
+def _required_generated_path(value: str | None, fallback: Path, label: str) -> Path:
+    path = Path(value).expanduser() if value else fallback
+    if not path.exists():
+        raise CM1SourceCustomizationError(f"Missing generated {label}: {path}")
+    return path
+
+
+def _validate_patch_provenance(
+    *,
+    manifest: RunManifest,
+    patch_path: Path,
+    customization_path: Path,
+) -> None:
+    if not patch_path.exists():
+        raise CM1SourceCustomizationError(f"Missing generated {patch_path.name}: {patch_path}")
+    if not customization_path.exists():
+        raise CM1SourceCustomizationError(
+            f"Missing generated {customization_path.name}: {customization_path}"
+        )
+    try:
+        customization = json.loads(customization_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise CM1SourceCustomizationError(
+            f"Generated CM1 source-customization manifest is invalid JSON: {customization_path}"
+        ) from exc
+    patch = manifest.run_configuration.get("surface_forcing_patch")
+    if not isinstance(patch, dict):
+        raise CM1SourceCustomizationError(
+            "Differential run manifest is missing surface_forcing_patch provenance."
+        )
+    expected_pattern_hash = patch.get("pattern_sha256")
+    if not isinstance(expected_pattern_hash, str) or not expected_pattern_hash:
+        raise CM1SourceCustomizationError(
+            "Differential run manifest is missing surface_forcing_patch.pattern_sha256."
+        )
+    if customization.get("surface_patch_sha256") != expected_pattern_hash:
+        raise CM1SourceCustomizationError(
+            "CM1 source-customization manifest does not match the run manifest patch hash."
+        )
+    expected_data_hash = customization.get("runtime_patch_file_sha256")
+    if not isinstance(expected_data_hash, str) or not expected_data_hash:
+        raise CM1SourceCustomizationError(
+            "CM1 source-customization manifest is missing runtime_patch_file_sha256."
+        )
+    actual_data_hash = _file_sha256(patch_path)
+    if actual_data_hash != expected_data_hash:
+        raise CM1SourceCustomizationError(
+            "Generated surface-forcing patch data does not match the source-customization "
+            f"manifest hash: expected {expected_data_hash}, got {actual_data_hash}."
+        )
+
+
+def _fail_if_source_already_customized(cm1_root: Path) -> None:
+    dirty_files = []
+    for relative_path in (SFCPHYS_TARGET,):
+        path = cm1_root / relative_path
+        if path.exists() and SFCPHYS_MARKER in path.read_text(errors="replace"):
+            dirty_files.append(str(relative_path))
+    if dirty_files:
+        raise CM1SourceCustomizationError(
+            "Configured CM1 source tree already contains Cloud Chamber differential "
+            "surface-forcing customization markers. Refusing to build from a dirty "
+            "source tree: " + ", ".join(dirty_files)
+        )
+
+
+@contextmanager
+def _cm1_build_lock(runtime_home: Path) -> Iterator[None]:
+    lock_dir = runtime_home / "cm1_source_builds"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / ".cm1-build.lock"
+    with lock_path.open("w") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _copytree_ignore(_directory: str, names: list[str]) -> set[str]:
+    ignored = {".git", "__pycache__", ".DS_Store"}
+    ignored.update(
+        name for name in names if name.startswith("cm1out_") or name in {"logs", "LOG", "output"}
+    )
+    return ignored
+
+
+def _source_tree_hash(src_dir: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(candidate for candidate in src_dir.rglob("*") if candidate.is_file()):
+        relative = path.relative_to(src_dir).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _built_executable_path(
+    *,
+    original_cm1_root: Path,
+    original_cm1_run_dir: Path,
+    build_root: Path,
+) -> Path:
+    try:
+        relative_run_dir = original_cm1_run_dir.relative_to(original_cm1_root)
+    except ValueError as exc:
+        raise CM1SourceCustomizationError(
+            "Differential surface forcing currently requires cm1_run_dir to live under cm1_root "
+            "so the isolated build tree can identify the generated executable."
+        ) from exc
+    return build_root / relative_run_dir / "cm1.exe"
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _patch_sfcphys_text(source: str) -> str:
+    if SFCPHYS_MARKER in source:
+        return source
+    declarations_anchor = "      real :: thmag,qvmag,trat1,trat2\n"
+    declarations_replacement = """      real :: thmag,qvmag,trat1,trat2
+      logical, save :: cc_patch_loaded = .false.
+      logical, save :: cc_patch_enabled = .false.
+      real, save :: cc_patch_bg_h = 0.0
+      real, save :: cc_patch_bg_q = 0.0
+      real, save :: cc_patch_dh = 0.0
+      real, save :: cc_patch_dq = 0.0
+      real, save :: cc_patch_cx = 0.0
+      real, save :: cc_patch_cy = 0.0
+      real, save :: cc_patch_rx = 0.0
+      real, save :: cc_patch_ry = 0.0
+      real, save :: cc_patch_taper = 0.0
+      real, save :: cc_patch_ramp = 0.0
+      integer :: cc_unit,cc_ios
+      real :: cc_x,cc_y,cc_r,cc_weight,cc_taper_norm,cc_ramp
+      character(len=256) :: cc_header
+"""
+    if declarations_anchor not in source:
+        raise CM1SourceCustomizationError(
+            "Unable to locate sfcphys.F declaration anchor for differential forcing."
+        )
+    source = source.replace(declarations_anchor, declarations_replacement, 1)
+
+    flux_anchor = """    ENDIF
+
+  !c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c!
+
+  ELSE
+"""
+    flux_replacement = f"""    ENDIF
+
+    ! {SFCPHYS_MARKER}
+    if( .not. cc_patch_loaded )then
+      inquire(file='{SURFACE_FORCING_PATCH_FILENAME}',exist=cc_patch_enabled)
+      if( .not. cc_patch_enabled )then
+        write(0,*) 'Cloud Chamber differential surface-forcing patch file is missing.'
+        stop 811
+      endif
+      cc_unit = 981
+      open(unit=cc_unit,file='{SURFACE_FORCING_PATCH_FILENAME}',status='old',action='read',iostat=cc_ios)
+      if( cc_ios.ne.0 )then
+        write(0,*) 'Cloud Chamber could not open differential surface-forcing patch file.'
+        stop 812
+      endif
+      read(cc_unit,'(A)',iostat=cc_ios) cc_header
+      if( cc_ios.ne.0 )then
+        write(0,*) 'Cloud Chamber differential surface-forcing patch header is malformed.'
+        close(cc_unit)
+        stop 813
+      endif
+      read(cc_unit,'(A)',iostat=cc_ios) cc_header
+      if( cc_ios.ne.0 )then
+        write(0,*) 'Cloud Chamber differential surface-forcing patch column header is malformed.'
+        close(cc_unit)
+        stop 814
+      endif
+      read(cc_unit,*,iostat=cc_ios) cc_patch_bg_h,cc_patch_bg_q,cc_patch_dh,cc_patch_dq,  &
+                                  cc_patch_cx,cc_patch_cy,cc_patch_rx,cc_patch_ry,      &
+                                  cc_patch_taper,cc_patch_ramp
+      close(cc_unit)
+      if( cc_ios.ne.0 )then
+        write(0,*) 'Cloud Chamber differential surface-forcing patch values are malformed.'
+        stop 815
+      endif
+      cc_patch_loaded = .true.
+    endif
+
+    if( cc_patch_enabled )then
+      cc_taper_norm = max( cc_patch_taper/min(cc_patch_rx,cc_patch_ry) , 1.0e-6 )
+      cc_ramp = min( max( rtime/max(cc_patch_ramp,1.0e-6) , 0.0 ) , 1.0 )
+      !$omp parallel do default(shared)   &
+      !$omp private(i,j,cc_x,cc_y,cc_r,cc_weight)
+      DO j=1,nj
+      do i=1,ni
+        cc_x = minx + (float(i)-0.5)*dx - centerx - cc_patch_cx
+        cc_y = miny + (float(j)-0.5)*dy - centery - cc_patch_cy
+        cc_r = sqrt( (cc_x/cc_patch_rx)**2 + (cc_y/cc_patch_ry)**2 )
+        if( cc_r.le.1.0 )then
+          cc_weight = 1.0
+        elseif( cc_r.lt.(1.0+cc_taper_norm) )then
+          cc_weight = 0.5*( 1.0 + cos( pi*(cc_r-1.0)/cc_taper_norm ) )
+        else
+          cc_weight = 0.0
+        endif
+        thflux(i,j) = cc_patch_bg_h + cc_patch_dh*cc_weight*cc_ramp
+        if( imoist.eq.1 ) qvflux(i,j) = cc_patch_bg_q + cc_patch_dq*cc_weight*cc_ramp
+      enddo
+      ENDDO
+    endif
+
+  !c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c!
+
+  ELSE
+"""
+    if flux_anchor not in source:
+        raise CM1SourceCustomizationError(
+            "Unable to locate sfcphys.F set_flx branch for differential forcing."
+        )
+    return source.replace(flux_anchor, flux_replacement, 1)
+
+
+__all__ = [
+    "CM1SourceCustomizationError",
+    "CM1SourceCustomizationResult",
+    "CUSTOM_EXECUTABLE_FILENAME",
+    "SOURCE_CUSTOMIZATION_STATUS_FILENAME",
+    "manifest_requires_cm1_source_customization",
+    "prepare_cm1_source_customization",
+]

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -38,6 +38,14 @@ from cloud_chamber.run_manifest import (
     ValidationStatus,
 )
 from cloud_chamber.scenario_schema import ScenarioTemplate, validate_scenario_template
+from cloud_chamber.surface_forcing import (
+    CM1_SOURCE_CUSTOMIZATION_FILENAME,
+    SURFACE_FORCING_PATCH_FILENAME,
+    SURFACE_FORCING_PATCH_JSON_FILENAME,
+    cm1_source_customization_artifact,
+    surface_forcing_patch_artifact,
+    surface_forcing_patch_data_text,
+)
 
 
 class DryRunPackageError(RuntimeError):
@@ -134,6 +142,10 @@ def generate_dry_run_package(
         "report": package_dir / "dry_run_report.json",
         "runtime_checklist": package_dir / "runtime_file_checklist.json",
     }
+    if contract.run_configuration.surface_forcing_patch is not None:
+        paths["surface_forcing_patch_json"] = package_dir / SURFACE_FORCING_PATCH_JSON_FILENAME
+        paths["surface_forcing_patch_data"] = package_dir / SURFACE_FORCING_PATCH_FILENAME
+        paths["cm1_source_customization"] = package_dir / CM1_SOURCE_CUSTOMIZATION_FILENAME
 
     manifest = RunManifest(
         run_id=run_id,
@@ -152,6 +164,16 @@ def generate_dry_run_package(
             namelist_input=str(paths["namelist"]),
             input_sounding=str(paths["input_sounding"]),
             dry_run_report=str(paths["report"]),
+            surface_forcing_patch=(
+                str(paths["surface_forcing_patch_data"])
+                if "surface_forcing_patch_data" in paths
+                else None
+            ),
+            cm1_source_customization=(
+                str(paths["cm1_source_customization"])
+                if "cm1_source_customization" in paths
+                else None
+            ),
             runtime_file_checklist=[str(paths["runtime_checklist"])],
         ),
         runtime_paths=RuntimePaths(runtime_home=str(runtime_home.expanduser())),
@@ -217,11 +239,28 @@ def generate_dry_run_package(
             "reference case where available, never committed to the repo."
         ),
     }
+    if contract.run_configuration.surface_forcing_patch is not None:
+        runtime_checklist["source_customization"] = {
+            "status": "checked_and_applied_at_launch",
+            "cm1_source_customization": str(paths["cm1_source_customization"]),
+            "surface_forcing_patch": str(paths["surface_forcing_patch_data"]),
+            "notes": (
+                "Differential surface-forcing packages require Cloud Chamber to patch and "
+                "rebuild the external local CM1 source tree before launch. A launch must "
+                "fail rather than silently run uniform forcing if this customization cannot "
+                "be applied."
+            ),
+        }
 
     _write_json(paths["manifest"], json.loads(manifest.to_json_text()))
     _write_json(paths["case_manifest"], case_manifest)
     paths["namelist"].write_text(render_namelist_fragment(contract))
     paths["input_sounding"].write_text(render_input_sounding_notes(contract))
+    if contract.run_configuration.surface_forcing_patch is not None:
+        patch = contract.run_configuration.surface_forcing_patch
+        _write_json(paths["surface_forcing_patch_json"], surface_forcing_patch_artifact(patch))
+        paths["surface_forcing_patch_data"].write_text(surface_forcing_patch_data_text(patch))
+        _write_json(paths["cm1_source_customization"], cm1_source_customization_artifact(patch))
     _write_json(paths["report"], report)
     _write_json(paths["runtime_checklist"], runtime_checklist)
 
@@ -499,6 +538,11 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
         "surface_flux_cm1_values": contract.run_configuration.surface_flux_cm1_values.model_dump(
             mode="json"
         ),
+        "surface_forcing_patch": (
+            contract.run_configuration.surface_forcing_patch.model_dump(mode="json")
+            if contract.run_configuration.surface_forcing_patch is not None
+            else None
+        ),
         "surface_flux_caveats": list(contract.run_configuration.surface_flux_caveats),
         "runtime_seconds": defaults.runtime_seconds,
         "output_cadence_seconds": defaults.output_cadence_seconds,
@@ -539,6 +583,16 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
 
 
 def _run_recipe_mapping_summary(contract: CM1InputContract) -> str:
+    if contract.run_configuration.surface_forcing_patch is not None:
+        return (
+            "observed IGRA external input_sounding profile; the run uses CM1 isnd=7, "
+            "configured duration, configured domain and output cadence, numeric background "
+            "lower-boundary heat/moisture flux values, a generated differential "
+            "surface-forcing patch file, and an external CM1 source customization that "
+            "applies the patch in the prescribed-flux path; no artificial atmospheric "
+            "trigger is used; wind direction/speed is converted to u/v and applied through "
+            "CM1 input_sounding handling"
+        )
     if contract.observed_sounding is not None:
         return (
             "observed IGRA external input_sounding profile; the run uses CM1 isnd=7, "
@@ -558,6 +612,12 @@ def _run_recipe_mapping_summary(contract: CM1InputContract) -> str:
 
 
 def _cm1_mapping_status(contract: CM1InputContract) -> str:
+    if contract.run_configuration.surface_forcing_patch is not None:
+        return (
+            "CM1-ready observed-sounding run with an explicit differential lower-boundary "
+            "heat/moisture forcing patch. Launch requires Cloud Chamber to patch and rebuild "
+            "the external local CM1 source tree; no uniform fallback is allowed."
+        )
     if contract.observed_sounding is not None:
         return (
             "CM1-ready observed-sounding run with explicit uniform lower-boundary "

--- a/app/backend/cloud_chamber/lan_worker.py
+++ b/app/backend/cloud_chamber/lan_worker.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+from cloud_chamber.cm1_source_customization import manifest_requires_cm1_source_customization
 from cloud_chamber.run_manifest import RunManifestError, load_run_manifest
 from cloud_chamber.settings import CloudChamberSettings
 
@@ -142,9 +143,14 @@ def _run_lan_worker_script(
 def _package_dir_from_manifest(manifest_path: Path) -> Path:
     expanded = manifest_path.expanduser()
     try:
-        load_run_manifest(expanded)
+        manifest = load_run_manifest(expanded)
     except RunManifestError as exc:
         raise LanWorkerApiError(str(exc)) from exc
+    if manifest_requires_cm1_source_customization(manifest):
+        raise LanWorkerApiError(
+            "Differential surface forcing is local-only until LAN worker CM1 source "
+            "customization and custom-executable provenance are implemented."
+        )
     return expanded.parent
 
 

--- a/app/backend/cloud_chamber/local_run_manager.py
+++ b/app/backend/cloud_chamber/local_run_manager.py
@@ -170,6 +170,11 @@ class LocalRunManager:
             if source_customization is not None
             else self._settings.cm1_run_dir / "cm1.exe"
         )
+        source_customization_status = (
+            _read_source_customization_status(source_customization.status_path)
+            if source_customization is not None
+            else None
+        )
         command = [str(executable)]
         log_dir = run_dir / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -183,6 +188,7 @@ class LocalRunManager:
             command=command,
             stdout_log=stdout_log,
             stderr_log=stderr_log,
+            cm1_source_customization_status=source_customization_status,
         )
         write_run_manifest(manifest_path, queued)
 
@@ -297,6 +303,7 @@ class LocalRunManager:
         exit_code: int | None = None,
         validation_status: ValidationStatus | None = None,
         outputs: OutputMetadata | None = None,
+        cm1_source_customization_status: dict[str, object] | None = None,
     ) -> RunManifest:
         now = datetime.now(UTC)
         existing_execution = manifest.execution
@@ -344,6 +351,11 @@ class LocalRunManager:
                 "execution": ExecutionMetadata.model_validate(execution.model_dump()),
                 "outputs": outputs or manifest.outputs,
                 "provenance": ProvenanceMetadata(product_state=product_state),
+                "cm1_source_customization_status": (
+                    cm1_source_customization_status
+                    if cm1_source_customization_status is not None
+                    else manifest.cm1_source_customization_status
+                ),
                 "updated_at": now,
             }
         )
@@ -361,6 +373,20 @@ def _status_from_manifest(manifest: RunManifest, manifest_path: Path) -> RunStat
         stderr_log=stderr_log,
         exit_code=manifest.execution.exit_code,
     )
+
+
+def _read_source_customization_status(path: Path) -> dict[str, object]:
+    try:
+        loaded = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LocalRunManagerError(
+            f"Unable to read applied CM1 source customization status: {path}"
+        ) from exc
+    if not isinstance(loaded, dict):
+        raise LocalRunManagerError(
+            f"Applied CM1 source customization status is not an object: {path}"
+        )
+    return loaded
 
 
 def reconcile_completed_run_manifest(

--- a/app/backend/cloud_chamber/local_run_manager.py
+++ b/app/backend/cloud_chamber/local_run_manager.py
@@ -15,6 +15,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol, TextIO
 
+from cloud_chamber.cm1_source_customization import (
+    CM1SourceCustomizationError,
+    CommandRunner,
+    prepare_cm1_source_customization,
+)
 from cloud_chamber.pre_run_validation import report_blocks_execution
 from cloud_chamber.run_manifest import (
     ExecutionMetadata,
@@ -111,9 +116,11 @@ class LocalRunManager:
         *,
         settings: CloudChamberSettings,
         process_factory: ProcessFactory = default_process_factory,
+        source_build_runner: CommandRunner = subprocess.run,
     ) -> None:
         self._settings = settings
         self._process_factory = process_factory
+        self._source_build_runner = source_build_runner
         self._active: _ActiveRun | None = None
 
     def launch(self, manifest_path: Path) -> RunStatus:
@@ -141,6 +148,14 @@ class LocalRunManager:
         run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
         if not run_dir.exists():
             raise LocalRunManagerError(f"Run package directory does not exist: {run_dir}")
+        try:
+            source_customization = prepare_cm1_source_customization(
+                settings=self._settings,
+                manifest=manifest,
+                command_runner=self._source_build_runner,
+            )
+        except CM1SourceCustomizationError as exc:
+            raise LocalRunManagerError(str(exc)) from exc
         _preflight_cm1_inputs(manifest)
         if _existing_output_paths(run_dir):
             raise LocalRunManagerError(
@@ -150,7 +165,12 @@ class LocalRunManager:
             raise LocalRunManagerError("CM1 run directory is not configured.")
         _stage_required_runtime_files(manifest, self._settings.cm1_run_dir, run_dir)
 
-        command = [str(self._settings.cm1_run_dir / "cm1.exe")]
+        executable = (
+            source_customization.executable_path
+            if source_customization is not None
+            else self._settings.cm1_run_dir / "cm1.exe"
+        )
+        command = [str(executable)]
         log_dir = run_dir / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
         stdout_log = log_dir / "stdout.log"

--- a/app/backend/cloud_chamber/local_run_queue.py
+++ b/app/backend/cloud_chamber/local_run_queue.py
@@ -164,8 +164,20 @@ class LocalRunQueueManager:
             )
 
     def _refresh_active_entry(self, entry: RunQueueEntry) -> None:
+        manifest_path = Path(entry.manifest_path)
+        if not manifest_path.exists():
+            now = _now()
+            entry.state = "failed"
+            entry.error = f"Active queue entry is missing its run manifest: {manifest_path}"
+            entry.message = (
+                "Active local CM1 queue entry is missing its run manifest; marking failed "
+                "so the serial queue can continue."
+            )
+            entry.finished_at = now
+            entry.updated_at = now
+            return
         try:
-            status = self._run_manager.status(Path(entry.manifest_path))
+            status = self._run_manager.status(manifest_path)
         except LocalRunManagerError as exc:
             entry.error = str(exc)
             entry.message = "Unable to refresh the active local CM1 run."

--- a/app/backend/cloud_chamber/pre_run_validation.py
+++ b/app/backend/cloud_chamber/pre_run_validation.py
@@ -186,6 +186,7 @@ def _hypothesis_recipe_alignment(
             "caveats": [],
         }
     if story in DEEP_CONVECTION_STORIES:
+        differential = run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION
         return {
             "status": "partial",
             "reasons": [
@@ -196,7 +197,7 @@ def _hypothesis_recipe_alignment(
             "blocking_errors": [],
             "caveats": [
                 "deep_convection_outcome_depends_on_surface_forcing_duration_domain_and_resolution",
-                "differential_surface_initiation_is_tracked_in_issue_307",
+                *([] if differential else ["differential_surface_forcing_is_a_separate_recipe"]),
             ],
         }
     if story == "humid_rainy_candidate":
@@ -279,7 +280,10 @@ def _input_validation_payload(
             "model_bottom_elevation": "generated_reference",
             "caveats": [],
         }
-    wind_required = contract.run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION
+    wind_required = contract.run_recipe in {
+        RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION,
+        RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION,
+    }
     complete_wind_profile = has_complete_rendered_observed_wind_profile(
         observed_sounding,
         defaults=contract.cloud_scale_defaults,
@@ -393,6 +397,17 @@ def _forcing_validation_payload(contract: CM1InputContract) -> dict[str, Any]:
 
 
 def _forcing_validation_for_recipe(run_recipe: str) -> dict[str, Any]:
+    if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION.value:
+        return {
+            "trigger": "none",
+            "surface_fluxes": {
+                "mode": "differential_surface_forcing_patch_v0",
+                "status": "selected_values_unavailable_before_configuration_resolves",
+            },
+            "radiation": "disabled",
+            "large_scale_forcing": "none",
+            "source_customization": "checked_and_applied_at_launch",
+        }
     if run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION.value:
         return {
             "trigger": "none",
@@ -419,7 +434,10 @@ def _required_outputs_for_story(
         return ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "qfx", "updraft_helicity"]
     if story == "humid_rainy_candidate":
         return ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "qfx"]
-    if run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
+    if run_recipe in {
+        RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION,
+        RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION,
+    }:
         return ["qv", "qc", "w", "hfx", "qfx"]
     return ["qc", "w"]
 

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -131,6 +131,7 @@ class ResultMetadata(BaseModel):
     expected_outputs: list[str] = Field(default_factory=list)
     run_caveats: list[str] = Field(default_factory=list)
     manual_validation_status: str | None = None
+    cm1_source_customization_status: dict[str, Any] | None = None
     candidate_screening: dict[str, Any] | None = None
     pre_run_validation_report: dict[str, Any] | None = None
     candidate_hypothesis_comparison: CandidateHypothesisComparison | None = None
@@ -354,6 +355,7 @@ def _result_from_model_output_files(
         expected_outputs=manifest.expected_outputs,
         run_caveats=manifest.run_caveats,
         manual_validation_status=manifest.manual_validation_status,
+        cm1_source_customization_status=manifest.cm1_source_customization_status,
         candidate_screening=manifest.candidate_screening,
         pre_run_validation_report=manifest.pre_run_validation_report,
         raw_cm1_artifacts=manifest.outputs.raw_cm1_artifacts,
@@ -1594,6 +1596,7 @@ def _result_from_dataset(
         expected_outputs=manifest.expected_outputs,
         run_caveats=manifest.run_caveats,
         manual_validation_status=manifest.manual_validation_status,
+        cm1_source_customization_status=manifest.cm1_source_customization_status,
         candidate_screening=manifest.candidate_screening,
         pre_run_validation_report=manifest.pre_run_validation_report,
         raw_cm1_artifacts=manifest.outputs.raw_cm1_artifacts,

--- a/app/backend/cloud_chamber/run_configuration.py
+++ b/app/backend/cloud_chamber/run_configuration.py
@@ -12,6 +12,15 @@ from typing import Any, Literal, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from cloud_chamber.surface_forcing import (
+    DIFFERENTIAL_SURFACE_FORCING_MODE,
+    UNIFORM_SURFACE_FLUX_MODE,
+    SurfaceForcingPatch,
+    resolve_surface_forcing_patch,
+    surface_forcing_mode_from_payload,
+    surface_forcing_patch_summary,
+)
+
 RunMode = Literal["smoke", "science"]
 
 
@@ -81,6 +90,7 @@ class RunConfiguration(BaseModel):
     surface_flux_mode: str
     surface_flux_summary: str
     surface_flux_cm1_values: RunConfigurationSurfaceFluxCM1Values
+    surface_forcing_patch: SurfaceForcingPatch | None = None
     surface_flux_caveats: list[str] = Field(default_factory=list)
     caveats: list[str] = Field(default_factory=list)
 
@@ -211,6 +221,7 @@ def default_run_configuration_payload(run_recipe: str | None = None) -> dict[str
             "diagnostic_set": "full",
             "surface_heat_flux_k_m_s": DEFAULT_SURFACE_HEAT_FLUX_K_M_S,
             "surface_moisture_flux_g_g_m_s": DEFAULT_SURFACE_MOISTURE_FLUX_G_G_M_S,
+            "surface_forcing_mode": UNIFORM_SURFACE_FLUX_MODE,
         }
     return {
         "duration": "short_6h",
@@ -220,6 +231,7 @@ def default_run_configuration_payload(run_recipe: str | None = None) -> dict[str
         "diagnostic_set": "full",
         "surface_heat_flux_k_m_s": DEFAULT_SURFACE_HEAT_FLUX_K_M_S,
         "surface_moisture_flux_g_g_m_s": DEFAULT_SURFACE_MOISTURE_FLUX_G_G_M_S,
+        "surface_forcing_mode": UNIFORM_SURFACE_FLUX_MODE,
     }
 
 
@@ -271,8 +283,26 @@ def resolve_run_configuration(
         "time step seconds",
         default=DEFAULT_TIME_STEP_SECONDS,
     )
+    nx = horizontal_cells.cells
+    ny = horizontal_cells.cells
+    dx_m = domain.x_km * 1000.0 / nx
+    dy_m = domain.y_km * 1000.0 / ny
+    restart_seconds = max(cadence.seconds, min(duration.seconds, 10800))
+    frames = _expected_output_frames(duration.seconds, cadence.seconds)
+    grid_cells = nx * ny * domain.nz
     surface_flux_enabled = True
-    surface_flux_mode = "constant_uniform_surface_flux_proxy"
+    surface_flux_mode = surface_forcing_mode_from_payload(payload)
+    surface_forcing_patch = resolve_surface_forcing_patch(
+        payload=payload,
+        mode=surface_flux_mode,
+        background_heat_flux_k_m_s=heat_flux,
+        background_moisture_flux_g_g_m_s=moisture_flux,
+        domain_x_m=domain.x_km * 1000.0,
+        domain_y_m=domain.y_km * 1000.0,
+        dx_m=dx_m,
+        dy_m=dy_m,
+        duration_seconds=duration.seconds,
+    )
     surface_flux_cm1_values = _surface_flux_cm1_values(
         enabled=surface_flux_enabled,
         heat_flux_k_m_s=heat_flux,
@@ -282,15 +312,8 @@ def resolve_run_configuration(
         surface_flux_mode,
         heat_flux_k_m_s=heat_flux,
         moisture_flux_g_g_m_s=moisture_flux,
+        surface_forcing_patch=surface_forcing_patch,
     )
-
-    nx = horizontal_cells.cells
-    ny = horizontal_cells.cells
-    dx_m = domain.x_km * 1000.0 / nx
-    dy_m = domain.y_km * 1000.0 / ny
-    restart_seconds = max(cadence.seconds, min(duration.seconds, 10800))
-    frames = _expected_output_frames(duration.seconds, cadence.seconds)
-    grid_cells = nx * ny * domain.nz
     configuration_id = _configuration_id(
         duration=str(payload["duration"]),
         horizontal_cell_count=str(payload["horizontal_cell_count"]),
@@ -300,6 +323,9 @@ def resolve_run_configuration(
         surface_heat_flux_k_m_s=heat_flux,
         surface_moisture_flux_g_g_m_s=moisture_flux,
         surface_flux_mode=surface_flux_mode,
+        surface_forcing_patch_sha256=(
+            surface_forcing_patch.pattern_sha256 if surface_forcing_patch is not None else None
+        ),
         time_step_seconds=time_step_seconds,
     )
     caveats = _configuration_caveats(
@@ -360,8 +386,10 @@ def resolve_run_configuration(
             surface_flux_mode,
             heat_flux,
             moisture_flux,
+            surface_forcing_patch=surface_forcing_patch,
         ),
         surface_flux_cm1_values=surface_flux_cm1_values,
+        surface_forcing_patch=surface_forcing_patch,
         surface_flux_caveats=surface_flux_caveats,
         caveats=caveats,
     )
@@ -419,6 +447,7 @@ def _configuration_id(
     surface_heat_flux_k_m_s: float,
     surface_moisture_flux_g_g_m_s: float,
     surface_flux_mode: str,
+    surface_forcing_patch_sha256: str | None,
     time_step_seconds: float,
 ) -> str:
     timestep_suffix = ""
@@ -432,7 +461,8 @@ def _configuration_id(
     return (
         f"{duration}__{horizontal_cell_count}__{domain_size}__{output_cadence}"
         f"__{diagnostic_set}__shflx_{_flux_id(surface_heat_flux_k_m_s)}"
-        f"__qflx_{_flux_id(surface_moisture_flux_g_g_m_s)}{timestep_suffix}"
+        f"__qflx_{_flux_id(surface_moisture_flux_g_g_m_s)}"
+        f"{_surface_mode_id(surface_flux_mode, surface_forcing_patch_sha256)}{timestep_suffix}"
     )
 
 
@@ -514,9 +544,13 @@ def _surface_flux_summary(
     surface_flux_mode: str,
     heat_flux_k_m_s: float,
     moisture_flux_g_g_m_s: float,
+    *,
+    surface_forcing_patch: SurfaceForcingPatch | None = None,
 ) -> str:
     if surface_flux_mode == "disabled":
         return "Surface heat/moisture flux forcing disabled"
+    if surface_flux_mode == DIFFERENTIAL_SURFACE_FORCING_MODE and surface_forcing_patch:
+        return surface_forcing_patch_summary(surface_forcing_patch)
     return (
         f"Surface heat flux {_format_scientific(heat_flux_k_m_s)} K m/s; "
         f"surface moisture flux {_format_scientific(moisture_flux_g_g_m_s)} g/g m/s; "
@@ -529,14 +563,24 @@ def _surface_flux_caveats(
     *,
     heat_flux_k_m_s: float,
     moisture_flux_g_g_m_s: float,
+    surface_forcing_patch: SurfaceForcingPatch | None = None,
 ) -> list[str]:
     if surface_flux_mode == "disabled":
         return []
-    caveats = [
-        "surface_flux_proxy_constant_uniform_not_place_time_energy_budget",
-        "surface_flux_proxy_not_real_land_surface_or_evaporation_model",
-        "surface_flux_proxy_values_need_local_smoke_validation",
-    ]
+    if surface_flux_mode == DIFFERENTIAL_SURFACE_FORCING_MODE:
+        caveats = [
+            "differential_surface_forcing_patch_not_real_land_surface_or_radiation",
+            "differential_surface_forcing_patch_requires_cm1_source_customization",
+            "differential_surface_forcing_patch_requires_emitted_flux_and_convergence_validation",
+        ]
+        if surface_forcing_patch is not None:
+            caveats.extend(surface_forcing_patch.caveats)
+    else:
+        caveats = [
+            "surface_flux_proxy_constant_uniform_not_place_time_energy_budget",
+            "surface_flux_proxy_not_real_land_surface_or_evaporation_model",
+            "surface_flux_proxy_values_need_local_smoke_validation",
+        ]
     if not _in_range(heat_flux_k_m_s, SURFACE_HEAT_FLUX_CONTEXT_RANGE_K_M_S):
         caveats.append("surface_heat_flux_outside_daytime_context_range")
     if not _in_range(moisture_flux_g_g_m_s, SURFACE_MOISTURE_FLUX_CONTEXT_RANGE_G_G_M_S):
@@ -555,6 +599,14 @@ def _format_scientific(value: float) -> str:
 
 def _flux_id(value: float) -> str:
     return f"{value:.3e}".replace("+", "").replace("-", "m").replace(".", "p")
+
+
+def _surface_mode_id(surface_flux_mode: str, patch_sha256: str | None) -> str:
+    if surface_flux_mode == DIFFERENTIAL_SURFACE_FORCING_MODE and patch_sha256:
+        return f"__diff_patch_{patch_sha256[:10]}"
+    if surface_flux_mode != UNIFORM_SURFACE_FLUX_MODE:
+        return f"__{surface_flux_mode}"
+    return ""
 
 
 def _rayleigh_damping_start_m() -> int:

--- a/app/backend/cloud_chamber/run_manifest.py
+++ b/app/backend/cloud_chamber/run_manifest.py
@@ -168,6 +168,7 @@ class RunManifest(BaseModel):
     run_limitations: list[str] = Field(default_factory=list)
     run_caveats: list[str] = Field(default_factory=list)
     manual_validation_status: str | None = None
+    cm1_source_customization_status: dict[str, Any] | None = None
 
     @model_validator(mode="after")
     def validate_state_contract(self) -> RunManifest:

--- a/app/backend/cloud_chamber/run_manifest.py
+++ b/app/backend/cloud_chamber/run_manifest.py
@@ -63,6 +63,8 @@ class GeneratedInputs(BaseModel):
     namelist_input: str | None = None
     input_sounding: str | None = None
     dry_run_report: str | None = None
+    surface_forcing_patch: str | None = None
+    cm1_source_customization: str | None = None
     runtime_file_checklist: list[str] = Field(default_factory=list)
 
 

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -1665,7 +1665,7 @@ def _candidate_recipe_fit(
     if story in DEEP_CONVECTION_STORY_IDS:
         caveats = [
             "deep_convection_outcome_depends_on_surface_forcing_duration_domain_and_resolution",
-            "differential_surface_initiation_is_tracked_in_issue_307",
+            "differential_surface_forcing_patch_recipe_available_for_initiation_tests",
         ]
         if features.get("observed_wind_available") is not True:
             caveats.append("complete_observed_wind_profile_required_for_input_sounding")
@@ -1674,8 +1674,8 @@ def _candidate_recipe_fit(
             "label": "testable as forced observed evolution",
             "summary": (
                 "This story screens deep-convection ingredients. CM1 can evolve the observed "
-                "atmosphere under selected uniform lower-boundary forcing; differential "
-                "initiation is a follow-up."
+                "atmosphere under selected lower-boundary forcing; a differential surface "
+                "patch can be selected when localized initiation is the question."
             ),
             "caveats": caveats,
         }

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -3063,7 +3063,7 @@ def _summary_caveats(
     result: ResultMetadata | None,
 ) -> list[str]:
     if run.resolved_run_configuration.get("surface_flux_mode") == DIFFERENTIAL_SURFACE_FORCING_MODE:
-        caveats = ["differential_surface_forcing_runtime_unvalidated"]
+        caveats = ["differential_surface_forcing_footprint_validated_response_not_validated"]
     else:
         caveats = ["surface_forcing_is_constant_uniform_proxy"]
     if run.optional:

--- a/app/backend/cloud_chamber/surface_forced_campaign.py
+++ b/app/backend/cloud_chamber/surface_forced_campaign.py
@@ -64,6 +64,7 @@ from cloud_chamber.sounding_candidates import (
     list_screening_inputs,
     screen_cached_soundings,
 )
+from cloud_chamber.surface_forcing import DIFFERENTIAL_SURFACE_FORCING_MODE
 
 MATRIX_SCHEMA_VERSION = "surface_forced_campaign_matrix_v1"
 CAMPAIGN_STATE_SCHEMA_VERSION = "surface_forced_campaign_state_v1"
@@ -82,10 +83,33 @@ RUN_CONFIGURATION_KEYS = {
     "domain_size",
     "output_cadence",
     "diagnostic_set",
+    "surface_forcing_mode",
+    "surface_flux_mode",
     "surface_heat_flux_k_m_s",
     "surface_moisture_flux_g_g_m_s",
+    "surface_patch_shape",
+    "surface_patch_radius_m",
+    "surface_patch_radius_x_m",
+    "surface_patch_radius_y_m",
+    "surface_patch_heat_flux_perturbation_k_m_s",
+    "surface_patch_moisture_flux_perturbation_g_g_m_s",
+    "surface_patch_taper_width_m",
+    "surface_patch_ramp_seconds",
     "time_step_seconds",
 }
+DIFFERENTIAL_SURFACE_CONFIGURATION_KEYS = {
+    "surface_forcing_mode",
+    "surface_flux_mode",
+    "surface_patch_shape",
+    "surface_patch_radius_m",
+    "surface_patch_radius_x_m",
+    "surface_patch_radius_y_m",
+    "surface_patch_heat_flux_perturbation_k_m_s",
+    "surface_patch_moisture_flux_perturbation_g_g_m_s",
+    "surface_patch_taper_width_m",
+    "surface_patch_ramp_seconds",
+}
+DIFFERENTIAL_SURFACE_KEY_PREFIXES = ("surface_patch_",)
 KNOWN_STATUS_VALUES = {
     "planned",
     "packaged",
@@ -138,6 +162,15 @@ SUPPORTED_REQUIRED_SUMMARY_FIELDS = {
     "surface_heat_flux_units",
     "surface_moisture_flux_g_g_m_s",
     "surface_moisture_flux_units",
+    "surface_flux_mode",
+    "surface_forcing_patch_sha256",
+    "surface_patch_shape",
+    "surface_patch_radius_x_m",
+    "surface_patch_radius_y_m",
+    "surface_patch_heat_flux_perturbation_k_m_s",
+    "surface_patch_moisture_flux_perturbation_g_g_m_s",
+    "surface_patch_taper_width_m",
+    "surface_patch_ramp_seconds",
     "cm1_cnst_shflx",
     "cm1_cnst_shflx_units",
     "cm1_cnst_lhflx",
@@ -267,6 +300,9 @@ MATRIX_CONTEXT_FIELDS = {
     "cm1_cnst_lhflx",
     "runtime_seconds",
     "time_step_seconds",
+    "surface_flux_mode",
+    "surface_forcing_patch_sha256",
+    "surface_patch_shape",
     "expected_output_frames",
     "expected_output_volume",
 }
@@ -439,6 +475,9 @@ def build_campaign_plan(
         matrix.get("required_summary_fields"), errors
     )
     _validate_execution(execution, errors)
+    _validate_run_configuration_key_scope(run_defaults, "run_defaults", errors)
+    for forcing_set_id, forcing in forcing_sets.items():
+        _validate_run_configuration_key_scope(forcing, f"forcing_sets[{forcing_set_id}]", errors)
 
     planned: list[CampaignRunPlan] = []
     matrix_ids: set[str] = set()
@@ -451,6 +490,7 @@ def build_campaign_plan(
 
     for index, run in enumerate(runs):
         context = f"runs[{index}]"
+        _validate_run_configuration_key_scope(run, context, errors)
         matrix_id = _required_string(run, "matrix_id", context, errors)
         if matrix_id in matrix_ids:
             errors.append(f"Duplicate run matrix_id: {matrix_id}")
@@ -497,6 +537,14 @@ def build_campaign_plan(
         except ValueError as exc:
             errors.append(f"{context}.run_configuration invalid: {exc}")
             continue
+        if (
+            resolved_configuration.surface_flux_mode == DIFFERENTIAL_SURFACE_FORCING_MODE
+            and queue_target == "lan"
+        ):
+            errors.append(
+                f"{context}.queue_target=lan is not supported for differential surface forcing; "
+                "remote CM1 source customization is not implemented."
+            )
 
         source_type = str(source.get("type", "unknown"))
         source_reference = _selection_source_reference(source)
@@ -1143,6 +1191,24 @@ def _resolved_run_configuration_payload(
                 payload[key] = source[key]
     payload["diagnostic_set"] = "full"
     return payload
+
+
+def _validate_run_configuration_key_scope(
+    source: Mapping[str, Any],
+    context: str,
+    errors: list[str],
+) -> None:
+    for key in source:
+        if key in RUN_CONFIGURATION_KEYS:
+            continue
+        if key in DIFFERENTIAL_SURFACE_CONFIGURATION_KEYS or any(
+            key.startswith(prefix) for prefix in DIFFERENTIAL_SURFACE_KEY_PREFIXES
+        ):
+            errors.append(
+                f"{context}.{key} is not a supported run-configuration field; "
+                "unknown differential surface-forcing fields are rejected to prevent "
+                "silent uniform fallback."
+            )
 
 
 def _stable_resume_identity(
@@ -2032,6 +2098,10 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
     )
     terminal_contamination = _terminal_output_contamination_summary(field_quality, warnings)
     runtime_integrity = result.runtime_integrity if result is not None else None
+    surface_forcing_patch = run.resolved_run_configuration.get("surface_forcing_patch")
+    surface_forcing_patch_map = (
+        surface_forcing_patch if isinstance(surface_forcing_patch, dict) else None
+    )
     summary = {
         "schema_version": CAMPAIGN_SUMMARY_SCHEMA_VERSION,
         "campaign_id": run.campaign_id,
@@ -2068,6 +2138,47 @@ def _summary_for_plan_run(run: CampaignRunPlan, state: CampaignState) -> dict[st
         "surface_heat_flux_units": "K m/s",
         "surface_moisture_flux_g_g_m_s": run.run_configuration["surface_moisture_flux_g_g_m_s"],
         "surface_moisture_flux_units": "g/g m/s",
+        "surface_flux_mode": run.resolved_run_configuration.get("surface_flux_mode"),
+        "surface_forcing_patch_sha256": (
+            surface_forcing_patch_map.get("pattern_sha256")
+            if surface_forcing_patch_map is not None
+            else None
+        ),
+        "surface_patch_shape": (
+            surface_forcing_patch_map.get("shape")
+            if surface_forcing_patch_map is not None
+            else None
+        ),
+        "surface_patch_radius_x_m": (
+            surface_forcing_patch_map.get("radius_x_m")
+            if surface_forcing_patch_map is not None
+            else None
+        ),
+        "surface_patch_radius_y_m": (
+            surface_forcing_patch_map.get("radius_y_m")
+            if surface_forcing_patch_map is not None
+            else None
+        ),
+        "surface_patch_heat_flux_perturbation_k_m_s": (
+            surface_forcing_patch_map.get("heat_flux_perturbation_k_m_s")
+            if surface_forcing_patch_map is not None
+            else None
+        ),
+        "surface_patch_moisture_flux_perturbation_g_g_m_s": (
+            surface_forcing_patch_map.get("moisture_flux_perturbation_g_g_m_s")
+            if surface_forcing_patch_map is not None
+            else None
+        ),
+        "surface_patch_taper_width_m": (
+            surface_forcing_patch_map.get("taper_width_m")
+            if surface_forcing_patch_map is not None
+            else None
+        ),
+        "surface_patch_ramp_seconds": (
+            surface_forcing_patch_map.get("ramp_seconds")
+            if surface_forcing_patch_map is not None
+            else None
+        ),
         "cm1_cnst_shflx": run.surface_flux_cm1_values.get("cnst_shflx"),
         "cm1_cnst_shflx_units": run.surface_flux_cm1_values.get("cnst_shflx_units"),
         "cm1_cnst_lhflx": run.surface_flux_cm1_values.get("cnst_lhflx"),
@@ -2951,9 +3062,10 @@ def _summary_caveats(
     state_run: CampaignStateRun | None,
     result: ResultMetadata | None,
 ) -> list[str]:
-    caveats = [
-        "surface_forcing_is_constant_uniform_proxy",
-    ]
+    if run.resolved_run_configuration.get("surface_flux_mode") == DIFFERENTIAL_SURFACE_FORCING_MODE:
+        caveats = ["differential_surface_forcing_runtime_unvalidated"]
+    else:
+        caveats = ["surface_forcing_is_constant_uniform_proxy"]
     if run.optional:
         caveats.append("optional_campaign_run")
     if state_run is not None and state_run.error:
@@ -4277,9 +4389,18 @@ def _station_time_label(run: Mapping[str, Any]) -> str:
 
 
 def _forcing_label(run: Mapping[str, Any]) -> str:
-    return (
+    base = (
         f"H {run.get('surface_heat_flux_k_m_s')} K m/s; "
         f"M {run.get('surface_moisture_flux_g_g_m_s')} g/g m/s"
+    )
+    if run.get("surface_flux_mode") != DIFFERENTIAL_SURFACE_FORCING_MODE:
+        return base
+    return (
+        f"{base}; differential patch "
+        f"{run.get('surface_patch_radius_x_m')}x{run.get('surface_patch_radius_y_m')} m; "
+        f"+H {run.get('surface_patch_heat_flux_perturbation_k_m_s')}; "
+        f"+M {run.get('surface_patch_moisture_flux_perturbation_g_g_m_s')}; "
+        f"hash {str(run.get('surface_forcing_patch_sha256') or 'unavailable')[:10]}"
     )
 
 

--- a/app/backend/cloud_chamber/surface_forcing.py
+++ b/app/backend/cloud_chamber/surface_forcing.py
@@ -1,0 +1,373 @@
+"""Surface-forcing configuration and provenance helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+UNIFORM_SURFACE_FLUX_MODE = "constant_uniform_surface_flux_proxy"
+DIFFERENTIAL_SURFACE_FORCING_MODE = "differential_surface_forcing_patch_v0"
+SURFACE_FORCING_PATCH_FILENAME = "cloud_chamber_surface_forcing_patch.dat"
+SURFACE_FORCING_PATCH_JSON_FILENAME = "surface_forcing_patch.json"
+CM1_SOURCE_CUSTOMIZATION_FILENAME = "cm1_source_customization.json"
+DIFFERENTIAL_SURFACE_FORCING_APPLICATION_NOTE = (
+    "Differential surface forcing uses CM1 source customization at launch. "
+    "Cloud Chamber copies the configured external CM1 tree into an isolated runtime "
+    "build tree, patches that copy, rebuilds cm1.exe, writes the patch file into "
+    "the run directory, and launches the copied custom executable; it must not "
+    "silently fall back to uniform forcing."
+)
+
+DEFAULT_PATCH_HEAT_FLUX_PERTURBATION_K_M_S = 4.0e-2
+DEFAULT_PATCH_MOISTURE_FLUX_PERTURBATION_G_G_M_S = 5.0e-5
+DEFAULT_PATCH_RADIUS_M = 1500.0
+DEFAULT_PATCH_TAPER_WIDTH_M = 500.0
+DEFAULT_PATCH_RAMP_SECONDS = 1800.0
+MIN_PATCH_RADIUS_GRID_CELLS = 3.0
+
+
+class SurfaceForcingPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = "surface_forcing_patch_v0"
+    shape: Literal["circle"]
+    center_x_m: float
+    center_y_m: float
+    radius_x_m: float
+    radius_y_m: float
+    taper_function: Literal["raised_cosine"]
+    taper_width_m: float
+    ramp_seconds: float
+    background_heat_flux_k_m_s: float
+    background_moisture_flux_g_g_m_s: float
+    heat_flux_perturbation_k_m_s: float
+    moisture_flux_perturbation_g_g_m_s: float
+    domain_x_m: float
+    domain_y_m: float
+    dx_m: float
+    dy_m: float
+    support_status: Literal["requires_cm1_source_customization"] = (
+        "requires_cm1_source_customization"
+    )
+    cm1_application_status: Literal["source_customization_required_at_launch"] = (
+        "source_customization_required_at_launch"
+    )
+    pattern_sha256: str
+    caveats: list[str] = Field(default_factory=list)
+
+
+def surface_forcing_mode_from_payload(payload: dict[str, Any]) -> str:
+    raw = payload.get("surface_forcing_mode", payload.get("surface_flux_mode"))
+    if raw is None:
+        return UNIFORM_SURFACE_FLUX_MODE
+    if raw == "uniform":
+        return UNIFORM_SURFACE_FLUX_MODE
+    if raw in {UNIFORM_SURFACE_FLUX_MODE, DIFFERENTIAL_SURFACE_FORCING_MODE}:
+        return str(raw)
+    raise ValueError(f"Unknown surface forcing mode: {raw}")
+
+
+def resolve_surface_forcing_patch(
+    *,
+    payload: dict[str, Any],
+    mode: str,
+    background_heat_flux_k_m_s: float,
+    background_moisture_flux_g_g_m_s: float,
+    domain_x_m: float,
+    domain_y_m: float,
+    dx_m: float,
+    dy_m: float,
+    duration_seconds: int,
+) -> SurfaceForcingPatch | None:
+    if mode != DIFFERENTIAL_SURFACE_FORCING_MODE:
+        return None
+
+    shape = _shape_payload(payload)
+    radius_x = _radius_payload(payload, "x", shape)
+    radius_y = _radius_payload(payload, "y", shape)
+    if shape == "circle":
+        _validate_circle_radius_payload(payload, radius_x)
+    center_x = _float_payload(payload, "surface_patch_center_x_m", "patch center x", default=0.0)
+    center_y = _float_payload(payload, "surface_patch_center_y_m", "patch center y", default=0.0)
+    taper_width = _float_payload(
+        payload,
+        "surface_patch_taper_width_m",
+        "patch taper width",
+        default=DEFAULT_PATCH_TAPER_WIDTH_M,
+    )
+    ramp_seconds = _float_payload(
+        payload,
+        "surface_patch_ramp_seconds",
+        "patch ramp seconds",
+        default=DEFAULT_PATCH_RAMP_SECONDS,
+    )
+    heat_perturbation = _float_payload(
+        payload,
+        "surface_patch_heat_flux_perturbation_k_m_s",
+        "patch heat-flux perturbation",
+        default=DEFAULT_PATCH_HEAT_FLUX_PERTURBATION_K_M_S,
+    )
+    moisture_perturbation = _float_payload(
+        payload,
+        "surface_patch_moisture_flux_perturbation_g_g_m_s",
+        "patch moisture-flux perturbation",
+        default=DEFAULT_PATCH_MOISTURE_FLUX_PERTURBATION_G_G_M_S,
+    )
+
+    _validate_patch_geometry(
+        center_x_m=center_x,
+        center_y_m=center_y,
+        radius_x_m=radius_x,
+        radius_y_m=radius_y,
+        taper_width_m=taper_width,
+        domain_x_m=domain_x_m,
+        domain_y_m=domain_y_m,
+        dx_m=dx_m,
+        dy_m=dy_m,
+    )
+    _validate_patch_forcing(
+        heat_perturbation_k_m_s=heat_perturbation,
+        moisture_perturbation_g_g_m_s=moisture_perturbation,
+        ramp_seconds=ramp_seconds,
+        duration_seconds=duration_seconds,
+    )
+
+    caveats = [
+        "differential_surface_forcing_patch_not_real_land_surface_or_radiation",
+        "differential_surface_forcing_patch_requires_cm1_source_customization",
+        "differential_surface_forcing_patch_applies_in_sfcphys_flux_path",
+        "differential_surface_forcing_v0_supports_circle_patch_only",
+        "differential_surface_forcing_patch_requires_emitted_flux_and_convergence_validation",
+    ]
+    base_payload: dict[str, object] = {
+        "schema_version": "surface_forcing_patch_v0",
+        "shape": shape,
+        "center_x_m": center_x,
+        "center_y_m": center_y,
+        "radius_x_m": radius_x,
+        "radius_y_m": radius_y,
+        "taper_function": "raised_cosine",
+        "taper_width_m": taper_width,
+        "ramp_seconds": ramp_seconds,
+        "background_heat_flux_k_m_s": background_heat_flux_k_m_s,
+        "background_moisture_flux_g_g_m_s": background_moisture_flux_g_g_m_s,
+        "heat_flux_perturbation_k_m_s": heat_perturbation,
+        "moisture_flux_perturbation_g_g_m_s": moisture_perturbation,
+        "domain_x_m": domain_x_m,
+        "domain_y_m": domain_y_m,
+        "dx_m": dx_m,
+        "dy_m": dy_m,
+        "support_status": "requires_cm1_source_customization",
+        "cm1_application_status": "source_customization_required_at_launch",
+        "caveats": caveats,
+    }
+    return SurfaceForcingPatch.model_validate(
+        {
+            **base_payload,
+            "pattern_sha256": _sha256_payload(base_payload),
+        }
+    )
+
+
+def surface_forcing_patch_artifact(patch: SurfaceForcingPatch) -> dict[str, object]:
+    payload = patch.model_dump(mode="json")
+    return {
+        "schema_version": patch.schema_version,
+        "surface_flux_mode": DIFFERENTIAL_SURFACE_FORCING_MODE,
+        "cm1_application_status": patch.cm1_application_status,
+        "cm1_application_note": DIFFERENTIAL_SURFACE_FORCING_APPLICATION_NOTE,
+        "cm1_patch_data_filename": SURFACE_FORCING_PATCH_FILENAME,
+        "cm1_source_customization_filename": CM1_SOURCE_CUSTOMIZATION_FILENAME,
+        "pattern_sha256": patch.pattern_sha256,
+        "pattern": payload,
+        "application_notes": [
+            "This is a Cloud Chamber declarative lower-boundary forcing pattern.",
+            (
+                "CM1 namelist.input preserves the background constant-flux values. "
+                "The spatial perturbation is applied by Cloud Chamber's local CM1 "
+                "source customization before launch."
+            ),
+            (
+                "The generated namelist keeps CM1's normal surface-initialization path. "
+                "The prescribed heat/moisture flux patch is applied in sfcphys.F where "
+                "CM1 writes thflux/qvflux for set_flx=1."
+            ),
+        ],
+    }
+
+
+def surface_forcing_patch_data_text(patch: SurfaceForcingPatch) -> str:
+    """Render the small runtime file read by the CM1 source customization."""
+
+    values = [
+        patch.background_heat_flux_k_m_s,
+        patch.background_moisture_flux_g_g_m_s,
+        patch.heat_flux_perturbation_k_m_s,
+        patch.moisture_flux_perturbation_g_g_m_s,
+        patch.center_x_m,
+        patch.center_y_m,
+        patch.radius_x_m,
+        patch.radius_y_m,
+        patch.taper_width_m,
+        patch.ramp_seconds,
+    ]
+    return (
+        "# Cloud Chamber surface forcing patch v0\n"
+        "# bg_h bg_q delta_h delta_q center_x center_y radius_x radius_y taper_width ramp_seconds\n"
+        + " ".join(f"{value:.12e}" for value in values)
+        + "\n"
+    )
+
+
+def surface_forcing_patch_data_sha256(patch: SurfaceForcingPatch) -> str:
+    return hashlib.sha256(surface_forcing_patch_data_text(patch).encode("utf-8")).hexdigest()
+
+
+def cm1_source_customization_artifact(patch: SurfaceForcingPatch) -> dict[str, object]:
+    return {
+        "schema_version": "cm1_source_customization_v0",
+        "surface_flux_mode": DIFFERENTIAL_SURFACE_FORCING_MODE,
+        "surface_patch_sha256": patch.pattern_sha256,
+        "runtime_patch_file_sha256": surface_forcing_patch_data_sha256(patch),
+        "runtime_patch_file": SURFACE_FORCING_PATCH_FILENAME,
+        "required_targets": [
+            {
+                "relative_path": "src/sfcphys.F",
+                "purpose": (
+                    "Read the per-run patch file and apply a raised-cosine heat/moisture "
+                    "flux perturbation to thflux/qvflux when set_flx=1."
+                ),
+                "marker": "CLOUD_CHAMBER_SURFACE_FORCING_PATCH_V0_SFCPHYS",
+            },
+        ],
+        "application_policy": {
+            "no_silent_uniform_fallback": True,
+            "isolated_runtime_build_tree": True,
+            "backup_original_source": False,
+            "rebuild_cm1_executable": True,
+            "copy_custom_executable_to_run_directory": True,
+            "cm1_source_committed_to_repo": False,
+        },
+    }
+
+
+def surface_forcing_patch_summary(patch: SurfaceForcingPatch) -> str:
+    return (
+        "Differential warm/moist surface patch; source customization required at launch; "
+        f"background H {patch.background_heat_flux_k_m_s:.3g} K m/s, "
+        f"M {patch.background_moisture_flux_g_g_m_s:.3g} g/g m/s; "
+        f"patch +H {patch.heat_flux_perturbation_k_m_s:.3g} K m/s, "
+        f"+M {patch.moisture_flux_perturbation_g_g_m_s:.3g} g/g m/s; "
+        f"{patch.radius_x_m:.0f} x {patch.radius_y_m:.0f} m {patch.shape}"
+    )
+
+
+def _shape_payload(payload: dict[str, Any]) -> Literal["circle"]:
+    raw = payload.get("surface_patch_shape", "circle")
+    if raw == "circle":
+        return cast(Literal["circle"], raw)
+    if raw == "ellipse":
+        raise ValueError(
+            "Differential surface forcing v0 supports circle patches only. "
+            "Ellipse support needs physical-coordinate taper validation before it is safe."
+        )
+    raise ValueError(f"Unknown surface patch shape: {raw}")
+
+
+def _radius_payload(payload: dict[str, Any], axis: Literal["x", "y"], shape: str) -> float:
+    if shape == "circle":
+        return _float_payload(
+            payload,
+            "surface_patch_radius_m",
+            "patch radius",
+            default=DEFAULT_PATCH_RADIUS_M,
+        )
+    raise ValueError(f"Unknown surface patch shape for radius {axis}: {shape}")
+
+
+def _validate_circle_radius_payload(payload: dict[str, Any], radius_m: float) -> None:
+    for key in ("surface_patch_radius_x_m", "surface_patch_radius_y_m"):
+        if key not in payload:
+            continue
+        axis_radius = _float_payload(payload, key, key, default=radius_m)
+        if not math.isclose(axis_radius, radius_m, rel_tol=0.0, abs_tol=1.0e-9):
+            raise ValueError(
+                "Differential surface forcing v0 supports circle patches only; use "
+                "surface_patch_radius_m instead of separate x/y radii."
+            )
+
+
+def _float_payload(
+    payload: dict[str, Any],
+    key: str,
+    label: str,
+    *,
+    default: float,
+) -> float:
+    value = payload.get(key, default)
+    if isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError as exc:
+            raise ValueError(f"Unknown {label}: {value}") from exc
+    elif isinstance(value, int | float):
+        parsed = float(value)
+    else:
+        raise ValueError(f"Unknown {label}: {value}")
+    if not math.isfinite(parsed):
+        raise ValueError(f"Invalid {label}: must be finite")
+    return parsed
+
+
+def _validate_patch_geometry(
+    *,
+    center_x_m: float,
+    center_y_m: float,
+    radius_x_m: float,
+    radius_y_m: float,
+    taper_width_m: float,
+    domain_x_m: float,
+    domain_y_m: float,
+    dx_m: float,
+    dy_m: float,
+) -> None:
+    if radius_x_m <= 0 or radius_y_m <= 0:
+        raise ValueError("Invalid patch radius: radii must be greater than zero")
+    if taper_width_m <= 0:
+        raise ValueError("Invalid patch taper width: must be greater than zero")
+    if radius_x_m < MIN_PATCH_RADIUS_GRID_CELLS * dx_m:
+        raise ValueError("Invalid patch radius x: patch must span at least 3 grid cells")
+    if radius_y_m < MIN_PATCH_RADIUS_GRID_CELLS * dy_m:
+        raise ValueError("Invalid patch radius y: patch must span at least 3 grid cells")
+    if abs(center_x_m) + radius_x_m + taper_width_m > domain_x_m / 2:
+        raise ValueError("Invalid patch geometry: x radius plus taper must fit inside domain")
+    if abs(center_y_m) + radius_y_m + taper_width_m > domain_y_m / 2:
+        raise ValueError("Invalid patch geometry: y radius plus taper must fit inside domain")
+
+
+def _validate_patch_forcing(
+    *,
+    heat_perturbation_k_m_s: float,
+    moisture_perturbation_g_g_m_s: float,
+    ramp_seconds: float,
+    duration_seconds: int,
+) -> None:
+    if heat_perturbation_k_m_s < 0 or moisture_perturbation_g_g_m_s < 0:
+        raise ValueError(
+            "Invalid patch perturbation: heat and moisture perturbations must be non-negative"
+        )
+    if heat_perturbation_k_m_s == 0 and moisture_perturbation_g_g_m_s == 0:
+        raise ValueError("Invalid patch perturbation: at least one perturbation must be positive")
+    if ramp_seconds <= 0:
+        raise ValueError("Invalid patch ramp seconds: must be greater than zero")
+    if ramp_seconds > duration_seconds:
+        raise ValueError("Invalid patch ramp seconds: ramp must not exceed run duration")
+
+
+def _sha256_payload(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -713,6 +713,45 @@ def test_lan_worker_endpoint_reports_clear_failure(monkeypatch: pytest.MonkeyPat
     assert response.json()["detail"] == "LAN worker SSH failed"
 
 
+def test_lan_worker_start_blocks_differential_surface_forcing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    result = generate_dry_run_package(
+        scenario_data=json.loads(BASELINE_TEMPLATE.read_text()),
+        runtime_home=tmp_path,
+        run_id="run-differential-lan-blocked",
+        observed_sounding=observed,
+        run_configuration={
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "wide_12km",
+            "output_cadence": "standard_15min",
+            "surface_forcing_mode": "differential_surface_forcing_patch_v0",
+            "surface_heat_flux_k_m_s": 8.0e-3,
+            "surface_moisture_flux_g_g_m_s": 5.2e-5,
+            "surface_patch_heat_flux_perturbation_k_m_s": 4.0e-2,
+            "surface_patch_moisture_flux_perturbation_g_g_m_s": 5.0e-5,
+            "surface_patch_radius_m": 1500.0,
+            "surface_patch_taper_width_m": 500.0,
+            "surface_patch_ramp_seconds": 1800.0,
+        },
+    )
+    monkeypatch.setenv("CLOUD_CHAMBER_RUNTIME_HOME", str(tmp_path))
+
+    response = TestClient(app).post(
+        "/api/lan-worker/start",
+        json={"manifest_path": str(result.manifest_path)},
+    )
+
+    assert response.status_code == 400
+    assert "Differential surface forcing is local-only" in response.json()["detail"]
+
+
 def test_storage_inventory_api_uses_runtime_home_override(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -39,7 +39,14 @@ def test_cm1_contract_documents_expected_generated_files_and_default_run_configu
     assert contract.run_configuration.duration == "short_6h"
     assert contract.run_configuration.domain_size == "local_6km"
     assert contract.run_configuration.diagnostic_set == "full"
-    assert {file.role for file in contract.generated_files} == set(GeneratedFileRole)
+    assert {file.role for file in contract.generated_files} == {
+        GeneratedFileRole.RUN_MANIFEST,
+        GeneratedFileRole.CASE_MANIFEST,
+        GeneratedFileRole.NAMELIST,
+        GeneratedFileRole.INPUT_SOUNDING,
+        GeneratedFileRole.DRY_RUN_REPORT,
+        GeneratedFileRole.RUNTIME_FILE_CHECKLIST,
+    }
     assert contract.cloud_scale_defaults.nx == 64
     assert contract.cloud_scale_defaults.ny == 64
     assert contract.cloud_scale_defaults.nz == 100
@@ -319,6 +326,60 @@ def test_observed_surface_flux_proxy_choices_render_namelist_and_surface_outputs
     assert "output_sfcflx    = 1," in namelist
     assert "output_sfcparams = 1," in namelist
     assert "output_sfcdiags  = 1," in namelist
+
+
+def test_differential_surface_forcing_declares_patch_recipe_and_source_hook() -> None:
+    from igra_fixtures import IGRA_FIXTURE
+
+    from cloud_chamber.observed_sounding import parse_igra_station_text
+
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+
+    contract = build_cm1_input_contract(
+        baseline_scenario(),
+        observed_sounding=observed,
+        run_configuration={
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "wide_12km",
+            "output_cadence": "standard_15min",
+            "surface_forcing_mode": "differential_surface_forcing_patch_v0",
+            "surface_heat_flux_k_m_s": 8.0e-3,
+            "surface_moisture_flux_g_g_m_s": 5.2e-5,
+            "surface_patch_heat_flux_perturbation_k_m_s": 4.0e-2,
+            "surface_patch_moisture_flux_perturbation_g_g_m_s": 5.0e-5,
+            "surface_patch_radius_m": 1500.0,
+            "surface_patch_taper_width_m": 500.0,
+            "surface_patch_ramp_seconds": 1800.0,
+        },
+    )
+    namelist = render_namelist_fragment(contract)
+    surface_fluxes = cast(dict[str, Any], contract.recipe_assumptions["surface_fluxes"])
+    patch = cast(dict[str, Any], surface_fluxes["surface_forcing_patch"])
+
+    assert contract.run_recipe.value == "differential_surface_forced_evolution"
+    assert contract.recipe_id == "differential_surface_forced_evolution_v0"
+    assert contract.assumption_mode == "differential_surface_forced_evolution"
+    assert "hfx" in contract.required_output_fields
+    assert "qfx" in contract.required_output_fields
+    assert "u" in contract.required_output_fields
+    assert "v" in contract.required_output_fields
+    assert {file.role for file in contract.generated_files} == set(GeneratedFileRole)
+    assert surface_fluxes["mode"] == "differential_surface_forcing_patch_v0"
+    assert surface_fluxes["cm1_runtime_files"]["surface_forcing_patch"] == (
+        "cloud_chamber_surface_forcing_patch.dat"
+    )
+    assert patch["radius_x_m"] == 1500.0
+    assert patch["heat_flux_perturbation_k_m_s"] == 4.0e-2
+    assert "source customization" in surface_fluxes["translation_method"]
+    assert "initsfc    =      1," in namelist
+    assert "cnst_shflx = 8.0e-3," in namelist
+    assert "cnst_lhflx = 5.2e-5," in namelist
+    assert contract.run_configuration.surface_forcing_patch is not None
+    assert "diff_patch_" in contract.run_configuration.configuration_id
 
 
 def test_baseline_humidity_ladder_only_changes_low_level_moisture_profile() -> None:

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -259,6 +259,109 @@ def test_observed_dry_run_package_persists_surface_flux_proxy_choices(
     assert "output_sfcdiags  = 1," in namelist
 
 
+def test_differential_surface_forcing_package_writes_patch_artifacts(
+    tmp_path: Path,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-differential-patch",
+        observed_sounding=observed,
+        run_configuration={
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "wide_12km",
+            "output_cadence": "standard_15min",
+            "surface_forcing_mode": "differential_surface_forcing_patch_v0",
+            "surface_heat_flux_k_m_s": 8.0e-3,
+            "surface_moisture_flux_g_g_m_s": 5.2e-5,
+            "surface_patch_heat_flux_perturbation_k_m_s": 4.0e-2,
+            "surface_patch_moisture_flux_perturbation_g_g_m_s": 5.0e-5,
+            "surface_patch_radius_m": 1500.0,
+            "surface_patch_taper_width_m": 500.0,
+            "surface_patch_ramp_seconds": 1800.0,
+        },
+    )
+
+    manifest = load_run_manifest(result.manifest_path)
+    report = json.loads(result.report_path.read_text())
+    patch_json = json.loads((result.package_dir / "surface_forcing_patch.json").read_text())
+    patch_data = (result.package_dir / "cloud_chamber_surface_forcing_patch.dat").read_text()
+    source_customization = json.loads(
+        (result.package_dir / "cm1_source_customization.json").read_text()
+    )
+    runtime_checklist = json.loads((result.package_dir / "runtime_file_checklist.json").read_text())
+    namelist = (result.package_dir / "namelist.input").read_text()
+
+    assert manifest.run_recipe == "differential_surface_forced_evolution"
+    assert manifest.recipe_id == "differential_surface_forced_evolution_v0"
+    assert manifest.assumption_mode == "differential_surface_forced_evolution"
+    assert manifest.generated_inputs.surface_forcing_patch == str(
+        result.package_dir / "cloud_chamber_surface_forcing_patch.dat"
+    )
+    assert manifest.generated_inputs.cm1_source_customization == str(
+        result.package_dir / "cm1_source_customization.json"
+    )
+    assert manifest.recipe_assumptions["surface_fluxes"]["mode"] == (
+        "differential_surface_forcing_patch_v0"
+    )
+    assert patch_json["pattern"]["radius_x_m"] == 1500.0
+    assert patch_json["cm1_patch_data_filename"] == "cloud_chamber_surface_forcing_patch.dat"
+    assert "4.000000000000e-02" in patch_data
+    assert "5.000000000000e+02" in patch_data
+    assert source_customization["application_policy"]["no_silent_uniform_fallback"] is True
+    assert source_customization["runtime_patch_file_sha256"]
+    assert runtime_checklist["source_customization"]["status"] == "checked_and_applied_at_launch"
+    assert (
+        report["run_configuration_summary"]["surface_forcing_patch"]["pattern_sha256"]
+        == (patch_json["pattern_sha256"])
+    )
+    assert "initsfc    =      1," in namelist
+    assert "cm1_source_customization.json" in report["generated_files"]["cm1_source_customization"]
+    assert {path.name for path in result.generated_files} >= {
+        "run_manifest.json",
+        "surface_forcing_patch.json",
+        "cloud_chamber_surface_forcing_patch.dat",
+        "cm1_source_customization.json",
+    }
+
+
+def test_differential_surface_forcing_rejects_ellipse_shape(
+    tmp_path: Path,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+
+    with pytest.raises(DryRunPackageError, match="supports circle patches only"):
+        generate_dry_run_package(
+            scenario_data=load_baseline_template(),
+            runtime_home=tmp_path,
+            run_id="run-differential-ellipse-blocked",
+            observed_sounding=observed,
+            run_configuration={
+                "duration": "short_6h",
+                "horizontal_cell_count": "cells_128",
+                "domain_size": "wide_12km",
+                "output_cadence": "standard_15min",
+                "surface_forcing_mode": "differential_surface_forcing_patch_v0",
+                "surface_heat_flux_k_m_s": 8.0e-3,
+                "surface_moisture_flux_g_g_m_s": 5.2e-5,
+                "surface_patch_shape": "ellipse",
+                "surface_patch_radius_x_m": 2000.0,
+                "surface_patch_radius_y_m": 1200.0,
+                "surface_patch_taper_width_m": 500.0,
+                "surface_patch_ramp_seconds": 1800.0,
+            },
+        )
+
+
 def test_triggered_deep_potential_package_generation_is_removed(
     tmp_path: Path,
 ) -> None:

--- a/app/backend/tests/test_local_run_manager.py
+++ b/app/backend/tests/test_local_run_manager.py
@@ -1,9 +1,16 @@
 import json
+import subprocess
 from pathlib import Path
 from typing import Any, TextIO
 
 import pytest
+from igra_fixtures import IGRA_FIXTURE
 
+from cloud_chamber.cm1_source_customization import (
+    CUSTOM_EXECUTABLE_FILENAME,
+    SFCPHYS_MARKER,
+    SOURCE_CUSTOMIZATION_STATUS_FILENAME,
+)
 from cloud_chamber.dry_run_package import generate_dry_run_package
 from cloud_chamber.local_run_manager import (
     LocalRunManager,
@@ -114,6 +121,76 @@ def dry_run_manifest_path(tmp_path: Path, run_id: str = "run-001") -> Path:
     return result.manifest_path
 
 
+def differential_dry_run_manifest_path(tmp_path: Path, run_id: str = "run-diff") -> Path:
+    from cloud_chamber.observed_sounding import parse_igra_station_text
+
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path / "CloudChamber",
+        run_id=run_id,
+        observed_sounding=observed,
+        run_configuration={
+            "duration": "short_6h",
+            "horizontal_cell_count": "cells_128",
+            "domain_size": "wide_12km",
+            "output_cadence": "standard_15min",
+            "surface_forcing_mode": "differential_surface_forcing_patch_v0",
+            "surface_heat_flux_k_m_s": 8.0e-3,
+            "surface_moisture_flux_g_g_m_s": 5.2e-5,
+            "surface_patch_heat_flux_perturbation_k_m_s": 4.0e-2,
+            "surface_patch_moisture_flux_perturbation_g_g_m_s": 5.0e-5,
+            "surface_patch_radius_m": 1500.0,
+            "surface_patch_taper_width_m": 500.0,
+            "surface_patch_ramp_seconds": 1800.0,
+        },
+    )
+    return result.manifest_path
+
+
+def write_fake_cm1_source_tree(settings: CloudChamberSettings) -> None:
+    assert settings.cm1_root is not None
+    src_dir = settings.cm1_root / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "Makefile").write_text("all:\n\t@true\n")
+    (src_dir / "init_surface.F").write_text(
+        """      subroutine init_surface
+!----------
+!  if initsfc is not 1,2:
+
+      ELSEIF( initsfc.ne.1 .and. initsfc.ne.2 )THEN
+
+        ! build your own initial conditions here:
+
+      ENDIF
+      end subroutine init_surface
+"""
+    )
+    (src_dir / "sfcphys.F").write_text(
+        """      subroutine sfcflux
+      real :: thmag,qvmag,trat1,trat2
+
+  IF( set_flx.eq.1 )THEN
+
+    IF( imoist.eq.1 )THEN
+
+      qvflux(1,1) = cnst_lhflx
+
+    ENDIF
+
+  !c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c!
+
+  ELSE
+
+  ENDIF
+      end subroutine sfcflux
+"""
+    )
+
+
 def test_default_process_factory_detaches_cm1_from_short_lived_callers(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -184,6 +261,92 @@ def test_launch_constructs_cm1_command_and_captures_logs(tmp_path: Path) -> None
     assert manifest.provenance.product_state == ProductState.QUEUED_RUNNING_CM1_PROCESS
     assert manifest.execution.command == [str(settings.cm1_run_dir / "cm1.exe")]
     assert manifest.execution.process_id == fake_process.pid
+
+
+def test_launch_applies_differential_surface_source_customization_before_cm1(
+    tmp_path: Path,
+) -> None:
+    settings = fake_settings(tmp_path)
+    assert settings.cm1_root is not None
+    assert settings.cm1_run_dir is not None
+    cm1_root = settings.cm1_root
+    write_fake_cm1_source_tree(settings)
+    manifest_path = differential_dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-diff"
+    fake_process = FakeProcess()
+    factory = FakeProcessFactory(fake_process)
+    build_calls: list[Path] = []
+
+    def fake_build(
+        command: list[str],
+        *,
+        cwd: Path,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        assert command == ["make"]
+        assert check is True
+        assert capture_output is True
+        assert text is True
+        assert cwd.parent != cm1_root
+        assert SFCPHYS_MARKER in (cwd / "sfcphys.F").read_text()
+        assert SFCPHYS_MARKER not in (cm1_root / "src" / "sfcphys.F").read_text()
+        build_calls.append(cwd)
+        return subprocess.CompletedProcess(command, 0, stdout="built\n", stderr="")
+
+    manager = LocalRunManager(
+        settings=settings,
+        process_factory=factory,
+        source_build_runner=fake_build,
+    )
+
+    status = manager.launch(manifest_path)
+
+    assert status.lifecycle_state == LifecycleState.RUNNING
+    assert len(build_calls) == 1
+    assert build_calls[0].name == "src"
+    custom_executable = run_dir / CUSTOM_EXECUTABLE_FILENAME
+    assert factory.commands == [[str(custom_executable)]]
+    status_payload = json.loads((run_dir / SOURCE_CUSTOMIZATION_STATUS_FILENAME).read_text())
+    assert status_payload["no_silent_uniform_fallback"] is True
+    assert status_payload["source_restored_after_build"] == "not_modified_isolated_build_tree"
+    assert status_payload["custom_executable"] == str(custom_executable)
+    assert status_payload["custom_executable_sha256"]
+    assert SFCPHYS_MARKER not in (cm1_root / "src" / "sfcphys.F").read_text()
+    assert custom_executable.exists()
+
+
+def test_launch_refuses_tampered_differential_patch_data(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    write_fake_cm1_source_tree(settings)
+    manifest_path = differential_dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-diff"
+    (run_dir / "cloud_chamber_surface_forcing_patch.dat").write_text("tampered\n")
+    manager = LocalRunManager(
+        settings=settings,
+        process_factory=FakeProcessFactory(FakeProcess()),
+    )
+
+    with pytest.raises(LocalRunManagerError, match="patch data does not match"):
+        manager.launch(manifest_path)
+
+
+def test_launch_refuses_dirty_differential_cm1_source_tree(tmp_path: Path) -> None:
+    settings = fake_settings(tmp_path)
+    assert settings.cm1_root is not None
+    write_fake_cm1_source_tree(settings)
+    (settings.cm1_root / "src" / "sfcphys.F").write_text(
+        (settings.cm1_root / "src" / "sfcphys.F").read_text() + f"\n! {SFCPHYS_MARKER}\n"
+    )
+    manifest_path = differential_dry_run_manifest_path(tmp_path)
+    manager = LocalRunManager(
+        settings=settings,
+        process_factory=FakeProcessFactory(FakeProcess()),
+    )
+
+    with pytest.raises(LocalRunManagerError, match="dirty source tree"):
+        manager.launch(manifest_path)
 
 
 def test_exit_zero_without_output_needs_review_not_completed_result(tmp_path: Path) -> None:

--- a/app/backend/tests/test_local_run_manager.py
+++ b/app/backend/tests/test_local_run_manager.py
@@ -313,6 +313,8 @@ def test_launch_applies_differential_surface_source_customization_before_cm1(
     assert status_payload["source_restored_after_build"] == "not_modified_isolated_build_tree"
     assert status_payload["custom_executable"] == str(custom_executable)
     assert status_payload["custom_executable_sha256"]
+    launched_manifest = load_run_manifest(manifest_path)
+    assert launched_manifest.cm1_source_customization_status == status_payload
     assert SFCPHYS_MARKER not in (cm1_root / "src" / "sfcphys.F").read_text()
     assert custom_executable.exists()
 

--- a/app/backend/tests/test_local_run_queue.py
+++ b/app/backend/tests/test_local_run_queue.py
@@ -163,6 +163,30 @@ def test_queue_records_ingest_failure_and_still_starts_next_package(
     assert refreshed.active_run_id == "run-after-ingest-failure"
 
 
+def test_queue_marks_missing_active_manifest_failed_and_starts_next_package(
+    tmp_path: Path,
+) -> None:
+    first = create_manifest(tmp_path, "run-missing-active-manifest")
+    second = create_manifest(tmp_path, "run-after-missing-active-manifest")
+    fake_manager = FakeRunManager()
+    queue = LocalRunQueueManager(settings=fake_settings(tmp_path), run_manager=fake_manager)
+    queue.enqueue(first)
+    queue.enqueue(second)
+    first.unlink()
+
+    refreshed = queue.refresh()
+
+    entries = {entry.run_id: entry for entry in refreshed.entries}
+    assert entries["run-missing-active-manifest"].state == "failed"
+    assert entries["run-missing-active-manifest"].message == (
+        "Active local CM1 queue entry is missing its run manifest; marking failed "
+        "so the serial queue can continue."
+    )
+    assert "missing its run manifest" in (entries["run-missing-active-manifest"].error or "")
+    assert entries["run-after-missing-active-manifest"].state == "running"
+    assert refreshed.active_run_id == "run-after-missing-active-manifest"
+
+
 def test_queue_records_launch_failures_when_local_launch_remains_blocked(tmp_path: Path) -> None:
     first = create_manifest(tmp_path, "run-launch-fails")
     second = create_manifest(tmp_path, "run-waits")

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -67,6 +67,34 @@ def complete_manifest(
     write_run_manifest(manifest_path, updated)
 
 
+def test_ingest_preserves_cm1_source_customization_status(tmp_path: Path) -> None:
+    manifest_path = create_manifest(tmp_path, run_id="run-custom-source")
+    run_dir = manifest_path.parent
+    output_path = run_dir / "cm1out_000001.nc"
+    write_model_netcdf(
+        output_path,
+        times=[0.0],
+        qc_values=[0.0],
+        w_values=[0.0],
+    )
+    complete_manifest(manifest_path, OutputMetadata(netcdf_paths=[str(output_path)]))
+    status = {
+        "schema_version": "cm1_source_customization_status_v0",
+        "surface_flux_mode": "differential_surface_forcing_patch_v0",
+        "custom_executable_sha256": "abc123",
+        "source_restored_after_build": "not_modified_isolated_build_tree",
+    }
+    manifest = load_run_manifest(manifest_path)
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(update={"cm1_source_customization_status": status}),
+    )
+
+    result = ingest_completed_run(manifest_path)
+
+    assert result.cm1_source_customization_status == status
+
+
 def write_tiny_netcdf(
     path: Path,
     *,

--- a/app/backend/tests/test_surface_forced_campaign.py
+++ b/app/backend/tests/test_surface_forced_campaign.py
@@ -324,6 +324,55 @@ def test_campaign_plan_preserves_explicit_timestep_target(tmp_path: Path) -> Non
     assert "dtl_1p000e00s" in run.resolved_run_configuration["configuration_id"]
 
 
+def test_campaign_plan_preserves_differential_surface_patch_configuration(
+    tmp_path: Path,
+) -> None:
+    matrix_path = write_matrix(tmp_path)
+    matrix = yaml.safe_load(matrix_path.read_text())
+    matrix["run_defaults"]["surface_forcing_mode"] = "differential_surface_forcing_patch_v0"
+    matrix["run_defaults"]["surface_patch_radius_m"] = 1600.0
+    matrix["run_defaults"]["surface_patch_heat_flux_perturbation_k_m_s"] = 4.5e-2
+    matrix["run_defaults"]["surface_patch_moisture_flux_perturbation_g_g_m_s"] = 5.0e-5
+    matrix["run_defaults"]["surface_patch_taper_width_m"] = 400.0
+    matrix["run_defaults"]["surface_patch_ramp_seconds"] = 1200.0
+    matrix_path.write_text(yaml.safe_dump(matrix, sort_keys=False))
+
+    plan = build_campaign_plan(yaml.safe_load(matrix_path.read_text()), matrix_path=matrix_path)
+    run = plan.runs[0]
+
+    assert run.run_configuration["surface_forcing_mode"] == (
+        "differential_surface_forcing_patch_v0"
+    )
+    assert run.resolved_run_configuration["surface_flux_mode"] == (
+        "differential_surface_forcing_patch_v0"
+    )
+    patch = run.resolved_run_configuration["surface_forcing_patch"]
+    assert patch["radius_x_m"] == pytest.approx(1600.0)
+    assert patch["radius_y_m"] == pytest.approx(1600.0)
+    assert patch["heat_flux_perturbation_k_m_s"] == pytest.approx(4.5e-2)
+    assert patch["moisture_flux_perturbation_g_g_m_s"] == pytest.approx(5.0e-5)
+    assert patch["pattern_sha256"]
+
+
+def test_campaign_plan_rejects_unknown_differential_surface_key(tmp_path: Path) -> None:
+    matrix_path = write_matrix(tmp_path)
+    matrix = yaml.safe_load(matrix_path.read_text())
+    matrix["run_defaults"]["surface_patch_magic_radius_m"] = 1200.0
+
+    with pytest.raises(CampaignError, match="surface_patch_magic_radius_m"):
+        build_campaign_plan(matrix, matrix_path=matrix_path)
+
+
+def test_campaign_plan_blocks_lan_for_differential_surface_forcing(tmp_path: Path) -> None:
+    matrix_path = write_matrix(tmp_path, queue_target="lan")
+    matrix = yaml.safe_load(matrix_path.read_text())
+    matrix["run_defaults"]["surface_forcing_mode"] = "differential_surface_forcing_patch_v0"
+    matrix["run_defaults"]["surface_patch_radius_m"] = 1600.0
+
+    with pytest.raises(CampaignError, match="queue_target=lan is not supported"):
+        build_campaign_plan(matrix, matrix_path=matrix_path)
+
+
 def test_campaign_plans_checked_in_example_matrix() -> None:
     plan = plan_campaign(
         REPO_ROOT / "docs/research/templates/surface-forced-campaign-matrix.example.yaml"

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -15,6 +15,17 @@ const defaultRunConfiguration = {
   output_cadence: "standard_15min",
   output_cadence_seconds: 900,
   diagnostic_set: "full",
+  surface_forcing_mode: "constant_uniform_surface_flux_proxy",
+  surface_heat_flux_k_m_s: 0.008,
+  surface_moisture_flux_g_g_m_s: 5.2e-5,
+  surface_patch_shape: "circle",
+  surface_patch_radius_m: "1500",
+  surface_patch_radius_x_m: "1500",
+  surface_patch_radius_y_m: "1500",
+  surface_patch_heat_flux_perturbation_k_m_s: "4.0e-2",
+  surface_patch_moisture_flux_perturbation_g_g_m_s: "5.0e-5",
+  surface_patch_taper_width_m: "500",
+  surface_patch_ramp_seconds: "1800",
   surface_flux_mode: "constant_uniform_surface_flux_proxy",
   surface_flux_summary:
     "Surface heat flux 0.008 K m/s; surface moisture flux 5.2e-5 g/g m/s; constant uniform proxy",
@@ -28,6 +39,7 @@ const defaultRunConfiguration = {
     cnst_lhflx: 5.2e-5,
     cnst_lhflx_units: "g/g m/s",
   },
+  surface_forcing_patch: null,
   surface_flux_caveats: [
     "surface_flux_proxy_constant_uniform_not_place_time_energy_budget",
     "surface_flux_proxy_not_real_land_surface_or_evaporation_model",
@@ -100,6 +112,7 @@ const defaultRunConfigurationSummary = {
   surface_flux_mode: defaultRunConfiguration.surface_flux_mode,
   surface_flux_summary: defaultRunConfiguration.surface_flux_summary,
   surface_flux_cm1_values: defaultRunConfiguration.surface_flux_cm1_values,
+  surface_forcing_patch: defaultRunConfiguration.surface_forcing_patch,
   surface_flux_caveats: defaultRunConfiguration.surface_flux_caveats,
 };
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -43,8 +43,41 @@ type RunConfigurationInput = {
   domain_size: string;
   output_cadence: string;
   diagnostic_set: string;
+  surface_forcing_mode: string;
   surface_heat_flux_k_m_s: string;
   surface_moisture_flux_g_g_m_s: string;
+  surface_patch_shape: string;
+  surface_patch_radius_m: string;
+  surface_patch_radius_x_m: string;
+  surface_patch_radius_y_m: string;
+  surface_patch_heat_flux_perturbation_k_m_s: string;
+  surface_patch_moisture_flux_perturbation_g_g_m_s: string;
+  surface_patch_taper_width_m: string;
+  surface_patch_ramp_seconds: string;
+};
+
+type SurfaceForcingPatch = {
+  schema_version: string;
+  shape: "circle" | string;
+  center_x_m: number;
+  center_y_m: number;
+  radius_x_m: number;
+  radius_y_m: number;
+  taper_function: string;
+  taper_width_m: number;
+  ramp_seconds: number;
+  background_heat_flux_k_m_s: number;
+  background_moisture_flux_g_g_m_s: number;
+  heat_flux_perturbation_k_m_s: number;
+  moisture_flux_perturbation_g_g_m_s: number;
+  domain_x_m: number;
+  domain_y_m: number;
+  dx_m: number;
+  dy_m: number;
+  support_status?: string;
+  cm1_application_status?: string;
+  pattern_sha256?: string;
+  caveats?: string[];
 };
 
 type RunConfigurationCM1Values = {
@@ -104,6 +137,7 @@ type RunConfiguration = Omit<
   surface_flux_mode: string;
   surface_flux_summary: string;
   surface_flux_cm1_values: RunConfigurationSurfaceFluxCM1Values;
+  surface_forcing_patch?: SurfaceForcingPatch | null;
   surface_flux_caveats: string[];
   caveats: string[];
 };
@@ -122,6 +156,7 @@ type RunConfigurationSummary = {
   surface_flux_mode?: string;
   surface_flux_summary?: string;
   surface_flux_cm1_values?: RunConfigurationSurfaceFluxCM1Values;
+  surface_forcing_patch?: SurfaceForcingPatch | null;
   surface_flux_caveats?: string[];
   runtime_seconds: number;
   output_cadence_seconds: number;
@@ -381,9 +416,12 @@ type CandidateRecipeFitDisplay = {
 
 type RunRecipe =
   | "generated_reference_lower_atmosphere"
-  | "observed_surface_forced_evolution";
+  | "observed_surface_forced_evolution"
+  | "differential_surface_forced_evolution";
 
-type ObservedRunRecipe = "observed_surface_forced_evolution";
+type ObservedRunRecipe =
+  | "observed_surface_forced_evolution"
+  | "differential_surface_forced_evolution";
 type AtmosphereSourcePath = "cached_recommendations" | "saved_candidates" | "upload_igra_text";
 type SearchIntent =
   | "best_overall"
@@ -395,6 +433,8 @@ type StationSelectionMode = "all_cached" | "selected";
 type CandidateHistoryScope = "all_cached" | "latest_per_station";
 type RunPlanQueueTarget = "local" | "lan";
 const CURRENT_OBSERVED_RUN_RECIPE: ObservedRunRecipe = "observed_surface_forced_evolution";
+const DIFFERENTIAL_SURFACE_FORCING_MODE = "differential_surface_forcing_patch_v0";
+const UNIFORM_SURFACE_FORCING_MODE = "constant_uniform_surface_flux_proxy";
 type RunPlanItemStatus =
   | "planned"
   | "packaging"
@@ -1365,8 +1405,17 @@ const DEFAULT_SHALLOW_RUN_CONFIGURATION: RunConfigurationInput = {
   domain_size: "local_6km",
   output_cadence: "standard_15min",
   diagnostic_set: "full",
+  surface_forcing_mode: UNIFORM_SURFACE_FORCING_MODE,
   surface_heat_flux_k_m_s: "8.0e-3",
   surface_moisture_flux_g_g_m_s: "5.2e-5",
+  surface_patch_shape: "circle",
+  surface_patch_radius_m: "1500",
+  surface_patch_radius_x_m: "1500",
+  surface_patch_radius_y_m: "1500",
+  surface_patch_heat_flux_perturbation_k_m_s: "4.0e-2",
+  surface_patch_moisture_flux_perturbation_g_g_m_s: "5.0e-5",
+  surface_patch_taper_width_m: "500",
+  surface_patch_ramp_seconds: "1800",
 };
 
 const DEFAULT_OBSERVED_RUN_CONFIGURATION: RunConfigurationInput = {
@@ -1375,8 +1424,17 @@ const DEFAULT_OBSERVED_RUN_CONFIGURATION: RunConfigurationInput = {
   domain_size: "wide_12km",
   output_cadence: "standard_15min",
   diagnostic_set: "full",
+  surface_forcing_mode: UNIFORM_SURFACE_FORCING_MODE,
   surface_heat_flux_k_m_s: "8.0e-3",
   surface_moisture_flux_g_g_m_s: "5.2e-5",
+  surface_patch_shape: "circle",
+  surface_patch_radius_m: "1500",
+  surface_patch_radius_x_m: "1500",
+  surface_patch_radius_y_m: "1500",
+  surface_patch_heat_flux_perturbation_k_m_s: "4.0e-2",
+  surface_patch_moisture_flux_perturbation_g_g_m_s: "5.0e-5",
+  surface_patch_taper_width_m: "500",
+  surface_patch_ramp_seconds: "1800",
 };
 
 const SEARCH_INTENT_OPTIONS: Array<{ value: SearchIntent; label: string }> = [
@@ -2892,6 +2950,7 @@ export function App() {
     updateRunPlanItem(itemId, (item) => ({
       ...item,
       runConfiguration,
+      runRecipe: runRecipeForRunConfiguration(runConfiguration),
       status: "planned",
       message: "Run configuration changed; package not created yet.",
       dryRun: null,
@@ -2952,7 +3011,7 @@ export function App() {
           OBSERVED_SOUNDING_BASE_SCENARIO_ID,
           item.controls,
           item.runConfiguration,
-          item.runRecipe,
+          runRecipeForRunConfiguration(item.runConfiguration),
           item.observedSounding,
           item.candidateScreening,
           packageUserMetadata,
@@ -3037,7 +3096,7 @@ export function App() {
         selectedScenario.id,
         controls,
         runConfiguration,
-        observedSoundingExperimentSelected ? CURRENT_OBSERVED_RUN_RECIPE : null,
+        observedSoundingExperimentSelected ? runRecipeForRunConfiguration(runConfiguration) : null,
         observedSoundingExperimentSelected ? observedSoundingParse?.selected_sounding : null,
         observedSoundingExperimentSelected ? selectedCandidateScreening : null,
         packageUserMetadata,
@@ -4531,6 +4590,14 @@ function RunConfigurationPanel({
       </div>
 
       <div className="run-configuration-grid">
+        <RunConfigurationSelect
+          id="run-surface-forcing-mode"
+          label="Surface forcing"
+          description="Uniform background fluxes, or an idealized warm/moist lower-boundary patch."
+          value={configuration.surface_forcing_mode}
+          options={SURFACE_FORCING_OPTIONS}
+          onChange={(value) => update("surface_forcing_mode", value)}
+        />
         <RunConfigurationTextInput
           id="run-surface-heat-flux"
           label="Surface heat flux"
@@ -4547,6 +4614,52 @@ function RunConfigurationPanel({
           value={configuration.surface_moisture_flux_g_g_m_s}
           onChange={(value) => update("surface_moisture_flux_g_g_m_s", value)}
         />
+        {configuration.surface_forcing_mode === DIFFERENTIAL_SURFACE_FORCING_MODE && (
+          <>
+            <RunConfigurationTextInput
+              id="run-surface-patch-radius"
+              label="Patch radius"
+              units="m"
+              description="Centered circle radius; must fit inside the domain and span at least three cells."
+              value={configuration.surface_patch_radius_m}
+              onChange={(value) => update("surface_patch_radius_m", value)}
+            />
+            <RunConfigurationTextInput
+              id="run-surface-patch-heat"
+              label="Patch heat perturbation"
+              units="K m/s"
+              description="Added to the background inside the patch after taper and ramp."
+              value={configuration.surface_patch_heat_flux_perturbation_k_m_s}
+              onChange={(value) => update("surface_patch_heat_flux_perturbation_k_m_s", value)}
+            />
+            <RunConfigurationTextInput
+              id="run-surface-patch-moisture"
+              label="Patch moisture perturbation"
+              units="g/g m/s"
+              description="Added to the background inside the patch after taper and ramp."
+              value={configuration.surface_patch_moisture_flux_perturbation_g_g_m_s}
+              onChange={(value) =>
+                update("surface_patch_moisture_flux_perturbation_g_g_m_s", value)
+              }
+            />
+            <RunConfigurationTextInput
+              id="run-surface-patch-taper"
+              label="Patch taper"
+              units="m"
+              description="Raised-cosine edge width."
+              value={configuration.surface_patch_taper_width_m}
+              onChange={(value) => update("surface_patch_taper_width_m", value)}
+            />
+            <RunConfigurationTextInput
+              id="run-surface-patch-ramp"
+              label="Patch ramp"
+              units="s"
+              description="Seconds to ramp from background to full perturbation."
+              value={configuration.surface_patch_ramp_seconds}
+              onChange={(value) => update("surface_patch_ramp_seconds", value)}
+            />
+          </>
+        )}
         <RunConfigurationSelect
           id="run-duration"
           label="Duration"
@@ -6264,7 +6377,7 @@ function ObservedRunRecipePanel({
       <dl className="compact-metrics">
         <Metric
           label="Run scope"
-          value="CM1 evolves the observed profile with the selected uniform lower-boundary heat/moisture forcing."
+          value="CM1 evolves the observed profile with the selected lower-boundary heat/moisture forcing."
         />
       </dl>
     </details>
@@ -6519,6 +6632,14 @@ function RunPlanConfigurationFields({
   };
   return (
     <>
+      <RunConfigurationSelect
+        id={`run-plan-surface-forcing-mode-${item.id}`}
+        label="Surface forcing"
+        description="Uniform background fluxes, or an idealized warm/moist lower-boundary patch."
+        value={item.runConfiguration.surface_forcing_mode}
+        options={SURFACE_FORCING_OPTIONS}
+        onChange={(value) => update("surface_forcing_mode", value)}
+      />
       <RunConfigurationTextInput
         id={`run-plan-surface-heat-flux-${item.id}`}
         label="Surface heat flux"
@@ -6535,6 +6656,52 @@ function RunPlanConfigurationFields({
         value={item.runConfiguration.surface_moisture_flux_g_g_m_s}
         onChange={(value) => update("surface_moisture_flux_g_g_m_s", value)}
       />
+      {item.runConfiguration.surface_forcing_mode === DIFFERENTIAL_SURFACE_FORCING_MODE && (
+        <>
+          <RunConfigurationTextInput
+            id={`run-plan-surface-patch-radius-${item.id}`}
+            label="Patch radius"
+            units="m"
+            description="Centered circle radius; must fit inside domain and span at least three cells."
+            value={item.runConfiguration.surface_patch_radius_m}
+            onChange={(value) => update("surface_patch_radius_m", value)}
+          />
+          <RunConfigurationTextInput
+            id={`run-plan-surface-patch-heat-${item.id}`}
+            label="Patch heat perturbation"
+            units="K m/s"
+            description="Added to background after taper and ramp."
+            value={item.runConfiguration.surface_patch_heat_flux_perturbation_k_m_s}
+            onChange={(value) => update("surface_patch_heat_flux_perturbation_k_m_s", value)}
+          />
+          <RunConfigurationTextInput
+            id={`run-plan-surface-patch-moisture-${item.id}`}
+            label="Patch moisture perturbation"
+            units="g/g m/s"
+            description="Added to background after taper and ramp."
+            value={item.runConfiguration.surface_patch_moisture_flux_perturbation_g_g_m_s}
+            onChange={(value) =>
+              update("surface_patch_moisture_flux_perturbation_g_g_m_s", value)
+            }
+          />
+          <RunConfigurationTextInput
+            id={`run-plan-surface-patch-taper-${item.id}`}
+            label="Patch taper"
+            units="m"
+            description="Raised-cosine edge width."
+            value={item.runConfiguration.surface_patch_taper_width_m}
+            onChange={(value) => update("surface_patch_taper_width_m", value)}
+          />
+          <RunConfigurationTextInput
+            id={`run-plan-surface-patch-ramp-${item.id}`}
+            label="Patch ramp"
+            units="s"
+            description="Seconds to ramp to full perturbation."
+            value={item.runConfiguration.surface_patch_ramp_seconds}
+            onChange={(value) => update("surface_patch_ramp_seconds", value)}
+          />
+        </>
+      )}
       <RunConfigurationSelect
         id={`run-plan-duration-${item.id}`}
         label="Duration"
@@ -10852,7 +11019,7 @@ function candidateRecipeFitForStory(
   if (deepConvectionStoryIds.has(story)) {
     const caveats = [
       "deep_convection_outcome_depends_on_surface_forcing_duration_domain_and_resolution",
-      "differential_surface_initiation_is_tracked_in_issue_307",
+      "differential_surface_forcing_patch_recipe_available_for_initiation_tests",
     ];
     if (candidate.features.observed_wind_available !== true) {
       caveats.push("complete_observed_wind_profile_required_for_input_sounding");
@@ -10861,7 +11028,7 @@ function candidateRecipeFitForStory(
       status: "partially_testable",
       label: "testable as forced observed evolution",
       summary:
-        "This story screens deep-convection ingredients. CM1 can evolve the observed atmosphere under the selected lower-boundary forcing; differential initiation is a follow-up.",
+        "This story screens deep-convection ingredients. CM1 can evolve the observed atmosphere under the selected lower-boundary forcing; choose the differential surface patch when localized initiation is the question.",
       caveats,
     };
   }
@@ -11032,7 +11199,7 @@ function candidateRecipeMismatchWarning(
             score.support !== "unavailable",
         )));
   if (hasMeaningfulDeepStory) {
-    return "This candidate was screened for deep-convection potential. This run will test how it evolves under the selected uniform lower-boundary forcing; differential surface initiation is tracked separately.";
+    return "This candidate was screened for deep-convection potential. This run will test how it evolves under the selected lower-boundary forcing; deep outcomes still depend on duration, domain, resolution, and diagnostics.";
   }
   const hasHumidRainyStory =
     activeStory === "humid_rainy_candidate" ||
@@ -11535,7 +11702,7 @@ function runPlanItemFromUploadedSounding({
     observedSounding,
     candidateScreening: selectedCandidateScreening,
     activeStory: observedRecipeStoryId(selectedCandidateScreening),
-    runRecipe: CURRENT_OBSERVED_RUN_RECIPE,
+    runRecipe: runRecipeForRunConfiguration(runConfiguration),
     runConfiguration,
     controls,
     queueTarget: "local",
@@ -11664,7 +11831,7 @@ function runPlanRecipeMetadata(item: RunPlanItem): {
   recipeCaveats: string[];
 } {
   const report = item.dryRun?.report;
-  const staticMetadata = staticRecipeMetadata();
+  const staticMetadata = staticRecipeMetadata(item.runRecipe);
   return {
     recipeId: report?.recipe_id ?? staticMetadata.recipeId,
     recipeDisplayName: report?.recipe_display_name ?? staticMetadata.recipeDisplayName,
@@ -11677,7 +11844,7 @@ function runPlanRecipeMetadata(item: RunPlanItem): {
   };
 }
 
-function staticRecipeMetadata(): {
+function staticRecipeMetadata(runRecipe: ObservedRunRecipe = CURRENT_OBSERVED_RUN_RECIPE): {
   recipeId: string;
   recipeDisplayName: string;
   assumptionSetId: string;
@@ -11685,6 +11852,20 @@ function staticRecipeMetadata(): {
   requiredOutputFields: string[];
   recipeCaveats: string[];
 } {
+  if (runRecipe === "differential_surface_forced_evolution") {
+    return {
+      recipeId: "differential_surface_forced_evolution_v0",
+      recipeDisplayName: "Differential Surface-Forced Evolution v0",
+      assumptionSetId: "differential_surface_forced_evolution_v0_assumptions",
+      assumptionMode: "differential_surface_forced_evolution",
+      requiredOutputFields: ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "qfx", "u", "v", "th", "updraft_helicity"],
+      recipeCaveats: [
+        "No artificial atmospheric trigger is applied.",
+        "A centered lower-boundary heat/moisture forcing patch is applied through Cloud Chamber's external CM1 source customization.",
+        "The patch is an idealized surface contrast, not a real land-surface or radiation model.",
+      ],
+    };
+  }
   return {
     recipeId: "observed_surface_forced_evolution_v0",
     recipeDisplayName: "Observed Surface-Forced Evolution v0",
@@ -11712,8 +11893,8 @@ function compactRecipeAssumptions(assumptions: Record<string, unknown> | undefin
     surfaceFluxes &&
     typeof surfaceFluxes === "object" &&
     "mode" in surfaceFluxes &&
-    surfaceFluxes.mode === "constant_uniform_surface_flux_proxy"
-      ? "numeric uniform surface fluxes"
+    surfaceFluxes.mode === DIFFERENTIAL_SURFACE_FORCING_MODE
+      ? "differential surface forcing patch"
       : "numeric uniform surface fluxes";
   const radiationLabel =
     radiation &&
@@ -12243,11 +12424,22 @@ const OUTPUT_CADENCE_OPTIONS = [
   { value: "detailed_5min", label: "Detailed (5 min)" },
 ];
 
+const SURFACE_FORCING_OPTIONS = [
+  { value: UNIFORM_SURFACE_FORCING_MODE, label: "Uniform surface forcing" },
+  { value: DIFFERENTIAL_SURFACE_FORCING_MODE, label: "Differential surface patch" },
+];
+
 function defaultRunConfigurationForSelection(scenarioId: string): RunConfigurationInput {
   if (scenarioId === OBSERVED_SOUNDING_EXPERIMENT_ID) {
     return { ...DEFAULT_OBSERVED_RUN_CONFIGURATION };
   }
   return { ...DEFAULT_SHALLOW_RUN_CONFIGURATION };
+}
+
+function runRecipeForRunConfiguration(configuration: RunConfigurationInput): ObservedRunRecipe {
+  return configuration.surface_forcing_mode === DIFFERENTIAL_SURFACE_FORCING_MODE
+    ? "differential_surface_forced_evolution"
+    : CURRENT_OBSERVED_RUN_RECIPE;
 }
 
 function previewRunConfiguration(configuration: RunConfigurationInput): RunConfiguration {
@@ -12256,6 +12448,10 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
   const domain = domainValue(configuration.domain_size);
   const cadence = cadenceValue(configuration.output_cadence);
   const diagnosticSet = { value: "full" };
+  const surfaceForcingMode =
+    configuration.surface_forcing_mode === DIFFERENTIAL_SURFACE_FORCING_MODE
+      ? DIFFERENTIAL_SURFACE_FORCING_MODE
+      : UNIFORM_SURFACE_FORCING_MODE;
   const heatFlux = numericConfigurationValue(configuration.surface_heat_flux_k_m_s, 8.0e-3);
   const moistureFlux = numericConfigurationValue(
     configuration.surface_moisture_flux_g_g_m_s,
@@ -12284,6 +12480,69 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
   }
   if (heatFlux < 0 || moistureFlux < 0) {
     caveats.push("surface_flux_values_must_be_non_negative");
+  }
+  const patchShape = "circle";
+  const patchRadiusM = numericConfigurationValue(configuration.surface_patch_radius_m, 1500);
+  const patchRadiusXM = patchRadiusM;
+  const patchRadiusYM = patchRadiusM;
+  const patchTaperM = numericConfigurationValue(configuration.surface_patch_taper_width_m, 500);
+  const patchRampSeconds = numericConfigurationValue(
+    configuration.surface_patch_ramp_seconds,
+    1800,
+  );
+  const patchHeatPerturbation = numericConfigurationValue(
+    configuration.surface_patch_heat_flux_perturbation_k_m_s,
+    4.0e-2,
+  );
+  const patchMoisturePerturbation = numericConfigurationValue(
+    configuration.surface_patch_moisture_flux_perturbation_g_g_m_s,
+    5.0e-5,
+  );
+  let surfaceForcingPatch: SurfaceForcingPatch | null = null;
+  if (surfaceForcingMode === DIFFERENTIAL_SURFACE_FORCING_MODE) {
+    surfaceForcingPatch = {
+      schema_version: "surface_forcing_patch_v0",
+      shape: patchShape,
+      center_x_m: 0,
+      center_y_m: 0,
+      radius_x_m: patchRadiusXM,
+      radius_y_m: patchRadiusYM,
+      taper_function: "raised_cosine",
+      taper_width_m: patchTaperM,
+      ramp_seconds: patchRampSeconds,
+      background_heat_flux_k_m_s: heatFlux,
+      background_moisture_flux_g_g_m_s: moistureFlux,
+      heat_flux_perturbation_k_m_s: patchHeatPerturbation,
+      moisture_flux_perturbation_g_g_m_s: patchMoisturePerturbation,
+      domain_x_m: domain.xKm * 1000,
+      domain_y_m: domain.yKm * 1000,
+      dx_m: dxM,
+      dy_m: dyM,
+      support_status: "requires_cm1_source_customization",
+      cm1_application_status: "source_customization_required_at_launch",
+      caveats: [
+        "differential_surface_forcing_patch_not_real_land_surface_or_radiation",
+        "differential_surface_forcing_patch_requires_cm1_source_customization",
+      ],
+    };
+    if (patchRadiusXM < 3 * dxM || patchRadiusYM < 3 * dyM) {
+      caveats.push("surface_patch_must_span_at_least_three_grid_cells");
+    }
+    if (
+      patchRadiusXM + patchTaperM > (domain.xKm * 1000) / 2 ||
+      patchRadiusYM + patchTaperM > (domain.yKm * 1000) / 2
+    ) {
+      caveats.push("surface_patch_radius_and_taper_must_fit_inside_domain");
+    }
+    if (patchHeatPerturbation < 0 || patchMoisturePerturbation < 0) {
+      caveats.push("surface_patch_perturbations_must_be_non_negative");
+    }
+    if (patchHeatPerturbation === 0 && patchMoisturePerturbation === 0) {
+      caveats.push("surface_patch_requires_heat_or_moisture_perturbation");
+    }
+    if (patchRampSeconds <= 0 || patchRampSeconds > duration.seconds) {
+      caveats.push("surface_patch_ramp_must_be_positive_and_within_run_duration");
+    }
   }
   const surfaceFluxCm1Values: RunConfigurationSurfaceFluxCM1Values = {
     isfcflx: 1,
@@ -12332,6 +12591,7 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
       configuration.domain_size,
       configuration.output_cadence,
       diagnosticSet.value,
+      surfaceForcingMode,
     ].join("__"),
     mode: duration.mode,
     label: `${duration.label}; ${domain.label}; ${horizontalCells.label}; ${formatMeters(dxM)} dx/dy; ${cadence.label}`,
@@ -12343,14 +12603,25 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
     cm1_values: cm1Values,
     surface_heat_flux_k_m_s: heatFlux,
     surface_moisture_flux_g_g_m_s: moistureFlux,
-    surface_flux_mode: "constant_uniform_surface_flux_proxy",
-    surface_flux_summary: `Surface heat flux ${formatCompactNumber(heatFlux)} K m/s; surface moisture flux ${formatCompactNumber(moistureFlux)} g/g m/s; constant uniform proxy`,
+    surface_flux_mode: surfaceForcingMode,
+    surface_flux_summary:
+      surfaceForcingMode === DIFFERENTIAL_SURFACE_FORCING_MODE && surfaceForcingPatch
+        ? `Differential warm/moist surface patch; source customization required at launch; background H ${formatCompactNumber(heatFlux)} K m/s, M ${formatCompactNumber(moistureFlux)} g/g m/s; patch +H ${formatCompactNumber(patchHeatPerturbation)} K m/s, +M ${formatCompactNumber(patchMoisturePerturbation)} g/g m/s; ${formatMeters(patchRadiusXM)} x ${formatMeters(patchRadiusYM)} ${patchShape}`
+        : `Surface heat flux ${formatCompactNumber(heatFlux)} K m/s; surface moisture flux ${formatCompactNumber(moistureFlux)} g/g m/s; constant uniform proxy`,
     surface_flux_cm1_values: surfaceFluxCm1Values,
-    surface_flux_caveats: [
-      "surface_flux_proxy_constant_uniform_not_place_time_energy_budget",
-      "surface_flux_proxy_not_real_land_surface_or_evaporation_model",
-      "surface_flux_proxy_values_need_local_smoke_validation",
-    ],
+    surface_forcing_patch: surfaceForcingPatch,
+    surface_flux_caveats:
+      surfaceForcingMode === DIFFERENTIAL_SURFACE_FORCING_MODE
+        ? [
+            "differential_surface_forcing_patch_not_real_land_surface_or_radiation",
+            "differential_surface_forcing_patch_requires_cm1_source_customization",
+            "differential_surface_forcing_patch_requires_emitted_flux_and_convergence_validation",
+          ]
+        : [
+            "surface_flux_proxy_constant_uniform_not_place_time_energy_budget",
+            "surface_flux_proxy_not_real_land_surface_or_evaporation_model",
+            "surface_flux_proxy_values_need_local_smoke_validation",
+          ],
     caveats,
   };
 }

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -172,8 +172,9 @@ and winter/cold-season stories so APIs can distinguish screenable environments
 from runnable configuration paths. Until a story has backend features, scoring
 tests, evidence, caveats, and recipe-fit support, it must not be emitted as an
 enabled runnable label. Severe/deep-convection candidates are currently
-inspectable only as observed-sounding experiments under selected numeric uniform
-surface forcing, with differential-forcing initiation tracked as future work.
+inspectable as observed-sounding experiments under selected lower-boundary
+forcing. The user can choose either numeric uniform surface forcing or the v0
+differential surface patch recipe when localized initiation is the question.
 
 The Build UI consumes this layer through bounded JSON only. `Observed Soundings`
 is the observed-atmosphere entry point, but the user chooses exactly one source
@@ -204,18 +205,25 @@ compare forcing or configuration variants, but package generation and pre-run
 validation remain backend-owned.
 
 Observed-sounding packages extend the same dry-run package contract rather than
-creating separate workflows by story. The package records
-`run_recipe = observed_surface_forced_evolution` as the current backend routing
-value, `input_source = observed_sounding`, numeric uniform surface heat/moisture
-flux selections, expected full output fields, run caveats, and any
+creating separate workflows by story. Uniform packages record
+`run_recipe = observed_surface_forced_evolution`; differential patch packages
+record `run_recipe = differential_surface_forced_evolution`. Both use
+`input_source = observed_sounding`, selected numeric lower-boundary
+heat/moisture values, expected full output fields, run caveats, and any
 candidate-screening payload on the run manifest, case manifest, and dry-run
 report. The generated namelist uses the observed `input_sounding` route
 (`isnd = 7`), requires complete usable observed u/v winds, applies no artificial
 atmospheric trigger, and enables cloud, moisture, wind, rain-water-aloft,
 surface-rain, reflectivity, surface-flux, vorticity, and updraft-helicity output.
-Each observed sounding remains an experiment whose outcome must be inspected
-after CM1 completes. Differential surface heating/moisture or convergence-like
-initiation is future work rather than a hidden current trigger.
+Differential surface forcing also writes a surface patch file and source
+customization manifest. Local launch must build from an isolated copy of the
+external CM1 source tree, copy the customized executable into the run directory,
+record executable/source provenance, and block rather than silently running a
+uniform package. Differential packages are local-only until trusted LAN worker
+custom-source execution is implemented. The v0 package/runtime path remains
+runtime-unvalidated until a real CM1 compile and forcing-footprint smoke test
+prove the emitted hfx/qfx pattern. Each observed sounding remains an experiment
+whose outcome must be inspected after CM1 completes.
 
 Observed surface-forced evolution v0 is the first concrete run configuration
 for observed-sounding hypotheses. Package generation records

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -117,21 +117,20 @@ comparison is defined in
 [contracts/analyzer-hypothesis-output-signature.md](contracts/analyzer-hypothesis-output-signature.md).
 The bridge from those hypotheses to CM1 run recipes is defined in
 [contracts/run-recipe-and-story-mapping.md](contracts/run-recipe-and-story-mapping.md):
-it maps current story IDs to observed surface-forced, blocked, or future recipes
-and names the assumptions and output fields required before Results can compare
-predicted signatures. Removed triggered deep-potential recipes are not a current
-product path.
+it maps current story IDs to observed surface-forced, differential
+surface-forced, blocked, or future recipes and names the assumptions and output
+fields required before Results can compare predicted signatures. Removed
+triggered deep-potential recipes are not a current product path.
 Real-sounding story families, including severe/deep-convection, boundary-layer,
 low-cloud, and winter/cold-season candidates, are defined in
 [research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md).
 Those labels must remain disabled, caveated, or absent from product UI until
 backend scoring, evidence, caveats, and package-readiness states support them.
-The first exception is the deep-convection observed-sounding preset backed by
-the internal `deep_convection_trial` package path: severe/deep-convection
-candidates may be presented as pre-run hypotheses for an idealized triggered
-CM1 experiment, not as forecasts or guaranteed storm outcomes. User-facing copy
-should emphasize a configurable deep-convection run starting point instead of a
-half-state "Trial" product when that distinction matters.
+Severe/deep-convection candidates may be presented as pre-run atmospheric
+hypotheses for observed-sounding experiments, not as forecasts or guaranteed
+storm outcomes. Product copy should make the selected run assumptions visible:
+uniform lower-boundary forcing is different from the differential surface patch,
+and neither is an artificial atmospheric trigger.
 The backend may compute richer sounding diagnostics such as profile quality,
 moisture/LCL proxies, lapse-rate and cap proxies, wind shear, dry-layer
 signals, and freezing-level context to support future screening. These are
@@ -183,17 +182,21 @@ packaging or queue failures should remain visible instead of clearing the failed
 item from the plan.
 
 Observed-sounding experiments use the observed temperature, moisture, and
-complete wind profile through CM1 `isnd = 7`, apply numeric uniform lower-boundary
-heat/moisture flux controls, and request the full Results/Explore output field
-set. Severe/deep-convection candidates remain first-class atmospheric hypotheses,
-but current packages do not add an artificial deep-convection trigger. Product
-copy should describe these as observed-sounding experiments under explicit
+complete wind profile through CM1 `isnd = 7`, apply selected lower-boundary
+heat/moisture forcing, and request the full Results/Explore output field set.
+Severe/deep-convection candidates remain first-class atmospheric hypotheses, but
+current packages do not add an artificial deep-convection trigger. Product copy
+should describe these as observed-sounding experiments under explicit
 surface-forcing, duration, grid, domain, and cadence assumptions. Differential
-surface heating/moisture forcing for initiation or boundary experiments is future
-work tracked separately. Short science configurations must still run long enough
-to be meteorologically useful. Build should show expected cost, runtime, and
-output volume, and note when a configuration is better suited to larger compute
-instead of making machine choice the primary product axis.
+surface heating/moisture forcing is a current v0 patch recipe for localized
+initiation or boundary-style experiments; it is not a real front, dryline,
+land-surface, GIS, or radiation model. Its initial v0 geometry is a centered
+circular patch. It is local-only and runtime-unvalidated until the external CM1
+source customization path has passed a real compile plus emitted hfx/qfx
+forcing-footprint smoke test. Short science configurations must still run long
+enough to be meteorologically useful. Build should show expected cost, runtime,
+and output volume, and note when a configuration is better suited to larger
+compute instead of making machine choice the primary product axis.
 
 The run monitor should be compact by default. It should summarize active,
 queued, and completed runtime work while keeping detailed package, queue, LAN,

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -191,9 +191,10 @@ surface-forcing, duration, grid, domain, and cadence assumptions. Differential
 surface heating/moisture forcing is a current v0 patch recipe for localized
 initiation or boundary-style experiments; it is not a real front, dryline,
 land-surface, GIS, or radiation model. Its initial v0 geometry is a centered
-circular patch. It is local-only and runtime-unvalidated until the external CM1
-source customization path has passed a real compile plus emitted hfx/qfx
-forcing-footprint smoke test. Short science configurations must still run long
+circular patch. It is local-only; the external CM1 source customization path has
+runtime-local compile and emitted hfx/qfx forcing-footprint smoke evidence, but
+localized convergence/updraft/cloud-response diagnostics remain the #307
+closure gate. Short science configurations must still run long
 enough to be meteorologically useful. Build should show expected cost, runtime,
 and output volume, and note when a configuration is better suited to larger
 compute instead of making machine choice the primary product axis.

--- a/docs/contracts/analyzer-hypothesis-output-signature.md
+++ b/docs/contracts/analyzer-hypothesis-output-signature.md
@@ -81,13 +81,13 @@ assumption_set:
   assumption_set_id: string
   label: string
   trigger:
-    mode: none | future_differential_surface_forcing | future_explicit_trigger | unavailable
+    mode: none | future_explicit_trigger | unavailable
     description: string
     caveats: [string]
   surface_fluxes:
     sensible_heat_flux: prescribed | derived | disabled | unavailable
     latent_heat_flux: prescribed | derived | disabled | unavailable
-    source: current_control | recipe_default | future_surface_model | none
+    source: current_control | recipe_default | differential_surface_patch | future_surface_model | none
     caveats: [string]
   radiation:
     mode: disabled | prescribed_time_place | future_interactive | unavailable
@@ -109,7 +109,7 @@ assumption_set:
 ```
 
 Assumption sets must distinguish observed evolution under explicit forcing from
-future forcing modes:
+current and future forcing modes:
 
 - `observed_surface_forced_evolution`: no artificial atmospheric trigger; useful
   for asking what the initialized atmosphere does under the selected numeric
@@ -118,9 +118,11 @@ future forcing modes:
 - `surface_forced_evolution`: explicit surface sensible/latent heat-flux
   assumptions; useful for boundary-layer growth, shallow cloud, drizzle, or
   suppression hypotheses.
-- `future_differential_surface_forcing`: spatially varying heating/moisture
-  forcing for initiation, boundaries, gradients, or patch experiments. This is
-  tracked separately from issue #305.
+- `differential_surface_forced_evolution`: one idealized lower-boundary
+  heat/moisture patch for initiation, localized updraft, and organization
+  questions. It is current v0 support, applied through Cloud Chamber's CM1
+  source customization path, and still requires CM1-observable diagnostics
+  before Results can compare predicted signatures.
 - `radiation_place_time_evolution`: radiation/place-time assumptions; future
   contract for fog, nocturnal, winter, and diurnal hypotheses.
 

--- a/docs/contracts/run-recipe-and-story-mapping.md
+++ b/docs/contracts/run-recipe-and-story-mapping.md
@@ -288,7 +288,7 @@ required_outputs:
     - max_surface_rain
     - max_dbz
 current_support:
-  status: runtime_unvalidated
+  status: local_footprint_smoke_validated
   caveats:
     - The v0 patch is centered, circular, and idealized.
     - It is not a real land-surface, soil-moisture, vegetation, radiation,
@@ -296,12 +296,13 @@ current_support:
     - Cloud Chamber copies the local external CM1 source tree into an isolated
       runtime build tree, patches that copy, rebuilds CM1, and launches the
       copied custom executable.
-    - Differential surface forcing is local-only until trusted LAN worker source
-      customization and custom-executable provenance are implemented.
+    - Differential surface forcing is local-only; LAN worker source
+      customization remains unsupported.
     - Missing, malformed, or hash-mismatched patch files block the run rather
       than silently falling back to uniform forcing.
-    - This path still requires a real CM1 compile and emitted forcing-footprint
-      smoke test before it can be treated as #307-complete.
+    - A runtime-local CM1 compile plus emitted hfx/qfx forcing-footprint smoke
+      has verified the v0 local execution path, but #307 still needs
+      localized-response diagnostics before closure.
     - Surface-driven convergence, localized updrafts, coherent cloud growth,
       rain-water aloft, surface rain, and reflectivity remain diagnostics to
       inspect, not guaranteed outcomes.

--- a/docs/contracts/run-recipe-and-story-mapping.md
+++ b/docs/contracts/run-recipe-and-story-mapping.md
@@ -63,7 +63,7 @@ run_recipe:
   assumption_mode:
     observed_surface_forced_evolution
     | surface_forced_evolution
-    | future_differential_surface_forcing
+    | differential_surface_forced_evolution
     | elevated_forced_evolution
     | future
   run_shape:
@@ -78,7 +78,7 @@ run_recipe:
     diagnostic_set: essential | process | full | null
   forcing:
     trigger:
-      mode: none | future_explicit_trigger | future_differential_surface_forcing | unavailable
+      mode: none | future_explicit_trigger | unavailable
       description: string
     surface_sensible_heat_flux:
       mode: current_recipe_default | prescribed | disabled | future | unavailable
@@ -116,6 +116,7 @@ run_recipe:
     run_recipe:
       generated_reference_lower_atmosphere
       | observed_surface_forced_evolution
+      | differential_surface_forced_evolution
       | future
     run_configuration_defaults:
       duration: string | null
@@ -151,13 +152,14 @@ latent heat flux assumptions are explicit. Humid, drizzle, warm-rain, fog,
 post-frontal, and boundary-layer hypotheses need this mode before product copy
 can claim surface-forced precipitation or low-cloud signatures.
 
-### `future_differential_surface_forcing`
+### `differential_surface_forced_evolution`
 
-A future differential-forcing recipe asks whether localized or spatially varying
-surface heating/moisture gradients can initiate or organize convection. It is the
-right shape for future boundary, patch, dryline, or differential-heating
-experiments. It is not implemented by issue #305 and should not be implied by the
-current uniform surface-flux controls.
+A differential surface-forced recipe asks whether one localized lower-boundary
+heat/moisture patch can focus convergence, updraft initiation, cloud growth, and
+later rain/reflectivity differently from the surrounding surface. It is a
+current v0 patch experiment, not a real land-surface, radiation, GIS, front, or
+dryline model. Cloud Chamber applies it through explicit CM1 source
+customization at launch and must not silently fall back to uniform forcing.
 
 ### `radiation_place_time_evolution`
 
@@ -177,8 +179,8 @@ current observed-sounding run builder does not supply.
 Artificial atmospheric perturbation recipes from the earlier deep-potential
 direction are not current product paths. Current observed-sounding experiments
 use no artificial atmospheric trigger and rely on explicit surface-forcing and
-run-shape assumptions. Differential surface forcing is tracked separately as
-future work.
+run-shape assumptions. Differential surface forcing is a current lower-boundary
+patch recipe, not an atmospheric-trigger recipe.
 
 ## Current Recipe Catalog
 
@@ -233,8 +235,83 @@ cm1_mapping:
 This v0 recipe can inspect shallow cloud, humid/rainy, capped, and deep-candidate
 signals when the predicted signature can be evaluated from full CM1 output fields
 and enough duration/cadence. Deep organization, cold-pool, and storm-mode claims
-remain caveated until comparison diagnostics and differential forcing are
-validated.
+remain caveated until comparison diagnostics and the selected forcing recipe can
+support those claims.
+
+### `differential_surface_forced_evolution_v0`
+
+```yaml
+recipe_id: differential_surface_forced_evolution_v0
+display_name: Differential surface-forced evolution v0
+product_question: What happens when one part of the lower boundary is heated
+  and/or moistened more strongly than its surroundings?
+assumption_set_id: differential_surface_forced_evolution_v0_assumptions
+assumption_mode: differential_surface_forced_evolution
+run_shape:
+  duration_seconds: 21600 | configured
+  horizontal_cell_count: 64 | 96 | 128 | 192 | 256 | 384 | configured
+  domain_width_m: 6400 | 12800 | 60000 | 120000 | configured
+  model_top_m: current observed-sounding LES model top
+  output_cadence_seconds: 3600 | 900 | 300 | configured
+  requested_fields: full_output_field_set
+forcing:
+  trigger: {mode: none}
+  surface_sensible_heat_flux:
+    mode: prescribed_background_plus_patch
+    units: K m/s
+    value: configured
+  surface_latent_heat_flux:
+    mode: prescribed_background_plus_patch
+    units: g/g m/s
+    value: configured
+  surface_patch:
+    shape: circle
+    center: domain_center_v0
+    radius_m: configured
+    taper: raised_cosine
+    ramp_seconds: configured
+  radiation: {mode: disabled}
+  large_scale_lift: {mode: none}
+  convergence: {mode: emergent_from_surface_patch}
+required_inputs:
+  observed_temperature_profile: required
+  observed_moisture_profile: required
+  observed_wind_profile: required
+required_outputs:
+  fields: [qv, qc, w, qr, rain, dbz, u, v, th, prs, hfx, qfx, updraft_helicity]
+  diagnostics:
+    - emitted_surface_flux_contrast
+    - convergence_or_divergence_response
+    - localized_updraft_response
+    - coherent_cloud_object_top
+    - rain_water_aloft_onset
+    - max_surface_rain
+    - max_dbz
+current_support:
+  status: runtime_unvalidated
+  caveats:
+    - The v0 patch is centered, circular, and idealized.
+    - It is not a real land-surface, soil-moisture, vegetation, radiation,
+      terrain, GIS, front, or dryline model.
+    - Cloud Chamber copies the local external CM1 source tree into an isolated
+      runtime build tree, patches that copy, rebuilds CM1, and launches the
+      copied custom executable.
+    - Differential surface forcing is local-only until trusted LAN worker source
+      customization and custom-executable provenance are implemented.
+    - Missing, malformed, or hash-mismatched patch files block the run rather
+      than silently falling back to uniform forcing.
+    - This path still requires a real CM1 compile and emitted forcing-footprint
+      smoke test before it can be treated as #307-complete.
+    - Surface-driven convergence, localized updrafts, coherent cloud growth,
+      rain-water aloft, surface rain, and reflectivity remain diagnostics to
+      inspect, not guaranteed outcomes.
+cm1_mapping:
+  run_recipe: differential_surface_forced_evolution
+  runtime_files_needed:
+    - surface_forcing_patch.json
+    - cloud_chamber_surface_forcing_patch.dat
+    - cm1_source_customization.json
+```
 
 ## Domain And Duration Expectations
 

--- a/docs/research/surface-flux-control-validation.md
+++ b/docs/research/surface-flux-control-validation.md
@@ -99,8 +99,10 @@ surface-flux path:
 
 The former idealized deep-trigger path is no longer a current Build recipe.
 Deep-convection candidates can still be run as observed-sounding experiments
-under the selected uniform lower-boundary forcing, with caveats that differential
-heating or convergence-style initiation is future work tracked in issue #307.
+under the selected lower-boundary forcing. Uniform forcing remains the baseline
+surface-flux path; the differential surface patch recipe is the current
+localized-initiation path when the experiment question is whether a warm/moist
+surface contrast focuses ascent.
 
 The current observed path is therefore best described as:
 

--- a/docs/research/surface-forced-sounding-verification-protocol.md
+++ b/docs/research/surface-forced-sounding-verification-protocol.md
@@ -50,7 +50,9 @@ Current assumptions:
 - Radiation is disabled.
 - Large-scale forcing/convergence is not implemented.
 - Terrain, GIS surface data, soil moisture, vegetation, wet ground, transpiration, and real place/time surface-energy budgets are not implemented.
-- Differential surface forcing is future work tracked separately.
+- Differential surface forcing is a separate v0 patch recipe. It adds an
+  idealized lower-boundary heat/moisture perturbation through CM1 source
+  customization, not through a real land-surface or radiation model.
 
 ## Campaign principles
 


### PR DESCRIPTION
## Summary

Refs #307.

Adds a v0 differential lower-boundary surface-forcing package path for observed soundings. This PR packages a centered circular warm/moist surface patch, preserves provenance, and implements the local-only CM1 source-customization path. A runtime-local CM1 compile and emitted hfx/qfx forcing-footprint smoke now passes, but this still should not close #307 because localized convergence/updraft/cloud-response diagnostics are not implemented yet.

What changed:

- Added backend surface-forcing patch models, validation, rendered patch artifacts, and source-customization provenance.
- Added a `differential_surface_forced_evolution_v0` recipe path with required observed winds, full diagnostics, normal CM1 surface initialization (`initsfc = 1`), and source-customization-required metadata.
- Hardened local launch for differential packages: validate patch-data hashes, build from an isolated copy of the configured external CM1 source tree, fail on already-patched source trees, copy the custom executable into the run directory, record source/executable hashes, and launch that run-specific executable.
- Preserved applied source-customization status in completed run manifests and ingested result metadata.
- Made the injected CM1 patch fail closed when the runtime patch file is missing, unreadable, or malformed rather than silently falling back to uniform forcing.
- Blocked LAN worker execution for differential packages until remote CM1 source customization/custom-executable provenance exists.
- Restricted v0 patch geometry to centered circle only; ellipse/x-y radius behavior remains out of scope until physical-coordinate taper validation exists.
- Extended the surface-forced campaign planner/reporting path to preserve differential patch settings and hash, reject unknown differential-looking fields, and block LAN differential rows.
- Updated Build/run-plan controls and docs so the product contract says circle-only, local-only, locally footprint-smoke validated, and not #307-complete yet.

## Runtime Smoke Evidence

Three runtime-local CM1 rows completed and auto-ingested:

- `differential_footprint_001-footprint_uniform_control-8b5d1c0da6`
- `differential_footprint_001-footprint_heat_patch-21216f1084`
- `differential_footprint_001-footprint_heat_moisture_patch-f89068698b`

Footprint checks passed:

- Uniform control final-frame hfx/qfx are effectively uniform.
- Heat-only patch final-frame hfx center/outside ratio is about 6.0; qfx remains effectively unenhanced.
- Heat+moisture patch final-frame hfx center/outside ratio is about 6.0; qfx center/outside ratio is about 1.96.
- Patch maxima remain inside the requested centered 1.5 km radius.
- Final-frame hfx/qfx fields are finite for all three rows.
- All three CM1 runs exited 0 and reported normal termination.
- All stderr warnings were underflow-only; no invalid, divide-by-zero, or overflow flags were reported.
- Patch runs used copied custom executables with SHA `7f91f628d87963861e76eba8b268de1647eae969af2005ea0161ea5647baf957`, distinct from the shared CM1 executable SHA.

## Verification

- Runtime-local CM1 forcing-footprint smoke: `differential_footprint_001`
- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_local_run_manager.py::test_launch_applies_differential_surface_source_customization_before_cm1 app/backend/tests/test_result_ingest.py::test_ingest_preserves_cm1_source_customization_status`
- `app/backend/.venv/bin/python -m pytest app/backend/tests/test_local_run_manager.py app/backend/tests/test_surface_forced_campaign.py app/backend/tests/test_cm1_input_contract.py app/backend/tests/test_dry_run_package.py app/backend/tests/test_app.py -q`
- `app/backend/.venv/bin/python -m ruff format --check app/backend/cloud_chamber app/backend/tests`
- `app/backend/.venv/bin/python -m ruff check app/backend/cloud_chamber app/backend/tests`
- `app/backend/.venv/bin/python -m mypy app/backend/cloud_chamber`
- `cd app/frontend && npm test -- App.test.tsx`
- `scripts/check.sh`
- `scripts/check-e2e.sh`

## Known Limitations

- This PR still does not close #307: forcing-footprint execution is validated, but localized-response diagnostics are not implemented.
- The PR does not add forcing-footprint, near-surface convergence, patch-to-updraft alignment, or patch-to-cloud alignment diagnostics as durable result products.
- Differential LAN execution is deliberately blocked.
- v0 geometry is centered circular patch only.
- The patch is an idealized lower-boundary contrast, not a real land-surface, radiation, GIS, front, dryline, or atmospheric warm-bubble implementation.
