### PR TITLE
docs: reset Cloud Chamber around cloud opportunities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,37 +2,142 @@
 
 ## Project Identity
 
-Cloud Chamber is a local-first configuration, run-management, diagnostics, and
-visualization environment for CM1 cloud experiments.
+Cloud Chamber is a local-first **cloud-making sandbox that uses real atmospheres
+as raw material**.
 
-The goal is to make CM1 usable, beautiful, and explainable for guided
-cloud-physics exploration.
+The organizing product question is:
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
-experiment builder, run manager, result notebook, diagnostics layer, and
-visualizer.
+> Given the soundings available, which ones can make interesting clouds, what
+> setup should I use, and how far do I need to push them?
+
+CM1 is the high-fidelity simulation engine. Cloud Chamber is the opportunity
+finder, recipe and run-setup recommender, local run manager, result notebook,
+diagnostics layer, and visualizer around CM1.
+
+The immediate visible priorities are growing cumulus/congestus, deep convective
+towers, and then precipitation. Cloud Chamber is not a forecast or warning
+product.
 
 ## Product Rule
 
-CM1 is the high-fidelity model. The app should not pretend to be CM1.
+CM1 is the source of truth for cloud evolution. The app should not pretend to be
+CM1.
 
-Reduced/light models may be used only for:
+Reduced/light models and analyzer scores may be used for:
 
-- preview
-- explanation
-- rough guidance
-- sanity checks
+- opportunity ranking;
+- recipe and run-setup recommendations;
+- preview and explanation;
+- scout continuation decisions;
+- rough guidance and sanity checks.
 
-They are not the source of truth for cloud evolution.
+They are decision aids, not simulated cloud output.
+
+## Cloud-Making Operating Mode
+
+This mode applies when the user or issue asks to find promising soundings, make
+interesting clouds, build a cloud recipe, run a scout, continue a promising run,
+or improve the cloud-making workflow. Issue #346 and its related recipe work are
+explicitly in this mode.
+
+Cloud-Making Mode overrides generic conservative defaults that would otherwise
+fragment or delay the outcome.
+
+### Outcome Priority
+
+Optimize for:
+
+```text
+visible cloud outcome + useful learning per unit of user time and compute
+```
+
+A useful result may be:
+
+- growing cumulus or congestus;
+- a deep tower;
+- precipitation or reflectivity;
+- a decisive recommendation to switch recipe or skip a poor sounding;
+- evidence that a run is actually broken or numerically suspicious.
+
+Package plumbing, provenance, diagnostics, and docs support those outcomes. They
+are not the outcome themselves.
+
+### Bounded Big Swings
+
+- Strong idealized assumptions are allowed when clearly labeled.
+- Scientific honesty means naming the added mechanism and limitations; it does
+  not mean always choosing the weakest forcing, smallest domain, shortest run,
+  or least effective trigger.
+- Prefer a meaningful three-run scout or one bold vertical slice over a chain of
+  prerequisite issues.
+- Run real CM1 early enough to influence the implementation.
+- If a run is merely boring, change the sounding, recipe, scale, duration, or
+  trigger before adding diagnostics.
+- Restore or reuse working cloud-making paths from repository history instead of
+  rebuilding them from scratch because later docs became more conservative.
+
+### Scout And Full Run
+
+Scouts must be meaningful for the recipe. When a scout meets explicit promotion
+criteria, it may visibly and automatically queue or continue a full run through
+the existing Build workflow.
+
+The user must be able to see:
+
+- the promoted run;
+- the reason for promotion;
+- configured duration;
+- progress and ETA;
+- stop/cancel and cleanup controls.
+
+Do not launch hidden or unbounded batches.
+
+### Diagnostic Burden
+
+Before adding a diagnostic, identify which decision it changes:
+
+```text
+continue
+scale up
+change one recipe parameter
+switch recipe
+skip sounding
+stop broken run
+```
+
+If it changes none of those decisions, do not make it the next task.
+
+Heavy trust and diagnostic work is appropriate when output is non-finite,
+numerically suspicious, missing the requested mechanism, missing evidence needed
+for the decision, or inconsistent with its configuration. It is not required
+merely because the result is shallow, surprising, or exploratory.
+
+### Issue Scope In Cloud-Making Mode
+
+Scope work to one **user outcome**, not one tiny implementation layer. A vertical
+slice may legitimately include analyzer logic, recipe configuration, Build UI,
+queue behavior, result copy, tests, docs, and a real CM1 scout when all are
+needed to produce the outcome.
+
+Do not create prerequisite or follow-up issues automatically. Create one only
+when the current work is genuinely blocked or the discovered work is an
+independent product decision. Do not use issue creation as a substitute for
+finishing the current outcome.
+
+Comparison is secondary. Compare two or a few runs when an actual cloud result
+creates a useful question; do not require formal matched campaigns before making
+interesting clouds.
 
 ## Durable Distinction
 
 Always distinguish:
 
 ```text
-Preview estimate
+Analyzer/recommendation estimate
 CM1 run configuration
-CM1 running/completed result
+Packaged run
+Queued/running CM1 process
+Completed/ingested CM1 result
 Visualization interpretation
 ```
 
@@ -40,34 +145,43 @@ Visualization interpretation
 
 Do not commit:
 
-- CM1 source
-- CM1 binaries
-- NetCDF output
-- generated run directories
-- LANDUSE.TBL
-- local-data
-- large processed visualization artifacts
+- CM1 source;
+- CM1 binaries;
+- NetCDF output;
+- generated run directories;
+- `LANDUSE.TBL`;
+- local data;
+- machine-private settings or paths;
+- large processed visualization artifacts.
 
 Do commit:
 
-- code
-- tests
-- docs
-- schemas
-- scenario templates
-- tiny fixtures
+- code;
+- tests;
+- docs;
+- schemas;
+- recipe definitions;
+- tiny fixtures.
 
 ## Development Expectations
 
 - Use GitHub issues and PRs.
 - Work on branches; do not push directly to `main`.
-- Keep work scoped to the issue.
+- Keep work scoped to the issue's user outcome.
 - Add tests for new behavior.
-- Update docs when architecture/workflow changes.
+- Update docs when architecture, workflow, recipe behavior, or product direction
+  changes.
 - Use local fake fixtures in CI; do not require real CM1 in automated tests.
-- Do not weaken scientific honesty to make UI look better.
-- For Codex issue work, enable auto-merge after required CI checks pass unless the user explicitly asks for manual review or the PR is high-risk/destructive.
-- Treat destructive cleanup, generated-data policy changes, scientific interpretation changes, and real CM1 execution changes as high-risk unless the user says otherwise.
+- Run real CM1 outside CI when the issue explicitly requires cloud-making or
+  runtime validation.
+- Do not weaken scientific honesty, but do not confuse honesty with weak
+  experiments.
+- Enable auto-merge after required CI checks pass unless the user asks for
+  manual review or the change is destructive/high-risk.
+- Destructive cleanup, generated-data policy changes, unbounded compute, and
+  backwards-incompatible data changes are high-risk.
+- Real CM1 execution is not an automatic stop condition when the user or issue
+  has explicitly authorized a bounded scout or cloud-making run.
 
 ## Initial Architecture Bias
 
@@ -81,7 +195,7 @@ until a stronger reason appears.
 
 ## Local CM1 Runtime
 
-CM1 should remain external to the repo.
+CM1 remains external to the repo.
 
 Likely local path for Tim:
 
@@ -99,200 +213,220 @@ Default Cloud Chamber runtime data belongs outside the repo:
 
 `./local-data/` is only a gitignored development override.
 
-## UI Language
+## Product Language
 
-Use atmospheric language first:
+Use cloud and atmosphere language first:
 
-- thermal fate
+- cloud opportunity;
+- recipe;
+- run setup;
+- growing cumulus;
+- congestus;
+- deep tower;
+- daytime evolution;
+- explicit thermal initiation;
+- broad warm/moist region;
+- suppression / cap challenge;
+- likely ceiling;
+- main obstacle;
+- scout;
+- continue / switch / skip;
+- cloud base and coherent cloud top;
+- updraft strength;
+- cloud water and ice;
+- rain onset and reflectivity;
 - What happened here?
-- selected region
-- lower-atmosphere humidity
-- surface moisture
-- surface heating
-- cap strength
-- cap height
-- dry air aloft
-- mixing / entrainment
-- updraft strength
-- saturation deficit
-- deep breakthrough
-- precipitation feedback
-- downdraft
-- cold pool
-- outflow boundary
-- cloud base
-- cloud top
-- first cloud time
-- rain onset
 
-Raw namelist settings and raw CM1 variable names belong in technical,
-advanced, or developer views. Product-facing views should start with thermal
-fate, selected-region inspection, and atmospheric process language.
+Raw namelist settings and raw CM1 variable names belong in technical, advanced,
+or developer views.
+
+Do not use forecast or warning language. Do not imply that an idealized trigger
+represents a real front, dryline, terrain feature, or observed initiating
+mechanism.
 
 ## Testing Notes
 
 Use fake/small fixtures to test:
 
-- scenario schemas
-- config generation
-- run manifest creation
-- fake process execution
-- NetCDF ingestion from tiny fixtures
-- visualizer metadata loading
+- recommendation and recipe contracts;
+- scenario/run schemas;
+- config generation;
+- run manifest creation;
+- scout/full-run relationship;
+- fake process execution;
+- NetCDF ingestion from tiny fixtures;
+- visualizer metadata loading.
 
-Do not require full CM1 runs in CI.
+Do not require full CM1 runs in CI. Real cloud-making evidence belongs in local
+manual/runtime verification and the PR description or approved research note,
+not in git as generated model output.
 
 ## Before Major Changes
 
-If changing product direction, ask first.
+Ask before changing product direction **outside** the approved cloud-first reset.
+The direction in `docs/cloud-first-product-reset.md` and #346 is already approved.
+Do not repeatedly ask for confirmation to implement it.
 
-If adding physics/science behavior, document:
+When adding a physical mechanism or recipe, document:
 
-1. what physical question it supports
-2. what user control it enables
-3. what diagnostics validate it
-4. what limitations must be disclosed
+1. the cloud outcome or learning question;
+2. the added assumption or mechanism;
+3. the useful user control or supported aggressiveness level;
+4. the meaningful scout and full-run setup;
+5. the continue/change/stop decision evidence;
+6. the limitations that must be visible.
 
 ---
 
-## Claude Code — Working Style and Expectations
+## Coding Agent Working Style
 
-This section governs how Claude Code operates on this project. It extends
-the rules above; nothing here overrides the product rule, guardrails, or
-scientific-honesty requirements.
+This section governs Codex, Claude Code, and similar coding agents.
 
-### Intent First
+### Intent First, Without Stalling
 
-Before writing any code on a non-trivial task, Claude Code must:
+For a non-trivial task:
 
-1. State what it understands the goal to be.
-2. Ask every question needed to fully understand intent — user workflow,
-   edge cases, acceptance criteria, what "done" looks like.
-3. Propose an approach and wait for a go-ahead before executing.
+1. State the user outcome you understand.
+2. Identify only material unresolved decisions.
+3. Make reasonable bounded assumptions for everything else.
+4. Propose the execution direction briefly and proceed when the issue/user intent
+   is already clear.
 
-For small, obviously-scoped tasks (typo fixes, single-line changes, adding
-a missing test for existing behavior) it may proceed directly.
+Do not ask every conceivable question. Do not require another go-ahead when the
+user has already approved the product direction or the issue has explicit
+acceptance criteria.
 
-When in doubt, ask. A short clarifying exchange is cheaper than a wrong
-implementation.
+A clarification is appropriate when different answers would materially change
+the product outcome, delete user data, create unbounded compute, or make the
+requested work unsafe. It is not appropriate merely because implementation has
+multiple reasonable choices.
 
 ### Autonomy
 
-Once intent is confirmed, Claude Code should execute as fully as possible
-without interruption:
+Once intent is clear, execute as fully as possible:
 
-- Write the code.
-- Write or update tests.
-- Run `scripts/check.sh` and fix any failures before committing.
-- Update relevant docs if architecture or workflow changed.
-- Open a PR with a clear description.
-- Create GitHub issues for anything discovered during work that is out of
-  scope for the current task (bugs, missing tests, doc gaps, a11y issues).
-  Do not silently leave TODOs for things that deserve tracking.
+- write the code;
+- add or update tests;
+- run meaningful local CM1 scouts when in scope;
+- inspect the outcome and adjust the implementation or run setup;
+- run `scripts/check.sh` and fix failures;
+- update relevant docs;
+- open a PR with clear verification and real-run evidence when applicable.
 
-Do not ask for permission to run the linter, run tests, fix a type error,
-or update a doc string. Those are part of the job.
+Do not ask permission to run tests, lint, type checks, Playwright, or bounded CM1
+scouts that the issue explicitly requests.
 
-### Branching and PRs
+Do not automatically open issues for every bug, missing test, doc gap, or idea.
+Fix it in the current outcome when reasonably related. Open a separate issue only
+for a real blocker or independent product decision.
 
-- Branch off `main`. Name branches `issue-NNN-short-description`.
-- One issue per branch. Keep PRs scoped.
-- PR description must include:
-  - What changed and why.
-  - How to verify it locally (specific commands or UI steps).
-  - Any known limitations or follow-up issues opened.
-- Enable auto-merge after CI passes unless the task is high-risk (see
-  Guardrails above) or the user asks for manual review.
+### Branching And PRs
+
+- Branch from current `main`.
+- Name branches `issue-NNN-short-description`.
+- One user outcome per branch. A cloud-making vertical slice may span multiple
+  technical layers.
+- Keep unrelated opportunistic cleanup out of the PR.
+- PR descriptions must include:
+  - the user outcome;
+  - what changed and why;
+  - how to verify it locally;
+  - real CM1 runs and visible outcomes when cloud-making is in scope;
+  - known limitations that affect the next decision.
+- Enable auto-merge after CI unless the task is destructive/high-risk or the user
+  asks for manual review.
 
 ### Commit Style
 
 - Conventional commits: `feat:`, `fix:`, `test:`, `docs:`, `chore:`, `refactor:`.
-- Subject line: imperative, ≤72 chars.
-- Body: include the issue number and a sentence on why, not just what.
-- Atomic commits — one logical change per commit. Do not bundle unrelated
-  fixes.
+- Subject line: imperative, at most 72 characters.
+- Body: include the issue number and why the change matters.
+- Keep commits logically coherent. Do not split a vertical slice into artificial
+  commits merely to appear small.
 
 ### Quality Bar
 
-Every PR must pass `scripts/check.sh` cleanly before merge:
+Every PR must pass `scripts/check.sh` before merge:
 
 - Frontend: lint, test, build.
 - Backend: ruff format, ruff check, mypy, pytest.
-- No new warnings introduced without explanation.
+- No unexplained new warnings.
 
-New behavior requires new tests. Refactors must not reduce test coverage.
-UI changes that affect user-visible text or workflow must include an update
-to the relevant doc in `docs/`.
+New behavior requires tests. UI changes that affect user-visible workflow must
+update the relevant docs.
+
+Tests and type safety support iteration; they must not become a reason to avoid a
+meaningful real run.
 
 ### GitHub Issues
 
-When Claude Code opens an issue it must:
+When opening an issue:
 
-- Use the correct label set (see repo labels).
-- Write a description a future developer can act on without context:
-  summary, observed behavior, expected behavior, reproduction steps or
-  fix hint.
-- Tag `priority:p1` for bugs that break core workflows; `priority:p2` for
-  everything else unless the user says otherwise.
-- Reference the PR or commit that surfaced it.
+- use the correct labels;
+- write it around a user-visible outcome or concrete bug;
+- include enough context for future work;
+- avoid turning implementation layers into separate roadmap items;
+- use `priority:p1` for core-workflow blockers and approved immediate product
+  work; `priority:p2` otherwise.
 
-### What Claude Code Must Not Do Without Asking
+### What Agents Must Ask Before Doing
 
-Even with full autonomy confirmed, always pause and ask before:
+Always ask before:
 
-- Changing product direction or adding a new top-level workspace/view.
-- Changing scientific interpretation, diagnostic labels, or provenance
-  language.
-- Modifying data deletion logic or storage cleanup policy.
-- Touching real CM1 execution paths.
-- Changing the run manifest schema or result card schema in a
-  backwards-incompatible way.
-- Removing or weakening a test rather than fixing the underlying issue.
+- deleting or overwriting user-owned runtime data beyond an explicit cleanup
+  request;
+- launching an unbounded or unexpectedly expensive batch;
+- changing product direction outside the approved cloud-first model;
+- making backwards-incompatible manifest/result changes without a migration;
+- removing or weakening tests rather than fixing the underlying issue.
+
+Do **not** pause merely because work touches:
+
+- real CM1 execution explicitly requested by the issue;
+- additive schemas;
+- recipe assumptions within the approved catalog;
+- recommendation or interpretation copy consistent with the approved product
+  model;
+- a bounded scout and visible automatic full-run promotion.
 
 ### Environment Assumptions
 
-Claude Code sessions assume:
+Coding sessions may assume:
 
-- `scripts/dev.sh start` has been run (frontend at `localhost:5173`,
-  backend at `127.0.0.1:8000`).
-- `~/CloudChamber/settings.json` exists with local CM1 paths if CM1
-  work is in scope.
-- `uv` or the pip fallback described in `docs/development.md` is
-  available for backend work.
-- The Playwright E2E suite lives at `~/e2e/` (separate from the repo)
-  and can be run with `npx playwright test` from that directory.
+- `scripts/dev.sh start` can run the frontend at `localhost:5173` and backend at
+  `127.0.0.1:8000`;
+- `~/CloudChamber/settings.json` contains local CM1 paths when CM1 work is in
+  scope;
+- `uv` or the documented pip fallback is available;
+- the Playwright E2E suite may live at `~/e2e/`.
 
 ### Playwright E2E
 
-When fixing a UI bug or adding a UI feature:
+For user-visible workflow changes:
 
-- Check whether an existing Playwright test covers it.
-- If yes, verify the test passes after the change.
-- If no, add a test or open an issue noting the gap.
-- Never delete or skip a Playwright test to make CI pass. Fix the
-  underlying issue or open an issue and mark the test `.skip` with a
-  comment referencing it.
+- check existing Playwright coverage;
+- update or add the smallest useful end-to-end test;
+- verify the actual UI when practical;
+- never delete or skip tests merely to make CI pass.
 
 ### Documentation Standard
 
-- `docs/development.md` is the canonical dev setup reference. Keep it
-  current.
-- `docs/architecture-and-data-model.md` must reflect any schema or
-  API contract changes.
-- `docs/roadmap-and-issues.md` should be updated when milestones
-  shift significantly.
-- Inline code comments explain *why*, not *what*. Remove comments that
-  just restate the code.
+- `docs/cloud-first-product-reset.md` is the current organizing product decision.
+- `docs/current-roadmap.md` is the active priority source.
+- `docs/product-vision.md` describes the durable product model.
+- `docs/development.md` is the canonical dev setup.
+- `docs/architecture-and-data-model.md` must reflect schema/API changes.
+- Inline comments explain why, not what.
 
 ### Maintainability Bias
 
 Prefer:
 
-- Explicit over clever.
-- Small, testable functions over large ones.
-- Types everywhere in TypeScript and Python.
-- Clear error messages that name the problem and suggest a fix.
-- Fail loudly on bad state rather than silently degrade.
+- explicit over clever;
+- small, testable functions over tangled ones;
+- types in TypeScript and Python;
+- clear errors that name the problem and suggest a fix;
+- fail loudly on bad state rather than silently degrade.
 
-When two approaches are roughly equivalent, choose the one that is easier
-to delete or replace later.
+Maintainability serves cloud-making iteration. When two designs are roughly
+equivalent, choose the one that is easier to change after real CM1 evidence.

--- a/README.md
+++ b/README.md
@@ -1,81 +1,120 @@
 # Cloud Chamber
 
-Cloud Chamber is a local CM1 experiment builder, run manager, results notebook,
-and Thermal Fate exploration workbench.
+Cloud Chamber is a local-first **cloud-making sandbox that uses real atmospheres
+as raw material**.
 
-It helps users configure CM1 scenarios, run them locally, ingest outputs, save
-and compare results, inspect CM1 fields, and understand the fate of thermals
-through diagnostics and provenance-labeled visualizations.
+Its organizing question is:
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
-experiment builder, run manager, result notebook, diagnostics layer, and
-visualizer.
+> Given the soundings available, which ones can make interesting clouds, what
+> setup should I use, and how far do I need to push them?
+
+CM1 is the high-fidelity simulation engine. Cloud Chamber finds cloud
+opportunities, recommends recipes and run setups, manages local CM1 runs,
+organizes results, and helps users watch and understand cloud evolution.
+
+The first visible priorities are growing cumulus/congestus, deep convective
+towers, and then precipitation. Cloud Chamber is not a forecast or warning
+product.
 
 ## Core Direction
 
-Build a local-first, personal-use CM1 configuration, run-management,
-diagnostics, and visualization environment for guided cloud-physics
-experiments.
+The primary experience should support both:
 
-The first executable Golden Path is **Baseline Shallow Cumulus**: a credible
-idealized CM1 case for learning how lower-atmosphere controls shape thermal
-fate, cloud formation, vertical motion, and rain.
+```text
+Show me something cool
+```
+
+and:
+
+```text
+What can we do with this sounding?
+```
+
+Cloud Chamber should rank:
+
+```text
+sounding + recipe + run setup
+```
+
+rather than asking the user to interpret a sounding and guess which CM1
+configuration might work.
 
 ## Core Workflow
 
 ```text
-Choose experiment
--> adjust meaningful atmospheric controls
--> preview likely behavior with a lightweight predictor
--> generate/launch a local CM1 run
--> monitor status/logs
--> ingest results
--> inspect and visualize CM1-derived fields
--> save/name/tag useful runs
--> replay and inspect them later
--> compare scenario variants
--> ask what happened to a selected thermal/region as diagnostics mature
+Find promising sounding–recipe pairs
+→ recommend a concrete run setup
+→ queue a meaningful scout through Build
+→ automatically promote a promising scout to a visible full run
+→ ingest the result
+→ explore the evolving cloud
 ```
 
-This repo is still evolving, but it is no longer only the initial scaffold. The
-current app has a guided local run loop, local CM1 launch/status handling,
-NetCDF ingest, result cards/notebook entries, Results/Compare/Storage
-workspaces, 2-D field inspection, and an initial 3-D cloud-water/slice
-visualization path. Real CM1 execution remains local/manual and outside CI.
+The existing Build workflow remains the execution center: run plan, package,
+queue, progress/ETA, stop, ingest, and cleanup. Automatic scout promotion must be
+visible and reversible.
+
+## Initial Cloud Recipes
+
+The starting recipe catalog is:
+
+1. **Daytime Evolution** — simplified ordinary heated-day evolution.
+2. **Broad Warm/Moist Surface Region** — lower-boundary heterogeneity intended to
+   organize growing ascent.
+3. **Explicit Thermal Initiation** — a clearly labeled supplied thermal.
+4. **Deep-Tower Benchmark** — strong explicit initiation intended to reveal the
+   sounding's convective ceiling.
+5. **Suppression / Cap Challenge** — learn what is required to make a capped
+   atmosphere produce cloud.
+
+Strong idealized assumptions are acceptable when clearly labeled. Scientific
+honesty does not require the weakest possible run setup.
+
+## Current Product Shape
+
+- **Build**: cloud-opportunity discovery, sounding/recipe recommendation, run
+  setup, package generation, queue/progress/ETA, stop, ingest, and cleanup.
+- **Results**: local notebook of completed and ingested CM1 cloud runs.
+- **Explore**: time replay, field inspection, cloud interpretation, and visual
+  payoff.
+- **Frontend**: TypeScript, React, Vite, Vitest, ESLint, Prettier.
+- **Backend/tooling**: Python 3.12+, FastAPI, xarray, pytest, ruff, mypy.
+- **CI**: GitHub Actions for frontend, backend, scripts, docs, and config sanity.
+
+Real CM1 execution remains local and outside CI.
+
+## Product Guardrails
+
+Cloud Chamber should not pretend to be CM1. Analyzer scores and previews support
+recommendation and explanation; CM1 output remains the source of truth for cloud
+evolution.
+
+Always distinguish:
+
+```text
+Analyzer/recommendation estimate
+CM1 run configuration
+Packaged run
+Queued/running CM1 process
+Completed/ingested CM1 result
+Visualization interpretation
+```
+
+Do not commit CM1 source, CM1 binaries, NetCDF output, generated run directories,
+`LANDUSE.TBL`, local data, machine-private settings, or large processed
+visualization artifacts.
 
 ## Docs
 
+- [Cloud-first product reset](docs/cloud-first-product-reset.md)
 - [Product vision](docs/product-vision.md)
+- [Current roadmap](docs/current-roadmap.md)
 - [Product spec](docs/cloud-chamber-product-spec.md)
 - [Architecture and data model](docs/architecture-and-data-model.md)
-- [Thermal Fate process diagnostics](docs/thermal-fate-process-diagnostics.md)
-- [Current roadmap](docs/current-roadmap.md)
-- [Codex project setup](docs/codex-project-setup.md)
+- [Agent operating rules](AGENTS.md)
 - [Development](docs/development.md)
 - [Testing and validation](docs/testing-and-validation.md)
 - [CI and branch protection](docs/ci-and-branch-protection.md)
-
-## Current App Shape
-
-- Frontend: TypeScript, React, Vite, Vitest, ESLint, Prettier.
-- Backend/tooling: Python 3.12+, pytest, ruff, mypy.
-- Build workspace: scenario selection, curated controls, package generation,
-  launch/status review, and ingest action against local backend APIs.
-- Results workspace: result notebook, comparison, and runtime storage views.
-- Explore workspace: 2-D slices and initial 3-D visualization over backend
-  visualization-ready data.
-- Local checks: `scripts/check.sh`.
-- CI: GitHub Actions jobs for frontend, backend, scripts, docs, and config sanity.
-
-## Guardrails
-
-Cloud Chamber should not pretend to be CM1. Lightweight previews may support explanation, rough guidance, and sanity checks, but CM1 remains the source of truth for cloud evolution.
-
-Saved results should behave like experiment notebook entries: named, tagged, replayable, inspectable, and explainable. Rerunning or duplicating a saved setup is useful later, but replay/inspect/save is the core MVP result behavior.
-
-Optional remote/cloud compute is not part of the MVP. The near-term heavier-run direction is a trusted LAN worker used as a CM1 compute appliance while Cloud Chamber remains local-first and MacBook-centered.
-
-Do not commit CM1 source, CM1 binaries, NetCDF output, generated run directories, `LANDUSE.TBL`, local data, or large processed visualization artifacts.
 
 ## Local Checks
 
@@ -85,13 +124,10 @@ From the repo root:
 scripts/check.sh
 ```
 
-The script is executable and runs the same fast checks as CI.
-
-`scripts/check.sh` is the canonical local validation gate. Run it before opening PRs. It intentionally does not run real CM1, require a local CM1 installation, use NetCDF sample output, or create generated CM1 artifacts.
+The script runs the fast checks used by CI. It intentionally does not require a
+real CM1 installation or generated model output.
 
 ## Local Dev Servers
-
-From the repo root:
 
 ```sh
 scripts/dev.sh start
@@ -99,11 +135,12 @@ scripts/dev.sh restart
 scripts/dev.sh stop
 ```
 
-The helper runs the FastAPI backend on `http://127.0.0.1:8000` and the Vite frontend on `http://localhost:5173`, with logs and PID files under `.dev/`.
+The helper runs the FastAPI backend on `http://127.0.0.1:8000` and the Vite
+frontend on `http://localhost:5173`, with logs and PID files under `.dev/`.
 
 ## Runtime Data
 
-Runtime data belongs outside the repo by default:
+Runtime data belongs outside the repo:
 
 ```text
 ~/CloudChamber/
@@ -113,14 +150,18 @@ Runtime data belongs outside the repo by default:
   logs/
 ```
 
-`./local-data/` may be used as a gitignored development override, but generated CM1 runs and outputs should not live in source control.
+`./local-data/` may be used as a gitignored development override. Generated CM1
+runs and outputs should not live in source control.
 
-The top-level `data/` directory is placeholder/fixture-only. It is not the runtime data home.
+## Immediate Work
 
-## Current Near-Term Scope
+- **#346**: rank cloud opportunities and build the visible scout-to-full-run
+  workflow.
+- **#341**: restore the proven explicit thermal/deep-tower capability from the
+  earlier Deep Convection Trial.
+- **#287**: implement a real daytime-evolution recipe using active place/time
+  forcing or an honestly labeled evolving proxy.
 
-Near-term work is shifting from the first executable Baseline Shallow Cumulus
-loop toward Thermal Fate diagnostics: process summaries, selected-region
-`What happened here?` inspection, surface-heating and deep-breakthrough
-scenario families, precipitation-feedback/cold-pool reasoning, and renderer
-upgrades only after those process needs are clear.
+Infrastructure is successful only when it helps produce an interesting cloud,
+continues a promising one, skips a poor bet, identifies a broken run, or makes a
+cloud easier to see and understand.

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -1,1742 +1,508 @@
 # Cloud Chamber Product Spec
 
+Status: current cloud-first product contract
+
 ## Product Summary
 
-Cloud Chamber is a local-first desktop/browser application for configuring,
-running, managing, diagnosing, comparing, and visualizing CM1 cloud experiments
-for personal learning and exploration.
+Cloud Chamber is a local-first **cloud-making sandbox that uses real atmospheres
+as raw material**.
 
-The product should make CM1 approachable without hiding scientific limits.
+The central question is:
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
-experiment builder, run manager, result notebook, diagnostics layer, and
-visualizer.
+> Given the soundings available, which ones can make interesting clouds, what
+> setup should I use, and how far do I need to push them?
 
-Cloud Chamber's main flow should be product-shaped, not namelist-shaped.
-Friendly atmospheric controls come first; raw CM1 namelist settings belong in
-advanced/developer views.
+CM1 is the high-fidelity model. Cloud Chamber owns:
 
-The current UX reset direction is:
+- sounding and cloud-opportunity discovery;
+- recipe and run-setup recommendations;
+- local CM1 package/run management;
+- scout and full-run orchestration;
+- result ingest and notebook organization;
+- visual exploration and explanation.
 
-```text
-Cloud Chamber is a guided experiment notebook for understanding why clouds formed, failed, stayed shallow, or grew stronger.
-```
+Cloud Chamber is for personal learning, cloud experimentation, and visual
+exploration. It is not a forecast, warning, or publication workflow.
 
-The current product model is:
+## Product Goals
 
-```text
-Build = configure and launch one or more planned CM1 runs
-Results = notebook for completed/ingested runs
-Explore = inspect one result with CM1-derived evidence
-```
+The first visible outcome priorities are:
 
-Build should be organized around configurable observed-sounding runs. Presets
-are useful starting points, not separate product cages: a user should be able to
-start from a sane preset, inspect the actual CM1-facing settings, and adjust
-numeric surface forcing, duration, horizontal cell budget, domain size, and
-output cadence within guarded bounds while requesting the full output field set.
+1. growing cumulus and congestus;
+2. deep convective towers;
+3. precipitation and reflectivity;
+4. useful suppression/cap cases when cloud growth is not a good bet.
 
-See [UX Reset: Guided Experiment Notebook](ux-reset-guided-experiment-notebook.md)
-for the PM/design source of truth for future UX work.
+The product should help the user spend compute on promising atmosphere–recipe
+combinations and avoid long runs that are likely to be boring.
 
-See [Current Roadmap](current-roadmap.md) for active sequencing after the
-realistic-input and output-product contracts. The legacy issue-by-issue roadmap
-is archived reference only.
+## Entry Modes
 
-The first Golden Path case is Baseline Shallow Cumulus. Warm rain remains early, but it should not block completing that first end-to-end case.
+### Show Me Something Cool
 
-Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
+Default discovery mode. Search a selectable recent or historical sounding scope
+and rank the best cloud-making opportunities.
 
-The user-facing product model is guided experiments, an experiment notebook,
-focused visualization, `What happened here?` selected-region explanation,
-plain-language explanation, comparison between variants, and technical details
-on demand.
+“Recent” does not mean only today. The user may return infrequently and should be
+able to search a week, month, season, or whole cached history.
 
-**Thermal Fate** remains the internal scientific diagnostic and explanation
-model. It should power explanations, confidence/caveat labels, comparison
-summaries, selected-region diagnostics, and technical provenance. It should not
-dominate the primary visible UI as a process-taxonomy cockpit.
+### Find / Inspect
 
-Cloud Chamber is not a real-time slider toy. Scenario design, result browsing,
-comparison, and inspection should feel interactive; CM1 execution is a local
-simulation run with latency, logs, outputs, and caveats.
+Support:
 
-See [Thermal Fate process diagnostics](thermal-fate-process-diagnostics.md) for
-the current process-diagnostics contract.
+- date/time range;
+- region or station set;
+- cloud target;
+- saved candidate;
+- specific sounding;
+- “what can we do with this atmosphere?”
 
-See [Cloud Chamber output product specification](contracts/output-product-specification.md)
-for the contract that separates raw CM1 NetCDF output, result metadata,
-derived scientific products, visualization-ready payloads, future render-ready
-products, and external export bundles. Future Explore, Diagnostics Lab, Render
-Studio, runtime cleanup, and export work should preserve that browser/backend boundary:
-the browser receives bounded backend-prepared products and does not parse raw
-NetCDF.
+## Primary Recommendation Object
 
-See [Cloud Chamber realistic LES input specification](contracts/realistic-les-input-specification.md)
-for the input-side contract before observed sounding import, location/date/
-radiation controls, surface-flux controls, GIS/map inputs, or Bench Mode UI.
-The first realistic-input path is observed/detailed sounding metadata plus the
-CM1 `input_sounding` conversion path, with place/time/source provenance
-preserved even when radiation remains disabled.
-
-The first implemented observed-sounding path is intentionally local and
-bounded. Build can accept an uploaded NOAA/NCEI IGRA station sounding-data text
-file, parse the available sounding times, default to the latest sounding, and
-show a package-review summary before generation. Cloud Chamber does not fetch
-remote sounding archives in v1. The converted package anchors CM1 `z = 0` to
-the station surface elevation, converts geopotential height above mean sea
-level into model height above the station, preserves station/location/elevation,
-valid time, source format, units, wind metadata, and caveats, and renders a
-numeric CM1-readable `input_sounding`. Observed wind direction/speed is
-converted to CM1 `u`/`v` wind components, written into the `input_sounding`
-profile, and applied through CM1's `isnd = 7` external-sounding path. Packages
-with missing or unusable observed winds should block rather than silently fall
-back to a reference wind profile.
-
-Cloud Chamber also owns a backend-only local cache foundation for recent IGRA
-station-period source files. V1 can refresh the NOAA/NCEI IGRA recent catalog,
-join station metadata, filter to a broad Great Plains / Midwest bounding box
-(`35.0` to `50.0` latitude, `-106.0` to `-82.0` longitude), and cache selected
-or batched station ZIP/text files under `<runtime-home>/cache/igra/recent/`.
-The local script surface can list cached sounding times so Tim can inspect a
-batch of recent soundings without hand-written HTTP requests. A backend
-screening layer can match cached sounding times against explicit pre-run
-experiment stories such as shallow cumulus, dry failed, capped/suppressed, or
-humid/rainy. There is no universal "best sounding" ranking: the useful candidate
-depends on the atmospheric question being tested. Ingredient scores are
-transparent candidate-selection aids that rank sounding ingredients only; they
-are not CM1 outcome predictions. Saved candidates live in the runtime cache and
-may be handed into package metadata as provenance for why a sounding was tried.
-The browser never parses remote directory listings, ZIP files, or station text
-files. The current story identifiers, feature inputs, evidence-tier states,
-evidence requirements, and caveat rules are defined in
-[contracts/sounding-candidate-screening.md](contracts/sounding-candidate-screening.md).
-The forward analyzer contract for testable hypotheses, explicit run
-assumptions, predicted CM1-observable signatures, and predicted-vs-actual
-comparison is defined in
-[contracts/analyzer-hypothesis-output-signature.md](contracts/analyzer-hypothesis-output-signature.md).
-The bridge from those hypotheses to CM1 run recipes is defined in
-[contracts/run-recipe-and-story-mapping.md](contracts/run-recipe-and-story-mapping.md):
-it maps current story IDs to observed surface-forced, differential
-surface-forced, blocked, or future recipes and names the assumptions and output
-fields required before Results can compare predicted signatures. Removed
-triggered deep-potential recipes are not a current product path.
-Real-sounding story families, including severe/deep-convection, boundary-layer,
-low-cloud, and winter/cold-season candidates, are defined in
-[research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md).
-Those labels must remain disabled, caveated, or absent from product UI until
-backend scoring, evidence, caveats, and package-readiness states support them.
-Severe/deep-convection candidates may be presented as pre-run atmospheric
-hypotheses for observed-sounding experiments, not as forecasts or guaranteed
-storm outcomes. Product copy should make the selected run assumptions visible:
-uniform lower-boundary forcing is different from the differential surface patch,
-and neither is an artificial atmospheric trigger.
-The backend may compute richer sounding diagnostics such as profile quality,
-moisture/LCL proxies, lapse-rate and cap proxies, wind shear, dry-layer
-signals, and freezing-level context to support future screening. These are
-pre-run evidence and context only. Parcel, storm-relative, wet-bulb, and
-winter-phase diagnostics must remain explicitly unavailable until their methods
-are implemented and tested.
-
-In Build, `Observed Soundings` is the product-facing entry point for observed
-atmosphere work. It should offer one source path at a time: cached local
-recommendations, saved candidates, or manual IGRA station text upload. The
-cached-recommendation path should lead with product-level search controls such
-as source region, search intent, station set, history scope, and returned
-candidate limit, with secondary backend filters kept in advanced refinements.
-The workbench can refresh the IGRA catalog, cache selected station files,
-analyze the selected station/history set into station-diverse recommendations,
-show the exact analyzed set and filter trace, show why each candidate is
-interesting, expose story, story-family, evidence-tier, readiness,
-station-search, and sort controls as advanced refinements, show package-ready
-and blocked candidates with evidence and caveats, and save candidates with
-freeform tags and notes for later review. History-scope labels must describe
-the actual set being analyzed. The default recommendation pass analyzes all
-cached history for all cached stations. `Latest N per station` is an explicit
-user selection, and the returned-candidate limit is applied only after the
-selected soundings have been analyzed. A deep-convection search intent scopes
-recommendations to deep-convection ingredient stories; it must not silently
-mean "supported-only" evidence or primary-story-only membership.
-Manual upload should stay hidden while cached recommendations or saved
-candidates are the active source path.
-
-Saved candidates are a source path and shortlist, not an always-visible side
-panel. Selecting the saved source should load saved candidates without requiring
-a catalog refresh, cache action, or new analysis run. All candidate language
-must remain pre-run and provisional: a candidate is an observed atmosphere worth
-trying, not a prediction that clouds, rain, or suppression will occur. When a
-candidate is selected for run setup, Build should use the same recipe and run
-configuration flow used for uploads. When that configured sounding is added to
-the run plan, its screening story, score, evidence, feature summary, saved
-tags/notes, selected numeric surface-forcing values, and caveats should be
-copied into package metadata as provenance.
-
-When an uploaded, cached, or saved observed sounding is selected, Build should
-show one shared selected-sounding setup flow above the run plan. The source path
-should determine where the selected atmosphere came from, not create a separate
-configuration workflow. The run plan should sit below the source/setup flow and
-support multiple candidate atmospheres, duplicate variants, per-item forcing and
-run-configuration edits, local or LAN queue target selection, remove/clear
-actions, and a batch action to create packages and queue selected runs. Per-item
-packaging or queue failures should remain visible instead of clearing the failed
-item from the plan.
-
-Observed-sounding experiments use the observed temperature, moisture, and
-complete wind profile through CM1 `isnd = 7`, apply selected lower-boundary
-heat/moisture forcing, and request the full Results/Explore output field set.
-Severe/deep-convection candidates remain first-class atmospheric hypotheses, but
-current packages do not add an artificial deep-convection trigger. Product copy
-should describe these as observed-sounding experiments under explicit
-surface-forcing, duration, grid, domain, and cadence assumptions. Differential
-surface heating/moisture forcing is a current v0 patch recipe for localized
-initiation or boundary-style experiments; it is not a real front, dryline,
-land-surface, GIS, or radiation model. Its initial v0 geometry is a centered
-circular patch. It is local-only; the external CM1 source customization path has
-runtime-local compile and emitted hfx/qfx forcing-footprint smoke evidence, but
-matched dynamic-response validation remains the #307 closure gate. Results carry
-per-run localized diagnostic availability for emitted footprint regions
-(core/taper/background), convergence when physical u/v coordinates are
-available, and instantaneous patch-to-updraft/cloud/rain/reflectivity distance
-metrics with field-quality state. These are not causal response verdicts until
-matched uniform-versus-patch comparisons define persistence and directional
-criteria. Short science configurations must still run long
-enough to be meteorologically useful. Build should show expected cost, runtime,
-and output volume, and note when a configuration is better suited to larger
-compute instead of making machine choice the primary product axis.
-
-The run monitor should be compact by default. It should summarize active,
-queued, and completed runtime work while keeping detailed package, queue, LAN,
-ingest, and cleanup actions reachable on demand. The package/run status rail is
-supporting context for the run plan, not the primary place to continue after
-choosing a sounding.
-
-Explore should be a focused visualization plus explanation screen for one
-selected result. Its core interaction is `What happened here?`: select a cloud,
-updraft, clear-air thermal, or no-cloud region and receive a CM1-backed
-explanation of what happened there and why. Thermal Fate process evidence
-remains available in secondary or technical layers, but the primary view should
-lead with the experiment story, outcome, visualization, selected-region
-explanation, and next action. The browser receives only backend-prepared
-slices, point clouds, result-card process fields, and bounded summaries; it
-does not parse raw NetCDF or invent process claims.
-
-## Personas
-
-### Primary User
-
-A technically curious atmospheric-physics learner/builder who wants to play with real cloud modeling locally.
-
-They are comfortable with long-running local jobs, but do not want to manually edit namelists, hunt for files, or use generic visualization tools for every experiment.
-
-### Secondary User
-
-A scientist/developer who wants a cleaner CM1 workflow for curated idealized cases and visual exploration.
-
-## Key Workflows
-
-### Workflow 0 — Baseline Shallow Cumulus Golden Path
-
-The first complete product loop is:
+Rank:
 
 ```text
-Pick Baseline Shallow Cumulus
--> adjust curated controls
--> choose or adjust run configuration
--> validate setup
--> generate CM1 run package
--> launch local CM1
--> monitor logs/status
--> ingest NetCDF output
--> create result card / experiment notebook entry
--> replay cloud evolution
--> open Explore
--> save/name/tag result
+sounding + recipe + run setup
 ```
 
-Physical question:
+Do not rank a sounding without explaining what Cloud Chamber should do with it.
 
-```text
-How do low-level moisture, surface heating, cap strength, cap height, dry air aloft, and mixing/entrainment affect shallow-cumulus formation, timing, depth, updraft strength, and cloud-water evolution?
-```
-
-Expected CM1-facing package contents:
-
-```text
-run_manifest.json
-scenario metadata / case_manifest.json
-namelist.input
-input_sounding or sounding/input profile file
-runtime file checklist
-dry-run report
-visualization defaults
-```
-
-Expected diagnostics:
-
-```text
-cloud formed / failed
-first cloud time
-cloud base
-cloud top
-max vertical velocity
-max or summary cloud water
-cloud-water time evolution
-rain onset if available
-main limiting factor or interpretation note
-```
-
-Exact morphology is not pass/fail. The acceptance question is whether the product honestly configures, runs, records, ingests, replays, inspects, and visualizes a credible idealized CM1 result.
-
-### Workflow 1 — Configure A CM1 Experiment
-
-1. Open app.
-2. Choose scenario category.
-3. Select a starting scenario or observed-sounding run direction.
-4. See expected behavior, controls, run cost, and output fields.
-5. Adjust numeric surface heat/moisture fluxes, duration, horizontal cells,
-   domain, and output cadence before package review.
-
-The Scenario Builder flow is intentionally bounded: it loads
-validated scenario templates from the local backend, defaults to Baseline
-Shallow Cumulus, displays the scenario description and physical question,
-exposes only product-facing curated controls, lets the user adjust explicit
-run-configuration choices, and requests a dry-run package for review.
-
-The primary current-run path should stay in one vertical flow: choose the
-atmosphere, choose or confirm the hypothesis, configure the CM1 run, review
-pre-run validation, then create the package and queue that package. The
-right-side launchpad is a status rail for generated packages, queue state,
-ingest, worker status, and cleanup; it should not force the user to hunt there
-for the next action after choosing a sounding or run configuration.
-
-Build should not assume the user is working one perfectly linear package at a
-time. Local experiments can be packaged, running, failed, completed-but-not-
-ingested, ingested, carrying legacy saved/protected metadata, or ready for
-cleanup at the same time. The Build workspace should include a compact local
-run launchpad for active and incomplete package/run work only: show generated
-package details, launch eligible stored packages, refresh running/failed/
-completed status, troubleshoot failed or no-output runs, and ingest completed
-output. Fully ingested results belong in Results.
-
-When a local backend restart leaves a completed CM1 run's manifest marked
-running, Build refresh may reconcile the state only if stdout contains
-normal CM1 termination evidence and output artifacts are present. The UI should
-then offer ingest rather than leaving the run stranded as running.
-
-The UI must continue to avoid raw CM1 namelist fields in the primary flow. Raw generated files can be listed in dry-run review because they are outputs of the package step, not user-facing controls.
-
-### Workflow 2 — Preview Setup
-
-1. Adjust controls.
-2. Placeholder preview panel reserves space for future guidance.
-3. Future preview diagnostics update quickly when implemented.
-4. User understands that preview is not CM1.
-
-Current behavior is a placeholder only. It must explicitly say preview is not implemented, not CM1 output, not a completed result, and not a visualization interpretation.
-
-### Workflow 2.5 — Package And Review Local Runs
-
-1. Request a dry-run package from the Scenario Builder.
-2. Backend validates the scenario template and selected controls.
-3. Backend writes package files under the configured runtime home, not the repo.
-4. UI displays run ID, package path, manifest path, scenario, validation/product state, generated files, physical question, selected run configuration, expected diagnostics, and cost/size notes.
-5. UI states that CM1 was not launched and the package is not a completed CM1 result.
-6. The launchpad also surfaces other local package/run directories from the
-   runtime inventory when they still need Build action: packaged-only, running,
-   completed with output and not yet ingested, completed without usable output,
-   failed/canceled, or malformed/missing manifest. Fully ingested results are
-   reviewed and managed in Results.
-
-### Workflow 3 — Launch CM1 Run
-
-1. Click `Queue local CM1 run` from the end of the current setup flow, or from
-   an eligible stored-package card in the launchpad.
-2. Backend launches local CM1 from the generated run package only after preflight passes.
-3. UI shows the running state, command/log paths, stdout/stderr tail when available, and one-local-run-at-a-time policy.
-4. If local CM1 settings are missing, the UI shows the backend failure reason and no run is implied.
-5. The UI continues to distinguish the package, running CM1 process, completed CM1 result, and later ingest/result states.
-
-### Workflow 4 — Monitor Runs
-
-Run manager shows:
-
-- queued
-- running
-- completed
-- failed
-- canceled
-
-For each run:
-
-- elapsed time
-- current log tail
-- output files seen
-- estimated output size
-- final status
-
-The Build workspace provides the first guided local launchpad without curl
-commands: create package, launch eligible local CM1 packages, refresh status/log
-summaries, see output-artifact counts, inspect elapsed wall-clock and model-time
-progress when CM1 logs expose it, ingest completed NetCDF output, and open
-created Result Cards in Results or Explore. Percent complete and ETA should only
-appear when configured model time and latest model time are both known. It is a
-pipeline view over local runtime state, not a single active wizard. This is
-local-first orchestration only; CI still uses fake fixtures and never runs CM1.
-
-Local package launch should go through a serial queue. Users can queue multiple
-ready packages, but Cloud Chamber must run only one local CM1 process at a time.
-When a queued run completes with usable NetCDF output, Build should auto-ingest
-the result and show the generated Result ID. Failed, no-output, or ingest-failed
-runs stay visible with manual fallback actions. Auto-ingest should finalize
-queue state, not silently delete result-backed local run data.
-
-### Workflow 4.5 — Manage Runtime Cleanup
-
-Build exposes runtime-home inventory for active, incomplete, and non-ingested
-package/run work. It shows lifecycle-aware identities for run directories that
-still need launch, status review, troubleshooting, ingest, or cleanup. Fully
-ingested results are omitted from Build cleanup and managed from Results.
-
-Build should describe each non-ingested local run directory as part of the
-experiment lifecycle: ready-to-run package, running/queued CM1 process,
-completed with usable output, completed with no usable output, failed/canceled,
-ready to ingest, or missing/malformed manifest that needs cleanup review. It
-should avoid duplicate or contradictory badges.
-
-Build offers non-destructive state transitions where they belong: launch
-packaged runs, refresh status, and ingest completed output when a
-completed-with-output run has a manifest but no associated result. Cleanup for
-non-ingested run directories remains behind preview and confirmation.
-
-Results owns destructive cleanup for ingested results. The selected notebook
-entry offers a secondary/danger action to preview deletion by result ID. The
-preview states that deleting removes the ingested result, notebook edits,
-diagnostics, derived products, CM1 output, logs, and local run files stored
-under the run directory, and that the result will disappear from Results,
-Explore, and local inventory after confirmation.
-
-Deletion is always explicit. The UI first requests a dry-run delete preview for
-one selected run/result, then requires a separate confirm action before
-deleting. Running runs cannot be deleted. Legacy saved/protected metadata does
-not make a non-running run/result undeletable. The warning threshold never
-auto-deletes anything. The relationship should be clear: Build moves local runs
-forward and cleans up non-ingested runs; Results reviews, edits, and deletes
-ingested experiment notebook entries plus their backing local data.
-
-### Workflow 5 — Open Result
-
-1. Select completed run.
-2. App ingests or loads processed data.
-3. App shows diagnostics and a unified Explore workspace.
-4. User can name, tag, and annotate the result.
-5. User can reopen, inspect, and explain the saved result later.
-
-### Workflow 6 — Unified Explore
-
-Explore is now the single selected-result inspection and explanation workspace.
-It should keep the current product loop focused on:
-
-```text
-selected-result trust
--> 3-D scalar-field context
--> shared time / field / slice controls
--> saved-output timelapse playback without interpolation
--> visible native-grid slice plane
--> matching 2-D slice inspector
--> click-cell "What happened here?" explanation
--> technical details on demand
-```
-
-The broad original visualizer goal in #31 has been superseded by staged
-implementation issues and the UX reset. Explore should build from saved/ingested
-results and backend visualization-ready data, not from raw NetCDF parsing in the
-browser. Every stage must preserve provenance labels and make clear that rendered
-output is an interpretation of CM1-derived data.
-
-Renderer upgrades such as isosurfaces, volumetric opacity, cinematic lighting,
-appearance presets, fly-through, and export are not near-term payoff work. They
-remain deferred to the renderer-upgrade decision (#112) and later visual polish
-planning (#80) after the guided experiment notebook and `What happened here?`
-loop are stable.
-
-### Workflow 6.5 — What Happened Here?
-
-`What happened here?` is the core Explore interaction, not a buried technical
-diagnostics panel:
-
-```text
-open a completed or ingested result
--> see the main 2-D or 3-D visualization
--> click a cloud, updraft, clear-air thermal, or no-cloud region
--> the app marks the selected spot or region
--> the app opens an explanation panel
--> the panel answers what happened there, what evidence supports it, and what is uncertain
-```
-
-This workflow must use backend diagnostics over CM1-derived fields. The browser
-must not parse raw NetCDF or invent scientific explanations.
-
-The first implementation can start with 2-D selection if 3-D selection is too
-hard. Users can click a backend-prepared heatmap cell to inspect the nearest
-native-grid column, select a bounded center point or small box, clear the
-selection, and review the backend-returned explanation, confidence, caveats,
-local `qc`/`w`/rain summaries, selected-region bounds, domain comparison, and
-provenance. The UI is presentation-only for scientific interpretation: labels
-and summaries come from the selected-region diagnostics API.
-
-The explanation should use simple primary language such as:
-
-```text
-What happened here?
-Cloud formed here
-Thermal without cloud
-Cloud stayed shallow
-Growth was limited
-Evidence
-Still uncertain
-Technical details
-```
-
-Thermal Fate labels, native variables, source fields, confidence details, and
-provenance remain available behind details/disclosure. They should not be the
-first-read interaction model.
-
-Process evidence controls in Explore should be result-aware. The primary
-`Explanation focus` control should show only supported modes and caveated modes
-that are still useful for the selected result. For example, direct `qc` cloud
-water and `w` updraft evidence can be normal focus choices when those fields are
-available, moisture limitation can be a candidate focus for Dry Failed-style
-results, and cap/inversion can be a candidate focus for stronger-cap results.
-Modes that need missing fields or future backend diagnostics, such as buoyancy,
-deep breakthrough, or precipitation feedback without cold-pool/outflow evidence,
-belong under a collapsed `Not available for this result` disclosure with plain
-reasons. The browser may gate presentation from existing result metadata,
-support/confidence labels, caveats, and available visualization fields, but it
-must not invent unsupported scientific classifications.
-
-### Workflow 7 — Duplicate / Tweak / Rerun
-
-1. Duplicate previous setup.
-2. Change one or more controls.
-3. Preview likely difference.
-4. Launch a new CM1 run.
-5. Inspect result differences later when a real comparison workflow exists.
-
-This workflow is useful, but it is not the core first-MVP result behavior. Replay, inspect, save, name, and tag completed CM1 results first; duplicate/tweak/rerun can mature after the Result Card / Experiment Notebook model is reliable.
-
-## Thermal Fate Diagnostic Scope
-
-Product diagnostics should be framed at three levels:
-
-- **Global run diagnostics**: cloud formed, first cloud time, cloud base/top,
-  `qc`, `w`, rain, cloud fraction, and later process summaries for the whole
-  completed CM1 result.
-- **Local selected-region diagnostics**: the `What happened here?` point,
-  column, or box story, including local `qc`, `w`, rain, saturation/cap evidence
-  where supported, and comparison to domain behavior.
-- **Comparison diagnostics**: what changed between Baseline and a variant, such
-  as Dry Failed, Capped / Suppressed, humidity-ladder, or future
-  surface-heating/deep-breakthrough cases.
-
-Deep-convection breakthrough and precipitation-feedback/cold-pool diagnostics
-are first-class science directions, but they should remain unavailable,
-candidate, or insufficient-evidence states until the required CM1 fields and
-derived diagnostics exist.
-
-The first backend process-diagnostics implementation supports a conservative
-global result summary. It can label moisture-limited thermal-without-cloud
-results when `w` is meaningful and `qc` stays below threshold, mark
-Capped / Suppressed as a candidate when the stronger-cap scenario/control path
-is selected, and expose growing/fair-weather cumulus candidate labels from
-available cloud-top and cloud-water diagnostics. It does not compute buoyancy,
-entrainment, CAPE/CIN/LFC/EL, cold pools, or selected-region explanations yet.
-
-## Run Configuration Model
-
-Build should present starting configuration choices for a CM1-facing run, not
-rigid experiment families or mandatory run-size schema slots. The
-user should be able to start from a trusted default, inspect what it means,
-adjust guarded settings, and receive a pre-run validation report before package
-generation or launch.
-
-Quick means quick to execute for the selected configuration; it must not mean
-meteorologically too short to produce useful evolution. Smoke checks prove that
-package generation, CM1 launch, output production, ingest, and basic
-visualization wiring are healthy. They are not evidence that a specific observed
-sounding validates a science hypothesis. Science runs should use enough model
-time, domain, and output cadence for the atmospheric question being asked.
-
-Grid/detail and output cadence are the main user-facing cost levers. Raw
-numerical timestep is not a normal v1 user control, but campaign and numerical
-validation matrices may set an explicit advanced timestep target when that value
-is part of the evidence being tested. Cloud Chamber should warn or caveat
-unvalidated control combinations when they can be safely generated, block
-configurations that cannot be rendered or launched honestly, and avoid silently
-replacing bad observed-sounding input with reference defaults.
-
-Generated packages include a backend-owned pre-run validation report. The
-report records the selected candidate/hypothesis, selected run recipe and
-assumption set, hypothesis/recipe alignment, observed-input validation,
-run-shape estimates, forcing support, required/enabled output fields, runtime
-file staging status, blocking errors, and caveats. Blocked reports stop package
-creation before a run directory is written; caveated reports may be packaged but
-must remain visibly caveated before launch and after ingest.
-
-Forward run configuration should include:
+Suggested contract:
 
 ```yaml
-run_configuration:
-  preset_id:
-    optional starting point, not a required product family
-  duration:
-    model_time_seconds
-    purpose: smoke_check | quick_science | standard_science | extended_science
-  grid_detail:
-    label
-    nx
-    ny
-    nz
-    dx_m
-    dy_m
-    vertical_grid_summary
-  domain:
-    width_m
-    depth_m
-    model_top_m
-  output_cadence:
-    model_seconds_between_outputs
-    expected_saved_frames
-  output_field_density:
-    minimal | standard | expanded
-    requested_fields
-  forcing:
-    surface_sensible_heat_flux
-    surface_latent_heat_flux
-    radiation_mode
-    place_time_context
-  advanced_cm1_values:
-    timestep_target_seconds
-    namelist_summary
-    input_sounding_summary
-    runtime_files_needed
-  pre_run_validation_report:
-    status
-    blocking_errors
-    caveats
-    estimated_runtime
-    estimated_output_volume
-```
-
-Starting choices may populate these fields, but former run-size tier names are
-not active product schema. Generated packages, manifests, reports, and result
-cards should use the resolved `run_configuration` object as the run-shape source
-of truth.
-
-## Current Run-Configuration Defaults
-
-Current defaults are product choices, not compatibility holdovers:
-
-- Baseline lower-atmosphere scenarios default to `short_6h`, `cells_64`,
-  `local_6km`, `standard_15min`, and full output fields. This keeps the
-  first run cheap enough to iterate while still giving six hours of model
-  evolution and enough fields for Results/Explore diagnostics.
-- Uploaded observed-sounding surface-forced runs default to the same duration,
-  cadence, and full output field set, but use `cells_128` and `wide_12km` so observed
-  winds do not make the package misleadingly small by default.
-- `smoke_1h` is an explicit smoke-check mode for package health, CM1 startup,
-  ingest, and basic visualization wiring. It is not evidence for normal
-  atmospheric evolution.
-
-The dry-run report must show runtime, output cadence, expected saved frames,
-grid dimensions, spacing, model top, grid-cell multiplier, output-frame
-multiplier, compute multiplier, output-volume multiplier, and a clear warning
-when wall-clock or storage estimates need local/manual validation.
-
-Runtime estimates are approximate until locally validated for a specific CM1 build, scenario, and machine. The first local hardware target is a 2024 MacBook Air with 8GB RAM, so the MVP should assume one local CM1 run at a time and conservative output handling.
-
-Run-configuration estimate metadata should be carried through scenario
-templates, generated run packages, dry-run reports, run manifests, result
-metadata, and result cards. If estimate data is not locally validated yet, the
-UI/report should say `unknown until validated` instead of inventing precision.
-
-## Run Configuration Schema
-
-Backend scenario templates are validated by the `ScenarioTemplate` contract.
-Scenario templates define product controls and science story metadata; run shape
-is carried by the resolved `run_configuration` object:
-
-```yaml
-id:
-name:
-category:
-question:
-plain_english_description:
-expected_behavior:
-controls:
-  - id
-  - label
-  - type
-  - default
-  - allowed range/options
-  - maps_to
-run_configuration:
-  duration:
-    model_time_seconds
-  grid_detail:
-    nx
-    ny
-    nz
-    dx_m
-    dy_m
-    vertical_grid_summary
-  domain:
-    width_m
-    depth_m
-    model_top_m
-  output_cadence:
-    model_seconds_between_outputs
-    expected_saved_frames
-  output_field_density:
-    level
-    requested_fields
-  forcing:
-    surface_sensible_heat_flux
-    surface_latent_heat_flux
-    radiation_mode
-    place_time_context
-  advanced_cm1_values:
-    timestep_target_seconds
-    namelist_summary
-    input_sounding_summary
-    runtime_files_needed
-pre_run_validation_report:
-  status:
-  blocking_errors:
+cloud_opportunity:
+  sounding_id:
+  station_id:
+  station_name:
+  valid_time_utc:
+  search_scope:
+  cloud_target: growing_cumulus | deep_tower | precipitation | suppression
+  recipe_id:
+  recipe_label:
+  opportunity_score:
+  expected_visible_outcome:
+  likely_ceiling:
+  main_obstacle:
+  why_this_pair:
+  why_not_free_evolution:
+  recommended_run_setup:
+  scout_checkpoint_plan:
+  automatic_promotion_plan:
+  stronger_alternative:
+  skip_recommendation:
+  confidence:
+  assumptions:
   caveats:
-  estimated_runtime:
-  estimated_output_volume:
-outputs_expected:
-  fields
-  diagnostics
-visualization_defaults:
-  camera
-  fields
-  color/opacity
-physical_question:
-learning_goals:
-variation_policy:
-  recommended_story_thread:
-  recommended_comparison_pattern:
-validation_status:
-  unrun | generated | accepted | needs_calibration
-notes:
 ```
 
-Validation rules should reject templates that:
+The score is a recommendation aid, not a forecast probability.
 
-- omit product-facing controls
-- omit a valid run-configuration default for package generation
-- define a choice control whose default is not one of its options
-- define a number control without a valid range
-- reference unknown controls from validation policy
-- include undeclared fields
+## Analyzer Responsibilities
 
-The schema is intentionally product-first. Raw CM1/developer controls can exist
-as advanced metadata, but product-facing controls and the pre-run validation
-report remain the primary path.
+The sounding analyzer should estimate:
 
-Thermal Fate diagnostic directions should include:
+1. **Growth ceiling** — what the atmosphere may sustain once useful ascent
+   exists.
+2. **Initiation difficulty** — how much help the selected CM1 setup likely needs
+   to create that ascent.
 
-1. Moisture-limited thermal fate: Baseline, Dry Failed, and humidity ladder.
-2. Surface-heating-driven thermal fate: weaker/baseline/stronger heating,
-   focused warm patch, patchy heating, and gradients.
-3. Cap-limited thermal fate: Capped / Suppressed Cumulus.
-4. Dry-air-aloft / dilution-limited thermal fate.
-5. Deep-convection breakthrough: growing, towering, and cumulonimbus candidates.
-6. Precipitation feedback / cold-pool interaction.
-7. Low stratus / low-cloud layer where appropriate.
+Rank separately for:
 
-Baseline shallow cumulus is the first hero case. Warm rain remains early but does not block the Golden Path.
+- growing cumulus/congestus;
+- deep tower after initiation;
+- precipitation;
+- suppression/cap challenge;
+- likely boring/skip.
 
-The initial lower-atmosphere templates live under `scenarios/lower-atmosphere/` as validated JSON metadata. They are honest scenario definitions and teaching contracts, not final scientific calibration. Baseline Shallow Cumulus now has a CM1-facing package candidate, while broader control-to-CM1 mapping fields remain provisional until local/manual CM1 validation accepts them.
+Where methods are supported, useful inputs include:
 
-## CM1 Input Generation Contract
+- low-level moisture and depth;
+- LCL and cloud-base accessibility;
+- CAPE, CIN, LFC, and EL for relevant parcels;
+- cap strength, depth, and height;
+- lapse rates;
+- midlevel humidity and entrainment risk;
+- precipitable water;
+- freezing level and mixed-phase depth;
+- profile quality and surface representativeness;
+- wind completeness when required by a recipe;
+- recipe compatibility and package readiness.
 
-Generated run packages should eventually include:
+Missing advanced diagnostics reduce recommendation confidence. They must not
+silently become negative atmospheric evidence.
+
+The analyzer may recommend:
 
 ```text
-run_manifest.json
-case_manifest.json
-namelist.input
-input_sounding
-dry_run_report.json
-runtime_file_checklist.json
+Natural evolution is likely boring.
+Use explicit initiation.
 ```
 
-The current Baseline Shallow Cumulus recovery contract renders CM1-facing `namelist.input` from CM1's local `les_ShallowCu` reference path. The external-sounding reproduction keeps `testcase = 3`, the reference grid, runtime, domain top, Rayleigh damping, surface/ocean/flux settings, surface stress path, and wind profile as much as possible, but switches the thermodynamic source from CM1's built-in BOMEX analytic sounding (`isnd = 19`) to CM1's external `input_sounding` route (`isnd = 17`). The generated `input_sounding` is a numeric CM1-readable BOMEX/Siebesma profile that extends above the 18 km model top.
-
-Observed IGRA sounding import uses the same external `input_sounding` route.
-The generated thermodynamic/moisture profile comes from the selected observed
-sounding after unit conversion and vertical-datum handling. Observed wind
-direction/speed is converted to CM1 `u`/`v`, written into `input_sounding`, and
-used by CM1 through `isnd = 7`. The generated
-package records the selected station, valid time, uploaded filename,
-provider/format, model-bottom elevation, conversion choices, wind-handling
-method, validation status, and caveats in the run manifest, case manifest, and
-dry-run report. It must not imply location/date/radiation behavior beyond the
-observed-profile provenance; radiation remains whatever the scenario package
-currently configures.
-
-The first full-sequence NetCDF ingest of `dry-run-157b09a178e1` found 25 model-output files and 25 time steps, but no usable cloud or vertical velocity: `max_qc_kg_kg = 0.0`, `max_w_m_s = 0.0`, and multiple NaN/Infinity caveats in surface and thermodynamic fields. The generated quick-look package therefore now uses a fixed small ocean roughness length (`set_znt = 1`, `cnst_znt = 0.0002`) instead of the reference dynamic roughness / fixed friction-velocity path that produced invalid local output.
-
-A follow-up local/manual validation run, `dry-run-calibration-20260522132903`, confirmed the fixed roughness value is written and CM1 completes with NetCDF output, but it still produces no cloud, no vertical motion, and NaN/Infinity caveats in target fields. The fixed-roughness derivative is therefore not the recovery baseline. Cloud Chamber should recover from `les_ShallowCu` first, then introduce any quick-look scaling one change at a time.
-
-The first `les_ShallowCu` reference-derived Cloud Chamber run, `dry-run-les-shallowcu-20260522140642`, completed with `exit_code = 0`, produced NetCDF output, and ingested 7 model-output time steps from 0 to 21600 seconds. First-pass diagnostics reported `cloud formed; rain detected`, first cloud time at 3600 seconds, `max_qc_kg_kg = 0.002192789688706398`, `max_w_m_s = 6.962291717529297`, and `min_w_m_s = -3.7671568393707275`. This validates the recovery direction: use the reference-derived case as the Baseline Shallow Cumulus Golden Path source, then derive shorter quick-look variants later.
-
-The first quick-look Baseline Shallow Cumulus variant is derived from that validated reference package by changing only runtime and output cadence: `timax = 10800.0` and `tapfrq = 900.0`. It intentionally preserves the reference domain/grid, vertical spacing, domain top, surface stress/roughness path, moisture/sounding, surface fluxes, turbulence/SGS settings, damping settings, boundary conditions, NetCDF output, and reference `LANDUSE.TBL` staging behavior.
-
-The first quick-look validation run, `dry-run-quicklook-les-shallowcu-20260522151536`, completed with `exit_code = 0`, produced NetCDF output, and ingested 13 model-output time steps from 0 to 10800 seconds. Package size was 206 MB. First-pass diagnostics reported `cloud formed; rain detected`, first cloud time at 1800 seconds, `max_qc_kg_kg = 0.002192789688706398`, `max_w_m_s = 6.866957187652588`, and `min_w_m_s = -4.21529483795166`. This confirms the shorter runtime/cadence-only quick-look variant still produces cloud and vertical motion while preserving the reference-derived settings.
-
-The external-sounding Baseline Shallow Cumulus reproduction run,
-`dry-run-external-sounding-baseline-20260522185000`, completed with
-`exit_code = 0`, produced NetCDF output, and ingested 13 model-output time
-steps from 0 to 10800 seconds. First-pass diagnostics reported `cloud formed;
-rain detected`, first cloud time at 1800 seconds, `max_qc_kg_kg =
-0.001976807601749897`, `max_w_m_s = 6.270190238952637`, and `min_w_m_s =
--4.416495323181152`. This accepts the external `input_sounding` path as the
-baseline reproduction path for the next one-factor moisture experiment.
-
-The Baseline Shallow Cumulus low-level humidity ladder now uses that accepted
-external-sounding path. `drier`, `baseline`, and `more humid` preserve the same
-grid/domain, selected run configuration, surface/ocean/flux settings,
-stress/roughness path, damping, turbulence/SGS settings, boundary conditions,
-NetCDF output, and runtime-file staging. The only intended generated-input difference is the
-low-level moisture profile in `input_sounding`. These variants are disciplined
-one-control-at-a-time experiments, not arbitrary parameter sweeps.
-
-Initial quick-look validation supports the ladder direction. The drier run
-`dry-run-004bd57bb8cc` completed, produced 13 model-output time steps, ingested
-successfully, and reported `no cloud formed; no rain detected` with meaningful
-vertical motion (`max_w_m_s = 2.0368008613586426`, `min_w_m_s =
--1.26932954788208`). The more-humid run `dry-run-4e64317c62ec` completed,
-produced 13 model-output time steps, ingested successfully, and reported `cloud
-formed; rain detected`, first cloud at 900 seconds, `max_qc_kg_kg =
-0.00285167433321476`, `max_w_m_s = 10.37020206451416`, and `min_w_m_s =
--5.2025837898254395`.
-
-### Dry Failed Cumulus Planning
-
-Dry Failed Cumulus is the next planned lower-atmosphere contrast case after
-Baseline Shallow Cumulus. It should answer:
+or:
 
 ```text
-How does insufficient low-level moisture prevent shallow cumulus formation even when boundary-layer thermals and vertical motion are present?
+Skip this sounding for cloud-making.
+Use it only for a suppression/cap challenge.
 ```
 
-This is a moisture-limited failed-cumulus case. It should not mean a dead
-simulation, a too-stable/capped atmosphere, weak surface forcing, numerical
-failure, or "no cloud" by itself. The target is thermals without meaningful
-cloud.
-
-Teaching contrast:
+## Workflow
 
 ```text
-Baseline Shallow Cumulus:
-  thermals rise
-  cloud water forms
-  rain may appear
-  qc and w are both visually/scientifically interesting
-
-Dry Failed Cumulus:
-  thermals still rise
-  parcels do not reach enough saturation
-  qc stays below cloud threshold or appears only as trace amounts
-  rain does not appear
-  w remains scientifically meaningful
+Find promising sounding–recipe pairs
+→ Recommend a concrete run setup
+→ Queue a meaningful scout through Build
+→ Automatically promote a promising scout to a full run
+→ Ingest
+→ Explore the evolving cloud
 ```
 
-The MVP product-facing variation should change one physical factor:
+## Build
+
+Build owns all active and incomplete work:
+
+- opportunity search and ranking;
+- selected sounding and recipe;
+- concrete run setup;
+- run plan;
+- package generation;
+- queue target;
+- progress and ETA;
+- scout checkpoints;
+- visible automatic full-run promotion;
+- stop/cancel;
+- completed-output ingest;
+- cleanup for non-ingested runtime work.
+
+The user should not need to move to another workspace to see or control an
+automatically promoted run.
+
+## Results
+
+Results is the notebook of completed and ingested runs.
+
+A result entry should lead with:
+
+- what cloud formed;
+- recipe and major added assumptions;
+- scout/full-run relationship;
+- coherent cloud growth;
+- updraft/cloud/rain/reflectivity highlights;
+- runtime-integrity or field-quality problems only when relevant;
+- notes, tags, and revisitability.
+
+Results owns explicit cleanup of ingested results and their backing local data.
+
+## Explore
+
+Explore is the visual payoff for one selected result.
+
+Core behaviors:
+
+- time replay and scrubbing;
+- cloud-water and ice context;
+- vertical velocity;
+- rain water and surface rain;
+- reflectivity;
+- slices and selected-region inspection;
+- coherent cloud base/top;
+- plain-language “what happened here?” explanation;
+- technical evidence on demand.
+
+The primary view should make cloud evolution rewarding to watch. Diagnostics
+must not crowd out the cloud.
+
+## Recipe Model
+
+A **recipe** is an honestly labeled way to help a real atmosphere produce or
+reveal a cloud outcome.
+
+A **run setup** is the concrete domain, grid, vertical top, duration, cadence,
+numerical assumptions, forcing, and output configuration used for that recipe.
+
+Recipes are tools. None is “the experiment” or the permanent center of the
+product.
+
+## Initial Recipe Catalog
+
+### Daytime Evolution
+
+Question:
+
+> What might this atmosphere do during an ordinary heated daytime evolution
+> under explicitly simplified assumptions?
+
+Use active place/time forcing where supported or an honestly labeled evolving
+diurnal proxy. Do not relabel constant domain-wide flux as real daytime
+evolution.
+
+### Broad Warm/Moist Surface Region
+
+Question:
+
+> Can a broad idealized lower-boundary region organize enough ascent to grow
+> visible clouds?
+
+Build on the completed differential surface-forcing mechanism. Choose region
+scale for cloud growth, not merely forcing-footprint validation.
+
+### Explicit Thermal Initiation
+
+Question:
+
+> If Cloud Chamber supplies a rising thermal, what kind of cloud can this
+> atmosphere sustain?
+
+Explicit initiation is a normal exploratory recipe when clearly labeled.
+
+### Deep-Tower Benchmark
+
+Question:
+
+> With strong explicit initiation, what is the atmosphere's convective ceiling?
+
+Restore and modernize the successful PR #270 Deep Convection Trial using stock
+CM1 `iinit = 3` unless current evidence requires a justified equivalent.
+
+### Suppression / Cap Challenge
+
+Question:
+
+> How much heating, moistening, or initiation is needed before this atmosphere
+> produces cloud or breaks through its cap?
+
+## Recipe Contract
+
+Every recipe must define:
+
+- target visible outcome and learning question;
+- suitable and poor sounding traits;
+- skip conditions;
+- exact added mechanism and assumptions;
+- meaningful scout setup;
+- full-run setup;
+- supported aggressiveness levels;
+- checkpoint times;
+- automatic-promotion criteria;
+- escalation order;
+- stop/switch behavior;
+- expected visible outcomes;
+- visible limitations.
+
+A mechanism implementation without this operating contract is incomplete.
+
+## Run Setup
+
+Run setup should expose product-level choices first:
+
+- target cloud mode;
+- recipe and aggressiveness;
+- domain and grid detail;
+- model top/vertical shape;
+- duration;
+- output cadence;
+- expected cost and ETA;
+- relevant forcing/trigger controls.
+
+Raw namelist and numerical values belong in advanced/technical views. Timestep is
+an advanced assumption, not a normal v1 primary control.
+
+Presets are starting hypotheses, not rigid cages. Real CM1 outcomes should change
+them.
+
+## Scout Contract
+
+A scout is a real CM1 run large and long enough to decide whether to invest more
+compute.
+
+At recipe-specific checkpoints, inspect only decision-changing evidence:
+
+- requested mechanism actually applied;
+- runtime integrity not broken;
+- boundary layer or trigger responding;
+- meaningful updraft developing;
+- coherent cloud water appearing and growing;
+- cloud capped, dying, or deepening;
+- precipitation or reflectivity beginning where relevant.
+
+Every scout resolves to:
 
 ```text
-low-level humidity = drier
+continue automatically to full run
+scale one run-shape parameter
+change one recipe parameter
+switch recipe
+skip sounding
+stop broken run
 ```
 
-Other curated controls should stay at the validated baseline for the first
-implementation:
+## Automatic Full-Run Promotion
+
+Automatic promotion is allowed when a recipe's criteria are met.
+
+Requirements:
+
+- visible in Build;
+- bounded;
+- promotion reason preserved;
+- duration/progress/ETA shown;
+- stoppable and cleanable;
+- scout relationship preserved;
+- use a trustworthy checkpoint/restart when supported, otherwise create a related
+  full-run package.
+
+No hidden background runs or unbounded batches.
+
+## Scientific Honesty
+
+Always distinguish:
 
 ```text
-surface heating = baseline
-cap strength = baseline
-dry air aloft = baseline
-mixing / entrainment = baseline
-```
-
-The diagnostic target is:
-
-```text
-CM1 completes cleanly
-NetCDF output is produced
-full output sequence ingests
-cloud_formed = false
-rain_present = false
-max_qc_kg_kg remains below the 1e-6 kg/kg cloud threshold,
-  or fewer than 10 grid cells exceed threshold
-max_w_m_s is meaningfully nonzero
-min_w_m_s is finite and preferably negative/nonzero
-no severe NaN/Infinity caveats in qc/w/qv/thermodynamic target fields
-main limiting factor = insufficient low-level moisture / saturation deficit
-```
-
-Inspection should show `w` without meaningful `qc`: 2-D `qc` slices should be
-mostly empty/trace while `w` slices still show thermal/updraft structure. The
-3-D cloud-water point cloud should be mostly absent, while slice planes remain
-useful for explaining the failed-cloud contrast.
-
-Dry Failed starts from the validated reference-derived Baseline Shallow Cumulus
-setup, not the old compact quick-look derivative that produced no cloud, no
-vertical motion, and NaN/Infinity caveats. The implementation path is:
-
-1. #102 validates an external-sounding Baseline Shallow Cumulus reproduction while
-   preserving the validated grid/domain/runtime/surface/damping/boundary
-   settings and changing only the thermodynamic sounding source.
-2. #103 implements the moisture-limited Dry Failed variant by drying the validated
-   external-sounding baseline and preserving vertical motion.
-
-The first Dry Failed Cumulus validation run,
-`dry-run-dry-failed-cumulus-20260522192000`, completed with `exit_code = 0`,
-produced NetCDF output, and ingested 13 model-output time steps from 0 to
-10800 seconds. First-pass diagnostics reported `no cloud formed; no rain
-detected`, `max_qc_kg_kg = 0.0`, `max_w_m_s = 1.949130654335022`, and
-`min_w_m_s = -1.0865488052368164`. This is the first accepted
-moisture-limited contrast case: thermals and vertical motion remain, but cloud
-water and rain stay absent by the MVP diagnostics.
-
-### Capped / Suppressed Cumulus Planning
-
-Capped / Suppressed Cumulus is the next planned lower-atmosphere contrast after
-Dry Failed Cumulus and the low-level humidity ladder. It should tell a distinct
-stability/inhibition story:
-
-```text
-How does a stronger cap suppress or limit shallow-cumulus growth even when moisture and boundary-layer thermals are available?
-```
-
-Dry Failed Cumulus is the moisture-limited no-cloud contrast. Capped /
-Suppressed Cumulus should not target a total no-cloud case for the first
-version. The first target is:
-
-```text
-same cloud setup, but a stronger lid
-```
-
-Moisture remains available and thermals still rise. Shallow or weak cloud may
-still form, but the stronger cap should limit cloud depth, reduce cloud water
-or cloud fraction, and suppress or reduce rain relative to the accepted Baseline
-Shallow Cumulus quick-look.
-
-Teaching contrast:
-
-```text
-Baseline Shallow Cumulus:
-  thermals rise
-  cloud water forms
-  cloud grows deeper
-  rain may appear
-  qc and w are both visually/scientifically interesting
-
-Dry Failed Cumulus:
-  thermals rise
-  lower atmosphere is too dry
-  cloud water stays absent or below threshold
-  rain does not appear
-  w remains scientifically meaningful
-
-Capped / Suppressed Cumulus:
-  thermals rise
-  moisture is available
-  cloud may still form
-  stronger cap limits vertical growth
-  cloud tops are lower
-  max qc / cloud fraction are reduced
-  rain is suppressed or absent
-```
-
-First product-facing controls:
-
-```text
-cap_strength:
-  baseline
-  stronger
-
-cap_height:
-  baseline initially
-  lower later
-
-low_level_humidity:
-  baseline for first implementation
-
-surface_heating:
-  baseline for first implementation
-```
-
-The first implementation, #140, uses `cap_strength = stronger`, keeps cap
-height at the accepted baseline, keeps low-level humidity and surface heating
-at baseline, and changes only the potential-temperature / stability structure
-near the capping layer in the generated external `input_sounding`.
-
-Expected MVP target:
-
-```text
-CM1 completes cleanly
-NetCDF output exists
-full output sequence ingests
-max w is meaningfully nonzero
-min w is finite
-cloud_formed may be true
-first_cloud_time may be delayed
-cloud_top lower than baseline
-max_qc lower than baseline
-cloud_fraction lower than baseline
-rain_present false or reduced
-main_limiting_factor = cap/stability
-```
-
-Exact morphology is not pass/fail. The key outcome is healthy thermals plus
-available moisture plus limited cloud depth because of the stronger cap. If the
-run becomes indistinguishable from Dry Failed Cumulus, or if diagnostics cannot
-separate cap limitation from moisture limitation, the scenario should be marked
-`needs_calibration` rather than overclaimed.
-
-The first stronger-cap validation run,
-`dry-run-capped-suppressed-20260526015634`, is accepted with notes as a
-cap-limited candidate. It completed local CM1 with `exit_code = 0`, produced
-NetCDF output, ingested 13 model-output time steps from 0 to 10800 seconds, and
-produced `cloud formed; rain detected`. Compared with the accepted
-external-sounding Baseline Shallow Cumulus quick-look, it reduced cloud top
-from about 2.14 km to about 1.34 km, reduced `max_qc_kg_kg` from
-0.001976807601749897 to 0.0013941252836957574, reduced max cloud fraction from
-about 0.01273 to about 0.00847, reduced max/min vertical velocity from about
-6.27 / -4.42 m/s to about 3.52 / -1.67 m/s, and reduced max rain water from
-about `1.3015507647651248e-05` to `4.473397439141991e-06`. Rain still occurred
-and first cloud time stayed at 1800 seconds, so the result should not be
-overstated as fully rain-suppressed or definitively process-diagnosed yet.
-Current language should remain candidate/accepted-with-notes until process
-diagnostics can directly explain cap limitation.
-
-Standard cloud-scale assumptions:
-
-```text
-64 x 64 x 100 grid
-100 m horizontal spacing
-stretched vertical grid: 40 m low-level spacing to 600 m aloft
-18000 m domain top
-21600 s runtime
-3600 s output cadence
-NetCDF output as the intentional Cloud Chamber ingest-path change
-```
-
-Quick-look timing for Baseline Shallow Cumulus:
-
-```text
-10800 s runtime
-900 s output cadence
-all other reference-derived case settings preserved
-```
-
-Deep / overnight differences:
-
-```text
-192 x 192 x 75 grid
-about 33.333 m horizontal spacing
-40 m nominal vertical spacing
-18000 m domain top
-21600 s runtime
-300 s output cadence
-3.0 s model timestep (unchanged from Standard)
-physical domain and reference-derived science settings preserved
-```
-
-If a scenario needs different size, spacing, runtime, cadence, or runtime files, the deviation must be explicit and documented.
-
-Dry-run package generation creates these files for review without launching CM1:
-
-- `run_manifest.json`
-- `case_manifest.json`
-- `namelist.input`
-- `input_sounding`
-- `dry_run_report.json`
-- `runtime_file_checklist.json`
-
-The dry-run report must state that it is not a completed CM1 result, record
-that CM1 was not launched, include the selected run configuration, include
-physical question and controls, include expected diagnostics and
-visualization defaults, show expected runtime/cost/output-volume information
-when available, and use `unknown until validated` for unvalidated estimates.
-
-Launch preflight must reject placeholder-only CM1-facing files, including old `&cloud_chamber_domain` fragments or notes-only `input_sounding` artifacts. Required external runtime files such as `LANDUSE.TBL` are copied from the configured local CM1 run directory into the generated runtime package at launch time. These staged files are local/generated artifacts and must not be committed.
-
-## Curated Controls And Diagnostics
-
-The first lower-atmosphere controls should use atmospheric language:
-
-```text
-low-level humidity
-surface heating
-surface moisture / moisture supply
-cap strength
-cap height
-dry air aloft
-mixing / entrainment
-```
-
-Early controls can be relative presets such as drier/baseline/more humid, weaker/baseline/stronger heating, lower/baseline/higher cap, and less dry/baseline/drier air aloft. Raw namelist fields belong in advanced/developer views.
-
-Initial diagnostics should include:
-
-```text
-cloud formed / failed
-first cloud time
-cloud base
-cloud top
-max vertical velocity
-max or summary cloud water
-cloud-water time evolution
-rain onset if available
-rain-water summary if available
-main limiting factor
-```
-
-First variations should favor one-control-at-a-time changes around Baseline Shallow Cumulus. Large arbitrary parameter sweeps are not the primary learning path.
-
-### First Baseline Shallow Cumulus Diagnostics
-
-The first implemented diagnostics are personal-learning summaries, not publication-quality LES validation. Exact cloud morphology is not pass/fail.
-
-Cloud detection uses:
-
-```text
-qc_cloud_threshold_kg_kg = 1e-6
-minimum_cloud_grid_cells = 10
-```
-
-Cloud Chamber marks `cloud_formed` only when at least one output time has 10 or more finite grid cells with `qc >= 1e-6 kg/kg`. This avoids declaring cloud from one isolated noisy cell. First cloud time is the first output time meeting the same rule.
-
-Cloud-water diagnostics include max `qc`, time of max `qc`, a `qc` max time series, cloud fraction time series, cloud-present time steps, and first-pass cloud base/top when a vertical coordinate is available. Cloud fraction is the count of finite cells at or above the `qc` threshold divided by the count of finite `qc` cells. Cloud base/top is a grid-cell diagnostic: lowest/highest vertical coordinate where any finite grid cell has `qc` above threshold. It is not yet a polished meteorological cloud-base product.
-
-Vertical velocity diagnostics use `w` when present and compute max/min `w`, time of max/min `w`, and max/min time series while preserving units when available.
-
-Rain diagnostics use `qr` when present:
-
-```text
-qr_rain_threshold_kg_kg = 1e-7
-```
-
-If `qr` is absent, the user-facing result must say that rain-water-aloft diagnostics are unavailable, not that rain water aloft was absent. The metadata records that the `qr` field was absent. Missing `qr` does not fail the diagnostics, but it cannot support a clean rain-water outcome.
-
-NaN and infinity values are ignored for finite min/max and fraction summaries. Field-specific caveats record non-finite values or entirely non-finite target fields. Target fields also carry field-quality state: `trusted`, `caveated`, `untrusted`, or `unavailable`. Entirely non-finite `qc`, `w`, `qr`, surface `rain`, or `dbz` fields are untrusted and must not be summarized as clean cloud, updraft, rain-water, surface-rain, or reflectivity evidence. CM1 runtime floating-point exception flags are preserved as caveats and evaluated against the target diagnostic fields rather than treated as automatic run failure.
-
-Shared controls are controls that can be compared across multiple lower-atmosphere scenarios, such as low-level humidity, surface heating, cap strength, cap height, dry air aloft, and mixing/entrainment. Scenario-specific controls should be introduced only when a scenario needs them to answer its physical question.
-
-## Run Manifest Schema
-
-Run manifests are validated metadata records. They describe what Cloud Chamber generated, where it lives, how it maps toward CM1, and what product state it is in. They do not require NetCDF output to exist.
-
-Each run should write a manifest like:
-
-```yaml
-run_id:
-scenario_id:
-name:
-created_at:
-status:
-cm1_version:
-cm1_run_dir:
-output_dir:
-configuration:
-  controls:
-  run_configuration:
-    duration:
-    grid_detail:
-    domain:
-    output_cadence:
-    output_field_density:
-    forcing:
-    advanced_cm1_values:
-      timestep_target_seconds:
-    pre_run_validation_report:
-  namelist_parameters:
-  input_sounding:
-preview:
-  expected_outcome:
-  warnings:
-execution:
-  command:
-  started_at:
-  finished_at:
-  exit_code:
-  logs:
-ingestion:
-  status:
-  processed_artifacts:
-visualization:
-  default_view:
-  thumbnails:
-result:
-  result_id:
-  diagnostics_summary:
-  key_frames:
-user:
-  saved:
-  tags:
-  notes:
-```
-
-Run lifecycle states should include:
-
-```text
-created
-packaged
-queued
-running
-completed
-failed
-canceled
-ingested
-saved
-```
-
-Dry-run packaged experiments must be distinct from queued/running/completed CM1 runs.
-
-Validation rules should reject packaged dry-run manifests that include NetCDF output paths, completed/ingested manifests that still claim to be dry-run packages, unknown lifecycle states, and inconsistent legacy saved metadata.
-
-## Product States And Provenance
-
-Cloud Chamber must preserve these distinctions in UI labels, manifests, result cards, and visualizer copy:
-
-```text
-Preview estimate
-Generated CM1 configuration
-Packaged dry-run output
+Analyzer/recommendation estimate
+CM1 run configuration
+Packaged run
 Queued/running CM1 process
 Completed CM1 result
-Failed/canceled CM1 run
 Ingested result metadata
-Visualizer interpretation
-Editable result/notebook entry
+Visualization interpretation
 ```
 
-A preview or dry-run package is not a completed CM1 result. A visualization is an interpretation of CM1 output, not a new physical source of truth.
+Strong idealized assumptions are acceptable when clearly labeled.
 
-Product copy and state names should prefer nouns that reveal provenance:
+Required honesty:
 
-- `Preview estimate`
-- `CM1 configuration package`
-- `CM1 run`
-- `Completed CM1 result`
-- `Ingested result metadata`
-- `Visualizer interpretation`
-- `Editable experiment notebook entry`
+- state what forcing or trigger was added;
+- preserve enough configuration/provenance to reproduce the run;
+- fail clearly when the requested mechanism did not execute;
+- surface non-finite or numerically suspicious output;
+- distinguish coherent cloud from sparse hydrometeor trace;
+- avoid forecast language;
+- do not imply an idealized mechanism represents a specific observed boundary.
 
-## Result Card / Experiment Notebook
+Scientific honesty does not require weak forcing, untriggered runs, tiny domains,
+or publication-style validation before exploratory use.
 
-A completed run should produce a replayable saved result. It should feel like an experiment notebook entry, not a disposable job row.
+## Evidence Modes
 
-Result cards should support:
+### Exploratory
+
+Bold labeled assumptions. Optimize for visible outcome and learning.
+
+### Compared
+
+Compare two or a few runs when an actual result creates a useful question.
+
+### Broken Or Suspicious
+
+Apply heavier diagnostics/trust work when output is non-finite, numerically
+unstable, missing a requested mechanism, missing evidence needed for a decision,
+or inconsistent with configuration.
+
+There is no current publication-style validated-claim product mode.
+
+## Diagnostic Burden
+
+Before adding a diagnostic, name the decision it changes:
 
 ```text
-result_id
-run_id
-name
-tags
-scenario_id
-scenario_name
-physical question
-created_at
-completed_at
-controls used
-run configuration
-CM1 version/path metadata
-status
-generated config paths
-output paths
-run logs
-diagnostics summary
-first cloud time
-cloud base/top
-max vertical velocity
-cloud-water summary
-rain onset if available
-key frames or bookmarked times
-visualization defaults
-notes
-provenance labels
-open in visualizer action
+continue
+scale
+change recipe parameter
+switch recipe
+skip sounding
+stop broken run
 ```
 
-The first backend Result Card / Experiment Notebook API exposes a scan-friendly
-card over ingested result metadata:
+If it changes none of those decisions, it should not be the next task.
+
+When a run is merely boring, first change sounding, recipe, scale, duration, or
+trigger.
+
+## Runtime And Storage
+
+Default runtime home:
 
 ```text
-run id
-scenario
-run configuration
-physical question
-diagnostics summary
-first cloud time
-max qc
-max/min w
-rain yes/no
-caveats
-output file summary
-notes/tags/name
+~/CloudChamber/
 ```
 
-Editable notebook state lives beside the local run as `result_card.json`; it
-stores `name`, `tags`, and `notes` without modifying or copying CM1 output.
-Older cards may still include `saved` and `protected` fields for compatibility,
-but the current product does not expose a separate save/protect mode.
-
-The Results Library UI is an experiment notebook, not an admin table. It lists
-result cards from the backend as scan-friendly experiment entries, lets the user
-select one result, and shows a detail/notebook card with scenario, run
-configuration, cloud/rain outcome, diagnostics summary, first
-cloud time, max `qc`, max/min `w`, caveats, output summary, and editable name/tags/notes. Notebook
-edits use `Save changes`; ingested results already appear in Results.
-The notebook also exposes backend-derived science summary fields such as
-first-cloud time, max `qc`, max updraft, rain onset, latest output time, and
-interesting-time evidence state so the user can search, filter, and sort the
-experiment list by meaningful scientific evidence rather than raw file order.
-Result Cards must also distinguish generated-reference runs from runs
-created from an uploaded observed sounding, preserving station/time/source
-metadata as provenance. Observed-sounding results should read as `Uploaded
-Sounding` or the active observed run recipe in notebook names, scenario labels,
-and scenario filtering while the underlying generated scenario ID remains
-available in technical details as lineage.
-Observed-sounding results should retain their run provenance after ingest: the
-original observed station/time, generated scenario ID, numeric surface-forcing
-values, expected outputs, caveats, and candidate-screening hypothesis remain
-available as provenance.
-Technical metadata such as raw lifecycle/product states, run IDs, provenance
-labels, controls, and detailed caveats remain available under disclosure rather
-than dominating the first read. The layout should be mobile-first: cards stack
-naturally on narrow screens, and desktop can use a list/detail notebook split.
-
-The library opens a 2-D field inspector from a result detail/notebook entry.
-The inspector is a CM1-output inspection surface, not a visualizer or replay
-system.
-
-The MVP frontend is organized as a task-based workspace:
-
-```text
-Build
-Results
-Explore
-```
-
-`Build` creates and runs experiments. `Results` reviews, edits, and
-manages experiment results. `Explore` inspects and visualizes one selected
-result's CM1 fields. The app should open on `Results`, because the most useful
-first click path is to choose the validated reference Baseline Shallow Cumulus
-result and open it in Explore or 3-D. Results should prioritize completed, ingested, cloud-forming
-reference baseline entries ahead of failed/no-cloud or historical
-attempts. User-facing labels should say `Completed CM1 result`, `Ingested`,
-`Needs review`, `Cloud formed`, `No cloud`, and `Rain detected` rather
-than leading with raw lifecycle strings. Raw lifecycle/product/provenance labels
-remain available under technical details.
-
-The shared visual system should read as an atmospheric experiment notebook, not
-a terminal dashboard or cockpit. The app chrome should use a soft neutral /
-pale blue-gray background, light or very soft slate surfaces, cloud/sky-inspired
-panels, blue / blue-gray primary accents, subtle amber warnings, and subtle red
-destructive/error states. Green is reserved for success or healthy states only;
-it is not the brand or primary navigation color. Visualization viewports may use
-dark plotting backgrounds when they make CM1-derived fields easier to read, but
-the surrounding app shell, navigation, cards, buttons, badges, loading/error
-states, and technical-detail areas should stay calm, readable, and secondary to
-the workspace content.
-
-For completed cloud-forming results, minor runtime or coordinate caveats should
-read as caveats, not failed-run warnings. A result can be a successful,
-inspectable CM1 run while still carrying `Minor caveat` details such as
-floating-point flags or vertical-coordinate unit notes. `Needs review` remains
-appropriate for no-cloud, missing-diagnostics, failed, or otherwise incomplete
-results.
-
-Dry Failed Cumulus is an intentional no-cloud contrast case, not a failed run,
-when it completes locally, ingests successfully, preserves meaningful vertical
-motion, and keeps cloud water below threshold. Its primary badges should read
-like an accepted moisture-limited outcome: `No cloud formed`, `No rain
-detected`, and `Moisture-limited`, with caveats secondary.
-
-`Results` is the Result Card / Experiment Notebook: a scan-friendly list of
-experiment cards plus a selected notebook detail, with technical run metadata
-kept secondary. It does not expose a Compare tab until Cloud Chamber has a real
-user-driven comparison workflow. Ingested-result cleanup lives on the selected
-notebook detail as a secondary/danger preview action, not as a separate Storage
-workspace.
-
-`Explore` is one desktop cloud-context and slice-inspection workflow for a
-single selected result. The old `2-D Slices` / `3-D View` split was useful
-scaffolding while capabilities were built separately, but the product workflow
-is now a unified instrument: compact selected-result context, shared
-field/time/slice controls, a 3-D scalar-field context, a visible native-grid
-slice plane, the matching 2-D slice inspector, and a `What happened here?`
-selected-point explanation panel. Selecting a result in Results should preserve
-that context. If no selected result is available, Explore should tell the user
-to select an ingested result from Results.
-
-Shared time controls should operate on actual saved CM1 output times. Explore
-may provide play/pause timelapse playback and a scrubber across those saved
-time indices, but it must not interpolate between model outputs or imply a
-continuous movie. Manual time changes and pausing playback update the 3-D
-scalar context and 2-D slice inspector together, preserve the current camera,
-field, slice orientation, and slice position, and clear selected-cell
-explanation state because the old point evidence belongs to a different model
-time. While playback is running, Explore should update the main 3-D scalar
-layer for the visible saved output time, but it should not refetch or recompute
-all synchronized field products every frame. The 2-D slice, selected-point
-diagnostics, defaults, and evidence panels may remain on the last committed time
-until playback is paused. At the end of the saved-output sequence, playback
-should stop and reset to the first output time rather than looping indefinitely.
-The selected-point panel should invite the user to pause before asking `What
-happened here?`.
-
-The first-read Explore screen should be an explanation workspace, not a
-process-mode cockpit. The 3-D context renders only backend-supported scalar
-layers: `qc` cloud water, `qr` rain water, `qv` water vapor, `dbz`
-reflectivity, and surface `rain` when those fields exist in the ingested result.
-It does not pretend that every CM1 output field has a trustworthy 3-D rendering.
-`w`, potential temperature, and direct temperature remain native-grid slice
-inspection fields until a later issue defines scientifically honest 3-D
-rendering for them. Core field/time/slice controls stay visible and shared
-across the 3-D context and slice inspector. Process focus,
-projection/rendering details, raw coordinate metadata, and long provenance
-labels belong behind details/disclosure until the user asks for them.
-
-Explore's cloud context and slice inspector should default to physically
-interesting output views, not arbitrary zero-index slices. The backend should
-provide default field/time/slice locations from native-grid data when possible:
-for `qc`, first cloud time or the max cloud-water location; for `w`, the
-max-updraft location. If those locations are unavailable, the UI may fall back
-to domain-center slices and clearly keep the native-grid/provenance caveats
-available. Explore should not open at `t=0` when diagnostics show clouds appear
-later.
-
-Future comparison work should be user-driven rather than a fixed lab pair. It
-should let the user choose results, explain the comparison target, and preserve
-the current scientific honesty boundary: no browser-side NetCDF parsing, no
-invented unsupported diagnostics, and clear provenance for every compared
-metric.
-
-The next comparison step may add side-by-side 2-D slices for an accepted lab
-pair. It consumes the existing backend visualization-ready fields/slice API for
-`qc` and `w`, supports shared output-index selection with mismatch labels when
-times differ, and shows units, min/max, finite/non-finite counts, and provenance
-for each result. The browser still does not parse raw NetCDF or implement new
-3-D rendering for this comparison.
-
-Completed results should be replayable and inspectable without rerunning CM1. Duplicate/tweak/rerun is useful later, but replay, inspect, explain, and edit notebook fields are the core MVP result-library behavior.
-
-## MVP Scope
-
-### In Scope
-
-- New local project skeleton
-- Preset scenario definitions
-- Local run manifest format
-- Generate CM1 case/run directories
-- Launch CM1 through local command
-- Track process/log status
-- Ingest NetCDF output or create intermediate artifacts
-- Unified Explore cloud context, slice inspector, and explanation workflow
-- Result library
-- Save/name/tag runs
-- Replay and inspect saved results
-
-### Out Of Scope For MVP
-
-- Cloud-hosted compute
-- Browser-native CM1 execution
-- Full namelist editor as primary UI
-- Full photorealistic cloud rendering
-- True production LES workflow guarantee
-- Terrain/orographic cases unless explicitly added
-- Warm-rain microphysics beyond fields CM1 already outputs
-- Publication-quality LES guarantees
-- Operational forecasting workflows
-
-### Current Near-Term Non-Goals
-
-- Build the full 3-D visualizer before the package/run spine exists.
-- Implement a fake physics predictor.
-- Vendor CM1.
-- Commit generated CM1 output or real NetCDF outputs.
-- Overbuild deployment.
-
-## Unified Explore MVP
-
-Start with a practical, trustworthy Explore instrument, not a cinematic
-renderer. The near-term MVP is the product loop: select a saved result, see the
-scalar-field context, inspect the synchronized native-grid slice, click a cell,
-and get a CM1-backed `What happened here?` explanation.
-
-The implemented/near-term Explore layers are:
-
-1. Visualization-ready backend data contract.
-2. Native-grid slice inspection for orientation, time indexing, scaling, and
-   field availability.
-3. Scalar 3-D context for supported fields using thresholded backend-prepared
-   point payloads (`qc`, `qr`, `qv`, `dbz`) and a surface-floor layer for
-   surface `rain`.
-4. Horizontal and vertical slice planes for native-grid fields such as `qc`,
-   `w`, `qr`, `qv`, `dbz`, temperature, and potential temperature when present.
-5. Selected-cell / selected-region explanation backed by Thermal Fate
-   diagnostics.
-
-Later renderer decisions live in #112 and #80, not in the near-term Explore MVP:
-volumetric ray marching, isosurfaces, lighting, appearance controls,
-fly-through/move-through, cinematic export, and thumbnail/preview generation.
-
-The browser should not parse raw CM1 NetCDF directly. Backend ingest and visualization-ready preprocessing should provide selected, provenance-labeled fields for inspection and rendering.
-
-The first 3-D scalar renderer uses thresholded point clouds and a surface-floor
-layer, not volumes or isosurfaces. The backend selects a supported field at a
-chosen output time, keeps native coordinates, returns points that pass the
-field-specific threshold, reports full NetCDF coordinate extents, active height
-range where applicable, thresholded point count, full selected-field
-min/max/mean stats, max-value location, and deterministic downsampling if
-needed. The browser renders those returned points only; it does not parse raw
-NetCDF, interpolate, run marching cubes, extract isosurfaces, ray march, or
-invent cloud physics. The rendering method should be labeled as a direct scalar
-point cloud or surface-floor layer, and the processing method should identify
-the backend native-grid threshold operation.
-
-Reflectivity uses weather-radar-style fixed dBZ colors rather than a dynamic
-per-run scale. The legend should cover 0 to 60+ dBZ even when a shallow-cumulus
-result only contains weak or sparse reflectivity. The UI should show the current
-field max and the visible-point threshold so a low-reflectivity case is
-understandable without presenting it as a rendering failure.
-
-Point placement must use full coordinate extents from the payload, not the
-min/max of returned cloudy points. Side/elevation views are the first scientific
-check: `Side x-z` and `Side y-z` map model height `z` to visual height so cloud
-base/top are legible. `Top-down x-y` is for horizontal footprint, and `Oblique
-overview` is an interpretive overview. The domain box, floor, axis labels, and
-points should use the same coordinate transform, with technical details showing
-the actual coordinate units and visualized extent.
-
-The MVP viewer uses a fixed scientific workbench rather than a long scrolling
-page section or a pretend physical camera. The workbench should keep primary
-visual controls near the viewport, keep timeline and slice-position controls
-directly below the render, and move provenance/details into a secondary
-collapsible panel. Zoom scales the rendered data layer while preserving the
-underlying CM1 coordinate transform; it does not change the model data, slice
-selection, axes labels, or diagnostic values. Projection labels should be
-explicit:
-
-- `Side x-z`: height is vertical; `y` is compressed or hidden.
-- `Side y-z`: height is vertical; `x` is compressed or hidden.
-- `Top-down x-y`: horizontal footprint; height is not shown vertically.
-- `Oblique overview`: interpretive overview, not a true perspective camera.
-
-Scale markers should show horizontal distance, height when visible, the domain
-floor, and the active cloud-water height range so the view remains readable at
-normal browser zoom and across common screen sizes.
-
-The first 3-D slice planes reuse the #72 JSON slice endpoint. The scene can
-request horizontal and vertical native-grid slices for the selected slice field
-at the same output time as the 3-D scalar layer. Slice
-planes are optional inspection aids, not the cloud itself: they should be
-toggleable, visually secondary, semi-transparent, and tied to the same
-interesting native-grid locations used by Inspect. The UI must show field name,
-units, selected time, slice location, min/max, native-grid caveats, and
-provenance labels. These planes are inspection overlays, not ray-marched volumes
-or interpolated fields.
-
-Slice-plane controls should let the user choose the native-grid plane and move
-it through the domain:
-
-- horizontal `z` / height slice: moves up and down through vertical levels;
-- vertical `x-z` slice: moves forward/back through `y`;
-- vertical `y-z` slice: moves left/right through `x`.
-
-These controls change the selected slice request to the backend. They are not
-true 3-D rotation controls, do not interpolate staggered grids, and do not
-change the underlying CM1 result.
-
-The 3-D viewer should provide simple view presets:
-
-- Cloud overview: cloud-water points with no planes or one subtle reference
-  slice.
-- Vertical cross-section: a vertical slice through max `qc` or max `w`.
-- Top-down slice: a horizontal slice through the cloud-bearing level.
-- Inspect updraft slice: `w` slice through the max-updraft location.
-
-The viewer should also provide quick jumps for first cloud, max cloud water, and
-max updraft when result diagnostics provide enough timing metadata. Slice-plane
-defaults should avoid empty zero-index views where a center/cloud-bearing level
-is more useful. Slice defaults should be selected for the current output time:
-`qc` slices should center on the selected-time max cloud-water cell, and `w`
-slices should center on the selected-time max-updraft cell. Native-grid/no-
-interpolation caveats and rendering provenance must stay available, but long
-technical labels belong under `About this visualization` rather than dominating
-the primary view.
-
-The first 3-D impression should make the validated reference baseline obvious:
-opening from Results should land on the first-cloud or max-cloud-water time when
-available, show a visible cloud-water point cloud, show the domain box, axes,
-ground/base plane, current time, and threshold, keep slice planes optional and
-secondary, and place detailed provenance/rendering labels under `About this
-visualization`.
-
-### Post-MVP Visual Polish, Fly-Through, and Export
-
-Visual polish is deliberately post-MVP. The first product loop should prove that
-Cloud Chamber can generate CM1 packages, run CM1 locally, ingest results,
-produce diagnostics, save/reopen result cards, inspect fields, and render a
-practical 3-D interpretation. Only after that loop is useful should the
-visualizer pursue cinematic work.
-
-Post-MVP visual work may include:
-
-- volumetric ray marching for cloud-water fields;
-- shadows and simple atmospheric lighting;
-- edge brightening to make cloud boundaries readable;
-- cloud-base darkening to emphasize vertical structure;
-- fly-through / move-through camera modes;
-- cinematic export for short videos or stills;
-- generated thumbnails or previews for saved results.
-
-These features must remain interpretations of CM1-derived data. The UI should
-continue to show the source result, field, units, processing method, rendering
-method, and any caveats. Visual polish must not imply extra model detail,
-interpolate native grids without disclosure, or turn preview imagery into a
-completed CM1 result.
-
-Generated thumbnails, videos, preview frames, and other visual artifacts are
-local/generated outputs by default. They should stay outside git unless a future
-issue defines a tiny fixture or documented artifact policy for tests. Large
-visualization artifacts must not be committed.
-
-## 2-D Field Inspection MVP
-
-The first inspector opens from a saved or ingested Result Card / Experiment
-Notebook entry. It consumes the #72 backend fields/slice API; the browser never
-parses raw CM1 NetCDF.
-
-MVP behavior:
-
-- list available fields from the backend, starting with `qc` and `w`, and `qr`
-  when present;
-- allow field selection and output time selection;
-- default to a physically interesting time and slice location using backend
-  defaults when available;
-- request horizontal and vertical slice payloads from the backend;
-- show one primary heatmap by default, with `Horizontal`, `Vertical X`, and
-  `Vertical Y` modes;
-- show heatmaps with field units, native
-  grid, selected time, slice shape/dimensions, min/max, finite and non-finite
-  counts, and provenance labels;
-- keep raw JSON numeric slice values available under technical details rather
-  than making matrix dumps the primary UI;
-- represent missing fields and bad slice requests as UI errors instead of
-  crashing;
-- clearly label slices as CM1-derived inspection data, not 3-D rendering.
-
-The 2-D inspector is deliberately practical and small. It helps verify field
-orientation, time indexing, vertical coordinates, units, and scaling inside the
-unified Explore workflow before any later renderer upgrade changes the visual
-representation.
-
-## Visualization-Ready Data Contract
-
-The first visualization contract is slice-first and backend-owned. The browser
-does not parse raw NetCDF; it asks the local backend for selected,
-provenance-labeled field metadata and JSON slice payloads from an ingested CM1
-result.
-
-Implemented backend endpoints:
-
-```text
-GET /api/results/{result_id}/visualization/fields
-GET /api/results/{result_id}/visualization/defaults
-GET /api/results/{result_id}/visualization/slice
-```
-
-The field catalog supports `qc` and `w` first, with `qr` exposed when present.
-Initial canonical mapping:
-
-```text
-qc   -> cloud_water
-w    -> vertical_velocity
-qr   -> rain_water
-rain -> accumulated_surface_rain
-dbz  -> reflectivity
-```
-
-The slice endpoint supports:
-
-```text
-horizontal: fixed vertical level, y-x plane
-vertical_x: fixed y index, z-x plane
-vertical_y: fixed x index, z-y plane
-```
-
-MVP slices use native CM1 grids and do not interpolate staggered fields:
-
-```text
-qc: time, zh, yh, xh
-w:  time, zf, yh, xh
-```
-
-Every slice payload includes field metadata, selected time/index, shape,
-dimension order, JSON numeric values, min/max/mean, finite/non-finite counts,
-native coordinate units, caveats, and provenance/rendering/processing labels.
-Non-finite values are represented as `null` in JSON.
-
-The defaults endpoint chooses physically interesting native-grid locations for
-the unified Explore workflow. It reports max-value locations for `qc` and `w` when
-available, including selected time index, horizontal level, vertical slice
-indices, source label, and caveats. It does not interpolate or invent data; if
-the field is missing or non-finite, the UI falls back to domain-center slices.
-
-Vertical coordinate units are preserved. If a vertical coordinate is in
-kilometers, Cloud Chamber may add a meter display value while still returning
-the native coordinate value and native units.
-
-Future 3-D block payloads should use JSON metadata plus binary `float32` arrays
-with max-voxel/downsampling controls. This is a future backend contract, not a
-requirement for the 2-D inspector.
-
-## Local Data Policy
-
-Do not commit:
-
-- CM1 source
-- CM1 binaries
-- NetCDF outputs
-- generated run directories
-- thumbnails if large
-- processed volume artifacts if large
-- local runtime data under `~/CloudChamber`
-
-Commit:
-
-- scenario templates
-- schema docs
-- scripts
-- tests
-- small fixtures
-- app code
-
-## Existing Tools To Learn From
-
-Evaluate but do not assume replacement by:
-
-- VAPOR
-- ParaView
-- Vis5D
-- GrADS
-- Tecplot
-
-Use them to understand data/visual targets. The product goal remains a CM1-specific guided studio.
+Runtime state includes packages, queue state, logs, CM1 outputs, ingested result
+metadata, cache, and generated visualization products. These remain outside git.
+
+The browser consumes bounded backend-prepared data and does not parse raw
+NetCDF.
+
+CM1 source, binaries, NetCDF output, generated runs, logs, machine-private
+settings, and large artifacts must not be committed.
+
+## Failure And Trust States
+
+Process exit zero does not guarantee scientifically usable output. Preserve:
+
+- lifecycle state;
+- runtime integrity;
+- required field availability;
+- field quality where output is non-finite or missing;
+- clear failed/canceled/incomplete states.
+
+Do not force every normal exploratory result through extensive trust reporting.
+Surface trust information when it affects whether the cloud can be interpreted.
+
+## Current Strategic Work
+
+### #346 — Cloud Opportunities And Scout-To-Full-Run
+
+Primary product lane: ranking sounding–recipe–run-setup opportunities, meaningful
+scouts, visible promotion, and at least one interesting cloud or decisive skip.
+
+### #341 — Explicit Thermal / Deep-Tower Recipes
+
+Restore the proven Deep Convection Trial from PR #270 and make deep cloud results
+available through the current Build/Results/Explore architecture.
+
+### #287 — Daytime Evolution
+
+Implement active place/time daytime evolution or an honestly labeled evolving
+proxy and use a real sounding early.
+
+The completed differential surface-forcing mechanism is one available recipe
+tool, not the product center.
+
+## Non-Goals For The Current Horizon
+
+- operational forecasting;
+- organized mesoscale-convection products;
+- publication-style experiment validation;
+- universal raw namelist editing;
+- arbitrary GIS/terrain/land-surface realism;
+- formal comparison as a prerequisite to exploration;
+- diagnostics or provenance as standalone product goals;
+- renderer features disconnected from an interesting cloud result.
+
+## Success Criteria
+
+Cloud Chamber should let a user:
+
+1. search a useful sounding history;
+2. see the best cloud-making opportunities;
+3. understand the recommended recipe and run setup;
+4. avoid likely boring soundings/setups;
+5. queue a meaningful scout;
+6. see progress and ETA;
+7. let a promising scout visibly promote to a full run;
+8. stop or clean it up;
+9. ingest and revisit the result;
+10. watch growing or deep cloud evolution;
+11. learn which atmosphere and assumptions shaped the result.
+
+Within a small number of scouts, the product should produce an interesting cloud
+or save substantial compute with a decisive switch/skip recommendation.
+
+## Strategic Sources
+
+- [Cloud-First Product Reset](cloud-first-product-reset.md)
+- [Product Vision](product-vision.md)
+- [Current Roadmap](current-roadmap.md)
+- [Agent Operating Rules](../AGENTS.md)
+- [Architecture And Data Model](architecture-and-data-model.md)
+- [Output Product Specification](contracts/output-product-specification.md)
+- [Sounding Candidate Screening Contract](contracts/sounding-candidate-screening.md)

--- a/docs/cloud-first-product-reset.md
+++ b/docs/cloud-first-product-reset.md
@@ -1,0 +1,500 @@
+# Cloud-First Product Reset
+
+Status: approved product direction
+
+## Organizing Principle
+
+Cloud Chamber is a **cloud-making sandbox that uses real atmospheres as raw material**.
+
+The central product question is:
+
+> Given the soundings available, which ones can make interesting clouds, what
+> setup should I use, and how far do I need to push them?
+
+The first visible outcomes to optimize for are:
+
+1. growing cumulus and congestus;
+2. deep convective towers;
+3. precipitation and reflectivity.
+
+Organized convection is not a current product priority. Cloud Chamber is not a
+forecast or warning product, and it is not trying to reproduce a publication
+workflow.
+
+## Why This Reset Is Necessary
+
+Cloud Chamber accumulated useful infrastructure, but the work drifted away from
+its experiential goal. Several reinforcing biases caused that drift:
+
+1. **The product ranked soundings, not useful things to do with them.**
+   A sounding can be poor for free evolution and excellent with explicit
+   initiation. A generic story label does not answer whether a run is worth the
+   time.
+
+2. **Natural or weak forcing became the implied scientific default.**
+   Real cloud initiation often depends on sunlight, boundary-layer evolution,
+   terrain, boundaries, convergence, or other heterogeneity. A horizontally
+   homogeneous untriggered CM1 domain should not be treated as the moral baseline
+   for every atmosphere.
+
+3. **Scientific honesty was confused with weak assumptions.**
+   Honesty means naming the assumption. It does not mean always selecting the
+   smallest domain, weakest forcing, shortest run, or least effective trigger.
+
+4. **Issues rewarded narrow plumbing slices.**
+   Package provenance, validation, trust gates, and diagnostics became the
+   deliverables instead of supporting a visible atmospheric outcome.
+
+5. **Diagnostics were added without a decision burden.**
+   A diagnostic is valuable when it changes continue/change/stop behavior or
+   reveals broken output. It is not automatically valuable because it can be
+   computed.
+
+6. **Working cloud-making capability was removed during a conservative reset.**
+   PR #270 proved that the Deep Convection Trial could produce a strong tower
+   from a real Fort Worth sounding using stock CM1 `iinit = 3`. Later planning
+   demoted that evidence while prioritizing untriggered evolution.
+
+7. **Agent rules rewarded fragmentation and permission-seeking.**
+   One-issue-per-branch, strict issue scope, mandatory questions, automatic
+   follow-up issue creation, and pausing before every real CM1 change made sense
+   as generic safeguards but became harmful defaults for exploratory cloud work.
+
+## Product Model
+
+The primary ranked object is:
+
+```text
+sounding + recipe + run setup
+```
+
+The analyzer should not only say that a sounding contains ingredients. It should
+say what Cloud Chamber can plausibly do with that atmosphere.
+
+Example:
+
+```text
+Best opportunity: Growing tower
+Sounding: Norman / Max Westheimer, 00Z
+Recommended recipe: Broad warm/moist surface region
+Why: Good moisture and growth potential; spontaneous initiation looks weak
+Expected visible result: Growing cumulus to congestus
+Natural free evolution: Likely shallow or delayed
+Stronger alternative: Explicit thermal initiation
+Run setup: 12.8 km, 100 m grid, 4 h scout, 5 min output
+```
+
+Cloud Chamber should also say:
+
+```text
+Skip this sounding for cloud-making.
+Strong cap and dry low levels make all current supported recipes poor bets.
+Use it only if you want to explore suppression.
+```
+
+## Entry Modes
+
+Support both entry modes without forcing the user to know meteorology first.
+
+### Show Me Something Cool
+
+This is the primary default entry point.
+
+Cloud Chamber searches the available cached history—not only today—and returns
+ranked sounding–recipe–run-setup opportunities. The user may select time range,
+region, cloud target, or compute appetite, but useful defaults should work without
+those choices.
+
+### Find / Inspect
+
+Support queries such as:
+
+```text
+What can we do with this sounding?
+Show me deep-tower opportunities from the last month.
+Find growing-cumulus opportunities in my whole cache.
+Which saved atmosphere is worth revisiting?
+```
+
+The user may not visit Cloud Chamber every day. Historical and selectable-range
+search is first-class.
+
+## Workflow
+
+```text
+Find promising sounding–recipe pairs
+→ Recommend a concrete run setup
+→ Queue a meaningful scout through Build
+→ Automatically promote a promising scout to a full run
+→ Explore the evolving cloud
+```
+
+### Find
+
+Search and rank cloud opportunities. Do not dump a station list and ask the user
+to interpret it.
+
+### Recommend
+
+Give one best bet, a clear reason, an expected visible outcome, a run setup, and
+one stronger alternative. Recommend against free evolution when it is likely to
+waste time.
+
+### Scout
+
+Run real CM1 with a recipe-specific setup large and long enough to answer whether
+the opportunity deserves more compute. A scout is not automatically tiny or
+short.
+
+### Full Run
+
+When a scout earns continuation, queue or continue the full run visibly through
+the existing Build workflow. The user sees duration, progress, ETA, and the
+promotion reason, and can stop or clean it up.
+
+### Explore
+
+The payoff is watching and understanding cloud evolution. Diagnostics support
+the visual story; they are not the product center.
+
+## Cloud Opportunity Contract
+
+A useful recommendation payload should include:
+
+```yaml
+cloud_opportunity:
+  sounding_id:
+  station_id:
+  station_name:
+  valid_time_utc:
+  search_scope:
+  cloud_target: growing_cumulus | deep_tower | precipitation | suppression
+  recipe_id:
+  recipe_label:
+  opportunity_score:
+  expected_visible_outcome:
+  likely_ceiling:
+  main_obstacle:
+  why_this_pair:
+  why_not_free_evolution:
+  recommended_run_setup:
+  scout_checkpoint_plan:
+  automatic_promotion_plan:
+  stronger_alternative:
+  skip_recommendation:
+  assumptions:
+  caveats:
+```
+
+The opportunity score is a product recommendation, not a forecast probability.
+It should improve as real CM1 outcomes accumulate, but it does not need
+publication-style validation before becoming useful.
+
+## Sounding Selection
+
+The analyzer should estimate two separate things:
+
+1. **Growth ceiling** — what the atmosphere may sustain once a useful updraft
+   exists.
+2. **Initiation difficulty** — how much help is likely needed to create that
+   updraft in the selected CM1 setup.
+
+Those two axes are more actionable than one generic severe/shallow score.
+
+### Useful Ingredients
+
+Where the profile supports reliable calculation, consider:
+
+- low-level moisture and depth;
+- LCL and cloud-base accessibility;
+- CAPE, CIN, LFC, and EL for relevant parcel choices;
+- cap strength, depth, and height;
+- low- and mid-level lapse rates;
+- midlevel relative humidity and dry-air entrainment risk;
+- precipitable water;
+- freezing-level and mixed-phase depth;
+- sounding vertical completeness and surface representativeness;
+- observed wind completeness where the run recipe requires it;
+- known recipe compatibility and package readiness.
+
+Do not make missing advanced diagnostics silently equivalent to a poor
+atmosphere. Preserve missing-data confidence separately.
+
+### Target-Specific Ranking
+
+Rank separately for:
+
+- growing cumulus/congestus;
+- deep-tower potential after initiation;
+- precipitation potential;
+- suppression/cap-learning value;
+- likely boring/skip.
+
+### Skip Logic
+
+Cloud Chamber should recommend skipping a cloud-making run when the current
+recipe catalog offers no plausible useful outcome for the requested target.
+Examples include very dry low levels, overwhelming inhibition, inadequate
+profile quality, or a model/run shape that cannot represent the target.
+
+A skip recommendation saves compute and user attention. It is a success, not a
+failure.
+
+## Initial Recipe Catalog
+
+These recipes are starting tools, not the final catalog and not separate product
+centers.
+
+### 1. Daytime Evolution
+
+Question:
+
+> What might this atmosphere do during an ordinary heated daytime evolution
+> under Cloud Chamber's explicitly simplified assumptions?
+
+Suitable for boundary-layer growth, growing cumulus, and congestus opportunities.
+Use active place/time forcing where supported. If a simplified diurnal proxy is
+used, label it clearly. Do not call constant domain-wide flux a real daytime
+cycle.
+
+### 2. Broad Warm/Moist Surface Region
+
+Question:
+
+> Can a broad heated or moistened lower-boundary region organize enough ascent to
+> grow visible clouds?
+
+This should build on the completed differential-forcing mechanism but use scales
+chosen for cloud growth, not merely a 1.5 km plumbing footprint.
+
+### 3. Explicit Thermal Initiation
+
+Question:
+
+> If Cloud Chamber supplies a rising thermal, what kind of cloud can this
+> atmosphere sustain?
+
+This is normal exploratory behavior. The UI label supplies the honesty.
+
+### 4. Deep-Tower Benchmark
+
+Question:
+
+> With strong explicit initiation, what is this atmosphere's convective ceiling?
+
+Restore and modernize the proven Deep Convection Trial from PR #270. This is the
+most direct initial path to reliably producing deep, visually interesting cloud
+results.
+
+### 5. Suppression / Cap Challenge
+
+Question:
+
+> How much heating, moistening, or initiation is needed before this atmosphere
+> produces a cloud or breaks through its cap?
+
+This recipe turns otherwise poor cloud candidates into useful learning cases.
+
+## Recipe Operating Contract
+
+Every recipe must define:
+
+- visible target and learning question;
+- suitable sounding traits;
+- poor/skip traits;
+- exact added mechanism and assumptions;
+- scout run setup;
+- full-run setup;
+- default and stronger supported levels;
+- checkpoint timing;
+- promotion criteria;
+- escalation order;
+- stop/switch criteria;
+- expected visible outcomes;
+- limitations and honest user label.
+
+A recipe name without this operating contract is not complete.
+
+## Initial Run-Shape Hypotheses
+
+These are starting hypotheses for real CM1 testing, not frozen validated presets.
+The implementation should change them when actual cloud results justify it.
+
+| Target / recipe | Meaningful scout starting point | Full-run direction |
+| --- | --- | --- |
+| Growing cumulus / Daytime Evolution | 12.8 km domain, ~100 m horizontal spacing, tall current vertical grid, 3–4 simulated hours, 5–10 min output | Continue to 6–8 h when cloud water and coherent top are growing |
+| Growing cumulus / Broad warm-moist region | 12.8–25.6 km domain, 100–200 m spacing, 2.5–3 km core region plus taper, 3–4 h | Broaden toward 3–5 km or extend duration before making a tiny patch dramatically hotter |
+| Explicit thermal | Use a supported stock-CM1 initiation setup, 20+ km cloud-resolving domain where practical, tall model top, early dense output | Continue or refine when the initiated cloud grows coherently |
+| Deep-tower benchmark | First restore the proven PR #270 configuration and Fort Worth case; then test a higher-resolution cloud-focused run shape | Refine horizontal/vertical detail and output cadence after the deep path works in current Build |
+| Suppression / cap challenge | Recipe-specific heating/trigger ladder with explicit levels and early checkpoints | Continue only when one level produces meaningful ascent or cloud growth |
+
+Raw timestep is an advanced numerical assumption. Use the safer supported value
+for the selected run shape and preserve it in provenance.
+
+## Scout Checkpoints And Decisions
+
+Checkpoints are recipe-specific.
+
+### Daytime Evolution
+
+Typical decision windows: roughly 90 minutes, 3 hours, then full-day continuation.
+
+Continue when the boundary layer responds and coherent cloud water begins to
+appear or grow. Switch recipe or skip when forcing is active but the atmosphere
+remains strongly capped/dry with no useful trend.
+
+### Broad Warm/Moist Region
+
+Typical decision windows: 60, 120, and 180 minutes.
+
+Continue when the forced region produces meaningful sustained ascent and growing
+cloud water. Broaden the region before blindly escalating amplitude. Switch to
+explicit initiation when growth potential looks good but initiation remains weak.
+
+### Explicit Thermal / Deep-Tower Benchmark
+
+Typical decision windows: 15, 30, 60, and 90 minutes.
+
+Continue when the trigger is applied, updraft strengthens, coherent cloud grows,
+and mixed-phase/precipitation evidence begins where expected. Change sounding or
+run shape promptly if the trigger works but the atmosphere cannot sustain a
+useful cloud.
+
+### Decision Set
+
+Every scout should resolve to one visible action:
+
+```text
+continue automatically to full run
+scale up one run-shape parameter
+change one recipe parameter
+switch recipe
+skip this sounding
+stop because the run is broken or suspicious
+```
+
+## Automatic Promotion
+
+Automatic scout-to-full-run promotion is allowed and expected when a recipe's
+criteria are met.
+
+Promotion must:
+
+- appear in the existing Build run plan and queue;
+- show configured model duration, progress, and ETA;
+- preserve the scout relationship and promotion reason;
+- allow stop/cancel and cleanup;
+- avoid hidden or unbounded batches;
+- use a trustworthy restart/checkpoint when supported, otherwise create a related
+  full-run package.
+
+## Evidence Modes
+
+Use two normal modes:
+
+### Exploratory
+
+Bold, labeled assumptions. Optimize for visible outcome and learning. Preserve
+enough configuration and provenance to reproduce the run.
+
+### Compared
+
+Compare two or a few runs when a result creates a useful question. Matching is a
+tool, not a universal prerequisite.
+
+### Broken Or Suspicious
+
+Heavy trust and diagnostic work belongs here: non-finite output, missing requested
+mechanism, numerical instability, missing fields needed for the decision, or a
+result that contradicts its configured setup.
+
+There is no separate publication-style "validated claim" workflow in the current
+product model.
+
+## Diagnostic Burden
+
+Before adding a diagnostic, state which decision it changes:
+
+```text
+continue
+scale
+change recipe parameter
+switch recipe
+skip sounding
+stop broken run
+```
+
+If it changes none of those decisions, do not make it the next task.
+
+When a run is simply boring, first consider changing the sounding, recipe,
+scale, duration, or trigger. Do not automatically add more diagnostics.
+
+## UX Direction
+
+The primary Build experience should be able to say:
+
+```text
+Here are the best cloud-making opportunities in your available sounding history.
+This one is the best bet for a growing tower.
+Use this recipe and run setup.
+Natural evolution is likely boring; explicit initiation is recommended.
+```
+
+The user should not need to read a sounding diagram expertly before receiving a
+useful recommendation.
+
+Build owns the scout/full-run queue, ETA, stop, and cleanup workflow. Results owns
+the notebook entry. Explore should make cloud evolution visually rewarding and
+technically inspectable without burying the user under diagnostics.
+
+## Agent Operating Rules
+
+For cloud-making work:
+
+- optimize visible cloud outcome and information gained per unit of user time;
+- take bounded big swings;
+- run meaningful CM1 early;
+- allow strong idealized assumptions when clearly labeled;
+- do not create prerequisite issues unless genuinely blocked;
+- do not let old roadmap sequencing override current user intent;
+- keep one outcome-oriented vertical slice together when code, UI, run setup, and
+  real execution are all required;
+- change sounding, recipe, scale, duration, or trigger before adding diagnostics
+  to a merely boring run;
+- compare second, not first;
+- keep generated model artifacts outside git.
+
+## Stop Doing
+
+- Stop treating free evolution as the default test of every sounding.
+- Stop treating Baseline Shallow Cumulus as the product hero outcome.
+- Stop creating a validation issue before every useful real run.
+- Stop requiring formal campaign comparison before shipping a recipe.
+- Stop adding diagnostics without a concrete next-run decision.
+- Stop ranking soundings without recommending a recipe and run setup.
+- Stop discarding working trigger paths because they are idealized.
+- Stop optimizing issue closure over cloud-making progress.
+
+## Immediate Repo Direction
+
+1. **#346:** build cloud-opportunity ranking and the visible scout-to-full-run
+   workflow.
+2. **#341:** restore the proven explicit thermal/deep-tower path from PR #270.
+3. **#287:** implement a real daytime-evolution recipe using active place/time
+   forcing or an honestly labeled evolving proxy.
+4. Treat the completed differential surface-forcing work as one available recipe
+   mechanism, not a roadmap center.
+5. Improve visual cloud presentation after current Build can reliably produce or
+   recommend interesting cloud runs.
+6. Create small comparisons only when actual results make the comparison useful.
+
+## Success Measure
+
+Within a small number of real scouts, Cloud Chamber should either:
+
+- produce a clearly growing, visually interesting cloud worth continuing;
+- produce a deep tower or precipitation-bearing result;
+- or save the user substantial compute by making a decisive skip/switch
+  recommendation before a long boring run.
+
+Infrastructure is successful only when it improves one of those outcomes.

--- a/docs/codex-project-setup.md
+++ b/docs/codex-project-setup.md
@@ -1,104 +1,47 @@
 # Codex Project Setup Notes
 
-## Recommended New Repo
+## Repository
 
 ```text
 cloud-chamber
 ```
 
-## Local Directory
-
-Recommended:
+Likely local directory:
 
 ```text
 /Users/timpeterson/Documents/Codex/cloud-chamber
 ```
 
-## Initial Files To Add
+## Current Strategic Files
 
-Copy these startup docs into the repo root or `docs/startup/`:
+Read these before product work:
 
 ```text
 README.md
 AGENTS.md
+docs/cloud-first-product-reset.md
 docs/product-vision.md
+docs/current-roadmap.md
 docs/cloud-chamber-product-spec.md
 docs/architecture-and-data-model.md
-docs/current-roadmap.md
 ```
 
-## Suggested Skeleton
+`AGENTS.md` is the operational authority for coding-agent behavior. The
+cloud-first reset and current roadmap are the strategic authority.
 
-```text
-cloud-chamber/
-  AGENTS.md
-  README.md
-  app/
-    frontend/
-    backend/
-  docs/
-    product-vision.md
-    cloud-chamber-product-spec.md
-    architecture-and-data-model.md
-    current-roadmap.md
-    data-policy.md
-  scenarios/
-    lower-atmosphere/
-      baseline-shallow-cumulus/
-      dry-failed-cumulus/
-      capped-suppressed/
-      humid-vigorous/
-      low-stratus/
-  local-data/              # ignored
-  scripts/
-    cm1/
-```
-
-## .gitignore Must Include
-
-```gitignore
-# Local CM1 data and generated artifacts
-local-data/
-data/generated/
-data/local/
-*.nc
-*.ctl
-*.dat
-cm1.exe
-LANDUSE.TBL
-
-# Python / node basics
-.venv/
-__pycache__/
-node_modules/
-dist/
-.env
-.env.local
-```
-
-## First Technical Decision
-
-Choose app architecture:
-
-Recommended:
+## App Architecture
 
 ```text
 React/Vite frontend + Python FastAPI local backend
 ```
 
-Reason:
+Why:
 
-- Python handles xarray/netCDF easily.
-- React handles UI and 3-D viewer.
-- Local backend can launch/manage CM1 processes.
+- Python handles xarray/NetCDF and local CM1 orchestration.
+- React handles Build, Results, Explore, and visual interaction.
+- The local backend can launch and manage CM1 processes.
 
-Alternative later:
-
-```text
-Tauri/Electron wrapper
-```
-
-Do not package too early.
+Do not package a desktop wrapper until the local workflow creates a clear need.
 
 ## CM1 Local Path
 
@@ -108,27 +51,81 @@ Likely current local CM1 path:
 /Users/timpeterson/cm1r21.1/run
 ```
 
-Do not hard-code this in app logic. Store in local settings.
+Do not hard-code it. Store local paths in `~/CloudChamber/settings.json`.
 
-## First Development Principles
+## Runtime And Git Policy
 
-1. No generated output in git.
-2. Every run has a manifest.
-3. Every visualization field has provenance.
-4. Preview and CM1 result are always distinct.
-5. Start with fake fixtures before requiring real CM1 in tests.
-6. Use local paths/settings, not global assumptions.
-7. Prefer one end-to-end scenario before many partial features.
+Runtime data belongs outside the repo:
+
+```text
+~/CloudChamber/
+```
+
+Never commit:
+
+- generated CM1 runs;
+- NetCDF output;
+- CM1 source or binaries;
+- logs;
+- machine-private settings or paths;
+- large visualization artifacts.
+
+Keep tiny fixtures, code, tests, docs, schemas, and recipe definitions in git.
+
+## Development Principles
+
+1. CM1 output is the source of truth for cloud evolution.
+2. Analyzer/recommendation, configuration, active process, completed result, and
+   visualization interpretation remain distinct.
+3. Build should recommend useful sounding–recipe–run-setup combinations rather
+   than requiring the user to interpret soundings alone.
+4. Strong idealized cloud recipes are acceptable when clearly labeled.
+5. Real CM1 scouts are part of cloud-making implementation; automated CI still
+   uses tiny fake fixtures.
+6. Use the existing Build queue/progress/ETA/stop/cleanup workflow for scouts and
+   visible automatic full-run promotion.
+7. Prefer one outcome-oriented vertical slice over many partial plumbing issues.
 
 ## Codex Workflow
 
 - Start from current `main`.
-- Work on a branch for each issue or tightly related issue set.
-- Open a PR; do not push directly to `main`.
-- Keep work scoped to the GitHub issue.
-- Add tests and docs with implementation changes.
-- Do not commit generated CM1 artifacts.
-- For Codex issue work, enable auto-merge after required CI checks pass unless the user explicitly asks for manual review or the PR is high-risk/destructive.
-- Treat destructive cleanup, generated-data policy changes, scientific interpretation changes, and real CM1 execution changes as high-risk unless the user says otherwise.
+- Work on a branch named for the user outcome or issue.
+- Do not push directly to `main`.
+- Read `AGENTS.md`, especially **Cloud-Making Operating Mode**.
+- Scope work to one user outcome, not one implementation layer.
+- Ask only material unresolved questions; do not wait for another go-ahead when
+  the issue and approved product direction are explicit.
+- Add tests and update docs with implementation changes.
+- Run meaningful bounded CM1 scouts early when cloud-making is in scope.
+- If a run is boring, change sounding, recipe, scale, duration, or trigger before
+  adding diagnostics.
+- Create a separate issue only for a real blocker or independent product
+  decision.
+- Run `scripts/check.sh` and relevant E2E checks before opening a PR.
+- Open a PR that describes the cloud/user outcome and real-run evidence where
+  applicable.
+- Enable auto-merge after CI unless the change is destructive/high-risk or the
+  user requests manual review.
 
-See also the root `AGENTS.md`.
+## High-Risk Actions
+
+Ask before:
+
+- deleting user runtime data beyond an explicit cleanup request;
+- launching an unbounded or unexpectedly expensive batch;
+- changing product direction outside the approved cloud-first reset;
+- making backwards-incompatible schema changes without migration;
+- weakening tests rather than fixing the underlying problem.
+
+Do not pause merely because an approved cloud-making issue touches real CM1,
+additive schemas, recipe assumptions, or a bounded scout/full-run workflow.
+
+## Local Checks
+
+```sh
+scripts/check.sh
+```
+
+Use Playwright for user-visible workflow changes when practical. Real CM1 evidence
+belongs in local runtime verification and the PR description; generated output
+stays outside git.

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -1,277 +1,267 @@
 # Current Roadmap
 
-Status: active roadmap for configurable observed-sounding CM1 runs
+Status: active cloud-first roadmap
 
-This is the active planning source for Cloud Chamber. The previous long
-issue-by-issue roadmap is archived at
-[archive/roadmap-and-issues-legacy.md](archive/roadmap-and-issues-legacy.md)
-for historical reference only.
+This is the current planning source for Cloud Chamber. Historical issue sequencing
+and archived roadmaps are evidence only; they do not override the product reset
+in [cloud-first-product-reset.md](cloud-first-product-reset.md).
 
 ## North Star
 
-Cloud Chamber is a real local LES experiment bench and notebook.
+Cloud Chamber is a **cloud-making sandbox that uses real atmospheres as raw
+material**.
 
-The product should help a user construct one credible CM1 LES experiment, run
-it locally, ingest the completed output, review it as an experiment notebook
-entry, and inspect what happened using CM1-derived evidence.
+The organizing question is:
 
-CM1 remains the high-fidelity source of truth. Cloud Chamber owns the local
-workflow, metadata, diagnostics, output products, and visualization
-interpretations around that source data.
+> Given the soundings available, which ones can make interesting clouds, what
+> setup should I use, and how far do I need to push them?
+
+The current visible outcome priorities are:
+
+1. growing cumulus and congestus;
+2. deep convective towers;
+3. precipitation and reflectivity.
+
+Cloud Chamber is local-first and CM1 remains the source of truth for cloud
+evolution. The product is not operational forecasting and is not a
+publication-style validation workflow.
 
 ## Current Product Model
 
-- **Build** = choose observed or generated atmospheres, configure one or more
-  planned CM1 runs, and launch or queue selected variants. Build owns active,
-  incomplete, and non-ingested package/run work.
-- **Results** = experiment notebook for completed and ingested runs. Results owns
-  ingested-result review, notes, and explicit ingested-result cleanup.
-- **Explore** = scientific inspection of one result using CM1-derived evidence.
+### Build
 
-Runtime inventory and cleanup are contextual actions inside Build and Results,
-not a separate top-level Storage workspace.
+Build should own the full active cloud-making workflow:
+
+- search recent and historical sounding opportunities;
+- answer “show me something cool” and “what can we do with this sounding?”;
+- rank sounding + recipe + run setup combinations;
+- recommend a concrete scout;
+- package and queue through the existing run plan;
+- show progress and ETA;
+- visibly auto-promote a promising scout to a full run;
+- allow stop/cancel, ingest, and cleanup.
+
+### Results
+
+Results is the notebook of completed and ingested cloud runs. It should emphasize
+what cloud formed, the recipe/setup used, and the relationship between scout and
+full run.
+
+### Explore
+
+Explore is the visual payoff: replay and inspect cloud water, ice, vertical
+motion, rain, reflectivity, and the evolving cloud story. Technical evidence
+belongs on demand, not as the primary experience.
 
 ## Hard Product Rules
 
-- LES only for the current planning horizon.
-- Local-first: local CM1, local runtime home, local result evidence.
 - CM1 output is the source of truth for cloud evolution.
-- Always distinguish preview estimate, CM1 run configuration, CM1
-  running/completed result, and visualization interpretation.
-- The browser must not parse raw NetCDF.
-- Generated artifacts do not go in git.
-- Quick means quick to execute, not meteorologically too short to be useful.
-- A smoke check proves package/run/ingest health; it is not a science result.
-- Science runs need enough model time to produce meaningful evolution.
-- Grid/detail and output cadence are the primary user-facing cost levers.
-- Raw numerical timestep is not a normal v1 user control.
-- Presets are starting points. They should expose actual CM1-facing values in an
-  advanced drawer instead of becoming rigid product families.
-- Warn or caveat unvalidated control combinations instead of hiding every
+- Always distinguish recommendation, configuration, packaged run, active process,
+  completed result, and visualization interpretation.
+- The browser does not parse raw NetCDF.
+- Generated CM1 artifacts and machine-private paths do not go in git.
+- A scout must be meaningful for its recipe; quick must not mean useless.
+- Strong idealized assumptions are allowed when clearly labeled.
+- Scientific honesty does not require weak or untriggered setups.
+- Natural/free evolution is one recipe, not the default test of every sounding.
+- The product may recommend skipping a sounding for a requested cloud target.
+- Diagnostics need a concrete continue/change/stop decision.
+- Compare runs only when the comparison answers a useful question.
+- Real CM1 evidence is part of cloud-making implementation, not a deferred final
+  validation ceremony.
+- A promising scout may automatically promote through the visible Build queue.
+- Automatic work must remain bounded, visible, stoppable, and cleanable.
+- Raw timestep remains an advanced numerical assumption, not a normal primary
   control.
-- Build owns non-ingested cleanup; Results owns ingested-result cleanup.
-- Explore remains scientific inspection, not Render Studio.
-
-## Active Source Documents
-
-Use these docs as the current strategic and contract sources:
-
-- [Realistic LES Input Architecture Research](research/realistic-les-input-architecture.md)
-- [Output And Visualization Architecture Research](research/output-and-visualization-architecture.md)
-- [Realistic LES Input Specification](contracts/realistic-les-input-specification.md)
-- [Output Product Specification](contracts/output-product-specification.md)
-- [Sounding Candidate Screening Contract](contracts/sounding-candidate-screening.md)
-- [Analyzer Hypothesis And Output-Signature Contract](contracts/analyzer-hypothesis-output-signature.md)
-- [Run Recipe And Story-Mapping Contract](contracts/run-recipe-and-story-mapping.md)
-- [Expanded Sounding Candidate Taxonomy](research/expanded-sounding-candidate-taxonomy.md)
-
-The research memos are PM input and evidence. The contract docs define the
-implementation boundary that future issues should build from.
-
-The expanded sounding taxonomy is product/science planning input for pre-run
-candidate stories. It does not make severe, winter, cold-pool, or specialized
-boundary-layer stories scientifically validated until their scoring, evidence,
-caveats, and package-readiness states are implemented and tested.
-
-The historical deep-convection package design is now evidence and background,
-not the active Build contract. User-facing docs should describe current
-observed-sounding packages as configurable experiments with numeric
-lower-boundary heat/moisture forcing, full output fields, and explicit caveats.
-Differential surface forcing for initiation or boundary experiments is future
-work.
 
 ## Current State
 
-- Observed-sounding upload and package generation now work through the backend
-  parser and CM1 `input_sounding` route. Observed temperature, moisture, and
-  complete usable u/v wind profiles are package inputs, not decorative metadata.
-- Cached IGRA recent sounding refresh, local cached-sounding inspection,
-  candidate screening, saved candidates, and package-ready/blocked candidate
-  states exist. Candidate scores are pre-run selection aids, not CM1 outcome
-  predictions.
-- The run-recipe contract now defines how current story IDs map to compatible,
-  caveated, blocked, or future CM1 run configurations. That mapping is the handoff from
-  cached-sounding analysis to pre-run validation and predicted-vs-actual Results
-  comparison.
-- Observed-sounding package generation now uses numeric uniform surface
-  heat/moisture forcing and complete observed u/v wind profiles. Deep-convection
-  candidates remain important pre-run hypotheses, but current packages do not add
-  an artificial deep trigger; each observed sounding remains its own experiment
-  whose result must be evaluated after CM1 runs.
-- Build owns active package/run work, including generated packages, queued or
-  running local CM1 work, failed or incomplete runs, completed-but-not-ingested
-  output, serial local queue state, auto-ingest for completed usable output, and
-  LAN-worker status/progress summaries.
-- Results owns ingested notebook entries, result-card review, notes/tags, and
-  explicit cleanup for ingested results plus their backing local data.
-- Explore consumes bounded backend output products, interesting times,
-  diagnostics summaries, native-grid slices, and visualization-ready point
-  layers. The browser still does not parse raw NetCDF.
+Cloud Chamber already has substantial infrastructure:
 
-## Next Roadmap Lanes
+- cached and uploaded IGRA sounding ingestion;
+- sounding candidate analysis and saved candidates;
+- observed temperature, moisture, and wind profile packaging;
+- configurable domain/grid/duration/cadence and surface forcing;
+- local queue, LAN-worker support where compatible, progress/status, ingest, and
+  cleanup;
+- runtime-integrity and field-quality handling;
+- Results notebook entries and Explore field products;
+- a completed differential surface-forcing recipe mechanism with safe local
+  custom-CM1 execution and localized-response diagnostics;
+- repository history proving a successful Deep Convection Trial from a real
+  sounding using stock CM1 `iinit = 3`.
 
-These are candidate implementation lanes for PM review. Do not create them
-automatically from this roadmap.
+The main missing product capability is not more generic plumbing. It is an
+opinionated layer that turns available atmospheres into useful cloud recipes and
+run setups, then follows promising scouts into visible clouds.
 
-### Cached-Sounding Analysis And Sorting
+## Immediate P1 Work
 
-Goal: make the cached IGRA workbench useful for choosing observed atmospheres
-without pretending the score predicts CM1 success.
+### #346 — Cloud Opportunities And Scout-To-Full-Run
 
-Scope: richer cached-sounding analysis, transparent sorting/filtering by story,
-quality and support-state explanations, saved-candidate ergonomics, and clearer
-blocked/package-ready evidence. Keep shallow, humid/rainy, and
-deep-convection-oriented candidate stories as pre-run hypotheses.
+This is the primary product lane.
 
-Non-goals: universal "best sounding" ranking, forecast language, browser-side
-station parsing, or unsupported story labels that look package-ready.
+Deliver:
 
-Why now: configurable observed-sounding runs need a better way to find and
-compare input atmospheres before packaging.
+- “Show me something cool” across selectable sounding history;
+- search by time range, region, target, saved candidate, or specific sounding;
+- ranking of sounding + recipe + run setup;
+- growth-ceiling and initiation-difficulty reasoning;
+- decisive skip recommendations;
+- recipe-specific scout setup and checkpoints;
+- visible automatic promotion into the existing Build queue;
+- at least one interesting cloud result or a decisive compute-saving switch/skip
+  outcome during implementation.
 
-### Configurable Observed-Sounding Run Controls
+This issue is intentionally a vertical slice. Do not split analyzer, UI, queue,
+recipe, and real-run work into prerequisite issues unless genuinely blocked.
 
-Goal: let Build start from a sane preset and then adjust run settings that map
-to real CM1 configuration.
+### #341 — Restore Explicit Thermal / Deep-Tower Recipes
 
-Scope: controls for numeric surface heat/moisture forcing, model duration,
-horizontal cell budget, domain size, and output cadence within guarded bounds.
-Starting points should remain available, and an advanced drawer should expose the
-actual CM1-facing values those choices imply. Current observed-sounding runs
-request the full output field set.
+Restore and modernize the proven Deep Convection Trial from PR #270.
 
-Non-goals: raw numerical timestep as a normal v1 control, raw trigger controls,
-new trigger types, or a full Build redesign in one issue.
+Start from working evidence:
 
-Why now: the product direction is configurable runs, not rigid scenario or
-package-family cages. Horizontal cell budget, domain, output cadence, and full
-output volume are the main cost levers; duration controls must preserve enough
-model time for meaningful evolution.
+- Fort Worth `1997-05-27T00Z`;
+- CM1 `iinit = 3` three-warm-bubble initiation;
+- strong deep convection with `54.126 m/s` maximum updraft and `64.522 dBZ`.
 
-### Pre-Run Configuration Validation
+The first objective is a visibly interesting current-product CM1 result, not a
+new trigger diagnostics framework.
 
-Goal: validate the selected atmosphere, preset, and adjusted CM1-facing settings
-before package generation or launch.
+Expose a first-class Deep-Tower Benchmark and, where stock CM1 cleanly supports
+it, a less aggressive Explicit Thermal recipe or level.
 
-Scope: backend validation for missing required observed fields, incomplete wind
-profiles, suspicious duration/cadence combinations, unsupported output-field
-requests, runtime-file requirements, cost/storage caveats, and clear dry-run
-messages. Unvalidated combinations should warn or caveat when safe rather than
-being hidden by default.
+## P2 Recipe Work
 
-Non-goals: running CM1 in CI, declaring scientific success before CM1 output,
-or silently patching bad input into something packageable.
+### #287 — Daytime Evolution
 
-Why now: configurable controls need trust boundaries before they become normal
-Build workflow.
+Implement an actual evolving heated-day recipe using active place/time radiation
+where supported, or an explicitly labeled simplified diurnal forcing schedule.
 
-### Deep-Convection Candidate Validation Across Soundings
+Do not complete this as a validation memo. Run a meaningful atmosphere early and
+use it to determine whether normal daytime evolution is a good cloud opportunity
+or whether the recommender should switch to explicit initiation.
 
-Goal: keep severe/deep-convection candidate stories first-class while measuring
-where current observed-sounding configurations are run-ready, caveated, or
-misleading.
+### Broad Warm/Moist Surface Region
 
-Scope: validate complete observed-wind requirements, duration, horizontal cell
-budget, domain size, output cadence, full expected fields,
-cost/runtime/output-volume notes, larger-compute suitability notes, numeric
-surface-forcing provenance, and candidate-provenance copy across selected
-observed soundings. Separate package/run/ingest smoke checks from science
-outcomes.
+The differential surface mechanism is complete under closed issue #307. Use it
+through #346 when the recommender identifies a cloud opportunity.
 
-Non-goals: adding artificial atmospheric triggers, exposing raw trigger controls,
-or treating a smoke run as evidence that a specific observed sounding should
-produce deep convection.
+The next useful scale is likely broader than the 1.5 km footprint smoke. Test
+roughly 2.5–3 km before dramatically increasing amplitude, and increase one
+run-shape choice at a time when a real result justifies it.
 
-Why now: deep-convection screening is useful, but the trust language must stay
-honest while observed-sounding configuration coverage expands.
+### Suppression / Cap Challenge
 
-### Surface Sensible/Latent Heat Flux Control Validation
+Add this as a recommendation/recipe under #346 when the analyzer can identify a
+sounding that is valuable specifically for learning how much help is needed to
+break through a cap.
 
-Goal: determine which surface sensible and latent heat flux controls can be
-safely exposed for observed-sounding runs.
+Do not create a standalone issue until a real candidate and useful run ladder are
+clear.
 
-Scope: audit CM1 reference paths and runtime-file requirements, define supported
-and caveated sensible/latent heat flux combinations, document manual smoke-run
-expectations, connect findings to pre-run validation, and decide how flux
-settings are represented in advanced CM1-facing values.
+## Opportunity And Recipe Model
 
-Non-goals: atmospheric radiation validation, GIS/map realism, arbitrary
-real-world terrain/surface initialization, or product promises that the current
-CM1 configuration cannot support.
+The analyzer/recommender should separate:
 
-Why now: surface forcing is a direct run-builder control and should be validated
-before the UI implies it can be varied safely across observed soundings.
+- **growth ceiling** — what the atmosphere may sustain after useful ascent exists;
+- **initiation difficulty** — how much help the selected CM1 setup probably needs.
 
-### Atmospheric Radiation And Place-Time Control Validation
+Rank separately for:
 
-Goal: determine which radiation, date/time, and location-derived settings can be
-safely exposed for observed-sounding runs.
+- growing cumulus/congestus;
+- deep tower after initiation;
+- precipitation;
+- suppression/cap challenge;
+- likely boring/skip.
 
-Scope: audit CM1 radiation/place-time reference paths and runtime-file
-requirements, define supported and caveated combinations, document manual
-smoke-run expectations, and connect findings to pre-run validation.
+The initial recipe catalog is:
 
-Non-goals: arbitrary real-world terrain/surface initialization, GIS/map realism,
-or product promises that the current CM1 configuration cannot support.
+1. Daytime Evolution;
+2. Broad Warm/Moist Surface Region;
+3. Explicit Thermal Initiation;
+4. Deep-Tower Benchmark;
+5. Suppression / Cap Challenge.
 
-Why later: observed soundings preserve place/time provenance, but radiation and
-place-time behavior should follow surface-flux validation unless a later PM
-decision changes that order.
+Each recipe needs an operating contract: suitable soundings, assumptions, scout,
+full run, aggressiveness levels, checkpoints, promotion, escalation, stop/switch,
+and expected visible outcome.
 
-### Evolved-Sounding Output Products
+## Agent Execution Rules
 
-Goal: make completed observed-sounding runs explain how the simulated atmosphere
-changed, not only whether cloud water or vertical velocity appeared.
+For cloud-making work:
 
-Scope: profile and time-height products, evolved thermodynamic/moisture/wind
-summaries, bounded field catalog expansion, provenance, caveats, and tiny
-fixture tests. Results and Explore should consume these as backend-prepared
-products.
+- optimize visible outcome and information per unit time;
+- take bounded big swings;
+- run meaningful CM1 early;
+- allow strong labeled idealizations;
+- do not create prerequisite issues unless blocked;
+- change sounding, recipe, scale, duration, or trigger before adding diagnostics
+  to a merely boring run;
+- keep one user outcome together across technical layers;
+- compare second;
+- keep model artifacts outside git.
 
-Non-goals: browser-side NetCDF parsing, broad diagnostics-lab UI, or external
-export bundles before core result explanation is stable.
+`AGENTS.md` defines the full operating rules.
 
-Why now: observed-sounding experiments become much more useful when users can
-compare the initial profile to CM1-evolved structure.
+## Recently Retired Roadmap Work
 
-## Not Now / Parked
+The following issues were closed during the reset because they would keep pulling
+the project toward mechanisms, formal comparisons, or old campaign gates:
 
-These are not rejected forever. They are parked because they depend on product
-contracts, output products, validation, or local bench maturity.
+- **#307** — completed differential surface-forcing mechanism. It is now one
+  recipe tool, not the roadmap center.
+- **#345** — formal matched initiation campaign. Compare later only when actual
+  cloud results create a useful question.
+- **#336** — forensic numerical investigation. Use safer supported numerical
+  settings and revisit only if a current promising run fails.
+- **#275** — generalized predicted-vs-actual verdict system. Recommendation
+  calibration is secondary to useful cloud opportunities.
 
-- **Bench Mode UI**: wait until realistic input records and output products are
-  stable enough to compare experiments honestly.
-- **Arbitrary GIS/map/imagery inputs**: wait for preprocessing, CM1
-  initialization, and surface-data architecture evidence.
-- **#153 surface heterogeneity**: blocked by realistic surface contract and
-  validation; do not treat it as the next scenario step.
-- **Additional severe-weather or deep-convection products**: the current
-  deep-convection observed-sounding preset stays first-class, but additional
-  severe-weather promises should wait for validation, evidence, and clear
-  caveats.
-- **Raw trigger controls and new trigger types**: keep trigger settings as
-  fixed package metadata until useful ranges are validated.
-- **Rigid experiment-family expansion**: prefer configurable observed-sounding
-  runs with presets as starting points over more separate user-facing families.
-- **#155 precipitation/cold-pool scenarios**: parked until output products can
-  support precipitation, downdraft, and surface-response evidence.
-- **#183 3-D vertical velocity layer**: useful later, but blocked by signed-flow
-  field-product and rendering decisions.
-- **#197 cloud appearance / renderer beauty pass**: parked until output
-  products and inspection workflow are stable.
-- **#198 cloud + field overlay**: parked until scalar/signed overlay contracts
-  are defined.
-- **Renderer-style timelapse ambition**: parked until output products mature.
-  The near-term #201 scope is limited to saved-output play/pause and scrubbing
-  across explicit backend time indices without interpolation, with the main 3-D
-  scalar layer animating while synchronized slice/evidence payloads are deferred
-  until pause and no default looping.
-- **#43 remote/HPC compute**: deferred. The near-term compute extension is a
-  trusted LAN worker used as a CM1 compute appliance while the MacBook remains
-  the Cloud Chamber system of record.
+## Stop Doing
+
+- Stop treating Baseline Shallow Cumulus as the hero outcome.
+- Stop treating natural free evolution as the default test of a sounding.
+- Stop ranking soundings without recommending what to do with them.
+- Stop turning every mechanism into the center of the roadmap.
+- Stop opening a validation issue before a useful real run.
+- Stop requiring formal matched campaigns before shipping a recipe.
+- Stop adding diagnostics that do not change a run decision.
+- Stop shrinking experiments because their assumptions are idealized.
+- Stop optimizing issue closure instead of cloud-making progress.
+
+## Parked / Later
+
+These may become useful after the opportunity and recipe loop works:
+
+- organized/mesoscale convection products;
+- terrain, GIS, or real land-surface initialization;
+- arbitrary user-drawn forcing maps;
+- general result-vs-result comparison surfaces;
+- broad export/reporting systems;
+- renderer-only feature work disconnected from a useful cloud result;
+- remote/HPC orchestration beyond the existing trusted LAN-worker direction;
+- publication-style validation or forecast verification.
+
+Visual quality is not parked indefinitely. Once #341/#346 reliably produce an
+interesting cloud, appearance and replay improvements that make that cloud lovely
+and rewarding to watch should move up immediately.
 
 ## Planning Rule
 
-When a future issue conflicts with this roadmap, update this file first or
-explicitly document why the roadmap no longer applies. Do not let archived
-roadmap material or old issue sequencing drive current planning.
+When an issue conflicts with this roadmap, update the roadmap or explicitly state
+why the issue should override it.
+
+Do not let archived docs, old issue sequencing, or conservative package history
+override the approved cloud-first product direction.
+
+A roadmap item is successful only when it improves one of these outcomes:
+
+```text
+interesting cloud produced
+promising cloud continued
+poor bet skipped
+broken run identified
+cloud easier to see and understand
+```

--- a/docs/product-vision.md
+++ b/docs/product-vision.md
@@ -6,310 +6,396 @@
 
 ## North Star
 
-Cloud Chamber helps users configure, run, manage, inspect, explain, and
-beautifully visualize local CM1 cloud experiments.
+Cloud Chamber is a **cloud-making sandbox that uses real atmospheres as raw
+material**.
+
+The organizing question is:
+
+> Given the soundings available, which ones can make interesting clouds, what
+> setup should I use, and how far do I need to push them?
 
 Short version:
 
-> A local CM1 workbench for exploring thermal fate and seeing cloud physics come alive.
+> Find a promising atmosphere, choose an honest cloud recipe, run CM1, and watch
+> something interesting evolve.
 
-Internal anchor:
+Cloud Chamber should help produce and understand:
 
-> Cloud Chamber is a personal, scientifically honest CM1 Thermal Fate workbench:
-> curated experiments, meaningful controls, local-first CM1 runs, replayable
-> saved results, process diagnostics, selected-region inspection, and beautiful
-> visualization.
+1. growing cumulus and congestus;
+2. deep convective towers;
+3. precipitation and reflectivity;
+4. useful suppression/cap cases when cloud growth is not a good bet.
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
-experiment builder, run manager, result notebook, diagnostics layer, and
-visualizer.
+CM1 is the high-fidelity simulation engine. Cloud Chamber owns opportunity
+finding, recipe and run-setup recommendations, local execution, result
+organization, interpretation, and visualization.
 
-The lesson from earlier Cloud Lab-style experimentation is simple: do not rebuild CM1 poorly. Cloud Chamber should wrap CM1 with a clearer product workflow, not replace the atmospheric model with hidden fake physics.
+The product is not a forecast or warning service. It is for personal cloud
+exploration, learning, and visual experimentation.
 
-Cloud Lab should be treated as archived lesson/source material only. New product work belongs in Cloud Chamber, with useful lessons ported intentionally.
+## Core Product Promise
+
+Cloud Chamber should answer:
+
+```text
+What are the coolest cloud-making opportunities in the sounding history I have?
+What can we do with this specific atmosphere?
+Which recipe and run setup should I use?
+Is this scout worth continuing?
+```
+
+The product should not require the user to be an expert sounding analyst before
+receiving a useful recommendation.
 
 ## What Cloud Chamber Is
 
-Cloud Chamber is a local-first experiment and visualization environment for
-CM1, primarily for personal exploration and learning. Its organizing product
-concept is **Thermal Fate**: why air rises, why some thermals do or do not form
-cloud, why some clouds stay shallow, why others grow taller, why some break
-through into deep convection, and how precipitation feedback can reorganize or
-suppress convection.
+Cloud Chamber is:
 
-It should help a user:
-
-```text
-Choose a cloud scenario
-→ adjust atmospheric controls
-→ preview likely behavior
-→ run CM1 locally
-→ track the run
-→ ingest and organize results
-→ inspect and visualize CM1-derived fields beautifully
-→ replay and inspect saved results later
-→ understand what happened
-```
+- a local-first CM1 cloud workbench;
+- an opinionated sounding–recipe opportunity finder;
+- a recipe and run-setup recommender;
+- a visible scout-to-full-run workflow;
+- a run manager with progress, ETA, stop, ingest, and cleanup;
+- a notebook of completed cloud runs;
+- a visual environment for watching cloud evolution;
+- a place to ask “what happened here?” after an interesting run.
 
 ## What Cloud Chamber Is Not
 
 Cloud Chamber is not:
 
-- a replacement for CM1
-- a lightweight solver pretending to be CM1
-- a generic scientific plotting tool
-- a web app that runs CM1 in the browser
-- a dashboard full of raw namelist parameters
-- a toy renderer with hidden fake physics
-- a real-time slider toy for CM1 execution
+- a replacement for CM1;
+- a weather forecast site;
+- an operational warning tool;
+- a publication or peer-review workflow;
+- a generic namelist editor;
+- a browser-based model solver;
+- a system that treats idealized initiation as dishonest;
+- a diagnostics project whose main output is more diagnostics.
 
-## Core Product Promise
-
-A user can choose or configure an atmospheric experiment, run CM1 locally, save
-the completed result, and explore what happened through diagnostics, comparison,
-selected-region inspection, and provenance-labeled visualization.
-
-CM1 run latency is part of the product model: scenario design, result browsing,
-comparison, and inspection are interactive; CM1 execution is a local simulation
-run, not an instant slider update.
-
-## First Useful Workflow
-
-The first useful workflow is not a full visualizer. It is the scenario package spine:
+## Primary Workflow
 
 ```text
-scenario template
--> user-adjusted experiment config
--> validation
--> run manifest
--> generated CM1 run package
--> dry-run report
+Find promising sounding–recipe pairs
+→ Recommend a concrete run setup
+→ Queue a meaningful scout through Build
+→ Automatically promote a promising scout to a full run
+→ Explore the evolving cloud
 ```
 
-That spine should lead directly to local CM1 launch/monitoring, then ingest and visualization.
+### Find
 
-## Primary User Loop
+Support two entry modes:
+
+1. **Show me something cool** — rank the best cloud-making opportunities across
+   a selectable recent or historical sounding scope.
+2. **Find / inspect** — search by date range, region, cloud target, saved
+   candidate, or specific sounding.
+
+The ranked object is:
 
 ```text
-Choose experiment
-→ adjust controls
-→ preview likely outcome
-→ launch CM1 run
-→ monitor status/logs
-→ open result
-→ inspect diagnostics and fields
-→ visualize in 2-D/3-D
-→ save/name/tag
-→ replay and inspect later
-→ compare with related scenario variants
-→ optionally create a new variation from the same setup
+sounding + recipe + run setup
 ```
 
-Replay / inspect / save is core MVP. Duplicate / tweak / rerun is later.
+A sounding may be boring under free evolution and excellent under explicit
+initiation. Rank the useful combination, not the sounding in isolation.
 
-## Golden Path Principle
+### Recommend
 
-Baseline Shallow Cumulus is the first hero case because it can prove the whole Cloud Chamber loop with one scientifically honest, approachable CM1 experiment.
+For each opportunity, show:
 
-The first hero case should answer:
+- target visible outcome;
+- opportunity score;
+- likely cloud ceiling;
+- main obstacle;
+- recommended recipe;
+- recommended scout setup;
+- why free evolution may be a poor choice;
+- stronger alternative;
+- skip recommendation where appropriate.
+
+The product should be comfortable saying:
 
 ```text
-How do low-level moisture, surface heating, cap strength, and dry air aloft shape whether shallow cumulus forms, when it appears, how tall it gets, and how much cloud water develops?
+Natural evolution is likely boring.
+Best bet: Deep-Tower Benchmark.
 ```
 
-Warm rain remains early, but it should not block the Golden Path. Precipitating shallow cloud workflows should build on the baseline loop after the baseline case can be configured, packaged, run locally, ingested, replayed, inspected, and opened in the visualizer.
+or:
 
-Baseline Shallow Cumulus proves the first executable loop. It is not the entire
-product vision. The broader product should grow into Thermal Fate scenario
-families: moisture-limited, surface-heating-driven, cap-limited,
-dry-air-aloft/dilution-limited, deep-convection breakthrough, precipitation
-feedback/cold-pool interaction, and low-cloud/stratus cases where useful.
+```text
+Skip this sounding for cloud-making.
+Use it only if you want to study suppression.
+```
 
-## User-Facing Concepts
+### Scout
 
-The product should use atmospheric language first:
+A scout is a real CM1 run large and long enough to answer whether the opportunity
+deserves more compute. It is recipe-specific; “scout” does not mean
+meteorologically useless.
 
-- low-level humidity
-- surface moisture
-- surface heating
-- cap strength
-- cap height
-- dry air aloft
-- mixing/entrainment
-- cloud base
-- cloud top
-- first cloud time
-- rain onset
-- updraft strength
-- cloud water
-- thermal fate
-- selected region
+The scout should resolve to one decision:
+
+```text
+continue automatically
+scale one run-shape parameter
+change one recipe parameter
+switch recipe
+skip sounding
+stop broken run
+```
+
+### Full Run
+
+A promising scout may automatically queue or continue a full run through the
+existing Build workflow.
+
+The promotion must be visible and reversible. Show:
+
+- promotion reason;
+- model duration;
+- progress and ETA;
+- stop/cancel control;
+- cleanup behavior;
+- relationship to the scout.
+
+### Explore
+
+Explore is the visual payoff. It should make it easy to:
+
+- replay cloud growth;
+- inspect cloud water, ice, vertical velocity, rain, and reflectivity;
+- understand why a cloud grew, stalled, precipitated, or collapsed;
+- inspect technical evidence on demand;
+- eventually make the cloud presentation beautiful.
+
+Diagnostics support the visible story; they are not the primary experience.
+
+## Analyzer Role
+
+The sounding analyzer should estimate two separate dimensions:
+
+1. **Growth ceiling** — what cloud the atmosphere may sustain once useful ascent
+   exists.
+2. **Initiation difficulty** — how much help the selected CM1 setup probably
+   needs to create that ascent.
+
+It should rank separately for:
+
+- growing cumulus/congestus;
+- deep tower after initiation;
+- precipitation;
+- suppression/cap-learning value;
+- likely boring/skip.
+
+Useful inputs may include CAPE/CIN/LFC/EL where reliable, moisture depth, LCL,
+lapse rates, cap structure, midlevel humidity, precipitable water, freezing
+level, profile quality, wind completeness, recipe compatibility, and package
+readiness.
+
+Missing diagnostics should reduce confidence, not silently become negative
+atmospheric evidence.
+
+## Cloud Recipes
+
+A **recipe** is an honestly labeled way to help a real atmosphere produce or
+reveal a cloud outcome. A **run setup** is the domain, grid, duration, cadence,
+numerical settings, forcing strength, and other concrete CM1 configuration used
+to execute the recipe.
+
+The initial recipe catalog is:
+
+### 1. Daytime Evolution
+
+Simplified normal heated-day evolution using active place/time forcing where
+supported. Intended for boundary-layer growth, growing cumulus, and congestus.
+
+### 2. Broad Warm/Moist Surface Region
+
+A broad idealized lower-boundary heating/moistening region intended to organize
+boundary-layer ascent and growing clouds.
+
+### 3. Explicit Thermal Initiation
+
+A clearly labeled supplied thermal or warm-bubble setup intended to test what an
+atmosphere can sustain when initiation is provided.
+
+### 4. Deep-Tower Benchmark
+
+A stronger controlled trigger intended to reveal the sounding's convective
+ceiling. Restore and modernize the proven Deep Convection Trial from PR #270.
+
+### 5. Suppression / Cap Challenge
+
+A controlled ladder of heating, moistening, or initiation intended to show what
+is required to break through a cap—or when current supported recipes cannot.
+
+These are starting tools, not rigid product families and never “the experiment.”
+The catalog should grow from useful cloud-making questions.
+
+## Recipe Contract
+
+Every recipe must define:
+
+- target visible outcome and learning question;
+- suitable sounding traits;
+- poor/skip traits;
+- exact added assumptions;
+- meaningful scout setup;
+- full-run setup;
+- supported aggressiveness levels;
+- checkpoint timing;
+- automatic-promotion criteria;
+- escalation order;
+- stop/switch criteria;
+- expected visible outcomes;
+- limitations and user-facing label.
+
+A mechanism implementation without this operating contract is incomplete.
+
+## Scientific Honesty
+
+Scientific honesty means:
+
+- distinguish recommendation from CM1 result;
+- show which mechanisms and assumptions were added;
+- preserve enough configuration/provenance to reproduce the run;
+- fail clearly when a requested mechanism did not execute;
+- expose broken or non-finite output;
+- do not use forecast language;
+- do not imply an idealized trigger represents an observed real-world boundary.
+
+Scientific honesty does **not** require weak forcing, untriggered evolution, tiny
+runs, or publication-style validation before exploratory use.
+
+Use two normal modes:
+
+### Exploratory
+
+Bold labeled assumptions. Optimize for learning and visible cloud outcome.
+
+### Compared
+
+Compare two or a few runs when an actual result creates a useful question.
+
+Heavy trust/diagnostic work is reserved for broken, suspicious, or
+configuration-inconsistent output.
+
+## Product Workspaces
+
+### Build
+
+Build owns:
+
+- cloud-opportunity discovery;
+- sounding and recipe recommendations;
+- concrete run setup;
+- scout and full-run plan;
+- package generation;
+- local/LAN execution where supported;
+- queue, progress, ETA, stop, ingest, and cleanup.
+
+### Results
+
+Results is the notebook of ingested cloud runs. It should emphasize what cloud
+formed and make useful runs easy to name, tag, revisit, and relate to their scout
+and recipe.
+
+### Explore
+
+Explore is the synchronized visual and explanatory view of one result. It should
+prioritize cloud evolution and keep technical detail available without making it
+the main event.
+
+## Run Latency
+
+CM1 execution is not an instant slider. Cloud Chamber should make latency useful:
+
+- recommend a setup worth the time;
+- show ETA;
+- checkpoint meaningful scouts;
+- stop poor bets;
+- automatically continue promising clouds;
+- let the user leave and return later.
+
+## Product Language
+
+Use:
+
+- cloud opportunity;
+- recipe;
+- run setup;
+- scout;
+- growing cumulus;
+- congestus;
+- deep tower;
+- daytime evolution;
+- explicit initiation supplied;
+- broad warm/moist region;
+- likely ceiling;
+- main obstacle;
+- continue / switch / skip;
 - What happened here?
-- saturation deficit
-- deep breakthrough
-- precipitation feedback
-- downdraft
-- cold pool
-- outflow boundary
 
-Raw CM1 namelist settings and raw variable names belong in technical,
-advanced, or developer views.
+Raw CM1 variables and namelist values belong in technical views.
 
-The first controls should favor relative, teachable changes around a baseline:
-
-- drier / baseline / more humid low-level air
-- weaker / baseline / stronger surface heating
-- lower / baseline / higher cap
-- weaker / baseline / stronger cap
-- less dry / baseline / drier air aloft
-- weaker / baseline / stronger mixing/entrainment
-
-The first variation workflow should change one control at a time. This is a product teaching choice, not a claim that the atmosphere changes one variable at a time.
-
-## Product Layers
-
-### 1. Scenario Builder
-
-Guided setup for CM1 experiments.
-
-It should provide presets and friendly controls that map to CM1 namelists/soundings/manifests.
-
-### 2. Preview / Light Predictor
-
-A simplified model or diagnostic layer that helps users understand likely behavior before running CM1.
-
-It should be clearly labeled as preview only.
-
-### 3. Local Run Manager
-
-Creates, launches, tracks, and logs CM1 runs.
-
-CM1 runs can be long and local. The user should be able to start a run, leave it, and come back later.
-
-### 4. Results Library
-
-Local library of completed/failed/running CM1 experiments.
-
-Users can name, save, tag, replay, inspect, explain, and delete runs. Saved completed results should behave like experiment notebook entries. Duplicating or rerunning a saved setup is useful later, but the first MVP does not need to make rerun a central result-library feature.
-
-### 5. Thermal Fate Diagnostics
-
-Backend-owned diagnostics should sit between result ingest and visualization.
-They should distinguish global run diagnostics, local selected-region
-diagnostics, comparison diagnostics, and visualizer interpretation.
-
-The selected-region product question is:
-
-```text
-What happened here?
-```
-
-### 6. Unified Explore
-
-An important payoff, but not the only product center of gravity. Explore should
-first feel like one trustworthy instrument for understanding a selected result:
-cloud context, synchronized slices, `What happened here?`, and technical
-evidence on demand.
-
-Near-term Explore should support:
-
-- time replay
-- projection/view controls
-- zoom and reset view
-- slices
-- projections
-- selected-region markers
-- plain-language explanations
-- provenance and caveats
-
-## First Scenario Set
-
-Thermal Fate scenario families should start with:
-
-1. Moisture-limited thermal fate: Baseline, Dry Failed, and humidity ladder.
-2. Surface-heating-driven thermal fate.
-3. Cap-limited thermal fate: Capped / Suppressed Cumulus.
-4. Dry-air-aloft / dilution-limited thermal fate.
-5. Deep-convection breakthrough.
-6. Precipitation feedback / cold-pool interaction.
-7. Low stratus / low-cloud layer where appropriate.
-
-Baseline shallow cumulus is the first end-to-end Golden Path scenario. Warm rain remains early and important, but it should not block proving the baseline shallow-cumulus loop first.
-
-The first variation workflow should favor one-control-at-a-time changes around the baseline instead of arbitrary giant parameter sweeps. This keeps the learning path understandable and keeps CM1 as the truth source.
-
-Later product families can include terrain/orographic cloud, layered
-atmospheres, fog / near-surface cloud, and mixed-phase / ice.
-
-## Thermal Fate And Visualization Philosophy
-
-CM1 output is physical source data. The visualizer may interpret it, but must label the interpretation.
-
-The visualizer should serve the Thermal Fate workbench: process overlays,
-selected-region markers, cloud base/top, cap/inversion context, updrafts,
-moisture/saturation evidence, and precipitation-feedback caveats should guide
-renderer choices. Visual polish follows process needs, not the other way
-around.
-
-Useful views for the current Explore loop:
-
-- Cloud-water context
-- Rain-water field
-- Vertical velocity field
-- Horizontal slices
-- Vertical slices
-- Cloud top/base diagnostics
-- Time replay
-- 3-D projection context
-- Selected-region explanation
-- Technical evidence and caveats
-
-Renderer upgrades such as isosurfaces, volumetric rendering, cinematic lighting,
-fly-through, export, and appearance polish should wait until the notebook,
-comparison, and `What happened here?` loop are stable.
-
-## Trust/Honesty Rules
+## Trust Distinctions
 
 Always distinguish:
 
 ```text
-Preview estimate
+Analyzer/recommendation estimate
 Generated CM1 configuration
-Packaged dry-run output
+Packaged run
 Queued/running CM1 process
 Completed CM1 result
-Failed/canceled CM1 run
 Ingested result metadata
-Visualizer interpretation
-Editable result/notebook entry
+Visualization interpretation
 ```
 
-Never imply:
+Never imply that a recommendation is CM1 output or that a package is a completed
+cloud result.
 
-- a preview is CM1 output
-- a dry-run package is a completed result
-- a visualization interpretation is a raw model field
-- CM1 runs live in browser
-- a scenario is validated if it has not been inspected
+## Current Golden Path
 
-## Success Criteria For The MVP
+The current hero workflow is no longer Baseline Shallow Cumulus.
 
-The MVP should let a user:
+The new Golden Path is:
 
-1. Pick a preset scenario.
-2. See/edit meaningful controls.
-3. Generate a CM1 run directory from the setup.
-4. Launch CM1 locally.
-5. Track whether the run is queued/running/done/failed.
-6. Ingest NetCDF output into an app-friendly format.
-7. Open diagnostics and visualization-ready fields.
-8. Replay and inspect cloud evolution over time.
-9. Save/name/tag the run.
-10. Reopen, replay, inspect, and explain a saved result later.
+```text
+Show me something cool
+→ receive a ranked sounding–recipe opportunity
+→ queue the recommended scout
+→ watch it earn or fail promotion
+→ open a visibly interesting cloud result in Explore
+```
 
-Optional later behavior:
+Baseline Shallow Cumulus remains a useful reference and learning case. It is not
+the product's aspirational ceiling.
 
-- Create a new variation from the same setup.
-- Duplicate and rerun a scenario when that workflow is implemented.
+## Success Criteria
 
-The MVP scientific standard is a credible idealized CM1 cloud lab for personal learning and exploration. It is not a publication-quality LES workflow and not operational forecasting.
+Cloud Chamber succeeds when a user can:
+
+1. search a useful sounding-history scope;
+2. see ranked cloud-making opportunities;
+3. understand why a recipe is recommended;
+4. avoid a likely boring sounding/setup;
+5. queue a meaningful scout through Build;
+6. see progress and ETA;
+7. let a promising scout visibly promote to a full run;
+8. stop or clean up when desired;
+9. ingest and open the result;
+10. watch growing or deep cloud evolution in Explore;
+11. learn which assumptions or atmospheric limits shaped the result.
+
+Within a small set of scouts, the product should produce an interesting cloud or
+save substantial compute with a decisive switch/skip recommendation.
+
+## Current Strategic Sources
+
+- [Cloud-First Product Reset](cloud-first-product-reset.md)
+- [Current Roadmap](current-roadmap.md)
+- [Architecture and Data Model](architecture-and-data-model.md)
+- [Product Spec](cloud-chamber-product-spec.md)


### PR DESCRIPTION
## Summary

Refs #346.

This PR resets Cloud Chamber around the approved organizing principle:

> Cloud Chamber is a cloud-making sandbox that uses real atmospheres as raw material.

The central question is now:

> Given the soundings available, which ones can make interesting clouds, what setup should I use, and how far do I need to push them?

## What changed

- Added `docs/cloud-first-product-reset.md` with the root-cause diagnosis, cloud-opportunity model, recipe taxonomy, sounding-selection direction, scout/full-run workflow, starting run-shape hypotheses, checkpoint decisions, and stop-doing list.
- Rewrote `AGENTS.md` with an explicit Cloud-Making Operating Mode:
  - optimize visible cloud outcome and useful learning per unit time;
  - take bounded big swings;
  - run meaningful CM1 early;
  - allow strong clearly labeled idealizations;
  - do not fragment work into prerequisite issues unless blocked;
  - require diagnostics to change a continue/change/stop decision;
  - visibly auto-promote promising scouts through the existing Build workflow.
- Rewrote the product vision so the hero workflow is `Show me something cool → recommended scout → visible full-run promotion → interesting cloud in Explore`.
- Replaced the old validation-lane roadmap with immediate priorities #346, #341, and #287.
- Replaced the legacy 1,700-line product spec with a concise current cloud-first contract.
- Updated README and Codex setup notes to make the new direction the repository entry point.

## Roadmap cleanup already applied

- Closed #307 as completed: differential surface forcing is now one recipe tool, not the roadmap center.
- Closed #345 as not planned: formal matched comparison is secondary to making useful clouds.
- Closed #336 as not planned: numerical characterization is no longer a product blocker.
- Closed #275 as not planned: generalized predicted-vs-actual verdicts are not the immediate priority.
- Rewrote #341 to restore the proven `iinit = 3` Deep Convection Trial from PR #270.
- Rewrote #287 as a real Daytime Evolution recipe, not a documentation-only validation memo.

## Verification

Docs-only product-direction change. Review rendered Markdown and run the standard repository checks through CI.

No CM1 runs or generated runtime artifacts are included.

## Review focus

- Does the repository now unambiguously organize around sounding + recipe + run setup opportunities?
- Are the agent rules strong enough to prevent another validation/plumbing loop?
- Are automatic scout promotion and user-visible Build controls stated clearly?
- Are strong idealized recipes treated honestly without being demoted?

This is intentionally a manual-review product-direction PR; auto-merge is not enabled.