### PR TITLE
Restore Deep-Tower Benchmark recipe

### DIFF
--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -23,6 +23,7 @@ from cloud_chamber.scenario_schema import ControlAudience, ScenarioTemplate
 from cloud_chamber.surface_forcing import (
     CM1_SOURCE_CUSTOMIZATION_FILENAME,
     DIFFERENTIAL_SURFACE_FORCING_MODE,
+    DISABLED_SURFACE_FLUX_MODE,
     SURFACE_FORCING_PATCH_FILENAME,
     SURFACE_FORCING_PATCH_JSON_FILENAME,
 )
@@ -43,9 +44,10 @@ class RunRecipe(StrEnum):
     GENERATED_REFERENCE_LOWER_ATMOSPHERE = "generated_reference_lower_atmosphere"
     OBSERVED_SURFACE_FORCED_EVOLUTION = "observed_surface_forced_evolution"
     DIFFERENTIAL_SURFACE_FORCED_EVOLUTION = "differential_surface_forced_evolution"
+    DEEP_TOWER_BENCHMARK = "deep_tower_benchmark"
 
 
-REMOVED_TRIGGERED_DEEP_POTENTIAL_RECIPE = "triggered_deep_potential"
+LEGACY_TRIGGERED_DEEP_POTENTIAL_RECIPE = "triggered_deep_potential"
 
 
 @dataclass(frozen=True)
@@ -215,6 +217,8 @@ def build_cm1_input_contract(
         resolved_run_configuration,
     )
     defaults = cloud_scale_defaults_for_configuration(resolved_run_configuration)
+    if resolved_run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK and observed_sounding is None:
+        raise ValueError("Deep-Tower Benchmark requires a validated observed sounding.")
     if observed_sounding is not None and not has_complete_rendered_observed_wind_profile(
         observed_sounding,
         defaults=defaults,
@@ -255,7 +259,9 @@ def build_cm1_input_contract(
         input_source="observed_sounding"
         if observed_sounding is not None
         else "generated_reference",
-        trigger_type=None,
+        trigger_type=(
+            "warm_bubble" if resolved_run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK else None
+        ),
         trigger_parameters=_trigger_parameters(resolved_run_recipe),
         scenario_id=scenario.id,
         physical_question=scenario.physical_question,
@@ -312,12 +318,8 @@ def _resolve_run_recipe(
     run_recipe: str | RunRecipe | None,
     observed_sounding: ObservedSoundingRecord | None,
 ) -> RunRecipe:
-    if run_recipe == REMOVED_TRIGGERED_DEEP_POTENTIAL_RECIPE:
-        raise ValueError(
-            "Triggered deep-potential package generation has been removed. "
-            "Use observed-sounding run configuration with numeric uniform or differential "
-            "lower-boundary heat/moisture forcing."
-        )
+    if run_recipe == LEGACY_TRIGGERED_DEEP_POTENTIAL_RECIPE:
+        return RunRecipe.DEEP_TOWER_BENCHMARK
     if isinstance(run_recipe, RunRecipe):
         return run_recipe
     if run_recipe:
@@ -334,6 +336,22 @@ def _run_recipe_for_configuration(
     run_recipe: RunRecipe,
     run_configuration: RunConfiguration,
 ) -> RunRecipe:
+    if (
+        run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK
+        and run_configuration.surface_forcing_patch is not None
+    ):
+        raise ValueError(
+            "Deep-Tower Benchmark uses CM1 iinit=3 explicit thermal initiation; "
+            "differential surface forcing must use its own run recipe."
+        )
+    if (
+        run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK
+        and run_configuration.surface_flux_mode != DISABLED_SURFACE_FLUX_MODE
+    ):
+        raise ValueError(
+            "Deep-Tower Benchmark requires surface_forcing_mode=disabled; "
+            "use an observed surface-forced recipe for lower-boundary forcing experiments."
+        )
     if run_configuration.surface_flux_mode == DIFFERENTIAL_SURFACE_FORCING_MODE:
         if run_recipe == RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
             raise ValueError(
@@ -352,6 +370,8 @@ def _run_recipe_display_name(run_recipe: RunRecipe) -> str:
     match run_recipe:
         case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
             return "Differential Surface-Forced Evolution"
+        case RunRecipe.DEEP_TOWER_BENCHMARK:
+            return "Deep-Tower Benchmark"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "Observed Surface-Forced Evolution"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -363,6 +383,8 @@ def recipe_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     match resolved:
         case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
             return "differential_surface_forced_evolution_v0"
+        case RunRecipe.DEEP_TOWER_BENCHMARK:
+            return "deep_tower_benchmark_v0"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "observed_surface_forced_evolution_v0"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -376,6 +398,8 @@ def recipe_display_name_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     match resolved:
         case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
             return "Differential Surface-Forced Evolution v0"
+        case RunRecipe.DEEP_TOWER_BENCHMARK:
+            return "Deep-Tower Benchmark v0"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "Observed Surface-Forced Evolution v0"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -389,6 +413,8 @@ def assumption_set_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     match resolved:
         case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
             return "differential_surface_forced_evolution_v0_assumptions"
+        case RunRecipe.DEEP_TOWER_BENCHMARK:
+            return "deep_tower_benchmark_v0_assumptions"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "observed_surface_forced_evolution_v0_assumptions"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -402,6 +428,8 @@ def assumption_mode_for_run_recipe(run_recipe: str | RunRecipe) -> str:
     match resolved:
         case RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
             return "differential_surface_forced_evolution"
+        case RunRecipe.DEEP_TOWER_BENCHMARK:
+            return "explicit_thermal_initiation"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "observed_surface_forced_evolution"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -423,6 +451,19 @@ def required_output_fields_for_run_recipe(run_recipe: str | RunRecipe) -> tuple[
                 "dbz",
                 "hfx",
                 "qfx",
+                "u",
+                "v",
+                "th",
+                "updraft_helicity",
+            )
+        case RunRecipe.DEEP_TOWER_BENCHMARK:
+            return (
+                "qv",
+                "qc",
+                "w",
+                "qr",
+                "rain",
+                "dbz",
                 "u",
                 "v",
                 "th",
@@ -454,6 +495,23 @@ def recipe_caveats_for_run_recipe(run_recipe: str | RunRecipe) -> tuple[str, ...
                     "Surface-driven convergence, localized updraft, coherent cloud growth, "
                     "rain-water, surface-rain, and reflectivity remain diagnostics to inspect, "
                     "not guaranteed outcomes."
+                ),
+            )
+        case RunRecipe.DEEP_TOWER_BENCHMARK:
+            return (
+                "Explicit initiation is supplied with CM1 iinit=3 three warm bubbles.",
+                (
+                    "The warm bubbles are an idealized trigger used to reveal the convective "
+                    "ceiling of a promising observed atmosphere; they are not a real front, "
+                    "dryline, terrain feature, or observed boundary."
+                ),
+                (
+                    "Surface heat/moisture fluxes, radiation, terrain, GIS surface "
+                    "initialization, and large-scale forcing are not part of v0."
+                ),
+                (
+                    "Storm mode, precipitation feedback, downdraft, cold pool, and outflow "
+                    "behavior remain CM1 outcomes to inspect after completion."
                 ),
             )
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
@@ -491,6 +549,15 @@ def _coerce_run_recipe(run_recipe: str | RunRecipe) -> RunRecipe | None:
 def _trigger_parameters(
     run_recipe: RunRecipe,
 ) -> dict[str, str | int | float | bool]:
+    if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK:
+        return {
+            "cm1_iinit": 3,
+            "cm1_trigger": (
+                "CM1 built-in three warm bubbles with 2 K maximum potential-temperature "
+                "perturbations in a line near 1.4 km AGL"
+            ),
+            "raw_controls_exposed": False,
+        }
     return {}
 
 
@@ -512,6 +579,7 @@ def _run_caveats(
     if run_recipe in {
         RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION,
         RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION,
+        RunRecipe.DEEP_TOWER_BENCHMARK,
     }:
         caveats.extend(recipe_caveats_for_run_recipe(run_recipe))
         return tuple(caveats)
@@ -519,6 +587,8 @@ def _run_caveats(
 
 
 def _manual_validation_status(run_recipe: RunRecipe) -> str:
+    if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK:
+        return "deep_tower_benchmark_iinit3_fort_worth_prior_smoke_validated"
     if run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
         return "observed_surface_forced_evolution_v0_metadata_only"
     if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
@@ -560,6 +630,7 @@ def _recipe_assumptions(
     if run_recipe in {
         RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION,
         RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION,
+        RunRecipe.DEEP_TOWER_BENCHMARK,
     }:
         trigger_description = "No artificial atmospheric trigger."
         if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
@@ -567,11 +638,26 @@ def _recipe_assumptions(
                 "No artificial atmospheric trigger; initiation is tested through the selected "
                 "lower-boundary differential surface-forcing patch."
             )
+        trigger_mode = "none"
+        if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK:
+            trigger_mode = "cm1_iinit_3_three_warm_bubbles"
+            trigger_description = (
+                "Explicit idealized thermal initiation supplied by stock CM1 iinit=3 "
+                "three-warm-bubble line trigger."
+            )
         return {
             **configured_shape,
             "trigger": {
-                "mode": "none",
+                "mode": trigger_mode,
                 "description": trigger_description,
+                **(
+                    {
+                        "cm1_iinit": 3,
+                        "raw_controls_exposed": False,
+                    }
+                    if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK
+                    else {}
+                ),
             },
             "observed_sounding": {
                 "temperature_profile": "required",
@@ -770,30 +856,31 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
     defaults = contract.cloud_scale_defaults
     sounding_source_id = 7 if contract.observed_sounding is not None else 17
     wind_profile_id = 0 if contract.observed_sounding is not None else 9
-    testcase = 3
-    adapt_dt = 1
+    deep_tower = contract.run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK
+    testcase = 0 if deep_tower else 3
+    adapt_dt = 0 if deep_tower else 1
     ptype = 5
-    ihail = 0
-    iautoc = 0
-    icor = 1
-    lspgrad = 2
-    idiss = 0
-    wbc = ebc = sbc = nbc = 1
-    bbc = 3
-    iinit = 0
-    irandp = 1
-    imove = 0
+    ihail = 1 if deep_tower else 0
+    iautoc = 1 if deep_tower else 0
+    icor = 0 if deep_tower else 1
+    lspgrad = 0 if deep_tower else 2
+    idiss = 1 if deep_tower else 0
+    wbc = ebc = sbc = nbc = 2 if deep_tower else 1
+    bbc = 1 if deep_tower else 3
+    iinit = 3 if deep_tower else 0
+    irandp = 0 if deep_tower else 1
+    imove = 1 if deep_tower else 0
     output = _output_switches(
         contract.run_configuration.diagnostic_set,
-        deep_convection=False,
+        deep_convection=deep_tower,
         surface_flux_outputs=contract.run_configuration.surface_flux_mode
         in {"constant_uniform_surface_flux_proxy", DIFFERENTIAL_SURFACE_FORCING_MODE},
     )
     surface = contract.run_configuration.surface_flux_cm1_values
-    l_h = 0.0
-    lhref1 = 0.0
-    lhref2 = 0.0
-    ndcnst = 100.0
+    l_h = 100.0 if deep_tower else 0.0
+    lhref1 = 100.0 if deep_tower else 0.0
+    lhref2 = 1000.0 if deep_tower else 0.0
+    ndcnst = 250.0 if deep_tower else 100.0
     return f"""
  &param0
  nx           =      {defaults.nx},

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -583,6 +583,14 @@ def _run_configuration_summary(contract: CM1InputContract) -> dict[str, object]:
 
 
 def _run_recipe_mapping_summary(contract: CM1InputContract) -> str:
+    if contract.run_recipe.value == "deep_tower_benchmark":
+        return (
+            "observed IGRA external input_sounding profile with observed u/v winds; "
+            "the run uses CM1 isnd=7, testcase=0, stock CM1 iinit=3 three-warm-bubble "
+            "line initiation, a storm-scale idealized domain, NetCDF output, rain output, "
+            "reflectivity output, vorticity output, and updraft-helicity output; explicit "
+            "initiation is supplied and must be interpreted as an idealized trigger"
+        )
     if contract.run_configuration.surface_forcing_patch is not None:
         return (
             "observed IGRA external input_sounding profile; the run uses CM1 isnd=7, "
@@ -612,6 +620,12 @@ def _run_recipe_mapping_summary(contract: CM1InputContract) -> str:
 
 
 def _cm1_mapping_status(contract: CM1InputContract) -> str:
+    if contract.run_recipe.value == "deep_tower_benchmark":
+        return (
+            "CM1-ready Deep-Tower Benchmark run with explicit stock-CM1 iinit=3 "
+            "three-warm-bubble initiation. Prior Fort Worth smoke evidence applies to "
+            "the recipe path; each observed sounding remains a CM1 experiment to inspect."
+        )
     if contract.run_configuration.surface_forcing_patch is not None:
         return (
             "CM1-ready observed-sounding run with an explicit differential lower-boundary "

--- a/app/backend/cloud_chamber/pre_run_validation.py
+++ b/app/backend/cloud_chamber/pre_run_validation.py
@@ -186,6 +186,19 @@ def _hypothesis_recipe_alignment(
             "caveats": [],
         }
     if story in DEEP_CONVECTION_STORIES:
+        if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK:
+            return {
+                "status": "aligned",
+                "reasons": [
+                    "Deep-convection ingredients can be tested with the explicit "
+                    "Deep-Tower Benchmark trigger."
+                ],
+                "missing_assumptions": [],
+                "blocking_errors": [],
+                "caveats": [
+                    "explicit_thermal_initiation_supplied_not_a_real_observed_trigger",
+                ],
+            }
         differential = run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION
         return {
             "status": "partial",
@@ -283,6 +296,7 @@ def _input_validation_payload(
     wind_required = contract.run_recipe in {
         RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION,
         RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION,
+        RunRecipe.DEEP_TOWER_BENCHMARK,
     }
     complete_wind_profile = has_complete_rendered_observed_wind_profile(
         observed_sounding,
@@ -397,6 +411,16 @@ def _forcing_validation_payload(contract: CM1InputContract) -> dict[str, Any]:
 
 
 def _forcing_validation_for_recipe(run_recipe: str) -> dict[str, Any]:
+    if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK.value:
+        return {
+            "trigger": "cm1_iinit_3_three_warm_bubbles",
+            "surface_fluxes": {
+                "mode": "disabled",
+                "status": "disabled_for_explicit_deep_tower_benchmark_v0",
+            },
+            "radiation": "disabled",
+            "large_scale_forcing": "none",
+        }
     if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION.value:
         return {
             "trigger": "none",
@@ -431,6 +455,8 @@ def _required_outputs_for_story(
     run_recipe: RunRecipe,
 ) -> list[str]:
     if story in DEEP_CONVECTION_STORIES:
+        if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK:
+            return ["qv", "qc", "w", "qr", "rain", "dbz", "u", "v", "th", "updraft_helicity"]
         return ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "qfx", "updraft_helicity"]
     if story == "humid_rainy_candidate":
         return ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "qfx"]
@@ -512,7 +538,9 @@ def _run_recipe(value: str) -> RunRecipe:
 
 def _run_recipe_display_name(run_recipe: str) -> str:
     if run_recipe == "triggered_deep_potential":
-        return "Removed Triggered Deep-Potential Path"
+        return "Deep-Tower Benchmark"
+    if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK.value:
+        return "Deep-Tower Benchmark"
     if run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION.value:
         return "Observed Surface-Forced Evolution"
     return "Generated Lower-Atmosphere Reference"

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -55,6 +55,8 @@ RESULT_METADATA_FILENAME = "result_metadata.json"
 REQUIRED_OUTPUT_FIELD_ALIASES: dict[str, set[str]] = {
     "qfx": {"qfx", "lhfx"},
     "lhfx": {"qfx", "lhfx"},
+    "updraft_helicity": {"updraft_helicity", "uh"},
+    "uh": {"updraft_helicity", "uh"},
 }
 MODEL_OUTPUT_PATTERN = re.compile(r"^cm1out_\d+\.nc(?:4)?$")
 STATS_OUTPUT_NAMES = {"cm1out_stats.nc", "cm1out_stats.nc4"}
@@ -2181,6 +2183,8 @@ def _candidate_story_label(story: str | None) -> str | None:
 
 
 def _display_run_recipe(run_recipe: str | None) -> str:
+    if run_recipe == "deep_tower_benchmark":
+        return "Deep-Tower Benchmark"
     if run_recipe == "observed_surface_forced_evolution":
         return "Observed Surface-Forced Evolution"
     return "CM1 run"

--- a/app/backend/cloud_chamber/run_configuration.py
+++ b/app/backend/cloud_chamber/run_configuration.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.surface_forcing import (
     DIFFERENTIAL_SURFACE_FORCING_MODE,
+    DISABLED_SURFACE_FLUX_MODE,
     UNIFORM_SURFACE_FLUX_MODE,
     SurfaceForcingPatch,
     resolve_surface_forcing_patch,
@@ -146,6 +147,7 @@ class _CadenceChoice(BaseModel):
 
 DURATION_CHOICES: dict[str, _DurationChoice] = {
     "smoke_1h": _DurationChoice(seconds=3600, mode="smoke", label="Smoke check"),
+    "scout_2h": _DurationChoice(seconds=7200, mode="science", label="Scout evolution"),
     "short_6h": _DurationChoice(seconds=21600, mode="science", label="Short evolution"),
     "standard_12h": _DurationChoice(seconds=43200, mode="science", label="Standard evolution"),
     "long_24h": _DurationChoice(seconds=86400, mode="science", label="Long evolution"),
@@ -154,6 +156,7 @@ DURATION_CHOICES: dict[str, _DurationChoice] = {
 HORIZONTAL_CELL_CHOICES: dict[str, _HorizontalCellChoice] = {
     "cells_64": _HorizontalCellChoice(cells=64, label="Scout 64 x 64"),
     "cells_96": _HorizontalCellChoice(cells=96, label="Light 96 x 96"),
+    "cells_120": _HorizontalCellChoice(cells=120, label="Deep-tower scout 120 x 120"),
     "cells_128": _HorizontalCellChoice(cells=128, label="Standard 128 x 128"),
     "cells_192": _HorizontalCellChoice(cells=192, label="Detailed 192 x 192"),
     "cells_256": _HorizontalCellChoice(cells=256, label="High detail 256 x 256"),
@@ -196,6 +199,19 @@ DOMAIN_CHOICES: dict[str, _DomainChoice] = {
         **TALL_STRETCHED_VERTICAL_GRID,
         label="Regional 120 km",
     ),
+    "deep_tower_120km": _DomainChoice(
+        x_km=120.0,
+        y_km=120.0,
+        nz=40,
+        dz_m=500.0,
+        stretch_z=0,
+        model_top_m=20000.0,
+        str_bot_m=0.0,
+        str_top_m=2000.0,
+        dz_bot_m=125.0,
+        dz_top_m=500.0,
+        label="Storm 120 km",
+    ),
 }
 
 CADENCE_CHOICES: dict[str, _CadenceChoice] = {
@@ -212,6 +228,18 @@ SURFACE_MOISTURE_FLUX_CONTEXT_RANGE_G_G_M_S = (0.0, 2.0e-4)
 
 
 def default_run_configuration_payload(run_recipe: str | None = None) -> dict[str, str | float]:
+    if run_recipe in {"deep_tower_benchmark", "triggered_deep_potential"}:
+        return {
+            "duration": "scout_2h",
+            "horizontal_cell_count": "cells_120",
+            "domain_size": "deep_tower_120km",
+            "output_cadence": "standard_15min",
+            "diagnostic_set": "full",
+            "surface_heat_flux_k_m_s": 0.0,
+            "surface_moisture_flux_g_g_m_s": 0.0,
+            "surface_forcing_mode": DISABLED_SURFACE_FLUX_MODE,
+            "time_step_seconds": 6.0,
+        }
     if run_recipe == "observed_surface_forced_evolution":
         return {
             "duration": "short_6h",
@@ -252,7 +280,11 @@ def resolve_run_configuration(
         **payload,
     }
 
-    initiation_method = "none"
+    initiation_method = (
+        "cm1_iinit_3_three_warm_bubbles"
+        if run_recipe in {"deep_tower_benchmark", "triggered_deep_potential"}
+        else "none"
+    )
 
     duration = _choice(DURATION_CHOICES, payload.get("duration"), "duration")
     horizontal_cells = _choice(
@@ -290,8 +322,8 @@ def resolve_run_configuration(
     restart_seconds = max(cadence.seconds, min(duration.seconds, 10800))
     frames = _expected_output_frames(duration.seconds, cadence.seconds)
     grid_cells = nx * ny * domain.nz
-    surface_flux_enabled = True
     surface_flux_mode = surface_forcing_mode_from_payload(payload)
+    surface_flux_enabled = surface_flux_mode != DISABLED_SURFACE_FLUX_MODE
     surface_forcing_patch = resolve_surface_forcing_patch(
         payload=payload,
         mode=surface_flux_mode,
@@ -330,6 +362,7 @@ def resolve_run_configuration(
     )
     caveats = _configuration_caveats(
         mode=duration.mode,
+        duration_seconds=duration.seconds,
         horizontal_cell_count=horizontal_cells.cells,
         domain_size=str(payload["domain_size"]),
         surface_flux_caveats=surface_flux_caveats,
@@ -373,7 +406,7 @@ def resolve_run_configuration(
             runtime_seconds=duration.seconds,
             output_cadence_seconds=cadence.seconds,
             restart_cadence_seconds=restart_seconds,
-            rayleigh_damping_start_m=_rayleigh_damping_start_m(),
+            rayleigh_damping_start_m=_rayleigh_damping_start_m(run_recipe),
             expected_output_frames=frames,
             grid_cell_count=grid_cells,
         ),
@@ -493,6 +526,7 @@ def _output_summary(frames: int, grid_cells: int, diagnostic_set: str) -> str:
 def _configuration_caveats(
     *,
     mode: RunMode,
+    duration_seconds: int,
     horizontal_cell_count: int,
     domain_size: str,
     surface_flux_caveats: list[str],
@@ -501,8 +535,12 @@ def _configuration_caveats(
     caveats: list[str] = list(surface_flux_caveats)
     if mode == "smoke":
         caveats.append("short_smoke_mode_is_for_package_health_not_science_evolution")
-    if mode == "science":
+    if domain_size == "deep_tower_120km":
+        caveats.append("storm_scale_domain_for_explicit_deep_tower_initiation")
+    if mode == "science" and duration_seconds >= 21600:
         caveats.append("science_run_configuration_minimum_duration_6h")
+    if mode == "science" and duration_seconds < 21600:
+        caveats.append("short_scout_duration_for_initial_deep_tower_chase")
     if horizontal_cell_count >= 256 or domain_size in {
         "wide_12km",
         "regional_60km",
@@ -515,6 +553,8 @@ def _configuration_caveats(
 
 
 def _initiation_summary(initiation_method: str) -> str:
+    if initiation_method == "cm1_iinit_3_three_warm_bubbles":
+        return "CM1 iinit=3 three warm bubbles"
     return "No artificial initiation"
 
 
@@ -609,7 +649,9 @@ def _surface_mode_id(surface_flux_mode: str, patch_sha256: str | None) -> str:
     return ""
 
 
-def _rayleigh_damping_start_m() -> int:
+def _rayleigh_damping_start_m(run_recipe: str | None = None) -> int:
+    if run_recipe in {"deep_tower_benchmark", "triggered_deep_potential"}:
+        return 15000
     return 12000
 
 

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -1664,18 +1664,18 @@ def _candidate_recipe_fit(
         }
     if story in DEEP_CONVECTION_STORY_IDS:
         caveats = [
-            "deep_convection_outcome_depends_on_surface_forcing_duration_domain_and_resolution",
-            "differential_surface_forcing_patch_recipe_available_for_initiation_tests",
+            "deep_convection_outcome_depends_on_explicit_trigger_duration_domain_and_resolution",
+            "deep_tower_benchmark_uses_idealized_warm_bubbles_not_observed_boundary",
         ]
         if features.get("observed_wind_available") is not True:
             caveats.append("complete_observed_wind_profile_required_for_input_sounding")
         return {
-            "status": "partially_testable",
-            "label": "testable as forced observed evolution",
+            "status": "testable_now",
+            "label": "testable with Deep-Tower Benchmark",
             "summary": (
                 "This story screens deep-convection ingredients. CM1 can evolve the observed "
-                "atmosphere under selected lower-boundary forcing; a differential surface "
-                "patch can be selected when localized initiation is the question."
+                "atmosphere with the explicit Deep-Tower Benchmark trigger; use surface-forced "
+                "recipes when lower-boundary initiation is the question."
             ),
             "caveats": caveats,
         }
@@ -2195,7 +2195,7 @@ def _score_features(
             ],
             caveats=[
                 "line/cold-pool-specific recipe support may come later; "
-                "v1 runs as observed surface-forced evolution",
+                "v1 uses the Deep-Tower Benchmark as a first experiment",
                 *deep_caveats,
             ],
         ),

--- a/app/backend/cloud_chamber/surface_forcing.py
+++ b/app/backend/cloud_chamber/surface_forcing.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 UNIFORM_SURFACE_FLUX_MODE = "constant_uniform_surface_flux_proxy"
 DIFFERENTIAL_SURFACE_FORCING_MODE = "differential_surface_forcing_patch_v0"
+DISABLED_SURFACE_FLUX_MODE = "disabled"
 SURFACE_FORCING_PATCH_FILENAME = "cloud_chamber_surface_forcing_patch.dat"
 SURFACE_FORCING_PATCH_JSON_FILENAME = "surface_forcing_patch.json"
 CM1_SOURCE_CUSTOMIZATION_FILENAME = "cm1_source_customization.json"
@@ -66,7 +67,11 @@ def surface_forcing_mode_from_payload(payload: dict[str, Any]) -> str:
         return UNIFORM_SURFACE_FLUX_MODE
     if raw == "uniform":
         return UNIFORM_SURFACE_FLUX_MODE
-    if raw in {UNIFORM_SURFACE_FLUX_MODE, DIFFERENTIAL_SURFACE_FORCING_MODE}:
+    if raw in {
+        UNIFORM_SURFACE_FLUX_MODE,
+        DIFFERENTIAL_SURFACE_FORCING_MODE,
+        DISABLED_SURFACE_FLUX_MODE,
+    }:
         return str(raw)
     raise ValueError(f"Unknown surface forcing mode: {raw}")
 

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -276,6 +276,79 @@ def test_observed_contract_declares_surface_forced_v0_recipe_assumptions() -> No
     assert "No artificial atmospheric trigger is applied." in contract.recipe_caveats
 
 
+def test_deep_tower_benchmark_declares_iinit3_assumptions_and_namelist() -> None:
+    from igra_fixtures import IGRA_FIXTURE
+
+    from cloud_chamber.observed_sounding import parse_igra_station_text
+
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+
+    contract = build_cm1_input_contract(
+        baseline_scenario(),
+        observed_sounding=observed,
+        run_recipe="deep_tower_benchmark",
+    )
+    namelist = render_namelist_fragment(contract)
+    trigger = cast(dict[str, Any], contract.recipe_assumptions["trigger"])
+    surface_fluxes = cast(dict[str, Any], contract.recipe_assumptions["surface_fluxes"])
+
+    assert contract.run_recipe.value == "deep_tower_benchmark"
+    assert contract.recipe_id == "deep_tower_benchmark_v0"
+    assert contract.recipe_display_name == "Deep-Tower Benchmark v0"
+    assert contract.assumption_set_id == "deep_tower_benchmark_v0_assumptions"
+    assert contract.assumption_mode == "explicit_thermal_initiation"
+    assert contract.required_output_fields == (
+        "qv",
+        "qc",
+        "w",
+        "qr",
+        "rain",
+        "dbz",
+        "u",
+        "v",
+        "th",
+        "updraft_helicity",
+    )
+    assert contract.run_configuration.duration == "scout_2h"
+    assert contract.run_configuration.duration_seconds == 7200
+    assert contract.run_configuration.domain_size == "deep_tower_120km"
+    assert contract.run_configuration.horizontal_cell_count == 120
+    assert contract.run_configuration.cm1_values.time_step_seconds == 6.0
+    assert contract.run_configuration.cm1_values.rayleigh_damping_start_m == 15000
+    assert contract.run_configuration.surface_flux_mode == "disabled"
+    assert trigger["mode"] == "cm1_iinit_3_three_warm_bubbles"
+    assert trigger["cm1_iinit"] == 3
+    assert trigger["raw_controls_exposed"] is False
+    assert surface_fluxes["mode"] == "disabled"
+    assert surface_fluxes["cm1_values"]["isfcflx"] == 0
+    assert surface_fluxes["cm1_values"]["set_flx"] == 0
+    assert "Explicit initiation is supplied with CM1 iinit=3 three warm bubbles." in (
+        contract.recipe_caveats
+    )
+    assert contract.manual_validation_status == (
+        "deep_tower_benchmark_iinit3_fort_worth_prior_smoke_validated"
+    )
+    assert "nx           =      120," in namelist
+    assert "ny           =      120," in namelist
+    assert "nz           =      40," in namelist
+    assert "dx     =   1000.0," in namelist
+    assert "dy     =   1000.0," in namelist
+    assert "dz     =   500.0," in namelist
+    assert "timax  = 7200.0," in namelist
+    assert "dtl    =   6.000," in namelist
+    assert "zd      =  15000.0," in namelist
+    assert "testcase  =  0," in namelist
+    assert "isnd      =  7," in namelist
+    assert "iwnd      =  0," in namelist
+    assert "iinit     =  3," in namelist
+    assert "isfcflx    =      0," in namelist
+    assert "cnst_shflx = 0.0," in namelist
+    assert "output_uh        = 1," in namelist
+
+
 def test_observed_surface_flux_proxy_choices_render_namelist_and_surface_outputs() -> None:
     from igra_fixtures import IGRA_FIXTURE
 

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -362,7 +362,108 @@ def test_differential_surface_forcing_rejects_ellipse_shape(
         )
 
 
-def test_triggered_deep_potential_package_generation_is_removed(
+def test_deep_tower_benchmark_package_uses_stock_iinit3_path(
+    tmp_path: Path,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    candidate_screening = {
+        "candidate_id": "USM00072558-supercell",
+        "primary_story": "supercell_environment",
+        "active_story": "supercell_environment",
+        "active_story_label": "Supercell-like environment",
+        "rank_score": 93.0,
+    }
+
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-deep-tower-benchmark",
+        run_recipe="deep_tower_benchmark",
+        observed_sounding=observed,
+        candidate_screening=candidate_screening,
+    )
+
+    manifest = load_run_manifest(result.manifest_path)
+    report = json.loads(result.report_path.read_text())
+    case_manifest = json.loads((result.package_dir / "case_manifest.json").read_text())
+    namelist = (result.package_dir / "namelist.input").read_text()
+
+    assert manifest.run_recipe == "deep_tower_benchmark"
+    assert manifest.run_recipe_display_name == "Deep-Tower Benchmark"
+    assert manifest.recipe_id == "deep_tower_benchmark_v0"
+    assert manifest.recipe_display_name == "Deep-Tower Benchmark v0"
+    assert manifest.assumption_set_id == "deep_tower_benchmark_v0_assumptions"
+    assert manifest.assumption_mode == "explicit_thermal_initiation"
+    assert manifest.trigger_type == "warm_bubble"
+    assert manifest.trigger_parameters == {
+        "cm1_iinit": 3,
+        "cm1_trigger": (
+            "CM1 built-in three warm bubbles with 2 K maximum potential-temperature "
+            "perturbations in a line near 1.4 km AGL"
+        ),
+        "raw_controls_exposed": False,
+    }
+    assert manifest.manual_validation_status == (
+        "deep_tower_benchmark_iinit3_fort_worth_prior_smoke_validated"
+    )
+    assert manifest.run_configuration["duration"] == "scout_2h"
+    assert manifest.run_configuration["duration_seconds"] == 7200
+    assert manifest.run_configuration["horizontal_cell_count"] == 120
+    assert manifest.run_configuration["domain_size"] == "deep_tower_120km"
+    assert manifest.run_configuration["surface_flux_mode"] == "disabled"
+    assert manifest.run_configuration["surface_flux_cm1_values"]["isfcflx"] == 0
+    assert manifest.run_configuration["surface_flux_cm1_values"]["set_flx"] == 0
+    assert manifest.run_configuration["cm1_values"]["runtime_seconds"] == 7200
+    assert manifest.run_configuration["cm1_values"]["rayleigh_damping_start_m"] == 15000
+    assert manifest.required_output_fields == [
+        "qv",
+        "qc",
+        "w",
+        "qr",
+        "rain",
+        "dbz",
+        "u",
+        "v",
+        "th",
+        "updraft_helicity",
+    ]
+    assert manifest.recipe_assumptions["trigger"]["mode"] == ("cm1_iinit_3_three_warm_bubbles")
+    assert manifest.recipe_assumptions["observed_sounding"]["wind_profile"] == (
+        "required_complete_rendered_u_v_profile"
+    )
+    assert manifest.recipe_assumptions["surface_fluxes"]["mode"] == "disabled"
+    assert manifest.pre_run_validation_report is not None
+    assert manifest.pre_run_validation_report["hypothesis_recipe_alignment"]["status"] == (
+        "aligned"
+    )
+    assert (
+        "Deep-convection ingredients can be tested with the explicit Deep-Tower Benchmark trigger."
+        in manifest.pre_run_validation_report["hypothesis_recipe_alignment"]["reasons"]
+    )
+    assert (
+        "explicit_thermal_initiation_supplied_not_a_real_observed_trigger"
+        in manifest.pre_run_validation_report["caveats"]
+    )
+    assert report["recipe_id"] == "deep_tower_benchmark_v0"
+    assert report["trigger_type"] == "warm_bubble"
+    assert report["variant_metadata"]["surface_flux_mode"] == "disabled"
+    assert "stock CM1 iinit=3 three-warm-bubble" in report["variant_metadata"]["mapping"]
+    assert "explicit stock-CM1 iinit=3" in report["cm1_mapping_status"]
+    assert case_manifest["contract"]["recipe_id"] == "deep_tower_benchmark_v0"
+    assert case_manifest["contract"]["trigger_type"] == "warm_bubble"
+    assert "testcase  =  0," in namelist
+    assert "isnd      =  7," in namelist
+    assert "iinit     =  3," in namelist
+    assert "isfcflx    =      0," in namelist
+    assert "set_flx    =      0," in namelist
+    assert "cnst_shflx = 0.0," in namelist
+    assert "output_uh        = 1," in namelist
+
+
+def test_legacy_triggered_deep_potential_maps_to_deep_tower_benchmark(
     tmp_path: Path,
 ) -> None:
     observed = parse_igra_station_text(
@@ -370,15 +471,22 @@ def test_triggered_deep_potential_package_generation_is_removed(
         uploaded_filename="USM00072558-data-beg2025.txt",
     ).selected_sounding
 
-    with pytest.raises(DryRunPackageError, match="package generation has been removed"):
-        generate_dry_run_package(
-            scenario_data=load_baseline_template(),
-            runtime_home=tmp_path,
-            run_id="run-triggered-removed",
-            run_recipe="triggered_deep_potential",
-            observed_sounding=observed,
-        )
-    assert not (tmp_path / "runs" / "run-triggered-removed").exists()
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-triggered-legacy",
+        run_recipe="triggered_deep_potential",
+        observed_sounding=observed,
+    )
+
+    manifest = load_run_manifest(result.manifest_path)
+    namelist = (result.package_dir / "namelist.input").read_text()
+
+    assert manifest.run_recipe == "deep_tower_benchmark"
+    assert manifest.recipe_id == "deep_tower_benchmark_v0"
+    assert manifest.run_configuration["surface_flux_mode"] == "disabled"
+    assert "testcase  =  0," in namelist
+    assert "iinit     =  3," in namelist
 
 
 def test_pre_run_validation_caveats_deep_hypothesis_under_uniform_forcing(

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -139,6 +139,7 @@ def write_model_netcdf(
     qfx_values: list[float] | None = None,
     qv_values: list[float] | None = None,
     th_values: list[float] | None = None,
+    uh_values: list[float] | None = None,
     z_values: list[float] | None = None,
     include_qc: bool = True,
     include_w: bool = True,
@@ -216,6 +217,12 @@ def write_model_netcdf(
                 for th_value in th_values
             ],
             {"units": "K"},
+        )
+    if uh_values is not None:
+        data_vars["uh"] = (
+            ("time", "y", "x"),
+            [[[uh_value for _x in range(4)] for _y in range(3)] for uh_value in uh_values],
+            {"units": "m2/s2"},
         )
     xr.Dataset(
         data_vars=data_vars,
@@ -386,6 +393,33 @@ def test_ingests_valid_tiny_netcdf_metadata(tmp_path: Path) -> None:
     assert [entry.time_index for entry in product_manifest.time_index] == [0]
     assert product_manifest.time_index[0].source_file == str(netcdf_path)
     assert product_manifest.time_index[0].local_time_index == 0
+
+
+def test_required_updraft_helicity_accepts_cm1_uh_variable(tmp_path: Path) -> None:
+    manifest_path = create_manifest(tmp_path, run_id="run-updraft-helicity-alias")
+    run_dir = manifest_path.parent
+    netcdf_path = run_dir / "cm1out_000001.nc"
+    write_model_netcdf(
+        netcdf_path,
+        times=[0.0],
+        qc_values=[0.0],
+        w_values=[0.0],
+        uh_values=[12.0],
+    )
+    manifest = load_run_manifest(manifest_path)
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(update={"required_output_fields": ["qc", "w", "updraft_helicity"]}),
+    )
+    complete_manifest(manifest_path, OutputMetadata(netcdf_paths=[str(netcdf_path)]))
+
+    result = ingest_completed_run(manifest_path)
+
+    assert set(result.variables) == {"qc", "w", "uh"}
+    assert result.missing_required_output_fields == []
+    assert not any(
+        warning.startswith("Recipe required output fields missing") for warning in result.warnings
+    )
 
 
 def test_result_metadata_serializes_and_lists_from_runtime_home(tmp_path: Path) -> None:

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3863,8 +3863,14 @@ describe("App", () => {
     expect(screenBody).toContain('"story_filter":"deep_convection_trial"');
     const deepCard = screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)");
     expect(deepCard).toHaveTextContent("Supercell-like environment");
+    expect(deepCard).toHaveTextContent(
+      "Deep-tower candidate with stronger screening support; use the benchmark trigger to test the convective ceiling.",
+    );
 
     fireEvent.click(within(deepCard).getByRole("button", { name: "Configure run" }));
+    expect(screen.getByLabelText("Candidate details")).toHaveTextContent(
+      "First run: Deep-Tower Benchmark · stock CM1 iinit=3 · ~120 km · 2 h.",
+    );
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
 
     expect(
@@ -4420,6 +4426,9 @@ describe("App", () => {
     expect(wilmingtonCard).not.toHaveTextContent("Primary: Humid / rainy");
     expect(wilmingtonCard).toHaveTextContent("48.9 % ingredient score");
     expect(wilmingtonCard).toHaveTextContent("testable with Deep-Tower Benchmark");
+    expect(wilmingtonCard).toHaveTextContent(
+      "Caveated deep-tower candidate; use the benchmark trigger to test the convective ceiling.",
+    );
     expect(
       screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
     ).not.toBeInTheDocument();

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -458,10 +458,15 @@ function preRunValidationReportForRequest(body: {
       ? "observed_surface_forced_evolution"
       : "generated_reference_lower_atmosphere");
   const observed = runRecipe === "observed_surface_forced_evolution";
-  const recipeId = observed
+  const deepTower = runRecipe === "deep_tower_benchmark";
+  const recipeId = deepTower
+    ? "deep_tower_benchmark_v0"
+    : observed
       ? "observed_surface_forced_evolution_v0"
       : "generated_reference_lower_atmosphere_v1";
-  const recipeDisplayName = observed
+  const recipeDisplayName = deepTower
+    ? "Deep-Tower Benchmark v0"
+    : observed
       ? "Observed Surface-Forced Evolution v0"
       : "Generated Lower-Atmosphere Reference";
   const activeStory =
@@ -500,19 +505,26 @@ function preRunValidationReportForRequest(body: {
         typeof body.candidate_screening?.rank_score === "number"
           ? body.candidate_screening.rank_score
           : null,
-      predicted_output_signature: observed ? ["qv", "qc", "w", "qr", "rain", "dbz"] : [],
+      predicted_output_signature:
+        observed || deepTower ? ["qv", "qc", "w", "qr", "rain", "dbz"] : [],
     },
     selected_run_recipe: {
       run_recipe: runRecipe,
       recipe_id: recipeId,
-      display_name: observed
+      display_name: deepTower
+        ? "Deep-Tower Benchmark"
+        : observed
           ? "Observed Surface-Forced Evolution"
           : "Generated Lower-Atmosphere Reference",
       recipe_display_name: recipeDisplayName,
-      assumption_set_id: observed
+      assumption_set_id: deepTower
+        ? "deep_tower_benchmark_v0_assumptions"
+        : observed
           ? "observed_surface_forced_evolution_v0_assumptions"
           : "generated_reference_lower_atmosphere_v1",
-      assumption_mode: observed
+      assumption_mode: deepTower
+        ? "explicit_thermal_initiation"
+        : observed
           ? "observed_surface_forced_evolution"
           : "generated_reference",
     },
@@ -918,15 +930,16 @@ function screeningResponseForRequest(init?: RequestInit) {
     .sort((left, right) => compareCandidateFixtures(left, right, storyFilter, storyFamily, sortBy));
   const limitedCandidates = candidates.slice(0, limit);
   const stationDistribution = Array.from(
-    limitedCandidates.reduce((counts, candidate) => {
-      const current = counts.get(candidate.station_id) ?? {
-        station_id: candidate.station_id,
-        station_name: candidate.station_name,
-        count: 0,
-      };
-      counts.set(candidate.station_id, { ...current, count: current.count + 1 });
-      return counts;
-    }, new Map<string, { station_id: string; station_name?: string | null; count: number }>())
+    limitedCandidates
+      .reduce((counts, candidate) => {
+        const current = counts.get(candidate.station_id) ?? {
+          station_id: candidate.station_id,
+          station_name: candidate.station_name,
+          count: 0,
+        };
+        counts.set(candidate.station_id, { ...current, count: current.count + 1 });
+        return counts;
+      }, new Map<string, { station_id: string; station_name?: string | null; count: number }>())
       .values(),
   );
   return {
@@ -3698,9 +3711,7 @@ describe("App", () => {
       screen.getByText("360 min runtime; 900 s output; 25 saved frames; 3 s timestep"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "64 x 64 x 100; dx/dy 100 m; top 18 km, dz 40 m to 600 m stretched",
-      ),
+      screen.getByText("64 x 64 x 100; dx/dy 100 m; top 18 km, dz 40 m to 600 m stretched"),
     ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Local run launchpad" })).toBeInTheDocument();
     expect(
@@ -3795,7 +3806,9 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
     expect(screen.getByRole("heading", { name: "Plan multiple CM1 runs" })).toBeInTheDocument();
-    expect(within(screen.getByLabelText("Run plan")).queryByLabelText("Recipe")).not.toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("Run plan")).queryByLabelText("Recipe"),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Create packages and queue selected runs" }),
@@ -3812,7 +3825,7 @@ describe("App", () => {
     });
   });
 
-  it("stages deep-convection candidates as observed forcing runs", async () => {
+  it("stages deep-convection candidates as Deep-Tower Benchmark runs", async () => {
     const defaultFetch = vi.mocked(fetch).getMockImplementation();
     let dryRunBody = "";
     let screenBody = "";
@@ -3859,10 +3872,16 @@ describe("App", () => {
     ).toBeInTheDocument();
     const runPlan = within(screen.getByLabelText("Run plan"));
     expect(runPlan.queryByLabelText("Recipe")).not.toBeInTheDocument();
-    expect(runPlan.getByLabelText("Surface heat flux")).toHaveValue("8.0e-3");
-    expect(runPlan.getByLabelText("Surface moisture flux")).toHaveValue("5.2e-5");
-    expect(screen.getByText("observed_surface_forced_evolution_v0")).toBeInTheDocument();
-    expect(screen.getByText(/No artificial trigger/i)).toBeInTheDocument();
+    expect(runPlan.getByLabelText("Surface forcing")).toHaveValue("disabled");
+    expect(runPlan.getByLabelText("Surface heat flux")).toHaveValue("0");
+    expect(runPlan.getByLabelText("Surface moisture flux")).toHaveValue("0");
+    expect(runPlan.getByLabelText("Duration")).toHaveValue("scout_2h");
+    expect(runPlan.getByLabelText("Horizontal cells")).toHaveValue("cells_120");
+    expect(runPlan.getByLabelText("Domain size")).toHaveValue("deep_tower_120km");
+    expect(screen.getByText("deep_tower_benchmark_v0")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Explicit initiation is supplied with CM1 iinit=3/i),
+    ).toBeInTheDocument();
     expect(screen.getAllByLabelText(/^Run plan item /)).toHaveLength(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Duplicate variant" }));
@@ -3874,10 +3893,15 @@ describe("App", () => {
     );
 
     await waitFor(() => {
-      expect(dryRunBody).toContain('"run_recipe":"observed_surface_forced_evolution"');
+      expect(dryRunBody).toContain('"run_recipe":"deep_tower_benchmark"');
       expect(dryRunBody).toContain('"diagnostic_set":"full"');
-      expect(dryRunBody).toContain('"surface_heat_flux_k_m_s":"8.0e-3"');
-      expect(dryRunBody).toContain('"surface_moisture_flux_g_g_m_s":"5.2e-5"');
+      expect(dryRunBody).toContain('"duration":"scout_2h"');
+      expect(dryRunBody).toContain('"horizontal_cell_count":"cells_120"');
+      expect(dryRunBody).toContain('"domain_size":"deep_tower_120km"');
+      expect(dryRunBody).toContain('"surface_forcing_mode":"disabled"');
+      expect(dryRunBody).toContain('"surface_heat_flux_k_m_s":"0"');
+      expect(dryRunBody).toContain('"surface_moisture_flux_g_g_m_s":"0"');
+      expect(dryRunBody).toContain('"time_step_seconds":"6.0"');
       expect(dryRunBody).toContain('"candidate_screening"');
       expect(dryRunBody).toContain('"primary_story":"supercell_environment"');
       expect(dryRunBody).toContain('"candidate_id":"USM00072357-2025052000-supercell"');
@@ -3922,7 +3946,9 @@ describe("App", () => {
     expect(
       await screen.findByText("Wilmington, Ohio (USM00072426) added to the run plan"),
     ).toBeInTheDocument();
-    expect(within(screen.getByLabelText("Run plan")).queryByLabelText("Recipe")).not.toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("Run plan")).queryByLabelText("Recipe"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("observed_surface_forced_evolution_v0")).toBeInTheDocument();
 
     fireEvent.click(
@@ -3975,9 +4001,7 @@ describe("App", () => {
     expect(screen.getByText(/Choose the stations and history/)).toBeInTheDocument();
     expect(screen.getByText("Cached soundings ready to search")).toBeInTheDocument();
     expect(screen.queryByLabelText("Save into")).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Search selected soundings" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Search selected soundings" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Advanced filters"));
     fireEvent.change(screen.getByLabelText("Story"), {
@@ -4006,12 +4030,12 @@ describe("App", () => {
     expect(candidateDetails).toHaveTextContent("Run fit");
     expect(candidateDetails).toHaveTextContent("Top limits");
     expect(candidateDetails).not.toHaveTextContent("Scores rank sounding ingredients only");
-    expect(within(candidateDetails).getByText("All evidence").closest("details")).not.toHaveAttribute(
-      "open",
-    );
-    expect(within(candidateDetails).getByText("Feature values").closest("details")).not.toHaveAttribute(
-      "open",
-    );
+    expect(
+      within(candidateDetails).getByText("All evidence").closest("details"),
+    ).not.toHaveAttribute("open");
+    expect(
+      within(candidateDetails).getByText("Feature values").closest("details"),
+    ).not.toHaveAttribute("open");
     expect(within(candidateDetails).queryByLabelText("Tags")).not.toBeInTheDocument();
     fireEvent.click(within(candidateDetails).getByRole("button", { name: "Save candidate" }));
     fireEvent.change(within(candidateDetails).getByLabelText("Tags"), {
@@ -4089,9 +4113,7 @@ describe("App", () => {
       screen.getByRole("heading", { name: "Recommended cached soundings" }),
     ).toBeInTheDocument();
 
-    fireEvent.click(
-      within(selectedValleyCard).getByRole("button", { name: "Configure run" }),
-    );
+    fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Configure run" }));
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
     expect(
       await screen.findByText("Valley, Nebraska (USM00072558) added to the run plan"),
@@ -4293,7 +4315,9 @@ describe("App", () => {
       target: { value: "deep_convection" },
     });
     expect(screen.getByText("Advanced filters").closest("details")).not.toHaveAttribute("open");
-    expect(screen.getByText("Search intent changed; search selected soundings")).toBeInTheDocument();
+    expect(
+      screen.getByText("Search intent changed; search selected soundings"),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Search selected soundings" }));
 
     expect(await screen.findByText("Recommendation run complete")).toBeInTheDocument();
@@ -4304,12 +4328,13 @@ describe("App", () => {
     expect(analyzeBody).toContain('"latest_per_station":null');
     expect(analyzeBody).toContain('"limit":100');
     expect(
-      screen.getByText((content) =>
-        content.includes("5 analyzed from 5 selected cached soundings") &&
-        content.includes("4 stations") &&
-        content.includes("all cached history") &&
-        content.includes("2 matched deep convection stories") &&
-        content.includes("2 shown"),
+      screen.getByText(
+        (content) =>
+          content.includes("5 analyzed from 5 selected cached soundings") &&
+          content.includes("4 stations") &&
+          content.includes("all cached history") &&
+          content.includes("2 matched deep convection stories") &&
+          content.includes("2 shown"),
       ),
     ).toBeInTheDocument();
     expect(
@@ -4367,8 +4392,7 @@ describe("App", () => {
       expect(analyzeBody).toContain('"latest_per_station":3');
     });
     expect(
-      (await screen.findAllByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"))
-        .length,
+      (await screen.findAllByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)")).length,
     ).toBeGreaterThan(0);
   });
 
@@ -4395,7 +4419,7 @@ describe("App", () => {
     expect(wilmingtonCard).toHaveTextContent("High-CAPE pulse storm");
     expect(wilmingtonCard).not.toHaveTextContent("Primary: Humid / rainy");
     expect(wilmingtonCard).toHaveTextContent("48.9 % ingredient score");
-    expect(wilmingtonCard).toHaveTextContent("testable as forced observed evolution");
+    expect(wilmingtonCard).toHaveTextContent("testable with Deep-Tower Benchmark");
     expect(
       screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
     ).not.toBeInTheDocument();
@@ -4460,9 +4484,7 @@ describe("App", () => {
         expect(init?.body).toEqual(expect.stringContaining('"domain_size":"wide_12km"'));
         expect(init?.body).toEqual(expect.stringContaining('"output_cadence":"detailed_5min"'));
         expect(init?.body).toEqual(expect.stringContaining('"diagnostic_set":"full"'));
-        expect(init?.body).toEqual(
-          expect.stringContaining('"surface_heat_flux_k_m_s":"0.04"'),
-        );
+        expect(init?.body).toEqual(expect.stringContaining('"surface_heat_flux_k_m_s":"0.04"'));
         expect(init?.body).toEqual(
           expect.stringContaining('"surface_moisture_flux_g_g_m_s":"1.1e-4"'),
         );
@@ -4961,14 +4983,10 @@ describe("App", () => {
     expect(within(card).getByText("Auto-ingested")).toBeInTheDocument();
     expect(within(card).queryByText("Ready to ingest")).not.toBeInTheDocument();
     expect(within(card).queryByText("Not ingested")).not.toBeInTheDocument();
-    expect(within(card).queryByRole("button", { name: "Ingest output" }))
-      .not.toBeInTheDocument();
-    expect(within(card).queryByRole("button", { name: "Preview cleanup" }))
-      .not.toBeInTheDocument();
-    expect(within(card).getByRole("button", { name: "Open result" }))
-      .toBeInTheDocument();
-    expect(within(card).getByRole("button", { name: "Open in Explore" }))
-      .toBeInTheDocument();
+    expect(within(card).queryByRole("button", { name: "Ingest output" })).not.toBeInTheDocument();
+    expect(within(card).queryByRole("button", { name: "Preview cleanup" })).not.toBeInTheDocument();
+    expect(within(card).getByRole("button", { name: "Open result" })).toBeInTheDocument();
+    expect(within(card).getByRole("button", { name: "Open in Explore" })).toBeInTheDocument();
   });
 
   it("automatically copies back, ingests, and cleans LAN worker output after completion", async () => {
@@ -5618,9 +5636,7 @@ describe("App", () => {
     render(<App />);
 
     const resultDetail = await screen.findByLabelText("Result detail");
-    expect(resultDetail).toHaveTextContent(
-      "Observed Surface-Forced Experiment — Norman, Oklahoma",
-    );
+    expect(resultDetail).toHaveTextContent("Observed Surface-Forced Experiment — Norman, Oklahoma");
     expect(resultDetail).toHaveTextContent("Deep convection formed");
     expect(resultDetail).toHaveTextContent("Screening vs CM1");
     expect(resultDetail).toHaveTextContent("Supercell-like environment");
@@ -7196,7 +7212,9 @@ describe("App", () => {
     expect(within(cameraControls).getByText(/Camera moved down/)).toBeInTheDocument();
     fireEvent.click(within(cameraControls).getByRole("button", { name: "Taller viewport" }));
     expect(within(cameraControls).getByText(/Viewport set taller/)).toBeInTheDocument();
-    expect(within(cameraControls).getByRole("button", { name: "Standard viewport" })).toBeInTheDocument();
+    expect(
+      within(cameraControls).getByRole("button", { name: "Standard viewport" }),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByText("Technical visualization details"));
     expect(screen.getByText("Direct Three.js point cloud")).toBeInTheDocument();
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -54,6 +54,7 @@ type RunConfigurationInput = {
   surface_patch_moisture_flux_perturbation_g_g_m_s: string;
   surface_patch_taper_width_m: string;
   surface_patch_ramp_seconds: string;
+  time_step_seconds?: string;
 };
 
 type SurfaceForcingPatch = {
@@ -417,11 +418,13 @@ type CandidateRecipeFitDisplay = {
 type RunRecipe =
   | "generated_reference_lower_atmosphere"
   | "observed_surface_forced_evolution"
-  | "differential_surface_forced_evolution";
+  | "differential_surface_forced_evolution"
+  | "deep_tower_benchmark";
 
 type ObservedRunRecipe =
   | "observed_surface_forced_evolution"
-  | "differential_surface_forced_evolution";
+  | "differential_surface_forced_evolution"
+  | "deep_tower_benchmark";
 type AtmosphereSourcePath = "cached_recommendations" | "saved_candidates" | "upload_igra_text";
 type SearchIntent =
   | "best_overall"
@@ -435,6 +438,7 @@ type RunPlanQueueTarget = "local" | "lan";
 const CURRENT_OBSERVED_RUN_RECIPE: ObservedRunRecipe = "observed_surface_forced_evolution";
 const DIFFERENTIAL_SURFACE_FORCING_MODE = "differential_surface_forcing_patch_v0";
 const UNIFORM_SURFACE_FORCING_MODE = "constant_uniform_surface_flux_proxy";
+const DISABLED_SURFACE_FORCING_MODE = "disabled";
 type RunPlanItemStatus =
   | "planned"
   | "packaging"
@@ -1545,6 +1549,26 @@ const DEFAULT_OBSERVED_RUN_CONFIGURATION: RunConfigurationInput = {
   surface_patch_ramp_seconds: "1800",
 };
 
+const DEFAULT_DEEP_TOWER_RUN_CONFIGURATION: RunConfigurationInput = {
+  duration: "scout_2h",
+  horizontal_cell_count: "cells_120",
+  domain_size: "deep_tower_120km",
+  output_cadence: "standard_15min",
+  diagnostic_set: "full",
+  surface_forcing_mode: DISABLED_SURFACE_FORCING_MODE,
+  surface_heat_flux_k_m_s: "0",
+  surface_moisture_flux_g_g_m_s: "0",
+  surface_patch_shape: "circle",
+  surface_patch_radius_m: "1500",
+  surface_patch_radius_x_m: "1500",
+  surface_patch_radius_y_m: "1500",
+  surface_patch_heat_flux_perturbation_k_m_s: "4.0e-2",
+  surface_patch_moisture_flux_perturbation_g_g_m_s: "5.0e-5",
+  surface_patch_taper_width_m: "500",
+  surface_patch_ramp_seconds: "1800",
+  time_step_seconds: "6.0",
+};
+
 const SEARCH_INTENT_OPTIONS: Array<{ value: SearchIntent; label: string }> = [
   { value: "best_overall", label: "Best overall recommendations" },
   { value: "deep_convection", label: "Deep-convection ingredients" },
@@ -2180,9 +2204,7 @@ export function App() {
   const [candidateLatestPerStation, setCandidateLatestPerStation] = useState(
     DEFAULT_LATEST_PER_STATION,
   );
-  const [candidateResultLimit, setCandidateResultLimit] = useState(
-    DEFAULT_CANDIDATE_RESULT_LIMIT,
-  );
+  const [candidateResultLimit, setCandidateResultLimit] = useState(DEFAULT_CANDIDATE_RESULT_LIMIT);
   const [candidateStatus, setCandidateStatus] = useState("IGRA cache not checked yet");
   const [candidateError, setCandidateError] = useState<string | null>(null);
   const [candidateScreening, setCandidateScreening] = useState<ScreeningResult | null>(null);
@@ -2948,18 +2970,15 @@ export function App() {
       return;
     }
     const selectedSounding = candidate.selected_sounding_payload;
+    const candidateScreening = candidateScreeningMetadata(candidate, savedCandidate, activeStory);
     setSelectedScenarioId(OBSERVED_SOUNDING_EXPERIMENT_ID);
     setObservedSoundingFilename(candidate.source_file_name);
     setObservedSoundingText(null);
     setObservedSoundingParse(observedSoundingParseFromCandidate(candidate, selectedSounding));
     setObservedSoundingStatus("Candidate loaded from recommendation");
     setObservedSoundingError(null);
-    setSelectedCandidateScreening(
-      candidateScreeningMetadata(candidate, savedCandidate, activeStory),
-    );
-    setRunConfiguration(
-      defaultRunConfigurationForSelection(OBSERVED_SOUNDING_EXPERIMENT_ID),
-    );
+    setSelectedCandidateScreening(candidateScreening);
+    setRunConfiguration(defaultRunConfigurationForCandidateScreening(candidateScreening));
     setDryRun(null);
     setBlockedPreRunValidationReport(null);
     setRunStatus(null);
@@ -3058,7 +3077,7 @@ export function App() {
     updateRunPlanItem(itemId, (item) => ({
       ...item,
       runConfiguration,
-      runRecipe: runRecipeForRunConfiguration(runConfiguration),
+      runRecipe: observedRecipeForSelection(item.candidateScreening, runConfiguration),
       status: "planned",
       message: "Run configuration changed; package not created yet.",
       dryRun: null,
@@ -3119,7 +3138,7 @@ export function App() {
           OBSERVED_SOUNDING_BASE_SCENARIO_ID,
           item.controls,
           item.runConfiguration,
-          runRecipeForRunConfiguration(item.runConfiguration),
+          item.runRecipe,
           item.observedSounding,
           item.candidateScreening,
           packageUserMetadata,
@@ -3204,7 +3223,9 @@ export function App() {
         selectedScenario.id,
         controls,
         runConfiguration,
-        observedSoundingExperimentSelected ? runRecipeForRunConfiguration(runConfiguration) : null,
+        observedSoundingExperimentSelected
+          ? observedRecipeForSelection(selectedCandidateScreening, runConfiguration)
+          : null,
         observedSoundingExperimentSelected ? observedSoundingParse?.selected_sounding : null,
         observedSoundingExperimentSelected ? selectedCandidateScreening : null,
         packageUserMetadata,
@@ -4653,13 +4674,13 @@ function RunConfigurationPanel({
   onChange,
   embedded = false,
 }: {
-	  configuration: RunConfigurationInput;
-	  preview: RunConfiguration;
-	  selectedCandidateScreening?: Record<string, unknown> | null;
-	  onAddToRunPlan?: () => void;
-	  onChange: (configuration: RunConfigurationInput) => void;
-	  embedded?: boolean;
-	}) {
+  configuration: RunConfigurationInput;
+  preview: RunConfiguration;
+  selectedCandidateScreening?: Record<string, unknown> | null;
+  onAddToRunPlan?: () => void;
+  onChange: (configuration: RunConfigurationInput) => void;
+  embedded?: boolean;
+}) {
   const recipeMismatchWarning = selectedCandidateScreening
     ? candidateRecipeMismatchWarning(selectedCandidateScreening)
     : null;
@@ -4827,9 +4848,7 @@ function RunConfigurationPanel({
       )}
 
       {selectedCandidateScreening && (
-        <ObservedRunRecipePanel
-          selectedCandidateScreening={selectedCandidateScreening}
-        />
+        <ObservedRunRecipePanel selectedCandidateScreening={selectedCandidateScreening} />
       )}
 
       <details className="technical-details">
@@ -5267,8 +5286,7 @@ function ObservedAtmosphereCandidatesPanel({
           <p className="eyebrow">Observed atmosphere</p>
           <h3 id="sounding-candidates-title">Find interesting soundings</h3>
           <p className="field-help">
-            Choose the stations and history to search, then review the matching candidate
-            evidence.
+            Choose the stations and history to search, then review the matching candidate evidence.
           </p>
         </div>
         <p className="state-chip" role="status">
@@ -5380,7 +5398,9 @@ function ObservedAtmosphereCandidatesPanel({
             <button
               type="button"
               className={
-                stationSelectionMode === "all_cached" ? "active-secondary-button" : "secondary-button"
+                stationSelectionMode === "all_cached"
+                  ? "active-secondary-button"
+                  : "secondary-button"
               }
               onClick={onSelectAllCachedStations}
             >
@@ -5449,11 +5469,7 @@ function ObservedAtmosphereCandidatesPanel({
           <Metric label="Region" value={catalog?.region.label ?? "Great Plains / Midwest"} />
           <Metric
             label="Catalog"
-            value={
-              catalog?.refreshed_at
-                ? formatDate(catalog.refreshed_at)
-                : "Not refreshed here"
-            }
+            value={catalog?.refreshed_at ? formatDate(catalog.refreshed_at) : "Not refreshed here"}
           />
           <Metric label="Station files" value={cachedStationFiles.toLocaleString()} />
           <Metric label="Parsed soundings" value={cachedInventorySummary} />
@@ -5627,13 +5643,9 @@ function ObservedAtmosphereCandidatesPanel({
                   ? "Refined candidates"
                   : "Recommended cached soundings"}
               </h4>
-              <p className="field-help">
-                {filterTraceSummary.summary}
-              </p>
+              <p className="field-help">{filterTraceSummary.summary}</p>
               {filterTraceSummary.detail && (
-                <p className="field-help candidate-filter-detail">
-                  {filterTraceSummary.detail}
-                </p>
+                <p className="field-help candidate-filter-detail">{filterTraceSummary.detail}</p>
               )}
             </div>
           )}
@@ -6031,11 +6043,7 @@ function SoundingCandidateDetail({
         >
           Configure run
         </button>
-        <button
-          type="button"
-          className="secondary-button"
-          onClick={() => setSaveDrawerOpen(true)}
-        >
+        <button type="button" className="secondary-button" onClick={() => setSaveDrawerOpen(true)}>
           {savedCandidate ? "Edit saved notes" : "Save candidate"}
         </button>
       </div>
@@ -6102,7 +6110,9 @@ function SoundingCandidateDetail({
       </section>
       <section className="candidate-detail-section">
         <h5>Run fit</h5>
-        <p className="candidate-interest-summary">{candidateKeyNote(candidate, story, recipeFit)}</p>
+        <p className="candidate-interest-summary">
+          {candidateKeyNote(candidate, story, recipeFit)}
+        </p>
         <p className="field-help">{recipeFit.summary}</p>
       </section>
       <section className="candidate-detail-section">
@@ -6485,7 +6495,11 @@ function ObservedRunRecipePanel({
       <dl className="compact-metrics">
         <Metric
           label="Run scope"
-          value="CM1 evolves the observed profile with the selected lower-boundary heat/moisture forcing."
+          value={
+            activeStory && deepConvectionStoryIds.has(activeStory)
+              ? "CM1 evolves the observed profile with explicit idealized thermal initiation."
+              : "CM1 evolves the observed profile with the selected lower-boundary heat/moisture forcing."
+          }
         />
       </dl>
     </details>
@@ -6788,9 +6802,7 @@ function RunPlanConfigurationFields({
             units="g/g m/s"
             description="Added to background after taper and ramp."
             value={item.runConfiguration.surface_patch_moisture_flux_perturbation_g_g_m_s}
-            onChange={(value) =>
-              update("surface_patch_moisture_flux_perturbation_g_g_m_s", value)
-            }
+            onChange={(value) => update("surface_patch_moisture_flux_perturbation_g_g_m_s", value)}
           />
           <RunConfigurationTextInput
             id={`run-plan-surface-patch-taper-${item.id}`}
@@ -7916,12 +7928,8 @@ function PipelineRunCard({
             tone={runQueueEntryTone(queueEntry)}
           />
         )}
-        {!resultBacked && resultPending && (
-          <StatusBadge label="Result pending" tone="neutral" />
-        )}
-        {!resultBacked && !resultPending && (
-          <StatusBadge label="Not ingested" tone="neutral" />
-        )}
+        {!resultBacked && resultPending && <StatusBadge label="Result pending" tone="neutral" />}
+        {!resultBacked && !resultPending && <StatusBadge label="Not ingested" tone="neutral" />}
       </div>
       <p>
         {humanize(result?.scenario_id ?? run.scenario_id ?? "unknown scenario")} ·{" "}
@@ -8169,9 +8177,7 @@ function queueEntryHasIngestedResult(entry: RunQueueEntry | undefined): boolean 
 }
 
 function latestAutoIngestedQueueEntry(queue: RunQueueResponse): RunQueueEntry | undefined {
-  return [...queue.entries]
-    .reverse()
-    .find((entry) => queueEntryHasIngestedResult(entry));
+  return [...queue.entries].reverse().find((entry) => queueEntryHasIngestedResult(entry));
 }
 
 function queueEntryForRun(
@@ -9020,14 +9026,8 @@ function LocalizedResponseSummary({ result }: { result: ResultCard }) {
       </div>
       <dl className="metric-grid">
         <Metric label="Patch" value={patchGeometryLabel(geometry)} />
-        <Metric
-          label="Heat footprint"
-          value={patchRatioLabel(response.hfx_footprint, "hfx")}
-        />
-        <Metric
-          label="Moisture footprint"
-          value={patchRatioLabel(response.qfx_footprint, "qfx")}
-        />
+        <Metric label="Heat footprint" value={patchRatioLabel(response.hfx_footprint, "hfx")} />
+        <Metric label="Moisture footprint" value={patchRatioLabel(response.qfx_footprint, "qfx")} />
         <Metric
           label="Near-surface convergence"
           value={convergenceLabel(response.near_surface_convergence)}
@@ -9094,16 +9094,14 @@ function patchRatioLabel(field: PatchSpatialFieldDiagnostics, label: string): st
 
 function convergenceLabel(convergence: PatchConvergenceDiagnostics): string {
   if (!convergence.available) return "Unavailable";
-  const fields = convergence.source_fields.length > 0 ? convergence.source_fields.join("/") : "winds";
+  const fields =
+    convergence.source_fields.length > 0 ? convergence.source_fields.join("/") : "winds";
   const time =
     convergence.time_seconds !== null && convergence.time_seconds !== undefined
       ? ` at ${formatNumber(convergence.time_seconds, "s")}`
       : "";
   const quality = convergence.quality_state ? `; ${humanize(convergence.quality_state)}` : "";
-  return `${formatScientific(
-    convergence.max_convergence_s_1 ?? null,
-    "s^-1",
-  )}; max ${formatNumber(
+  return `${formatScientific(convergence.max_convergence_s_1 ?? null, "s^-1")}; max ${formatNumber(
     convergence.max_convergence_distance_from_patch_center_m ?? null,
     "m from center",
   )}${time}; ${fields}${quality}`;
@@ -11244,17 +11242,17 @@ function candidateRecipeFitForStory(
   }
   if (deepConvectionStoryIds.has(story)) {
     const caveats = [
-      "deep_convection_outcome_depends_on_surface_forcing_duration_domain_and_resolution",
-      "differential_surface_forcing_patch_recipe_available_for_initiation_tests",
+      "deep_convection_outcome_depends_on_explicit_trigger_duration_domain_and_resolution",
+      "deep_tower_benchmark_uses_idealized_warm_bubbles_not_observed_boundary",
     ];
     if (candidate.features.observed_wind_available !== true) {
       caveats.push("complete_observed_wind_profile_required_for_input_sounding");
     }
     return {
       status: "partially_testable",
-      label: "testable as forced observed evolution",
+      label: "testable with Deep-Tower Benchmark",
       summary:
-        "This story screens deep-convection ingredients. CM1 can evolve the observed atmosphere under the selected lower-boundary forcing; choose the differential surface patch when localized initiation is the question.",
+        "This story screens deep-convection ingredients. CM1 can evolve the observed atmosphere with the explicit Deep-Tower Benchmark trigger; use surface-forced recipes when lower-boundary initiation is the question.",
       caveats,
     };
   }
@@ -11311,7 +11309,7 @@ function observedRecipeHypothesisSummary(story: CandidateStoryId | null): string
     return "Inspect cloud, updraft, moisture, and precipitation evolution without a saved pre-run story.";
   }
   if (deepConvectionStoryIds.has(story)) {
-    return "Deep-convection ingredients are present; check whether the selected lower-boundary forcing, duration, domain, and resolution produce deep cloud, strong updraft, and precipitation signatures.";
+    return "Deep-convection ingredients are present; check whether explicit thermal initiation produces deep cloud, strong updraft, and precipitation signatures.";
   }
   switch (story) {
     case "shallow_cumulus_candidate":
@@ -11392,7 +11390,7 @@ function observedRecipeFitSummary(
     return fitSummary;
   }
   if (story && deepConvectionStoryIds.has(story)) {
-    return "Inspectable under the selected surface forcing; deep outcomes depend on duration, domain, resolution, and later differential-forcing support.";
+    return "Inspectable with the explicit Deep-Tower Benchmark trigger; deep outcomes still depend on duration, domain, resolution, and CM1 output fields.";
   }
   return "The selected observed-sounding method can inspect this story when duration, cadence, and requested fields are adequate.";
 }
@@ -11425,7 +11423,7 @@ function candidateRecipeMismatchWarning(
             score.support !== "unavailable",
         )));
   if (hasMeaningfulDeepStory) {
-    return "This candidate was screened for deep-convection potential. This run will test how it evolves under the selected lower-boundary forcing; deep outcomes still depend on duration, domain, resolution, and diagnostics.";
+    return "This candidate was screened for deep-convection potential. This run will test how it evolves under explicit thermal initiation; deep outcomes still depend on duration, domain, resolution, and diagnostics.";
   }
   const hasHumidRainyStory =
     activeStory === "humid_rainy_candidate" ||
@@ -11528,7 +11526,10 @@ function candidateActiveStoryId(
   if (candidate.active_story && scopedStories.has(candidate.active_story)) {
     return candidate.active_story;
   }
-  return candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter)?.story ?? candidate.primary_story;
+  return (
+    candidateActiveStoryScore(candidate, storyFilter, storyFamilyFilter)?.story ??
+    candidate.primary_story
+  );
 }
 
 function candidateDisplayStoryLabel(
@@ -11538,7 +11539,9 @@ function candidateDisplayStoryLabel(
 ): string {
   const activeStory = candidateActiveStoryId(candidate, storyFilter, storyFamilyFilter);
   if (candidate.active_story === activeStory) {
-    return candidate.display_story ?? candidate.active_story_label ?? candidateStoryLabel(activeStory);
+    return (
+      candidate.display_story ?? candidate.active_story_label ?? candidateStoryLabel(activeStory)
+    );
   }
   return candidateStoryLabel(activeStory);
 }
@@ -11624,7 +11627,7 @@ function candidateKeyNote(
     return candidateTopLimits(candidate, story, recipeFit)[0] ?? "Needs review before run setup.";
   }
   if (candidateStoryFamilyForStory(story) === "deep_convection") {
-    return "Strong signal, but initiation may need more than uniform forcing.";
+    return "Strong signal; use the benchmark trigger to inspect the convective ceiling.";
   }
   if (
     story === "humid_rainy_candidate" ||
@@ -11741,8 +11744,7 @@ function candidateFilterTraceSummary(
       : filters.storyFamilyFilter !== "all"
         ? trace.stage_counts.story_family
         : undefined;
-  const supportStage =
-    filters.supportFilter !== "all" ? trace.stage_counts.support : undefined;
+  const supportStage = filters.supportFilter !== "all" ? trace.stage_counts.support : undefined;
   const readinessStage =
     filters.readinessFilter !== "all" ? trace.stage_counts.readiness : undefined;
   const stationDistribution = trace.station_distribution ?? [];
@@ -11751,8 +11753,7 @@ function candidateFilterTraceSummary(
     trace.history_scope === "latest_per_station" && trace.latest_per_station
       ? `latest ${trace.latest_per_station.toLocaleString()} per station`
       : "all cached history";
-  const selectedStations =
-    trace.selected_station_count ?? stationDistribution.length;
+  const selectedStations = trace.selected_station_count ?? stationDistribution.length;
   const selectedSoundings = trace.selected_cached_soundings ?? trace.analyzed_soundings;
   const parts = [
     `${trace.analyzed_soundings.toLocaleString()} analyzed from ${selectedSoundings.toLocaleString()} selected cached sounding${selectedSoundings === 1 ? "" : "s"}`,
@@ -11788,7 +11789,8 @@ function candidateTraceScopeLabel(
   storyFamilyFilter: CandidateStoryFamilyFilter,
 ): string {
   if (storyFilter !== "all") return candidateStoryLabel(storyFilter).toLowerCase();
-  if (storyFamilyFilter !== "all") return candidateStoryFamilyLabel(storyFamilyFilter).toLowerCase();
+  if (storyFamilyFilter !== "all")
+    return candidateStoryFamilyLabel(storyFamilyFilter).toLowerCase();
   return "selected intent";
 }
 
@@ -11928,7 +11930,7 @@ function runPlanItemFromUploadedSounding({
     observedSounding,
     candidateScreening: selectedCandidateScreening,
     activeStory: observedRecipeStoryId(selectedCandidateScreening),
-    runRecipe: runRecipeForRunConfiguration(runConfiguration),
+    runRecipe: observedRecipeForSelection(selectedCandidateScreening, runConfiguration),
     runConfiguration,
     controls,
     queueTarget: "local",
@@ -12078,13 +12080,51 @@ function staticRecipeMetadata(runRecipe: ObservedRunRecipe = CURRENT_OBSERVED_RU
   requiredOutputFields: string[];
   recipeCaveats: string[];
 } {
+  if (runRecipe === "deep_tower_benchmark") {
+    return {
+      recipeId: "deep_tower_benchmark_v0",
+      recipeDisplayName: "Deep-Tower Benchmark v0",
+      assumptionSetId: "deep_tower_benchmark_v0_assumptions",
+      assumptionMode: "explicit_thermal_initiation",
+      requiredOutputFields: [
+        "qv",
+        "qc",
+        "w",
+        "qr",
+        "rain",
+        "dbz",
+        "u",
+        "v",
+        "th",
+        "updraft_helicity",
+      ],
+      recipeCaveats: [
+        "Explicit initiation is supplied with CM1 iinit=3 three warm bubbles.",
+        "The warm bubbles are an idealized trigger, not a real front, dryline, terrain feature, or observed boundary.",
+        "Surface heat/moisture fluxes, radiation, terrain, GIS surface initialization, and large-scale forcing are not part of v0.",
+      ],
+    };
+  }
   if (runRecipe === "differential_surface_forced_evolution") {
     return {
       recipeId: "differential_surface_forced_evolution_v0",
       recipeDisplayName: "Differential Surface-Forced Evolution v0",
       assumptionSetId: "differential_surface_forced_evolution_v0_assumptions",
       assumptionMode: "differential_surface_forced_evolution",
-      requiredOutputFields: ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "qfx", "u", "v", "th", "updraft_helicity"],
+      requiredOutputFields: [
+        "qv",
+        "qc",
+        "w",
+        "qr",
+        "rain",
+        "dbz",
+        "hfx",
+        "qfx",
+        "u",
+        "v",
+        "th",
+        "updraft_helicity",
+      ],
       recipeCaveats: [
         "No artificial atmospheric trigger is applied.",
         "A centered lower-boundary heat/moisture forcing patch is applied through Cloud Chamber's external CM1 source customization.",
@@ -12112,8 +12152,11 @@ function compactRecipeAssumptions(assumptions: Record<string, unknown> | undefin
   const radiation = assumptions?.radiation;
   const largeScaleForcing = assumptions?.large_scale_forcing;
   const triggerLabel =
-    trigger && typeof trigger === "object" && "mode" in trigger && trigger.mode === "none"
-      ? "No artificial trigger"
+    trigger &&
+    typeof trigger === "object" &&
+    "mode" in trigger &&
+    trigger.mode === "cm1_iinit_3_three_warm_bubbles"
+      ? "CM1 iinit=3 three warm bubbles"
       : "No artificial trigger";
   const fluxLabel =
     surfaceFluxes &&
@@ -12121,7 +12164,12 @@ function compactRecipeAssumptions(assumptions: Record<string, unknown> | undefin
     "mode" in surfaceFluxes &&
     surfaceFluxes.mode === DIFFERENTIAL_SURFACE_FORCING_MODE
       ? "differential surface forcing patch"
-      : "numeric uniform surface fluxes";
+      : surfaceFluxes &&
+          typeof surfaceFluxes === "object" &&
+          "mode" in surfaceFluxes &&
+          surfaceFluxes.mode === DISABLED_SURFACE_FORCING_MODE
+        ? "surface fluxes disabled"
+        : "numeric uniform surface fluxes";
   const radiationLabel =
     radiation &&
     typeof radiation === "object" &&
@@ -12623,6 +12671,7 @@ function parseTags(value: string): string[] {
 
 const DURATION_OPTIONS = [
   { value: "smoke_1h", label: "Smoke check (1 h)" },
+  { value: "scout_2h", label: "Scout evolution (2 h)" },
   { value: "short_6h", label: "Short evolution (6 h)" },
   { value: "standard_12h", label: "Standard evolution (12 h)" },
   { value: "long_24h", label: "Long evolution (24 h)" },
@@ -12631,6 +12680,7 @@ const DURATION_OPTIONS = [
 const HORIZONTAL_CELL_OPTIONS = [
   { value: "cells_64", label: "Scout (64 x 64)" },
   { value: "cells_96", label: "Light (96 x 96)" },
+  { value: "cells_120", label: "Deep-tower scout (120 x 120)" },
   { value: "cells_128", label: "Standard (128 x 128)" },
   { value: "cells_192", label: "Detailed (192 x 192)" },
   { value: "cells_256", label: "High detail (256 x 256)" },
@@ -12642,6 +12692,7 @@ const DOMAIN_OPTIONS = [
   { value: "wide_12km", label: "Wide 12 km" },
   { value: "regional_60km", label: "Regional 60 km" },
   { value: "regional_120km", label: "Regional 120 km" },
+  { value: "deep_tower_120km", label: "Deep tower 120 km" },
 ];
 
 const OUTPUT_CADENCE_OPTIONS = [
@@ -12653,6 +12704,7 @@ const OUTPUT_CADENCE_OPTIONS = [
 const SURFACE_FORCING_OPTIONS = [
   { value: UNIFORM_SURFACE_FORCING_MODE, label: "Uniform surface forcing" },
   { value: DIFFERENTIAL_SURFACE_FORCING_MODE, label: "Differential surface patch" },
+  { value: DISABLED_SURFACE_FORCING_MODE, label: "Disabled surface fluxes" },
 ];
 
 function defaultRunConfigurationForSelection(scenarioId: string): RunConfigurationInput {
@@ -12662,10 +12714,41 @@ function defaultRunConfigurationForSelection(scenarioId: string): RunConfigurati
   return { ...DEFAULT_SHALLOW_RUN_CONFIGURATION };
 }
 
+function defaultRunConfigurationForCandidateScreening(
+  selectedCandidateScreening: Record<string, unknown> | null,
+): RunConfigurationInput {
+  if (selectedCandidateUsesDeepTowerRecipe(selectedCandidateScreening)) {
+    return { ...DEFAULT_DEEP_TOWER_RUN_CONFIGURATION };
+  }
+  return { ...DEFAULT_OBSERVED_RUN_CONFIGURATION };
+}
+
 function runRecipeForRunConfiguration(configuration: RunConfigurationInput): ObservedRunRecipe {
-  return configuration.surface_forcing_mode === DIFFERENTIAL_SURFACE_FORCING_MODE
-    ? "differential_surface_forced_evolution"
-    : CURRENT_OBSERVED_RUN_RECIPE;
+  const surfaceForcingMode = surfaceForcingModeValue(configuration.surface_forcing_mode);
+  if (surfaceForcingMode === DIFFERENTIAL_SURFACE_FORCING_MODE) {
+    return "differential_surface_forced_evolution";
+  }
+  if (surfaceForcingMode === DISABLED_SURFACE_FORCING_MODE) {
+    return "deep_tower_benchmark";
+  }
+  return CURRENT_OBSERVED_RUN_RECIPE;
+}
+
+function observedRecipeForSelection(
+  selectedCandidateScreening: Record<string, unknown> | null,
+  configuration: RunConfigurationInput,
+): ObservedRunRecipe {
+  if (configuration.surface_forcing_mode === DIFFERENTIAL_SURFACE_FORCING_MODE) {
+    return "differential_surface_forced_evolution";
+  }
+  return runRecipeForRunConfiguration(configuration);
+}
+
+function selectedCandidateUsesDeepTowerRecipe(
+  selectedCandidateScreening: Record<string, unknown> | null,
+): boolean {
+  const story = observedRecipeStoryId(selectedCandidateScreening);
+  return Boolean(story && deepConvectionStoryIds.has(story));
 }
 
 function previewRunConfiguration(configuration: RunConfigurationInput): RunConfiguration {
@@ -12674,14 +12757,20 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
   const domain = domainValue(configuration.domain_size);
   const cadence = cadenceValue(configuration.output_cadence);
   const diagnosticSet = { value: "full" };
-  const surfaceForcingMode =
-    configuration.surface_forcing_mode === DIFFERENTIAL_SURFACE_FORCING_MODE
-      ? DIFFERENTIAL_SURFACE_FORCING_MODE
-      : UNIFORM_SURFACE_FORCING_MODE;
-  const heatFlux = numericConfigurationValue(configuration.surface_heat_flux_k_m_s, 8.0e-3);
-  const moistureFlux = numericConfigurationValue(
-    configuration.surface_moisture_flux_g_g_m_s,
-    5.2e-5,
+  const surfaceForcingMode = surfaceForcingModeValue(configuration.surface_forcing_mode);
+  const surfaceFluxEnabled = surfaceForcingMode !== DISABLED_SURFACE_FORCING_MODE;
+  const deepTowerShape =
+    surfaceForcingMode === DISABLED_SURFACE_FORCING_MODE &&
+    configuration.domain_size === "deep_tower_120km";
+  const heatFlux = surfaceFluxEnabled
+    ? numericConfigurationValue(configuration.surface_heat_flux_k_m_s, 8.0e-3)
+    : 0;
+  const moistureFlux = surfaceFluxEnabled
+    ? numericConfigurationValue(configuration.surface_moisture_flux_g_g_m_s, 5.2e-5)
+    : 0;
+  const timeStepSeconds = numericConfigurationValue(
+    configuration.time_step_seconds,
+    deepTowerShape ? 6 : 3,
   );
   const nx = horizontalCells.cells;
   const ny = horizontalCells.cells;
@@ -12693,8 +12782,14 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
   if (duration.mode === "smoke") {
     caveats.push("short_smoke_mode_is_for_package_health_not_science_evolution");
   }
-  if (duration.mode === "science") {
+  if (duration.mode === "science" && duration.seconds >= 21600) {
     caveats.push("science_run_configuration_minimum_duration_6h");
+  }
+  if (duration.mode === "science" && duration.seconds < 21600) {
+    caveats.push("short_scout_duration_for_initial_deep_tower_chase");
+  }
+  if (domain.value === "deep_tower_120km") {
+    caveats.push("storm_scale_domain_for_explicit_deep_tower_initiation");
   }
   if (
     horizontalCells.cells >= 256 ||
@@ -12706,6 +12801,9 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
   }
   if (heatFlux < 0 || moistureFlux < 0) {
     caveats.push("surface_flux_values_must_be_non_negative");
+  }
+  if (timeStepSeconds !== 3) {
+    caveats.push("non_default_timestep_target_requires_like_for_like_campaign_evidence");
   }
   const patchShape = "circle";
   const patchRadiusM = numericConfigurationValue(configuration.surface_patch_radius_m, 1500);
@@ -12771,17 +12869,17 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
     }
   }
   const surfaceFluxCm1Values: RunConfigurationSurfaceFluxCM1Values = {
-    isfcflx: 1,
-    sfcmodel: 1,
-    oceanmodel: 1,
-    set_flx: 1,
+    isfcflx: surfaceFluxEnabled ? 1 : 0,
+    sfcmodel: surfaceFluxEnabled ? 1 : 0,
+    oceanmodel: surfaceFluxEnabled ? 1 : 0,
+    set_flx: surfaceFluxEnabled ? 1 : 0,
     cnst_shflx: heatFlux,
     cnst_shflx_units: "K m/s",
     cnst_lhflx: moistureFlux,
     cnst_lhflx_units: "g/g m/s",
     set_znt: 0,
     cnst_znt: 0,
-    set_ust: 1,
+    set_ust: surfaceFluxEnabled ? 1 : 0,
     cnst_ust: 0.28,
   };
   const cm1Values: RunConfigurationCM1Values = {
@@ -12799,11 +12897,11 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
     model_top_m: domain.modelTopM,
     domain_x_km: domain.xKm,
     domain_y_km: domain.yKm,
-    time_step_seconds: 3,
+    time_step_seconds: timeStepSeconds,
     runtime_seconds: duration.seconds,
     output_cadence_seconds: cadence.seconds,
     restart_cadence_seconds: Math.max(cadence.seconds, Math.min(duration.seconds, 10800)),
-    rayleigh_damping_start_m: 12000,
+    rayleigh_damping_start_m: deepTowerShape ? 15000 : 12000,
     expected_output_frames: expectedFrames,
     grid_cell_count: gridCellCount,
   };
@@ -12833,7 +12931,9 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
     surface_flux_summary:
       surfaceForcingMode === DIFFERENTIAL_SURFACE_FORCING_MODE && surfaceForcingPatch
         ? `Differential warm/moist surface patch; source customization required at launch; background H ${formatCompactNumber(heatFlux)} K m/s, M ${formatCompactNumber(moistureFlux)} g/g m/s; patch +H ${formatCompactNumber(patchHeatPerturbation)} K m/s, +M ${formatCompactNumber(patchMoisturePerturbation)} g/g m/s; ${formatMeters(patchRadiusXM)} x ${formatMeters(patchRadiusYM)} ${patchShape}`
-        : `Surface heat flux ${formatCompactNumber(heatFlux)} K m/s; surface moisture flux ${formatCompactNumber(moistureFlux)} g/g m/s; constant uniform proxy`,
+        : surfaceForcingMode === DISABLED_SURFACE_FORCING_MODE
+          ? "Surface heat/moisture flux forcing disabled"
+          : `Surface heat flux ${formatCompactNumber(heatFlux)} K m/s; surface moisture flux ${formatCompactNumber(moistureFlux)} g/g m/s; constant uniform proxy`,
     surface_flux_cm1_values: surfaceFluxCm1Values,
     surface_forcing_patch: surfaceForcingPatch,
     surface_flux_caveats:
@@ -12843,18 +12943,26 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
             "differential_surface_forcing_patch_requires_cm1_source_customization",
             "differential_surface_forcing_patch_requires_emitted_flux_and_convergence_validation",
           ]
-        : [
-            "surface_flux_proxy_constant_uniform_not_place_time_energy_budget",
-            "surface_flux_proxy_not_real_land_surface_or_evaporation_model",
-            "surface_flux_proxy_values_need_local_smoke_validation",
-          ],
+        : surfaceForcingMode === DISABLED_SURFACE_FORCING_MODE
+          ? []
+          : [
+              "surface_flux_proxy_constant_uniform_not_place_time_energy_budget",
+              "surface_flux_proxy_not_real_land_surface_or_evaporation_model",
+              "surface_flux_proxy_values_need_local_smoke_validation",
+            ],
     caveats,
   };
 }
 
-function numericConfigurationValue(value: string, fallback: number): number {
+function numericConfigurationValue(value: string | undefined, fallback: number): number {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function surfaceForcingModeValue(value: string): string {
+  if (value === DIFFERENTIAL_SURFACE_FORCING_MODE) return DIFFERENTIAL_SURFACE_FORCING_MODE;
+  if (value === DISABLED_SURFACE_FORCING_MODE) return DISABLED_SURFACE_FORCING_MODE;
+  return UNIFORM_SURFACE_FORCING_MODE;
 }
 
 function durationValue(value: string): {
@@ -12863,6 +12971,7 @@ function durationValue(value: string): {
   label: string;
 } {
   if (value === "smoke_1h") return { seconds: 3600, mode: "smoke", label: "Smoke check" };
+  if (value === "scout_2h") return { seconds: 7200, mode: "science", label: "Scout evolution" };
   if (value === "standard_12h") {
     return { seconds: 43200, mode: "science", label: "Standard evolution" };
   }
@@ -12873,6 +12982,7 @@ function durationValue(value: string): {
 function horizontalCellValue(value: string): { cells: number; label: string } {
   if (value === "cells_64") return { cells: 64, label: "Scout 64 x 64" };
   if (value === "cells_96") return { cells: 96, label: "Light 96 x 96" };
+  if (value === "cells_120") return { cells: 120, label: "Deep-tower scout 120 x 120" };
   if (value === "cells_192") return { cells: 192, label: "Detailed 192 x 192" };
   if (value === "cells_256") return { cells: 256, label: "High detail 256 x 256" };
   if (value === "cells_384") return { cells: 384, label: "Very high detail 384 x 384" };
@@ -12941,6 +13051,22 @@ function domainValue(value: string): {
       label: "Regional 120 km",
     };
   }
+  if (value === "deep_tower_120km") {
+    return {
+      value,
+      xKm: 120,
+      yKm: 120,
+      nz: 40,
+      dzM: 500,
+      stretchZ: 0,
+      strBotM: 0,
+      strTopM: 2000,
+      dzBotM: 125,
+      dzTopM: 500,
+      modelTopM: 20000,
+      label: "Storm 120 km",
+    };
+  }
   return {
     value: "local_6km",
     xKm: 6.4,
@@ -13003,11 +13129,7 @@ function runConfigurationVerticalSummary(values: RunConfigurationCM1Values): str
 }
 
 function runConfigurationSummaryVertical(details: RunConfigurationSummary): string {
-  if (
-    details.stretch_z === 1 &&
-    details.dz_bot_m !== undefined &&
-    details.dz_top_m !== undefined
-  ) {
+  if (details.stretch_z === 1 && details.dz_bot_m !== undefined && details.dz_top_m !== undefined) {
     return `top ${formatKilometers(details.model_top_m)}, dz ${formatMeters(details.dz_bot_m)} to ${formatMeters(details.dz_top_m)} stretched`;
   }
   return `top ${formatKilometers(details.model_top_m)}, dz ${formatMeters(details.dz_m)}`;

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -11627,7 +11627,17 @@ function candidateKeyNote(
     return candidateTopLimits(candidate, story, recipeFit)[0] ?? "Needs review before run setup.";
   }
   if (candidateStoryFamilyForStory(story) === "deep_convection") {
-    return "Strong signal; use the benchmark trigger to inspect the convective ceiling.";
+    const activeSupport =
+      candidate.active_story === story
+        ? candidate.active_story_support
+        : candidate.story_scores.find((score) => score.story === story)?.support;
+    if (activeSupport === "supported") {
+      return "Deep-tower candidate with stronger screening support; use the benchmark trigger to test the convective ceiling.";
+    }
+    if (activeSupport === "weak") {
+      return "Caveated deep-tower candidate; use the benchmark trigger to test the convective ceiling.";
+    }
+    return "Deep-tower candidate; use the benchmark trigger to test the convective ceiling.";
   }
   if (
     story === "humid_rainy_candidate" ||
@@ -11693,9 +11703,11 @@ function candidateRunRecommendation(
   }
   if (candidateStoryFamilyForStory(story) === "deep_convection") {
     return {
-      title: "First run: Wide 12 km · 6 h · baseline surface forcing.",
-      detail: "Cheap scout run before trying longer regional runs.",
-      followUp: "Next if scout stays shallow: stronger heat + moisture forcing.",
+      title: "First run: Deep-Tower Benchmark · stock CM1 iinit=3 · ~120 km · 2 h.",
+      detail:
+        "Disable surface fluxes and use explicit thermal initiation to test this observed atmosphere's convective ceiling.",
+      followUp:
+        "Inspect cloud depth, updraft, precipitation, and reflectivity before changing the trigger or resolution.",
     };
   }
   if (story === "dry_failed_candidate" || story === "capped_suppressed_candidate") {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -336,9 +336,13 @@ generated lower-atmosphere references use a six-hour local-domain science run,
 and uploaded or cached observed soundings use observed surface-forced evolution
 with numeric uniform surface heat/moisture forcing, complete observed
 temperature/moisture/wind input, full output fields, and a wider default domain.
-Deep-convection candidates are candidate stories under that run configuration,
-not a separate hidden package family or storm-domain route. One-hour smoke mode
-is an explicit package-health check, not the default science path.
+Cached observed soundings selected through severe/deep-convection stories use
+the Deep-Tower Benchmark instead: complete observed input sounding, surface
+fluxes disabled, stock CM1 `iinit = 3` three-warm-bubble line initiation,
+`testcase = 0`, a two-hour storm-scale scout shape, and explicit caveats that
+the trigger is idealized rather than an observed front, dryline, terrain
+feature, or boundary. One-hour smoke mode is an explicit package-health check,
+not the default science path.
 
 The first quick-look validation run, `dry-run-quicklook-les-shallowcu-20260522151536`, preserved those settings, completed locally, and ingested 13 model-output time steps over 10800 seconds. Diagnostics still reported cloud formation, vertical motion, and rain, so the architecture can treat this runtime-only quick-look preset as the first validated shorter Baseline Shallow Cumulus variant.
 

--- a/docs/cloud-chamber-product-spec.md
+++ b/docs/cloud-chamber-product-spec.md
@@ -118,19 +118,21 @@ comparison is defined in
 The bridge from those hypotheses to CM1 run recipes is defined in
 [contracts/run-recipe-and-story-mapping.md](contracts/run-recipe-and-story-mapping.md):
 it maps current story IDs to observed surface-forced, differential
-surface-forced, blocked, or future recipes and names the assumptions and output
-fields required before Results can compare predicted signatures. Removed
-triggered deep-potential recipes are not a current product path.
+surface-forced, Deep-Tower Benchmark, blocked, or future recipes and names the
+assumptions and output fields required before Results can compare predicted
+signatures. The legacy `triggered_deep_potential` identifier is only a
+compatibility alias for the current Deep-Tower Benchmark recipe.
 Real-sounding story families, including severe/deep-convection, boundary-layer,
 low-cloud, and winter/cold-season candidates, are defined in
 [research/expanded-sounding-candidate-taxonomy.md](research/expanded-sounding-candidate-taxonomy.md).
 Those labels must remain disabled, caveated, or absent from product UI until
 backend scoring, evidence, caveats, and package-readiness states support them.
 Severe/deep-convection candidates may be presented as pre-run atmospheric
-hypotheses for observed-sounding experiments, not as forecasts or guaranteed
-storm outcomes. Product copy should make the selected run assumptions visible:
-uniform lower-boundary forcing is different from the differential surface patch,
-and neither is an artificial atmospheric trigger.
+hypotheses for the Deep-Tower Benchmark, not as forecasts or guaranteed storm
+outcomes. Product copy should make the selected run assumptions visible:
+CM1 `iinit = 3` warm-bubble initiation is an idealized trigger, uniform
+lower-boundary forcing is a separate surface-forced recipe, and the differential
+surface patch is a separate lower-boundary initiation experiment.
 The backend may compute richer sounding diagnostics such as profile quality,
 moisture/LCL proxies, lapse-rate and cap proxies, wind shear, dry-layer
 signals, and freezing-level context to support future screening. These are
@@ -182,16 +184,17 @@ packaging or queue failures should remain visible instead of clearing the failed
 item from the plan.
 
 Observed-sounding experiments use the observed temperature, moisture, and
-complete wind profile through CM1 `isnd = 7`, apply selected lower-boundary
-heat/moisture forcing, and request the full Results/Explore output field set.
-Severe/deep-convection candidates remain first-class atmospheric hypotheses, but
-current packages do not add an artificial deep-convection trigger. Product copy
-should describe these as observed-sounding experiments under explicit
-surface-forcing, duration, grid, domain, and cadence assumptions. Differential
-surface heating/moisture forcing is a current v0 patch recipe for localized
-initiation or boundary-style experiments; it is not a real front, dryline,
-land-surface, GIS, or radiation model. Its initial v0 geometry is a centered
-circular patch. It is local-only; the external CM1 source customization path has
+complete wind profile through CM1 `isnd = 7` and request the full
+Results/Explore output field set. Severe/deep-convection candidates remain
+first-class atmospheric hypotheses and default to the Deep-Tower Benchmark:
+surface fluxes disabled, stock CM1 `iinit = 3` three-warm-bubble initiation,
+storm-scale domain, and explicit caveats that the trigger is idealized rather
+than an observed boundary. Observed surface-forced runs still apply selected
+lower-boundary heat/moisture forcing. Differential surface heating/moisture
+forcing is a current v0 patch recipe for localized initiation or boundary-style
+experiments; it is not a real front, dryline, land-surface, GIS, or radiation
+model. Its initial v0 geometry is a centered circular patch. It is local-only;
+the external CM1 source customization path has
 runtime-local compile and emitted hfx/qfx forcing-footprint smoke evidence, but
 matched dynamic-response validation remains the #307 closure gate. Results carry
 per-run localized diagnostic availability for emitted footprint regions
@@ -680,32 +683,25 @@ controls:
   - allowed range/options
   - maps_to
 run_configuration:
-  duration:
-    model_time_seconds
-  grid_detail:
-    nx
+  duration: model_time_seconds
+  grid_detail: nx
     ny
     nz
     dx_m
     dy_m
     vertical_grid_summary
-  domain:
-    width_m
+  domain: width_m
     depth_m
     model_top_m
-  output_cadence:
-    model_seconds_between_outputs
+  output_cadence: model_seconds_between_outputs
     expected_saved_frames
-  output_field_density:
-    level
+  output_field_density: level
     requested_fields
-  forcing:
-    surface_sensible_heat_flux
+  forcing: surface_sensible_heat_flux
     surface_latent_heat_flux
     radiation_mode
     place_time_context
-  advanced_cm1_values:
-    timestep_target_seconds
+  advanced_cm1_values: timestep_target_seconds
     namelist_summary
     input_sounding_summary
     runtime_files_needed
@@ -715,11 +711,9 @@ pre_run_validation_report:
   caveats:
   estimated_runtime:
   estimated_output_volume:
-outputs_expected:
-  fields
+outputs_expected: fields
   diagnostics
-visualization_defaults:
-  camera
+visualization_defaults: camera
   fields
   color/opacity
 physical_question:
@@ -727,8 +721,7 @@ learning_goals:
 variation_policy:
   recommended_story_thread:
   recommended_comparison_pattern:
-validation_status:
-  unrun | generated | accepted | needs_calibration
+validation_status: unrun | generated | accepted | needs_calibration
 notes:
 ```
 

--- a/docs/contracts/analyzer-hypothesis-output-signature.md
+++ b/docs/contracts/analyzer-hypothesis-output-signature.md
@@ -171,18 +171,18 @@ output or a clearly labeled supported diagnostic, not from cloud water alone.
 
 ## Outcome Types And Required Fields
 
-| Prediction type | Required fields | Notes |
-| --- | --- | --- |
-| First cloud / cloud formed | `qc`, time coordinate | Uses backend cloud-water threshold and minimum grid-cell rules. |
-| Cloud depth/top | `qc`, vertical coordinate, time coordinate | Must report threshold and cloud-top method. |
-| Shallow cloud persistence | `qc`, time coordinate | Needs enough duration and cadence to distinguish transient noise from evolution. |
-| Updraft strength | `w`, time coordinate | May include height/region caveats when available. |
-| Deep breakthrough | `qc`, `w`, vertical coordinate, time coordinate | Current observed-sounding runs can inspect deep-cloud/updraft evidence under uniform forcing, but broad deep-convection prediction remains caveated until differential forcing and comparison diagnostics are validated. |
-| Rain water aloft | `qr`, time coordinate | User-facing label should say rain water aloft. |
-| Surface rain | `rain` or supported surface precipitation field | Must preserve units and must not be inferred from `qr`. |
-| Reflectivity | `dbz` or supported reflectivity diagnostic | Unsupported reflectivity stays unavailable. |
-| Cold-pool or outflow proxy | near-surface thermodynamic/wind fields plus time coordinate | Must be caveated until backend diagnostics are implemented. |
-| Suppression / no cloud | `qc`, `w`, duration/cadence context | Requires enough run length and output cadence to say the test was meaningful. |
+| Prediction type            | Required fields                                             | Notes                                                                                                                                                                                                                                                  |
+| -------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| First cloud / cloud formed | `qc`, time coordinate                                       | Uses backend cloud-water threshold and minimum grid-cell rules.                                                                                                                                                                                        |
+| Cloud depth/top            | `qc`, vertical coordinate, time coordinate                  | Must report threshold and cloud-top method.                                                                                                                                                                                                            |
+| Shallow cloud persistence  | `qc`, time coordinate                                       | Needs enough duration and cadence to distinguish transient noise from evolution.                                                                                                                                                                       |
+| Updraft strength           | `w`, time coordinate                                        | May include height/region caveats when available.                                                                                                                                                                                                      |
+| Deep breakthrough          | `qc`, `w`, vertical coordinate, time coordinate             | Current observed-sounding runs can inspect deep-cloud/updraft evidence with the explicit Deep-Tower Benchmark trigger, but broad deep-convection prediction remains caveated until observed-boundary forcing and comparison diagnostics are validated. |
+| Rain water aloft           | `qr`, time coordinate                                       | User-facing label should say rain water aloft.                                                                                                                                                                                                         |
+| Surface rain               | `rain` or supported surface precipitation field             | Must preserve units and must not be inferred from `qr`.                                                                                                                                                                                                |
+| Reflectivity               | `dbz` or supported reflectivity diagnostic                  | Unsupported reflectivity stays unavailable.                                                                                                                                                                                                            |
+| Cold-pool or outflow proxy | near-surface thermodynamic/wind fields plus time coordinate | Must be caveated until backend diagnostics are implemented.                                                                                                                                                                                            |
+| Suppression / no cloud     | `qc`, `w`, duration/cadence context                         | Requires enough run length and output cadence to say the test was meaningful.                                                                                                                                                                          |
 
 If a required field is absent from the run recipe, the prediction is not
 testable and must not be compared as a miss.
@@ -198,8 +198,7 @@ shape below is the analyzer payload reference to that contract.
 recommended_run_recipes:
   - recipe_id: string
     label: string
-    run_recipe:
-      generated_reference_lower_atmosphere
+    run_recipe: generated_reference_lower_atmosphere
       | observed_surface_forced_evolution
       | future
     run_configuration:
@@ -286,15 +285,15 @@ Explore should inspect the CM1-derived evidence:
 
 Current `story_scores` can map into the future hypothesis object as follows:
 
-| Current field | Future field |
-| --- | --- |
-| `story` | `story_id` |
-| `label` | `story_label` |
-| `score_0_to_100` | `ingredient_score_0_to_100` |
-| `support` | `support` |
-| `reasons` / evidence items | `evidence` |
-| `caveats` | `caveats` |
-| `recipe_fit_status` | `testability.status` seed |
+| Current field              | Future field                |
+| -------------------------- | --------------------------- |
+| `story`                    | `story_id`                  |
+| `label`                    | `story_label`               |
+| `score_0_to_100`           | `ingredient_score_0_to_100` |
+| `support`                  | `support`                   |
+| `reasons` / evidence items | `evidence`                  |
+| `caveats`                  | `caveats`                   |
+| `recipe_fit_status`        | `testability.status` seed   |
 
 Until assumption sets and predicted output signatures exist, the analyzer should
 emit ingredient/screening scores, recipe-fit caveats, and no predicted output
@@ -307,8 +306,8 @@ Tests for the future implementation should prove:
 - hypotheses cannot include predicted signatures without assumption sets;
 - missing required output fields produce `inconclusive` or field-level
   `unavailable`, not a failed prediction;
-- observed surface-forced hypotheses remain distinct from future differential
-  forcing and radiation/place-time hypotheses;
+- Deep-Tower Benchmark hypotheses remain distinct from observed surface-forced,
+  differential-forcing, and radiation/place-time hypotheses;
 - `qr`, surface `rain`, and `dbz` are labeled and evaluated separately;
 - the browser receives bounded backend JSON and does not parse raw IGRA, ZIP, or
   NetCDF data;

--- a/docs/contracts/run-recipe-and-story-mapping.md
+++ b/docs/contracts/run-recipe-and-story-mapping.md
@@ -60,10 +60,10 @@ run_recipe:
   product_question: string
   compatible_story_ids: [string]
   assumption_set_id: string
-  assumption_mode:
-    observed_surface_forced_evolution
+  assumption_mode: observed_surface_forced_evolution
     | surface_forced_evolution
     | differential_surface_forced_evolution
+    | explicit_thermal_initiation
     | elevated_forced_evolution
     | future
   run_shape:
@@ -113,10 +113,10 @@ run_recipe:
     status: supported | caveated | blocked | future
     caveats: [string]
   cm1_mapping:
-    run_recipe:
-      generated_reference_lower_atmosphere
+    run_recipe: generated_reference_lower_atmosphere
       | observed_surface_forced_evolution
       | differential_surface_forced_evolution
+      | deep_tower_benchmark
       | future
     run_configuration_defaults:
       duration: string | null
@@ -201,12 +201,14 @@ run_shape:
   output_cadence_seconds: 3600 | 900 | 300 | configured
   requested_fields: full_output_field_set
 forcing:
-  trigger: {mode: none}
-  surface_sensible_heat_flux: {mode: prescribed, units: K m/s, value: configured}
-  surface_latent_heat_flux: {mode: prescribed, units: g/g m/s, value: configured}
-  radiation: {mode: disabled}
-  large_scale_lift: {mode: none}
-  convergence: {mode: none}
+  trigger: { mode: none }
+  surface_sensible_heat_flux:
+    { mode: prescribed, units: K m/s, value: configured }
+  surface_latent_heat_flux:
+    { mode: prescribed, units: g/g m/s, value: configured }
+  radiation: { mode: disabled }
+  large_scale_lift: { mode: none }
+  convergence: { mode: none }
 required_inputs:
   observed_temperature_profile: required
   observed_moisture_profile: required
@@ -398,11 +400,40 @@ This is the honest bridge for `humid_rainy_candidate`: Cloud Chamber may run a
 moist observed-sounding experiment now, but precipitation signatures are only
 testable when the required fields are requested, ingested, and clearly labeled.
 
-Deep-convection candidate stories currently use the same observed-sounding
-surface-forced run path with stronger caveats. The run can inspect whether deep
-cloud, strong updraft, rain-water aloft, surface rain, and reflectivity occur
-under selected uniform lower-boundary forcing. It does not claim to supply a
-localized storm trigger.
+### `deep_tower_benchmark_v0`
+
+```yaml
+recipe_id: deep_tower_benchmark_v0
+display_name: Deep-Tower Benchmark
+product_question: What convective ceiling does this observed atmosphere show
+  under explicit idealized thermal initiation?
+assumption_set_id: deep_tower_benchmark_v0_assumptions
+assumption_mode: explicit_thermal_initiation
+required_outputs:
+  fields: [qv, qc, w, qr, rain, dbz, u, v, th, updraft_helicity]
+  diagnostics:
+    - first_cloud
+    - first_deep_convection
+    - max_updraft_w
+    - rain_water_aloft_onset
+    - max_surface_rain
+    - max_dbz
+current_support:
+  status: supported
+  caveats:
+    - The trigger is CM1's stock `iinit = 3` three-warm-bubble line; it is not
+      a real front, dryline, terrain feature, or observed boundary.
+    - Surface heat/moisture fluxes, radiation, terrain, GIS surface
+      initialization, and large-scale forcing are disabled in v0.
+cm1_mapping:
+  run_recipe: deep_tower_benchmark
+```
+
+Deep-convection candidate stories route to this benchmark when an observed
+sounding has a complete rendered wind profile. The result can inspect whether
+deep cloud, strong updraft, rain-water aloft, surface rain, and reflectivity
+occur under the explicit trigger. Surface-forced and differential surface patch
+recipes remain separate lower-boundary initiation questions.
 
 ### `squall_line_cold_pool_future`
 
@@ -450,26 +481,26 @@ source layer and forcing assumptions being tested.
 
 ## Initial Story-To-Recipe Mapping
 
-| Story ID | Primary recipe | Recipe fit | Required assumptions | Required outputs for comparison | Result comparison intent |
-| --- | --- | --- | --- | --- | --- |
-| `shallow_cumulus_candidate` | `observed_surface_forced_evolution_v0` | `testable_now` when the run is long enough | no artificial trigger; numeric uniform surface heat/moisture fluxes; complete observed temperature/moisture/wind profile | `qv`, `qc`, `w`, time and vertical coordinates | cloud formation, cloud top/depth, persistence, vertical velocity |
-| `dry_failed_candidate` | `observed_surface_forced_evolution_v0` | `testable_now` when duration/cadence can support a no-cloud conclusion | no artificial trigger; numeric uniform surface heat/moisture fluxes; complete observed temperature/moisture/wind profile | `qv`, `qc`, `w`, time coordinate | weak/no cloud with meaningful vertical motion; moisture limitation remains caveated |
-| `capped_suppressed_candidate` | `observed_capped_evolution_v1` | `partially_testable` | no explicit trigger; cap comes from observed profile; enough run time to observe delayed growth | `qc`, `w`, `th`, time and vertical coordinates | reduced cloud depth, delayed cloud, or capped vertical motion |
-| `humid_rainy_candidate` | `surface_forced_moist_evolution_v1` | `partially_testable` until surface-flux smoke evidence is broad | numeric uniform surface-flux assumptions; no artificial trigger; precipitation fields requested | `qc`, `w`, `qr`, `rain`, `dbz` when precipitation is predicted | cloud, rain water aloft, surface rain, and reflectivity evaluated separately |
-| `severe_thunderstorm_environment` | `observed_surface_forced_evolution_v0` plus future differential forcing | `partially_testable` | no artificial trigger; numeric uniform surface fluxes; complete observed wind profile; domain/duration/resolution caveats | `qc`, `w`, `qr`, `rain`, `dbz`, `u`, `v`, updraft diagnostics | whether deep cloud and strong updraft occur under the selected uniform forcing; not a storm-initiation guarantee |
-| `supercell_environment` | `observed_surface_forced_evolution_v0` plus future differential forcing | `partially_testable` | no artificial trigger; complete observed wind profile; rotation diagnostics caveated | `qc`, `w`, `qr`, `rain`, `dbz`, `u`, `v`, updraft-helicity when available | deep convection and organization evidence under uniform forcing; not a tornado or forecast product |
-| `high_cape_pulse_storm` | `observed_surface_forced_evolution_v0` plus future differential forcing | `partially_testable` | no artificial trigger; high-CAPE interpretation caveated until parcel diagnostics are implemented | `qc`, `w`, `qr`, `rain`, `dbz` | strong buoyant updraft and deep cloud if CM1 produces them under selected forcing |
-| `dry_microburst_inverted_v` | `observed_surface_forced_evolution_v0` plus future downdraft diagnostics | `partially_testable` only if precipitation/downdraft pathway develops | precipitation aloft; subcloud dry-layer evidence; downdraft diagnostics caveated | `qr`, `rain`, `w`, `th`, near-surface wind fields when implemented | rain water aloft, downdraft/cooling/outflow evidence; not a wind-gust forecast |
-| `squall_line_cold_pool_candidate` | `observed_surface_forced_evolution_v0` plus future `squall_line_cold_pool_future` | `partially_testable` for generic deep-cloud evidence; `requires_recipe` for line/cold-pool claims | no line trigger now; future line forcing and cold-pool diagnostics for the full story | `qc`, `w`, `qr`, `rain`, `dbz`, `th`, `u`, `v` | current run can inspect storm/deep-cloud evidence; cold-pool/line match is future |
-| `elevated_convection` | `elevated_forced_evolution_future` | `requires_recipe` unless a chosen recipe declares source-layer assumptions | elevated source layer, forcing, and surface-decoupling assumptions | `qc`, `w`, `qr`, `rain`, `dbz`, layer diagnostics | future elevated cloud/updraft source-layer comparison |
-| `needs_review` | none by default; user selects a concrete hypothesis first | `not_evaluated` | depends on selected hypothesis | depends on selected hypothesis | cannot compare until an active story and recipe are chosen |
-| `poor_or_incomplete_candidate` | none | `blocked` | package-readiness blockers must be resolved | none | no runnable recipe until profile/input safety passes |
+| Story ID                          | Primary recipe                                                                           | Recipe fit                                                                                        | Required assumptions                                                                                                                  | Required outputs for comparison                                                 | Result comparison intent                                                                                                                                     |
+| --------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `shallow_cumulus_candidate`       | `observed_surface_forced_evolution_v0`                                                   | `testable_now` when the run is long enough                                                        | no artificial trigger; numeric uniform surface heat/moisture fluxes; complete observed temperature/moisture/wind profile              | `qv`, `qc`, `w`, time and vertical coordinates                                  | cloud formation, cloud top/depth, persistence, vertical velocity                                                                                             |
+| `dry_failed_candidate`            | `observed_surface_forced_evolution_v0`                                                   | `testable_now` when duration/cadence can support a no-cloud conclusion                            | no artificial trigger; numeric uniform surface heat/moisture fluxes; complete observed temperature/moisture/wind profile              | `qv`, `qc`, `w`, time coordinate                                                | weak/no cloud with meaningful vertical motion; moisture limitation remains caveated                                                                          |
+| `capped_suppressed_candidate`     | `observed_capped_evolution_v1`                                                           | `partially_testable`                                                                              | no explicit trigger; cap comes from observed profile; enough run time to observe delayed growth                                       | `qc`, `w`, `th`, time and vertical coordinates                                  | reduced cloud depth, delayed cloud, or capped vertical motion                                                                                                |
+| `humid_rainy_candidate`           | `surface_forced_moist_evolution_v1`                                                      | `partially_testable` until surface-flux smoke evidence is broad                                   | numeric uniform surface-flux assumptions; no artificial trigger; precipitation fields requested                                       | `qc`, `w`, `qr`, `rain`, `dbz` when precipitation is predicted                  | cloud, rain water aloft, surface rain, and reflectivity evaluated separately                                                                                 |
+| `severe_thunderstorm_environment` | `deep_tower_benchmark_v0` plus future observed-boundary and differential forcing recipes | `partially_testable`                                                                              | explicit CM1 `iinit = 3` thermal trigger; surface fluxes disabled; complete observed wind profile; domain/duration/resolution caveats | `qc`, `w`, `qr`, `rain`, `dbz`, `u`, `v`, `th`, updraft diagnostics             | whether the observed environment can support deep cloud, rain, and strong updrafts under the benchmark trigger; not an observed initiation or forecast claim |
+| `supercell_environment`           | `deep_tower_benchmark_v0` plus future observed-boundary and storm-mode recipes           | `partially_testable`                                                                              | explicit CM1 `iinit = 3` thermal trigger; surface fluxes disabled; complete observed wind profile; rotation diagnostics caveated      | `qc`, `w`, `qr`, `rain`, `dbz`, `u`, `v`, `th`, updraft-helicity when available | deep convection and organization evidence under the benchmark trigger; not a tornado or forecast product                                                     |
+| `high_cape_pulse_storm`           | `observed_surface_forced_evolution_v0` plus future differential forcing                  | `partially_testable`                                                                              | no artificial trigger; high-CAPE interpretation caveated until parcel diagnostics are implemented                                     | `qc`, `w`, `qr`, `rain`, `dbz`                                                  | strong buoyant updraft and deep cloud if CM1 produces them under selected forcing                                                                            |
+| `dry_microburst_inverted_v`       | `observed_surface_forced_evolution_v0` plus future downdraft diagnostics                 | `partially_testable` only if precipitation/downdraft pathway develops                             | precipitation aloft; subcloud dry-layer evidence; downdraft diagnostics caveated                                                      | `qr`, `rain`, `w`, `th`, near-surface wind fields when implemented              | rain water aloft, downdraft/cooling/outflow evidence; not a wind-gust forecast                                                                               |
+| `squall_line_cold_pool_candidate` | `observed_surface_forced_evolution_v0` plus future `squall_line_cold_pool_future`        | `partially_testable` for generic deep-cloud evidence; `requires_recipe` for line/cold-pool claims | no line trigger now; future line forcing and cold-pool diagnostics for the full story                                                 | `qc`, `w`, `qr`, `rain`, `dbz`, `th`, `u`, `v`                                  | current run can inspect storm/deep-cloud evidence; cold-pool/line match is future                                                                            |
+| `elevated_convection`             | `elevated_forced_evolution_future`                                                       | `requires_recipe` unless a chosen recipe declares source-layer assumptions                        | elevated source layer, forcing, and surface-decoupling assumptions                                                                    | `qc`, `w`, `qr`, `rain`, `dbz`, layer diagnostics                               | future elevated cloud/updraft source-layer comparison                                                                                                        |
+| `needs_review`                    | none by default; user selects a concrete hypothesis first                                | `not_evaluated`                                                                                   | depends on selected hypothesis                                                                                                        | depends on selected hypothesis                                                  | cannot compare until an active story and recipe are chosen                                                                                                   |
+| `poor_or_incomplete_candidate`    | none                                                                                     | `blocked`                                                                                         | package-readiness blockers must be resolved                                                                                           | none                                                                            | no runnable recipe until profile/input safety passes                                                                                                         |
 
-Deep-convection stories should not silently promise initiation. The current
-observed-sounding run path can inspect deep-cloud/updraft evidence under selected
-uniform lower-boundary forcing; Results must keep differential-initiation,
-storm-mode, cold-pool, and severe-weather claims caveated unless the required
-fields and diagnostics exist.
+Deep-convection stories should not silently promise observed initiation. The
+current observed-sounding run path can inspect deep-cloud/updraft evidence with
+the explicit Deep-Tower Benchmark trigger; Results must keep observed-boundary,
+differential-initiation, storm-mode, cold-pool, and severe-weather claims
+caveated unless the required fields and diagnostics exist.
 
 ## Pre-Run Validation Feed (#284)
 

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -73,12 +73,12 @@ candidate stories. It does not make severe, winter, cold-pool, or specialized
 boundary-layer stories scientifically validated until their scoring, evidence,
 caveats, and package-readiness states are implemented and tested.
 
-The historical deep-convection package design is now evidence and background,
-not the active Build contract. User-facing docs should describe current
-observed-sounding packages as configurable experiments with numeric
-lower-boundary heat/moisture forcing, full output fields, and explicit caveats.
-Differential surface forcing for initiation or boundary experiments is future
-work.
+The Deep-Tower Benchmark is the active first experiment for severe/deep-
+convection sounding stories. It uses observed temperature/moisture/wind input,
+stock CM1 `iinit = 3` three-warm-bubble initiation, disabled surface fluxes,
+storm-scale scout defaults, full output fields, and explicit caveats that the
+trigger is idealized. Observed surface-forced and differential surface-patch
+recipes remain separate lower-boundary forcing questions.
 
 ## Current State
 

--- a/docs/research/cloud-chase-001-fort-worth-deep-tower.md
+++ b/docs/research/cloud-chase-001-fort-worth-deep-tower.md
@@ -1,0 +1,124 @@
+# Cloud Chase 001: Deep-Tower Benchmark
+
+Issue: #348  
+Implementation vehicle: #341
+
+## Recipe Setup
+
+- Recipe: `deep_tower_benchmark_v0`.
+- Initiation: stock CM1 `iinit = 3`, the built-in three-warm-bubble line trigger.
+- Lower boundary: surface heat and moisture fluxes disabled.
+- Domain/run shape: 120 km by 120 km, 120 by 120 horizontal cells, 40 vertical levels, 20 km model top, 2 hour scout, 15 minute output cadence, 6 s time step.
+
+This was an explicit thermal-initiation experiment. It does not claim a real
+front, dryline, outflow boundary, terrain trigger, or forecast initialization.
+
+## Attempts
+
+1. The legacy `triggered_deep_potential` path failed closed because that package
+   generator had been removed from the current architecture.
+2. Restoring the Deep-Tower Benchmark path through #341 produced one real CM1
+   run: `cloud_chase_001-fort_worth_deep_tower_probe`.
+3. The existing sounding analyzer was broadened beyond the short initial cache
+   and used to select a non-Aberdeen high-potential comparison case:
+   `cloud_chase_001-north_platte_high_potential`.
+4. A marginal/capped comparison package was created but not launched after the
+   North Platte run showed low compute value:
+   `cloud_chase_001-rapid_city_marginal_capped`.
+
+## Best Result
+
+Fort Worth, TX, `USM00072249`, `1997-05-27T00:00:00Z`.
+
+- CM1 completed normally with 9 model-output NetCDF frames from 0 to 7200 s.
+- Ingest completed with no missing required output fields.
+- Remaining runtime warning: `IEEE_UNDERFLOW_FLAG`.
+- Diagnostic summary: cloud formed, rain water aloft detected, surface rain
+  reached ground, reflectivity available.
+- First cloud: 900 s.
+- First deep convection: 1800 s.
+- Highest coherent cloud-object top: 17,250 m.
+- Highest hydrometeor envelope top: 19,750 m.
+- Highest liquid cloud-water top: 10,750 m.
+- Maximum updraft: 54.13 m/s at 1800 s.
+- Minimum downdraft: -15.89 m/s at 1800 s.
+- Maximum cloud water: 0.005071 kg/kg.
+- Maximum rain water aloft: 0.006555 kg/kg.
+- Maximum surface rainfall accumulation: 0.721 cm.
+- Maximum reflectivity: 65.38 dBZ.
+
+Visual-interest rating: 5/5.  
+Compute value: high. The scout produced a clear, inspectable deep-convective
+result by 1800 s.
+
+## Comparison Run
+
+North Platte, NE, `USM00072562`, `2026-07-02T00:00:00Z`.
+
+Analyzer expectation:
+
+- Selection: top non-Aberdeen candidate from the broadened
+  `deep_convection_trial` target-story ranking.
+- Story: severe thunderstorm environment.
+- Rank score: 62.6.
+- Summary: some deep-convection ingredients are present, but evidence is
+  caveated.
+
+Actual outcome:
+
+- Run stopped at user request after eight model-output frames through 6300 s.
+- No coherent cloud formed by the product threshold.
+- Coherent cloud top: unavailable.
+- Trace raw/liquid hydrometeor envelope appeared briefly near 1750 m at 900 s,
+  but did not meet coherent cloud-object support.
+- Maximum cloud water: 8.36e-5 kg/kg at 900 s.
+- Maximum updraft: 0.86 m/s at 900 s.
+- Rain water aloft: none.
+- Surface rain: none.
+- Reflectivity: field available, no meaningful signal.
+- Runtime integrity: partial output was finite and interpretable.
+
+Visual-interest rating: 1/5.  
+Compute value: low. The run was numerically useful enough to reject the setup,
+but it was not worth completing once the weak response persisted past 6300 s.
+
+## Canceled Contrast Package
+
+Rapid City WFO, SD, `USM00072662`, `2026-07-15T00:00:00Z`.
+
+Analyzer expectation:
+
+- Selection: low-score weak capped/suppressed package-ready candidate from the
+  broadened analyzer pool.
+- Active story: capped / suppressed cumulus candidate.
+- Active-story score: 35.0, weak support.
+- Summary: dry-layer signal could matter for entrainment or downdraft behavior.
+
+The package was generated with the same Deep-Tower Benchmark settings but was
+canceled before launch after the North Platte comparison showed that the next
+product value was analyzer selection improvement, not another immediate CM1
+run.
+
+## What Worked
+
+The Fort Worth environment responded strongly once explicit initiation was
+supplied. The run produced a deep, intense convective result quickly enough for a
+2 hour scout to be useful, and the core cloud, updraft, rain, reflectivity, wind,
+theta, and CM1 `uh` updraft-helicity output were available for product
+inspection.
+
+## What Failed
+
+The broader analyzer still pushed a scientifically plausible but visually poor
+high-potential case. North Platte had enough moisture/shear proxy support to rank
+high after excluding Aberdeen, but the same explicit Deep-Tower Benchmark
+produced only a weak, shallow, transient response.
+
+## Product Recommendation
+
+Keep Deep-Tower Benchmark as a repeatable Build recipe, but improve the analyzer
+before spending more CM1 runs: down-rank known-boring stations/cases from prior
+Deep-Tower outcomes and require stronger deep-instability evidence than moisture
+and shear proxies alone before labeling a case high-potential. Build should
+still label the recipe as explicit initiation and keep surface-forced and
+observed-boundary initiation recipes separate.

--- a/docs/research/cloud-chase-001-fort-worth-deep-tower.md
+++ b/docs/research/cloud-chase-001-fort-worth-deep-tower.md
@@ -116,9 +116,18 @@ produced only a weak, shallow, transient response.
 
 ## Product Recommendation
 
-Keep Deep-Tower Benchmark as a repeatable Build recipe, but improve the analyzer
-before spending more CM1 runs: down-rank known-boring stations/cases from prior
-Deep-Tower outcomes and require stronger deep-instability evidence than moisture
-and shear proxies alone before labeling a case high-potential. Build should
-still label the recipe as explicit initiation and keep surface-forced and
-observed-boundary initiation recipes separate.
+Keep Deep-Tower Benchmark as a repeatable Build recipe, but treat North Platte
+`USM00072562` at `2026-07-02T00:00:00Z` as a negative recommendation trial for
+this exact setup: `deep_tower_benchmark_v0`, stock CM1 `iinit = 3`, 120 km by
+120 km domain, 120 by 120 horizontal cells, 20 km model top, 2 hour scout,
+15 minute output cadence, 6 s time step, and disabled surface fluxes. The actual
+outcome was no coherent cloud, no precipitation, maximum updraft near 0.86 m/s,
+and visual-interest rating 1/5 through 6300 s.
+
+Do not infer a station-level penalty from that miss; a different North Platte
+sounding may be excellent. The analyzer should instead learn from the specific
+valid time, recipe version, run setup, and outcome pattern, and require stronger
+deep-instability evidence before labeling a case high-potential for this
+explicit-initiation benchmark. Build should still label the recipe as explicit
+initiation and keep surface-forced and observed-boundary initiation recipes
+separate.

--- a/docs/testing-and-validation.md
+++ b/docs/testing-and-validation.md
@@ -85,9 +85,9 @@ Future analyzer hypothesis and predicted-output signature tests should follow
 [contracts/analyzer-hypothesis-output-signature.md](contracts/analyzer-hypothesis-output-signature.md):
 no predicted signature without an explicit assumption set, missing output fields
 produce `inconclusive` or field-level `unavailable` states rather than failed
-predictions, observed surface-forced hypotheses remain distinct from future
-differential-forcing and radiation/place-time hypotheses, and `qr`, surface
-`rain`, and `dbz` are evaluated separately.
+predictions, Deep-Tower Benchmark hypotheses remain distinct from observed
+surface-forced, differential-forcing, and radiation/place-time hypotheses, and
+`qr`, surface `rain`, and `dbz` are evaluated separately.
 Future run-recipe mapping tests should follow
 [contracts/run-recipe-and-story-mapping.md](contracts/run-recipe-and-story-mapping.md):
 story IDs must resolve to compatible, partially testable, blocked, or future
@@ -151,8 +151,8 @@ should verify that package generation:
   numeric constant surface fluxes, full output fields, rain output, reflectivity
   output, vorticity output, and updraft-helicity output;
 - writes a numeric `input_sounding` with observed wind components; and
-- preserves observed surface-forced package identity, candidate-screening
-  provenance, numeric forcing, and notes/tags through ingest into Result Cards.
+- preserves declared package identity, candidate-screening provenance, forcing
+  state, and notes/tags through ingest into Result Cards.
 
 Manual/local QA is required before treating the package as scientifically
 accepted for a selected real sounding. New soundings remain experiments whose
@@ -163,16 +163,19 @@ outcomes must be inspected after CM1 runs. The manual smoke loop should:
 3. generate a science package;
 4. inspect `run_manifest.json`, `dry_run_report.json`, `namelist.input`, and
    `input_sounding`;
-5. confirm `isnd = 7`, no artificial deep-trigger path, the selected
-   numeric constant surface-flux values, full output-field switches including
+5. confirm the recipe's declared initiation and lower-boundary path: observed
+   surface-forced runs keep `isnd = 7`, no artificial deep-trigger path, and
+   their selected numeric constant surface-flux values; Deep-Tower Benchmark
+   runs keep `isnd = 7`, CM1 `iinit = 3`, and disabled surface fluxes. In both
+   cases confirm full output-field switches including
    rain/reflectivity/vorticity/updraft-helicity support, complete observed u/v
    wind columns, and domain/grid/runtime values that match the chosen run
    configuration;
 6. run CM1 locally or on the LAN worker outside CI;
 7. ingest completed output;
-8. open Results and Explore to confirm observed surface-forced identity,
-   candidate-screening provenance, numeric forcing, and interpretable CM1 output
-   products; and
+8. open Results and Explore to confirm the declared run identity,
+   candidate-screening provenance, recipe assumptions, forcing state, and
+   interpretable CM1 output products; and
 9. confirm no generated run folders, logs, NetCDF output, copied runtime files,
    screenshots, or videos are committed.
 


### PR DESCRIPTION
## Summary

- Restores the explicit CM1 `iinit=3` Deep-Tower Benchmark as a repeatable Build recipe, with disabled surface fluxes, observed-sounding input, 2 hour scout defaults, and the legacy `triggered_deep_potential` alias mapped forward.
- Updates frontend Build defaults, backend recipe contracts, dry-run packaging, pre-run validation, candidate recipe-fit copy, and result ingest so CM1 `uh` satisfies the required updraft-helicity output.
- Adds the Cloud Chase 001 report preserving the successful Fort Worth result and recording the North Platte and Rapid City comparison work.
- Addresses PM review by replacing stale deep-convection surface-forcing recommendations with Deep-Tower Benchmark copy, using score/support-aware candidate language, and recording North Platte as a specific negative recommendation trial rather than a station penalty.

Closes #341.
Closes #348.

## Cloud Chase 001 evidence

- Fort Worth `USM00072249`, `1997-05-27T00:00:00Z`: completed and ingested with no missing required output fields. First cloud at 900 s, first deep convection at 1800 s, coherent cloud top 17,250 m, hydrometeor envelope top 19,750 m, max updraft 54.13 m/s, surface rain max 0.721 cm, max reflectivity 65.38 dBZ. Visual-interest rating: 5/5; compute value: high.
- North Platte `USM00072562`, `2026-07-02T00:00:00Z`: selected as the high-potential non-Aberdeen comparison. Stopped at user request after eight model-output frames through 6300 s. No coherent cloud, no precipitation, max updraft 0.86 m/s. Visual-interest rating: 1/5; compute value: low. Treat this exact valid time + recipe + setup as a negative recommendation trial, not as a station blacklist.
- Rapid City WFO `USM00072662`, `2026-07-15T00:00:00Z`: selected as the marginal/capped comparison and packaged with the same recipe, then canceled before launch after the North Platte scout showed low value for further compute.

## Verification

- `npm test -- App.test.tsx -t "stages deep-convection candidates as Deep-Tower Benchmark runs|shows secondary family candidates with the scoped story ingredient score"`
- `BACKEND_PYTHON=/Users/timpeterson/Documents/Codex/cloud-chamber/app/backend/.venv/bin/python scripts/check.sh`

## Known limitations

- The additional comparison work was stopped by user direction after the North Platte scout showed low compute value, so Rapid City is recorded as a selected and packaged canceled contrast rather than a completed CM1 run.
