### PR TITLE
Add Fort Worth detail run shape

### DIFF
--- a/app/backend/cloud_chamber/run_configuration.py
+++ b/app/backend/cloud_chamber/run_configuration.py
@@ -147,6 +147,7 @@ class _CadenceChoice(BaseModel):
 
 DURATION_CHOICES: dict[str, _DurationChoice] = {
     "smoke_1h": _DurationChoice(seconds=3600, mode="smoke", label="Smoke check"),
+    "detail_60min": _DurationChoice(seconds=3600, mode="science", label="Detail scout"),
     "scout_2h": _DurationChoice(seconds=7200, mode="science", label="Scout evolution"),
     "short_6h": _DurationChoice(seconds=21600, mode="science", label="Short evolution"),
     "standard_12h": _DurationChoice(seconds=43200, mode="science", label="Standard evolution"),
@@ -212,6 +213,19 @@ DOMAIN_CHOICES: dict[str, _DomainChoice] = {
         dz_top_m=500.0,
         label="Storm 120 km",
     ),
+    "deep_tower_detail_120km": _DomainChoice(
+        x_km=120.0,
+        y_km=120.0,
+        nz=100,
+        dz_m=250.0,
+        stretch_z=0,
+        model_top_m=25000.0,
+        str_bot_m=0.0,
+        str_top_m=2000.0,
+        dz_bot_m=250.0,
+        dz_top_m=250.0,
+        label="Deep tower detail 120 km",
+    ),
 }
 
 CADENCE_CHOICES: dict[str, _CadenceChoice] = {
@@ -270,6 +284,9 @@ def resolve_run_configuration(
 ) -> RunConfiguration:
     if isinstance(run_configuration, RunConfiguration):
         return run_configuration
+    explicit_time_step = (
+        isinstance(run_configuration, dict) and "time_step_seconds" in run_configuration
+    )
     if run_configuration is None:
         payload = default_run_configuration_payload(run_recipe)
     else:
@@ -279,6 +296,8 @@ def resolve_run_configuration(
         **default_run_configuration_payload(run_recipe),
         **payload,
     }
+    if not explicit_time_step:
+        payload["time_step_seconds"] = _default_time_step_seconds(str(payload["domain_size"]))
 
     initiation_method = (
         "cm1_iinit_3_three_warm_bubbles"
@@ -313,7 +332,7 @@ def resolve_run_configuration(
         payload,
         "time_step_seconds",
         "time step seconds",
-        default=DEFAULT_TIME_STEP_SECONDS,
+        default=_default_time_step_seconds(str(payload["domain_size"])),
     )
     nx = horizontal_cells.cells
     ny = horizontal_cells.cells
@@ -406,7 +425,10 @@ def resolve_run_configuration(
             runtime_seconds=duration.seconds,
             output_cadence_seconds=cadence.seconds,
             restart_cadence_seconds=restart_seconds,
-            rayleigh_damping_start_m=_rayleigh_damping_start_m(run_recipe),
+            rayleigh_damping_start_m=_rayleigh_damping_start_m(
+                run_recipe,
+                domain_size=str(payload["domain_size"]),
+            ),
             expected_output_frames=frames,
             grid_cell_count=grid_cells,
         ),
@@ -535,7 +557,7 @@ def _configuration_caveats(
     caveats: list[str] = list(surface_flux_caveats)
     if mode == "smoke":
         caveats.append("short_smoke_mode_is_for_package_health_not_science_evolution")
-    if domain_size == "deep_tower_120km":
+    if domain_size in {"deep_tower_120km", "deep_tower_detail_120km"}:
         caveats.append("storm_scale_domain_for_explicit_deep_tower_initiation")
     if mode == "science" and duration_seconds >= 21600:
         caveats.append("science_run_configuration_minimum_duration_6h")
@@ -545,6 +567,7 @@ def _configuration_caveats(
         "wide_12km",
         "regional_60km",
         "regional_120km",
+        "deep_tower_detail_120km",
     }:
         caveats.append("configuration_better_suited_to_larger_compute")
     if not math.isclose(time_step_seconds, DEFAULT_TIME_STEP_SECONDS):
@@ -649,10 +672,24 @@ def _surface_mode_id(surface_flux_mode: str, patch_sha256: str | None) -> str:
     return ""
 
 
-def _rayleigh_damping_start_m(run_recipe: str | None = None) -> int:
+def _rayleigh_damping_start_m(
+    run_recipe: str | None = None,
+    *,
+    domain_size: str | None = None,
+) -> int:
+    if domain_size == "deep_tower_detail_120km":
+        return 21000
     if run_recipe in {"deep_tower_benchmark", "triggered_deep_potential"}:
         return 15000
     return 12000
+
+
+def _default_time_step_seconds(domain_size: str) -> float:
+    if domain_size == "deep_tower_detail_120km":
+        return 1.5
+    if domain_size == "deep_tower_120km":
+        return 6.0
+    return DEFAULT_TIME_STEP_SECONDS
 
 
 def _expected_output_frames(runtime_seconds: int, output_cadence_seconds: int) -> int:

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -349,6 +349,64 @@ def test_deep_tower_benchmark_declares_iinit3_assumptions_and_namelist() -> None
     assert "output_uh        = 1," in namelist
 
 
+def test_deep_tower_detail_shape_raises_top_and_uses_finer_timestep() -> None:
+    from igra_fixtures import IGRA_FIXTURE
+
+    from cloud_chamber.observed_sounding import parse_igra_station_text
+
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+
+    contract = build_cm1_input_contract(
+        baseline_scenario(),
+        observed_sounding=observed,
+        run_recipe="deep_tower_benchmark",
+        run_configuration={
+            "duration": "detail_60min",
+            "horizontal_cell_count": "cells_256",
+            "domain_size": "deep_tower_detail_120km",
+            "output_cadence": "detailed_5min",
+            "diagnostic_set": "full",
+            "surface_forcing_mode": "disabled",
+            "surface_heat_flux_k_m_s": 0.0,
+            "surface_moisture_flux_g_g_m_s": 0.0,
+        },
+    )
+    values = contract.run_configuration.cm1_values
+    namelist = render_namelist_fragment(contract)
+
+    assert contract.run_configuration.duration == "detail_60min"
+    assert contract.run_configuration.duration_seconds == 3600
+    assert contract.run_configuration.horizontal_cell_count == 256
+    assert contract.run_configuration.domain_size == "deep_tower_detail_120km"
+    assert contract.run_configuration.output_cadence == "detailed_5min"
+    assert values.nx == 256
+    assert values.ny == 256
+    assert values.nz == 100
+    assert values.dx_m == 468.75
+    assert values.dy_m == 468.75
+    assert values.dz_m == 250.0
+    assert values.model_top_m == 25000.0
+    assert values.rayleigh_damping_start_m == 21000
+    assert values.output_cadence_seconds == 300
+    assert values.expected_output_frames == 13
+    assert values.time_step_seconds == 1.5
+    assert "configuration_better_suited_to_larger_compute" in contract.run_configuration.caveats
+    assert "nx           =      256," in namelist
+    assert "ny           =      256," in namelist
+    assert "nz           =      100," in namelist
+    assert "dx     =   468.75," in namelist
+    assert "dy     =   468.75," in namelist
+    assert "dz     =   250.0," in namelist
+    assert "dtl    =   1.500," in namelist
+    assert "timax  = 3600.0," in namelist
+    assert "tapfrq =  300.0," in namelist
+    assert "zd      =  21000.0," in namelist
+    assert "ztop      = 25000.0," in namelist
+
+
 def test_observed_surface_flux_proxy_choices_render_namelist_and_surface_outputs() -> None:
     from igra_fixtures import IGRA_FIXTURE
 

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3884,6 +3884,24 @@ describe("App", () => {
     expect(runPlan.getByLabelText("Duration")).toHaveValue("scout_2h");
     expect(runPlan.getByLabelText("Horizontal cells")).toHaveValue("cells_120");
     expect(runPlan.getByLabelText("Domain size")).toHaveValue("deep_tower_120km");
+    fireEvent.change(runPlan.getByLabelText("Duration"), {
+      target: { value: "detail_60min" },
+    });
+    fireEvent.change(runPlan.getByLabelText("Horizontal cells"), {
+      target: { value: "cells_256" },
+    });
+    fireEvent.change(runPlan.getByLabelText("Domain size"), {
+      target: { value: "deep_tower_detail_120km" },
+    });
+    fireEvent.change(runPlan.getByLabelText("Output cadence"), {
+      target: { value: "detailed_5min" },
+    });
+    expect(runPlan.getByLabelText("Duration")).toHaveValue("detail_60min");
+    expect(runPlan.getByLabelText("Horizontal cells")).toHaveValue("cells_256");
+    expect(runPlan.getByLabelText("Domain size")).toHaveValue("deep_tower_detail_120km");
+    expect(
+      runPlan.getByText(/256 x 256 x 100; dx\/dy 468.75 m; top 25 km, dz 250 m/),
+    ).toBeInTheDocument();
     expect(screen.getByText("deep_tower_benchmark_v0")).toBeInTheDocument();
     expect(
       screen.getByText(/Explicit initiation is supplied with CM1 iinit=3/i),
@@ -3901,13 +3919,14 @@ describe("App", () => {
     await waitFor(() => {
       expect(dryRunBody).toContain('"run_recipe":"deep_tower_benchmark"');
       expect(dryRunBody).toContain('"diagnostic_set":"full"');
-      expect(dryRunBody).toContain('"duration":"scout_2h"');
-      expect(dryRunBody).toContain('"horizontal_cell_count":"cells_120"');
-      expect(dryRunBody).toContain('"domain_size":"deep_tower_120km"');
+      expect(dryRunBody).toContain('"duration":"detail_60min"');
+      expect(dryRunBody).toContain('"horizontal_cell_count":"cells_256"');
+      expect(dryRunBody).toContain('"domain_size":"deep_tower_detail_120km"');
+      expect(dryRunBody).toContain('"output_cadence":"detailed_5min"');
       expect(dryRunBody).toContain('"surface_forcing_mode":"disabled"');
       expect(dryRunBody).toContain('"surface_heat_flux_k_m_s":"0"');
       expect(dryRunBody).toContain('"surface_moisture_flux_g_g_m_s":"0"');
-      expect(dryRunBody).toContain('"time_step_seconds":"6.0"');
+      expect(dryRunBody).toContain('"time_step_seconds":"1.5"');
       expect(dryRunBody).toContain('"candidate_screening"');
       expect(dryRunBody).toContain('"primary_story":"supercell_environment"');
       expect(dryRunBody).toContain('"candidate_id":"USM00072357-2025052000-supercell"');

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -4699,7 +4699,7 @@ function RunConfigurationPanel({
     );
   }
   const update = (key: keyof RunConfigurationInput, value: string) => {
-    onChange({ ...configuration, [key]: value });
+    onChange(updatedRunConfigurationInput(configuration, key, value));
   };
   const panelClassName = embedded
     ? "run-configuration-panel embedded-run-configuration-panel"
@@ -6750,7 +6750,7 @@ function RunPlanConfigurationFields({
   onConfigurationChange: (itemId: string, configuration: RunConfigurationInput) => void;
 }) {
   const update = (key: keyof RunConfigurationInput, value: string) => {
-    onConfigurationChange(item.id, { ...item.runConfiguration, [key]: value });
+    onConfigurationChange(item.id, updatedRunConfigurationInput(item.runConfiguration, key, value));
   };
   return (
     <>
@@ -12683,6 +12683,7 @@ function parseTags(value: string): string[] {
 
 const DURATION_OPTIONS = [
   { value: "smoke_1h", label: "Smoke check (1 h)" },
+  { value: "detail_60min", label: "Detail scout (60 min)" },
   { value: "scout_2h", label: "Scout evolution (2 h)" },
   { value: "short_6h", label: "Short evolution (6 h)" },
   { value: "standard_12h", label: "Standard evolution (12 h)" },
@@ -12705,6 +12706,7 @@ const DOMAIN_OPTIONS = [
   { value: "regional_60km", label: "Regional 60 km" },
   { value: "regional_120km", label: "Regional 120 km" },
   { value: "deep_tower_120km", label: "Deep tower 120 km" },
+  { value: "deep_tower_detail_120km", label: "Deep tower detail 120 km" },
 ];
 
 const OUTPUT_CADENCE_OPTIONS = [
@@ -12763,6 +12765,21 @@ function selectedCandidateUsesDeepTowerRecipe(
   return Boolean(story && deepConvectionStoryIds.has(story));
 }
 
+function updatedRunConfigurationInput(
+  configuration: RunConfigurationInput,
+  key: keyof RunConfigurationInput,
+  value: string,
+): RunConfigurationInput {
+  const updated = { ...configuration, [key]: value };
+  if (key === "domain_size" && value === "deep_tower_detail_120km") {
+    return { ...updated, time_step_seconds: "1.5" };
+  }
+  if (key === "domain_size" && value === "deep_tower_120km") {
+    return { ...updated, time_step_seconds: "6.0" };
+  }
+  return updated;
+}
+
 function previewRunConfiguration(configuration: RunConfigurationInput): RunConfiguration {
   const duration = durationValue(configuration.duration);
   const horizontalCells = horizontalCellValue(configuration.horizontal_cell_count);
@@ -12771,9 +12788,12 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
   const diagnosticSet = { value: "full" };
   const surfaceForcingMode = surfaceForcingModeValue(configuration.surface_forcing_mode);
   const surfaceFluxEnabled = surfaceForcingMode !== DISABLED_SURFACE_FORCING_MODE;
-  const deepTowerShape =
+  const deepTowerScoutShape =
     surfaceForcingMode === DISABLED_SURFACE_FORCING_MODE &&
     configuration.domain_size === "deep_tower_120km";
+  const deepTowerDetailShape =
+    surfaceForcingMode === DISABLED_SURFACE_FORCING_MODE &&
+    configuration.domain_size === "deep_tower_detail_120km";
   const heatFlux = surfaceFluxEnabled
     ? numericConfigurationValue(configuration.surface_heat_flux_k_m_s, 8.0e-3)
     : 0;
@@ -12782,7 +12802,7 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
     : 0;
   const timeStepSeconds = numericConfigurationValue(
     configuration.time_step_seconds,
-    deepTowerShape ? 6 : 3,
+    deepTowerDetailShape ? 1.5 : deepTowerScoutShape ? 6 : 3,
   );
   const nx = horizontalCells.cells;
   const ny = horizontalCells.cells;
@@ -12800,14 +12820,15 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
   if (duration.mode === "science" && duration.seconds < 21600) {
     caveats.push("short_scout_duration_for_initial_deep_tower_chase");
   }
-  if (domain.value === "deep_tower_120km") {
+  if (domain.value === "deep_tower_120km" || domain.value === "deep_tower_detail_120km") {
     caveats.push("storm_scale_domain_for_explicit_deep_tower_initiation");
   }
   if (
     horizontalCells.cells >= 256 ||
     domain.value === "wide_12km" ||
     domain.value === "regional_60km" ||
-    domain.value === "regional_120km"
+    domain.value === "regional_120km" ||
+    domain.value === "deep_tower_detail_120km"
   ) {
     caveats.push("configuration_better_suited_to_larger_compute");
   }
@@ -12913,7 +12934,7 @@ function previewRunConfiguration(configuration: RunConfigurationInput): RunConfi
     runtime_seconds: duration.seconds,
     output_cadence_seconds: cadence.seconds,
     restart_cadence_seconds: Math.max(cadence.seconds, Math.min(duration.seconds, 10800)),
-    rayleigh_damping_start_m: deepTowerShape ? 15000 : 12000,
+    rayleigh_damping_start_m: deepTowerDetailShape ? 21000 : deepTowerScoutShape ? 15000 : 12000,
     expected_output_frames: expectedFrames,
     grid_cell_count: gridCellCount,
   };
@@ -12983,6 +13004,7 @@ function durationValue(value: string): {
   label: string;
 } {
   if (value === "smoke_1h") return { seconds: 3600, mode: "smoke", label: "Smoke check" };
+  if (value === "detail_60min") return { seconds: 3600, mode: "science", label: "Detail scout" };
   if (value === "scout_2h") return { seconds: 7200, mode: "science", label: "Scout evolution" };
   if (value === "standard_12h") {
     return { seconds: 43200, mode: "science", label: "Standard evolution" };
@@ -13077,6 +13099,22 @@ function domainValue(value: string): {
       dzTopM: 500,
       modelTopM: 20000,
       label: "Storm 120 km",
+    };
+  }
+  if (value === "deep_tower_detail_120km") {
+    return {
+      value,
+      xKm: 120,
+      yKm: 120,
+      nz: 100,
+      dzM: 250,
+      stretchZ: 0,
+      strBotM: 0,
+      strTopM: 2000,
+      dzBotM: 250,
+      dzTopM: 250,
+      modelTopM: 25000,
+      label: "Deep tower detail 120 km",
     };
   }
   return {

--- a/docs/architecture-and-data-model.md
+++ b/docs/architecture-and-data-model.md
@@ -344,6 +344,13 @@ the trigger is idealized rather than an observed front, dryline, terrain
 feature, or boundary. One-hour smoke mode is an explicit package-health check,
 not the default science path.
 
+The Fort Worth detail probe adds an opt-in one-hour Deep-Tower detail shape for
+manual visual follow-up: 120 km by 120 km, 256 by 256 horizontal cells, 100
+vertical levels, 25 km model top, Rayleigh damping from 21 km, 5 minute output
+cadence, and a 1.5 s timestep target. Cloud Chase 002 showed that this exact
+shape is larger-compute territory locally; it should be treated as a
+configuration record and cautionary result, not a new default.
+
 The first quick-look validation run, `dry-run-quicklook-les-shallowcu-20260522151536`, preserved those settings, completed locally, and ingested 13 model-output time steps over 10800 seconds. Diagnostics still reported cloud formation, vertical motion, and rain, so the architecture can treat this runtime-only quick-look preset as the first validated shorter Baseline Shallow Cumulus variant.
 
 The external-sounding reproduction run, `dry-run-external-sounding-baseline-20260522185000`,

--- a/docs/research/cloud-chase-002-fort-worth-detail.md
+++ b/docs/research/cloud-chase-002-fort-worth-detail.md
@@ -1,0 +1,86 @@
+# Cloud Chase 002: Fort Worth Detail Run
+
+Issue: #350
+
+## Fixed Setup
+
+- Sounding: Fort Worth, TX, `USM00072249`, valid
+  `1997-05-27T00:00:00Z`.
+- Recipe: `deep_tower_benchmark_v0`.
+- Initiation: stock CM1 `iinit = 3`, the built-in three-warm-bubble line
+  trigger.
+- Lower boundary: surface heat and moisture fluxes disabled.
+- Sounding, microphysics, and trigger assumptions match the successful
+  Cloud Chase 001 Fort Worth scout.
+
+This was a resolution/detail probe for the already successful Fort Worth
+deep-tower result. It was not a new sounding-selection test.
+
+## Target Detail Shape
+
+- Domain: 120 km by 120 km.
+- Horizontal grid: 256 by 256 cells, 468.75 m dx/dy.
+- Vertical grid: 100 levels, 250 m spacing, 25 km model top.
+- Rayleigh damping: starts at 21 km.
+- Output cadence: 5 minutes.
+- Initial bounded duration: 60 simulated minutes.
+- Expected saved frames: 13.
+
+The run shape was intentionally above the prior scout's 20 km model top and put
+Rayleigh damping above the prior 17.25 km coherent cloud top.
+
+## Attempt 1: 3 s Timestep
+
+Run ID: `cloud_chase_002-fort_worth_detail_60min`
+
+- Runtime and integrity: CM1 ran for about 57.7 wall-clock minutes and reached
+  13.0 simulated minutes, then stopped after `CFLMAX` exceeded 1.5. Runtime
+  integrity is failed, not complete.
+- Saved output: three model-output frames before failure.
+- Coherent cloud top: existing partial diagnostics were not a stable coherent
+  cloud-top result. The coherent object briefly reached the top-adjacent layer
+  in the partial sequence and then collapsed to a shallow object by the last
+  saved frame.
+- Upper-cloud headroom: poor. The hydrometeor envelope reached about
+  24.875 km in a 25 km domain, leaving only about 125 m of headroom.
+- Maximum updraft: about 106.09 m/s in the saved partial diagnostics; the final
+  CM1 stdout report before failure still showed `WMAX` about 102.43 m/s.
+- Precipitation and reflectivity: no surface precipitation before failure.
+  CM1 stdout showed rain water aloft by the terminal stats report, while the
+  saved partial diagnostics only supported trace rain water aloft. Maximum
+  reflectivity in the partial saved diagnostics was about 50.95 dBZ.
+- Visibly better than the scout: not as a usable product result. The partial
+  run was more intense and finer-gridded, but it was numerically unstable and
+  upper-boundary limited before producing a useful 60-minute detail sequence.
+- Worth the compute: no. The failure arrived before the run could produce a
+  trustworthy visual-detail result.
+
+## Attempt 2: 1.5 s Timestep
+
+Run ID: `cloud_chase_002-fort_worth_detail_60min_dtl1p5`
+
+- Runtime and integrity: stopped at user request after about 40.8 wall-clock
+  minutes because the compute value was too low. CM1 had reached only about
+  238.5 simulated seconds, before the first 5-minute output frame.
+- Saved output: the initial model-output frame and stats file only.
+- Coherent cloud top: unavailable as an interpretable saved-output diagnostic.
+  The CM1 stdout stats near 4 simulated minutes reported `QCTOP` near
+  24.875 km, but that is not a coherent-cloud product diagnostic.
+- Upper-cloud headroom: still concerning. The stdout `QCTOP` signal already
+  reached the top-adjacent layer before a useful saved frame existed.
+- Maximum updraft: about 6.32 m/s in the latest stdout stats before stop.
+- Precipitation and reflectivity: no saved diagnostic evidence beyond the
+  initial frame. The latest stdout stats showed no surface precipitation.
+- Visibly better than the scout: no interpretable visual result. The corrected
+  timestep appeared numerically calmer, but the local wall-clock slope made the
+  run non-useful before it produced a viewable 5-minute frame.
+- Worth the compute: no. The projected local runtime for a 60-minute detail run
+  was too high relative to the evidence it was likely to add.
+
+## Recommendation
+
+Do not extend or rerun the current 256 by 256 by 100 Fort Worth detail shape on
+the current local compute path. The next Fort Worth visual-detail attempt should
+keep the same sounding, Deep-Tower Benchmark trigger, disabled surface fluxes,
+25 km top, and damping above 21 km, but use a compute-balanced detail shape
+before launching another real CM1 run.


### PR DESCRIPTION
## What Changed

- Added an opt-in Deep-Tower detail configuration for the Fort Worth follow-up: 60 minutes, 120 km domain, 256 x 256 x 100 grid, 25 km model top, 21 km Rayleigh damping, 5 minute output cadence, disabled surface fluxes, and a 1.5 s timestep default for that detail domain.
- Updated Build preview/staging so the detail domain sends the finer timestep and shows the raised model top/headroom.
- Recorded Cloud Chase 002 in `docs/research/cloud-chase-002-fort-worth-detail.md` without committing generated packages, NetCDF files, logs, screenshots, or runtime state.

## Runtime Evidence

Refs #350.

- `dtl = 3.0 s` attempt failed after about 57.7 wall-clock minutes / 13.0 simulated minutes when `CFLMAX` exceeded 1.5. Partial output showed an intense but top-limited cloud signal rather than a usable 60-minute detail result.
- `dtl = 1.5 s` attempt was stopped at user request after about 40.8 wall-clock minutes / 238.5 simulated seconds because the local compute value was too low before the first 5-minute output frame.
- Recommendation recorded: do not extend or rerun the current 256 x 256 x 100 shape on the current local compute path; keep the same Fort Worth science setup but use a compute-balanced detail shape before another real CM1 run.

## Verification

- `python -m pytest app/backend/tests/test_cm1_input_contract.py::test_deep_tower_detail_shape_raises_top_and_uses_finer_timestep`
- `npm test -- App.test.tsx -t "stages deep-convection candidates as Deep-Tower Benchmark runs"`
- `scripts/check.sh`

## Notes

The original Fort Worth scout remains the preserved successful result. This PR records the bounded detail attempt as a low-compute-value visual follow-up, not as a replacement for the successful Deep-Tower Benchmark scout.
