### PR TITLE
Calibrate Deep-Tower opportunity scoring

### DIFF
--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -33,7 +33,7 @@ from cloud_chamber.observed_sounding import (
 from cloud_chamber.settings import CloudChamberSettings
 from cloud_chamber.sounding_diagnostics import compute_sounding_diagnostics
 
-SCREENING_VERSION = "sounding-screening-v1"
+SCREENING_VERSION = "sounding-screening-v2"
 
 StoryId = Literal[
     "shallow_cumulus_candidate",
@@ -103,6 +103,7 @@ CandidateSortKey = Literal[
     "primary_story",
     "story_family",
     "rank_score",
+    "deep_tower_opportunity",
     "confidence",
     "support",
     "package_readiness",
@@ -129,6 +130,7 @@ CandidateSortKey = Literal[
 SortValue = bool | float | str | datetime
 
 _FEATURE_SORT_KEYS: dict[CandidateSortKey, str] = {
+    "deep_tower_opportunity": "deep_tower_opportunity",
     "observed_wind_available": "observed_wind_available",
     "profile_top_m_agl": "profile_top_m_agl",
     "lowest_level_m_agl": "lowest_level_m_agl",
@@ -158,6 +160,7 @@ _DEFAULT_SORT_DIRECTIONS: dict[CandidateSortKey, CandidateSortDirection] = {
     "primary_story": "asc",
     "story_family": "asc",
     "rank_score": "desc",
+    "deep_tower_opportunity": "desc",
     "confidence": "desc",
     "support": "desc",
     "package_readiness": "desc",
@@ -437,6 +440,12 @@ SORT_OPTIONS: tuple[CandidateSortOption, ...] = (
     CandidateSortOption(key="story_family", label="Story family", default_direction="asc"),
     CandidateSortOption(
         key="rank_score", label="Rank score", units="0-100", default_direction="desc"
+    ),
+    CandidateSortOption(
+        key="deep_tower_opportunity",
+        label="Deep-Tower opportunity",
+        units="0-100",
+        default_direction="desc",
     ),
     CandidateSortOption(key="confidence", label="Confidence", default_direction="desc"),
     CandidateSortOption(key="support", label="Evidence tier", default_direction="desc"),
@@ -798,6 +807,14 @@ def _candidate_with_analysis_context(
     active_label = active_score.label if active_score else candidate.primary_story_label
     active_support = active_score.support if active_score else None
     active_score_value = active_score.score_0_to_100 if active_score else candidate.rank_score
+    scoped_to_deep_tower = (
+        story_filter == "deep_convection_trial" or story_family == "deep_convection"
+    )
+    ingredient_score = (
+        _candidate_deep_tower_opportunity_score(candidate)
+        if scoped_to_deep_tower
+        else active_score_value
+    )
     recipe_fit = _candidate_recipe_fit(
         active_story,
         features=candidate.features,
@@ -831,7 +848,7 @@ def _candidate_with_analysis_context(
             "display_story": active_label,
             "matched_story_ids": [score.story for score in matched_scores],
             "active_story_score": round(active_score_value, 2),
-            "ingredient_score": round(active_score_value, 2),
+            "ingredient_score": round(ingredient_score, 2),
             "active_story_support": active_support,
             "package_readiness": "package_ready" if candidate.package_ready else "blocked",
             "recipe_fit": recipe_fit["status"],
@@ -886,18 +903,7 @@ def _candidate_story_score(candidate: SoundingCandidate, story: TargetStoryId | 
     if story is None:
         return candidate.rank_score
     if story == "deep_convection_trial":
-        return (
-            max(
-                (
-                    score.score_0_to_100
-                    for score in candidate.story_scores
-                    if score.story in DEEP_CONVECTION_STORY_IDS
-                ),
-                default=0.0,
-            )
-            if candidate.package_ready
-            else 0.0
-        )
+        return _candidate_deep_tower_opportunity_score(candidate)
     for score in candidate.story_scores:
         if score.story == story:
             return score.score_0_to_100 if candidate.package_ready else 0.0
@@ -1354,6 +1360,8 @@ def _candidate_sort_value(
     story_family: CandidateStoryFamilyFilter,
 ) -> SortValue | None:
     if sort_by == "best_match":
+        if story_filter == "deep_convection_trial" or story_family == "deep_convection":
+            return _candidate_deep_tower_opportunity_score(candidate)
         score = _candidate_story_score_model(candidate, story_filter, story_family)
         return score.score_0_to_100 if score else candidate.rank_score
     if sort_by == "valid_time":
@@ -1890,6 +1898,16 @@ def _score_features(
     if not observed_wind_available:
         deep_caveats.append("complete_observed_wind_profile_required_for_input_sounding")
 
+    (
+        deep_tower_opportunity,
+        deep_tower_opportunity_support,
+        deep_tower_opportunity_summary,
+        deep_tower_opportunity_caveats,
+    ) = _deep_tower_opportunity(features, package_ready=package_ready)
+    features["deep_tower_opportunity"] = deep_tower_opportunity
+    features["deep_tower_opportunity_support"] = deep_tower_opportunity_support
+    features["deep_tower_opportunity_summary"] = deep_tower_opportunity_summary
+
     moist = _score_high(qv, low=4.0, high=10.0)
     dry = _score_low(qv, low=3.0, high=8.0)
     storm_moisture = _weighted_score(
@@ -2227,6 +2245,20 @@ def _score_features(
         ),
     ]
     evidence = [
+        EvidenceItem(
+            label="Deep-Tower opportunity",
+            value=features.get("deep_tower_opportunity"),
+            units="0-100",
+            interpretation=deep_tower_opportunity_summary,
+            supports_story=[
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "high_cape_pulse_storm",
+                "squall_line_cold_pool_candidate",
+                "elevated_convection",
+            ],
+            caveats=deep_tower_opportunity_caveats,
+        ),
         EvidenceItem(
             label="Low-level qv",
             value=features.get("low_level_qv_g_kg"),
@@ -2602,6 +2634,182 @@ def _story_score(
     )
 
 
+def _deep_tower_opportunity(
+    features: dict[str, float | int | str | bool | None],
+    *,
+    package_ready: bool,
+) -> tuple[float, Support, str, list[str]]:
+    if not package_ready:
+        return (
+            0.0,
+            "unavailable",
+            "Blocked profile; Deep-Tower opportunity cannot be evaluated until packaging works.",
+            ["package_generation_blocked"],
+        )
+
+    sbcape = _numeric_feature(features, "surface_based_cape_j_kg")
+    mlcape = _numeric_feature(features, "mixed_layer_cape_j_kg")
+    sbcin = _numeric_feature(features, "surface_based_cin_j_kg")
+    mlcin = _numeric_feature(features, "mixed_layer_cin_j_kg")
+    lfc = _numeric_feature(features, "lfc_height_m_agl")
+    el = _numeric_feature(features, "el_height_m_agl")
+    qv = _numeric_feature(features, "mean_qv_0_1000m_g_kg")
+    qv_500 = _numeric_feature(features, "mean_qv_0_500m_g_kg")
+    qv_3000 = _numeric_feature(features, "mean_qv_0_3000m_g_kg")
+    precipitable_water = _numeric_feature(features, "precipitable_water_proxy_or_unavailable")
+    moisture_depth = _numeric_feature(features, "moisture_depth_m")
+    lcl = _numeric_feature(features, "estimated_lcl_height_m_agl")
+    lapse_0_1km = _numeric_feature(features, "lapse_rate_0_1000m_c_per_km")
+    lapse_0_3km = _numeric_feature(features, "lapse_rate_0_3000m_c_per_km")
+    midlevel_lapse = _numeric_feature(features, "midlevel_lapse_rate_700_500_hpa_c_per_km")
+    cap = _numeric_feature(features, "cap_strength_proxy")
+    completeness = _numeric_feature(features, "data_completeness_score")
+    lowest_level = _numeric_feature(features, "lowest_level_m_agl")
+    profile_top = _numeric_feature(features, "profile_top_m_agl")
+    near_surface_ok = features.get("near_surface_discontinuity_flag") is not True
+
+    cape_score = _weighted_score(
+        [
+            (_score_high(sbcape, low=500.0, high=2500.0), 0.55),
+            (_score_high(mlcape, low=500.0, high=2500.0), 0.45),
+        ]
+    )
+    effective_cin = min(value for value in (sbcin or 0.0, mlcin or 0.0))
+    inhibition_score = _weighted_score(
+        [
+            (_score_low(abs(effective_cin), low=25.0, high=200.0), 0.45),
+            (_score_low(lfc, low=750.0, high=2500.0), 0.30),
+            (_score_low(cap, low=0.5, high=4.0), 0.25),
+        ]
+    )
+    low_moisture_score = _weighted_score(
+        [
+            (_score_high(qv, low=12.0, high=20.0), 0.45),
+            (_score_high(qv_500, low=12.0, high=20.0), 0.35),
+            (_score_high(precipitable_water, low=25.0, high=45.0), 0.20),
+        ]
+    )
+    deep_moisture_score = _weighted_score(
+        [
+            (_score_high(moisture_depth, low=1000.0, high=3000.0), 0.35),
+            (_score_high(qv_3000, low=9.0, high=14.0), 0.40),
+            (_score_high(precipitable_water, low=25.0, high=45.0), 0.25),
+        ]
+    )
+    lapse_score = _weighted_score(
+        [
+            (_score_high(lapse_0_3km, low=5.5, high=8.0), 0.45),
+            (_score_high(midlevel_lapse, low=6.0, high=8.0), 0.45),
+            (_score_high(lapse_0_1km, low=6.0, high=9.5), 0.10),
+        ]
+    )
+    profile_score = _weighted_score(
+        [
+            (_score_high(completeness, low=70.0, high=95.0), 0.45),
+            (_score_low(lowest_level, low=50.0, high=250.0), 0.20),
+            (100.0 if near_surface_ok else 25.0, 0.25),
+            (_score_high(profile_top, low=12000.0, high=18000.0), 0.10),
+        ]
+    )
+    buoyancy_depth_score = 50.0
+    if el is not None and lfc is not None and el >= 3000.0 and el > lfc:
+        buoyancy_depth_available = True
+        buoyancy_depth_score = _score_high(el - lfc, low=5000.0, high=12000.0)
+    else:
+        buoyancy_depth_available = False
+
+    score = _weighted_score(
+        [
+            (cape_score, 0.30),
+            (low_moisture_score, 0.25),
+            (deep_moisture_score, 0.20),
+            (inhibition_score, 0.10),
+            (lapse_score, 0.08),
+            (profile_score, 0.05),
+            (buoyancy_depth_score, 0.02),
+        ]
+    )
+    effective_cape = max(value for value in (sbcape or 0.0, mlcape or 0.0))
+    if effective_cape < 750.0:
+        score = min(score, 42.0)
+    elif effective_cape < 1200.0:
+        score = min(score, 55.0)
+    elif effective_cape < 1500.0:
+        score = min(score, 65.0)
+    rounded = round(max(0.0, min(100.0, score)), 1)
+    if rounded >= 70.0:
+        support: Support = "supported"
+        summary = (
+            "Deep-Tower opportunity is supported for the convective-ceiling question: "
+            "buoyancy, low-level moisture, deeper moisture, and profile quality align."
+        )
+    elif rounded >= 45.0:
+        support = "weak"
+        summary = (
+            "Deep-Tower opportunity is caveated: some cloud-depth ingredients are present, "
+            "but moisture depth, CAPE, LCL, or inhibition support is not strong."
+        )
+    else:
+        support = "unavailable"
+        summary = (
+            "Deep-Tower opportunity is low for this recipe: the thermodynamic profile does "
+            "not strongly support a tall, useful benchmark cloud."
+        )
+
+    caveats: list[str] = []
+    required_features = [
+        "surface_based_cape_j_kg",
+        "mixed_layer_cape_j_kg",
+        "surface_based_cin_j_kg",
+        "mixed_layer_cin_j_kg",
+        "lfc_height_m_agl",
+        "mean_qv_0_1000m_g_kg",
+        "mean_qv_0_3000m_g_kg",
+        "moisture_depth_m",
+        "lapse_rate_0_3000m_c_per_km",
+        "midlevel_lapse_rate_700_500_hpa_c_per_km",
+        "data_completeness_score",
+        "lowest_level_m_agl",
+    ]
+    caveats.extend(
+        f"missing_or_unavailable_feature:{name}"
+        for name in required_features
+        if _numeric_feature(features, name) is None
+    )
+    if sbcape is not None and mlcape is not None and max(sbcape, mlcape) < 1500.0:
+        caveats.append("deep_tower_opportunity_limited_cape")
+    if qv is not None and qv < 16.0:
+        caveats.append("deep_tower_opportunity_limited_low_level_moisture")
+    if moisture_depth is not None and moisture_depth < 1800.0:
+        caveats.append("deep_tower_opportunity_limited_moisture_depth")
+    if lcl is not None and lcl > 1000.0:
+        caveats.append("deep_tower_opportunity_high_lcl")
+    if cap is not None and cap >= 1.0:
+        caveats.append("deep_tower_opportunity_cap_proxy_present")
+    if not near_surface_ok:
+        caveats.append("near_surface_discontinuity_caveat")
+    if not buoyancy_depth_available:
+        caveats.append("deep_tower_simple_el_not_used_as_hard_gate")
+    caveats.append("deep_tower_opportunity_gives_little_weight_to_shear")
+    return rounded, support, summary, _dedupe_nonempty_strings(caveats)
+
+
+def _candidate_deep_tower_opportunity_score(candidate: SoundingCandidate) -> float:
+    if not candidate.package_ready:
+        return 0.0
+    opportunity = _numeric_feature(candidate.features, "deep_tower_opportunity")
+    if opportunity is not None:
+        return opportunity
+    return max(
+        (
+            score.score_0_to_100
+            for score in candidate.story_scores
+            if score.story in DEEP_CONVECTION_STORY_IDS
+        ),
+        default=0.0,
+    )
+
+
 def _deep_story_score(score: float, *, observed_wind_available: bool) -> float:
     """Let strong deep-convection evidence win over broad moist/shallow labels."""
 
@@ -2649,8 +2857,13 @@ def _candidate_interest_reasons(
         ),
         default=0.0,
     )
-    if deep_score >= 65.0:
-        reasons.append("Strong deep-convection ingredients with observed wind support.")
+    deep_tower_opportunity = _numeric_feature(features, "deep_tower_opportunity")
+    if deep_tower_opportunity is not None and deep_tower_opportunity >= 70.0:
+        reasons.append("Higher Deep-Tower opportunity for testing the convective ceiling.")
+    elif deep_tower_opportunity is not None and deep_tower_opportunity >= 45.0:
+        reasons.append("Caveated Deep-Tower opportunity; cloud-depth ingredients are mixed.")
+    elif deep_score >= 65.0:
+        reasons.append("Supported deep-convection ingredients with observed wind context.")
     elif deep_score >= 35.0:
         reasons.append(
             "Some deep-convection ingredients are present, but the evidence is caveated."

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -281,6 +281,7 @@ class SoundingCandidate(BaseModel):
     matched_story_ids: list[StoryId] = Field(default_factory=list)
     active_story_score: float | None = None
     ingredient_score: float | None = None
+    ingredient_score_label: str | None = None
     active_story_support: Support | None = None
     package_readiness: str | None = None
     recipe_fit: str | None = None
@@ -807,13 +808,22 @@ def _candidate_with_analysis_context(
     active_label = active_score.label if active_score else candidate.primary_story_label
     active_support = active_score.support if active_score else None
     active_score_value = active_score.score_0_to_100 if active_score else candidate.rank_score
-    scoped_to_deep_tower = (
-        story_filter == "deep_convection_trial" or story_family == "deep_convection"
-    )
+    scoped_to_deep_tower = _candidate_scope_is_deep_tower(story_filter, story_family)
     ingredient_score = (
         _candidate_deep_tower_opportunity_score(candidate)
         if scoped_to_deep_tower
         else active_score_value
+    )
+    ingredient_score_label = (
+        "Deep-Tower opportunity" if scoped_to_deep_tower else "Ingredient score"
+    )
+    visible_support = (
+        _candidate_deep_tower_opportunity_support(candidate)
+        if scoped_to_deep_tower
+        else active_support
+    )
+    opportunity_summary = (
+        _candidate_deep_tower_opportunity_summary(candidate) if scoped_to_deep_tower else None
     )
     recipe_fit = _candidate_recipe_fit(
         active_story,
@@ -828,6 +838,7 @@ def _candidate_with_analysis_context(
     evidence_summary = _candidate_evidence_summary(candidate, active_story)
     top_reasons = _dedupe_nonempty_strings(
         [
+            opportunity_summary or "",
             *(active_score.reasons if active_score else []),
             *candidate.interest_reasons,
             *(evidence_summary[:2]),
@@ -849,7 +860,8 @@ def _candidate_with_analysis_context(
             "matched_story_ids": [score.story for score in matched_scores],
             "active_story_score": round(active_score_value, 2),
             "ingredient_score": round(ingredient_score, 2),
-            "active_story_support": active_support,
+            "ingredient_score_label": ingredient_score_label,
+            "active_story_support": visible_support,
             "package_readiness": "package_ready" if candidate.package_ready else "blocked",
             "recipe_fit": recipe_fit["status"],
             "top_reasons": top_reasons,
@@ -1191,6 +1203,8 @@ def _candidate_matches_support_filter(
 ) -> bool:
     if support == "all":
         return True
+    if _candidate_scope_is_deep_tower(story_filter, story_family):
+        return _candidate_deep_tower_opportunity_support(candidate) == support
     scoped_scores = _candidate_story_scores_for_scope(
         candidate,
         story_filter=story_filter,
@@ -1271,7 +1285,7 @@ def _support_label(support: CandidateSupportFilter) -> str:
     if support == "all":
         return "all evidence tiers"
     if support == "supported":
-        return "strong signal"
+        return "supported"
     if support == "weak":
         return "plausible / caveated"
     return "little or no signal"
@@ -1299,12 +1313,13 @@ def _candidate_matches_analysis_filters(
     if story_filter != "all":
         if score is None or not _meaningful_story_score(score):
             return False
-    if support != "all":
-        if story_filter == "all" and story_family == "all":
-            if score is None or score.support != support:
-                return False
-        elif not any(score.support == support for score in scoped_scores):
-            return False
+    if support != "all" and not _candidate_matches_support_filter(
+        candidate,
+        story_filter=story_filter,
+        story_family=story_family,
+        support=support,
+    ):
+        return False
     if not _candidate_matches_station_search(candidate, station_search):
         return False
     return True
@@ -1360,7 +1375,7 @@ def _candidate_sort_value(
     story_family: CandidateStoryFamilyFilter,
 ) -> SortValue | None:
     if sort_by == "best_match":
-        if story_filter == "deep_convection_trial" or story_family == "deep_convection":
+        if _candidate_scope_is_deep_tower(story_filter, story_family):
             return _candidate_deep_tower_opportunity_score(candidate)
         score = _candidate_story_score_model(candidate, story_filter, story_family)
         return score.score_0_to_100 if score else candidate.rank_score
@@ -1380,6 +1395,9 @@ def _candidate_sort_value(
     if sort_by == "confidence":
         return {"low": 0.0, "medium": 1.0, "high": 2.0}[candidate.confidence]
     if sort_by == "support":
+        if _candidate_scope_is_deep_tower(story_filter, story_family):
+            support = _candidate_deep_tower_opportunity_support(candidate)
+            return {"unavailable": 0.0, "weak": 1.0, "supported": 2.0}[support] if support else None
         score = _candidate_story_score_model(candidate, story_filter, story_family)
         return {"unavailable": 0.0, "weak": 1.0, "supported": 2.0}[score.support] if score else None
     if sort_by == "package_readiness":
@@ -2808,6 +2826,31 @@ def _candidate_deep_tower_opportunity_score(candidate: SoundingCandidate) -> flo
         ),
         default=0.0,
     )
+
+
+def _candidate_scope_is_deep_tower(
+    story_filter: CandidateStoryFilter,
+    story_family: CandidateStoryFamilyFilter,
+) -> bool:
+    return story_filter == "deep_convection_trial" or story_family == "deep_convection"
+
+
+def _candidate_deep_tower_opportunity_support(candidate: SoundingCandidate) -> Support | None:
+    support = candidate.features.get("deep_tower_opportunity_support")
+    if support == "supported":
+        return "supported"
+    if support == "weak":
+        return "weak"
+    if support == "unavailable":
+        return "unavailable"
+    return None
+
+
+def _candidate_deep_tower_opportunity_summary(candidate: SoundingCandidate) -> str | None:
+    summary = candidate.features.get("deep_tower_opportunity_summary")
+    if isinstance(summary, str) and summary.strip():
+        return summary.strip()
+    return None
 
 
 def _deep_story_score(score: float, *, observed_wind_available: bool) -> float:

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -1,6 +1,7 @@
 import json
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 import pytest
 from fastapi.testclient import TestClient
@@ -35,6 +36,7 @@ from cloud_chamber.sounding_candidates import (
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
+type FeatureValue = float | int | str | bool | None
 
 
 def _settings(tmp_path: Path) -> CloudChamberSettings:
@@ -184,7 +186,7 @@ def test_screen_cached_soundings_returns_ranked_package_ready_candidates(
 
     result = screen_cached_soundings(settings, latest_per_station=2, limit=10)
 
-    assert result.screening_version == "sounding-screening-v1"
+    assert result.screening_version == "sounding-screening-v2"
     assert len(result.candidates) == 2
     candidate = result.candidates[0]
     assert candidate.station_id == "USM00072558"
@@ -1075,6 +1077,113 @@ def test_deep_convection_scoring_requires_observed_wind_support() -> None:
     assert supercell.support == "unavailable"
     assert severe.support == "unavailable"
     assert "complete_observed_wind_profile_required_for_input_sounding" in supercell.caveats
+
+
+def test_deep_tower_opportunity_separates_success_from_miss_features() -> None:
+    fort_worth_like: dict[str, FeatureValue] = {
+        "data_completeness_score": 100.0,
+        "low_level_qv_g_kg": 22.094,
+        "mean_qv_0_500m_g_kg": 22.094,
+        "mean_qv_0_1000m_g_kg": 20.398,
+        "mean_qv_0_3000m_g_kg": 14.623,
+        "precipitable_water_proxy_or_unavailable": 43.11,
+        "surface_t_td_spread_c": 6.0,
+        "estimated_lcl_height_m_agl": 750.1,
+        "lapse_rate_0_1000m_c_per_km": 8.36,
+        "lapse_rate_0_3000m_c_per_km": 6.88,
+        "midlevel_lapse_rate_700_500_hpa_c_per_km": 7.97,
+        "cap_strength_proxy": 0.0,
+        "cap_height_m_agl": None,
+        "moisture_depth_m": 1893.8,
+        "midlevel_dry_layer_proxy": 10.0,
+        "qv_drop_0_3000m_g_kg": 7.471,
+        "observed_wind_available": True,
+        "bulk_shear_0_1km_m_s": 8.0,
+        "bulk_shear_0_3km_m_s": 15.0,
+        "bulk_shear_0_6km_m_s": 19.88,
+        "dry_microburst_inverted_v_proxy": 50.0,
+        "freezing_level_m_agl": 4200.0,
+        "surface_based_cape_j_kg": 1781.0,
+        "mixed_layer_cape_j_kg": 1820.3,
+        "surface_based_cin_j_kg": 0.0,
+        "mixed_layer_cin_j_kg": -5.3,
+        "lfc_height_m_agl": 2.8,
+        "el_height_m_agl": 98.2,
+        "profile_top_m_agl": 19311.8,
+        "lowest_level_m_agl": 2.8,
+        "near_surface_discontinuity_flag": False,
+    }
+    north_platte_like = {
+        **fort_worth_like,
+        "low_level_qv_g_kg": 16.199,
+        "mean_qv_0_500m_g_kg": 15.723,
+        "mean_qv_0_1000m_g_kg": 14.83,
+        "mean_qv_0_3000m_g_kg": 11.052,
+        "precipitable_water_proxy_or_unavailable": 27.56,
+        "surface_t_td_spread_c": 9.8,
+        "estimated_lcl_height_m_agl": 1225.1,
+        "lapse_rate_0_1000m_c_per_km": 9.59,
+        "lapse_rate_0_3000m_c_per_km": 8.09,
+        "midlevel_lapse_rate_700_500_hpa_c_per_km": 7.58,
+        "cap_strength_proxy": 0.4,
+        "cap_height_m_agl": 1473.2,
+        "moisture_depth_m": 1542.2,
+        "qv_drop_0_3000m_g_kg": 5.148,
+        "bulk_shear_0_1km_m_s": 2.19,
+        "bulk_shear_0_3km_m_s": 9.47,
+        "bulk_shear_0_6km_m_s": 22.39,
+        "dry_microburst_inverted_v_proxy": 69.6,
+        "surface_based_cape_j_kg": 1081.7,
+        "mixed_layer_cape_j_kg": 994.6,
+        "mixed_layer_cin_j_kg": -1.7,
+        "lfc_height_m_agl": 0.2,
+        "el_height_m_agl": 9390.3,
+        "profile_top_m_agl": 19917.2,
+        "lowest_level_m_agl": 0.2,
+    }
+
+    _score_features(fort_worth_like, package_ready=True)
+    _score_features(north_platte_like, package_ready=True)
+
+    fort_score = cast(float, fort_worth_like["deep_tower_opportunity"])
+    north_platte_score = cast(float, north_platte_like["deep_tower_opportunity"])
+    assert fort_score == pytest.approx(81.7)
+    assert fort_worth_like["deep_tower_opportunity_support"] == "supported"
+    assert north_platte_score == pytest.approx(46.1)
+    assert north_platte_like["deep_tower_opportunity_support"] == "weak"
+    assert fort_score > north_platte_score + 30.0
+
+
+def test_analysis_deep_family_best_match_uses_deep_tower_opportunity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    high_story_low_opportunity = _analysis_candidate(
+        "high-story-low-opportunity",
+        deep_score=91.0,
+        deep_support="supported",
+    ).model_copy(update={"features": {"deep_tower_opportunity": 41.0}})
+    lower_story_better_opportunity = _analysis_candidate(
+        "lower-story-better-opportunity",
+        deep_score=72.0,
+        deep_support="supported",
+    ).model_copy(update={"features": {"deep_tower_opportunity": 82.0}})
+    _patch_screened_candidates(
+        monkeypatch,
+        [high_story_low_opportunity, lower_story_better_opportunity],
+    )
+
+    result = analyze_cached_soundings(
+        _settings(tmp_path),
+        story_family="deep_convection",
+        sort_by="best_match",
+    )
+
+    assert [item.candidate_id for item in result.candidates] == [
+        "lower-story-better-opportunity",
+        "high-story-low-opportunity",
+    ]
+    assert [item.active_story_score for item in result.candidates] == [72.0, 91.0]
+    assert [item.ingredient_score for item in result.candidates] == [82.0, 41.0]
 
 
 def test_story_scores_and_evidence_are_traceable_to_soundings() -> None:

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -104,8 +104,18 @@ def _analysis_candidate(
     primary_support: Support = "supported",
     deep_score: float = 70.0,
     deep_support: Support = "supported",
+    deep_opportunity_score: float | None = None,
+    deep_opportunity_support: Support | None = None,
+    deep_opportunity_summary: str | None = None,
     deep_story: StoryId = "supercell_environment",
 ) -> SoundingCandidate:
+    opportunity_score = deep_score if deep_opportunity_score is None else deep_opportunity_score
+    opportunity_support = (
+        deep_support if deep_opportunity_support is None else deep_opportunity_support
+    )
+    opportunity_summary = deep_opportunity_summary or (
+        f"Deep-Tower opportunity fixture summary for {candidate_id}."
+    )
     story_scores = [
         StoryScore(
             story="humid_rainy_candidate",
@@ -135,7 +145,11 @@ def _analysis_candidate(
         rank_score=primary_score,
         confidence="high",
         package_ready=True,
-        features={},
+        features={
+            "deep_tower_opportunity": opportunity_score,
+            "deep_tower_opportunity_support": opportunity_support,
+            "deep_tower_opportunity_summary": opportunity_summary,
+        },
         evidence=[],
         created_at=datetime(2026, 7, 1, tzinfo=UTC),
     )
@@ -530,9 +544,14 @@ def test_analysis_family_filter_includes_supported_secondary_deep_story(
     assert result.candidates[0].matched_story_ids == ["supercell_environment"]
     assert result.candidates[0].active_story_score == 74.0
     assert result.candidates[0].active_story_support == "supported"
+    assert result.candidates[0].ingredient_score == 74.0
+    assert result.candidates[0].ingredient_score_label == "Deep-Tower opportunity"
+    assert result.candidates[0].top_reasons == [
+        "Deep-Tower opportunity fixture summary for primary-humid-supported-secondary-supercell."
+    ]
 
 
-def test_analysis_family_support_filter_uses_deep_family_scores(
+def test_analysis_family_support_filter_uses_deep_tower_opportunity_support(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     supported = _analysis_candidate(
@@ -540,14 +559,18 @@ def test_analysis_family_support_filter_uses_deep_family_scores(
         primary_score=92.0,
         deep_score=74.0,
         deep_support="supported",
+        deep_opportunity_score=82.0,
+        deep_opportunity_support="supported",
     )
-    weak = _analysis_candidate(
-        "secondary-deep-weak",
+    story_supported_low_opportunity = _analysis_candidate(
+        "secondary-deep-story-supported-low-opportunity",
         primary_score=96.0,
-        deep_score=48.0,
-        deep_support="weak",
+        deep_score=88.0,
+        deep_support="supported",
+        deep_opportunity_score=41.0,
+        deep_opportunity_support="unavailable",
     )
-    _patch_screened_candidates(monkeypatch, [weak, supported])
+    _patch_screened_candidates(monkeypatch, [story_supported_low_opportunity, supported])
 
     result = analyze_cached_soundings(
         _settings(tmp_path),
@@ -558,9 +581,11 @@ def test_analysis_family_support_filter_uses_deep_family_scores(
     assert [item.candidate_id for item in result.candidates] == ["secondary-deep-supported"]
     assert result.filtered_candidate_count == 1
     assert result.candidates[0].active_story == "supercell_environment"
+    assert result.candidates[0].ingredient_score == 82.0
+    assert result.candidates[0].active_story_support == "supported"
     assert result.filter_trace.stage_counts["story_family"] == 2
     assert result.filter_trace.stage_counts["support"] == 1
-    assert result.filter_trace.top_excluded_reasons[0].reason == "Evidence tier: strong signal"
+    assert result.filter_trace.top_excluded_reasons[0].reason == "Evidence tier: supported"
     assert result.filter_trace.top_excluded_reasons[0].count == 1
 
 
@@ -570,14 +595,18 @@ def test_analysis_deep_family_best_match_sort_uses_best_deep_score(
     humid_but_weaker_deep = _analysis_candidate(
         "humid-high-weaker-deep",
         primary_score=99.0,
-        deep_score=67.0,
+        deep_score=91.0,
         deep_support="supported",
+        deep_opportunity_score=41.0,
+        deep_opportunity_support="unavailable",
     )
     lower_primary_better_deep = _analysis_candidate(
         "humid-lower-better-deep",
         primary_score=76.0,
-        deep_score=91.0,
+        deep_score=67.0,
         deep_support="supported",
+        deep_opportunity_score=82.0,
+        deep_opportunity_support="supported",
     )
     _patch_screened_candidates(monkeypatch, [humid_but_weaker_deep, lower_primary_better_deep])
 
@@ -591,7 +620,12 @@ def test_analysis_deep_family_best_match_sort_uses_best_deep_score(
         "humid-lower-better-deep",
         "humid-high-weaker-deep",
     ]
-    assert [item.active_story_score for item in result.candidates] == [91.0, 67.0]
+    assert [item.active_story_score for item in result.candidates] == [67.0, 91.0]
+    assert [item.ingredient_score for item in result.candidates] == [82.0, 41.0]
+    assert [item.active_story_support for item in result.candidates] == [
+        "supported",
+        "unavailable",
+    ]
 
 
 def test_analysis_filter_trace_preserves_distinct_candidate_rows_after_grouping(

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -502,8 +502,14 @@ function preRunValidationReportForRequest(body: {
       story_id: activeStory,
       story_label: activeLabel,
       ingredient_score:
-        typeof body.candidate_screening?.rank_score === "number"
-          ? body.candidate_screening.rank_score
+        typeof body.candidate_screening?.ingredient_score === "number"
+          ? body.candidate_screening.ingredient_score
+          : typeof body.candidate_screening?.rank_score === "number"
+            ? body.candidate_screening.rank_score
+            : null,
+      ingredient_score_label:
+        typeof body.candidate_screening?.ingredient_score_label === "string"
+          ? body.candidate_screening.ingredient_score_label
           : null,
       predicted_output_signature:
         observed || deepTower ? ["qv", "qc", "w", "qr", "rain", "dbz"] : [],
@@ -675,6 +681,10 @@ const secondaryShallowCandidate = {
     ...shallowCandidate.features,
     mean_qv_0_1000m_g_kg: 13.6,
     estimated_lcl_height_m_agl: 640,
+    deep_tower_opportunity: 48.9,
+    deep_tower_opportunity_support: "weak",
+    deep_tower_opportunity_summary:
+      "Deep-Tower opportunity is caveated: some cloud-depth ingredients are present, but moisture depth, CAPE, LCL, or inhibition support is not strong.",
   },
   interest_summary: "Very moist lower atmosphere.",
   interest_reasons: [
@@ -740,6 +750,13 @@ const deepConvectionCandidate = {
     "Strong deep-convection ingredients with observed wind support.",
     "Observed 0-6 km shear gives storm-organization context.",
   ],
+  features: {
+    ...shallowCandidate.features,
+    deep_tower_opportunity: 82,
+    deep_tower_opportunity_support: "supported",
+    deep_tower_opportunity_summary:
+      "Deep-Tower opportunity is supported for the convective-ceiling question.",
+  },
   discovery_bucket: "Deep convection",
 };
 
@@ -902,6 +919,9 @@ function screeningResponseForRequest(init?: RequestInit) {
   });
   const supportFiltered = storyFiltered.filter((candidate) => {
     if (support === "all") return true;
+    if (storyFilter === "deep_convection_trial" || storyFamily === "deep_convection") {
+      return candidateDeepTowerSupportForTest(candidate) === support;
+    }
     const scopedScores = storyScoresForTest(candidate, storyFilter, storyFamily);
     if (storyFilter === "all" && storyFamily === "all") {
       const score = storyScoreForTest(candidate, storyFilter, storyFamily);
@@ -1025,6 +1045,10 @@ function candidateWithActiveFieldsForTest(
     )[0] ?? null;
   const activeStory = activeScore?.story ?? candidate.primary_story;
   const activeLabel = activeScore?.label ?? candidate.primary_story_label;
+  const deepScope = storyFilter === "deep_convection_trial" || storyFamily === "deep_convection";
+  const deepOpportunity = candidateDeepTowerOpportunityForTest(candidate);
+  const deepSupport = candidateDeepTowerSupportForTest(candidate);
+  const deepSummary = candidateDeepTowerSummaryForTest(candidate);
   return {
     ...candidate,
     active_story: activeStory,
@@ -1034,12 +1058,16 @@ function candidateWithActiveFieldsForTest(
       .sort((left, right) => right.score_0_to_100 - left.score_0_to_100)
       .map((score) => score.story),
     active_story_score: activeScore?.score_0_to_100 ?? candidate.rank_score,
-    ingredient_score: activeScore?.score_0_to_100 ?? candidate.rank_score,
-    active_story_support: activeScore?.support ?? null,
+    ingredient_score:
+      deepScope && deepOpportunity !== null
+        ? deepOpportunity
+        : (activeScore?.score_0_to_100 ?? candidate.rank_score),
+    ingredient_score_label: deepScope ? "Deep-Tower opportunity" : "Ingredient score",
+    active_story_support: deepScope ? deepSupport : (activeScore?.support ?? null),
     package_readiness: candidate.package_ready ? "package_ready" : "blocked",
     recipe_fit:
       "recipe_fit_status" in candidate ? candidate.recipe_fit_status : "partially_testable",
-    top_reasons: candidate.interest_reasons ?? [],
+    top_reasons: deepScope && deepSummary ? [deepSummary] : (candidate.interest_reasons ?? []),
     top_caveats: candidate.caveats.slice(0, 2),
     evidence_summary: candidate.evidence.map((item) => item.interpretation).slice(0, 3),
   };
@@ -1106,6 +1134,9 @@ function candidateSortValueForTest(
   sortBy: string,
 ) {
   if (sortBy === "best_match") {
+    if (storyFilter === "deep_convection_trial" || storyFamily === "deep_convection") {
+      return candidateDeepTowerOpportunityForTest(candidate);
+    }
     return (
       storyScoreForTest(candidate, storyFilter, storyFamily)?.score_0_to_100 ?? candidate.rank_score
     );
@@ -1115,6 +1146,27 @@ function candidateSortValueForTest(
   if (sortBy === "package_readiness") return Number(candidate.package_ready);
   const value = (candidate.features as Record<string, unknown>)[sortBy];
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function candidateDeepTowerOpportunityForTest(
+  candidate: (typeof screeningResponse.candidates)[number],
+): number | null {
+  const value = (candidate.features as Record<string, unknown>).deep_tower_opportunity;
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function candidateDeepTowerSupportForTest(
+  candidate: (typeof screeningResponse.candidates)[number],
+): string | null {
+  const value = (candidate.features as Record<string, unknown>).deep_tower_opportunity_support;
+  return typeof value === "string" ? value : null;
+}
+
+function candidateDeepTowerSummaryForTest(
+  candidate: (typeof screeningResponse.candidates)[number],
+): string | null {
+  const value = (candidate.features as Record<string, unknown>).deep_tower_opportunity_summary;
+  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 const savedCandidatesResponse = {
@@ -3864,12 +3916,13 @@ describe("App", () => {
     const deepCard = screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)");
     expect(deepCard).toHaveTextContent("Supercell-like environment");
     expect(deepCard).toHaveTextContent(
-      "Deep-tower candidate with stronger screening support; use the benchmark trigger to test the convective ceiling.",
+      "Deep-Tower opportunity is supported for the convective-ceiling question.",
     );
+    expect(deepCard).toHaveTextContent("Deep-Tower opportunity");
 
     fireEvent.click(within(deepCard).getByRole("button", { name: "Configure run" }));
     expect(screen.getByLabelText("Candidate details")).toHaveTextContent(
-      "First run: Deep-Tower Benchmark · stock CM1 iinit=3 · ~120 km · 2 h.",
+      "Recommended Deep-Tower scout · stock CM1 iinit=3 · ~120 km · 2 h.",
     );
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
 
@@ -3911,7 +3964,136 @@ describe("App", () => {
       expect(dryRunBody).toContain('"candidate_screening"');
       expect(dryRunBody).toContain('"primary_story":"supercell_environment"');
       expect(dryRunBody).toContain('"candidate_id":"USM00072357-2025052000-supercell"');
+      expect(dryRunBody).toContain('"ingredient_score":82');
+      expect(dryRunBody).toContain('"ingredient_score_label":"Deep-Tower opportunity"');
     });
+  });
+
+  it("does not present severe-story support as Deep-Tower opportunity support", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    const lowOpportunityCandidate = {
+      ...deepConvectionCandidate,
+      candidate_id: "USM00072456-2025060300-low-deep-opportunity",
+      station_id: "USM00072456",
+      station_name: "Topeka, Kansas",
+      valid_time_utc: "2025-06-03T00:00:00Z",
+      rank_score: 91,
+      story_scores: [
+        {
+          story: "supercell_environment",
+          label: "Supercell-like environment",
+          score_0_to_100: 91,
+          support: "supported",
+        },
+        {
+          story: "severe_thunderstorm_environment",
+          label: "Severe thunderstorm environment",
+          score_0_to_100: 84,
+          support: "supported",
+        },
+      ],
+      features: {
+        ...deepConvectionCandidate.features,
+        deep_tower_opportunity: 41,
+        deep_tower_opportunity_support: "unavailable",
+        deep_tower_opportunity_summary:
+          "Deep-Tower opportunity is low for this recipe: the thermodynamic profile does not strongly support a tall, useful benchmark cloud.",
+      },
+    };
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/sounding-candidates/analyze") {
+        const request = JSON.parse(String(init?.body ?? "{}")) as {
+          story_filter?: string;
+          story_family?: string;
+          support?: string;
+        };
+        const activeCandidate = candidateWithActiveFieldsForTest(
+          lowOpportunityCandidate as (typeof screeningResponse.candidates)[number],
+          request.story_filter ?? "all",
+          request.story_family ?? "all",
+        );
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ...screeningResponse,
+              candidates:
+                request.support === "supported" ? [] : [activeCandidate],
+              total_candidate_count: 1,
+              filtered_candidate_count: request.support === "supported" ? 0 : 1,
+              filters: {
+                ...screeningResponse.filters,
+                story_filter: request.story_filter ?? "all",
+                story_family: request.story_family ?? "all",
+                support: request.support ?? "all",
+              },
+              filter_trace: {
+                ...screeningResponse.filter_trace,
+                selected_station_count: 1,
+                selected_cached_soundings: 1,
+                analyzed_soundings: 1,
+                story_score_records: 2,
+                stage_counts: {
+                  ...screeningResponse.filter_trace.stage_counts,
+                  analyzed_soundings: 1,
+                  story_filter: 1,
+                  story_family: 1,
+                  support: request.support === "supported" ? 0 : 1,
+                  readiness: request.support === "supported" ? 0 : 1,
+                  station_search: request.support === "supported" ? 0 : 1,
+                  sorted_or_recommended: request.support === "supported" ? 0 : 1,
+                  limited: request.support === "supported" ? 0 : 1,
+                },
+                station_distribution:
+                  request.support === "supported"
+                    ? []
+                    : [
+                        {
+                          station_id: "USM00072456",
+                          station_name: "Topeka, Kansas",
+                          count: 1,
+                        },
+                      ],
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+    fireEvent.change(await screen.findByLabelText("Experiment"), {
+      target: { value: "__observed_sounding_upload__" },
+    });
+    fireEvent.click(await screen.findByText("Advanced filters"));
+    fireEvent.change(await screen.findByLabelText("Story"), {
+      target: { value: "deep_convection_trial" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply advanced filters" }));
+
+    const lowCard = await screen.findByLabelText("Sounding candidate Topeka, Kansas (USM00072456)");
+    expect(lowCard).toHaveTextContent("Supercell-like environment");
+    expect(lowCard).toHaveTextContent("Deep-Tower opportunity");
+    expect(lowCard).toHaveTextContent("41 %");
+    expect(lowCard).toHaveTextContent(
+      "Deep-Tower opportunity is low for this recipe: the thermodynamic profile does not strongly support a tall, useful benchmark cloud.",
+    );
+    expect(lowCard).not.toHaveTextContent("stronger screening support");
+
+    fireEvent.click(within(lowCard).getByRole("button", { name: "Configure run" }));
+    const details = screen.getByLabelText("Candidate details");
+    expect(details).toHaveTextContent(
+      "Skip for Deep-Tower cloud-making unless deliberately overriding.",
+    );
+    expect(details).toHaveTextContent("Deep-Tower opportunity");
+    expect(details).toHaveTextContent("41 %");
+    expect(within(lowCard).getByRole("button", { name: "Configure run" })).not.toBeDisabled();
   });
 
   it("keeps humid/rainy candidates with weak deep scores on observed quick-look", async () => {
@@ -4424,10 +4606,10 @@ describe("App", () => {
     );
     expect(wilmingtonCard).toHaveTextContent("High-CAPE pulse storm");
     expect(wilmingtonCard).not.toHaveTextContent("Primary: Humid / rainy");
-    expect(wilmingtonCard).toHaveTextContent("48.9 % ingredient score");
+    expect(wilmingtonCard).toHaveTextContent("48.9 % deep-tower opportunity");
     expect(wilmingtonCard).toHaveTextContent("testable with Deep-Tower Benchmark");
     expect(wilmingtonCard).toHaveTextContent(
-      "Caveated deep-tower candidate; use the benchmark trigger to test the convective ceiling.",
+      "Deep-Tower opportunity is caveated: some cloud-depth ingredients are present, but moisture depth, CAPE, LCL, or inhibition support is not strong.",
     );
     expect(
       screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -376,6 +376,7 @@ type CandidateSort =
   | "primary_story"
   | "story_family"
   | "rank_score"
+  | "deep_tower_opportunity"
   | "confidence"
   | "support"
   | "package_readiness"
@@ -5563,6 +5564,7 @@ function ObservedAtmosphereCandidatesPanel({
               <option value="primary_story">Primary story</option>
               <option value="story_family">Story family</option>
               <option value="rank_score">Rank score</option>
+              <option value="deep_tower_opportunity">Deep-Tower opportunity</option>
               <option value="confidence">Confidence</option>
               <option value="support">Evidence tier</option>
               <option value="package_readiness">Package readiness</option>
@@ -11171,6 +11173,7 @@ function candidateSortLabel(sort: CandidateSort): string {
     primary_story: "Primary story",
     story_family: "Story family",
     rank_score: "Rank score",
+    deep_tower_opportunity: "Deep-Tower opportunity",
     confidence: "Confidence",
     support: "Evidence tier",
     package_readiness: "Package readiness",

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -198,6 +198,7 @@ type PreRunValidationReport = {
     story_id?: string | null;
     story_label?: string | null;
     ingredient_score?: number | null;
+    ingredient_score_label?: string | null;
     predicted_output_signature?: string[];
   } | null;
   selected_run_recipe?: {
@@ -522,6 +523,7 @@ type SoundingCandidate = {
   matched_story_ids?: CandidateStoryId[];
   active_story_score?: number | null;
   ingredient_score?: number | null;
+  ingredient_score_label?: string | null;
   active_story_support?: "supported" | "weak" | "unavailable" | null;
   package_readiness?: string | null;
   recipe_fit?: CandidateRecipeFitStatus | string | null;
@@ -4531,7 +4533,10 @@ function PreRunValidationReportPanel({ report }: { report: PreRunValidationRepor
           }
         />
         {typeof hypothesis?.ingredient_score === "number" && (
-          <Metric label="Ingredient score" value={`${Math.round(hypothesis.ingredient_score)} %`} />
+          <Metric
+            label={hypothesis.ingredient_score_label ?? "Ingredient score"}
+            value={`${Math.round(hypothesis.ingredient_score)} %`}
+          />
         )}
         <Metric
           label="Run recipe"
@@ -5546,7 +5551,7 @@ function ObservedAtmosphereCandidatesPanel({
               }
             >
               <option value="all">All evidence tiers</option>
-              <option value="supported">Strong signal</option>
+              <option value="supported">Supported</option>
               <option value="weak">Plausible / caveated</option>
               <option value="unavailable">Little or no signal</option>
             </select>
@@ -5890,6 +5895,11 @@ function SoundingCandidateCard({
   const story = candidateActiveStoryId(candidate, storyFilter, storyFamilyFilter);
   const activeFamily = story ? candidateStoryFamilyForStory(story) : candidate.story_family;
   const ingredientScore = candidateIngredientScore(candidate, storyFilter, storyFamilyFilter);
+  const ingredientScoreLabel = candidateIngredientScoreLabel(
+    candidate,
+    storyFilter,
+    storyFamilyFilter,
+  );
   const recipeFit = candidateRecipeFitForStory(candidate, story);
   const reasons = candidateInterestReasons(candidate).slice(0, 3);
   const keyNote = candidateKeyNote(candidate, story, recipeFit);
@@ -5909,7 +5919,7 @@ function SoundingCandidateCard({
         </span>
         <span className="candidate-card-storyline">
           {candidateDisplayStoryLabel(candidate, storyFilter, storyFamilyFilter)} ·{" "}
-          {formatNumber(ingredientScore, "%")} ingredient score ·{" "}
+          {formatNumber(ingredientScore, "%")} {ingredientScoreLabel.toLowerCase()} ·{" "}
           {candidate.package_ready ? "Package-ready" : "Blocked"}
         </span>
       </button>
@@ -5984,6 +5994,11 @@ function SoundingCandidateDetail({
   const story = candidateActiveStoryId(activeCandidate, storyFilter, storyFamilyFilter);
   const activeFamily = story ? candidateStoryFamilyForStory(story) : activeCandidate.story_family;
   const ingredientScore = candidateIngredientScore(activeCandidate, storyFilter, storyFamilyFilter);
+  const ingredientScoreLabel = candidateIngredientScoreLabel(
+    activeCandidate,
+    storyFilter,
+    storyFamilyFilter,
+  );
   const recipeFit = candidateRecipeFitForStory(activeCandidate, story);
   const reasons = candidateInterestReasons(activeCandidate).slice(0, 5);
   const topLimits = candidateTopLimits(activeCandidate, story, recipeFit);
@@ -6126,7 +6141,7 @@ function SoundingCandidateDetail({
         </ul>
       </section>
       <dl className="compact-metrics">
-        <Metric label="Ingredient score" value={formatNumber(ingredientScore, "%")} />
+        <Metric label={ingredientScoreLabel} value={formatNumber(ingredientScore, "%")} />
         <Metric label="Evidence level" value={humanize(candidate.confidence)} />
         <Metric label="Screened story family" value={candidateStoryFamilyLabel(activeFamily)} />
         <Metric label="Recipe fit" value={recipeFit.label} />
@@ -11203,7 +11218,7 @@ function candidateSortLabel(sort: CandidateSort): string {
 function supportTierLabel(support: CandidateSupportFilter): string {
   const labels: Record<CandidateSupportFilter, string> = {
     all: "All evidence tiers",
-    supported: "Strong signal",
+    supported: "Supported",
     weak: "Plausible / caveated",
     unavailable: "Little or no signal",
   };
@@ -11568,6 +11583,24 @@ function candidateIngredientScore(
   );
 }
 
+function candidateIngredientScoreLabel(
+  candidate: SoundingCandidate,
+  storyFilter: CandidateStoryFilter,
+  storyFamilyFilter: CandidateStoryFamilyFilter = "all",
+): string {
+  if (candidateScopeIsDeepTower(storyFilter, storyFamilyFilter)) {
+    return candidate.ingredient_score_label ?? "Deep-Tower opportunity";
+  }
+  return candidate.ingredient_score_label ?? "Ingredient score";
+}
+
+function candidateScopeIsDeepTower(
+  storyFilter: CandidateStoryFilter,
+  storyFamilyFilter: CandidateStoryFamilyFilter,
+): boolean {
+  return storyFilter === "deep_convection_trial" || storyFamilyFilter === "deep_convection";
+}
+
 function candidateActiveStoryScore(
   candidate: SoundingCandidate,
   storyFilter: CandidateStoryFilter,
@@ -11630,17 +11663,19 @@ function candidateKeyNote(
     return candidateTopLimits(candidate, story, recipeFit)[0] ?? "Needs review before run setup.";
   }
   if (candidateStoryFamilyForStory(story) === "deep_convection") {
+    const opportunitySummary = candidateDeepTowerOpportunitySummary(candidate);
+    if (opportunitySummary) return opportunitySummary;
     const activeSupport =
       candidate.active_story === story
         ? candidate.active_story_support
         : candidate.story_scores.find((score) => score.story === story)?.support;
     if (activeSupport === "supported") {
-      return "Deep-tower candidate with stronger screening support; use the benchmark trigger to test the convective ceiling.";
+      return "Deep-Tower opportunity is supported; use the benchmark trigger to test the convective ceiling.";
     }
     if (activeSupport === "weak") {
-      return "Caveated deep-tower candidate; use the benchmark trigger to test the convective ceiling.";
+      return "Caveated Deep-Tower opportunity; use the benchmark trigger to test the convective ceiling.";
     }
-    return "Deep-tower candidate; use the benchmark trigger to test the convective ceiling.";
+    return "Deep-Tower candidate; use the benchmark trigger to test the convective ceiling.";
   }
   if (
     story === "humid_rainy_candidate" ||
@@ -11651,6 +11686,22 @@ function candidateKeyNote(
     return "Good for a surface-forced run.";
   }
   return candidateTopLimits(candidate, story, recipeFit)[0] ?? "No major blocker found.";
+}
+
+function candidateDeepTowerOpportunitySummary(candidate: SoundingCandidate): string | null {
+  const summary = candidate.features.deep_tower_opportunity_summary;
+  return typeof summary === "string" && summary.length > 0 ? summary : null;
+}
+
+function candidateDeepTowerOpportunityScore(candidate: SoundingCandidate): number | null {
+  if (typeof candidate.ingredient_score === "number" && Number.isFinite(candidate.ingredient_score)) {
+    return candidate.ingredient_score;
+  }
+  const opportunity = candidate.features.deep_tower_opportunity;
+  if (typeof opportunity === "number" && Number.isFinite(opportunity)) {
+    return opportunity;
+  }
+  return null;
 }
 
 function candidateTopLimits(
@@ -11705,12 +11756,32 @@ function candidateRunRecommendation(
     };
   }
   if (candidateStoryFamilyForStory(story) === "deep_convection") {
+    const opportunityScore = candidateDeepTowerOpportunityScore(candidate);
+    if (opportunityScore !== null && opportunityScore >= 70) {
+      return {
+        title: "Recommended Deep-Tower scout · stock CM1 iinit=3 · ~120 km · 2 h.",
+        detail:
+          "Disable surface fluxes and use explicit thermal initiation to test this observed atmosphere's convective ceiling.",
+        followUp:
+          "Inspect cloud depth, updraft, precipitation, and reflectivity before changing the trigger or resolution.",
+      };
+    }
+    if (opportunityScore !== null && opportunityScore >= 45) {
+      return {
+        title:
+          "Weak Deep-Tower opportunity · run for calibration or learning, not as a best cloud bet.",
+        detail:
+          "If deliberately running it, keep the Deep-Tower Benchmark setup comparable: stock CM1 iinit=3, ~120 km domain, 2 h, and disabled surface fluxes.",
+        followUp:
+          "Use the result to calibrate the selector rather than treating it as the next visual cloud-making target.",
+      };
+    }
     return {
-      title: "First run: Deep-Tower Benchmark · stock CM1 iinit=3 · ~120 km · 2 h.",
+      title: "Skip for Deep-Tower cloud-making unless deliberately overriding.",
       detail:
-        "Disable surface fluxes and use explicit thermal initiation to test this observed atmosphere's convective ceiling.",
+        "Manual configuration remains available; if overriding, keep the Deep-Tower Benchmark setup comparable so the outcome is interpretable.",
       followUp:
-        "Inspect cloud depth, updraft, precipitation, and reflectivity before changing the trigger or resolution.",
+        "Spend normal cloud-making scout compute on candidates with supported Deep-Tower opportunity.",
     };
   }
   if (story === "dry_failed_candidate" || story === "capped_suppressed_candidate") {
@@ -11878,6 +11949,7 @@ function candidateScreeningMetadata(
     rank_score: candidate.rank_score,
     active_story_score: candidate.active_story_score ?? null,
     ingredient_score: candidate.ingredient_score ?? null,
+    ingredient_score_label: candidate.ingredient_score_label ?? null,
     active_story_support: candidate.active_story_support ?? null,
     confidence: candidate.confidence,
     features: candidate.features,

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -30,8 +30,8 @@ The v1 candidate stories are:
 
 Visible labels may be friendlier, but every visible story must be backed by
 `story_scores`, feature values, evidence items, caveats, and package readiness.
-Deep-convection-oriented stories are pre-run hypotheses for Deep Convection
-Trial routing, not outcome claims.
+Deep-convection-oriented stories are pre-run hypotheses for Deep-Tower
+Benchmark routing, not outcome claims.
 
 ## Feature Inputs
 
@@ -89,9 +89,24 @@ profile fields, including:
 - required thermodynamic fields
 - observed u/v wind components
 
-The v1 screen does not compute CAPE, CIN, LFC, EL, storm-relative helicity,
-map/GIS forcing, or radar/precipitation predictors. Those require separate
-research, diagnostics, and validation before becoming product-facing evidence.
+The current screen includes simple sounding-only CAPE, CIN, LFC, and EL
+proxies for Deep-Tower Benchmark opportunity scoring. It still does not compute
+storm-relative helicity, map/GIS forcing, or radar/precipitation predictors.
+Those require separate research, diagnostics, and validation before becoming
+product-facing evidence.
+
+### Deep-Tower Opportunity
+
+`deep_tower_opportunity` is a recipe-specific 0-100 selector for the
+Deep-Tower Benchmark. It is not a replacement for severe/supercell story
+scores and should not be read as an observed storm forecast.
+
+The score weights surface-based CAPE, mixed-layer CAPE, CIN, LFC, cap proxy,
+low-level moisture, deeper moisture, 0-3 km and midlevel lapse rates, profile
+completeness, and near-surface continuity. EL or buoyancy depth contributes
+only when the simple EL estimate is usable. Deep-layer shear receives little or
+no weight because this selector asks whether the benchmark trigger can reveal a
+deep convective ceiling, not whether a storm will organize.
 
 ## Story Logic
 

--- a/docs/research/cloud-chase-003-deep-tower-opportunity.md
+++ b/docs/research/cloud-chase-003-deep-tower-opportunity.md
@@ -1,0 +1,144 @@
+# Cloud Chase 003: Deep-Tower Opportunity Calibration
+
+Issue: #351
+
+## Goal
+
+Improve the analyzer's answer to one recipe-specific question:
+
+> Which observed soundings are worth spending a Deep-Tower Benchmark scout on?
+
+This does not replace the existing severe/supercell story scores. Those remain
+broader sounding hypotheses. The new `deep_tower_opportunity` field is narrower:
+it scores whether the observed thermodynamic profile looks worth testing with
+the Deep-Tower Benchmark's explicit CM1 thermal trigger.
+
+## Scoring Change
+
+Analyzer version: `sounding-screening-v2`.
+
+The score favors ingredients that actually decide the cloud-depth question for
+the benchmark trigger:
+
+- surface-based and mixed-layer CAPE;
+- CIN, LFC, and cap proxy;
+- low-level moisture and deeper moisture;
+- 0-3 km and midlevel lapse rates;
+- profile completeness and near-surface continuity;
+- EL or buoyancy depth only when the simple EL estimate is usable.
+
+Deep-layer shear receives no positive weight in this recipe-specific score. It
+remains useful for storm-organization stories, but Fort Worth versus North
+Platte showed that shear can make a poor Deep-Tower Benchmark target look too
+good.
+
+## Outcome Evidence Compared
+
+| Feature | Fort Worth success | North Platte miss |
+| --- | ---: | ---: |
+| Station / time | `USM00072249` / `1997-05-27T00:00:00Z` | `USM00072562` / `2026-07-02T00:00:00Z` |
+| Surface-based CAPE | 1781.0 J/kg | 1081.7 J/kg |
+| Mixed-layer CAPE | 1820.3 J/kg | 994.6 J/kg |
+| Mixed-layer CIN | -5.3 J/kg | -1.7 J/kg |
+| LFC | 2.8 m AGL | 0.2 m AGL |
+| Mean qv 0-1 km | 20.398 g/kg | 14.83 g/kg |
+| Mean qv 0-3 km | 14.623 g/kg | 11.052 g/kg |
+| Moisture depth | 1893.8 m | 1542.2 m |
+| Estimated LCL | 750.1 m AGL | 1225.1 m AGL |
+| Cap proxy | 0.0 | 0.4 |
+| 0-3 km lapse rate | 6.88 C/km | 8.09 C/km |
+| Midlevel lapse rate | 7.97 C/km | 7.58 C/km |
+| 0-6 km shear | 19.88 m/s | 22.39 m/s |
+| Previous strongest deep story | 77.3 supported | 62.6 weak |
+| `deep_tower_opportunity` | 81.7 supported | 46.1 weak |
+
+The most plausible separators are CAPE, low-level/deep moisture, lower cloud
+base, and absence of cap support. North Platte had stronger shear and steeper
+low-level lapse-rate support, but those ingredients did not translate into a
+coherent cloud under the benchmark trigger.
+
+## Recommendation Trials
+
+| Sounding | Analyzer version | Recipe / setup | Actual outcome |
+| --- | --- | --- | --- |
+| Fort Worth `USM00072249`, `1997-05-27T00:00:00Z` | `sounding-screening-v2` | `deep_tower_benchmark_v0`; stock CM1 `iinit = 3`; 120 km x 120 km; 120 x 120 x 40; 20 km model top; Rayleigh 15 km; 2 h; 15 min output; 6 s step; surface fluxes disabled | Success: coherent cloud top about 17.25 km, hydrometeor envelope about 19.75 km, max updraft 54.13 m/s, precipitation and 65.38 dBZ reflectivity, visual interest 5/5. |
+| North Platte `USM00072562`, `2026-07-02T00:00:00Z` | `sounding-screening-v2` | Same Deep-Tower Benchmark setup; stopped after partial scout through 6300 s | Miss: no coherent cloud, no precipitation, max updraft about 0.86 m/s, visual interest 1/5. |
+| Topeka `USM00072456`, `2026-06-10T00:00:00Z` | `sounding-screening-v2` | Same Deep-Tower Benchmark setup; completed 7200 s | Weak/shallow miss: shallow coherent cloud object only, no deep breakthrough. |
+
+## New Candidate Selection
+
+The revised analyzer scanned cached history with:
+
+- `history_scope = all_cached`
+- `story_family = deep_convection`
+- `readiness = package_ready`
+- `sort_by = best_match`
+
+It analyzed 16,306 cached profiles and found 629 package-ready deep-family
+candidates. The top remaining score after excluding the two executed outcomes
+and Rapid City was a weak 55/100 tie between Aberdeen and Topeka. Topeka was
+selected as the single new calibration scout because Aberdeen had already been
+the explicitly skipped candidate in Cloud Chase 001; this is a tie-breaker for
+new calibration value, not a station blacklist.
+
+Selected candidate:
+
+- Station: Topeka/Mun., KS, `USM00072456`.
+- Valid time: `2026-06-10T00:00:00Z`.
+- Predicted opportunity: 55.0/100, weak.
+- Active story: dry microburst / inverted-V candidate, 54.3.
+- Ingredients: SBCAPE 628.2 J/kg, MLCAPE 932.5 J/kg, qv 0-1 km 19.282 g/kg,
+  qv 0-3 km 11.875 g/kg, moisture depth 1837.9 m, LCL 825.1 m, cap proxy 1.0.
+
+## Topeka CM1 Result
+
+Run: `cloud_chase_003-topeka_deep_tower_opportunity`.
+
+Exact run shape:
+
+- Recipe: `deep_tower_benchmark_v0`.
+- Initiation: stock CM1 `iinit = 3` three-warm-bubble line trigger.
+- Lower boundary: surface heat/moisture fluxes disabled.
+- Domain: 120 km x 120 km.
+- Grid: 120 x 120 x 40; 1 km dx/dy; 500 m dz.
+- Model top: 20 km.
+- Rayleigh damping start: 15 km.
+- Duration: 7200 s.
+- Output cadence: 900 s.
+- Time step: 6 s.
+
+Runtime and integrity:
+
+- Completed normally with exit code 0.
+- Queue interval was about 12 minutes wall-clock.
+- CM1 reported total runtime 666.125 s.
+- Ingest completed and retained the run for Explore.
+- Runtime warning: `IEEE_UNDERFLOW_FLAG` only.
+- Output: 10 NetCDF paths cataloged, including 9 model-output frames plus stats.
+
+Actual cloud outcome:
+
+- Category: weak shallow cloud / failed deep-tower candidate.
+- First cloud: 1800 s.
+- Coherent cloud-object top: 1250 m.
+- Hydrometeor envelope top: 1250 m.
+- Highest liquid cloud top: 1250 m.
+- Maximum updraft: 0.890 m/s at 2700 s.
+- Maximum cloud water: 8.878e-4 kg/kg at 4500 s.
+- Rain water aloft: trace, first detected at 2700 s; max qr 7.22e-6 kg/kg.
+- Surface rain: trace, max 2.82e-6 cm.
+- Reflectivity: available but not meaningful; max diagnostic value 0.0 dBZ
+  with negative values during the shallow-cloud period.
+
+Ratings:
+
+- Visual-interest rating: 2/5.
+- Worth-the-compute rating: 4/5 for calibration, 1/5 for visual output.
+
+## Recommendation
+
+For the next calibration step, spend the next real scout only on a supported
+`deep_tower_opportunity` candidate above the weak band, preferably one with
+effective CAPE at least 1500 J/kg and richer 0-3 km moisture, so the analyzer
+gets a positive-or-near-positive test instead of another weak shallow-cloud
+case.

--- a/docs/research/expanded-sounding-candidate-taxonomy.md
+++ b/docs/research/expanded-sounding-candidate-taxonomy.md
@@ -199,11 +199,12 @@ Non-goals: do not allow package generation from blocked candidates.
 
 ## Deep Convection / Severe Environments
 
-These stories are first-class product concepts, but they are not current
-package-ready stories. Most require thermodynamic and wind diagnostics that are
-not part of the current candidate scoring contract, such as CAPE, CIN, LFC,
-EL, 0-6 km shear, storm-relative helicity, DCAPE, freezing-level diagnostics,
-or forcing/cold-pool architecture.
+These stories are first-class product concepts, but they are not validated
+severe-weather package stories. The current analyzer exposes a narrower
+`deep_tower_opportunity` selector for the Deep-Tower Benchmark; that selector
+uses simple sounding-only CAPE, CIN, LFC, moisture, lapse-rate, cap, and
+profile-quality inputs to choose a benchmark scout. It does not make
+supercell, squall-line, hail, tornado, or observed-initiation claims.
 
 | Story ID | Visible Label | Family | screenable_from_sounding_now | runnable_with_current_observed_sounding_package | specialized_package_recommended | future_package_required | candidate_can_be_saved | candidate_can_generate_current_package | Implementation Priority |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |


### PR DESCRIPTION
## What changed

- Adds `deep_tower_opportunity` as a recipe-specific sounding score for the Deep-Tower Benchmark, versioned as `sounding-screening-v2`.
- Keeps existing severe/supercell story scores intact, but uses the new opportunity score for deep-family best-match sorting and ingredient display.
- Adds backend coverage for Fort Worth-vs-North Platte separation and deep-family best-match behavior.
- Exposes the new sort option in Build and documents the scoring contract.
- Records the #351 calibration work in `docs/research/cloud-chase-003-deep-tower-opportunity.md`, including the Topeka scout outcome.

## CM1 run recorded

One new Deep-Tower Benchmark scout was run:

- Topeka/Mun., KS `USM00072456`, valid `2026-06-10T00:00:00Z`
- Predicted opportunity: 55.0/100, weak
- Actual outcome: shallow weak cloud, coherent cloud top 1250 m, max updraft 0.890 m/s, trace rain only, no deep breakthrough
- Runtime: completed normally and auto-ingested; generated runtime files remain outside git

## Validation

- `PYTHONPATH=/Users/timpeterson/Documents/Codex/cloud-chamber-issue-341/app/backend /Users/timpeterson/Documents/Codex/cloud-chamber/app/backend/.venv/bin/python -m pytest app/backend/tests/test_sounding_candidates.py`
- `npm test -- --run App.test.tsx`
- `BACKEND_PYTHON=/Users/timpeterson/Documents/Codex/cloud-chamber/app/backend/.venv/bin/python scripts/check.sh`

Closes #351.