### PR TITLE
Mark Deep-Tower score experimental and record selector misses

### DIFF
--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -33,7 +33,7 @@ from cloud_chamber.observed_sounding import (
 from cloud_chamber.settings import CloudChamberSettings
 from cloud_chamber.sounding_diagnostics import compute_sounding_diagnostics
 
-SCREENING_VERSION = "sounding-screening-v2"
+SCREENING_VERSION = "sounding-screening-v3"
 
 StoryId = Literal[
     "shallow_cumulus_candidate",
@@ -2320,8 +2320,9 @@ def _score_features(
             value=features.get("trigger_layer_mean_qv_750_2250m_g_kg"),
             units="g/kg",
             interpretation=(
-                "Moisture in the approximate stock warm-bubble layer helps judge whether "
-                "the Deep-Tower Benchmark trigger is lifting a useful source layer."
+                "Descriptive moisture evidence in the approximate stock warm-bubble layer; "
+                "computed as an unweighted mean of available sounding levels, not as a "
+                "validated Deep-Tower recommendation gate."
             ),
             supports_story=[
                 "severe_thunderstorm_environment",
@@ -2692,7 +2693,6 @@ def _deep_tower_opportunity(
     qv = _numeric_feature(features, "mean_qv_0_1000m_g_kg")
     qv_500 = _numeric_feature(features, "mean_qv_0_500m_g_kg")
     qv_3000 = _numeric_feature(features, "mean_qv_0_3000m_g_kg")
-    trigger_layer_qv = _numeric_feature(features, "trigger_layer_mean_qv_750_2250m_g_kg")
     precipitable_water = _numeric_feature(features, "precipitable_water_proxy_or_unavailable")
     moisture_depth = _numeric_feature(features, "moisture_depth_m")
     lcl = _numeric_feature(features, "estimated_lcl_height_m_agl")
@@ -2772,12 +2772,6 @@ def _deep_tower_opportunity(
             (buoyancy_depth_score, 0.02),
         ]
     )
-    if trigger_layer_qv is None:
-        score = min(score, 69.0)
-    elif trigger_layer_qv < 11.5:
-        score = min(score, 44.0)
-    elif trigger_layer_qv < 13.0:
-        score = min(score, 69.0)
     if not near_surface_ok:
         score = min(score, 69.0)
     if effective_cape < 750.0:
@@ -2815,7 +2809,6 @@ def _deep_tower_opportunity(
         "lfc_height_m_agl",
         "mean_qv_0_1000m_g_kg",
         "mean_qv_0_3000m_g_kg",
-        "trigger_layer_mean_qv_750_2250m_g_kg",
         "moisture_depth_m",
         "lapse_rate_0_3000m_c_per_km",
         "midlevel_lapse_rate_700_500_hpa_c_per_km",
@@ -2831,12 +2824,6 @@ def _deep_tower_opportunity(
         caveats.append("deep_tower_opportunity_limited_cape")
     if qv is not None and qv < 16.0:
         caveats.append("deep_tower_opportunity_limited_low_level_moisture")
-    if trigger_layer_qv is None:
-        caveats.append("deep_tower_opportunity_trigger_layer_moisture_unavailable")
-    elif trigger_layer_qv < 11.5:
-        caveats.append("deep_tower_opportunity_poor_trigger_layer_moisture")
-    elif trigger_layer_qv < 13.0:
-        caveats.append("deep_tower_opportunity_caveated_trigger_layer_moisture")
     if moisture_depth is not None and moisture_depth < 1800.0:
         caveats.append("deep_tower_opportunity_limited_moisture_depth")
     if lcl is not None and lcl > 1000.0:

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -444,7 +444,7 @@ SORT_OPTIONS: tuple[CandidateSortOption, ...] = (
     ),
     CandidateSortOption(
         key="deep_tower_opportunity",
-        label="Deep-Tower opportunity",
+        label="Experimental Deep-Tower evidence",
         units="0-100",
         default_direction="desc",
     ),
@@ -815,7 +815,7 @@ def _candidate_with_analysis_context(
         else active_score_value
     )
     ingredient_score_label = (
-        "Deep-Tower opportunity" if scoped_to_deep_tower else "Ingredient score"
+        "Experimental Deep-Tower evidence" if scoped_to_deep_tower else "Ingredient score"
     )
     visible_support = (
         _candidate_deep_tower_opportunity_support(candidate)
@@ -1696,12 +1696,12 @@ def _candidate_recipe_fit(
         if features.get("observed_wind_available") is not True:
             caveats.append("complete_observed_wind_profile_required_for_input_sounding")
         return {
-            "status": "testable_now",
-            "label": "testable with Deep-Tower Benchmark",
+            "status": "partially_testable",
+            "label": "optional Deep-Tower benchmark context",
             "summary": (
-                "This story screens deep-convection ingredients. CM1 can evolve the observed "
-                "atmosphere with the explicit Deep-Tower Benchmark trigger; use surface-forced "
-                "recipes when lower-boundary initiation is the question."
+                "This story screens deep-convection ingredients. The fixed Deep-Tower "
+                "Benchmark is available for deliberate comparison, but current evidence "
+                "does not make it a reliable first-run recommendation."
             ),
             "caveats": caveats,
         }
@@ -1824,7 +1824,6 @@ def _features_from_record(
     diagnostics = compute_sounding_diagnostics(record)
     for key in (
         "mean_qv_0_3000m_g_kg",
-        "trigger_layer_mean_qv_750_2250m_g_kg",
         "precipitable_water_proxy_or_unavailable",
         "midlevel_lapse_rate_700_500_hpa_c_per_km",
         "has_observed_wind_profile",
@@ -2232,7 +2231,7 @@ def _score_features(
             ],
             caveats=[
                 "line/cold-pool-specific recipe support may come later; "
-                "v1 uses the Deep-Tower Benchmark as a first experiment",
+                "the fixed Deep-Tower Benchmark is only optional comparison context",
                 *deep_caveats,
             ],
         ),
@@ -2265,7 +2264,7 @@ def _score_features(
     ]
     evidence = [
         EvidenceItem(
-            label="Deep-Tower opportunity",
+            label="Experimental Deep-Tower evidence",
             value=features.get("deep_tower_opportunity"),
             units="0-100",
             interpretation=deep_tower_opportunity_summary,
@@ -2314,24 +2313,6 @@ def _score_features(
                 "squall_line_cold_pool_candidate",
             ],
             caveats=_feature_caveats(features, "mean_qv_0_1000m_g_kg"),
-        ),
-        EvidenceItem(
-            label="Trigger-layer mean qv",
-            value=features.get("trigger_layer_mean_qv_750_2250m_g_kg"),
-            units="g/kg",
-            interpretation=(
-                "Descriptive moisture evidence in the approximate stock warm-bubble layer; "
-                "computed as an unweighted mean of available sounding levels, not as a "
-                "validated Deep-Tower recommendation gate."
-            ),
-            supports_story=[
-                "severe_thunderstorm_environment",
-                "supercell_environment",
-                "high_cape_pulse_storm",
-                "squall_line_cold_pool_candidate",
-                "elevated_convection",
-            ],
-            caveats=_feature_caveats(features, "trigger_layer_mean_qv_750_2250m_g_kg"),
         ),
         EvidenceItem(
             label="Near-surface continuity",
@@ -2680,7 +2661,8 @@ def _deep_tower_opportunity(
         return (
             0.0,
             "unavailable",
-            "Blocked profile; Deep-Tower opportunity cannot be evaluated until packaging works.",
+            "Blocked profile; experimental Deep-Tower evidence cannot be evaluated until "
+            "packaging works.",
             ["package_generation_blocked"],
         )
 
@@ -2782,22 +2764,22 @@ def _deep_tower_opportunity(
         score = min(score, 65.0)
     rounded = round(max(0.0, min(100.0, score)), 1)
     if rounded >= 70.0:
-        support: Support = "supported"
+        support: Support = "weak"
         summary = (
-            "Deep-Tower opportunity is supported for the convective-ceiling question: "
-            "buoyancy, low-level moisture, deeper moisture, and profile quality align."
+            "Experimental Deep-Tower evidence is high, but recent benchmark misses show "
+            "this score is not a reliable recommendation to spend scout compute."
         )
     elif rounded >= 45.0:
         support = "weak"
         summary = (
-            "Deep-Tower opportunity is caveated: some cloud-depth ingredients are present, "
-            "but moisture depth, CAPE, LCL, or inhibition support is not strong."
+            "Experimental Deep-Tower evidence is caveated: some cloud-depth ingredients "
+            "are present, but the fixed benchmark response is uncertain."
         )
     else:
         support = "unavailable"
         summary = (
-            "Deep-Tower opportunity is low for this recipe: the thermodynamic profile does "
-            "not strongly support a tall, useful benchmark cloud."
+            "Experimental Deep-Tower evidence is low: the current heuristic does not "
+            "surface this as a strong fixed-benchmark comparison case."
         )
 
     caveats: list[str] = []
@@ -2929,9 +2911,11 @@ def _candidate_interest_reasons(
     )
     deep_tower_opportunity = _numeric_feature(features, "deep_tower_opportunity")
     if deep_tower_opportunity is not None and deep_tower_opportunity >= 70.0:
-        reasons.append("Higher Deep-Tower opportunity for testing the convective ceiling.")
+        reasons.append("Higher experimental Deep-Tower evidence for comparison sorting.")
     elif deep_tower_opportunity is not None and deep_tower_opportunity >= 45.0:
-        reasons.append("Caveated Deep-Tower opportunity; cloud-depth ingredients are mixed.")
+        reasons.append(
+            "Caveated experimental Deep-Tower evidence; cloud-depth ingredients are mixed."
+        )
     elif deep_score >= 65.0:
         reasons.append("Supported deep-convection ingredients with observed wind context.")
     elif deep_score >= 35.0:

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -1375,8 +1375,6 @@ def _candidate_sort_value(
     story_family: CandidateStoryFamilyFilter,
 ) -> SortValue | None:
     if sort_by == "best_match":
-        if _candidate_scope_is_deep_tower(story_filter, story_family):
-            return _candidate_deep_tower_opportunity_score(candidate)
         score = _candidate_story_score_model(candidate, story_filter, story_family)
         return score.score_0_to_100 if score else candidate.rank_score
     if sort_by == "valid_time":

--- a/app/backend/cloud_chamber/sounding_candidates.py
+++ b/app/backend/cloud_chamber/sounding_candidates.py
@@ -1824,6 +1824,7 @@ def _features_from_record(
     diagnostics = compute_sounding_diagnostics(record)
     for key in (
         "mean_qv_0_3000m_g_kg",
+        "trigger_layer_mean_qv_750_2250m_g_kg",
         "precipitable_water_proxy_or_unavailable",
         "midlevel_lapse_rate_700_500_hpa_c_per_km",
         "has_observed_wind_profile",
@@ -2315,6 +2316,23 @@ def _score_features(
             caveats=_feature_caveats(features, "mean_qv_0_1000m_g_kg"),
         ),
         EvidenceItem(
+            label="Trigger-layer mean qv",
+            value=features.get("trigger_layer_mean_qv_750_2250m_g_kg"),
+            units="g/kg",
+            interpretation=(
+                "Moisture in the approximate stock warm-bubble layer helps judge whether "
+                "the Deep-Tower Benchmark trigger is lifting a useful source layer."
+            ),
+            supports_story=[
+                "severe_thunderstorm_environment",
+                "supercell_environment",
+                "high_cape_pulse_storm",
+                "squall_line_cold_pool_candidate",
+                "elevated_convection",
+            ],
+            caveats=_feature_caveats(features, "trigger_layer_mean_qv_750_2250m_g_kg"),
+        ),
+        EvidenceItem(
             label="Near-surface continuity",
             value="large jump" if features.get("near_surface_discontinuity_flag") else "ok",
             interpretation=(
@@ -2674,6 +2692,7 @@ def _deep_tower_opportunity(
     qv = _numeric_feature(features, "mean_qv_0_1000m_g_kg")
     qv_500 = _numeric_feature(features, "mean_qv_0_500m_g_kg")
     qv_3000 = _numeric_feature(features, "mean_qv_0_3000m_g_kg")
+    trigger_layer_qv = _numeric_feature(features, "trigger_layer_mean_qv_750_2250m_g_kg")
     precipitable_water = _numeric_feature(features, "precipitable_water_proxy_or_unavailable")
     moisture_depth = _numeric_feature(features, "moisture_depth_m")
     lcl = _numeric_feature(features, "estimated_lcl_height_m_agl")
@@ -2686,13 +2705,19 @@ def _deep_tower_opportunity(
     profile_top = _numeric_feature(features, "profile_top_m_agl")
     near_surface_ok = features.get("near_surface_discontinuity_flag") is not True
 
-    cape_score = _weighted_score(
-        [
-            (_score_high(sbcape, low=500.0, high=2500.0), 0.55),
-            (_score_high(mlcape, low=500.0, high=2500.0), 0.45),
-        ]
-    )
-    effective_cin = min(value for value in (sbcin or 0.0, mlcin or 0.0))
+    if near_surface_ok:
+        cape_score = _weighted_score(
+            [
+                (_score_high(sbcape, low=500.0, high=2500.0), 0.55),
+                (_score_high(mlcape, low=500.0, high=2500.0), 0.45),
+            ]
+        )
+        effective_cape = max(value for value in (sbcape or 0.0, mlcape or 0.0))
+        effective_cin = min(value for value in (sbcin or 0.0, mlcin or 0.0))
+    else:
+        cape_score = _score_high(mlcape, low=500.0, high=2500.0)
+        effective_cape = mlcape or 0.0
+        effective_cin = mlcin or 0.0
     inhibition_score = _weighted_score(
         [
             (_score_low(abs(effective_cin), low=25.0, high=200.0), 0.45),
@@ -2747,7 +2772,14 @@ def _deep_tower_opportunity(
             (buoyancy_depth_score, 0.02),
         ]
     )
-    effective_cape = max(value for value in (sbcape or 0.0, mlcape or 0.0))
+    if trigger_layer_qv is None:
+        score = min(score, 69.0)
+    elif trigger_layer_qv < 11.5:
+        score = min(score, 44.0)
+    elif trigger_layer_qv < 13.0:
+        score = min(score, 69.0)
+    if not near_surface_ok:
+        score = min(score, 69.0)
     if effective_cape < 750.0:
         score = min(score, 42.0)
     elif effective_cape < 1200.0:
@@ -2783,6 +2815,7 @@ def _deep_tower_opportunity(
         "lfc_height_m_agl",
         "mean_qv_0_1000m_g_kg",
         "mean_qv_0_3000m_g_kg",
+        "trigger_layer_mean_qv_750_2250m_g_kg",
         "moisture_depth_m",
         "lapse_rate_0_3000m_c_per_km",
         "midlevel_lapse_rate_700_500_hpa_c_per_km",
@@ -2798,6 +2831,12 @@ def _deep_tower_opportunity(
         caveats.append("deep_tower_opportunity_limited_cape")
     if qv is not None and qv < 16.0:
         caveats.append("deep_tower_opportunity_limited_low_level_moisture")
+    if trigger_layer_qv is None:
+        caveats.append("deep_tower_opportunity_trigger_layer_moisture_unavailable")
+    elif trigger_layer_qv < 11.5:
+        caveats.append("deep_tower_opportunity_poor_trigger_layer_moisture")
+    elif trigger_layer_qv < 13.0:
+        caveats.append("deep_tower_opportunity_caveated_trigger_layer_moisture")
     if moisture_depth is not None and moisture_depth < 1800.0:
         caveats.append("deep_tower_opportunity_limited_moisture_depth")
     if lcl is not None and lcl > 1000.0:
@@ -2806,6 +2845,7 @@ def _deep_tower_opportunity(
         caveats.append("deep_tower_opportunity_cap_proxy_present")
     if not near_surface_ok:
         caveats.append("near_surface_discontinuity_caveat")
+        caveats.append("surface_based_cape_ignored_due_to_near_surface_discontinuity")
     if not buoyancy_depth_available:
         caveats.append("deep_tower_simple_el_not_used_as_hard_gate")
     caveats.append("deep_tower_opportunity_gives_little_weight_to_shear")

--- a/app/backend/cloud_chamber/sounding_diagnostics.py
+++ b/app/backend/cloud_chamber/sounding_diagnostics.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.observed_sounding import ObservedSoundingLevel, ObservedSoundingRecord
 
-DIAGNOSTIC_VERSION = "sounding-diagnostics-v1"
+DIAGNOSTIC_VERSION = "sounding-diagnostics-v2"
 
 SupportState = Literal["supported", "weak", "unavailable"]
 
@@ -312,7 +312,7 @@ def compute_sounding_diagnostics(record: ObservedSoundingRecord) -> SoundingDiag
             "Trigger-layer mean qv 750-2250 m",
             _mean_qv(levels, 750.0, 2250.0),
             "g/kg",
-            "mean finite qv over the approximate stock iinit=3 warm-bubble layer",
+            "unweighted mean finite qv over available levels from 750-2250 m AGL",
         )
     )
     add(
@@ -742,7 +742,7 @@ def _unavailable(
         label,
         None,
         units,
-        "not implemented in sounding-diagnostics-v1",
+        f"not implemented in {DIAGNOSTIC_VERSION}",
         support_state="unavailable",
         caveats=[caveat],
     )

--- a/app/backend/cloud_chamber/sounding_diagnostics.py
+++ b/app/backend/cloud_chamber/sounding_diagnostics.py
@@ -308,6 +308,15 @@ def compute_sounding_diagnostics(record: ObservedSoundingRecord) -> SoundingDiag
     )
     add(
         _feature(
+            "trigger_layer_mean_qv_750_2250m_g_kg",
+            "Trigger-layer mean qv 750-2250 m",
+            _mean_qv(levels, 750.0, 2250.0),
+            "g/kg",
+            "mean finite qv over the approximate stock iinit=3 warm-bubble layer",
+        )
+    )
+    add(
+        _feature(
             "moisture_depth_m",
             "Moisture depth",
             _moisture_depth(levels, min_qv_g_kg=6.0),

--- a/app/backend/cloud_chamber/sounding_diagnostics.py
+++ b/app/backend/cloud_chamber/sounding_diagnostics.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.observed_sounding import ObservedSoundingLevel, ObservedSoundingRecord
 
-DIAGNOSTIC_VERSION = "sounding-diagnostics-v2"
+DIAGNOSTIC_VERSION = "sounding-diagnostics-v1"
 
 SupportState = Literal["supported", "weak", "unavailable"]
 
@@ -304,15 +304,6 @@ def compute_sounding_diagnostics(record: ObservedSoundingRecord) -> SoundingDiag
             _mean_qv(levels, 0.0, 3000.0),
             "g/kg",
             "mean finite qv over levels from 0-3000 m AGL",
-        )
-    )
-    add(
-        _feature(
-            "trigger_layer_mean_qv_750_2250m_g_kg",
-            "Trigger-layer mean qv 750-2250 m",
-            _mean_qv(levels, 750.0, 2250.0),
-            "g/kg",
-            "unweighted mean finite qv over available levels from 750-2250 m AGL",
         )
     )
     add(

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -111,10 +111,12 @@ def _analysis_candidate(
 ) -> SoundingCandidate:
     opportunity_score = deep_score if deep_opportunity_score is None else deep_opportunity_score
     opportunity_support = (
-        deep_support if deep_opportunity_support is None else deep_opportunity_support
+        ("weak" if opportunity_score >= 45.0 else "unavailable")
+        if deep_opportunity_support is None
+        else deep_opportunity_support
     )
     opportunity_summary = deep_opportunity_summary or (
-        f"Deep-Tower opportunity fixture summary for {candidate_id}."
+        f"Experimental Deep-Tower evidence fixture summary for {candidate_id}."
     )
     story_scores = [
         StoryScore(
@@ -543,24 +545,25 @@ def test_analysis_family_filter_includes_supported_secondary_deep_story(
     assert result.candidates[0].display_story == "Supercell-like environment"
     assert result.candidates[0].matched_story_ids == ["supercell_environment"]
     assert result.candidates[0].active_story_score == 74.0
-    assert result.candidates[0].active_story_support == "supported"
+    assert result.candidates[0].active_story_support == "weak"
     assert result.candidates[0].ingredient_score == 74.0
-    assert result.candidates[0].ingredient_score_label == "Deep-Tower opportunity"
+    assert result.candidates[0].ingredient_score_label == "Experimental Deep-Tower evidence"
     assert result.candidates[0].top_reasons == [
-        "Deep-Tower opportunity fixture summary for primary-humid-supported-secondary-supercell."
+        "Experimental Deep-Tower evidence fixture summary for "
+        "primary-humid-supported-secondary-supercell."
     ]
 
 
-def test_analysis_family_support_filter_uses_deep_tower_opportunity_support(
+def test_analysis_family_support_filter_uses_experimental_deep_tower_support(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    supported = _analysis_candidate(
-        "secondary-deep-supported",
+    weak_experimental = _analysis_candidate(
+        "secondary-deep-weak-experimental",
         primary_score=92.0,
         deep_score=74.0,
         deep_support="supported",
         deep_opportunity_score=82.0,
-        deep_opportunity_support="supported",
+        deep_opportunity_support="weak",
     )
     story_supported_low_opportunity = _analysis_candidate(
         "secondary-deep-story-supported-low-opportunity",
@@ -570,22 +573,24 @@ def test_analysis_family_support_filter_uses_deep_tower_opportunity_support(
         deep_opportunity_score=41.0,
         deep_opportunity_support="unavailable",
     )
-    _patch_screened_candidates(monkeypatch, [story_supported_low_opportunity, supported])
+    _patch_screened_candidates(monkeypatch, [story_supported_low_opportunity, weak_experimental])
 
     result = analyze_cached_soundings(
         _settings(tmp_path),
         story_family="deep_convection",
-        support="supported",
+        support="weak",
     )
 
-    assert [item.candidate_id for item in result.candidates] == ["secondary-deep-supported"]
+    assert [item.candidate_id for item in result.candidates] == ["secondary-deep-weak-experimental"]
     assert result.filtered_candidate_count == 1
     assert result.candidates[0].active_story == "supercell_environment"
     assert result.candidates[0].ingredient_score == 82.0
-    assert result.candidates[0].active_story_support == "supported"
+    assert result.candidates[0].active_story_support == "weak"
     assert result.filter_trace.stage_counts["story_family"] == 2
     assert result.filter_trace.stage_counts["support"] == 1
-    assert result.filter_trace.top_excluded_reasons[0].reason == "Evidence tier: supported"
+    assert (
+        result.filter_trace.top_excluded_reasons[0].reason == "Evidence tier: plausible / caveated"
+    )
     assert result.filter_trace.top_excluded_reasons[0].count == 1
 
 
@@ -606,7 +611,7 @@ def test_analysis_deep_family_best_match_sort_uses_best_deep_score(
         deep_score=67.0,
         deep_support="supported",
         deep_opportunity_score=82.0,
-        deep_opportunity_support="supported",
+        deep_opportunity_support="weak",
     )
     _patch_screened_candidates(monkeypatch, [humid_but_weaker_deep, lower_primary_better_deep])
 
@@ -623,7 +628,7 @@ def test_analysis_deep_family_best_match_sort_uses_best_deep_score(
     assert [item.active_story_score for item in result.candidates] == [67.0, 91.0]
     assert [item.ingredient_score for item in result.candidates] == [82.0, 41.0]
     assert [item.active_story_support for item in result.candidates] == [
-        "supported",
+        "weak",
         "unavailable",
     ]
 
@@ -1120,7 +1125,6 @@ def test_deep_tower_opportunity_separates_success_from_miss_features() -> None:
         "mean_qv_0_500m_g_kg": 22.094,
         "mean_qv_0_1000m_g_kg": 20.398,
         "mean_qv_0_3000m_g_kg": 14.623,
-        "trigger_layer_mean_qv_750_2250m_g_kg": 13.336,
         "precipitable_water_proxy_or_unavailable": 43.11,
         "surface_t_td_spread_c": 6.0,
         "estimated_lcl_height_m_agl": 750.1,
@@ -1154,7 +1158,6 @@ def test_deep_tower_opportunity_separates_success_from_miss_features() -> None:
         "mean_qv_0_500m_g_kg": 15.723,
         "mean_qv_0_1000m_g_kg": 14.83,
         "mean_qv_0_3000m_g_kg": 11.052,
-        "trigger_layer_mean_qv_750_2250m_g_kg": 9.783,
         "precipitable_water_proxy_or_unavailable": 27.56,
         "surface_t_td_spread_c": 9.8,
         "estimated_lcl_height_m_agl": 1225.1,
@@ -1184,7 +1187,7 @@ def test_deep_tower_opportunity_separates_success_from_miss_features() -> None:
     fort_score = cast(float, fort_worth_like["deep_tower_opportunity"])
     north_platte_score = cast(float, north_platte_like["deep_tower_opportunity"])
     assert fort_score == pytest.approx(81.7)
-    assert fort_worth_like["deep_tower_opportunity_support"] == "supported"
+    assert fort_worth_like["deep_tower_opportunity_support"] == "weak"
     assert north_platte_score == pytest.approx(46.1)
     assert north_platte_like["deep_tower_opportunity_support"] == "weak"
     assert fort_score > north_platte_score + 30.0
@@ -1197,7 +1200,6 @@ def test_deep_tower_opportunity_caps_discontinuous_surface_cape_signal() -> None
         "mean_qv_0_500m_g_kg": 21.5,
         "mean_qv_0_1000m_g_kg": 19.6,
         "mean_qv_0_3000m_g_kg": 12.4,
-        "trigger_layer_mean_qv_750_2250m_g_kg": 12.42,
         "precipitable_water_proxy_or_unavailable": 48.0,
         "surface_t_td_spread_c": 2.2,
         "estimated_lcl_height_m_agl": 275.0,
@@ -1229,7 +1231,7 @@ def test_deep_tower_opportunity_caps_discontinuous_surface_cape_signal() -> None
     _, evidence = _score_features(slidell_like, package_ready=True)
 
     score = cast(float, slidell_like["deep_tower_opportunity"])
-    deep_tower = next(item for item in evidence if item.label == "Deep-Tower opportunity")
+    deep_tower = next(item for item in evidence if item.label == "Experimental Deep-Tower evidence")
     assert score < 70.0
     assert slidell_like["deep_tower_opportunity_support"] == "weak"
     assert score >= 45.0
@@ -1237,14 +1239,13 @@ def test_deep_tower_opportunity_caps_discontinuous_surface_cape_signal() -> None
     assert "surface_based_cape_ignored_due_to_near_surface_discontinuity" in deep_tower.caveats
 
 
-def test_deep_tower_opportunity_trigger_layer_qv_is_descriptive_not_a_hard_gate() -> None:
-    poor_trigger_layer_qv: dict[str, FeatureValue] = {
+def test_high_deep_tower_opportunity_is_experimental_not_supported() -> None:
+    high_experimental_evidence: dict[str, FeatureValue] = {
         "data_completeness_score": 96.0,
         "low_level_qv_g_kg": 22.0,
         "mean_qv_0_500m_g_kg": 21.0,
         "mean_qv_0_1000m_g_kg": 19.5,
         "mean_qv_0_3000m_g_kg": 14.8,
-        "trigger_layer_mean_qv_750_2250m_g_kg": 9.5,
         "precipitable_water_proxy_or_unavailable": 46.0,
         "surface_t_td_spread_c": 5.0,
         "estimated_lcl_height_m_agl": 625.0,
@@ -1273,13 +1274,16 @@ def test_deep_tower_opportunity_trigger_layer_qv_is_descriptive_not_a_hard_gate(
         "near_surface_discontinuity_flag": False,
     }
 
-    scores, evidence = _score_features(poor_trigger_layer_qv, package_ready=True)
+    scores, evidence = _score_features(high_experimental_evidence, package_ready=True)
 
     severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
-    deep_tower = next(item for item in evidence if item.label == "Deep-Tower opportunity")
+    deep_tower = next(item for item in evidence if item.label == "Experimental Deep-Tower evidence")
     assert severe.support == "supported"
-    assert poor_trigger_layer_qv["deep_tower_opportunity_support"] == "supported"
-    assert cast(float, poor_trigger_layer_qv["deep_tower_opportunity"]) >= 70.0
+    assert high_experimental_evidence["deep_tower_opportunity_support"] == "weak"
+    assert cast(float, high_experimental_evidence["deep_tower_opportunity"]) >= 70.0
+    assert "not a reliable recommendation" in str(
+        high_experimental_evidence["deep_tower_opportunity_summary"]
+    )
     assert "deep_tower_opportunity_poor_trigger_layer_moisture" not in deep_tower.caveats
 
 
@@ -1290,7 +1294,6 @@ def test_deep_tower_opportunity_near_surface_guardrail_is_not_overridden_by_seve
         "mean_qv_0_500m_g_kg": 21.0,
         "mean_qv_0_1000m_g_kg": 19.5,
         "mean_qv_0_3000m_g_kg": 14.8,
-        "trigger_layer_mean_qv_750_2250m_g_kg": 14.0,
         "precipitable_water_proxy_or_unavailable": 46.0,
         "surface_t_td_spread_c": 2.0,
         "estimated_lcl_height_m_agl": 250.0,
@@ -1322,7 +1325,7 @@ def test_deep_tower_opportunity_near_surface_guardrail_is_not_overridden_by_seve
     scores, evidence = _score_features(discontinuous_profile, package_ready=True)
 
     severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
-    deep_tower = next(item for item in evidence if item.label == "Deep-Tower opportunity")
+    deep_tower = next(item for item in evidence if item.label == "Experimental Deep-Tower evidence")
     assert severe.support == "supported"
     assert discontinuous_profile["deep_tower_opportunity_support"] == "weak"
     assert cast(float, discontinuous_profile["deep_tower_opportunity"]) < 70.0

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -622,14 +622,14 @@ def test_analysis_deep_family_best_match_sort_uses_best_deep_score(
     )
 
     assert [item.candidate_id for item in result.candidates] == [
-        "humid-lower-better-deep",
         "humid-high-weaker-deep",
+        "humid-lower-better-deep",
     ]
-    assert [item.active_story_score for item in result.candidates] == [67.0, 91.0]
-    assert [item.ingredient_score for item in result.candidates] == [82.0, 41.0]
+    assert [item.active_story_score for item in result.candidates] == [91.0, 67.0]
+    assert [item.ingredient_score for item in result.candidates] == [41.0, 82.0]
     assert [item.active_story_support for item in result.candidates] == [
-        "weak",
         "unavailable",
+        "weak",
     ]
 
 
@@ -1333,7 +1333,7 @@ def test_deep_tower_opportunity_near_surface_guardrail_is_not_overridden_by_seve
     assert "surface_based_cape_ignored_due_to_near_surface_discontinuity" in deep_tower.caveats
 
 
-def test_analysis_deep_family_best_match_uses_deep_tower_opportunity(
+def test_analysis_deep_family_explicit_opportunity_sort_uses_experimental_score(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     high_story_low_opportunity = _analysis_candidate(
@@ -1351,18 +1351,32 @@ def test_analysis_deep_family_best_match_uses_deep_tower_opportunity(
         [high_story_low_opportunity, lower_story_better_opportunity],
     )
 
-    result = analyze_cached_soundings(
+    best_match_result = analyze_cached_soundings(
         _settings(tmp_path),
         story_family="deep_convection",
         sort_by="best_match",
     )
+    opportunity_result = analyze_cached_soundings(
+        _settings(tmp_path),
+        story_family="deep_convection",
+        sort_by="deep_tower_opportunity",
+    )
 
-    assert [item.candidate_id for item in result.candidates] == [
+    assert [item.candidate_id for item in best_match_result.candidates] == [
+        "high-story-low-opportunity",
+        "lower-story-better-opportunity",
+    ]
+    assert [item.active_story_score for item in best_match_result.candidates] == [91.0, 72.0]
+    assert [item.ingredient_score for item in best_match_result.candidates] == [41.0, 82.0]
+    assert [item.candidate_id for item in opportunity_result.candidates] == [
         "lower-story-better-opportunity",
         "high-story-low-opportunity",
     ]
-    assert [item.active_story_score for item in result.candidates] == [72.0, 91.0]
-    assert [item.ingredient_score for item in result.candidates] == [82.0, 41.0]
+    assert [item.active_story_score for item in opportunity_result.candidates] == [72.0, 91.0]
+    assert [item.ingredient_score for item in opportunity_result.candidates] == [82.0, 41.0]
+    assert [item.candidate_id for item in best_match_result.candidates] != [
+        item.candidate_id for item in opportunity_result.candidates
+    ]
 
 
 def test_story_scores_and_evidence_are_traceable_to_soundings() -> None:

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -1120,6 +1120,7 @@ def test_deep_tower_opportunity_separates_success_from_miss_features() -> None:
         "mean_qv_0_500m_g_kg": 22.094,
         "mean_qv_0_1000m_g_kg": 20.398,
         "mean_qv_0_3000m_g_kg": 14.623,
+        "trigger_layer_mean_qv_750_2250m_g_kg": 13.336,
         "precipitable_water_proxy_or_unavailable": 43.11,
         "surface_t_td_spread_c": 6.0,
         "estimated_lcl_height_m_agl": 750.1,
@@ -1153,6 +1154,7 @@ def test_deep_tower_opportunity_separates_success_from_miss_features() -> None:
         "mean_qv_0_500m_g_kg": 15.723,
         "mean_qv_0_1000m_g_kg": 14.83,
         "mean_qv_0_3000m_g_kg": 11.052,
+        "trigger_layer_mean_qv_750_2250m_g_kg": 9.783,
         "precipitable_water_proxy_or_unavailable": 27.56,
         "surface_t_td_spread_c": 9.8,
         "estimated_lcl_height_m_agl": 1225.1,
@@ -1183,9 +1185,103 @@ def test_deep_tower_opportunity_separates_success_from_miss_features() -> None:
     north_platte_score = cast(float, north_platte_like["deep_tower_opportunity"])
     assert fort_score == pytest.approx(81.7)
     assert fort_worth_like["deep_tower_opportunity_support"] == "supported"
-    assert north_platte_score == pytest.approx(46.1)
-    assert north_platte_like["deep_tower_opportunity_support"] == "weak"
+    assert north_platte_score == pytest.approx(44.0)
+    assert north_platte_like["deep_tower_opportunity_support"] == "unavailable"
     assert fort_score > north_platte_score + 30.0
+
+
+def test_deep_tower_opportunity_caps_discontinuous_surface_cape_signal() -> None:
+    slidell_like: dict[str, FeatureValue] = {
+        "data_completeness_score": 70.0,
+        "low_level_qv_g_kg": 31.0,
+        "mean_qv_0_500m_g_kg": 21.5,
+        "mean_qv_0_1000m_g_kg": 19.6,
+        "mean_qv_0_3000m_g_kg": 12.4,
+        "trigger_layer_mean_qv_750_2250m_g_kg": 12.42,
+        "precipitable_water_proxy_or_unavailable": 48.0,
+        "surface_t_td_spread_c": 2.2,
+        "estimated_lcl_height_m_agl": 275.0,
+        "lapse_rate_0_1000m_c_per_km": 6.9,
+        "lapse_rate_0_3000m_c_per_km": 6.4,
+        "midlevel_lapse_rate_700_500_hpa_c_per_km": 6.7,
+        "cap_strength_proxy": 0.0,
+        "cap_height_m_agl": None,
+        "moisture_depth_m": 3000.0,
+        "midlevel_dry_layer_proxy": 7.0,
+        "qv_drop_0_3000m_g_kg": 18.6,
+        "observed_wind_available": True,
+        "bulk_shear_0_1km_m_s": 9.0,
+        "bulk_shear_0_3km_m_s": 16.0,
+        "bulk_shear_0_6km_m_s": 28.0,
+        "dry_microburst_inverted_v_proxy": 35.0,
+        "freezing_level_m_agl": 4600.0,
+        "surface_based_cape_j_kg": 3762.0,
+        "mixed_layer_cape_j_kg": 1300.0,
+        "surface_based_cin_j_kg": 0.0,
+        "mixed_layer_cin_j_kg": -20.0,
+        "lfc_height_m_agl": 900.0,
+        "el_height_m_agl": 12000.0,
+        "profile_top_m_agl": 18000.0,
+        "lowest_level_m_agl": 0.0,
+        "near_surface_discontinuity_flag": True,
+    }
+
+    _, evidence = _score_features(slidell_like, package_ready=True)
+
+    score = cast(float, slidell_like["deep_tower_opportunity"])
+    deep_tower = next(item for item in evidence if item.label == "Deep-Tower opportunity")
+    assert score < 70.0
+    assert slidell_like["deep_tower_opportunity_support"] == "weak"
+    assert score >= 45.0
+    assert "near_surface_discontinuity_caveat" in deep_tower.caveats
+    assert "surface_based_cape_ignored_due_to_near_surface_discontinuity" in deep_tower.caveats
+    assert "deep_tower_opportunity_caveated_trigger_layer_moisture" in deep_tower.caveats
+
+
+def test_deep_tower_opportunity_trigger_layer_fit_is_not_overridden_by_severe_story() -> None:
+    poor_trigger_layer_fit: dict[str, FeatureValue] = {
+        "data_completeness_score": 96.0,
+        "low_level_qv_g_kg": 22.0,
+        "mean_qv_0_500m_g_kg": 21.0,
+        "mean_qv_0_1000m_g_kg": 19.5,
+        "mean_qv_0_3000m_g_kg": 14.8,
+        "trigger_layer_mean_qv_750_2250m_g_kg": 9.5,
+        "precipitable_water_proxy_or_unavailable": 46.0,
+        "surface_t_td_spread_c": 5.0,
+        "estimated_lcl_height_m_agl": 625.0,
+        "lapse_rate_0_1000m_c_per_km": 8.0,
+        "lapse_rate_0_3000m_c_per_km": 7.8,
+        "midlevel_lapse_rate_700_500_hpa_c_per_km": 8.0,
+        "cap_strength_proxy": 0.0,
+        "cap_height_m_agl": None,
+        "moisture_depth_m": 4200.0,
+        "midlevel_dry_layer_proxy": 2.0,
+        "qv_drop_0_3000m_g_kg": 7.2,
+        "observed_wind_available": True,
+        "bulk_shear_0_1km_m_s": 10.0,
+        "bulk_shear_0_3km_m_s": 20.0,
+        "bulk_shear_0_6km_m_s": 32.0,
+        "dry_microburst_inverted_v_proxy": 30.0,
+        "freezing_level_m_agl": 4300.0,
+        "surface_based_cape_j_kg": 3200.0,
+        "mixed_layer_cape_j_kg": 2800.0,
+        "surface_based_cin_j_kg": -10.0,
+        "mixed_layer_cin_j_kg": -15.0,
+        "lfc_height_m_agl": 700.0,
+        "el_height_m_agl": 15000.0,
+        "profile_top_m_agl": 19000.0,
+        "lowest_level_m_agl": 0.0,
+        "near_surface_discontinuity_flag": False,
+    }
+
+    scores, evidence = _score_features(poor_trigger_layer_fit, package_ready=True)
+
+    severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
+    deep_tower = next(item for item in evidence if item.label == "Deep-Tower opportunity")
+    assert severe.support == "supported"
+    assert poor_trigger_layer_fit["deep_tower_opportunity_support"] == "unavailable"
+    assert cast(float, poor_trigger_layer_fit["deep_tower_opportunity"]) == pytest.approx(44.0)
+    assert "deep_tower_opportunity_poor_trigger_layer_moisture" in deep_tower.caveats
 
 
 def test_analysis_deep_family_best_match_uses_deep_tower_opportunity(

--- a/app/backend/tests/test_sounding_candidates.py
+++ b/app/backend/tests/test_sounding_candidates.py
@@ -200,7 +200,7 @@ def test_screen_cached_soundings_returns_ranked_package_ready_candidates(
 
     result = screen_cached_soundings(settings, latest_per_station=2, limit=10)
 
-    assert result.screening_version == "sounding-screening-v2"
+    assert result.screening_version == "sounding-screening-v3"
     assert len(result.candidates) == 2
     candidate = result.candidates[0]
     assert candidate.station_id == "USM00072558"
@@ -1185,8 +1185,8 @@ def test_deep_tower_opportunity_separates_success_from_miss_features() -> None:
     north_platte_score = cast(float, north_platte_like["deep_tower_opportunity"])
     assert fort_score == pytest.approx(81.7)
     assert fort_worth_like["deep_tower_opportunity_support"] == "supported"
-    assert north_platte_score == pytest.approx(44.0)
-    assert north_platte_like["deep_tower_opportunity_support"] == "unavailable"
+    assert north_platte_score == pytest.approx(46.1)
+    assert north_platte_like["deep_tower_opportunity_support"] == "weak"
     assert fort_score > north_platte_score + 30.0
 
 
@@ -1235,11 +1235,10 @@ def test_deep_tower_opportunity_caps_discontinuous_surface_cape_signal() -> None
     assert score >= 45.0
     assert "near_surface_discontinuity_caveat" in deep_tower.caveats
     assert "surface_based_cape_ignored_due_to_near_surface_discontinuity" in deep_tower.caveats
-    assert "deep_tower_opportunity_caveated_trigger_layer_moisture" in deep_tower.caveats
 
 
-def test_deep_tower_opportunity_trigger_layer_fit_is_not_overridden_by_severe_story() -> None:
-    poor_trigger_layer_fit: dict[str, FeatureValue] = {
+def test_deep_tower_opportunity_trigger_layer_qv_is_descriptive_not_a_hard_gate() -> None:
+    poor_trigger_layer_qv: dict[str, FeatureValue] = {
         "data_completeness_score": 96.0,
         "low_level_qv_g_kg": 22.0,
         "mean_qv_0_500m_g_kg": 21.0,
@@ -1274,14 +1273,61 @@ def test_deep_tower_opportunity_trigger_layer_fit_is_not_overridden_by_severe_st
         "near_surface_discontinuity_flag": False,
     }
 
-    scores, evidence = _score_features(poor_trigger_layer_fit, package_ready=True)
+    scores, evidence = _score_features(poor_trigger_layer_qv, package_ready=True)
 
     severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
     deep_tower = next(item for item in evidence if item.label == "Deep-Tower opportunity")
     assert severe.support == "supported"
-    assert poor_trigger_layer_fit["deep_tower_opportunity_support"] == "unavailable"
-    assert cast(float, poor_trigger_layer_fit["deep_tower_opportunity"]) == pytest.approx(44.0)
-    assert "deep_tower_opportunity_poor_trigger_layer_moisture" in deep_tower.caveats
+    assert poor_trigger_layer_qv["deep_tower_opportunity_support"] == "supported"
+    assert cast(float, poor_trigger_layer_qv["deep_tower_opportunity"]) >= 70.0
+    assert "deep_tower_opportunity_poor_trigger_layer_moisture" not in deep_tower.caveats
+
+
+def test_deep_tower_opportunity_near_surface_guardrail_is_not_overridden_by_severe_story() -> None:
+    discontinuous_profile: dict[str, FeatureValue] = {
+        "data_completeness_score": 96.0,
+        "low_level_qv_g_kg": 32.0,
+        "mean_qv_0_500m_g_kg": 21.0,
+        "mean_qv_0_1000m_g_kg": 19.5,
+        "mean_qv_0_3000m_g_kg": 14.8,
+        "trigger_layer_mean_qv_750_2250m_g_kg": 14.0,
+        "precipitable_water_proxy_or_unavailable": 46.0,
+        "surface_t_td_spread_c": 2.0,
+        "estimated_lcl_height_m_agl": 250.0,
+        "lapse_rate_0_1000m_c_per_km": 8.0,
+        "lapse_rate_0_3000m_c_per_km": 7.8,
+        "midlevel_lapse_rate_700_500_hpa_c_per_km": 8.0,
+        "cap_strength_proxy": 0.0,
+        "cap_height_m_agl": None,
+        "moisture_depth_m": 4200.0,
+        "midlevel_dry_layer_proxy": 2.0,
+        "qv_drop_0_3000m_g_kg": 17.2,
+        "observed_wind_available": True,
+        "bulk_shear_0_1km_m_s": 10.0,
+        "bulk_shear_0_3km_m_s": 20.0,
+        "bulk_shear_0_6km_m_s": 32.0,
+        "dry_microburst_inverted_v_proxy": 30.0,
+        "freezing_level_m_agl": 4300.0,
+        "surface_based_cape_j_kg": 3200.0,
+        "mixed_layer_cape_j_kg": 1800.0,
+        "surface_based_cin_j_kg": -10.0,
+        "mixed_layer_cin_j_kg": -15.0,
+        "lfc_height_m_agl": 700.0,
+        "el_height_m_agl": 15000.0,
+        "profile_top_m_agl": 19000.0,
+        "lowest_level_m_agl": 0.0,
+        "near_surface_discontinuity_flag": True,
+    }
+
+    scores, evidence = _score_features(discontinuous_profile, package_ready=True)
+
+    severe = next(score for score in scores if score.story == "severe_thunderstorm_environment")
+    deep_tower = next(item for item in evidence if item.label == "Deep-Tower opportunity")
+    assert severe.support == "supported"
+    assert discontinuous_profile["deep_tower_opportunity_support"] == "weak"
+    assert cast(float, discontinuous_profile["deep_tower_opportunity"]) < 70.0
+    assert "near_surface_discontinuity_caveat" in deep_tower.caveats
+    assert "surface_based_cape_ignored_due_to_near_surface_discontinuity" in deep_tower.caveats
 
 
 def test_analysis_deep_family_best_match_uses_deep_tower_opportunity(

--- a/app/backend/tests/test_sounding_diagnostics.py
+++ b/app/backend/tests/test_sounding_diagnostics.py
@@ -155,6 +155,7 @@ def test_sounding_diagnostics_payload_has_quality_provenance_and_required_featur
         "has_observed_wind_profile",
         "estimated_lcl_height_m_agl",
         "mean_qv_0_1000m_g_kg",
+        "trigger_layer_mean_qv_750_2250m_g_kg",
         "lapse_rate_0_1000m_c_per_km",
         "cap_strength_proxy",
         "bulk_shear_0_6km_m_s",

--- a/app/backend/tests/test_sounding_diagnostics.py
+++ b/app/backend/tests/test_sounding_diagnostics.py
@@ -137,7 +137,7 @@ def test_synthetic_profile_has_known_numeric_diagnostics() -> None:
 def test_sounding_diagnostics_payload_has_quality_provenance_and_required_features() -> None:
     diagnostics = compute_sounding_diagnostics(_record())
 
-    assert diagnostics.diagnostic_version == "sounding-diagnostics-v2"
+    assert diagnostics.diagnostic_version == "sounding-diagnostics-v1"
     assert diagnostics.station_id == "USM00072558"
     assert diagnostics.provenance["source_format"] == "igra_station_text"
     assert diagnostics.provenance["diagnostic_claim"].startswith("computed from observed sounding")
@@ -155,7 +155,6 @@ def test_sounding_diagnostics_payload_has_quality_provenance_and_required_featur
         "has_observed_wind_profile",
         "estimated_lcl_height_m_agl",
         "mean_qv_0_1000m_g_kg",
-        "trigger_layer_mean_qv_750_2250m_g_kg",
         "lapse_rate_0_1000m_c_per_km",
         "cap_strength_proxy",
         "bulk_shear_0_6km_m_s",

--- a/app/backend/tests/test_sounding_diagnostics.py
+++ b/app/backend/tests/test_sounding_diagnostics.py
@@ -137,7 +137,7 @@ def test_synthetic_profile_has_known_numeric_diagnostics() -> None:
 def test_sounding_diagnostics_payload_has_quality_provenance_and_required_features() -> None:
     diagnostics = compute_sounding_diagnostics(_record())
 
-    assert diagnostics.diagnostic_version == "sounding-diagnostics-v1"
+    assert diagnostics.diagnostic_version == "sounding-diagnostics-v2"
     assert diagnostics.station_id == "USM00072558"
     assert diagnostics.provenance["source_format"] == "igra_station_text"
     assert diagnostics.provenance["diagnostic_claim"].startswith("computed from observed sounding")

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -152,7 +152,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(valleyCard).toContainText("Good for a surface-forced run");
     const candidateDetails = page.getByLabel("Candidate details");
     await expect(candidateDetails).toContainText("Why this is interesting");
-    await expect(candidateDetails).toContainText("Recommended first run");
+    await expect(candidateDetails).toContainText("Run guidance");
     await expect(candidateDetails).toContainText("Run fit");
     await expect(candidateDetails).toContainText("Top limits");
     await expect(candidateDetails).not.toContainText("Scores rank sounding ingredients only");

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -1134,9 +1134,6 @@ function candidateSortValueForTest(
   sortBy: string,
 ) {
   if (sortBy === "best_match") {
-    if (storyFilter === "deep_convection_trial" || storyFamily === "deep_convection") {
-      return candidateDeepTowerOpportunityForTest(candidate);
-    }
     return (
       storyScoreForTest(candidate, storyFilter, storyFamily)?.score_0_to_100 ?? candidate.rank_score
     );
@@ -3920,7 +3917,7 @@ describe("App", () => {
     );
     expect(deepCard).toHaveTextContent("Experimental Deep-Tower evidence");
 
-    fireEvent.click(within(deepCard).getByRole("button", { name: "Configure run" }));
+    fireEvent.click(within(deepCard).getByRole("button", { name: "Configure benchmark probe" }));
     expect(screen.getByLabelText("Candidate details")).toHaveTextContent(
       "Experimental Deep-Tower evidence only.",
     );
@@ -4094,12 +4091,12 @@ describe("App", () => {
     );
     expect(lowCard).not.toHaveTextContent("stronger screening support");
 
-    fireEvent.click(within(lowCard).getByRole("button", { name: "Configure run" }));
+    fireEvent.click(within(lowCard).getByRole("button", { name: "Configure benchmark probe" }));
     const details = screen.getByLabelText("Candidate details");
     expect(details).toHaveTextContent("Low experimental Deep-Tower evidence.");
     expect(details).toHaveTextContent("Experimental Deep-Tower evidence");
     expect(details).toHaveTextContent("41 %");
-    expect(within(lowCard).getByRole("button", { name: "Configure run" })).not.toBeDisabled();
+    expect(within(lowCard).getByRole("button", { name: "Configure benchmark probe" })).not.toBeDisabled();
   });
 
   it("keeps humid/rainy candidates with weak deep scores on observed quick-look", async () => {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -684,7 +684,7 @@ const secondaryShallowCandidate = {
     deep_tower_opportunity: 48.9,
     deep_tower_opportunity_support: "weak",
     deep_tower_opportunity_summary:
-      "Deep-Tower opportunity is caveated: some cloud-depth ingredients are present, but moisture depth, CAPE, LCL, or inhibition support is not strong.",
+      "Experimental Deep-Tower evidence is caveated: some cloud-depth ingredients are present, but the fixed benchmark response is uncertain.",
   },
   interest_summary: "Very moist lower atmosphere.",
   interest_reasons: [
@@ -753,9 +753,9 @@ const deepConvectionCandidate = {
   features: {
     ...shallowCandidate.features,
     deep_tower_opportunity: 82,
-    deep_tower_opportunity_support: "supported",
+    deep_tower_opportunity_support: "weak",
     deep_tower_opportunity_summary:
-      "Deep-Tower opportunity is supported for the convective-ceiling question.",
+      "Experimental Deep-Tower evidence is high, but recent benchmark misses show this score is not a reliable recommendation to spend scout compute.",
   },
   discovery_bucket: "Deep convection",
 };
@@ -1062,7 +1062,7 @@ function candidateWithActiveFieldsForTest(
       deepScope && deepOpportunity !== null
         ? deepOpportunity
         : (activeScore?.score_0_to_100 ?? candidate.rank_score),
-    ingredient_score_label: deepScope ? "Deep-Tower opportunity" : "Ingredient score",
+    ingredient_score_label: deepScope ? "Experimental Deep-Tower evidence" : "Ingredient score",
     active_story_support: deepScope ? deepSupport : (activeScore?.support ?? null),
     package_readiness: candidate.package_ready ? "package_ready" : "blocked",
     recipe_fit:
@@ -3916,13 +3916,19 @@ describe("App", () => {
     const deepCard = screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)");
     expect(deepCard).toHaveTextContent("Supercell-like environment");
     expect(deepCard).toHaveTextContent(
-      "Deep-Tower opportunity is supported for the convective-ceiling question.",
+      "Experimental Deep-Tower evidence is high, but recent benchmark misses show this score is not a reliable recommendation to spend scout compute.",
     );
-    expect(deepCard).toHaveTextContent("Deep-Tower opportunity");
+    expect(deepCard).toHaveTextContent("Experimental Deep-Tower evidence");
 
     fireEvent.click(within(deepCard).getByRole("button", { name: "Configure run" }));
     expect(screen.getByLabelText("Candidate details")).toHaveTextContent(
-      "Recommended Deep-Tower scout · stock CM1 iinit=3 · ~120 km · 2 h.",
+      "Experimental Deep-Tower evidence only.",
+    );
+    expect(screen.getByLabelText("Candidate details")).toHaveTextContent(
+      "not a reliable recommendation to spend scout compute",
+    );
+    expect(screen.getByLabelText("Candidate details")).not.toHaveTextContent(
+      "Recommended Deep-Tower scout",
     );
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
 
@@ -3965,11 +3971,13 @@ describe("App", () => {
       expect(dryRunBody).toContain('"primary_story":"supercell_environment"');
       expect(dryRunBody).toContain('"candidate_id":"USM00072357-2025052000-supercell"');
       expect(dryRunBody).toContain('"ingredient_score":82');
-      expect(dryRunBody).toContain('"ingredient_score_label":"Deep-Tower opportunity"');
+      expect(dryRunBody).toContain(
+        '"ingredient_score_label":"Experimental Deep-Tower evidence"',
+      );
     });
   });
 
-  it("does not present severe-story support as Deep-Tower opportunity support", async () => {
+  it("does not present severe-story support as experimental Deep-Tower support", async () => {
     const defaultFetch = vi.mocked(fetch).getMockImplementation();
     const lowOpportunityCandidate = {
       ...deepConvectionCandidate,
@@ -3997,7 +4005,7 @@ describe("App", () => {
         deep_tower_opportunity: 41,
         deep_tower_opportunity_support: "unavailable",
         deep_tower_opportunity_summary:
-          "Deep-Tower opportunity is low for this recipe: the thermodynamic profile does not strongly support a tall, useful benchmark cloud.",
+          "Experimental Deep-Tower evidence is low: the current heuristic does not surface this as a strong fixed-benchmark comparison case.",
       },
     };
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -4079,19 +4087,17 @@ describe("App", () => {
 
     const lowCard = await screen.findByLabelText("Sounding candidate Topeka, Kansas (USM00072456)");
     expect(lowCard).toHaveTextContent("Supercell-like environment");
-    expect(lowCard).toHaveTextContent("Deep-Tower opportunity");
+    expect(lowCard).toHaveTextContent("Experimental Deep-Tower evidence");
     expect(lowCard).toHaveTextContent("41 %");
     expect(lowCard).toHaveTextContent(
-      "Deep-Tower opportunity is low for this recipe: the thermodynamic profile does not strongly support a tall, useful benchmark cloud.",
+      "Experimental Deep-Tower evidence is low: the current heuristic does not surface this as a strong fixed-benchmark comparison case.",
     );
     expect(lowCard).not.toHaveTextContent("stronger screening support");
 
     fireEvent.click(within(lowCard).getByRole("button", { name: "Configure run" }));
     const details = screen.getByLabelText("Candidate details");
-    expect(details).toHaveTextContent(
-      "Skip for Deep-Tower cloud-making unless deliberately overriding.",
-    );
-    expect(details).toHaveTextContent("Deep-Tower opportunity");
+    expect(details).toHaveTextContent("Low experimental Deep-Tower evidence.");
+    expect(details).toHaveTextContent("Experimental Deep-Tower evidence");
     expect(details).toHaveTextContent("41 %");
     expect(within(lowCard).getByRole("button", { name: "Configure run" })).not.toBeDisabled();
   });
@@ -4214,7 +4220,7 @@ describe("App", () => {
       screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
     ).not.toBeInTheDocument();
     const candidateDetails = screen.getByLabelText("Candidate details");
-    expect(candidateDetails).toHaveTextContent("Recommended first run");
+    expect(candidateDetails).toHaveTextContent("Run guidance");
     expect(candidateDetails).toHaveTextContent("Run fit");
     expect(candidateDetails).toHaveTextContent("Top limits");
     expect(candidateDetails).not.toHaveTextContent("Scores rank sounding ingredients only");
@@ -4298,7 +4304,7 @@ describe("App", () => {
       "Sounding candidate Valley, Nebraska (USM00072558)",
     );
     expect(
-      screen.getByRole("heading", { name: "Recommended cached soundings" }),
+      screen.getByRole("heading", { name: "Screened cached soundings" }),
     ).toBeInTheDocument();
 
     fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Configure run" }));
@@ -4606,14 +4612,14 @@ describe("App", () => {
     );
     expect(wilmingtonCard).toHaveTextContent("High-CAPE pulse storm");
     expect(wilmingtonCard).not.toHaveTextContent("Primary: Humid / rainy");
-    expect(wilmingtonCard).toHaveTextContent("48.9 % deep-tower opportunity");
-    expect(wilmingtonCard).toHaveTextContent("testable with Deep-Tower Benchmark");
+    expect(wilmingtonCard).toHaveTextContent("48.9 % experimental deep-tower evidence");
+    expect(wilmingtonCard).toHaveTextContent("optional Deep-Tower benchmark context");
     expect(wilmingtonCard).toHaveTextContent(
-      "Deep-Tower opportunity is caveated: some cloud-depth ingredients are present, but moisture depth, CAPE, LCL, or inhibition support is not strong.",
+      "Experimental Deep-Tower evidence is caveated: some cloud-depth ingredients are present, but the fixed benchmark response is uncertain.",
     );
     expect(
-      screen.queryByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
-    ).not.toBeInTheDocument();
+      screen.getByLabelText("Sounding candidate Norman, Oklahoma (USM00072357)"),
+    ).toHaveTextContent("82 % experimental deep-tower evidence");
 
     fireEvent.click(within(wilmingtonCard).getByRole("button", { name: /Wilmington, Ohio/ }));
     const candidateDetails = screen.getByLabelText("Candidate details");

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -5562,14 +5562,14 @@ function ObservedAtmosphereCandidatesPanel({
               value={sort}
               onChange={(event) => onSortChange(event.target.value as CandidateSort)}
             >
-              <option value="best_match">Recommended</option>
+              <option value="best_match">Best match</option>
               <option value="valid_time">Valid time</option>
               <option value="station_id">Station ID</option>
               <option value="station_name">Station name</option>
               <option value="primary_story">Primary story</option>
               <option value="story_family">Story family</option>
               <option value="rank_score">Rank score</option>
-              <option value="deep_tower_opportunity">Deep-Tower opportunity</option>
+              <option value="deep_tower_opportunity">Experimental Deep-Tower evidence</option>
               <option value="confidence">Confidence</option>
               <option value="support">Evidence tier</option>
               <option value="package_readiness">Package readiness</option>
@@ -5648,7 +5648,7 @@ function ObservedAtmosphereCandidatesPanel({
               <h4>
                 {activeRefinements.length > 0
                   ? "Refined candidates"
-                  : "Recommended cached soundings"}
+                  : "Screened cached soundings"}
               </h4>
               <p className="field-help">{filterTraceSummary.summary}</p>
               {filterTraceSummary.detail && (
@@ -6120,7 +6120,7 @@ function SoundingCandidateDetail({
         </ul>
       </section>
       <section className="candidate-detail-section">
-        <h5>Recommended first run</h5>
+        <h5>Run guidance</h5>
         <p className="candidate-interest-summary">{runRecommendation.title}</p>
         <p className="field-help">{runRecommendation.detail}</p>
         {runRecommendation.followUp && <p className="field-help">{runRecommendation.followUp}</p>}
@@ -11181,14 +11181,14 @@ function candidateStoryFamilyForStory(story: CandidateStoryId): CandidateStoryFa
 
 function candidateSortLabel(sort: CandidateSort): string {
   const labels: Record<CandidateSort, string> = {
-    best_match: "Recommended",
+    best_match: "Best match",
     valid_time: "Valid time",
     station_id: "Station ID",
     station_name: "Station name",
     primary_story: "Primary story",
     story_family: "Story family",
     rank_score: "Rank score",
-    deep_tower_opportunity: "Deep-Tower opportunity",
+    deep_tower_opportunity: "Experimental Deep-Tower evidence",
     confidence: "Confidence",
     support: "Evidence tier",
     package_readiness: "Package readiness",
@@ -11268,9 +11268,9 @@ function candidateRecipeFitForStory(
     }
     return {
       status: "partially_testable",
-      label: "testable with Deep-Tower Benchmark",
+      label: "optional Deep-Tower benchmark context",
       summary:
-        "This story screens deep-convection ingredients. CM1 can evolve the observed atmosphere with the explicit Deep-Tower Benchmark trigger; use surface-forced recipes when lower-boundary initiation is the question.",
+        "This story screens deep-convection ingredients. The fixed Deep-Tower Benchmark is available for deliberate comparison, but current evidence does not make it a reliable first-run recommendation.",
       caveats,
     };
   }
@@ -11408,7 +11408,7 @@ function observedRecipeFitSummary(
     return fitSummary;
   }
   if (story && deepConvectionStoryIds.has(story)) {
-    return "Inspectable with the explicit Deep-Tower Benchmark trigger; deep outcomes still depend on duration, domain, resolution, and CM1 output fields.";
+    return "Inspectable with an explicit Deep-Tower Benchmark trigger only as deliberate comparison context; deep outcomes still depend on duration, domain, resolution, and CM1 output fields.";
   }
   return "The selected observed-sounding method can inspect this story when duration, cadence, and requested fields are adequate.";
 }
@@ -11589,7 +11589,7 @@ function candidateIngredientScoreLabel(
   storyFamilyFilter: CandidateStoryFamilyFilter = "all",
 ): string {
   if (candidateScopeIsDeepTower(storyFilter, storyFamilyFilter)) {
-    return candidate.ingredient_score_label ?? "Deep-Tower opportunity";
+    return candidate.ingredient_score_label ?? "Experimental Deep-Tower evidence";
   }
   return candidate.ingredient_score_label ?? "Ingredient score";
 }
@@ -11665,17 +11665,7 @@ function candidateKeyNote(
   if (candidateStoryFamilyForStory(story) === "deep_convection") {
     const opportunitySummary = candidateDeepTowerOpportunitySummary(candidate);
     if (opportunitySummary) return opportunitySummary;
-    const activeSupport =
-      candidate.active_story === story
-        ? candidate.active_story_support
-        : candidate.story_scores.find((score) => score.story === story)?.support;
-    if (activeSupport === "supported") {
-      return "Deep-Tower opportunity is supported; use the benchmark trigger to test the convective ceiling.";
-    }
-    if (activeSupport === "weak") {
-      return "Caveated Deep-Tower opportunity; use the benchmark trigger to test the convective ceiling.";
-    }
-    return "Deep-Tower candidate; use the benchmark trigger to test the convective ceiling.";
+    return "Experimental Deep-Tower evidence only; do not treat this as a reliable fixed-recipe recommendation.";
   }
   if (
     story === "humid_rainy_candidate" ||
@@ -11759,29 +11749,27 @@ function candidateRunRecommendation(
     const opportunityScore = candidateDeepTowerOpportunityScore(candidate);
     if (opportunityScore !== null && opportunityScore >= 70) {
       return {
-        title: "Recommended Deep-Tower scout · stock CM1 iinit=3 · ~120 km · 2 h.",
+        title: "Experimental Deep-Tower evidence only.",
         detail:
-          "Disable surface fluxes and use explicit thermal initiation to test this observed atmosphere's convective ceiling.",
+          "A high score can help sort comparison cases, but it is not a reliable recommendation to spend scout compute on the fixed stock iinit=3 benchmark.",
         followUp:
-          "Inspect cloud depth, updraft, precipitation, and reflectivity before changing the trigger or resolution.",
+          "Manual configuration remains available if you deliberately want a comparable benchmark probe.",
       };
     }
     if (opportunityScore !== null && opportunityScore >= 45) {
       return {
-        title:
-          "Weak Deep-Tower opportunity · run for calibration or learning, not as a best cloud bet.",
+        title: "Caveated experimental Deep-Tower evidence.",
         detail:
-          "If deliberately running it, keep the Deep-Tower Benchmark setup comparable: stock CM1 iinit=3, ~120 km domain, 2 h, and disabled surface fluxes.",
+          "The fixed benchmark response is uncertain; this is comparison context, not automatic compute-spending advice.",
         followUp:
-          "Use the result to calibrate the selector rather than treating it as the next visual cloud-making target.",
+          "Manual configuration remains available if a reviewer deliberately chooses a comparable probe.",
       };
     }
     return {
-      title: "Skip for Deep-Tower cloud-making unless deliberately overriding.",
+      title: "Low experimental Deep-Tower evidence.",
       detail:
-        "Manual configuration remains available; if overriding, keep the Deep-Tower Benchmark setup comparable so the outcome is interpretable.",
-      followUp:
-        "Spend normal cloud-making scout compute on candidates with supported Deep-Tower opportunity.",
+        "This score does not support using the fixed Deep-Tower Benchmark as a product recommendation.",
+      followUp: "Manual configuration remains available for deliberate overrides.",
     };
   }
   if (story === "dry_failed_candidate" || story === "capped_suppressed_candidate") {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -5903,6 +5903,8 @@ function SoundingCandidateCard({
   const recipeFit = candidateRecipeFitForStory(candidate, story);
   const reasons = candidateInterestReasons(candidate).slice(0, 3);
   const keyNote = candidateKeyNote(candidate, story, recipeFit);
+  const configureActionLabel =
+    activeFamily === "deep_convection" ? "Configure benchmark probe" : "Configure run";
   return (
     <article
       className={`candidate-card${selected ? " selected-candidate-card" : ""}`}
@@ -5944,7 +5946,7 @@ function SoundingCandidateCard({
           disabled={!candidate.package_ready}
           onClick={() => onSelectForRunSetup(story)}
         >
-          Configure run
+          {configureActionLabel}
         </button>
         <button type="button" className="secondary-button" disabled={saved} onClick={onSave}>
           {saved ? "Saved" : "Save"}
@@ -6003,6 +6005,8 @@ function SoundingCandidateDetail({
   const reasons = candidateInterestReasons(activeCandidate).slice(0, 5);
   const topLimits = candidateTopLimits(activeCandidate, story, recipeFit);
   const runRecommendation = candidateRunRecommendation(activeCandidate, story, recipeFit);
+  const configureActionLabel =
+    activeFamily === "deep_convection" ? "Configure benchmark probe" : "Configure run";
   const savedTagValues = parseTags(tagDraft);
   function handleTagSuggestion(tag: string) {
     setTagDraft(_dedupeStrings([...savedTagValues, tag]).join(", "));
@@ -6058,7 +6062,7 @@ function SoundingCandidateDetail({
           disabled={!candidate.package_ready}
           onClick={() => onSelectForRunSetup(candidate, story)}
         >
-          Configure run
+          {configureActionLabel}
         </button>
         <button type="button" className="secondary-button" onClick={() => setSaveDrawerOpen(true)}>
           {savedCandidate ? "Edit saved notes" : "Save candidate"}

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -102,11 +102,14 @@ Deep-Tower Benchmark. It is not a replacement for severe/supercell story
 scores and should not be read as an observed storm forecast.
 
 The score weights surface-based CAPE, mixed-layer CAPE, CIN, LFC, cap proxy,
-low-level moisture, deeper moisture, 0-3 km and midlevel lapse rates, profile
-completeness, and near-surface continuity. EL or buoyancy depth contributes
-only when the simple EL estimate is usable. Deep-layer shear receives little or
-no weight because this selector asks whether the benchmark trigger can reveal a
-deep convective ceiling, not whether a storm will organize.
+low-level moisture, trigger-layer moisture around the stock warm-bubble layer,
+deeper moisture, 0-3 km and midlevel lapse rates, profile completeness, and
+near-surface continuity. EL or buoyancy depth contributes only when the simple
+EL estimate is usable. Deep-layer shear receives little or no weight because
+this selector asks whether the benchmark trigger can reveal a deep convective
+ceiling, not whether a storm will organize. If the near-surface profile has a
+large discontinuity, the selector cannot return `supported`; the opportunity
+uses mixed-layer CAPE rather than allowing one suspect lowest level to dominate.
 
 ## Story Logic
 

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -102,14 +102,20 @@ Deep-Tower Benchmark. It is not a replacement for severe/supercell story
 scores and should not be read as an observed storm forecast.
 
 The score weights surface-based CAPE, mixed-layer CAPE, CIN, LFC, cap proxy,
-low-level moisture, trigger-layer moisture around the stock warm-bubble layer,
-deeper moisture, 0-3 km and midlevel lapse rates, profile completeness, and
-near-surface continuity. EL or buoyancy depth contributes only when the simple
-EL estimate is usable. Deep-layer shear receives little or no weight because
-this selector asks whether the benchmark trigger can reveal a deep convective
-ceiling, not whether a storm will organize. If the near-surface profile has a
-large discontinuity, the selector cannot return `supported`; the opportunity
-uses mixed-layer CAPE rather than allowing one suspect lowest level to dominate.
+low-level moisture, deeper moisture, 0-3 km and midlevel lapse rates, profile
+completeness, and near-surface continuity. EL or buoyancy depth contributes
+only when the simple EL estimate is usable. Deep-layer shear receives little or
+no weight because this selector asks whether the benchmark trigger can reveal a
+deep convective ceiling, not whether a storm will organize. If the near-surface
+profile has a large discontinuity, the selector cannot return `supported`; the
+opportunity uses mixed-layer CAPE rather than allowing one suspect lowest level
+to dominate.
+
+The diagnostic payload also exposes `trigger_layer_mean_qv_750_2250m_g_kg` as
+descriptive evidence around the stock `iinit = 3` warm-bubble layer. It is an
+unweighted mean of available sounding levels in that height range, not a
+thickness-weighted layer mean, and it is not currently a validated
+recommendation gate.
 
 ## Story Logic
 

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -97,25 +97,21 @@ product-facing evidence.
 
 ### Deep-Tower Opportunity
 
-`deep_tower_opportunity` is a recipe-specific 0-100 selector for the
-Deep-Tower Benchmark. It is not a replacement for severe/supercell story
-scores and should not be read as an observed storm forecast.
+`deep_tower_opportunity` is an experimental 0-100 sounding heuristic for
+comparing possible Deep-Tower Benchmark cases. It is not a recipe
+recommendation, not a promise that the fixed stock `iinit = 3` benchmark will
+make a deep cloud, and not a replacement for severe/supercell story scores.
+High values may be used as optional sort evidence, but they must not drive
+automatic compute-spending advice.
 
 The score weights surface-based CAPE, mixed-layer CAPE, CIN, LFC, cap proxy,
 low-level moisture, deeper moisture, 0-3 km and midlevel lapse rates, profile
 completeness, and near-surface continuity. EL or buoyancy depth contributes
 only when the simple EL estimate is usable. Deep-layer shear receives little or
-no weight because this selector asks whether the benchmark trigger can reveal a
-deep convective ceiling, not whether a storm will organize. If the near-surface
-profile has a large discontinuity, the selector cannot return `supported`; the
-opportunity uses mixed-layer CAPE rather than allowing one suspect lowest level
-to dominate.
-
-The diagnostic payload also exposes `trigger_layer_mean_qv_750_2250m_g_kg` as
-descriptive evidence around the stock `iinit = 3` warm-bubble layer. It is an
-unweighted mean of available sounding levels in that height range, not a
-thickness-weighted layer mean, and it is not currently a validated
-recommendation gate.
+no weight because this heuristic is scoped to possible cloud-depth ingredients,
+not storm organization. If the near-surface profile has a large discontinuity,
+the heuristic cannot surface as clean `supported` evidence; it uses mixed-layer
+CAPE rather than allowing one suspect lowest level to dominate.
 
 ## Story Logic
 

--- a/docs/research/cloud-chase-005-slidell-false-positive-correction.md
+++ b/docs/research/cloud-chase-005-slidell-false-positive-correction.md
@@ -1,0 +1,115 @@
+# Cloud Chase 005: Slidell False-Positive Correction
+
+## Scope
+
+This note records the bounded analyzer correction after the Slidell supported
+Deep-Tower miss, plus the single Topeka period-of-record Deep-Tower Benchmark
+trial used to test the corrected selector. It does not add a candidate-supply
+path, scoring platform, diagnostics framework, or new CM1 recipe.
+
+## Correction
+
+The `deep_tower_opportunity` selector now treats a large near-surface
+temperature or moisture discontinuity as a hard caveat for the Deep-Tower
+Benchmark. A discontinuous profile cannot return `supported`, and surface-based
+CAPE from the suspect lowest copied level no longer dominates the
+recipe-specific recommendation. In that case the selector uses mixed-layer CAPE
+for the CAPE gate and records a caveat that surface-based CAPE was ignored.
+
+The selector also adds one trigger-layer moisture check:
+`trigger_layer_mean_qv_750_2250m_g_kg`. This is the mean qv through the
+approximate stock `iinit = 3` warm-bubble layer. It is evidence about what the
+fixed benchmark trigger is actually lifting, not a new trigger recipe or a new
+diagnostics framework.
+
+## Calibration Checks
+
+- Fort Worth-like clean profile remains supported:
+  `USM00072249`, `1997-05-27T00:00:00Z`, revised score 81.7.
+- Slidell-like profile with high surface CAPE and a near-surface discontinuity
+  is capped below supported:
+  `USM00072233`, `1998-06-20T00:00:00Z`, revised score 65.0 weak.
+- North Platte-like profile falls to unavailable because the trigger-layer qv is
+  poor for the fixed warm-bubble layer:
+  `USM00072562`, `2026-07-02T00:00:00Z`, revised score 44.0.
+
+## Candidate Supply Finding and Run Selection
+
+Re-ranking the current recent-cache analyzer pool found no package-ready
+candidate meeting the requested run predicate:
+
+- supported revised opportunity;
+- no near-surface discontinuity;
+- strong mixed-layer CAPE;
+- adequate trigger-layer and lower-3-km moisture.
+
+That is not evidence that summer Midwest severe environments are absent. It is
+evidence that the current recent-cache analyzer pool is too narrow for this
+selection task.
+
+A bounded direct scan of existing local period-of-record cached station files
+did find clean supported candidates. The run target selected by PM decision was:
+
+- Topeka `USM00072456`, valid `2017-06-18T00:00:00Z`;
+- station metadata: `TOPEKA/MUN.; KS.`, 39.0722 N, 95.6305 W,
+  elevation 268.1 m MSL;
+- source file: `USM00072456-data.txt`;
+- source-file SHA-256:
+  `de1817eaec60d6d47ad5840d0a3e8998dbadf943d026edf74a3950bfdcf3aad2`;
+- selection provenance: `direct_local_period_of_record_scan`;
+- caveat:
+  `current_product_analyzer_does_not_yet_search_local_period_of_record_collection`;
+- revised opportunity 78.0 supported;
+- surface-based CAPE 1722.0 J/kg;
+- mixed-layer CAPE 1787.5 J/kg;
+- trigger-layer qv 17.031 g/kg;
+- mean qv 0-3 km 15.298 g/kg;
+- no near-surface discontinuity;
+- normalized observed sounding: 12 rendered levels, lowest level 0.0 m AGL,
+  top 18461.9 m AGL, complete thermodynamic and observed wind profile;
+- package readiness: usable, with `needs_review` source/provenance caveats
+  about preserved IGRA flags, station-elevation join, surface anchoring, and
+  upper-profile truncation.
+
+The current product analyzer UI did not discover this candidate. It came from
+the direct local period-of-record scan.
+
+## Topeka CM1 Scout
+
+- run id: `cloud_chase_005-topeka_20170618_deep_tower_scout`;
+- result id: `result-cloud_chase_005-topeka_20170618_deep_tower_scout`;
+- recipe: `deep_tower_benchmark_v0`;
+- initiation: stock CM1 `iinit = 3`;
+- run shape: 120 km domain, `120 x 120 x 40`, 20 km model top, 2-hour
+  duration, 15-minute output cadence, 6-second timestep, surface fluxes
+  disabled, existing full output set.
+
+Runtime integrity: completed and ingested with 9 model output frames, exit code
+0, normal CM1 termination reported, and an `IEEE_UNDERFLOW_FLAG` runtime caveat
+only.
+
+Outcome:
+
+- actual cloud category: transient shallow cloud;
+- first cloud time: 900 s;
+- first deep-convection time: none;
+- coherent cloud top: 1750.0 m;
+- liquid cloud top: 1750.0 m;
+- hydrometeor-envelope top: 1750.0 m;
+- maximum updraft: 0.554 m/s at 900 s;
+- maximum cloud water: `7.185e-05 kg/kg`;
+- rain water aloft: no meaningful rain water, maximum `5.368e-10 kg/kg`;
+- surface rain: 0.0 cm;
+- maximum reflectivity: 0.0 dBZ metadata maximum; no reflective precipitation
+  signal after model start;
+- visual-interest rating: 1/5;
+- worth-the-compute rating: 1/5.
+
+The corrected selector did not earn confidence on this run: a second supported
+candidate outside the recent-cache pool still produced only a weak shallow
+response under the fixed Deep-Tower Benchmark trigger.
+
+## Recommendation
+
+Stop and request PM review before retuning the score, running another candidate,
+or changing the candidate-supply path.

--- a/docs/research/cloud-chase-005-slidell-false-positive-correction.md
+++ b/docs/research/cloud-chase-005-slidell-false-positive-correction.md
@@ -1,115 +1,191 @@
-# Cloud Chase 005: Slidell False-Positive Correction
+# Cloud Chase 005: Deep-Tower Benchmark Audit
 
-## Scope
+## Observed evidence
 
-This note records the bounded analyzer correction after the Slidell supported
-Deep-Tower miss, plus the single Topeka period-of-record Deep-Tower Benchmark
-trial used to test the corrected selector. It does not add a candidate-supply
-path, scoring platform, diagnostics framework, or new CM1 recipe.
+PR #355 no longer treats the Slidell/Topeka work as a validated scoring
+correction. The durable product change is narrower: a major near-surface
+discontinuity prevents a clean `supported` Deep-Tower recommendation, and the
+score uses mixed-layer CAPE instead of allowing one suspect lowest level to
+dominate. The retained trigger-layer qv field is descriptive evidence only: it
+is an unweighted mean of available rendered sounding levels from 750-2250 m
+AGL, not a thickness-weighted layer mean and not a validated recommendation
+gate.
 
-## Correction
+The exact CM1 benchmark artifacts show that the Fort Worth success, Slidell
+miss, and Topeka 2017 miss used the same Deep-Tower Benchmark namelist:
+`3417c51c22a92c09e57298389fda5130b2267cc7f605c026ac950042aa7d5cee`.
+They also used the same `cm1_config.txt` hash,
+`2cdf5ef37465a5b55b07eca57c710e004656d5643d6e2d2f507d4448bcb692d3`.
+The benchmark configuration was `iinit = 3`, `120 x 120 x 40`, 1 km
+horizontal spacing, 500 m vertical spacing, 20 km model top, 7200 s duration,
+900 s output cadence, 6 s timestep, Rayleigh damping enabled from 15 km, and
+surface fluxes disabled. Runtime integrity was caveated only by
+`IEEE_UNDERFLOW_FLAG` for the three main runs.
 
-The `deep_tower_opportunity` selector now treats a large near-surface
-temperature or moisture discontinuity as a hard caveat for the Deep-Tower
-Benchmark. A discontinuous profile cannot return `supported`, and surface-based
-CAPE from the suspect lowest copied level no longer dominates the
-recipe-specific recommendation. In that case the selector uses mixed-layer CAPE
-for the CAPE gate and records a caveat that surface-based CAPE was ignored.
+| Case | Run id | Sounding | App commit | `input_sounding` SHA-256 | Outcome |
+|---|---|---|---|---|---|
+| Fort Worth 1997 | `cloud_chase_001-fort_worth_deep_tower_probe` | `USM00072249`, `1997-05-27T00:00:00Z` | not recorded | `08a9012ff831568cf6af45713d217a6c448067a85a459e830f40aed00d6826a5` | coherent cloud top 17.25 km, hydrometeor envelope 19.75 km, max updraft 54.13 m/s, surface rain 0.721 cm |
+| Slidell 1998 | `dry-run-2b944f5bc653` | `USM00072233`, `1998-06-20T00:00:00Z` | not recorded | `7fbba5362d048dbfa7f1a69c101c0321c33a377132cf5bc2f601acde95dabd03` | no coherent cloud, liquid top 2.75 km, max updraft 0.79 m/s, no surface rain |
+| Topeka 2017 | `cloud_chase_005-topeka_20170618_deep_tower_scout` | `USM00072456`, `2017-06-18T00:00:00Z` | `597e8fd5cd8b0c6e07ca23ac071e07fda522abae` | `38304066848f39f66e265872456d5f3f39bf7f2db3078b42b0bbd51b1564b392` | transient shallow cloud, coherent top 1.75 km, max updraft 0.55 m/s, no surface rain |
+| North Platte 2026 | `cloud_chase_001-north_platte_high_potential` | `USM00072562`, `2026-07-02T00:00:00Z` | not recorded | `437b0ec1791021a41d86aee8e547dbb38892e484395c28922695cc852ada13af` | exact outputs available; result metadata absent |
+| Topeka 2026 | `cloud_chase_003-topeka_deep_tower_opportunity` | `USM00072456`, `2026-06-10T00:00:00Z` | not recorded | `f8b8e8eb556403761fed2980c1490046ba3c30e206e5aee1bb0fda7378ac270a` | coherent cloud top 1.25 km, max updraft 0.89 m/s |
 
-The selector also adds one trigger-layer moisture check:
-`trigger_layer_mean_qv_750_2250m_g_kg`. This is the mean qv through the
-approximate stock `iinit = 3` warm-bubble layer. It is evidence about what the
-fixed benchmark trigger is actually lifting, not a new trigger recipe or a new
-diagnostics framework.
+The CM1 executable was `/Users/timpeterson/cm1r21.1/run/cm1.exe`, SHA-256
+`5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1`.
+The source tree is not a git checkout. A text-source hash over the local CM1
+source tree was
+`87cb9ea94b623d4c9e026424b5e2967bf829c17e7e8621a1360423b41373c2fa`;
+`/Users/timpeterson/cm1r21.1/src/init3d.F` was
+`9c45c0982ba194ea6ea74afd6a2516445cdd011fc90902091d089f4cb92dfd28`.
 
-## Calibration Checks
+The authoritative `init3d.F` implementation defines `iinit = 3` as a line of
+three warm bubbles. The source constants are: `nbub = 3`, `ric = 30000 m`,
+`rjc = 3000, 33000, 63000 m`, `zc = 1400 m`, `bhrad = 10000 m`,
+`bvrad = 1400 m`, and `bptpert = 2.0 K`. The perturbation is a
+cosine-squared potential-temperature perturbation. `maintain_rh = .false.`, so
+the warm bubble does not modify qv. These center/radius/temperature constants
+are defined by CM1 source, not by Cloud Chamber package controls.
 
-- Fort Worth-like clean profile remains supported:
-  `USM00072249`, `1997-05-27T00:00:00Z`, revised score 81.7.
-- Slidell-like profile with high surface CAPE and a near-surface discontinuity
-  is capped below supported:
-  `USM00072233`, `1998-06-20T00:00:00Z`, revised score 65.0 weak.
-- North Platte-like profile falls to unavailable because the trigger-layer qv is
-  poor for the fixed warm-bubble layer:
-  `USM00072562`, `2026-07-02T00:00:00Z`, revised score 44.0.
+The first output frame confirms that the three main runs received materially
+the same initial trigger. At `t = 0`, each had `theta_p_max = 1.9198 K` at
+approximately x = 29.5 km, y = 2.5 km, z = 1.25 km, with `theta_p > 0.1 K`
+from x = 22.5-37.5 km, y = -4.5-59.5 km, z = 0.25-2.25 km, and zero maximum
+vertical velocity. The third source bubble center is partly outside the
+120 km domain in all three cases because CM1 places it at y = 63 km while the
+resolved scalar grid reaches about y = 59.5 km.
 
-## Candidate Supply Finding and Run Selection
+The early response diverged after the common trigger. At 900 s, Fort Worth had
+maximum vertical velocity 4.23 m/s near z = 2.0 km; Slidell had 0.79 m/s near
+z = 1.0 km; Topeka 2017 had 0.55 m/s near z = 1.0 km. At 1800 s, Fort Worth
+had maximum vertical velocity 54.13 m/s near z = 12.5 km; Slidell remained
+0.45 m/s and Topeka 2017 remained 0.53 m/s.
 
-Re-ranking the current recent-cache analyzer pool found no package-ready
-candidate meeting the requested run predicate:
+Rendered lower-profile evidence from the exact normalized soundings supplied
+to CM1:
 
-- supported revised opportunity;
-- no near-surface discontinuity;
-- strong mixed-layer CAPE;
-- adequate trigger-layer and lower-3-km moisture.
+| Case | levels / below 3 km / top | Bubble center estimate at 1.4 km | Trigger qv evidence |
+|---|---|---|---|
+| Fort Worth | 50 / 10 / 19.31 km | 838.6 hPa, 21.2 C, theta 309.52 K, qv 14.21 g/kg, saturation deficit 4.67 g/kg | 6 available levels, unweighted mean 13.34 g/kg |
+| Slidell | 84 / 15 / 19.77 km | 864.9 hPa, 21.4 C, theta 307.01 K, qv 12.28 g/kg, saturation deficit 6.25 g/kg | 9 available levels, unweighted mean 12.42 g/kg |
+| Topeka 2017 | 12 / 4 / 18.46 km | 829.9 hPa, 20.4 C, theta 309.79 K, qv 15.43 g/kg, saturation deficit 2.73 g/kg | 1 available level, unweighted mean 17.03 g/kg |
 
-That is not evidence that summer Midwest severe environments are absent. It is
-evidence that the current recent-cache analyzer pool is too narrow for this
-selection task.
+| Case | z m | dz m | p hPa | T C | theta K | qv g/kg | RH % | sat deficit g/kg |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Fort Worth | 2.8 |  | 981.6 | 32.1 | 306.87 | 22.19 | 71.8 | 8.71 |
+| Fort Worth | 33.8 | 31 | 978.2 | 31.8 | 306.87 | 22.00 | 72.2 | 8.48 |
+| Fort Worth | 535.8 | 502 | 925.0 | 27.8 | 307.72 | 18.76 | 73.5 | 6.76 |
+| Fort Worth | 860.8 | 325 | 891.8 | 24.8 | 307.85 | 20.22 | 91.4 | 1.90 |
+| Fort Worth | 887.8 | 27 | 889.0 | 24.7 | 308.02 | 18.82 | 85.3 | 3.24 |
+| Fort Worth | 1281.8 | 394 | 850.0 | 21.8 | 308.95 | 15.77 | 81.6 | 3.56 |
+| Fort Worth | 1614.8 | 333 | 818.0 | 20.1 | 310.55 | 11.36 | 62.9 | 6.71 |
+| Fort Worth | 1893.8 | 279 | 791.9 | 18.2 | 311.41 | 9.53 | 57.5 | 7.04 |
+| Fort Worth | 2240.8 | 347 | 760.4 | 17.1 | 313.85 | 4.32 | 26.8 | 11.78 |
+| Fort Worth | 2938.8 | 698 | 700.0 | 11.9 | 315.59 | 3.26 | 26.2 | 9.20 |
+| Slidell | 0.1 |  | 1012.8 | 34.4 | 306.44 | 31.03 | 90.9 | 3.11 |
+| Slidell | 116.1 | 116 | 1000.0 | 32.5 | 305.65 | 20.47 | 66.0 | 10.56 |
+| Slidell | 152.1 | 36 | 996.0 | 31.8 | 305.30 | 17.38 | 58.1 | 12.54 |
+| Slidell | 414.1 | 262 | 967.4 | 29.1 | 305.12 | 17.14 | 65.1 | 9.19 |
+| Slidell | 812.1 | 398 | 925.0 | 25.5 | 305.37 | 15.82 | 71.1 | 6.42 |
+| Slidell | 939.1 | 127 | 911.7 | 24.1 | 305.20 | 15.65 | 75.5 | 5.09 |
+| Slidell | 1081.1 | 142 | 897.1 | 24.0 | 306.50 | 12.94 | 61.8 | 8.01 |
+| Slidell | 1358.1 | 277 | 869.1 | 21.8 | 307.00 | 11.49 | 60.8 | 7.41 |
+| Slidell | 1442.1 | 84 | 860.7 | 21.0 | 307.02 | 13.07 | 71.9 | 5.10 |
+| Slidell | 1550.1 | 108 | 850.0 | 20.3 | 307.38 | 11.07 | 62.9 | 6.53 |
+| Slidell | 1744.1 | 194 | 831.1 | 18.8 | 307.78 | 11.64 | 71.0 | 4.76 |
+| Slidell | 1862.1 | 118 | 819.8 | 18.3 | 308.46 | 9.58 | 59.5 | 6.52 |
+| Slidell | 2083.1 | 221 | 798.9 | 16.7 | 309.03 | 10.52 | 70.5 | 4.40 |
+| Slidell | 2442.1 | 359 | 765.8 | 13.8 | 309.66 | 9.14 | 70.8 | 3.77 |
+| Slidell | 2902.1 | 460 | 725.0 | 10.6 | 311.03 | 7.79 | 70.6 | 3.24 |
+| Topeka 2017 | 0.0 |  | 971.0 | 32.2 | 307.93 | 21.23 | 67.6 | 10.19 |
+| Topeka 2017 | 432.9 | 433 | 925.0 | 27.6 | 307.52 | 17.84 | 70.7 | 7.38 |
+| Topeka 2017 | 1176.9 | 744 | 850.0 | 21.4 | 308.53 | 17.03 | 90.3 | 1.82 |
+| Topeka 2017 | 2843.9 | 1667 | 700.0 | 14.0 | 317.92 | 5.09 | 35.6 | 9.23 |
 
-A bounded direct scan of existing local period-of-record cached station files
-did find clean supported candidates. The run target selected by PM decision was:
+The Topeka 2017 selection came from a direct local period-of-record scan, not
+from the current analyzer UI. Its recorded selection provenance is
+`direct_local_period_of_record_scan`; source collection is
+`local_igra_period_of_record_cache`; source file is `USM00072456-data.txt`;
+source-file hash is
+`de1817eaec60d6d47ad5840d0a3e8998dbadf943d026edf74a3950bfdcf3aad2`.
+The current product analyzer does not yet search that local period-of-record
+collection.
 
-- Topeka `USM00072456`, valid `2017-06-18T00:00:00Z`;
-- station metadata: `TOPEKA/MUN.; KS.`, 39.0722 N, 95.6305 W,
-  elevation 268.1 m MSL;
-- source file: `USM00072456-data.txt`;
-- source-file SHA-256:
-  `de1817eaec60d6d47ad5840d0a3e8998dbadf943d026edf74a3950bfdcf3aad2`;
-- selection provenance: `direct_local_period_of_record_scan`;
-- caveat:
-  `current_product_analyzer_does_not_yet_search_local_period_of_record_collection`;
-- revised opportunity 78.0 supported;
-- surface-based CAPE 1722.0 J/kg;
-- mixed-layer CAPE 1787.5 J/kg;
-- trigger-layer qv 17.031 g/kg;
-- mean qv 0-3 km 15.298 g/kg;
-- no near-surface discontinuity;
-- normalized observed sounding: 12 rendered levels, lowest level 0.0 m AGL,
-  top 18461.9 m AGL, complete thermodynamic and observed wind profile;
-- package readiness: usable, with `needs_review` source/provenance caveats
-  about preserved IGRA flags, station-elevation join, surface anchoring, and
-  upper-profile truncation.
+The current simple parcel diagnostics are screening estimates. The surface
+parcel starts from the lowest finite rendered level. The mixed-layer parcel is
+an arithmetic mean of rendered levels from 0-500 m and requires at least two
+levels. LCL uses `125 * (T - Td)` meters. The lifted parcel samples the
+rendered sounding grid plus the LCL, follows dry ascent below LCL and an
+approximate moist lapse-rate integration above LCL, and integrates CAPE over
+all positive layer-mean buoyancy. CIN is accumulated only before the first
+positive layer. LFC is the first positive-buoyancy crossing; EL is the first
+negative crossing after LFC. Because CAPE can continue accumulating after the
+first reported EL, Fort Worth can show large simple CAPE while reporting a
+surface-based EL near 98 m. No trusted independent parcel library was installed
+locally (`metpy` and `sharppy` were not available), so no external parcel
+cross-check was performed.
 
-The current product analyzer UI did not discover this candidate. It came from
-the direct local period-of-record scan.
+Current branch diagnostics from the rendered profiles are:
 
-## Topeka CM1 Scout
+| Case | SBCAPE | MLCAPE | SBCIN | MLCIN | LFC | EL | mean qv 0-3 km | trigger qv evidence | moisture depth |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Fort Worth | 1781.0 | 1820.3 | 0.0 | -5.3 | 2.8 m | 98.2 m | 14.62 g/kg | 13.34 g/kg | 1893.8 m |
+| Slidell | 3762.4 | 1256.2 | 0.0 | -4.4 | 0.1 m | unavailable | 14.32 g/kg | 12.42 g/kg | 2902.1 m |
+| Topeka 2017 | 1722.0 | 1787.5 | 0.0 | -0.2 | 0.0 m | 12548.9 m | 15.30 g/kg | 17.03 g/kg | 1176.9 m |
 
-- run id: `cloud_chase_005-topeka_20170618_deep_tower_scout`;
-- result id: `result-cloud_chase_005-topeka_20170618_deep_tower_scout`;
-- recipe: `deep_tower_benchmark_v0`;
-- initiation: stock CM1 `iinit = 3`;
-- run shape: 120 km domain, `120 x 120 x 40`, 20 km model top, 2-hour
-  duration, 15-minute output cadence, 6-second timestep, surface fluxes
-  disabled, existing full output set.
+## Reasonable inferences
 
-Runtime integrity: completed and ingested with 9 model output frames, exit code
-0, normal CM1 termination reported, and an `IEEE_UNDERFLOW_FLAG` runtime caveat
-only.
+The three main atmospheres received the same stock `iinit = 3` thermal at model
+start. The Fort Worth success versus Slidell and Topeka misses is therefore
+not explained by a different Cloud Chamber recipe, a different namelist, or a
+missing initial warm bubble.
 
-Outcome:
+The Slidell guardrail is still justified as a data-quality/product-semantics
+change. Its rendered profile has an extreme lowest-level qv value followed by a
+sharp low-level moisture drop, and the surface-based CAPE is much larger than
+mixed-layer CAPE. That is enough to prevent a clean `supported`
+recommendation, but it does not prove Slidell could never support deep
+convection under a different trigger or configuration.
 
-- actual cloud category: transient shallow cloud;
-- first cloud time: 900 s;
-- first deep-convection time: none;
-- coherent cloud top: 1750.0 m;
-- liquid cloud top: 1750.0 m;
-- hydrometeor-envelope top: 1750.0 m;
-- maximum updraft: 0.554 m/s at 900 s;
-- maximum cloud water: `7.185e-05 kg/kg`;
-- rain water aloft: no meaningful rain water, maximum `5.368e-10 kg/kg`;
-- surface rain: 0.0 cm;
-- maximum reflectivity: 0.0 dBZ metadata maximum; no reflective precipitation
-  signal after model start;
-- visual-interest rating: 1/5;
-- worth-the-compute rating: 1/5.
+Topeka 2017 is the more important miss for product confidence. It was clean
+with respect to the near-surface discontinuity rule and still scored about
+78 supported, yet produced only a transient 1.75 km cloud. Its rendered profile
+is sparse below 3 km, and the very favorable trigger-layer qv evidence comes
+from one available level. The actual profile also dries sharply by 2.84 km.
+Those facts make the analyzer evidence weaker than the headline score, but they
+do not by themselves establish a validated physical separator.
 
-The corrected selector did not earn confidence on this run: a second supported
-candidate outside the recent-cache pool still produced only a weak shallow
-response under the fixed Deep-Tower Benchmark trigger.
+The current parcel diagnostics do not represent the actual `iinit = 3` bubble
+parcel. They answer a simpler surface or mixed-layer lifted-parcel question on
+the rendered sounding grid. They can be useful evidence, but the Fort Worth,
+Slidell, and Topeka outcomes show that they are not a reliable standalone
+recommender for this fixed benchmark trigger.
 
-## Recommendation
+## Untested hypotheses
 
-Stop and request PM review before retuning the score, running another candidate,
-or changing the candidate-supply path.
+The stock 2 K, 1.4 km-center warm bubbles may be too weak, too high, or too
+geometrically specific for many otherwise interesting observed soundings.
+
+Topeka 2017 may have failed because sparse lower-tropospheric sampling hid a
+layer structure that mattered to the fixed bubble response.
+
+Slidell may have failed because the lowest-level moisture/CAPE signal was not
+representative of the effective inflow actually lifted by the CM1 thermal.
+
+Fort Worth may have had a favorable combination of local moisture, lapse rate,
+and vertical structure near the bubble that the current scalar diagnostics do
+not isolate.
+
+## Decision
+
+### C. No clear separator exists
+
+The fixed stock `iinit = 3` Deep-Tower Benchmark is not predictably related to
+the current sounding diagnostics. The available artifacts show benchmark
+consistency and real outcome separation, but they do not reveal a validated
+profile or trigger-fit criterion that cleanly separates Fort Worth from both
+Slidell and Topeka 2017.
+
+Recommendation: stop presenting `deep_tower_opportunity` as a reliable
+recommender for this fixed recipe. Keep Fort Worth as a known-good
+demonstration, keep the narrow near-surface guardrail, and reserve any future
+work for PM review of an adaptive, explicitly parameterized thermal setup.

--- a/docs/research/cloud-chase-005-slidell-false-positive-correction.md
+++ b/docs/research/cloud-chase-005-slidell-false-positive-correction.md
@@ -6,10 +6,9 @@ PR #355 no longer treats the Slidell/Topeka work as a validated scoring
 correction. The durable product change is narrower: a major near-surface
 discontinuity prevents a clean `supported` Deep-Tower recommendation, and the
 score uses mixed-layer CAPE instead of allowing one suspect lowest level to
-dominate. The retained trigger-layer qv field is descriptive evidence only: it
-is an unweighted mean of available rendered sounding levels from 750-2250 m
-AGL, not a thickness-weighted layer mean and not a validated recommendation
-gate.
+dominate. The trigger-layer qv values below are retained only as audit
+evidence; the production diagnostic field and candidate payload were removed
+because those values did not separate outcomes or drive a product decision.
 
 The exact CM1 benchmark artifacts show that the Fort Worth success, Slidell
 miss, and Topeka 2017 miss used the same Deep-Tower Benchmark namelist:
@@ -30,12 +29,15 @@ surface fluxes disabled. Runtime integrity was caveated only by
 | North Platte 2026 | `cloud_chase_001-north_platte_high_potential` | `USM00072562`, `2026-07-02T00:00:00Z` | not recorded | `437b0ec1791021a41d86aee8e547dbb38892e484395c28922695cc852ada13af` | exact outputs available; result metadata absent |
 | Topeka 2026 | `cloud_chase_003-topeka_deep_tower_opportunity` | `USM00072456`, `2026-06-10T00:00:00Z` | not recorded | `f8b8e8eb556403761fed2980c1490046ba3c30e206e5aee1bb0fda7378ac270a` | coherent cloud top 1.25 km, max updraft 0.89 m/s |
 
-The CM1 executable was `/Users/timpeterson/cm1r21.1/run/cm1.exe`, SHA-256
-`5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1`.
-The source tree is not a git checkout. A text-source hash over the local CM1
+The run manifests identify the CM1 run tree as `cm1r21.1/run` and executable
+as `cm1.exe`. The executable/source hashes were not captured at run time; they
+were measured post hoc during this audit from the configured local CM1
+source/build. The executable SHA-256 was
+`5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1`. The CM1
+source tree was not a git checkout. A text-source hash over the configured CM1
 source tree was
 `87cb9ea94b623d4c9e026424b5e2967bf829c17e7e8621a1360423b41373c2fa`;
-`/Users/timpeterson/cm1r21.1/src/init3d.F` was
+`src/init3d.F` was
 `9c45c0982ba194ea6ea74afd6a2516445cdd011fc90902091d089f4cb92dfd28`.
 
 The authoritative `init3d.F` implementation defines `iinit = 3` as a line of
@@ -148,7 +150,8 @@ convection under a different trigger or configuration.
 
 Topeka 2017 is the more important miss for product confidence. It was clean
 with respect to the near-surface discontinuity rule and still scored about
-78 supported, yet produced only a transient 1.75 km cloud. Its rendered profile
+78 under the experimental numeric heuristic, yet produced only a transient
+1.75 km cloud. Its rendered profile
 is sparse below 3 km, and the very favorable trigger-layer qv evidence comes
 from one available level. The actual profile also dries sharply by 2.84 km.
 Those facts make the analyzer evidence weaker than the headline score, but they


### PR DESCRIPTION
## Summary

This PR now makes one narrow Deep-Tower product-semantics change, preserves the near-surface data-quality guardrail, and records the evidence audit after the Slidell and Topeka misses.

What changed:

- Keeps the near-surface discontinuity guardrail: `near_surface_discontinuity_flag=true` cannot receive clean supported Deep-Tower evidence.
- Uses mixed-layer CAPE instead of surface-based CAPE when the lowest rendered level is discontinuous.
- Keeps `deep_tower_opportunity` only as an experimental numeric heuristic and explicit optional sort/evidence field.
- Keeps default deep-convection `best_match` ordering on the strongest active deep-story ingredient score, not `deep_tower_opportunity`.
- Removes product copy that treated a high score as a reliable recipe recommendation or automatic scout-compute advice.
- Removes `trigger_layer_mean_qv_750_2250m_g_kg` from production diagnostics, candidate payloads, tests, and contracts.
- Reverts the sounding diagnostic version to `sounding-diagnostics-v1`; keeps the screening behavior bump at `sounding-screening-v3`.
- Adds frontend coverage proving a score >=70 does not render a `Recommended Deep-Tower scout` action.
- Renames deep-convection card actions to `Configure benchmark probe` so the fixed benchmark reads as deliberate, not recommended by default.

## Topeka selection and outcome

The Topeka 2017 run target came from `direct_local_period_of_record_scan`, not from the current analyzer UI.

- station: `USM00072456`, `TOPEKA/MUN.; KS.`
- valid time: `2017-06-18T00:00:00Z`
- source collection: local IGRA period-of-record cache
- source file: `USM00072456-data.txt`
- source SHA-256: `de1817eaec60d6d47ad5840d0a3e8998dbadf943d026edf74a3950bfdcf3aad2`
- score at run time: about 78 under the then-current heuristic
- final PR semantics: high score is experimental evidence only, not a reliable fixed-recipe recommendation
- caveat: `current_product_analyzer_does_not_yet_search_local_period_of_record_collection`

Run: `cloud_chase_005-topeka_20170618_deep_tower_scout`  
Recipe: `deep_tower_benchmark_v0`, stock CM1 `iinit = 3`, 120 km domain, `120 x 120 x 40`, 20 km model top, 2-hour duration, 15-minute output cadence, 6-second timestep, surface fluxes disabled.

The run completed and ingested with normal CM1 termination, exit code 0, 9 output frames, and an underflow-only runtime caveat. Actual outcome was another miss: transient shallow cloud only, coherent cloud top 1750 m, max updraft 0.554 m/s, no surface rain, max reflectivity metadata 0.0 dBZ, visual-interest 1/5, worth-the-compute 1/5.

## Benchmark audit decision

The research note records the source/rendered-profile/trigger/parcel audit from existing artifacts only. It removes machine-private absolute paths from the committed note and states that executable/source hashes were measured post hoc during the audit, not captured at run time.

Decision:

**C. No clear separator exists.** The Fort Worth, Slidell, and Topeka 2017 runs received materially the same stock `iinit = 3` trigger and benchmark configuration, but the current sounding diagnostics do not reveal a validated profile or trigger-fit criterion that separates the Fort Worth success from both misses.

Recommendation in the note: stop presenting `deep_tower_opportunity` as a reliable recommender for this fixed recipe. Keep Fort Worth as a known-good demonstration, keep the narrow near-surface guardrail, and reserve future work for PM review of an adaptive, explicitly parameterized thermal setup.

## Validation

- `PYTHONPATH=/Users/timpeterson/Documents/Codex/cloud-chamber-issue-341/app/backend /Users/timpeterson/Documents/Codex/cloud-chamber/app/backend/.venv/bin/python -m pytest app/backend/tests/test_sounding_candidates.py`
- `npm test -- src/App.test.tsx`
- `BACKEND_PYTHON=/Users/timpeterson/Documents/Codex/cloud-chamber/app/backend/.venv/bin/python ./scripts/check.sh`
- `git diff --check`

All passed locally after the final PR #355 edits.

## Known limits

- The normal analyzer currently reads the recent-cache collection, not the local period-of-record collection used for the direct Topeka scan.
- This PR does not add a period-of-record UI, cache abstraction, generalized recommendation system, new recipe, new diagnostics framework, scoring retune, or another CM1 run.