### PR TITLE
Add explicit localized thermal probe

### DIFF
--- a/app/backend/cloud_chamber/cm1_input_contract.py
+++ b/app/backend/cloud_chamber/cm1_input_contract.py
@@ -45,6 +45,7 @@ class RunRecipe(StrEnum):
     OBSERVED_SURFACE_FORCED_EVOLUTION = "observed_surface_forced_evolution"
     DIFFERENTIAL_SURFACE_FORCED_EVOLUTION = "differential_surface_forced_evolution"
     DEEP_TOWER_BENCHMARK = "deep_tower_benchmark"
+    EXPLICIT_LOCALIZED_THERMAL = "explicit_localized_thermal"
 
 
 LEGACY_TRIGGERED_DEEP_POTENTIAL_RECIPE = "triggered_deep_potential"
@@ -217,8 +218,15 @@ def build_cm1_input_contract(
         resolved_run_configuration,
     )
     defaults = cloud_scale_defaults_for_configuration(resolved_run_configuration)
-    if resolved_run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK and observed_sounding is None:
-        raise ValueError("Deep-Tower Benchmark requires a validated observed sounding.")
+    if (
+        resolved_run_recipe
+        in {RunRecipe.DEEP_TOWER_BENCHMARK, RunRecipe.EXPLICIT_LOCALIZED_THERMAL}
+        and observed_sounding is None
+    ):
+        raise ValueError(
+            f"{_run_recipe_display_name(resolved_run_recipe)} requires a validated "
+            "observed sounding."
+        )
     if observed_sounding is not None and not has_complete_rendered_observed_wind_profile(
         observed_sounding,
         defaults=defaults,
@@ -260,7 +268,10 @@ def build_cm1_input_contract(
         if observed_sounding is not None
         else "generated_reference",
         trigger_type=(
-            "warm_bubble" if resolved_run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK else None
+            "warm_bubble"
+            if resolved_run_recipe
+            in {RunRecipe.DEEP_TOWER_BENCHMARK, RunRecipe.EXPLICIT_LOCALIZED_THERMAL}
+            else None
         ),
         trigger_parameters=_trigger_parameters(resolved_run_recipe),
         scenario_id=scenario.id,
@@ -337,19 +348,19 @@ def _run_recipe_for_configuration(
     run_configuration: RunConfiguration,
 ) -> RunRecipe:
     if (
-        run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK
+        run_recipe in {RunRecipe.DEEP_TOWER_BENCHMARK, RunRecipe.EXPLICIT_LOCALIZED_THERMAL}
         and run_configuration.surface_forcing_patch is not None
     ):
         raise ValueError(
-            "Deep-Tower Benchmark uses CM1 iinit=3 explicit thermal initiation; "
+            f"{_run_recipe_display_name(run_recipe)} uses explicit thermal initiation; "
             "differential surface forcing must use its own run recipe."
         )
     if (
-        run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK
+        run_recipe in {RunRecipe.DEEP_TOWER_BENCHMARK, RunRecipe.EXPLICIT_LOCALIZED_THERMAL}
         and run_configuration.surface_flux_mode != DISABLED_SURFACE_FLUX_MODE
     ):
         raise ValueError(
-            "Deep-Tower Benchmark requires surface_forcing_mode=disabled; "
+            f"{_run_recipe_display_name(run_recipe)} requires surface_forcing_mode=disabled; "
             "use an observed surface-forced recipe for lower-boundary forcing experiments."
         )
     if run_configuration.surface_flux_mode == DIFFERENTIAL_SURFACE_FORCING_MODE:
@@ -372,6 +383,8 @@ def _run_recipe_display_name(run_recipe: RunRecipe) -> str:
             return "Differential Surface-Forced Evolution"
         case RunRecipe.DEEP_TOWER_BENCHMARK:
             return "Deep-Tower Benchmark"
+        case RunRecipe.EXPLICIT_LOCALIZED_THERMAL:
+            return "Explicit localized thermal"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "Observed Surface-Forced Evolution"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -385,6 +398,8 @@ def recipe_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
             return "differential_surface_forced_evolution_v0"
         case RunRecipe.DEEP_TOWER_BENCHMARK:
             return "deep_tower_benchmark_v0"
+        case RunRecipe.EXPLICIT_LOCALIZED_THERMAL:
+            return "explicit_localized_thermal_v0"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "observed_surface_forced_evolution_v0"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -400,6 +415,8 @@ def recipe_display_name_for_run_recipe(run_recipe: str | RunRecipe) -> str:
             return "Differential Surface-Forced Evolution v0"
         case RunRecipe.DEEP_TOWER_BENCHMARK:
             return "Deep-Tower Benchmark v0"
+        case RunRecipe.EXPLICIT_LOCALIZED_THERMAL:
+            return "Explicit localized thermal v0"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "Observed Surface-Forced Evolution v0"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -415,6 +432,8 @@ def assumption_set_id_for_run_recipe(run_recipe: str | RunRecipe) -> str:
             return "differential_surface_forced_evolution_v0_assumptions"
         case RunRecipe.DEEP_TOWER_BENCHMARK:
             return "deep_tower_benchmark_v0_assumptions"
+        case RunRecipe.EXPLICIT_LOCALIZED_THERMAL:
+            return "explicit_localized_thermal_v0_assumptions"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "observed_surface_forced_evolution_v0_assumptions"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -430,6 +449,8 @@ def assumption_mode_for_run_recipe(run_recipe: str | RunRecipe) -> str:
             return "differential_surface_forced_evolution"
         case RunRecipe.DEEP_TOWER_BENCHMARK:
             return "explicit_thermal_initiation"
+        case RunRecipe.EXPLICIT_LOCALIZED_THERMAL:
+            return "explicit_localized_thermal"
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return "observed_surface_forced_evolution"
         case RunRecipe.GENERATED_REFERENCE_LOWER_ATMOSPHERE:
@@ -456,7 +477,7 @@ def required_output_fields_for_run_recipe(run_recipe: str | RunRecipe) -> tuple[
                 "th",
                 "updraft_helicity",
             )
-        case RunRecipe.DEEP_TOWER_BENCHMARK:
+        case RunRecipe.DEEP_TOWER_BENCHMARK | RunRecipe.EXPLICIT_LOCALIZED_THERMAL:
             return (
                 "qv",
                 "qc",
@@ -514,6 +535,23 @@ def recipe_caveats_for_run_recipe(run_recipe: str | RunRecipe) -> tuple[str, ...
                     "behavior remain CM1 outcomes to inspect after completion."
                 ),
             )
+        case RunRecipe.EXPLICIT_LOCALIZED_THERMAL:
+            return (
+                "Explicit localized thermal initiation is supplied with stock CM1 iinit=1.",
+                (
+                    "The thermal is an idealized single warm bubble, not a real front, "
+                    "dryline, terrain feature, sea breeze, outflow boundary, or forecast "
+                    "of spontaneous convection."
+                ),
+                (
+                    "Surface heat/moisture fluxes, radiation, terrain, GIS surface "
+                    "initialization, and large-scale forcing are not part of v0."
+                ),
+                (
+                    "Cloud growth, updraft, precipitation, and reflectivity remain CM1 "
+                    "outcomes to inspect after completion."
+                ),
+            )
         case RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
             return (
                 "No artificial atmospheric trigger is applied.",
@@ -558,6 +596,26 @@ def _trigger_parameters(
             ),
             "raw_controls_exposed": False,
         }
+    if run_recipe == RunRecipe.EXPLICIT_LOCALIZED_THERMAL:
+        return {
+            "cm1_iinit": 1,
+            "cm1_trigger": (
+                "CM1 built-in single warm bubble with 1 K maximum "
+                "potential-temperature perturbation centered at the domain center "
+                "near 1.4 km AGL"
+            ),
+            "bubble_count": 1,
+            "center_x": "domain center",
+            "center_y": "domain center",
+            "center_height_m_agl": 1400.0,
+            "horizontal_radius_m": 10000.0,
+            "vertical_radius_m": 1400.0,
+            "max_theta_perturbation_k": 1.0,
+            "shape": "cosine-squared ellipsoid for beta < 1",
+            "qv_behavior": "no direct qv perturbation; maintain_rh is false in stock source",
+            "pressure_balance": "namelist ibalance=0; no pressure-balancing solve is applied",
+            "raw_controls_exposed": False,
+        }
     return {}
 
 
@@ -580,6 +638,7 @@ def _run_caveats(
         RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION,
         RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION,
         RunRecipe.DEEP_TOWER_BENCHMARK,
+        RunRecipe.EXPLICIT_LOCALIZED_THERMAL,
     }:
         caveats.extend(recipe_caveats_for_run_recipe(run_recipe))
         return tuple(caveats)
@@ -589,6 +648,8 @@ def _run_caveats(
 def _manual_validation_status(run_recipe: RunRecipe) -> str:
     if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK:
         return "deep_tower_benchmark_iinit3_fort_worth_prior_smoke_validated"
+    if run_recipe == RunRecipe.EXPLICIT_LOCALIZED_THERMAL:
+        return "explicit_localized_thermal_fort_worth_growing_cloud_validated"
     if run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION:
         return "observed_surface_forced_evolution_v0_metadata_only"
     if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
@@ -631,6 +692,7 @@ def _recipe_assumptions(
         RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION,
         RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION,
         RunRecipe.DEEP_TOWER_BENCHMARK,
+        RunRecipe.EXPLICIT_LOCALIZED_THERMAL,
     }:
         trigger_description = "No artificial atmospheric trigger."
         if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION:
@@ -645,6 +707,12 @@ def _recipe_assumptions(
                 "Explicit idealized thermal initiation supplied by stock CM1 iinit=3 "
                 "three-warm-bubble line trigger."
             )
+        if run_recipe == RunRecipe.EXPLICIT_LOCALIZED_THERMAL:
+            trigger_mode = "cm1_iinit_1_single_warm_bubble"
+            trigger_description = (
+                "Explicit localized thermal initiation supplied by stock CM1 iinit=1 "
+                "single warm bubble."
+            )
         return {
             **configured_shape,
             "trigger": {
@@ -656,6 +724,19 @@ def _recipe_assumptions(
                         "raw_controls_exposed": False,
                     }
                     if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK
+                    else {}
+                ),
+                **(
+                    {
+                        "cm1_iinit": 1,
+                        "bubble_count": 1,
+                        "center_height_m_agl": 1400.0,
+                        "horizontal_radius_m": 10000.0,
+                        "vertical_radius_m": 1400.0,
+                        "max_theta_perturbation_k": 1.0,
+                        "raw_controls_exposed": False,
+                    }
+                    if run_recipe == RunRecipe.EXPLICIT_LOCALIZED_THERMAL
                     else {}
                 ),
             },
@@ -857,30 +938,32 @@ def render_cm1_namelist(contract: CM1InputContract) -> str:
     sounding_source_id = 7 if contract.observed_sounding is not None else 17
     wind_profile_id = 0 if contract.observed_sounding is not None else 9
     deep_tower = contract.run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK
-    testcase = 0 if deep_tower else 3
-    adapt_dt = 0 if deep_tower else 1
+    localized_thermal = contract.run_recipe == RunRecipe.EXPLICIT_LOCALIZED_THERMAL
+    explicit_thermal = deep_tower or localized_thermal
+    testcase = 0 if explicit_thermal else 3
+    adapt_dt = 0 if explicit_thermal else 1
     ptype = 5
-    ihail = 1 if deep_tower else 0
-    iautoc = 1 if deep_tower else 0
-    icor = 0 if deep_tower else 1
-    lspgrad = 0 if deep_tower else 2
-    idiss = 1 if deep_tower else 0
-    wbc = ebc = sbc = nbc = 2 if deep_tower else 1
-    bbc = 1 if deep_tower else 3
-    iinit = 3 if deep_tower else 0
-    irandp = 0 if deep_tower else 1
-    imove = 1 if deep_tower else 0
+    ihail = 1 if explicit_thermal else 0
+    iautoc = 1 if explicit_thermal else 0
+    icor = 0 if explicit_thermal else 1
+    lspgrad = 0 if explicit_thermal else 2
+    idiss = 1 if explicit_thermal else 0
+    wbc = ebc = sbc = nbc = 2 if explicit_thermal else 1
+    bbc = 1 if explicit_thermal else 3
+    iinit = 3 if deep_tower else 1 if localized_thermal else 0
+    irandp = 0 if explicit_thermal else 1
+    imove = 1 if explicit_thermal else 0
     output = _output_switches(
         contract.run_configuration.diagnostic_set,
-        deep_convection=deep_tower,
+        deep_convection=explicit_thermal,
         surface_flux_outputs=contract.run_configuration.surface_flux_mode
         in {"constant_uniform_surface_flux_proxy", DIFFERENTIAL_SURFACE_FORCING_MODE},
     )
     surface = contract.run_configuration.surface_flux_cm1_values
-    l_h = 100.0 if deep_tower else 0.0
-    lhref1 = 100.0 if deep_tower else 0.0
-    lhref2 = 1000.0 if deep_tower else 0.0
-    ndcnst = 250.0 if deep_tower else 100.0
+    l_h = 100.0 if explicit_thermal else 0.0
+    lhref1 = 100.0 if explicit_thermal else 0.0
+    lhref2 = 1000.0 if explicit_thermal else 0.0
+    ndcnst = 250.0 if explicit_thermal else 100.0
     return f"""
  &param0
  nx           =      {defaults.nx},

--- a/app/backend/cloud_chamber/dry_run_package.py
+++ b/app/backend/cloud_chamber/dry_run_package.py
@@ -591,6 +591,15 @@ def _run_recipe_mapping_summary(contract: CM1InputContract) -> str:
             "reflectivity output, vorticity output, and updraft-helicity output; explicit "
             "initiation is supplied and must be interpreted as an idealized trigger"
         )
+    if contract.run_recipe.value == "explicit_localized_thermal":
+        return (
+            "observed IGRA external input_sounding profile with observed u/v winds; "
+            "the run uses CM1 isnd=7, testcase=0, stock CM1 iinit=1 single warm-bubble "
+            "localized thermal initiation, a storm-scale idealized domain, NetCDF output, "
+            "rain output, reflectivity output, vorticity output, and updraft-helicity output; "
+            "explicit initiation is supplied and must be interpreted as an idealized trigger, "
+            "not an observed boundary or spontaneous-convection claim"
+        )
     if contract.run_configuration.surface_forcing_patch is not None:
         return (
             "observed IGRA external input_sounding profile; the run uses CM1 isnd=7, "
@@ -625,6 +634,13 @@ def _cm1_mapping_status(contract: CM1InputContract) -> str:
             "CM1-ready Deep-Tower Benchmark run with explicit stock-CM1 iinit=3 "
             "three-warm-bubble initiation. Prior Fort Worth smoke evidence applies to "
             "the recipe path; each observed sounding remains a CM1 experiment to inspect."
+        )
+    if contract.run_recipe.value == "explicit_localized_thermal":
+        return (
+            "CM1-ready Explicit localized thermal run with stock-CM1 iinit=1 single "
+            "warm-bubble initiation. The trigger is an idealized localized thermal; "
+            "Fort Worth positive-control evidence produced a growing shallow cloud, "
+            "while each observed sounding remains a case-dependent CM1 experiment to inspect."
         )
     if contract.run_configuration.surface_forcing_patch is not None:
         return (

--- a/app/backend/cloud_chamber/pre_run_validation.py
+++ b/app/backend/cloud_chamber/pre_run_validation.py
@@ -186,13 +186,20 @@ def _hypothesis_recipe_alignment(
             "caveats": [],
         }
     if story in DEEP_CONVECTION_STORIES:
-        if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK:
+        if run_recipe in {
+            RunRecipe.DEEP_TOWER_BENCHMARK,
+            RunRecipe.EXPLICIT_LOCALIZED_THERMAL,
+        }:
+            reason = (
+                "Deep-convection ingredients can be tested with the explicit "
+                "Deep-Tower Benchmark trigger."
+                if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK
+                else "Deep-convection ingredients can be tested with the "
+                "Explicit localized thermal trigger."
+            )
             return {
                 "status": "aligned",
-                "reasons": [
-                    "Deep-convection ingredients can be tested with the explicit "
-                    "Deep-Tower Benchmark trigger."
-                ],
+                "reasons": [reason],
                 "missing_assumptions": [],
                 "blocking_errors": [],
                 "caveats": [
@@ -421,6 +428,16 @@ def _forcing_validation_for_recipe(run_recipe: str) -> dict[str, Any]:
             "radiation": "disabled",
             "large_scale_forcing": "none",
         }
+    if run_recipe == RunRecipe.EXPLICIT_LOCALIZED_THERMAL.value:
+        return {
+            "trigger": "cm1_iinit_1_single_warm_bubble",
+            "surface_fluxes": {
+                "mode": "disabled",
+                "status": "disabled_for_explicit_localized_thermal_v0",
+            },
+            "radiation": "disabled",
+            "large_scale_forcing": "none",
+        }
     if run_recipe == RunRecipe.DIFFERENTIAL_SURFACE_FORCED_EVOLUTION.value:
         return {
             "trigger": "none",
@@ -455,7 +472,10 @@ def _required_outputs_for_story(
     run_recipe: RunRecipe,
 ) -> list[str]:
     if story in DEEP_CONVECTION_STORIES:
-        if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK:
+        if run_recipe in {
+            RunRecipe.DEEP_TOWER_BENCHMARK,
+            RunRecipe.EXPLICIT_LOCALIZED_THERMAL,
+        }:
             return ["qv", "qc", "w", "qr", "rain", "dbz", "u", "v", "th", "updraft_helicity"]
         return ["qv", "qc", "w", "qr", "rain", "dbz", "hfx", "qfx", "updraft_helicity"]
     if story == "humid_rainy_candidate":
@@ -541,6 +561,8 @@ def _run_recipe_display_name(run_recipe: str) -> str:
         return "Deep-Tower Benchmark"
     if run_recipe == RunRecipe.DEEP_TOWER_BENCHMARK.value:
         return "Deep-Tower Benchmark"
+    if run_recipe == RunRecipe.EXPLICIT_LOCALIZED_THERMAL.value:
+        return "Explicit localized thermal"
     if run_recipe == RunRecipe.OBSERVED_SURFACE_FORCED_EVOLUTION.value:
         return "Observed Surface-Forced Evolution"
     return "Generated Lower-Atmosphere Reference"

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -2185,6 +2185,8 @@ def _candidate_story_label(story: str | None) -> str | None:
 def _display_run_recipe(run_recipe: str | None) -> str:
     if run_recipe == "deep_tower_benchmark":
         return "Deep-Tower Benchmark"
+    if run_recipe == "explicit_localized_thermal":
+        return "Explicit localized thermal"
     if run_recipe == "observed_surface_forced_evolution":
         return "Observed Surface-Forced Evolution"
     return "CM1 run"

--- a/app/backend/cloud_chamber/run_configuration.py
+++ b/app/backend/cloud_chamber/run_configuration.py
@@ -228,6 +228,18 @@ SURFACE_MOISTURE_FLUX_CONTEXT_RANGE_G_G_M_S = (0.0, 2.0e-4)
 
 
 def default_run_configuration_payload(run_recipe: str | None = None) -> dict[str, str | float]:
+    if run_recipe == "explicit_localized_thermal":
+        return {
+            "duration": "smoke_1h",
+            "horizontal_cell_count": "cells_120",
+            "domain_size": "deep_tower_120km",
+            "output_cadence": "detailed_5min",
+            "diagnostic_set": "full",
+            "surface_heat_flux_k_m_s": 0.0,
+            "surface_moisture_flux_g_g_m_s": 0.0,
+            "surface_forcing_mode": DISABLED_SURFACE_FLUX_MODE,
+            "time_step_seconds": 6.0,
+        }
     if run_recipe in {"deep_tower_benchmark", "triggered_deep_potential"}:
         return {
             "duration": "scout_2h",
@@ -283,6 +295,8 @@ def resolve_run_configuration(
     initiation_method = (
         "cm1_iinit_3_three_warm_bubbles"
         if run_recipe in {"deep_tower_benchmark", "triggered_deep_potential"}
+        else "cm1_iinit_1_single_warm_bubble"
+        if run_recipe == "explicit_localized_thermal"
         else "none"
     )
 
@@ -555,6 +569,8 @@ def _configuration_caveats(
 def _initiation_summary(initiation_method: str) -> str:
     if initiation_method == "cm1_iinit_3_three_warm_bubbles":
         return "CM1 iinit=3 three warm bubbles"
+    if initiation_method == "cm1_iinit_1_single_warm_bubble":
+        return "CM1 iinit=1 single warm bubble"
     return "No artificial initiation"
 
 
@@ -650,7 +666,11 @@ def _surface_mode_id(surface_flux_mode: str, patch_sha256: str | None) -> str:
 
 
 def _rayleigh_damping_start_m(run_recipe: str | None = None) -> int:
-    if run_recipe in {"deep_tower_benchmark", "triggered_deep_potential"}:
+    if run_recipe in {
+        "deep_tower_benchmark",
+        "triggered_deep_potential",
+        "explicit_localized_thermal",
+    }:
         return 15000
     return 12000
 

--- a/app/backend/tests/test_cm1_input_contract.py
+++ b/app/backend/tests/test_cm1_input_contract.py
@@ -349,6 +349,87 @@ def test_deep_tower_benchmark_declares_iinit3_assumptions_and_namelist() -> None
     assert "output_uh        = 1," in namelist
 
 
+def test_explicit_localized_thermal_declares_stock_iinit1_assumptions_and_namelist() -> None:
+    from igra_fixtures import IGRA_FIXTURE
+
+    from cloud_chamber.observed_sounding import parse_igra_station_text
+
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+
+    contract = build_cm1_input_contract(
+        baseline_scenario(),
+        observed_sounding=observed,
+        run_recipe="explicit_localized_thermal",
+    )
+    namelist = render_namelist_fragment(contract)
+    trigger = cast(dict[str, Any], contract.recipe_assumptions["trigger"])
+    surface_fluxes = cast(dict[str, Any], contract.recipe_assumptions["surface_fluxes"])
+
+    assert contract.run_recipe.value == "explicit_localized_thermal"
+    assert contract.run_recipe_display_name == "Explicit localized thermal"
+    assert contract.recipe_id == "explicit_localized_thermal_v0"
+    assert contract.recipe_display_name == "Explicit localized thermal v0"
+    assert contract.assumption_set_id == "explicit_localized_thermal_v0_assumptions"
+    assert contract.assumption_mode == "explicit_localized_thermal"
+    assert contract.required_output_fields == (
+        "qv",
+        "qc",
+        "w",
+        "qr",
+        "rain",
+        "dbz",
+        "u",
+        "v",
+        "th",
+        "updraft_helicity",
+    )
+    assert contract.run_configuration.duration == "smoke_1h"
+    assert contract.run_configuration.duration_seconds == 3600
+    assert contract.run_configuration.output_cadence == "detailed_5min"
+    assert contract.run_configuration.cm1_values.output_cadence_seconds == 300
+    assert contract.run_configuration.domain_size == "deep_tower_120km"
+    assert contract.run_configuration.horizontal_cell_count == 120
+    assert contract.run_configuration.cm1_values.time_step_seconds == 6.0
+    assert contract.run_configuration.cm1_values.rayleigh_damping_start_m == 15000
+    assert contract.run_configuration.surface_flux_mode == "disabled"
+    assert trigger["mode"] == "cm1_iinit_1_single_warm_bubble"
+    assert trigger["cm1_iinit"] == 1
+    assert trigger["bubble_count"] == 1
+    assert trigger["center_height_m_agl"] == 1400.0
+    assert trigger["horizontal_radius_m"] == 10000.0
+    assert trigger["vertical_radius_m"] == 1400.0
+    assert trigger["max_theta_perturbation_k"] == 1.0
+    assert trigger["raw_controls_exposed"] is False
+    assert surface_fluxes["mode"] == "disabled"
+    assert surface_fluxes["cm1_values"]["isfcflx"] == 0
+    assert surface_fluxes["cm1_values"]["set_flx"] == 0
+    assert "Explicit localized thermal initiation is supplied with stock CM1 iinit=1." in (
+        contract.recipe_caveats
+    )
+    assert (
+        contract.manual_validation_status
+        == "explicit_localized_thermal_fort_worth_growing_cloud_validated"
+    )
+    assert "nx           =      120," in namelist
+    assert "ny           =      120," in namelist
+    assert "nz           =      40," in namelist
+    assert "timax  = 3600.0," in namelist
+    assert "tapfrq =  300.0," in namelist
+    assert "dtl    =   6.000," in namelist
+    assert "zd      =  15000.0," in namelist
+    assert "testcase  =  0," in namelist
+    assert "isnd      =  7," in namelist
+    assert "iwnd      =  0," in namelist
+    assert "iinit     =  1," in namelist
+    assert "ibalance  =  0," in namelist
+    assert "isfcflx    =      0," in namelist
+    assert "cnst_shflx = 0.0," in namelist
+    assert "output_uh        = 1," in namelist
+
+
 def test_observed_surface_flux_proxy_choices_render_namelist_and_surface_outputs() -> None:
     from igra_fixtures import IGRA_FIXTURE
 

--- a/app/backend/tests/test_dry_run_package.py
+++ b/app/backend/tests/test_dry_run_package.py
@@ -463,6 +463,102 @@ def test_deep_tower_benchmark_package_uses_stock_iinit3_path(
     assert "output_uh        = 1," in namelist
 
 
+def test_explicit_localized_thermal_package_uses_stock_iinit1_path(
+    tmp_path: Path,
+) -> None:
+    observed = parse_igra_station_text(
+        IGRA_FIXTURE,
+        uploaded_filename="USM00072558-data-beg2025.txt",
+    ).selected_sounding
+    candidate_screening = {
+        "candidate_id": "USM00072558-supercell",
+        "primary_story": "supercell_environment",
+        "active_story": "supercell_environment",
+        "active_story_label": "Supercell-like environment",
+        "rank_score": 93.0,
+    }
+
+    result = generate_dry_run_package(
+        scenario_data=load_baseline_template(),
+        runtime_home=tmp_path,
+        run_id="run-explicit-localized-thermal",
+        run_recipe="explicit_localized_thermal",
+        observed_sounding=observed,
+        candidate_screening=candidate_screening,
+    )
+
+    manifest = load_run_manifest(result.manifest_path)
+    report = json.loads(result.report_path.read_text())
+    case_manifest = json.loads((result.package_dir / "case_manifest.json").read_text())
+    namelist = (result.package_dir / "namelist.input").read_text()
+
+    assert manifest.run_recipe == "explicit_localized_thermal"
+    assert manifest.run_recipe_display_name == "Explicit localized thermal"
+    assert manifest.recipe_id == "explicit_localized_thermal_v0"
+    assert manifest.recipe_display_name == "Explicit localized thermal v0"
+    assert manifest.assumption_set_id == "explicit_localized_thermal_v0_assumptions"
+    assert manifest.assumption_mode == "explicit_localized_thermal"
+    assert manifest.trigger_type == "warm_bubble"
+    trigger_parameters = manifest.trigger_parameters
+    assert trigger_parameters is not None
+    assert trigger_parameters["cm1_iinit"] == 1
+    assert trigger_parameters["bubble_count"] == 1
+    assert trigger_parameters["center_height_m_agl"] == 1400.0
+    assert trigger_parameters["horizontal_radius_m"] == 10000.0
+    assert trigger_parameters["vertical_radius_m"] == 1400.0
+    assert trigger_parameters["max_theta_perturbation_k"] == 1.0
+    assert trigger_parameters["raw_controls_exposed"] is False
+    assert (
+        manifest.manual_validation_status
+        == "explicit_localized_thermal_fort_worth_growing_cloud_validated"
+    )
+    assert manifest.run_configuration["duration"] == "smoke_1h"
+    assert manifest.run_configuration["duration_seconds"] == 3600
+    assert manifest.run_configuration["output_cadence"] == "detailed_5min"
+    assert manifest.run_configuration["output_cadence_seconds"] == 300
+    assert manifest.run_configuration["horizontal_cell_count"] == 120
+    assert manifest.run_configuration["domain_size"] == "deep_tower_120km"
+    assert manifest.run_configuration["surface_flux_mode"] == "disabled"
+    assert manifest.run_configuration["surface_flux_cm1_values"]["isfcflx"] == 0
+    assert manifest.run_configuration["surface_flux_cm1_values"]["set_flx"] == 0
+    assert manifest.run_configuration["cm1_values"]["runtime_seconds"] == 3600
+    assert manifest.run_configuration["cm1_values"]["output_cadence_seconds"] == 300
+    assert manifest.run_configuration["cm1_values"]["rayleigh_damping_start_m"] == 15000
+    assert manifest.recipe_assumptions["trigger"]["mode"] == "cm1_iinit_1_single_warm_bubble"
+    assert manifest.recipe_assumptions["trigger"]["cm1_iinit"] == 1
+    assert manifest.recipe_assumptions["observed_sounding"]["wind_profile"] == (
+        "required_complete_rendered_u_v_profile"
+    )
+    assert manifest.recipe_assumptions["surface_fluxes"]["mode"] == "disabled"
+    assert manifest.pre_run_validation_report is not None
+    assert manifest.pre_run_validation_report["hypothesis_recipe_alignment"]["status"] == (
+        "aligned"
+    )
+    assert (
+        "Deep-convection ingredients can be tested with the Explicit localized thermal trigger."
+        in manifest.pre_run_validation_report["hypothesis_recipe_alignment"]["reasons"]
+    )
+    assert (
+        "explicit_thermal_initiation_supplied_not_a_real_observed_trigger"
+        in manifest.pre_run_validation_report["caveats"]
+    )
+    assert report["recipe_id"] == "explicit_localized_thermal_v0"
+    assert report["trigger_type"] == "warm_bubble"
+    assert report["variant_metadata"]["surface_flux_mode"] == "disabled"
+    assert "stock CM1 iinit=1 single warm-bubble" in report["variant_metadata"]["mapping"]
+    assert "stock-CM1 iinit=1" in report["cm1_mapping_status"]
+    assert case_manifest["contract"]["recipe_id"] == "explicit_localized_thermal_v0"
+    assert case_manifest["contract"]["trigger_type"] == "warm_bubble"
+    assert "testcase  =  0," in namelist
+    assert "isnd      =  7," in namelist
+    assert "iinit     =  1," in namelist
+    assert "ibalance  =  0," in namelist
+    assert "isfcflx    =      0," in namelist
+    assert "set_flx    =      0," in namelist
+    assert "cnst_shflx = 0.0," in namelist
+    assert "output_uh        = 1," in namelist
+
+
 def test_legacy_triggered_deep_potential_maps_to_deep_tower_benchmark(
     tmp_path: Path,
 ) -> None:

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -38,6 +38,7 @@ type ScenarioResponse = {
 };
 
 type RunConfigurationInput = {
+  run_recipe?: ObservedRunRecipe;
   duration: string;
   horizontal_cell_count: string;
   domain_size: string;
@@ -421,12 +422,14 @@ type RunRecipe =
   | "generated_reference_lower_atmosphere"
   | "observed_surface_forced_evolution"
   | "differential_surface_forced_evolution"
-  | "deep_tower_benchmark";
+  | "deep_tower_benchmark"
+  | "explicit_localized_thermal";
 
 type ObservedRunRecipe =
   | "observed_surface_forced_evolution"
   | "differential_surface_forced_evolution"
-  | "deep_tower_benchmark";
+  | "deep_tower_benchmark"
+  | "explicit_localized_thermal";
 type AtmosphereSourcePath = "cached_recommendations" | "saved_candidates" | "upload_igra_text";
 type SearchIntent =
   | "best_overall"
@@ -12184,6 +12187,31 @@ function staticRecipeMetadata(runRecipe: ObservedRunRecipe = CURRENT_OBSERVED_RU
       ],
     };
   }
+  if (runRecipe === "explicit_localized_thermal") {
+    return {
+      recipeId: "explicit_localized_thermal_v0",
+      recipeDisplayName: "Explicit localized thermal v0",
+      assumptionSetId: "explicit_localized_thermal_v0_assumptions",
+      assumptionMode: "explicit_localized_thermal",
+      requiredOutputFields: [
+        "qv",
+        "qc",
+        "w",
+        "qr",
+        "rain",
+        "dbz",
+        "u",
+        "v",
+        "th",
+        "updraft_helicity",
+      ],
+      recipeCaveats: [
+        "Explicit localized thermal initiation is supplied with stock CM1 iinit=1.",
+        "The thermal is an idealized single warm bubble, not a real front, dryline, terrain feature, sea breeze, outflow boundary, or forecast of spontaneous convection.",
+        "Surface heat/moisture fluxes, radiation, terrain, GIS surface initialization, and large-scale forcing are not part of v0.",
+      ],
+    };
+  }
   if (runRecipe === "differential_surface_forced_evolution") {
     return {
       recipeId: "differential_surface_forced_evolution_v0",
@@ -12803,6 +12831,9 @@ function defaultRunConfigurationForCandidateScreening(
 }
 
 function runRecipeForRunConfiguration(configuration: RunConfigurationInput): ObservedRunRecipe {
+  if (configuration.run_recipe) {
+    return configuration.run_recipe;
+  }
   const surfaceForcingMode = surfaceForcingModeValue(configuration.surface_forcing_mode);
   if (surfaceForcingMode === DIFFERENTIAL_SURFACE_FORCING_MODE) {
     return "differential_surface_forced_evolution";

--- a/docs/contracts/run-recipe-and-story-mapping.md
+++ b/docs/contracts/run-recipe-and-story-mapping.md
@@ -64,6 +64,7 @@ run_recipe:
     | surface_forced_evolution
     | differential_surface_forced_evolution
     | explicit_thermal_initiation
+    | explicit_localized_thermal
     | elevated_forced_evolution
     | future
   run_shape:
@@ -117,6 +118,7 @@ run_recipe:
       | observed_surface_forced_evolution
       | differential_surface_forced_evolution
       | deep_tower_benchmark
+      | explicit_localized_thermal
       | future
     run_configuration_defaults:
       duration: string | null
@@ -174,13 +176,15 @@ An elevated recipe asks whether an above-surface source layer can sustain cloud
 or convection. It needs source-layer, forcing, and output assumptions that the
 current observed-sounding run builder does not supply.
 
-### Removed Or Not Active
+### Legacy Or Non-Recipe Trigger Paths
 
-Artificial atmospheric perturbation recipes from the earlier deep-potential
-direction are not current product paths. Current observed-sounding experiments
-use no artificial atmospheric trigger and rely on explicit surface-forcing and
-run-shape assumptions. Differential surface forcing is a current lower-boundary
-patch recipe, not an atmospheric-trigger recipe.
+Artificial atmospheric perturbation paths must be named recipes with explicit
+assumptions before product surfaces can offer them. The current supported
+atmospheric-trigger paths are limited to the Deep-Tower Benchmark and Explicit
+localized thermal recipes below. They are idealized probes, not observed
+boundaries, weather forecasts, or claims of spontaneous convection.
+Differential surface forcing remains a separate lower-boundary patch recipe,
+not an atmospheric-trigger recipe.
 
 ## Current Recipe Catalog
 
@@ -434,6 +438,71 @@ sounding has a complete rendered wind profile. The result can inspect whether
 deep cloud, strong updraft, rain-water aloft, surface rain, and reflectivity
 occur under the explicit trigger. Surface-forced and differential surface patch
 recipes remain separate lower-boundary initiation questions.
+
+### `explicit_localized_thermal_v0`
+
+```yaml
+recipe_id: explicit_localized_thermal_v0
+display_name: Explicit localized thermal
+product_question: How does this observed atmosphere respond to one modest,
+  localized idealized warm bubble?
+assumption_set_id: explicit_localized_thermal_v0_assumptions
+assumption_mode: explicit_localized_thermal
+run_shape:
+  duration_seconds: 3600
+  horizontal_cell_count: 120
+  domain_width_m: 120000
+  model_top_m: 20000
+  output_cadence_seconds: 300
+  requested_fields: full_output_field_set
+forcing:
+  trigger:
+    mode: stock_cm1_iinit_1
+    description: one 1 K cosine-squared warm bubble centered in the domain
+      near 1.4 km AGL
+  surface_sensible_heat_flux: {mode: disabled}
+  surface_latent_heat_flux: {mode: disabled}
+  radiation: {mode: disabled}
+  large_scale_lift: {mode: none}
+  convergence: {mode: none}
+required_inputs:
+  observed_temperature_profile: required
+  observed_moisture_profile: required
+  observed_wind_profile: required
+required_outputs:
+  fields: [qv, qc, w, qr, rain, dbz, u, v, th, updraft_helicity]
+  diagnostics:
+    - first_cloud
+    - cloud_top
+    - max_updraft_w
+    - rain_water_aloft_onset
+    - max_surface_rain
+    - max_dbz
+current_support:
+  status: fort_worth_growing_cloud_positive_control
+  caveats:
+    - The trigger is CM1's stock `iinit = 1` single warm bubble; it is not a
+      real front, dryline, terrain feature, sea breeze, outflow boundary, or
+      forecast of spontaneous convection.
+    - The trigger is fixed and modest, with no product-facing trigger editor.
+    - Surface heat/moisture fluxes, radiation, terrain, GIS surface
+      initialization, and large-scale forcing are disabled in v0.
+    - Fort Worth produced a growing shallow cloud under this recipe; Topeka
+      did not form cloud under the identical trigger and run shape.
+cm1_mapping:
+  run_recipe: explicit_localized_thermal
+  run_configuration_defaults:
+    duration: smoke_1h
+    horizontal_cell_count: cells_120
+    domain_size: deep_tower_120km
+    output_cadence: detailed_5min
+    requested_fields: full_output_field_set
+```
+
+This recipe is an exploratory localized-thermal probe. It can preserve one
+known-capable positive control and compare case-dependent response to the same
+modest thermal, but it is not a default compute-spending recommendation for
+deep-convection candidates.
 
 ### `squall_line_cold_pool_future`
 

--- a/docs/research/cloud-chase-006-explicit-localized-thermal.md
+++ b/docs/research/cloud-chase-006-explicit-localized-thermal.md
@@ -1,0 +1,140 @@
+# Cloud Chase 006: Explicit Localized Thermal
+
+Status: positive-control passed; Topeka contrast failed to form cloud
+
+## Question
+
+Can Cloud Chamber preserve the smallest honest localized-thermal setup that
+produces one growing cloud in a known-capable atmosphere without escalating to
+an arbitrarily strong trigger?
+
+This is not daytime evolution. It is not an observed boundary, forecast, or
+claim of spontaneous convection. Product copy should label it:
+
+```text
+Explicit localized thermal
+```
+
+## CM1 Source Inspection
+
+Configured CM1 source: `cm1r21.1/src/init3d.F`
+
+Source hash measured before the runs:
+`9c45c0982ba194ea6ea74afd6a2516445cdd011fc90902091d089f4cb92dfd28`
+
+Executable identity: `cm1r21.1/run/cm1.exe`
+
+Executable hash measured before the runs:
+`5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1`
+
+Stock CM1 r21.1 `iinit = 1` implements one warm bubble:
+
+- Bubble count: 1.
+- Center: domain center horizontally.
+- Center height: 1400 m AGL in source.
+- Horizontal radius: 10000 m.
+- Vertical radius: 1400 m.
+- Maximum potential-temperature perturbation: 1.0 K.
+- Shape: cosine-squared ellipsoid for `beta < 1`.
+- qv behavior: no direct qv perturbation; source sets `maintain_rh = .false.`.
+- Pressure balancing: Cloud Chamber namelist used `ibalance = 0`, so no
+  pressure-balancing solve was applied.
+
+The first output frame confirmed the imposed thermal was comparable in both
+runs: maximum theta anomaly about 0.96 K at the domain center near the 1.25 km
+scalar level, with zero qv anomaly.
+
+## Recipe Setup
+
+Recipe: `explicit_localized_thermal_v0`
+
+Run shape for both cases:
+
+- Domain: 120 km x 120 km.
+- Grid: 120 x 120 x 40.
+- Model top: 20 km.
+- Duration: 60 simulated minutes.
+- Output cadence: 5 minutes.
+- Time step: 6 s.
+- Surface heat and moisture fluxes: disabled.
+- Radiation, terrain/GIS surface initialization, and large-scale forcing:
+  disabled/not part of v0.
+- Output fields: current full output set.
+
+The recipe exposes no raw trigger controls in the UI. It is a fixed benchmark
+probe using stock CM1 `iinit = 1`.
+
+## Fort Worth Positive Control
+
+Case: Fort Worth `USM00072249`, valid `1997-05-27T00:00:00Z`.
+
+Normalized sounding: exact `input_sounding` from the prior successful Fort
+Worth Deep-Tower run, hash
+`08a9012ff831568cf6af45713d217a6c448067a85a459e830f40aed00d6826a5`.
+
+Run ID: `cloud_chase_006-fort_worth_explicit_localized_thermal_60min`.
+
+Runtime integrity: completed normally and auto-ingested; runtime caveat was
+underflow-only.
+
+Outcome:
+
+- First liquid cloud: 20 minutes.
+- Liquid cloud top: grew from 1.25 km to 1.75 km.
+- Maximum cloud water: `8.82e-4 kg/kg` at 40 minutes.
+- Maximum updraft: `1.31 m/s` at 60 minutes.
+- Rain water aloft: trace, maximum `2.77e-7 kg/kg`.
+- Surface rain: trace, maximum `6.42e-12 cm`.
+- Post-initial reflectivity: weak trace, peak about `-27.6 dBZ`.
+- Visual-interest rating: 2/5.
+
+Fort Worth passed the positive-control gate because the modest stock thermal
+produced a real growing shallow cloud with sustained cloud water and weak
+precipitation traces.
+
+## Topeka Contrast
+
+Case: Topeka/Mun., Kansas `USM00072456`, valid `2017-06-18T00:00:00Z`.
+
+Normalized sounding: exact `input_sounding` from Cloud Chase 005, hash
+`38304066848f39f66e265872456d5f3f39bf7f2db3078b42b0bbd51b1564b392`.
+
+Run ID: `cloud_chase_006-topeka_explicit_localized_thermal_60min`.
+
+Runtime integrity: completed normally and auto-ingested; runtime caveat was
+underflow-only.
+
+Outcome:
+
+- First liquid cloud: none.
+- Liquid cloud top: none.
+- Maximum cloud water: `0 kg/kg`.
+- Maximum updraft: `0.65 m/s` at 5 minutes, then decayed below `0.30 m/s`.
+- Rain water aloft: none.
+- Surface rain: none.
+- Post-initial reflectivity: no hydrometeor signal; `-35.2 dBZ` field floor.
+- Visual-interest rating: 1/5.
+
+Topeka received the same initial localized thermal but did not form cloud.
+
+## Interpretation
+
+The stock `iinit = 1` setup is modest enough to pass an honesty check: it does
+not force every supported-looking sounding to make a cloud. Fort Worth and
+Topeka responded differently even though the imposed thermal was materially the
+same. That makes the recipe useful as a bounded exploratory probe, not as a
+guaranteed cloud-maker.
+
+The Fort Worth response was shallow, not a deep tower. The positive control
+therefore validates only this narrow claim: a fixed 1 K localized thermal can
+produce a growing cloud in a known-capable atmosphere under Cloud Chamber's
+coarse storm-scale setup.
+
+## Decision
+
+C. It works for Fort Worth but not Topeka; preserve it as a benchmark while
+treating atmospheric response as case-dependent.
+
+Recommendation: preserve `explicit_localized_thermal_v0` as an exploratory
+benchmark probe with explicit trigger assumptions and no product-facing trigger
+editor.


### PR DESCRIPTION
## Summary

Adds `explicit_localized_thermal_v0`, a fixed exploratory recipe labeled **Explicit localized thermal**. It uses stock CM1 `iinit = 1` as a modest single warm bubble, with no product-facing trigger editor and no claim of observed initiation, spontaneous convection, or forecast behavior.

This PR opened only after the Fort Worth positive control passed.

## Trigger/source provenance

- CM1 source identity: `cm1r21.1/src/init3d.F`
- Source hash measured before the runs: `9c45c0982ba194ea6ea74afd6a2516445cdd011fc90902091d089f4cb92dfd28`
- Executable identity: `cm1r21.1/run/cm1.exe`
- Executable hash measured before the runs: `5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1`
- Source customization: none

Stock `iinit = 1` is one 1 K cosine-squared warm bubble centered horizontally in the domain, centered near 1.4 km AGL, with 10 km horizontal radius, 1.4 km vertical radius, no direct qv perturbation, and no pressure-balancing solve under Cloud Chamber's `ibalance = 0` namelist.

## Runs

Shared setup:

- 120 km x 120 km domain
- 120 x 120 x 40 grid
- 20 km model top
- 60 simulated minutes
- 5 minute output cadence
- 6 s timestep
- surface fluxes disabled
- current full output set

Fort Worth positive control:

- Run ID: `cloud_chase_006-fort_worth_explicit_localized_thermal_60min`
- Sounding: `USM00072249`, valid `1997-05-27T00:00:00Z`
- Normalized sounding hash: `08a9012ff831568cf6af45713d217a6c448067a85a459e830f40aed00d6826a5`
- Outcome: growing shallow cloud; first liquid cloud at 20 min; liquid top 1.75 km; max qc `8.82e-4 kg/kg`; max updraft `1.31 m/s`; trace rain water aloft and trace surface rain.

Topeka contrast:

- Run ID: `cloud_chase_006-topeka_explicit_localized_thermal_60min`
- Sounding: `USM00072456`, valid `2017-06-18T00:00:00Z`
- Normalized sounding hash: `38304066848f39f66e265872456d5f3f39bf7f2db3078b42b0bbd51b1564b392`
- Outcome: no cloud; max qc `0 kg/kg`; max updraft `0.65 m/s` early then decayed; no rain water aloft; no surface rain.

## Decision

C. It works for Fort Worth but not Topeka; preserve it as a benchmark while treating atmospheric response as case-dependent.

## Verification

- `PYTHONPATH=app/backend /Users/timpeterson/Documents/Codex/cloud-chamber/app/backend/.venv/bin/python -m pytest app/backend/tests/test_cm1_input_contract.py app/backend/tests/test_dry_run_package.py`
- `BACKEND_PYTHON=/Users/timpeterson/Documents/Codex/cloud-chamber/app/backend/.venv/bin/python scripts/check.sh`
- `git diff --check`

Note: frontend tests still emit the existing React `act(...)` warning in `src/App.test.tsx`; tests pass.

## Merge posture

Manual review requested. Auto-merge is not enabled because this adds a real CM1 execution recipe.
