### PR TITLE
Recovery Batch 1: establish product authority and agent guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,298 +1,141 @@
-# AGENTS.md - Cloud Chamber
+# AGENTS.md — Cloud Chamber Repository Recovery
 
-## Project Identity
+## Product authority
 
-Cloud Chamber is a local-first configuration, run-management, diagnostics, and
-visualization environment for CM1 cloud experiments.
+Before any nontrivial work, read:
 
-The goal is to make CM1 usable, beautiful, and explainable for guided
-cloud-physics exploration.
+1. `NORTH_STAR.md`
+2. `docs/product/PRODUCT_VISION.md`
 
-CM1 is the high-fidelity simulation engine; Cloud Chamber is the local
-experiment builder, run manager, result notebook, diagnostics layer, and
-visualizer.
+These are the controlling statements of why Cloud Chamber exists and what product it is intended to become.
 
-## Product Rule
+Existing issues, scenarios, roadmaps, product specifications, research notes, UI language, and implementation structures may reflect superseded product directions. They are evidence and history, not automatic product authority.
 
-CM1 is the high-fidelity model. The app should not pretend to be CM1.
+When a lower-level artifact conflicts with the North Star or Product Vision, stop and ask for direction. Do not reconcile the conflict by silently changing the product.
 
-Reduced/light models may be used only for:
+## Repository recovery mode
 
-- preview
-- explanation
-- rough guidance
-- sanity checks
+Cloud Chamber is currently in repository recovery.
 
-They are not the source of truth for cloud evolution.
+Until recovery mode is explicitly ended:
 
-## Durable Distinction
+- all pull requests require manual review;
+- do not enable auto-merge;
+- do not create follow-up issues autonomously;
+- do not infer roadmap priority from the open issue backlog;
+- do not treat the current app structure as the final product design;
+- do not treat current scenarios as validated recipes;
+- do not promote research mechanisms, scores, triggers, or one-off runs into product concepts;
+- do not revise the North Star or Product Vision;
+- do not make product, science, recipe, scenario, roadmap, or UX decisions unless the task explicitly supplies the decision.
 
-Always distinguish:
+## Codex and agent role
+
+During recovery, agents execute bounded decisions. They do not formulate product strategy.
+
+A recovery task must specify:
+
+- the exact files allowed to change;
+- the exact intended disposition or replacement content;
+- what must not change;
+- whether the task is mechanical, descriptive, research, or product work;
+- the required manual-review posture.
+
+If a task requires deciding whether a historical document, scenario, issue, experiment, or capability is still valid, stop and ask. That is PM judgment, not mechanical cleanup.
+
+## Product-drift check
+
+Before proposing or implementing a nontrivial change, state:
 
 ```text
-Preview estimate
-CM1 run configuration
-CM1 running/completed result
-Visualization interpretation
+Stable vision:
+What remains unchanged?
+
+Current task:
+What specific part of the vision or recovery does this advance?
+
+Non-implications:
+What does this work not redefine?
+
+Portfolio effect:
+Does this preserve, broaden, or accidentally narrow Cloud Chamber?
 ```
 
-## Guardrails
+The current experiment is never the whole product.
+
+## Allowed work during recovery
+
+Allowed when explicitly requested:
+
+- repository inventory and read-only audits;
+- exact documentation changes supplied by the PM;
+- approved mechanical file moves or link updates;
+- tests and fixes required by those exact changes;
+- critical fixes preventing data loss, corrupted results, or broken development workflows;
+- manually reviewed dependency and security maintenance;
+- preservation of existing research and experimental evidence.
+
+## Work that requires explicit approval
+
+Always stop and ask before:
+
+- changing product direction;
+- changing scientific interpretation;
+- adding or promoting a recipe or scenario;
+- changing default cloud regimes, triggers, forcing, or sounding behavior;
+- changing user-facing scientific language;
+- changing navigation or top-level workspaces;
+- changing destructive cleanup behavior;
+- touching real CM1 execution paths;
+- making backwards-incompatible manifest, result, or scenario-schema changes;
+- closing, rewriting, reprioritizing, or creating issues;
+- changing authoritative documents.
+
+## Engineering guardrails
 
 Do not commit:
 
-- CM1 source
-- CM1 binaries
-- NetCDF output
-- generated run directories
-- LANDUSE.TBL
-- local-data
-- large processed visualization artifacts
+- CM1 source;
+- CM1 binaries;
+- NetCDF output;
+- generated run directories;
+- `LANDUSE.TBL`;
+- local runtime data;
+- downloaded IGRA cache data;
+- large processed visualization artifacts;
+- machine-private paths or settings.
 
-Do commit:
+Use tiny fixtures and fake process execution in automated tests. Do not require real CM1 runs in CI.
 
-- code
-- tests
-- docs
-- schemas
-- scenario templates
-- tiny fixtures
+Use branches and pull requests. Do not push directly to `main`.
 
-## Development Expectations
+Run `scripts/check.sh` before opening a PR unless the task explicitly explains why it cannot be run.
 
-- Use GitHub issues and PRs.
-- Work on branches; do not push directly to `main`.
-- Keep work scoped to the issue.
-- Add tests for new behavior.
-- Update docs when architecture/workflow changes.
-- Use local fake fixtures in CI; do not require real CM1 in automated tests.
-- Do not weaken scientific honesty to make UI look better.
-- For Codex issue work, enable auto-merge after required CI checks pass unless the user explicitly asks for manual review or the PR is high-risk/destructive.
-- Treat destructive cleanup, generated-data policy changes, scientific interpretation changes, and real CM1 execution changes as high-risk unless the user says otherwise.
+Do not remove or weaken tests merely to make a change pass.
 
-## Initial Architecture Bias
-
-Prefer:
+Preserve the distinction between:
 
 ```text
-React/Vite frontend + Python FastAPI local backend
+configured experiment
+running CM1 process
+completed CM1 output
+backend-derived diagnostic
+visualization interpretation
 ```
 
-until a stronger reason appears.
+## Current implementation is not current vision
 
-## Local CM1 Runtime
+Existing capabilities may remain valuable even when their framing is under review. Preserve working infrastructure unless a reviewed task explicitly removes it.
 
-CM1 should remain external to the repo.
+In particular, do not assume that repository recovery means deleting:
 
-Likely local path for Tim:
+- local CM1 execution;
+- run queueing and progress;
+- ingest and result persistence;
+- observed-sounding support;
+- scientific field products;
+- result replay and timelapse;
+- 2-D or 3-D visualization;
+- provenance and runtime-integrity handling.
 
-```text
-/Users/timpeterson/cm1r21.1/run
-```
-
-Treat this as a local setting, not a hard-coded app constant.
-
-Default Cloud Chamber runtime data belongs outside the repo:
-
-```text
-~/CloudChamber/
-```
-
-`./local-data/` is only a gitignored development override.
-
-## UI Language
-
-Use atmospheric language first:
-
-- thermal fate
-- What happened here?
-- selected region
-- lower-atmosphere humidity
-- surface moisture
-- surface heating
-- cap strength
-- cap height
-- dry air aloft
-- mixing / entrainment
-- updraft strength
-- saturation deficit
-- deep breakthrough
-- precipitation feedback
-- downdraft
-- cold pool
-- outflow boundary
-- cloud base
-- cloud top
-- first cloud time
-- rain onset
-
-Raw namelist settings and raw CM1 variable names belong in technical,
-advanced, or developer views. Product-facing views should start with thermal
-fate, selected-region inspection, and atmospheric process language.
-
-## Testing Notes
-
-Use fake/small fixtures to test:
-
-- scenario schemas
-- config generation
-- run manifest creation
-- fake process execution
-- NetCDF ingestion from tiny fixtures
-- visualizer metadata loading
-
-Do not require full CM1 runs in CI.
-
-## Before Major Changes
-
-If changing product direction, ask first.
-
-If adding physics/science behavior, document:
-
-1. what physical question it supports
-2. what user control it enables
-3. what diagnostics validate it
-4. what limitations must be disclosed
-
----
-
-## Claude Code — Working Style and Expectations
-
-This section governs how Claude Code operates on this project. It extends
-the rules above; nothing here overrides the product rule, guardrails, or
-scientific-honesty requirements.
-
-### Intent First
-
-Before writing any code on a non-trivial task, Claude Code must:
-
-1. State what it understands the goal to be.
-2. Ask every question needed to fully understand intent — user workflow,
-   edge cases, acceptance criteria, what "done" looks like.
-3. Propose an approach and wait for a go-ahead before executing.
-
-For small, obviously-scoped tasks (typo fixes, single-line changes, adding
-a missing test for existing behavior) it may proceed directly.
-
-When in doubt, ask. A short clarifying exchange is cheaper than a wrong
-implementation.
-
-### Autonomy
-
-Once intent is confirmed, Claude Code should execute as fully as possible
-without interruption:
-
-- Write the code.
-- Write or update tests.
-- Run `scripts/check.sh` and fix any failures before committing.
-- Update relevant docs if architecture or workflow changed.
-- Open a PR with a clear description.
-- Create GitHub issues for anything discovered during work that is out of
-  scope for the current task (bugs, missing tests, doc gaps, a11y issues).
-  Do not silently leave TODOs for things that deserve tracking.
-
-Do not ask for permission to run the linter, run tests, fix a type error,
-or update a doc string. Those are part of the job.
-
-### Branching and PRs
-
-- Branch off `main`. Name branches `issue-NNN-short-description`.
-- One issue per branch. Keep PRs scoped.
-- PR description must include:
-  - What changed and why.
-  - How to verify it locally (specific commands or UI steps).
-  - Any known limitations or follow-up issues opened.
-- Enable auto-merge after CI passes unless the task is high-risk (see
-  Guardrails above) or the user asks for manual review.
-
-### Commit Style
-
-- Conventional commits: `feat:`, `fix:`, `test:`, `docs:`, `chore:`, `refactor:`.
-- Subject line: imperative, ≤72 chars.
-- Body: include the issue number and a sentence on why, not just what.
-- Atomic commits — one logical change per commit. Do not bundle unrelated
-  fixes.
-
-### Quality Bar
-
-Every PR must pass `scripts/check.sh` cleanly before merge:
-
-- Frontend: lint, test, build.
-- Backend: ruff format, ruff check, mypy, pytest.
-- No new warnings introduced without explanation.
-
-New behavior requires new tests. Refactors must not reduce test coverage.
-UI changes that affect user-visible text or workflow must include an update
-to the relevant doc in `docs/`.
-
-### GitHub Issues
-
-When Claude Code opens an issue it must:
-
-- Use the correct label set (see repo labels).
-- Write a description a future developer can act on without context:
-  summary, observed behavior, expected behavior, reproduction steps or
-  fix hint.
-- Tag `priority:p1` for bugs that break core workflows; `priority:p2` for
-  everything else unless the user says otherwise.
-- Reference the PR or commit that surfaced it.
-
-### What Claude Code Must Not Do Without Asking
-
-Even with full autonomy confirmed, always pause and ask before:
-
-- Changing product direction or adding a new top-level workspace/view.
-- Changing scientific interpretation, diagnostic labels, or provenance
-  language.
-- Modifying data deletion logic or storage cleanup policy.
-- Touching real CM1 execution paths.
-- Changing the run manifest schema or result card schema in a
-  backwards-incompatible way.
-- Removing or weakening a test rather than fixing the underlying issue.
-
-### Environment Assumptions
-
-Claude Code sessions assume:
-
-- `scripts/dev.sh start` has been run (frontend at `localhost:5173`,
-  backend at `127.0.0.1:8000`).
-- `~/CloudChamber/settings.json` exists with local CM1 paths if CM1
-  work is in scope.
-- `uv` or the pip fallback described in `docs/development.md` is
-  available for backend work.
-- The Playwright E2E suite lives at `~/e2e/` (separate from the repo)
-  and can be run with `npx playwright test` from that directory.
-
-### Playwright E2E
-
-When fixing a UI bug or adding a UI feature:
-
-- Check whether an existing Playwright test covers it.
-- If yes, verify the test passes after the change.
-- If no, add a test or open an issue noting the gap.
-- Never delete or skip a Playwright test to make CI pass. Fix the
-  underlying issue or open an issue and mark the test `.skip` with a
-  comment referencing it.
-
-### Documentation Standard
-
-- `docs/development.md` is the canonical dev setup reference. Keep it
-  current.
-- `docs/architecture-and-data-model.md` must reflect any schema or
-  API contract changes.
-- `docs/roadmap-and-issues.md` should be updated when milestones
-  shift significantly.
-- Inline code comments explain *why*, not *what*. Remove comments that
-  just restate the code.
-
-### Maintainability Bias
-
-Prefer:
-
-- Explicit over clever.
-- Small, testable functions over large ones.
-- Types everywhere in TypeScript and Python.
-- Clear error messages that name the problem and suggest a fix.
-- Fail loudly on bad state rather than silently degrade.
-
-When two approaches are roughly equivalent, choose the one that is easier
-to delete or replace later.
+Their future product roles will be decided after the experimentation path and MVP are defined.

--- a/NORTH_STAR.md
+++ b/NORTH_STAR.md
@@ -1,0 +1,27 @@
+# Cloud Chamber North Star
+
+## See clouds from the inside
+
+Cloud Chamber exists because clouds are beautiful, dynamic, and mostly hidden from us.
+
+We can see their outlines, but not the thermals building them, the downdrafts hollowing them out, the eddies mixing cloud and clear air, the droplets coalescing, the ice crystals competing for vapor, or the cold pools spreading beneath storms.
+
+Cloud Chamber should provide something close to magic vision.
+
+> **Cloud Chamber lets people create beautiful, scientifically meaningful cloud worlds, see the invisible processes inside them, change the atmosphere, and learn by watching the clouds respond.**
+
+It should grow into a collection of cloud worlds: fair-weather cumulus, trade cumulus, congestus, deep convection, coastal stratus and stratocumulus, boundary-triggered clouds, orographic clouds, and others CM1 can illuminate well.
+
+No single cloud type, sounding, forcing method, or current experiment defines the product.
+
+## Keep this front and center
+
+Every major product decision should help deliver at least one of these:
+
+- a cloud worth watching;
+- an invisible atmospheric process made visible;
+- a meaningful experiment the user can perform;
+- a clearer explanation of why the cloud behaved as it did;
+- a new scientifically defensible cloud world.
+
+Scientific rigor, recipes, compute, and software architecture are essential—but they serve the experience. They are not the experience.

--- a/docs/product/PRODUCT_VISION.md
+++ b/docs/product/PRODUCT_VISION.md
@@ -1,0 +1,288 @@
+# Cloud Chamber
+
+## Product Vision
+
+### See clouds from the inside
+
+Cloud Chamber exists because clouds are beautiful, dynamic, and mostly hidden from us.
+
+We can watch a cumulus tower grow, a storm darken, or coastal stratus move inland, but we cannot normally see the machinery inside: the thermals feeding the cloud, the entrainment peeling it apart, the eddies rolling through it, the droplets colliding and coalescing, the ice crystals competing for vapor, the precipitation loading the updraft, or the cold pool forming and spreading beneath the storm.
+
+Cloud Chamber should provide something close to magic vision.
+
+It should let people create scientifically meaningful cloud worlds, watch them evolve, reveal the invisible processes inside them, change the atmosphere, and learn by seeing how the cloud responds.
+
+## The Product Promise
+
+A user should be able to:
+
+1. enter a cloud regime;
+2. watch a beautiful cloud or cloud field form and evolve;
+3. reveal the hidden motions and processes inside it;
+4. change something physically meaningful;
+5. compare what happened;
+6. understand why the cloud changed.
+
+The central experience is not configuring CM1.
+
+The central experience is seeing and understanding clouds in ways the real sky normally does not allow.
+
+## A World of Clouds
+
+Cloud Chamber is not about one favorite cloud type.
+
+It should grow into a collection of scientifically grounded cloud worlds, including:
+
+- continental fair-weather cumulus;
+- marine trade cumulus;
+- cumulus congestus;
+- deep precipitating convection;
+- coastal stratus and stratocumulus;
+- stratocumulus breakup and transition;
+- sea-breeze or boundary-triggered convection;
+- orographic cloud;
+- cold-pool-driven convection;
+- other regimes that CM1 can represent credibly.
+
+Each cloud world should have its own characteristic beauty, physics, questions, and controls.
+
+Fair-weather cumulus can reveal boundary-layer thermals, entrainment, and repeated growth and decay.
+
+Congestus can reveal thermal succession, dilution, precipitation onset, and the transition toward deeper convection.
+
+Deep convection can reveal organized updrafts, ice processes, precipitation loading, downdrafts, and cold pools.
+
+Coastal stratus can reveal radiative cooling, surface coupling, inversion structure, advection, and breakup.
+
+No one cloud regime defines Cloud Chamber. Any recipe we build first is one entry point into a broader atmospheric laboratory.
+
+## Seeing the Invisible
+
+Cloud Chamber should make normally invisible atmospheric processes visible and understandable.
+
+Depending on the cloud regime and the fidelity of the simulation, the user should be able to reveal:
+
+- updrafts and downdrafts;
+- buoyancy;
+- turbulent eddies;
+- entrainment and detrainment;
+- temperature and moisture structure;
+- liquid cloud water;
+- rain;
+- cloud ice, snow, graupel, or hail;
+- pressure perturbations;
+- precipitation loading;
+- evaporation and cooling;
+- cold-pool formation and expansion;
+- droplet and ice-particle behavior where the model supports it.
+
+The goal is not to place scientific overlays on top of a cloud as decoration.
+
+The goal is to let the user look inside the cloud and understand what it is doing.
+
+## Learning by Changing the Atmosphere
+
+Cloud Chamber should support controlled exploration.
+
+A user might ask:
+
+- What happens when the air above the cloud is drier?
+- What does a stronger inversion do to fair-weather cumulus?
+- What happens when the surface supplies more moisture than heat?
+- How does wind shear reshape a deep convective tower?
+- What causes a shallow cloud to become congestus?
+- When does rain begin, and how does it change the cloud that produced it?
+- What maintains a coastal stratus deck?
+- What causes a cold pool to strengthen and spread?
+- What additional structures appear when the simulation is run at finer resolution?
+
+The product should connect the experiment to the response:
+
+```text
+What changed in the cloud world
+→ what atmospheric process responded
+→ how the cloud changed
+→ what became visible
+```
+
+The user should begin from a cloud world that already works, change something meaningful, and learn from the difference.
+
+## Scientifically Grounded Cloud Worlds
+
+Cloud Chamber should be scientifically grounded because the real physics are more interesting than arbitrary animation.
+
+Each cloud world should be based on a complete and defensible atmospheric experiment. That may draw from:
+
+- an official CM1 case;
+- a peer-reviewed CM1 study;
+- a documented adaptation;
+- a real observed atmosphere combined with explicit idealized forcing.
+
+A complete cloud world may include:
+
+- an atmospheric profile;
+- a wind profile;
+- a surface state;
+- surface heat and moisture exchange;
+- radiation;
+- large-scale tendencies;
+- an initiation or forcing mechanism;
+- cloud and precipitation physics;
+- turbulence treatment;
+- a numerical domain and resolution.
+
+A sounding can make the atmosphere less arbitrary, but it is one part of the cloud world rather than a complete weather system.
+
+Observed soundings, aerosol measurements, surface conditions, and cloud observations should be used to constrain experiments—not to turn Cloud Chamber into a forecasting product.
+
+The relevant question is:
+
+> How does this atmosphere behave inside this cloud world?
+
+Not:
+
+> Will this reproduce the weather that occurred?
+
+Idealization is not a defect when it is explicit, purposeful, and physically coherent.
+
+## Beauty Is Part of the Product
+
+Cloud Chamber should make atmospheric simulation visually compelling.
+
+The user should want to watch the cloud.
+
+A successful result should have form, depth, movement, scale, and temporal life. It should reveal both the visible cloud and the hidden atmosphere that creates it.
+
+Possible views include:
+
+- a beautiful volumetric cloud evolving through time;
+- transparent or sliced views into the cloud interior;
+- particles, vectors, or streamlines revealing airflow;
+- liquid, ice, and precipitation shown distinctly;
+- close views of turrets, mixing zones, and precipitation shafts;
+- ground-level views of spreading cold air;
+- side-by-side comparisons between experiments;
+- changes in resolution or physics made visible.
+
+Visual quality is not decoration added after the science. It is how the user encounters and understands the science.
+
+The visual representation should remain honest about what the model resolved. Rendering may improve clarity, depth, contrast, motion, and beauty, but it should not silently invent physical structure that was never simulated.
+
+The quality bar is not one specific cloud or published figure. It is the ambition to make every supported cloud regime as compelling as its physics and practical compute allow.
+
+## The Role of Recipes
+
+Cloud Chamber will need cloud recipes, but recipes are not the emotional center of the product.
+
+A recipe is a reliable, scientifically grounded way to create and explore a particular cloud world.
+
+It should define:
+
+- the cloud regime;
+- the complete base experiment;
+- the expected cloud behavior;
+- the expected visual character;
+- the meaningful ways the user can modify it;
+- the limits of what can be inferred.
+
+Recipes should prevent two bad extremes:
+
+- fixed demonstrations that cannot be explored;
+- arbitrary model controls that make it easy to create uninterpretable simulations.
+
+The user should experience a coherent cloud world and meaningful choices, not a wall of namelist options.
+
+## A Spectrum of Fidelity
+
+Cloud Chamber should support different levels of fidelity over time.
+
+Some cloud worlds may be practical to explore quickly. Others may require finer resolution, larger domains, more complete cloud physics, or remote compute to reveal additional structure.
+
+A lower-cost experiment can still be valuable if it is scientifically coherent, visually worthwhile, and honest about its limits.
+
+High-resolution CM1 studies provide a scientific and visual north star. They show what becomes possible when more of the cloud's turbulence and microphysics are resolved. They should inspire the product without narrowing it to one cloud type or making research-scale compute the minimum acceptable experience.
+
+## What Cloud Chamber Is Not
+
+Cloud Chamber is not primarily:
+
+- a weather forecasting system;
+- a tool for predicting whether one sounding will produce a storm;
+- a universal sounding-ranking system;
+- a severe-weather simulator only;
+- a cumulus simulator only;
+- a gallery of fixed CM1 demonstrations;
+- a free-form CM1 namelist editor;
+- a mechanism for increasing forcing until an interesting cloud appears;
+- a graphics product detached from atmospheric physics.
+
+These capabilities may appear in supporting roles, but none defines the product.
+
+## Enduring Principles
+
+### Wonder comes first
+
+The project exists because clouds are fascinating and because seeing inside them would be extraordinary.
+
+Scientific rigor, recipes, compute, and software architecture should serve that experience.
+
+### The current experiment is never the whole product
+
+A success or failure in one cloud regime should not redefine Cloud Chamber around that result.
+
+### The real physics are the attraction
+
+Scientific grounding should deepen the user's sense of wonder, not bury it under disclaimers.
+
+### Cloud worlds must be explorable
+
+The user should be able to change meaningful conditions and learn from the response.
+
+### Controls belong to regimes
+
+Fair-weather cumulus, coastal stratus, congestus, and deep convection should not be forced into one universal set of controls.
+
+### Seeing is part of understanding
+
+Visualization is a primary product capability, not postprocessing.
+
+### Limits should clarify, not dominate
+
+The product should communicate what is idealized, parameterized, or unresolved in a direct and natural way without making caution the center of the experience.
+
+### One beautiful cloud is not enough
+
+Cloud Chamber should become a varied collection of cloud worlds and atmospheric questions.
+
+## North Star
+
+> **Cloud Chamber lets people create beautiful, scientifically meaningful cloud worlds, see the invisible processes inside them, change the atmosphere, and learn by watching the clouds respond.**
+
+## The Test
+
+A major product decision should bring Cloud Chamber closer to at least one of these outcomes:
+
+- a cloud worth watching;
+- an invisible atmospheric process made visible;
+- a meaningful experiment the user can perform;
+- a clearer explanation of why the cloud behaved as it did;
+- a new scientifically defensible cloud world.
+
+Work that does none of these may be necessary infrastructure, but it is not the product and should not be allowed to become the center of the project.
+
+## Scope of This Document
+
+This document defines why Cloud Chamber exists and what experience it should ultimately create.
+
+It does not decide:
+
+- which cloud world to build first;
+- the experimentation path;
+- the MVP;
+- recipe implementation details;
+- validation procedures;
+- application architecture;
+- compute infrastructure;
+- interface design.
+
+Those decisions should follow from this vision rather than redefine it.


### PR DESCRIPTION
## Summary

Implements Recovery Batch 1 from #357.

Closes #357.

This PR establishes the first trustworthy product-authority layer for Cloud Chamber:

- adds `NORTH_STAR.md`;
- adds `docs/product/PRODUCT_VISION.md`;
- completely replaces `AGENTS.md` with repository-recovery instructions.

The North Star and Product Vision are copied exactly from the approved text in #357.

## Scope

Exactly three files changed:

```text
NORTH_STAR.md
docs/product/PRODUCT_VISION.md
AGENTS.md
```

No legacy documents, scenarios, app code, tests, workflows, templates, dependency files, runtime configuration, or CM1 configuration are changed.

## Verification

- `git diff --name-only main...HEAD`
- `git diff --check main...HEAD`
- `scripts/check.sh`
- Compared all three resulting files against the exact approved text in #357.
- Confirmed no generated or local artifacts remain in the recovery worktree.

`scripts/check.sh` passed using the existing local backend venv and frontend dependency install. It emitted the existing React `act(...)` warning and the existing Vite chunk-size warning, but exited cleanly.

## Review posture

Manual review required. Auto-merge is intentionally not enabled.