### PR TITLE
Stage 3: classify implemented contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — Cloud Chamber Repository Recovery
+# AGENTS.md — Cloud Chamber Gated Product Architecture
 
 ## Product authority
 
@@ -6,18 +6,23 @@ Before any nontrivial work, read:
 
 1. `NORTH_STAR.md`
 2. `docs/product/PRODUCT_VISION.md`
+3. `docs/product/APPLICATION_SEMANTICS.md`
 
-These are the controlling statements of why Cloud Chamber exists and what product it is intended to become.
+These are the controlling statements of why Cloud Chamber exists, what product
+it is intended to become, and the approved product-semantic vocabulary.
 
 Existing issues, scenarios, roadmaps, product specifications, research notes, UI language, and implementation structures may reflect superseded product directions. They are evidence and history, not automatic product authority.
 
-When a lower-level artifact conflicts with the North Star or Product Vision, stop and ask for direction. Do not reconcile the conflict by silently changing the product.
+When a lower-level artifact conflicts with the North Star, Product Vision, or
+Application Semantics, stop and ask for direction. Do not reconcile the conflict
+by silently changing the product.
 
-## Repository recovery mode
+## Gated product-architecture mode
 
-Cloud Chamber is currently in repository recovery.
+Cloud Chamber is currently in a gated product-architecture program after the
+initial repository-recovery and semantic-architecture stages.
 
-Until recovery mode is explicitly ended:
+Until this gated program is explicitly ended:
 
 - all pull requests require manual review;
 - do not enable auto-merge;
@@ -27,13 +32,14 @@ Until recovery mode is explicitly ended:
 - do not treat current scenarios as validated recipes;
 - do not promote research mechanisms, scores, triggers, or one-off runs into product concepts;
 - do not revise the North Star or Product Vision;
-- do not make product, science, recipe, scenario, roadmap, or UX decisions unless the task explicitly supplies the decision.
+- do not make product, science, Recipe, Cloud World, scenario, roadmap, MVP, or UX decisions unless the task explicitly supplies the decision.
 
 ## Codex and agent role
 
-During recovery, agents execute bounded decisions. They do not formulate product strategy.
+During the gated program, agents execute bounded decisions. They do not
+formulate product strategy.
 
-A recovery task must specify:
+A bounded task must specify:
 
 - the exact files allowed to change;
 - the exact intended disposition or replacement content;
@@ -52,7 +58,7 @@ Stable vision:
 What remains unchanged?
 
 Current task:
-What specific part of the vision or recovery does this advance?
+What specific part of the vision or gated program does this advance?
 
 Non-implications:
 What does this work not redefine?
@@ -61,9 +67,9 @@ Portfolio effect:
 Does this preserve, broaden, or accidentally narrow Cloud Chamber?
 ```
 
-The current experiment is never the whole product.
+The current run, research effort, or implementation path is never the whole product.
 
-## Allowed work during recovery
+## Allowed work during the gated program
 
 Allowed when explicitly requested:
 
@@ -81,7 +87,7 @@ Always stop and ask before:
 
 - changing product direction;
 - changing scientific interpretation;
-- adding or promoting a recipe or scenario;
+- adding or promoting a Recipe or scenario;
 - changing default cloud regimes, triggers, forcing, or sounding behavior;
 - changing user-facing scientific language;
 - changing navigation or top-level workspaces;
@@ -116,9 +122,10 @@ Do not remove or weaken tests merely to make a change pass.
 Preserve the distinction between:
 
 ```text
-configured experiment
+configured run
+generated package
 running CM1 process
-completed CM1 output
+completed model output
 backend-derived diagnostic
 visualization interpretation
 ```
@@ -127,7 +134,7 @@ visualization interpretation
 
 Existing capabilities may remain valuable even when their framing is under review. Preserve working infrastructure unless a reviewed task explicitly removes it.
 
-In particular, do not assume that repository recovery means deleting:
+In particular, do not assume that gated product-architecture work means deleting:
 
 - local CM1 execution;
 - run queueing and progress;

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Cloud Chamber exists because clouds are beautiful, dynamic, and mostly hidden fr
 
 That is the product vision, not a description of the software as it exists today.
 
-Today, Cloud Chamber is a working but uneven collection of CM1 experiment-building, run-management, sounding, diagnostics, and visualization capabilities shaped by several earlier product directions. Some of those capabilities are strong foundations. Others are incomplete, misframed, or may not belong in the eventual product.
+Today, Cloud Chamber is a working but uneven collection of CM1 run-building, run-management, sounding, diagnostics, and visualization capabilities shaped by several earlier product directions. Some of those capabilities are strong foundations. Others are incomplete, misframed, or may not belong in the eventual product.
 
 The long-term vision is a scientific cloud laboratory: a collection of explorable cloud worlds where users can watch clouds form and evolve, reveal the normally invisible processes inside them, change meaningful atmospheric conditions, and understand how the clouds respond.
 
@@ -16,10 +16,12 @@ Read the controlling product documents:
 
 - [North Star](NORTH_STAR.md)
 - [Product Vision](docs/product/PRODUCT_VISION.md)
+- [Application Semantics](docs/product/APPLICATION_SEMANTICS.md)
 
 ## Repository status
 
-Cloud Chamber is currently in **product and repository recovery**.
+Cloud Chamber is currently in a **gated product-architecture program** after
+the initial repository-recovery and semantic-architecture stages.
 
 The repository contains substantial working simulation, run-management, data, and visualization infrastructure. It also contains scenarios, workflows, terminology, and planning documents inherited from several earlier product directions.
 
@@ -32,7 +34,7 @@ Do not infer the long-term product from:
 - existing sounding scores or recommendation language;
 - a particular trigger or forcing mechanism;
 - an old roadmap, product specification, or issue;
-- one successful or unsuccessful CM1 experiment.
+- one successful or unsuccessful CM1 run.
 
 See [Current State](docs/current/CURRENT_STATE.md) for a candid description of what exists today and what remains under review.
 
@@ -48,7 +50,7 @@ Cloud Chamber currently provides useful foundations for future product developme
 - saved-output playback and time-based result inspection;
 - 2-D slices and 3-D inspection of CM1-derived fields;
 - separate treatment of cloud water, ice and other hydrometeors, rain water aloft, surface rain, and reflectivity;
-- observed-sounding ingest, caching, diagnostics, and experiment configuration;
+- observed-sounding ingest, caching, diagnostics, and run configuration;
 - runtime-integrity and field-quality checks that distinguish a completed process from trustworthy scientific output.
 
 These capabilities are not all guaranteed to appear in the eventual product in their current form. They should be preserved while their future roles are evaluated.
@@ -80,7 +82,14 @@ Start here:
 - [Testing](docs/development/TESTING.md)
 - [CI and Branch Protection](docs/development/CI_AND_BRANCH_PROTECTION.md)
 
-The read-only documentation disposition audit is complete and approved. The highest-risk superseded product-direction documents are preserved under `docs/archive/`, current operational docs are maintained under `docs/current/` and `docs/development/`, and the repository intentionally has no controlling roadmap during recovery. The [documentation status and authority guide](docs/DOCUMENTATION_STATUS.md) explains how to interpret remaining documents during recovery.
+The read-only documentation disposition audit is complete and approved. The
+highest-risk superseded product-direction documents are preserved under
+`docs/archive/`, current operational docs are maintained under `docs/current/`
+and `docs/development/`, Application Semantics is the approved semantic
+authority, and the repository intentionally has no controlling roadmap during
+the gated product-architecture program. The
+[documentation status and authority guide](docs/DOCUMENTATION_STATUS.md)
+explains how to interpret remaining documents.
 
 ## Development
 
@@ -139,13 +148,13 @@ Do not commit:
 - local settings or machine-private paths;
 - screenshots, videos, traces, logs, or large processed visualization artifacts.
 
-## Contributing during recovery
+## Contributing during the gated product-architecture program
 
 Read [AGENTS.md](AGENTS.md) before nontrivial work.
 
 Use the [controlled-work issue template](.github/ISSUE_TEMPLATE/controlled-work.md) to define bounded work before implementation, and the [Codex task prompt template](docs/templates/codex-task-prompt.md) to translate an approved issue into execution instructions.
 
-During repository recovery:
+During the gated product-architecture program:
 
 - all pull requests require manual review;
 - auto-merge is disabled;

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -4,7 +4,8 @@
 
 The Cloud Chamber documentation tree contains current technical information, research evidence, historical decisions, proposals, and superseded product direction.
 
-During repository recovery, a document’s presence under `docs/` does not make it current authority.
+During the gated product-architecture program, a document’s presence under
+`docs/` does not make it current authority.
 
 Use the hierarchy below.
 
@@ -14,8 +15,16 @@ These documents define why Cloud Chamber exists and what it is intended to becom
 
 1. [North Star](../NORTH_STAR.md)
 2. [Product Vision](product/PRODUCT_VISION.md)
+3. [Application Semantics](product/APPLICATION_SEMANTICS.md)
 
-They are the highest product authority in the repository.
+The North Star and Product Vision are the highest product authority in the
+repository. Application Semantics is the approved product-semantic authority for
+Cloud World, Recipe, Simulation, Lens, Saved View, Comparison, Exploration,
+Experiment, and supporting terms.
+
+Approved PM stage decisions control bounded stage work where they explicitly
+apply. They do not silently rewrite the North Star, Product Vision, or
+Application Semantics.
 
 No roadmap, issue, scenario, research note, architecture document, product specification, or implementation should silently redefine them.
 
@@ -25,7 +34,8 @@ Changes require explicit PM approval.
 
 - [AGENTS.md](../AGENTS.md)
 
-`AGENTS.md` defines how agents and contributors must operate during repository recovery.
+`AGENTS.md` defines how agents and contributors must operate during the gated
+product-architecture program.
 
 It does not replace the Product Vision. It prevents lower-level work from rewriting it.
 
@@ -51,13 +61,22 @@ Documents such as these contain setup, testing, CI, runtime, and engineering inf
 
 Use their operational instructions where they remain accurate.
 
-The read-only documentation disposition audit is complete and approved. Batch 3B-1 implemented the approved archive moves for the highest-risk superseded product-direction documents. Batch 3B-2 rebuilt the active architecture, development, testing, CI, lifecycle, and LAN-worker operational docs listed above.
+Stage 1 operational-documentation recovery is complete. The read-only
+documentation disposition audit is complete and approved. Batch 3B-1
+implemented the approved archive moves for the highest-risk superseded
+product-direction documents. Batch 3B-2 rebuilt the active architecture,
+development, testing, CI, lifecycle, and LAN-worker operational docs listed
+above.
+
+Stage 2 semantic architecture is complete. Application Semantics is now the
+approved semantic authority.
 
 For documents not yet handled by a recovery batch:
 
 - prefer commands, paths, APIs, test procedures, and implemented behavior that can be verified;
 - do not treat their product priorities, old priority labels, scenario sequencing, or future-work language as authoritative;
-- resolve any conflict in favor of the North Star, Product Vision, Current State, and `AGENTS.md`.
+- resolve any conflict in favor of the North Star, Product Vision, Application
+  Semantics, Current State, and `AGENTS.md`.
 
 ## 5. Architecture and data-model documents
 
@@ -75,19 +94,22 @@ Do not automatically interpret them as:
 
 Architecture changes remain subject to the Product Vision and future experimentation and MVP decisions.
 
-## 6. Contracts
+## 6. Implemented contracts
 
-Documents under `contracts/` may describe:
+The active `docs/contracts/` directory contains only current implemented
+contracts verified against code and tests:
 
-- implemented data contracts;
-- current API behavior;
-- partially implemented interfaces;
-- proposed future contracts;
-- product semantics that were codified before the current vision.
+- [Output Product Specification](contracts/output-product-specification.md)
+- [Sounding Candidate Screening Contract](contracts/sounding-candidate-screening.md)
 
-The approved documentation disposition includes the contracts directory.
+These contracts describe current interfaces and implementation behavior. They
+do not establish final product architecture or define supported Cloud Worlds,
+Recipes, Simulations, Explorations, or Experiments.
 
-Until the approved contract dispositions are implemented, verify a contract against current code before treating it as implemented. Do not use a proposal-only or stale contract to create new product direction.
+Archived contract proposals and mixed historical contracts live under
+`docs/archive/contracts/`. Those files preserve historical design and
+implementation context, but they are not active implemented contracts and do not
+establish current product direction.
 
 ## 7. Research and experiment evidence
 
@@ -121,13 +143,11 @@ Known high-risk archived examples include:
 - [legacy roadmap and startup issues](archive/roadmaps/roadmap-and-issues-legacy.md);
 - [deep-convection package design proposal](archive/proposals/deep-convection-package-design-legacy.md).
 
-Additional active-path documents may still contain superseded framing and approved disposition recommendations, including:
+Additional active-path documents may still contain superseded framing and
+approved disposition recommendations.
 
-- scenario and recipe planning contracts tied to older product directions.
-
-These files may contain useful technical or historical content.
-
-Until they are archived, split, or rewritten:
+These files may contain useful technical or historical content. Until they are
+archived, split, or rewritten:
 
 - do not use them as controlling product authority;
 - do not update them merely to make them appear consistent with the new vision;
@@ -149,7 +169,8 @@ The documentation audit classified documents using these terms:
 | **Superseded** | Conflicts with or has been replaced by current authority |
 | **Unresolved** | Requires product, scientific, or implementation review |
 
-These labels are interpretive aids. Repository recovery does not yet move or relabel every file.
+These labels are interpretive aids. The gated product-architecture program has
+not moved or relabeled every file.
 
 ## Recommended reading paths
 
@@ -157,16 +178,18 @@ These labels are interpretive aids. Repository recovery does not yet move or rel
 
 1. [North Star](../NORTH_STAR.md)
 2. [Product Vision](product/PRODUCT_VISION.md)
-3. [Current State](current/CURRENT_STATE.md)
-4. [Current Architecture](current/CURRENT_ARCHITECTURE.md)
+3. [Application Semantics](product/APPLICATION_SEMANTICS.md)
+4. [Current State](current/CURRENT_STATE.md)
+5. [Current Architecture](current/CURRENT_ARCHITECTURE.md)
 
-### Contribute during recovery
+### Contribute during the gated product-architecture program
 
 1. [AGENTS.md](../AGENTS.md)
-2. [Current State](current/CURRENT_STATE.md)
-3. [Development](development/DEVELOPMENT.md)
-4. [Testing](development/TESTING.md)
-5. [CI and Branch Protection](development/CI_AND_BRANCH_PROTECTION.md)
+2. [Application Semantics](product/APPLICATION_SEMANTICS.md)
+3. [Current State](current/CURRENT_STATE.md)
+4. [Development](development/DEVELOPMENT.md)
+5. [Testing](development/TESTING.md)
+6. [CI and Branch Protection](development/CI_AND_BRANCH_PROTECTION.md)
 
 Ignore conflicting product-direction language in lower-authority documents and ask for direction when a conflict affects the task.
 
@@ -183,9 +206,9 @@ Use the current source code, tests, runtime contracts, and Current State documen
 
 Do not rely on a single old product specification or roadmap.
 
-## Recovery note
+## Program note
 
-The documentation tree has not yet been comprehensively reorganized.
+The documentation tree has not been comprehensively reorganized.
 
 A read-only disposition manifest has evaluated every document and its recommendations have been approved. Those recommendations indicate whether to:
 
@@ -199,6 +222,12 @@ A read-only disposition manifest has evaluated every document and its recommenda
 Batch 3B-1 implemented the approved quarantine of the highest-risk superseded product-direction documents and retired the obsolete roadmap pointer.
 
 Batch 3B-2 rebuilt the current operational documentation set for architecture, development, testing, CI, lifecycle, and LAN-worker setup.
+
+Stage 2 added the approved Application Semantics document.
+
+Stage 3 classified the active contract directory: two implemented contracts
+remain active, and five historical/proposal contract documents are preserved
+under `docs/archive/contracts/`.
 
 Remaining repository moves, rewrites, splits, archives, deletions, and deferrals from the approved disposition may still exist outside those handled paths.
 

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -11,20 +11,23 @@ Use the hierarchy below.
 
 ## 1. Controlling product authority
 
-These documents define why Cloud Chamber exists and what it is intended to become:
+Use this product-authority order:
 
 1. [North Star](../NORTH_STAR.md)
 2. [Product Vision](product/PRODUCT_VISION.md)
-3. [Application Semantics](product/APPLICATION_SEMANTICS.md)
+3. explicit approved PM decisions for bounded stage work
+4. approved product-architecture documents such as
+   [Application Semantics](product/APPLICATION_SEMANTICS.md)
+5. current implementation documentation
 
 The North Star and Product Vision are the highest product authority in the
-repository. Application Semantics is the approved product-semantic authority for
-Cloud World, Recipe, Simulation, Lens, Saved View, Comparison, Exploration,
-Experiment, and supporting terms.
+repository. Approved PM decisions control bounded stage work where they
+explicitly apply. Application Semantics is the approved product-semantic
+authority for Cloud World, Recipe, Simulation, Lens, Saved View, Comparison,
+Exploration, Experiment, and supporting terms.
 
-Approved PM stage decisions control bounded stage work where they explicitly
-apply. They do not silently rewrite the North Star, Product Vision, or
-Application Semantics.
+PM decisions and product-architecture documents do not silently rewrite higher
+authority.
 
 No roadmap, issue, scenario, research note, architecture document, product specification, or implementation should silently redefine them.
 
@@ -75,8 +78,9 @@ For documents not yet handled by a recovery batch:
 
 - prefer commands, paths, APIs, test procedures, and implemented behavior that can be verified;
 - do not treat their product priorities, old priority labels, scenario sequencing, or future-work language as authoritative;
-- resolve any conflict in favor of the North Star, Product Vision, Application
-  Semantics, Current State, and `AGENTS.md`.
+- resolve any conflict in favor of the North Star, Product Vision, explicit
+  approved PM decisions for bounded stage work, Application Semantics, Current
+  State, and `AGENTS.md`.
 
 ## 5. Architecture and data-model documents
 

--- a/docs/archive/contracts/analyzer-hypothesis-output-signature-legacy.md
+++ b/docs/archive/contracts/analyzer-hypothesis-output-signature-legacy.md
@@ -1,3 +1,9 @@
+# Archived Contract: Analyzer Hypothesis And Output-Signature
+
+> **Status: Historical proposal contract**
+>
+> This document is preserved as historical design and implementation context. It is not an active implemented contract and does not establish current product direction, supported Recipe status, roadmap priority, MVP scope, or final application architecture. Current product semantics are defined in `docs/product/APPLICATION_SEMANTICS.md`.
+
 # Analyzer Hypothesis And Output-Signature Contract
 
 Status: forward product/data contract

--- a/docs/archive/contracts/output-product-specification-legacy.md
+++ b/docs/archive/contracts/output-product-specification-legacy.md
@@ -1,0 +1,824 @@
+# Archived Contract: Output Product Specification
+
+> **Status: Historical mixed contract**
+>
+> This document is preserved as historical design and implementation context. It is not an active implemented contract and does not establish current product direction, supported Recipe status, roadmap priority, MVP scope, or final application architecture. Current product semantics are defined in `docs/product/APPLICATION_SEMANTICS.md`.
+
+# Cloud Chamber Output Product Specification
+
+Issue: #214
+
+Status: v1 product/data contract
+
+Source context:
+
+- #210 output and visualization architecture research
+- #215 deep-output Explore timeout fix
+- current NetCDF ingest, Result Card, Explore, Storage, and selected-region
+  diagnostics behavior
+
+This specification defines what Cloud Chamber may produce from completed CM1
+output before more rendering, diagnostics, export, or UI surfaces are added.
+It is a contract between backend ingest, Results, Explore, Storage, future
+Diagnostics Lab, future Render Studio, docs, and tests.
+
+It does not implement new output products.
+
+## Executive Contract
+
+CM1 NetCDF output remains the source data. Cloud Chamber output products are
+derived local records or bounded payloads that make completed CM1 runs easier
+to inspect, explain, compare, render, cache, or export.
+
+The browser must not parse raw NetCDF. It should request backend-owned,
+provenance-labeled products with explicit size, time, field, and processing
+boundaries.
+
+The next implementation should create:
+
+```text
+output product manifest skeleton
++ robust file/time index mapping
++ interesting-time products
++ profile/time-height product definitions
+```
+
+That should happen before adding new renderer dependencies, Render Studio,
+Diagnostics Lab, or external export workflows.
+
+## Artifact Classes
+
+| Artifact class | What it is | Source of truth? | Typical owner | Browser access |
+| --- | --- | --- | --- | --- |
+| Raw CM1 NetCDF output | `cm1out_*.nc` model-field files and `cm1out_stats.nc` stats files written by CM1 | Yes, for model fields | CM1 / local runtime directory | Never directly |
+| Runtime logs/manifests | `run_manifest.json`, `case_manifest.json`, `stdout.log`, `stderr.log`, package inputs, runtime checklist | Yes, for run configuration and execution state | Build / local run manager | Only summarized through API |
+| Result metadata / notebook state | `result_metadata.json` plus optional `result_card.json` | Source for ingested metadata and notebook state, not raw model values | Ingest / Results | Through Results API |
+| Output product manifest | Generated index of derived products, time mapping, cache keys, and provenance | Source for derived-product availability, not raw model values | Backend product builder | Through bounded API summaries |
+| Derived scientific products | Diagnostics, profiles, time-height arrays, selected-place summaries, interesting times | Derived from raw output and metadata | Backend diagnostics/product layer | Bounded JSON or future binary payloads |
+| Visualization-ready payloads | Field catalogs, slices, point clouds, defaults, selected-region evidence | Derived request payloads for Explore | Backend visualization/data layer | Yes, bounded and provenance-labeled |
+| Future render-ready products | Multiresolution volumes, transfer-function metadata, scalar/signed-flow arrays | Derived, cacheable render inputs | Future Render Studio backend | Only through render APIs, not raw NetCDF |
+| External export bundles | VAPOR, ParaView/VTK, xarray/hvPlot/Panel, or future Zarr sidecars | Derived/export copies, not source truth | Future export jobs | Download/open workflow only |
+
+## Source Of Truth And Browser / Backend Boundary
+
+CM1 is the high-fidelity model. Raw CM1 NetCDF files, run manifests, and logs
+are the durable local evidence for what ran and what CM1 produced.
+
+Cloud Chamber may create derived products, but those products must remain
+clearly labeled as:
+
+- diagnostics derived from CM1 output;
+- visualization interpretations of CM1 output;
+- cached local products that can become stale or be deleted;
+- export bundles for external tools.
+
+The backend owns:
+
+- NetCDF/xarray access;
+- file/time mapping;
+- field selection;
+- finite/non-finite checks;
+- unit and coordinate interpretation;
+- downsampling and bounded payload construction;
+- provenance and caveat construction.
+
+The browser owns:
+
+- user selection state;
+- requesting one bounded product at a time;
+- rendering received payloads;
+- displaying provenance and caveats;
+- never treating visualization as a new physical source of truth.
+
+The browser must not:
+
+- open raw NetCDF files;
+- infer multi-file time mapping on its own;
+- compute global scientific diagnostics from raw field arrays;
+- silently invent fields, units, coordinates, or physical explanations.
+
+## Multi-File Output And Time-Index Mapping
+
+CM1 runs can produce many model-output NetCDF files. Cloud Chamber must treat
+the model run as one time sequence, even when each output time is written to a
+separate file.
+
+The output product manifest should define a global output-time index:
+
+```json
+{
+  "time_index": 12,
+  "time_seconds": 7200.0,
+  "source_file": "<runtime-home>/runs/<run-id>/cm1out_000013.nc",
+  "source_file_kind": "model_output_netcdf",
+  "local_time_index": 0,
+  "time_source": "netcdf_time_coordinate",
+  "time_caveats": []
+}
+```
+
+Rules:
+
+- `cm1out_stats.nc` is not a model-field time-series file.
+- Model-output files must be sorted by direct time coordinate when available,
+  otherwise by validated output index.
+- `time_index` is the global model-output index used by Results, Explore,
+  comparison views, diagnostics, and future renderer products.
+- `local_time_index` is the index inside the source file after the global time
+  is resolved.
+- Selected timestep requests must resolve through this mapping before any
+  NetCDF file is opened.
+- A selected timestep request should open only the required file when the
+  mapping proves that the file contains that timestep.
+- If files contain multiple timesteps, the mapping should preserve both global
+  and local indices.
+- Missing, corrupt, skipped, inferred, duplicated, or non-monotonic times must
+  become caveats.
+
+### #215 Performance Lesson
+
+Field catalogs and default view state should be served from ingested metadata or
+bounded derived products whenever possible.
+
+Basic Explore startup must not trigger raw full-sequence NetCDF parsing. The
+field catalog, field availability, broad time range, and default-interesting
+time should be metadata-backed or product-backed. Slice and point-cloud
+requests for a selected time should use the explicit file/time mapping to open a
+bounded source, not concatenate the full output sequence per request.
+
+## Output Product Manifest
+
+Cloud Chamber should introduce an output product manifest as a generated,
+local, rebuildable index for output-derived products.
+
+It is distinct from:
+
+- `run_manifest.json`, which records generated package and execution state;
+- `result_metadata.json`, which records ingested result metadata and first-pass
+  diagnostics;
+- `result_card.json`, which records notebook/user state.
+
+Draft manifest shape:
+
+```json
+{
+  "manifest_version": 1,
+  "product_manifest_id": "output-products-<result-id>",
+  "result_id": "result-<run-id>",
+  "run_id": "<run-id>",
+  "scenario_id": "baseline-shallow-cumulus",
+  "source_model": "CM1",
+  "source_result_metadata_path": ".../result_metadata.json",
+  "source_run_manifest_path": ".../run_manifest.json",
+  "source_raw_outputs": {
+    "model_output_files": [],
+    "stats_files": [],
+    "raw_cm1_artifacts": []
+  },
+  "time_index": [],
+  "field_catalog_product": {},
+  "interesting_time_product": {},
+  "products": [],
+  "cache": {
+    "product_root": ".../derived-products",
+    "cache_key": "result-metadata-and-source-output-fingerprint",
+    "invalidated": false
+  },
+  "provenance": {},
+  "caveats": [],
+  "created_at": "2026-06-29T00:00:00Z",
+  "updated_at": "2026-06-29T00:00:00Z"
+}
+```
+
+The manifest should record what products exist, how they were made, what source
+files they depend on, and how to invalidate or delete them. It should not copy
+large raw NetCDF files into the repository or make derived products appear more
+authoritative than CM1 output.
+
+Implementation note: the first backend foundation for this contract lives in
+`cloud_chamber.output_products`. Ingested results now write a runtime-local
+`derived-products/output_product_manifest.json` beside the run directory's
+result metadata. That manifest currently focuses on source output references
+and global file/time index mapping; later product records should build on it
+rather than inventing separate time addressing.
+
+## Product Type Decisions
+
+| Product type | When computed | Format now | Future format | Size class | API owner | Frontend consumer |
+| --- | --- | --- | --- | --- | --- | --- |
+| File/time index | At ingest or first product-build pass | JSON | JSON | small | backend ingest/product layer | Results, Explore, Storage, tests |
+| Interesting times | At ingest or first product-build pass | JSON | JSON | small | diagnostics/product layer | Results, Explore, future Compare |
+| Field catalog | At ingest or metadata-backed request | JSON | JSON | small | visualization/product layer | Explore, future Compare, future Render Studio |
+| Slice products | Lazy request, optionally cached | JSON numeric arrays | binary or chunked arrays for large slices | small to medium | visualization API | Explore, future Compare |
+| Vertical profiles | Lazy or cached from selected fields | JSON arrays | binary/chunked for long sequences | small to medium | diagnostics/product API | future Diagnostics Lab, Explore evidence |
+| Time-height products | Cached derived product | JSON for tiny fixtures | binary/chunked arrays | medium | diagnostics/product API | future Diagnostics Lab |
+| Selected-point/column products | Lazy bounded request, optionally cached | JSON summaries/arrays | JSON plus binary arrays if needed | small to medium | selected-region diagnostics API | Explore `What happened here?` |
+| Render-ready products | Cached explicit build | none yet | binary float32, multiresolution, or chunked store | medium to large | future render-product API | future Render Studio |
+| External export bundles | Explicit user/export job | none yet | tool-specific files | medium to large | future export API/job | external apps |
+
+## Interesting-Time Products
+
+Interesting-time products provide small, reusable time landmarks for Results,
+Explore, comparison, diagnostics, and future time-lapse rendering.
+
+Near-term interesting times:
+
+- first cloud;
+- max `qc`;
+- max updraft `w`;
+- min downdraft `w`;
+- highest liquid cloud-water top from `qc`;
+- highest coherent cloud-object top from supported, vertically connected `qc`, `qr`, `qi`, `qs`, and `qg` levels when present;
+- highest raw hydrometeor trace top from any `qc`, `qr`, `qi`, `qs`, or `qg` threshold crossing;
+- rain-water onset from `qr`;
+- max rain water aloft from `qr`;
+- max `dbz`;
+- max surface rain;
+- selected-time fallback such as latest output.
+
+Each interesting time should include:
+
+```json
+{
+  "key": "max_qc",
+  "label": "Max cloud water",
+  "time_index": 3,
+  "time_seconds": 2700.0,
+  "field": "qc",
+  "value": 0.0028,
+  "units": "kg/kg",
+  "source": "diagnostics.max_qc",
+  "confidence": "supported",
+  "caveats": []
+}
+```
+
+Interesting-time products should not require opening the full NetCDF sequence
+when a user merely opens Explore. They should be computed from existing
+diagnostics, stored product summaries, or a bounded product-build pass.
+
+The first implementation stores an `interesting_time_product` in the runtime
+output product manifest and mirrors compact fields into `result_metadata.json`:
+`interesting_times`, `default_time_by_field`, `science_summary`, and
+`interesting_time_caveats`. It uses the output-product manifest time index plus
+existing CM1-derived diagnostics; it does not build a second time index and it
+does not ask the browser to parse NetCDF. The science summary also carries the
+backend-owned low-level `qv` and theta/temperature response diagnostics when
+available, including early 30-90 minute forcing-response deltas and separate
+full-run deltas from 0-1 km AGL thickness-weighted domain means. Early and
+full-run response availability are exposed separately so consumers do not treat
+bad final-output evolution evidence as a missing early forcing response. Missing
+fields, no-event outcomes, and diagnostics that are not implemented yet are
+represented explicitly with support states such as
+`unavailable`, `unsupported_missing_fields`, and
+`unsupported_missing_diagnostic` rather than silently falling back to a
+misleading cloud/rain-water landmark.
+
+Interesting-time records, field defaults, diagnostic availability records, and
+science summaries may carry target-field `field_quality` metadata for `qc`, `w`,
+`qr`, surface `rain`, `dbz`, `hfx`, and `qfx`, plus present ice/snow/graupel
+fields when they contribute to cloud-top diagnostics. Entirely non-finite source
+fields are `untrusted` and must not produce supported landmarks or clean
+comparison evidence. Partially non-finite fields may remain usable only with
+visible caveats and finite/non-finite counts.
+
+Triggered deep-potential results extend the same product with backend-owned
+summary fields for deep-cloud formation, first deep-convection time, strong
+updraft detection, liquid cloud-water top, coherent cloud-object top, raw
+hydrometeor trace top, rain-water onset, max `qr`, and the default Explore time.
+The deep-cloud classifier must use coherent cloud-object top, not an isolated raw
+hydrometeor trace. The product must not use a generic "cloud top" label when the
+value comes from the broader trace envelope rather than visible `qc` alone.
+
+Unsupported severe-storm diagnostics such as reflectivity maxima, surface-rain
+maxima, updraft-depth proxy, cold-pool proxy, and near-surface theta
+perturbation proxy must be recorded as unavailable or caveated until a supported
+backend diagnostic exists. When candidate-screening metadata is
+present, result metadata may include a compact `candidate_hypothesis_comparison`
+with `Screened as`, `Ran as`, `CM1 outcome`, match state, evidence, and caveats.
+The comparison uses simple v1 rules and remains a post-run interpretation of
+CM1 output, not proof that the observed sounding was validated in advance.
+
+## Field Catalog Products
+
+The field catalog answers:
+
+```text
+What fields are available for this result, and what can Cloud Chamber safely do
+with each one?
+```
+
+The field catalog should include:
+
+- raw field name;
+- canonical field name;
+- display name;
+- units;
+- dimensions;
+- coordinate names;
+- native grid;
+- shape;
+- time availability;
+- direct vs inferred coordinate caveats;
+- supported product capabilities:
+  - slice;
+  - point cloud;
+  - selected point;
+  - selected column;
+  - profile;
+  - time-height;
+  - render-ready candidate;
+  - export candidate;
+- frontend consumer guidance;
+- provenance.
+
+The current implementation exposes these as backend-owned field metadata on the
+visualization field-catalog API. Each available field includes conservative
+capability flags for slice, point-cloud, selected-point, selected-column,
+profile, time-height, render-ready-candidate, and external-export-candidate
+use. Known fields that were expected by the run but absent from ingested NetCDF
+metadata are returned as unavailable fields with caveats; arbitrary unknown raw
+fields are not exposed as supported catalog entries.
+
+Example:
+
+```json
+{
+  "raw_field_name": "qc",
+  "canonical_field_name": "cloud_water",
+  "display_name": "Cloud water",
+  "units": "kg/kg",
+  "dimensions": ["time", "zh", "yh", "xh"],
+  "native_grid": "cell_center",
+  "coordinates": {"time": "time", "z": "zh", "y": "yh", "x": "xh"},
+  "capabilities": {
+    "slice": true,
+    "point_cloud": true,
+    "selected_point": true,
+    "selected_column": true,
+    "profile": true,
+    "time_height": true,
+    "render_ready_candidate": true,
+    "external_export_candidate": true
+  },
+  "provenance": {
+    "source_model": "CM1",
+    "processing_method": "ingested_result_metadata_field_catalog"
+  },
+  "caveats": []
+}
+```
+
+## Slice Products
+
+Slice products are the current everyday Explore payload. They provide one
+native-grid 2-D field view for one result, field, global time index,
+orientation, and level/index.
+
+Supported MVP orientations:
+
+- horizontal layer;
+- vertical `x-z` slice;
+- vertical `y-z` slice;
+- surface 2-D field when the field is already surface-native.
+
+Rules:
+
+- Use native grids first.
+- Do not interpolate staggered fields unless a future product explicitly says
+  so.
+- Preserve native coordinate names and units.
+- Include display-friendly coordinate values where safe.
+- Include min, max, mean, finite count, non-finite count, and caveats.
+- Include the global `time_index`, `time_seconds`, source file, and local time
+  index when available.
+- JSON arrays are acceptable for MVP-size slices.
+- Larger slices may require binary arrays or a chunked product later.
+
+## Vertical Profile Products
+
+Vertical profile products summarize a field as a function of height for a
+selected time, selected column, region, or domain.
+
+Candidate profiles:
+
+- domain mean/min/max `qv`, temperature, potential temperature, pressure;
+- selected-column `qc`, `qr`, `qv`, `w`, temperature, potential temperature;
+- profile at selected point/column for `What happened here?`;
+- cloud-base/cloud-top-relevant vertical summaries.
+
+Profile products should preserve:
+
+- field units;
+- vertical coordinate units;
+- height conversion where safe;
+- selected horizontal coordinate/index;
+- aggregation method;
+- caveats for missing or inferred coordinates.
+
+The current backend skeleton exposes bounded vertical profile products through
+the result output-products API. Supported MVP aggregations are domain mean,
+domain min, domain max, and selected column for profile-capable 3-D fields.
+Payloads include the global output `time_index`, resolved local source-file
+index when the output product manifest is available, vertical coordinate values,
+finite/non-finite counts, field-quality metadata, provenance, and caveats.
+Surface-only fields such as surface rain and surface fluxes remain unavailable
+for vertical profiles rather than being reshaped into misleading columns.
+
+## Time-Height Products
+
+Time-height products summarize evolution across output times and vertical
+levels. They are the likely bridge from Explore to a future Diagnostics Lab.
+
+Candidate time-height products:
+
+- cloud fraction by time and height;
+- max `qc` by time and height;
+- max/min `w` by time and height;
+- domain mean `qv` by time and height;
+- domain mean temperature/potential temperature by time and height;
+- selected-column cloud-water time-height;
+- cloud-base/cloud-top time series.
+
+Rules:
+
+- These products should be computed by backend jobs or bounded product builders,
+  not by the browser.
+- They should include direct/inferred time caveats and coordinate metadata.
+- They should be cacheable because they may require reading the full sequence.
+- JSON is acceptable for tiny fixtures; binary/chunked formats should be
+  considered for real deep outputs.
+
+The current backend skeleton exposes time-height products for time-height-capable
+3-D fields. Supported MVP aggregations are domain mean, domain min, domain max,
+and cloud fraction for `qc` using the documented cloud-water threshold. Payloads
+include global output time indices, source-file/local-time mappings when
+available, vertical coordinates, shape and size class, finite/non-finite counts,
+field-quality metadata, provenance, and caveats. The browser consumes the
+bounded payload only; it does not parse raw NetCDF.
+
+## Evolved-Run Time-Series Products
+
+Simple time-series products summarize scalar evolution across saved output
+times. Initial supported aggregations are domain max, domain mean, domain min,
+and cloud fraction where the field supports it. These products cover current
+MVP fields such as surface rain, rain water aloft, reflectivity, cloud water,
+`u` / `v` / `w` wind components, surface sensible/latent heat flux, and other
+known field-catalog entries when present.
+
+Missing fields must return an unavailable/caveated catalog state or a clear
+product error, not a guessed scientific result. Boundary-layer-depth and
+mixed-layer-depth style products remain future diagnostics until a defensible
+method is documented and tested.
+
+Field-product payloads must be self-describing. Vertical profile, time-height,
+time-series, native slice, and point-cloud payloads carry a `field_quality`
+object for the requested raw field when diagnostics can evaluate it. The object
+records whether quality was assessed, the source field, quality state, finite
+count, non-finite count, total count, reason, and quality caveats. Tracked fields
+use the current `qc`, `w`, `qr`, surface `rain`, `dbz`, `hfx`, and `qfx`
+diagnostic quality records. Untracked fields such as `qv` must
+explicitly report that field quality is not tracked rather than implying trusted
+status. Older results or partial metadata with no assessment signal must report
+`assessed = false`; only an explicit assessed `trusted` field-quality record is
+trusted evidence.
+
+Wind-component products are scalar summaries of native-grid CM1 `u` and `v`
+components. They may support vertical profiles and time-height products when
+the fields and coordinates are present, but they must carry native staggered-grid
+and no-vector-interpolation caveats. They are not wind gust, outflow, rotation,
+or storm-organization diagnostics. Near-surface wind time-series products remain
+explicitly unavailable until the lowest-level selection method is defined and
+tested.
+
+## Selected-Point And Selected-Column Products
+
+Selected-place products power the user-facing question:
+
+```text
+What happened here?
+```
+
+Supported or near-term selections:
+
+- selected point from a 2-D slice;
+- selected vertical column;
+- selected small 2-D region;
+- selected 3-D box later;
+- selected cloud object later;
+- selected updraft core later.
+
+Selected-point product requirements:
+
+- selected field and value;
+- selected time;
+- selected native-grid indices;
+- selected physical coordinates;
+- local `qc`, `w`, and optional `qr` summaries;
+- comparison to domain where practical;
+- conservative explanation label;
+- caveats;
+- source fields and processing method.
+
+Selected-column product requirements:
+
+- column profile at selected time;
+- local time history where practical;
+- first local cloud time;
+- local max `qc`;
+- local max/min `w`;
+- local rain-water onset when `qr` exists;
+- cloud-base/cloud-top evidence where supported.
+
+These products should not become cloud-object tracking unless a future issue
+adds object definitions and validation.
+
+## Visualization-Ready Payloads
+
+Visualization-ready payloads are small request/response products consumed by
+Explore and comparison views.
+
+Current examples:
+
+- field catalog;
+- view/defaults payload;
+- slice payload;
+- point-cloud payload;
+- selected-region diagnostics payload.
+
+Contract:
+
+- bounded in size;
+- backend-prepared;
+- provenance-labeled;
+- caveated;
+- no browser NetCDF parsing;
+- no silent interpolation;
+- no hidden full-sequence reads for simple startup state.
+
+The endpoint implementation may be lazy, cached, or metadata-backed. The
+payload contract should remain stable even if the backend later introduces an
+output product manifest and caches.
+
+## Future Render-Ready Products
+
+Render-ready products are future artifacts for Render Studio or external
+renderers. They are not required for current Explore.
+
+Candidate render-ready products:
+
+- thresholded scalar point sets;
+- downsampled scalar volumes;
+- multiresolution `qc` volumes;
+- rain-water point/volume products;
+- reflectivity render arrays;
+- signed `w` updraft/downdraft products;
+- transfer-function metadata;
+- camera/render preset metadata;
+- provenance and interpretation labels.
+
+Render-ready products must state:
+
+- source field(s);
+- time index and time seconds;
+- grid and coordinate assumptions;
+- downsampling or thresholding method;
+- color/opacity transfer function;
+- whether the payload is exact, approximate, downsampled, or interpreted.
+
+Explore may keep using lightweight point and slice payloads. Render Studio, if
+built later, should consume explicit render-ready products rather than direct
+raw CM1 NetCDF.
+
+## Future Diagnostics Lab Boundary
+
+Diagnostics Lab is a future analysis surface for profiles, time-height plots,
+field time series, and process evidence.
+
+It should consume:
+
+- interesting-time products;
+- field catalog products;
+- vertical profile products;
+- time-height products;
+- selected-column products;
+- process-diagnostics products.
+
+It should not be implemented by making the React browser parse NetCDF or by
+turning Explore into a broad plotting cockpit.
+
+Python/xarray/hvPlot/Panel sidecar prototypes may be useful research later, but
+they should not become product dependencies until the product contract and
+workflow are accepted.
+
+## Future Render Studio Boundary
+
+Render Studio is a future optional visual-rendering surface. It is not the
+source of truth and should not displace Explore's scientific inspection role.
+
+Render Studio should depend on:
+
+- output product manifest;
+- render-ready products;
+- explicit cache and invalidation behavior;
+- provenance and interpretation labels;
+- browser memory constraints;
+- external renderer prototype evidence.
+
+Do not add vtk.js, trame, VAPOR, ParaView, Zarr, hvPlot, or Panel dependencies
+as part of this spec.
+
+## External Export Bundle Candidates
+
+External export bundles are opt-in derived products for tool-specific
+workflows.
+
+Candidate bundles:
+
+- VAPOR open/export package;
+- ParaView/VTK structured-grid package;
+- xarray analysis sidecar;
+- hvPlot/Panel diagnostics sidecar;
+- future Zarr derived store.
+
+Export bundles should record:
+
+- source result ID and run ID;
+- source raw files;
+- fields included;
+- times included;
+- coordinate assumptions;
+- conversion method;
+- generated file paths;
+- external tool/version target if known;
+- caveats;
+- cleanup behavior.
+
+They should be prototypes before Cloud Chamber commits to embedding a heavy
+renderer stack.
+
+## Cache, Storage, Invalidation, And Cleanup
+
+Output products live under the configured runtime home, not in the repository.
+
+They should be treated as generated local artifacts:
+
+- safe to rebuild when raw outputs and result metadata still exist;
+- eligible for cleanup through Storage policy;
+- never committed to git;
+- protected only when product policy explicitly says so.
+
+The output product manifest should record a cache key or fingerprint derived
+from:
+
+- result metadata version;
+- product manifest version;
+- source raw output file list;
+- source file sizes and modified times, or stronger hashes where practical;
+- product parameters such as field, time, threshold, orientation, level, and
+  downsampling method.
+
+Invalidation rules:
+
+- If `result_metadata.json` changes, derived products should be considered
+  stale unless their cache key still matches.
+- If source raw output files are missing or changed, dependent products should
+  be invalidated.
+- If product schema/version changes, products should be rebuilt or marked
+  stale.
+- If a run directory is deleted, products inside it are deleted too.
+- If products later move outside the run directory, Storage must still show the
+  relationship and cleanup impact clearly.
+
+Storage should show output-product artifacts as generated local data associated
+with a run/result. Results should not become a deletion surface. Explore should
+handle missing or stale products with retry/rebuild states when implementation
+exists.
+
+## Provenance And Caveats
+
+Every output product must carry enough provenance to answer:
+
+```text
+What CM1 run and result did this come from?
+Which raw files and fields contributed?
+What time and coordinate mapping was used?
+What processing was applied?
+What is direct model output versus derived interpretation?
+What caveats should the user know?
+```
+
+Minimum provenance:
+
+- source model;
+- run ID;
+- result ID;
+- scenario ID;
+- raw source file(s);
+- raw field name(s);
+- canonical field name(s);
+- time index and time seconds;
+- coordinate names and units;
+- processing method;
+- product version;
+- rendering method when visual;
+- source warnings/caveats.
+- field-quality assessment state for each field product, including explicit
+  not-assessed/not-tracked states when no trusted quality record exists.
+
+Common caveats:
+
+- inferred time coordinate;
+- inferred units;
+- missing target field;
+- non-finite values detected;
+- skipped/corrupt file;
+- downsampled payload;
+- native-grid view, no interpolation;
+- visualization interpretation, not source truth;
+- runtime stderr warning surfaced from CM1.
+
+## Results, Explore, And Storage Consumers
+
+Results should consume small result metadata, notebook state, diagnostics
+summaries, interesting-time summaries, and output-product availability. It
+should not fetch large field payloads just to list notebook entries.
+
+Explore should consume one selected result and one bounded field/time/selection
+payload at a time. It may use metadata-backed defaults and interesting-time
+products to open at useful frames. It should not parse raw NetCDF or request a
+full sequence just to load field availability.
+
+Storage should inventory raw outputs, logs, result metadata, result-card state,
+and generated output products as local runtime artifacts. It should explain
+which artifacts are source data, which are derived/cache, and what cleanup will
+remove.
+
+Future diagnostics and rendering surfaces should build on the output product
+manifest rather than inventing independent file discovery rules.
+
+## First Implementation Recommendation
+
+The first issue after this spec should implement:
+
+```text
+output product manifest skeleton
++ robust time index / interesting-time product
++ vertical profile and time-height product definitions
+```
+
+Suggested scope:
+
+- define a small output product manifest model;
+- write or expose a file/time mapping derived from existing result metadata and
+  model-output files;
+- populate interesting times from existing diagnostics where available;
+- define profile/time-height product records without computing heavy products;
+- add tests using tiny synthetic fixtures only;
+- update docs to point Results, Explore, Storage, future Diagnostics Lab, and
+  future Render Studio at the manifest.
+
+Non-goals for that first implementation:
+
+- no new renderer dependencies;
+- no UI redesign;
+- no external export implementation;
+- no heavy full-run derived arrays unless test fixtures prove the shape;
+- no raw NetCDF parsing in the browser.
+
+## PM Decisions Needed
+
+These decisions should be made before or during the first implementation issue:
+
+- Where should `output_product_manifest.json` live: inside each run directory,
+  inside a sibling derived-products directory, or both via pointer?
+- Should derived products be rebuilt automatically on demand, or only through
+  explicit product-build actions?
+- Which derived products should be retained if a future archive or keep-local-output mode is introduced?
+- What is the first supported binary/chunked payload format after JSON slices
+  become too large?
+- Which fields are MVP profile/time-height fields?
+- Should external VAPOR/ParaView/xarray export be an export action, an external
+  open action, or a separate local sidecar workflow?
+- What UI language should distinguish "raw output", "derived product", and
+  "render-ready product" without overwhelming the user?
+
+## Acceptance Checklist
+
+- Raw CM1 NetCDF output remains the source data.
+- Runtime logs/manifests remain distinct from result metadata.
+- Result metadata/notebook state remains distinct from output products.
+- Output product manifest is a generated local index, not a new physical source
+  of truth.
+- Derived scientific products are labeled with provenance and caveats.
+- Visualization-ready payloads are bounded backend products.
+- Future render-ready products are separated from current Explore payloads.
+- External export bundles are future derived artifacts, not embedded product
+  dependencies.
+- Multi-file output uses explicit global time-index mapping.
+- Basic field catalog/default loading must not read the full NetCDF sequence.
+- Selected time requests resolve through file/time mapping.
+- Browser code does not parse raw NetCDF.
+- Storage and cleanup understand generated products as local artifacts.
+- Diagnostics Lab and Render Studio boundaries remain future contracts.

--- a/docs/archive/contracts/realistic-les-input-specification-legacy.md
+++ b/docs/archive/contracts/realistic-les-input-specification-legacy.md
@@ -1,3 +1,9 @@
+# Archived Contract: Realistic LES Input Specification
+
+> **Status: Superseded product/data proposal**
+>
+> This document is preserved as historical design and implementation context. It is not an active implemented contract and does not establish current product direction, supported Recipe status, roadmap priority, MVP scope, or final application architecture. Current product semantics are defined in `docs/product/APPLICATION_SEMANTICS.md`.
+
 # Cloud Chamber Realistic LES Input Specification
 
 Issue: #213

--- a/docs/archive/contracts/run-recipe-and-story-mapping-legacy.md
+++ b/docs/archive/contracts/run-recipe-and-story-mapping-legacy.md
@@ -1,3 +1,9 @@
+# Archived Contract: Run Recipe And Story-Mapping
+
+> **Status: Historical mixed proposal contract**
+>
+> This document is preserved as historical design and implementation context. It is not an active implemented contract and does not establish current product direction, supported Recipe status, roadmap priority, MVP scope, or final application architecture. Current product semantics are defined in `docs/product/APPLICATION_SEMANTICS.md`.
+
 # Run Recipe And Story-Mapping Contract
 
 Status: forward product/data contract

--- a/docs/archive/contracts/sounding-candidate-screening-legacy.md
+++ b/docs/archive/contracts/sounding-candidate-screening-legacy.md
@@ -1,0 +1,348 @@
+# Archived Contract: Sounding Candidate Screening
+
+> **Status: Historical implemented/mixed contract**
+>
+> This document is preserved as historical design and implementation context. It is not an active implemented contract and does not establish current product direction, supported Recipe status, roadmap priority, MVP scope, or final application architecture. Current product semantics are defined in `docs/product/APPLICATION_SEMANTICS.md`.
+
+# Sounding Candidate Screening Contract
+
+Status: v1 product/data contract
+
+Cloud Chamber sounding candidates are pre-run hypotheses for choosing an
+observed atmosphere to try in CM1. They are not forecasts, verification, or
+proof that a run will form cloud, rain, or suppression. CM1 output remains the
+source of truth.
+
+The browser does not parse IGRA station text, ZIP archives, or raw NetCDF.
+Candidate screening and analysis are backend-owned and use cached IGRA station
+text plus runtime-local cache metadata.
+
+## Current Story Set
+
+The v1 candidate stories are:
+
+- `shallow_cumulus_candidate`
+- `dry_failed_candidate`
+- `capped_suppressed_candidate`
+- `humid_rainy_candidate`
+- `severe_thunderstorm_environment`
+- `supercell_environment`
+- `high_cape_pulse_storm`
+- `dry_microburst_inverted_v`
+- `squall_line_cold_pool_candidate`
+- `elevated_convection`
+- `needs_review`
+- `poor_or_incomplete_candidate`
+
+Visible labels may be friendlier, but every visible story must be backed by
+`story_scores`, feature values, evidence items, caveats, and package readiness.
+Deep-convection-oriented stories are pre-run hypotheses for Deep-Tower
+Benchmark routing, not outcome claims.
+
+## Feature Inputs
+
+The backend derives several feature groups from the selected IGRA sounding
+after converting source height to model height above the station. Not every
+derived or displayed field directly changes the story score.
+
+### Scoring Inputs
+
+The current story scores primarily use:
+
+- data completeness score
+- mean qv from 0-1000 m
+- estimated LCL
+- lapse rate from 0-1 km
+- inversion/cap strength proxy
+- moisture depth above a 6 g/kg qv threshold
+- low-level to midlevel qv drop / dry-layer proxy
+
+Missing scoring inputs weaken/caveat story support instead of being interpreted
+as meaningful physical zero values.
+
+### Evidence / Context Fields
+
+The candidate UI may also display these fields as evidence or context:
+
+- lowest usable model level
+- profile top
+- low-level qv
+- mean qv from 0-500 m
+- surface or lowest-level temperature-dewpoint spread
+- lapse rate from 0-3 km
+- cap height proxy
+- observed wind availability
+- midlevel lapse rate when available
+- bulk shear from 0-1, 0-3, and 0-6 km when observed winds exist
+- dry microburst / inverted-V proxy
+- freezing-level proxy
+- package readiness
+
+These fields help explain the sounding and package path. They do not directly
+drive story scores unless the implementation and tests are updated to say so.
+
+### Package-Readiness Fields
+
+Package readiness is determined by the observed-sounding parser and
+normalization path. It depends on station metadata and usable CM1-facing
+profile fields, including:
+
+- station elevation and model-z conversion
+- enough usable levels
+- profile top high enough for the selected domain
+- lowest usable level close enough to the model bottom
+- monotonic and finite converted levels
+- required thermodynamic fields
+- observed u/v wind components
+
+The current screen includes simple sounding-only CAPE, CIN, LFC, and EL
+proxies for Deep-Tower Benchmark opportunity scoring. It still does not compute
+storm-relative helicity, map/GIS forcing, or radar/precipitation predictors.
+Those require separate research, diagnostics, and validation before becoming
+product-facing evidence.
+
+### Deep-Tower Opportunity
+
+`deep_tower_opportunity` is an experimental 0-100 sounding heuristic for
+comparing possible Deep-Tower Benchmark cases. It is not a recipe
+recommendation, not a promise that the fixed stock `iinit = 3` benchmark will
+make a deep cloud, and not a replacement for severe/supercell story scores.
+High values may be used as optional sort evidence, but they must not drive
+automatic compute-spending advice.
+
+The score weights surface-based CAPE, mixed-layer CAPE, CIN, LFC, cap proxy,
+low-level moisture, deeper moisture, 0-3 km and midlevel lapse rates, profile
+completeness, and near-surface continuity. EL or buoyancy depth contributes
+only when the simple EL estimate is usable. Deep-layer shear receives little or
+no weight because this heuristic is scoped to possible cloud-depth ingredients,
+not storm organization. If the near-surface profile has a large discontinuity,
+the heuristic cannot surface as clean `supported` evidence; it uses mixed-layer
+CAPE rather than allowing one suspect lowest level to dominate.
+
+## Story Logic
+
+Scores are 0-100 candidate-selection aids. They are weighted heuristics, not
+probabilities. A score of `supported` means the available sounding-derived
+features support trying that story; it does not mean CM1 will produce that
+outcome.
+
+### Cloud-Forming Shallow Cumulus Candidate
+
+Scoring primarily uses:
+
+- moderate to high mean qv from 0-1 km
+- low to moderate estimated LCL
+- deeper moisture depth
+- weak to moderate cap proxy
+- useful low-level lapse rate
+- profile completeness
+
+Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
+estimated LCL, low-level and 0-3 km lapse rates, moisture depth, cap
+strength/height context, profile coverage, wind availability, and package
+readiness.
+
+Package readiness depends on the observed-sounding parser and normalization
+path, including usable model-z conversion, profile depth, required
+thermodynamic fields, and observed u/v winds.
+
+High support requires moisture, plausible LCL, thermal support, weak or
+moderate cap, and good data completeness. Missing moisture, LCL, lapse-rate,
+cap, or moisture-depth inputs caveat the score and push the candidate toward
+`needs_review`.
+
+### Dry Failed Cumulus Candidate
+
+Scoring primarily uses:
+
+- low mean qv from 0-1 km
+- high estimated LCL
+- shallow moisture depth
+- midlevel dry-layer proxy
+- useful low-level lapse rate
+- profile completeness
+
+Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
+estimated LCL, low-level and 0-3 km lapse rates, moisture depth, dry-layer
+proxy, profile coverage, wind availability, and package readiness.
+
+Package readiness depends on the observed-sounding parser and normalization
+path, including usable model-z conversion, profile depth, required
+thermodynamic fields, and observed u/v winds.
+
+Missing moisture is not treated as dry air. Missing qv, LCL, moisture-depth,
+or dry-layer inputs produce caveats and weak or unavailable support rather than
+a confident dry-failed label.
+
+### Capped / Suppressed Candidate
+
+Scoring primarily uses:
+
+- mean qv from 0-1 km
+- plausible estimated LCL
+- strong inversion/cap proxy
+- useful low-level lapse rate
+- profile completeness
+
+Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
+estimated LCL, low-level and 0-3 km lapse rates, cap strength, cap height,
+moisture depth, profile coverage, wind availability, and package readiness.
+
+Package readiness depends on the observed-sounding parser and normalization
+path, including usable model-z conversion, profile depth, required
+thermodynamic fields, and observed u/v winds.
+
+This story supports the hypothesis that moisture and thermals may exist but a
+stable layer could limit depth. It does not prove that CM1 will suppress cloud
+growth.
+
+### Humid / Rainy Candidate
+
+Scoring primarily uses:
+
+- high mean qv from 0-1 km
+- low estimated LCL
+- deep moisture
+- weak cap proxy
+- profile completeness
+
+Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread, LCL,
+low-level and 0-3 km lapse rates, moisture depth, weak-cap support, profile
+coverage, wind availability, and package readiness.
+
+Package readiness depends on the observed-sounding parser and normalization
+path, including usable model-z conversion, profile depth, required
+thermodynamic fields, and observed u/v winds.
+
+This story is deliberately caveated because current packages still use
+idealized local forcing. It should be read as “humid atmosphere worth trying,”
+not as a rain forecast.
+
+Future predicted-output language belongs in
+[Analyzer Hypothesis And Output-Signature Contract](analyzer-hypothesis-output-signature.md).
+Until that contract is implemented, this screen emits ingredient/screening
+scores and recipe-fit caveats, not output predictions.
+The bridge from story IDs to explicit CM1 run recipes is defined in
+[Run Recipe And Story-Mapping Contract](run-recipe-and-story-mapping.md).
+
+### Needs Review
+
+Scoring primarily uses:
+
+- weak data completeness
+- missing story-driving features
+- screening uncertainty
+- package-ready profiles whose evidence is not strong enough for a clear story
+
+Evidence also shows whatever profile, moisture, stability, wind, and
+package-readiness context is available.
+
+`needs_review` can still be package-ready. It means the sounding may be worth
+manual inspection, not that it is unusable.
+
+### Poor Or Incomplete Candidate
+
+Scoring primarily uses:
+
+- blocked package generation
+
+Package readiness depends on:
+
+- missing station elevation or unsafe height conversion
+- too few usable levels
+- profile top too low for the selected domain
+- lowest usable level too far above model bottom
+- nonmonotonic or nonfinite converted levels
+- missing required observed winds
+
+Evidence also shows any available profile, moisture, stability, wind, and
+package-readiness context so the UI can explain why the candidate is blocked.
+
+Poor/incomplete candidates are not package-ready in the current path. They may
+still be useful after parser, station metadata, or profile-quality improvements,
+but the UI must show why they are blocked.
+
+## Missing Data Rules
+
+Missing physical evidence is not interpreted as a physical condition. For
+example:
+
+- missing qv is not dry air;
+- missing LCL is not a high LCL;
+- missing cap proxy is not a weak cap;
+- missing wind is a package-readiness blocker for the current external-sounding
+  path.
+
+Missing features become score caveats and evidence caveats. Blocked parser or
+normalization states become `poor_or_incomplete_candidate`.
+
+## Package Readiness
+
+A package-ready candidate has a selected observed sounding payload that can
+enter the current external-sounding package path. Package readiness depends on
+the parser and normalization contract, including station elevation, model-z
+conversion, profile depth, required thermodynamic fields, and observed u/v wind
+components.
+
+Candidate screening metadata may be copied into `run_manifest.json`,
+`case_manifest.json`, and `dry_run_report.json` as provenance when a candidate
+is used to create a package. If the candidate was saved with tags or notes,
+those annotations may also be copied into package user metadata and run-status
+payloads so the generated package remains tied to the reason it was selected.
+
+## UI Contract
+
+Candidate cards and details must keep this language:
+
+- Screening guidance only.
+- Candidate ingredient/screening scores rank sounding ingredients only.
+- Scores do not predict what the current CM1 package will produce.
+- CM1 decides what actually happens.
+
+The backend analysis API owns default recommendations, interest reasons,
+discovery buckets, story/story-family/support/readiness/station-search
+refinements, and sort-key ordering. The default UI should answer which cached
+soundings are interesting and why before exposing advanced refinements. It must
+display the backend-returned candidate list rather than parsing raw sounding
+files or recomputing story scores in the browser. Analysis must include
+secondary story scores when `story_scores` contain meaningful support for the
+selected story or selected story family. Story-family filtering, support
+filtering, and highest-ingredient-score sorting must use the same family-scoped `story_scores`
+set, so a sounding with a lower-atmosphere primary story can still appear as a
+deep-convection recommendation when a secondary deep-convection score has
+meaningful support. Missing feature values must remain unavailable/caveated and
+sort last instead of becoming zero-valued evidence. The UI must not show a
+confident story label without evidence, caveats, and package readiness.
+The workbench should also show a minimal experiment-fit status, such as
+`testable_now`, `partially_testable`, `requires_surface_forcing_recipe`, or
+`blocked_profile`, so candidate interest remains separate from what the current
+run configuration can actually test.
+
+Saved candidates may carry freeform tags and notes such as `Deep convection
+candidates`, `Surface-forced candidates`, `Needs longer run`, `Needs finer
+output cadence`, `Maybe rerun`, and `Needs review`. These annotations are
+runtime-local pre-run organization metadata; they are not Results and are not
+committed.
+
+## Testing Contract
+
+Automated tests use tiny synthetic IGRA-style fixtures or direct deterministic
+feature dictionaries. Tests must not fetch live NOAA/NCEI data, run CM1, parse
+station text in the browser, or commit cached station files.
+
+Tests should prove:
+
+- every current story can be produced deterministically;
+- every story has reasons and evidence;
+- missing features caveat or weaken support instead of producing confident
+  labels;
+- backend analysis works across multiple cached sounding blocks;
+- physical-field sorting keeps missing values last;
+- default recommendations and interest reasons are backend-owned;
+- story, support, and readiness refinements are backend-owned;
+- saved tags and notes round-trip through runtime-local JSON;
+- saved tags and notes follow a used candidate into package metadata;
+- poor/incomplete candidates are blocked from package generation;
+- package-ready but weak profiles become `needs_review`;
+- candidate-screening provenance is copied into generated package metadata
+  when provided.

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -1,818 +1,234 @@
-# Cloud Chamber Output Product Specification
-
-Issue: #214
-
-Status: v1 product/data contract
-
-Source context:
-
-- #210 output and visualization architecture research
-- #215 deep-output Explore timeout fix
-- current NetCDF ingest, Result Card, Explore, Storage, and selected-region
-  diagnostics behavior
-
-This specification defines what Cloud Chamber may produce from completed CM1
-output before more rendering, diagnostics, export, or UI surfaces are added.
-It is a contract between backend ingest, Results, Explore, Storage, future
-Diagnostics Lab, future Render Studio, docs, and tests.
-
-It does not implement new output products.
-
-## Executive Contract
-
-CM1 NetCDF output remains the source data. Cloud Chamber output products are
-derived local records or bounded payloads that make completed CM1 runs easier
-to inspect, explain, compare, render, cache, or export.
-
-The browser must not parse raw NetCDF. It should request backend-owned,
-provenance-labeled products with explicit size, time, field, and processing
-boundaries.
-
-The next implementation should create:
-
-```text
-output product manifest skeleton
-+ robust file/time index mapping
-+ interesting-time products
-+ profile/time-height product definitions
-```
-
-That should happen before adding new renderer dependencies, Render Studio,
-Diagnostics Lab, or external export workflows.
-
-## Artifact Classes
-
-| Artifact class | What it is | Source of truth? | Typical owner | Browser access |
-| --- | --- | --- | --- | --- |
-| Raw CM1 NetCDF output | `cm1out_*.nc` model-field files and `cm1out_stats.nc` stats files written by CM1 | Yes, for model fields | CM1 / local runtime directory | Never directly |
-| Runtime logs/manifests | `run_manifest.json`, `case_manifest.json`, `stdout.log`, `stderr.log`, package inputs, runtime checklist | Yes, for run configuration and execution state | Build / local run manager | Only summarized through API |
-| Result metadata / notebook state | `result_metadata.json` plus optional `result_card.json` | Source for ingested metadata and notebook state, not raw model values | Ingest / Results | Through Results API |
-| Output product manifest | Generated index of derived products, time mapping, cache keys, and provenance | Source for derived-product availability, not raw model values | Backend product builder | Through bounded API summaries |
-| Derived scientific products | Diagnostics, profiles, time-height arrays, selected-place summaries, interesting times | Derived from raw output and metadata | Backend diagnostics/product layer | Bounded JSON or future binary payloads |
-| Visualization-ready payloads | Field catalogs, slices, point clouds, defaults, selected-region evidence | Derived request payloads for Explore | Backend visualization/data layer | Yes, bounded and provenance-labeled |
-| Future render-ready products | Multiresolution volumes, transfer-function metadata, scalar/signed-flow arrays | Derived, cacheable render inputs | Future Render Studio backend | Only through render APIs, not raw NetCDF |
-| External export bundles | VAPOR, ParaView/VTK, xarray/hvPlot/Panel, or future Zarr sidecars | Derived/export copies, not source truth | Future export jobs | Download/open workflow only |
-
-## Source Of Truth And Browser / Backend Boundary
-
-CM1 is the high-fidelity model. Raw CM1 NetCDF files, run manifests, and logs
-are the durable local evidence for what ran and what CM1 produced.
-
-Cloud Chamber may create derived products, but those products must remain
-clearly labeled as:
-
-- diagnostics derived from CM1 output;
-- visualization interpretations of CM1 output;
-- cached local products that can become stale or be deleted;
-- export bundles for external tools.
-
-The backend owns:
-
-- NetCDF/xarray access;
-- file/time mapping;
-- field selection;
-- finite/non-finite checks;
-- unit and coordinate interpretation;
-- downsampling and bounded payload construction;
-- provenance and caveat construction.
-
-The browser owns:
-
-- user selection state;
-- requesting one bounded product at a time;
-- rendering received payloads;
-- displaying provenance and caveats;
-- never treating visualization as a new physical source of truth.
-
-The browser must not:
-
-- open raw NetCDF files;
-- infer multi-file time mapping on its own;
-- compute global scientific diagnostics from raw field arrays;
-- silently invent fields, units, coordinates, or physical explanations.
-
-## Multi-File Output And Time-Index Mapping
-
-CM1 runs can produce many model-output NetCDF files. Cloud Chamber must treat
-the model run as one time sequence, even when each output time is written to a
-separate file.
-
-The output product manifest should define a global output-time index:
-
-```json
-{
-  "time_index": 12,
-  "time_seconds": 7200.0,
-  "source_file": "<runtime-home>/runs/<run-id>/cm1out_000013.nc",
-  "source_file_kind": "model_output_netcdf",
-  "local_time_index": 0,
-  "time_source": "netcdf_time_coordinate",
-  "time_caveats": []
-}
-```
-
-Rules:
-
-- `cm1out_stats.nc` is not a model-field time-series file.
-- Model-output files must be sorted by direct time coordinate when available,
-  otherwise by validated output index.
-- `time_index` is the global model-output index used by Results, Explore,
-  comparison views, diagnostics, and future renderer products.
-- `local_time_index` is the index inside the source file after the global time
-  is resolved.
-- Selected timestep requests must resolve through this mapping before any
-  NetCDF file is opened.
-- A selected timestep request should open only the required file when the
-  mapping proves that the file contains that timestep.
-- If files contain multiple timesteps, the mapping should preserve both global
-  and local indices.
-- Missing, corrupt, skipped, inferred, duplicated, or non-monotonic times must
-  become caveats.
-
-### #215 Performance Lesson
-
-Field catalogs and default view state should be served from ingested metadata or
-bounded derived products whenever possible.
-
-Basic Explore startup must not trigger raw full-sequence NetCDF parsing. The
-field catalog, field availability, broad time range, and default-interesting
-time should be metadata-backed or product-backed. Slice and point-cloud
-requests for a selected time should use the explicit file/time mapping to open a
-bounded source, not concatenate the full output sequence per request.
-
-## Output Product Manifest
-
-Cloud Chamber should introduce an output product manifest as a generated,
-local, rebuildable index for output-derived products.
-
-It is distinct from:
-
-- `run_manifest.json`, which records generated package and execution state;
-- `result_metadata.json`, which records ingested result metadata and first-pass
-  diagnostics;
-- `result_card.json`, which records notebook/user state.
-
-Draft manifest shape:
-
-```json
-{
-  "manifest_version": 1,
-  "product_manifest_id": "output-products-<result-id>",
-  "result_id": "result-<run-id>",
-  "run_id": "<run-id>",
-  "scenario_id": "baseline-shallow-cumulus",
-  "source_model": "CM1",
-  "source_result_metadata_path": ".../result_metadata.json",
-  "source_run_manifest_path": ".../run_manifest.json",
-  "source_raw_outputs": {
-    "model_output_files": [],
-    "stats_files": [],
-    "raw_cm1_artifacts": []
-  },
-  "time_index": [],
-  "field_catalog_product": {},
-  "interesting_time_product": {},
-  "products": [],
-  "cache": {
-    "product_root": ".../derived-products",
-    "cache_key": "result-metadata-and-source-output-fingerprint",
-    "invalidated": false
-  },
-  "provenance": {},
-  "caveats": [],
-  "created_at": "2026-06-29T00:00:00Z",
-  "updated_at": "2026-06-29T00:00:00Z"
-}
-```
-
-The manifest should record what products exist, how they were made, what source
-files they depend on, and how to invalidate or delete them. It should not copy
-large raw NetCDF files into the repository or make derived products appear more
-authoritative than CM1 output.
-
-Implementation note: the first backend foundation for this contract lives in
-`cloud_chamber.output_products`. Ingested results now write a runtime-local
-`derived-products/output_product_manifest.json` beside the run directory's
-result metadata. That manifest currently focuses on source output references
-and global file/time index mapping; later product records should build on it
-rather than inventing separate time addressing.
-
-## Product Type Decisions
-
-| Product type | When computed | Format now | Future format | Size class | API owner | Frontend consumer |
-| --- | --- | --- | --- | --- | --- | --- |
-| File/time index | At ingest or first product-build pass | JSON | JSON | small | backend ingest/product layer | Results, Explore, Storage, tests |
-| Interesting times | At ingest or first product-build pass | JSON | JSON | small | diagnostics/product layer | Results, Explore, future Compare |
-| Field catalog | At ingest or metadata-backed request | JSON | JSON | small | visualization/product layer | Explore, future Compare, future Render Studio |
-| Slice products | Lazy request, optionally cached | JSON numeric arrays | binary or chunked arrays for large slices | small to medium | visualization API | Explore, future Compare |
-| Vertical profiles | Lazy or cached from selected fields | JSON arrays | binary/chunked for long sequences | small to medium | diagnostics/product API | future Diagnostics Lab, Explore evidence |
-| Time-height products | Cached derived product | JSON for tiny fixtures | binary/chunked arrays | medium | diagnostics/product API | future Diagnostics Lab |
-| Selected-point/column products | Lazy bounded request, optionally cached | JSON summaries/arrays | JSON plus binary arrays if needed | small to medium | selected-region diagnostics API | Explore `What happened here?` |
-| Render-ready products | Cached explicit build | none yet | binary float32, multiresolution, or chunked store | medium to large | future render-product API | future Render Studio |
-| External export bundles | Explicit user/export job | none yet | tool-specific files | medium to large | future export API/job | external apps |
-
-## Interesting-Time Products
-
-Interesting-time products provide small, reusable time landmarks for Results,
-Explore, comparison, diagnostics, and future time-lapse rendering.
-
-Near-term interesting times:
-
-- first cloud;
-- max `qc`;
-- max updraft `w`;
-- min downdraft `w`;
-- highest liquid cloud-water top from `qc`;
-- highest coherent cloud-object top from supported, vertically connected `qc`, `qr`, `qi`, `qs`, and `qg` levels when present;
-- highest raw hydrometeor trace top from any `qc`, `qr`, `qi`, `qs`, or `qg` threshold crossing;
-- rain-water onset from `qr`;
-- max rain water aloft from `qr`;
-- max `dbz`;
-- max surface rain;
-- selected-time fallback such as latest output.
-
-Each interesting time should include:
-
-```json
-{
-  "key": "max_qc",
-  "label": "Max cloud water",
-  "time_index": 3,
-  "time_seconds": 2700.0,
-  "field": "qc",
-  "value": 0.0028,
-  "units": "kg/kg",
-  "source": "diagnostics.max_qc",
-  "confidence": "supported",
-  "caveats": []
-}
-```
-
-Interesting-time products should not require opening the full NetCDF sequence
-when a user merely opens Explore. They should be computed from existing
-diagnostics, stored product summaries, or a bounded product-build pass.
-
-The first implementation stores an `interesting_time_product` in the runtime
-output product manifest and mirrors compact fields into `result_metadata.json`:
-`interesting_times`, `default_time_by_field`, `science_summary`, and
-`interesting_time_caveats`. It uses the output-product manifest time index plus
-existing CM1-derived diagnostics; it does not build a second time index and it
-does not ask the browser to parse NetCDF. The science summary also carries the
-backend-owned low-level `qv` and theta/temperature response diagnostics when
-available, including early 30-90 minute forcing-response deltas and separate
-full-run deltas from 0-1 km AGL thickness-weighted domain means. Early and
-full-run response availability are exposed separately so consumers do not treat
-bad final-output evolution evidence as a missing early forcing response. Missing
-fields, no-event outcomes, and diagnostics that are not implemented yet are
-represented explicitly with support states such as
-`unavailable`, `unsupported_missing_fields`, and
-`unsupported_missing_diagnostic` rather than silently falling back to a
-misleading cloud/rain-water landmark.
-
-Interesting-time records, field defaults, diagnostic availability records, and
-science summaries may carry target-field `field_quality` metadata for `qc`, `w`,
-`qr`, surface `rain`, `dbz`, `hfx`, and `qfx`, plus present ice/snow/graupel
-fields when they contribute to cloud-top diagnostics. Entirely non-finite source
-fields are `untrusted` and must not produce supported landmarks or clean
-comparison evidence. Partially non-finite fields may remain usable only with
-visible caveats and finite/non-finite counts.
-
-Triggered deep-potential results extend the same product with backend-owned
-summary fields for deep-cloud formation, first deep-convection time, strong
-updraft detection, liquid cloud-water top, coherent cloud-object top, raw
-hydrometeor trace top, rain-water onset, max `qr`, and the default Explore time.
-The deep-cloud classifier must use coherent cloud-object top, not an isolated raw
-hydrometeor trace. The product must not use a generic "cloud top" label when the
-value comes from the broader trace envelope rather than visible `qc` alone.
-
-Unsupported severe-storm diagnostics such as reflectivity maxima, surface-rain
-maxima, updraft-depth proxy, cold-pool proxy, and near-surface theta
-perturbation proxy must be recorded as unavailable or caveated until a supported
-backend diagnostic exists. When candidate-screening metadata is
-present, result metadata may include a compact `candidate_hypothesis_comparison`
-with `Screened as`, `Ran as`, `CM1 outcome`, match state, evidence, and caveats.
-The comparison uses simple v1 rules and remains a post-run interpretation of
-CM1 output, not proof that the observed sounding was validated in advance.
-
-## Field Catalog Products
-
-The field catalog answers:
-
-```text
-What fields are available for this result, and what can Cloud Chamber safely do
-with each one?
-```
-
-The field catalog should include:
-
-- raw field name;
-- canonical field name;
-- display name;
-- units;
-- dimensions;
-- coordinate names;
-- native grid;
-- shape;
-- time availability;
-- direct vs inferred coordinate caveats;
-- supported product capabilities:
-  - slice;
-  - point cloud;
-  - selected point;
-  - selected column;
-  - profile;
-  - time-height;
-  - render-ready candidate;
-  - export candidate;
-- frontend consumer guidance;
-- provenance.
-
-The current implementation exposes these as backend-owned field metadata on the
-visualization field-catalog API. Each available field includes conservative
-capability flags for slice, point-cloud, selected-point, selected-column,
-profile, time-height, render-ready-candidate, and external-export-candidate
-use. Known fields that were expected by the run but absent from ingested NetCDF
-metadata are returned as unavailable fields with caveats; arbitrary unknown raw
-fields are not exposed as supported catalog entries.
-
-Example:
-
-```json
-{
-  "raw_field_name": "qc",
-  "canonical_field_name": "cloud_water",
-  "display_name": "Cloud water",
-  "units": "kg/kg",
-  "dimensions": ["time", "zh", "yh", "xh"],
-  "native_grid": "cell_center",
-  "coordinates": {"time": "time", "z": "zh", "y": "yh", "x": "xh"},
-  "capabilities": {
-    "slice": true,
-    "point_cloud": true,
-    "selected_point": true,
-    "selected_column": true,
-    "profile": true,
-    "time_height": true,
-    "render_ready_candidate": true,
-    "external_export_candidate": true
-  },
-  "provenance": {
-    "source_model": "CM1",
-    "processing_method": "ingested_result_metadata_field_catalog"
-  },
-  "caveats": []
-}
-```
-
-## Slice Products
-
-Slice products are the current everyday Explore payload. They provide one
-native-grid 2-D field view for one result, field, global time index,
-orientation, and level/index.
-
-Supported MVP orientations:
-
-- horizontal layer;
-- vertical `x-z` slice;
-- vertical `y-z` slice;
-- surface 2-D field when the field is already surface-native.
-
-Rules:
-
-- Use native grids first.
-- Do not interpolate staggered fields unless a future product explicitly says
-  so.
-- Preserve native coordinate names and units.
-- Include display-friendly coordinate values where safe.
-- Include min, max, mean, finite count, non-finite count, and caveats.
-- Include the global `time_index`, `time_seconds`, source file, and local time
-  index when available.
-- JSON arrays are acceptable for MVP-size slices.
-- Larger slices may require binary arrays or a chunked product later.
-
-## Vertical Profile Products
-
-Vertical profile products summarize a field as a function of height for a
-selected time, selected column, region, or domain.
-
-Candidate profiles:
-
-- domain mean/min/max `qv`, temperature, potential temperature, pressure;
-- selected-column `qc`, `qr`, `qv`, `w`, temperature, potential temperature;
-- profile at selected point/column for `What happened here?`;
-- cloud-base/cloud-top-relevant vertical summaries.
-
-Profile products should preserve:
-
-- field units;
-- vertical coordinate units;
-- height conversion where safe;
-- selected horizontal coordinate/index;
-- aggregation method;
-- caveats for missing or inferred coordinates.
-
-The current backend skeleton exposes bounded vertical profile products through
-the result output-products API. Supported MVP aggregations are domain mean,
-domain min, domain max, and selected column for profile-capable 3-D fields.
-Payloads include the global output `time_index`, resolved local source-file
-index when the output product manifest is available, vertical coordinate values,
-finite/non-finite counts, field-quality metadata, provenance, and caveats.
-Surface-only fields such as surface rain and surface fluxes remain unavailable
-for vertical profiles rather than being reshaped into misleading columns.
-
-## Time-Height Products
-
-Time-height products summarize evolution across output times and vertical
-levels. They are the likely bridge from Explore to a future Diagnostics Lab.
-
-Candidate time-height products:
-
-- cloud fraction by time and height;
-- max `qc` by time and height;
-- max/min `w` by time and height;
-- domain mean `qv` by time and height;
-- domain mean temperature/potential temperature by time and height;
-- selected-column cloud-water time-height;
-- cloud-base/cloud-top time series.
-
-Rules:
-
-- These products should be computed by backend jobs or bounded product builders,
-  not by the browser.
-- They should include direct/inferred time caveats and coordinate metadata.
-- They should be cacheable because they may require reading the full sequence.
-- JSON is acceptable for tiny fixtures; binary/chunked formats should be
-  considered for real deep outputs.
-
-The current backend skeleton exposes time-height products for time-height-capable
-3-D fields. Supported MVP aggregations are domain mean, domain min, domain max,
-and cloud fraction for `qc` using the documented cloud-water threshold. Payloads
-include global output time indices, source-file/local-time mappings when
-available, vertical coordinates, shape and size class, finite/non-finite counts,
-field-quality metadata, provenance, and caveats. The browser consumes the
-bounded payload only; it does not parse raw NetCDF.
-
-## Evolved-Run Time-Series Products
-
-Simple time-series products summarize scalar evolution across saved output
-times. Initial supported aggregations are domain max, domain mean, domain min,
-and cloud fraction where the field supports it. These products cover current
-MVP fields such as surface rain, rain water aloft, reflectivity, cloud water,
-`u` / `v` / `w` wind components, surface sensible/latent heat flux, and other
-known field-catalog entries when present.
-
-Missing fields must return an unavailable/caveated catalog state or a clear
-product error, not a guessed scientific result. Boundary-layer-depth and
-mixed-layer-depth style products remain future diagnostics until a defensible
-method is documented and tested.
-
-Field-product payloads must be self-describing. Vertical profile, time-height,
-time-series, native slice, and point-cloud payloads carry a `field_quality`
-object for the requested raw field when diagnostics can evaluate it. The object
-records whether quality was assessed, the source field, quality state, finite
-count, non-finite count, total count, reason, and quality caveats. Tracked fields
-use the current `qc`, `w`, `qr`, surface `rain`, `dbz`, `hfx`, and `qfx`
-diagnostic quality records. Untracked fields such as `qv` must
-explicitly report that field quality is not tracked rather than implying trusted
-status. Older results or partial metadata with no assessment signal must report
-`assessed = false`; only an explicit assessed `trusted` field-quality record is
-trusted evidence.
-
-Wind-component products are scalar summaries of native-grid CM1 `u` and `v`
-components. They may support vertical profiles and time-height products when
-the fields and coordinates are present, but they must carry native staggered-grid
-and no-vector-interpolation caveats. They are not wind gust, outflow, rotation,
-or storm-organization diagnostics. Near-surface wind time-series products remain
-explicitly unavailable until the lowest-level selection method is defined and
-tested.
-
-## Selected-Point And Selected-Column Products
-
-Selected-place products power the user-facing question:
-
-```text
-What happened here?
-```
-
-Supported or near-term selections:
-
-- selected point from a 2-D slice;
-- selected vertical column;
-- selected small 2-D region;
-- selected 3-D box later;
-- selected cloud object later;
-- selected updraft core later.
-
-Selected-point product requirements:
-
-- selected field and value;
-- selected time;
-- selected native-grid indices;
-- selected physical coordinates;
-- local `qc`, `w`, and optional `qr` summaries;
-- comparison to domain where practical;
-- conservative explanation label;
-- caveats;
-- source fields and processing method.
-
-Selected-column product requirements:
-
-- column profile at selected time;
-- local time history where practical;
-- first local cloud time;
-- local max `qc`;
-- local max/min `w`;
-- local rain-water onset when `qr` exists;
-- cloud-base/cloud-top evidence where supported.
-
-These products should not become cloud-object tracking unless a future issue
-adds object definitions and validation.
-
-## Visualization-Ready Payloads
-
-Visualization-ready payloads are small request/response products consumed by
-Explore and comparison views.
-
-Current examples:
-
-- field catalog;
-- view/defaults payload;
-- slice payload;
-- point-cloud payload;
-- selected-region diagnostics payload.
-
-Contract:
-
-- bounded in size;
-- backend-prepared;
-- provenance-labeled;
-- caveated;
-- no browser NetCDF parsing;
-- no silent interpolation;
-- no hidden full-sequence reads for simple startup state.
-
-The endpoint implementation may be lazy, cached, or metadata-backed. The
-payload contract should remain stable even if the backend later introduces an
-output product manifest and caches.
-
-## Future Render-Ready Products
-
-Render-ready products are future artifacts for Render Studio or external
-renderers. They are not required for current Explore.
-
-Candidate render-ready products:
-
-- thresholded scalar point sets;
-- downsampled scalar volumes;
-- multiresolution `qc` volumes;
-- rain-water point/volume products;
-- reflectivity render arrays;
-- signed `w` updraft/downdraft products;
-- transfer-function metadata;
-- camera/render preset metadata;
-- provenance and interpretation labels.
-
-Render-ready products must state:
-
-- source field(s);
-- time index and time seconds;
-- grid and coordinate assumptions;
-- downsampling or thresholding method;
-- color/opacity transfer function;
-- whether the payload is exact, approximate, downsampled, or interpreted.
-
-Explore may keep using lightweight point and slice payloads. Render Studio, if
-built later, should consume explicit render-ready products rather than direct
-raw CM1 NetCDF.
-
-## Future Diagnostics Lab Boundary
-
-Diagnostics Lab is a future analysis surface for profiles, time-height plots,
-field time series, and process evidence.
-
-It should consume:
-
-- interesting-time products;
-- field catalog products;
-- vertical profile products;
-- time-height products;
-- selected-column products;
-- process-diagnostics products.
-
-It should not be implemented by making the React browser parse NetCDF or by
-turning Explore into a broad plotting cockpit.
-
-Python/xarray/hvPlot/Panel sidecar prototypes may be useful research later, but
-they should not become product dependencies until the product contract and
-workflow are accepted.
-
-## Future Render Studio Boundary
-
-Render Studio is a future optional visual-rendering surface. It is not the
-source of truth and should not displace Explore's scientific inspection role.
-
-Render Studio should depend on:
-
-- output product manifest;
-- render-ready products;
-- explicit cache and invalidation behavior;
-- provenance and interpretation labels;
-- browser memory constraints;
-- external renderer prototype evidence.
-
-Do not add vtk.js, trame, VAPOR, ParaView, Zarr, hvPlot, or Panel dependencies
-as part of this spec.
-
-## External Export Bundle Candidates
-
-External export bundles are opt-in derived products for tool-specific
-workflows.
-
-Candidate bundles:
-
-- VAPOR open/export package;
-- ParaView/VTK structured-grid package;
-- xarray analysis sidecar;
-- hvPlot/Panel diagnostics sidecar;
-- future Zarr derived store.
-
-Export bundles should record:
-
-- source result ID and run ID;
-- source raw files;
-- fields included;
-- times included;
-- coordinate assumptions;
-- conversion method;
-- generated file paths;
-- external tool/version target if known;
-- caveats;
-- cleanup behavior.
-
-They should be prototypes before Cloud Chamber commits to embedding a heavy
-renderer stack.
-
-## Cache, Storage, Invalidation, And Cleanup
-
-Output products live under the configured runtime home, not in the repository.
-
-They should be treated as generated local artifacts:
-
-- safe to rebuild when raw outputs and result metadata still exist;
-- eligible for cleanup through Storage policy;
-- never committed to git;
-- protected only when product policy explicitly says so.
-
-The output product manifest should record a cache key or fingerprint derived
-from:
-
-- result metadata version;
-- product manifest version;
-- source raw output file list;
-- source file sizes and modified times, or stronger hashes where practical;
-- product parameters such as field, time, threshold, orientation, level, and
-  downsampling method.
-
-Invalidation rules:
-
-- If `result_metadata.json` changes, derived products should be considered
-  stale unless their cache key still matches.
-- If source raw output files are missing or changed, dependent products should
-  be invalidated.
-- If product schema/version changes, products should be rebuilt or marked
-  stale.
-- If a run directory is deleted, products inside it are deleted too.
-- If products later move outside the run directory, Storage must still show the
-  relationship and cleanup impact clearly.
-
-Storage should show output-product artifacts as generated local data associated
-with a run/result. Results should not become a deletion surface. Explore should
-handle missing or stale products with retry/rebuild states when implementation
-exists.
-
-## Provenance And Caveats
-
-Every output product must carry enough provenance to answer:
-
-```text
-What CM1 run and result did this come from?
-Which raw files and fields contributed?
-What time and coordinate mapping was used?
-What processing was applied?
-What is direct model output versus derived interpretation?
-What caveats should the user know?
-```
-
-Minimum provenance:
-
-- source model;
-- run ID;
-- result ID;
-- scenario ID;
-- raw source file(s);
-- raw field name(s);
-- canonical field name(s);
-- time index and time seconds;
-- coordinate names and units;
-- processing method;
-- product version;
-- rendering method when visual;
-- source warnings/caveats.
-- field-quality assessment state for each field product, including explicit
-  not-assessed/not-tracked states when no trusted quality record exists.
-
-Common caveats:
-
-- inferred time coordinate;
-- inferred units;
-- missing target field;
-- non-finite values detected;
-- skipped/corrupt file;
-- downsampled payload;
-- native-grid view, no interpolation;
-- visualization interpretation, not source truth;
-- runtime stderr warning surfaced from CM1.
-
-## Results, Explore, And Storage Consumers
-
-Results should consume small result metadata, notebook state, diagnostics
-summaries, interesting-time summaries, and output-product availability. It
-should not fetch large field payloads just to list notebook entries.
-
-Explore should consume one selected result and one bounded field/time/selection
-payload at a time. It may use metadata-backed defaults and interesting-time
-products to open at useful frames. It should not parse raw NetCDF or request a
-full sequence just to load field availability.
-
-Storage should inventory raw outputs, logs, result metadata, result-card state,
-and generated output products as local runtime artifacts. It should explain
-which artifacts are source data, which are derived/cache, and what cleanup will
-remove.
-
-Future diagnostics and rendering surfaces should build on the output product
-manifest rather than inventing independent file discovery rules.
-
-## First Implementation Recommendation
-
-The first issue after this spec should implement:
-
-```text
-output product manifest skeleton
-+ robust time index / interesting-time product
-+ vertical profile and time-height product definitions
-```
-
-Suggested scope:
-
-- define a small output product manifest model;
-- write or expose a file/time mapping derived from existing result metadata and
-  model-output files;
-- populate interesting times from existing diagnostics where available;
-- define profile/time-height product records without computing heavy products;
-- add tests using tiny synthetic fixtures only;
-- update docs to point Results, Explore, Storage, future Diagnostics Lab, and
-  future Render Studio at the manifest.
-
-Non-goals for that first implementation:
-
-- no new renderer dependencies;
-- no UI redesign;
-- no external export implementation;
-- no heavy full-run derived arrays unless test fixtures prove the shape;
-- no raw NetCDF parsing in the browser.
-
-## PM Decisions Needed
-
-These decisions should be made before or during the first implementation issue:
-
-- Where should `output_product_manifest.json` live: inside each run directory,
-  inside a sibling derived-products directory, or both via pointer?
-- Should derived products be rebuilt automatically on demand, or only through
-  explicit product-build actions?
-- Which derived products should be retained if a future archive or keep-local-output mode is introduced?
-- What is the first supported binary/chunked payload format after JSON slices
-  become too large?
-- Which fields are MVP profile/time-height fields?
-- Should external VAPOR/ParaView/xarray export be an export action, an external
-  open action, or a separate local sidecar workflow?
-- What UI language should distinguish "raw output", "derived product", and
-  "render-ready product" without overwhelming the user?
-
-## Acceptance Checklist
-
-- Raw CM1 NetCDF output remains the source data.
-- Runtime logs/manifests remain distinct from result metadata.
-- Result metadata/notebook state remains distinct from output products.
-- Output product manifest is a generated local index, not a new physical source
-  of truth.
-- Derived scientific products are labeled with provenance and caveats.
-- Visualization-ready payloads are bounded backend products.
-- Future render-ready products are separated from current Explore payloads.
-- External export bundles are future derived artifacts, not embedded product
-  dependencies.
-- Multi-file output uses explicit global time-index mapping.
-- Basic field catalog/default loading must not read the full NetCDF sequence.
-- Selected time requests resolve through file/time mapping.
-- Browser code does not parse raw NetCDF.
-- Storage and cleanup understand generated products as local artifacts.
-- Diagnostics Lab and Render Studio boundaries remain future contracts.
+# Output Product Specification
+
+**Status:** Implemented contract
+
+## Purpose
+
+This contract documents the current implemented output-product behavior for
+ingested CM1 results: runtime-local metadata, derived output-product manifests,
+backend diagnostics, and bounded browser-facing visualization payloads.
+
+## Authority Boundary
+
+This is a current implementation contract. It does not define final product
+architecture, final persistence, final visualization surfaces, or supported
+Cloud Worlds or Recipes.
+
+Current implementation terms such as Result, Result Card, Results, Explore, and
+output product are subordinate to
+`docs/product/APPLICATION_SEMANTICS.md`. Current code and tests remain the
+source of truth for implemented behavior.
+
+## Current Implemented Model
+
+Current ingest accepts completed run manifests whose lifecycle state is
+`completed` and whose product state is `completed_cm1_result`. NetCDF model-field
+files named like `cm1out_<number>.nc` or `cm1out_<number>.nc4` are required for
+ingest. Stats NetCDF files and raw CM1 `.dat` / `.ctl` artifacts may be
+cataloged, but stats-only output is not enough for current field diagnostics.
+
+Ingest writes these runtime-local records in the original run directory:
+
+- `result_metadata.json`;
+- `derived-products/output_product_manifest.json`;
+- optional `result_card.json` when the editable Result Card state is updated.
+
+`result_metadata.json` records run, scenario, input, observed-sounding,
+`run_recipe`, recipe metadata, candidate-screening, pre-run-validation, output
+file, diagnostic, runtime-integrity, field-quality, interesting-time, and
+science-summary fields where available.
+
+The output-product manifest is versioned as manifest version `1`. It records:
+
+- `product_manifest_id`, `result_id`, `run_id`, optional `scenario_id`, and
+  source model;
+- source `result_metadata.json` and `run_manifest.json` paths when available;
+- classified source outputs: model-output NetCDF, stats NetCDF, and raw CM1
+  artifacts;
+- a global output time index mapping each `time_index` to source file, source
+  kind, local file index, time seconds/source value, and time caveats;
+- cache metadata for the runtime-local derived-products directory;
+- provenance and caveats;
+- an optional embedded interesting-time product.
+
+Interesting-time and science-summary records are derived from backend
+diagnostics and output-time mapping. Current records include cloud, cloud-top,
+cloud-water, updraft/downdraft, rain, reflectivity, latest-output, and
+field-default-time evidence when the required diagnostics and fields exist.
+Support states are `supported`, `fallback`, `unavailable`,
+`unsupported_missing_fields`, and `unsupported_missing_diagnostic`.
+
+Field catalogs expose recognized CM1 fields with raw and canonical field names,
+display labels, units, dimensions, native-grid class, coordinate names,
+capabilities, provenance, and caveats. Current recognized fields include cloud
+water, vertical velocity, wind components, rain water aloft, water vapor,
+temperature/potential temperature, pressure, accumulated surface rain,
+reflectivity, surface fluxes, selected surface diagnostics, parcel-diagnostic
+fields when present, and radiation tendency fields when present.
+
+Current backend output-product payloads include:
+
+- field catalogs;
+- view defaults;
+- bounded 2-D slices;
+- thresholded point clouds for supported scalar fields;
+- output-product catalogs;
+- vertical profiles;
+- time-height arrays;
+- time-series arrays;
+- selected-region diagnostics for point, column, and box requests.
+
+## Behavioral Rules And Invariants
+
+Raw NetCDF stays backend-owned. The browser receives JSON payloads produced by
+backend code; `encoding=json` is the only supported browser-facing encoding for
+current slice and point-cloud endpoints.
+
+The output time index excludes stats files from model-field time mapping. When
+all model-output files expose numeric time coordinates, the global index is
+sorted by time. When times must be inferred, filename order is preserved and a
+caveat is recorded. Missing, skipped, duplicate, or non-model files are recorded
+as caveats where applicable.
+
+Field quality is assessed by backend diagnostics for tracked fields and is
+propagated into interesting-time, Result Card, and output-product payloads where
+available. Missing fields are represented as unavailable/caveated behavior, not
+as physically meaningful zero values.
+
+Visualization payloads use native-grid views and aggregations. Current profile
+aggregation methods are `domain_mean`, `domain_min`, `domain_max`, and
+`selected_column`. Current time-height and time-series methods are
+`cloud_fraction`, `domain_mean`, `domain_min`, and `domain_max` where supported
+for the selected field.
+
+Large output defaults may be metadata-based instead of full-field scans so that
+Explore can open without scanning gigabytes of NetCDF first. Such defaults carry
+caveats.
+
+Deleting a managed runtime run directory deletes current package files, logs,
+CM1 output, `result_metadata.json`, optional `result_card.json`, and derived
+product files under that directory. Result deletion resolves `result_id` to the
+run directory and requires explicit confirmation before deleting.
+
+## Current Ownership And Interfaces
+
+The backend owns ingest, NetCDF/xarray access, diagnostics, output-product
+manifest generation, field catalogs, slices, point clouds, profiles,
+time-height/time-series products, selected-region diagnostics, Result Cards,
+and runtime cleanup.
+
+The frontend owns current Build, Results, and Explore interaction and
+presentation. It does not parse raw NetCDF and does not own scientific truth.
+
+CM1 owns simulated atmospheric evolution for a given executable and
+configuration. Runtime storage owns only current local files and cache state; its
+location does not define product identity.
+
+Current API routes include:
+
+- `/api/results/ingest`;
+- `/api/results`;
+- `/api/results/{result_id}`;
+- `/api/results/{result_id}/delete-preview`;
+- `/api/results/{result_id}/delete`;
+- `/api/results/{result_id}`;
+- `/api/results/{result_id}/save`;
+- `/api/results/{result_id}/visualization/fields`;
+- `/api/results/{result_id}/visualization/defaults`;
+- `/api/results/{result_id}/visualization/slice`;
+- `/api/results/{result_id}/visualization/point-cloud`;
+- `/api/results/{result_id}/output-products`;
+- `/api/results/{result_id}/output-products/profile`;
+- `/api/results/{result_id}/output-products/time-height`;
+- `/api/results/{result_id}/output-products/time-series`;
+- `/api/results/{result_id}/diagnostics/selected-region`;
+- `/api/storage/inventory`;
+- `/api/storage/delete-run`.
+
+## Persistence Or Runtime Records
+
+Current implemented records live under `<runtime-home>/runs/<run-id>/`. Results
+are discovered by scanning `<runtime-home>/runs/*/result_metadata.json`. Explore
+requires both discoverable result metadata and readable NetCDF paths referenced
+by that metadata.
+
+`result_card.json` stores editable current Result Card state: name, tags, notes,
+and compatibility saved/protected fields. It is a sidecar to current result
+metadata, not a final product persistence model.
+
+## Terminology Mapping
+
+- **Result**: current API/UI term for ingested result metadata and its card
+  projection; not the product center.
+- **Result Card**: current UI/API projection over `result_metadata.json` plus
+  optional `result_card.json`; not a canonical saved view or Experiment.
+- **Results**: current UI surface for locating ingested output.
+- **Explore**: current UI surface for inspecting backend-derived visualization
+  payloads and diagnostics.
+- **Output product**: current backend-derived payload or manifest for bounded
+  browser consumption; not raw model data.
+- **Model data**: CM1-produced output files, primarily NetCDF model-field files.
+- **Diagnostic**: backend-derived scientific or quality summary, not raw CM1
+  state.
+- **Run**: current execution/package machinery beneath a Simulation.
+- **Simulation**: product-semantic term for the evolving modeled cloud or cloud
+  field the user watches; current output records can support viewing a
+  Simulation but do not define the final product object.
+
+## Evidence Map
+
+Implementation evidence:
+
+- `app/backend/cloud_chamber/result_ingest.py`;
+- `app/backend/cloud_chamber/output_products.py`;
+- `app/backend/cloud_chamber/result_diagnostics.py`;
+- `app/backend/cloud_chamber/visualization_data.py`;
+- `app/backend/cloud_chamber/selected_region_diagnostics.py`;
+- `app/backend/cloud_chamber/result_cards.py`;
+- `app/backend/cloud_chamber/runtime_storage.py`;
+- `app/backend/cloud_chamber/run_manifest.py`;
+- `app/backend/cloud_chamber/app.py`.
+
+Frontend consumers:
+
+- `app/frontend/src/App.tsx`;
+- `app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts`.
+
+Tests:
+
+- `app/backend/tests/test_result_ingest.py`;
+- `app/backend/tests/test_output_products.py`;
+- `app/backend/tests/test_result_diagnostics.py`;
+- `app/backend/tests/test_visualization_data.py`;
+- `app/backend/tests/test_selected_region_diagnostics.py`;
+- `app/backend/tests/test_result_cards.py`;
+- `app/backend/tests/test_runtime_storage.py`;
+- `app/backend/tests/test_app.py`;
+- `app/frontend/src/App.test.tsx`.
+
+## Known Implementation Limits
+
+Current result discovery is filesystem-coupled to run directories under the
+runtime home. There is no separate database-backed result index.
+
+Current output products are JSON payloads and runtime-local derived records.
+There is no implemented Render Studio, Diagnostics Lab, VAPOR/ParaView/VTK/Zarr
+export path, browser-side raw NetCDF parser, or future binary/chunked product
+format in this contract.
+
+Field availability, field quality, interesting times, and diagnostics depend on
+the fields produced by the run and on backend diagnostic support. Unsupported
+or missing fields produce unavailable/caveated payloads.
+
+Current cleanup deletes the managed run directory. The implementation records
+the storage coupling; it does not choose a future archive or metadata-only
+retention model.
+
+## Non-Implications
+
+This contract does not approve final storage, cleanup, rendering, export,
+notebook, comparison, database, or compute architecture.
+
+It does not make Results or Result Cards the product center, does not define a
+Cloud World, does not approve a Recipe, and does not make an ingested record or
+notebook sidecar an Experiment.

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -126,24 +126,24 @@ location does not define product identity.
 
 Current API routes include:
 
-- `/api/results/ingest`;
-- `/api/results`;
-- `/api/results/{result_id}`;
-- `/api/results/{result_id}/delete-preview`;
-- `/api/results/{result_id}/delete`;
-- `/api/results/{result_id}`;
-- `/api/results/{result_id}/save`;
-- `/api/results/{result_id}/visualization/fields`;
-- `/api/results/{result_id}/visualization/defaults`;
-- `/api/results/{result_id}/visualization/slice`;
-- `/api/results/{result_id}/visualization/point-cloud`;
-- `/api/results/{result_id}/output-products`;
-- `/api/results/{result_id}/output-products/profile`;
-- `/api/results/{result_id}/output-products/time-height`;
-- `/api/results/{result_id}/output-products/time-series`;
-- `/api/results/{result_id}/diagnostics/selected-region`;
-- `/api/storage/inventory`;
-- `/api/storage/delete-run`.
+- `POST /api/results/ingest`;
+- `GET /api/results`;
+- `GET /api/results/{result_id}`;
+- `POST /api/results/{result_id}/delete-preview`;
+- `POST /api/results/{result_id}/delete`;
+- `PATCH /api/results/{result_id}`;
+- `POST /api/results/{result_id}/save`;
+- `GET /api/results/{result_id}/visualization/fields`;
+- `GET /api/results/{result_id}/visualization/defaults`;
+- `GET /api/results/{result_id}/visualization/slice`;
+- `GET /api/results/{result_id}/visualization/point-cloud`;
+- `GET /api/results/{result_id}/output-products`;
+- `GET /api/results/{result_id}/output-products/profile`;
+- `GET /api/results/{result_id}/output-products/time-height`;
+- `GET /api/results/{result_id}/output-products/time-series`;
+- `GET /api/results/{result_id}/diagnostics/selected-region`;
+- `GET /api/storage/inventory`;
+- `POST /api/storage/delete-run`.
 
 ## Persistence Or Runtime Records
 
@@ -211,10 +211,10 @@ Tests:
 Current result discovery is filesystem-coupled to run directories under the
 runtime home. There is no separate database-backed result index.
 
-Current output products are JSON payloads and runtime-local derived records.
-There is no implemented Render Studio, Diagnostics Lab, VAPOR/ParaView/VTK/Zarr
-export path, browser-side raw NetCDF parser, or future binary/chunked product
-format in this contract.
+Current browser-facing output products use bounded JSON payloads. The persisted
+derived record is the runtime-local output-product manifest. No additional
+output or export format is part of this implemented contract. The browser does
+not parse raw NetCDF.
 
 Field availability, field quality, interesting times, and diagnostics depend on
 the fields produced by the run and on backend diagnostic support. Unsupported

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -1,342 +1,236 @@
 # Sounding Candidate Screening Contract
 
-Status: v1 product/data contract
-
-Cloud Chamber sounding candidates are pre-run hypotheses for choosing an
-observed atmosphere to try in CM1. They are not forecasts, verification, or
-proof that a run will form cloud, rain, or suppression. CM1 output remains the
-source of truth.
-
-The browser does not parse IGRA station text, ZIP archives, or raw NetCDF.
-Candidate screening and analysis are backend-owned and use cached IGRA station
-text plus runtime-local cache metadata.
-
-## Current Story Set
-
-The v1 candidate stories are:
-
-- `shallow_cumulus_candidate`
-- `dry_failed_candidate`
-- `capped_suppressed_candidate`
-- `humid_rainy_candidate`
-- `severe_thunderstorm_environment`
-- `supercell_environment`
-- `high_cape_pulse_storm`
-- `dry_microburst_inverted_v`
-- `squall_line_cold_pool_candidate`
-- `elevated_convection`
-- `needs_review`
-- `poor_or_incomplete_candidate`
-
-Visible labels may be friendlier, but every visible story must be backed by
-`story_scores`, feature values, evidence items, caveats, and package readiness.
-Deep-convection-oriented stories are pre-run hypotheses for Deep-Tower
-Benchmark routing, not outcome claims.
-
-## Feature Inputs
-
-The backend derives several feature groups from the selected IGRA sounding
-after converting source height to model height above the station. Not every
-derived or displayed field directly changes the story score.
-
-### Scoring Inputs
-
-The current story scores primarily use:
-
-- data completeness score
-- mean qv from 0-1000 m
-- estimated LCL
-- lapse rate from 0-1 km
-- inversion/cap strength proxy
-- moisture depth above a 6 g/kg qv threshold
-- low-level to midlevel qv drop / dry-layer proxy
-
-Missing scoring inputs weaken/caveat story support instead of being interpreted
-as meaningful physical zero values.
-
-### Evidence / Context Fields
-
-The candidate UI may also display these fields as evidence or context:
-
-- lowest usable model level
-- profile top
-- low-level qv
-- mean qv from 0-500 m
-- surface or lowest-level temperature-dewpoint spread
-- lapse rate from 0-3 km
-- cap height proxy
-- observed wind availability
-- midlevel lapse rate when available
-- bulk shear from 0-1, 0-3, and 0-6 km when observed winds exist
-- dry microburst / inverted-V proxy
-- freezing-level proxy
-- package readiness
-
-These fields help explain the sounding and package path. They do not directly
-drive story scores unless the implementation and tests are updated to say so.
-
-### Package-Readiness Fields
-
-Package readiness is determined by the observed-sounding parser and
-normalization path. It depends on station metadata and usable CM1-facing
-profile fields, including:
-
-- station elevation and model-z conversion
-- enough usable levels
-- profile top high enough for the selected domain
-- lowest usable level close enough to the model bottom
-- monotonic and finite converted levels
-- required thermodynamic fields
-- observed u/v wind components
-
-The current screen includes simple sounding-only CAPE, CIN, LFC, and EL
-proxies for Deep-Tower Benchmark opportunity scoring. It still does not compute
-storm-relative helicity, map/GIS forcing, or radar/precipitation predictors.
-Those require separate research, diagnostics, and validation before becoming
-product-facing evidence.
-
-### Deep-Tower Opportunity
-
-`deep_tower_opportunity` is an experimental 0-100 sounding heuristic for
-comparing possible Deep-Tower Benchmark cases. It is not a recipe
-recommendation, not a promise that the fixed stock `iinit = 3` benchmark will
-make a deep cloud, and not a replacement for severe/supercell story scores.
-High values may be used as optional sort evidence, but they must not drive
-automatic compute-spending advice.
-
-The score weights surface-based CAPE, mixed-layer CAPE, CIN, LFC, cap proxy,
-low-level moisture, deeper moisture, 0-3 km and midlevel lapse rates, profile
-completeness, and near-surface continuity. EL or buoyancy depth contributes
-only when the simple EL estimate is usable. Deep-layer shear receives little or
-no weight because this heuristic is scoped to possible cloud-depth ingredients,
-not storm organization. If the near-surface profile has a large discontinuity,
-the heuristic cannot surface as clean `supported` evidence; it uses mixed-layer
-CAPE rather than allowing one suspect lowest level to dominate.
-
-## Story Logic
-
-Scores are 0-100 candidate-selection aids. They are weighted heuristics, not
-probabilities. A score of `supported` means the available sounding-derived
-features support trying that story; it does not mean CM1 will produce that
-outcome.
-
-### Cloud-Forming Shallow Cumulus Candidate
-
-Scoring primarily uses:
-
-- moderate to high mean qv from 0-1 km
-- low to moderate estimated LCL
-- deeper moisture depth
-- weak to moderate cap proxy
-- useful low-level lapse rate
-- profile completeness
-
-Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
-estimated LCL, low-level and 0-3 km lapse rates, moisture depth, cap
-strength/height context, profile coverage, wind availability, and package
-readiness.
-
-Package readiness depends on the observed-sounding parser and normalization
-path, including usable model-z conversion, profile depth, required
-thermodynamic fields, and observed u/v winds.
-
-High support requires moisture, plausible LCL, thermal support, weak or
-moderate cap, and good data completeness. Missing moisture, LCL, lapse-rate,
-cap, or moisture-depth inputs caveat the score and push the candidate toward
-`needs_review`.
-
-### Dry Failed Cumulus Candidate
-
-Scoring primarily uses:
-
-- low mean qv from 0-1 km
-- high estimated LCL
-- shallow moisture depth
-- midlevel dry-layer proxy
-- useful low-level lapse rate
-- profile completeness
-
-Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
-estimated LCL, low-level and 0-3 km lapse rates, moisture depth, dry-layer
-proxy, profile coverage, wind availability, and package readiness.
-
-Package readiness depends on the observed-sounding parser and normalization
-path, including usable model-z conversion, profile depth, required
-thermodynamic fields, and observed u/v winds.
-
-Missing moisture is not treated as dry air. Missing qv, LCL, moisture-depth,
-or dry-layer inputs produce caveats and weak or unavailable support rather than
-a confident dry-failed label.
-
-### Capped / Suppressed Candidate
-
-Scoring primarily uses:
-
-- mean qv from 0-1 km
-- plausible estimated LCL
-- strong inversion/cap proxy
-- useful low-level lapse rate
-- profile completeness
-
-Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread,
-estimated LCL, low-level and 0-3 km lapse rates, cap strength, cap height,
-moisture depth, profile coverage, wind availability, and package readiness.
-
-Package readiness depends on the observed-sounding parser and normalization
-path, including usable model-z conversion, profile depth, required
-thermodynamic fields, and observed u/v winds.
-
-This story supports the hypothesis that moisture and thermals may exist but a
-stable layer could limit depth. It does not prove that CM1 will suppress cloud
-growth.
-
-### Humid / Rainy Candidate
-
-Scoring primarily uses:
-
-- high mean qv from 0-1 km
-- low estimated LCL
-- deep moisture
-- weak cap proxy
-- profile completeness
-
-Evidence also shows low-level qv, 0-500 m qv, 0-1 km qv, T-Td spread, LCL,
-low-level and 0-3 km lapse rates, moisture depth, weak-cap support, profile
-coverage, wind availability, and package readiness.
-
-Package readiness depends on the observed-sounding parser and normalization
-path, including usable model-z conversion, profile depth, required
-thermodynamic fields, and observed u/v winds.
-
-This story is deliberately caveated because current packages still use
-idealized local forcing. It should be read as “humid atmosphere worth trying,”
-not as a rain forecast.
-
-Future predicted-output language belongs in
-[Analyzer Hypothesis And Output-Signature Contract](analyzer-hypothesis-output-signature.md).
-Until that contract is implemented, this screen emits ingredient/screening
-scores and recipe-fit caveats, not output predictions.
-The bridge from story IDs to explicit CM1 run recipes is defined in
-[Run Recipe And Story-Mapping Contract](run-recipe-and-story-mapping.md).
-
-### Needs Review
-
-Scoring primarily uses:
-
-- weak data completeness
-- missing story-driving features
-- screening uncertainty
-- package-ready profiles whose evidence is not strong enough for a clear story
-
-Evidence also shows whatever profile, moisture, stability, wind, and
-package-readiness context is available.
-
-`needs_review` can still be package-ready. It means the sounding may be worth
-manual inspection, not that it is unusable.
-
-### Poor Or Incomplete Candidate
-
-Scoring primarily uses:
-
-- blocked package generation
-
-Package readiness depends on:
-
-- missing station elevation or unsafe height conversion
-- too few usable levels
-- profile top too low for the selected domain
-- lowest usable level too far above model bottom
-- nonmonotonic or nonfinite converted levels
-- missing required observed winds
-
-Evidence also shows any available profile, moisture, stability, wind, and
-package-readiness context so the UI can explain why the candidate is blocked.
-
-Poor/incomplete candidates are not package-ready in the current path. They may
-still be useful after parser, station metadata, or profile-quality improvements,
-but the UI must show why they are blocked.
-
-## Missing Data Rules
-
-Missing physical evidence is not interpreted as a physical condition. For
-example:
-
-- missing qv is not dry air;
-- missing LCL is not a high LCL;
-- missing cap proxy is not a weak cap;
-- missing wind is a package-readiness blocker for the current external-sounding
-  path.
-
-Missing features become score caveats and evidence caveats. Blocked parser or
-normalization states become `poor_or_incomplete_candidate`.
-
-## Package Readiness
-
-A package-ready candidate has a selected observed sounding payload that can
-enter the current external-sounding package path. Package readiness depends on
-the parser and normalization contract, including station elevation, model-z
-conversion, profile depth, required thermodynamic fields, and observed u/v wind
-components.
-
-Candidate screening metadata may be copied into `run_manifest.json`,
-`case_manifest.json`, and `dry_run_report.json` as provenance when a candidate
-is used to create a package. If the candidate was saved with tags or notes,
-those annotations may also be copied into package user metadata and run-status
-payloads so the generated package remains tied to the reason it was selected.
-
-## UI Contract
-
-Candidate cards and details must keep this language:
-
-- Screening guidance only.
-- Candidate ingredient/screening scores rank sounding ingredients only.
-- Scores do not predict what the current CM1 package will produce.
-- CM1 decides what actually happens.
-
-The backend analysis API owns default recommendations, interest reasons,
-discovery buckets, story/story-family/support/readiness/station-search
-refinements, and sort-key ordering. The default UI should answer which cached
-soundings are interesting and why before exposing advanced refinements. It must
-display the backend-returned candidate list rather than parsing raw sounding
-files or recomputing story scores in the browser. Analysis must include
-secondary story scores when `story_scores` contain meaningful support for the
-selected story or selected story family. Story-family filtering, support
-filtering, and highest-ingredient-score sorting must use the same family-scoped `story_scores`
-set, so a sounding with a lower-atmosphere primary story can still appear as a
-deep-convection recommendation when a secondary deep-convection score has
-meaningful support. Missing feature values must remain unavailable/caveated and
-sort last instead of becoming zero-valued evidence. The UI must not show a
-confident story label without evidence, caveats, and package readiness.
-The workbench should also show a minimal experiment-fit status, such as
-`testable_now`, `partially_testable`, `requires_surface_forcing_recipe`, or
-`blocked_profile`, so candidate interest remains separate from what the current
-run configuration can actually test.
-
-Saved candidates may carry freeform tags and notes such as `Deep convection
-candidates`, `Surface-forced candidates`, `Needs longer run`, `Needs finer
-output cadence`, `Maybe rerun`, and `Needs review`. These annotations are
-runtime-local pre-run organization metadata; they are not Results and are not
-committed.
-
-## Testing Contract
-
-Automated tests use tiny synthetic IGRA-style fixtures or direct deterministic
-feature dictionaries. Tests must not fetch live NOAA/NCEI data, run CM1, parse
-station text in the browser, or commit cached station files.
-
-Tests should prove:
-
-- every current story can be produced deterministically;
-- every story has reasons and evidence;
-- missing features caveat or weaken support instead of producing confident
-  labels;
-- backend analysis works across multiple cached sounding blocks;
-- physical-field sorting keeps missing values last;
-- default recommendations and interest reasons are backend-owned;
-- story, support, and readiness refinements are backend-owned;
-- saved tags and notes round-trip through runtime-local JSON;
-- saved tags and notes follow a used candidate into package metadata;
-- poor/incomplete candidates are blocked from package generation;
-- package-ready but weak profiles become `needs_review`;
-- candidate-screening provenance is copied into generated package metadata
-  when provided.
+**Status:** Implemented contract
+
+## Purpose
+
+This contract documents the current implemented screening behavior for cached
+IGRA sounding candidates, including deterministic story scores, evidence
+records, caveats, package-readiness state, saved candidate annotations,
+candidate-to-package provenance, and current backend/frontend interfaces.
+
+## Authority Boundary
+
+This is a current implementation contract. It does not define final product
+architecture, final recommendation policy, supported Cloud Worlds, supported
+Recipes, or future analyzer behavior.
+
+Current implementation labels such as `story`, `story_scores`, `candidate`,
+`run_recipe`, Build, Results, and Explore are subordinate to
+`docs/product/APPLICATION_SEMANTICS.md`. Current code and tests remain the
+source of truth for implemented behavior.
+
+## Current Implemented Model
+
+The current screening version is `sounding-screening-v3`. The current sounding
+diagnostics version is `sounding-diagnostics-v1`.
+
+Screening reads cached IGRA station text files from the runtime cache manifest,
+summarizes available soundings, parses selected observed soundings, computes
+bounded diagnostic features, and returns `SoundingCandidate` records. Each
+candidate includes station metadata, valid time, source file name, source file
+hash, source provider/format, selected sounding payload when parsing succeeds,
+features, evidence, caveats, story scores, package readiness, and created time.
+
+Current story identifiers are implementation classifier labels:
+
+- `shallow_cumulus_candidate`;
+- `dry_failed_candidate`;
+- `capped_suppressed_candidate`;
+- `humid_rainy_candidate`;
+- `severe_thunderstorm_environment`;
+- `supercell_environment`;
+- `high_cape_pulse_storm`;
+- `dry_microburst_inverted_v`;
+- `squall_line_cold_pool_candidate`;
+- `elevated_convection`;
+- `needs_review`;
+- `poor_or_incomplete_candidate`.
+
+Current story families are `lower_atmosphere`, `deep_convection`, and `review`.
+
+Implemented deterministic feature inputs include data completeness, profile
+depth, lowest usable level, usable lower-level counts, temperature, pressure,
+moisture, derived dewpoint, estimated LCL, low-level and layer-mean qv,
+moisture depth, qv drop, precipitable-water proxy, lapse-rate proxies,
+inversion/cap proxies, simple surface-based and mixed-layer parcel diagnostics,
+LFC/EL estimates, observed wind availability, wind-profile depth, bulk shear,
+SRH placeholders, dry-microburst/inverted-V proxy, freezing level, and
+near-surface discontinuity evidence.
+
+`StoryScore.support` is assigned deterministically from the story score:
+`supported` at 65 or higher, `weak` from 35 through less than 65, and
+`unavailable` below 35. Candidate `confidence` is `low`, `medium`, or `high`
+from package readiness, rank score, and completeness.
+
+`deep_tower_opportunity` is an experimental numeric heuristic stored in
+candidate features and evidence. It remains an evidence/sort field only. A high
+value is not a reliable fixed-recipe recommendation and must not automatically
+authorize expensive compute. Current high values are intentionally summarized as
+experimental evidence rather than as supported Deep-Tower scout advice.
+
+The current near-surface guardrail prevents a major near-surface discontinuity
+from producing clean Deep-Tower support: surface-based CAPE is ignored for that
+experimental heuristic, mixed-layer CAPE becomes the primary buoyancy input, and
+the experimental score is capped below the old supported tier.
+
+## Behavioral Rules And Invariants
+
+Candidate scores are deterministic screening heuristics. They are not
+probabilities, forecasts, Simulation outcomes, scientific validation, or proof
+that CM1 will produce cloud, rain, suppression, rotation, cold-pool behavior, or
+visual interest.
+
+Missing physical evidence is not interpreted as a physical zero. Missing or
+unsupported evidence appears as unavailable features, caveats, weaker support,
+or blocked package-readiness state.
+
+`package_ready` means the parsed sounding currently has a selected normalized
+payload that can attempt the current package-generation path. It does not make
+the candidate an approved Recipe and does not guarantee that pre-run validation
+or CM1 execution will succeed.
+
+Deep-convection `story` labels remain broad ingredient classifiers. They are
+not a canonical Deep-Tower recommendation. The fixed Deep-Tower Benchmark may be
+available for deliberate comparison when the user configures it, but screening
+does not make that compute automatically worthwhile.
+
+No candidate, score, story, saved candidate, readiness state, or `run_recipe`
+label creates a Cloud World, Recipe, Simulation, Exploration, or Experiment.
+
+## Current Ownership And Interfaces
+
+The backend owns cached-station discovery, IGRA parsing, diagnostic feature
+calculation, story scoring, support states, caveats, package-readiness state,
+saved candidate persistence, sorting, filtering, and candidate analysis payloads.
+
+The frontend owns current candidate presentation, filter controls, saved
+candidate interactions, and copying selected candidate metadata into run-plan
+and package requests. It does not own the scoring rules and does not validate
+the science of a candidate by rendering it.
+
+Current API routes include:
+
+- `/api/sounding-candidates/screening-inputs`;
+- `/api/sounding-candidates/screen`;
+- `/api/sounding-candidates/analyze`;
+- `/api/sounding-candidates/saved`;
+- `/api/sounding-candidates/saved/{saved_candidate_id}`.
+
+`/api/sounding-candidates/analyze` is backend-owned for filtering and sorting.
+Its default `sort_by` is `best_match`. In a deep-convection scope, `best_match`
+uses the strongest relevant scoped deep-story score. The explicit
+`deep_tower_opportunity` sort uses the experimental numeric field. These
+orderings can differ.
+
+In deep-convection scope, visible support and support filtering currently use
+`deep_tower_opportunity_support`. The field remains experimental evidence, not a
+canonical Recipe recommendation.
+
+Saved candidates are stored in:
+
+```text
+<runtime-cache>/sounding-candidates/saved_candidates.json
+```
+
+Saved records preserve the candidate, selected sounding payload, screening
+version, primary story, story family, story scores, features, evidence, caveats,
+tags, notes, timestamps, and linked run/result identifiers when present.
+
+When a selected candidate is used to generate a package, frontend metadata is
+copied into the `candidate_screening` payload. Package generation preserves that
+payload in `run_manifest.json`, `case_manifest.json`, and `dry_run_report.json`.
+Pre-run validation also records selected candidate, selected implementation
+story, selected `run_recipe`, required output fields, alignment status, caveats,
+and blocking errors.
+
+## Persistence Or Runtime Records
+
+Candidate screening reads from the current runtime cache manifest and cached
+IGRA station text files. It does not currently create a durable product object
+for every analyzed sounding.
+
+Saved candidate annotations are runtime-local JSON records under the configured
+cache directory. Generated packages copy selected candidate provenance into the
+run directory, but that copy remains current run/package metadata rather than a
+final product evidence model.
+
+## Terminology Mapping
+
+- **story**: current implementation classifier label for a pre-run screening
+  interpretation; not a product story system.
+- **story_scores**: deterministic current screening outputs; not forecasts or
+  probabilities.
+- **candidate**: current cached sounding plus diagnostics and screening
+  metadata; not a Cloud World, Recipe, Simulation, Exploration, or Experiment.
+- **screening score**: heuristic ingredient ranking value, not scientific
+  validation.
+- **package readiness**: compatibility with current package-generation
+  machinery, not Recipe approval.
+- **run_recipe**: current code-level run-generation label; not canonical Recipe
+  semantics.
+- **Recipe**: approved product-semantic term for a complete, known-working,
+  modifiable simulation design within a Cloud World.
+- **Experiment**: approved product-semantic term for deliberate exploration
+  structured around a question or controlled comparison; not a package, run,
+  result, or saved candidate.
+- **Simulation**: approved product-semantic term for one evolving modeled cloud
+  or cloud field the user watches.
+
+## Evidence Map
+
+Implementation evidence:
+
+- `app/backend/cloud_chamber/sounding_candidates.py`;
+- `app/backend/cloud_chamber/sounding_diagnostics.py`;
+- `app/backend/cloud_chamber/observed_sounding.py`;
+- `app/backend/cloud_chamber/igra_catalog.py`;
+- `app/backend/cloud_chamber/igra_recent_cli.py`;
+- `app/backend/cloud_chamber/pre_run_validation.py`;
+- `app/backend/cloud_chamber/dry_run_package.py`;
+- `app/backend/cloud_chamber/cm1_input_contract.py`;
+- `app/backend/cloud_chamber/run_manifest.py`;
+- `app/backend/cloud_chamber/app.py`;
+- `app/frontend/src/App.tsx`.
+
+Tests:
+
+- `app/backend/tests/test_sounding_candidates.py`;
+- `app/backend/tests/test_sounding_diagnostics.py`;
+- `app/backend/tests/test_observed_sounding.py`;
+- `app/backend/tests/test_igra_catalog.py`;
+- `app/backend/tests/test_igra_recent_cli.py`;
+- `app/backend/tests/test_dry_run_package.py`;
+- `app/backend/tests/test_app.py`;
+- `app/frontend/src/App.test.tsx`;
+- `app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts`.
+
+## Known Implementation Limits
+
+The current analyzer uses deterministic heuristics and simple diagnostics,
+including simple parcel estimates. It is not an independent trusted parcel
+analysis package and does not predict the actual CM1 response.
+
+The current product analyzer reads the implemented cache collection available
+through the runtime cache workflow. It does not by itself define candidate
+supply strategy or period-of-record search policy.
+
+Current saved candidate persistence is runtime-local JSON. There is no final
+database, collaborative review, or durable product evidence model in this
+contract.
+
+Current pre-run validation still contains some legacy implementation vocabulary,
+including `selected_hypothesis` and a small `predicted_output_signature` list.
+Those fields are current package/validation payload fields only and do not
+activate the archived analyzer-hypothesis or output-signature proposal.
+
+## Non-Implications
+
+This contract does not approve a future analyzer hypothesis object, predicted
+output-signature system, story-to-Recipe product mapping, recommendation
+platform, station blacklist, candidate-supply strategy, or automatic
+compute-spending policy.
+
+It does not choose observed soundings as the primary future product path, does
+not approve any current `run_recipe` as a canonical Recipe, and does not make a
+candidate-screening result an Experiment.

--- a/docs/contracts/sounding-candidate-screening.md
+++ b/docs/contracts/sounding-candidate-screening.md
@@ -64,10 +64,23 @@ near-surface discontinuity evidence.
 from package readiness, rank score, and completeness.
 
 `deep_tower_opportunity` is an experimental numeric heuristic stored in
-candidate features and evidence. It remains an evidence/sort field only. A high
-value is not a reliable fixed-recipe recommendation and must not automatically
-authorize expensive compute. Current high values are intentionally summarized as
-experimental evidence rather than as supported Deep-Tower scout advice.
+candidate features and evidence. Current implementation uses it to:
+
+- populate the deep-scope displayed `ingredient_score` and
+  `ingredient_score_label`;
+- derive visible deep-scope support through
+  `deep_tower_opportunity_support`;
+- filter deep-convection-scope candidates by support;
+- rank the `deep_convection_trial` target screening path;
+- order the explicit `deep_tower_opportunity` sort;
+- contribute a bounded bonus, capped at 10 points, to the default discovery
+  ranking.
+
+Those are implemented screening, display, filtering, and ranking roles. A high
+value remains experimental evidence, not a reliable fixed-recipe
+recommendation, and must not automatically authorize expensive compute. Current
+high values are intentionally summarized as experimental evidence rather than
+as supported Deep-Tower scout advice.
 
 The current near-surface guardrail prevents a major near-surface discontinuity
 from producing clean Deep-Tower support: surface-based CAPE is ignored for that

--- a/docs/current/CURRENT_ARCHITECTURE.md
+++ b/docs/current/CURRENT_ARCHITECTURE.md
@@ -9,7 +9,8 @@ The controlling product documents remain:
 
 1. [North Star](../../NORTH_STAR.md)
 2. [Product Vision](../product/PRODUCT_VISION.md)
-3. [Current State](CURRENT_STATE.md)
+3. [Application Semantics](../product/APPLICATION_SEMANTICS.md)
+4. [Current State](CURRENT_STATE.md)
 
 ## Current Implementation Flow
 
@@ -172,7 +173,8 @@ The current architecture leaves several decisions unresolved:
 - whether filesystem-backed result metadata remains sufficient;
 - whether observed soundings, candidate screening, local queueing, LAN execution, or specific
   initiation and forcing mechanisms remain product priorities;
-- which current scenarios or run paths become supported cloud worlds;
+- which current scenarios or run paths provide implementation evidence or
+  ingredients for future Recipes within a Cloud World;
 - how visualization and process explanation are combined in the final experience.
 
 Those decisions are outside this descriptive architecture snapshot.

--- a/docs/current/CURRENT_STATE.md
+++ b/docs/current/CURRENT_STATE.md
@@ -19,6 +19,7 @@ The controlling product documents are:
 
 1. [North Star](../../NORTH_STAR.md)
 2. [Product Vision](../product/PRODUCT_VISION.md)
+3. [Application Semantics](../product/APPLICATION_SEMANTICS.md)
 
 Where this document describes current implementation that does not match the Product Vision, the mismatch is intentional and should remain visible.
 
@@ -49,7 +50,7 @@ The current technical flow is broadly:
 ```text
 React / TypeScript frontend
 → Python / FastAPI backend
-→ experiment configuration and package generation
+→ configured run and package generation
 → external CM1 execution
 → runtime and NetCDF ingest
 → persistent result metadata
@@ -67,7 +68,7 @@ This is the present interface structure. No decision has been made that it is th
 
 ## Implemented capabilities
 
-### Experiment configuration and packaging
+### Run configuration and packaging
 
 The repository currently supports combinations of:
 
@@ -150,7 +151,7 @@ The repository currently includes:
 
 The existence of these capabilities does not decide how important observed soundings will be in the eventual product.
 
-### Experiment and scenario content
+### Run, research, and scenario content
 
 The repository currently contains:
 
@@ -179,11 +180,16 @@ The documentation tree contains a mixture of:
 
 Batch 1 established the North Star, Product Vision, and repository-recovery `AGENTS.md`.
 
-A full file-by-file read-only documentation disposition audit has been completed and approved.
+A full file-by-file read-only documentation disposition audit has been
+completed and approved. Stage 1 operational-documentation recovery and Stage 2
+semantic architecture are complete. The active contract directory has been
+classified so implemented contracts remain active while proposal and historical
+mixed contracts are archived under `docs/archive/contracts/`.
 
-The repository moves, rewrites, archives, splits, deletions, and deferrals from that approved disposition have not yet been implemented.
+Remaining repository moves, rewrites, archives, splits, deletions, and deferrals
+outside those completed stages may still exist.
 
-Until those approved repository changes are implemented:
+Until a document is handled by an approved bounded stage:
 
 - lower-authority documents may contain useful facts;
 - their product framing may be stale;
@@ -192,26 +198,27 @@ Until those approved repository changes are implemented:
 
 See [Documentation Status and Authority](../DOCUMENTATION_STATUS.md).
 
-## Current recovery status
+## Current gated product-architecture status
 
 Completed:
 
 - approved North Star;
 - approved Product Vision;
-- recovery-mode `AGENTS.md`;
+- gated-program `AGENTS.md`;
 - closure of selected superseded product-direction issues and pull requests;
 - replacement README;
 - this descriptive Current State document;
 - documentation status and authority guide;
+- operational-documentation recovery;
+- approved Application Semantics;
+- active contract classification for implemented contracts;
 - concise pull-request template update;
 - controlled-work issue template;
 - reusable Codex task prompt template.
 
 Not yet completed:
 
-- implementation of the approved documentation disposition;
 - scenario dependency and status review;
-- application semantic map;
 - CM1 experimentation strategy;
 - MVP definition;
 - final application architecture or workflow decisions.

--- a/docs/current/INGEST_RESULTS_STORAGE_LIFECYCLE.md
+++ b/docs/current/INGEST_RESULTS_STORAGE_LIFECYCLE.md
@@ -271,41 +271,18 @@ bulky output and notebook metadata. That is simple and local-first, but it
 means cleanup is not just "delete bulky output." It also deletes the Result
 Card and diagnostics unless those are moved or copied elsewhere first.
 
-## Compatibility With The Desired Product Model
+## Current Storage Coupling
 
-Desired future model to evaluate:
+Current compatibility finding:
 
-```text
-Ingested = appears in Results as an experiment notebook entry.
-Save changes = title/notes/tags edits.
-Local data retention = whether bulky local run data remains available.
-```
+- Ingest creates metadata that appears in the current Results surface.
+- Title, notes, and tags are current local Result Card sidecar state.
+- Legacy saved/protected fields may exist in old local metadata, but they are no
+  longer the current user-facing retention mode.
+- Because `result_metadata.json` and `result_card.json` live inside the run
+  directory, deleting the managed run directory also removes the current
+  discoverable metadata, editable card state, diagnostics, and source output
+  for that result.
 
-Current compatibility: **partially compatible, blocked by storage architecture.**
-
-- Compatible: ingest already creates metadata that appears in Results.
-- Compatible: title/notes/tags edits are already local Result Card state.
-- Compatible with caveat: legacy saved/protected fields may exist in old local
-  metadata, but they are no longer the current user-facing mode.
-- Blocked: because `result_metadata.json` and `result_card.json` live inside the
-  run directory, deleting "bulky local run data" also deletes the notebook entry
-  and diagnostics. A true "ingested notebook entry can remain after local output
-  cleanup" model requires moving or copying result metadata/card state outside
-  the deletable run directory, or adding an archive/metadata-only cleanup mode
-  that preserves those files while removing large output.
-
-## Product Decision Hooks
-
-Before changing UI labels or cleanup behavior, decide these separately:
-
-1. Should ingested metadata move to a stable notebook/results directory outside
-   `runs/<run-id>`?
-2. Should `result_card.json` remain sidecar state, or become part of a central
-   notebook store?
-3. Should cleanup support "remove bulky output but keep metadata/card" as a
-   distinct action from "delete entire run directory"?
-4. Should backend delete protection read Result Card state, update manifest
-   state when a card is saved, or both?
-5. Should "Saved" mean editable notebook changes are persisted, or should the
-   UI use different language such as "Protected" / "Keep local output" for
-   cleanup protection?
+This audit records the current storage coupling. It does not choose a future
+notebook, database, archive, metadata-only cleanup, or storage-retention model.

--- a/docs/product/APPLICATION_SEMANTICS.md
+++ b/docs/product/APPLICATION_SEMANTICS.md
@@ -1,6 +1,6 @@
 # Cloud Chamber Application Semantics
 
-**Status:** Proposed product-semantic authority for review
+**Status:** Approved product-semantic authority
 
 This document defines the foundational product vocabulary for Cloud Chamber.
 


### PR DESCRIPTION
## Summary
Closes #368.
Classifies all five formerly active contract documents under the approved Cloud Chamber application semantics.

### Active implemented contracts
- `docs/contracts/output-product-specification.md`
- `docs/contracts/sounding-candidate-screening.md`

### Archived contract material
- `docs/archive/contracts/output-product-specification-legacy.md`
- `docs/archive/contracts/sounding-candidate-screening-legacy.md`
- `docs/archive/contracts/realistic-les-input-specification-legacy.md`
- `docs/archive/contracts/analyzer-hypothesis-output-signature-legacy.md`
- `docs/archive/contracts/run-recipe-and-story-mapping-legacy.md`

## Disposition by original document
| Original document | Classification | Disposition |
|---|---|---|
| output product specification | mixed | archived original plus active implemented replacement |
| sounding candidate screening | implemented but mixed | archived original plus active implemented replacement |
| realistic LES input specification | proposal/mixed | archived; no active replacement |
| analyzer hypothesis/output signature | proposal-only | archived; no active replacement |
| run recipe/story mapping | mixed proposal conflicting with canonical Recipe semantics | archived; no active replacement |

## Stable vision
Cloud Chamber remains an experience-first collection of explorable Cloud Worlds where users can watch beautiful Simulations, reveal hidden atmospheric processes through Lenses, change meaningful conditions, compare outcomes, and understand clouds better.

## Current task
Make the active contract directory trustworthy by ensuring active contracts describe only code-verified current behavior and by moving proposals and historical mixed documents out of the active contract path.

## Non-implications
This work does not decide the first Cloud World, supported Recipes, whether current scenarios survive, whether observed soundings remain central, final UX/navigation, final APIs/schemas, databases/persistence, storage/cleanup redesign, compute tiers, experimentation strategy, MVP, or migration/retirement plans.

## Portfolio effect
This preserves useful current capabilities while preventing one historical product direction, current implementation vocabulary, or current Build/Results/Explore shape from defining the full Cloud Chamber product.

## Code and test evidence
### Output products
- implementation: `output_products.py`, `result_diagnostics.py`, `result_ingest.py`, `visualization_data.py`, `selected_region_diagnostics.py`, `runtime_storage.py`, `result_cards.py`, `run_manifest.py`, `app.py`
- endpoints: result ingest/list/detail/save/delete, storage inventory/delete, visualization fields/defaults/slice/point-cloud, output-product catalog/profile/time-height/time-series, selected-region diagnostics
- persisted records: runtime-local `result_metadata.json`, optional `result_card.json`, and `derived-products/output_product_manifest.json`
- tests: `test_output_products.py`, `test_result_diagnostics.py`, `test_result_ingest.py`, `test_visualization_data.py`, `test_selected_region_diagnostics.py`, `test_runtime_storage.py`, `test_result_cards.py`, `test_app.py`, `App.test.tsx`, and mocked Build/Results/Explore e2e coverage

### Sounding candidate screening
- implementation: `sounding_candidates.py`, `sounding_diagnostics.py`, `observed_sounding.py`, `igra_catalog.py`, `igra_recent_cli.py`, `pre_run_validation.py`, `dry_run_package.py`, `cm1_input_contract.py`, `run_manifest.py`, `app.py`, `App.tsx`
- endpoints: screening inputs, screen, analyze, saved candidate list/create, saved candidate update/delete
- persisted records: runtime-cache saved candidates JSON and copied `candidate_screening` package provenance in `run_manifest.json`, `case_manifest.json`, and `dry_run_report.json`
- tests: `test_sounding_candidates.py`, `test_sounding_diagnostics.py`, `test_observed_sounding.py`, `test_igra_catalog.py`, `test_igra_recent_cli.py`, `test_dry_run_package.py`, `test_app.py`, `App.test.tsx`, and mocked Build/Results/Explore e2e coverage

## Direct authority repairs
- Application Semantics: changed status to approved product-semantic authority.
- Documentation Status: added Application Semantics to active authority, recorded Stage 1 and Stage 2 completion, identified the two active implemented contracts, and identified `docs/archive/contracts/` as the home for archived contract proposals and mixed historical contracts.
- Current State: removed stale unfinished semantic-map/recovery status, described the current gated product-architecture program, and preserved open product questions and the implemented-versus-approved boundary.
- Current Architecture: clarified that current scenarios and run paths may provide implementation evidence or ingredients for future Recipes within a Cloud World, but are not Cloud Worlds by themselves.
- Lifecycle: removed the future model equating ingestion with an experiment notebook entry while preserving the code-backed storage-coupling finding.
- README: updated repository status to the gated product-architecture program and added Application Semantics to the reading path.
- AGENTS: updated recovery-mode language to the gated product-architecture program and restated manual review, no auto-merge, no autonomous follow-up issues, no PM-decision substitution, and current implementation versus future-product boundaries.

## Changed paths
- `AGENTS.md`
- `README.md`
- `docs/DOCUMENTATION_STATUS.md`
- `docs/product/APPLICATION_SEMANTICS.md`
- `docs/current/CURRENT_STATE.md`
- `docs/current/CURRENT_ARCHITECTURE.md`
- `docs/current/INGEST_RESULTS_STORAGE_LIFECYCLE.md`
- `docs/contracts/output-product-specification.md`
- `docs/contracts/sounding-candidate-screening.md`
- `docs/archive/contracts/output-product-specification-legacy.md`
- `docs/archive/contracts/sounding-candidate-screening-legacy.md`
- `docs/archive/contracts/realistic-les-input-specification-legacy.md`
- `docs/archive/contracts/analyzer-hypothesis-output-signature-legacy.md`
- `docs/archive/contracts/run-recipe-and-story-mapping-legacy.md`

## Stale, unverified, or contradictory claims found but not implemented
- The old output-product contract included future Render Studio, Diagnostics Lab, export-format, binary/chunked-format, implementation-sequencing, and PM-decision material; those claims were archived and omitted from the active implemented contract.
- The old sounding contract mixed implemented screening behavior with forward analyzer, run-recipe mapping, assumption-set, and workflow claims; only verified current screening behavior remains active.
- The realistic LES input specification remains proposal/mixed historical material; no active input contract or canonical observed-sounding Recipe was created.
- The analyzer hypothesis/output-signature contract remains proposal-only historical material. Current legacy payload names such as `selected_hypothesis` and small `predicted_output_signature` lists are documented only as implementation fields, not active product contracts.
- The run recipe/story mapping contract conflicts with canonical Recipe semantics by treating implementation `run_recipe` labels as product recipe authority; it was archived with no active replacement.
- `app/backend/tests/test_pre_run_validation.py` was listed in the issue as possible evidence but does not exist in the current tree; pre-run-validation behavior was verified through implementation and adjacent package/app tests.
- Historical archive documents retain historical relative links among moved contract names as preserved body content. Active current documents do not link to the three removed active contract paths.

Do not create follow-up issues automatically.

## Scope confirmation
No changes were made to:
- application code;
- tests;
- APIs;
- schemas;
- scenarios;
- UI behavior;
- scientific calculations;
- runtime behavior;
- storage behavior.

## Verification
- `git diff --name-only main...HEAD`: listed only the 14 authorized documentation paths above.
- `git diff --check main...HEAD`: passed.
- `scripts/check.sh`: passed frontend lint/tests/build, backend formatting/lint/typecheck/tests, script syntax checks, forbidden tracked artifact checks, and docs/JSON/YAML sanity checks.
- active contract count: exactly two files under `docs/contracts/`.
- archive preservation check: passed for all five legacy files by comparing each original contract body from `main` to the archived body after removing the new heading-led banner.
- link/terminology searches: stale authority phrases returned no active hits; terminology hits are qualified current implementation terms or approved product-semantic definitions; moved-contract links remain only inside historical archive bodies.

## Review posture
Manual PM review required.
Auto-merge is disabled.
