### PR TITLE
Stage 4: reproduce canonical BOMEX baseline

### DIFF
--- a/app/backend/cloud_chamber/bomex_case.py
+++ b/app/backend/cloud_chamber/bomex_case.py
@@ -1,0 +1,925 @@
+"""Deterministic packaging and evidence extraction for the canonical BOMEX case."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber import __version__
+from cloud_chamber.result_diagnostics import QC_CLOUD_THRESHOLD_KG_KG
+from cloud_chamber.result_ingest import ResultMetadata
+from cloud_chamber.run_manifest import (
+    AppMetadata,
+    GeneratedInputs,
+    LifecycleState,
+    ProductState,
+    ProvenanceMetadata,
+    RunManifest,
+    RuntimePaths,
+    ScenarioReference,
+    UserMetadata,
+    ValidationStatus,
+    write_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings, discover_cm1
+
+CASE_ID = "bomex_trade_cumulus_baseline_v0"
+MAPPING_VERSION = "bomex_cm1_mapping_v1"
+SMOKE_DURATION_SECONDS = 600
+FULL_DURATION_SECONDS = 21_600
+OUTPUT_CADENCE_SECONDS = 300
+DIAGNOSTIC_CADENCE_SECONDS = 60
+CM1_RELEASE = "21.1"
+CM1_TAG_COMMIT = "0f734f64efa89a684963a66d2ac32db67617912b"
+CM1_SOURCE_MANIFEST_SHA256 = "fbe2367dfcd6d8c55cac4bd03362d8d49f13f80cebd13b36230c20d71119a84e"
+CM1_README_NAMELIST_SHA256 = "7b95be56db51f5c9396c59dca252cf96b918a312cc70107451f91149a34ab3b5"
+CM1_EXECUTABLE_SHA256 = "5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1"
+CM1_BOMEX_NAMELIST_SHA256 = "4aa2f7cfad8c918801e0768c2618a37740e3966bc8f47205e5fafda3e506f965"
+CM1_BOMEX_README_SHA256 = "368c6ca53445f920f0e89d6e4273111f0378785e393e1efa63a7758f2dc5ae56"
+SCIENTIFIC_SOURCE_DOI = "https://doi.org/10.1175/1520-0469(2003)60%3C1201:ALESIS%3E2.0.CO;2"
+SCIENTIFIC_SOURCE_RECORD = "https://pure.mpg.de/view/item_995314"
+CM1_SOURCE_TAG = "https://github.com/NCAR/CM1/tree/21.1"
+
+CRITICAL_SOURCE_HASHES = {
+    "src/adv_routines.F": "265723c8b19e300592ddbad3839ee689aa4933ac2f0ae236c61f4d5d40ef7f00",
+    "src/base.F": "9c88a1021ddde22d02680786246c52bcffb040cbd72c3c4708f24fe24eec32ef",
+    "src/domaindiag.F": "a926b4938c6b576e2ec634c14dbf177f8bdcc557ddefa3b8155326e5f8ef7dff",
+    "src/init3d.F": "9c45c0982ba194ea6ea74afd6a2516445cdd011fc90902091d089f4cb92dfd28",
+    "src/kessler.F": "f232f840e425d8c9abd28841e0a46a06e0dbf641460224fa61b6a82e5a650472",
+    "src/mp_driver.F": "f70684282df49338dbb6336c7f3ca538c66e8cc99933fe5fb52325303c394134",
+    "src/param.F": "cac64a6cb4363c6b88367b5cb9391f1bcf2130c63ffedef6e5973c03b190c349",
+    "src/sfcphys.F": "7cb54de579b8bb038285430890e075ab19ed2e6d93158bd50d656209d64696a7",
+    "src/solve1.F": "515346f18268aea39e7a919536ee6187386e5db6d184e6e4c597509c701e2076",
+    "src/testcase_simple_phys.F": (
+        "ce0a74ba558634cf712669aae3cbee2eafeb4e23a116e0fe3d819886938ffc72"
+    ),
+}
+
+REQUIRED_OUTPUT_FIELDS = (
+    "ql",
+    "qv",
+    "th",
+    "prs",
+    "u",
+    "v",
+    "w",
+    "tke",
+    "kmh",
+    "khh",
+    "cwp",
+    "hfx",
+    "qfx",
+    "rain",
+)
+
+REQUIRED_OUTPUT_SWITCHES = {
+    "output_format": "2",
+    "output_filetype": "2",
+    "output_rain": "1",
+    "output_sfcflx": "1",
+    "output_sfcparams": "1",
+    "output_sfcdiags": "1",
+    "output_th": "1",
+    "output_prs": "1",
+    "output_rho": "1",
+    "output_tke": "1",
+    "output_km": "1",
+    "output_kh": "1",
+    "output_qv": "1",
+    "output_q": "1",
+    "output_u": "1",
+    "output_v": "1",
+    "output_w": "1",
+    "output_pwat": "1",
+    "output_lwp": "1",
+}
+
+_COMMON_NAMELIST_OVERRIDES = {
+    "tapfrq": f"{OUTPUT_CADENCE_SECONDS}.0",
+    "rstfrq": "86400.0",
+    "statfrq": f"{DIAGNOSTIC_CADENCE_SECONDS}.0",
+    "testcase": "3",
+    "adapt_dt": "1",
+    "ptype": "6",
+    "iautoc": "0",
+    "efall": "0",
+    "isnd": "19",
+    "iwnd": "9",
+    "iinit": "0",
+    "irandp": "1",
+    "v_t": "0.0",
+    "ztop": "3000.0",
+    "output_format": "2",
+    "output_filetype": "2",
+    "output_interp": "0",
+    "output_dbz": "0",
+    "output_uinterp": "0",
+    "output_vinterp": "0",
+    "output_winterp": "0",
+    "output_rho": "1",
+    "output_pwat": "1",
+    "output_lwp": "1",
+    "output_thbudget": "0",
+    "output_qvbudget": "0",
+    "output_ubudget": "0",
+    "output_vbudget": "0",
+    "output_wbudget": "0",
+    "dodomaindiag": ".true.",
+    "diagfrq": f"{DIAGNOSTIC_CADENCE_SECONDS}.0",
+}
+
+_PROFILE_HEIGHTS_M = (0.0, 300.0, 500.0, 520.0, 700.0, 1480.0, 1500.0, 2000.0, 2100.0, 3000.0)
+_THETA_L_KNOTS = ((0.0, 298.7), (520.0, 298.7), (1480.0, 302.4), (2000.0, 308.2), (3000.0, 311.85))
+_QT_G_KG_KNOTS = ((0.0, 17.0), (520.0, 16.3), (1480.0, 10.7), (2000.0, 4.2), (3000.0, 3.0))
+_U_M_S_KNOTS = ((0.0, -8.75), (700.0, -8.75), (3000.0, -4.61))
+
+
+class BomexCaseError(RuntimeError):
+    """Raised when BOMEX package or evidence generation cannot proceed."""
+
+
+class BomexVariant(StrEnum):
+    SMOKE = "smoke"
+    FULL = "full"
+
+    @property
+    def duration_seconds(self) -> int:
+        if self is BomexVariant.SMOKE:
+            return SMOKE_DURATION_SECONDS
+        return FULL_DURATION_SECONDS
+
+
+class CM1Provenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    release: str
+    official_tag_commit: str
+    official_source_tag: str
+    source_tree_path: str
+    run_directory_path: str
+    executable_path: str
+    executable_sha256: str
+    readme_namelist_path: str
+    readme_namelist_sha256: str
+    source_manifest_method: str
+    source_manifest_sha256: str
+    critical_source_sha256: dict[str, str]
+    bundled_bomex_namelist_path: str
+    bundled_bomex_namelist_sha256: str
+    bundled_bomex_readme_path: str
+    bundled_bomex_readme_sha256: str
+
+
+@dataclass(frozen=True)
+class BomexPackageResult:
+    run_id: str
+    variant: BomexVariant
+    package_dir: Path
+    manifest_path: Path
+    case_manifest_path: Path
+    generated_files: tuple[Path, ...]
+
+
+class BomexRunEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evidence_version: str = "bomex_run_evidence_v1"
+    case_id: str = CASE_ID
+    run_id: str
+    result_id: str
+    variant: str
+    duration_seconds: int
+    output_cadence_seconds: int
+    wall_clock_seconds: float | None = None
+    model_output_count: int
+    expected_model_output_count: int
+    netcdf_output_bytes: int
+    runtime_integrity_state: str
+    runtime_integrity_reason: str
+    available_model_fields: list[str]
+    missing_required_fields: list[str]
+    field_non_finite_counts: dict[str, int]
+    first_output_time_seconds: float | None = None
+    last_output_time_seconds: float | None = None
+    cloud_formed: bool | None = None
+    first_cloud_time_seconds: float | None = None
+    cloud_base_m: float | None = None
+    cloud_top_m: float | None = None
+    max_cloud_liquid_kg_kg: float | None = None
+    max_updraft_m_s: float | None = None
+    min_downdraft_m_s: float | None = None
+    max_surface_rain: float | None = None
+    mean_total_cloud_cover_final_three_hours_percent: float | None = None
+    peak_cloud_fraction_final_three_hours_percent: float | None = None
+    mean_lwp_final_three_hours_kg_m2: float | None = None
+    max_lwp_kg_m2: float | None = None
+    lwp_cycle_peak_count: int
+    liquid_water_path_source_field: str = "cwp"
+    cm1_lwp_field_status: str = "unusable_without_rain_allocation"
+    forcing_diagnostic_fields: dict[str, dict[str, float | None]]
+    resolved_turbulent_flux_fields: list[str]
+    final_domain_mean_profiles: dict[str, list[float | None]] = Field(default_factory=dict)
+    final_profile_height_m: list[float | None] = Field(default_factory=list)
+    caveats: list[str] = Field(default_factory=list)
+
+    def to_json_text(self) -> str:
+        return self.model_dump_json(indent=2) + "\n"
+
+
+def collect_cm1_provenance(settings: CloudChamberSettings) -> CM1Provenance:
+    """Verify the configured executable and scientific source against pinned CM1 r21.1."""
+    discovery = discover_cm1(settings)
+    if not discovery.ready or settings.cm1_root is None or settings.cm1_run_dir is None:
+        detail = "; ".join(discovery.missing)
+        raise BomexCaseError(f"Configured CM1 runtime is not ready: {detail}")
+
+    root = settings.cm1_root.resolve()
+    run_dir = settings.cm1_run_dir.resolve()
+    executable = run_dir / "cm1.exe"
+    readme_namelist = root / "README.namelist"
+    bundled_dir = run_dir / "config_files" / "les_ShallowCu"
+    bundled_namelist = bundled_dir / "namelist.input"
+    bundled_readme = bundled_dir / "README"
+
+    expected_files = {
+        executable: CM1_EXECUTABLE_SHA256,
+        readme_namelist: CM1_README_NAMELIST_SHA256,
+        bundled_namelist: CM1_BOMEX_NAMELIST_SHA256,
+        bundled_readme: CM1_BOMEX_README_SHA256,
+        **{root / relative: expected for relative, expected in CRITICAL_SOURCE_HASHES.items()},
+    }
+    mismatches: list[str] = []
+    for path, expected in expected_files.items():
+        if not path.is_file():
+            mismatches.append(f"missing:{path}")
+            continue
+        actual = sha256_file(path)
+        if actual != expected:
+            mismatches.append(f"sha256_mismatch:{path.name}:{actual}")
+
+    source_manifest_hash = source_manifest_sha256(root)
+    if source_manifest_hash != CM1_SOURCE_MANIFEST_SHA256:
+        mismatches.append(f"source_manifest_sha256_mismatch:{source_manifest_hash}")
+    if mismatches:
+        raise BomexCaseError(
+            "Configured CM1 provenance does not match the pinned r21.1 evidence: "
+            + "; ".join(mismatches)
+        )
+
+    return CM1Provenance(
+        release=CM1_RELEASE,
+        official_tag_commit=CM1_TAG_COMMIT,
+        official_source_tag=CM1_SOURCE_TAG,
+        source_tree_path=str(root),
+        run_directory_path=str(run_dir),
+        executable_path=str(executable),
+        executable_sha256=CM1_EXECUTABLE_SHA256,
+        readme_namelist_path=str(readme_namelist),
+        readme_namelist_sha256=CM1_README_NAMELIST_SHA256,
+        source_manifest_method=(
+            "sha256 each sorted src/*.F line as '<sha256>  src/<name>\\n', then sha256 manifest"
+        ),
+        source_manifest_sha256=source_manifest_hash,
+        critical_source_sha256=dict(CRITICAL_SOURCE_HASHES),
+        bundled_bomex_namelist_path=str(bundled_namelist),
+        bundled_bomex_namelist_sha256=CM1_BOMEX_NAMELIST_SHA256,
+        bundled_bomex_readme_path=str(bundled_readme),
+        bundled_bomex_readme_sha256=CM1_BOMEX_README_SHA256,
+    )
+
+
+def source_manifest_sha256(cm1_root: Path) -> str:
+    source_paths = sorted((cm1_root / "src").glob("*.F"), key=lambda path: path.name)
+    if not source_paths:
+        raise BomexCaseError(f"No original CM1 src/*.F files found under {cm1_root}")
+    lines = [
+        f"{sha256_file(path)}  {path.relative_to(cm1_root).as_posix()}\n" for path in source_paths
+    ]
+    return sha256_text("".join(lines))
+
+
+def render_bomex_namelist(reference_text: str, variant: BomexVariant) -> str:
+    """Render the pinned CM1 BOMEX namelist with explicit Stage 4 translations."""
+    rendered = reference_text
+    overrides = {**_COMMON_NAMELIST_OVERRIDES, "timax": f"{variant.duration_seconds}.0"}
+    for name, value in overrides.items():
+        rendered = _replace_namelist_assignment(rendered, name, value)
+    for name, value in REQUIRED_OUTPUT_SWITCHES.items():
+        rendered = _replace_namelist_assignment(rendered, name, value)
+    return rendered.rstrip() + "\n"
+
+
+def normalized_science_namelist(namelist_text: str) -> str:
+    """Normalize the sole smoke/full science difference for equivalence checks."""
+    return _replace_namelist_assignment(namelist_text, "timax", "<duration_seconds>")
+
+
+def render_profile_audit() -> str:
+    """Render a deterministic WRF-format audit of the canonical initial profile."""
+    lines = ["  1015.0000   298.7000   17.000000"]
+    for height in _PROFILE_HEIGHTS_M:
+        theta_l = _linear_profile_value(height, _THETA_L_KNOTS)
+        qt = _linear_profile_value(height, _QT_G_KG_KNOTS)
+        u = _linear_profile_value(height, _U_M_S_KNOTS)
+        lines.append(f"  {height:9.4f}  {theta_l:9.4f}  {qt:10.6f}  {u:9.4f}  {0.0:9.4f}")
+    return "\n".join(lines) + "\n"
+
+
+def generate_bomex_package(
+    *,
+    settings: CloudChamberSettings,
+    variant: BomexVariant,
+    run_id: str,
+    allow_overwrite: bool = False,
+    app_commit: str | None = None,
+) -> BomexPackageResult:
+    """Generate a deterministic, provenance-rich BOMEX runtime package."""
+    provenance = collect_cm1_provenance(settings)
+    package_dir = settings.runtime_home.expanduser() / "runs" / run_id
+    if package_dir.exists():
+        if not allow_overwrite:
+            raise BomexCaseError(f"Run package already exists: {package_dir}")
+        shutil.rmtree(package_dir)
+    package_dir.mkdir(parents=True)
+
+    paths = {
+        "manifest": package_dir / "run_manifest.json",
+        "case_manifest": package_dir / "case_manifest.json",
+        "namelist": package_dir / "namelist.input",
+        "input_sounding": package_dir / "input_sounding",
+        "report": package_dir / "dry_run_report.json",
+        "runtime_checklist": package_dir / "runtime_file_checklist.json",
+    }
+    reference_namelist = Path(provenance.bundled_bomex_namelist_path).read_text()
+    namelist_text = render_bomex_namelist(reference_namelist, variant)
+    profile_text = render_profile_audit()
+    runtime_checklist = {
+        "status": "external_runtime_files_not_committed",
+        "required_files": ["LANDUSE.TBL"],
+        "source_candidates": {
+            "LANDUSE.TBL": ["config_files/les_ShallowCu/LANDUSE.TBL", "LANDUSE.TBL"]
+        },
+        "notes": "Stage the CM1 r21.1 bundled shallow-cumulus runtime table.",
+    }
+    paths["namelist"].write_text(namelist_text)
+    paths["input_sounding"].write_text(profile_text)
+    _write_json(paths["runtime_checklist"], runtime_checklist)
+
+    generated_hashes = {
+        "namelist.input": sha256_text(namelist_text),
+        "input_sounding": sha256_text(profile_text),
+        "runtime_file_checklist.json": sha256_file(paths["runtime_checklist"]),
+    }
+    science_settings_hash = sha256_text(normalized_science_namelist(namelist_text))
+    case_manifest = _case_manifest_payload(
+        variant=variant,
+        provenance=provenance,
+        generated_hashes=generated_hashes,
+        science_settings_hash=science_settings_hash,
+    )
+    _write_json(paths["case_manifest"], case_manifest)
+    generated_hashes["case_manifest.json"] = sha256_file(paths["case_manifest"])
+
+    now = datetime.now(UTC)
+    resolved_commit = app_commit if app_commit is not None else _git_commit()
+    run_configuration: dict[str, Any] = {
+        "case_id": CASE_ID,
+        "mapping_version": MAPPING_VERSION,
+        "variant": variant.value,
+        "duration_seconds": variant.duration_seconds,
+        "output_cadence_seconds": OUTPUT_CADENCE_SECONDS,
+        "diagnostic_cadence_seconds": DIAGNOSTIC_CADENCE_SECONDS,
+        "expected_model_output_count": variant.duration_seconds // OUTPUT_CADENCE_SECONDS + 1,
+        "domain": {
+            "nx": 64,
+            "ny": 64,
+            "nz": 75,
+            "dx_m": 100.0,
+            "dy_m": 100.0,
+            "dz_m": 40.0,
+            "model_top_m": 3000.0,
+        },
+        "time_step": {"target_seconds": 3.0, "adaptive": True},
+        "microphysics": {
+            "ptype": 6,
+            "terminal_velocity_m_s": 0.0,
+            "precipitation_treatment": "reversible_moist_thermodynamics_no_fallout",
+            "cloud_liquid_output_field": "ql",
+        },
+        "scientific_sources": [SCIENTIFIC_SOURCE_DOI, SCIENTIFIC_SOURCE_RECORD],
+        "cm1_provenance": provenance.model_dump(mode="json"),
+        "generated_input_sha256": dict(generated_hashes),
+        "generated_forcing_input_sha256": {},
+        "science_settings_sha256": science_settings_hash,
+        "case_manifest_path": str(paths["case_manifest"]),
+        "approximations": [
+            "cm1_analytic_isnd19_iwnd9_testcase3_instead_of_external_case_files",
+            "prescribed_radiative_tendency_not_interactive_radiation",
+            "cm1_specific_upper_rayleigh_damping_above_2500m",
+            "ql_mapped_to_cloud_chamber_canonical_cloud_liquid_diagnostics",
+        ],
+        "unsupported_components": [],
+    }
+    manifest = RunManifest(
+        run_id=run_id,
+        scenario=ScenarioReference(id=CASE_ID, schema_version=MAPPING_VERSION),
+        controls={"variant": variant.value},
+        run_configuration=run_configuration,
+        physical_question=(
+            "Can the canonical steady nonprecipitating BOMEX setup produce a recognizable, "
+            "watchable, locally practical trade-cumulus field in configured CM1 r21.1?"
+        ),
+        expected_diagnostics=[
+            "cloud_liquid_and_lwp",
+            "cloud_fraction_by_height_and_time",
+            "cloud_base_and_top_evolution",
+            "vertical_velocity",
+            "domain_mean_thermodynamic_profiles",
+            "surface_and_resolved_turbulent_fluxes",
+            "large_scale_forcing_profiles",
+            "runtime_integrity_and_non_finite_scan",
+        ],
+        generated_inputs=GeneratedInputs(
+            run_directory=str(package_dir),
+            manifest_path=str(paths["manifest"]),
+            namelist_input=str(paths["namelist"]),
+            input_sounding=str(paths["input_sounding"]),
+            dry_run_report=str(paths["report"]),
+            runtime_file_checklist=[str(paths["runtime_checklist"])],
+        ),
+        runtime_paths=RuntimePaths(runtime_home=str(settings.runtime_home.expanduser())),
+        app=AppMetadata(app_version=__version__, commit=resolved_commit),
+        lifecycle_state=LifecycleState.PACKAGED,
+        validation_status=ValidationStatus.VALID,
+        provenance=ProvenanceMetadata(product_state=ProductState.PACKAGED_DRY_RUN_OUTPUT),
+        created_at=now,
+        updated_at=now,
+        user=UserMetadata(name=f"Canonical BOMEX baseline ({variant.value})"),
+        run_recipe=None,
+        required_output_fields=list(REQUIRED_OUTPUT_FIELDS),
+        input_source="canonical_bomex_analytic_case",
+        expected_outputs=["cm1_model_netcdf", "cm1_domain_diagnostic_netcdf"],
+        run_limitations=[
+            "stage4_evidence_only_not_product_recipe",
+            "single_cm1_les_translation_not_all_model_intercomparison",
+        ],
+        run_caveats=list(run_configuration["approximations"]),
+        manual_validation_status="stage4_evidence_pending",
+    )
+    write_run_manifest(paths["manifest"], manifest)
+    report = {
+        "status": "packaged_not_executed",
+        "case_id": CASE_ID,
+        "mapping_version": MAPPING_VERSION,
+        "variant": variant.value,
+        "run_id": run_id,
+        "generated_input_sha256": generated_hashes,
+        "science_settings_sha256": science_settings_hash,
+        "cm1_release": provenance.release,
+        "cm1_executable_sha256": provenance.executable_sha256,
+        "source_manifest_sha256": provenance.source_manifest_sha256,
+        "required_output_fields": list(REQUIRED_OUTPUT_FIELDS),
+        "run_recipe": None,
+        "notes": "Generated package is configured run evidence, not scientific success.",
+    }
+    _write_json(paths["report"], report)
+    return BomexPackageResult(
+        run_id=run_id,
+        variant=variant,
+        package_dir=package_dir,
+        manifest_path=paths["manifest"],
+        case_manifest_path=paths["case_manifest"],
+        generated_files=tuple(paths.values()),
+    )
+
+
+def build_bomex_run_evidence(
+    result: ResultMetadata,
+    *,
+    wall_clock_seconds: float | None = None,
+) -> BomexRunEvidence:
+    """Build bounded BOMEX science/process evidence from an ingested result."""
+    config = result.run_configuration
+    variant = str(config.get("variant", "unknown"))
+    duration_seconds = int(config.get("duration_seconds", 0))
+    expected_count = int(config.get("expected_model_output_count", 0))
+    required_missing = _missing_required_fields(result.variables)
+    paths = [Path(path) for path in result.model_output_paths]
+    frame_metrics, non_finite_counts, final_profiles, final_heights = _model_frame_evidence(paths)
+    final_three_hour = [
+        frame
+        for frame in frame_metrics
+        if frame["time_seconds"] is not None and frame["time_seconds"] >= 10_800.0
+    ]
+    lwp_values = [
+        float(frame["mean_lwp"]) for frame in frame_metrics if frame["mean_lwp"] is not None
+    ]
+    diag_summary, flux_fields = _diagnostic_evidence(
+        [Path(path) for path in result.netcdf_paths if "cm1out_diag_" in Path(path).name]
+    )
+    diagnostics = result.diagnostics
+    cloud = diagnostics.cloud if diagnostics is not None else None
+    vertical_velocity = diagnostics.vertical_velocity if diagnostics is not None else None
+    surface_rain = diagnostics.surface_rain if diagnostics is not None else None
+    caveats: list[str] = [
+        "cm1_cwp_used_as_liquid_water_path_for_nonprecipitating_ptype6",
+        "cm1_lwp_unusable_without_rain_allocation",
+    ]
+    caveats.extend(result.runtime_integrity.caveats)
+    if not final_three_hour and variant == BomexVariant.FULL.value:
+        caveats.append("final_three_hour_evidence_unavailable")
+    if required_missing:
+        caveats.append("required_output_fields_missing")
+    if not diag_summary:
+        caveats.append("forcing_diagnostic_fields_unavailable")
+
+    return BomexRunEvidence(
+        run_id=result.run_id,
+        result_id=result.result_id,
+        variant=variant,
+        duration_seconds=duration_seconds,
+        output_cadence_seconds=int(config.get("output_cadence_seconds", 0)),
+        wall_clock_seconds=wall_clock_seconds,
+        model_output_count=result.model_output_file_count,
+        expected_model_output_count=expected_count,
+        netcdf_output_bytes=sum(path.stat().st_size for path in map(Path, result.netcdf_paths)),
+        runtime_integrity_state=result.runtime_integrity.state,
+        runtime_integrity_reason=result.runtime_integrity.reason,
+        available_model_fields=sorted(result.variables),
+        missing_required_fields=required_missing,
+        field_non_finite_counts=non_finite_counts,
+        first_output_time_seconds=result.first_output_time_seconds,
+        last_output_time_seconds=result.last_output_time_seconds,
+        cloud_formed=cloud.formed if cloud is not None else None,
+        first_cloud_time_seconds=cloud.first_cloud_time_seconds if cloud is not None else None,
+        cloud_base_m=cloud.cloud_base_m if cloud is not None else None,
+        cloud_top_m=cloud.cloud_top_m if cloud is not None else None,
+        max_cloud_liquid_kg_kg=cloud.max_qc_kg_kg if cloud is not None else None,
+        max_updraft_m_s=(vertical_velocity.max_w_m_s if vertical_velocity is not None else None),
+        min_downdraft_m_s=(vertical_velocity.min_w_m_s if vertical_velocity is not None else None),
+        max_surface_rain=(surface_rain.max_surface_rain if surface_rain is not None else None),
+        mean_total_cloud_cover_final_three_hours_percent=_mean_metric(
+            final_three_hour, "total_cloud_cover_percent"
+        ),
+        peak_cloud_fraction_final_three_hours_percent=_max_metric(
+            final_three_hour, "peak_cloud_fraction_percent"
+        ),
+        mean_lwp_final_three_hours_kg_m2=_mean_metric(final_three_hour, "mean_lwp"),
+        max_lwp_kg_m2=max(lwp_values) if lwp_values else None,
+        lwp_cycle_peak_count=_local_peak_count(lwp_values),
+        forcing_diagnostic_fields=diag_summary,
+        resolved_turbulent_flux_fields=flux_fields,
+        final_domain_mean_profiles=final_profiles,
+        final_profile_height_m=final_heights,
+        caveats=caveats,
+    )
+
+
+def write_bomex_run_evidence(path: Path, evidence: BomexRunEvidence) -> None:
+    path.write_text(evidence.to_json_text())
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _case_manifest_payload(
+    *,
+    variant: BomexVariant,
+    provenance: CM1Provenance,
+    generated_hashes: dict[str, str],
+    science_settings_hash: str,
+) -> dict[str, Any]:
+    return {
+        "case_id": CASE_ID,
+        "mapping_version": MAPPING_VERSION,
+        "authority_state": "stage4_candidate_evidence_not_product_recipe",
+        "variant": variant.value,
+        "duration_seconds": variant.duration_seconds,
+        "scientific_sources": [SCIENTIFIC_SOURCE_DOI, SCIENTIFIC_SOURCE_RECORD],
+        "canonical_definition": {
+            "domain_grid": {
+                "nx": 64,
+                "ny": 64,
+                "nz": 75,
+                "dx_m": 100.0,
+                "dy_m": 100.0,
+                "dz_m": 40.0,
+            },
+            "surface_fluxes": {
+                "sensible_heat_flux_k_m_s": 8.0e-3,
+                "moisture_flux_g_g_m_s": 5.2e-5,
+                "friction_velocity_m_s": 0.28,
+            },
+            "coriolis_s_1": 0.376e-4,
+            "nonprecipitating": True,
+        },
+        "cm1_translation": {
+            "testcase": 3,
+            "isnd": 19,
+            "iwnd": 9,
+            "ptype": 6,
+            "v_t_m_s": 0.0,
+            "cloud_liquid_output_field": "ql",
+            "output_format": "netcdf",
+            "output_cadence_seconds": OUTPUT_CADENCE_SECONDS,
+            "diagnostic_cadence_seconds": DIAGNOSTIC_CADENCE_SECONDS,
+        },
+        "cm1_provenance": provenance.model_dump(mode="json"),
+        "generated_input_sha256": generated_hashes,
+        "generated_forcing_input_sha256": {},
+        "science_settings_sha256": science_settings_hash,
+        "approximations": [
+            "analytic_cm1_bomex_source_capability",
+            "prescribed_radiative_tendency",
+            "cm1_upper_rayleigh_damping",
+            "cloud_fraction_derived_from_ql_threshold",
+        ],
+        "unsupported_components": [],
+    }
+
+
+def _replace_namelist_assignment(text: str, name: str, value: str) -> str:
+    pattern = re.compile(
+        rf"^(?P<prefix>\s*{re.escape(name)}\s*=\s*)(?P<value>[^,!\n]+)(?P<suffix>\s*,.*)$",
+        re.MULTILINE,
+    )
+    matches = list(pattern.finditer(text))
+    if len(matches) != 1:
+        raise BomexCaseError(
+            f"Expected exactly one {name!r} assignment in pinned BOMEX namelist; "
+            f"found {len(matches)}."
+        )
+    return pattern.sub(rf"\g<prefix>{value}\g<suffix>", text, count=1)
+
+
+def _linear_profile_value(height_m: float, knots: tuple[tuple[float, float], ...]) -> float:
+    for (lower_z, lower_value), (upper_z, upper_value) in zip(knots, knots[1:], strict=False):
+        if height_m <= upper_z:
+            fraction = (height_m - lower_z) / (upper_z - lower_z)
+            return lower_value + fraction * (upper_value - lower_value)
+    return knots[-1][1]
+
+
+def _git_commit() -> str | None:
+    repo_root = Path(__file__).resolve().parents[3]
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return completed.stdout.strip() or None
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _missing_required_fields(variables: list[str]) -> list[str]:
+    available = set(variables)
+    aliases = {"kmh": {"kmh", "km"}, "khh": {"khh", "kh"}}
+    return [
+        field for field in REQUIRED_OUTPUT_FIELDS if not (aliases.get(field, {field}) & available)
+    ]
+
+
+def _model_frame_evidence(
+    paths: list[Path],
+) -> tuple[
+    list[dict[str, float | None]],
+    dict[str, int],
+    dict[str, list[float | None]],
+    list[float | None],
+]:
+    xarray = importlib.import_module("xarray")
+    metrics: list[dict[str, float | None]] = []
+    non_finite_counts: dict[str, int] = {}
+    final_profiles: dict[str, list[float | None]] = {}
+    final_heights: list[float | None] = []
+    for file_index, path in enumerate(paths):
+        dataset = xarray.open_dataset(path, decode_times=False)
+        try:
+            time_seconds = _dataset_time_seconds(dataset, file_index)
+            liquid_name = "qc" if "qc" in dataset.data_vars else "ql"
+            liquid = dataset[liquid_name]
+            liquid_values = np.asarray(liquid.values, dtype=float)
+            liquid_values = _first_time_slice(liquid_values, liquid.dims)
+            vertical_axis, vertical_name = _vertical_axis(liquid)
+            cloud_mask = np.isfinite(liquid_values) & (liquid_values >= QC_CLOUD_THRESHOLD_KG_KG)
+            horizontal_axes = tuple(
+                axis for axis in range(cloud_mask.ndim) if axis != vertical_axis
+            )
+            level_fraction = np.mean(cloud_mask, axis=horizontal_axes)
+            column_cloud = np.any(cloud_mask, axis=vertical_axis)
+            lwp = _optional_array(dataset, "cwp")
+            w = _optional_array(dataset, "w")
+            metrics.append(
+                {
+                    "time_seconds": time_seconds,
+                    "total_cloud_cover_percent": float(np.mean(column_cloud) * 100.0),
+                    "peak_cloud_fraction_percent": float(np.max(level_fraction) * 100.0),
+                    "mean_lwp": _finite_mean(lwp),
+                    "max_lwp": _finite_max(lwp),
+                    "max_w": _finite_max(w),
+                    "min_w": _finite_min(w),
+                }
+            )
+            for field in REQUIRED_OUTPUT_FIELDS:
+                source = field
+                if field == "ql" and source not in dataset.data_vars and "qc" in dataset.data_vars:
+                    source = "qc"
+                if source in dataset.data_vars:
+                    values = np.asarray(dataset[source].values, dtype=float)
+                    non_finite_counts[field] = non_finite_counts.get(field, 0) + int(
+                        values.size - np.count_nonzero(np.isfinite(values))
+                    )
+            if path == paths[-1]:
+                final_profiles = _final_profiles(dataset)
+                final_heights = _vertical_values(liquid, vertical_name)
+        finally:
+            dataset.close()
+    return metrics, non_finite_counts, final_profiles, final_heights
+
+
+def _diagnostic_evidence(
+    paths: list[Path],
+) -> tuple[dict[str, dict[str, float | None]], list[str]]:
+    if not paths:
+        return {}, []
+    xarray = importlib.import_module("xarray")
+    required = ("wprof", "ptb_frc", "qvb_frc", "ug", "vg", "thflux", "qvflux", "ust")
+    flux_candidates = (
+        "upwp",
+        "vpwp",
+        "wpwp",
+        "ufr",
+        "vfr",
+        "ptfr",
+        "qvfr",
+        "ptb_vturbr",
+        "qvb_vturbr",
+    )
+    summary: dict[str, dict[str, float | None]] = {}
+    flux_fields: set[str] = set()
+    for path in (paths[0], paths[-1]) if len(paths) > 1 else (paths[0],):
+        dataset = xarray.open_dataset(path, decode_times=False)
+        try:
+            for field in required:
+                if field in dataset.data_vars:
+                    values = np.asarray(dataset[field].values, dtype=float)
+                    summary[field] = {"min": _finite_min(values), "max": _finite_max(values)}
+            flux_fields.update(field for field in flux_candidates if field in dataset.data_vars)
+        finally:
+            dataset.close()
+    return summary, sorted(flux_fields)
+
+
+def _dataset_time_seconds(dataset: Any, fallback_index: int) -> float:
+    for name in ("time", "mtime", "t"):
+        if name in dataset.coords or name in dataset.variables:
+            values = np.asarray(dataset[name].values).reshape(-1)
+            if values.size:
+                return float(values[-1])
+    return float(fallback_index * OUTPUT_CADENCE_SECONDS)
+
+
+def _first_time_slice(
+    values: np.ndarray[Any, Any], dimensions: tuple[str, ...]
+) -> np.ndarray[Any, Any]:
+    for candidate in ("time", "mtime", "t"):
+        if candidate in dimensions:
+            return np.asarray(np.take(values, 0, axis=dimensions.index(candidate)))
+    return values
+
+
+def _vertical_axis(data_array: Any) -> tuple[int, str]:
+    dimensions = tuple(str(name) for name in data_array.dims)
+    for candidate in ("zh", "z", "zf", "height", "height_m"):
+        if candidate in dimensions:
+            time_offset = 1 if dimensions and dimensions[0] in {"time", "mtime", "t"} else 0
+            return dimensions.index(candidate) - time_offset, candidate
+    raise BomexCaseError(f"Cloud-liquid field lacks a recognized vertical dimension: {dimensions}")
+
+
+def _vertical_values(data_array: Any, vertical_name: str) -> list[float | None]:
+    if vertical_name not in data_array.coords:
+        return [float(index) for index in range(int(data_array.sizes[vertical_name]))]
+    coordinate = data_array.coords[vertical_name]
+    values = np.asarray(coordinate.values, dtype=float).reshape(-1)
+    units = str(coordinate.attrs.get("units", "")).strip().lower()
+    if units in {"km", "kilometer", "kilometers"}:
+        values = values * 1000.0
+    return [float(value) if np.isfinite(value) else None for value in values]
+
+
+def _optional_array(dataset: Any, field: str) -> np.ndarray[Any, Any] | None:
+    if field not in dataset.data_vars:
+        return None
+    return np.asarray(dataset[field].values, dtype=float)
+
+
+def _final_profiles(dataset: Any) -> dict[str, list[float | None]]:
+    profiles: dict[str, list[float | None]] = {}
+    for field in ("qv", "th", "u", "v"):
+        if field not in dataset.data_vars:
+            continue
+        data_array = dataset[field]
+        values = np.asarray(data_array.values, dtype=float)
+        dimensions = [str(name) for name in data_array.dims]
+        if dimensions and dimensions[0] in {"time", "mtime", "t"}:
+            values = values[-1]
+            dimensions = dimensions[1:]
+        vertical_name = next(
+            (name for name in ("zh", "z", "zf", "height", "height_m") if name in dimensions),
+            None,
+        )
+        if vertical_name is None:
+            continue
+        vertical_axis = dimensions.index(vertical_name)
+        mean_axes = tuple(axis for axis in range(values.ndim) if axis != vertical_axis)
+        profile = np.nanmean(values, axis=mean_axes) if mean_axes else values
+        profiles[field] = [
+            float(value) if np.isfinite(value) else None
+            for value in np.asarray(profile).reshape(-1)
+        ]
+    return profiles
+
+
+def _finite_mean(values: np.ndarray[Any, Any] | None) -> float | None:
+    if values is None:
+        return None
+    finite = values[np.isfinite(values)]
+    return float(np.mean(finite)) if finite.size else None
+
+
+def _finite_max(values: np.ndarray[Any, Any] | None) -> float | None:
+    if values is None:
+        return None
+    finite = values[np.isfinite(values)]
+    return float(np.max(finite)) if finite.size else None
+
+
+def _finite_min(values: np.ndarray[Any, Any] | None) -> float | None:
+    if values is None:
+        return None
+    finite = values[np.isfinite(values)]
+    return float(np.min(finite)) if finite.size else None
+
+
+def _mean_metric(frames: list[dict[str, float | None]], key: str) -> float | None:
+    values: list[float] = []
+    for frame in frames:
+        value = frame.get(key)
+        if value is not None:
+            values.append(value)
+    return float(np.mean(values)) if values else None
+
+
+def _max_metric(frames: list[dict[str, float | None]], key: str) -> float | None:
+    values: list[float] = []
+    for frame in frames:
+        value = frame.get(key)
+        if value is not None:
+            values.append(value)
+    return max(values) if values else None
+
+
+def _local_peak_count(values: list[float]) -> int:
+    if len(values) < 3:
+        return 0
+    maximum = max(values)
+    if maximum <= 0.0:
+        return 0
+    floor = maximum * 0.1
+    return sum(
+        1
+        for index in range(1, len(values) - 1)
+        if values[index] >= floor
+        and values[index] > values[index - 1]
+        and values[index] >= values[index + 1]
+    )

--- a/app/backend/cloud_chamber/bomex_case.py
+++ b/app/backend/cloud_chamber/bomex_case.py
@@ -192,6 +192,12 @@ class BomexPackageResult:
     generated_files: tuple[Path, ...]
 
 
+@dataclass(frozen=True)
+class _CloudFractionProfile:
+    time_seconds: float
+    values_percent: tuple[float, ...]
+
+
 class BomexRunEvidence(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -223,6 +229,8 @@ class BomexRunEvidence(BaseModel):
     max_surface_rain: float | None = None
     mean_total_cloud_cover_final_three_hours_percent: float | None = None
     peak_cloud_fraction_final_three_hours_percent: float | None = None
+    peak_cloud_fraction_final_three_hours_height_m: float | None = None
+    max_instantaneous_peak_cloud_fraction_final_three_hours_percent: float | None = None
     mean_lwp_final_three_hours_kg_m2: float | None = None
     max_lwp_kg_m2: float | None = None
     lwp_cycle_peak_count: int
@@ -343,9 +351,9 @@ def generate_bomex_package(
     variant: BomexVariant,
     run_id: str,
     allow_overwrite: bool = False,
-    app_commit: str | None = None,
 ) -> BomexPackageResult:
     """Generate a deterministic, provenance-rich BOMEX runtime package."""
+    resolved_commit = _clean_git_commit()
     provenance = collect_cm1_provenance(settings)
     package_dir = settings.runtime_home.expanduser() / "runs" / run_id
     if package_dir.exists():
@@ -393,7 +401,6 @@ def generate_bomex_package(
     generated_hashes["case_manifest.json"] = sha256_file(paths["case_manifest"])
 
     now = datetime.now(UTC)
-    resolved_commit = app_commit if app_commit is not None else _git_commit()
     run_configuration: dict[str, Any] = {
         "case_id": CASE_ID,
         "mapping_version": MAPPING_VERSION,
@@ -517,7 +524,13 @@ def build_bomex_run_evidence(
     expected_count = int(config.get("expected_model_output_count", 0))
     required_missing = _missing_required_fields(result.variables)
     paths = [Path(path) for path in result.model_output_paths]
-    frame_metrics, non_finite_counts, final_profiles, final_heights = _model_frame_evidence(paths)
+    (
+        frame_metrics,
+        cloud_fraction_profiles,
+        non_finite_counts,
+        final_profiles,
+        final_heights,
+    ) = _model_frame_evidence(paths)
     final_three_hour = [
         frame
         for frame in frame_metrics
@@ -544,6 +557,9 @@ def build_bomex_run_evidence(
         caveats.append("required_output_fields_missing")
     if not diag_summary:
         caveats.append("forcing_diagnostic_fields_unavailable")
+    peak_time_mean_cloud_fraction, peak_time_mean_cloud_fraction_height = (
+        _final_three_hour_cloud_fraction_peak(cloud_fraction_profiles, final_heights)
+    )
 
     return BomexRunEvidence(
         run_id=result.run_id,
@@ -573,7 +589,9 @@ def build_bomex_run_evidence(
         mean_total_cloud_cover_final_three_hours_percent=_mean_metric(
             final_three_hour, "total_cloud_cover_percent"
         ),
-        peak_cloud_fraction_final_three_hours_percent=_max_metric(
+        peak_cloud_fraction_final_three_hours_percent=peak_time_mean_cloud_fraction,
+        peak_cloud_fraction_final_three_hours_height_m=peak_time_mean_cloud_fraction_height,
+        max_instantaneous_peak_cloud_fraction_final_three_hours_percent=_max_metric(
             final_three_hour, "peak_cloud_fraction_percent"
         ),
         mean_lwp_final_three_hours_kg_m2=_mean_metric(final_three_hour, "mean_lwp"),
@@ -681,19 +699,35 @@ def _linear_profile_value(height_m: float, knots: tuple[tuple[float, float], ...
     return knots[-1][1]
 
 
-def _git_commit() -> str | None:
+def _clean_git_commit() -> str:
+    commit = _git_output("rev-parse", "HEAD")
+    dirty_state = _git_output("status", "--porcelain=v1", "--untracked-files=all")
+    if dirty_state:
+        raise BomexCaseError(
+            "BOMEX evidence generation requires a clean Git worktree; commit or stash all "
+            "tracked and untracked changes before packaging."
+        )
+    if not commit:
+        raise BomexCaseError("Unable to identify the clean Cloud Chamber Git commit.")
+    return commit
+
+
+def _git_output(*args: str) -> str:
     repo_root = Path(__file__).resolve().parents[3]
     try:
         completed = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
+            ["git", *args],
             cwd=repo_root,
             check=True,
             capture_output=True,
             text=True,
         )
-    except (OSError, subprocess.CalledProcessError):
-        return None
-    return completed.stdout.strip() or None
+    except (OSError, subprocess.CalledProcessError) as exc:
+        command = " ".join(("git", *args))
+        raise BomexCaseError(
+            f"Unable to verify Cloud Chamber Git provenance with {command}."
+        ) from exc
+    return completed.stdout.strip()
 
 
 def _write_json(path: Path, payload: object) -> None:
@@ -712,12 +746,14 @@ def _model_frame_evidence(
     paths: list[Path],
 ) -> tuple[
     list[dict[str, float | None]],
+    list[_CloudFractionProfile],
     dict[str, int],
     dict[str, list[float | None]],
     list[float | None],
 ]:
     xarray = importlib.import_module("xarray")
     metrics: list[dict[str, float | None]] = []
+    cloud_fraction_profiles: list[_CloudFractionProfile] = []
     non_finite_counts: dict[str, int] = {}
     final_profiles: dict[str, list[float | None]] = {}
     final_heights: list[float | None] = []
@@ -735,6 +771,14 @@ def _model_frame_evidence(
                 axis for axis in range(cloud_mask.ndim) if axis != vertical_axis
             )
             level_fraction = np.mean(cloud_mask, axis=horizontal_axes)
+            cloud_fraction_profiles.append(
+                _CloudFractionProfile(
+                    time_seconds=time_seconds,
+                    values_percent=tuple(
+                        float(value * 100.0) for value in np.asarray(level_fraction).reshape(-1)
+                    ),
+                )
+            )
             column_cloud = np.any(cloud_mask, axis=vertical_axis)
             lwp = _optional_array(dataset, "cwp")
             w = _optional_array(dataset, "w")
@@ -763,7 +807,7 @@ def _model_frame_evidence(
                 final_heights = _vertical_values(liquid, vertical_name)
         finally:
             dataset.close()
-    return metrics, non_finite_counts, final_profiles, final_heights
+    return metrics, cloud_fraction_profiles, non_finite_counts, final_profiles, final_heights
 
 
 def _diagnostic_evidence(
@@ -907,6 +951,22 @@ def _max_metric(frames: list[dict[str, float | None]], key: str) -> float | None
         if value is not None:
             values.append(value)
     return max(values) if values else None
+
+
+def _final_three_hour_cloud_fraction_peak(
+    profiles: list[_CloudFractionProfile],
+    heights_m: list[float | None],
+) -> tuple[float | None, float | None]:
+    selected = [profile.values_percent for profile in profiles if profile.time_seconds >= 10_800.0]
+    if not selected:
+        return None, None
+    profile_lengths = {len(profile) for profile in selected}
+    if len(profile_lengths) != 1:
+        raise BomexCaseError("Final-three-hour cloud-fraction profiles use inconsistent grids.")
+    time_mean_profile = np.mean(np.asarray(selected, dtype=float), axis=0)
+    peak_index = int(np.argmax(time_mean_profile))
+    peak_height = heights_m[peak_index] if peak_index < len(heights_m) else None
+    return float(time_mean_profile[peak_index]), peak_height
 
 
 def _local_peak_count(values: list[float]) -> int:

--- a/app/backend/cloud_chamber/result_diagnostics.py
+++ b/app/backend/cloud_chamber/result_diagnostics.py
@@ -498,7 +498,11 @@ def compute_process_diagnostics(
     """Compute conservative Thermal Fate process summaries from supported diagnostics."""
 
     available_fields = set(variables)
-    caveats: list[str] = []
+    if "qc" not in available_fields and "ql" in available_fields:
+        available_fields.add("qc")
+        caveats = ["cloud_liquid_ql_mapped_to_canonical_qc_diagnostics"]
+    else:
+        caveats = []
     if not diagnostics.cloud.available:
         caveats.append("thermal_fate_missing_qc")
     if not diagnostics.vertical_velocity.available:
@@ -679,6 +683,11 @@ def compute_baseline_diagnostics(
 ) -> ResultDiagnostics:
     """Compute MVP Baseline Shallow Cumulus diagnostics from an xarray dataset."""
     caveats = list(inherited_caveats)
+    cloud_liquid_source = "qc"
+    if "qc" not in dataset.data_vars and "ql" in dataset.data_vars:
+        dataset = dataset.rename({"ql": "qc"})
+        cloud_liquid_source = "ql"
+        caveats.append("cloud_liquid_ql_mapped_to_canonical_qc_diagnostics")
     time_context = _time_context(dataset, _primary_time_dimension(dataset))
     cloud = _cloud_diagnostics(dataset, time_context, caveats)
     vertical_velocity = _vertical_velocity_diagnostics(dataset, time_context, caveats)
@@ -688,6 +697,19 @@ def compute_baseline_diagnostics(
     surface_fluxes = _surface_flux_diagnostics(dataset, time_context, caveats)
     low_level_response = _low_level_response_diagnostics(dataset, time_context, caveats)
     field_quality = _field_quality_map(dataset, time_context)
+    if cloud_liquid_source == "ql" and "qc" in field_quality:
+        qc_quality = field_quality["qc"]
+        field_quality["qc"] = qc_quality.model_copy(
+            update={
+                "source_field": "ql",
+                "caveats": _dedupe(
+                    [
+                        *qc_quality.caveats,
+                        "cloud_liquid_ql_mapped_to_canonical_qc_diagnostics",
+                    ]
+                ),
+            }
+        )
     localized_response = _localized_response_diagnostics(
         dataset,
         time_context,

--- a/app/backend/cloud_chamber/result_ingest.py
+++ b/app/backend/cloud_chamber/result_ingest.py
@@ -53,6 +53,8 @@ from cloud_chamber.settings import CloudChamberSettings
 
 RESULT_METADATA_FILENAME = "result_metadata.json"
 REQUIRED_OUTPUT_FIELD_ALIASES: dict[str, set[str]] = {
+    "qc": {"qc", "ql"},
+    "ql": {"qc", "ql"},
     "qfx": {"qfx", "lhfx"},
     "lhfx": {"qfx", "lhfx"},
     "updraft_helicity": {"updraft_helicity", "uh"},
@@ -303,11 +305,10 @@ def _result_from_model_output_files(
 
     warnings = list(manifest.outputs.runtime_warnings)
     warnings.extend(f"skipped_netcdf_output:{path}" for path in skipped_paths)
-    missing_expected = [
-        field
-        for field in ("qc", "w")
-        if field not in metadata_snapshot.variables and field not in metadata_snapshot.coordinates
-    ]
+    missing_expected = _missing_expected_fields(
+        metadata_snapshot.variables,
+        metadata_snapshot.coordinates,
+    )
     if missing_expected:
         warnings.append(
             "Expected fields missing from NetCDF metadata: " + ", ".join(missing_expected)
@@ -1831,9 +1832,7 @@ def _result_from_dataset(
     grid_shape = _grid_shape(dimensions)
     warnings = list(manifest.outputs.runtime_warnings)
     warnings.extend(f"skipped_netcdf_output:{path}" for path in skipped_paths)
-    missing_expected = [
-        field for field in ("qc", "w") if field not in variables and field not in coordinates
-    ]
+    missing_expected = _missing_expected_fields(variables, coordinates)
     if missing_expected:
         warnings.append(
             "Expected fields missing from NetCDF metadata: " + ", ".join(missing_expected)
@@ -2001,6 +2000,16 @@ def _missing_required_output_fields(
         for field in manifest.required_output_fields
         if not (REQUIRED_OUTPUT_FIELD_ALIASES.get(field, {field}) & available)
     ]
+
+
+def _missing_expected_fields(variables: list[str], coordinates: list[str]) -> list[str]:
+    available = set(variables) | set(coordinates)
+    missing: list[str] = []
+    if not ({"qc", "ql"} & available):
+        missing.append("qc")
+    if "w" not in available:
+        missing.append("w")
+    return missing
 
 
 def _candidate_hypothesis_comparison(

--- a/app/backend/cloud_chamber/runtime_integrity.py
+++ b/app/backend/cloud_chamber/runtime_integrity.py
@@ -60,7 +60,7 @@ CM1_STATS_INTEGRITY_VARIABLES = {
 TERMINAL_FIELD_CATEGORIES = {
     "dynamics": {"u", "v", "w", "uinterp", "vinterp", "winterp", "u10", "v10"},
     "thermodynamics": {"prs", "pressure", "q2", "qv", "t", "t2", "temperature", "th", "theta"},
-    "hydrometeors": {"dbz", "qc", "qg", "qi", "qr", "qs"},
+    "hydrometeors": {"dbz", "qc", "ql", "qg", "qi", "qr", "qs"},
     "surface": {"hfx", "prate", "qfx", "rain", "surface_rain"},
 }
 

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -46,6 +46,7 @@ TimeSeriesAggregationMethod = Literal["cloud_fraction", "domain_mean", "domain_m
 
 FIELD_QUALITY_KEY_BY_RAW_FIELD = {
     "qc": "qc",
+    "ql": "qc",
     "w": "w",
     "qr": "qr",
     "rain": "surface_rain",
@@ -77,6 +78,15 @@ FIELD_DEFINITIONS: dict[str, FieldDefinition] = {
         "Supported for native slices, selected-place diagnostics, and 3-D scalar points.",
         point_cloud_allowed=True,
         render_ready_candidate=True,
+    ),
+    "ql": FieldDefinition(
+        "cloud_water",
+        "Cloud water",
+        "cloud_hydrometeor",
+        "CM1 reversible-moist cloud liquid; supported as canonical cloud water.",
+        point_cloud_allowed=True,
+        render_ready_candidate=True,
+        caveats=("cm1_ql_mapped_to_canonical_cloud_water",),
     ),
     "w": FieldDefinition(
         "vertical_velocity",
@@ -272,6 +282,21 @@ FIELD_DEFINITIONS: dict[str, FieldDefinition] = {
         profile_candidate=False,
         time_height_candidate=False,
         caveats=("column_integrated_field_no_vertical_profile",),
+    ),
+    "cwp": FieldDefinition(
+        "liquid_water_path",
+        "Cloud water path",
+        "column_integrated_water",
+        (
+            "CM1 cloud-water path; for nonprecipitating reversible-moist cases this is "
+            "the liquid-water path field."
+        ),
+        profile_candidate=False,
+        time_height_candidate=False,
+        caveats=(
+            "column_integrated_field_no_vertical_profile",
+            "cm1_cwp_is_nonprecipitating_liquid_water_path",
+        ),
     ),
     "cape": FieldDefinition(
         "cape",
@@ -845,7 +870,11 @@ def _metadata_view_defaults(
                     else []
                 ),
                 *metadata.warnings,
-                *(["missing_visualization_field:qc"] if "qc" not in fields else []),
+                *(
+                    ["missing_visualization_field:qc_or_ql"]
+                    if not ({"qc", "ql"} & fields.keys())
+                    else []
+                ),
                 *(["missing_visualization_field:w"] if "w" not in fields else []),
             ]
         ),
@@ -920,26 +949,37 @@ def _metadata_horizontal_level_index(
 ) -> int:
     if vertical_size <= 1:
         return 0
-    if field.raw_field_name not in {"qc", "qr", "dbz"} or metadata.diagnostics is None:
+    if field.raw_field_name not in {"qc", "ql", "qr", "dbz"} or metadata.diagnostics is None:
         return max(0, vertical_size // 2)
 
     target_height_m = _metadata_cloud_focus_height_m(metadata, field.raw_field_name)
     if target_height_m is None:
         return max(0, vertical_size // 2)
 
-    # Metadata-only defaults intentionally avoid opening large output sequences.
-    # CM1 deep-trial files currently expose 500 m-ish scalar levels; this maps
-    # shallow cloud-water metadata away from the domain midpoint without
-    # pretending we know the exact native coordinate.
-    estimated_index = math.ceil(max(0.0, target_height_m) / 500.0) - 1
+    domain = metadata.run_configuration.get("domain")
+    configured_dz = domain.get("dz_m") if isinstance(domain, Mapping) else None
+    if configured_dz is None:
+        vertical_spacing_m = 500.0
+    else:
+        try:
+            vertical_spacing_m = float(configured_dz)
+        except (TypeError, ValueError):
+            vertical_spacing_m = 500.0
+    if not math.isfinite(vertical_spacing_m) or vertical_spacing_m <= 0.0:
+        vertical_spacing_m = 500.0
+
+    # Scalar levels are centered at dz / 2 for the uniform grids represented by
+    # current run metadata. Fall back to the established 500 m estimate when dz
+    # was not recorded.
+    estimated_index = round(max(0.0, target_height_m) / vertical_spacing_m - 0.5)
     return max(0, min(vertical_size - 1, estimated_index))
 
 
 def _metadata_cloud_focus_height_m(metadata: ResultMetadata, field_name: str) -> float | None:
     diagnostics = metadata.diagnostics
-    if diagnostics is None or field_name not in {"qc", "qr", "dbz"}:
+    if diagnostics is None or field_name not in {"qc", "ql", "qr", "dbz"}:
         return None
-    if field_name == "qc" and diagnostics.cloud.time_of_max_qc_seconds is not None:
+    if field_name in {"qc", "ql"} and diagnostics.cloud.time_of_max_qc_seconds is not None:
         height = _time_value_at(
             diagnostics.cloud.max_qc_height_time_series,
             diagnostics.cloud.time_of_max_qc_seconds,
@@ -1483,7 +1523,11 @@ def view_defaults(
                         else []
                     ),
                     *metadata.warnings,
-                    *(["missing_visualization_field:qc"] if "qc" not in fields else []),
+                    *(
+                        ["missing_visualization_field:qc_or_ql"]
+                        if not ({"qc", "ql"} & fields.keys())
+                        else []
+                    ),
                     *(["missing_visualization_field:w"] if "w" not in fields else []),
                 ]
             ),
@@ -1764,7 +1808,10 @@ def _fallback_view_defaults(
 def _preferred_field(metadata: ResultMetadata, fields: Mapping[str, object]) -> str | None:
     if _metadata_is_deep_candidate(metadata) and "w" in fields:
         return "w"
-    return "qc" if "qc" in fields else next(iter(fields), None)
+    for cloud_liquid_field in ("qc", "ql"):
+        if cloud_liquid_field in fields:
+            return cloud_liquid_field
+    return next(iter(fields), None)
 
 
 def _metadata_is_deep_candidate(metadata: ResultMetadata) -> bool:
@@ -2737,9 +2784,10 @@ def _catalog_caveats(
 ) -> list[str]:
     available = {field.raw_field_name for field in fields}
     caveats = list(metadata.warnings)
-    for required in ("qc", "w"):
-        if required not in available:
-            caveats.append(f"missing_visualization_field:{required}")
+    if not ({"qc", "ql"} & available):
+        caveats.append("missing_visualization_field:qc_or_ql")
+    if "w" not in available:
+        caveats.append("missing_visualization_field:w")
     caveats.extend(
         f"expected_field_unavailable:{field.raw_field_name}" for field in unavailable_fields
     )

--- a/app/backend/tests/test_bomex_case.py
+++ b/app/backend/tests/test_bomex_case.py
@@ -124,18 +124,17 @@ def test_package_records_hashes_provenance_and_no_recipe(
     settings = fake_settings(tmp_path)
     provenance = fake_provenance(tmp_path)
     monkeypatch.setattr(bomex_case, "collect_cm1_provenance", lambda _settings: provenance)
+    monkeypatch.setattr(bomex_case, "_clean_git_commit", lambda: "commit-test")
 
     smoke = generate_bomex_package(
         settings=settings,
         variant=BomexVariant.SMOKE,
         run_id="bomex-smoke-test",
-        app_commit="commit-test",
     )
     full = generate_bomex_package(
         settings=settings,
         variant=BomexVariant.FULL,
         run_id="bomex-full-test",
-        app_commit="commit-test",
     )
 
     smoke_manifest = load_run_manifest(smoke.manifest_path)
@@ -143,6 +142,7 @@ def test_package_records_hashes_provenance_and_no_recipe(
     smoke_config = smoke_manifest.run_configuration
     full_config = full_manifest.run_configuration
     assert smoke_manifest.run_recipe is None
+    assert smoke_manifest.app.commit == "commit-test"
     assert smoke_manifest.observed_sounding is None
     assert smoke_manifest.trigger_type is None
     assert smoke_config["case_id"] == bomex_case.CASE_ID
@@ -185,8 +185,70 @@ def test_model_frame_evidence_uses_cwp_and_converts_km_heights(tmp_path: Path) -
         },
     ).to_netcdf(path)
 
-    metrics, _non_finite, _profiles, heights = bomex_case._model_frame_evidence([path])
+    metrics, _cloud_profiles, _non_finite, _profiles, heights = bomex_case._model_frame_evidence(
+        [path]
+    )
 
     assert metrics[0]["mean_lwp"] == pytest.approx(0.25)
     assert metrics[0]["max_lwp"] == pytest.approx(0.25)
     assert heights == pytest.approx([20.0, 60.0])
+
+
+def test_package_refuses_dirty_worktree_before_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = fake_settings(tmp_path)
+
+    def dirty_git_output(*args: str) -> str:
+        if args == ("rev-parse", "HEAD"):
+            return "clean-commit"
+        if args == ("status", "--porcelain=v1", "--untracked-files=all"):
+            return " M app/backend/cloud_chamber/bomex_case.py"
+        raise AssertionError(args)
+
+    monkeypatch.setattr(bomex_case, "_git_output", dirty_git_output)
+
+    with pytest.raises(bomex_case.BomexCaseError, match="requires a clean Git worktree"):
+        generate_bomex_package(
+            settings=settings,
+            variant=BomexVariant.SMOKE,
+            run_id="dirty-bomex-package",
+        )
+
+    assert not (settings.runtime_home / "runs" / "dirty-bomex-package").exists()
+
+
+def test_final_three_hour_cloud_fraction_peak_uses_time_mean_profile(tmp_path: Path) -> None:
+    first_path = tmp_path / "cm1out_000001.nc"
+    second_path = tmp_path / "cm1out_000002.nc"
+    first_liquid = np.zeros((1, 2, 2, 2), dtype=float)
+    first_liquid[0, 0, :, :] = 2.0e-6
+    second_liquid = np.zeros((1, 2, 2, 2), dtype=float)
+    second_liquid[0, 1, 0, :] = 2.0e-6
+
+    for path, time_seconds, liquid in (
+        (first_path, 10_800.0, first_liquid),
+        (second_path, 11_100.0, second_liquid),
+    ):
+        xr.Dataset(
+            data_vars={"ql": (("time", "zh", "yh", "xh"), liquid)},
+            coords={
+                "time": ("time", [time_seconds]),
+                "zh": ("zh", [20.0, 60.0], {"units": "m"}),
+                "yh": ("yh", [0.0, 100.0]),
+                "xh": ("xh", [0.0, 100.0]),
+            },
+        ).to_netcdf(path)
+
+    metrics, cloud_profiles, _non_finite, _profiles, heights = bomex_case._model_frame_evidence(
+        [first_path, second_path]
+    )
+    peak_percent, peak_height_m = bomex_case._final_three_hour_cloud_fraction_peak(
+        cloud_profiles, heights
+    )
+
+    assert [metric["peak_cloud_fraction_percent"] for metric in metrics] == pytest.approx(
+        [100.0, 50.0]
+    )
+    assert peak_percent == pytest.approx(50.0)
+    assert peak_height_m == pytest.approx(20.0)

--- a/app/backend/tests/test_bomex_case.py
+++ b/app/backend/tests/test_bomex_case.py
@@ -1,0 +1,192 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from cloud_chamber import bomex_case
+from cloud_chamber.bomex_case import (
+    REQUIRED_OUTPUT_SWITCHES,
+    BomexVariant,
+    CM1Provenance,
+    generate_bomex_package,
+    normalized_science_namelist,
+    render_bomex_namelist,
+    render_profile_audit,
+    sha256_text,
+)
+from cloud_chamber.run_manifest import load_run_manifest
+from cloud_chamber.settings import CloudChamberSettings
+
+
+def reference_namelist_text() -> str:
+    names = sorted(
+        {
+            *bomex_case._COMMON_NAMELIST_OVERRIDES,
+            *REQUIRED_OUTPUT_SWITCHES,
+            "timax",
+        }
+    )
+    return "&bomex_test\n" + "".join(f"  {name} = -999,\n" for name in names) + "/\n"
+
+
+def fake_settings(tmp_path: Path) -> CloudChamberSettings:
+    runtime_home = tmp_path / "CloudChamber"
+    cm1_root = tmp_path / "cm1r21.1"
+    cm1_run_dir = cm1_root / "run"
+    cm1_run_dir.mkdir(parents=True)
+    return CloudChamberSettings(
+        runtime_home=runtime_home,
+        cm1_root=cm1_root,
+        cm1_run_dir=cm1_run_dir,
+        cache_dir=runtime_home / "cache",
+        log_dir=runtime_home / "logs",
+    )
+
+
+def fake_provenance(tmp_path: Path) -> CM1Provenance:
+    reference_path = tmp_path / "cm1r21.1" / "run" / "namelist.input.reference"
+    reference_path.write_text(reference_namelist_text())
+    return CM1Provenance(
+        release="21.1",
+        official_tag_commit=bomex_case.CM1_TAG_COMMIT,
+        official_source_tag=bomex_case.CM1_SOURCE_TAG,
+        source_tree_path=str(tmp_path / "cm1r21.1"),
+        run_directory_path=str(tmp_path / "cm1r21.1" / "run"),
+        executable_path=str(tmp_path / "cm1r21.1" / "run" / "cm1.exe"),
+        executable_sha256="executable-hash",
+        readme_namelist_path=str(tmp_path / "cm1r21.1" / "README.namelist"),
+        readme_namelist_sha256="readme-hash",
+        source_manifest_method="test manifest",
+        source_manifest_sha256="source-hash",
+        critical_source_sha256={"src/base.F": "base-hash"},
+        bundled_bomex_namelist_path=str(reference_path),
+        bundled_bomex_namelist_sha256="reference-hash",
+        bundled_bomex_readme_path=str(tmp_path / "cm1r21.1" / "README"),
+        bundled_bomex_readme_sha256="case-readme-hash",
+    )
+
+
+def assignment(text: str, name: str) -> str:
+    for line in text.splitlines():
+        if line.strip().startswith(f"{name} ="):
+            return line.split("=", 1)[1].split(",", 1)[0].strip()
+    raise AssertionError(f"missing assignment: {name}")
+
+
+def test_rendered_namelist_uses_exact_bomex_science_and_output_settings() -> None:
+    rendered = render_bomex_namelist(reference_namelist_text(), BomexVariant.FULL)
+
+    assert assignment(rendered, "timax") == "21600.0"
+    assert assignment(rendered, "testcase") == "3"
+    assert assignment(rendered, "isnd") == "19"
+    assert assignment(rendered, "iwnd") == "9"
+    assert assignment(rendered, "iinit") == "0"
+    assert assignment(rendered, "irandp") == "1"
+    assert assignment(rendered, "ptype") == "6"
+    assert assignment(rendered, "v_t") == "0.0"
+    assert assignment(rendered, "tapfrq") == "300.0"
+    assert assignment(rendered, "diagfrq") == "60.0"
+    assert assignment(rendered, "output_dbz") == "0"
+    for name, value in REQUIRED_OUTPUT_SWITCHES.items():
+        assert assignment(rendered, name) == value
+
+
+def test_smoke_and_full_namelists_differ_only_in_duration() -> None:
+    reference = reference_namelist_text()
+    smoke = render_bomex_namelist(reference, BomexVariant.SMOKE)
+    full = render_bomex_namelist(reference, BomexVariant.FULL)
+
+    assert smoke != full
+    assert assignment(smoke, "timax") == "600.0"
+    assert normalized_science_namelist(smoke) == normalized_science_namelist(full)
+    assert sha256_text(normalized_science_namelist(smoke)) == sha256_text(
+        normalized_science_namelist(full)
+    )
+
+
+def test_profile_audit_is_deterministic_and_contains_canonical_knots() -> None:
+    first = render_profile_audit()
+    second = render_profile_audit()
+
+    assert first == second
+    assert "     0.0000   298.7000   17.000000    -8.7500" in first
+    assert "   520.0000   298.7000   16.300000" in first
+    assert "  1480.0000   302.4000   10.700000" in first
+    assert "  3000.0000   311.8500    3.000000    -4.6100" in first
+
+
+def test_package_records_hashes_provenance_and_no_recipe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = fake_settings(tmp_path)
+    provenance = fake_provenance(tmp_path)
+    monkeypatch.setattr(bomex_case, "collect_cm1_provenance", lambda _settings: provenance)
+
+    smoke = generate_bomex_package(
+        settings=settings,
+        variant=BomexVariant.SMOKE,
+        run_id="bomex-smoke-test",
+        app_commit="commit-test",
+    )
+    full = generate_bomex_package(
+        settings=settings,
+        variant=BomexVariant.FULL,
+        run_id="bomex-full-test",
+        app_commit="commit-test",
+    )
+
+    smoke_manifest = load_run_manifest(smoke.manifest_path)
+    full_manifest = load_run_manifest(full.manifest_path)
+    smoke_config = smoke_manifest.run_configuration
+    full_config = full_manifest.run_configuration
+    assert smoke_manifest.run_recipe is None
+    assert smoke_manifest.observed_sounding is None
+    assert smoke_manifest.trigger_type is None
+    assert smoke_config["case_id"] == bomex_case.CASE_ID
+    assert smoke_config["mapping_version"] == bomex_case.MAPPING_VERSION
+    assert smoke_config["science_settings_sha256"] == full_config["science_settings_sha256"]
+    assert smoke_config["duration_seconds"] == 600
+    assert full_config["duration_seconds"] == 21_600
+    assert smoke_config["generated_forcing_input_sha256"] == {}
+    generated_hashes = smoke_config["generated_input_sha256"]
+    assert isinstance(generated_hashes, dict)
+    assert set(generated_hashes) == {
+        "case_manifest.json",
+        "input_sounding",
+        "namelist.input",
+        "runtime_file_checklist.json",
+    }
+    assert smoke_config["cm1_provenance"] == provenance.model_dump(mode="json")
+    case_manifest = json.loads(smoke.case_manifest_path.read_text())
+    assert case_manifest["authority_state"] == "stage4_candidate_evidence_not_product_recipe"
+    assert case_manifest["cm1_translation"]["ptype"] == 6
+    assert case_manifest["cm1_translation"]["v_t_m_s"] == 0.0
+    assert case_manifest["unsupported_components"] == []
+
+
+def test_model_frame_evidence_uses_cwp_and_converts_km_heights(tmp_path: Path) -> None:
+    path = tmp_path / "cm1out_000001.nc"
+    liquid = np.zeros((1, 2, 2, 2), dtype=float)
+    liquid[0, 0, 0, 0] = 2.0e-6
+    xr.Dataset(
+        data_vars={
+            "ql": (("time", "zh", "yh", "xh"), liquid),
+            "cwp": (("time", "yh", "xh"), np.full((1, 2, 2), 0.25)),
+            "lwp": (("time", "yh", "xh"), np.zeros((1, 2, 2))),
+        },
+        coords={
+            "time": ("time", [300.0]),
+            "zh": ("zh", [0.02, 0.06], {"units": "km"}),
+            "yh": ("yh", [0.0, 0.1]),
+            "xh": ("xh", [0.0, 0.1]),
+        },
+    ).to_netcdf(path)
+
+    metrics, _non_finite, _profiles, heights = bomex_case._model_frame_evidence([path])
+
+    assert metrics[0]["mean_lwp"] == pytest.approx(0.25)
+    assert metrics[0]["max_lwp"] == pytest.approx(0.25)
+    assert heights == pytest.approx([20.0, 60.0])

--- a/app/backend/tests/test_result_diagnostics.py
+++ b/app/backend/tests/test_result_diagnostics.py
@@ -15,6 +15,36 @@ def write_dataset(path: Path, dataset: xr.Dataset) -> xr.Dataset:
     return xr.open_dataset(path)
 
 
+def test_ql_is_supported_as_canonical_cloud_liquid() -> None:
+    values = [
+        [
+            [[2.0e-6 for _x in range(4)] for _y in range(3)],
+            [[0.0 for _x in range(4)] for _y in range(3)],
+        ],
+        [
+            [[3.0e-6 for _x in range(4)] for _y in range(3)],
+            [[0.0 for _x in range(4)] for _y in range(3)],
+        ],
+    ]
+    dataset = base_dataset(qc_values=values, w_values=values).rename({"qc": "ql"})
+
+    diagnostics = compute_baseline_diagnostics(dataset, [])
+    process = compute_process_diagnostics(
+        diagnostics,
+        scenario_id="bomex_trade_cumulus_baseline_v0",
+        controls={},
+        variables=["ql", "w"],
+    )
+
+    assert diagnostics.cloud.available is True
+    assert diagnostics.cloud.formed is True
+    assert diagnostics.cloud.max_qc_kg_kg == pytest.approx(3.0e-6)
+    assert diagnostics.field_quality["qc"].source_field == "ql"
+    assert diagnostics.field_quality["qc"].quality_state == "trusted"
+    assert "cloud_liquid_ql_mapped_to_canonical_qc_diagnostics" in diagnostics.caveats
+    assert process.cloud_lifecycle.status == "supported"
+
+
 def base_dataset(
     *,
     qc_values: list[list[list[list[float]]]] | None = None,

--- a/app/backend/tests/test_result_ingest.py
+++ b/app/backend/tests/test_result_ingest.py
@@ -422,6 +422,37 @@ def test_required_updraft_helicity_accepts_cm1_uh_variable(tmp_path: Path) -> No
     )
 
 
+def test_ingest_accepts_cm1_ql_as_cloud_liquid_alias(tmp_path: Path) -> None:
+    manifest_path = create_manifest(tmp_path, run_id="run-cloud-liquid-ql-alias")
+    run_dir = manifest_path.parent
+    netcdf_path = run_dir / "cm1out_000001.nc"
+    write_model_netcdf(
+        netcdf_path,
+        times=[0.0],
+        qc_values=[2.0e-6],
+        w_values=[0.5],
+    )
+    with xr.open_dataset(netcdf_path) as source:
+        renamed = source.rename({"qc": "ql"}).load()
+    netcdf_path.unlink()
+    renamed.to_netcdf(netcdf_path, engine="scipy")
+    manifest = load_run_manifest(manifest_path)
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(update={"required_output_fields": ["qc", "ql", "w"]}),
+    )
+    complete_manifest(manifest_path, OutputMetadata(netcdf_paths=[str(netcdf_path)]))
+
+    result = ingest_completed_run(manifest_path)
+
+    assert set(result.variables) == {"ql", "w"}
+    assert result.missing_required_output_fields == []
+    assert result.diagnostics is not None
+    assert result.diagnostics.cloud.formed is True
+    assert result.diagnostics.field_quality["qc"].source_field == "ql"
+    assert not any("Expected fields missing" in warning for warning in result.warnings)
+
+
 def test_result_metadata_serializes_and_lists_from_runtime_home(tmp_path: Path) -> None:
     settings = fake_settings(tmp_path)
     manifest_path = create_manifest(tmp_path)

--- a/app/backend/tests/test_runtime_integrity.py
+++ b/app/backend/tests/test_runtime_integrity.py
@@ -162,6 +162,17 @@ def test_runtime_integrity_fails_terminal_multi_category_non_finite_output() -> 
     )
 
 
+def test_runtime_integrity_classifies_ql_as_a_hydrometeor() -> None:
+    integrity = assess_runtime_integrity(
+        lifecycle_state="completed",
+        exit_code=0,
+        field_quality=_terminal_field_quality(["ql", "w"]),
+    )
+
+    assert integrity.state == "failed"
+    assert integrity.terminal_non_finite_fields == ["ql", "w"]
+
+
 def test_runtime_integrity_fails_surface_forced_002_terminal_pattern() -> None:
     integrity = assess_runtime_integrity(
         lifecycle_state="completed",

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -56,6 +56,7 @@ def create_visualization_result(
     include_qr: bool = False,
     include_qv: bool = True,
     include_dbz: bool = True,
+    cloud_liquid_field: str = "qc",
     run_id: str = "run-visualization",
     package_updates: dict[str, object] | None = None,
 ) -> tuple[CloudChamberSettings, str, Path]:
@@ -75,6 +76,7 @@ def create_visualization_result(
         include_qr=include_qr,
         include_qv=include_qv,
         include_dbz=include_dbz,
+        cloud_liquid_field=cloud_liquid_field,
     )
     manifest = load_run_manifest(package.manifest_path)
     update_payload = {
@@ -93,6 +95,7 @@ def create_multifile_visualization_result(
     *,
     file_count: int = 3,
     run_id: str = "run-multifile-visualization",
+    domain_dz_m: float | None = None,
 ) -> tuple[CloudChamberSettings, str, Path]:
     settings = fake_settings(tmp_path)
     package = generate_dry_run_package(
@@ -111,15 +114,19 @@ def create_multifile_visualization_result(
         )
         paths.append(path)
     manifest = load_run_manifest(package.manifest_path)
+    update_payload: dict[str, object] = {
+        "lifecycle_state": LifecycleState.COMPLETED,
+        "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+        "outputs": OutputMetadata(netcdf_paths=[str(path) for path in paths]),
+    }
+    if domain_dz_m is not None:
+        update_payload["run_configuration"] = {
+            **manifest.run_configuration,
+            "domain": {"dz_m": domain_dz_m},
+        }
     write_run_manifest(
         package.manifest_path,
-        manifest.model_copy(
-            update={
-                "lifecycle_state": LifecycleState.COMPLETED,
-                "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
-                "outputs": OutputMetadata(netcdf_paths=[str(path) for path in paths]),
-            }
-        ),
+        manifest.model_copy(update=update_payload),
     )
     result = ingest_completed_run(package.manifest_path)
     return settings, result.result_id, package.package_dir
@@ -178,13 +185,14 @@ def write_visualization_netcdf(
     include_qr: bool,
     include_qv: bool,
     include_dbz: bool,
+    cloud_liquid_field: str,
 ) -> None:
     data_vars: dict[str, Any] = {}
     if include_qc:
         qc = np.arange(2 * 2 * 3 * 4, dtype=float).reshape(2, 2, 3, 4) * 1e-6
         qc[0, 0, 0, 0] = np.nan
         qc[1, 1, 2, 3] = np.inf
-        data_vars["qc"] = (
+        data_vars[cloud_liquid_field] = (
             ("time", "zh", "yh", "xh"),
             qc,
             {"units": "kg/kg"},
@@ -323,6 +331,11 @@ def write_realistic_field_catalog_netcdf(path: Path) -> None:
                 surface * 1e-3,
                 {"units": "kg m-2"},
             ),
+            "cwp": (
+                ("time", "yh", "xh"),
+                surface * 2e-3,
+                {"units": "kg m-2"},
+            ),
             "CAPE": (
                 ("time", "yh", "xh"),
                 surface * 10.0,
@@ -420,6 +433,25 @@ def test_field_catalog_includes_qc_and_w_with_provenance(tmp_path: Path) -> None
     assert "native-grid view" in catalog.provenance.provenance_label
 
 
+def test_field_catalog_supports_cm1_ql_as_cloud_water(tmp_path: Path) -> None:
+    settings, result_id, _run_dir = create_visualization_result(
+        tmp_path,
+        cloud_liquid_field="ql",
+        run_id="run-visualization-ql",
+    )
+
+    catalog = field_catalog(settings, result_id)
+    fields = {field.raw_field_name: field for field in catalog.available_fields}
+
+    assert fields["ql"].canonical_field_name == "cloud_water"
+    assert fields["ql"].native_grid == "zh/yh/xh"
+    assert "cm1_ql_mapped_to_canonical_cloud_water" in fields["ql"].caveats
+
+    defaults = view_defaults(settings, result_id)
+    assert defaults.preferred_field == "ql"
+    assert "missing_visualization_field:qc_or_ql" not in defaults.caveats
+
+
 def test_field_catalog_uses_ingested_metadata_without_reopening_netcdf(tmp_path: Path) -> None:
     settings, result_id, run_dir = create_visualization_result(tmp_path)
     for path in run_dir.glob("cm1out_*.nc"):
@@ -452,7 +484,7 @@ def test_field_catalog_handles_missing_qc_and_missing_w(tmp_path: Path) -> None:
     w_missing = field_catalog(settings_w_missing, result_id_w_missing)
 
     assert "qc" not in {field.raw_field_name for field in qc_missing.available_fields}
-    assert "missing_visualization_field:qc" in qc_missing.caveats
+    assert "missing_visualization_field:qc_or_ql" in qc_missing.caveats
     assert "w" not in {field.raw_field_name for field in w_missing.available_fields}
     assert "missing_visualization_field:w" in w_missing.caveats
 
@@ -473,6 +505,7 @@ def test_field_catalog_classifies_realistic_output_fields_conservatively(
         "psfc",
         "swten",
         "lwp",
+        "cwp",
         "CAPE",
         "CIN",
         "LCL",
@@ -515,6 +548,12 @@ def test_field_catalog_classifies_realistic_output_fields_conservatively(
     assert fields["lwp"].native_grid_class == "surface_2d"
     assert fields["lwp"].capabilities.profile_candidate is False
     assert "column_integrated_field_no_vertical_profile" in fields["lwp"].caveats
+
+    assert fields["cwp"].canonical_field_name == "liquid_water_path"
+    assert fields["cwp"].field_family == "column_integrated_water"
+    assert fields["cwp"].native_grid_class == "surface_2d"
+    assert fields["cwp"].capabilities.profile_candidate is False
+    assert "cm1_cwp_is_nonprecipitating_liquid_water_path" in fields["cwp"].caveats
 
     assert fields["CAPE"].canonical_field_name == "cape"
     assert fields["CAPE"].display_name == "CAPE"
@@ -931,6 +970,20 @@ def test_metadata_defaults_use_multifile_interesting_time_for_large_results(
     assert defaults.fields["qc"].time_index == 9
     assert defaults.fields["qc"].time_seconds == 5400.0
     assert defaults.fields["qc"].horizontal_level_index == 0
+
+
+def test_metadata_defaults_use_recorded_vertical_spacing_for_large_results(
+    tmp_path: Path,
+) -> None:
+    settings, result_id, _run_dir = create_multifile_visualization_result(
+        tmp_path,
+        file_count=10,
+        domain_dz_m=40.0,
+    )
+
+    defaults = view_defaults(settings, result_id)
+
+    assert defaults.fields["qc"].horizontal_level_index == 1
 
 
 def test_horizontal_qc_slice_uses_json_values_and_counts_non_finite(

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -4949,6 +4949,50 @@ describe("App", () => {
     expect(screen.queryByText(/Preview estimate not implemented/)).not.toBeInTheDocument();
   });
 
+  it("renders Build pipeline runs with case-manifest run configurations", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    const bomexStoredRun = {
+      ...storageRuns[0],
+      run_id: "bomex-full",
+      scenario_id: "bomex_trade_cumulus_baseline_v0",
+      scenario_name: null,
+      worker_state: "running",
+      worker_progress: null,
+      worker_started_at: "2026-07-19T15:00:00Z",
+      worker_netcdf_count: 2,
+      run_configuration: {
+        case_id: "bomex_trade_cumulus_baseline_v0",
+        mapping_version: "bomex_cm1_mapping_v1",
+        variant: "full",
+        expected_model_output_count: 73,
+      },
+    };
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ...storageInventoryResponse,
+              runs: [bomexStoredRun],
+              largest_runs: [bomexStoredRun],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Build" }));
+
+    const pipeline = await screen.findByLabelText("Local packages and runs");
+    expect(pipeline).toHaveTextContent("bomex-full");
+    expect(pipeline).toHaveTextContent("bomex trade cumulus baseline v0");
+  });
+
   it("can move completed local output from the Build pipeline into result ingest", async () => {
     render(<App />);
 
@@ -5768,6 +5812,41 @@ describe("App", () => {
       screen.getByText("CM1 stderr reported floating-point exception flags: IEEE_INVALID_FLAG"),
     ).toBeInTheDocument();
     expect(screen.getAllByText("Completed CM1 result").length).toBeGreaterThan(0);
+    expect(within(resultDetail).getByRole("button", { name: "Open in Explore" })).toBeEnabled();
+  });
+
+  it("renders result cards with case-manifest run configurations", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    const bomexResultCard = {
+      ...resultCard,
+      result_id: "result-bomex-full",
+      run_id: "bomex-full",
+      name: "BOMEX full baseline",
+      scenario_id: "bomex_trade_cumulus_baseline_v0",
+      scenario_name: null,
+      run_configuration: {
+        case_id: "bomex_trade_cumulus_baseline_v0",
+        mapping_version: "bomex_cm1_mapping_v1",
+        variant: "full",
+        duration_seconds: 21600,
+      },
+    };
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/results") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ results: [bomexResultCard] }), { status: 200 }),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    const resultDetail = await screen.findByLabelText("Result detail");
+    expect(resultDetail).toHaveTextContent("BOMEX full baseline");
+    expect(screen.getAllByText("bomex trade cumulus baseline v0").length).toBeGreaterThan(0);
     expect(within(resultDetail).getByRole("button", { name: "Open in Explore" })).toBeEnabled();
   });
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1062,6 +1062,15 @@ type CandidateHypothesisComparison = {
   caveats: string[];
 };
 
+type PersistedRunConfiguration = {
+  label?: string | null;
+  configuration_id?: string | null;
+  case_id?: string | null;
+  mapping_version?: string | null;
+  cm1_values?: RunConfigurationCM1Values | null;
+  expected_model_output_count?: number | null;
+};
+
 type ResultCard = {
   result_id: string;
   run_id: string;
@@ -1072,7 +1081,7 @@ type ResultCard = {
   protected: boolean;
   scenario_id: string;
   scenario_name: string | null;
-  run_configuration: RunConfiguration;
+  run_configuration: PersistedRunConfiguration | null;
   pre_run_validation_report?: PreRunValidationReport | null;
   physical_question: string;
   controls: Record<string, string | number | boolean>;
@@ -1167,7 +1176,7 @@ type RunStorageEntry = {
   lifecycle_state: string | null;
   validation_status: string | null;
   product_state: string | null;
-  run_configuration: RunConfiguration | null;
+  run_configuration: PersistedRunConfiguration | null;
   pre_run_validation_report?: PreRunValidationReport | null;
   created_at: string | null;
   updated_at: string | null;
@@ -7956,7 +7965,7 @@ function PipelineRunCard({
         {humanize(result?.scenario_id ?? run.scenario_id ?? "unknown scenario")} ·{" "}
         {result
           ? resultRunConfigurationLabel(result.run_configuration)
-          : runConfigurationLabel(run.run_configuration)}
+          : resultRunConfigurationLabel(run.run_configuration)}
       </p>
       <p className="state-note">
         {pipelineRunOutputSummary(run, result)} · Local package {formatBytes(run.size_bytes)}
@@ -8400,7 +8409,10 @@ function workerProgressSummary(run: RunStorageEntry): string | null {
 
 function workerEstimatedFinish(run: RunStorageEntry): string | null {
   if (!run.worker_started_at) return null;
-  const expectedFrames = run.run_configuration?.cm1_values.expected_output_frames ?? null;
+  const expectedFrames =
+    run.run_configuration?.cm1_values?.expected_output_frames ??
+    run.run_configuration?.expected_model_output_count ??
+    null;
   if (!expectedFrames) return null;
   const netcdfCount = run.worker_netcdf_count ?? 0;
   const observedModelFrames = Math.max(0, netcdfCount - 1);
@@ -13187,13 +13199,14 @@ function formatSeconds(value: number | null): string {
   return `${value.toLocaleString()} s`;
 }
 
-function runConfigurationLabel(configuration: RunConfiguration | null | undefined): string {
+function resultRunConfigurationLabel(
+  configuration: PersistedRunConfiguration | null | undefined,
+): string {
   if (!configuration) return "Run configuration unavailable";
-  return configuration.label || humanize(configuration.configuration_id);
-}
+  if (configuration.label?.trim()) return configuration.label;
 
-function resultRunConfigurationLabel(configuration: RunConfiguration): string {
-  return runConfigurationLabel(configuration);
+  const identifier = configuration.configuration_id ?? configuration.case_id;
+  return identifier?.trim() ? humanize(identifier) : "Custom run configuration";
 }
 
 function runConfigurationSummaryGrid(details: RunConfigurationSummary): string {

--- a/docs/research/bomex/bomex-run-report.md
+++ b/docs/research/bomex/bomex-run-report.md
@@ -28,9 +28,23 @@ Intercomparison Study of Shallow Cumulus Convection*:
 
 ## Configuration and Provenance
 
-Both runs used app commit `6808e5f5962bb42b58c450d3e564a4a00f58fdeb`
-and configured CM1 release `21.1`. All 91 original configured `src/*.F` files
-matched official NCAR tag `21.1` commit
+The executed run manifests recorded app commit
+`6808e5f5962bb42b58c450d3e564a4a00f58fdeb`, but package generation occurred
+from a dirty worktree containing the then-uncommitted BOMEX implementation.
+That commit is the Stage 3 merge base and cannot by itself reproduce these
+packages. It is retained here as the original manifest value, not treated as
+valid implementation provenance.
+
+The corrected package generator now fails closed unless tracked and untracked
+worktree state is clean. Package-only smoke and full variants were regenerated
+from clean implementation commit
+`84126c75c2db31deb8ba0a3e3bb447a1f94dad27`. Their namelist, profile audit,
+runtime checklist, case manifest, and normalized science hashes match the
+executed packages byte-for-byte. This clean-commit equivalence establishes
+reproducible implementation provenance without repeating either CM1 run.
+
+Both executed and regenerated packages use configured CM1 release `21.1`. All
+91 original configured `src/*.F` files matched official NCAR tag `21.1` commit
 `0f734f64efa89a684963a66d2ac32db67617912b` byte-for-byte.
 
 | Evidence | SHA-256 |
@@ -40,13 +54,18 @@ matched official NCAR tag `21.1` commit
 | CM1 `README.namelist` | `7b95be56db51f5c9396c59dca252cf96b918a312cc70107451f91149a34ab3b5` |
 | Normalized non-duration science settings | `c65b5d4052ff78fe00d447050e2e72a3b62c3a074bee3a17b31cb0a669333e0b` |
 | Generated profile audit, both variants | `703cdbd38f9ef13712b86e1cc8d7aa19f40478947325d75b5266fafa94d6f645` |
+| Runtime checklist, both variants | `f0967d30d8b26bcc4a9e205a4d658ec7ee3a7d12f6c1a60d3e8dea3f82a8d22d` |
 | Smoke namelist | `52435321e13a9a4a53f14a172af942d60a3df3d8679e5bcdcf4aeceecbb929f2` |
+| Smoke case manifest | `d206efc5692be15cb277add2a5d2bba0c9ff96897c85314775f15258ad386753` |
 | Full namelist | `0928f137668663fec38276ea02dc76b2eb2390b6a8904e409249f113055bc8e2` |
+| Full case manifest | `14acd71d736c998e3946c473b7c09c63414a48fdbac3632bbd10c2b20843b5c8` |
 
 The normalized science hash and profile hash are identical. Direct generated
 namelist comparison found only `timax=600 s` versus `timax=21600 s`; the output
-count changes consequently. No observed sounding, sounding candidate,
-analyzer, `run_recipe`, or warm-bubble initiation path was used.
+count changes consequently. The clean regeneration produced no differing
+scientific or package artifact hash, so no rerun threshold was triggered. No
+observed sounding, sounding candidate, analyzer, `run_recipe`, or warm-bubble
+initiation path was used.
 
 ## Smoke Gate
 
@@ -100,9 +119,11 @@ During the final three hours:
 
 - mean total cloud cover was `10.61%`, with frame means from `8.13%` to
   `13.18%`; the published model means span `8-17%` with a `13%` ensemble mean;
-- the time-mean cloud-fraction profile peaked at `6.53%` near `620 m`, close to
-  the published approximately `6%` maximum near cloud base, and decreased
-  upward through the cloud layer;
+- the evaluator retained the per-level cloud-fraction profile for all 37 frames
+  from hour three through hour six, averaged each level across those frames,
+  and found the resulting time-mean profile peak at `6.5344%` at `620 m`, close
+  to the published approximately `6%` maximum near cloud base; the distinct
+  maximum instantaneous per-frame profile peak was `8.9600%`;
 - supported cloud base averaged `569 m` and ranged from `540-580 m`, close to
   the published approximately `500 m` cloud base;
 - supported cloud top averaged `1,784 m` and ranged from `1,500-2,140 m`.

--- a/docs/research/bomex/bomex-run-report.md
+++ b/docs/research/bomex/bomex-run-report.md
@@ -1,0 +1,229 @@
+# Canonical BOMEX Baseline Run Report
+
+## Status and Boundaries
+
+This report evaluates `bomex_trade_cumulus_baseline_v0` as Stage 4 scientific
+evidence. It does not approve a Cloud World, product Recipe, default case, MVP,
+or final application architecture.
+
+The complete source definition and CM1 translation are recorded in
+[`bomex-setup-and-cm1-mapping.md`](bomex-setup-and-cm1-mapping.md). The primary
+scientific authority is Siebesma et al. (2003), *A Large Eddy Simulation
+Intercomparison Study of Shallow Cumulus Convection*:
+
+- DOI: <https://doi.org/10.1175/1520-0469(2003)60%3C1201:ALESIS%3E2.0.CO;2>
+- publisher record: <https://journals.ametsoc.org/view/journals/atsc/60/10/1520-0469_2003_60_1201_alesis_2.0.co_2.xml>
+- public institutional record: <https://pure.mpg.de/view/item_995314>
+
+## Evidence Chain
+
+| State | Evidence |
+| --- | --- |
+| Canonical source specification | Steady, nonprecipitating BOMEX LES case; `64 x 64 x 75`, `100 x 100 x 40 m`, six hours, prescribed profiles and forcing from Siebesma et al. Appendix B |
+| CM1 translation | CM1 r21.1 analytic BOMEX paths `testcase=3`, `isnd=19`, `iwnd=9`; reversible moist `ptype=6`, zero terminal velocity, periodic lateral boundaries, prescribed fluxes and tendencies |
+| Cloud Chamber implementation | Deterministic isolated package generator, duration-only smoke/full variants, pinned provenance, hashes, current local execution, ingest, integrity, diagnostics, and visualization payloads |
+| Measured run evidence | One 10-minute smoke run followed by one complete six-hour run; both ingested; all required fields finite; full run carries an underflow-only runtime caveat |
+| Interpretation | A recognizable, sustained, low-cover shallow trade-cumulus field formed with published-order cloud structure and locally practical cost |
+| Product authority | None; PM review remains required |
+
+## Configuration and Provenance
+
+Both runs used app commit `6808e5f5962bb42b58c450d3e564a4a00f58fdeb`
+and configured CM1 release `21.1`. All 91 original configured `src/*.F` files
+matched official NCAR tag `21.1` commit
+`0f734f64efa89a684963a66d2ac32db67617912b` byte-for-byte.
+
+| Evidence | SHA-256 |
+| --- | --- |
+| CM1 source manifest | `fbe2367dfcd6d8c55cac4bd03362d8d49f13f80cebd13b36230c20d71119a84e` |
+| CM1 executable | `5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1` |
+| CM1 `README.namelist` | `7b95be56db51f5c9396c59dca252cf96b918a312cc70107451f91149a34ab3b5` |
+| Normalized non-duration science settings | `c65b5d4052ff78fe00d447050e2e72a3b62c3a074bee3a17b31cb0a669333e0b` |
+| Generated profile audit, both variants | `703cdbd38f9ef13712b86e1cc8d7aa19f40478947325d75b5266fafa94d6f645` |
+| Smoke namelist | `52435321e13a9a4a53f14a172af942d60a3df3d8679e5bcdcf4aeceecbb929f2` |
+| Full namelist | `0928f137668663fec38276ea02dc76b2eb2390b6a8904e409249f113055bc8e2` |
+
+The normalized science hash and profile hash are identical. Direct generated
+namelist comparison found only `timax=600 s` versus `timax=21600 s`; the output
+count changes consequently. No observed sounding, sounding candidate,
+analyzer, `run_recipe`, or warm-bubble initiation path was used.
+
+## Smoke Gate
+
+| Item | Result |
+| --- | --- |
+| Run ID | `bomex-370-smoke-20260719` |
+| Result ID | `result-bomex-370-smoke-20260719` |
+| Duration and cadence | 600 s; 300 s model output; 60 s domain diagnostics |
+| Completion | Exit 0; normal CM1 termination; empty stderr |
+| Runtime integrity | `trusted`; no warning or fatal flags |
+| Output | 3/3 model frames, 11 domain-diagnostic frames, one stats file; 30,264,681 bytes total NetCDF |
+| Runtime | 32.15 s wall clock; 31.13 s CM1-reported |
+| Ingest and fields | Ingest succeeded; no required fields missing; no non-finite values in required fields |
+| Forcing evidence | Surface heat `0.008 K m/s`, moisture `5.2e-5 g/g m/s`, `u*=0.28 m/s`, cooling minimum `-2 K/day`, drying minimum `-1.2e-8 s^-1`, subsidence minimum `-0.006413 m/s`, geostrophic wind and Coriolis diagnostics present |
+| Gate disposition | Pass; science run authorized without a post-smoke modeling correction |
+
+The absence of cloud after ten minutes was expected and was not used as science
+evidence. The smoke gate established package, forcing, execution, output,
+ingest, and numerical integrity only.
+
+## Six-Hour Science Run
+
+| Item | Result |
+| --- | --- |
+| Run ID | `bomex-370-full-20260719` |
+| Result ID | `result-bomex-370-full-20260719` |
+| Domain and grid | `6.4 x 6.4 x 3.0 km`; `64 x 64 x 75`; `100 x 100 x 40 m` |
+| Time integration | Six hours; 3 s target with adaptive time stepping |
+| Output cadence | 300 s model fields and 60 s domain diagnostics |
+| Completion and ingest | Exit 0; normal termination; ingest succeeded |
+| Output inventory | 73/73 model frames, 361 domain-diagnostic frames, one stats file |
+| Runtime | 1,161.81 s wall clock; 1,160.75 s CM1-reported, approximately 19.4 minutes |
+| Compute environment | One local CM1 process on Apple M3 hardware with 8 GiB memory |
+| Storage | Prelaunch estimate approximately 0.96 GB; actual 1,041,678,203 bytes (1.042 GB, 0.970 GiB), 8.5% above estimate and within the available local space |
+
+## Scientific Recognizability
+
+### Cloud onset and spinup
+
+The first isolated `ql >= 1e-6 kg/kg` cells appeared at 20 minutes. The current
+coherent-cloud diagnostic, which requires at least ten qualifying cells,
+declared onset at 25 minutes. Siebesma et al. reports first clouds after about
+30 minutes. The simulation then produced a startup wave: domain-mean
+liquid-water path reached 8.53 g/m2 and total cover 16.28% at 40 minutes, then
+fell to 1.18 g/m2 and 9.62% at one hour. This reproduces the published sequence
+of a synchronized first cloud wave followed by a roughly one-hour minimum.
+
+### Cloud layer and cover
+
+During the final three hours:
+
+- mean total cloud cover was `10.61%`, with frame means from `8.13%` to
+  `13.18%`; the published model means span `8-17%` with a `13%` ensemble mean;
+- the time-mean cloud-fraction profile peaked at `6.53%` near `620 m`, close to
+  the published approximately `6%` maximum near cloud base, and decreased
+  upward through the cloud layer;
+- supported cloud base averaged `569 m` and ranged from `540-580 m`, close to
+  the published approximately `500 m` cloud base;
+- supported cloud top averaged `1,784 m` and ranged from `1,500-2,140 m`.
+  Siebesma et al. treats cloud samples above about `2,000 m` as sparse, so the
+  highest cells are retained as real output but not treated as a robust mean
+  cloud-top target.
+
+### Liquid water and vertical motion
+
+CM1 `cwp` is the scientific liquid-water path for this nonprecipitating
+reversible-moist case. Final-three-hour domain-mean LWP was `6.35 g/m2`, ranged
+from `1.95-14.16 g/m2`, and had a maximum individual-column value of
+`1.492 kg/m2`. The time variation is low and intermittent as in the published
+intercomparison; no exact numeric acceptance band was inferred from its plotted
+LWP envelope.
+
+The final-three-hour cloud-conditioned vertical velocity was `1.11 m/s` at the
+lowest supported 540 m level and peaked at `1.38 m/s` near 1,220 m. Published
+cloud-ensemble values are about `0.6 m/s` near base and peak around `1 m/s`, so
+the CM1 cloud ensemble is somewhat stronger but of the same order. Raw extrema
+of `+8.28` and `-5.23 m/s` are localized grid-cell values and are not compared
+with ensemble means.
+
+### Mean thermodynamic structure
+
+The final profile retained a mixed subcloud layer, conditionally unstable cloud
+layer, and inversion. From hour three to hour six, the 100-500 m layer warmed at
+an extrapolated `1.09-1.25 K/day` and dried at `1.25-1.27 g/kg/day`; these are
+the same order as the approximately `1 K/day` and `1 g/kg/day` last-three-hour
+tendencies discussed for the intercomparison. At 1,000 m the corresponding
+changes were approximately `0.01 K/day` and `-0.44 g/kg/day`. Moistening near
+1,500 m reflects turbulent redistribution into the inversion. No mean-profile
+collapse or destructive secular drift appeared over six hours.
+
+## Forcing and Process Evidence
+
+The initial and final domain-diagnostic files preserve the intended forcing:
+
+- `thflux=0.008 K m/s`, `qvflux=5.2e-5 g/g m/s`, and `ust=0.28 m/s`;
+- `wprof` spans `0` to `-0.006413 m/s`, the discrete-grid representation of
+  the `-0.0065 m/s` subsidence knot;
+- `ptb_frc` spans `0` to `-2.3148148e-5 K/s`, exactly `-2 K/day`;
+- `qvb_frc` spans `0` to `-1.2e-8 s^-1`;
+- `ug` spans `-9.964` to `-4.636 m/s` on scalar levels and `vg=0`;
+- resolved or SGS turbulent-process diagnostics include `upwp`, `vpwp`,
+  `wpwp`, `ufr`, `vfr`, `qvfr`, `ptb_vturbr`, and `qvb_vturbr`.
+
+These fields make surface production, subsidence, prescribed cooling and
+drying, geostrophic adjustment, vertical transport, condensation, and cloud
+layer evolution observable. They preserve the distinction between configured
+forcing, completed CM1 fields, backend-derived diagnostics, and visual
+interpretation.
+
+## Repeated Evolution and Watchability
+
+Cloud liquid persisted in 69 of 73 five-minute frames after first appearance.
+The domain-mean LWP series contains 12 local growth-decay maxima; 10 retain at
+least `1 g/m2` prominence. This includes repeated cycles during the final three
+hours, not only the startup wave. Final-three-hour frames contain roughly
+1,302-3,260 cloudy grid cells above the threshold.
+
+Current backend visualization machinery exposes:
+
+- a `73 x 75` `ql` time-height cloud-fraction payload with no non-finite cells;
+- a 73-point `cwp` domain-mean LWP series;
+- domain-mean `th`, `qv`, `u`, and `v` profiles;
+- native-grid `ql` slices and thresholded point clouds;
+- `w` slices, with signed-flow 3-D rendering explicitly unavailable.
+
+At hours 3, 4.5, and 6, the `ql` point-cloud payload contained 2,761, 1,553, and
+2,654 active native-grid points, with changing vertical extents. The preferred
+large-result field is now the canonical `ql` cloud-water alias rather than a
+zero-rain field. The changing sparse cloud population, vertical growth, and
+repeated LWP cycles make the result visually worth watching at five-minute
+cadence. This is backend inspection evidence, not approval of a final visual
+experience.
+
+## Integrity, Missing Fields, and Potentially Misleading Evidence
+
+All required fields were present and had zero non-finite values. Cloud liquid
+(`ql`), vertical velocity, surface fluxes, and rain each had trusted field
+quality over all 73 frames. Surface rain remained exactly zero, as required by
+the nonprecipitating case. Rainwater and reflectivity are intentionally absent.
+
+The full run emitted only `IEEE_UNDERFLOW_FLAG` on stderr. CM1 reported normal
+termination; exit code was zero; no fatal flags, stats-sentinel collapse,
+terminal non-finite field, or all-non-finite frame was found. The result is
+therefore `caveated`, not `trusted`, under the current runtime-integrity
+contract. Underflow-only arithmetic is not evidence of scientific failure, but
+the caveat remains visible.
+
+CM1 also emits an `lwp` variable that is hard-zero under `ptype=6` because its
+source calculation requires both cloud and rain arrays. It is potentially
+misleading and is not used. CM1 `cwp`, which integrates cloud liquid through the
+column, is LWP for this no-rain case. The evidence schema, required-field check,
+and visualization catalog record this distinction explicitly.
+
+## Departures and Unresolved Uncertainty
+
+- **Canonical-source ambiguity:** no consequential source disagreement was
+  found. Intercomparison spread remains the correct comparison basis rather
+  than one exact-model target.
+- **CM1 representation:** CM1's Deardorff-family closure, adaptive timestep,
+  upper 500 m Rayleigh damping, analytic case implementation, and reversible
+  all-or-nothing microphysics are explicit model-specific translations.
+- **Cloud Chamber implementation:** `ql` is aliased to canonical cloud water;
+  cloud fraction uses `ql >= 1e-6 kg/kg`; `cwp` is used as no-rain LWP. These are
+  documented diagnostic choices, not changes to the simulated state.
+- **Unresolved science:** this is one deterministic realization from one LES
+  model. It does not quantify seed sensitivity, model uncertainty, or product
+  response to controls. The somewhat stronger cloud-conditioned velocity and
+  sparse cells above 2 km should remain visible in later review.
+
+## PM Recommendation
+
+The run reproduces the canonical spinup sequence, final-three-hour cloud-cover
+range, near-base cloud-fraction maximum, shallow cloud layer, repeated cloud
+growth and decay, and physically defensible mean structure at practical local
+cost. Required forcing and process fields are observable, and the remaining
+limitations are explicit CM1/diagnostic caveats rather than a failed scientific
+question. This supports carrying the evidence into Stage 5 consideration
+without approving a Cloud World, Recipe, or product direction.
+
+advance_as_stage5_candidate_evidence

--- a/docs/research/bomex/bomex-setup-and-cm1-mapping.md
+++ b/docs/research/bomex/bomex-setup-and-cm1-mapping.md
@@ -1,0 +1,128 @@
+# BOMEX Setup and CM1 Mapping
+
+## Status and Scope
+
+This document records the pre-implementation mapping for
+`bomex_trade_cumulus_baseline_v0`. The identifier is a provisional Stage 4
+technical identifier, not an approved Cloud World or product Recipe.
+
+Mapping gate disposition: **pass**. Every material component of the canonical,
+steady, nonprecipitating BOMEX LES case is represented by direct CM1 r21.1
+configuration or an existing case-specific source capability. No CM1 source
+customization or generalized forcing infrastructure is required.
+
+## Scientific Authority
+
+The controlling scientific source is Siebesma et al. (2003), *A Large Eddy
+Simulation Intercomparison Study of Shallow Cumulus Convection*, Journal of the
+Atmospheric Sciences 60, 1201-1219:
+
+- DOI: <https://doi.org/10.1175/1520-0469(2003)60%3C1201:ALESIS%3E2.0.CO;2>
+- publisher record: <https://journals.ametsoc.org/view/journals/atsc/60/10/1520-0469_2003_60_1201_alesis_2.0.co_2.xml>
+- public institutional record: <https://pure.mpg.de/view/item_995314>
+
+Appendix B supplies the domain, initial profiles, forcing profiles, surface
+fluxes, geostrophic wind, Coriolis parameter, perturbations, and six-hour
+duration. Appendix A identifies all-or-nothing condensation as the prevalent
+grid-cell condensation treatment in the intercomparison.
+
+CM1 implementation authority is the configured CM1 r21.1 source and
+documentation, cross-checked against NCAR's `21.1` tag at commit
+`0f734f64efa89a684963a66d2ac32db67617912b`:
+
+- CM1: <https://www.mmm.ucar.edu/models/cm1>
+- source tag: <https://github.com/NCAR/CM1/tree/21.1>
+- namelist documentation: <https://cm1.readthedocs.io/en/latest/README.namelist/>
+
+## Configured CM1 Provenance
+
+The exact absolute local paths remain in generated runtime-only package
+metadata and are omitted here under the repository's machine-private-path
+restriction.
+
+| Evidence | Configured value |
+| --- | --- |
+| Source tree | `cm1_root` from runtime `settings.json`; final component `cm1r21.1` |
+| Run directory | `cm1_run_dir` from runtime `settings.json` |
+| Release evidence | source `README.md`: `CM1 Numerical Model, Release 21.1`, 24 March 2024 |
+| Source-control alignment | all 91 local original `src/*.F` files byte-match NCAR tag `21.1` |
+| Source manifest method | SHA-256 each sorted original `src/*.F`, then SHA-256 the newline-delimited manifest |
+| Source manifest SHA-256 | `fbe2367dfcd6d8c55cac4bd03362d8d49f13f80cebd13b36230c20d71119a84e` |
+| `README.namelist` SHA-256 | `7b95be56db51f5c9396c59dca252cf96b918a312cc70107451f91149a34ab3b5` |
+| Configured `cm1.exe` SHA-256 | `5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1` |
+| Bundled BOMEX namelist SHA-256 | `4aa2f7cfad8c918801e0768c2618a37740e3966bc8f47205e5fafda3e506f965` |
+| Bundled BOMEX README SHA-256 | `368c6ca53445f920f0e89d6e4273111f0378785e393e1efa63a7758f2dc5ae56` |
+
+Directly relevant source hashes:
+
+| Source file | SHA-256 |
+| --- | --- |
+| `src/base.F` | `9c88a1021ddde22d02680786246c52bcffb040cbd72c3c4708f24fe24eec32ef` |
+| `src/init3d.F` | `9c45c0982ba194ea6ea74afd6a2516445cdd011fc90902091d089f4cb92dfd28` |
+| `src/sfcphys.F` | `7cb54de579b8bb038285430890e075ab19ed2e6d93158bd50d656209d64696a7` |
+| `src/testcase_simple_phys.F` | `ce0a74ba558634cf712669aae3cbee2eafeb4e23a116e0fe3d819886938ffc72` |
+| `src/adv_routines.F` | `265723c8b19e300592ddbad3839ee689aa4933ac2f0ae236c61f4d5d40ef7f00` |
+| `src/solve1.F` | `515346f18268aea39e7a919536ee6187386e5db6d184e6e4c597509c701e2076` |
+| `src/param.F` | `cac64a6cb4363c6b88367b5cb9391f1bcf2130c63ffedef6e5973c03b190c349` |
+| `src/domaindiag.F` | `a926b4938c6b576e2ec634c14dbf177f8bdcc557ddefa3b8155326e5f8ef7dff` |
+| `src/mp_driver.F` | recorded in generated package metadata |
+| `src/kessler.F` | recorded in generated package metadata |
+
+The local build Makefile differs from the release tag only for local NetCDF
+build configuration. The scientific Fortran sources above match the official
+tag byte-for-byte. Package generation rechecks all pinned evidence and fails
+closed on a mismatch.
+
+## Source-to-CM1 Mapping
+
+The scientific-source column refers to Siebesma et al. Appendix B unless a CM1
+source file is named explicitly.
+
+| Component | Scientific source and exact value or formula | CM1 representation | Classification | Approximation or uncertainty | Verification method |
+| --- | --- | --- | --- | --- | --- |
+| Liquid-water potential temperature | `theta_l=298.7 K` at 0 and 520 m; `302.4 K` at 1480 m; `308.2 K` at 2000 m; `311.85 K` at 3000 m; linear interpolation | `isnd=19`; exact knots and interpolation in `src/base.F` | existing CM1 source capability | CM1 initializes its prognostic thermodynamic variables from the analytic profile | Source review, startup diagnostics, and initial domain-mean profile |
+| Total water | `q_t=17.0 g/kg` at 0 m, `16.3` at 520 m, `10.7` at 1480 m, `4.2` at 2000 m, `3.0` at 3000 m; linear interpolation | `isnd=19`; exact knots in `src/base.F` | existing CM1 source capability | Initial cloud liquid is zero, so initialized vapor is equivalent to total water | Source review and initial `qv` profile |
+| Wind | `u=-8.75 m/s` through 700 m, then linear to `-4.61 m/s` at 3000 m; `v=0` | `iwnd=9` in `src/base.F` | existing CM1 source capability | None material | Source review and initial `u`, `v` profiles |
+| Surface sensible heat flux | `8.0e-3 K m/s` | `set_flx=1`, `cnst_shflx=8.0e-3` | direct namelist support | Kinematic flux, as specified by the case | Namelist review and `thflux`/`hfx` output |
+| Surface moisture flux | `5.2e-5 m/s` in specific-humidity units | `set_flx=1`, `cnst_lhflx=5.2e-5` | direct namelist support | CM1 documents units as `g/g m/s`, numerically equivalent | Namelist review and `qvflux`/`qfx` output |
+| Momentum | Friction velocity `u*=0.28 m/s`; stress aligned against low-level wind | `set_ust=1`, `cnst_ust=0.28`, `bbc=3`; BOMEX `testcase=3` surface logic | existing CM1 source capability | CM1 applies the case-specific vector stress formula in `src/sfcphys.F` | Source review and `ust`, stress diagnostics |
+| Subsidence | `w_ls=0` at 0 m, `-0.0065 m/s` at 1500 m, `0` at 2100 m; piecewise linear | `testcase=3` builds `wprof`; large-scale vertical advection is active | existing CM1 source capability | None material | Source review and domain diagnostic `wprof` |
+| Thermodynamic advection | All large-scale thermodynamic advection other than specified subsidence and radiation is zero | No added horizontal thermodynamic-advection tendency | existing CM1 source capability | Subsidence acts through CM1's large-scale vertical-advection path | Source review and tendency diagnostics |
+| Moisture advection | `dq_t/dt=-1.2e-8 s^-1` through 300 m, linearly to zero at 500 m | `testcase=3` `qvfrc` profile | existing CM1 source capability | Applied to vapor; with reversible condensation, this is the CM1 translation of total-water drying | Source review and `qvb_frc` diagnostic |
+| Radiation | `-2 K/day` through 1500 m, linearly to zero at 2100 m | `testcase=3` `thfrc` profile with `radopt=0` | existing CM1 source capability | Prescribed tendency, not interactive radiative transfer | Source review and `ptb_frc` diagnostic |
+| Coriolis and pressure gradient | `f=0.376e-4 s^-1`; `u_g=-10+1.8e-3 z m/s`, `v_g=0` | `icor=1`, `lspgrad=2`, `fcor=0.376e-4`; `testcase=3` geostrophic profile | existing CM1 source capability | None material | Namelist/source review and `ug`, `vg`, momentum diagnostics |
+| Lateral boundaries | Doubly periodic LES domain | `wbc=ebc=sbc=nbc=1` | direct namelist support | None | Namelist review |
+| Upper boundary and damping | Rigid LES top; canonical source does not prescribe implementation-specific damping | `tbc=1` free-slip; `irdamp=1`, `zd=2500 m`, `rdalpha=1/300 s^-1` in top 500 m | direct namelist support | CM1-specific numerical treatment inherited from the authoritative bundled BOMEX case | Namelist review; verify damping remains above half-domain preflight limit |
+| Turbulence closure | Prognostic 1.5-order TKE is within the intercomparison family; initial TKE `1-z/3000 m2/s2` | `sgsmodel=1`, `tconfig=1`, `testcase=3` TKE initialization | existing CM1 source capability | CM1's Deardorff-family implementation is one valid intercomparison-style closure, not a claim of model identity | Namelist/source review and `tke`, `km`, `kh` outputs |
+| Cloud microphysics | Steady nonprecipitating case; Appendix A describes all-or-nothing condensation | `ptype=6`, `v_t=0`: CM1 source labels this reversible moist thermodynamics; only `qv` and `ql` are prognosed and zero fall speed makes fallout zero | direct namelist support | Deliberate correction to the bundled example's `ptype=5`; that example's `iautoc=0` does not disable Morrison precipitation | Source review, generated namelist assertion, `ql` availability, zero rain/fallout evidence |
+| Initial perturbations | Random `theta` amplitude +/-0.1 K and moisture amplitude +/-0.025 g/kg in lowest 40 levels | `iinit=0`, `irandp=1`; `testcase=3` deterministic default random seed and exact amplitudes in `src/init3d.F` | existing CM1 source capability | Deterministic for the pinned executable/source | Source review and repeatable input hashes/startup output |
+| Domain | `64 x 64 x 75` points; `6.4 x 6.4 x 3.0 km` | `nx=64`, `ny=64`, `nz=75` | direct namelist support | None | Namelist review and NetCDF dimensions |
+| Grid | `dx=dy=100 m`, `dz=40 m`, uniform | `dx=100`, `dy=100`, `dz=40`, all stretch flags zero, `ztop=3000` | direct namelist support | None | Namelist review and NetCDF coordinates |
+| Time step | Intercomparison time steps varied by model | `dtl=3 s`, `adapt_dt=1`, matching bundled CM1 BOMEX case | direct namelist support | Model-specific adaptive strategy; three seconds is a target, not a scientific source value | Startup/output log review and numerical-integrity checks |
+| Smoke duration | Operational gate only | `timax=600 s` | direct namelist support | Duration-only variant; not science evidence | Smoke/full configuration comparison |
+| Full duration | Six hours | `timax=21600 s` | direct namelist support | None | Manifest, namelist, output endpoint |
+| Output cadence | Must support repeated evolution inspection | Three-dimensional output every `300 s`; domain diagnostics every `60 s` | direct namelist support | Five-minute 3-D cadence is a watchability/storage tradeoff, not canonical science | Output count, time coordinates, storage estimate versus actual |
+| Required fields | Cloud liquid, vapor, thermodynamics, motion, pressure, surface fluxes, cloud fraction, liquid-water path, profiles, turbulent fluxes, cloud bounds, and integrity | NetCDF `ql`, `qv`, `th`, `prs`, `u`, `v`, `w`, `tke`, `km`, `kh`, `cwp`, surface fields, plus domain diagnostics including forcing and resolved flux profiles | direct namelist support | `ql` is mapped to Cloud Chamber's canonical cloud-liquid `qc` diagnostic alias. Under `ptype=6`, CM1's `cwp` is cloud liquid integrated through the column and therefore the scientific liquid-water path; CM1's emitted `lwp` is hard-zero because its source calculation requires rain allocation. Radiative-scheme `cldfra` is not used because `radopt=0`. | Automated switch tests, ingest field catalog, BOMEX evidence calculation, non-finite scan |
+
+## Explicit Approximations and Limitations
+
+1. CM1's case-specific analytic `isnd=19`, `iwnd=9`, and `testcase=3` code is
+   used instead of external sounding and forcing files. A generated profile
+   audit file records the canonical knots but is not consumed by CM1.
+2. The prescribed `-2 K/day` tendency is implemented by CM1's BOMEX idealized
+   forcing path, not an interactive radiation scheme.
+3. Upper Rayleigh damping is a CM1 numerical treatment inherited from the
+   bundled case, not a published BOMEX physical forcing.
+4. Cloud fraction is derived from grid-cell `ql >= 1e-6 kg/kg`; it is not the
+   inactive radiation scheme's `cldfra` field.
+5. Five-minute 3-D output is selected to expose repeated cloud growth and decay
+   while keeping the projected local output below available storage. The smoke
+   run will supply an empirical bytes-per-frame estimate before the six-hour
+   launch.
+6. For reversible nonprecipitating `ptype=6`, CM1's `cwp` output is used as
+   liquid-water path. The separately emitted `lwp` field is unavailable as
+   scientific evidence because CM1 only accumulates it when both cloud and rain
+   arrays are allocated.
+
+These translations preserve the canonical BOMEX question. They do not approve
+the case as a product Recipe or establish a generalized forcing architecture.

--- a/scripts/run_bomex_baseline.py
+++ b/scripts/run_bomex_baseline.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Package, execute, ingest, and evaluate one canonical BOMEX baseline run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_ROOT = REPO_ROOT / "app" / "backend"
+BACKEND_VENV_PYTHON = BACKEND_ROOT / ".venv" / "bin" / "python"
+
+if sys.version_info < (3, 12):
+    if BACKEND_VENV_PYTHON.exists() and Path(sys.executable) != BACKEND_VENV_PYTHON:
+        os.execv(
+            str(BACKEND_VENV_PYTHON),
+            [str(BACKEND_VENV_PYTHON), str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    raise SystemExit("run_bomex_baseline.py requires Python 3.12 or newer.")
+
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from cloud_chamber.bomex_case import (  # noqa: E402
+    BomexCaseError,
+    BomexVariant,
+    build_bomex_run_evidence,
+    generate_bomex_package,
+    write_bomex_run_evidence,
+)
+from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError  # noqa: E402
+from cloud_chamber.result_ingest import ResultIngestError, ingest_completed_run  # noqa: E402
+from cloud_chamber.run_manifest import LifecycleState  # noqa: E402
+from cloud_chamber.settings import load_settings  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    variant = BomexVariant(args.variant)
+    runtime_home = Path(args.runtime_home).expanduser() if args.runtime_home else None
+    settings = load_settings(home=runtime_home)
+    run_id = args.run_id or _default_run_id(variant)
+
+    try:
+        package = generate_bomex_package(
+            settings=settings,
+            variant=variant,
+            run_id=run_id,
+            allow_overwrite=args.allow_overwrite,
+        )
+        if args.package_only:
+            print(
+                json.dumps(
+                    {
+                        "status": "packaged",
+                        "run_id": run_id,
+                        "variant": variant.value,
+                        "manifest_path": str(package.manifest_path),
+                        "case_manifest_path": str(package.case_manifest_path),
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+
+        manager = LocalRunManager(settings=settings)
+        started = time.monotonic()
+        status = manager.launch(package.manifest_path)
+        try:
+            while status.lifecycle_state in {
+                LifecycleState.QUEUED,
+                LifecycleState.RUNNING,
+            }:
+                time.sleep(args.poll_seconds)
+                status = manager.status(package.manifest_path)
+        except KeyboardInterrupt:
+            manager.cancel()
+            raise
+        wall_clock_seconds = time.monotonic() - started
+        if status.lifecycle_state != LifecycleState.COMPLETED or status.exit_code != 0:
+            print(
+                json.dumps(
+                    {
+                        "status": "run_failed",
+                        "run_id": run_id,
+                        "lifecycle_state": status.lifecycle_state.value,
+                        "exit_code": status.exit_code,
+                        "manifest_path": str(package.manifest_path),
+                    },
+                    indent=2,
+                ),
+                file=sys.stderr,
+            )
+            return 2
+
+        result = ingest_completed_run(package.manifest_path)
+        evidence = build_bomex_run_evidence(
+            result, wall_clock_seconds=wall_clock_seconds
+        )
+        evidence_path = package.package_dir / "bomex_run_evidence.json"
+        write_bomex_run_evidence(evidence_path, evidence)
+        print(
+            json.dumps(
+                {
+                    "status": "completed_ingested_and_evaluated",
+                    "run_id": run_id,
+                    "result_id": result.result_id,
+                    "variant": variant.value,
+                    "manifest_path": str(package.manifest_path),
+                    "result_metadata_path": str(
+                        package.package_dir / "result_metadata.json"
+                    ),
+                    "evidence_path": str(evidence_path),
+                    "runtime_integrity_state": evidence.runtime_integrity_state,
+                    "missing_required_fields": evidence.missing_required_fields,
+                    "wall_clock_seconds": wall_clock_seconds,
+                    "netcdf_output_bytes": evidence.netcdf_output_bytes,
+                },
+                indent=2,
+            )
+        )
+        return 0
+    except KeyboardInterrupt:
+        print("bomex-baseline: canceled", file=sys.stderr)
+        return 130
+    except (BomexCaseError, LocalRunManagerError, ResultIngestError) as exc:
+        print(f"bomex-baseline: {exc}", file=sys.stderr)
+        return 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run one deterministic canonical BOMEX smoke or six-hour case."
+    )
+    parser.add_argument(
+        "--variant", required=True, choices=[variant.value for variant in BomexVariant]
+    )
+    parser.add_argument("--run-id", help="Runtime-local run identifier.")
+    parser.add_argument(
+        "--runtime-home",
+        help="Cloud Chamber runtime home. Defaults to settings/CLOUD_CHAMBER_RUNTIME_HOME.",
+    )
+    parser.add_argument(
+        "--package-only",
+        action="store_true",
+        help="Generate and verify the package without launching CM1.",
+    )
+    parser.add_argument(
+        "--allow-overwrite",
+        action="store_true",
+        help="Replace an existing package with the same run id before execution.",
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=float,
+        default=2.0,
+        help="Status polling interval while CM1 is active.",
+    )
+    return parser
+
+
+def _default_run_id(variant: BomexVariant) -> str:
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"{variant.value}-{variant.duration_seconds}s-{timestamp}-{os.getpid()}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Reproduce the canonical steady, nonprecipitating BOMEX trade-cumulus LES case in configured CM1 r21.1 and record enough source, runtime, scientific, process, and visualization evidence for the Stage 4 PM gate.

The implementation adds an isolated deterministic package/run/evidence path, the complete source-to-CM1 mapping, minimum `ql`/`cwp` compatibility in current ingest and visualization machinery, focused tests, and the smoke/full-run report.

Closes #370

## Scope

Related issue: #370. Issue #364 identifies #370 as the sole active Stage 4 execution vehicle.

Stable vision: Cloud Chamber remains an experience-first collection of scientifically meaningful cloud worlds where people can watch clouds evolve, reveal invisible atmospheric processes, change meaningful conditions, compare outcomes, and understand the response.

Files changed:

```text
app/backend/cloud_chamber/bomex_case.py
app/backend/cloud_chamber/result_diagnostics.py
app/backend/cloud_chamber/result_ingest.py
app/backend/cloud_chamber/runtime_integrity.py
app/backend/cloud_chamber/visualization_data.py
app/backend/tests/test_bomex_case.py
app/backend/tests/test_result_diagnostics.py
app/backend/tests/test_result_ingest.py
app/backend/tests/test_runtime_integrity.py
app/backend/tests/test_visualization_data.py
docs/research/bomex/bomex-run-report.md
docs/research/bomex/bomex-setup-and-cm1-mapping.md
scripts/run_bomex_baseline.py
app/frontend/src/App.tsx
app/frontend/src/App.test.tsx
```

Explicitly out of scope: Cloud World or Recipe approval, product vocabulary, broader frontend or UX changes, generalized forcing/diagnostics architecture, observed-sounding selection, parameter sweeps, another cloud case, remote compute, MVP definition, and historical campaign changes.

## Product and science impact

Does this change any of the following?

- product direction: no;
- scientific interpretation: only the explicit #370 BOMEX-to-CM1 translation and measured Stage 4 assessment;
- recipe or scenario status: no, `bomex_trade_cumulus_baseline_v0` remains a provisional technical identifier and `run_recipe` is null;
- user-facing scientific language: no;
- destructive cleanup behavior: no;
- real CM1 execution behavior: adds an explicit opt-in BOMEX script using current local execution machinery; no existing run path changes;
- backwards-incompatible manifest, result, or scenario schema: no.

What this PR does not establish: a Trade Cumulus Cloud World, product Recipe, MVP/default case, generalized forcing platform, final controls/lenses/explanation/persistence/rendering architecture, or validation of all CM1/Cloud Chamber science.

### Scientific authority and mapping

Primary source: Siebesma et al. (2003), *A Large Eddy Simulation Intercomparison Study of Shallow Cumulus Convection*, DOI <https://doi.org/10.1175/1520-0469(2003)60%3C1201:ALESIS%3E2.0.CO;2>. Appendix B supplies profiles, forcing, domain/grid, perturbations, and duration; Appendix A supports the all-or-nothing condensation treatment. The public institutional record is <https://pure.mpg.de/view/item_995314>.

Mapping disposition: pass. Every material BOMEX component maps to direct CM1 r21.1 configuration or existing case-specific source behavior. No CM1 source customization or generalized forcing implementation was needed.

Key translation:

- `testcase=3`, `isnd=19`, and `iwnd=9` provide the canonical analytic profiles and forcing;
- `64 x 64 x 75`, `100 x 100 x 40 m`, `6.4 x 6.4 x 3.0 km`, periodic lateral boundaries, six hours;
- prescribed `0.008 K m/s` heat flux, `5.2e-5 g/g m/s` moisture flux, `u*=0.28 m/s`;
- canonical subsidence, radiative cooling, moisture drying, geostrophic wind, and Coriolis paths;
- `ptype=6`, `v_t=0` provides reversible nonprecipitating moist thermodynamics with `qv`/`ql` and no fallout;
- 300 s model fields and 60 s domain diagnostics;
- the smoke variant changes only duration and consequent output count.

Configured provenance:

- CM1 release `21.1`, aligned with official tag commit `0f734f64efa89a684963a66d2ac32db67617912b`;
- all 91 original configured `src/*.F` files byte-match the official tag;
- source manifest SHA-256 `fbe2367dfcd6d8c55cac4bd03362d8d49f13f80cebd13b36230c20d71119a84e`;
- executable SHA-256 `5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1`;
- `README.namelist` SHA-256 `7b95be56db51f5c9396c59dca252cf96b918a312cc70107451f91149a34ab3b5`;
- normalized smoke/full science SHA-256 `c65b5d4052ff78fe00d447050e2e72a3b62c3a074bee3a17b31cb0a669333e0b`.

Approximations and uncertainty:

- CM1 analytic case code is used instead of external sounding/forcing files; the generated profile is an audit artifact, not a consumed sounding;
- prescribed radiative tendency is not interactive radiation;
- CM1's upper 500 m Rayleigh damping and Deardorff-family closure are model-specific translations;
- cloud fraction uses `ql >= 1e-6 kg/kg`;
- `ql` maps to canonical cloud-water diagnostics;
- for no-rain `ptype=6`, `cwp` is the scientific liquid-water path; CM1's separately emitted `lwp` is hard-zero because its source calculation requires rain allocation and is marked unusable;
- this is one deterministic realization from one LES model, not a seed/model ensemble;
- sparse cloud cells above 2 km and somewhat stronger cloud-conditioned vertical velocity remain review caveats.

Unsupported or intentionally unavailable evidence: rainwater and reflectivity are absent by design; signed-flow 3-D rendering remains unavailable, while vertical-velocity slices are available.

### Smoke gate

- Run `bomex-370-smoke-20260719`; result `result-bomex-370-smoke-20260719`.
- Completed normally with exit 0 and empty stderr; runtime integrity `trusted`.
- 3/3 model frames, 11 diagnostic frames, one stats file; 30,264,681 bytes NetCDF.
- 32.15 s wall clock; 31.13 s CM1-reported.
- Ingest passed, required fields were present, and all required-field non-finite counts were zero.
- Surface flux, subsidence, cooling, drying, geostrophic wind, and friction velocity were present at intended values.
- Science gate passed without a post-smoke modeling correction.

### Six-hour science gate

- Run `bomex-370-full-20260719`; result `result-bomex-370-full-20260719`.
- Completed normally with exit 0 and ingested successfully.
- 73/73 model frames, 361 diagnostic frames, one stats file.
- 1,161.81 s wall clock and 1,160.75 s CM1-reported, about 19.4 minutes on local Apple M3/8 GiB hardware.
- Estimated output approximately 0.96 GB; actual 1,041,678,203 bytes (1.042 GB / 0.970 GiB), 8.5% above estimate and within available space.
- Full runtime integrity is `caveated` solely for `IEEE_UNDERFLOW_FLAG`; normal termination, no fatal flag, no stats collapse, no terminal non-finite field, and no all-non-finite frame.
- All required fields were present with zero non-finite values; surface rain remained zero.

Scientific recognizability:

- isolated cloud liquid at 20 minutes and coherent-cloud onset at 25 minutes, versus published onset around 30 minutes;
- synchronized startup wave at 40 minutes followed by a one-hour minimum, matching the published spinup sequence;
- final-three-hour mean total cloud cover `10.61%`, inside the published `8-17%` model range;
- final-three-hour time-mean cloud fraction peaks at `6.5344%` at 620 m, close to the published approximately 6% peak near cloud base; the distinct maximum instantaneous profile peak is `8.9600%`;
- supported cloud base averages 569 m; supported cloud top averages 1,784 m;
- final-three-hour mean LWP `6.35 g/m2`, with repeated growth/decay rather than one isolated artifact;
- mean thermodynamic structure retains the mixed subcloud layer, conditionally unstable cloud layer, and inversion;
- required surface, large-scale forcing, and resolved/SGS transport diagnostics are present.

Repeated evolution and watchability:

- cloud liquid persists in 69/73 five-minute frames after first appearance;
- the LWP series has 12 local growth-decay maxima, including repeated final-three-hour cycles;
- current payloads expose a `73 x 75` cloud-fraction time-height product, 73-point LWP series, thermodynamic profiles, cloud-liquid slices, point clouds, and vertical-velocity slices;
- `ql` point clouds at hours 3, 4.5, and 6 contain 2,761, 1,553, and 2,654 active points with changing vertical extent;
- large-result defaults now select `ql` as cloud water and use recorded vertical spacing rather than preferring zero rain or assuming a deep-run level spacing.

Final recommendation: `advance_as_stage5_candidate_evidence`.

### PM review corrections

The two blocking evidence findings are addressed in commits `84126c75` and `30d5ca5c`:

- BOMEX package generation now fails before writing artifacts unless Git provenance can be verified and tracked plus untracked worktree state is clean.
- Package-only smoke and full variants regenerated from clean implementation commit `84126c75c2db31deb8ba0a3e3bb447a1f94dad27` exactly match the executed namelist, profile audit, runtime checklist, case manifest, and normalized science hashes.
- Because every compared artifact hash matches, the original CM1 executions remain scientifically equivalent and no smoke or six-hour rerun was triggered.
- The evaluator now retains every frame-specific per-level cloud-fraction profile, averages all 37 final-three-hour profiles level by level, and then records the time-mean peak and its height.
- The corrected published-comparable result is `6.5344%` at `620 m`. The old computation is retained separately and accurately labeled as the `8.9600%` maximum instantaneous profile peak.
- A focused regression distinguishes a `50%` time-mean profile peak from a `100%` instantaneous maximum. The full gate passes with 73 frontend and 461 backend tests.

### App recovery follow-up

Live use after ingest exposed a persisted-configuration compatibility bug: BOMEX stores a case-manifest configuration, while Results and Build assumed every persisted run used the interactive builder configuration shape. The follow-up commit:

- accepts either persisted configuration shape when labeling Results and Build cards;
- uses either standard or case-manifest expected-frame counts for worker estimates;
- adds regression coverage for BOMEX-shaped Results and Build payloads;
- verifies the live Build -> Results -> BOMEX Explore flow with the 3-D ql layer and synchronized slice loaded and no new browser errors.

## Verification

Commands and manual checks performed:

```text
git diff --name-only main...HEAD
git diff --check
BACKEND_PYTHON=app/backend/.venv/bin/python scripts/check.sh
git status --short
git ls-files
```

Focused verification:

```text
ruff check: passed
mypy (5 changed source modules): passed
141 focused backend tests: passed
```

Full repository gate:

```text
frontend lint: passed
frontend tests: 73 passed
frontend production build: passed
backend Ruff format/check: passed
backend mypy: passed
backend tests: 461 passed, 1 known NumPy ABI warning
script syntax: passed
forbidden tracked artifacts: passed
docs/JSON/YAML sanity: passed
```

Manual review completed for the source mapping, generated namelists/profile audit, smoke/full non-duration equivalence, CM1 provenance/hashes, smoke forcing evidence, six-hour output and ingest, storage estimate/actual, field quality, non-finite counts, scientific metrics, repeated evolution, and visualization payloads.

## Risks and review focus

Review the `ptype=6` no-precipitation translation, the `cwp` versus CM1 `lwp` source semantics, the cloud-fraction threshold, the underflow-only integrity disposition, final-three-hour comparisons with published model spread, and the boundary between Stage 4 evidence and later product authority.

Known non-failing repository warnings during `scripts/check.sh`: existing React `act(...)` test messages, Vite chunk-size warning, and NumPy ABI runtime warning.

## Artifact check

- [x] No CM1 source or binaries were committed.
- [x] No NetCDF output, generated run directories, runtime data, or sounding caches were committed.
- [x] No machine-private paths, settings, logs, screenshots, videos, traces, papers, or large generated artifacts were committed.

## Merge posture

- [x] Manual review required.
- [x] Auto-merge is not enabled.
- [x] Draft PR; do not merge during repository recovery.