### PR TITLE
Stage 5B-1: implement the Trade Cumulus Updraft Lens

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -85,6 +85,12 @@ from cloud_chamber.sounding_candidates import (
     screen_cached_soundings,
     update_saved_candidate,
 )
+from cloud_chamber.trade_cumulus_updraft_lens import (
+    TradeCumulusUpdraftLensError,
+    WindMode,
+    trade_cumulus_updraft_lens_defaults,
+    trade_cumulus_updraft_lens_frame,
+)
 from cloud_chamber.visualization_data import (
     ProfileAggregationMethod,
     TimeHeightAggregationMethod,
@@ -699,6 +705,41 @@ def get_visualization_point_cloud(
     except ResultIngestError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except VisualizationDataError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/results/{result_id}/visualization/trade-cumulus-updraft-lens/defaults")
+def get_trade_cumulus_updraft_lens_defaults(result_id: str) -> dict[str, object]:
+    try:
+        result = trade_cumulus_updraft_lens_defaults(load_settings(), result_id)
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except TradeCumulusUpdraftLensError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/results/{result_id}/visualization/trade-cumulus-updraft-lens/frame")
+def get_trade_cumulus_updraft_lens_frame(
+    result_id: str,
+    time_index: int,
+    plane_index: int,
+    wind_mode: str = "perturbation",
+) -> dict[str, object]:
+    if wind_mode not in {"perturbation", "total"}:
+        raise HTTPException(status_code=400, detail=f"Unsupported wind_mode: {wind_mode}")
+    try:
+        result = trade_cumulus_updraft_lens_frame(
+            load_settings(),
+            result_id,
+            time_index=time_index,
+            plane_index=plane_index,
+            wind_mode=cast(WindMode, wind_mode),
+        )
+    except ResultIngestError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except TradeCumulusUpdraftLensError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return result.model_dump(mode="json")
 

--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -86,6 +86,7 @@ from cloud_chamber.sounding_candidates import (
     update_saved_candidate,
 )
 from cloud_chamber.trade_cumulus_updraft_lens import (
+    LensOrientation,
     TradeCumulusUpdraftLensError,
     WindMode,
     trade_cumulus_updraft_lens_defaults,
@@ -725,8 +726,11 @@ def get_trade_cumulus_updraft_lens_frame(
     result_id: str,
     time_index: int,
     plane_index: int,
+    orientation: str = "vertical_x",
     wind_mode: str = "perturbation",
 ) -> dict[str, object]:
+    if orientation not in {"horizontal", "vertical_x", "vertical_y"}:
+        raise HTTPException(status_code=400, detail=f"Unsupported orientation: {orientation}")
     if wind_mode not in {"perturbation", "total"}:
         raise HTTPException(status_code=400, detail=f"Unsupported wind_mode: {wind_mode}")
     try:
@@ -734,6 +738,7 @@ def get_trade_cumulus_updraft_lens_frame(
             load_settings(),
             result_id,
             time_index=time_index,
+            orientation=cast(LensOrientation, orientation),
             plane_index=plane_index,
             wind_mode=cast(WindMode, wind_mode),
         )

--- a/app/backend/cloud_chamber/trade_cumulus_updraft_lens.py
+++ b/app/backend/cloud_chamber/trade_cumulus_updraft_lens.py
@@ -28,6 +28,8 @@ WIND_ARROW_DOMAIN_FRACTION = 0.08
 MIN_COHERENT_CLOUD_CELLS = 10
 
 WindMode = Literal["perturbation", "total"]
+LensOrientation = Literal["horizontal", "vertical_x", "vertical_y"]
+LensDimension = Literal["x", "y", "z"]
 
 
 class TradeCumulusUpdraftLensError(RuntimeError):
@@ -97,13 +99,16 @@ class TradeCumulusUpdraftLensFrame(BaseModel):
     result_id: str
     time_index: int
     time_seconds: float | None
-    orientation: Literal["vertical_x"] = "vertical_x"
-    plane_dimension: Literal["y"] = "y"
+    orientation: LensOrientation
+    plane_dimension: LensDimension
     plane_index: int
     plane_coordinate: float | None
     plane_units: str | None
+    dimension_order: list[LensDimension]
     x_indices: list[int]
     x_values_km: list[float]
+    y_indices: list[int]
+    y_values_km: list[float]
     z_indices: list[int]
     z_values_km: list[float]
     w_values_m_s: list[list[float | None]]
@@ -162,6 +167,7 @@ def trade_cumulus_updraft_lens_frame(
     result_id: str,
     *,
     time_index: int,
+    orientation: LensOrientation = "vertical_x",
     plane_index: int,
     wind_mode: WindMode,
 ) -> TradeCumulusUpdraftLensFrame:
@@ -173,6 +179,8 @@ def trade_cumulus_updraft_lens_frame(
         )
     if plane_index < 0:
         raise TradeCumulusUpdraftLensError("plane_index must be non-negative.")
+    if orientation not in {"horizontal", "vertical_x", "vertical_y"}:
+        raise TradeCumulusUpdraftLensError(f"Unsupported orientation: {orientation}")
     if wind_mode not in {"perturbation", "total"}:
         raise TradeCumulusUpdraftLensError(f"Unsupported wind_mode: {wind_mode}")
 
@@ -182,16 +190,37 @@ def trade_cumulus_updraft_lens_frame(
         ql, dimensions = _scalar_ql(dataset, frame.local_index)
         w = _center_w(dataset, frame.local_index, dimensions, ql.shape)
         nz, ny, nx = ql.shape
-        if plane_index >= ny:
+        plane_size = {
+            "horizontal": nz,
+            "vertical_x": ny,
+            "vertical_y": nx,
+        }[orientation]
+        if plane_index >= plane_size:
             raise TradeCumulusUpdraftLensError(
-                f"plane_index must be between 0 and {max(0, ny - 1)}."
+                f"plane_index must be between 0 and {max(0, plane_size - 1)}."
             )
 
         x_values = _coordinate_as(dataset, dimensions[2], "km", nx)
-        y_values = _coordinate_values(dataset, dimensions[1], ny)
+        y_values = _coordinate_as(dataset, dimensions[1], "km", ny)
         z_values = _coordinate_as(dataset, dimensions[0], "km", nz)
-        plane_coordinate = _finite_float(y_values[plane_index])
-        plane_units = _coordinate_units(dataset, dimensions[1])
+        if orientation == "horizontal":
+            plane_dimension: LensDimension = "z"
+            dimension_order: list[LensDimension] = ["y", "x"]
+            plane_coordinate = _finite_float(z_values[plane_index])
+            w_slice = w[plane_index, :, :]
+            cloud_slice = ql[plane_index, :, :] >= CLOUD_THRESHOLD_KG_KG
+        elif orientation == "vertical_x":
+            plane_dimension = "y"
+            dimension_order = ["z", "x"]
+            plane_coordinate = _finite_float(y_values[plane_index])
+            w_slice = w[:, plane_index, :]
+            cloud_slice = ql[:, plane_index, :] >= CLOUD_THRESHOLD_KG_KG
+        else:
+            plane_dimension = "x"
+            dimension_order = ["z", "y"]
+            plane_coordinate = _finite_float(x_values[plane_index])
+            w_slice = w[:, :, plane_index]
+            cloud_slice = ql[:, :, plane_index] >= CLOUD_THRESHOLD_KG_KG
 
         u, v = _center_horizontal_wind(dataset, frame.local_index, dimensions, ql.shape)
         wind_level_index = cached.response.wind_level_index
@@ -210,21 +239,24 @@ def trade_cumulus_updraft_lens_frame(
             shown_u,
             shown_v,
             x_values,
-            _values_as(y_values, plane_units, "km"),
+            y_values,
             cached.response.wind_actual_level_m / 1000.0,
         )
 
-        w_slice = w[:, plane_index, :]
-        cloud_slice = ql[:, plane_index, :] >= CLOUD_THRESHOLD_KG_KG
         return TradeCumulusUpdraftLensFrame(
             result_id=metadata.result_id,
             time_index=time_index,
             time_seconds=frame.time_seconds,
+            orientation=orientation,
+            plane_dimension=plane_dimension,
             plane_index=plane_index,
             plane_coordinate=plane_coordinate,
-            plane_units=plane_units,
+            plane_units="km",
+            dimension_order=dimension_order,
             x_indices=list(range(nx)),
             x_values_km=[float(value) for value in x_values],
+            y_indices=list(range(ny)),
+            y_values_km=[float(value) for value in y_values],
             z_indices=list(range(nz)),
             z_values_km=[float(value) for value in z_values],
             w_values_m_s=_json_float_matrix(w_slice),

--- a/app/backend/cloud_chamber/trade_cumulus_updraft_lens.py
+++ b/app/backend/cloud_chamber/trade_cumulus_updraft_lens.py
@@ -1,0 +1,794 @@
+"""Bounded Trade Cumulus Updraft Lens data products."""
+
+from __future__ import annotations
+
+import importlib
+import math
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.result_ingest import ResultMetadata, get_result_metadata
+from cloud_chamber.settings import CloudChamberSettings
+
+CASE_ID = "bomex_trade_cumulus_baseline_v0"
+CLOUD_THRESHOLD_KG_KG = 1e-6
+W_PERCENTILE = 99
+W_MIN_RANGE_M_S = 0.5
+W_ROUNDING_M_S = 0.1
+WIND_TARGET_LEVEL_M = 600
+WIND_STRIDE = 8
+WIND_PERCENTILE = 95
+WIND_MIN_REFERENCE_M_S = 0.5
+WIND_ARROW_DOMAIN_FRACTION = 0.08
+MIN_COHERENT_CLOUD_CELLS = 10
+
+WindMode = Literal["perturbation", "total"]
+
+
+class TradeCumulusUpdraftLensError(RuntimeError):
+    """Raised when the bounded Updraft Lens product cannot be produced."""
+
+
+class UpdraftLensProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_model: str
+    result_id: str
+    run_id: str
+    scenario_id: str
+    processing_method: str
+    rendering_method: str
+    provenance_label: str
+
+
+class TradeCumulusUpdraftLensDefaults(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    case_id: str
+    eligible: bool
+    primary_field: Literal["w"] = "w"
+    cloud_field: Literal["ql"] = "ql"
+    orientation: Literal["vertical_x"] = "vertical_x"
+    default_time_index: int
+    default_time_seconds: float | None
+    default_time_method: str
+    default_plane_dimension: Literal["y"] = "y"
+    default_plane_index: int
+    default_plane_coordinate: float | None
+    default_plane_units: str | None
+    default_plane_method: str
+    cloud_threshold_kg_kg: float = CLOUD_THRESHOLD_KG_KG
+    w_range_min_m_s: float
+    w_range_max_m_s: float
+    w_range_method: str
+    wind_target_level_m: float = WIND_TARGET_LEVEL_M
+    wind_actual_level_m: float
+    wind_level_index: int
+    wind_default_mode: Literal["perturbation"] = "perturbation"
+    wind_stride: int = WIND_STRIDE
+    wind_shown_by_default: bool = True
+    perturbation_wind_reference_m_s: float
+    total_wind_reference_m_s: float
+    wind_arrow_domain_fraction: float = WIND_ARROW_DOMAIN_FRACTION
+    provenance: UpdraftLensProvenance
+    caveats: list[str] = Field(default_factory=list)
+
+
+class UpdraftLensWindVector(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    x_km: float
+    y_km: float
+    z_km: float
+    u_m_s: float
+    v_m_s: float
+    magnitude_m_s: float
+
+
+class TradeCumulusUpdraftLensFrame(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    time_index: int
+    time_seconds: float | None
+    orientation: Literal["vertical_x"] = "vertical_x"
+    plane_dimension: Literal["y"] = "y"
+    plane_index: int
+    plane_coordinate: float | None
+    plane_units: str | None
+    x_indices: list[int]
+    x_values_km: list[float]
+    z_indices: list[int]
+    z_values_km: list[float]
+    w_values_m_s: list[list[float | None]]
+    cloud_mask: list[list[bool]]
+    cloud_threshold_kg_kg: float = CLOUD_THRESHOLD_KG_KG
+    w_range_min_m_s: float
+    w_range_max_m_s: float
+    w_range_method: str
+    wind_mode: WindMode
+    wind_target_level_m: float = WIND_TARGET_LEVEL_M
+    wind_actual_level_m: float
+    wind_level_index: int
+    wind_stride: int = WIND_STRIDE
+    wind_reference_m_s: float
+    wind_arrow_domain_fraction: float = WIND_ARROW_DOMAIN_FRACTION
+    domain_mean_u_m_s: float
+    domain_mean_v_m_s: float
+    wind_vectors: list[UpdraftLensWindVector]
+    provenance: UpdraftLensProvenance
+    caveats: list[str] = Field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _FrameLocation:
+    global_index: int
+    path: Path
+    local_index: int
+    time_seconds: float | None
+
+
+@dataclass(frozen=True)
+class _CachedDefaults:
+    response: TradeCumulusUpdraftLensDefaults
+    frames: tuple[_FrameLocation, ...]
+
+
+_DEFAULTS_CACHE: OrderedDict[tuple[object, ...], _CachedDefaults] = OrderedDict()
+_MAX_CACHE_ENTRIES = 8
+
+
+def trade_cumulus_updraft_lens_eligible(metadata: ResultMetadata) -> bool:
+    """Return eligibility from approved case identifiers only."""
+    return metadata.scenario_id == CASE_ID or metadata.run_configuration.get("case_id") == CASE_ID
+
+
+def trade_cumulus_updraft_lens_defaults(
+    settings: CloudChamberSettings,
+    result_id: str,
+) -> TradeCumulusUpdraftLensDefaults:
+    metadata = get_result_metadata(settings, result_id)
+    return _cached_defaults(metadata).response
+
+
+def trade_cumulus_updraft_lens_frame(
+    settings: CloudChamberSettings,
+    result_id: str,
+    *,
+    time_index: int,
+    plane_index: int,
+    wind_mode: WindMode,
+) -> TradeCumulusUpdraftLensFrame:
+    metadata = get_result_metadata(settings, result_id)
+    cached = _cached_defaults(metadata)
+    if time_index < 0 or time_index >= len(cached.frames):
+        raise TradeCumulusUpdraftLensError(
+            f"time_index must be between 0 and {max(0, len(cached.frames) - 1)}."
+        )
+    if plane_index < 0:
+        raise TradeCumulusUpdraftLensError("plane_index must be non-negative.")
+    if wind_mode not in {"perturbation", "total"}:
+        raise TradeCumulusUpdraftLensError(f"Unsupported wind_mode: {wind_mode}")
+
+    frame = cached.frames[time_index]
+    dataset = _open_dataset(frame.path)
+    try:
+        ql, dimensions = _scalar_ql(dataset, frame.local_index)
+        w = _center_w(dataset, frame.local_index, dimensions, ql.shape)
+        nz, ny, nx = ql.shape
+        if plane_index >= ny:
+            raise TradeCumulusUpdraftLensError(
+                f"plane_index must be between 0 and {max(0, ny - 1)}."
+            )
+
+        x_values = _coordinate_as(dataset, dimensions[2], "km", nx)
+        y_values = _coordinate_values(dataset, dimensions[1], ny)
+        z_values = _coordinate_as(dataset, dimensions[0], "km", nz)
+        plane_coordinate = _finite_float(y_values[plane_index])
+        plane_units = _coordinate_units(dataset, dimensions[1])
+
+        u, v = _center_horizontal_wind(dataset, frame.local_index, dimensions, ql.shape)
+        wind_level_index = cached.response.wind_level_index
+        level_u = u[wind_level_index]
+        level_v = v[wind_level_index]
+        mean_u = _finite_mean(level_u)
+        mean_v = _finite_mean(level_v)
+        shown_u = level_u - mean_u if wind_mode == "perturbation" else level_u
+        shown_v = level_v - mean_v if wind_mode == "perturbation" else level_v
+        wind_reference = (
+            cached.response.perturbation_wind_reference_m_s
+            if wind_mode == "perturbation"
+            else cached.response.total_wind_reference_m_s
+        )
+        wind_vectors = _wind_vectors(
+            shown_u,
+            shown_v,
+            x_values,
+            _values_as(y_values, plane_units, "km"),
+            cached.response.wind_actual_level_m / 1000.0,
+        )
+
+        w_slice = w[:, plane_index, :]
+        cloud_slice = ql[:, plane_index, :] >= CLOUD_THRESHOLD_KG_KG
+        return TradeCumulusUpdraftLensFrame(
+            result_id=metadata.result_id,
+            time_index=time_index,
+            time_seconds=frame.time_seconds,
+            plane_index=plane_index,
+            plane_coordinate=plane_coordinate,
+            plane_units=plane_units,
+            x_indices=list(range(nx)),
+            x_values_km=[float(value) for value in x_values],
+            z_indices=list(range(nz)),
+            z_values_km=[float(value) for value in z_values],
+            w_values_m_s=_json_float_matrix(w_slice),
+            cloud_mask=cloud_slice.astype(bool).tolist(),
+            w_range_min_m_s=cached.response.w_range_min_m_s,
+            w_range_max_m_s=cached.response.w_range_max_m_s,
+            w_range_method=cached.response.w_range_method,
+            wind_mode=wind_mode,
+            wind_actual_level_m=cached.response.wind_actual_level_m,
+            wind_level_index=wind_level_index,
+            wind_reference_m_s=wind_reference,
+            domain_mean_u_m_s=mean_u,
+            domain_mean_v_m_s=mean_v,
+            wind_vectors=wind_vectors,
+            provenance=_provenance(metadata, "trade_cumulus_updraft_lens_frame"),
+            caveats=[
+                "vertical_velocity_centered_to_cloud_liquid_scalar_levels",
+                "cloud_boundary_uses_fixed_1e-6_kg_kg_threshold",
+                "horizontal_wind_vectors_sampled_on_scalar_grid",
+            ],
+        )
+    finally:
+        dataset.close()
+
+
+def clear_trade_cumulus_updraft_lens_cache() -> None:
+    """Clear the bounded process cache for deterministic tests."""
+    _DEFAULTS_CACHE.clear()
+
+
+def _cached_defaults(metadata: ResultMetadata) -> _CachedDefaults:
+    if not trade_cumulus_updraft_lens_eligible(metadata):
+        raise TradeCumulusUpdraftLensError(
+            f"Result {metadata.result_id} is not eligible for the Trade Cumulus Updraft Lens."
+        )
+    paths = _source_paths(metadata)
+    key = (
+        metadata.result_id,
+        metadata.scenario_id,
+        metadata.run_configuration.get("case_id"),
+        metadata.updated_at.isoformat(),
+        tuple(_path_state(path) for path in paths),
+    )
+    cached = _DEFAULTS_CACHE.get(key)
+    if cached is not None:
+        _DEFAULTS_CACHE.move_to_end(key)
+        return cached
+    computed = _compute_defaults(metadata, paths)
+    _DEFAULTS_CACHE[key] = computed
+    _DEFAULTS_CACHE.move_to_end(key)
+    while len(_DEFAULTS_CACHE) > _MAX_CACHE_ENTRIES:
+        _DEFAULTS_CACHE.popitem(last=False)
+    return computed
+
+
+def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDefaults:
+    frames: list[_FrameLocation] = []
+    cwp_scores: list[float | None] = []
+    absolute_w: list[np.ndarray[Any, np.dtype[np.floating[Any]]]] = []
+    perturbation_speeds: list[np.ndarray[Any, np.dtype[np.floating[Any]]]] = []
+    total_speeds: list[np.ndarray[Any, np.dtype[np.floating[Any]]]] = []
+    wind_level_index: int | None = None
+    wind_actual_level_m: float | None = None
+    first_dimensions: tuple[str, str, str] | None = None
+    global_index = 0
+
+    for path in paths:
+        dataset = _open_dataset(path)
+        try:
+            local_count = _time_count(dataset)
+            for local_index in range(local_count):
+                ql, dimensions = _scalar_ql(dataset, local_index)
+                w = _center_w(dataset, local_index, dimensions, ql.shape)
+                if first_dimensions is None:
+                    first_dimensions = dimensions
+                elif dimensions != first_dimensions:
+                    raise TradeCumulusUpdraftLensError(
+                        "Trade Cumulus source files do not share one scalar-grid layout."
+                    )
+                frame_time = _time_seconds(dataset, local_index, metadata, global_index)
+                frames.append(
+                    _FrameLocation(
+                        global_index=global_index,
+                        path=path,
+                        local_index=local_index,
+                        time_seconds=frame_time,
+                    )
+                )
+                cwp_scores.append(_domain_mean_cwp(dataset, local_index))
+                finite_absolute_w = np.abs(w[np.isfinite(w)])
+                if finite_absolute_w.size:
+                    absolute_w.append(finite_absolute_w.astype(np.float32, copy=False))
+
+                if wind_level_index is None:
+                    z_values_m = _coordinate_as(dataset, dimensions[0], "m", ql.shape[0])
+                    wind_level_index = int(np.argmin(np.abs(z_values_m - WIND_TARGET_LEVEL_M)))
+                    wind_actual_level_m = float(z_values_m[wind_level_index])
+                u, v = _center_horizontal_wind(dataset, local_index, dimensions, ql.shape)
+                level_u = u[wind_level_index]
+                level_v = v[wind_level_index]
+                mean_u = _finite_mean(level_u)
+                mean_v = _finite_mean(level_v)
+                total_speed = np.hypot(level_u, level_v)
+                perturbation_speed = np.hypot(level_u - mean_u, level_v - mean_v)
+                finite_total = total_speed[np.isfinite(total_speed)]
+                finite_perturbation = perturbation_speed[np.isfinite(perturbation_speed)]
+                if finite_total.size:
+                    total_speeds.append(finite_total.astype(np.float32, copy=False))
+                if finite_perturbation.size:
+                    perturbation_speeds.append(finite_perturbation.astype(np.float32, copy=False))
+                global_index += 1
+        finally:
+            dataset.close()
+
+    if not frames or first_dimensions is None:
+        raise TradeCumulusUpdraftLensError("No readable model-output frames are available.")
+    if wind_level_index is None or wind_actual_level_m is None:
+        raise TradeCumulusUpdraftLensError("No supported wind level is available.")
+
+    default_time_index, default_time_method, time_caveats = _select_default_time(
+        metadata, frames, cwp_scores
+    )
+    selected_frame = frames[default_time_index]
+    selected_dataset = _open_dataset(selected_frame.path)
+    try:
+        selected_ql, dimensions = _scalar_ql(selected_dataset, selected_frame.local_index)
+        selected_w = _center_w(
+            selected_dataset,
+            selected_frame.local_index,
+            dimensions,
+            selected_ql.shape,
+        )
+        default_plane_index, default_plane_method = _select_default_plane(selected_ql, selected_w)
+        y_values = _coordinate_values(selected_dataset, dimensions[1], selected_ql.shape[1])
+        default_plane_coordinate = _finite_float(y_values[default_plane_index])
+        default_plane_units = _coordinate_units(selected_dataset, dimensions[1])
+    finally:
+        selected_dataset.close()
+
+    w_range = _rounded_reference(absolute_w, W_PERCENTILE, W_MIN_RANGE_M_S)
+    perturbation_reference = _rounded_reference(
+        perturbation_speeds, WIND_PERCENTILE, WIND_MIN_REFERENCE_M_S
+    )
+    total_reference = _rounded_reference(total_speeds, WIND_PERCENTILE, WIND_MIN_REFERENCE_M_S)
+    response = TradeCumulusUpdraftLensDefaults(
+        result_id=metadata.result_id,
+        case_id=CASE_ID,
+        eligible=True,
+        default_time_index=default_time_index,
+        default_time_seconds=frames[default_time_index].time_seconds,
+        default_time_method=default_time_method,
+        default_plane_index=default_plane_index,
+        default_plane_coordinate=default_plane_coordinate,
+        default_plane_units=default_plane_units,
+        default_plane_method=default_plane_method,
+        w_range_min_m_s=-w_range,
+        w_range_max_m_s=w_range,
+        w_range_method=("all_frames_p99_absolute_centered_w_rounded_up_0.1_m_s_with_0.5_m_s_floor"),
+        wind_actual_level_m=wind_actual_level_m,
+        wind_level_index=wind_level_index,
+        perturbation_wind_reference_m_s=perturbation_reference,
+        total_wind_reference_m_s=total_reference,
+        provenance=_provenance(metadata, "trade_cumulus_updraft_lens_defaults"),
+        caveats=[
+            *time_caveats,
+            "candidate_trade_cumulus_lens_not_a_supported_product",
+            "fixed_scales_are_derived_from_this_result_only",
+        ],
+    )
+    return _CachedDefaults(response=response, frames=tuple(frames))
+
+
+def _select_default_time(
+    metadata: ResultMetadata,
+    frames: list[_FrameLocation],
+    cwp_scores: list[float | None],
+) -> tuple[int, str, list[str]]:
+    eligible_scores = [
+        (score, frame.global_index)
+        for frame, score in zip(frames, cwp_scores, strict=True)
+        if frame.time_seconds is not None
+        and frame.time_seconds >= 10_800
+        and score is not None
+        and math.isfinite(score)
+    ]
+    if eligible_scores:
+        best_score = max(score for score, _ in eligible_scores)
+        best_index = min(index for score, index in eligible_scores if score == best_score)
+        return best_index, "max_finite_domain_mean_cwp_at_or_after_10800_seconds", []
+
+    diagnostic_index = _diagnostic_cloud_liquid_time_index(metadata, frames)
+    if diagnostic_index is not None:
+        return (
+            diagnostic_index,
+            "diagnostics_supported_time_of_max_cloud_liquid",
+            ["domain_mean_cwp_default_unavailable"],
+        )
+
+    finite_times = [
+        (frame.time_seconds, frame.global_index)
+        for frame in frames
+        if frame.time_seconds is not None and math.isfinite(frame.time_seconds)
+    ]
+    if finite_times:
+        latest_time = max(time for time, _ in finite_times)
+        final_three_hour_start = latest_time - 10_800
+        final_frames = [
+            (time, index) for time, index in finite_times if time >= final_three_hour_start
+        ]
+        if final_frames:
+            selected_time = max(time for time, _ in final_frames)
+            selected_index = min(index for time, index in final_frames if time == selected_time)
+            return (
+                selected_index,
+                "latest_output_in_final_three_hours",
+                ["domain_mean_cwp_and_supported_cloud_liquid_defaults_unavailable"],
+            )
+    return (
+        frames[-1].global_index,
+        "latest_available_output",
+        ["output_times_and_science_defaults_unavailable"],
+    )
+
+
+def _diagnostic_cloud_liquid_time_index(
+    metadata: ResultMetadata, frames: list[_FrameLocation]
+) -> int | None:
+    for field_name in ("ql", "qc"):
+        field_default = metadata.default_time_by_field.get(field_name)
+        if (
+            field_default is not None
+            and field_default.support_state == "supported"
+            and field_default.time_index is not None
+            and 0 <= field_default.time_index < len(frames)
+        ):
+            return field_default.time_index
+    for record in metadata.interesting_times:
+        record_time = record.time_seconds
+        if (
+            record.key == "max_qc"
+            and record.support_state == "supported"
+            and record_time is not None
+        ):
+            return min(
+                frames,
+                key=lambda frame: abs((frame.time_seconds or 0.0) - record_time),
+            ).global_index
+    return None
+
+
+def _select_default_plane(ql: np.ndarray[Any, Any], w: np.ndarray[Any, Any]) -> tuple[int, str]:
+    cloud_mask = np.isfinite(ql) & (ql >= CLOUD_THRESHOLD_KG_KG)
+    structure = np.asarray([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=np.uint8)
+    ndimage = importlib.import_module("scipy.ndimage")
+    scored: list[tuple[float, int]] = []
+    coherent_sizes: list[tuple[int, int]] = []
+    for y_index in range(ql.shape[1]):
+        plane_mask = cloud_mask[:, y_index, :]
+        labels, count = ndimage.label(plane_mask, structure=structure)
+        plane_score = 0.0
+        finite_component_score_found = False
+        for label_index in range(1, count + 1):
+            component = labels == label_index
+            cell_count = int(np.count_nonzero(component))
+            if cell_count < MIN_COHERENT_CLOUD_CELLS:
+                continue
+            coherent_sizes.append((cell_count, y_index))
+            contribution = np.where(
+                component,
+                np.maximum(w[:, y_index, :], 0.0) * ql[:, y_index, :],
+                0.0,
+            )
+            score = float(np.sum(contribution))
+            if math.isfinite(score):
+                plane_score += score
+                finite_component_score_found = True
+        if finite_component_score_found:
+            scored.append((plane_score, y_index))
+    if scored:
+        best_score = max(score for score, _ in scored)
+        return (
+            min(y_index for score, y_index in scored if score == best_score),
+            "greatest_coherent_positive_w_times_ql_score",
+        )
+    if coherent_sizes:
+        largest = max(size for size, _ in coherent_sizes)
+        return (
+            min(y_index for size, y_index in coherent_sizes if size == largest),
+            "largest_coherent_cloud_component_fallback",
+        )
+    return ql.shape[1] // 2, "domain_midpoint_fallback"
+
+
+def _scalar_ql(dataset: Any, time_index: int) -> tuple[np.ndarray[Any, Any], tuple[str, str, str]]:
+    if "ql" not in dataset.data_vars:
+        raise TradeCumulusUpdraftLensError("Eligible result is missing required ql output.")
+    data = _select_time(dataset["ql"], time_index)
+    dimensions = _scalar_dimensions(data)
+    values = np.asarray(data.transpose(*dimensions).values, dtype=float)
+    return values, dimensions
+
+
+def _center_w(
+    dataset: Any,
+    time_index: int,
+    scalar_dimensions: tuple[str, str, str],
+    scalar_shape: tuple[int, ...],
+) -> np.ndarray[Any, Any]:
+    if "w" not in dataset.data_vars:
+        raise TradeCumulusUpdraftLensError("Eligible result is missing required w output.")
+    data = _select_time(dataset["w"], time_index)
+    vertical = _dimension_for_axis(data.dims, "z")
+    y_dimension = _dimension_for_axis(data.dims, "y")
+    x_dimension = _dimension_for_axis(data.dims, "x")
+    values = np.asarray(data.transpose(vertical, y_dimension, x_dimension).values, dtype=float)
+    if values.shape[1:] != scalar_shape[1:]:
+        raise TradeCumulusUpdraftLensError("w horizontal grid does not match the ql scalar grid.")
+    if values.shape[0] == scalar_shape[0] + 1:
+        return np.asarray(0.5 * (values[:-1] + values[1:]), dtype=float)
+    if values.shape[0] == scalar_shape[0]:
+        return values
+    raise TradeCumulusUpdraftLensError(
+        "w vertical grid must match ql or have exactly one additional vertical face."
+    )
+
+
+def _center_horizontal_wind(
+    dataset: Any,
+    time_index: int,
+    scalar_dimensions: tuple[str, str, str],
+    scalar_shape: tuple[int, ...],
+) -> tuple[np.ndarray[Any, Any], np.ndarray[Any, Any]]:
+    del scalar_dimensions
+    if "u" not in dataset.data_vars or "v" not in dataset.data_vars:
+        raise TradeCumulusUpdraftLensError("Eligible result is missing required u/v wind output.")
+    u_data = _select_time(dataset["u"], time_index)
+    v_data = _select_time(dataset["v"], time_index)
+    u = _transpose_zyx(u_data)
+    v = _transpose_zyx(v_data)
+    if u.shape[0] != scalar_shape[0] or u.shape[1] != scalar_shape[1]:
+        raise TradeCumulusUpdraftLensError("u vertical/y grid does not match ql.")
+    if v.shape[0] != scalar_shape[0] or v.shape[2] != scalar_shape[2]:
+        raise TradeCumulusUpdraftLensError("v vertical/x grid does not match ql.")
+    if u.shape[2] == scalar_shape[2] + 1:
+        u = 0.5 * (u[:, :, :-1] + u[:, :, 1:])
+    elif u.shape[2] != scalar_shape[2]:
+        raise TradeCumulusUpdraftLensError(
+            "u x grid must match ql or have exactly one additional x face."
+        )
+    if v.shape[1] == scalar_shape[1] + 1:
+        v = 0.5 * (v[:, :-1, :] + v[:, 1:, :])
+    elif v.shape[1] != scalar_shape[1]:
+        raise TradeCumulusUpdraftLensError(
+            "v y grid must match ql or have exactly one additional y face."
+        )
+    return u, v
+
+
+def _wind_vectors(
+    u: np.ndarray[Any, Any],
+    v: np.ndarray[Any, Any],
+    x_km: np.ndarray[Any, Any],
+    y_km: np.ndarray[Any, Any],
+    z_km: float,
+) -> list[UpdraftLensWindVector]:
+    vectors: list[UpdraftLensWindVector] = []
+    for y_index in range(0, u.shape[0], WIND_STRIDE):
+        for x_index in range(0, u.shape[1], WIND_STRIDE):
+            u_value = float(u[y_index, x_index])
+            v_value = float(v[y_index, x_index])
+            if not math.isfinite(u_value) or not math.isfinite(v_value):
+                continue
+            magnitude = math.hypot(u_value, v_value)
+            if magnitude == 0:
+                continue
+            vectors.append(
+                UpdraftLensWindVector(
+                    x_km=float(x_km[x_index]),
+                    y_km=float(y_km[y_index]),
+                    z_km=z_km,
+                    u_m_s=u_value,
+                    v_m_s=v_value,
+                    magnitude_m_s=magnitude,
+                )
+            )
+    return vectors
+
+
+def _source_paths(metadata: ResultMetadata) -> list[Path]:
+    raw_paths = metadata.model_output_paths or metadata.netcdf_paths
+    paths = [Path(path).expanduser() for path in raw_paths]
+    if not paths:
+        raise TradeCumulusUpdraftLensError("No NetCDF model-output paths are available.")
+    missing = [path for path in paths if not path.is_file()]
+    if missing:
+        raise TradeCumulusUpdraftLensError(f"Model-output file is unavailable: {missing[0].name}")
+    return paths
+
+
+def _path_state(path: Path) -> tuple[str, int, int]:
+    stat = path.stat()
+    return str(path), stat.st_size, stat.st_mtime_ns
+
+
+def _open_dataset(path: Path) -> Any:
+    xarray = importlib.import_module("xarray")
+    try:
+        return xarray.open_dataset(path, decode_times=False)
+    except Exception as exc:
+        raise TradeCumulusUpdraftLensError(
+            f"Could not open model-output file {path.name}: {exc}"
+        ) from exc
+
+
+def _time_count(dataset: Any) -> int:
+    for candidate in ("time", "mtime", "t"):
+        if candidate in dataset.sizes:
+            return int(dataset.sizes[candidate])
+    return 1
+
+
+def _select_time(data_array: Any, index: int) -> Any:
+    for candidate in ("time", "mtime", "t"):
+        if candidate in data_array.dims:
+            return data_array.isel({candidate: index})
+    if index != 0:
+        raise TradeCumulusUpdraftLensError("Source field has no selectable time dimension.")
+    return data_array
+
+
+def _time_seconds(
+    dataset: Any, local_index: int, metadata: ResultMetadata, global_index: int
+) -> float | None:
+    for candidate in ("time", "mtime", "t"):
+        if candidate in dataset.coords:
+            values = np.asarray(dataset.coords[candidate].values).reshape(-1)
+            if local_index < values.size:
+                return _finite_float(values[local_index])
+    if (
+        metadata.first_output_time_seconds is not None
+        and metadata.last_output_time_seconds is not None
+    ):
+        count = max(1, (metadata.time_steps or 1) - 1)
+        fraction = min(global_index, count) / count
+        return metadata.first_output_time_seconds + fraction * (
+            metadata.last_output_time_seconds - metadata.first_output_time_seconds
+        )
+    return None
+
+
+def _domain_mean_cwp(dataset: Any, local_index: int) -> float | None:
+    if "cwp" not in dataset.data_vars:
+        return None
+    values = np.asarray(_select_time(dataset["cwp"], local_index).values, dtype=float)
+    finite = values[np.isfinite(values)]
+    return float(np.mean(finite)) if finite.size else None
+
+
+def _scalar_dimensions(data_array: Any) -> tuple[str, str, str]:
+    return (
+        _dimension_for_axis(data_array.dims, "z"),
+        _dimension_for_axis(data_array.dims, "y"),
+        _dimension_for_axis(data_array.dims, "x"),
+    )
+
+
+def _dimension_for_axis(dimensions: tuple[str, ...], axis: str) -> str:
+    candidates = {
+        "z": ("zh", "zf", "z", "height", "height_m", "height_km"),
+        "y": ("yh", "yf", "y"),
+        "x": ("xh", "xf", "x"),
+    }[axis]
+    for candidate in candidates:
+        if candidate in dimensions:
+            return candidate
+    raise TradeCumulusUpdraftLensError(f"Field is missing a supported {axis} dimension.")
+
+
+def _transpose_zyx(data_array: Any) -> np.ndarray[Any, Any]:
+    dimensions = (
+        _dimension_for_axis(data_array.dims, "z"),
+        _dimension_for_axis(data_array.dims, "y"),
+        _dimension_for_axis(data_array.dims, "x"),
+    )
+    return np.asarray(data_array.transpose(*dimensions).values, dtype=float)
+
+
+def _coordinate_values(dataset: Any, name: str, expected_size: int) -> np.ndarray[Any, Any]:
+    if name not in dataset.coords:
+        return np.arange(expected_size, dtype=float)
+    values = np.asarray(dataset.coords[name].values, dtype=float).reshape(-1)
+    if values.size != expected_size:
+        raise TradeCumulusUpdraftLensError(f"Coordinate {name} does not match its field dimension.")
+    return values
+
+
+def _coordinate_as(
+    dataset: Any, name: str, target_units: Literal["m", "km"], expected_size: int
+) -> np.ndarray[Any, Any]:
+    values = _coordinate_values(dataset, name, expected_size)
+    return _values_as(values, _coordinate_units(dataset, name), target_units)
+
+
+def _values_as(
+    values: np.ndarray[Any, Any],
+    source_units: str | None,
+    target_units: Literal["m", "km"],
+) -> np.ndarray[Any, Any]:
+    normalized = (source_units or "").strip().lower()
+    if target_units == "m" and normalized in {"km", "kilometer", "kilometers"}:
+        return values * 1000.0
+    if target_units == "km" and normalized in {"m", "meter", "meters"}:
+        return values / 1000.0
+    return values
+
+
+def _coordinate_units(dataset: Any, name: str) -> str | None:
+    if name not in dataset.coords:
+        return None
+    units = dataset.coords[name].attrs.get("units")
+    return str(units) if units is not None else None
+
+
+def _rounded_reference(
+    arrays: list[np.ndarray[Any, Any]], percentile: float, minimum: float
+) -> float:
+    if not arrays:
+        return minimum
+    values = np.concatenate(arrays)
+    if not values.size:
+        return minimum
+    selected = float(np.percentile(values, percentile))
+    if not math.isfinite(selected):
+        return minimum
+    rounded = math.ceil(selected / W_ROUNDING_M_S - 1e-12) * W_ROUNDING_M_S
+    return max(minimum, round(rounded, 10))
+
+
+def _finite_mean(values: np.ndarray[Any, Any]) -> float:
+    finite = values[np.isfinite(values)]
+    return float(np.mean(finite)) if finite.size else 0.0
+
+
+def _finite_float(value: Any) -> float | None:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric if math.isfinite(numeric) else None
+
+
+def _json_float_matrix(values: np.ndarray[Any, Any]) -> list[list[float | None]]:
+    return [[_finite_float(value) for value in row] for row in np.asarray(values).tolist()]
+
+
+def _provenance(metadata: ResultMetadata, product: str) -> UpdraftLensProvenance:
+    return UpdraftLensProvenance(
+        source_model=metadata.source_model,
+        result_id=metadata.result_id,
+        run_id=metadata.run_id,
+        scenario_id=metadata.scenario_id,
+        processing_method=f"backend_xarray_{product}",
+        rendering_method="json_native_grid_trade_cumulus_updraft_lens",
+        provenance_label=(
+            "CM1-derived Trade Cumulus candidate Lens; native scalar grid; no interpolation"
+        ),
+    )

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -151,12 +151,14 @@ def test_trade_cumulus_updraft_lens_frame_endpoint_validates_and_forwards_query(
         result_id: str,
         *,
         time_index: int,
+        orientation: str,
         plane_index: int,
         wind_mode: str,
     ) -> FakeResponse:
         received.update(
             result_id=result_id,
             time_index=time_index,
+            orientation=orientation,
             plane_index=plane_index,
             wind_mode=wind_mode,
         )
@@ -167,7 +169,7 @@ def test_trade_cumulus_updraft_lens_frame_endpoint_validates_and_forwards_query(
 
     response = client.get(
         "/api/results/result-bomex/visualization/trade-cumulus-updraft-lens/frame"
-        "?time_index=4&plane_index=3&wind_mode=total"
+        "?time_index=4&plane_index=3&orientation=vertical_y&wind_mode=total"
     )
     invalid = client.get(
         "/api/results/result-bomex/visualization/trade-cumulus-updraft-lens/frame"
@@ -179,10 +181,17 @@ def test_trade_cumulus_updraft_lens_frame_endpoint_validates_and_forwards_query(
     assert received == {
         "result_id": "result-bomex",
         "time_index": 4,
+        "orientation": "vertical_y",
         "plane_index": 3,
         "wind_mode": "total",
     }
     assert invalid.status_code == 400
+
+    invalid_orientation = client.get(
+        "/api/results/result-bomex/visualization/trade-cumulus-updraft-lens/frame"
+        "?time_index=4&plane_index=3&orientation=diagonal"
+    )
+    assert invalid_orientation.status_code == 400
 
 
 def test_list_scenarios_includes_baseline_golden_path() -> None:

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -105,6 +105,86 @@ def test_health_endpoint_identifies_scaffold_without_cm1() -> None:
     assert "CM1 is the high-fidelity simulation engine" in response.json()["engine_note"]
 
 
+def test_trade_cumulus_updraft_lens_defaults_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        def model_dump(self, *, mode: str) -> dict[str, object]:
+            assert mode == "json"
+            return {
+                "result_id": "result-bomex",
+                "eligible": True,
+                "default_time_index": 61,
+                "default_plane_index": 5,
+            }
+
+    monkeypatch.setattr(
+        "cloud_chamber.app.trade_cumulus_updraft_lens_defaults",
+        lambda _settings, result_id: FakeResponse(),
+    )
+
+    response = TestClient(app).get(
+        "/api/results/result-bomex/visualization/trade-cumulus-updraft-lens/defaults"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "result_id": "result-bomex",
+        "eligible": True,
+        "default_time_index": 61,
+        "default_plane_index": 5,
+    }
+
+
+def test_trade_cumulus_updraft_lens_frame_endpoint_validates_and_forwards_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    received: dict[str, object] = {}
+
+    class FakeResponse:
+        def model_dump(self, *, mode: str) -> dict[str, object]:
+            assert mode == "json"
+            return {"result_id": "result-bomex", "wind_mode": "total"}
+
+    def fake_frame(
+        _settings: object,
+        result_id: str,
+        *,
+        time_index: int,
+        plane_index: int,
+        wind_mode: str,
+    ) -> FakeResponse:
+        received.update(
+            result_id=result_id,
+            time_index=time_index,
+            plane_index=plane_index,
+            wind_mode=wind_mode,
+        )
+        return FakeResponse()
+
+    monkeypatch.setattr("cloud_chamber.app.trade_cumulus_updraft_lens_frame", fake_frame)
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/results/result-bomex/visualization/trade-cumulus-updraft-lens/frame"
+        "?time_index=4&plane_index=3&wind_mode=total"
+    )
+    invalid = client.get(
+        "/api/results/result-bomex/visualization/trade-cumulus-updraft-lens/frame"
+        "?time_index=4&plane_index=3&wind_mode=unsupported"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["wind_mode"] == "total"
+    assert received == {
+        "result_id": "result-bomex",
+        "time_index": 4,
+        "plane_index": 3,
+        "wind_mode": "total",
+    }
+    assert invalid.status_code == 400
+
+
 def test_list_scenarios_includes_baseline_golden_path() -> None:
     response = TestClient(app).get("/api/scenarios")
 

--- a/app/backend/tests/test_trade_cumulus_updraft_lens.py
+++ b/app/backend/tests/test_trade_cumulus_updraft_lens.py
@@ -299,6 +299,43 @@ def test_frame_switches_between_perturbation_and_total_wind(tmp_path: Path) -> N
     assert total.wind_reference_m_s == defaults.total_wind_reference_m_s
 
 
+@pytest.mark.parametrize(
+    ("orientation", "plane_index", "plane_dimension", "dimension_order", "shape"),
+    [
+        ("horizontal", 1, "z", ["y", "x"], (4, 4)),
+        ("vertical_x", 1, "y", ["z", "x"], (3, 4)),
+        ("vertical_y", 2, "x", ["z", "y"], (3, 4)),
+    ],
+)
+def test_frame_returns_native_grid_for_each_slice_orientation(
+    tmp_path: Path,
+    orientation: lens.LensOrientation,
+    plane_index: int,
+    plane_dimension: str,
+    dimension_order: list[str],
+    shape: tuple[int, int],
+) -> None:
+    settings, _ = _install_result(tmp_path, _dataset(scalar_w=True))
+    frame = trade_cumulus_updraft_lens_frame(
+        settings,
+        "result-trade-cumulus",
+        time_index=1,
+        orientation=orientation,
+        plane_index=plane_index,
+        wind_mode="perturbation",
+    )
+
+    assert frame.orientation == orientation
+    assert frame.plane_dimension == plane_dimension
+    assert frame.dimension_order == dimension_order
+    assert np.asarray(frame.w_values_m_s).shape == shape
+    assert np.asarray(frame.cloud_mask).shape == shape
+    assert frame.plane_units == "km"
+    assert frame.x_values_km == pytest.approx([-0.15, -0.05, 0.05, 0.15])
+    assert frame.y_values_km == pytest.approx([-0.15, -0.05, 0.05, 0.15])
+    assert frame.z_values_km == pytest.approx([0.2, 0.6, 1.0])
+
+
 def test_wind_stride_bounds_arrow_count_and_skips_zero_vectors() -> None:
     u = np.ones((64, 64))
     v = np.zeros((64, 64))
@@ -337,6 +374,15 @@ def test_invalid_indices_and_wind_mode_are_rejected(tmp_path: Path) -> None:
             settings,
             "result-trade-cumulus",
             time_index=-1,
+            plane_index=0,
+            wind_mode="total",
+        )
+    with pytest.raises(TradeCumulusUpdraftLensError, match="orientation"):
+        trade_cumulus_updraft_lens_frame(
+            settings,
+            "result-trade-cumulus",
+            time_index=0,
+            orientation="diagonal",  # type: ignore[arg-type]
             plane_index=0,
             wind_mode="total",
         )

--- a/app/backend/tests/test_trade_cumulus_updraft_lens.py
+++ b/app/backend/tests/test_trade_cumulus_updraft_lens.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import cloud_chamber.trade_cumulus_updraft_lens as lens
+from cloud_chamber.result_ingest import ResultMetadata
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.trade_cumulus_updraft_lens import (
+    CASE_ID,
+    TradeCumulusUpdraftLensError,
+    clear_trade_cumulus_updraft_lens_cache,
+    trade_cumulus_updraft_lens_defaults,
+    trade_cumulus_updraft_lens_eligible,
+    trade_cumulus_updraft_lens_frame,
+)
+
+
+def _dataset(
+    *,
+    times: list[float] | None = None,
+    scalar_w: bool = False,
+    include_cwp: bool = True,
+) -> xr.Dataset:
+    times = times or [10_800.0, 11_100.0]
+    nt, nz, ny, nx = len(times), 3, 4, 4
+    ql = np.zeros((nt, nz, ny, nx), dtype=float)
+    ql[:, :, 1, :] = 2e-6
+    w_scalar = np.zeros_like(ql)
+    w_scalar[:, :, 1, :] = 2.0
+    if scalar_w:
+        w = w_scalar
+        w_dimensions = ("time", "zh", "yh", "xh")
+    else:
+        w = np.zeros((nt, nz + 1, ny, nx), dtype=float)
+        w[:, :, 1, :] = 2.0
+        w_dimensions = ("time", "zf", "yh", "xh")
+    u = np.broadcast_to(
+        np.arange(nx + 1, dtype=float)[None, None, None, :],
+        (nt, nz, ny, nx + 1),
+    ).copy()
+    v = np.broadcast_to(
+        np.arange(ny + 1, dtype=float)[None, None, :, None],
+        (nt, nz, ny + 1, nx),
+    ).copy()
+    data_vars: dict[str, Any] = {
+        "ql": (("time", "zh", "yh", "xh"), ql, {"units": "kg/kg"}),
+        "w": (w_dimensions, w, {"units": "m/s"}),
+        "u": (("time", "zh", "yh", "xf"), u, {"units": "m/s"}),
+        "v": (("time", "zh", "yf", "xh"), v, {"units": "m/s"}),
+    }
+    if include_cwp:
+        cwp = np.zeros((nt, ny, nx), dtype=float)
+        for index in range(nt):
+            cwp[index] = float(index + 1)
+        data_vars["cwp"] = (("time", "yh", "xh"), cwp, {"units": "kg/m^2"})
+    return xr.Dataset(
+        data_vars,
+        coords={
+            "time": ("time", times, {"units": "s"}),
+            "zh": ("zh", [0.2, 0.6, 1.0], {"units": "km"}),
+            "zf": ("zf", [0.0, 0.4, 0.8, 1.2], {"units": "km"}),
+            "yh": ("yh", [-0.15, -0.05, 0.05, 0.15], {"units": "km"}),
+            "xh": ("xh", [-0.15, -0.05, 0.05, 0.15], {"units": "km"}),
+            "yf": ("yf", [-0.2, -0.1, 0.0, 0.1, 0.2], {"units": "km"}),
+            "xf": ("xf", [-0.2, -0.1, 0.0, 0.1, 0.2], {"units": "km"}),
+        },
+    )
+
+
+def _metadata(
+    path: Path,
+    *,
+    scenario_id: str = CASE_ID,
+    case_id: str | None = None,
+    time_steps: int = 2,
+    default_time_by_field: dict[str, Any] | None = None,
+) -> ResultMetadata:
+    now = datetime(2026, 7, 19, tzinfo=UTC)
+    return ResultMetadata(
+        result_id="result-trade-cumulus",
+        run_id="trade-cumulus",
+        scenario_id=scenario_id,
+        physical_question="Where does cloud-forming ascent occur?",
+        controls={},
+        run_configuration={"case_id": case_id} if case_id else {},
+        source_lifecycle_state="completed",
+        source_product_state="candidate",
+        source_model="CM1",
+        model_output_paths=[str(path)],
+        model_output_file_count=1,
+        time_steps=time_steps,
+        first_output_time_seconds=10_800,
+        last_output_time_seconds=11_100,
+        default_time_by_field=default_time_by_field or {},
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _install_result(
+    tmp_path: Path,
+    dataset: xr.Dataset,
+    **metadata_options: Any,
+) -> tuple[CloudChamberSettings, ResultMetadata]:
+    run_dir = tmp_path / "runs" / "trade-cumulus"
+    run_dir.mkdir(parents=True)
+    path = run_dir / "cm1out.nc"
+    dataset.to_netcdf(path)
+    metadata = _metadata(path, time_steps=int(dataset.sizes["time"]), **metadata_options)
+    (run_dir / "result_metadata.json").write_text(metadata.to_json_text())
+    settings = CloudChamberSettings(
+        runtime_home=tmp_path,
+        cm1_root=None,
+        cm1_run_dir=None,
+        cache_dir=tmp_path / "cache",
+        log_dir=tmp_path / "logs",
+    )
+    clear_trade_cumulus_updraft_lens_cache()
+    return settings, metadata
+
+
+def test_eligibility_accepts_exact_scenario_id(tmp_path: Path) -> None:
+    metadata = _metadata(tmp_path / "output.nc")
+    assert trade_cumulus_updraft_lens_eligible(metadata) is True
+
+
+def test_eligibility_accepts_exact_run_configuration_case_id(tmp_path: Path) -> None:
+    metadata = _metadata(tmp_path / "output.nc", scenario_id="historical", case_id=CASE_ID)
+    assert trade_cumulus_updraft_lens_eligible(metadata) is True
+
+
+def test_eligibility_does_not_infer_from_raw_fields(tmp_path: Path) -> None:
+    metadata = _metadata(tmp_path / "output.nc", scenario_id="lookalike")
+    metadata.variables = ["ql", "w", "u", "v", "cwp"]
+    assert trade_cumulus_updraft_lens_eligible(metadata) is False
+
+
+def test_w_face_grid_is_centered_to_ql_levels() -> None:
+    dataset = _dataset()
+    ql, dimensions = lens._scalar_ql(dataset, 0)
+    centered = lens._center_w(dataset, 0, dimensions, ql.shape)
+    assert centered.shape == ql.shape
+    assert centered[:, 1, :] == pytest.approx(np.full((3, 4), 2.0))
+
+
+def test_w_scalar_grid_is_used_directly() -> None:
+    dataset = _dataset(scalar_w=True)
+    ql, dimensions = lens._scalar_ql(dataset, 0)
+    centered = lens._center_w(dataset, 0, dimensions, ql.shape)
+    assert centered[:, 1, :] == pytest.approx(np.full((3, 4), 2.0))
+
+
+def test_w_rejects_unsupported_vertical_stagger() -> None:
+    dataset = _dataset().drop_vars("w")
+    dataset["w"] = (("time", "bad_z", "yh", "xh"), np.zeros((2, 5, 4, 4)))
+    with pytest.raises(TradeCumulusUpdraftLensError, match="supported z dimension"):
+        ql, dimensions = lens._scalar_ql(dataset, 0)
+        lens._center_w(dataset, 0, dimensions, ql.shape)
+
+
+def test_default_time_uses_max_domain_mean_cwp_after_three_hours(tmp_path: Path) -> None:
+    settings, _ = _install_result(tmp_path, _dataset())
+    defaults = trade_cumulus_updraft_lens_defaults(settings, "result-trade-cumulus")
+    assert defaults.default_time_index == 1
+    assert defaults.default_time_seconds == 11_100
+
+
+def test_default_time_tie_uses_earlier_frame() -> None:
+    metadata = _metadata(Path("output.nc"))
+    frames = [
+        lens._FrameLocation(0, Path("a.nc"), 0, 10_800),
+        lens._FrameLocation(1, Path("b.nc"), 0, 11_100),
+    ]
+    assert lens._select_default_time(metadata, frames, [2.0, 2.0])[0] == 0
+
+
+def test_default_time_falls_back_to_supported_cloud_liquid_diagnostic() -> None:
+    metadata = _metadata(
+        Path("output.nc"),
+        default_time_by_field={
+            "ql": {
+                "field": "ql",
+                "time_index": 0,
+                "time_seconds": 10_800,
+                "source_interesting_time_key": "max_qc",
+                "support_state": "supported",
+                "caveats": [],
+            }
+        },
+    )
+    frames = [
+        lens._FrameLocation(0, Path("a.nc"), 0, 10_800),
+        lens._FrameLocation(1, Path("b.nc"), 0, 11_100),
+    ]
+    index, method, caveats = lens._select_default_time(metadata, frames, [None, None])
+    assert (index, method) == (0, "diagnostics_supported_time_of_max_cloud_liquid")
+    assert "domain_mean_cwp_default_unavailable" in caveats
+
+
+def test_default_time_falls_back_to_latest_final_three_hour_output() -> None:
+    metadata = _metadata(Path("output.nc"))
+    frames = [
+        lens._FrameLocation(0, Path("a.nc"), 0, None),
+        lens._FrameLocation(1, Path("b.nc"), 0, 20_000),
+    ]
+    index, method, _ = lens._select_default_time(metadata, frames, [None, None])
+    assert (index, method) == (1, "latest_output_in_final_three_hours")
+
+
+def test_plane_uses_greatest_positive_w_times_ql_score() -> None:
+    ql = np.zeros((3, 3, 4))
+    ql[:, 0, :] = 2e-6
+    ql[:, 2, :] = 2e-6
+    w = np.zeros_like(ql)
+    w[:, 0, :] = -20
+    w[:, 2, :] = 1
+    assert lens._select_default_plane(ql, w) == (
+        2,
+        "greatest_coherent_positive_w_times_ql_score",
+    )
+
+
+def test_plane_ignores_small_disconnected_cloud_objects() -> None:
+    ql = np.zeros((4, 3, 4))
+    ql[0, 0, 0] = 1e-3
+    ql[:, 1, :] = 2e-6
+    w = np.ones_like(ql)
+    assert lens._select_default_plane(ql, w)[0] == 1
+
+
+def test_plane_score_combines_all_coherent_components_on_each_y_plane() -> None:
+    ql = np.zeros((5, 2, 10))
+    ql[:, 0, 0:2] = 2e-6
+    ql[:, 0, 4:6] = 2e-6
+    ql[:, 1, 0:2] = 2e-6
+    w = np.zeros_like(ql)
+    w[:, 0, :] = 1.0
+    w[:, 1, :] = 1.5
+    assert lens._select_default_plane(ql, w)[0] == 0
+
+
+def test_plane_falls_back_to_largest_coherent_cloud_component() -> None:
+    ql = np.zeros((4, 3, 4))
+    ql[:3, 0, :] = 2e-6
+    ql[:, 2, :] = 2e-6
+    w = np.full_like(ql, np.nan)
+    assert lens._select_default_plane(ql, w) == (
+        2,
+        "largest_coherent_cloud_component_fallback",
+    )
+
+
+def test_plane_falls_back_to_domain_midpoint_without_coherent_cloud() -> None:
+    ql = np.zeros((3, 4, 4))
+    w = np.ones_like(ql)
+    assert lens._select_default_plane(ql, w) == (2, "domain_midpoint_fallback")
+
+
+def test_fixed_range_uses_percentile_floor_and_rounding() -> None:
+    assert lens._rounded_reference([np.asarray([0.2, 0.21])], 99, 0.5) == 0.5
+    assert lens._rounded_reference([np.asarray([0.61, 0.62])], 99, 0.5) == 0.7
+
+
+def test_u_and_v_faces_are_centered_to_scalar_grid() -> None:
+    dataset = _dataset()
+    ql, dimensions = lens._scalar_ql(dataset, 0)
+    u, v = lens._center_horizontal_wind(dataset, 0, dimensions, ql.shape)
+    assert u.shape == ql.shape
+    assert v.shape == ql.shape
+    assert u[0, 0] == pytest.approx([0.5, 1.5, 2.5, 3.5])
+    assert v[0, :, 0] == pytest.approx([0.5, 1.5, 2.5, 3.5])
+
+
+def test_frame_switches_between_perturbation_and_total_wind(tmp_path: Path) -> None:
+    settings, _ = _install_result(tmp_path, _dataset())
+    defaults = trade_cumulus_updraft_lens_defaults(settings, "result-trade-cumulus")
+    perturbation = trade_cumulus_updraft_lens_frame(
+        settings,
+        "result-trade-cumulus",
+        time_index=defaults.default_time_index,
+        plane_index=defaults.default_plane_index,
+        wind_mode="perturbation",
+    )
+    total = trade_cumulus_updraft_lens_frame(
+        settings,
+        "result-trade-cumulus",
+        time_index=defaults.default_time_index,
+        plane_index=defaults.default_plane_index,
+        wind_mode="total",
+    )
+    assert perturbation.domain_mean_u_m_s == pytest.approx(2.0)
+    assert total.wind_vectors[0].u_m_s != perturbation.wind_vectors[0].u_m_s
+    assert total.wind_reference_m_s == defaults.total_wind_reference_m_s
+
+
+def test_wind_stride_bounds_arrow_count_and_skips_zero_vectors() -> None:
+    u = np.ones((64, 64))
+    v = np.zeros((64, 64))
+    vectors = lens._wind_vectors(u, v, np.arange(64), np.arange(64), 0.6)
+    assert len(vectors) == 64
+    zero_vectors = lens._wind_vectors(
+        np.zeros((8, 8)), np.zeros((8, 8)), np.arange(8), np.arange(8), 0.6
+    )
+    assert zero_vectors == []
+
+
+def test_wind_references_use_p95_floor() -> None:
+    assert lens._rounded_reference([np.asarray([0.1, 0.2])], 95, 0.5) == 0.5
+    assert lens._rounded_reference([np.asarray([0.81, 0.82])], 95, 0.5) == 0.9
+
+
+def test_frame_orders_z_ascending_and_serializes_nonfinite_values(tmp_path: Path) -> None:
+    dataset = _dataset()
+    dataset["w"].values[1, 1, 1, 0] = np.nan
+    settings, _ = _install_result(tmp_path, dataset)
+    frame = trade_cumulus_updraft_lens_frame(
+        settings,
+        "result-trade-cumulus",
+        time_index=1,
+        plane_index=1,
+        wind_mode="perturbation",
+    )
+    assert frame.z_values_km == sorted(frame.z_values_km)
+    assert frame.w_values_m_s[0][0] is None or frame.w_values_m_s[1][0] is None
+
+
+def test_invalid_indices_and_wind_mode_are_rejected(tmp_path: Path) -> None:
+    settings, _ = _install_result(tmp_path, _dataset())
+    with pytest.raises(TradeCumulusUpdraftLensError, match="time_index"):
+        trade_cumulus_updraft_lens_frame(
+            settings,
+            "result-trade-cumulus",
+            time_index=-1,
+            plane_index=0,
+            wind_mode="total",
+        )
+    with pytest.raises(TradeCumulusUpdraftLensError, match="plane_index"):
+        trade_cumulus_updraft_lens_frame(
+            settings,
+            "result-trade-cumulus",
+            time_index=0,
+            plane_index=99,
+            wind_mode="total",
+        )
+
+
+def test_ineligible_result_is_rejected_even_with_required_fields(tmp_path: Path) -> None:
+    settings, _ = _install_result(tmp_path, _dataset(), scenario_id="lookalike")
+    with pytest.raises(TradeCumulusUpdraftLensError, match="not eligible"):
+        trade_cumulus_updraft_lens_defaults(settings, "result-trade-cumulus")
+
+
+def test_defaults_cache_reuses_computation_and_closes_every_open_dataset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "output.nc"
+    source.touch()
+    metadata = _metadata(source)
+    dataset = _dataset()
+    opens = 0
+    closes = 0
+
+    class DatasetProxy:
+        def __getattr__(self, name: str) -> Any:
+            return getattr(dataset, name)
+
+        def __getitem__(self, name: str) -> Any:
+            return dataset[name]
+
+        def close(self) -> None:
+            nonlocal closes
+            closes += 1
+
+    def open_dataset(_path: Path) -> DatasetProxy:
+        nonlocal opens
+        opens += 1
+        return DatasetProxy()
+
+    clear_trade_cumulus_updraft_lens_cache()
+    monkeypatch.setattr(lens, "_open_dataset", open_dataset)
+    first = lens._cached_defaults(metadata)
+    second = lens._cached_defaults(metadata)
+    assert first is second
+    assert opens == 2
+    assert closes == opens

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { gotoApp, gotoBuild, gotoResults, openRunMonitor } from "../helpers";
-import { mockCloudChamberApis } from "../fixtures";
+import { mockCloudChamberApis, results } from "../fixtures";
 
 test.describe("mocked smoke: Build, Results, Explore path", () => {
   test.beforeEach(async ({ page }) => {
@@ -179,10 +179,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       .getByRole("button", { name: "Save candidate" })
       .click();
     await page.getByRole("textbox", { name: "Tags" }).fill("smoke");
-    await page
-      .getByLabel("Save candidate notes")
-      .getByRole("button", { name: "Save" })
-      .click();
+    await page.getByLabel("Save candidate notes").getByRole("button", { name: "Save" }).click();
     await expect(page.getByText("Sounding candidate saved")).toBeVisible();
     await page.getByRole("tab", { name: /Saved candidates/ }).click();
     const savedCard = page.getByLabel("Saved sounding candidate Valley, Nebraska (USM00072558)");
@@ -198,10 +195,10 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       const runPlan = document.querySelector('[aria-label="Run plan"]');
       return Boolean(
         saved &&
-          setup &&
-          runPlan &&
-          (saved.compareDocumentPosition(setup) & Node.DOCUMENT_POSITION_FOLLOWING) &&
-          (setup.compareDocumentPosition(runPlan) & Node.DOCUMENT_POSITION_FOLLOWING),
+        setup &&
+        runPlan &&
+        saved.compareDocumentPosition(setup) & Node.DOCUMENT_POSITION_FOLLOWING &&
+        setup.compareDocumentPosition(runPlan) & Node.DOCUMENT_POSITION_FOLLOWING,
       );
     });
     expect(selectedSetupOrderIsCorrect).toBe(true);
@@ -400,6 +397,198 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("Cloud formed here")).toHaveCount(0);
     await expect(page.getByRole("button", { name: /reset camera/i })).toBeVisible();
     await expect(page.getByText(/selected point: x/i)).toBeVisible();
+  });
+
+  test("Trade Cumulus activates the Updraft Lens with bounded process controls", async ({
+    page,
+  }) => {
+    const catalog = await page.evaluate(async () =>
+      fetch("/api/results/result-baseline/visualization/fields").then((response) =>
+        response.json(),
+      ),
+    );
+    const tradeResult = {
+      ...results[0],
+      name: "Trade Cumulus",
+      scenario_id: "bomex_trade_cumulus_baseline_v0",
+      scenario_name: "Trade Cumulus",
+      run_configuration: {
+        ...results[0].run_configuration,
+        case_id: "bomex_trade_cumulus_baseline_v0",
+      },
+    };
+    catalog.scenario_id = "bomex_trade_cumulus_baseline_v0";
+    catalog.available_fields[0] = {
+      ...catalog.available_fields[0],
+      raw_field: "ql",
+      raw_field_name: "ql",
+      display_name: "Cloud liquid",
+    };
+
+    await page.route("**/api/results", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ results: [tradeResult] }),
+      }),
+    );
+    await page.route("**/api/results/result-baseline/visualization/fields", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(catalog),
+      }),
+    );
+    await page.route(
+      "**/api/results/result-baseline/visualization/trade-cumulus-updraft-lens/defaults",
+      (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            result_id: "result-baseline",
+            case_id: "bomex_trade_cumulus_baseline_v0",
+            eligible: true,
+            primary_field: "w",
+            cloud_field: "ql",
+            orientation: "vertical_x",
+            default_time_index: 1,
+            default_time_seconds: 1800,
+            default_time_method: "max_finite_domain_mean_cwp_at_or_after_10800_seconds",
+            default_plane_dimension: "y",
+            default_plane_index: 2,
+            default_plane_coordinate: 0.05,
+            default_plane_units: "km",
+            default_plane_method: "greatest_coherent_positive_w_times_ql_score",
+            cloud_threshold_kg_kg: 1e-6,
+            w_range_min_m_s: -0.9,
+            w_range_max_m_s: 0.9,
+            w_range_method: "all_frames_p99_absolute_centered_w",
+            wind_target_level_m: 600,
+            wind_actual_level_m: 580,
+            wind_level_index: 1,
+            wind_default_mode: "perturbation",
+            wind_stride: 8,
+            wind_shown_by_default: true,
+            perturbation_wind_reference_m_s: 0.9,
+            total_wind_reference_m_s: 8.8,
+            wind_arrow_domain_fraction: 0.08,
+            provenance: catalog.provenance,
+            caveats: [],
+          }),
+        }),
+    );
+    await page.route(
+      "**/api/results/result-baseline/visualization/trade-cumulus-updraft-lens/frame**",
+      (route) => {
+        const url = new URL(route.request().url());
+        const windMode = url.searchParams.get("wind_mode") === "total" ? "total" : "perturbation";
+        const planeIndex = Number(url.searchParams.get("plane_index") ?? 2);
+        const timeIndex = Number(url.searchParams.get("time_index") ?? 1);
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            result_id: "result-baseline",
+            time_index: timeIndex,
+            time_seconds: [0, 1800, 3600][timeIndex] ?? 1800,
+            orientation: "vertical_x",
+            plane_dimension: "y",
+            plane_index: planeIndex,
+            plane_coordinate: [-0.15, -0.05, 0.05, 0.15][planeIndex] ?? 0.05,
+            plane_units: "km",
+            x_indices: [0, 1, 2, 3],
+            x_values_km: [-0.15, -0.05, 0.05, 0.15],
+            z_indices: [0, 1, 2, 3],
+            z_values_km: [0.1, 0.3, 0.5, 0.7],
+            w_values_m_s: [
+              [-0.9, -0.4, 0.2, 0.6],
+              [-0.5, 0, 0.5, 0.9],
+              [-0.2, 0.3, 0.7, null],
+              [0, 0.1, 0.4, 0.2],
+            ],
+            cloud_mask: [
+              [false, false, false, false],
+              [false, true, true, false],
+              [true, true, true, false],
+              [false, true, false, false],
+            ],
+            cloud_threshold_kg_kg: 1e-6,
+            w_range_min_m_s: -0.9,
+            w_range_max_m_s: 0.9,
+            w_range_method: "fixed",
+            wind_mode: windMode,
+            wind_target_level_m: 600,
+            wind_actual_level_m: 580,
+            wind_level_index: 1,
+            wind_stride: 8,
+            wind_reference_m_s: windMode === "total" ? 8.8 : 0.9,
+            wind_arrow_domain_fraction: 0.08,
+            domain_mean_u_m_s: -8,
+            domain_mean_v_m_s: 0,
+            wind_vectors: [
+              {
+                x_km: 0,
+                y_km: 0,
+                z_km: 0.58,
+                u_m_s: windMode === "total" ? -7.5 : 0.5,
+                v_m_s: 0.2,
+                magnitude_m_s: windMode === "total" ? 7.5 : 0.54,
+              },
+            ],
+            provenance: catalog.provenance,
+            caveats: [],
+          }),
+        });
+      },
+    );
+
+    await page.reload();
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+
+    const ordinaryTimeValue = await page.getByRole("combobox", { name: "Time" }).inputValue();
+    const lensToggle = page.getByRole("button", { name: "Updraft Lens" });
+    await expect(lensToggle).toBeEnabled();
+    await lensToggle.click();
+    await expect(page.getByRole("heading", { name: "Updraft Lens" })).toBeVisible();
+    await expect(page.getByRole("img", { name: /Updraft Lens vertical x-z slice/ })).toBeVisible();
+    await expect(page.getByLabel("Cloud boundary")).toBeChecked();
+    await expect(page.getByRole("checkbox", { name: "Horizontal wind" })).toBeChecked();
+    await expect(page.getByRole("button", { name: "Local departures" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(page.getByLabel("Horizontal wind overlay legend")).toContainText(
+      "0.9 m/s reference",
+    );
+    await expect(page.getByLabel("Vertical velocity color scale")).toContainText("0.9 m/s");
+    await expect(page.getByLabel("Updraft Lens vertical plane")).toHaveValue("2");
+    await expect(page.getByLabel("Slice field")).toHaveCount(0);
+    await expect(page.locator("#explore-3d-field")).toHaveCount(0);
+
+    await page.getByLabel("Updraft Lens vertical plane").fill("3");
+    await expect(page.getByLabel("Updraft Lens vertical plane")).toHaveValue("3");
+    await expect(page.getByRole("img", { name: /y index 3/ })).toBeVisible();
+    await page.getByRole("combobox", { name: "Time" }).selectOption({ label: "3,600 s" });
+    await expect(
+      page.getByText("Vertical x-z slice at y = 0.15 km · w · 3,600 s", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Vertical velocity color scale")).toContainText("-0.9");
+    await expect(page.getByLabel("Vertical velocity color scale")).toContainText("0.9 m/s");
+
+    await page.getByRole("button", { name: "Total wind" }).click();
+    await expect(page.getByLabel("Horizontal wind overlay legend")).toContainText(
+      "8.8 m/s reference",
+    );
+    await page.getByLabel("Cloud boundary").uncheck();
+    await expect(page.getByTestId("updraft-lens-cloud-boundary")).toHaveCount(0);
+    await page.getByRole("checkbox", { name: "Horizontal wind" }).uncheck();
+    await expect(page.getByLabel("Horizontal wind overlay legend")).toHaveCount(0);
+    await page.getByRole("button", { name: "Turn off Updraft Lens" }).click();
+    await expect(page.getByRole("heading", { name: "Inspect the current slice" })).toBeVisible();
+    await expect(page.getByLabel("Slice field")).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Time" })).toHaveValue(ordinaryTimeValue);
   });
 
   test("Unified Explore plays through saved output times", async ({ page }) => {

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -373,6 +373,23 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("button", { name: /move up/i })).toBeVisible();
     const heatmap = page.getByRole("img", { name: /heatmap/i });
     await expect(heatmap).toBeVisible();
+    await expect(page.getByTestId("slice-cloud-boundary")).toBeVisible();
+    const heatmapLayout = await heatmap.evaluate((element) => {
+      const bounds = element.getBoundingClientRect();
+      const grid = element.querySelector<HTMLElement>(".slice-heatmap-grid");
+      const row = element.querySelector<HTMLElement>(".heatmap-row");
+      return {
+        declaredAspect: Number(element.getAttribute("data-domain-aspect")),
+        renderedAspect: bounds.width / bounds.height,
+        gridGap: grid ? getComputedStyle(grid).gap : null,
+        rowGap: row ? getComputedStyle(row).gap : null,
+        padding: getComputedStyle(element).padding,
+      };
+    });
+    expect(Math.abs(heatmapLayout.declaredAspect - heatmapLayout.renderedAspect)).toBeLessThan(0.03);
+    expect(heatmapLayout.gridGap).toBe("0px");
+    expect(heatmapLayout.rowGap).toBe("0px");
+    expect(heatmapLayout.padding).toBe("0px");
     const fieldControlsPrecedeHeatmap = await heatmap.evaluate((element) => {
       const fieldControl = document.querySelector("#explore-slice-field");
       return Boolean(
@@ -483,8 +500,36 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       (route) => {
         const url = new URL(route.request().url());
         const windMode = url.searchParams.get("wind_mode") === "total" ? "total" : "perturbation";
+        const orientation =
+          url.searchParams.get("orientation") === "horizontal"
+            ? "horizontal"
+            : url.searchParams.get("orientation") === "vertical_y"
+              ? "vertical_y"
+              : "vertical_x";
         const planeIndex = Number(url.searchParams.get("plane_index") ?? 2);
         const timeIndex = Number(url.searchParams.get("time_index") ?? 1);
+        const planeDimension =
+          orientation === "horizontal" ? "z" : orientation === "vertical_y" ? "x" : "y";
+        const dimensionOrder =
+          orientation === "horizontal"
+            ? ["y", "x"]
+            : orientation === "vertical_y"
+              ? ["z", "y"]
+              : ["z", "x"];
+        const wValues =
+          orientation === "horizontal"
+            ? [
+                [-0.9, -0.4, 0.2, 0.6],
+                [-0.5, 0, 0.5, 0.9],
+                [-0.2, 0.3, 0.7, null],
+                [0, 0.1, 0.4, 0.2],
+              ]
+            : [
+                [-0.9, -0.4, 0.2, 0.6],
+                [-0.5, 0, 0.5, 0.9],
+                [-0.2, 0.3, 0.7, null],
+                [0, 0.1, 0.4, 0.2],
+              ];
         return route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -492,21 +537,19 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
             result_id: "result-baseline",
             time_index: timeIndex,
             time_seconds: [0, 1800, 3600][timeIndex] ?? 1800,
-            orientation: "vertical_x",
-            plane_dimension: "y",
+            orientation,
+            plane_dimension: planeDimension,
             plane_index: planeIndex,
             plane_coordinate: [-0.15, -0.05, 0.05, 0.15][planeIndex] ?? 0.05,
             plane_units: "km",
+            dimension_order: dimensionOrder,
             x_indices: [0, 1, 2, 3],
             x_values_km: [-0.15, -0.05, 0.05, 0.15],
+            y_indices: [0, 1, 2, 3],
+            y_values_km: [-0.15, -0.05, 0.05, 0.15],
             z_indices: [0, 1, 2, 3],
             z_values_km: [0.1, 0.3, 0.5, 0.7],
-            w_values_m_s: [
-              [-0.9, -0.4, 0.2, 0.6],
-              [-0.5, 0, 0.5, 0.9],
-              [-0.2, 0.3, 0.7, null],
-              [0, 0.1, 0.4, 0.2],
-            ],
+            w_values_m_s: wValues,
             cloud_mask: [
               [false, false, false, false],
               [false, true, true, false],
@@ -548,7 +591,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
     const ordinaryTimeValue = await page.getByRole("combobox", { name: "Time" }).inputValue();
-    const lensToggle = page.getByRole("button", { name: "Updraft Lens" });
+    const viewMode = page.getByLabel("Explore view mode");
+    await expect(viewMode).toBeVisible();
+    const lensToggle = viewMode.getByRole("button", { name: "Updraft Lens" });
     await expect(lensToggle).toBeEnabled();
     await lensToggle.click();
     await expect(page.getByRole("heading", { name: "Updraft Lens" })).toBeVisible();
@@ -563,13 +608,51 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       "0.9 m/s reference",
     );
     await expect(page.getByLabel("Vertical velocity color scale")).toContainText("0.9 m/s");
-    await expect(page.getByLabel("Updraft Lens vertical plane")).toHaveValue("2");
+    await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("2");
+    await expect(page.getByRole("button", { name: "Vertical x-z" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(
+      page.getByText("Updraft Lens slice: Vertical x-z slice at y = 0.05 km", { exact: true }),
+    ).toBeVisible();
     await expect(page.getByLabel("Slice field")).toHaveCount(0);
-    await expect(page.locator("#explore-3d-field")).toHaveCount(0);
+    const scalarField = page.getByLabel("3-D scalar field", { exact: true });
+    await expect(scalarField).toBeVisible();
+    await scalarField.selectOption("qv");
+    await expect(scalarField).toHaveValue("qv");
+    await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("2");
+    await expect(page.getByRole("img", { name: /y index 2/ })).toBeVisible();
+    await page.getByLabel("Layer opacity").fill("0.45");
+    await page.getByLabel("Point size").fill("14");
+    await expect(page.getByLabel("Layer opacity")).toHaveValue("0.45");
+    await expect(page.getByLabel("Point size")).toHaveValue("14");
+    const sliceAspect = await page.locator(".updraft-lens-svg").evaluate((element) => {
+      const bounds = element.getBoundingClientRect();
+      return {
+        declared: Number(element.getAttribute("data-domain-aspect")),
+        rendered: bounds.width / bounds.height,
+      };
+    });
+    expect(Math.abs(sliceAspect.declared - sliceAspect.rendered)).toBeLessThan(0.03);
 
-    await page.getByLabel("Updraft Lens vertical plane").fill("3");
-    await expect(page.getByLabel("Updraft Lens vertical plane")).toHaveValue("3");
+    await page.getByRole("button", { name: "Horizontal x-y" }).click();
+    await expect(
+      page.getByRole("img", { name: /Updraft Lens horizontal x-y slice/ }),
+    ).toBeVisible();
+    await expect(page.getByText(/Updraft Lens slice: Horizontal x-y layer at z =/)).toBeVisible();
+    await page.getByRole("button", { name: "Vertical y-z" }).click();
+    await expect(page.getByRole("img", { name: /Updraft Lens vertical y-z slice/ })).toBeVisible();
+    await expect(page.getByText(/Updraft Lens slice: Vertical y-z slice at x =/)).toBeVisible();
+    await page.getByRole("button", { name: "Vertical x-z" }).click();
+    await expect(page.getByRole("img", { name: /Updraft Lens vertical x-z slice/ })).toBeVisible();
+
+    await page.getByLabel("Updraft Lens slice position").fill("3");
+    await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("3");
     await expect(page.getByRole("img", { name: /y index 3/ })).toBeVisible();
+    await expect(
+      page.getByText("Updraft Lens slice: Vertical x-z slice at y = 0.15 km", { exact: true }),
+    ).toBeVisible();
     await page.getByRole("combobox", { name: "Time" }).selectOption({ label: "3,600 s" });
     await expect(
       page.getByText("Vertical x-z slice at y = 0.15 km · w · 3,600 s", { exact: true }),
@@ -585,7 +668,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByTestId("updraft-lens-cloud-boundary")).toHaveCount(0);
     await page.getByRole("checkbox", { name: "Horizontal wind" }).uncheck();
     await expect(page.getByLabel("Horizontal wind overlay legend")).toHaveCount(0);
-    await page.getByRole("button", { name: "Turn off Updraft Lens" }).click();
+    await viewMode.getByRole("button", { name: "Standard" }).click();
     await expect(page.getByRole("heading", { name: "Inspect the current slice" })).toBeVisible();
     await expect(page.getByLabel("Slice field")).toBeVisible();
     await expect(page.getByRole("combobox", { name: "Time" })).toHaveValue(ordinaryTimeValue);

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1685,8 +1685,16 @@ details[open] > summary {
   align-items: start;
 }
 
+.explore-control-deck-has-view-mode {
+  grid-template-columns:
+    minmax(10rem, 0.45fr) minmax(12rem, 0.9fr) minmax(22rem, 1.55fr)
+    minmax(16rem, 1fr);
+}
+
 .explore-control-deck-lens {
-  grid-template-columns: minmax(14rem, 0.8fr) minmax(24rem, 1.2fr);
+  grid-template-columns:
+    minmax(10rem, 0.45fr) minmax(14rem, 0.8fr) minmax(22rem, 1.15fr)
+    minmax(16rem, 1fr);
 }
 
 .visualizer-heading-actions {
@@ -1695,12 +1703,6 @@ details[open] > summary {
   gap: 0.45rem;
   justify-content: flex-end;
   align-items: center;
-}
-
-.updraft-lens-toggle[aria-pressed="true"] {
-  border-color: #8e2530;
-  background: #fff1f1;
-  color: #8e2530;
 }
 
 .explore-control-card {
@@ -1713,6 +1715,11 @@ details[open] > summary {
   border-radius: 8px;
   padding: 0.55rem;
   background: rgba(255, 255, 255, 0.78);
+}
+
+.explore-control-card-view-mode .segmented-buttons {
+  display: grid;
+  gap: 0.25rem;
 }
 
 .explore-control-card legend {
@@ -1805,10 +1812,19 @@ details[open] > summary {
 }
 
 .explore-control-card-updraft-lens legend,
+.explore-control-card-updraft-lens > .segmented-buttons,
 .explore-control-card-updraft-lens > label:first-of-type,
+.explore-control-card-updraft-lens .slice-move-buttons,
 .explore-control-card-updraft-lens .control-help,
 .explore-control-card-updraft-lens [role="alert"] {
   grid-column: 1 / -1;
+}
+
+.explore-control-card-updraft-lens > .segmented-buttons,
+.explore-control-card-updraft-lens .slice-move-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
 }
 
 .explore-control-card-updraft-lens .checkbox-label {
@@ -2094,6 +2110,12 @@ details[open] > summary {
   background: rgba(255, 251, 235, 0.9);
   color: #7c4a03;
   font-weight: 850;
+}
+
+.true3d-slice-label-updraft-lens {
+  border-color: rgba(38, 50, 56, 0.32);
+  background: rgba(255, 255, 255, 0.9);
+  color: #263238;
 }
 
 .true3d-selected-point-label {
@@ -2866,31 +2888,61 @@ details[open] > summary {
 }
 
 .slice-heatmap {
-  display: grid;
-  gap: 0.04rem;
-  max-height: min(34vh, 19rem);
+  position: relative;
+  width: 100%;
+  min-width: 0;
+  margin-inline: auto;
   overflow: hidden;
   border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 0.45rem;
-  background: linear-gradient(180deg, #f7fbfd, #eef5f9);
+  border-radius: 4px;
+  background: #747b80;
+}
+
+.slice-heatmap-grid {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: grid;
+  gap: 0;
 }
 
 .heatmap-row {
   display: grid;
   grid-auto-columns: minmax(0.44rem, 1fr);
   grid-auto-flow: column;
-  gap: 0.04rem;
+  gap: 0;
+  min-height: 0;
 }
 
 .heatmap-cell {
   appearance: none;
-  min-height: clamp(0.44rem, 0.88vh, 0.7rem);
-  min-width: 0.44rem;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
   border: 0;
-  border-radius: 1px;
+  border-radius: 0;
+  padding: 0;
   cursor: crosshair;
   box-shadow: none;
+}
+
+.slice-cloud-boundary-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.slice-cloud-boundary-overlay path {
+  fill: none;
+  stroke: #0b0c0c;
+  stroke-width: 1.25;
+  stroke-linecap: square;
+  stroke-linejoin: miter;
 }
 
 .heatmap-cell:focus-visible,
@@ -2922,15 +2974,15 @@ details[open] > summary {
 
 .heatmap-scale-default,
 .heatmap-scale-cloud-water {
-  background: linear-gradient(90deg, #eaf4f8, #6bb6cf, #b4efe4);
+  background: linear-gradient(90deg, #f2f7f9, #58a9c2, #007ea7);
 }
 
 .heatmap-scale-rain-water {
-  background: linear-gradient(90deg, #e7efff, #7fa0e9, #8674d9);
+  background: linear-gradient(90deg, #eff2ff, #927edc, #5b41b4);
 }
 
 .heatmap-scale-water-vapor {
-  background: linear-gradient(90deg, #e8f8f5, #8be0c8, #4daa92);
+  background: linear-gradient(90deg, #edf8f5, #64c3aa, #0d7f67);
 }
 
 .heatmap-scale-surface-rain {
@@ -2956,7 +3008,7 @@ details[open] > summary {
 }
 
 .heatmap-scale-velocity {
-  background: linear-gradient(90deg, #6b8ebf, #f1f6f8, #80b87a);
+  background: linear-gradient(90deg, #2166ac, #f7f7f7, #b2182b);
 }
 
 .slice-row {
@@ -2979,7 +3031,9 @@ details[open] > summary {
   gap: 0.55rem;
   align-items: stretch;
   width: 100%;
+  max-width: 68rem;
   min-width: 0;
+  margin-inline: auto;
 }
 
 .updraft-lens-plot-column {
@@ -2991,7 +3045,7 @@ details[open] > summary {
 .updraft-lens-svg {
   display: block;
   width: 100%;
-  max-height: 34rem;
+  height: auto;
   border: 1px solid rgba(36, 63, 82, 0.36);
   border-radius: 4px;
   background: #747b80;

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1685,6 +1685,24 @@ details[open] > summary {
   align-items: start;
 }
 
+.explore-control-deck-lens {
+  grid-template-columns: minmax(14rem, 0.8fr) minmax(24rem, 1.2fr);
+}
+
+.visualizer-heading-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.updraft-lens-toggle[aria-pressed="true"] {
+  border-color: #8e2530;
+  background: #fff1f1;
+  color: #8e2530;
+}
+
 .explore-control-card {
   display: grid;
   gap: 0.42rem;
@@ -1780,6 +1798,43 @@ details[open] > summary {
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   color: var(--color-accent-primary);
+}
+
+.explore-control-card-updraft-lens {
+  grid-template-columns: minmax(15rem, 1fr) minmax(10rem, auto);
+}
+
+.explore-control-card-updraft-lens legend,
+.explore-control-card-updraft-lens > label:first-of-type,
+.explore-control-card-updraft-lens .control-help,
+.explore-control-card-updraft-lens [role="alert"] {
+  grid-column: 1 / -1;
+}
+
+.explore-control-card-updraft-lens .checkbox-label {
+  display: flex;
+  gap: 0.42rem;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.explore-control-card-updraft-lens .checkbox-label input {
+  width: auto;
+}
+
+.updraft-lens-mode-control {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 0.24rem;
+  color: var(--color-text-primary);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.updraft-lens-mode-control .segmented-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
 }
 
 .slice-position-label {
@@ -1923,6 +1978,28 @@ details[open] > summary {
   color: #244457;
   box-shadow: 0 8px 22px rgba(40, 80, 110, 0.08);
   pointer-events: none;
+}
+
+.true3d-wind-legend {
+  position: absolute;
+  z-index: 2;
+  left: 0.75rem;
+  top: 3.7rem;
+  display: grid;
+  gap: 0.1rem;
+  max-width: min(24rem, calc(100% - 1.5rem));
+  border: 1px solid rgba(38, 50, 56, 0.22);
+  border-radius: 8px;
+  padding: 0.38rem 0.52rem;
+  background: rgba(255, 255, 255, 0.86);
+  color: #263238;
+  font-size: 0.76rem;
+  pointer-events: none;
+}
+
+.true3d-wind-legend span {
+  color: var(--color-text-muted);
+  font-weight: 700;
 }
 
 .true3d-field-legend > span {
@@ -2896,6 +2973,91 @@ details[open] > summary {
   font-variant-numeric: tabular-nums;
 }
 
+.updraft-lens-slice {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.55rem;
+  align-items: stretch;
+  width: 100%;
+  min-width: 0;
+}
+
+.updraft-lens-plot-column {
+  display: grid;
+  gap: 0.38rem;
+  min-width: 0;
+}
+
+.updraft-lens-svg {
+  display: block;
+  width: 100%;
+  max-height: 34rem;
+  border: 1px solid rgba(36, 63, 82, 0.36);
+  border-radius: 4px;
+  background: #747b80;
+  cursor: crosshair;
+}
+
+.updraft-lens-cloud-boundary {
+  stroke: #0b0c0c;
+  stroke-width: 1.25;
+  stroke-linecap: square;
+  stroke-linejoin: miter;
+  pointer-events: none;
+}
+
+.updraft-lens-selected-point {
+  fill: none;
+  stroke: #f8d44d;
+  stroke-width: 2;
+  pointer-events: none;
+}
+
+.updraft-lens-axis {
+  display: flex;
+  justify-content: space-between;
+  color: var(--color-text-muted);
+  font-size: 0.76rem;
+  font-weight: 750;
+}
+
+.updraft-lens-axis strong {
+  color: var(--color-text-primary);
+  font-size: 0.78rem;
+}
+
+.updraft-lens-axis-z {
+  flex-direction: column;
+  align-items: center;
+  padding: 0.1rem 0 1.75rem;
+}
+
+.updraft-lens-axis-z strong {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+
+.updraft-lens-axis-x {
+  align-items: center;
+}
+
+.updraft-lens-legend {
+  display: grid;
+  grid-template-columns: auto minmax(8rem, 1fr) auto;
+  gap: 0.48rem;
+  align-items: center;
+  color: var(--color-text-primary);
+  font-size: 0.78rem;
+  font-weight: 750;
+}
+
+.updraft-lens-color-ramp {
+  height: 0.72rem;
+  border: 1px solid rgba(23, 43, 58, 0.14);
+  border-radius: 3px;
+  background: linear-gradient(90deg, #2166ac 0%, #f7f7f7 50%, #b2182b 100%);
+}
+
 @media (max-width: 860px) {
   .topbar,
   .builder-layout,
@@ -2980,9 +3142,14 @@ details[open] > summary {
 
   .explore-control-deck,
   .explore-control-card-slice,
+  .explore-control-card-updraft-lens,
   .timelapse-controls,
   .true3d-controls {
     grid-template-columns: 1fr;
+  }
+
+  .visualizer-heading-actions {
+    justify-content: flex-start;
   }
 
   .notebook-list-panel {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3166,6 +3166,184 @@ function pointCloudResponse({
   };
 }
 
+const tradeCumulusResultCard = {
+  ...resultCard,
+  result_id: "result-trade-cumulus",
+  run_id: "trade-cumulus",
+  name: "Trade Cumulus",
+  scenario_id: "bomex_trade_cumulus_baseline_v0",
+  scenario_name: "Trade Cumulus",
+  run_configuration: {
+    ...defaultRunConfiguration,
+    case_id: "bomex_trade_cumulus_baseline_v0",
+  },
+};
+
+const tradeCumulusFieldCatalog = {
+  ...fieldCatalogResponse,
+  result_id: "result-trade-cumulus",
+  run_id: "trade-cumulus",
+  scenario_id: "bomex_trade_cumulus_baseline_v0",
+  available_fields: [
+    {
+      ...fieldCatalogResponse.available_fields[0],
+      raw_field_name: "ql",
+      display_name: "Cloud liquid",
+      provenance: {
+        ...provenance,
+        result_id: "result-trade-cumulus",
+        run_id: "trade-cumulus",
+        scenario_id: "bomex_trade_cumulus_baseline_v0",
+      },
+    },
+    fieldCatalogResponse.available_fields[1],
+  ],
+};
+
+const tradeCumulusViewDefaults = {
+  ...viewDefaultsResponse,
+  result_id: "result-trade-cumulus",
+  run_id: "trade-cumulus",
+  scenario_id: "bomex_trade_cumulus_baseline_v0",
+  preferred_field: "ql",
+  fields: {
+    ql: { ...viewDefaultsResponse.fields.qc, field: "ql" },
+    w: viewDefaultsResponse.fields.w,
+  },
+};
+
+const tradeCumulusUpdraftLensDefaults = {
+  result_id: "result-trade-cumulus",
+  case_id: "bomex_trade_cumulus_baseline_v0",
+  eligible: true,
+  primary_field: "w",
+  cloud_field: "ql",
+  orientation: "vertical_x",
+  default_time_index: 2,
+  default_time_seconds: 1800,
+  default_time_method: "max_finite_domain_mean_cwp_at_or_after_10800_seconds",
+  default_plane_dimension: "y",
+  default_plane_index: 1,
+  default_plane_coordinate: 0.05,
+  default_plane_units: "km",
+  default_plane_method: "greatest_coherent_positive_w_times_ql_score",
+  cloud_threshold_kg_kg: 1e-6,
+  w_range_min_m_s: -0.9,
+  w_range_max_m_s: 0.9,
+  w_range_method: "all_frames_p99_absolute_centered_w",
+  wind_target_level_m: 600,
+  wind_actual_level_m: 580,
+  wind_level_index: 1,
+  wind_default_mode: "perturbation",
+  wind_stride: 8,
+  wind_shown_by_default: true,
+  perturbation_wind_reference_m_s: 0.9,
+  total_wind_reference_m_s: 8.8,
+  wind_arrow_domain_fraction: 0.08,
+  provenance: {
+    ...provenance,
+    result_id: "result-trade-cumulus",
+    run_id: "trade-cumulus",
+    scenario_id: "bomex_trade_cumulus_baseline_v0",
+  },
+  caveats: [],
+};
+
+function tradeCumulusUpdraftLensFrame({
+  timeIndex = 2,
+  planeIndex = 1,
+  windMode = "perturbation",
+  range = 0.9,
+}: {
+  timeIndex?: number;
+  planeIndex?: number;
+  windMode?: "perturbation" | "total";
+  range?: number;
+} = {}) {
+  const reference = windMode === "perturbation" ? 0.9 : 8.8;
+  return {
+    result_id: "result-trade-cumulus",
+    time_index: timeIndex,
+    time_seconds: [0, 900, 1800, 2700][timeIndex] ?? 1800,
+    orientation: "vertical_x",
+    plane_dimension: "y",
+    plane_index: planeIndex,
+    plane_coordinate: [-0.05, 0.05][planeIndex] ?? 0.05,
+    plane_units: "km",
+    x_indices: [0, 1, 2],
+    x_values_km: [-0.1, 0, 0.1],
+    z_indices: [0, 1],
+    z_values_km: [0.1, 0.3],
+    w_values_m_s: [
+      [-range, 0, range],
+      [null, -range / 2, range / 2],
+    ],
+    cloud_mask: [
+      [true, true, false],
+      [false, true, false],
+    ],
+    cloud_threshold_kg_kg: 1e-6,
+    w_range_min_m_s: -range,
+    w_range_max_m_s: range,
+    w_range_method: "fixed",
+    wind_mode: windMode,
+    wind_target_level_m: 600,
+    wind_actual_level_m: 580,
+    wind_level_index: 1,
+    wind_stride: 8,
+    wind_reference_m_s: reference,
+    wind_arrow_domain_fraction: 0.08,
+    domain_mean_u_m_s: -8,
+    domain_mean_v_m_s: 0,
+    wind_vectors: [
+      {
+        x_km: 0,
+        y_km: 0,
+        z_km: 0.58,
+        u_m_s: windMode === "perturbation" ? 0.5 : -7.5,
+        v_m_s: 0.2,
+        magnitude_m_s: windMode === "perturbation" ? 0.54 : 7.5,
+      },
+    ],
+    provenance: tradeCumulusUpdraftLensDefaults.provenance,
+    caveats: [],
+  };
+}
+
+function tradeCumulusPointCloudResponse() {
+  const response = pointCloudResponse({ field: "qc", timeIndex: 2 });
+  return {
+    ...response,
+    result_id: "result-trade-cumulus",
+    run_id: "trade-cumulus",
+    scenario_id: "bomex_trade_cumulus_baseline_v0",
+    field: tradeCumulusFieldCatalog.available_fields[0],
+    selection: { ...response.selection, field: "ql" },
+  };
+}
+
+function tradeCumulusSliceResponse(url: string) {
+  const parsed = new URL(url, "http://localhost");
+  const field = parsed.searchParams.get("field") === "w" ? "w" : "qc";
+  const response = sliceResponse({
+    field,
+    orientation:
+      parsed.searchParams.get("orientation") === "vertical_x" ? "vertical_x" : "horizontal",
+    timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
+    levelIndex: Number(parsed.searchParams.get("level_index") ?? 0),
+  });
+  return {
+    ...response,
+    result_id: "result-trade-cumulus",
+    run_id: "trade-cumulus",
+    scenario_id: "bomex_trade_cumulus_baseline_v0",
+    field:
+      field === "w"
+        ? tradeCumulusFieldCatalog.available_fields[1]
+        : tradeCumulusFieldCatalog.available_fields[0],
+  };
+}
+
 function mockFieldRange(field: MockPointFieldName): { min: number; max: number; mean: number } {
   const ranges: Record<MockPointFieldName, { min: number; max: number; mean: number }> = {
     qc: { min: 0, max: 0.000008, mean: 0.000002 },
@@ -3724,6 +3902,65 @@ async function openSelectedResultInExplore() {
   fireEvent.click(await within(resultDetail).findByRole("button", { name: "Open in Explore" }));
 }
 
+function mockTradeCumulusVisualizer(
+  frameResponse?: (url: string, init?: RequestInit) => Promise<Response>,
+) {
+  const defaultFetch = vi.mocked(fetch).getMockImplementation();
+  vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === "/api/results/result-trade-cumulus/visualization/trade-cumulus-updraft-lens/defaults"
+    ) {
+      return Promise.resolve(
+        new Response(JSON.stringify(tradeCumulusUpdraftLensDefaults), { status: 200 }),
+      );
+    }
+    if (
+      url.startsWith(
+        "/api/results/result-trade-cumulus/visualization/trade-cumulus-updraft-lens/frame",
+      )
+    ) {
+      if (frameResponse) return frameResponse(url, init);
+      const parsed = new URL(url, "http://localhost");
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(
+            tradeCumulusUpdraftLensFrame({
+              timeIndex: Number(parsed.searchParams.get("time_index") ?? 2),
+              planeIndex: Number(parsed.searchParams.get("plane_index") ?? 1),
+              windMode: parsed.searchParams.get("wind_mode") === "total" ? "total" : "perturbation",
+            }),
+          ),
+          { status: 200 },
+        ),
+      );
+    }
+    if (url === "/api/results/result-trade-cumulus/visualization/fields") {
+      return Promise.resolve(
+        new Response(JSON.stringify(tradeCumulusFieldCatalog), { status: 200 }),
+      );
+    }
+    if (url.startsWith("/api/results/result-trade-cumulus/visualization/defaults")) {
+      return Promise.resolve(
+        new Response(JSON.stringify(tradeCumulusViewDefaults), { status: 200 }),
+      );
+    }
+    if (url.includes("/api/results/result-trade-cumulus/visualization/point-cloud")) {
+      return Promise.resolve(
+        new Response(JSON.stringify(tradeCumulusPointCloudResponse()), { status: 200 }),
+      );
+    }
+    if (url.includes("/api/results/result-trade-cumulus/visualization/slice")) {
+      return Promise.resolve(
+        new Response(JSON.stringify(tradeCumulusSliceResponse(url)), { status: 200 }),
+      );
+    }
+    return (
+      defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+    );
+  });
+}
+
 describe("App", () => {
   it("renders guided Build setup with extensible experiment metadata", async () => {
     render(<App />);
@@ -3968,9 +4205,7 @@ describe("App", () => {
       expect(dryRunBody).toContain('"primary_story":"supercell_environment"');
       expect(dryRunBody).toContain('"candidate_id":"USM00072357-2025052000-supercell"');
       expect(dryRunBody).toContain('"ingredient_score":82');
-      expect(dryRunBody).toContain(
-        '"ingredient_score_label":"Experimental Deep-Tower evidence"',
-      );
+      expect(dryRunBody).toContain('"ingredient_score_label":"Experimental Deep-Tower evidence"');
     });
   });
 
@@ -4022,8 +4257,7 @@ describe("App", () => {
           new Response(
             JSON.stringify({
               ...screeningResponse,
-              candidates:
-                request.support === "supported" ? [] : [activeCandidate],
+              candidates: request.support === "supported" ? [] : [activeCandidate],
               total_candidate_count: 1,
               filtered_candidate_count: request.support === "supported" ? 0 : 1,
               filters: {
@@ -4096,7 +4330,9 @@ describe("App", () => {
     expect(details).toHaveTextContent("Low experimental Deep-Tower evidence.");
     expect(details).toHaveTextContent("Experimental Deep-Tower evidence");
     expect(details).toHaveTextContent("41 %");
-    expect(within(lowCard).getByRole("button", { name: "Configure benchmark probe" })).not.toBeDisabled();
+    expect(
+      within(lowCard).getByRole("button", { name: "Configure benchmark probe" }),
+    ).not.toBeDisabled();
   });
 
   it("keeps humid/rainy candidates with weak deep scores on observed quick-look", async () => {
@@ -4300,9 +4536,7 @@ describe("App", () => {
     const selectedValleyCard = await screen.findByLabelText(
       "Sounding candidate Valley, Nebraska (USM00072558)",
     );
-    expect(
-      screen.getByRole("heading", { name: "Screened cached soundings" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Screened cached soundings" })).toBeInTheDocument();
 
     fireEvent.click(within(selectedValleyCard).getByRole("button", { name: "Configure run" }));
     fireEvent.click(screen.getByRole("button", { name: "Add to run plan" }));
@@ -6459,6 +6693,122 @@ describe("App", () => {
         }),
       }),
     );
+  });
+
+  it("does not expose the Updraft Lens for an unapproved case", async () => {
+    const visualizerResult = resultCard as unknown as Parameters<
+      typeof VisualizerSceneShell
+    >[0]["result"];
+    render(<VisualizerSceneShell result={visualizerResult} />);
+    await screen.findByText("Slice synced");
+    expect(screen.queryByRole("button", { name: "Updraft Lens" })).not.toBeInTheDocument();
+  });
+
+  it("activates the Updraft Lens, applies defaults, controls overlays, and restores Explore", async () => {
+    mockTradeCumulusVisualizer();
+    const visualizerResult = tradeCumulusResultCard as unknown as Parameters<
+      typeof VisualizerSceneShell
+    >[0]["result"];
+    render(<VisualizerSceneShell result={visualizerResult} />);
+
+    const lensToggle = await screen.findByRole("button", { name: "Updraft Lens" });
+    await waitFor(() => expect(lensToggle).toBeEnabled());
+    expect(screen.queryByRole("heading", { name: "Updraft Lens" })).not.toBeInTheDocument();
+    fireEvent.click(lensToggle);
+
+    expect(await screen.findByRole("heading", { name: "Updraft Lens" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("img", { name: /Updraft Lens vertical x-z slice/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Time")).toHaveValue("2");
+    expect(screen.getByLabelText("Updraft Lens vertical plane")).toHaveValue("1");
+    expect(screen.getByLabelText("Cloud boundary")).toBeChecked();
+    expect(screen.getByLabelText("Horizontal wind")).toBeChecked();
+    expect(screen.getByRole("button", { name: "Local departures" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.queryByLabelText("Slice field")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("3-D scalar field")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Horizontal wind overlay legend")).toHaveTextContent(
+      "0.9 m/s reference",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Total wind" }));
+    await waitFor(() =>
+      expect(screen.getByLabelText("Horizontal wind overlay legend")).toHaveTextContent(
+        "8.8 m/s reference",
+      ),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("wind_mode=total"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    fireEvent.click(screen.getByLabelText("Cloud boundary"));
+    expect(screen.queryByTestId("updraft-lens-cloud-boundary")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Horizontal wind"));
+    expect(screen.queryByLabelText("Horizontal wind overlay legend")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Updraft Lens vertical plane"), {
+      target: { value: "0" },
+    });
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("plane_index=0"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Turn off Updraft Lens" }));
+    expect(await screen.findByLabelText("Slice field")).toBeInTheDocument();
+    expect(screen.getByLabelText("3-D scalar field")).toBeInTheDocument();
+    expect(screen.getByLabelText("Time")).toHaveValue("3");
+    expect(screen.queryByRole("heading", { name: "Updraft Lens" })).not.toBeInTheDocument();
+  });
+
+  it("ignores stale Updraft Lens frame responses", async () => {
+    let resolveFirst: ((response: Response) => void) | undefined;
+    let resolveSecond: ((response: Response) => void) | undefined;
+    mockTradeCumulusVisualizer((url) => {
+      const parsed = new URL(url, "http://localhost");
+      const timeIndex = Number(parsed.searchParams.get("time_index"));
+      return new Promise<Response>((resolve) => {
+        if (timeIndex === 2) resolveFirst = resolve;
+        else resolveSecond = resolve;
+      });
+    });
+    const visualizerResult = tradeCumulusResultCard as unknown as Parameters<
+      typeof VisualizerSceneShell
+    >[0]["result"];
+    render(<VisualizerSceneShell result={visualizerResult} />);
+
+    const lensToggle = await screen.findByRole("button", { name: "Updraft Lens" });
+    await waitFor(() => expect(lensToggle).toBeEnabled());
+    fireEvent.click(lensToggle);
+    await waitFor(() => expect(resolveFirst).toBeDefined());
+    fireEvent.change(screen.getByLabelText("Time"), { target: { value: "1" } });
+    await waitFor(() => expect(resolveSecond).toBeDefined());
+
+    await act(async () => {
+      resolveSecond?.(
+        new Response(JSON.stringify(tradeCumulusUpdraftLensFrame({ timeIndex: 1, range: 1.4 })), {
+          status: 200,
+        }),
+      );
+    });
+    const legend = await screen.findByLabelText("Vertical velocity color scale");
+    expect(legend).toHaveTextContent("1.4 m/s");
+
+    await act(async () => {
+      resolveFirst?.(
+        new Response(JSON.stringify(tradeCumulusUpdraftLensFrame({ timeIndex: 2, range: 0.9 })), {
+          status: 200,
+        }),
+      );
+    });
+    expect(legend).toHaveTextContent("1.4 m/s");
+    expect(legend).not.toHaveTextContent("0.9 m/s");
   });
 
   it("opens the 2-D field inspector from a result and shows qc slices", async () => {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3196,6 +3196,7 @@ const tradeCumulusFieldCatalog = {
         scenario_id: "bomex_trade_cumulus_baseline_v0",
       },
     },
+    fieldCatalogResponse.available_fields[5],
     fieldCatalogResponse.available_fields[1],
   ],
 };
@@ -3252,36 +3253,56 @@ const tradeCumulusUpdraftLensDefaults = {
 function tradeCumulusUpdraftLensFrame({
   timeIndex = 2,
   planeIndex = 1,
+  orientation = "vertical_x",
   windMode = "perturbation",
   range = 0.9,
 }: {
   timeIndex?: number;
   planeIndex?: number;
+  orientation?: "horizontal" | "vertical_x" | "vertical_y";
   windMode?: "perturbation" | "total";
   range?: number;
 } = {}) {
   const reference = windMode === "perturbation" ? 0.9 : 8.8;
+  const planeDimension =
+    orientation === "horizontal" ? "z" : orientation === "vertical_y" ? "x" : "y";
+  const dimensionOrder =
+    orientation === "horizontal"
+      ? (["y", "x"] as const)
+      : orientation === "vertical_y"
+        ? (["z", "y"] as const)
+        : (["z", "x"] as const);
+  const wValues =
+    orientation === "vertical_y"
+      ? [
+          [-range, range],
+          [null, range / 2],
+        ]
+      : [
+          [-range, 0, range],
+          [null, -range / 2, range / 2],
+        ];
+  const cloudMask = wValues.map((row, rowIndex) =>
+    row.map((_, columnIndex) => rowIndex === 0 || columnIndex === 1),
+  );
   return {
     result_id: "result-trade-cumulus",
     time_index: timeIndex,
     time_seconds: [0, 900, 1800, 2700][timeIndex] ?? 1800,
-    orientation: "vertical_x",
-    plane_dimension: "y",
+    orientation,
+    plane_dimension: planeDimension,
     plane_index: planeIndex,
     plane_coordinate: [-0.05, 0.05][planeIndex] ?? 0.05,
     plane_units: "km",
+    dimension_order: dimensionOrder,
     x_indices: [0, 1, 2],
     x_values_km: [-0.1, 0, 0.1],
+    y_indices: [0, 1],
+    y_values_km: [-0.05, 0.05],
     z_indices: [0, 1],
     z_values_km: [0.1, 0.3],
-    w_values_m_s: [
-      [-range, 0, range],
-      [null, -range / 2, range / 2],
-    ],
-    cloud_mask: [
-      [true, true, false],
-      [false, true, false],
-    ],
+    w_values_m_s: wValues,
+    cloud_mask: cloudMask,
     cloud_threshold_kg_kg: 1e-6,
     w_range_min_m_s: -range,
     w_range_max_m_s: range,
@@ -3328,7 +3349,11 @@ function tradeCumulusSliceResponse(url: string) {
   const response = sliceResponse({
     field,
     orientation:
-      parsed.searchParams.get("orientation") === "vertical_x" ? "vertical_x" : "horizontal",
+      parsed.searchParams.get("orientation") === "vertical_x"
+        ? "vertical_x"
+        : parsed.searchParams.get("orientation") === "vertical_y"
+          ? "vertical_y"
+          : "horizontal",
     timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
     levelIndex: Number(parsed.searchParams.get("level_index") ?? 0),
   });
@@ -3928,6 +3953,12 @@ function mockTradeCumulusVisualizer(
             tradeCumulusUpdraftLensFrame({
               timeIndex: Number(parsed.searchParams.get("time_index") ?? 2),
               planeIndex: Number(parsed.searchParams.get("plane_index") ?? 1),
+              orientation:
+                parsed.searchParams.get("orientation") === "horizontal"
+                  ? "horizontal"
+                  : parsed.searchParams.get("orientation") === "vertical_y"
+                    ? "vertical_y"
+                    : "vertical_x",
               windMode: parsed.searchParams.get("wind_mode") === "total" ? "total" : "perturbation",
             }),
           ),
@@ -6702,6 +6733,7 @@ describe("App", () => {
     render(<VisualizerSceneShell result={visualizerResult} />);
     await screen.findByText("Slice synced");
     expect(screen.queryByRole("button", { name: "Updraft Lens" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Explore view mode")).not.toBeInTheDocument();
   });
 
   it("activates the Updraft Lens, applies defaults, controls overlays, and restores Explore", async () => {
@@ -6711,8 +6743,13 @@ describe("App", () => {
     >[0]["result"];
     render(<VisualizerSceneShell result={visualizerResult} />);
 
-    const lensToggle = await screen.findByRole("button", { name: "Updraft Lens" });
+    const viewMode = await screen.findByLabelText("Explore view mode");
+    const lensToggle = within(viewMode).getByRole("button", { name: "Updraft Lens" });
     await waitFor(() => expect(lensToggle).toBeEnabled());
+    expect(within(viewMode).getByRole("button", { name: "Standard" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
     expect(screen.queryByRole("heading", { name: "Updraft Lens" })).not.toBeInTheDocument();
     fireEvent.click(lensToggle);
 
@@ -6721,7 +6758,11 @@ describe("App", () => {
       await screen.findByRole("img", { name: /Updraft Lens vertical x-z slice/ }),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Time")).toHaveValue("2");
-    expect(screen.getByLabelText("Updraft Lens vertical plane")).toHaveValue("1");
+    expect(screen.getByLabelText("Updraft Lens slice position")).toHaveValue("1");
+    expect(screen.getByRole("button", { name: "Vertical x-z" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
     expect(screen.getByLabelText("Cloud boundary")).toBeChecked();
     expect(screen.getByLabelText("Horizontal wind")).toBeChecked();
     expect(screen.getByRole("button", { name: "Local departures" })).toHaveAttribute(
@@ -6729,10 +6770,41 @@ describe("App", () => {
       "true",
     );
     expect(screen.queryByLabelText("Slice field")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("3-D scalar field")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("3-D scalar field")).toHaveValue("ql");
+    fireEvent.change(screen.getByLabelText("3-D scalar field"), { target: { value: "qv" } });
+    expect(screen.getByLabelText("3-D scalar field")).toHaveValue("qv");
+    expect(screen.getByLabelText("Updraft Lens slice position")).toHaveValue("1");
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/orientation=vertical_x.*plane_index=1/),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
+    fireEvent.change(screen.getByLabelText("Layer opacity"), { target: { value: "0.45" } });
+    fireEvent.change(screen.getByLabelText("Point size"), { target: { value: "14" } });
+    expect(screen.getByLabelText("Layer opacity")).toHaveValue("0.45");
+    expect(screen.getByLabelText("Point size")).toHaveValue("14");
     expect(screen.getByLabelText("Horizontal wind overlay legend")).toHaveTextContent(
       "0.9 m/s reference",
     );
+    expect(screen.getByText(/Updraft Lens slice: Vertical x-z slice at y =/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Horizontal x-y" }));
+    expect(
+      await screen.findByRole("img", { name: /Updraft Lens horizontal x-y slice/ }),
+    ).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("orientation=horizontal"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Vertical y-z" }));
+    expect(
+      await screen.findByRole("img", { name: /Updraft Lens vertical y-z slice/ }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Vertical x-z" }));
+    expect(
+      await screen.findByRole("img", { name: /Updraft Lens vertical x-z slice/ }),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Total wind" }));
     await waitFor(() =>
@@ -6750,7 +6822,7 @@ describe("App", () => {
     fireEvent.click(screen.getByLabelText("Horizontal wind"));
     expect(screen.queryByLabelText("Horizontal wind overlay legend")).not.toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("Updraft Lens vertical plane"), {
+    fireEvent.change(screen.getByLabelText("Updraft Lens slice position"), {
       target: { value: "0" },
     });
     await waitFor(() =>
@@ -6760,7 +6832,7 @@ describe("App", () => {
       ),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Turn off Updraft Lens" }));
+    fireEvent.click(within(viewMode).getByRole("button", { name: "Standard" }));
     expect(await screen.findByLabelText("Slice field")).toBeInTheDocument();
     expect(screen.getByLabelText("3-D scalar field")).toBeInTheDocument();
     expect(screen.getByLabelText("Time")).toHaveValue("3");
@@ -6832,6 +6904,11 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "Move up" })).toBeInTheDocument();
     const horizontalHeatmap = screen.getByLabelText(/Horizontal layer at z = .* heatmap/);
     expect(horizontalHeatmap).toBeInTheDocument();
+    expect(horizontalHeatmap).toHaveAttribute("data-domain-aspect", "1.000000");
+    expect(within(horizontalHeatmap).getByTestId("slice-cloud-boundary")).toBeInTheDocument();
+    const minimumCell = within(horizontalHeatmap).getByRole("button", { name: /row 1, column 1/i });
+    const maximumCell = within(horizontalHeatmap).getByRole("button", { name: /row 2, column 3/i });
+    expect(minimumCell.style.background).not.toBe(maximumCell.style.background);
     const colorScale = screen.getByLabelText(/Horizontal layer at z = .* color scale/);
     expect(colorScale).toBeInTheDocument();
     expect(colorScale.querySelector(".heatmap-scale-cloud-water")).not.toBeNull();

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -3,6 +3,13 @@ import type { CSSProperties, FormEvent } from "react";
 
 import "./App.css";
 import { True3DViewer } from "./True3DViewer";
+import {
+  type UpdraftLensDefaults,
+  type UpdraftLensFrame,
+  type UpdraftLensPointSelection,
+  type UpdraftLensWindMode,
+  UpdraftLensSlice,
+} from "./UpdraftLensSlice";
 
 type ControlOption = {
   value: string;
@@ -1489,7 +1496,20 @@ type ProcessMode =
   | "precipitation_feedback";
 type SceneSlicePlane = "horizontal" | "vertical_x" | "vertical_y";
 
+type OrdinaryExploreState = {
+  selectedFieldName: string;
+  sliceFieldName: string;
+  timeIndex: number;
+  activeSlicePlane: SceneSlicePlane;
+  sliceOrientation: "vertical_x" | "vertical_y";
+  horizontalSliceLevel: number;
+  verticalSliceIndex: number;
+  showSlicePlanes: boolean;
+  threshold: number;
+};
+
 const FIELD_LOAD_TIMEOUT_MS = 30000;
+const TRADE_CUMULUS_CASE_ID = "bomex_trade_cumulus_baseline_v0";
 const OBSERVED_SOUNDING_EXPERIMENT_ID = "__observed_sounding_upload__";
 const OBSERVED_SOUNDING_BASE_SCENARIO_ID = "baseline-shallow-cumulus";
 const candidateStoryIdValues = new Set<string>([
@@ -2090,6 +2110,42 @@ async function fetchVisualizationDefaults(
     throw new Error(await responseError(response, "Unable to load visualization defaults."));
   }
   return response.json() as Promise<ViewDefaultsResponse>;
+}
+
+async function fetchTradeCumulusUpdraftLensDefaults(
+  resultId: string,
+): Promise<UpdraftLensDefaults> {
+  const response = await fetch(
+    `/api/results/${resultId}/visualization/trade-cumulus-updraft-lens/defaults`,
+  );
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to load Updraft Lens defaults."));
+  }
+  return response.json() as Promise<UpdraftLensDefaults>;
+}
+
+async function fetchTradeCumulusUpdraftLensFrame(
+  resultId: string,
+  params: {
+    timeIndex: number;
+    planeIndex: number;
+    windMode: UpdraftLensWindMode;
+  },
+  signal?: AbortSignal,
+): Promise<UpdraftLensFrame> {
+  const search = new URLSearchParams({
+    time_index: String(params.timeIndex),
+    plane_index: String(params.planeIndex),
+    wind_mode: params.windMode,
+  });
+  const response = await fetch(
+    `/api/results/${resultId}/visualization/trade-cumulus-updraft-lens/frame?${search}`,
+    { signal },
+  );
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to load Updraft Lens frame."));
+  }
+  return response.json() as Promise<UpdraftLensFrame>;
 }
 
 async function fetchVisualizationSlice(
@@ -9275,8 +9331,16 @@ function sliceFieldOptionLabel(field: VisualizableField): string {
   return `${field.raw_field_name} - ${field.display_name}${suffix}`;
 }
 
+function tradeCumulusUpdraftLensEligible(result: ResultCard): boolean {
+  return (
+    result.scenario_id === TRADE_CUMULUS_CASE_ID ||
+    result.run_configuration?.case_id === TRADE_CUMULUS_CASE_ID
+  );
+}
+
 export function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const resultId = result.result_id;
+  const updraftLensEligible = tradeCumulusUpdraftLensEligible(result);
   const initialResultRef = useRef(result);
   if (initialResultRef.current.result_id !== resultId) {
     initialResultRef.current = result;
@@ -9316,6 +9380,17 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     useState<SelectedRegionDiagnosticsResponse | null>(null);
   const [regionStatus, setRegionStatus] = useState("Click a slice cell to inspect that point.");
   const [regionError, setRegionError] = useState<string | null>(null);
+  const [updraftLensDefaults, setUpdraftLensDefaults] = useState<UpdraftLensDefaults | null>(null);
+  const [updraftLensActive, setUpdraftLensActive] = useState(false);
+  const [updraftLensFrame, setUpdraftLensFrame] = useState<UpdraftLensFrame | null>(null);
+  const [updraftLensLoading, setUpdraftLensLoading] = useState(false);
+  const [updraftLensError, setUpdraftLensError] = useState<string | null>(null);
+  const [showUpdraftLensBoundary, setShowUpdraftLensBoundary] = useState(true);
+  const [showUpdraftLensWind, setShowUpdraftLensWind] = useState(true);
+  const [updraftLensWindMode, setUpdraftLensWindMode] =
+    useState<UpdraftLensWindMode>("perturbation");
+  const ordinaryExploreStateRef = useRef<OrdinaryExploreState | null>(null);
+  const updraftLensRequestRef = useRef(0);
   const maxPoints = 50_000;
 
   useEffect(() => {
@@ -9348,6 +9423,16 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setRegionDiagnostics(null);
     setRegionError(null);
     setRegionStatus("Click a slice cell to inspect that point.");
+    setUpdraftLensDefaults(null);
+    setUpdraftLensActive(false);
+    setUpdraftLensFrame(null);
+    setUpdraftLensLoading(false);
+    setUpdraftLensError(null);
+    setShowUpdraftLensBoundary(true);
+    setShowUpdraftLensWind(true);
+    setUpdraftLensWindMode("perturbation");
+    ordinaryExploreStateRef.current = null;
+    updraftLensRequestRef.current += 1;
     setSceneStatus("Loading scene data...");
     withTimeout(
       Promise.all([
@@ -9411,6 +9496,30 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
       active = false;
     };
   }, [fieldLoadAttempt, resultId]);
+
+  useEffect(() => {
+    if (!updraftLensEligible) {
+      setUpdraftLensDefaults(null);
+      return;
+    }
+    let active = true;
+    setUpdraftLensError(null);
+    fetchTradeCumulusUpdraftLensDefaults(resultId)
+      .then((defaults) => {
+        if (!active) return;
+        setUpdraftLensDefaults(defaults);
+      })
+      .catch((caught: unknown) => {
+        if (!active) return;
+        setUpdraftLensDefaults(null);
+        setUpdraftLensError(
+          caught instanceof Error ? caught.message : "Unable to load Updraft Lens defaults.",
+        );
+      });
+    return () => {
+      active = false;
+    };
+  }, [resultId, updraftLensEligible]);
 
   const selectedField = useMemo(
     () => catalog?.available_fields.find((field) => field.raw_field_name === selectedFieldName),
@@ -9486,8 +9595,20 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const playbackIntervalMs = Math.max(150, Math.round(900 / playbackSpeed));
   const canPlayTimelapse = timeOptions.length > 1;
   const activeSlice = activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice;
-  const activeSliceLabel = slicePlainLabel(activeSlice, activeSlicePlane, activeSliceIndex);
-  const selectedSliceValue = selectedSliceCellValue(activeSlice, selectedRegion);
+  const ordinaryActiveSliceLabel = slicePlainLabel(activeSlice, activeSlicePlane, activeSliceIndex);
+  const updraftLensPlaneLabel = updraftLensFrame
+    ? `Vertical x-z slice at y = ${
+        updraftLensFrame.plane_coordinate === null
+          ? `index ${updraftLensFrame.plane_index}`
+          : formatCompactNumber(updraftLensFrame.plane_coordinate)
+      }${updraftLensFrame.plane_units ? ` ${updraftLensFrame.plane_units}` : ""}`
+    : updraftLensDefaults
+      ? `Vertical x-z slice at y index ${verticalSliceIndex}`
+      : "Vertical x-z slice";
+  const activeSliceLabel = updraftLensActive ? updraftLensPlaneLabel : ordinaryActiveSliceLabel;
+  const selectedSliceValue = updraftLensActive
+    ? selectedUpdraftLensValue(updraftLensFrame, selectedRegion)
+    : selectedSliceCellValue(activeSlice, selectedRegion);
   const processModeStates = useMemo(
     () => processModeClassifications(result, catalog, sliceField, activeSlice),
     [activeSlice, catalog, result, sliceField],
@@ -9554,6 +9675,80 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     playbackTimeIndex,
     resolvedTimeIndex,
     timeOptions.length,
+  ]);
+
+  const handleUpdraftLensToggle = useCallback(() => {
+    if (updraftLensActive) {
+      const ordinary = ordinaryExploreStateRef.current;
+      setUpdraftLensActive(false);
+      setUpdraftLensFrame(null);
+      setUpdraftLensLoading(false);
+      setUpdraftLensError(null);
+      updraftLensRequestRef.current += 1;
+      if (ordinary) {
+        setSelectedFieldName(ordinary.selectedFieldName);
+        setSliceFieldName(ordinary.sliceFieldName);
+        setTimeIndex(ordinary.timeIndex);
+        setPlaybackTimeIndex(ordinary.timeIndex);
+        setActiveSlicePlane(ordinary.activeSlicePlane);
+        setSliceOrientation(ordinary.sliceOrientation);
+        setHorizontalSliceLevel(ordinary.horizontalSliceLevel);
+        setVerticalSliceIndex(ordinary.verticalSliceIndex);
+        setShowSlicePlanes(ordinary.showSlicePlanes);
+        setThreshold(ordinary.threshold);
+      }
+      ordinaryExploreStateRef.current = null;
+      clearSelectedRegionForTimeChange();
+      return;
+    }
+    if (!updraftLensDefaults || !catalog) return;
+    ordinaryExploreStateRef.current = {
+      selectedFieldName,
+      sliceFieldName,
+      timeIndex: resolvedTimeIndex,
+      activeSlicePlane,
+      sliceOrientation,
+      horizontalSliceLevel,
+      verticalSliceIndex,
+      showSlicePlanes,
+      threshold,
+    };
+    const cloudField = catalog.available_fields.find(
+      (field) => field.raw_field_name === updraftLensDefaults.cloud_field,
+    );
+    const primaryField = catalog.available_fields.find(
+      (field) => field.raw_field_name === updraftLensDefaults.primary_field,
+    );
+    setSelectedFieldName(cloudField?.raw_field_name ?? selectedFieldName);
+    setSliceFieldName(primaryField?.raw_field_name ?? sliceFieldName);
+    setTimeIndex(updraftLensDefaults.default_time_index);
+    setPlaybackTimeIndex(updraftLensDefaults.default_time_index);
+    setIsPlaybackRunning(false);
+    setActiveSlicePlane("vertical_x");
+    setSliceOrientation("vertical_x");
+    setVerticalSliceIndex(updraftLensDefaults.default_plane_index);
+    setShowSlicePlanes(true);
+    setThreshold(updraftLensDefaults.cloud_threshold_kg_kg);
+    setShowUpdraftLensBoundary(true);
+    setShowUpdraftLensWind(updraftLensDefaults.wind_shown_by_default);
+    setUpdraftLensWindMode(updraftLensDefaults.wind_default_mode);
+    setUpdraftLensError(null);
+    setUpdraftLensActive(true);
+    clearSelectedRegionForTimeChange();
+  }, [
+    activeSlicePlane,
+    catalog,
+    clearSelectedRegionForTimeChange,
+    horizontalSliceLevel,
+    resolvedTimeIndex,
+    selectedFieldName,
+    showSlicePlanes,
+    sliceFieldName,
+    sliceOrientation,
+    threshold,
+    updraftLensActive,
+    updraftLensDefaults,
+    verticalSliceIndex,
   ]);
 
   useEffect(() => {
@@ -9663,6 +9858,13 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
       setSliceLoading(false);
       return;
     }
+    if (updraftLensActive) {
+      setSceneHorizontalSlice(null);
+      setSceneVerticalSlice(null);
+      setSliceLoading(false);
+      setSliceError(null);
+      return;
+    }
     let active = true;
     setSliceLoading(true);
     setSliceError(null);
@@ -9704,6 +9906,52 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     sliceField,
     sliceSupportsVertical,
     sliceOrientation,
+    verticalSliceIndex,
+    updraftLensActive,
+  ]);
+
+  useEffect(() => {
+    if (!updraftLensActive || !updraftLensDefaults) {
+      setUpdraftLensFrame(null);
+      setUpdraftLensLoading(false);
+      return;
+    }
+    const requestId = updraftLensRequestRef.current + 1;
+    updraftLensRequestRef.current = requestId;
+    const controller = new AbortController();
+    setUpdraftLensLoading(true);
+    setUpdraftLensError(null);
+    fetchTradeCumulusUpdraftLensFrame(
+      result.result_id,
+      {
+        timeIndex: resolvedTimeIndex,
+        planeIndex: verticalSliceIndex,
+        windMode: updraftLensWindMode,
+      },
+      controller.signal,
+    )
+      .then((payload) => {
+        if (updraftLensRequestRef.current !== requestId) return;
+        setUpdraftLensFrame(payload);
+        setUpdraftLensLoading(false);
+      })
+      .catch((caught: unknown) => {
+        if (controller.signal.aborted || updraftLensRequestRef.current !== requestId) return;
+        setUpdraftLensFrame(null);
+        setUpdraftLensLoading(false);
+        setUpdraftLensError(
+          caught instanceof Error ? caught.message : "Unable to load Updraft Lens frame.",
+        );
+      });
+    return () => {
+      controller.abort();
+    };
+  }, [
+    resolvedTimeIndex,
+    result.result_id,
+    updraftLensActive,
+    updraftLensDefaults,
+    updraftLensWindMode,
     verticalSliceIndex,
   ]);
 
@@ -9747,6 +9995,21 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setSelectedRegion(selectionFromSlice(slice, rowIndex, columnIndex, "point"));
   }
 
+  function selectPointFromUpdraftLens(selection: UpdraftLensPointSelection) {
+    if (isPlaybackRunning) {
+      clearSelectedRegionForTimeChange(
+        "Pause playback to select a cell and explain this time step.",
+      );
+      return;
+    }
+    setSelectedRegion({
+      regionType: "point",
+      xIndex: selection.xIndex,
+      yIndex: selection.yIndex,
+      zIndex: selection.zIndex,
+    });
+  }
+
   return (
     <section className="visualizer-shell" aria-labelledby="visualizer-shell-title">
       <div className="section-heading">
@@ -9754,7 +10017,26 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
           <p className="eyebrow">Field view</p>
           <h2 id="visualizer-shell-title">What happened in this result?</h2>
         </div>
-        <p className="state-chip">{sceneStatus}</p>
+        <div className="visualizer-heading-actions">
+          <p className="state-chip">
+            {updraftLensActive
+              ? updraftLensLoading
+                ? "Loading Updraft Lens"
+                : "Updraft Lens active"
+              : sceneStatus}
+          </p>
+          {updraftLensEligible && (
+            <button
+              type="button"
+              className="updraft-lens-toggle"
+              aria-pressed={updraftLensActive}
+              disabled={!updraftLensActive && !updraftLensDefaults}
+              onClick={handleUpdraftLensToggle}
+            >
+              {updraftLensActive ? "Turn off Updraft Lens" : "Updraft Lens"}
+            </button>
+          )}
+        </div>
       </div>
 
       {sceneError && (
@@ -9768,6 +10050,10 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
 
       {catalog && catalog.available_fields.length === 0 && (
         <p role="status">No visualization-ready fields are available for this result.</p>
+      )}
+
+      {updraftLensEligible && !updraftLensActive && updraftLensError && (
+        <p role="alert">{updraftLensError}</p>
       )}
 
       <div className="visualizer-workbench" aria-label="Scientific visualization workbench">
@@ -9784,10 +10070,14 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
               selectedEncoding?.valueChannel ?? "3-D scalar rendering unavailable."
             }
             activeSlice={
-              activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice
+              updraftLensActive
+                ? null
+                : activeSlicePlane === "horizontal"
+                  ? sceneHorizontalSlice
+                  : sceneVerticalSlice
             }
             activeSliceLabel={activeSliceLabel}
-            showSlicePlane={showSlicePlanes}
+            showSlicePlane={!updraftLensActive && showSlicePlanes}
             selectedRegion={selectedRegion}
             coordinateSizes={{ x: sliceXSize, y: sliceYSize, z: sliceVerticalSize }}
             selectedTimeLabel={selectedTimeLabel}
@@ -9804,9 +10094,19 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
                   ? "No cloud water formed in this result; vertical velocity is available in the 2-D slice inspector."
                   : selectedEncoding.emptyStateTitle
             }
+            windVectors={updraftLensFrame?.wind_vectors ?? []}
+            showWindVectors={updraftLensActive && showUpdraftLensWind && Boolean(updraftLensFrame)}
+            windMode={updraftLensWindMode}
+            windReferenceMps={updraftLensFrame?.wind_reference_m_s ?? 0}
+            windArrowDomainFraction={updraftLensFrame?.wind_arrow_domain_fraction ?? 0.08}
           />
           {catalog && sliceField && (
-            <section className="explore-control-deck" aria-label="Explore viewer controls">
+            <section
+              className={`explore-control-deck${
+                updraftLensActive ? " explore-control-deck-lens" : ""
+              }`}
+              aria-label="Explore viewer controls"
+            >
               <fieldset className="explore-control-card explore-control-card-time">
                 <legend>Time</legend>
                 <div className="timelapse-controls" aria-label="Timelapse playback controls">
@@ -9893,252 +10193,333 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
                 )}
               </fieldset>
 
-              <fieldset className="explore-control-card explore-control-card-slice">
-                <legend>Slice</legend>
-                <label htmlFor="explore-slice-field">
-                  2-D slice field
-                  <select
-                    id="explore-slice-field"
-                    aria-label="Slice field"
-                    value={sliceFieldName}
-                    onChange={(event) => {
-                      const nextField = catalog.available_fields.find(
-                        (field) => field.raw_field_name === event.target.value,
-                      );
-                      setSliceFieldName(event.target.value);
-                      const nextDefaults = defaultsForField(viewDefaults, event.target.value);
-                      setHorizontalSliceLevel(defaultHorizontalLevel(nextField, nextDefaults));
-                      setVerticalSliceIndex(
-                        defaultVerticalIndex(nextField, sliceOrientation, nextDefaults),
-                      );
-                      if (!nextField?.coordinate_names.vertical) {
-                        setActiveSlicePlane("horizontal");
-                      }
-                      setSelectedRegion(null);
-                    }}
-                  >
-                    {catalog.available_fields.map((field) => (
-                      <option key={field.raw_field_name} value={field.raw_field_name}>
-                        {sliceFieldOptionLabel(field)}
-                      </option>
-                    ))}
-                  </select>
-                </label>
+              {updraftLensActive ? (
+                <fieldset className="explore-control-card explore-control-card-updraft-lens">
+                  <legend>Updraft Lens</legend>
+                  <label htmlFor="updraft-lens-plane-position">
+                    Vertical plane
+                    <input
+                      id="updraft-lens-plane-position"
+                      aria-label="Updraft Lens vertical plane"
+                      type="range"
+                      min={0}
+                      max={Math.max(0, sliceYSize - 1)}
+                      value={verticalSliceIndex}
+                      onChange={(event) => {
+                        setVerticalSliceIndex(Number(event.target.value));
+                        setSelectedRegion(null);
+                      }}
+                    />
+                    <span className="slice-position-label">
+                      <span>{updraftLensPlaneLabel}</span>
+                      <small>index {verticalSliceIndex}</small>
+                    </span>
+                  </label>
 
-                <div className="segmented-buttons" aria-label="Slice orientation">
-                  <button
-                    type="button"
-                    className={activeSlicePlane === "horizontal" ? "active-control" : ""}
-                    onClick={() => {
-                      setActiveSlicePlane("horizontal");
-                      setSelectedRegion(null);
-                    }}
-                  >
-                    Horizontal layer
-                  </button>
-                  <button
-                    type="button"
-                    className={activeSlicePlane === "vertical_x" ? "active-control" : ""}
-                    disabled={!sliceSupportsVertical}
-                    onClick={() => {
-                      setActiveSlicePlane("vertical_x");
-                      setSliceOrientation("vertical_x");
-                      setSelectedRegion(null);
-                    }}
-                  >
-                    Vertical x-z slice
-                  </button>
-                  <button
-                    type="button"
-                    className={activeSlicePlane === "vertical_y" ? "active-control" : ""}
-                    disabled={!sliceSupportsVertical}
-                    onClick={() => {
-                      setActiveSlicePlane("vertical_y");
-                      setSliceOrientation("vertical_y");
-                      setSelectedRegion(null);
-                    }}
-                  >
-                    Vertical y-z slice
-                  </button>
-                </div>
+                  <label className="checkbox-label" htmlFor="updraft-lens-cloud-boundary">
+                    <input
+                      id="updraft-lens-cloud-boundary"
+                      type="checkbox"
+                      checked={showUpdraftLensBoundary}
+                      onChange={(event) => setShowUpdraftLensBoundary(event.target.checked)}
+                    />
+                    Cloud boundary
+                  </label>
 
-                <label htmlFor="explore-slice-position">
-                  Position
-                  <input
-                    id="explore-slice-position"
-                    aria-label="Slice position"
-                    type="range"
-                    min={0}
-                    max={Math.max(0, activeSliceMax - 1)}
-                    value={activeSliceIndex}
-                    onChange={(event) => {
-                      const nextIndex = Number(event.target.value);
-                      if (activeSlicePlane === "horizontal") {
-                        setHorizontalSliceLevel(nextIndex);
-                      } else {
-                        setVerticalSliceIndex(nextIndex);
-                      }
-                      setSelectedRegion(null);
-                    }}
-                  />
-                  <span className="slice-position-label">
-                    {activeSlicePositionLabel || `index ${activeSliceIndex}`}{" "}
-                    <small>index {activeSliceIndex}</small>
-                  </span>
-                </label>
+                  <label className="checkbox-label" htmlFor="updraft-lens-wind-overlay">
+                    <input
+                      id="updraft-lens-wind-overlay"
+                      type="checkbox"
+                      checked={showUpdraftLensWind}
+                      onChange={(event) => setShowUpdraftLensWind(event.target.checked)}
+                    />
+                    Horizontal wind
+                  </label>
 
-                <div className="button-row slice-move-buttons">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      const nextIndex = Math.max(0, activeSliceIndex - 1);
-                      if (activeSlicePlane === "horizontal") {
-                        setHorizontalSliceLevel(nextIndex);
-                      } else {
-                        setVerticalSliceIndex(nextIndex);
-                      }
-                      setSelectedRegion(null);
-                    }}
-                  >
-                    {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      const nextIndex = Math.min(
-                        Math.max(0, activeSliceMax - 1),
-                        activeSliceIndex + 1,
-                      );
-                      if (activeSlicePlane === "horizontal") {
-                        setHorizontalSliceLevel(nextIndex);
-                      } else {
-                        setVerticalSliceIndex(nextIndex);
-                      }
-                      setSelectedRegion(null);
-                    }}
-                  >
-                    {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
-                  </button>
-                </div>
-
-                <label className="checkbox-label" htmlFor="show-slice-plane">
-                  <input
-                    id="show-slice-plane"
-                    type="checkbox"
-                    checked={showSlicePlanes}
-                    onChange={(event) => setShowSlicePlanes(event.target.checked)}
-                  />
-                  Show slice plane
-                </label>
-              </fieldset>
-
-              <fieldset className="explore-control-card explore-control-card-rendering">
-                <legend>3-D scalar layer</legend>
-                <label htmlFor="explore-3d-field">
-                  3-D field
-                  <select
-                    id="explore-3d-field"
-                    aria-label="3-D scalar field"
-                    value={selectedFieldName}
-                    disabled={threeDScalarEncodings.length === 0}
-                    onChange={(event) => {
-                      const nextEncoding =
-                        threeDScalarEncodings.find(
-                          (encoding) => encoding.field.raw_field_name === event.target.value,
-                        ) ?? null;
-                      setSelectedFieldName(event.target.value);
-                      if (nextEncoding) {
-                        setSliceFieldName(nextEncoding.field.raw_field_name);
-                        setThreshold(nextEncoding.defaultThreshold);
-                        if (!nextEncoding.field.coordinate_names.vertical) {
-                          setActiveSlicePlane("horizontal");
-                        }
-                        const nextDefaults =
-                          defaultsForField(
-                            selectedTimeDefaults,
-                            nextEncoding.field.raw_field_name,
-                          ) ?? defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
-                        setHorizontalSliceLevel(
-                          defaultHorizontalLevel(nextEncoding.field, nextDefaults),
-                        );
-                        setVerticalSliceIndex(
-                          defaultVerticalIndex(nextEncoding.field, sliceOrientation, nextDefaults),
-                        );
-                      }
-                      setSelectedRegion(null);
-                    }}
-                  >
-                    {threeDScalarEncodings.length === 0 && (
-                      <option value="">No 3-D scalar fields</option>
-                    )}
-                    {threeDScalarEncodings.map((encoding) => (
-                      <option
-                        key={encoding.field.raw_field_name}
-                        value={encoding.field.raw_field_name}
+                  <div className="updraft-lens-mode-control">
+                    <span>Wind mode</span>
+                    <div className="segmented-buttons" aria-label="Updraft Lens wind mode">
+                      <button
+                        type="button"
+                        className={updraftLensWindMode === "perturbation" ? "active-control" : ""}
+                        aria-pressed={updraftLensWindMode === "perturbation"}
+                        onClick={() => setUpdraftLensWindMode("perturbation")}
                       >
-                        {encoding.field.raw_field_name} - {encoding.field.display_name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <p className="control-help">
-                  {selectedEncoding
-                    ? selectedEncoding.valueChannel
-                    : "Only fields with a defined 3-D scalar encoding appear here; vertical velocity remains slice-only."}
-                </p>
-                {pointCloud && selectedEncoding && (
-                  <p className="control-help">
-                    {pointCloudFieldSummary(pointCloud)}
-                    {selectedEncoding.field.raw_field_name === "dbz"
-                      ? " Weather-radar colors use a fixed 0 to 60+ dBZ scale."
-                      : ""}
-                  </p>
-                )}
-                {selectedEncoding?.field.raw_field_name === "qc" &&
-                  cloudTopMismatchNotice(result) && (
-                    <p className="control-help">{cloudTopMismatchNotice(result)}</p>
+                        Local departures
+                      </button>
+                      <button
+                        type="button"
+                        className={updraftLensWindMode === "total" ? "active-control" : ""}
+                        aria-pressed={updraftLensWindMode === "total"}
+                        onClick={() => setUpdraftLensWindMode("total")}
+                      >
+                        Total wind
+                      </button>
+                    </div>
+                  </div>
+                  {updraftLensFrame && (
+                    <p className="control-help">
+                      Wind level {Math.round(updraftLensFrame.wind_actual_level_m)} m · reference{" "}
+                      {updraftLensFrame.wind_reference_m_s.toFixed(1)} m/s
+                    </p>
                   )}
-                <label htmlFor="cloud-threshold">
-                  {selectedEncoding?.thresholdLabel ?? "Visible minimum"}
-                  <input
-                    id="cloud-threshold"
-                    aria-label={selectedEncoding?.thresholdAriaLabel ?? "3-D scalar threshold"}
-                    type="number"
-                    min={0}
-                    step={selectedEncoding?.thresholdStep ?? 0.000001}
-                    value={threshold}
-                    onChange={(event) => setThreshold(Number(event.target.value))}
-                    disabled={!selectedEncoding}
-                  />
-                </label>
-                <label htmlFor="cloud-opacity">
-                  Opacity
-                  <input
-                    id="cloud-opacity"
-                    aria-label="Layer opacity"
-                    type="range"
-                    min={0.1}
-                    max={1}
-                    step={0.05}
-                    value={opacity}
-                    onChange={(event) => setOpacity(Number(event.target.value))}
-                  />
-                  <output htmlFor="cloud-opacity">{opacity}</output>
-                </label>
-                <label htmlFor="cloud-point-size">
-                  Point size
-                  <input
-                    id="cloud-point-size"
-                    aria-label="Point size"
-                    type="range"
-                    min={3}
-                    max={18}
-                    value={pointSize}
-                    onChange={(event) => setPointSize(Number(event.target.value))}
-                  />
-                  <output htmlFor="cloud-point-size">{pointSize}px</output>
-                </label>
-              </fieldset>
+                  {updraftLensError && <p role="alert">{updraftLensError}</p>}
+                </fieldset>
+              ) : (
+                <>
+                  <fieldset className="explore-control-card explore-control-card-slice">
+                    <legend>Slice</legend>
+                    <label htmlFor="explore-slice-field">
+                      2-D slice field
+                      <select
+                        id="explore-slice-field"
+                        aria-label="Slice field"
+                        value={sliceFieldName}
+                        onChange={(event) => {
+                          const nextField = catalog.available_fields.find(
+                            (field) => field.raw_field_name === event.target.value,
+                          );
+                          setSliceFieldName(event.target.value);
+                          const nextDefaults = defaultsForField(viewDefaults, event.target.value);
+                          setHorizontalSliceLevel(defaultHorizontalLevel(nextField, nextDefaults));
+                          setVerticalSliceIndex(
+                            defaultVerticalIndex(nextField, sliceOrientation, nextDefaults),
+                          );
+                          if (!nextField?.coordinate_names.vertical) {
+                            setActiveSlicePlane("horizontal");
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        {catalog.available_fields.map((field) => (
+                          <option key={field.raw_field_name} value={field.raw_field_name}>
+                            {sliceFieldOptionLabel(field)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+
+                    <div className="segmented-buttons" aria-label="Slice orientation">
+                      <button
+                        type="button"
+                        className={activeSlicePlane === "horizontal" ? "active-control" : ""}
+                        onClick={() => {
+                          setActiveSlicePlane("horizontal");
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        Horizontal layer
+                      </button>
+                      <button
+                        type="button"
+                        className={activeSlicePlane === "vertical_x" ? "active-control" : ""}
+                        disabled={!sliceSupportsVertical}
+                        onClick={() => {
+                          setActiveSlicePlane("vertical_x");
+                          setSliceOrientation("vertical_x");
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        Vertical x-z slice
+                      </button>
+                      <button
+                        type="button"
+                        className={activeSlicePlane === "vertical_y" ? "active-control" : ""}
+                        disabled={!sliceSupportsVertical}
+                        onClick={() => {
+                          setActiveSlicePlane("vertical_y");
+                          setSliceOrientation("vertical_y");
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        Vertical y-z slice
+                      </button>
+                    </div>
+
+                    <label htmlFor="explore-slice-position">
+                      Position
+                      <input
+                        id="explore-slice-position"
+                        aria-label="Slice position"
+                        type="range"
+                        min={0}
+                        max={Math.max(0, activeSliceMax - 1)}
+                        value={activeSliceIndex}
+                        onChange={(event) => {
+                          const nextIndex = Number(event.target.value);
+                          if (activeSlicePlane === "horizontal") {
+                            setHorizontalSliceLevel(nextIndex);
+                          } else {
+                            setVerticalSliceIndex(nextIndex);
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      />
+                      <span className="slice-position-label">
+                        {activeSlicePositionLabel || `index ${activeSliceIndex}`}{" "}
+                        <small>index {activeSliceIndex}</small>
+                      </span>
+                    </label>
+
+                    <div className="button-row slice-move-buttons">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const nextIndex = Math.max(0, activeSliceIndex - 1);
+                          if (activeSlicePlane === "horizontal") {
+                            setHorizontalSliceLevel(nextIndex);
+                          } else {
+                            setVerticalSliceIndex(nextIndex);
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const nextIndex = Math.min(
+                            Math.max(0, activeSliceMax - 1),
+                            activeSliceIndex + 1,
+                          );
+                          if (activeSlicePlane === "horizontal") {
+                            setHorizontalSliceLevel(nextIndex);
+                          } else {
+                            setVerticalSliceIndex(nextIndex);
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
+                      </button>
+                    </div>
+
+                    <label className="checkbox-label" htmlFor="show-slice-plane">
+                      <input
+                        id="show-slice-plane"
+                        type="checkbox"
+                        checked={showSlicePlanes}
+                        onChange={(event) => setShowSlicePlanes(event.target.checked)}
+                      />
+                      Show slice plane
+                    </label>
+                  </fieldset>
+
+                  <fieldset className="explore-control-card explore-control-card-rendering">
+                    <legend>3-D scalar layer</legend>
+                    <label htmlFor="explore-3d-field">
+                      3-D field
+                      <select
+                        id="explore-3d-field"
+                        aria-label="3-D scalar field"
+                        value={selectedFieldName}
+                        disabled={threeDScalarEncodings.length === 0}
+                        onChange={(event) => {
+                          const nextEncoding =
+                            threeDScalarEncodings.find(
+                              (encoding) => encoding.field.raw_field_name === event.target.value,
+                            ) ?? null;
+                          setSelectedFieldName(event.target.value);
+                          if (nextEncoding) {
+                            setSliceFieldName(nextEncoding.field.raw_field_name);
+                            setThreshold(nextEncoding.defaultThreshold);
+                            if (!nextEncoding.field.coordinate_names.vertical) {
+                              setActiveSlicePlane("horizontal");
+                            }
+                            const nextDefaults =
+                              defaultsForField(
+                                selectedTimeDefaults,
+                                nextEncoding.field.raw_field_name,
+                              ) ??
+                              defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
+                            setHorizontalSliceLevel(
+                              defaultHorizontalLevel(nextEncoding.field, nextDefaults),
+                            );
+                            setVerticalSliceIndex(
+                              defaultVerticalIndex(
+                                nextEncoding.field,
+                                sliceOrientation,
+                                nextDefaults,
+                              ),
+                            );
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        {threeDScalarEncodings.length === 0 && (
+                          <option value="">No 3-D scalar fields</option>
+                        )}
+                        {threeDScalarEncodings.map((encoding) => (
+                          <option
+                            key={encoding.field.raw_field_name}
+                            value={encoding.field.raw_field_name}
+                          >
+                            {encoding.field.raw_field_name} - {encoding.field.display_name}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <p className="control-help">
+                      {selectedEncoding
+                        ? selectedEncoding.valueChannel
+                        : "Only fields with a defined 3-D scalar encoding appear here; vertical velocity remains slice-only."}
+                    </p>
+                    {pointCloud && selectedEncoding && (
+                      <p className="control-help">
+                        {pointCloudFieldSummary(pointCloud)}
+                        {selectedEncoding.field.raw_field_name === "dbz"
+                          ? " Weather-radar colors use a fixed 0 to 60+ dBZ scale."
+                          : ""}
+                      </p>
+                    )}
+                    {selectedEncoding?.field.raw_field_name === "qc" &&
+                      cloudTopMismatchNotice(result) && (
+                        <p className="control-help">{cloudTopMismatchNotice(result)}</p>
+                      )}
+                    <label htmlFor="cloud-threshold">
+                      {selectedEncoding?.thresholdLabel ?? "Visible minimum"}
+                      <input
+                        id="cloud-threshold"
+                        aria-label={selectedEncoding?.thresholdAriaLabel ?? "3-D scalar threshold"}
+                        type="number"
+                        min={0}
+                        step={selectedEncoding?.thresholdStep ?? 0.000001}
+                        value={threshold}
+                        onChange={(event) => setThreshold(Number(event.target.value))}
+                        disabled={!selectedEncoding}
+                      />
+                    </label>
+                    <label htmlFor="cloud-opacity">
+                      Opacity
+                      <input
+                        id="cloud-opacity"
+                        aria-label="Layer opacity"
+                        type="range"
+                        min={0.1}
+                        max={1}
+                        step={0.05}
+                        value={opacity}
+                        onChange={(event) => setOpacity(Number(event.target.value))}
+                      />
+                      <output htmlFor="cloud-opacity">{opacity}</output>
+                    </label>
+                    <label htmlFor="cloud-point-size">
+                      Point size
+                      <input
+                        id="cloud-point-size"
+                        aria-label="Point size"
+                        type="range"
+                        min={3}
+                        max={18}
+                        value={pointSize}
+                        onChange={(event) => setPointSize(Number(event.target.value))}
+                      />
+                      <output htmlFor="cloud-point-size">{pointSize}px</output>
+                    </label>
+                  </fieldset>
+                </>
+              )}
             </section>
           )}
         </div>
@@ -10307,33 +10688,65 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
           <div className="section-heading compact-heading">
             <div>
               <p className="eyebrow">Slice inspector</p>
-              <h2 id="unified-slice-title">Inspect the current slice</h2>
+              <h2 id="unified-slice-title">
+                {updraftLensActive ? "Updraft Lens" : "Inspect the current slice"}
+              </h2>
               <p>
-                {activeSliceLabel} · {sliceField.raw_field_name} · {selectedTimeLabel}
+                {activeSliceLabel} · {updraftLensActive ? "w" : sliceField.raw_field_name} ·{" "}
+                {selectedTimeLabel}
               </p>
             </div>
             <p className="state-chip">
-              {sliceError
-                ? "Slice unavailable"
-                : sliceLoading || !activeSlice
-                  ? "Loading slice"
-                  : "Slice synced"}
+              {updraftLensActive
+                ? updraftLensError
+                  ? "Lens unavailable"
+                  : updraftLensLoading || !updraftLensFrame
+                    ? "Loading Lens"
+                    : "Lens synced"
+                : sliceError
+                  ? "Slice unavailable"
+                  : sliceLoading || !activeSlice
+                    ? "Loading slice"
+                    : "Slice synced"}
             </p>
           </div>
 
           {sliceError && <p role="alert">{sliceError}</p>}
 
-          <SlicePanel
-            title={activeSliceLabel}
-            slice={activeSlice}
-            pointCloud={pointCloud}
-            selectedRegion={selectedRegion}
-            onSelectRegion={selectPointFromSlice}
-          />
+          {updraftLensActive ? (
+            updraftLensFrame ? (
+              <UpdraftLensSlice
+                frame={updraftLensFrame}
+                showCloudBoundary={showUpdraftLensBoundary}
+                selectedPoint={
+                  selectedRegion?.xIndex !== undefined &&
+                  selectedRegion.yIndex !== undefined &&
+                  selectedRegion.zIndex !== undefined
+                    ? {
+                        xIndex: selectedRegion.xIndex,
+                        yIndex: selectedRegion.yIndex,
+                        zIndex: selectedRegion.zIndex,
+                      }
+                    : null
+                }
+                onSelectPoint={selectPointFromUpdraftLens}
+              />
+            ) : (
+              !updraftLensError && <p role="status">Loading Updraft Lens frame...</p>
+            )
+          ) : (
+            <SlicePanel
+              title={activeSliceLabel}
+              slice={activeSlice}
+              pointCloud={pointCloud}
+              selectedRegion={selectedRegion}
+              onSelectRegion={selectPointFromSlice}
+            />
+          )}
 
           <SelectedRegionInspector
             selectedRegion={selectedRegion}
-            slice={activeSlice}
+            slice={updraftLensActive ? null : activeSlice}
             selectedValue={selectedSliceValue}
             diagnostics={regionDiagnostics}
             status={regionStatus}
@@ -10488,6 +10901,21 @@ function selectedSliceCellValue(
     }
   }
   return null;
+}
+
+function selectedUpdraftLensValue(
+  frame: UpdraftLensFrame | null,
+  selectedRegion: SelectedRegionRequest | null,
+): number | null {
+  if (
+    !frame ||
+    selectedRegion?.xIndex === undefined ||
+    selectedRegion.yIndex !== frame.plane_index ||
+    selectedRegion.zIndex === undefined
+  ) {
+    return null;
+  }
+  return frame.w_values_m_s[selectedRegion.zIndex]?.[selectedRegion.xIndex] ?? null;
 }
 
 function SlicePanel({

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -6,9 +6,12 @@ import { True3DViewer } from "./True3DViewer";
 import {
   type UpdraftLensDefaults,
   type UpdraftLensFrame,
+  type UpdraftLensOrientation,
   type UpdraftLensPointSelection,
   type UpdraftLensWindMode,
   UpdraftLensSlice,
+  updraftLensBoundaryPath,
+  updraftLensColor,
 } from "./UpdraftLensSlice";
 
 type ControlOption = {
@@ -2128,6 +2131,7 @@ async function fetchTradeCumulusUpdraftLensFrame(
   resultId: string,
   params: {
     timeIndex: number;
+    orientation: UpdraftLensOrientation;
     planeIndex: number;
     windMode: UpdraftLensWindMode;
   },
@@ -2135,6 +2139,7 @@ async function fetchTradeCumulusUpdraftLensFrame(
 ): Promise<UpdraftLensFrame> {
   const search = new URLSearchParams({
     time_index: String(params.timeIndex),
+    orientation: params.orientation,
     plane_index: String(params.planeIndex),
     wind_mode: params.windMode,
   });
@@ -9209,6 +9214,14 @@ function patchDistanceLabel(field: PatchSpatialFieldDiagnostics): string {
   )}${time}${quality}`;
 }
 
+function isCloudWaterField(field: VisualizableField): boolean {
+  return (
+    field.raw_field_name === "qc" ||
+    field.raw_field_name === "ql" ||
+    field.canonical_field_name === "cloud_water"
+  );
+}
+
 function threeDScalarEncoding(field: VisualizableField | undefined): ThreeDScalarEncoding | null {
   if (
     !field ||
@@ -9224,7 +9237,7 @@ function threeDScalarEncoding(field: VisualizableField | undefined): ThreeDScala
   if (isSliceOnlyTemperatureField(field)) return null;
   const hasVerticalGrid = Boolean(field.coordinate_names.vertical);
 
-  if (field.canonical_field_name === "cloud_water" || field.raw_field_name === "qc") {
+  if (isCloudWaterField(field)) {
     if (!hasVerticalGrid) return null;
     return {
       field,
@@ -9370,6 +9383,9 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const [verticalSliceIndex, setVerticalSliceIndex] = useState(0);
   const [sceneHorizontalSlice, setSceneHorizontalSlice] = useState<SliceResponse | null>(null);
   const [sceneVerticalSlice, setSceneVerticalSlice] = useState<SliceResponse | null>(null);
+  const [sceneCloudBoundarySlice, setSceneCloudBoundarySlice] = useState<SliceResponse | null>(
+    null,
+  );
   const [sceneStatus, setSceneStatus] = useState("Loading scene data...");
   const [sceneError, setSceneError] = useState<string | null>(null);
   const [sliceLoading, setSliceLoading] = useState(false);
@@ -9417,6 +9433,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setVerticalSliceIndex(0);
     setSceneHorizontalSlice(null);
     setSceneVerticalSlice(null);
+    setSceneCloudBoundarySlice(null);
     setSliceLoading(false);
     setSliceError(null);
     setSelectedRegion(null);
@@ -9543,6 +9560,10 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
       ) ?? null,
     [selectedFieldName, threeDScalarEncodings],
   );
+  const cloudBoundaryField = useMemo(
+    () => catalog?.available_fields.find(isCloudWaterField) ?? null,
+    [catalog],
+  );
   const controlField = selectedField ?? sliceField;
 
   const timeOptions = controlField?.time_coordinate_values ?? [];
@@ -9595,16 +9616,16 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const playbackIntervalMs = Math.max(150, Math.round(900 / playbackSpeed));
   const canPlayTimelapse = timeOptions.length > 1;
   const activeSlice = activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice;
+  const activeCloudBoundarySlice =
+    !updraftLensActive && sliceField && isCloudWaterField(sliceField)
+      ? activeSlice
+      : sceneCloudBoundarySlice;
   const ordinaryActiveSliceLabel = slicePlainLabel(activeSlice, activeSlicePlane, activeSliceIndex);
-  const updraftLensPlaneLabel = updraftLensFrame
-    ? `Vertical x-z slice at y = ${
-        updraftLensFrame.plane_coordinate === null
-          ? `index ${updraftLensFrame.plane_index}`
-          : formatCompactNumber(updraftLensFrame.plane_coordinate)
-      }${updraftLensFrame.plane_units ? ` ${updraftLensFrame.plane_units}` : ""}`
-    : updraftLensDefaults
-      ? `Vertical x-z slice at y index ${verticalSliceIndex}`
-      : "Vertical x-z slice";
+  const updraftLensPlaneLabel = updraftLensSliceLabel(
+    updraftLensFrame,
+    activeSlicePlane,
+    activeSliceIndex,
+  );
   const activeSliceLabel = updraftLensActive ? updraftLensPlaneLabel : ordinaryActiveSliceLabel;
   const selectedSliceValue = updraftLensActive
     ? selectedUpdraftLensValue(updraftLensFrame, selectedRegion)
@@ -9719,6 +9740,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     const primaryField = catalog.available_fields.find(
       (field) => field.raw_field_name === updraftLensDefaults.primary_field,
     );
+    const primaryDefaults = defaultsForField(viewDefaults, primaryField?.raw_field_name ?? "");
     setSelectedFieldName(cloudField?.raw_field_name ?? selectedFieldName);
     setSliceFieldName(primaryField?.raw_field_name ?? sliceFieldName);
     setTimeIndex(updraftLensDefaults.default_time_index);
@@ -9726,6 +9748,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setIsPlaybackRunning(false);
     setActiveSlicePlane("vertical_x");
     setSliceOrientation("vertical_x");
+    setHorizontalSliceLevel(defaultHorizontalLevel(primaryField, primaryDefaults));
     setVerticalSliceIndex(updraftLensDefaults.default_plane_index);
     setShowSlicePlanes(true);
     setThreshold(updraftLensDefaults.cloud_threshold_kg_kg);
@@ -9749,6 +9772,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     updraftLensActive,
     updraftLensDefaults,
     verticalSliceIndex,
+    viewDefaults,
   ]);
 
   useEffect(() => {
@@ -9911,6 +9935,38 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
   ]);
 
   useEffect(() => {
+    if (updraftLensActive || !sliceField || !cloudBoundaryField || isCloudWaterField(sliceField)) {
+      setSceneCloudBoundarySlice(null);
+      return;
+    }
+    let active = true;
+    setSceneCloudBoundarySlice(null);
+    fetchVisualizationSlice(result.result_id, {
+      field: cloudBoundaryField.raw_field_name,
+      timeIndex: resolvedTimeIndex,
+      orientation: activeSlicePlane,
+      levelIndex: activeSliceIndex,
+    })
+      .then((payload) => {
+        if (active) setSceneCloudBoundarySlice(payload);
+      })
+      .catch(() => {
+        if (active) setSceneCloudBoundarySlice(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, [
+    activeSliceIndex,
+    activeSlicePlane,
+    cloudBoundaryField,
+    resolvedTimeIndex,
+    result.result_id,
+    sliceField,
+    updraftLensActive,
+  ]);
+
+  useEffect(() => {
     if (!updraftLensActive || !updraftLensDefaults) {
       setUpdraftLensFrame(null);
       setUpdraftLensLoading(false);
@@ -9925,7 +9981,8 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
       result.result_id,
       {
         timeIndex: resolvedTimeIndex,
-        planeIndex: verticalSliceIndex,
+        orientation: activeSlicePlane,
+        planeIndex: activeSliceIndex,
         windMode: updraftLensWindMode,
       },
       controller.signal,
@@ -9947,12 +10004,13 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
       controller.abort();
     };
   }, [
+    activeSliceIndex,
+    activeSlicePlane,
     resolvedTimeIndex,
     result.result_id,
     updraftLensActive,
     updraftLensDefaults,
     updraftLensWindMode,
-    verticalSliceIndex,
   ]);
 
   useEffect(() => {
@@ -10025,17 +10083,6 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
                 : "Updraft Lens active"
               : sceneStatus}
           </p>
-          {updraftLensEligible && (
-            <button
-              type="button"
-              className="updraft-lens-toggle"
-              aria-pressed={updraftLensActive}
-              disabled={!updraftLensActive && !updraftLensDefaults}
-              onClick={handleUpdraftLensToggle}
-            >
-              {updraftLensActive ? "Turn off Updraft Lens" : "Updraft Lens"}
-            </button>
-          )}
         </div>
       </div>
 
@@ -10099,14 +10146,44 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
             windMode={updraftLensWindMode}
             windReferenceMps={updraftLensFrame?.wind_reference_m_s ?? 0}
             windArrowDomainFraction={updraftLensFrame?.wind_arrow_domain_fraction ?? 0.08}
+            updraftLensFrame={updraftLensActive ? updraftLensFrame : null}
           />
           {catalog && sliceField && (
             <section
               className={`explore-control-deck${
-                updraftLensActive ? " explore-control-deck-lens" : ""
-              }`}
+                updraftLensEligible ? " explore-control-deck-has-view-mode" : ""
+              }${updraftLensActive ? " explore-control-deck-lens" : ""}`}
               aria-label="Explore viewer controls"
             >
+              {updraftLensEligible && (
+                <fieldset className="explore-control-card explore-control-card-view-mode">
+                  <legend>View</legend>
+                  <div className="segmented-buttons" aria-label="Explore view mode">
+                    <button
+                      type="button"
+                      className={!updraftLensActive ? "active-control" : ""}
+                      aria-pressed={!updraftLensActive}
+                      onClick={() => {
+                        if (updraftLensActive) handleUpdraftLensToggle();
+                      }}
+                    >
+                      Standard
+                    </button>
+                    <button
+                      type="button"
+                      className={updraftLensActive ? "active-control" : ""}
+                      aria-pressed={updraftLensActive}
+                      disabled={!updraftLensActive && !updraftLensDefaults}
+                      onClick={() => {
+                        if (!updraftLensActive) handleUpdraftLensToggle();
+                      }}
+                    >
+                      Updraft Lens
+                    </button>
+                  </div>
+                </fieldset>
+              )}
+
               <fieldset className="explore-control-card explore-control-card-time">
                 <legend>Time</legend>
                 <div className="timelapse-controls" aria-label="Timelapse playback controls">
@@ -10196,25 +10273,111 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
               {updraftLensActive ? (
                 <fieldset className="explore-control-card explore-control-card-updraft-lens">
                   <legend>Updraft Lens</legend>
+                  <div className="segmented-buttons" aria-label="Updraft Lens slice orientation">
+                    <button
+                      type="button"
+                      className={activeSlicePlane === "horizontal" ? "active-control" : ""}
+                      aria-pressed={activeSlicePlane === "horizontal"}
+                      onClick={() => {
+                        setActiveSlicePlane("horizontal");
+                        setHorizontalSliceLevel((current) =>
+                          Math.min(current, Math.max(0, sliceVerticalSize - 1)),
+                        );
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      Horizontal x-y
+                    </button>
+                    <button
+                      type="button"
+                      className={activeSlicePlane === "vertical_x" ? "active-control" : ""}
+                      aria-pressed={activeSlicePlane === "vertical_x"}
+                      onClick={() => {
+                        setActiveSlicePlane("vertical_x");
+                        setSliceOrientation("vertical_x");
+                        setVerticalSliceIndex((current) =>
+                          Math.min(current, Math.max(0, sliceYSize - 1)),
+                        );
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      Vertical x-z
+                    </button>
+                    <button
+                      type="button"
+                      className={activeSlicePlane === "vertical_y" ? "active-control" : ""}
+                      aria-pressed={activeSlicePlane === "vertical_y"}
+                      onClick={() => {
+                        setActiveSlicePlane("vertical_y");
+                        setSliceOrientation("vertical_y");
+                        setVerticalSliceIndex((current) =>
+                          Math.min(current, Math.max(0, sliceXSize - 1)),
+                        );
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      Vertical y-z
+                    </button>
+                  </div>
+
                   <label htmlFor="updraft-lens-plane-position">
-                    Vertical plane
+                    Position
                     <input
                       id="updraft-lens-plane-position"
-                      aria-label="Updraft Lens vertical plane"
+                      aria-label="Updraft Lens slice position"
                       type="range"
                       min={0}
-                      max={Math.max(0, sliceYSize - 1)}
-                      value={verticalSliceIndex}
+                      max={Math.max(0, activeSliceMax - 1)}
+                      value={activeSliceIndex}
                       onChange={(event) => {
-                        setVerticalSliceIndex(Number(event.target.value));
+                        const nextIndex = Number(event.target.value);
+                        if (activeSlicePlane === "horizontal") {
+                          setHorizontalSliceLevel(nextIndex);
+                        } else {
+                          setVerticalSliceIndex(nextIndex);
+                        }
                         setSelectedRegion(null);
                       }}
                     />
                     <span className="slice-position-label">
                       <span>{updraftLensPlaneLabel}</span>
-                      <small>index {verticalSliceIndex}</small>
+                      <small>index {activeSliceIndex}</small>
                     </span>
                   </label>
+
+                  <div className="button-row slice-move-buttons">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const nextIndex = Math.max(0, activeSliceIndex - 1);
+                        if (activeSlicePlane === "horizontal") {
+                          setHorizontalSliceLevel(nextIndex);
+                        } else {
+                          setVerticalSliceIndex(nextIndex);
+                        }
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const nextIndex = Math.min(
+                          Math.max(0, activeSliceMax - 1),
+                          activeSliceIndex + 1,
+                        );
+                        if (activeSlicePlane === "horizontal") {
+                          setHorizontalSliceLevel(nextIndex);
+                        } else {
+                          setVerticalSliceIndex(nextIndex);
+                        }
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
+                    </button>
+                  </div>
 
                   <label className="checkbox-label" htmlFor="updraft-lens-cloud-boundary">
                     <input
@@ -10266,260 +10429,255 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
                   {updraftLensError && <p role="alert">{updraftLensError}</p>}
                 </fieldset>
               ) : (
-                <>
-                  <fieldset className="explore-control-card explore-control-card-slice">
-                    <legend>Slice</legend>
-                    <label htmlFor="explore-slice-field">
-                      2-D slice field
-                      <select
-                        id="explore-slice-field"
-                        aria-label="Slice field"
-                        value={sliceFieldName}
-                        onChange={(event) => {
-                          const nextField = catalog.available_fields.find(
-                            (field) => field.raw_field_name === event.target.value,
-                          );
-                          setSliceFieldName(event.target.value);
-                          const nextDefaults = defaultsForField(viewDefaults, event.target.value);
-                          setHorizontalSliceLevel(defaultHorizontalLevel(nextField, nextDefaults));
-                          setVerticalSliceIndex(
-                            defaultVerticalIndex(nextField, sliceOrientation, nextDefaults),
-                          );
-                          if (!nextField?.coordinate_names.vertical) {
+                <fieldset className="explore-control-card explore-control-card-slice">
+                  <legend>Slice</legend>
+                  <label htmlFor="explore-slice-field">
+                    2-D slice field
+                    <select
+                      id="explore-slice-field"
+                      aria-label="Slice field"
+                      value={sliceFieldName}
+                      onChange={(event) => {
+                        const nextField = catalog.available_fields.find(
+                          (field) => field.raw_field_name === event.target.value,
+                        );
+                        setSliceFieldName(event.target.value);
+                        const nextDefaults = defaultsForField(viewDefaults, event.target.value);
+                        setHorizontalSliceLevel(defaultHorizontalLevel(nextField, nextDefaults));
+                        setVerticalSliceIndex(
+                          defaultVerticalIndex(nextField, sliceOrientation, nextDefaults),
+                        );
+                        if (!nextField?.coordinate_names.vertical) {
+                          setActiveSlicePlane("horizontal");
+                        }
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      {catalog.available_fields.map((field) => (
+                        <option key={field.raw_field_name} value={field.raw_field_name}>
+                          {sliceFieldOptionLabel(field)}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <div className="segmented-buttons" aria-label="Slice orientation">
+                    <button
+                      type="button"
+                      className={activeSlicePlane === "horizontal" ? "active-control" : ""}
+                      onClick={() => {
+                        setActiveSlicePlane("horizontal");
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      Horizontal layer
+                    </button>
+                    <button
+                      type="button"
+                      className={activeSlicePlane === "vertical_x" ? "active-control" : ""}
+                      disabled={!sliceSupportsVertical}
+                      onClick={() => {
+                        setActiveSlicePlane("vertical_x");
+                        setSliceOrientation("vertical_x");
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      Vertical x-z slice
+                    </button>
+                    <button
+                      type="button"
+                      className={activeSlicePlane === "vertical_y" ? "active-control" : ""}
+                      disabled={!sliceSupportsVertical}
+                      onClick={() => {
+                        setActiveSlicePlane("vertical_y");
+                        setSliceOrientation("vertical_y");
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      Vertical y-z slice
+                    </button>
+                  </div>
+
+                  <label htmlFor="explore-slice-position">
+                    Position
+                    <input
+                      id="explore-slice-position"
+                      aria-label="Slice position"
+                      type="range"
+                      min={0}
+                      max={Math.max(0, activeSliceMax - 1)}
+                      value={activeSliceIndex}
+                      onChange={(event) => {
+                        const nextIndex = Number(event.target.value);
+                        if (activeSlicePlane === "horizontal") {
+                          setHorizontalSliceLevel(nextIndex);
+                        } else {
+                          setVerticalSliceIndex(nextIndex);
+                        }
+                        setSelectedRegion(null);
+                      }}
+                    />
+                    <span className="slice-position-label">
+                      {activeSlicePositionLabel || `index ${activeSliceIndex}`}{" "}
+                      <small>index {activeSliceIndex}</small>
+                    </span>
+                  </label>
+
+                  <div className="button-row slice-move-buttons">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const nextIndex = Math.max(0, activeSliceIndex - 1);
+                        if (activeSlicePlane === "horizontal") {
+                          setHorizontalSliceLevel(nextIndex);
+                        } else {
+                          setVerticalSliceIndex(nextIndex);
+                        }
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const nextIndex = Math.min(
+                          Math.max(0, activeSliceMax - 1),
+                          activeSliceIndex + 1,
+                        );
+                        if (activeSlicePlane === "horizontal") {
+                          setHorizontalSliceLevel(nextIndex);
+                        } else {
+                          setVerticalSliceIndex(nextIndex);
+                        }
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
+                    </button>
+                  </div>
+
+                  <label className="checkbox-label" htmlFor="show-slice-plane">
+                    <input
+                      id="show-slice-plane"
+                      type="checkbox"
+                      checked={showSlicePlanes}
+                      onChange={(event) => setShowSlicePlanes(event.target.checked)}
+                    />
+                    Show slice plane
+                  </label>
+                </fieldset>
+              )}
+
+              <fieldset className="explore-control-card explore-control-card-rendering">
+                <legend>3-D scalar layer</legend>
+                <label htmlFor="explore-3d-field">
+                  3-D field
+                  <select
+                    id="explore-3d-field"
+                    aria-label="3-D scalar field"
+                    value={selectedFieldName}
+                    disabled={threeDScalarEncodings.length === 0}
+                    onChange={(event) => {
+                      const nextEncoding =
+                        threeDScalarEncodings.find(
+                          (encoding) => encoding.field.raw_field_name === event.target.value,
+                        ) ?? null;
+                      setSelectedFieldName(event.target.value);
+                      if (nextEncoding) {
+                        setThreshold(nextEncoding.defaultThreshold);
+                        if (!updraftLensActive) {
+                          setSliceFieldName(nextEncoding.field.raw_field_name);
+                          if (!nextEncoding.field.coordinate_names.vertical) {
                             setActiveSlicePlane("horizontal");
                           }
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        {catalog.available_fields.map((field) => (
-                          <option key={field.raw_field_name} value={field.raw_field_name}>
-                            {sliceFieldOptionLabel(field)}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-
-                    <div className="segmented-buttons" aria-label="Slice orientation">
-                      <button
-                        type="button"
-                        className={activeSlicePlane === "horizontal" ? "active-control" : ""}
-                        onClick={() => {
-                          setActiveSlicePlane("horizontal");
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        Horizontal layer
-                      </button>
-                      <button
-                        type="button"
-                        className={activeSlicePlane === "vertical_x" ? "active-control" : ""}
-                        disabled={!sliceSupportsVertical}
-                        onClick={() => {
-                          setActiveSlicePlane("vertical_x");
-                          setSliceOrientation("vertical_x");
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        Vertical x-z slice
-                      </button>
-                      <button
-                        type="button"
-                        className={activeSlicePlane === "vertical_y" ? "active-control" : ""}
-                        disabled={!sliceSupportsVertical}
-                        onClick={() => {
-                          setActiveSlicePlane("vertical_y");
-                          setSliceOrientation("vertical_y");
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        Vertical y-z slice
-                      </button>
-                    </div>
-
-                    <label htmlFor="explore-slice-position">
-                      Position
-                      <input
-                        id="explore-slice-position"
-                        aria-label="Slice position"
-                        type="range"
-                        min={0}
-                        max={Math.max(0, activeSliceMax - 1)}
-                        value={activeSliceIndex}
-                        onChange={(event) => {
-                          const nextIndex = Number(event.target.value);
-                          if (activeSlicePlane === "horizontal") {
-                            setHorizontalSliceLevel(nextIndex);
-                          } else {
-                            setVerticalSliceIndex(nextIndex);
-                          }
-                          setSelectedRegion(null);
-                        }}
-                      />
-                      <span className="slice-position-label">
-                        {activeSlicePositionLabel || `index ${activeSliceIndex}`}{" "}
-                        <small>index {activeSliceIndex}</small>
-                      </span>
-                    </label>
-
-                    <div className="button-row slice-move-buttons">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const nextIndex = Math.max(0, activeSliceIndex - 1);
-                          if (activeSlicePlane === "horizontal") {
-                            setHorizontalSliceLevel(nextIndex);
-                          } else {
-                            setVerticalSliceIndex(nextIndex);
-                          }
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const nextIndex = Math.min(
-                            Math.max(0, activeSliceMax - 1),
-                            activeSliceIndex + 1,
+                          const nextDefaults =
+                            defaultsForField(
+                              selectedTimeDefaults,
+                              nextEncoding.field.raw_field_name,
+                            ) ?? defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
+                          setHorizontalSliceLevel(
+                            defaultHorizontalLevel(nextEncoding.field, nextDefaults),
                           );
-                          if (activeSlicePlane === "horizontal") {
-                            setHorizontalSliceLevel(nextIndex);
-                          } else {
-                            setVerticalSliceIndex(nextIndex);
-                          }
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
-                      </button>
-                    </div>
-
-                    <label className="checkbox-label" htmlFor="show-slice-plane">
-                      <input
-                        id="show-slice-plane"
-                        type="checkbox"
-                        checked={showSlicePlanes}
-                        onChange={(event) => setShowSlicePlanes(event.target.checked)}
-                      />
-                      Show slice plane
-                    </label>
-                  </fieldset>
-
-                  <fieldset className="explore-control-card explore-control-card-rendering">
-                    <legend>3-D scalar layer</legend>
-                    <label htmlFor="explore-3d-field">
-                      3-D field
-                      <select
-                        id="explore-3d-field"
-                        aria-label="3-D scalar field"
-                        value={selectedFieldName}
-                        disabled={threeDScalarEncodings.length === 0}
-                        onChange={(event) => {
-                          const nextEncoding =
-                            threeDScalarEncodings.find(
-                              (encoding) => encoding.field.raw_field_name === event.target.value,
-                            ) ?? null;
-                          setSelectedFieldName(event.target.value);
-                          if (nextEncoding) {
-                            setSliceFieldName(nextEncoding.field.raw_field_name);
-                            setThreshold(nextEncoding.defaultThreshold);
-                            if (!nextEncoding.field.coordinate_names.vertical) {
-                              setActiveSlicePlane("horizontal");
-                            }
-                            const nextDefaults =
-                              defaultsForField(
-                                selectedTimeDefaults,
-                                nextEncoding.field.raw_field_name,
-                              ) ??
-                              defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
-                            setHorizontalSliceLevel(
-                              defaultHorizontalLevel(nextEncoding.field, nextDefaults),
-                            );
-                            setVerticalSliceIndex(
-                              defaultVerticalIndex(
-                                nextEncoding.field,
-                                sliceOrientation,
-                                nextDefaults,
-                              ),
-                            );
-                          }
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        {threeDScalarEncodings.length === 0 && (
-                          <option value="">No 3-D scalar fields</option>
-                        )}
-                        {threeDScalarEncodings.map((encoding) => (
-                          <option
-                            key={encoding.field.raw_field_name}
-                            value={encoding.field.raw_field_name}
-                          >
-                            {encoding.field.raw_field_name} - {encoding.field.display_name}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                    <p className="control-help">
-                      {selectedEncoding
-                        ? selectedEncoding.valueChannel
-                        : "Only fields with a defined 3-D scalar encoding appear here; vertical velocity remains slice-only."}
-                    </p>
-                    {pointCloud && selectedEncoding && (
-                      <p className="control-help">
-                        {pointCloudFieldSummary(pointCloud)}
-                        {selectedEncoding.field.raw_field_name === "dbz"
-                          ? " Weather-radar colors use a fixed 0 to 60+ dBZ scale."
-                          : ""}
-                      </p>
+                          setVerticalSliceIndex(
+                            defaultVerticalIndex(nextEncoding.field, sliceOrientation, nextDefaults),
+                          );
+                        }
+                      }
+                      setSelectedRegion(null);
+                    }}
+                  >
+                    {threeDScalarEncodings.length === 0 && (
+                      <option value="">No 3-D scalar fields</option>
                     )}
-                    {selectedEncoding?.field.raw_field_name === "qc" &&
-                      cloudTopMismatchNotice(result) && (
-                        <p className="control-help">{cloudTopMismatchNotice(result)}</p>
-                      )}
-                    <label htmlFor="cloud-threshold">
-                      {selectedEncoding?.thresholdLabel ?? "Visible minimum"}
-                      <input
-                        id="cloud-threshold"
-                        aria-label={selectedEncoding?.thresholdAriaLabel ?? "3-D scalar threshold"}
-                        type="number"
-                        min={0}
-                        step={selectedEncoding?.thresholdStep ?? 0.000001}
-                        value={threshold}
-                        onChange={(event) => setThreshold(Number(event.target.value))}
-                        disabled={!selectedEncoding}
-                      />
-                    </label>
-                    <label htmlFor="cloud-opacity">
-                      Opacity
-                      <input
-                        id="cloud-opacity"
-                        aria-label="Layer opacity"
-                        type="range"
-                        min={0.1}
-                        max={1}
-                        step={0.05}
-                        value={opacity}
-                        onChange={(event) => setOpacity(Number(event.target.value))}
-                      />
-                      <output htmlFor="cloud-opacity">{opacity}</output>
-                    </label>
-                    <label htmlFor="cloud-point-size">
-                      Point size
-                      <input
-                        id="cloud-point-size"
-                        aria-label="Point size"
-                        type="range"
-                        min={3}
-                        max={18}
-                        value={pointSize}
-                        onChange={(event) => setPointSize(Number(event.target.value))}
-                      />
-                      <output htmlFor="cloud-point-size">{pointSize}px</output>
-                    </label>
-                  </fieldset>
-                </>
-              )}
+                    {threeDScalarEncodings.map((encoding) => (
+                      <option
+                        key={encoding.field.raw_field_name}
+                        value={encoding.field.raw_field_name}
+                      >
+                        {encoding.field.raw_field_name} - {encoding.field.display_name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <p className="control-help">
+                  {selectedEncoding
+                    ? selectedEncoding.valueChannel
+                    : "Only fields with a defined 3-D scalar encoding appear here; vertical velocity remains slice-only."}
+                </p>
+                {pointCloud && selectedEncoding && (
+                  <p className="control-help">
+                    {pointCloudFieldSummary(pointCloud)}
+                    {selectedEncoding.field.raw_field_name === "dbz"
+                      ? " Weather-radar colors use a fixed 0 to 60+ dBZ scale."
+                      : ""}
+                  </p>
+                )}
+                {selectedEncoding?.field.raw_field_name === "qc" &&
+                  cloudTopMismatchNotice(result) && (
+                    <p className="control-help">{cloudTopMismatchNotice(result)}</p>
+                  )}
+                <label htmlFor="cloud-threshold">
+                  {selectedEncoding?.thresholdLabel ?? "Visible minimum"}
+                  <input
+                    id="cloud-threshold"
+                    aria-label={selectedEncoding?.thresholdAriaLabel ?? "3-D scalar threshold"}
+                    type="number"
+                    min={0}
+                    step={selectedEncoding?.thresholdStep ?? 0.000001}
+                    value={threshold}
+                    onChange={(event) => setThreshold(Number(event.target.value))}
+                    disabled={!selectedEncoding}
+                  />
+                </label>
+                <label htmlFor="cloud-opacity">
+                  Opacity
+                  <input
+                    id="cloud-opacity"
+                    aria-label="Layer opacity"
+                    type="range"
+                    min={0.1}
+                    max={1}
+                    step={0.05}
+                    value={opacity}
+                    onChange={(event) => setOpacity(Number(event.target.value))}
+                  />
+                  <output htmlFor="cloud-opacity">{opacity}</output>
+                </label>
+                <label htmlFor="cloud-point-size">
+                  Point size
+                  <input
+                    id="cloud-point-size"
+                    aria-label="Point size"
+                    type="range"
+                    min={3}
+                    max={18}
+                    value={pointSize}
+                    onChange={(event) => setPointSize(Number(event.target.value))}
+                  />
+                  <output htmlFor="cloud-point-size">{pointSize}px</output>
+                </label>
+              </fieldset>
             </section>
           )}
         </div>
@@ -10739,6 +10897,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
               title={activeSliceLabel}
               slice={activeSlice}
               pointCloud={pointCloud}
+              cloudBoundarySlice={activeCloudBoundarySlice}
               selectedRegion={selectedRegion}
               onSelectRegion={selectPointFromSlice}
             />
@@ -10907,27 +11066,51 @@ function selectedUpdraftLensValue(
   frame: UpdraftLensFrame | null,
   selectedRegion: SelectedRegionRequest | null,
 ): number | null {
-  if (
-    !frame ||
-    selectedRegion?.xIndex === undefined ||
-    selectedRegion.yIndex !== frame.plane_index ||
-    selectedRegion.zIndex === undefined
-  ) {
-    return null;
-  }
-  return frame.w_values_m_s[selectedRegion.zIndex]?.[selectedRegion.xIndex] ?? null;
+  if (!frame || !selectedRegion) return null;
+  const xIndex = selectedRegion.xIndex;
+  const yIndex = selectedRegion.yIndex;
+  const zIndex = selectedRegion.zIndex;
+  if (xIndex === undefined || yIndex === undefined || zIndex === undefined) return null;
+  const indices = { x: xIndex, y: yIndex, z: zIndex };
+  if (indices[frame.plane_dimension] !== frame.plane_index) return null;
+  const rowDimension = frame.dimension_order[0];
+  const columnDimension = frame.dimension_order[1];
+  if (!rowDimension || !columnDimension) return null;
+  return frame.w_values_m_s[indices[rowDimension]]?.[indices[columnDimension]] ?? null;
+}
+
+function updraftLensSliceLabel(
+  frame: UpdraftLensFrame | null,
+  orientation: SceneSlicePlane,
+  fallbackIndex: number,
+): string {
+  const labels: Record<SceneSlicePlane, { slice: string; fixed: "x" | "y" | "z" }> = {
+    horizontal: { slice: "Horizontal x-y layer", fixed: "z" },
+    vertical_x: { slice: "Vertical x-z slice", fixed: "y" },
+    vertical_y: { slice: "Vertical y-z slice", fixed: "x" },
+  };
+  const resolvedOrientation = frame?.orientation ?? orientation;
+  const label = labels[resolvedOrientation];
+  const coordinate = frame?.plane_coordinate;
+  const position =
+    coordinate === null || coordinate === undefined
+      ? `index ${frame?.plane_index ?? fallbackIndex}`
+      : `${formatCompactNumber(coordinate)}${frame?.plane_units ? ` ${frame.plane_units}` : ""}`;
+  return `${label.slice} at ${label.fixed} = ${position}`;
 }
 
 function SlicePanel({
   title,
   slice,
   pointCloud,
+  cloudBoundarySlice,
   selectedRegion,
   onSelectRegion,
 }: {
   title: string;
   slice: SliceResponse | null;
   pointCloud?: PointCloudResponse | null;
+  cloudBoundarySlice?: SliceResponse | null;
   selectedRegion?: SelectedRegionRequest | null;
   onSelectRegion?: (slice: SliceResponse, rowIndex: number, columnIndex: number) => void;
 }) {
@@ -10952,6 +11135,8 @@ function SlicePanel({
         <SliceHeatmap
           title={title}
           slice={slice}
+          pointCloud={pointCloud}
+          cloudBoundarySlice={cloudBoundarySlice}
           selectedRegion={selectedRegion}
           onSelectRegion={onSelectRegion}
         />
@@ -11406,38 +11591,146 @@ function SelectedPointContext({
 function SliceHeatmap({
   title,
   slice,
+  pointCloud,
+  cloudBoundarySlice,
   selectedRegion,
   onSelectRegion,
 }: {
   title: string;
   slice: SliceResponse;
+  pointCloud?: PointCloudResponse | null;
+  cloudBoundarySlice?: SliceResponse | null;
   selectedRegion?: SelectedRegionRequest | null;
   onSelectRegion?: (slice: SliceResponse, rowIndex: number, columnIndex: number) => void;
 }) {
   const displayRows = downsampleSliceValues(slice);
+  const renderedRows = displayRows.map((row, index) => ({ row, index })).reverse();
+  const columnCount = displayRows[0]?.length ?? 1;
+  const rowCount = displayRows.length || 1;
+  const aspect = slicePhysicalAspect(slice, pointCloud, columnCount / rowCount);
+  const cloudBoundaryPath = sliceCloudBoundaryPath(displayRows, slice, cloudBoundarySlice);
   return (
-    <div className="slice-heatmap" role="img" aria-label={`${title} heatmap`}>
-      {displayRows.map((row, displayRowIndex) => (
-        <div className="heatmap-row" key={`${title}-heatmap-${displayRowIndex}`}>
-          {row.map((cell, displayColumnIndex) => {
-            const selected = isSelectedSliceDisplayCell(slice, selectedRegion, cell);
-            return (
-              <button
-                type="button"
-                className={`heatmap-cell${selected ? " heatmap-cell-selected" : ""}`}
-                key={`${title}-heatmap-${displayRowIndex}-${displayColumnIndex}`}
-                title={
-                  cell.value === null ? "missing" : formatMaybeNumber(cell.value, slice.field.units)
-                }
-                aria-label={`Inspect ${title} row ${displayRowIndex + 1}, column ${displayColumnIndex + 1}`}
-                style={sliceCellStyle(cell.value, slice)}
-                onClick={() => onSelectRegion?.(slice, cell.sourceRowIndex, cell.sourceColumnIndex)}
-              />
-            );
-          })}
-        </div>
-      ))}
+    <div
+      className="slice-heatmap"
+      role="img"
+      aria-label={`${title} heatmap`}
+      data-domain-aspect={aspect.toFixed(6)}
+      style={{
+        aspectRatio: `${aspect}`,
+        maxWidth: `min(68rem, ${Math.max(55, Math.min(160, aspect * 70))}vh)`,
+      }}
+    >
+      <div
+        className="slice-heatmap-grid"
+        style={{ gridTemplateRows: `repeat(${rowCount}, minmax(0, 1fr))` }}
+      >
+        {renderedRows.map(({ row, index: displayRowIndex }) => (
+          <div className="heatmap-row" key={`${title}-heatmap-${displayRowIndex}`}>
+            {row.map((cell, displayColumnIndex) => {
+              const selected = isSelectedSliceDisplayCell(slice, selectedRegion, cell);
+              return (
+                <button
+                  type="button"
+                  className={`heatmap-cell${selected ? " heatmap-cell-selected" : ""}`}
+                  key={`${title}-heatmap-${displayRowIndex}-${displayColumnIndex}`}
+                  title={
+                    cell.value === null
+                      ? "missing"
+                      : formatMaybeNumber(cell.value, slice.field.units)
+                  }
+                  aria-label={`Inspect ${title} row ${displayRowIndex + 1}, column ${displayColumnIndex + 1}`}
+                  style={sliceCellStyle(cell.value, slice)}
+                  onClick={() =>
+                    onSelectRegion?.(slice, cell.sourceRowIndex, cell.sourceColumnIndex)
+                  }
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      {cloudBoundaryPath && (
+        <svg
+          className="slice-cloud-boundary-overlay"
+          data-testid="slice-cloud-boundary"
+          viewBox={`0 0 ${columnCount} ${rowCount}`}
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <g transform={`translate(0 ${rowCount}) scale(1 -1)`}>
+            <path d={cloudBoundaryPath} vectorEffect="non-scaling-stroke" />
+          </g>
+        </svg>
+      )}
     </div>
+  );
+}
+
+function slicePhysicalAspect(
+  slice: SliceResponse,
+  pointCloud: PointCloudResponse | null | undefined,
+  fallback: number,
+): number {
+  const xRange = coordinateRange(pointCloud, ["xh", "x"]);
+  const yRange = coordinateRange(pointCloud, ["yh", "y"]);
+  const zRange = coordinateRange(pointCloud, ["zh", "zf", "z"]);
+  let width = xRange;
+  let height = yRange;
+  if (slice.selection.orientation === "vertical_x") {
+    height = zRange;
+  } else if (slice.selection.orientation === "vertical_y") {
+    width = yRange;
+    height = zRange;
+  }
+  if (!width || !height) return Math.max(Number.EPSILON, fallback);
+  return Math.max(Number.EPSILON, width / height);
+}
+
+function coordinateRange(
+  pointCloud: PointCloudResponse | null | undefined,
+  names: string[],
+): number | null {
+  for (const name of names) {
+    const extent = pointCloud?.coordinate_extents[name];
+    if (extent && Number.isFinite(extent.min) && Number.isFinite(extent.max)) {
+      const range = extent.max - extent.min;
+      if (range > 0) return range;
+    }
+  }
+  return null;
+}
+
+function sliceCloudBoundaryPath(
+  displayRows: DisplayHeatmapCell[][],
+  slice: SliceResponse,
+  cloudBoundarySlice: SliceResponse | null | undefined,
+): string {
+  if (
+    !cloudBoundarySlice ||
+    cloudBoundarySlice.selection.orientation !== slice.selection.orientation ||
+    cloudBoundarySlice.selection.selected_index !== slice.selection.selected_index ||
+    cloudBoundarySlice.values.length !== slice.values.length ||
+    (cloudBoundarySlice.values[0]?.length ?? 0) !== (slice.values[0]?.length ?? 0)
+  ) {
+    return "";
+  }
+  const mask = displayRows.map((row) =>
+    row.map((cell) => {
+      for (let rowIndex = cell.rowStart; rowIndex <= cell.rowEnd; rowIndex += 1) {
+        for (let columnIndex = cell.columnStart; columnIndex <= cell.columnEnd; columnIndex += 1) {
+          const value = cloudBoundarySlice.values[rowIndex]?.[columnIndex];
+          if (typeof value === "number" && Number.isFinite(value) && value >= 1e-6) return true;
+        }
+      }
+      return false;
+    }),
+  );
+  const columnCount = displayRows[0]?.length ?? 0;
+  const rowCount = displayRows.length;
+  return updraftLensBoundaryPath(
+    mask,
+    Array.from({ length: columnCount + 1 }, (_, index) => index),
+    Array.from({ length: rowCount + 1 }, (_, index) => index),
   );
 }
 
@@ -11545,8 +11838,7 @@ function summarizeSliceBlock(
 
 function sliceAggregationMode(field: VisualizableField): "max" | "largest_magnitude" | "mean" {
   if (
-    field.raw_field_name === "qc" ||
-    field.canonical_field_name === "cloud_water" ||
+    isCloudWaterField(field) ||
     field.raw_field_name === "qr" ||
     field.canonical_field_name === "rain_water"
   ) {
@@ -13815,7 +14107,7 @@ function heatmapScaleClass(field: VisualizableField): string {
   if (isSurfaceRainField(field)) {
     return "heatmap-scale-surface-rain";
   }
-  if (field.raw_field_name === "qc" || field.canonical_field_name === "cloud_water") {
+  if (isCloudWaterField(field)) {
     return "heatmap-scale-cloud-water";
   }
   if (field.raw_field_name === "qr" || field.canonical_field_name === "rain_water") {
@@ -13826,7 +14118,7 @@ function heatmapScaleClass(field: VisualizableField): string {
 
 function sliceCellStyle(value: number | null, slice: SliceResponse): CSSProperties {
   if (value === null) {
-    return { background: "rgba(255, 255, 255, 0.36)" };
+    return { background: "#747b80" };
   }
 
   if (
@@ -13838,16 +14130,7 @@ function sliceCellStyle(value: number | null, slice: SliceResponse): CSSProperti
       Math.abs(slice.stats.max ?? value),
       Number.EPSILON,
     );
-    const scaled = Math.max(-1, Math.min(1, value / maxMagnitude));
-    if (scaled >= 0) {
-      return {
-        background: `rgba(${224 - scaled * 96}, ${242 - scaled * 86}, ${236 - scaled * 132}, ${0.58 + scaled * 0.34})`,
-      };
-    }
-    const magnitude = Math.abs(scaled);
-    return {
-      background: `rgba(${229 - magnitude * 90}, ${238 - magnitude * 112}, ${247 - magnitude * 88}, ${0.58 + magnitude * 0.32})`,
-    };
+    return { background: updraftLensColor(value, -maxMagnitude, maxMagnitude) };
   }
 
   if (slice.field.raw_field_name === "dbz" || slice.field.canonical_field_name === "reflectivity") {
@@ -13864,10 +14147,7 @@ function sliceCellStyle(value: number | null, slice: SliceResponse): CSSProperti
     return { background: temperatureBackground(normalized) };
   }
 
-  const intensity = Math.sqrt(Math.max(0, normalized));
-  if (intensity < 0.015) {
-    return { background: "rgba(234, 244, 248, 0.72)" };
-  }
+  const intensity = Math.max(0, Math.min(1, normalized));
   return { background: scalarMagnitudeBackground(slice.field, intensity) };
 }
 
@@ -13895,8 +14175,8 @@ function radarReflectivityBackground(dbz: number): string {
     { value: 50, color: [194, 27, 42] },
     { value: 60, color: [165, 45, 188] },
   ];
-  const alpha = 0.72;
-  if (!Number.isFinite(dbz)) return "rgba(255, 255, 255, 0.36)";
+  const alpha = 1;
+  if (!Number.isFinite(dbz)) return "#747b80";
   if (dbz <= stops[0].value) return `rgba(${stops[0].color.join(", ")}, ${alpha})`;
   for (let index = 1; index < stops.length; index += 1) {
     const lower = stops[index - 1];
@@ -13913,23 +14193,22 @@ function radarReflectivityBackground(dbz: number): string {
 }
 
 function scalarMagnitudeBackground(field: VisualizableField, intensity: number): string {
-  const alpha = 0.58 + intensity * 0.34;
-  let start = [234, 244, 248];
-  let end = [180, 239, 228];
+  let start = [242, 247, 249];
+  let end = [0, 126, 167];
   if (field.raw_field_name === "qr" || field.canonical_field_name === "rain_water") {
-    start = [231, 239, 255];
-    end = [134, 116, 217];
+    start = [239, 242, 255];
+    end = [91, 65, 180];
   } else if (field.raw_field_name === "qv" || field.canonical_field_name === "water_vapor") {
-    start = [232, 248, 245];
-    end = [77, 170, 146];
+    start = [237, 248, 245];
+    end = [13, 127, 103];
   } else if (isSurfaceRainField(field)) {
-    start = [229, 242, 255];
-    end = [46, 116, 190];
+    start = [236, 244, 252];
+    end = [32, 92, 160];
   }
   const color = start.map((component, index) =>
     Math.round(component + (end[index] - component) * intensity),
   );
-  return `rgba(${color.join(", ")}, ${alpha})`;
+  return `rgb(${color.join(", ")})`;
 }
 
 function temperatureBackground(intensity: number): string {
@@ -13943,7 +14222,7 @@ function temperatureBackground(intensity: number): string {
   const color = lower.map((component, index) =>
     Math.round(component + (upper[index] - component) * amount),
   );
-  return `rgba(${color.join(", ")}, ${0.52 + clamped * 0.34})`;
+  return `rgb(${color.join(", ")})`;
 }
 
 function formatDate(value: string | null): string {

--- a/app/frontend/src/True3DViewer.test.tsx
+++ b/app/frontend/src/True3DViewer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { cameraDistanceLimits, scalarPointPixelSize } from "./True3DViewer.utils";
+import { cameraDistanceLimits, scalarPointPixelSize, windArrowLength } from "./True3DViewer.utils";
 
 describe("True3DViewer scalar point sizing", () => {
   it("uses the UI point-size value as a bounded screen-pixel size", () => {
@@ -19,5 +19,18 @@ describe("True3DViewer camera limits", () => {
     const largeDomainLimits = cameraDistanceLimits(120);
     expect(largeDomainLimits.minDistance).toBeCloseTo(1.8);
     expect(largeDomainLimits.maxDistance).toBe(360);
+  });
+});
+
+describe("True3DViewer wind arrow scaling", () => {
+  it("maps the reference wind to eight percent of horizontal domain width", () => {
+    expect(windArrowLength(1, 1, 6.4)).toBeCloseTo(0.512);
+    expect(windArrowLength(0.5, 1, 6.4)).toBeCloseTo(0.256);
+  });
+
+  it("skips zero and invalid vectors", () => {
+    expect(windArrowLength(0, 1, 6.4)).toBe(0);
+    expect(windArrowLength(1, 0, 6.4)).toBe(0);
+    expect(windArrowLength(Number.NaN, 1, 6.4)).toBe(0);
   });
 });

--- a/app/frontend/src/True3DViewer.test.tsx
+++ b/app/frontend/src/True3DViewer.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { cameraDistanceLimits, scalarPointPixelSize, windArrowLength } from "./True3DViewer.utils";
+import {
+  cameraDistanceLimits,
+  scalarPointPixelSize,
+  updraftLensTextureData,
+  windArrowLength,
+} from "./True3DViewer.utils";
 
 describe("True3DViewer scalar point sizing", () => {
   it("uses the UI point-size value as a bounded screen-pixel size", () => {
@@ -32,5 +37,26 @@ describe("True3DViewer wind arrow scaling", () => {
     expect(windArrowLength(0, 1, 6.4)).toBe(0);
     expect(windArrowLength(1, 0, 6.4)).toBe(0);
     expect(windArrowLength(Number.NaN, 1, 6.4)).toBe(0);
+  });
+});
+
+describe("True3DViewer Updraft Lens texture", () => {
+  it("uses the exact fixed-scale colors and missing-data color", () => {
+    expect(
+      Array.from(
+        updraftLensTextureData(
+          [
+            [-1, 0],
+            [1, null],
+          ],
+          2,
+          2,
+          -1,
+          1,
+        ),
+      ),
+    ).toEqual([
+      0x21, 0x66, 0xac, 255, 0xf7, 0xf7, 0xf7, 255, 0xb2, 0x18, 0x2b, 255, 0x74, 0x7b, 0x80, 255,
+    ]);
   });
 });

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -2,8 +2,17 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
-import type { UpdraftLensWindMode, UpdraftLensWindVector } from "./UpdraftLensSlice";
-import { cameraDistanceLimits, scalarPointPixelSize, windArrowLength } from "./True3DViewer.utils";
+import type {
+  UpdraftLensFrame,
+  UpdraftLensWindMode,
+  UpdraftLensWindVector,
+} from "./UpdraftLensSlice";
+import {
+  cameraDistanceLimits,
+  scalarPointPixelSize,
+  updraftLensTextureData,
+  windArrowLength,
+} from "./True3DViewer.utils";
 
 type CoordinateExtent = { min: number; max: number; units: string | null };
 
@@ -89,6 +98,7 @@ type True3DViewerProps = {
   windMode?: UpdraftLensWindMode;
   windReferenceMps?: number;
   windArrowDomainFraction?: number;
+  updraftLensFrame?: UpdraftLensFrame | null;
 };
 
 type SceneRefs = {
@@ -151,6 +161,7 @@ export function True3DViewer({
   windMode = "perturbation",
   windReferenceMps = 0,
   windArrowDomainFraction = 0.08,
+  updraftLensFrame = null,
 }: True3DViewerProps) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const axisLabelLayerRef = useRef<HTMLDivElement | null>(null);
@@ -314,6 +325,7 @@ export function True3DViewer({
       showWindVectors,
       windReferenceMps,
       windArrowDomainFraction,
+      updraftLensFrame,
     });
   }, [
     activeSlice,
@@ -328,6 +340,7 @@ export function True3DViewer({
     windArrowDomainFraction,
     windReferenceMps,
     windVectors,
+    updraftLensFrame,
   ]);
 
   return (
@@ -387,8 +400,13 @@ export function True3DViewer({
             </span>
           ))}
         </div>
-        {showSlicePlane && activeSlice && (
-          <p className="true3d-slice-label">Slice plane: {activeSliceLabel}</p>
+        {updraftLensFrame ? (
+          <p className="true3d-slice-label true3d-slice-label-updraft-lens">
+            Updraft Lens slice: {activeSliceLabel}
+          </p>
+        ) : (
+          showSlicePlane &&
+          activeSlice && <p className="true3d-slice-label">Slice plane: {activeSliceLabel}</p>
         )}
         {selectedPoint && (
           <p className="true3d-selected-point-label">
@@ -481,6 +499,7 @@ function rebuildScene(
     showWindVectors,
     windReferenceMps,
     windArrowDomainFraction,
+    updraftLensFrame,
   }: {
     bounds: SceneBounds;
     pointCloud: PointCloudResponse | null;
@@ -494,6 +513,7 @@ function rebuildScene(
     showWindVectors: boolean;
     windReferenceMps: number;
     windArrowDomainFraction: number;
+    updraftLensFrame: UpdraftLensFrame | null;
   },
 ) {
   disposeScene(scene);
@@ -515,6 +535,10 @@ function rebuildScene(
     scene.add(horizontalWindLayer(windVectors, bounds, windReferenceMps, windArrowDomainFraction));
   }
 
+  if (updraftLensFrame) {
+    scene.add(updraftLensSlicePlane(updraftLensFrame, bounds));
+  }
+
   if (showSlicePlane && activeSlice) {
     scene.add(slicePlane(activeSlice, activeSliceLabel, bounds));
   }
@@ -522,6 +546,71 @@ function rebuildScene(
   if (selectedPoint) {
     scene.add(selectedPointMarker(selectedPoint, bounds));
   }
+}
+
+function updraftLensSlicePlane(frame: UpdraftLensFrame, bounds: SceneBounds): THREE.Group {
+  const width = Math.max(1, frame.w_values_m_s[0]?.length ?? 0);
+  const height = Math.max(1, frame.w_values_m_s.length);
+  const texture = new THREE.DataTexture(
+    updraftLensTextureData(
+      frame.w_values_m_s,
+      width,
+      height,
+      frame.w_range_min_m_s,
+      frame.w_range_max_m_s,
+    ),
+    width,
+    height,
+    THREE.RGBAFormat,
+    THREE.UnsignedByteType,
+  );
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.magFilter = THREE.NearestFilter;
+  texture.minFilter = THREE.NearestFilter;
+  texture.generateMipmaps = false;
+  texture.needsUpdate = true;
+
+  let geometry: THREE.PlaneGeometry;
+  if (frame.orientation === "horizontal") {
+    geometry = new THREE.PlaneGeometry(bounds.xRange, bounds.yRange);
+  } else if (frame.orientation === "vertical_y") {
+    geometry = new THREE.PlaneGeometry(bounds.yRange, bounds.zRange);
+  } else {
+    geometry = new THREE.PlaneGeometry(bounds.xRange, bounds.zRange);
+  }
+  const material = new THREE.MeshBasicMaterial({
+    map: texture,
+    transparent: true,
+    opacity: 0.68,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+  });
+  const plane = new THREE.Mesh(geometry, material);
+  plane.name = `Updraft Lens ${frame.orientation} vertical-velocity plane`;
+  if (frame.orientation === "horizontal") {
+    plane.rotation.x = Math.PI / 2;
+    plane.position.y = centeredCoordinate(frame.plane_coordinate ?? 0, bounds.z);
+  } else if (frame.orientation === "vertical_y") {
+    plane.rotation.y = -Math.PI / 2;
+    plane.position.x = centeredCoordinate(frame.plane_coordinate ?? 0, bounds.x);
+  } else {
+    plane.position.z = centeredCoordinate(frame.plane_coordinate ?? 0, bounds.y);
+  }
+  plane.renderOrder = 10;
+
+  const outline = new THREE.LineSegments(
+    new THREE.EdgesGeometry(geometry),
+    new THREE.LineBasicMaterial({ color: 0x263238, transparent: true, opacity: 0.9 }),
+  );
+  outline.name = "Updraft Lens plane outline";
+  outline.position.copy(plane.position);
+  outline.rotation.copy(plane.rotation);
+  outline.renderOrder = 11;
+
+  const group = new THREE.Group();
+  group.name = "trade-cumulus-updraft-lens-slice-plane";
+  group.add(plane, outline);
+  return group;
 }
 
 function horizontalWindLayer(

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
-import { cameraDistanceLimits, scalarPointPixelSize } from "./True3DViewer.utils";
+import type { UpdraftLensWindMode, UpdraftLensWindVector } from "./UpdraftLensSlice";
+import { cameraDistanceLimits, scalarPointPixelSize, windArrowLength } from "./True3DViewer.utils";
 
 type CoordinateExtent = { min: number; max: number; units: string | null };
 
@@ -83,6 +84,11 @@ type True3DViewerProps = {
   status: string;
   provenanceLabel: string;
   noCloudMessage: string;
+  windVectors?: UpdraftLensWindVector[];
+  showWindVectors?: boolean;
+  windMode?: UpdraftLensWindMode;
+  windReferenceMps?: number;
+  windArrowDomainFraction?: number;
 };
 
 type SceneRefs = {
@@ -140,6 +146,11 @@ export function True3DViewer({
   status,
   provenanceLabel,
   noCloudMessage,
+  windVectors = [],
+  showWindVectors = false,
+  windMode = "perturbation",
+  windReferenceMps = 0,
+  windArrowDomainFraction = 0.08,
 }: True3DViewerProps) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const axisLabelLayerRef = useRef<HTMLDivElement | null>(null);
@@ -299,6 +310,10 @@ export function True3DViewer({
       selectedPoint,
       opacity,
       pointSize,
+      windVectors,
+      showWindVectors,
+      windReferenceMps,
+      windArrowDomainFraction,
     });
   }, [
     activeSlice,
@@ -309,6 +324,10 @@ export function True3DViewer({
     pointSize,
     selectedPoint,
     showSlicePlane,
+    showWindVectors,
+    windArrowDomainFraction,
+    windReferenceMps,
+    windVectors,
   ]);
 
   return (
@@ -345,6 +364,12 @@ export function True3DViewer({
               />
               <small>{fieldLegendMaximum(pointCloud)}</small>
             </div>
+          </div>
+        )}
+        {showWindVectors && windVectors.length > 0 && (
+          <div className="true3d-wind-legend" aria-label="Horizontal wind overlay legend">
+            <strong>{windMode === "perturbation" ? "Local departures" : "Total wind"}</strong>
+            <span>{windReferenceMps.toFixed(1)} m/s reference = 8% domain width</span>
           </div>
         )}
         <div
@@ -452,6 +477,10 @@ function rebuildScene(
     selectedPoint,
     opacity,
     pointSize,
+    windVectors,
+    showWindVectors,
+    windReferenceMps,
+    windArrowDomainFraction,
   }: {
     bounds: SceneBounds;
     pointCloud: PointCloudResponse | null;
@@ -461,6 +490,10 @@ function rebuildScene(
     selectedPoint: { x: number; y: number; z: number } | null;
     opacity: number;
     pointSize: number;
+    windVectors: UpdraftLensWindVector[];
+    showWindVectors: boolean;
+    windReferenceMps: number;
+    windArrowDomainFraction: number;
   },
 ) {
   disposeScene(scene);
@@ -478,6 +511,10 @@ function rebuildScene(
     scene.add(cloudPointLayer(pointCloud, bounds, opacity, pointSize));
   }
 
+  if (showWindVectors && windVectors.length) {
+    scene.add(horizontalWindLayer(windVectors, bounds, windReferenceMps, windArrowDomainFraction));
+  }
+
   if (showSlicePlane && activeSlice) {
     scene.add(slicePlane(activeSlice, activeSliceLabel, bounds));
   }
@@ -485,6 +522,42 @@ function rebuildScene(
   if (selectedPoint) {
     scene.add(selectedPointMarker(selectedPoint, bounds));
   }
+}
+
+function horizontalWindLayer(
+  vectors: UpdraftLensWindVector[],
+  bounds: SceneBounds,
+  referenceMps: number,
+  domainFraction: number,
+): THREE.Group {
+  const group = new THREE.Group();
+  group.name = "trade-cumulus-updraft-lens-wind-vectors";
+  for (const vector of vectors) {
+    const length = windArrowLength(
+      vector.magnitude_m_s,
+      referenceMps,
+      bounds.xRange,
+      domainFraction,
+    );
+    if (length <= 0) continue;
+    const direction = new THREE.Vector3(vector.u_m_s, 0, vector.v_m_s);
+    if (direction.lengthSq() === 0) continue;
+    direction.normalize();
+    const mapped = mapCoordinate(vector.x_km, vector.y_km, vector.z_km, bounds);
+    const headLength = Math.min(length * 0.36, Math.max(0.04, bounds.xRange * 0.025));
+    const headWidth = Math.min(length * 0.24, Math.max(0.025, bounds.xRange * 0.016));
+    const arrow = new THREE.ArrowHelper(
+      direction,
+      new THREE.Vector3(mapped.x, mapped.y, mapped.z),
+      length,
+      0x263238,
+      headLength,
+      headWidth,
+    );
+    arrow.name = "horizontal-wind-vector";
+    group.add(arrow);
+  }
+  return group;
 }
 
 function boundsSignature(pointCloud: PointCloudResponse | null): string {

--- a/app/frontend/src/True3DViewer.utils.ts
+++ b/app/frontend/src/True3DViewer.utils.ts
@@ -18,3 +18,23 @@ export function cameraDistanceLimits(maxRange: number): {
     maxDistance: Math.max(40, resolvedMaxRange * 3),
   };
 }
+
+export function windArrowLength(
+  magnitudeMps: number,
+  referenceMps: number,
+  domainWidth: number,
+  domainFraction = 0.08,
+): number {
+  if (
+    !Number.isFinite(magnitudeMps) ||
+    magnitudeMps <= 0 ||
+    !Number.isFinite(referenceMps) ||
+    referenceMps <= 0 ||
+    !Number.isFinite(domainWidth) ||
+    domainWidth <= 0
+  ) {
+    return 0;
+  }
+  const fraction = Number.isFinite(domainFraction) && domainFraction > 0 ? domainFraction : 0.08;
+  return (magnitudeMps / referenceMps) * domainWidth * fraction;
+}

--- a/app/frontend/src/True3DViewer.utils.ts
+++ b/app/frontend/src/True3DViewer.utils.ts
@@ -1,3 +1,5 @@
+import { updraftLensColor } from "./UpdraftLensSlice";
+
 const DEFAULT_SCALAR_POINT_PIXEL_SIZE = 11;
 const MIN_SCALAR_POINT_PIXEL_SIZE = 3;
 const MAX_SCALAR_POINT_PIXEL_SIZE = 18;
@@ -37,4 +39,34 @@ export function windArrowLength(
   }
   const fraction = Number.isFinite(domainFraction) && domainFraction > 0 ? domainFraction : 0.08;
   return (magnitudeMps / referenceMps) * domainWidth * fraction;
+}
+
+export function updraftLensTextureData(
+  values: Array<Array<number | null>>,
+  width: number,
+  height: number,
+  rangeMinimum: number,
+  rangeMaximum: number,
+): Uint8Array {
+  const resolvedWidth = Math.max(1, Math.trunc(width));
+  const resolvedHeight = Math.max(1, Math.trunc(height));
+  const data = new Uint8Array(resolvedWidth * resolvedHeight * 4);
+  for (let zIndex = 0; zIndex < resolvedHeight; zIndex += 1) {
+    for (let xIndex = 0; xIndex < resolvedWidth; xIndex += 1) {
+      const offset = (zIndex * resolvedWidth + xIndex) * 4;
+      const [red, green, blue] = hexColorChannels(
+        updraftLensColor(values[zIndex]?.[xIndex] ?? null, rangeMinimum, rangeMaximum),
+      );
+      data[offset] = red;
+      data[offset + 1] = green;
+      data[offset + 2] = blue;
+      data[offset + 3] = 255;
+    }
+  }
+  return data;
+}
+
+function hexColorChannels(color: string): [number, number, number] {
+  const value = Number.parseInt(color.slice(1), 16);
+  return [(value >> 16) & 255, (value >> 8) & 255, value & 255];
 }

--- a/app/frontend/src/UpdraftLensSlice.test.tsx
+++ b/app/frontend/src/UpdraftLensSlice.test.tsx
@@ -19,8 +19,11 @@ const frame: UpdraftLensFrame = {
   plane_index: 5,
   plane_coordinate: -2.65,
   plane_units: "km",
+  dimension_order: ["z", "x"],
   x_indices: [0, 1, 2],
   x_values_km: [-0.1, 0, 0.1],
+  y_indices: [0, 1, 2, 3, 4, 5],
+  y_values_km: [-0.5, -0.4, -0.3, -0.2, -0.1, 0],
   z_indices: [0, 1],
   z_values_km: [0.1, 0.3],
   w_values_m_s: [
@@ -91,11 +94,18 @@ describe("UpdraftLensSlice geometry", () => {
   });
 
   it("maps top-left pointer position to highest-z native indices", () => {
-    expect(updraftLensSelectionFromPointer(0, 0, 300, 200, [-0.1, 0, 0.1], [0.1, 0.3], 5)).toEqual({
-      xIndex: 0,
-      yIndex: 5,
-      zIndex: 1,
-    });
+    expect(
+      updraftLensSelectionFromPointer(0, 0, 300, 200, [-0.1, 0, 0.1], [0.1, 0.3], "vertical_x", 5),
+    ).toEqual({ xIndex: 0, yIndex: 5, zIndex: 1 });
+  });
+
+  it("maps pointer positions for horizontal and y-z slices", () => {
+    expect(
+      updraftLensSelectionFromPointer(300, 0, 300, 200, [0, 1, 2], [0, 1], "horizontal", 4),
+    ).toEqual({ xIndex: 2, yIndex: 1, zIndex: 4 });
+    expect(
+      updraftLensSelectionFromPointer(300, 200, 300, 200, [0, 1, 2], [0, 1], "vertical_y", 3),
+    ).toEqual({ xIndex: 3, yIndex: 2, zIndex: 0 });
   });
 });
 
@@ -104,6 +114,7 @@ describe("UpdraftLensSlice rendering", () => {
     const { container } = render(<UpdraftLensSlice frame={frame} />);
     const plot = screen.getByRole("img", { name: /Updraft Lens vertical x-z slice/ });
     expect(plot).toHaveAttribute("data-domain-aspect", "0.750000");
+    expect(plot).toHaveAttribute("data-orientation", "vertical_x");
     expect(container.querySelectorAll("rect")).toHaveLength(6);
     expect(screen.getByLabelText("Vertical velocity color scale")).toHaveTextContent("-1.0");
     expect(screen.getByTestId("updraft-lens-cloud-boundary")).toBeInTheDocument();
@@ -129,5 +140,31 @@ describe("UpdraftLensSlice rendering", () => {
     fireEvent.click(plot, { clientX: 300, clientY: 200 });
     expect(onSelectPoint).toHaveBeenCalledWith({ xIndex: 2, yIndex: 5, zIndex: 0 });
     expect(screen.queryByTestId("updraft-lens-cloud-boundary")).not.toBeInTheDocument();
+  });
+
+  it("renders horizontal axes from the frame dimension order", () => {
+    render(
+      <UpdraftLensSlice
+        frame={{
+          ...frame,
+          orientation: "horizontal",
+          plane_dimension: "z",
+          plane_index: 1,
+          dimension_order: ["y", "x"],
+          w_values_m_s: [
+            [-1, 0, 1],
+            [0, 0.5, 1],
+          ],
+          cloud_mask: [
+            [false, true, false],
+            [false, true, false],
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByRole("img", { name: /horizontal x-y slice/ })).toHaveAttribute(
+      "data-orientation",
+      "horizontal",
+    );
   });
 });

--- a/app/frontend/src/UpdraftLensSlice.test.tsx
+++ b/app/frontend/src/UpdraftLensSlice.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type UpdraftLensFrame,
+  UpdraftLensSlice,
+  updraftLensBoundaryPath,
+  updraftLensCellGeometry,
+  updraftLensColor,
+  updraftLensSelectionFromPointer,
+} from "./UpdraftLensSlice";
+
+const frame: UpdraftLensFrame = {
+  result_id: "result-bomex",
+  time_index: 61,
+  time_seconds: 18_300,
+  orientation: "vertical_x",
+  plane_dimension: "y",
+  plane_index: 5,
+  plane_coordinate: -2.65,
+  plane_units: "km",
+  x_indices: [0, 1, 2],
+  x_values_km: [-0.1, 0, 0.1],
+  z_indices: [0, 1],
+  z_values_km: [0.1, 0.3],
+  w_values_m_s: [
+    [-1, 0, 1],
+    [null, -0.5, 0.5],
+  ],
+  cloud_mask: [
+    [true, true, false],
+    [false, true, false],
+  ],
+  cloud_threshold_kg_kg: 1e-6,
+  w_range_min_m_s: -1,
+  w_range_max_m_s: 1,
+  w_range_method: "fixed",
+  wind_mode: "perturbation",
+  wind_target_level_m: 600,
+  wind_actual_level_m: 580,
+  wind_level_index: 14,
+  wind_stride: 8,
+  wind_reference_m_s: 0.9,
+  wind_arrow_domain_fraction: 0.08,
+  domain_mean_u_m_s: -8,
+  domain_mean_v_m_s: 0,
+  wind_vectors: [],
+  provenance: {
+    source_model: "CM1",
+    result_id: "result-bomex",
+    run_id: "bomex",
+    scenario_id: "bomex_trade_cumulus_baseline_v0",
+    processing_method: "test",
+    rendering_method: "test",
+    provenance_label: "test",
+  },
+  caveats: [],
+};
+
+describe("UpdraftLensSlice colors", () => {
+  it("uses the approved fixed diverging palette and distinct missing color", () => {
+    expect(updraftLensColor(-1, -1, 1)).toBe("#2166ac");
+    expect(updraftLensColor(0, -1, 1)).toBe("#f7f7f7");
+    expect(updraftLensColor(1, -1, 1)).toBe("#b2182b");
+    expect(updraftLensColor(null, -1, 1)).toBe("#747b80");
+    expect(updraftLensColor(-20, -1, 1)).toBe("#2166ac");
+    expect(updraftLensColor(20, -1, 1)).toBe("#b2182b");
+  });
+});
+
+describe("UpdraftLensSlice geometry", () => {
+  it("makes adjacent native-grid cells contiguous without gutters", () => {
+    const first = updraftLensCellGeometry([-0.15, -0.05, 0.05], [0, 0.2], 0, 0);
+    const second = updraftLensCellGeometry([-0.15, -0.05, 0.05], [0, 0.2], 1, 0);
+    expect(first.x + first.width).toBeCloseTo(second.x);
+    expect(first.height).toBeCloseTo(second.height);
+  });
+
+  it("draws cloud-clear and outer cloud edges", () => {
+    const path = updraftLensBoundaryPath(
+      [
+        [true, true],
+        [false, true],
+      ],
+      [0, 1, 2],
+      [0, 1, 2],
+    );
+    expect(path).toContain("M 0 0 L 0 1");
+    expect(path).toContain("M 0 1 L 1 1");
+    expect(path).toContain("M 2 1 L 2 2");
+  });
+
+  it("maps top-left pointer position to highest-z native indices", () => {
+    expect(updraftLensSelectionFromPointer(0, 0, 300, 200, [-0.1, 0, 0.1], [0.1, 0.3], 5)).toEqual({
+      xIndex: 0,
+      yIndex: 5,
+      zIndex: 1,
+    });
+  });
+});
+
+describe("UpdraftLensSlice rendering", () => {
+  it("preserves physical aspect, fixed legend, boundary, and accessible summary", () => {
+    const { container } = render(<UpdraftLensSlice frame={frame} />);
+    const plot = screen.getByRole("img", { name: /Updraft Lens vertical x-z slice/ });
+    expect(plot).toHaveAttribute("data-domain-aspect", "0.750000");
+    expect(container.querySelectorAll("rect")).toHaveLength(6);
+    expect(screen.getByLabelText("Vertical velocity color scale")).toHaveTextContent("-1.0");
+    expect(screen.getByTestId("updraft-lens-cloud-boundary")).toBeInTheDocument();
+  });
+
+  it("hides the boundary and reports native indices on click", () => {
+    const onSelectPoint = vi.fn();
+    render(
+      <UpdraftLensSlice frame={frame} showCloudBoundary={false} onSelectPoint={onSelectPoint} />,
+    );
+    const plot = screen.getByRole("img", { name: /Updraft Lens vertical x-z slice/ });
+    vi.spyOn(plot, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 300,
+      bottom: 200,
+      width: 300,
+      height: 200,
+      toJSON: () => ({}),
+    });
+    fireEvent.click(plot, { clientX: 300, clientY: 200 });
+    expect(onSelectPoint).toHaveBeenCalledWith({ xIndex: 2, yIndex: 5, zIndex: 0 });
+    expect(screen.queryByTestId("updraft-lens-cloud-boundary")).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/UpdraftLensSlice.tsx
+++ b/app/frontend/src/UpdraftLensSlice.tsx
@@ -2,6 +2,8 @@
 import type { MouseEvent as ReactMouseEvent } from "react";
 
 export type UpdraftLensWindMode = "perturbation" | "total";
+export type UpdraftLensOrientation = "horizontal" | "vertical_x" | "vertical_y";
+export type UpdraftLensDimension = "x" | "y" | "z";
 
 export type UpdraftLensWindVector = {
   x_km: number;
@@ -16,13 +18,16 @@ export type UpdraftLensFrame = {
   result_id: string;
   time_index: number;
   time_seconds: number | null;
-  orientation: "vertical_x";
-  plane_dimension: "y";
+  orientation: UpdraftLensOrientation;
+  plane_dimension: UpdraftLensDimension;
   plane_index: number;
   plane_coordinate: number | null;
   plane_units: string | null;
+  dimension_order: UpdraftLensDimension[];
   x_indices: number[];
   x_values_km: number[];
+  y_indices: number[];
+  y_values_km: number[];
   z_indices: number[];
   z_values_km: number[];
   w_values_m_s: Array<Array<number | null>>;
@@ -116,24 +121,38 @@ export function UpdraftLensSlice({
   selectedPoint = null,
   onSelectPoint,
 }: UpdraftLensSliceProps) {
-  const xEdges = coordinateEdges(frame.x_values_km);
-  const zEdges = coordinateEdges(frame.z_values_km);
-  const xMin = xEdges[0] ?? 0;
-  const xMax = xEdges.at(-1) ?? 1;
-  const zMin = zEdges[0] ?? 0;
-  const zMax = zEdges.at(-1) ?? 1;
-  const width = Math.max(Number.EPSILON, xMax - xMin);
-  const height = Math.max(Number.EPSILON, zMax - zMin);
+  const rowDimension = frame.dimension_order[0] ?? "z";
+  const columnDimension = frame.dimension_order[1] ?? "x";
+  const rowValues = updraftLensCoordinateValues(frame, rowDimension);
+  const columnValues = updraftLensCoordinateValues(frame, columnDimension);
+  const columnEdges = coordinateEdges(columnValues);
+  const rowEdges = coordinateEdges(rowValues);
+  const columnMin = columnEdges[0] ?? 0;
+  const columnMax = columnEdges.at(-1) ?? 1;
+  const rowMin = rowEdges[0] ?? 0;
+  const rowMax = rowEdges.at(-1) ?? 1;
+  const width = Math.max(Number.EPSILON, columnMax - columnMin);
+  const height = Math.max(Number.EPSILON, rowMax - rowMin);
   const boundaryPath = showCloudBoundary
-    ? updraftLensBoundaryPath(frame.cloud_mask, xEdges, zEdges)
+    ? updraftLensBoundaryPath(frame.cloud_mask, columnEdges, rowEdges)
     : "";
-  const selectedX =
-    selectedPoint && selectedPoint.yIndex === frame.plane_index
-      ? frame.x_values_km[selectedPoint.xIndex]
+  const selectedColumnIndex = selectedPoint
+    ? updraftLensPointIndex(selectedPoint, columnDimension)
+    : undefined;
+  const selectedRowIndex = selectedPoint
+    ? updraftLensPointIndex(selectedPoint, rowDimension)
+    : undefined;
+  const selectedColumn =
+    selectedPoint &&
+    updraftLensPointIndex(selectedPoint, frame.plane_dimension) === frame.plane_index &&
+    selectedColumnIndex !== undefined
+      ? columnValues[selectedColumnIndex]
       : undefined;
-  const selectedZ =
-    selectedPoint && selectedPoint.yIndex === frame.plane_index
-      ? frame.z_values_km[selectedPoint.zIndex]
+  const selectedRow =
+    selectedPoint &&
+    updraftLensPointIndex(selectedPoint, frame.plane_dimension) === frame.plane_index &&
+    selectedRowIndex !== undefined
+      ? rowValues[selectedRowIndex]
       : undefined;
 
   function handlePointer(event: ReactMouseEvent<SVGSVGElement>) {
@@ -144,8 +163,9 @@ export function UpdraftLensSlice({
       event.clientY - bounds.top,
       bounds.width,
       bounds.height,
-      frame.x_values_km,
-      frame.z_values_km,
+      columnValues,
+      rowValues,
+      frame.orientation,
       frame.plane_index,
     );
     if (selection) onSelectPoint(selection);
@@ -154,9 +174,9 @@ export function UpdraftLensSlice({
   return (
     <section className="updraft-lens-slice" aria-label="Updraft Lens vertical slice">
       <div className="updraft-lens-axis updraft-lens-axis-z" aria-hidden="true">
-        <span>{formatKilometers(zMax)}</span>
-        <strong>z (km)</strong>
-        <span>{formatKilometers(zMin)}</span>
+        <span>{formatKilometers(rowMax)}</span>
+        <strong>{rowDimension} (km)</strong>
+        <span>{formatKilometers(rowMin)}</span>
       </div>
       <div className="updraft-lens-plot-column">
         <svg
@@ -164,16 +184,17 @@ export function UpdraftLensSlice({
           role="img"
           aria-label={updraftLensAccessibleSummary(frame)}
           data-domain-aspect={(width / height).toFixed(6)}
-          viewBox={`${xMin} ${zMin} ${width} ${height}`}
+          data-orientation={frame.orientation}
+          viewBox={`${columnMin} ${rowMin} ${width} ${height}`}
           preserveAspectRatio="none"
           style={{ aspectRatio: `${width} / ${height}` }}
           shapeRendering="crispEdges"
           onClick={handlePointer}
         >
-          <g transform={`translate(0 ${zMin + zMax}) scale(1 -1)`}>
+          <g transform={`translate(0 ${rowMin + rowMax}) scale(1 -1)`}>
             {frame.w_values_m_s.map((row, zIndex) =>
               row.map((value, xIndex) => {
-                const geometry = updraftLensCellGeometry(xEdges, zEdges, xIndex, zIndex);
+                const geometry = updraftLensCellGeometry(columnEdges, rowEdges, xIndex, zIndex);
                 return (
                   <rect
                     key={`${zIndex}-${xIndex}`}
@@ -196,11 +217,11 @@ export function UpdraftLensSlice({
                 vectorEffect="non-scaling-stroke"
               />
             )}
-            {selectedX !== undefined && selectedZ !== undefined && (
+            {selectedColumn !== undefined && selectedRow !== undefined && (
               <circle
                 className="updraft-lens-selected-point"
-                cx={selectedX}
-                cy={selectedZ}
+                cx={selectedColumn}
+                cy={selectedRow}
                 r={Math.min(width, height) * 0.018}
                 vectorEffect="non-scaling-stroke"
               />
@@ -208,9 +229,9 @@ export function UpdraftLensSlice({
           </g>
         </svg>
         <div className="updraft-lens-axis updraft-lens-axis-x" aria-hidden="true">
-          <span>{formatKilometers(xMin)}</span>
-          <strong>x (km)</strong>
-          <span>{formatKilometers(xMax)}</span>
+          <span>{formatKilometers(columnMin)}</span>
+          <strong>{columnDimension} (km)</strong>
+          <span>{formatKilometers(columnMax)}</span>
         </div>
         <div className="updraft-lens-legend" aria-label="Vertical velocity color scale">
           <span>{frame.w_range_min_m_s.toFixed(1)}</span>
@@ -279,25 +300,54 @@ export function updraftLensSelectionFromPointer(
   pointerY: number,
   renderedWidth: number,
   renderedHeight: number,
-  xValues: number[],
-  zValues: number[],
-  yIndex: number,
+  columnValues: number[],
+  rowValues: number[],
+  orientation: UpdraftLensOrientation,
+  planeIndex: number,
 ): UpdraftLensPointSelection | null {
-  if (renderedWidth <= 0 || renderedHeight <= 0 || xValues.length === 0 || zValues.length === 0) {
+  if (
+    renderedWidth <= 0 ||
+    renderedHeight <= 0 ||
+    columnValues.length === 0 ||
+    rowValues.length === 0
+  ) {
     return null;
   }
-  const xEdges = coordinateEdges(xValues);
-  const zEdges = coordinateEdges(zValues);
-  const xCoordinate =
-    (xEdges[0] ?? 0) + clamp(pointerX / renderedWidth) * ((xEdges.at(-1) ?? 1) - (xEdges[0] ?? 0));
-  const zCoordinate =
-    (zEdges.at(-1) ?? 1) -
-    clamp(pointerY / renderedHeight) * ((zEdges.at(-1) ?? 1) - (zEdges[0] ?? 0));
-  return {
-    xIndex: nearestIndex(xValues, xCoordinate),
-    yIndex,
-    zIndex: nearestIndex(zValues, zCoordinate),
-  };
+  const columnEdges = coordinateEdges(columnValues);
+  const rowEdges = coordinateEdges(rowValues);
+  const columnCoordinate =
+    (columnEdges[0] ?? 0) +
+    clamp(pointerX / renderedWidth) * ((columnEdges.at(-1) ?? 1) - (columnEdges[0] ?? 0));
+  const rowCoordinate =
+    (rowEdges.at(-1) ?? 1) -
+    clamp(pointerY / renderedHeight) * ((rowEdges.at(-1) ?? 1) - (rowEdges[0] ?? 0));
+  const columnIndex = nearestIndex(columnValues, columnCoordinate);
+  const rowIndex = nearestIndex(rowValues, rowCoordinate);
+  if (orientation === "horizontal") {
+    return { xIndex: columnIndex, yIndex: rowIndex, zIndex: planeIndex };
+  }
+  if (orientation === "vertical_x") {
+    return { xIndex: columnIndex, yIndex: planeIndex, zIndex: rowIndex };
+  }
+  return { xIndex: planeIndex, yIndex: columnIndex, zIndex: rowIndex };
+}
+
+export function updraftLensCoordinateValues(
+  frame: UpdraftLensFrame,
+  dimension: UpdraftLensDimension,
+): number[] {
+  if (dimension === "x") return frame.x_values_km;
+  if (dimension === "y") return frame.y_values_km;
+  return frame.z_values_km;
+}
+
+function updraftLensPointIndex(
+  selection: UpdraftLensPointSelection,
+  dimension: UpdraftLensDimension,
+): number {
+  if (dimension === "x") return selection.xIndex;
+  if (dimension === "y") return selection.yIndex;
+  return selection.zIndex;
 }
 
 function coordinateEdges(values: number[]): number[] {
@@ -357,5 +407,11 @@ function updraftLensAccessibleSummary(frame: UpdraftLensFrame): string {
   const updraftCells = finiteValues.filter((value) => value > 0).length;
   const downdraftCells = finiteValues.filter((value) => value < 0).length;
   const cloudCells = frame.cloud_mask.flat().filter(Boolean).length;
-  return `Updraft Lens vertical x-z slice at y index ${frame.plane_index}; ${updraftCells} updraft cells, ${downdraftCells} downdraft cells, and ${cloudCells} cloud cells.`;
+  return `Updraft Lens ${updraftLensOrientationLabel(frame.orientation)} at ${frame.plane_dimension} index ${frame.plane_index}; ${updraftCells} updraft cells, ${downdraftCells} downdraft cells, and ${cloudCells} cloud cells.`;
+}
+
+function updraftLensOrientationLabel(orientation: UpdraftLensOrientation): string {
+  if (orientation === "horizontal") return "horizontal x-y slice";
+  if (orientation === "vertical_y") return "vertical y-z slice";
+  return "vertical x-z slice";
 }

--- a/app/frontend/src/UpdraftLensSlice.tsx
+++ b/app/frontend/src/UpdraftLensSlice.tsx
@@ -1,0 +1,361 @@
+/* eslint-disable react-refresh/only-export-components */
+import type { MouseEvent as ReactMouseEvent } from "react";
+
+export type UpdraftLensWindMode = "perturbation" | "total";
+
+export type UpdraftLensWindVector = {
+  x_km: number;
+  y_km: number;
+  z_km: number;
+  u_m_s: number;
+  v_m_s: number;
+  magnitude_m_s: number;
+};
+
+export type UpdraftLensFrame = {
+  result_id: string;
+  time_index: number;
+  time_seconds: number | null;
+  orientation: "vertical_x";
+  plane_dimension: "y";
+  plane_index: number;
+  plane_coordinate: number | null;
+  plane_units: string | null;
+  x_indices: number[];
+  x_values_km: number[];
+  z_indices: number[];
+  z_values_km: number[];
+  w_values_m_s: Array<Array<number | null>>;
+  cloud_mask: boolean[][];
+  cloud_threshold_kg_kg: number;
+  w_range_min_m_s: number;
+  w_range_max_m_s: number;
+  w_range_method: string;
+  wind_mode: UpdraftLensWindMode;
+  wind_target_level_m: number;
+  wind_actual_level_m: number;
+  wind_level_index: number;
+  wind_stride: number;
+  wind_reference_m_s: number;
+  wind_arrow_domain_fraction: number;
+  domain_mean_u_m_s: number;
+  domain_mean_v_m_s: number;
+  wind_vectors: UpdraftLensWindVector[];
+  provenance: {
+    source_model: string;
+    result_id: string;
+    run_id: string;
+    scenario_id: string;
+    processing_method: string;
+    rendering_method: string;
+    provenance_label: string;
+  };
+  caveats: string[];
+};
+
+export type UpdraftLensPointSelection = {
+  xIndex: number;
+  yIndex: number;
+  zIndex: number;
+};
+
+export type UpdraftLensDefaults = {
+  result_id: string;
+  case_id: string;
+  eligible: boolean;
+  primary_field: "w";
+  cloud_field: "ql";
+  orientation: "vertical_x";
+  default_time_index: number;
+  default_time_seconds: number | null;
+  default_time_method: string;
+  default_plane_dimension: "y";
+  default_plane_index: number;
+  default_plane_coordinate: number | null;
+  default_plane_units: string | null;
+  default_plane_method: string;
+  cloud_threshold_kg_kg: number;
+  w_range_min_m_s: number;
+  w_range_max_m_s: number;
+  w_range_method: string;
+  wind_target_level_m: number;
+  wind_actual_level_m: number;
+  wind_level_index: number;
+  wind_default_mode: "perturbation";
+  wind_stride: number;
+  wind_shown_by_default: boolean;
+  perturbation_wind_reference_m_s: number;
+  total_wind_reference_m_s: number;
+  wind_arrow_domain_fraction: number;
+  provenance: UpdraftLensFrame["provenance"];
+  caveats: string[];
+};
+
+type UpdraftLensSliceProps = {
+  frame: UpdraftLensFrame;
+  showCloudBoundary?: boolean;
+  selectedPoint?: UpdraftLensPointSelection | null;
+  onSelectPoint?: (selection: UpdraftLensPointSelection) => void;
+};
+
+type CellGeometry = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+const DOWNDRAFT_COLOR = "#2166ac";
+const NEUTRAL_COLOR = "#f7f7f7";
+const UPDRAFT_COLOR = "#b2182b";
+const MISSING_COLOR = "#747b80";
+
+export function UpdraftLensSlice({
+  frame,
+  showCloudBoundary = true,
+  selectedPoint = null,
+  onSelectPoint,
+}: UpdraftLensSliceProps) {
+  const xEdges = coordinateEdges(frame.x_values_km);
+  const zEdges = coordinateEdges(frame.z_values_km);
+  const xMin = xEdges[0] ?? 0;
+  const xMax = xEdges.at(-1) ?? 1;
+  const zMin = zEdges[0] ?? 0;
+  const zMax = zEdges.at(-1) ?? 1;
+  const width = Math.max(Number.EPSILON, xMax - xMin);
+  const height = Math.max(Number.EPSILON, zMax - zMin);
+  const boundaryPath = showCloudBoundary
+    ? updraftLensBoundaryPath(frame.cloud_mask, xEdges, zEdges)
+    : "";
+  const selectedX =
+    selectedPoint && selectedPoint.yIndex === frame.plane_index
+      ? frame.x_values_km[selectedPoint.xIndex]
+      : undefined;
+  const selectedZ =
+    selectedPoint && selectedPoint.yIndex === frame.plane_index
+      ? frame.z_values_km[selectedPoint.zIndex]
+      : undefined;
+
+  function handlePointer(event: ReactMouseEvent<SVGSVGElement>) {
+    if (!onSelectPoint) return;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const selection = updraftLensSelectionFromPointer(
+      event.clientX - bounds.left,
+      event.clientY - bounds.top,
+      bounds.width,
+      bounds.height,
+      frame.x_values_km,
+      frame.z_values_km,
+      frame.plane_index,
+    );
+    if (selection) onSelectPoint(selection);
+  }
+
+  return (
+    <section className="updraft-lens-slice" aria-label="Updraft Lens vertical slice">
+      <div className="updraft-lens-axis updraft-lens-axis-z" aria-hidden="true">
+        <span>{formatKilometers(zMax)}</span>
+        <strong>z (km)</strong>
+        <span>{formatKilometers(zMin)}</span>
+      </div>
+      <div className="updraft-lens-plot-column">
+        <svg
+          className="updraft-lens-svg"
+          role="img"
+          aria-label={updraftLensAccessibleSummary(frame)}
+          data-domain-aspect={(width / height).toFixed(6)}
+          viewBox={`${xMin} ${zMin} ${width} ${height}`}
+          preserveAspectRatio="none"
+          style={{ aspectRatio: `${width} / ${height}` }}
+          shapeRendering="crispEdges"
+          onClick={handlePointer}
+        >
+          <g transform={`translate(0 ${zMin + zMax}) scale(1 -1)`}>
+            {frame.w_values_m_s.map((row, zIndex) =>
+              row.map((value, xIndex) => {
+                const geometry = updraftLensCellGeometry(xEdges, zEdges, xIndex, zIndex);
+                return (
+                  <rect
+                    key={`${zIndex}-${xIndex}`}
+                    data-cell={`${zIndex}-${xIndex}`}
+                    x={geometry.x}
+                    y={geometry.y}
+                    width={geometry.width}
+                    height={geometry.height}
+                    fill={updraftLensColor(value, frame.w_range_min_m_s, frame.w_range_max_m_s)}
+                  />
+                );
+              }),
+            )}
+            {boundaryPath && (
+              <path
+                className="updraft-lens-cloud-boundary"
+                data-testid="updraft-lens-cloud-boundary"
+                d={boundaryPath}
+                fill="none"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+            {selectedX !== undefined && selectedZ !== undefined && (
+              <circle
+                className="updraft-lens-selected-point"
+                cx={selectedX}
+                cy={selectedZ}
+                r={Math.min(width, height) * 0.018}
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+          </g>
+        </svg>
+        <div className="updraft-lens-axis updraft-lens-axis-x" aria-hidden="true">
+          <span>{formatKilometers(xMin)}</span>
+          <strong>x (km)</strong>
+          <span>{formatKilometers(xMax)}</span>
+        </div>
+        <div className="updraft-lens-legend" aria-label="Vertical velocity color scale">
+          <span>{frame.w_range_min_m_s.toFixed(1)}</span>
+          <span className="updraft-lens-color-ramp" />
+          <span>{frame.w_range_max_m_s.toFixed(1)} m/s</span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function updraftLensColor(
+  value: number | null,
+  rangeMinimum: number,
+  rangeMaximum: number,
+): string {
+  if (value === null || !Number.isFinite(value)) return MISSING_COLOR;
+  if (value <= 0) {
+    const denominator = Math.max(Number.EPSILON, Math.abs(rangeMinimum));
+    return interpolateHex(DOWNDRAFT_COLOR, NEUTRAL_COLOR, 1 - clamp(Math.abs(value) / denominator));
+  }
+  const denominator = Math.max(Number.EPSILON, Math.abs(rangeMaximum));
+  return interpolateHex(NEUTRAL_COLOR, UPDRAFT_COLOR, clamp(value / denominator));
+}
+
+export function updraftLensCellGeometry(
+  xEdges: number[],
+  zEdges: number[],
+  xIndex: number,
+  zIndex: number,
+): CellGeometry {
+  const x = xEdges[xIndex] ?? 0;
+  const y = zEdges[zIndex] ?? 0;
+  return {
+    x,
+    y,
+    width: Math.max(0, (xEdges[xIndex + 1] ?? x) - x),
+    height: Math.max(0, (zEdges[zIndex + 1] ?? y) - y),
+  };
+}
+
+export function updraftLensBoundaryPath(
+  cloudMask: boolean[][],
+  xEdges: number[],
+  zEdges: number[],
+): string {
+  const segments: string[] = [];
+  for (let zIndex = 0; zIndex < cloudMask.length; zIndex += 1) {
+    for (let xIndex = 0; xIndex < (cloudMask[zIndex]?.length ?? 0); xIndex += 1) {
+      if (!cloudMask[zIndex]?.[xIndex]) continue;
+      const x0 = xEdges[xIndex] ?? 0;
+      const x1 = xEdges[xIndex + 1] ?? x0;
+      const z0 = zEdges[zIndex] ?? 0;
+      const z1 = zEdges[zIndex + 1] ?? z0;
+      if (!cloudMask[zIndex]?.[xIndex - 1]) segments.push(`M ${x0} ${z0} L ${x0} ${z1}`);
+      if (!cloudMask[zIndex]?.[xIndex + 1]) segments.push(`M ${x1} ${z0} L ${x1} ${z1}`);
+      if (!cloudMask[zIndex - 1]?.[xIndex]) segments.push(`M ${x0} ${z0} L ${x1} ${z0}`);
+      if (!cloudMask[zIndex + 1]?.[xIndex]) segments.push(`M ${x0} ${z1} L ${x1} ${z1}`);
+    }
+  }
+  return segments.join(" ");
+}
+
+export function updraftLensSelectionFromPointer(
+  pointerX: number,
+  pointerY: number,
+  renderedWidth: number,
+  renderedHeight: number,
+  xValues: number[],
+  zValues: number[],
+  yIndex: number,
+): UpdraftLensPointSelection | null {
+  if (renderedWidth <= 0 || renderedHeight <= 0 || xValues.length === 0 || zValues.length === 0) {
+    return null;
+  }
+  const xEdges = coordinateEdges(xValues);
+  const zEdges = coordinateEdges(zValues);
+  const xCoordinate =
+    (xEdges[0] ?? 0) + clamp(pointerX / renderedWidth) * ((xEdges.at(-1) ?? 1) - (xEdges[0] ?? 0));
+  const zCoordinate =
+    (zEdges.at(-1) ?? 1) -
+    clamp(pointerY / renderedHeight) * ((zEdges.at(-1) ?? 1) - (zEdges[0] ?? 0));
+  return {
+    xIndex: nearestIndex(xValues, xCoordinate),
+    yIndex,
+    zIndex: nearestIndex(zValues, zCoordinate),
+  };
+}
+
+function coordinateEdges(values: number[]): number[] {
+  if (values.length === 0) return [0, 1];
+  if (values.length === 1) return [values[0] - 0.5, values[0] + 0.5];
+  const edges = [values[0] - (values[1] - values[0]) / 2];
+  for (let index = 1; index < values.length; index += 1) {
+    edges.push((values[index - 1] + values[index]) / 2);
+  }
+  edges.push(values.at(-1)! + (values.at(-1)! - values.at(-2)!) / 2);
+  return edges;
+}
+
+function nearestIndex(values: number[], target: number): number {
+  let selected = 0;
+  let distance = Number.POSITIVE_INFINITY;
+  values.forEach((value, index) => {
+    const candidateDistance = Math.abs(value - target);
+    if (candidateDistance < distance) {
+      selected = index;
+      distance = candidateDistance;
+    }
+  });
+  return selected;
+}
+
+function interpolateHex(start: string, end: string, amount: number): string {
+  const startRgb = hexToRgb(start);
+  const endRgb = hexToRgb(end);
+  return `#${[0, 1, 2]
+    .map((index) =>
+      Math.round(startRgb[index] + (endRgb[index] - startRgb[index]) * clamp(amount))
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  return [
+    Number.parseInt(hex.slice(1, 3), 16),
+    Number.parseInt(hex.slice(3, 5), 16),
+    Number.parseInt(hex.slice(5, 7), 16),
+  ];
+}
+
+function clamp(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function formatKilometers(value: number): string {
+  return `${Number(value.toFixed(2))}`;
+}
+
+function updraftLensAccessibleSummary(frame: UpdraftLensFrame): string {
+  const finiteValues = frame.w_values_m_s.flat().filter((value): value is number => value !== null);
+  const updraftCells = finiteValues.filter((value) => value > 0).length;
+  const downdraftCells = finiteValues.filter((value) => value < 0).length;
+  const cloudCells = frame.cloud_mask.flat().filter(Boolean).length;
+  return `Updraft Lens vertical x-z slice at y index ${frame.plane_index}; ${updraftCells} updraft cells, ${downdraftCells} downdraft cells, and ${cloudCells} cloud cells.`;
+}


### PR DESCRIPTION
Closes #376

## Summary

- Implements the dedicated Trade Cumulus Updraft Lens defaults and frame contracts for eligible BOMEX results.
- Renders the Lens vertical-velocity plane in the Three.js scene and in a physically proportioned, gapless 2-D inspector with the fixed blue/neutral/red scale and black cloud boundary.
- Places the Standard/Updraft Lens mode control with the Explore controls and keeps the 3-D scalar field, threshold, opacity, and point-size controls available in Lens mode.
- Extends the Lens plane control to horizontal x-y, vertical x-z, and vertical y-z orientations while retaining the approved vertical x-z backend default.
- Corrects the Standard slice renderer to use full-domain physical proportions, contiguous cells, stronger min-to-max colors, and the same fixed-threshold black cloud-water boundary.
- Preserves Lens orientation and position when the user changes the independent 3-D scalar layer.

## Scope

Related issue: #376

Files changed:

```text
app/backend/cloud_chamber/app.py
app/backend/cloud_chamber/trade_cumulus_updraft_lens.py
app/backend/tests/test_app.py
app/backend/tests/test_trade_cumulus_updraft_lens.py
app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
app/frontend/src/App.css
app/frontend/src/App.test.tsx
app/frontend/src/App.tsx
app/frontend/src/True3DViewer.test.tsx
app/frontend/src/True3DViewer.tsx
app/frontend/src/True3DViewer.utils.ts
app/frontend/src/UpdraftLensSlice.test.tsx
app/frontend/src/UpdraftLensSlice.tsx
```

This is exactly the 13-path approved scope. Explicitly out of scope: CM1 execution, BOMEX configuration, Moisture Control, Comparison, Saved Views, a generic Lens/vector framework, cloud-object tracking, Build/Results restructuring, and persisted schema changes.

## Backend contract

Endpoints:

```text
GET /api/results/{result_id}/visualization/trade-cumulus-updraft-lens/defaults
GET /api/results/{result_id}/visualization/trade-cumulus-updraft-lens/frame
```

The frame endpoint accepts `time_index`, `plane_index`, `orientation` in `horizontal|vertical_x|vertical_y`, and `wind_mode` in `perturbation|total`. The response identifies `orientation`, fixed `plane_dimension`, native `dimension_order`, x/y/z indices and km coordinates, w values, cloud mask, fixed scale, wind metadata/vectors, provenance, and caveats.

Preserved-result grid evidence used:

```text
ql  time,zh,yh,xh  1x75x64x64
w   time,zf,yh,xh  1x76x64x64 -> centered to zh
u   time,zh,yh,xf  1x75x64x65 -> centered to xh
v   time,zh,yf,xh  1x75x65x64 -> centered to yh
cwp time,yh,xh     1x64x64 per output file
```

The dedicated module retains the approved eligibility, time/plane selection, centering, threshold, percentile, rounding, stride, and wind-reference algorithms and constants.

## Product and science impact

This implements the approved candidate Updraft Lens and PM-directed review corrections. It does not change product direction, scientific interpretation, recipe/scenario status, destructive cleanup, real CM1 execution, or any manifest/result/scenario schema.

This PR does not establish a universal Lens system, validate Trade Cumulus as a supported product, or define Moisture Control/Comparison behavior.

## Preserved BOMEX validation

Validated read-only against `result-bomex-370-full-20260719`; no CM1 run occurred:

```text
default output: frame 61 at 18,300 s
default vertical plane: y index 5 at -2.65 km
fixed w range: -0.9 to +0.9 m/s
wind level: 580 m
perturbation/total references: 0.9/8.8 m/s
```

Unmocked Playwright covered the normal Results-to-Explore path after startup synchronization, Standard x-y/x-z/y-z views, Lens x-y/x-z/y-z views and native point mapping, the actual Three.js planes, scalar/opacity/size controls, preservation of plane 5 after changing `ql` to `qv`, and desktop plus 390x844 mobile layouts. Measured Standard ratios were 1.0 for x-y and 2.128 for both vertical planes; Lens ratios were 1.0 and 2.133. There were no console errors, page errors, request failures, or horizontal overflow.

## Verification

```text
BACKEND_PYTHON=app/backend/.venv/bin/python scripts/check.sh
# 87 frontend tests passed; 490 backend tests passed

npx playwright test e2e/mocked-smoke/build-results-explore.spec.ts --project=chromium
# 16 passed

git diff --check
```

Focused backend, Vitest, and Chromium checks also passed. Expected existing warnings remain: React `act(...)` output in one test, Vite's large-chunk advisory, and the backend numpy ABI warning.

## Risks and review focus

- Verify texture orientation and plane placement for all three Lens orientations.
- Verify Standard and Lens aspect ratios remain tied to physical coordinate extents.
- Verify the Standard cloud boundary follows `ql >= 1e-6 kg/kg` for both cloud-water and non-cloud scalar slices.
- Verify changing the 3-D scalar layer in Lens mode does not move or replace the w slice.
- Verify deactivation restores the prior ordinary Explore state.

## Artifact check

- [x] No CM1 source or binaries were committed.
- [x] No NetCDF output, generated run directories, runtime data, or sounding caches were committed.
- [x] No machine-private paths, settings, logs, screenshots, videos, traces, or large generated artifacts were committed.

## Merge posture

- [x] Manual review required.
- [x] Auto-merge is not enabled.

Draft PR. Do not merge under this handoff.
