### PR TITLE
Stage 5B-2: run the Trade Cumulus moisture comparison

### DIFF
--- a/app/backend/cloud_chamber/bomex_case.py
+++ b/app/backend/cloud_chamber/bomex_case.py
@@ -323,15 +323,15 @@ def render_bomex_namelist(reference_text: str, variant: BomexVariant) -> str:
     rendered = reference_text
     overrides = {**_COMMON_NAMELIST_OVERRIDES, "timax": f"{variant.duration_seconds}.0"}
     for name, value in overrides.items():
-        rendered = _replace_namelist_assignment(rendered, name, value)
+        rendered = replace_bomex_namelist_assignment(rendered, name, value)
     for name, value in REQUIRED_OUTPUT_SWITCHES.items():
-        rendered = _replace_namelist_assignment(rendered, name, value)
+        rendered = replace_bomex_namelist_assignment(rendered, name, value)
     return rendered.rstrip() + "\n"
 
 
 def normalized_science_namelist(namelist_text: str) -> str:
     """Normalize the sole smoke/full science difference for equivalence checks."""
-    return _replace_namelist_assignment(namelist_text, "timax", "<duration_seconds>")
+    return replace_bomex_namelist_assignment(namelist_text, "timax", "<duration_seconds>")
 
 
 def render_profile_audit() -> str:
@@ -353,7 +353,7 @@ def generate_bomex_package(
     allow_overwrite: bool = False,
 ) -> BomexPackageResult:
     """Generate a deterministic, provenance-rich BOMEX runtime package."""
-    resolved_commit = _clean_git_commit()
+    resolved_commit = verified_clean_git_commit()
     provenance = collect_cm1_provenance(settings)
     package_dir = settings.runtime_home.expanduser() / "runs" / run_id
     if package_dir.exists():
@@ -596,7 +596,7 @@ def build_bomex_run_evidence(
         ),
         mean_lwp_final_three_hours_kg_m2=_mean_metric(final_three_hour, "mean_lwp"),
         max_lwp_kg_m2=max(lwp_values) if lwp_values else None,
-        lwp_cycle_peak_count=_local_peak_count(lwp_values),
+        lwp_cycle_peak_count=cloud_water_cycle_peak_count(lwp_values),
         forcing_diagnostic_fields=diag_summary,
         resolved_turbulent_flux_fields=flux_fields,
         final_domain_mean_profiles=final_profiles,
@@ -677,7 +677,8 @@ def _case_manifest_payload(
     }
 
 
-def _replace_namelist_assignment(text: str, name: str, value: str) -> str:
+def replace_bomex_namelist_assignment(text: str, name: str, value: str) -> str:
+    """Replace exactly one assignment in the pinned BOMEX namelist."""
     pattern = re.compile(
         rf"^(?P<prefix>\s*{re.escape(name)}\s*=\s*)(?P<value>[^,!\n]+)(?P<suffix>\s*,.*)$",
         re.MULTILINE,
@@ -699,7 +700,8 @@ def _linear_profile_value(height_m: float, knots: tuple[tuple[float, float], ...
     return knots[-1][1]
 
 
-def _clean_git_commit() -> str:
+def verified_clean_git_commit() -> str:
+    """Return HEAD only when the repository worktree is verifiably clean."""
     commit = _git_output("rev-parse", "HEAD")
     dirty_state = _git_output("status", "--porcelain=v1", "--untracked-files=all")
     if dirty_state:
@@ -969,7 +971,8 @@ def _final_three_hour_cloud_fraction_peak(
     return float(time_mean_profile[peak_index]), peak_height
 
 
-def _local_peak_count(values: list[float]) -> int:
+def cloud_water_cycle_peak_count(values: list[float]) -> int:
+    """Count cloud-water cycle peaks using the preserved Stage 4 method."""
     if len(values) < 3:
         return 0
     maximum = max(values)

--- a/app/backend/cloud_chamber/trade_cumulus_moisture_comparison.py
+++ b/app/backend/cloud_chamber/trade_cumulus_moisture_comparison.py
@@ -1,0 +1,1997 @@
+"""Bounded matched-run evidence for the Trade Cumulus moisture Control."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import re
+import shutil
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.bomex_case import (
+    CASE_ID,
+    DIAGNOSTIC_CADENCE_SECONDS,
+    MAPPING_VERSION,
+    REQUIRED_OUTPUT_FIELDS,
+    SCIENTIFIC_SOURCE_DOI,
+    SCIENTIFIC_SOURCE_RECORD,
+    BomexCaseError,
+    BomexVariant,
+    cloud_water_cycle_peak_count,
+    generate_bomex_package,
+    render_bomex_namelist,
+    replace_bomex_namelist_assignment,
+    sha256_file,
+    sha256_text,
+    verified_clean_git_commit,
+)
+from cloud_chamber.result_ingest import ResultMetadata
+from cloud_chamber.run_manifest import load_run_manifest, write_run_manifest
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.trade_cumulus_updraft_lens import (
+    CLOUD_THRESHOLD_KG_KG,
+    W_MIN_RANGE_M_S,
+    W_PERCENTILE,
+    WIND_MIN_REFERENCE_M_S,
+    WIND_PERCENTILE,
+    WIND_STRIDE,
+    WIND_TARGET_LEVEL_M,
+    center_horizontal_wind_to_scalar_grid,
+    center_vertical_velocity_to_scalar_grid,
+    rounded_percentile_reference,
+    trade_cumulus_updraft_lens_defaults,
+)
+
+PRODUCT_SLICE_ID = "trade_cumulus_v1"
+COMPARISON_GROUP_ID = "trade_cumulus_moisture_v1"
+RECIPE_CANDIDATE_ID = "canonical_bomex_baseline"
+CONTROL_ID = "surface_moisture_supply"
+OUTPUT_CADENCE_SECONDS = 120
+MINIMUM_FREE_BYTES = 8 * 1024**3
+STAGE4_RESULT_ID = "result-bomex-370-full-20260719"
+STAGE4_ATOL = 1e-10
+STAGE4_RTOL = 1e-6
+FINAL_THREE_HOUR_START_SECONDS = 10_800.0
+PERCENT_DELTA_MINIMUM_DENOMINATOR = 1e-12
+
+
+class TradeCumulusMoistureComparisonError(RuntimeError):
+    """Raised when the bounded matched comparison cannot proceed."""
+
+
+class TradeCumulusMoistureState(StrEnum):
+    BASELINE = "baseline"
+    MORE_MOISTURE = "more_moisture"
+
+    @property
+    def surface_moisture_flux_g_g_m_s(self) -> float:
+        if self is TradeCumulusMoistureState.BASELINE:
+            return 5.2e-5
+        return 7.8e-5
+
+    @property
+    def namelist_value(self) -> str:
+        if self is TradeCumulusMoistureState.BASELINE:
+            return "5.2e-5"
+        return "7.8e-5"
+
+
+class TradeCumulusRunLength(StrEnum):
+    SMOKE = "smoke"
+    FULL = "full"
+
+    @property
+    def duration_seconds(self) -> int:
+        if self is TradeCumulusRunLength.SMOKE:
+            return 600
+        return 21_600
+
+    @property
+    def expected_model_output_count(self) -> int:
+        return self.duration_seconds // OUTPUT_CADENCE_SECONDS + 1
+
+    @property
+    def expected_diagnostic_output_count(self) -> int:
+        return self.duration_seconds // DIAGNOSTIC_CADENCE_SECONDS + 1
+
+    @property
+    def bomex_variant(self) -> BomexVariant:
+        if self is TradeCumulusRunLength.SMOKE:
+            return BomexVariant.SMOKE
+        return BomexVariant.FULL
+
+
+@dataclass(frozen=True)
+class TradeCumulusMatchedPackage:
+    run_id: str
+    control_state: TradeCumulusMoistureState
+    run_length: TradeCumulusRunLength
+    package_dir: Path
+    manifest_path: Path
+    case_manifest_path: Path
+    namelist_path: Path
+    science_settings_sha256: str
+    fixed_assumptions_sha256: str
+    app_commit: str
+
+
+class PackageComparisonProof(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    comparison_group_id: str = COMPARISON_GROUP_ID
+    run_length: str
+    baseline_run_id: str
+    more_moisture_run_id: str
+    differing_namelist_assignments: list[str]
+    fixed_assumptions_sha256: str
+    baseline_science_settings_sha256: str
+    more_moisture_science_settings_sha256: str
+    shared_cm1_source_manifest_sha256: str | None = None
+    shared_cm1_executable_sha256: str | None = None
+    valid: bool
+
+
+class TimedValue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time_seconds: float
+    value: float | None
+
+
+class VerticalProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    height_m: list[float]
+    values: list[float | None]
+    units: str
+    method: str
+    window: str
+    quality: str = "trusted"
+    caveats: list[str] = Field(default_factory=list)
+
+
+class ScalarRunMetric(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    value: float | None
+    units: str
+    method: str
+    window: str
+    quality: str = "trusted"
+    unavailable_reason: str | None = None
+    caveats: list[str] = Field(default_factory=list)
+
+
+class PairedScalarMetric(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    units: str
+    method: str
+    window: str
+    baseline: float | None
+    more_moisture: float | None
+    absolute_delta: float | None
+    percent_delta: float | None
+    percent_delta_unavailable_reason: str | None = None
+    quality: str
+    caveats: list[str] = Field(default_factory=list)
+
+
+class RunGateEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    valid: bool
+    lifecycle_state: str
+    product_state: str
+    exit_code: int | None
+    normal_completion_reported: bool | None
+    runtime_integrity_state: str
+    runtime_integrity_reason: str
+    runtime_integrity_caveats: list[str]
+    model_output_count: int
+    expected_model_output_count: int
+    diagnostic_output_count: int
+    expected_diagnostic_output_count: int
+    missing_required_fields: list[str]
+    required_field_non_finite_counts: dict[str, int]
+    intended_surface_moisture_flux_g_g_m_s: float
+    emitted_surface_moisture_flux_min_g_g_m_s: float | None
+    emitted_surface_moisture_flux_max_g_g_m_s: float | None
+    failures: list[str] = Field(default_factory=list)
+
+
+class TradeCumulusRunEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evidence_version: str = "trade_cumulus_moisture_run_evidence_v1"
+    product_slice_id: str = PRODUCT_SLICE_ID
+    comparison_group_id: str = COMPARISON_GROUP_ID
+    case_id: str = CASE_ID
+    recipe_candidate_id: str = RECIPE_CANDIDATE_ID
+    control_id: str = CONTROL_ID
+    control_state: str
+    run_length: str
+    run_id: str
+    result_id: str
+    app_commit: str
+    surface_moisture_flux_g_g_m_s: float
+    duration_seconds: int
+    output_cadence_seconds: int = OUTPUT_CADENCE_SECONDS
+    diagnostic_cadence_seconds: int = DIAGNOSTIC_CADENCE_SECONDS
+    wall_clock_seconds: float | None = None
+    cm1_reported_runtime_seconds: float | None = None
+    output_bytes: int
+    gate: RunGateEvidence
+    scalar_metrics: dict[str, ScalarRunMetric]
+    time_series: dict[str, list[TimedValue]]
+    vertical_profiles: dict[str, VerticalProfile]
+    final_domain_mean_profiles: dict[str, VerticalProfile]
+    forcing_diagnostics: dict[str, dict[str, float | None]]
+    forcing_and_transport_fields_available: list[str]
+    available_fields: list[str]
+    caveats: list[str] = Field(default_factory=list)
+
+    def to_json_text(self) -> str:
+        return self.model_dump_json(indent=2) + "\n"
+
+
+class Stage4FieldDifference(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    maximum_absolute_difference: float
+    maximum_relative_difference: float
+
+
+class Stage4FirstFailure(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time_seconds: float
+    field: str
+    index: list[int]
+    stage4_value: float
+    new_baseline_value: float
+    absolute_difference: float
+    allowed_difference: float
+
+
+class Stage4ConsistencyEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    preserved_result_id: str
+    new_baseline_result_id: str
+    common_times_seconds: list[float]
+    absolute_tolerance: float = STAGE4_ATOL
+    relative_tolerance: float = STAGE4_RTOL
+    field_differences: list[Stage4FieldDifference]
+    first_failure: Stage4FirstFailure | None = None
+    passed: bool
+
+
+class JointLensPreparation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    baseline_result_id: str
+    more_moisture_result_id: str
+    baseline_default_time_index: int
+    baseline_default_time_seconds: float | None
+    baseline_default_plane_index: int
+    baseline_default_plane_coordinate: float | None
+    baseline_default_plane_units: str | None
+    inherited_variant_time_index: int
+    inherited_variant_plane_index: int
+    wind_target_level_m: float = WIND_TARGET_LEVEL_M
+    wind_level_index: int
+    wind_actual_level_m: float
+    wind_stride: int = WIND_STRIDE
+    cloud_threshold_kg_kg: float = CLOUD_THRESHOLD_KG_KG
+    joint_w_range_min_m_s: float
+    joint_w_range_max_m_s: float
+    joint_perturbation_wind_reference_m_s: float
+    joint_total_wind_reference_m_s: float
+    coordinate_compatibility: str
+    field_availability: dict[str, list[str]]
+
+
+class TradeCumulusPairedEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evidence_version: str = "trade_cumulus_moisture_comparison_evidence_v1"
+    evidence_state: Literal[
+        "matched_runs_valid",
+        "baseline_invalid",
+        "more_moisture_invalid",
+        "comparison_inconclusive_missing_evidence",
+    ]
+    implementation_commit: str
+    baseline: TradeCumulusRunEvidence
+    more_moisture: TradeCumulusRunEvidence
+    scalar_metrics: dict[str, PairedScalarMetric]
+    exact_time_pairing: dict[str, list[TimedValue]]
+    stage4_consistency: Stage4ConsistencyEvidence
+    lens_preparation: JointLensPreparation
+    estimated_full_pair_bytes: int
+    actual_full_pair_bytes: int
+    runtime_local_evidence_path: str | None = None
+    caveats: list[str] = Field(default_factory=list)
+
+    def to_json_text(self) -> str:
+        return self.model_dump_json(indent=2) + "\n"
+
+
+def render_trade_cumulus_matched_namelist(
+    reference_text: str,
+    control_state: TradeCumulusMoistureState,
+    run_length: TradeCumulusRunLength,
+) -> str:
+    """Render one of the four approved matched-run namelists."""
+    rendered = render_bomex_namelist(reference_text, run_length.bomex_variant)
+    rendered = replace_bomex_namelist_assignment(rendered, "tapfrq", f"{OUTPUT_CADENCE_SECONDS}.0")
+    rendered = replace_bomex_namelist_assignment(
+        rendered, "diagfrq", f"{DIAGNOSTIC_CADENCE_SECONDS}.0"
+    )
+    rendered = replace_bomex_namelist_assignment(
+        rendered, "cnst_lhflx", control_state.namelist_value
+    )
+    return rendered.rstrip() + "\n"
+
+
+def normalized_trade_cumulus_science_namelist(namelist_text: str) -> str:
+    """Normalize duration only for state-specific science equivalence."""
+    return replace_bomex_namelist_assignment(namelist_text, "timax", "<duration>")
+
+
+def normalized_trade_cumulus_fixed_assumptions_namelist(namelist_text: str) -> str:
+    """Normalize only duration and the approved moisture Control."""
+    normalized = normalized_trade_cumulus_science_namelist(namelist_text)
+    return replace_bomex_namelist_assignment(normalized, "cnst_lhflx", "<surface_moisture_control>")
+
+
+def generate_trade_cumulus_matched_package(
+    *,
+    settings: CloudChamberSettings,
+    control_state: TradeCumulusMoistureState,
+    run_length: TradeCumulusRunLength,
+    run_id: str,
+    comparison_group_id: str = COMPARISON_GROUP_ID,
+    allow_overwrite: bool = False,
+    app_commit: str | None = None,
+) -> TradeCumulusMatchedPackage:
+    """Generate one exact package in the approved matched comparison."""
+    if comparison_group_id != COMPARISON_GROUP_ID:
+        raise TradeCumulusMoistureComparisonError(
+            f"Unsupported comparison_group_id: {comparison_group_id}"
+        )
+    try:
+        verified_commit = verified_clean_git_commit()
+    except BomexCaseError as exc:
+        raise TradeCumulusMoistureComparisonError(str(exc)) from exc
+    if app_commit is not None and app_commit != verified_commit:
+        raise TradeCumulusMoistureComparisonError(
+            "Requested app_commit does not match the verified clean Git HEAD."
+        )
+    try:
+        base = generate_bomex_package(
+            settings=settings,
+            variant=run_length.bomex_variant,
+            run_id=run_id,
+            allow_overwrite=allow_overwrite,
+        )
+    except BomexCaseError as exc:
+        raise TradeCumulusMoistureComparisonError(str(exc)) from exc
+
+    try:
+        manifest = load_run_manifest(base.manifest_path)
+        paths = {
+            "manifest": base.manifest_path,
+            "case_manifest": base.case_manifest_path,
+            "namelist": base.package_dir / "namelist.input",
+            "input_sounding": base.package_dir / "input_sounding",
+            "report": base.package_dir / "dry_run_report.json",
+            "runtime_checklist": base.package_dir / "runtime_file_checklist.json",
+        }
+        provenance = manifest.run_configuration["cm1_provenance"]
+        reference_path = Path(str(provenance["bundled_bomex_namelist_path"]))
+        namelist_text = render_trade_cumulus_matched_namelist(
+            reference_path.read_text(), control_state, run_length
+        )
+        paths["namelist"].write_text(namelist_text)
+        generated_hashes = {
+            "namelist.input": sha256_text(namelist_text),
+            "input_sounding": sha256_file(paths["input_sounding"]),
+            "runtime_file_checklist.json": sha256_file(paths["runtime_checklist"]),
+        }
+        science_hash = sha256_text(normalized_trade_cumulus_science_namelist(namelist_text))
+        fixed_hash = sha256_text(normalized_trade_cumulus_fixed_assumptions_namelist(namelist_text))
+        fixed_assumptions = _fixed_assumptions()
+        changed_assumptions = {
+            "control_id": CONTROL_ID,
+            "control_state": control_state.value,
+            "surface_moisture_flux_g_g_m_s": control_state.surface_moisture_flux_g_g_m_s,
+        }
+        case_manifest: dict[str, Any] = {
+            "case_id": CASE_ID,
+            "mapping_version": MAPPING_VERSION,
+            "authority_state": "stage5b2_matched_evidence_not_product_graduation",
+            "product_slice_id": PRODUCT_SLICE_ID,
+            "comparison_group_id": COMPARISON_GROUP_ID,
+            "recipe_candidate_id": RECIPE_CANDIDATE_ID,
+            "control_id": CONTROL_ID,
+            "control_state": control_state.value,
+            "run_length": run_length.value,
+            "duration_seconds": run_length.duration_seconds,
+            "surface_moisture_flux_g_g_m_s": control_state.surface_moisture_flux_g_g_m_s,
+            "changed_assumptions": changed_assumptions,
+            "fixed_assumptions": fixed_assumptions,
+            "scientific_sources": [SCIENTIFIC_SOURCE_DOI, SCIENTIFIC_SOURCE_RECORD],
+            "cm1_translation": {
+                "testcase": 3,
+                "isnd": 19,
+                "iwnd": 9,
+                "ptype": 6,
+                "v_t_m_s": 0.0,
+                "cloud_liquid_output_field": "ql",
+                "output_format": "netcdf",
+                "output_cadence_seconds": OUTPUT_CADENCE_SECONDS,
+                "diagnostic_cadence_seconds": DIAGNOSTIC_CADENCE_SECONDS,
+            },
+            "cm1_provenance": provenance,
+            "cloud_chamber_commit": verified_commit,
+            "generated_input_sha256": generated_hashes,
+            "generated_forcing_input_sha256": {},
+            "science_settings_sha256": science_hash,
+            "fixed_assumptions_sha256": fixed_hash,
+            "unsupported_components": [],
+        }
+        _write_json(paths["case_manifest"], case_manifest)
+        generated_hashes["case_manifest.json"] = sha256_file(paths["case_manifest"])
+
+        run_configuration = dict(manifest.run_configuration)
+        run_configuration.update(
+            {
+                "product_slice_id": PRODUCT_SLICE_ID,
+                "comparison_group_id": COMPARISON_GROUP_ID,
+                "recipe_candidate_id": RECIPE_CANDIDATE_ID,
+                "control_id": CONTROL_ID,
+                "control_state": control_state.value,
+                "surface_moisture_flux_g_g_m_s": (control_state.surface_moisture_flux_g_g_m_s),
+                "changed_assumptions": changed_assumptions,
+                "fixed_assumptions": fixed_assumptions,
+                "fixed_assumptions_sha256": fixed_hash,
+                "science_settings_sha256": science_hash,
+                "generated_input_sha256": generated_hashes,
+                "run_length": run_length.value,
+                "variant": run_length.value,
+                "duration_seconds": run_length.duration_seconds,
+                "output_cadence_seconds": OUTPUT_CADENCE_SECONDS,
+                "diagnostic_cadence_seconds": DIAGNOSTIC_CADENCE_SECONDS,
+                "expected_model_output_count": run_length.expected_model_output_count,
+                "expected_diagnostic_output_count": (run_length.expected_diagnostic_output_count),
+            }
+        )
+        updated_manifest = manifest.model_copy(
+            update={
+                "controls": {
+                    "control_id": CONTROL_ID,
+                    "control_state": control_state.value,
+                    "surface_moisture_flux_g_g_m_s": (control_state.surface_moisture_flux_g_g_m_s),
+                },
+                "run_configuration": run_configuration,
+                "physical_question": (
+                    "How does stronger surface moisture supply change the trade-cumulus field?"
+                ),
+                "app": manifest.app.model_copy(update={"commit": verified_commit}),
+                "user": manifest.user.model_copy(
+                    update={
+                        "name": (
+                            "Trade Cumulus moisture comparison "
+                            f"{control_state.value} ({run_length.value})"
+                        )
+                    }
+                ),
+                "run_recipe": None,
+                "run_limitations": [
+                    "stage5b2_matched_evidence_not_product_graduation",
+                    "one_deterministic_les_realization_per_control_state",
+                    "individual_clouds_are_not_paired_one_to_one",
+                ],
+                "manual_validation_status": "stage5b2_evidence_pending",
+            }
+        )
+        write_run_manifest(paths["manifest"], updated_manifest)
+        report = {
+            "status": "packaged_not_executed",
+            "product_slice_id": PRODUCT_SLICE_ID,
+            "comparison_group_id": COMPARISON_GROUP_ID,
+            "case_id": CASE_ID,
+            "recipe_candidate_id": RECIPE_CANDIDATE_ID,
+            "control_id": CONTROL_ID,
+            "control_state": control_state.value,
+            "run_length": run_length.value,
+            "run_id": run_id,
+            "surface_moisture_flux_g_g_m_s": control_state.surface_moisture_flux_g_g_m_s,
+            "duration_seconds": run_length.duration_seconds,
+            "output_cadence_seconds": OUTPUT_CADENCE_SECONDS,
+            "diagnostic_cadence_seconds": DIAGNOSTIC_CADENCE_SECONDS,
+            "expected_model_output_count": run_length.expected_model_output_count,
+            "expected_diagnostic_output_count": run_length.expected_diagnostic_output_count,
+            "changed_assumptions": changed_assumptions,
+            "fixed_assumptions": fixed_assumptions,
+            "generated_input_sha256": generated_hashes,
+            "science_settings_sha256": science_hash,
+            "fixed_assumptions_sha256": fixed_hash,
+            "cloud_chamber_commit": verified_commit,
+            "cm1_release": provenance["release"],
+            "cm1_executable_sha256": provenance["executable_sha256"],
+            "source_manifest_sha256": provenance["source_manifest_sha256"],
+            "required_output_fields": list(REQUIRED_OUTPUT_FIELDS),
+            "run_recipe": None,
+            "notes": "Generated package is configured evidence, not scientific success.",
+        }
+        _write_json(paths["report"], report)
+    except (KeyError, OSError, TypeError, ValueError) as exc:
+        shutil.rmtree(base.package_dir, ignore_errors=True)
+        raise TradeCumulusMoistureComparisonError(
+            f"Unable to specialize the canonical BOMEX package: {exc}"
+        ) from exc
+
+    return TradeCumulusMatchedPackage(
+        run_id=run_id,
+        control_state=control_state,
+        run_length=run_length,
+        package_dir=base.package_dir,
+        manifest_path=base.manifest_path,
+        case_manifest_path=base.case_manifest_path,
+        namelist_path=paths["namelist"],
+        science_settings_sha256=science_hash,
+        fixed_assumptions_sha256=fixed_hash,
+        app_commit=verified_commit,
+    )
+
+
+def compare_matched_packages(
+    baseline: TradeCumulusMatchedPackage,
+    more_moisture: TradeCumulusMatchedPackage,
+) -> PackageComparisonProof:
+    """Fail closed unless one same-length pair differs only in the approved Control."""
+    if baseline.control_state is not TradeCumulusMoistureState.BASELINE:
+        raise TradeCumulusMoistureComparisonError("The baseline package has the wrong state.")
+    if more_moisture.control_state is not TradeCumulusMoistureState.MORE_MOISTURE:
+        raise TradeCumulusMoistureComparisonError("The More Moisture package has the wrong state.")
+    if baseline.run_length is not more_moisture.run_length:
+        raise TradeCumulusMoistureComparisonError("Matched packages must use one run length.")
+    differences = namelist_difference_names(
+        baseline.namelist_path.read_text(), more_moisture.namelist_path.read_text()
+    )
+    if differences != ["cnst_lhflx"]:
+        raise TradeCumulusMoistureComparisonError(
+            f"Matched package proof failed: unauthorized namelist differences {differences}."
+        )
+    baseline_manifest = load_run_manifest(baseline.manifest_path)
+    variant_manifest = load_run_manifest(more_moisture.manifest_path)
+    baseline_configuration = baseline_manifest.run_configuration
+    variant_configuration = variant_manifest.run_configuration
+    baseline_provenance = baseline_configuration.get("cm1_provenance")
+    variant_provenance = variant_configuration.get("cm1_provenance")
+    provenance_matches = baseline_provenance == variant_provenance
+    fixed_records_match = baseline_configuration.get(
+        "fixed_assumptions"
+    ) == variant_configuration.get("fixed_assumptions")
+    baseline_hashes = baseline_configuration.get("generated_input_sha256")
+    variant_hashes = variant_configuration.get("generated_input_sha256")
+    fixed_generated_inputs_match = (
+        isinstance(baseline_hashes, dict)
+        and isinstance(variant_hashes, dict)
+        and all(
+            baseline_hashes.get(name) == variant_hashes.get(name)
+            for name in ("input_sounding", "runtime_file_checklist.json")
+        )
+    )
+    valid = (
+        differences == ["cnst_lhflx"]
+        and baseline.fixed_assumptions_sha256 == more_moisture.fixed_assumptions_sha256
+        and baseline.science_settings_sha256 != more_moisture.science_settings_sha256
+        and baseline.app_commit == more_moisture.app_commit
+        and provenance_matches
+        and fixed_records_match
+        and fixed_generated_inputs_match
+    )
+    shared_source_hash = (
+        str(baseline_provenance.get("source_manifest_sha256"))
+        if isinstance(baseline_provenance, dict) and provenance_matches
+        else None
+    )
+    shared_executable_hash = (
+        str(baseline_provenance.get("executable_sha256"))
+        if isinstance(baseline_provenance, dict) and provenance_matches
+        else None
+    )
+    proof = PackageComparisonProof(
+        run_length=baseline.run_length.value,
+        baseline_run_id=baseline.run_id,
+        more_moisture_run_id=more_moisture.run_id,
+        differing_namelist_assignments=differences,
+        fixed_assumptions_sha256=baseline.fixed_assumptions_sha256,
+        baseline_science_settings_sha256=baseline.science_settings_sha256,
+        more_moisture_science_settings_sha256=more_moisture.science_settings_sha256,
+        shared_cm1_source_manifest_sha256=shared_source_hash,
+        shared_cm1_executable_sha256=shared_executable_hash,
+        valid=valid,
+    )
+    if not valid:
+        raise TradeCumulusMoistureComparisonError(
+            "Matched package proof failed: " + proof.model_dump_json()
+        )
+    return proof
+
+
+def verify_smoke_full_equivalence(
+    smoke: TradeCumulusMatchedPackage,
+    full: TradeCumulusMatchedPackage,
+) -> None:
+    """Fail unless one state differs between smoke and full only in duration."""
+    if smoke.control_state is not full.control_state:
+        raise TradeCumulusMoistureComparisonError("Smoke/full packages use different states.")
+    if smoke.run_length is not TradeCumulusRunLength.SMOKE:
+        raise TradeCumulusMoistureComparisonError("Expected a smoke package.")
+    if full.run_length is not TradeCumulusRunLength.FULL:
+        raise TradeCumulusMoistureComparisonError("Expected a full package.")
+    differences = namelist_difference_names(
+        smoke.namelist_path.read_text(), full.namelist_path.read_text()
+    )
+    if differences != ["timax"]:
+        raise TradeCumulusMoistureComparisonError(
+            f"Smoke/full namelists differ outside duration: {differences}"
+        )
+    if smoke.science_settings_sha256 != full.science_settings_sha256:
+        raise TradeCumulusMoistureComparisonError(
+            "Smoke/full state-specific science hashes do not match."
+        )
+    if smoke.fixed_assumptions_sha256 != full.fixed_assumptions_sha256:
+        raise TradeCumulusMoistureComparisonError(
+            "Smoke/full fixed-assumption hashes do not match."
+        )
+
+
+def namelist_difference_names(left: str, right: str) -> list[str]:
+    """Return sorted assignments whose generated values differ."""
+    left_values = _namelist_assignments(left)
+    right_values = _namelist_assignments(right)
+    if left_values.keys() != right_values.keys():
+        missing_left = sorted(right_values.keys() - left_values.keys())
+        missing_right = sorted(left_values.keys() - right_values.keys())
+        raise TradeCumulusMoistureComparisonError(
+            f"Namelist assignment sets differ; left missing {missing_left}, "
+            f"right missing {missing_right}."
+        )
+    return sorted(name for name in left_values if left_values[name] != right_values[name])
+
+
+def pair_scalar_metric(
+    baseline: ScalarRunMetric,
+    more_moisture: ScalarRunMetric,
+) -> PairedScalarMetric:
+    """Pair one identically defined scalar metric without inventing missing values."""
+    if (baseline.units, baseline.method, baseline.window) != (
+        more_moisture.units,
+        more_moisture.method,
+        more_moisture.window,
+    ):
+        raise TradeCumulusMoistureComparisonError(
+            "Paired scalar metrics must share units, method, and window."
+        )
+    absolute_delta: float | None = None
+    percent_delta: float | None = None
+    unavailable_reason: str | None = None
+    if baseline.value is None or more_moisture.value is None:
+        unavailable_reason = (
+            baseline.unavailable_reason
+            or more_moisture.unavailable_reason
+            or "metric_value_unavailable"
+        )
+    else:
+        absolute_delta = more_moisture.value - baseline.value
+        if abs(baseline.value) <= PERCENT_DELTA_MINIMUM_DENOMINATOR:
+            unavailable_reason = "baseline_denominator_zero_or_near_zero"
+        else:
+            percent_delta = absolute_delta / baseline.value * 100.0
+    qualities = {baseline.quality, more_moisture.quality}
+    quality = "trusted" if qualities == {"trusted"} else "+".join(sorted(qualities))
+    return PairedScalarMetric(
+        units=baseline.units,
+        method=baseline.method,
+        window=baseline.window,
+        baseline=baseline.value,
+        more_moisture=more_moisture.value,
+        absolute_delta=absolute_delta,
+        percent_delta=percent_delta,
+        percent_delta_unavailable_reason=unavailable_reason,
+        quality=quality,
+        caveats=sorted(set(baseline.caveats + more_moisture.caveats)),
+    )
+
+
+def thickness_weighted_layer_mean(
+    profile: np.ndarray[Any, Any],
+    height_centers_m: np.ndarray[Any, Any],
+    *,
+    bottom_m: float = 0.0,
+    top_m: float = 1000.0,
+) -> float | None:
+    """Average a scalar-level profile using geometric overlap with one height layer."""
+    values = np.asarray(profile, dtype=float).reshape(-1)
+    centers = np.asarray(height_centers_m, dtype=float).reshape(-1)
+    if values.size != centers.size or not values.size:
+        raise TradeCumulusMoistureComparisonError(
+            "Profile and height-center arrays must have the same nonzero length."
+        )
+    if not np.all(np.isfinite(centers)) or np.any(np.diff(centers) <= 0.0):
+        raise TradeCumulusMoistureComparisonError(
+            "Height centers must be finite and strictly increasing."
+        )
+    if top_m <= bottom_m:
+        raise TradeCumulusMoistureComparisonError("Layer top must be above layer bottom.")
+    interfaces = np.empty(centers.size + 1, dtype=float)
+    if centers.size == 1:
+        interfaces[:] = (bottom_m, top_m)
+    else:
+        interfaces[1:-1] = 0.5 * (centers[:-1] + centers[1:])
+        interfaces[0] = max(0.0, centers[0] - 0.5 * (centers[1] - centers[0]))
+        interfaces[-1] = centers[-1] + 0.5 * (centers[-1] - centers[-2])
+    weights = np.maximum(
+        0.0,
+        np.minimum(interfaces[1:], top_m) - np.maximum(interfaces[:-1], bottom_m),
+    )
+    finite = np.isfinite(values) & (weights > 0.0)
+    if not np.any(finite):
+        return None
+    return float(np.sum(values[finite] * weights[finite]) / np.sum(weights[finite]))
+
+
+def pair_exact_time_series(
+    baseline: list[TimedValue],
+    more_moisture: list[TimedValue],
+) -> list[TimedValue]:
+    """Return variant-minus-baseline values only for identical ordered model times."""
+    baseline_times = [point.time_seconds for point in baseline]
+    variant_times = [point.time_seconds for point in more_moisture]
+    if baseline_times != variant_times:
+        raise TradeCumulusMoistureComparisonError(
+            "Time-series pairing requires exact identical model times; interpolation is forbidden."
+        )
+    paired: list[TimedValue] = []
+    for baseline_point, variant_point in zip(baseline, more_moisture, strict=True):
+        value = None
+        if baseline_point.value is not None and variant_point.value is not None:
+            value = variant_point.value - baseline_point.value
+        paired.append(TimedValue(time_seconds=baseline_point.time_seconds, value=value))
+    return paired
+
+
+def build_trade_cumulus_run_evidence(
+    result: ResultMetadata,
+    package: TradeCumulusMatchedPackage,
+    *,
+    wall_clock_seconds: float | None = None,
+) -> TradeCumulusRunEvidence:
+    """Calculate the approved metrics and fail-closed run gate for one matched run."""
+    if result.run_id != package.run_id:
+        raise TradeCumulusMoistureComparisonError(
+            f"Result {result.result_id} does not belong to package {package.run_id}."
+        )
+    manifest = load_run_manifest(package.manifest_path)
+    frames = _analyze_model_frames(result)
+    forcing, forcing_fields, diagnostic_times = _analyze_diagnostic_frames(result)
+    cm1_reported_runtime_seconds = _cm1_reported_runtime_seconds(manifest)
+    gate = _build_run_gate(
+        result=result,
+        package=package,
+        manifest=manifest,
+        frame_analysis=frames,
+        forcing=forcing,
+        diagnostic_times=diagnostic_times,
+    )
+    final_indices = [
+        index
+        for index, time_seconds in enumerate(frames.times_seconds)
+        if time_seconds >= FINAL_THREE_HOUR_START_SECONDS
+    ]
+    final_cwp = [frames.domain_mean_cwp[index] for index in final_indices]
+    final_cover = [frames.total_cloud_cover_percent[index] for index in final_indices]
+    final_cloud_profiles = [frames.cloud_fraction_profiles[index] for index in final_indices]
+    final_cloud_w_profiles = [frames.cloud_conditioned_w_profiles[index] for index in final_indices]
+    time_mean_cloud_profile = _mean_optional_profiles(final_cloud_profiles)
+    cloud_w_profile = _mean_optional_profiles(final_cloud_w_profiles)
+    peak_fraction, peak_height = _profile_peak(time_mean_cloud_profile, frames.height_m)
+    cloud = result.diagnostics.cloud if result.diagnostics is not None else None
+    coherent_top_series = (
+        [
+            TimedValue(time_seconds=float(point.time_seconds), value=point.value)
+            for point in cloud.coherent_cloud_object_top_time_series
+            if point.time_seconds is not None
+        ]
+        if cloud is not None
+        else []
+    )
+    final_coherent_tops = [
+        point.value
+        for point in coherent_top_series
+        if point.time_seconds >= FINAL_THREE_HOUR_START_SECONDS and point.value is not None
+    ]
+    positive_cloud_fraction = (
+        frames.final_positive_cloudy_count / frames.final_cloudy_count * 100.0
+        if frames.final_cloudy_count
+        else None
+    )
+    scalar_metrics = {
+        "first_isolated_cloud_liquid_time": _metric(
+            frames.first_isolated_cloud_time_seconds,
+            "s",
+            "first model frame with any finite ql >= 1e-6 kg/kg",
+            "full run",
+        ),
+        "first_coherent_cloud_time": _metric(
+            cloud.first_cloud_time_seconds if cloud is not None else None,
+            "s",
+            "first ingested frame with at least 10 cloud-liquid grid cells",
+            "full run",
+            unavailable_reason="coherent_cloud_diagnostic_unavailable",
+        ),
+        "mean_total_cloud_cover_final_three_hours": _metric(
+            _finite_mean_list(final_cover),
+            "%",
+            "time mean of horizontal columns containing ql >= 1e-6 kg/kg",
+            "time >= 10800 s",
+        ),
+        "time_mean_cloud_fraction_profile_peak": _metric(
+            peak_fraction,
+            "%",
+            "peak of final-three-hour time-mean horizontal cloud-fraction profile",
+            "time >= 10800 s",
+        ),
+        "time_mean_cloud_fraction_profile_peak_height": _metric(
+            peak_height,
+            "m",
+            "height of first maximum in final-three-hour time-mean cloud-fraction profile",
+            "time >= 10800 s",
+        ),
+        "domain_mean_cwp_final_three_hour_mean": _metric(
+            _finite_mean_list(final_cwp),
+            "kg/m^2",
+            "time mean of horizontal domain-mean cwp",
+            "time >= 10800 s",
+        ),
+        "domain_mean_cwp_final_three_hour_minimum": _metric(
+            _finite_min_list(final_cwp),
+            "kg/m^2",
+            "minimum horizontal domain-mean cwp",
+            "time >= 10800 s",
+        ),
+        "domain_mean_cwp_final_three_hour_maximum": _metric(
+            _finite_max_list(final_cwp),
+            "kg/m^2",
+            "maximum horizontal domain-mean cwp",
+            "time >= 10800 s",
+        ),
+        "cloud_water_growth_decay_peak_count": _metric(
+            float(cloud_water_cycle_peak_count(frames.domain_mean_cwp)),
+            "count",
+            "Stage 4 local-peak count above 10% of full-run maximum cwp",
+            "full run",
+        ),
+        "coherent_cloud_base": _metric(
+            cloud.coherent_cloud_object_base_m if cloud is not None else None,
+            "m",
+            "lowest supported coherent cloud-object level from ingest diagnostics",
+            "full run",
+            unavailable_reason="coherent_cloud_base_unavailable",
+        ),
+        "coherent_cloud_top_maximum": _metric(
+            cloud.coherent_cloud_object_top_m if cloud is not None else None,
+            "m",
+            "highest supported coherent cloud-object level from ingest diagnostics",
+            "full run",
+            unavailable_reason="coherent_cloud_top_unavailable",
+        ),
+        "coherent_cloud_top_final_three_hour_mean": _metric(
+            _finite_mean_list(final_coherent_tops),
+            "m",
+            "mean supported coherent cloud-object top",
+            "time >= 10800 s",
+            unavailable_reason="final_three_hour_coherent_cloud_top_unavailable",
+        ),
+        "coherent_cloud_top_final_three_hour_minimum": _metric(
+            _finite_min_list(final_coherent_tops),
+            "m",
+            "minimum supported coherent cloud-object top",
+            "time >= 10800 s",
+            unavailable_reason="final_three_hour_coherent_cloud_top_unavailable",
+        ),
+        "coherent_cloud_top_final_three_hour_maximum": _metric(
+            _finite_max_list(final_coherent_tops),
+            "m",
+            "maximum supported coherent cloud-object top",
+            "time >= 10800 s",
+            unavailable_reason="final_three_hour_coherent_cloud_top_unavailable",
+        ),
+        "maximum_cloud_liquid": _metric(
+            frames.maximum_ql,
+            "kg/kg",
+            "maximum finite raw ql value",
+            "full run",
+        ),
+        "raw_w_minimum": _metric(
+            frames.raw_w_minimum,
+            "m/s",
+            "minimum finite raw staggered w value",
+            "full run",
+        ),
+        "raw_w_maximum": _metric(
+            frames.raw_w_maximum,
+            "m/s",
+            "maximum finite raw staggered w value",
+            "full run",
+        ),
+        "cloudy_scalar_cells_with_positive_centered_w": _metric(
+            positive_cloud_fraction,
+            "%",
+            "pooled fraction of cloudy scalar cells with centered w > 0",
+            "time >= 10800 s",
+            unavailable_reason="no_cloudy_scalar_cells_in_window",
+        ),
+        "qv_0_1000m_final_three_hour_mean": _metric(
+            _finite_mean_list([frames.low_level_qv[index] for index in final_indices]),
+            "kg/kg",
+            "time mean of thickness-weighted horizontal/domain qv over 0-1000 m",
+            "time >= 10800 s",
+        ),
+        "th_0_1000m_final_three_hour_mean": _metric(
+            _finite_mean_list([frames.low_level_th[index] for index in final_indices]),
+            "K",
+            "time mean of thickness-weighted horizontal/domain th over 0-1000 m",
+            "time >= 10800 s",
+        ),
+        "wall_clock_runtime": _metric(
+            wall_clock_seconds,
+            "s",
+            "monotonic wall-clock duration around local CM1 launch and completion",
+            "process execution",
+            unavailable_reason="wall_clock_runtime_not_recorded",
+        ),
+        "cm1_reported_runtime": _metric(
+            cm1_reported_runtime_seconds,
+            "s",
+            "CM1 terminal Total time value parsed from the process stdout log",
+            "process execution",
+            unavailable_reason="cm1_reported_runtime_not_recorded",
+        ),
+        "netcdf_output_storage": _metric(
+            float(frames.output_bytes),
+            "bytes",
+            "sum of ingested NetCDF artifact sizes",
+            "completed run",
+        ),
+    }
+    time_series = {
+        "domain_mean_cwp": _timed_values(frames.times_seconds, frames.domain_mean_cwp),
+        "total_cloud_cover_percent": _timed_values(
+            frames.times_seconds, frames.total_cloud_cover_percent
+        ),
+        "qv_0_1000m": _timed_values(frames.times_seconds, frames.low_level_qv),
+        "th_0_1000m": _timed_values(frames.times_seconds, frames.low_level_th),
+        "coherent_cloud_top": coherent_top_series,
+    }
+    vertical_profiles = {
+        "cloud_fraction_final_three_hours": VerticalProfile(
+            height_m=frames.height_m,
+            values=time_mean_cloud_profile,
+            units="%",
+            method="time mean of horizontal ql >= 1e-6 kg/kg fraction by scalar level",
+            window="time >= 10800 s",
+        ),
+        "cloud_conditioned_centered_w_final_three_hours": VerticalProfile(
+            height_m=frames.height_m,
+            values=cloud_w_profile,
+            units="m/s",
+            method="time mean of per-frame centered w mean over cloudy scalar cells by level",
+            window="time >= 10800 s",
+            quality="trusted"
+            if any(value is not None for value in cloud_w_profile)
+            else "unavailable",
+            caveats=(
+                [] if any(value is not None for value in cloud_w_profile) else ["no_cloudy_cells"]
+            ),
+        ),
+    }
+    final_profiles = {
+        name: VerticalProfile(
+            height_m=frames.height_m,
+            values=values,
+            units="kg/kg" if name == "qv" else "K" if name == "th" else "m/s",
+            method="horizontal domain mean on the final scalar-grid frame",
+            window=f"time = {frames.times_seconds[-1]:g} s",
+        )
+        for name, values in frames.final_domain_mean_profiles.items()
+    }
+    caveats = sorted(set(result.runtime_integrity.caveats))
+    return TradeCumulusRunEvidence(
+        control_state=package.control_state.value,
+        run_length=package.run_length.value,
+        run_id=result.run_id,
+        result_id=result.result_id,
+        app_commit=package.app_commit,
+        surface_moisture_flux_g_g_m_s=(package.control_state.surface_moisture_flux_g_g_m_s),
+        duration_seconds=package.run_length.duration_seconds,
+        wall_clock_seconds=wall_clock_seconds,
+        cm1_reported_runtime_seconds=cm1_reported_runtime_seconds,
+        output_bytes=frames.output_bytes,
+        gate=gate,
+        scalar_metrics=scalar_metrics,
+        time_series=time_series,
+        vertical_profiles=vertical_profiles,
+        final_domain_mean_profiles=final_profiles,
+        forcing_diagnostics=forcing,
+        forcing_and_transport_fields_available=forcing_fields,
+        available_fields=sorted(result.variables),
+        caveats=caveats,
+    )
+
+
+def write_trade_cumulus_run_evidence(path: Path, evidence: TradeCumulusRunEvidence) -> None:
+    path.write_text(evidence.to_json_text())
+
+
+def build_paired_evidence(
+    baseline: TradeCumulusRunEvidence,
+    more_moisture: TradeCumulusRunEvidence,
+    *,
+    implementation_commit: str,
+    stage4_consistency: Stage4ConsistencyEvidence,
+    lens_preparation: JointLensPreparation,
+    estimated_full_pair_bytes: int,
+) -> TradeCumulusPairedEvidence:
+    """Pair identically defined metrics after both full-run gates pass."""
+    if baseline.control_state != TradeCumulusMoistureState.BASELINE.value:
+        raise TradeCumulusMoistureComparisonError("Baseline evidence has the wrong state.")
+    if more_moisture.control_state != TradeCumulusMoistureState.MORE_MOISTURE.value:
+        raise TradeCumulusMoistureComparisonError("Variant evidence has the wrong state.")
+    if (
+        baseline.app_commit != implementation_commit
+        or more_moisture.app_commit != implementation_commit
+    ):
+        raise TradeCumulusMoistureComparisonError(
+            "Run evidence does not share the exact implementation commit."
+        )
+    metric_names = baseline.scalar_metrics.keys() & more_moisture.scalar_metrics.keys()
+    paired_metrics = {
+        name: pair_scalar_metric(baseline.scalar_metrics[name], more_moisture.scalar_metrics[name])
+        for name in sorted(metric_names)
+    }
+    series_names = baseline.time_series.keys() & more_moisture.time_series.keys()
+    paired_series = {
+        name: pair_exact_time_series(baseline.time_series[name], more_moisture.time_series[name])
+        for name in sorted(series_names)
+    }
+    if not baseline.gate.valid:
+        state: Literal[
+            "matched_runs_valid",
+            "baseline_invalid",
+            "more_moisture_invalid",
+            "comparison_inconclusive_missing_evidence",
+        ] = "baseline_invalid"
+    elif not more_moisture.gate.valid:
+        state = "more_moisture_invalid"
+    elif not stage4_consistency.passed:
+        state = "comparison_inconclusive_missing_evidence"
+    else:
+        state = "matched_runs_valid"
+    return TradeCumulusPairedEvidence(
+        evidence_state=state,
+        implementation_commit=implementation_commit,
+        baseline=baseline,
+        more_moisture=more_moisture,
+        scalar_metrics=paired_metrics,
+        exact_time_pairing=paired_series,
+        stage4_consistency=stage4_consistency,
+        lens_preparation=lens_preparation,
+        estimated_full_pair_bytes=estimated_full_pair_bytes,
+        actual_full_pair_bytes=baseline.output_bytes + more_moisture.output_bytes,
+        caveats=[
+            "one_deterministic_les_realization_per_control_state",
+            "individual_clouds_are_not_paired_one_to_one",
+            "comparison_evidence_does_not_establish_product_graduation",
+        ],
+    )
+
+
+def write_paired_evidence(path: Path, evidence: TradeCumulusPairedEvidence) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(evidence.to_json_text())
+
+
+@dataclass(frozen=True)
+class _ModelFrameAnalysis:
+    times_seconds: list[float]
+    height_m: list[float]
+    domain_mean_cwp: list[float]
+    total_cloud_cover_percent: list[float]
+    cloud_fraction_profiles: list[list[float | None]]
+    cloud_conditioned_w_profiles: list[list[float | None]]
+    low_level_qv: list[float]
+    low_level_th: list[float]
+    final_domain_mean_profiles: dict[str, list[float | None]]
+    first_isolated_cloud_time_seconds: float | None
+    maximum_ql: float | None
+    raw_w_minimum: float | None
+    raw_w_maximum: float | None
+    final_cloudy_count: int
+    final_positive_cloudy_count: int
+    non_finite_counts: dict[str, int]
+    output_bytes: int
+
+
+def _analyze_model_frames(result: ResultMetadata) -> _ModelFrameAnalysis:
+    xarray = importlib.import_module("xarray")
+    times: list[float] = []
+    heights: list[float] | None = None
+    cwp_means: list[float] = []
+    cloud_cover: list[float] = []
+    cloud_profiles: list[list[float | None]] = []
+    cloud_w_profiles: list[list[float | None]] = []
+    low_qv: list[float] = []
+    low_th: list[float] = []
+    final_profiles: dict[str, list[float | None]] = {}
+    first_isolated: float | None = None
+    maximum_ql: float | None = None
+    raw_w_minimum: float | None = None
+    raw_w_maximum: float | None = None
+    final_cloudy_count = 0
+    final_positive_count = 0
+    non_finite_counts = {field: 0 for field in REQUIRED_OUTPUT_FIELDS}
+    paths = [Path(path) for path in result.model_output_paths]
+    if not paths:
+        raise TradeCumulusMoistureComparisonError("Result has no model-output paths.")
+    for path in paths:
+        dataset = xarray.open_dataset(path, decode_times=False)
+        try:
+            local_count = _time_count(dataset)
+            for local_index in range(local_count):
+                ql, scalar_dimensions = _scalar_field(dataset, "ql", local_index)
+                qv, qv_dimensions = _scalar_field(dataset, "qv", local_index)
+                th, th_dimensions = _scalar_field(dataset, "th", local_index)
+                if qv_dimensions != scalar_dimensions or th_dimensions != scalar_dimensions:
+                    raise TradeCumulusMoistureComparisonError(
+                        "ql, qv, and th do not share one scalar-grid dimension order."
+                    )
+                w = center_vertical_velocity_to_scalar_grid(
+                    dataset, local_index, scalar_dimensions, ql.shape
+                )
+                u, v = center_horizontal_wind_to_scalar_grid(
+                    dataset, local_index, scalar_dimensions, ql.shape
+                )
+                frame_heights = _coordinate_as_m(dataset, scalar_dimensions[0], ql.shape[0])
+                if heights is None:
+                    heights = [float(value) for value in frame_heights]
+                elif not np.array_equal(np.asarray(heights), frame_heights):
+                    raise TradeCumulusMoistureComparisonError(
+                        "Model frames do not share identical scalar-level heights."
+                    )
+                time_seconds = _time_seconds(dataset, local_index)
+                if times and time_seconds <= times[-1]:
+                    raise TradeCumulusMoistureComparisonError(
+                        "Model output times must be finite and strictly increasing."
+                    )
+                times.append(time_seconds)
+                cloud_mask = np.isfinite(ql) & (ql >= CLOUD_THRESHOLD_KG_KG)
+                cloudy_count = int(np.count_nonzero(cloud_mask))
+                if first_isolated is None and cloudy_count:
+                    first_isolated = time_seconds
+                level_fraction = np.mean(cloud_mask, axis=(1, 2)) * 100.0
+                cloud_profiles.append([float(value) for value in level_fraction])
+                cloud_cover.append(float(np.mean(np.any(cloud_mask, axis=0)) * 100.0))
+                cloud_w_profiles.append(_cloud_conditioned_profile(w, cloud_mask))
+                cwp = _horizontal_field(dataset, "cwp", local_index, scalar_dimensions[1:])
+                finite_cwp = cwp[np.isfinite(cwp)]
+                if not finite_cwp.size:
+                    raise TradeCumulusMoistureComparisonError(
+                        f"cwp has no finite values at {time_seconds:g} s."
+                    )
+                cwp_means.append(float(np.mean(finite_cwp)))
+                qv_profile = _horizontal_mean_profile(qv)
+                th_profile = _horizontal_mean_profile(th)
+                qv_layer = thickness_weighted_layer_mean(qv_profile, frame_heights)
+                th_layer = thickness_weighted_layer_mean(th_profile, frame_heights)
+                if qv_layer is None or th_layer is None:
+                    raise TradeCumulusMoistureComparisonError(
+                        f"Low-level qv/th evidence is unavailable at {time_seconds:g} s."
+                    )
+                low_qv.append(qv_layer)
+                low_th.append(th_layer)
+                finite_ql = ql[np.isfinite(ql)]
+                if finite_ql.size:
+                    maximum_ql = _max_optional(maximum_ql, float(np.max(finite_ql)))
+                raw_w, _ = _raw_field(dataset, "w", local_index)
+                finite_raw_w = raw_w[np.isfinite(raw_w)]
+                if finite_raw_w.size:
+                    raw_w_minimum = _min_optional(raw_w_minimum, float(np.min(finite_raw_w)))
+                    raw_w_maximum = _max_optional(raw_w_maximum, float(np.max(finite_raw_w)))
+                for required_field in REQUIRED_OUTPUT_FIELDS:
+                    source = _required_field_source(dataset, required_field)
+                    if source is None:
+                        continue
+                    values, _ = _raw_field(dataset, source, local_index)
+                    non_finite_counts[required_field] += int(
+                        values.size - np.count_nonzero(np.isfinite(values))
+                    )
+                if time_seconds >= FINAL_THREE_HOUR_START_SECONDS:
+                    final_cloudy_count += cloudy_count
+                    final_positive_count += int(np.count_nonzero(cloud_mask & (w > 0.0)))
+                final_profiles = {
+                    "qv": _optional_float_list(qv_profile),
+                    "th": _optional_float_list(th_profile),
+                    "u": _optional_float_list(_horizontal_mean_profile(u)),
+                    "v": _optional_float_list(_horizontal_mean_profile(v)),
+                }
+        finally:
+            dataset.close()
+    if heights is None:
+        raise TradeCumulusMoistureComparisonError("No readable model frames were analyzed.")
+    return _ModelFrameAnalysis(
+        times_seconds=times,
+        height_m=heights,
+        domain_mean_cwp=cwp_means,
+        total_cloud_cover_percent=cloud_cover,
+        cloud_fraction_profiles=cloud_profiles,
+        cloud_conditioned_w_profiles=cloud_w_profiles,
+        low_level_qv=low_qv,
+        low_level_th=low_th,
+        final_domain_mean_profiles=final_profiles,
+        first_isolated_cloud_time_seconds=first_isolated,
+        maximum_ql=maximum_ql,
+        raw_w_minimum=raw_w_minimum,
+        raw_w_maximum=raw_w_maximum,
+        final_cloudy_count=final_cloudy_count,
+        final_positive_cloudy_count=final_positive_count,
+        non_finite_counts=non_finite_counts,
+        output_bytes=sum(path.stat().st_size for path in map(Path, result.netcdf_paths)),
+    )
+
+
+def _analyze_diagnostic_frames(
+    result: ResultMetadata,
+) -> tuple[dict[str, dict[str, float | None]], list[str], list[float]]:
+    xarray = importlib.import_module("xarray")
+    paths = _diagnostic_paths(result)
+    fields = (
+        "wprof",
+        "ptb_frc",
+        "qvb_frc",
+        "ug",
+        "vg",
+        "thflux",
+        "qvflux",
+        "ust",
+        "upwp",
+        "vpwp",
+        "wpwp",
+        "ufr",
+        "vfr",
+        "ptfr",
+        "qvfr",
+        "ptb_vturbr",
+        "qvb_vturbr",
+    )
+    extrema: dict[str, tuple[float, float]] = {}
+    available: set[str] = set()
+    times: list[float] = []
+    for path in paths:
+        dataset = xarray.open_dataset(path, decode_times=False)
+        try:
+            local_count = _time_count(dataset)
+            for local_index in range(local_count):
+                time_seconds = _time_seconds(dataset, local_index)
+                if times and time_seconds <= times[-1]:
+                    raise TradeCumulusMoistureComparisonError(
+                        "Diagnostic output times must be finite and strictly increasing."
+                    )
+                times.append(time_seconds)
+                for field in fields:
+                    if field not in dataset.data_vars:
+                        continue
+                    available.add(field)
+                    values, _ = _raw_field(dataset, field, local_index)
+                    finite = values[np.isfinite(values)]
+                    if not finite.size:
+                        continue
+                    frame_min = float(np.min(finite))
+                    frame_max = float(np.max(finite))
+                    prior = extrema.get(field)
+                    extrema[field] = (
+                        min(frame_min, prior[0]) if prior is not None else frame_min,
+                        max(frame_max, prior[1]) if prior is not None else frame_max,
+                    )
+        finally:
+            dataset.close()
+    summary = {
+        field: {
+            "min": extrema[field][0] if field in extrema else None,
+            "max": extrema[field][1] if field in extrema else None,
+        }
+        for field in sorted(available)
+    }
+    return summary, sorted(available), times
+
+
+def _build_run_gate(
+    *,
+    result: ResultMetadata,
+    package: TradeCumulusMatchedPackage,
+    manifest: Any,
+    frame_analysis: _ModelFrameAnalysis,
+    forcing: dict[str, dict[str, float | None]],
+    diagnostic_times: list[float],
+) -> RunGateEvidence:
+    expected_model = package.run_length.expected_model_output_count
+    expected_diagnostic = package.run_length.expected_diagnostic_output_count
+    failures: list[str] = []
+    if result.source_lifecycle_state != "completed":
+        failures.append(f"lifecycle_state:{result.source_lifecycle_state}")
+    if result.source_product_state != "completed_cm1_result":
+        failures.append(f"product_state:{result.source_product_state}")
+    if manifest.execution.exit_code != 0:
+        failures.append(f"exit_code:{manifest.execution.exit_code}")
+    if result.runtime_integrity.normal_completion_reported is not True:
+        failures.append("normal_completion_marker_missing")
+    allowed_integrity = result.runtime_integrity.state == "trusted" or (
+        result.runtime_integrity.state == "caveated"
+        and result.runtime_integrity.caveats == ["runtime_integrity_caveated_underflow_only"]
+        and not result.runtime_integrity.fatal_warning_flags
+        and not result.runtime_integrity.terminal_non_finite_fields
+        and not result.runtime_integrity.stats_sentinel_collapse_detected
+    )
+    if not allowed_integrity:
+        failures.append(f"runtime_integrity:{result.runtime_integrity.state}")
+    missing = _missing_required_fields(result.variables)
+    if missing:
+        failures.append("missing_required_fields:" + ",".join(missing))
+    contaminated = {
+        field: count for field, count in frame_analysis.non_finite_counts.items() if count
+    }
+    if contaminated:
+        failures.append("required_field_non_finite_values")
+    if result.model_output_file_count != expected_model:
+        failures.append(f"model_output_count:{result.model_output_file_count}!={expected_model}")
+    if len(frame_analysis.times_seconds) != expected_model:
+        failures.append(f"model_frame_count:{len(frame_analysis.times_seconds)}!={expected_model}")
+    expected_model_times = [
+        float(index * OUTPUT_CADENCE_SECONDS) for index in range(expected_model)
+    ]
+    if frame_analysis.times_seconds != expected_model_times:
+        failures.append("model_output_times_do_not_match_120_second_cadence")
+    if len(diagnostic_times) != expected_diagnostic:
+        failures.append(f"diagnostic_frame_count:{len(diagnostic_times)}!={expected_diagnostic}")
+    expected_diagnostic_times = [
+        float(index * DIAGNOSTIC_CADENCE_SECONDS) for index in range(expected_diagnostic)
+    ]
+    if diagnostic_times != expected_diagnostic_times:
+        failures.append("diagnostic_output_times_do_not_match_60_second_cadence")
+    required_diagnostic_fields = {
+        "wprof",
+        "ptb_frc",
+        "qvb_frc",
+        "ug",
+        "vg",
+        "thflux",
+        "qvflux",
+        "ust",
+    }
+    missing_diagnostic_fields = sorted(required_diagnostic_fields - forcing.keys())
+    if missing_diagnostic_fields:
+        failures.append("missing_required_diagnostic_fields:" + ",".join(missing_diagnostic_fields))
+    intended = package.control_state.surface_moisture_flux_g_g_m_s
+    emitted = forcing.get("qvflux", {})
+    emitted_min = emitted.get("min")
+    emitted_max = emitted.get("max")
+    if emitted_min is None or emitted_max is None:
+        failures.append("surface_moisture_forcing_diagnostic_unavailable")
+    elif not (
+        math.isclose(emitted_min, intended, rel_tol=1e-6, abs_tol=1e-10)
+        and math.isclose(emitted_max, intended, rel_tol=1e-6, abs_tol=1e-10)
+    ):
+        failures.append(f"surface_moisture_forcing_mismatch:{emitted_min}:{emitted_max}:{intended}")
+    namelist_value = _namelist_assignments(package.namelist_path.read_text()).get("cnst_lhflx")
+    if namelist_value != package.control_state.namelist_value:
+        failures.append(f"namelist_surface_moisture_forcing_mismatch:{namelist_value}")
+    return RunGateEvidence(
+        valid=not failures,
+        lifecycle_state=result.source_lifecycle_state,
+        product_state=result.source_product_state,
+        exit_code=manifest.execution.exit_code,
+        normal_completion_reported=result.runtime_integrity.normal_completion_reported,
+        runtime_integrity_state=result.runtime_integrity.state,
+        runtime_integrity_reason=result.runtime_integrity.reason,
+        runtime_integrity_caveats=result.runtime_integrity.caveats,
+        model_output_count=result.model_output_file_count,
+        expected_model_output_count=expected_model,
+        diagnostic_output_count=len(diagnostic_times),
+        expected_diagnostic_output_count=expected_diagnostic,
+        missing_required_fields=missing,
+        required_field_non_finite_counts=frame_analysis.non_finite_counts,
+        intended_surface_moisture_flux_g_g_m_s=intended,
+        emitted_surface_moisture_flux_min_g_g_m_s=emitted_min,
+        emitted_surface_moisture_flux_max_g_g_m_s=emitted_max,
+        failures=failures,
+    )
+
+
+def compare_stage4_baseline(
+    preserved: ResultMetadata,
+    new_baseline: ResultMetadata,
+) -> Stage4ConsistencyEvidence:
+    """Compare exact common 600-second fields with explicit grid alignment."""
+    xarray = importlib.import_module("xarray")
+    preserved_frames = _result_frame_locations(preserved)
+    baseline_frames = _result_frame_locations(new_baseline)
+    expected_times = [float(value) for value in range(0, 21_601, 600)]
+    common_times = [
+        time_seconds
+        for time_seconds in expected_times
+        if time_seconds in preserved_frames and time_seconds in baseline_frames
+    ]
+    if common_times != expected_times:
+        missing = sorted(set(expected_times) - set(common_times))
+        raise TradeCumulusMoistureComparisonError(
+            f"Stage 4 consistency check lacks required common times: {missing}"
+        )
+    fields = ("ql", "qv", "th", "w", "cwp")
+    maxima = {field: [0.0, 0.0] for field in fields}
+    first_failure: Stage4FirstFailure | None = None
+    for time_seconds in common_times:
+        preserved_location = preserved_frames[time_seconds]
+        baseline_location = baseline_frames[time_seconds]
+        preserved_dataset = xarray.open_dataset(preserved_location[0], decode_times=False)
+        baseline_dataset = xarray.open_dataset(baseline_location[0], decode_times=False)
+        try:
+            preserved_values = _comparison_fields(preserved_dataset, preserved_location[1])
+            baseline_values = _comparison_fields(baseline_dataset, baseline_location[1])
+            for field in fields:
+                reference, reference_coordinates = preserved_values[field]
+                candidate, candidate_coordinates = baseline_values[field]
+                if reference.shape != candidate.shape:
+                    raise TradeCumulusMoistureComparisonError(
+                        f"Stage 4 {field} shape mismatch at {time_seconds:g} s."
+                    )
+                if len(reference_coordinates) != len(candidate_coordinates) or any(
+                    not np.array_equal(left, right)
+                    for left, right in zip(
+                        reference_coordinates, candidate_coordinates, strict=True
+                    )
+                ):
+                    raise TradeCumulusMoistureComparisonError(
+                        f"Stage 4 {field} coordinate mismatch at {time_seconds:g} s."
+                    )
+                if not np.all(np.isfinite(reference)) or not np.all(np.isfinite(candidate)):
+                    raise TradeCumulusMoistureComparisonError(
+                        f"Stage 4 {field} contains non-finite comparison values."
+                    )
+                absolute = np.abs(candidate - reference)
+                nonzero_reference = np.abs(reference) > 0.0
+                relative = np.zeros_like(absolute)
+                np.divide(
+                    absolute,
+                    np.abs(reference),
+                    out=relative,
+                    where=nonzero_reference,
+                )
+                maximum_absolute = float(np.max(absolute)) if absolute.size else 0.0
+                maximum_relative = float(np.max(relative)) if relative.size else 0.0
+                maxima[field][0] = max(maxima[field][0], maximum_absolute)
+                maxima[field][1] = max(maxima[field][1], maximum_relative)
+                allowed = STAGE4_ATOL + STAGE4_RTOL * np.abs(reference)
+                failed = absolute > allowed
+                if first_failure is None and np.any(failed):
+                    failure_index = tuple(int(value) for value in np.argwhere(failed)[0])
+                    first_failure = Stage4FirstFailure(
+                        time_seconds=time_seconds,
+                        field=field,
+                        index=list(failure_index),
+                        stage4_value=float(reference[failure_index]),
+                        new_baseline_value=float(candidate[failure_index]),
+                        absolute_difference=float(absolute[failure_index]),
+                        allowed_difference=float(allowed[failure_index]),
+                    )
+        finally:
+            preserved_dataset.close()
+            baseline_dataset.close()
+    return Stage4ConsistencyEvidence(
+        preserved_result_id=preserved.result_id,
+        new_baseline_result_id=new_baseline.result_id,
+        common_times_seconds=common_times,
+        field_differences=[
+            Stage4FieldDifference(
+                field=field,
+                maximum_absolute_difference=maxima[field][0],
+                maximum_relative_difference=maxima[field][1],
+            )
+            for field in fields
+        ],
+        first_failure=first_failure,
+        passed=first_failure is None,
+    )
+
+
+def build_joint_lens_preparation(
+    settings: CloudChamberSettings,
+    baseline: ResultMetadata,
+    more_moisture: ResultMetadata,
+) -> JointLensPreparation:
+    """Calculate pair-wide Lens references with the merged Lens algorithms."""
+    xarray = importlib.import_module("xarray")
+    defaults = trade_cumulus_updraft_lens_defaults(settings, baseline.result_id)
+    absolute_w: list[np.ndarray[Any, Any]] = []
+    perturbation_speeds: list[np.ndarray[Any, Any]] = []
+    total_speeds: list[np.ndarray[Any, Any]] = []
+    reference_coordinates: tuple[np.ndarray[Any, Any], ...] | None = None
+    wind_actual_level_m: float | None = None
+    field_availability: dict[str, list[str]] = {}
+    for result in (baseline, more_moisture):
+        field_availability[result.result_id] = sorted(
+            set(result.variables) & {"ql", "w", "u", "v", "cwp"}
+        )
+        for path, local_index in _ordered_result_frames(result):
+            dataset = xarray.open_dataset(path, decode_times=False)
+            try:
+                ql, dimensions = _scalar_field(dataset, "ql", local_index)
+                coordinates = tuple(
+                    _coordinate_as_m(dataset, dimension, size)
+                    for dimension, size in zip(dimensions, ql.shape, strict=True)
+                )
+                if reference_coordinates is None:
+                    reference_coordinates = coordinates
+                elif any(
+                    not np.array_equal(left, right)
+                    for left, right in zip(reference_coordinates, coordinates, strict=True)
+                ):
+                    raise TradeCumulusMoistureComparisonError(
+                        "Matched Lens preparation requires exact coordinate compatibility."
+                    )
+                w = center_vertical_velocity_to_scalar_grid(
+                    dataset, local_index, dimensions, ql.shape
+                )
+                finite_absolute_w = np.abs(w[np.isfinite(w)])
+                if finite_absolute_w.size:
+                    absolute_w.append(finite_absolute_w.astype(np.float32, copy=False))
+                z_values_m = coordinates[0]
+                wind_level_index = defaults.wind_level_index
+                if not 0 <= wind_level_index < z_values_m.size:
+                    raise TradeCumulusMoistureComparisonError(
+                        "Baseline Lens wind-level index is invalid for the matched grid."
+                    )
+                actual_level = float(z_values_m[wind_level_index])
+                if wind_actual_level_m is None:
+                    wind_actual_level_m = actual_level
+                elif wind_actual_level_m != actual_level:
+                    raise TradeCumulusMoistureComparisonError(
+                        "Matched Lens wind level differs between result frames."
+                    )
+                u, v = center_horizontal_wind_to_scalar_grid(
+                    dataset, local_index, dimensions, ql.shape
+                )
+                level_u = u[wind_level_index]
+                level_v = v[wind_level_index]
+                mean_u = _finite_mean_array(level_u)
+                mean_v = _finite_mean_array(level_v)
+                total = np.hypot(level_u, level_v)
+                perturbation = np.hypot(level_u - mean_u, level_v - mean_v)
+                finite_total = total[np.isfinite(total)]
+                finite_perturbation = perturbation[np.isfinite(perturbation)]
+                if finite_total.size:
+                    total_speeds.append(finite_total.astype(np.float32, copy=False))
+                if finite_perturbation.size:
+                    perturbation_speeds.append(finite_perturbation.astype(np.float32, copy=False))
+            finally:
+                dataset.close()
+    if reference_coordinates is None or wind_actual_level_m is None:
+        raise TradeCumulusMoistureComparisonError(
+            "No readable fields are available for joint Lens preparation."
+        )
+    if more_moisture.time_steps is None or defaults.default_time_index >= more_moisture.time_steps:
+        raise TradeCumulusMoistureComparisonError(
+            "Baseline Lens default time index is unavailable in More Moisture result."
+        )
+    if defaults.default_plane_index >= reference_coordinates[1].size:
+        raise TradeCumulusMoistureComparisonError(
+            "Baseline Lens default y-plane is unavailable in More Moisture result."
+        )
+    joint_w = rounded_percentile_reference(absolute_w, W_PERCENTILE, W_MIN_RANGE_M_S)
+    return JointLensPreparation(
+        baseline_result_id=baseline.result_id,
+        more_moisture_result_id=more_moisture.result_id,
+        baseline_default_time_index=defaults.default_time_index,
+        baseline_default_time_seconds=defaults.default_time_seconds,
+        baseline_default_plane_index=defaults.default_plane_index,
+        baseline_default_plane_coordinate=defaults.default_plane_coordinate,
+        baseline_default_plane_units=defaults.default_plane_units,
+        inherited_variant_time_index=defaults.default_time_index,
+        inherited_variant_plane_index=defaults.default_plane_index,
+        wind_level_index=defaults.wind_level_index,
+        wind_actual_level_m=wind_actual_level_m,
+        joint_w_range_min_m_s=-joint_w,
+        joint_w_range_max_m_s=joint_w,
+        joint_perturbation_wind_reference_m_s=rounded_percentile_reference(
+            perturbation_speeds, WIND_PERCENTILE, WIND_MIN_REFERENCE_M_S
+        ),
+        joint_total_wind_reference_m_s=rounded_percentile_reference(
+            total_speeds, WIND_PERCENTILE, WIND_MIN_REFERENCE_M_S
+        ),
+        coordinate_compatibility="exact_scalar_grid_coordinates_match",
+        field_availability=field_availability,
+    )
+
+
+def _comparison_fields(
+    dataset: Any,
+    time_index: int,
+) -> dict[str, tuple[np.ndarray[Any, Any], tuple[np.ndarray[Any, Any], ...]]]:
+    ql, dimensions = _scalar_field(dataset, "ql", time_index)
+    coordinates = tuple(
+        _coordinate_as_m(dataset, dimension, size)
+        for dimension, size in zip(dimensions, ql.shape, strict=True)
+    )
+    fields: dict[str, tuple[np.ndarray[Any, Any], tuple[np.ndarray[Any, Any], ...]]] = {
+        "ql": (ql, coordinates)
+    }
+    for field in ("qv", "th"):
+        values, field_dimensions = _scalar_field(dataset, field, time_index)
+        if field_dimensions != dimensions:
+            raise TradeCumulusMoistureComparisonError(
+                f"Stage 4 field {field} does not use the ql scalar grid."
+            )
+        fields[field] = (values, coordinates)
+    fields["w"] = (
+        center_vertical_velocity_to_scalar_grid(dataset, time_index, dimensions, ql.shape),
+        coordinates,
+    )
+    fields["cwp"] = (
+        _horizontal_field(dataset, "cwp", time_index, dimensions[1:]),
+        coordinates[1:],
+    )
+    return fields
+
+
+def _result_frame_locations(result: ResultMetadata) -> dict[float, tuple[Path, int]]:
+    xarray = importlib.import_module("xarray")
+    locations: dict[float, tuple[Path, int]] = {}
+    for path in map(Path, result.model_output_paths):
+        dataset = xarray.open_dataset(path, decode_times=False)
+        try:
+            for local_index in range(_time_count(dataset)):
+                time_seconds = _time_seconds(dataset, local_index)
+                if time_seconds in locations:
+                    raise TradeCumulusMoistureComparisonError(
+                        f"Duplicate model-output time {time_seconds:g} s."
+                    )
+                locations[time_seconds] = (path, local_index)
+        finally:
+            dataset.close()
+    return locations
+
+
+def _ordered_result_frames(result: ResultMetadata) -> list[tuple[Path, int]]:
+    return [location for _, location in sorted(_result_frame_locations(result).items())]
+
+
+def _scalar_field(
+    dataset: Any, field: str, time_index: int
+) -> tuple[np.ndarray[Any, Any], tuple[str, str, str]]:
+    if field not in dataset.data_vars:
+        raise TradeCumulusMoistureComparisonError(f"Required scalar field {field} is absent.")
+    data = _select_time(dataset[field], time_index)
+    dimensions = (
+        _dimension_for_axis(data.dims, "z"),
+        _dimension_for_axis(data.dims, "y"),
+        _dimension_for_axis(data.dims, "x"),
+    )
+    values = np.asarray(data.transpose(*dimensions).values, dtype=float)
+    if values.ndim != 3:
+        raise TradeCumulusMoistureComparisonError(
+            f"Scalar field {field} is not three-dimensional after time selection."
+        )
+    return values, dimensions
+
+
+def _horizontal_field(
+    dataset: Any,
+    field: str,
+    time_index: int,
+    dimensions: tuple[str, str],
+) -> np.ndarray[Any, Any]:
+    if field not in dataset.data_vars:
+        raise TradeCumulusMoistureComparisonError(f"Required horizontal field {field} is absent.")
+    data = _select_time(dataset[field], time_index)
+    if not all(dimension in data.dims for dimension in dimensions):
+        raise TradeCumulusMoistureComparisonError(
+            f"Horizontal field {field} does not use the scalar horizontal grid."
+        )
+    values = np.asarray(data.transpose(*dimensions).values, dtype=float)
+    if values.ndim != 2:
+        raise TradeCumulusMoistureComparisonError(
+            f"Horizontal field {field} is not two-dimensional after time selection."
+        )
+    return values
+
+
+def _raw_field(
+    dataset: Any, field: str, time_index: int
+) -> tuple[np.ndarray[Any, Any], tuple[str, ...]]:
+    if field not in dataset.data_vars:
+        raise TradeCumulusMoistureComparisonError(f"Required field {field} is absent.")
+    data = _select_time(dataset[field], time_index)
+    return np.asarray(data.values, dtype=float), tuple(str(value) for value in data.dims)
+
+
+def _select_time(data: Any, time_index: int) -> Any:
+    for candidate in ("time", "mtime", "t"):
+        if candidate in data.dims:
+            size = int(data.sizes[candidate])
+            if not 0 <= time_index < size:
+                raise TradeCumulusMoistureComparisonError(
+                    f"time_index {time_index} is outside {candidate} size {size}."
+                )
+            return data.isel({candidate: time_index})
+    if time_index != 0:
+        raise TradeCumulusMoistureComparisonError(
+            "A field without a time dimension supports only local time index zero."
+        )
+    return data
+
+
+def _dimension_for_axis(dimensions: Any, axis: Literal["x", "y", "z"]) -> str:
+    candidates = {
+        "x": ("xh", "x"),
+        "y": ("yh", "y"),
+        "z": ("zh", "z", "height", "height_m"),
+    }[axis]
+    names = tuple(str(value) for value in dimensions)
+    for candidate in candidates:
+        if candidate in names:
+            return candidate
+    raise TradeCumulusMoistureComparisonError(f"Field lacks a supported {axis} dimension: {names}.")
+
+
+def _coordinate_as_m(dataset: Any, name: str, expected_size: int) -> np.ndarray[Any, Any]:
+    if name not in dataset.coords:
+        raise TradeCumulusMoistureComparisonError(f"Coordinate {name} is absent.")
+    coordinate = dataset.coords[name]
+    values = np.asarray(coordinate.values, dtype=float).reshape(-1)
+    if values.size != expected_size:
+        raise TradeCumulusMoistureComparisonError(
+            f"Coordinate {name} does not match its field dimension."
+        )
+    units = str(coordinate.attrs.get("units", "")).strip().lower()
+    if units in {"km", "kilometer", "kilometers"}:
+        values = values * 1000.0
+    return values
+
+
+def _time_count(dataset: Any) -> int:
+    for candidate in ("time", "mtime", "t"):
+        if candidate in dataset.sizes:
+            return int(dataset.sizes[candidate])
+    return 1
+
+
+def _time_seconds(dataset: Any, time_index: int) -> float:
+    for candidate in ("time", "mtime", "t"):
+        if candidate in dataset.coords or candidate in dataset.variables:
+            values = np.asarray(dataset[candidate].values, dtype=float).reshape(-1)
+            if not 0 <= time_index < values.size:
+                continue
+            value = float(values[time_index])
+            if not math.isfinite(value):
+                break
+            return value
+    raise TradeCumulusMoistureComparisonError("A finite model time coordinate is required.")
+
+
+def _required_field_source(dataset: Any, field: str) -> str | None:
+    candidates = {
+        "ql": ("ql", "qc"),
+        "kmh": ("kmh", "km"),
+        "khh": ("khh", "kh"),
+    }.get(field, (field,))
+    return next((candidate for candidate in candidates if candidate in dataset.data_vars), None)
+
+
+def _missing_required_fields(variables: list[str]) -> list[str]:
+    available = set(variables)
+    aliases = {"ql": {"ql", "qc"}, "kmh": {"kmh", "km"}, "khh": {"khh", "kh"}}
+    return [
+        field for field in REQUIRED_OUTPUT_FIELDS if not (aliases.get(field, {field}) & available)
+    ]
+
+
+def _diagnostic_paths(result: ResultMetadata) -> list[Path]:
+    return sorted(
+        (Path(path) for path in result.netcdf_paths if Path(path).name.startswith("cm1out_diag_")),
+        key=lambda path: path.name,
+    )
+
+
+def _cm1_reported_runtime_seconds(manifest: Any) -> float | None:
+    configured = manifest.execution.stdout_log
+    if not configured:
+        return None
+    path = Path(str(configured)).expanduser()
+    if not path.is_file():
+        return None
+    matches = re.findall(
+        r"^\s*Total time:\s*([0-9]+(?:\.[0-9]*)?)\s*$", path.read_text(), re.MULTILINE
+    )
+    if not matches:
+        return None
+    value = float(matches[-1])
+    return value if math.isfinite(value) else None
+
+
+def _horizontal_mean_profile(values: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+    finite = np.isfinite(values)
+    counts = np.sum(finite, axis=(1, 2))
+    sums = np.sum(np.where(finite, values, 0.0), axis=(1, 2))
+    profile = np.full(values.shape[0], np.nan, dtype=float)
+    np.divide(sums, counts, out=profile, where=counts > 0)
+    return profile
+
+
+def _cloud_conditioned_profile(
+    w: np.ndarray[Any, Any], cloud_mask: np.ndarray[Any, Any]
+) -> list[float | None]:
+    selected = cloud_mask & np.isfinite(w)
+    counts = np.sum(selected, axis=(1, 2))
+    sums = np.sum(np.where(selected, w, 0.0), axis=(1, 2))
+    profile = np.full(w.shape[0], np.nan, dtype=float)
+    np.divide(sums, counts, out=profile, where=counts > 0)
+    return _optional_float_list(profile)
+
+
+def _mean_optional_profiles(profiles: list[list[float | None]]) -> list[float | None]:
+    if not profiles:
+        return []
+    widths = {len(profile) for profile in profiles}
+    if len(widths) != 1:
+        raise TradeCumulusMoistureComparisonError("Vertical profiles use inconsistent grids.")
+    matrix = np.asarray(
+        [[np.nan if value is None else value for value in profile] for profile in profiles],
+        dtype=float,
+    )
+    finite = np.isfinite(matrix)
+    counts = np.sum(finite, axis=0)
+    sums = np.sum(np.where(finite, matrix, 0.0), axis=0)
+    means = np.full(matrix.shape[1], np.nan, dtype=float)
+    np.divide(sums, counts, out=means, where=counts > 0)
+    return _optional_float_list(means)
+
+
+def _profile_peak(
+    profile: list[float | None], heights_m: list[float]
+) -> tuple[float | None, float | None]:
+    finite = [
+        (value, heights_m[index])
+        for index, value in enumerate(profile)
+        if value is not None and index < len(heights_m)
+    ]
+    if not finite:
+        return None, None
+    maximum = max(value for value, _ in finite)
+    height = min(height for value, height in finite if value == maximum)
+    return maximum, height
+
+
+def _metric(
+    value: float | None,
+    units: str,
+    method: str,
+    window: str,
+    *,
+    unavailable_reason: str | None = None,
+) -> ScalarRunMetric:
+    if value is None:
+        return ScalarRunMetric(
+            value=None,
+            units=units,
+            method=method,
+            window=window,
+            quality="unavailable",
+            unavailable_reason=unavailable_reason or "metric_value_unavailable",
+        )
+    return ScalarRunMetric(value=value, units=units, method=method, window=window)
+
+
+def _timed_values(times: list[float], values: list[float]) -> list[TimedValue]:
+    if len(times) != len(values):
+        raise TradeCumulusMoistureComparisonError(
+            "Time and value sequences must have identical lengths."
+        )
+    return [
+        TimedValue(time_seconds=time_seconds, value=value)
+        for time_seconds, value in zip(times, values, strict=True)
+    ]
+
+
+def _optional_float_list(values: np.ndarray[Any, Any]) -> list[float | None]:
+    return [float(value) if math.isfinite(float(value)) else None for value in values]
+
+
+def _finite_mean_array(values: np.ndarray[Any, Any]) -> float:
+    finite = values[np.isfinite(values)]
+    if not finite.size:
+        raise TradeCumulusMoistureComparisonError("A finite horizontal wind mean is required.")
+    return float(np.mean(finite))
+
+
+def _finite_mean_list(values: list[float]) -> float | None:
+    finite = [value for value in values if math.isfinite(value)]
+    return float(np.mean(finite)) if finite else None
+
+
+def _finite_min_list(values: list[float]) -> float | None:
+    finite = [value for value in values if math.isfinite(value)]
+    return min(finite) if finite else None
+
+
+def _finite_max_list(values: list[float]) -> float | None:
+    finite = [value for value in values if math.isfinite(value)]
+    return max(finite) if finite else None
+
+
+def _min_optional(current: float | None, candidate: float) -> float:
+    return min(current, candidate) if current is not None else candidate
+
+
+def _max_optional(current: float | None, candidate: float) -> float:
+    return max(current, candidate) if current is not None else candidate
+
+
+def _fixed_assumptions() -> dict[str, Any]:
+    return {
+        "case_id": CASE_ID,
+        "canonical_profiles": "cm1_r21_1_analytic_isnd19_iwnd9_testcase3",
+        "deterministic_perturbation": {"irandp": 1},
+        "surface_sensible_heat_flux_k_m_s": 8.0e-3,
+        "friction_velocity_m_s": 0.28,
+        "large_scale_forcing": "canonical_bomex",
+        "physics": {"ptype": 6, "terminal_velocity_m_s": 0.0},
+        "grid": {"nx": 64, "ny": 64, "nz": 75},
+        "spacing_m": {"dx": 100.0, "dy": 100.0, "dz": 40.0},
+        "domain_m": {"x": 6400.0, "y": 6400.0, "z": 3000.0},
+        "time_step": {"target_seconds": 3.0, "adaptive": True},
+        "output_cadence_seconds": OUTPUT_CADENCE_SECONDS,
+        "diagnostic_cadence_seconds": DIAGNOSTIC_CADENCE_SECONDS,
+        "required_output_fields": list(REQUIRED_OUTPUT_FIELDS),
+    }
+
+
+def _namelist_assignments(text: str) -> dict[str, str]:
+    pattern = re.compile(
+        r"^\s*(?P<name>[A-Za-z][A-Za-z0-9_]*)\s*=\s*(?P<value>[^,!\n]+)", re.MULTILINE
+    )
+    values: dict[str, str] = {}
+    for match in pattern.finditer(text):
+        name = match.group("name")
+        if name in values:
+            raise TradeCumulusMoistureComparisonError(
+                f"Generated namelist contains duplicate assignment {name!r}."
+            )
+        values[name] = match.group("value").strip()
+    return values
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")

--- a/app/backend/cloud_chamber/trade_cumulus_updraft_lens.py
+++ b/app/backend/cloud_chamber/trade_cumulus_updraft_lens.py
@@ -188,7 +188,9 @@ def trade_cumulus_updraft_lens_frame(
     dataset = _open_dataset(frame.path)
     try:
         ql, dimensions = _scalar_ql(dataset, frame.local_index)
-        w = _center_w(dataset, frame.local_index, dimensions, ql.shape)
+        w = center_vertical_velocity_to_scalar_grid(
+            dataset, frame.local_index, dimensions, ql.shape
+        )
         nz, ny, nx = ql.shape
         plane_size = {
             "horizontal": nz,
@@ -222,7 +224,9 @@ def trade_cumulus_updraft_lens_frame(
             w_slice = w[:, :, plane_index]
             cloud_slice = ql[:, :, plane_index] >= CLOUD_THRESHOLD_KG_KG
 
-        u, v = _center_horizontal_wind(dataset, frame.local_index, dimensions, ql.shape)
+        u, v = center_horizontal_wind_to_scalar_grid(
+            dataset, frame.local_index, dimensions, ql.shape
+        )
         wind_level_index = cached.response.wind_level_index
         level_u = u[wind_level_index]
         level_v = v[wind_level_index]
@@ -329,7 +333,9 @@ def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDef
             local_count = _time_count(dataset)
             for local_index in range(local_count):
                 ql, dimensions = _scalar_ql(dataset, local_index)
-                w = _center_w(dataset, local_index, dimensions, ql.shape)
+                w = center_vertical_velocity_to_scalar_grid(
+                    dataset, local_index, dimensions, ql.shape
+                )
                 if first_dimensions is None:
                     first_dimensions = dimensions
                 elif dimensions != first_dimensions:
@@ -354,7 +360,9 @@ def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDef
                     z_values_m = _coordinate_as(dataset, dimensions[0], "m", ql.shape[0])
                     wind_level_index = int(np.argmin(np.abs(z_values_m - WIND_TARGET_LEVEL_M)))
                     wind_actual_level_m = float(z_values_m[wind_level_index])
-                u, v = _center_horizontal_wind(dataset, local_index, dimensions, ql.shape)
+                u, v = center_horizontal_wind_to_scalar_grid(
+                    dataset, local_index, dimensions, ql.shape
+                )
                 level_u = u[wind_level_index]
                 level_v = v[wind_level_index]
                 mean_u = _finite_mean(level_u)
@@ -383,7 +391,7 @@ def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDef
     selected_dataset = _open_dataset(selected_frame.path)
     try:
         selected_ql, dimensions = _scalar_ql(selected_dataset, selected_frame.local_index)
-        selected_w = _center_w(
+        selected_w = center_vertical_velocity_to_scalar_grid(
             selected_dataset,
             selected_frame.local_index,
             dimensions,
@@ -396,11 +404,13 @@ def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDef
     finally:
         selected_dataset.close()
 
-    w_range = _rounded_reference(absolute_w, W_PERCENTILE, W_MIN_RANGE_M_S)
-    perturbation_reference = _rounded_reference(
+    w_range = rounded_percentile_reference(absolute_w, W_PERCENTILE, W_MIN_RANGE_M_S)
+    perturbation_reference = rounded_percentile_reference(
         perturbation_speeds, WIND_PERCENTILE, WIND_MIN_REFERENCE_M_S
     )
-    total_reference = _rounded_reference(total_speeds, WIND_PERCENTILE, WIND_MIN_REFERENCE_M_S)
+    total_reference = rounded_percentile_reference(
+        total_speeds, WIND_PERCENTILE, WIND_MIN_REFERENCE_M_S
+    )
     response = TradeCumulusUpdraftLensDefaults(
         result_id=metadata.result_id,
         case_id=CASE_ID,
@@ -559,7 +569,7 @@ def _scalar_ql(dataset: Any, time_index: int) -> tuple[np.ndarray[Any, Any], tup
     return values, dimensions
 
 
-def _center_w(
+def center_vertical_velocity_to_scalar_grid(
     dataset: Any,
     time_index: int,
     scalar_dimensions: tuple[str, str, str],
@@ -583,7 +593,7 @@ def _center_w(
     )
 
 
-def _center_horizontal_wind(
+def center_horizontal_wind_to_scalar_grid(
     dataset: Any,
     time_index: int,
     scalar_dimensions: tuple[str, str, str],
@@ -780,7 +790,7 @@ def _coordinate_units(dataset: Any, name: str) -> str | None:
     return str(units) if units is not None else None
 
 
-def _rounded_reference(
+def rounded_percentile_reference(
     arrays: list[np.ndarray[Any, Any]], percentile: float, minimum: float
 ) -> float:
     if not arrays:

--- a/app/backend/tests/test_bomex_case.py
+++ b/app/backend/tests/test_bomex_case.py
@@ -124,7 +124,7 @@ def test_package_records_hashes_provenance_and_no_recipe(
     settings = fake_settings(tmp_path)
     provenance = fake_provenance(tmp_path)
     monkeypatch.setattr(bomex_case, "collect_cm1_provenance", lambda _settings: provenance)
-    monkeypatch.setattr(bomex_case, "_clean_git_commit", lambda: "commit-test")
+    monkeypatch.setattr(bomex_case, "verified_clean_git_commit", lambda: "commit-test")
 
     smoke = generate_bomex_package(
         settings=settings,

--- a/app/backend/tests/test_trade_cumulus_moisture_comparison.py
+++ b/app/backend/tests/test_trade_cumulus_moisture_comparison.py
@@ -1,0 +1,445 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import cloud_chamber.trade_cumulus_moisture_comparison as comparison
+from cloud_chamber import bomex_case
+from cloud_chamber.bomex_case import CM1Provenance
+from cloud_chamber.result_ingest import ResultMetadata
+from cloud_chamber.run_manifest import load_run_manifest
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.trade_cumulus_moisture_comparison import (
+    COMPARISON_GROUP_ID,
+    OUTPUT_CADENCE_SECONDS,
+    PERCENT_DELTA_MINIMUM_DENOMINATOR,
+    PackageComparisonProof,
+    RunGateEvidence,
+    ScalarRunMetric,
+    TimedValue,
+    TradeCumulusMatchedPackage,
+    TradeCumulusMoistureComparisonError,
+    TradeCumulusMoistureState,
+    TradeCumulusRunEvidence,
+    TradeCumulusRunLength,
+    VerticalProfile,
+    compare_matched_packages,
+    compare_stage4_baseline,
+    generate_trade_cumulus_matched_package,
+    namelist_difference_names,
+    normalized_trade_cumulus_fixed_assumptions_namelist,
+    normalized_trade_cumulus_science_namelist,
+    pair_exact_time_series,
+    pair_scalar_metric,
+    render_trade_cumulus_matched_namelist,
+    thickness_weighted_layer_mean,
+    verify_smoke_full_equivalence,
+)
+from cloud_chamber.trade_cumulus_updraft_lens import rounded_percentile_reference
+
+
+def _reference_namelist_text() -> str:
+    names = sorted(
+        {
+            *bomex_case._COMMON_NAMELIST_OVERRIDES,
+            *bomex_case.REQUIRED_OUTPUT_SWITCHES,
+            "cnst_lhflx",
+            "timax",
+        }
+    )
+    return "&bomex_test\n" + "".join(f"  {name} = -999,\n" for name in names) + "/\n"
+
+
+def _assignment(text: str, name: str) -> str:
+    for line in text.splitlines():
+        if line.strip().startswith(f"{name} ="):
+            return line.split("=", 1)[1].split(",", 1)[0].strip()
+    raise AssertionError(f"missing assignment: {name}")
+
+
+def _settings(tmp_path: Path) -> CloudChamberSettings:
+    runtime_home = tmp_path / "CloudChamber"
+    cm1_root = tmp_path / "cm1r21.1"
+    cm1_run_dir = cm1_root / "run"
+    cm1_run_dir.mkdir(parents=True)
+    return CloudChamberSettings(
+        runtime_home=runtime_home,
+        cm1_root=cm1_root,
+        cm1_run_dir=cm1_run_dir,
+        cache_dir=runtime_home / "cache",
+        log_dir=runtime_home / "logs",
+    )
+
+
+def _provenance(tmp_path: Path) -> CM1Provenance:
+    reference_path = tmp_path / "cm1r21.1" / "run" / "namelist.input.reference"
+    reference_path.write_text(_reference_namelist_text())
+    return CM1Provenance(
+        release="21.1",
+        official_tag_commit=bomex_case.CM1_TAG_COMMIT,
+        official_source_tag=bomex_case.CM1_SOURCE_TAG,
+        source_tree_path=str(tmp_path / "cm1r21.1"),
+        run_directory_path=str(tmp_path / "cm1r21.1" / "run"),
+        executable_path=str(tmp_path / "cm1r21.1" / "run" / "cm1.exe"),
+        executable_sha256="executable-hash",
+        readme_namelist_path=str(tmp_path / "cm1r21.1" / "README.namelist"),
+        readme_namelist_sha256="readme-hash",
+        source_manifest_method="test manifest",
+        source_manifest_sha256="source-hash",
+        critical_source_sha256={"src/base.F": "base-hash"},
+        bundled_bomex_namelist_path=str(reference_path),
+        bundled_bomex_namelist_sha256="reference-hash",
+        bundled_bomex_readme_path=str(tmp_path / "cm1r21.1" / "README"),
+        bundled_bomex_readme_sha256="case-readme-hash",
+    )
+
+
+def _install_package_mocks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> CloudChamberSettings:
+    settings = _settings(tmp_path)
+    provenance = _provenance(tmp_path)
+    monkeypatch.setattr(bomex_case, "collect_cm1_provenance", lambda _settings: provenance)
+    monkeypatch.setattr(bomex_case, "verified_clean_git_commit", lambda: "commit-test")
+    monkeypatch.setattr(comparison, "verified_clean_git_commit", lambda: "commit-test")
+    return settings
+
+
+def test_exact_states_lengths_cadences_and_counts() -> None:
+    assert TradeCumulusMoistureState.BASELINE.surface_moisture_flux_g_g_m_s == 5.2e-5
+    assert TradeCumulusMoistureState.MORE_MOISTURE.surface_moisture_flux_g_g_m_s == 7.8e-5
+    assert OUTPUT_CADENCE_SECONDS == 120
+    assert TradeCumulusRunLength.SMOKE.duration_seconds == 600
+    assert TradeCumulusRunLength.SMOKE.expected_model_output_count == 6
+    assert TradeCumulusRunLength.SMOKE.expected_diagnostic_output_count == 11
+    assert TradeCumulusRunLength.FULL.duration_seconds == 21_600
+    assert TradeCumulusRunLength.FULL.expected_model_output_count == 181
+    assert TradeCumulusRunLength.FULL.expected_diagnostic_output_count == 361
+
+
+def test_rendered_pair_diff_and_normalized_hash_contract() -> None:
+    reference = _reference_namelist_text()
+    baseline_smoke = render_trade_cumulus_matched_namelist(
+        reference, TradeCumulusMoistureState.BASELINE, TradeCumulusRunLength.SMOKE
+    )
+    baseline_full = render_trade_cumulus_matched_namelist(
+        reference, TradeCumulusMoistureState.BASELINE, TradeCumulusRunLength.FULL
+    )
+    variant_full = render_trade_cumulus_matched_namelist(
+        reference, TradeCumulusMoistureState.MORE_MOISTURE, TradeCumulusRunLength.FULL
+    )
+
+    assert _assignment(baseline_smoke, "timax") == "600.0"
+    assert _assignment(baseline_full, "tapfrq") == "120.0"
+    assert _assignment(baseline_full, "diagfrq") == "60.0"
+    assert _assignment(baseline_full, "cnst_lhflx") == "5.2e-5"
+    assert _assignment(variant_full, "cnst_lhflx") == "7.8e-5"
+    assert namelist_difference_names(baseline_smoke, baseline_full) == ["timax"]
+    assert namelist_difference_names(baseline_full, variant_full) == ["cnst_lhflx"]
+    assert normalized_trade_cumulus_science_namelist(baseline_smoke) == (
+        normalized_trade_cumulus_science_namelist(baseline_full)
+    )
+    assert normalized_trade_cumulus_science_namelist(baseline_full) != (
+        normalized_trade_cumulus_science_namelist(variant_full)
+    )
+    assert normalized_trade_cumulus_fixed_assumptions_namelist(baseline_full) == (
+        normalized_trade_cumulus_fixed_assumptions_namelist(variant_full)
+    )
+
+
+def test_packages_record_exact_identifiers_hashes_and_null_recipe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _install_package_mocks(tmp_path, monkeypatch)
+    packages: dict[tuple[TradeCumulusMoistureState, TradeCumulusRunLength], Any] = {}
+    for state in TradeCumulusMoistureState:
+        for run_length in TradeCumulusRunLength:
+            packages[(state, run_length)] = generate_trade_cumulus_matched_package(
+                settings=settings,
+                control_state=state,
+                run_length=run_length,
+                run_id=f"{run_length.value}-{state.value}",
+                app_commit="commit-test",
+            )
+
+    baseline_smoke = packages[(TradeCumulusMoistureState.BASELINE, TradeCumulusRunLength.SMOKE)]
+    variant_smoke = packages[(TradeCumulusMoistureState.MORE_MOISTURE, TradeCumulusRunLength.SMOKE)]
+    baseline_full = packages[(TradeCumulusMoistureState.BASELINE, TradeCumulusRunLength.FULL)]
+    variant_full = packages[(TradeCumulusMoistureState.MORE_MOISTURE, TradeCumulusRunLength.FULL)]
+    proof = compare_matched_packages(baseline_smoke, variant_smoke)
+    assert proof.valid is True
+    compare_matched_packages(baseline_full, variant_full)
+    verify_smoke_full_equivalence(baseline_smoke, baseline_full)
+    verify_smoke_full_equivalence(variant_smoke, variant_full)
+    assert baseline_full.fixed_assumptions_sha256 == variant_full.fixed_assumptions_sha256
+    assert baseline_full.science_settings_sha256 != variant_full.science_settings_sha256
+
+    manifest = load_run_manifest(variant_full.manifest_path)
+    assert manifest.scenario.id == bomex_case.CASE_ID
+    assert manifest.run_recipe is None
+    assert manifest.app.commit == "commit-test"
+    assert manifest.run_configuration["product_slice_id"] == "trade_cumulus_v1"
+    assert manifest.run_configuration["comparison_group_id"] == COMPARISON_GROUP_ID
+    assert manifest.run_configuration["recipe_candidate_id"] == "canonical_bomex_baseline"
+    assert manifest.run_configuration["control_id"] == "surface_moisture_supply"
+    assert manifest.run_configuration["control_state"] == "more_moisture"
+    assert manifest.run_configuration["expected_model_output_count"] == 181
+    assert manifest.run_configuration["expected_diagnostic_output_count"] == 361
+    changed = manifest.run_configuration["changed_assumptions"]
+    assert set(changed) == {
+        "control_id",
+        "control_state",
+        "surface_moisture_flux_g_g_m_s",
+    }
+
+
+def test_package_refuses_dirty_or_mismatched_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path)
+
+    def dirty() -> str:
+        raise bomex_case.BomexCaseError("requires a clean Git worktree")
+
+    monkeypatch.setattr(comparison, "verified_clean_git_commit", dirty)
+    with pytest.raises(TradeCumulusMoistureComparisonError, match="clean Git worktree"):
+        generate_trade_cumulus_matched_package(
+            settings=settings,
+            control_state=TradeCumulusMoistureState.BASELINE,
+            run_length=TradeCumulusRunLength.SMOKE,
+            run_id="dirty",
+        )
+    assert not (settings.runtime_home / "runs" / "dirty").exists()
+
+
+def test_thickness_weighted_mean_is_not_arithmetic_mean() -> None:
+    profile = np.asarray([0.0, 10.0, 20.0])
+    heights = np.asarray([50.0, 200.0, 800.0])
+    weighted = thickness_weighted_layer_mean(profile, heights)
+    assert weighted == pytest.approx(13.75)
+    assert weighted != pytest.approx(float(np.mean(profile)))
+
+
+def test_time_mean_profile_peak_is_not_instantaneous_peak() -> None:
+    profile = comparison._mean_optional_profiles([[100.0, 0.0], [0.0, 80.0], [0.0, 80.0]])
+    peak, height = comparison._profile_peak(profile, [100.0, 500.0])
+    assert profile == pytest.approx([100.0 / 3.0, 160.0 / 3.0])
+    assert (peak, height) == pytest.approx((160.0 / 3.0, 500.0))
+
+
+def test_cloud_conditioned_w_excludes_clear_raw_extrema() -> None:
+    w = np.asarray([[[1.0, -20.0], [3.0, 40.0]]])
+    cloud = np.asarray([[[True, False], [True, False]]])
+    assert comparison._cloud_conditioned_profile(w, cloud) == pytest.approx([2.0])
+    assert float(np.max(w)) == 40.0
+
+
+def test_exact_time_pairing_rejects_interpolation() -> None:
+    baseline = [TimedValue(time_seconds=0.0, value=1.0), TimedValue(time_seconds=120.0, value=2.0)]
+    variant = [TimedValue(time_seconds=0.0, value=2.0), TimedValue(time_seconds=180.0, value=4.0)]
+    with pytest.raises(TradeCumulusMoistureComparisonError, match="interpolation is forbidden"):
+        pair_exact_time_series(baseline, variant)
+
+
+def test_percent_delta_is_unavailable_for_zero_and_near_zero_baselines() -> None:
+    for value in (0.0, PERCENT_DELTA_MINIMUM_DENOMINATOR):
+        paired = pair_scalar_metric(
+            ScalarRunMetric(value=value, units="m/s", method="same", window="same"),
+            ScalarRunMetric(value=1.0, units="m/s", method="same", window="same"),
+        )
+        assert paired.percent_delta is None
+        assert paired.percent_delta_unavailable_reason == "baseline_denominator_zero_or_near_zero"
+
+
+def _stage4_dataset(delta: float = 0.0) -> xr.Dataset:
+    times = np.arange(0.0, 21_601.0, 600.0)
+    shape = (times.size, 2, 2, 2)
+    ql = np.full(shape, 2e-6)
+    qv = np.full(shape, 0.01)
+    qv[1, 0, 0, 0] += delta
+    th = np.full(shape, 300.0)
+    w = np.ones((times.size, 3, 2, 2))
+    cwp = np.full((times.size, 2, 2), 0.1)
+    return xr.Dataset(
+        {
+            "ql": (("time", "zh", "yh", "xh"), ql),
+            "qv": (("time", "zh", "yh", "xh"), qv),
+            "th": (("time", "zh", "yh", "xh"), th),
+            "w": (("time", "zf", "yh", "xh"), w),
+            "cwp": (("time", "yh", "xh"), cwp),
+        },
+        coords={
+            "time": ("time", times, {"units": "s"}),
+            "zh": ("zh", [0.1, 0.3], {"units": "km"}),
+            "zf": ("zf", [0.0, 0.2, 0.4], {"units": "km"}),
+            "yh": ("yh", [0.0, 0.1], {"units": "km"}),
+            "xh": ("xh", [0.0, 0.1], {"units": "km"}),
+        },
+    )
+
+
+def _result(path: Path, result_id: str) -> ResultMetadata:
+    now = datetime(2026, 7, 20, tzinfo=UTC)
+    return ResultMetadata(
+        result_id=result_id,
+        run_id=result_id.removeprefix("result-"),
+        scenario_id=bomex_case.CASE_ID,
+        physical_question="comparison",
+        controls={},
+        run_configuration={"case_id": bomex_case.CASE_ID},
+        source_lifecycle_state="completed",
+        source_product_state="completed_cm1_result",
+        source_model="CM1",
+        model_output_paths=[str(path)],
+        model_output_file_count=37,
+        time_steps=37,
+        first_output_time_seconds=0.0,
+        last_output_time_seconds=21_600.0,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_stage4_consistency_checker_passes_and_reports_maxima(tmp_path: Path) -> None:
+    preserved_path = tmp_path / "preserved.nc"
+    candidate_path = tmp_path / "candidate.nc"
+    _stage4_dataset().to_netcdf(preserved_path)
+    _stage4_dataset(delta=1e-12).to_netcdf(candidate_path)
+    evidence = compare_stage4_baseline(
+        _result(preserved_path, "result-stage4"),
+        _result(candidate_path, "result-new"),
+    )
+    assert evidence.passed is True
+    assert evidence.first_failure is None
+    assert evidence.field_differences[1].maximum_absolute_difference == pytest.approx(1e-12)
+
+
+def test_stage4_consistency_checker_records_first_failure(tmp_path: Path) -> None:
+    preserved_path = tmp_path / "preserved.nc"
+    candidate_path = tmp_path / "candidate.nc"
+    _stage4_dataset().to_netcdf(preserved_path)
+    _stage4_dataset(delta=1e-5).to_netcdf(candidate_path)
+    evidence = compare_stage4_baseline(
+        _result(preserved_path, "result-stage4"),
+        _result(candidate_path, "result-new"),
+    )
+    assert evidence.passed is False
+    assert evidence.first_failure is not None
+    assert evidence.first_failure.time_seconds == 600.0
+    assert evidence.first_failure.field == "qv"
+    assert evidence.first_failure.index == [0, 0, 0]
+
+
+def test_joint_reference_uses_values_from_either_member() -> None:
+    baseline = np.asarray([0.2, 0.3])
+    variant = np.asarray([1.01, 1.02])
+    joint = rounded_percentile_reference([baseline, variant], 99, 0.5)
+    assert joint == 1.1
+
+
+def _minimal_run_evidence() -> TradeCumulusRunEvidence:
+    gate = RunGateEvidence(
+        valid=True,
+        lifecycle_state="completed",
+        product_state="completed_cm1_result",
+        exit_code=0,
+        normal_completion_reported=True,
+        runtime_integrity_state="trusted",
+        runtime_integrity_reason="passed",
+        runtime_integrity_caveats=[],
+        model_output_count=6,
+        expected_model_output_count=6,
+        diagnostic_output_count=11,
+        expected_diagnostic_output_count=11,
+        missing_required_fields=[],
+        required_field_non_finite_counts={},
+        intended_surface_moisture_flux_g_g_m_s=5.2e-5,
+        emitted_surface_moisture_flux_min_g_g_m_s=5.2e-5,
+        emitted_surface_moisture_flux_max_g_g_m_s=5.2e-5,
+    )
+    return TradeCumulusRunEvidence(
+        control_state="baseline",
+        run_length="smoke",
+        run_id="run",
+        result_id="result-run",
+        app_commit="commit",
+        surface_moisture_flux_g_g_m_s=5.2e-5,
+        duration_seconds=600,
+        output_bytes=123,
+        gate=gate,
+        scalar_metrics={
+            "metric": ScalarRunMetric(value=1.0, units="1", method="deterministic", window="all")
+        },
+        time_series={"series": [TimedValue(time_seconds=0.0, value=1.0)]},
+        vertical_profiles={
+            "profile": VerticalProfile(
+                height_m=[100.0],
+                values=[1.0],
+                units="1",
+                method="deterministic",
+                window="all",
+            )
+        },
+        final_domain_mean_profiles={},
+        forcing_diagnostics={},
+        forcing_and_transport_fields_available=[],
+        available_fields=[],
+    )
+
+
+def test_run_evidence_serialization_is_deterministic() -> None:
+    evidence = _minimal_run_evidence()
+    assert evidence.to_json_text() == evidence.model_copy(deep=True).to_json_text()
+    assert evidence.to_json_text().endswith("\n")
+
+
+def test_package_comparison_proof_forbids_extra_difference(tmp_path: Path) -> None:
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+    left.mkdir()
+    right.mkdir()
+    (left / "namelist.input").write_text("a = 1,\ncnst_lhflx = 5.2e-5,\n")
+    (right / "namelist.input").write_text("a = 2,\ncnst_lhflx = 7.8e-5,\n")
+    baseline = TradeCumulusMatchedPackage(
+        run_id="baseline",
+        control_state=TradeCumulusMoistureState.BASELINE,
+        run_length=TradeCumulusRunLength.FULL,
+        package_dir=left,
+        manifest_path=left / "manifest",
+        case_manifest_path=left / "case",
+        namelist_path=left / "namelist.input",
+        science_settings_sha256="baseline-science",
+        fixed_assumptions_sha256="fixed",
+        app_commit="commit",
+    )
+    variant = TradeCumulusMatchedPackage(
+        run_id="variant",
+        control_state=TradeCumulusMoistureState.MORE_MOISTURE,
+        run_length=TradeCumulusRunLength.FULL,
+        package_dir=right,
+        manifest_path=right / "manifest",
+        case_manifest_path=right / "case",
+        namelist_path=right / "namelist.input",
+        science_settings_sha256="variant-science",
+        fixed_assumptions_sha256="fixed",
+        app_commit="commit",
+    )
+    with pytest.raises(TradeCumulusMoistureComparisonError, match="proof failed"):
+        compare_matched_packages(baseline, variant)
+
+
+def test_package_proof_model_serializes_stably() -> None:
+    proof = PackageComparisonProof(
+        run_length="smoke",
+        baseline_run_id="baseline",
+        more_moisture_run_id="variant",
+        differing_namelist_assignments=["cnst_lhflx"],
+        fixed_assumptions_sha256="fixed",
+        baseline_science_settings_sha256="one",
+        more_moisture_science_settings_sha256="two",
+        valid=True,
+    )
+    assert proof.model_dump_json() == proof.model_copy().model_dump_json()

--- a/app/backend/tests/test_trade_cumulus_updraft_lens.py
+++ b/app/backend/tests/test_trade_cumulus_updraft_lens.py
@@ -144,7 +144,7 @@ def test_eligibility_does_not_infer_from_raw_fields(tmp_path: Path) -> None:
 def test_w_face_grid_is_centered_to_ql_levels() -> None:
     dataset = _dataset()
     ql, dimensions = lens._scalar_ql(dataset, 0)
-    centered = lens._center_w(dataset, 0, dimensions, ql.shape)
+    centered = lens.center_vertical_velocity_to_scalar_grid(dataset, 0, dimensions, ql.shape)
     assert centered.shape == ql.shape
     assert centered[:, 1, :] == pytest.approx(np.full((3, 4), 2.0))
 
@@ -152,7 +152,7 @@ def test_w_face_grid_is_centered_to_ql_levels() -> None:
 def test_w_scalar_grid_is_used_directly() -> None:
     dataset = _dataset(scalar_w=True)
     ql, dimensions = lens._scalar_ql(dataset, 0)
-    centered = lens._center_w(dataset, 0, dimensions, ql.shape)
+    centered = lens.center_vertical_velocity_to_scalar_grid(dataset, 0, dimensions, ql.shape)
     assert centered[:, 1, :] == pytest.approx(np.full((3, 4), 2.0))
 
 
@@ -161,7 +161,7 @@ def test_w_rejects_unsupported_vertical_stagger() -> None:
     dataset["w"] = (("time", "bad_z", "yh", "xh"), np.zeros((2, 5, 4, 4)))
     with pytest.raises(TradeCumulusUpdraftLensError, match="supported z dimension"):
         ql, dimensions = lens._scalar_ql(dataset, 0)
-        lens._center_w(dataset, 0, dimensions, ql.shape)
+        lens.center_vertical_velocity_to_scalar_grid(dataset, 0, dimensions, ql.shape)
 
 
 def test_default_time_uses_max_domain_mean_cwp_after_three_hours(tmp_path: Path) -> None:
@@ -263,18 +263,26 @@ def test_plane_falls_back_to_domain_midpoint_without_coherent_cloud() -> None:
 
 
 def test_fixed_range_uses_percentile_floor_and_rounding() -> None:
-    assert lens._rounded_reference([np.asarray([0.2, 0.21])], 99, 0.5) == 0.5
-    assert lens._rounded_reference([np.asarray([0.61, 0.62])], 99, 0.5) == 0.7
+    assert lens.rounded_percentile_reference([np.asarray([0.2, 0.21])], 99, 0.5) == 0.5
+    assert lens.rounded_percentile_reference([np.asarray([0.61, 0.62])], 99, 0.5) == 0.7
 
 
 def test_u_and_v_faces_are_centered_to_scalar_grid() -> None:
     dataset = _dataset()
     ql, dimensions = lens._scalar_ql(dataset, 0)
-    u, v = lens._center_horizontal_wind(dataset, 0, dimensions, ql.shape)
+    u, v = lens.center_horizontal_wind_to_scalar_grid(dataset, 0, dimensions, ql.shape)
     assert u.shape == ql.shape
     assert v.shape == ql.shape
     assert u[0, 0] == pytest.approx([0.5, 1.5, 2.5, 3.5])
     assert v[0, :, 0] == pytest.approx([0.5, 1.5, 2.5, 3.5])
+
+
+def test_horizontal_wind_rejects_unsupported_face_stagger() -> None:
+    dataset = _dataset().drop_vars("u")
+    dataset["u"] = (("time", "zh", "yh", "bad_x"), np.zeros((2, 3, 4, 6)))
+    ql, dimensions = lens._scalar_ql(dataset, 0)
+    with pytest.raises(TradeCumulusUpdraftLensError, match="supported x dimension"):
+        lens.center_horizontal_wind_to_scalar_grid(dataset, 0, dimensions, ql.shape)
 
 
 def test_frame_switches_between_perturbation_and_total_wind(tmp_path: Path) -> None:
@@ -348,8 +356,8 @@ def test_wind_stride_bounds_arrow_count_and_skips_zero_vectors() -> None:
 
 
 def test_wind_references_use_p95_floor() -> None:
-    assert lens._rounded_reference([np.asarray([0.1, 0.2])], 95, 0.5) == 0.5
-    assert lens._rounded_reference([np.asarray([0.81, 0.82])], 95, 0.5) == 0.9
+    assert lens.rounded_percentile_reference([np.asarray([0.1, 0.2])], 95, 0.5) == 0.5
+    assert lens.rounded_percentile_reference([np.asarray([0.81, 0.82])], 95, 0.5) == 0.9
 
 
 def test_frame_orders_z_ascending_and_serializes_nonfinite_values(tmp_path: Path) -> None:

--- a/docs/research/trade-cumulus/trade-cumulus-moisture-comparison-run-report.md
+++ b/docs/research/trade-cumulus/trade-cumulus-moisture-comparison-run-report.md
@@ -1,0 +1,302 @@
+# Trade Cumulus Moisture Comparison Run Report
+
+## Status and authority
+
+Implementation evidence state: `matched_runs_valid`.
+
+This report records research and implementation evidence for the bounded Stage
+5B-2 matched pair. It does not graduate the Trade Cumulus Control, Lens, Recipe,
+World, or MVP; establish one-to-one identity between individual LES clouds;
+approve a synchronized Comparison design; select a vertical-velocity color
+scale; or supply final product explanation copy.
+
+The deliberate question remains: how does stronger surface moisture supply
+change the trade-cumulus field? The measured response below comes from one
+deterministic LES realization per Control state.
+
+## Sources, provenance, and identifiers
+
+All four packages and runs were generated from clean Cloud Chamber commit
+`49da1defc9914d3cc903ed9589c1312ddd843726`.
+
+| Evidence | Value |
+| --- | --- |
+| Product slice | `trade_cumulus_v1` |
+| Comparison group | `trade_cumulus_moisture_v1` |
+| Case | `bomex_trade_cumulus_baseline_v0` |
+| Recipe candidate | `canonical_bomex_baseline` |
+| Run recipe | `null` |
+| Control | `surface_moisture_supply` |
+| CM1 release | `21.1` |
+| CM1 official tag commit | `0f734f64efa89a684963a66d2ac32db67617912b` |
+| CM1 source manifest SHA-256 | `fbe2367dfcd6d8c55cac4bd03362d8d49f13f80cebd13b36230c20d71119a84e` |
+| CM1 executable SHA-256 | `5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1` |
+| Bundled BOMEX namelist SHA-256 | `4aa2f7cfad8c918801e0768c2618a37740e3966bc8f47205e5fafda3e506f965` |
+| Fixed-assumptions SHA-256, both states | `71d746b110fb1310ebb6dafbef4cfa4bd44c379fc6964ed1787deaf45e422535` |
+| Baseline science-settings SHA-256 | `b73d57b22c7e1e5b42688989d5c6c6752640c9e0c5c3b80de651cd36d53cf5e5` |
+| More Moisture science-settings SHA-256 | `4365be4e5283531aeaea99c81c5003b2b743ebc726bb98cde913e966bc9af672` |
+
+Scientific configuration sources are the CM1 r21.1 bundled shallow-cumulus
+case and the BOMEX references recorded in each package manifest. The generated
+full-run `input_sounding` hash was identical for both states:
+`703cdbd38f9ef13712b86e1cc8d7aa19f40478947325d75b5266fafa94d6f645`.
+The full-run namelist hashes were
+`79ac6e7995733446cb372db54822b8fc60cc3c83ccb615fcfde70190ffbf8ea8`
+for Baseline and
+`88d88fe14783e4d76452bcbb3f5060d53c4e38f001c5abe7588f21348136e63f`
+for More Moisture.
+
+## Fixed and changed assumptions
+
+The package comparison proved that the generated scientific namelists differ
+only at `cnst_lhflx` after excluding package identity and provenance fields.
+Baseline used `5.2e-5 g/g m/s`; More Moisture used `7.8e-5 g/g m/s`.
+`changed_assumptions` contains only the Control identifier, Control state, and
+surface moisture flux. The equal fixed-assumptions hashes cover the canonical
+profiles, deterministic perturbation, `64 x 64 x 75` grid, `100 x 100 x 40 m`
+spacing, `6.4 x 6.4 x 3.0 km` domain, surface sensible heat flux, friction
+velocity, large-scale forcing, `ptype=6`, zero terminal velocity, adaptive
+timestep target, required fields, and `120/60 s` output cadences.
+
+The smoke/full package comparison found duration and consequent output count as
+the only run-length differences. All packages used the same CM1 source,
+executable, and Cloud Chamber commit.
+
+## Run inventory
+
+| State | Length | Run ID | Result ID |
+| --- | --- | --- | --- |
+| Baseline | smoke | `trade-cumulus-5b-smoke-baseline-20260720T162342Z` | `result-trade-cumulus-5b-smoke-baseline-20260720T162342Z` |
+| More Moisture | smoke | `trade-cumulus-5b-smoke-more_moisture-20260720T162342Z` | `result-trade-cumulus-5b-smoke-more_moisture-20260720T162342Z` |
+| Baseline | full | `trade-cumulus-5b-full-baseline-20260720T162342Z` | `result-trade-cumulus-5b-full-baseline-20260720T162342Z` |
+| More Moisture | full | `trade-cumulus-5b-full-more_moisture-20260720T162342Z` | `result-trade-cumulus-5b-full-more_moisture-20260720T162342Z` |
+
+## Smoke outcomes
+
+The smokes ran sequentially and both passed before either full run launched.
+
+| State | Model / diagnostic frames | Integrity | Required-field non-finite count | Emitted `qvflux` (g/g m/s) | Wall / CM1 time (s) | Output bytes |
+| --- | ---: | --- | ---: | ---: | ---: | ---: |
+| Baseline | 6 / 11 | trusted | 0 | `5.1999999414e-5` | 34.155 / 33.830 | 64,748,298 |
+| More Moisture | 6 / 11 | trusted | 0 | `7.7999997302e-5` | 34.167 / 33.757 | 64,759,552 |
+
+Both smokes completed with exit code zero, normal termination, successful
+ingest, all required fields present, exact expected counts, no integrity
+caveats, and no gate failures.
+
+The observed smoke outputs estimated a 4,129,014,983-byte full pair. The launch
+gate required 5,161,268,729 bytes after adding 25% headroom; 37,503,324,160
+bytes were available after the smokes.
+
+## Full-run outcomes
+
+| State | Model / diagnostic frames | Integrity | Required-field non-finite count | Emitted `qvflux` (g/g m/s) | Wall / CM1 time (s) | Output bytes |
+| --- | ---: | --- | ---: | ---: | ---: | ---: |
+| Baseline | 181 / 361 | underflow-only caveat | 0 | `5.1999999414e-5` | 1,317.343 / 1,316.619 | 2,458,804,996 |
+| More Moisture | 181 / 361 | underflow-only caveat | 0 | `7.7999997302e-5` | 1,394.962 / 1,394.195 | 2,530,095,437 |
+
+Both six-hour runs completed sequentially with exit code zero, normal
+termination, successful ingest, all required fields present, exact expected
+counts, and no fatal or field-contamination evidence. The visible runtime
+integrity caveat is limited to `IEEE_UNDERFLOW_FLAG`. No invalid,
+divide-by-zero, overflow, stats-collapse, terminal-contamination, or gate
+failure evidence was found.
+
+Actual full-pair storage was 4,988,900,433 bytes. More Moisture used 71,290,441
+additional bytes (+2.899%) and 77.619 additional wall-clock seconds (+5.892%).
+
+## Stage 4 consistency
+
+The new 120-second Baseline was compared with preserved result
+`result-bomex-370-full-20260719` at all 37 exact common times from 0 through
+21,600 seconds in 600-second increments. Coordinates and dimensions were
+aligned explicitly. Tolerances were `atol=1e-10` and `rtol=1e-6`.
+
+| Field | Maximum absolute difference | Maximum relative difference |
+| --- | ---: | ---: |
+| `ql` | 0 | 0 |
+| `qv` | 0 | 0 |
+| `th` | 0 | 0 |
+| centered `w` | 0 | 0 |
+| `cwp` | 0 | 0 |
+
+The Stage 4 consistency gate passed with no first failure.
+
+## Paired scalar metrics
+
+Except where the method column says otherwise, aggregate cloud metrics use the
+final three hours (`time >= 10800 s`). Percent deltas use Baseline as the
+denominator and are reported only where meaningful. All entries have trusted
+metric quality.
+
+| Metric | Method / units | Baseline | More Moisture | Absolute delta | Percent delta |
+| --- | --- | ---: | ---: | ---: | ---: |
+| First isolated cloud liquid | first `ql >= 1e-6 kg/kg`, s | 1,080 | 1,080 | 0 | 0% |
+| First coherent cloud | first frame with >=10 cloud cells, s | 1,320 | 1,200 | -120 | -9.091% |
+| Mean total cloud cover | cloudy columns, % | 10.596 | 12.711 | +2.115 points | +19.956% |
+| Cloud-fraction-profile peak | time-mean profile, % | 6.528 | 6.832 | +0.304 points | +4.652% |
+| Cloud-fraction peak height | first peak, m | 620 | 620 | 0 | 0% |
+| Domain-mean CWP mean | kg/m2 | 0.006352 | 0.009071 | +0.002719 | +42.812% |
+| Domain-mean CWP minimum | kg/m2 | 0.001920 | 0.002379 | +0.000458 | +23.867% |
+| Domain-mean CWP maximum | kg/m2 | 0.014611 | 0.020274 | +0.005663 | +38.757% |
+| CWP growth/decay peaks | Stage 4 method, full run | 15 | 20 | +5 | +33.333% |
+| Coherent cloud base | lowest supported level, m | 540 | 500 | -40 | -7.407% |
+| Coherent cloud top mean | m | 1,668 | 1,805 | +137 | +8.194% |
+| Coherent cloud top minimum | m | 1,140 | 1,300 | +160 | +14.035% |
+| Coherent cloud top maximum | final-three-hour, m | 2,020 | 2,060 | +40 | +1.980% |
+| Coherent cloud top maximum | full run, m | 2,020 | 2,220 | +200 | +9.901% |
+| Maximum cloud liquid | raw `ql`, kg/kg | 0.002691 | 0.002942 | +0.000251 | +9.311% |
+| Raw `w` minimum | m/s | -5.459 | -6.179 | -0.720 | +13.187% |
+| Raw `w` maximum | m/s | 9.112 | 9.357 | +0.245 | +2.691% |
+| Cloudy cells with positive centered `w` | pooled cloudy scalar cells, % | 90.379 | 90.451 | +0.072 points | +0.080% |
+| Mean `qv`, 0-1000 m | thickness-weighted, kg/kg | 0.015947 | 0.016048 | +0.000101 | +0.634% |
+| Mean `th`, 0-1000 m | thickness-weighted, K | 299.285 | 299.402 | +0.117 | +0.039% |
+
+### Time-series markers
+
+The complete 120-second series are retained in runtime evidence and are paired
+by exact model time without interpolation. These markers summarize the cloud
+series.
+
+| Time (s) | CWP Baseline / More (kg/m2) | Cover Baseline / More (%) | Coherent top Baseline / More (m) |
+| ---: | ---: | ---: | ---: |
+| 10,800 | 0.007629 / 0.010541 | 12.939 / 13.599 | 1,740 / 1,860 |
+| 14,400 | 0.006099 / 0.006887 | 10.254 / 12.158 | 1,660 / 1,660 |
+| 18,000 | 0.011132 / 0.006576 | 10.059 / 11.938 | 1,780 / 1,860 |
+| 21,600 | 0.007434 / 0.004003 | 10.400 / 12.305 | 1,620 / 1,660 |
+
+| Time (s) | 0-1000 m `qv` Baseline / More (kg/kg) | 0-1000 m `th` Baseline / More (K) |
+| ---: | ---: | ---: |
+| 10,800 | 0.016016 / 0.016076 | 299.232 / 299.318 |
+| 14,400 | 0.015978 / 0.016081 | 299.266 / 299.367 |
+| 18,000 | 0.015934 / 0.016040 | 299.301 / 299.428 |
+| 21,600 | 0.015891 / 0.016007 | 299.332 / 299.490 |
+
+### Vertical-profile markers
+
+Full final-frame `qv`, `th`, `u`, and `v` profiles and final-three-hour cloud
+fraction and cloud-conditioned centered-`w` profiles are retained in runtime
+evidence.
+
+| Profile marker | Baseline | More Moisture |
+| --- | ---: | ---: |
+| Time-mean cloud-fraction peak | 6.528% at 620 m | 6.832% at 620 m |
+| Cloud-conditioned centered `w` at 620 m | 0.562 m/s | 0.649 m/s |
+| Maximum of cloud-conditioned centered-`w` profile | 1.394 m/s at 2,100 m | 1.263 m/s at 1,260 m |
+| Final domain-mean `qv` at 620 m | 0.015809 kg/kg | 0.015889 kg/kg |
+| Final domain-mean `th` at 620 m | 299.271 K | 299.433 K |
+| Final domain-mean `u` at 580 m | -7.455 m/s | -7.496 m/s |
+| Final domain-mean `v` at 580 m | -0.857 m/s | -0.961 m/s |
+
+## Forcing and field trust
+
+The emitted sensible heat flux was identical at
+`0.00800000038 K m/s`; friction velocity was identical at
+`0.2800000012 m/s`. The emitted surface moisture flux was constant within each
+run and matched its intended Control value. Large-scale and transport fields
+`ptb_frc`, `ptb_vturbr`, `qvb_frc`, `qvb_vturbr`, `qvflux`, `qvfr`, `thflux`,
+`ufr`, `ug`, `upwp`, `ust`, `vfr`, `vg`, `vpwp`, `wprof`, and `wpwp` were
+available in both results. Prescribed `ptb_frc`, `qvb_frc`, `ug`, `vg`, and
+`wprof` ranges were unchanged.
+
+All required fields had zero non-finite values in all four results. The full
+runs expose the same 64 ingested fields, and neither full result has a missing
+required field.
+
+## Updraft Lens preparation and live checks
+
+The merged Baseline Lens default is time index `152` (`18,240 s`) and vertical
+x-z plane index `5` at `y=-2.650000095 km`. The same indices were applied to
+More Moisture. Both results provide `ql`, centered `w`, centered `u/v`, and
+`cwp` on exactly matching scalar-grid coordinates.
+
+| Preparation value | Pair value |
+| --- | ---: |
+| Joint symmetric `w` range | -1.0 to +1.0 m/s |
+| Joint perturbation-wind p95 reference | 0.9 m/s |
+| Joint total-wind p95 reference | 8.8 m/s |
+| Wind target / actual level | 600 / 580.000043 m |
+| Wind stride | 8 |
+| Cloud threshold | `1e-6 kg/kg` |
+
+Playwright opened both full results in the live Explore implementation. At the
+matched indices, both Updraft Lens views rendered the black cloud boundary,
+horizontal perturbation arrows, working total-wind toggle, and the existing
+3-D scalar field, threshold, opacity, and point-size controls. The fixed
+individual-result `w` scales displayed as +/-0.9 m/s for Baseline and
++/-1.1 m/s for More Moisture. Desktop checks used a 1440 x 1000 viewport; an
+additional 390 x 844 check had no horizontal document overflow and retained a
+legible, proportioned slice. Screenshot-pixel analysis of the WebGL canvas
+found 1,100 sampled colors with nonzero luminance variance. No console error,
+page error, or failed request was recorded. Screenshots were not committed.
+
+## Vertical-velocity calibration carryover
+
+This report-only calibration responds to the PM evidence-carryover comment for
+queued issue #379. It uses the exact merged
+`center_vertical_velocity_to_scalar_grid` calculation over every full-run
+scalar cell, without interpolation. It is calibration evidence only; no color
+breakpoint or product decision is selected here.
+
+| Dataset | Finite centered `w` cells | Minimum / maximum (m/s) | Negative / positive cells | Cloudy positive cells |
+| --- | ---: | ---: | ---: | ---: |
+| Baseline | 55,603,200 | -5.438223 / 9.082246 | 29,142,402 / 26,153,598 | 388,608 |
+| More Moisture | 55,603,200 | -6.159492 / 9.343031 | 29,197,064 / 26,098,936 | 511,313 |
+| Pair combined | 111,206,400 | -6.159492 / 9.343031 | 58,339,466 / 52,252,534 | 899,921 |
+
+Negative-subset quantiles, in m/s:
+
+| Dataset | p1 | p5 | p10 | p25 | p50 | p75 | p90 | p95 | p99 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Baseline | -0.662683 | -0.394454 | -0.296529 | -0.169646 | -0.072893 | -0.021260 | -0.004710 | -0.001585 | -0.000151 |
+| More Moisture | -0.786535 | -0.466533 | -0.353980 | -0.208470 | -0.093865 | -0.028284 | -0.006086 | -0.001980 | -0.000170 |
+| Pair combined | -0.729601 | -0.432517 | -0.326226 | -0.188851 | -0.082705 | -0.024392 | -0.005320 | -0.001760 | -0.000160 |
+
+Positive-subset quantiles, in m/s:
+
+| Dataset | p1 | p5 | p10 | p25 | p50 | p75 | p90 | p95 | p99 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Baseline | 0.000140 | 0.001356 | 0.003995 | 0.018010 | 0.064116 | 0.159325 | 0.323232 | 0.505377 | 1.051013 |
+| More Moisture | 0.000155 | 0.001641 | 0.005014 | 0.023763 | 0.083693 | 0.200694 | 0.394275 | 0.596454 | 1.216397 |
+| Pair combined | 0.000147 | 0.001485 | 0.004450 | 0.020558 | 0.073159 | 0.179692 | 0.360132 | 0.553657 | 1.133881 |
+
+Positive-`w` quantiles for cloudy cells (`ql >= 1e-6 kg/kg`), in m/s:
+
+| Dataset | p25 | p50 | p75 | p90 | p95 | p99 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Baseline | 0.347638 | 0.715970 | 1.342463 | 2.223742 | 2.924758 | 4.492927 |
+| More Moisture | 0.410502 | 0.829783 | 1.516918 | 2.481667 | 3.241838 | 4.826632 |
+| Pair combined | 0.381276 | 0.778887 | 1.441908 | 2.373120 | 3.111509 | 4.699079 |
+
+The existing pair-joint absolute-`w` p99 is `0.947341 m/s`; the merged rounded
+reference is `1.0 m/s`, yielding the existing `[-1.0, +1.0] m/s` preparation
+range.
+
+## Direct observations and limits
+
+Under the fixed methods, More Moisture had the same first isolated-cloud time,
+an earlier first coherent-cloud frame, higher final-three-hour mean cloud
+cover and CWP, a higher mean coherent cloud top, a higher near-surface `qv`
+mean, and different cloud-cycle and vertical-velocity measurements. The exact
+time markers also show that the CWP ordering is not uniform at every saved
+time. Process cost and output size were higher for More Moisture by the amounts
+reported above.
+
+These are direct measurements from one deterministic realization per state.
+Individual clouds are not paired one-to-one, sampling variability has not been
+estimated, and the underflow-only runtime caveat remains visible for both full
+runs. The comparison establishes neither general response uncertainty nor a
+product disposition.
+
+## Runtime-local evidence
+
+Relative to the configured Cloud Chamber runtime home:
+
+- `comparisons/trade-cumulus-moisture-20260720T162342Z/comparison_evidence.json`
+- `comparisons/trade-cumulus-moisture-20260720T162342Z/vertical_velocity_calibration.json`
+- each run directory listed above contains `trade_cumulus_moisture_run_evidence.json`, manifests, logs, and ingested result metadata
+
+No generated package, NetCDF output, runtime JSON, log, screenshot, trace, CM1
+source, executable, or local setting is committed with this report.
+
+PM disposition pending

--- a/scripts/run_trade_cumulus_moisture_comparison.py
+++ b/scripts/run_trade_cumulus_moisture_comparison.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Run the one approved matched Trade Cumulus moisture comparison."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shutil
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_ROOT = REPO_ROOT / "app" / "backend"
+BACKEND_VENV_PYTHON = BACKEND_ROOT / ".venv" / "bin" / "python"
+
+if (
+    BACKEND_VENV_PYTHON.exists()
+    and Path(sys.executable).resolve() != BACKEND_VENV_PYTHON.resolve()
+):
+    os.execv(
+        str(BACKEND_VENV_PYTHON),
+        [str(BACKEND_VENV_PYTHON), str(Path(__file__).resolve()), *sys.argv[1:]],
+    )
+if sys.version_info < (3, 12):
+    raise SystemExit(
+        "run_trade_cumulus_moisture_comparison.py requires Python 3.12 or newer."
+    )
+
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from cloud_chamber.bomex_case import (  # noqa: E402
+    BomexCaseError,
+    collect_cm1_provenance,
+    verified_clean_git_commit,
+)
+from cloud_chamber.local_run_manager import (  # noqa: E402
+    LocalRunManager,
+    LocalRunManagerError,
+)
+from cloud_chamber.result_ingest import (  # noqa: E402
+    ResultIngestError,
+    ResultMetadata,
+    get_result_metadata,
+    ingest_completed_run,
+)
+from cloud_chamber.run_manifest import LifecycleState  # noqa: E402
+from cloud_chamber.settings import CloudChamberSettings, load_settings  # noqa: E402
+from cloud_chamber.trade_cumulus_moisture_comparison import (  # noqa: E402
+    MINIMUM_FREE_BYTES,
+    STAGE4_RESULT_ID,
+    PackageComparisonProof,
+    TradeCumulusMatchedPackage,
+    TradeCumulusMoistureComparisonError,
+    TradeCumulusMoistureState,
+    TradeCumulusPairedEvidence,
+    TradeCumulusRunEvidence,
+    TradeCumulusRunLength,
+    build_joint_lens_preparation,
+    build_paired_evidence,
+    build_trade_cumulus_run_evidence,
+    compare_matched_packages,
+    compare_stage4_baseline,
+    generate_trade_cumulus_matched_package,
+    verify_smoke_full_equivalence,
+    write_paired_evidence,
+    write_trade_cumulus_run_evidence,
+)
+
+
+@dataclass(frozen=True)
+class _CompletedRun:
+    result: ResultMetadata
+    evidence: TradeCumulusRunEvidence
+    evidence_path: Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    runtime_home = Path(args.runtime_home).expanduser() if args.runtime_home else None
+    settings = load_settings(home=runtime_home)
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    try:
+        implementation_commit = verified_clean_git_commit()
+        provenance = collect_cm1_provenance(settings)
+        preserved = _verify_preserved_stage4_result(settings)
+        initial_free_bytes = _free_bytes(settings)
+        if initial_free_bytes < MINIMUM_FREE_BYTES:
+            raise TradeCumulusMoistureComparisonError(
+                f"Preflight requires at least {MINIMUM_FREE_BYTES} free bytes; "
+                f"found {initial_free_bytes}."
+            )
+        packages = _generate_all_packages(
+            settings=settings,
+            timestamp=timestamp,
+            implementation_commit=implementation_commit,
+        )
+        proofs = _verify_all_packages(packages)
+        _verify_execution_commit(implementation_commit)
+
+        baseline_smoke = _run_one(
+            settings,
+            packages[(TradeCumulusRunLength.SMOKE, TradeCumulusMoistureState.BASELINE)],
+            poll_seconds=args.poll_seconds,
+            implementation_commit=implementation_commit,
+        )
+        variant_smoke = _run_one(
+            settings,
+            packages[
+                (TradeCumulusRunLength.SMOKE, TradeCumulusMoistureState.MORE_MOISTURE)
+            ],
+            poll_seconds=args.poll_seconds,
+            implementation_commit=implementation_commit,
+        )
+        estimated_full_pair_bytes = _estimated_full_pair_bytes(
+            baseline_smoke.evidence.output_bytes,
+            variant_smoke.evidence.output_bytes,
+        )
+        required_with_headroom = math.ceil(estimated_full_pair_bytes * 1.25)
+        available_after_smokes = _free_bytes(settings)
+        if available_after_smokes < required_with_headroom:
+            raise TradeCumulusMoistureComparisonError(
+                "Full-pair storage gate failed: "
+                f"estimated {estimated_full_pair_bytes} bytes plus 25% headroom requires "
+                f"{required_with_headroom}, found {available_after_smokes}."
+            )
+
+        baseline_full = _run_one(
+            settings,
+            packages[(TradeCumulusRunLength.FULL, TradeCumulusMoistureState.BASELINE)],
+            poll_seconds=args.poll_seconds,
+            implementation_commit=implementation_commit,
+        )
+        stage4 = compare_stage4_baseline(preserved, baseline_full.result)
+        stage4_path = (
+            baseline_full.evidence_path.parent / "stage4_consistency_evidence.json"
+        )
+        stage4_path.write_text(stage4.model_dump_json(indent=2) + "\n")
+        if not stage4.passed:
+            raise TradeCumulusMoistureComparisonError(
+                "The new 120-second baseline failed the Stage 4 common-time consistency gate: "
+                + (
+                    stage4.first_failure.model_dump_json()
+                    if stage4.first_failure
+                    else "unknown"
+                )
+            )
+
+        variant_full = _run_one(
+            settings,
+            packages[
+                (TradeCumulusRunLength.FULL, TradeCumulusMoistureState.MORE_MOISTURE)
+            ],
+            poll_seconds=args.poll_seconds,
+            implementation_commit=implementation_commit,
+        )
+        lens = build_joint_lens_preparation(
+            settings, baseline_full.result, variant_full.result
+        )
+        paired = build_paired_evidence(
+            baseline_full.evidence,
+            variant_full.evidence,
+            implementation_commit=implementation_commit,
+            stage4_consistency=stage4,
+            lens_preparation=lens,
+            estimated_full_pair_bytes=estimated_full_pair_bytes,
+        )
+        comparison_dir = (
+            settings.runtime_home.expanduser()
+            / "comparisons"
+            / (f"trade-cumulus-moisture-{timestamp}")
+        )
+        evidence_path = comparison_dir / "comparison_evidence.json"
+        paired = paired.model_copy(
+            update={"runtime_local_evidence_path": str(evidence_path)}
+        )
+        write_paired_evidence(evidence_path, paired)
+        print(
+            json.dumps(
+                _success_summary(
+                    paired=paired,
+                    evidence_path=evidence_path,
+                    packages=packages,
+                    proofs=proofs,
+                    smoke_runs=(baseline_smoke, variant_smoke),
+                    full_runs=(baseline_full, variant_full),
+                    initial_free_bytes=initial_free_bytes,
+                    available_after_smokes=available_after_smokes,
+                    required_with_headroom=required_with_headroom,
+                    cm1_release=provenance.release,
+                    cm1_executable_sha256=provenance.executable_sha256,
+                ),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    except KeyboardInterrupt:
+        print("trade-cumulus-moisture-comparison: canceled", file=sys.stderr)
+        return 130
+    except (
+        BomexCaseError,
+        LocalRunManagerError,
+        ResultIngestError,
+        TradeCumulusMoistureComparisonError,
+        OSError,
+        ValueError,
+    ) as exc:
+        print(
+            json.dumps(
+                {"status": "controlled_gate_failure", "error": str(exc)},
+                indent=2,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the exact baseline and More Moisture Trade Cumulus smoke/full sequence."
+        )
+    )
+    parser.add_argument(
+        "--runtime-home",
+        help="Cloud Chamber runtime home. Defaults to configured settings.",
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=float,
+        default=2.0,
+        help="Status polling interval while each sequential CM1 run is active.",
+    )
+    return parser
+
+
+def _generate_all_packages(
+    *,
+    settings: CloudChamberSettings,
+    timestamp: str,
+    implementation_commit: str,
+) -> dict[
+    tuple[TradeCumulusRunLength, TradeCumulusMoistureState], TradeCumulusMatchedPackage
+]:
+    packages: dict[
+        tuple[TradeCumulusRunLength, TradeCumulusMoistureState],
+        TradeCumulusMatchedPackage,
+    ] = {}
+    for run_length in (TradeCumulusRunLength.SMOKE, TradeCumulusRunLength.FULL):
+        for state in (
+            TradeCumulusMoistureState.BASELINE,
+            TradeCumulusMoistureState.MORE_MOISTURE,
+        ):
+            run_id = f"trade-cumulus-5b-{run_length.value}-{state.value}-{timestamp}"
+            packages[(run_length, state)] = generate_trade_cumulus_matched_package(
+                settings=settings,
+                control_state=state,
+                run_length=run_length,
+                run_id=run_id,
+                app_commit=implementation_commit,
+            )
+    return packages
+
+
+def _verify_all_packages(
+    packages: dict[
+        tuple[TradeCumulusRunLength, TradeCumulusMoistureState],
+        TradeCumulusMatchedPackage,
+    ],
+) -> list[PackageComparisonProof]:
+    proofs: list[PackageComparisonProof] = []
+    for run_length in (TradeCumulusRunLength.SMOKE, TradeCumulusRunLength.FULL):
+        proofs.append(
+            compare_matched_packages(
+                packages[(run_length, TradeCumulusMoistureState.BASELINE)],
+                packages[(run_length, TradeCumulusMoistureState.MORE_MOISTURE)],
+            )
+        )
+    for state in (
+        TradeCumulusMoistureState.BASELINE,
+        TradeCumulusMoistureState.MORE_MOISTURE,
+    ):
+        verify_smoke_full_equivalence(
+            packages[(TradeCumulusRunLength.SMOKE, state)],
+            packages[(TradeCumulusRunLength.FULL, state)],
+        )
+    return proofs
+
+
+def _run_one(
+    settings: CloudChamberSettings,
+    package: TradeCumulusMatchedPackage,
+    *,
+    poll_seconds: float,
+    implementation_commit: str,
+) -> _CompletedRun:
+    _verify_execution_commit(implementation_commit)
+    manager = LocalRunManager(settings=settings)
+    started = time.monotonic()
+    status = manager.launch(package.manifest_path)
+    try:
+        while status.lifecycle_state in {LifecycleState.QUEUED, LifecycleState.RUNNING}:
+            time.sleep(poll_seconds)
+            status = manager.status(package.manifest_path)
+    except KeyboardInterrupt:
+        manager.cancel()
+        raise
+    wall_clock_seconds = time.monotonic() - started
+    if status.lifecycle_state != LifecycleState.COMPLETED or status.exit_code != 0:
+        raise TradeCumulusMoistureComparisonError(
+            f"Run {package.run_id} failed with lifecycle {status.lifecycle_state.value} "
+            f"and exit code {status.exit_code}."
+        )
+    result = ingest_completed_run(package.manifest_path)
+    evidence = build_trade_cumulus_run_evidence(
+        result, package, wall_clock_seconds=wall_clock_seconds
+    )
+    evidence_path = package.package_dir / "trade_cumulus_moisture_run_evidence.json"
+    write_trade_cumulus_run_evidence(evidence_path, evidence)
+    if not evidence.gate.valid:
+        raise TradeCumulusMoistureComparisonError(
+            f"Run {package.run_id} failed its evidence gate: {evidence.gate.failures}"
+        )
+    return _CompletedRun(result=result, evidence=evidence, evidence_path=evidence_path)
+
+
+def _verify_execution_commit(expected_commit: str) -> None:
+    actual_commit = verified_clean_git_commit()
+    if actual_commit != expected_commit:
+        raise TradeCumulusMoistureComparisonError(
+            f"Execution commit changed from {expected_commit} to {actual_commit}."
+        )
+
+
+def _verify_preserved_stage4_result(settings: CloudChamberSettings) -> ResultMetadata:
+    xarray = __import__("xarray")
+    result = get_result_metadata(settings, STAGE4_RESULT_ID)
+    if len(result.model_output_paths) != 73:
+        raise TradeCumulusMoistureComparisonError(
+            f"Preserved Stage 4 result has {len(result.model_output_paths)} model paths, expected 73."
+        )
+    for configured_path in result.model_output_paths:
+        path = Path(configured_path)
+        if not path.is_file():
+            raise TradeCumulusMoistureComparisonError(
+                f"Preserved Stage 4 model output is unavailable: {path}"
+            )
+        with xarray.open_dataset(path, decode_times=False) as dataset:
+            missing = [
+                field
+                for field in ("ql", "qv", "th", "w", "cwp")
+                if field not in dataset
+            ]
+            if missing:
+                raise TradeCumulusMoistureComparisonError(
+                    f"Preserved Stage 4 output {path} lacks required fields: {missing}"
+                )
+    return result
+
+
+def _estimated_full_pair_bytes(
+    baseline_smoke_bytes: int, variant_smoke_bytes: int
+) -> int:
+    smoke_frames = (
+        TradeCumulusRunLength.SMOKE.expected_model_output_count
+        + TradeCumulusRunLength.SMOKE.expected_diagnostic_output_count
+    )
+    full_frames = (
+        TradeCumulusRunLength.FULL.expected_model_output_count
+        + TradeCumulusRunLength.FULL.expected_diagnostic_output_count
+    )
+    return math.ceil(
+        (baseline_smoke_bytes + variant_smoke_bytes) * full_frames / smoke_frames
+    )
+
+
+def _free_bytes(settings: CloudChamberSettings) -> int:
+    settings.runtime_home.expanduser().mkdir(parents=True, exist_ok=True)
+    return shutil.disk_usage(settings.runtime_home.expanduser()).free
+
+
+def _success_summary(
+    *,
+    paired: TradeCumulusPairedEvidence,
+    evidence_path: Path,
+    packages: dict[
+        tuple[TradeCumulusRunLength, TradeCumulusMoistureState],
+        TradeCumulusMatchedPackage,
+    ],
+    proofs: list[PackageComparisonProof],
+    smoke_runs: tuple[_CompletedRun, _CompletedRun],
+    full_runs: tuple[_CompletedRun, _CompletedRun],
+    initial_free_bytes: int,
+    available_after_smokes: int,
+    required_with_headroom: int,
+    cm1_release: str,
+    cm1_executable_sha256: str,
+) -> dict[str, Any]:
+    completed = [*smoke_runs, *full_runs]
+    return {
+        "status": "completed_ingested_and_evaluated",
+        "evidence_state": paired.evidence_state,
+        "implementation_commit": paired.implementation_commit,
+        "comparison_evidence_path": str(evidence_path),
+        "run_ids": [item.evidence.run_id for item in completed],
+        "result_ids": [item.evidence.result_id for item in completed],
+        "run_evidence_paths": [str(item.evidence_path) for item in completed],
+        "package_manifest_paths": [
+            str(package.manifest_path) for package in packages.values()
+        ],
+        "package_proofs": [proof.model_dump(mode="json") for proof in proofs],
+        "run_gates": {
+            item.evidence.run_id: item.evidence.gate.model_dump(mode="json")
+            for item in completed
+        },
+        "stage4_consistency": paired.stage4_consistency.model_dump(mode="json"),
+        "lens_preparation": paired.lens_preparation.model_dump(mode="json"),
+        "runtime_seconds": {
+            item.evidence.run_id: item.evidence.wall_clock_seconds for item in completed
+        },
+        "output_bytes": {
+            item.evidence.run_id: item.evidence.output_bytes for item in completed
+        },
+        "storage": {
+            "initial_free_bytes": initial_free_bytes,
+            "available_after_smokes": available_after_smokes,
+            "estimated_full_pair_bytes": paired.estimated_full_pair_bytes,
+            "required_with_25_percent_headroom_bytes": required_with_headroom,
+            "actual_full_pair_bytes": paired.actual_full_pair_bytes,
+        },
+        "cm1_release": cm1_release,
+        "cm1_executable_sha256": cm1_executable_sha256,
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements and executes the bounded Stage 5B-2 matched Trade Cumulus moisture comparison. The pair preserves canonical BOMEX and changes only `cnst_lhflx` from `5.2e-5` to `7.8e-5 g/g m/s`.

All smoke and full-run evidence comes from clean implementation commit `49da1defc9914d3cc903ed9589c1312ddd843726`. Report commit: `8392957a`. Evidence state: `matched_runs_valid`.

Closes #377.

## Scope

Related issue: #377

Files or systems changed:

- `app/backend/cloud_chamber/bomex_case.py`
- `app/backend/cloud_chamber/trade_cumulus_updraft_lens.py`
- `app/backend/cloud_chamber/trade_cumulus_moisture_comparison.py`
- `app/backend/tests/test_bomex_case.py`
- `app/backend/tests/test_trade_cumulus_updraft_lens.py`
- `app/backend/tests/test_trade_cumulus_moisture_comparison.py`
- `scripts/run_trade_cumulus_moisture_comparison.py`
- `docs/research/trade-cumulus/trade-cumulus-moisture-comparison-run-report.md`
- Configured local CM1/runtime systems were used for sequential execution and runtime-local evidence only.

Explicitly out of scope:

- frontend or Updraft Lens API/default changes;
- Comparison UI or final explanation copy;
- Control tuning, a third run, or a sweep;
- product graduation or a follow-up issue.

## Product and science impact

Does this change any of the following?

- product direction: No.
- scientific interpretation: No product disposition; the report records direct measurements and limits only.
- recipe or scenario status: No; `run_recipe` remains `null` and the candidate does not graduate.
- user-facing scientific language: No.
- destructive cleanup behavior: No.
- real CM1 execution behavior: Yes. The dedicated generator/runner and exact matched execution were explicitly approved by #377.
- a backwards-incompatible manifest, result, or scenario schema: No.

Fixed/changed-assumption proof:

- Both states share fixed-assumptions hash `71d746b110fb1310ebb6dafbef4cfa4bd44c379fc6964ed1787deaf45e422535`.
- Science hashes differ as required: Baseline `b73d57b...`; More Moisture `4365be4e...`.
- Generated namelist diff is limited to `cnst_lhflx` after identity/provenance exclusions.
- Smoke/full differences are duration and consequent output count only.
- CM1 r21.1 source manifest `fbe2367d...` and executable `5b7304bb...` are identical for all packages.

Runs and results:

- Baseline smoke: `trade-cumulus-5b-smoke-baseline-20260720T162342Z` / `result-trade-cumulus-5b-smoke-baseline-20260720T162342Z`
- More Moisture smoke: `trade-cumulus-5b-smoke-more_moisture-20260720T162342Z` / `result-trade-cumulus-5b-smoke-more_moisture-20260720T162342Z`
- Baseline full: `trade-cumulus-5b-full-baseline-20260720T162342Z` / `result-trade-cumulus-5b-full-baseline-20260720T162342Z`
- More Moisture full: `trade-cumulus-5b-full-more_moisture-20260720T162342Z` / `result-trade-cumulus-5b-full-more_moisture-20260720T162342Z`

Gate outcomes:

- Both smokes: 6 model / 11 diagnostic frames, trusted integrity, exact forcing, zero required-field non-finite values.
- Both full runs: 181 model / 361 diagnostic frames, successful ingest, exact forcing, zero required-field non-finite values, underflow-only caveat with no fatal or contamination evidence.
- Stage 4 comparison: all 37 common times passed; maximum absolute and relative differences are zero for `ql`, `qv`, `th`, centered `w`, and `cwp`.

Selected paired measurements:

- Final-three-hour mean cloud cover: 10.596% to 12.711% (+2.115 points).
- Final-three-hour mean domain CWP: 0.006352 to 0.009071 kg/m2 (+42.812%).
- Mean coherent cloud top: 1,668 to 1,805 m.
- Thickness-weighted 0-1000 m `qv`: 0.015947 to 0.016048 kg/kg.
- Full scalar metrics, exact-time series, profiles, forcing diagnostics, and the requested vertical-velocity calibration quantiles are in the committed report.

Lens preparation:

- Baseline default and inherited variant view: time index 152 / 18,240 s; plane index 5 / y=-2.650000095 km.
- Joint `w` range: +/-1.0 m/s.
- Joint perturbation / total wind references: 0.9 / 8.8 m/s.
- Exact scalar-grid coordinate match and required fields available in both results.

Practical cost:

- Full wall time: 1,317.343 s Baseline; 1,394.962 s More Moisture.
- Full output: 2,458,804,996 and 2,530,095,437 bytes; 4,988,900,433 bytes combined.
- Smoke-based storage estimate plus 25% headroom passed before launch.

What does this PR **not** establish?

It does not establish product graduation, a preferred Control value, a general response uncertainty, one-to-one cloud identity, synchronized Comparison UX, fixed #379 color breakpoints, or final explanation copy.

## Verification

Commands and manual checks performed:

```text
git diff --check main...HEAD
BACKEND_PYTHON=/Users/timpeterson/Documents/Codex/cloud-chamber/app/backend/.venv/bin/python scripts/check.sh
```

Results:

- frontend lint, 87 tests, and production build passed;
- backend formatting, lint, typing, and 506 tests passed;
- script syntax, forbidden-artifact, and docs/JSON/YAML checks passed;
- known React `act`, Vite chunk-size, and NumPy ABI warnings only.

Playwright opened both full results in Explore and verified the Updraft Lens boundary, perturbation arrows, total-wind toggle, scalar controls, matched variant indices, and fixed individual scales. Desktop and 390 px checks completed with a nonblank canvas pixel check and no console, page, or request failures. No screenshots were committed.

## Risks and review focus

Review the exact package normalization/hashes, gate definitions, Stage 4 coordinate/time alignment, paired metric methods, report transcription, and the report-only #379 vertical-velocity calibration. Both full runs retain an explicit underflow-only integrity caveat. Scientific and PM review should not treat one deterministic matched pair as a general uncertainty estimate.

## Artifact check

- [x] No CM1 source or binaries were committed.
- [x] No NetCDF output, generated run directories, runtime data, or sounding caches were committed.
- [x] No machine-private paths, settings, logs, screenshots, videos, traces, or large generated artifacts were committed unless explicitly approved.

## Merge posture

- [x] Manual review required.
- [x] Auto-merge is not enabled.
