### PR TITLE
Stage 5B-3: fix the Trade Cumulus Updraft Lens scale

### DIFF
--- a/app/backend/cloud_chamber/trade_cumulus_updraft_lens.py
+++ b/app/backend/cloud_chamber/trade_cumulus_updraft_lens.py
@@ -7,7 +7,7 @@ import math
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
@@ -20,6 +20,40 @@ CLOUD_THRESHOLD_KG_KG = 1e-6
 W_PERCENTILE = 99
 W_MIN_RANGE_M_S = 0.5
 W_ROUNDING_M_S = 0.1
+TRADE_CUMULUS_UPDRAFT_SCALE_ID = "trade_cumulus_updraft_velocity_v1"
+TRADE_CUMULUS_UPDRAFT_SCALE_OWNER = "trade_cumulus"
+TRADE_CUMULUS_UPDRAFT_LENS_ID = "updraft"
+TRADE_CUMULUS_UPDRAFT_SCALE_TYPE: Literal["fixed_discrete"] = "fixed_discrete"
+TRADE_CUMULUS_UPDRAFT_SCALE_UNITS: Literal["m/s"] = "m/s"
+TRADE_CUMULUS_UPDRAFT_SCALE_BREAKPOINTS_M_S = (
+    -1.0,
+    -0.5,
+    -0.1,
+    0.1,
+    0.5,
+    1.0,
+    2.0,
+    3.0,
+    5.0,
+)
+TRADE_CUMULUS_UPDRAFT_SCALE_COLORS = (
+    "#4b0082",
+    "#0057d9",
+    "#00c9d8",
+    "#ffffff",
+    "#00d63b",
+    "#8fe000",
+    "#ffe000",
+    "#ff9800",
+    "#ff3b00",
+    "#c40000",
+)
+TRADE_CUMULUS_UPDRAFT_SCALE_NEUTRAL_INTERVAL_M_S = (-0.1, 0.1)
+TRADE_CUMULUS_UPDRAFT_SCALE_SOURCE = "pm_approved_issue_379_from_stage5b2_matched_pair"
+TRADE_CUMULUS_UPDRAFT_SCALE_CLIPPING_BEHAVIOR = (
+    "values_below_-1.0_and_at_or_above_5.0_use_endpoint_colors_and_are_reported_as_clipped"
+)
+TRADE_CUMULUS_UPDRAFT_RANGE_METHOD = "fixed_trade_cumulus_updraft_velocity_v1"
 WIND_TARGET_LEVEL_M = 600
 WIND_STRIDE = 8
 WIND_PERCENTILE = 95
@@ -28,6 +62,23 @@ WIND_ARROW_DOMAIN_FRACTION = 0.08
 MIN_COHERENT_CLOUD_CELLS = 10
 
 WindMode = Literal["perturbation", "total"]
+
+
+class _WScalePayload(TypedDict):
+    w_range_min_m_s: float
+    w_range_max_m_s: float
+    w_range_method: str
+    w_scale_id: str
+    w_scale_owner: str
+    w_scale_type: Literal["fixed_discrete"]
+    w_scale_units: Literal["m/s"]
+    w_scale_breakpoints_m_s: list[float]
+    w_scale_colors: list[str]
+    w_scale_neutral_interval_m_s: list[float]
+    w_scale_source: str
+    w_scale_clipping_behavior: str
+
+
 LensOrientation = Literal["horizontal", "vertical_x", "vertical_y"]
 LensDimension = Literal["x", "y", "z"]
 
@@ -69,6 +120,15 @@ class TradeCumulusUpdraftLensDefaults(BaseModel):
     w_range_min_m_s: float
     w_range_max_m_s: float
     w_range_method: str
+    w_scale_id: str
+    w_scale_owner: str
+    w_scale_type: Literal["fixed_discrete"]
+    w_scale_units: Literal["m/s"]
+    w_scale_breakpoints_m_s: list[float]
+    w_scale_colors: list[str]
+    w_scale_neutral_interval_m_s: list[float]
+    w_scale_source: str
+    w_scale_clipping_behavior: str
     wind_target_level_m: float = WIND_TARGET_LEVEL_M
     wind_actual_level_m: float
     wind_level_index: int
@@ -117,6 +177,20 @@ class TradeCumulusUpdraftLensFrame(BaseModel):
     w_range_min_m_s: float
     w_range_max_m_s: float
     w_range_method: str
+    w_scale_id: str
+    w_scale_owner: str
+    w_scale_type: Literal["fixed_discrete"]
+    w_scale_units: Literal["m/s"]
+    w_scale_breakpoints_m_s: list[float]
+    w_scale_colors: list[str]
+    w_scale_neutral_interval_m_s: list[float]
+    w_scale_source: str
+    w_scale_clipping_behavior: str
+    w_finite_count: int
+    w_low_clipped_count: int
+    w_high_clipped_count: int
+    w_low_clipped_fraction: float | None
+    w_high_clipped_fraction: float | None
     wind_mode: WindMode
     wind_target_level_m: float = WIND_TARGET_LEVEL_M
     wind_actual_level_m: float
@@ -246,6 +320,18 @@ def trade_cumulus_updraft_lens_frame(
             y_values,
             cached.response.wind_actual_level_m / 1000.0,
         )
+        finite_w = np.isfinite(w_slice)
+        w_finite_count = int(np.count_nonzero(finite_w))
+        w_low_clipped_count = int(
+            np.count_nonzero(finite_w & (w_slice < TRADE_CUMULUS_UPDRAFT_SCALE_BREAKPOINTS_M_S[0]))
+        )
+        w_high_clipped_count = int(
+            np.count_nonzero(
+                finite_w & (w_slice >= TRADE_CUMULUS_UPDRAFT_SCALE_BREAKPOINTS_M_S[-1])
+            )
+        )
+        w_low_clipped_fraction = w_low_clipped_count / w_finite_count if w_finite_count else None
+        w_high_clipped_fraction = w_high_clipped_count / w_finite_count if w_finite_count else None
 
         return TradeCumulusUpdraftLensFrame(
             result_id=metadata.result_id,
@@ -265,9 +351,12 @@ def trade_cumulus_updraft_lens_frame(
             z_values_km=[float(value) for value in z_values],
             w_values_m_s=_json_float_matrix(w_slice),
             cloud_mask=cloud_slice.astype(bool).tolist(),
-            w_range_min_m_s=cached.response.w_range_min_m_s,
-            w_range_max_m_s=cached.response.w_range_max_m_s,
-            w_range_method=cached.response.w_range_method,
+            **_w_scale_payload(),
+            w_finite_count=w_finite_count,
+            w_low_clipped_count=w_low_clipped_count,
+            w_high_clipped_count=w_high_clipped_count,
+            w_low_clipped_fraction=w_low_clipped_fraction,
+            w_high_clipped_fraction=w_high_clipped_fraction,
             wind_mode=wind_mode,
             wind_actual_level_m=cached.response.wind_actual_level_m,
             wind_level_index=wind_level_index,
@@ -319,7 +408,6 @@ def _cached_defaults(metadata: ResultMetadata) -> _CachedDefaults:
 def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDefaults:
     frames: list[_FrameLocation] = []
     cwp_scores: list[float | None] = []
-    absolute_w: list[np.ndarray[Any, np.dtype[np.floating[Any]]]] = []
     perturbation_speeds: list[np.ndarray[Any, np.dtype[np.floating[Any]]]] = []
     total_speeds: list[np.ndarray[Any, np.dtype[np.floating[Any]]]] = []
     wind_level_index: int | None = None
@@ -333,9 +421,6 @@ def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDef
             local_count = _time_count(dataset)
             for local_index in range(local_count):
                 ql, dimensions = _scalar_ql(dataset, local_index)
-                w = center_vertical_velocity_to_scalar_grid(
-                    dataset, local_index, dimensions, ql.shape
-                )
                 if first_dimensions is None:
                     first_dimensions = dimensions
                 elif dimensions != first_dimensions:
@@ -352,10 +437,6 @@ def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDef
                     )
                 )
                 cwp_scores.append(_domain_mean_cwp(dataset, local_index))
-                finite_absolute_w = np.abs(w[np.isfinite(w)])
-                if finite_absolute_w.size:
-                    absolute_w.append(finite_absolute_w.astype(np.float32, copy=False))
-
                 if wind_level_index is None:
                     z_values_m = _coordinate_as(dataset, dimensions[0], "m", ql.shape[0])
                     wind_level_index = int(np.argmin(np.abs(z_values_m - WIND_TARGET_LEVEL_M)))
@@ -404,7 +485,6 @@ def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDef
     finally:
         selected_dataset.close()
 
-    w_range = rounded_percentile_reference(absolute_w, W_PERCENTILE, W_MIN_RANGE_M_S)
     perturbation_reference = rounded_percentile_reference(
         perturbation_speeds, WIND_PERCENTILE, WIND_MIN_REFERENCE_M_S
     )
@@ -422,9 +502,7 @@ def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDef
         default_plane_coordinate=default_plane_coordinate,
         default_plane_units=default_plane_units,
         default_plane_method=default_plane_method,
-        w_range_min_m_s=-w_range,
-        w_range_max_m_s=w_range,
-        w_range_method=("all_frames_p99_absolute_centered_w_rounded_up_0.1_m_s_with_0.5_m_s_floor"),
+        **_w_scale_payload(),
         wind_actual_level_m=wind_actual_level_m,
         wind_level_index=wind_level_index,
         perturbation_wind_reference_m_s=perturbation_reference,
@@ -433,10 +511,27 @@ def _compute_defaults(metadata: ResultMetadata, paths: list[Path]) -> _CachedDef
         caveats=[
             *time_caveats,
             "candidate_trade_cumulus_lens_not_a_supported_product",
-            "fixed_scales_are_derived_from_this_result_only",
+            "world_owned_fixed_scale_is_specific_to_trade_cumulus",
         ],
     )
     return _CachedDefaults(response=response, frames=tuple(frames))
+
+
+def _w_scale_payload() -> _WScalePayload:
+    return {
+        "w_range_min_m_s": TRADE_CUMULUS_UPDRAFT_SCALE_BREAKPOINTS_M_S[0],
+        "w_range_max_m_s": TRADE_CUMULUS_UPDRAFT_SCALE_BREAKPOINTS_M_S[-1],
+        "w_range_method": TRADE_CUMULUS_UPDRAFT_RANGE_METHOD,
+        "w_scale_id": TRADE_CUMULUS_UPDRAFT_SCALE_ID,
+        "w_scale_owner": TRADE_CUMULUS_UPDRAFT_SCALE_OWNER,
+        "w_scale_type": TRADE_CUMULUS_UPDRAFT_SCALE_TYPE,
+        "w_scale_units": TRADE_CUMULUS_UPDRAFT_SCALE_UNITS,
+        "w_scale_breakpoints_m_s": list(TRADE_CUMULUS_UPDRAFT_SCALE_BREAKPOINTS_M_S),
+        "w_scale_colors": list(TRADE_CUMULUS_UPDRAFT_SCALE_COLORS),
+        "w_scale_neutral_interval_m_s": list(TRADE_CUMULUS_UPDRAFT_SCALE_NEUTRAL_INTERVAL_M_S),
+        "w_scale_source": TRADE_CUMULUS_UPDRAFT_SCALE_SOURCE,
+        "w_scale_clipping_behavior": TRADE_CUMULUS_UPDRAFT_SCALE_CLIPPING_BEHAVIOR,
+    }
 
 
 def _select_default_time(

--- a/app/backend/tests/test_trade_cumulus_updraft_lens.py
+++ b/app/backend/tests/test_trade_cumulus_updraft_lens.py
@@ -267,6 +267,84 @@ def test_fixed_range_uses_percentile_floor_and_rounding() -> None:
     assert lens.rounded_percentile_reference([np.asarray([0.61, 0.62])], 99, 0.5) == 0.7
 
 
+def test_defaults_return_exact_world_owned_fixed_scale(tmp_path: Path) -> None:
+    settings, _ = _install_result(tmp_path, _dataset(scalar_w=True))
+    defaults = trade_cumulus_updraft_lens_defaults(settings, "result-trade-cumulus")
+
+    assert defaults.w_scale_id == "trade_cumulus_updraft_velocity_v1"
+    assert defaults.w_scale_owner == "trade_cumulus"
+    assert lens.TRADE_CUMULUS_UPDRAFT_LENS_ID == "updraft"
+    assert defaults.w_scale_type == "fixed_discrete"
+    assert defaults.w_scale_units == "m/s"
+    assert defaults.w_scale_breakpoints_m_s == [
+        -1.0,
+        -0.5,
+        -0.1,
+        0.1,
+        0.5,
+        1.0,
+        2.0,
+        3.0,
+        5.0,
+    ]
+    assert defaults.w_scale_colors == [
+        "#4b0082",
+        "#0057d9",
+        "#00c9d8",
+        "#ffffff",
+        "#00d63b",
+        "#8fe000",
+        "#ffe000",
+        "#ff9800",
+        "#ff3b00",
+        "#c40000",
+    ]
+    assert defaults.w_scale_neutral_interval_m_s == [-0.1, 0.1]
+    assert defaults.w_scale_source == "pm_approved_issue_379_from_stage5b2_matched_pair"
+    assert defaults.w_scale_clipping_behavior == (
+        "values_below_-1.0_and_at_or_above_5.0_use_endpoint_colors_and_are_reported_as_clipped"
+    )
+    assert defaults.w_range_min_m_s == -1.0
+    assert defaults.w_range_max_m_s == 5.0
+    assert defaults.w_range_method == "fixed_trade_cumulus_updraft_velocity_v1"
+
+
+def test_defaults_scale_is_independent_of_result_w_distribution(tmp_path: Path) -> None:
+    low_dataset = _dataset(scalar_w=True)
+    low_dataset["w"].values[:] = -40.0
+    middle_dataset = _dataset(scalar_w=True)
+    middle_dataset["w"].values[:] = 0.02
+    high_dataset = _dataset(scalar_w=True)
+    high_dataset["w"].values[:] = 40.0
+
+    low_settings, _ = _install_result(tmp_path / "low", low_dataset)
+    low_defaults = trade_cumulus_updraft_lens_defaults(low_settings, "result-trade-cumulus")
+    middle_settings, _ = _install_result(tmp_path / "middle", middle_dataset)
+    middle_defaults = trade_cumulus_updraft_lens_defaults(middle_settings, "result-trade-cumulus")
+    high_settings, _ = _install_result(tmp_path / "high", high_dataset)
+    high_defaults = trade_cumulus_updraft_lens_defaults(high_settings, "result-trade-cumulus")
+
+    scale_fields = (
+        "w_scale_id",
+        "w_scale_owner",
+        "w_scale_type",
+        "w_scale_units",
+        "w_scale_breakpoints_m_s",
+        "w_scale_colors",
+        "w_scale_neutral_interval_m_s",
+        "w_scale_source",
+        "w_scale_clipping_behavior",
+        "w_range_min_m_s",
+        "w_range_max_m_s",
+        "w_range_method",
+    )
+    scale_payloads = [
+        defaults.model_dump(include=set(scale_fields))
+        for defaults in (low_defaults, middle_defaults, high_defaults)
+    ]
+    assert scale_payloads[0] == scale_payloads[1] == scale_payloads[2]
+
+
 def test_u_and_v_faces_are_centered_to_scalar_grid() -> None:
     dataset = _dataset()
     ql, dimensions = lens._scalar_ql(dataset, 0)
@@ -373,6 +451,52 @@ def test_frame_orders_z_ascending_and_serializes_nonfinite_values(tmp_path: Path
     )
     assert frame.z_values_km == sorted(frame.z_values_km)
     assert frame.w_values_m_s[0][0] is None or frame.w_values_m_s[1][0] is None
+
+
+def test_frame_reports_exact_finite_and_clipping_semantics(tmp_path: Path) -> None:
+    dataset = _dataset(scalar_w=True)
+    dataset["w"].values[1, :, 1, :] = np.asarray(
+        [
+            [-1.01, -1.0, 4.99, 5.0],
+            [np.nan, np.inf, -np.inf, 0.0],
+            [-2.0, 8.0, -0.1, 0.1],
+        ]
+    )
+    settings, _ = _install_result(tmp_path, dataset)
+    frame = trade_cumulus_updraft_lens_frame(
+        settings,
+        "result-trade-cumulus",
+        time_index=1,
+        plane_index=1,
+        wind_mode="perturbation",
+    )
+
+    assert frame.w_finite_count == 9
+    assert frame.w_low_clipped_count == 2
+    assert frame.w_high_clipped_count == 2
+    assert frame.w_low_clipped_fraction == pytest.approx(2 / 9)
+    assert frame.w_high_clipped_fraction == pytest.approx(2 / 9)
+    assert frame.w_scale_breakpoints_m_s == [-1.0, -0.5, -0.1, 0.1, 0.5, 1.0, 2.0, 3.0, 5.0]
+    assert frame.w_range_method == "fixed_trade_cumulus_updraft_velocity_v1"
+
+
+def test_frame_uses_null_clipping_fractions_when_no_finite_w_exists(tmp_path: Path) -> None:
+    dataset = _dataset(scalar_w=True)
+    dataset["w"].values[:] = np.nan
+    settings, _ = _install_result(tmp_path, dataset)
+    frame = trade_cumulus_updraft_lens_frame(
+        settings,
+        "result-trade-cumulus",
+        time_index=1,
+        plane_index=1,
+        wind_mode="perturbation",
+    )
+
+    assert frame.w_finite_count == 0
+    assert frame.w_low_clipped_count == 0
+    assert frame.w_high_clipped_count == 0
+    assert frame.w_low_clipped_fraction is None
+    assert frame.w_high_clipped_fraction is None
 
 
 def test_invalid_indices_and_wind_mode_are_rejected(tmp_path: Path) -> None:

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -386,7 +386,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
         padding: getComputedStyle(element).padding,
       };
     });
-    expect(Math.abs(heatmapLayout.declaredAspect - heatmapLayout.renderedAspect)).toBeLessThan(0.03);
+    expect(Math.abs(heatmapLayout.declaredAspect - heatmapLayout.renderedAspect)).toBeLessThan(
+      0.03,
+    );
     expect(heatmapLayout.gridGap).toBe("0px");
     expect(heatmapLayout.rowGap).toBe("0px");
     expect(heatmapLayout.padding).toBe("0px");
@@ -441,6 +443,32 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       raw_field_name: "ql",
       display_name: "Cloud liquid",
     };
+    const updraftScale = {
+      w_range_min_m_s: -1.0,
+      w_range_max_m_s: 5.0,
+      w_range_method: "fixed_trade_cumulus_updraft_velocity_v1",
+      w_scale_id: "trade_cumulus_updraft_velocity_v1",
+      w_scale_owner: "trade_cumulus",
+      w_scale_type: "fixed_discrete",
+      w_scale_units: "m/s",
+      w_scale_breakpoints_m_s: [-1.0, -0.5, -0.1, 0.1, 0.5, 1.0, 2.0, 3.0, 5.0],
+      w_scale_colors: [
+        "#4b0082",
+        "#0057d9",
+        "#00c9d8",
+        "#ffffff",
+        "#00d63b",
+        "#8fe000",
+        "#ffe000",
+        "#ff9800",
+        "#ff3b00",
+        "#c40000",
+      ],
+      w_scale_neutral_interval_m_s: [-0.1, 0.1],
+      w_scale_source: "pm_approved_issue_379_from_stage5b2_matched_pair",
+      w_scale_clipping_behavior:
+        "values_below_-1.0_and_at_or_above_5.0_use_endpoint_colors_and_are_reported_as_clipped",
+    };
 
     await page.route("**/api/results", (route) =>
       route.fulfill({
@@ -478,9 +506,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
             default_plane_units: "km",
             default_plane_method: "greatest_coherent_positive_w_times_ql_score",
             cloud_threshold_kg_kg: 1e-6,
-            w_range_min_m_s: -0.9,
-            w_range_max_m_s: 0.9,
-            w_range_method: "all_frames_p99_absolute_centered_w",
+            ...updraftScale,
             wind_target_level_m: 600,
             wind_actual_level_m: 580,
             wind_level_index: 1,
@@ -519,17 +545,20 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
         const wValues =
           orientation === "horizontal"
             ? [
-                [-0.9, -0.4, 0.2, 0.6],
+                [-1.2, -0.4, 0.2, 0.6],
                 [-0.5, 0, 0.5, 0.9],
-                [-0.2, 0.3, 0.7, null],
+                [-0.2, 0.3, 0.7, 5.2],
                 [0, 0.1, 0.4, 0.2],
               ]
             : [
-                [-0.9, -0.4, 0.2, 0.6],
+                [-1.2, -0.4, 0.2, 0.6],
                 [-0.5, 0, 0.5, 0.9],
-                [-0.2, 0.3, 0.7, null],
+                [-0.2, 0.3, 0.7, 5.2],
                 [0, 0.1, 0.4, 0.2],
               ];
+        const finiteW = wValues.flat().filter((value): value is number => Number.isFinite(value));
+        const lowClippedCount = finiteW.filter((value) => value < -1.0).length;
+        const highClippedCount = finiteW.filter((value) => value >= 5.0).length;
         return route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -557,9 +586,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
               [false, true, false, false],
             ],
             cloud_threshold_kg_kg: 1e-6,
-            w_range_min_m_s: -0.9,
-            w_range_max_m_s: 0.9,
-            w_range_method: "fixed",
+            ...updraftScale,
+            w_finite_count: finiteW.length,
+            w_low_clipped_count: lowClippedCount,
+            w_high_clipped_count: highClippedCount,
+            w_low_clipped_fraction: lowClippedCount / finiteW.length,
+            w_high_clipped_fraction: highClippedCount / finiteW.length,
             wind_mode: windMode,
             wind_target_level_m: 600,
             wind_actual_level_m: 580,
@@ -607,7 +639,14 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByLabel("Horizontal wind overlay legend")).toContainText(
       "0.9 m/s reference",
     );
-    await expect(page.getByLabel("Vertical velocity color scale")).toContainText("0.9 m/s");
+    const inspectorLegend = page.getByLabel(/2-D inspector Vertical velocity \(w\), m\/s/);
+    const viewerLegend = page.getByLabel(/3-D viewer Vertical velocity \(w\), m\/s/);
+    await expect(inspectorLegend).toContainText("Vertical velocity (w), m/s");
+    await expect(viewerLegend).toContainText("-0.1 to < 0.1");
+    await expect(page.locator(".updraft-lens-scale-swatch")).toHaveCount(20);
+    await expect(page.getByText("Slice maximum 5.20 m/s.")).toHaveCount(2);
+    await expect(page.getByText("Slice minimum -1.20 m/s.")).toHaveCount(2);
+    await expect(page.getByText(/Clipped in this slice/)).toHaveCount(0);
     await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("2");
     await expect(page.getByRole("button", { name: "Vertical x-z" })).toHaveAttribute(
       "aria-pressed",
@@ -657,8 +696,8 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(
       page.getByText("Vertical x-z slice at y = 0.15 km · w · 3,600 s", { exact: true }),
     ).toBeVisible();
-    await expect(page.getByLabel("Vertical velocity color scale")).toContainText("-0.9");
-    await expect(page.getByLabel("Vertical velocity color scale")).toContainText("0.9 m/s");
+    await expect(inspectorLegend).toContainText("Vertical velocity (w), m/s");
+    await expect(inspectorLegend).toContainText(">= 5.0");
 
     await page.getByRole("button", { name: "Total wind" }).click();
     await expect(page.getByLabel("Horizontal wind overlay legend")).toContainText(
@@ -668,6 +707,17 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByTestId("updraft-lens-cloud-boundary")).toHaveCount(0);
     await page.getByRole("checkbox", { name: "Horizontal wind" }).uncheck();
     await expect(page.getByLabel("Horizontal wind overlay legend")).toHaveCount(0);
+    expect(
+      await page.evaluate(
+        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+      ),
+    ).toBe(true);
+    await page.setViewportSize({ width: 390, height: 844 });
+    expect(
+      await page.evaluate(
+        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+      ),
+    ).toBe(true);
     await viewMode.getByRole("button", { name: "Standard" }).click();
     await expect(page.getByRole("heading", { name: "Inspect the current slice" })).toBeVisible();
     await expect(page.getByLabel("Slice field")).toBeVisible();

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -3027,7 +3027,7 @@ details[open] > summary {
 
 .updraft-lens-slice {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr) minmax(12.5rem, 15rem);
   gap: 0.55rem;
   align-items: stretch;
   width: 100%;
@@ -3095,21 +3095,98 @@ details[open] > summary {
   align-items: center;
 }
 
-.updraft-lens-legend {
+.updraft-lens-scale-legend {
+  box-sizing: border-box;
   display: grid;
-  grid-template-columns: auto minmax(8rem, 1fr) auto;
-  gap: 0.48rem;
-  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  border: 1px solid rgba(36, 63, 82, 0.2);
+  border-radius: 6px;
+  padding: 0.55rem;
+  background: rgba(255, 255, 255, 0.72);
   color: var(--color-text-primary);
-  font-size: 0.78rem;
-  font-weight: 750;
 }
 
-.updraft-lens-color-ramp {
-  height: 0.72rem;
-  border: 1px solid rgba(23, 43, 58, 0.14);
-  border-radius: 3px;
-  background: linear-gradient(90deg, #2166ac 0%, #f7f7f7 50%, #b2182b 100%);
+.updraft-lens-scale-legend-2d {
+  align-self: start;
+}
+
+.true3d-scene-frame > .updraft-lens-scale-legend-3d {
+  position: absolute;
+  z-index: 3;
+  top: 50%;
+  right: 0.75rem;
+  width: min(13rem, calc(100% - 1.5rem));
+  max-height: calc(100% - 1.5rem);
+  overflow: auto;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 8px 24px rgba(40, 80, 110, 0.1);
+}
+
+.updraft-lens-scale-heading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 0.75rem;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.updraft-lens-scale-heading strong {
+  font-size: 0.82rem;
+}
+
+.updraft-lens-scale-intervals {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.updraft-lens-scale-intervals li {
+  display: grid;
+  grid-template-columns: 0.72rem minmax(0, 1fr);
+  gap: 0.3rem;
+  align-items: center;
+  min-width: 0;
+  color: var(--color-text-primary);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.updraft-lens-scale-legend-2d .updraft-lens-scale-intervals {
+  grid-template-columns: 1fr;
+}
+
+.updraft-lens-scale-legend-3d .updraft-lens-scale-intervals {
+  grid-template-columns: 1fr;
+}
+
+.updraft-lens-scale-swatch {
+  width: 0.72rem;
+  height: 100%;
+  min-height: 1.25rem;
+  border: 1px solid rgba(23, 43, 58, 0.24);
+  border-radius: 2px;
+}
+
+.updraft-lens-slice-range {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.updraft-lens-slice-range-maximum {
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.4rem;
+}
+
+.updraft-lens-slice-range-minimum {
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.4rem;
 }
 
 @media (max-width: 860px) {
@@ -3200,6 +3277,31 @@ details[open] > summary {
   .timelapse-controls,
   .true3d-controls {
     grid-template-columns: 1fr;
+  }
+
+  .updraft-lens-scale-intervals {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .updraft-lens-slice {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .updraft-lens-scale-legend-2d {
+    grid-column: 2;
+  }
+
+  .updraft-lens-scale-legend-2d .updraft-lens-scale-intervals {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .true3d-scene-frame > .updraft-lens-scale-legend-3d {
+    top: auto;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    width: min(9.5rem, calc(100% - 1rem));
+    max-height: calc(100% - 1rem);
+    transform: none;
   }
 
   .visualizer-heading-actions {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3213,6 +3213,33 @@ const tradeCumulusViewDefaults = {
   },
 };
 
+const tradeCumulusUpdraftScale = {
+  w_range_min_m_s: -1.0,
+  w_range_max_m_s: 5.0,
+  w_range_method: "fixed_trade_cumulus_updraft_velocity_v1",
+  w_scale_id: "trade_cumulus_updraft_velocity_v1",
+  w_scale_owner: "trade_cumulus",
+  w_scale_type: "fixed_discrete",
+  w_scale_units: "m/s",
+  w_scale_breakpoints_m_s: [-1.0, -0.5, -0.1, 0.1, 0.5, 1.0, 2.0, 3.0, 5.0],
+  w_scale_colors: [
+    "#4b0082",
+    "#0057d9",
+    "#00c9d8",
+    "#ffffff",
+    "#00d63b",
+    "#8fe000",
+    "#ffe000",
+    "#ff9800",
+    "#ff3b00",
+    "#c40000",
+  ],
+  w_scale_neutral_interval_m_s: [-0.1, 0.1],
+  w_scale_source: "pm_approved_issue_379_from_stage5b2_matched_pair",
+  w_scale_clipping_behavior:
+    "values_below_-1.0_and_at_or_above_5.0_use_endpoint_colors_and_are_reported_as_clipped",
+} as const;
+
 const tradeCumulusUpdraftLensDefaults = {
   result_id: "result-trade-cumulus",
   case_id: "bomex_trade_cumulus_baseline_v0",
@@ -3229,9 +3256,7 @@ const tradeCumulusUpdraftLensDefaults = {
   default_plane_units: "km",
   default_plane_method: "greatest_coherent_positive_w_times_ql_score",
   cloud_threshold_kg_kg: 1e-6,
-  w_range_min_m_s: -0.9,
-  w_range_max_m_s: 0.9,
-  w_range_method: "all_frames_p99_absolute_centered_w",
+  ...tradeCumulusUpdraftScale,
   wind_target_level_m: 600,
   wind_actual_level_m: 580,
   wind_level_index: 1,
@@ -3255,13 +3280,13 @@ function tradeCumulusUpdraftLensFrame({
   planeIndex = 1,
   orientation = "vertical_x",
   windMode = "perturbation",
-  range = 0.9,
+  valueRange = 0.9,
 }: {
   timeIndex?: number;
   planeIndex?: number;
   orientation?: "horizontal" | "vertical_x" | "vertical_y";
   windMode?: "perturbation" | "total";
-  range?: number;
+  valueRange?: number;
 } = {}) {
   const reference = windMode === "perturbation" ? 0.9 : 8.8;
   const planeDimension =
@@ -3275,16 +3300,19 @@ function tradeCumulusUpdraftLensFrame({
   const wValues =
     orientation === "vertical_y"
       ? [
-          [-range, range],
-          [null, range / 2],
+          [-valueRange, valueRange],
+          [null, valueRange / 2],
         ]
       : [
-          [-range, 0, range],
-          [null, -range / 2, range / 2],
+          [-valueRange, 0, valueRange],
+          [null, -valueRange / 2, valueRange / 2],
         ];
   const cloudMask = wValues.map((row, rowIndex) =>
     row.map((_, columnIndex) => rowIndex === 0 || columnIndex === 1),
   );
+  const finiteW = wValues.flat().filter((value): value is number => Number.isFinite(value));
+  const lowClippedCount = finiteW.filter((value) => value < -1.0).length;
+  const highClippedCount = finiteW.filter((value) => value >= 5.0).length;
   return {
     result_id: "result-trade-cumulus",
     time_index: timeIndex,
@@ -3304,9 +3332,12 @@ function tradeCumulusUpdraftLensFrame({
     w_values_m_s: wValues,
     cloud_mask: cloudMask,
     cloud_threshold_kg_kg: 1e-6,
-    w_range_min_m_s: -range,
-    w_range_max_m_s: range,
-    w_range_method: "fixed",
+    ...tradeCumulusUpdraftScale,
+    w_finite_count: finiteW.length,
+    w_low_clipped_count: lowClippedCount,
+    w_high_clipped_count: highClippedCount,
+    w_low_clipped_fraction: finiteW.length ? lowClippedCount / finiteW.length : null,
+    w_high_clipped_fraction: finiteW.length ? highClippedCount / finiteW.length : null,
     wind_mode: windMode,
     wind_target_level_m: 600,
     wind_actual_level_m: 580,
@@ -6787,6 +6818,13 @@ describe("App", () => {
     expect(screen.getByLabelText("Horizontal wind overlay legend")).toHaveTextContent(
       "0.9 m/s reference",
     );
+    expect(screen.getAllByText("Vertical velocity (w), m/s")).toHaveLength(2);
+    expect(screen.getByLabelText(/2-D inspector Vertical velocity \(w\), m\/s/)).toHaveTextContent(
+      "-0.1 to < 0.1",
+    );
+    expect(screen.getByLabelText(/3-D viewer Vertical velocity \(w\), m\/s/)).toHaveTextContent(
+      "m/s",
+    );
     expect(screen.getByText(/Updraft Lens slice: Vertical x-z slice at y =/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Horizontal x-y" }));
@@ -6864,23 +6902,31 @@ describe("App", () => {
 
     await act(async () => {
       resolveSecond?.(
-        new Response(JSON.stringify(tradeCumulusUpdraftLensFrame({ timeIndex: 1, range: 1.4 })), {
-          status: 200,
-        }),
+        new Response(
+          JSON.stringify(tradeCumulusUpdraftLensFrame({ timeIndex: 1, valueRange: 1.4 })),
+          { status: 200 },
+        ),
       );
     });
-    const legend = await screen.findByLabelText("Vertical velocity color scale");
-    expect(legend).toHaveTextContent("1.4 m/s");
+    const legend = await screen.findByLabelText(/2-D inspector Vertical velocity \(w\), m\/s/);
+    expect(legend).toHaveTextContent("Vertical velocity (w), m/s");
+    expect(screen.getAllByText("Slice maximum 1.40 m/s.")).toHaveLength(2);
+    expect(screen.getAllByText("Slice minimum -1.40 m/s.")).toHaveLength(2);
 
     await act(async () => {
       resolveFirst?.(
-        new Response(JSON.stringify(tradeCumulusUpdraftLensFrame({ timeIndex: 2, range: 0.9 })), {
-          status: 200,
-        }),
+        new Response(
+          JSON.stringify(tradeCumulusUpdraftLensFrame({ timeIndex: 2, valueRange: 0.9 })),
+          { status: 200 },
+        ),
       );
     });
-    expect(legend).toHaveTextContent("1.4 m/s");
-    expect(legend).not.toHaveTextContent("0.9 m/s");
+    expect(legend).toHaveTextContent("Vertical velocity (w), m/s");
+    expect(screen.getAllByText("Slice maximum 1.40 m/s.")).toHaveLength(2);
+    expect(screen.getAllByText("Slice minimum -1.40 m/s.")).toHaveLength(2);
+    expect(screen.queryByText("Slice maximum 0.90 m/s.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Slice minimum -0.90 m/s.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Clipped in this slice/)).not.toBeInTheDocument();
   });
 
   it("opens the 2-D field inspector from a result and shows qc slices", async () => {

--- a/app/frontend/src/True3DViewer.test.tsx
+++ b/app/frontend/src/True3DViewer.test.tsx
@@ -6,6 +6,7 @@ import {
   updraftLensTextureData,
   windArrowLength,
 } from "./True3DViewer.utils";
+import { updraftLensDiscreteColor } from "./UpdraftLensSlice";
 
 describe("True3DViewer scalar point sizing", () => {
   it("uses the UI point-size value as a bounded screen-pixel size", () => {
@@ -42,21 +43,39 @@ describe("True3DViewer wind arrow scaling", () => {
 
 describe("True3DViewer Updraft Lens texture", () => {
   it("uses the exact fixed-scale colors and missing-data color", () => {
-    expect(
-      Array.from(
-        updraftLensTextureData(
-          [
-            [-1, 0],
-            [1, null],
-          ],
-          2,
-          2,
-          -1,
-          1,
-        ),
-      ),
-    ).toEqual([
-      0x21, 0x66, 0xac, 255, 0xf7, 0xf7, 0xf7, 255, 0xb2, 0x18, 0x2b, 255, 0x74, 0x7b, 0x80, 255,
+    const breakpoints = [-1.0, -0.5, -0.1, 0.1, 0.5, 1.0, 2.0, 3.0, 5.0];
+    const colors = [
+      "#4b0082",
+      "#0057d9",
+      "#00c9d8",
+      "#ffffff",
+      "#00d63b",
+      "#8fe000",
+      "#ffe000",
+      "#ff9800",
+      "#ff3b00",
+      "#c40000",
+    ];
+    const values = [
+      [-1.01, -1.0, -0.1, 0],
+      [0.1, 1.0, 5.0, null],
+    ];
+    const textureBytes = Array.from(updraftLensTextureData(values, 4, 2, breakpoints, colors));
+    expect(textureBytes).toEqual([
+      0x4b, 0x00, 0x82, 255, 0x00, 0x57, 0xd9, 255, 0xff, 0xff, 0xff, 255, 0xff, 0xff, 0xff, 255,
+      0x00, 0xd6, 0x3b, 255, 0xff, 0xe0, 0x00, 255, 0xc4, 0x00, 0x00, 255, 0x74, 0x7b, 0x80, 255,
     ]);
+    const sliceBytes = values.flatMap((row) =>
+      row.flatMap((value) => {
+        const color = updraftLensDiscreteColor(value, breakpoints, colors);
+        return [
+          Number.parseInt(color.slice(1, 3), 16),
+          Number.parseInt(color.slice(3, 5), 16),
+          Number.parseInt(color.slice(5, 7), 16),
+          255,
+        ];
+      }),
+    );
+    expect(textureBytes).toEqual(sliceBytes);
   });
 });

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -7,6 +7,7 @@ import type {
   UpdraftLensWindMode,
   UpdraftLensWindVector,
 } from "./UpdraftLensSlice";
+import { UpdraftLensScaleLegend } from "./UpdraftLensSlice";
 import {
   cameraDistanceLimits,
   scalarPointPixelSize,
@@ -385,6 +386,9 @@ export function True3DViewer({
             <span>{windReferenceMps.toFixed(1)} m/s reference = 8% domain width</span>
           </div>
         )}
+        {updraftLensFrame && (
+          <UpdraftLensScaleLegend frame={updraftLensFrame} viewLabel="3-D viewer" />
+        )}
         <div
           ref={axisLabelLayerRef}
           className="true3d-axis-label-layer"
@@ -556,8 +560,8 @@ function updraftLensSlicePlane(frame: UpdraftLensFrame, bounds: SceneBounds): TH
       frame.w_values_m_s,
       width,
       height,
-      frame.w_range_min_m_s,
-      frame.w_range_max_m_s,
+      frame.w_scale_breakpoints_m_s,
+      frame.w_scale_colors,
     ),
     width,
     height,

--- a/app/frontend/src/True3DViewer.utils.ts
+++ b/app/frontend/src/True3DViewer.utils.ts
@@ -1,4 +1,4 @@
-import { updraftLensColor } from "./UpdraftLensSlice";
+import { updraftLensDiscreteColor } from "./UpdraftLensSlice";
 
 const DEFAULT_SCALAR_POINT_PIXEL_SIZE = 11;
 const MIN_SCALAR_POINT_PIXEL_SIZE = 3;
@@ -45,8 +45,8 @@ export function updraftLensTextureData(
   values: Array<Array<number | null>>,
   width: number,
   height: number,
-  rangeMinimum: number,
-  rangeMaximum: number,
+  breakpoints: number[],
+  colors: string[],
 ): Uint8Array {
   const resolvedWidth = Math.max(1, Math.trunc(width));
   const resolvedHeight = Math.max(1, Math.trunc(height));
@@ -55,7 +55,7 @@ export function updraftLensTextureData(
     for (let xIndex = 0; xIndex < resolvedWidth; xIndex += 1) {
       const offset = (zIndex * resolvedWidth + xIndex) * 4;
       const [red, green, blue] = hexColorChannels(
-        updraftLensColor(values[zIndex]?.[xIndex] ?? null, rangeMinimum, rangeMaximum),
+        updraftLensDiscreteColor(values[zIndex]?.[xIndex] ?? null, breakpoints, colors),
       );
       data[offset] = red;
       data[offset + 1] = green;

--- a/app/frontend/src/UpdraftLensSlice.test.tsx
+++ b/app/frontend/src/UpdraftLensSlice.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -6,9 +6,23 @@ import {
   UpdraftLensSlice,
   updraftLensBoundaryPath,
   updraftLensCellGeometry,
-  updraftLensColor,
+  updraftLensDiscreteColor,
   updraftLensSelectionFromPointer,
 } from "./UpdraftLensSlice";
+
+const breakpoints = [-1.0, -0.5, -0.1, 0.1, 0.5, 1.0, 2.0, 3.0, 5.0];
+const colors = [
+  "#4b0082",
+  "#0057d9",
+  "#00c9d8",
+  "#ffffff",
+  "#00d63b",
+  "#8fe000",
+  "#ffe000",
+  "#ff9800",
+  "#ff3b00",
+  "#c40000",
+];
 
 const frame: UpdraftLensFrame = {
   result_id: "result-bomex",
@@ -36,8 +50,23 @@ const frame: UpdraftLensFrame = {
   ],
   cloud_threshold_kg_kg: 1e-6,
   w_range_min_m_s: -1,
-  w_range_max_m_s: 1,
-  w_range_method: "fixed",
+  w_range_max_m_s: 5,
+  w_range_method: "fixed_trade_cumulus_updraft_velocity_v1",
+  w_scale_id: "trade_cumulus_updraft_velocity_v1",
+  w_scale_owner: "trade_cumulus",
+  w_scale_type: "fixed_discrete",
+  w_scale_units: "m/s",
+  w_scale_breakpoints_m_s: breakpoints,
+  w_scale_colors: colors,
+  w_scale_neutral_interval_m_s: [-0.1, 0.1],
+  w_scale_source: "pm_approved_issue_379_from_stage5b2_matched_pair",
+  w_scale_clipping_behavior:
+    "values_below_-1.0_and_at_or_above_5.0_use_endpoint_colors_and_are_reported_as_clipped",
+  w_finite_count: 5,
+  w_low_clipped_count: 0,
+  w_high_clipped_count: 0,
+  w_low_clipped_fraction: 0,
+  w_high_clipped_fraction: 0,
   wind_mode: "perturbation",
   wind_target_level_m: 600,
   wind_actual_level_m: 580,
@@ -61,13 +90,25 @@ const frame: UpdraftLensFrame = {
 };
 
 describe("UpdraftLensSlice colors", () => {
-  it("uses the approved fixed diverging palette and distinct missing color", () => {
-    expect(updraftLensColor(-1, -1, 1)).toBe("#2166ac");
-    expect(updraftLensColor(0, -1, 1)).toBe("#f7f7f7");
-    expect(updraftLensColor(1, -1, 1)).toBe("#b2182b");
-    expect(updraftLensColor(null, -1, 1)).toBe("#747b80");
-    expect(updraftLensColor(-20, -1, 1)).toBe("#2166ac");
-    expect(updraftLensColor(20, -1, 1)).toBe("#b2182b");
+  it("uses exact half-open classes immediately below, at, and above every breakpoint", () => {
+    breakpoints.forEach((breakpoint, index) => {
+      expect(updraftLensDiscreteColor(breakpoint - 1e-6, breakpoints, colors)).toBe(colors[index]);
+      expect(updraftLensDiscreteColor(breakpoint, breakpoints, colors)).toBe(colors[index + 1]);
+      expect(updraftLensDiscreteColor(breakpoint + 1e-6, breakpoints, colors)).toBe(
+        colors[index + 1],
+      );
+    });
+  });
+
+  it("keeps neutral boundaries, missing values, and classes deterministic without interpolation", () => {
+    expect(updraftLensDiscreteColor(-0.1, breakpoints, colors)).toBe("#ffffff");
+    expect(updraftLensDiscreteColor(0, breakpoints, colors)).toBe("#ffffff");
+    expect(updraftLensDiscreteColor(0.1, breakpoints, colors)).toBe("#00d63b");
+    expect(updraftLensDiscreteColor(0.11, breakpoints, colors)).toBe("#00d63b");
+    expect(updraftLensDiscreteColor(0.49, breakpoints, colors)).toBe("#00d63b");
+    expect(updraftLensDiscreteColor(null, breakpoints, colors)).toBe("#747b80");
+    expect(updraftLensDiscreteColor(Number.NaN, breakpoints, colors)).toBe("#747b80");
+    expect(updraftLensDiscreteColor(Number.POSITIVE_INFINITY, breakpoints, colors)).toBe("#747b80");
   });
 });
 
@@ -110,14 +151,57 @@ describe("UpdraftLensSlice geometry", () => {
 });
 
 describe("UpdraftLensSlice rendering", () => {
-  it("preserves physical aspect, fixed legend, boundary, and accessible summary", () => {
+  it("preserves physical aspect, fixed legend, boundary, and slice range", () => {
     const { container } = render(<UpdraftLensSlice frame={frame} />);
     const plot = screen.getByRole("img", { name: /Updraft Lens vertical x-z slice/ });
     expect(plot).toHaveAttribute("data-domain-aspect", "0.750000");
     expect(plot).toHaveAttribute("data-orientation", "vertical_x");
     expect(container.querySelectorAll("rect")).toHaveLength(6);
-    expect(screen.getByLabelText("Vertical velocity color scale")).toHaveTextContent("-1.0");
+    const legend = screen.getByLabelText(/2-D inspector Vertical velocity \(w\), m\/s/);
+    expect(legend).toHaveTextContent("-0.1 to < 0.1 m/s");
+    expect(legend).toHaveTextContent(">= 5.0 m/s");
+    expect(legend).not.toHaveTextContent("near-neutral motion");
+    expect(legend).not.toHaveTextContent("#ffffff");
+    expect(legend.querySelectorAll(".updraft-lens-scale-swatch")).toHaveLength(10);
+    expect(
+      within(legend)
+        .getAllByRole("listitem")
+        .map((item) => item.textContent),
+    ).toEqual([
+      ">= 5.0 m/s",
+      "3.0 to < 5.0 m/s",
+      "2.0 to < 3.0 m/s",
+      "1.0 to < 2.0 m/s",
+      "0.5 to < 1.0 m/s",
+      "0.1 to < 0.5 m/s",
+      "-0.1 to < 0.1 m/s",
+      "-0.5 to < -0.1 m/s",
+      "-1.0 to < -0.5 m/s",
+      "< -1.0 m/s",
+    ]);
+    expect(legend).toHaveTextContent("Slice maximum 1.00 m/s.");
+    expect(legend).toHaveTextContent("Slice minimum -1.00 m/s.");
+    expect(screen.queryByText(/Clipped in this slice/)).not.toBeInTheDocument();
     expect(screen.getByTestId("updraft-lens-cloud-boundary")).toBeInTheDocument();
+  });
+
+  it.each([
+    [2, 0],
+    [0, 3],
+    [2, 3],
+  ])("keeps clipping counts out of the visible range summary (%s, %s)", (lowCount, highCount) => {
+    render(
+      <UpdraftLensSlice
+        frame={{
+          ...frame,
+          w_low_clipped_count: lowCount,
+          w_high_clipped_count: highCount,
+        }}
+      />,
+    );
+    expect(screen.getByText("Slice maximum 1.00 m/s.")).toBeInTheDocument();
+    expect(screen.getByText("Slice minimum -1.00 m/s.")).toBeInTheDocument();
+    expect(screen.queryByText(/Clipped in this slice/)).not.toBeInTheDocument();
   });
 
   it("hides the boundary and reports native indices on click", () => {

--- a/app/frontend/src/UpdraftLensSlice.tsx
+++ b/app/frontend/src/UpdraftLensSlice.tsx
@@ -36,6 +36,20 @@ export type UpdraftLensFrame = {
   w_range_min_m_s: number;
   w_range_max_m_s: number;
   w_range_method: string;
+  w_scale_id: string;
+  w_scale_owner: string;
+  w_scale_type: "fixed_discrete";
+  w_scale_units: "m/s";
+  w_scale_breakpoints_m_s: number[];
+  w_scale_colors: string[];
+  w_scale_neutral_interval_m_s: number[];
+  w_scale_source: string;
+  w_scale_clipping_behavior: string;
+  w_finite_count: number;
+  w_low_clipped_count: number;
+  w_high_clipped_count: number;
+  w_low_clipped_fraction: number | null;
+  w_high_clipped_fraction: number | null;
   wind_mode: UpdraftLensWindMode;
   wind_target_level_m: number;
   wind_actual_level_m: number;
@@ -83,6 +97,15 @@ export type UpdraftLensDefaults = {
   w_range_min_m_s: number;
   w_range_max_m_s: number;
   w_range_method: string;
+  w_scale_id: string;
+  w_scale_owner: string;
+  w_scale_type: "fixed_discrete";
+  w_scale_units: "m/s";
+  w_scale_breakpoints_m_s: number[];
+  w_scale_colors: string[];
+  w_scale_neutral_interval_m_s: number[];
+  w_scale_source: string;
+  w_scale_clipping_behavior: string;
   wind_target_level_m: number;
   wind_actual_level_m: number;
   wind_level_index: number;
@@ -110,10 +133,23 @@ type CellGeometry = {
   height: number;
 };
 
-const DOWNDRAFT_COLOR = "#2166ac";
-const NEUTRAL_COLOR = "#f7f7f7";
-const UPDRAFT_COLOR = "#b2182b";
 const MISSING_COLOR = "#747b80";
+const LEGACY_DOWNDRAFT_COLOR = "#2166ac";
+const LEGACY_NEUTRAL_COLOR = "#f7f7f7";
+const LEGACY_UPDRAFT_COLOR = "#b2182b";
+const SCALE_TITLE = "Vertical velocity (w), m/s";
+const INTERVAL_MEANINGS = [
+  "strongest or clipped downdraft",
+  "downdraft",
+  "weak downdraft",
+  "near-neutral motion",
+  "weak updraft",
+  "moderate updraft",
+  "active updraft",
+  "strong updraft",
+  "very strong updraft",
+  "exceptional or clipped updraft",
+];
 
 export function UpdraftLensSlice({
   frame,
@@ -203,7 +239,11 @@ export function UpdraftLensSlice({
                     y={geometry.y}
                     width={geometry.width}
                     height={geometry.height}
-                    fill={updraftLensColor(value, frame.w_range_min_m_s, frame.w_range_max_m_s)}
+                    fill={updraftLensDiscreteColor(
+                      value,
+                      frame.w_scale_breakpoints_m_s,
+                      frame.w_scale_colors,
+                    )}
                   />
                 );
               }),
@@ -233,16 +273,27 @@ export function UpdraftLensSlice({
           <strong>{columnDimension} (km)</strong>
           <span>{formatKilometers(columnMax)}</span>
         </div>
-        <div className="updraft-lens-legend" aria-label="Vertical velocity color scale">
-          <span>{frame.w_range_min_m_s.toFixed(1)}</span>
-          <span className="updraft-lens-color-ramp" />
-          <span>{frame.w_range_max_m_s.toFixed(1)} m/s</span>
-        </div>
       </div>
+      <UpdraftLensScaleLegend frame={frame} viewLabel="2-D inspector" />
     </section>
   );
 }
 
+export function updraftLensDiscreteColor(
+  value: number | null,
+  breakpoints: number[],
+  colors: string[],
+): string {
+  if (value === null || !Number.isFinite(value)) return MISSING_COLOR;
+  if (colors.length !== breakpoints.length + 1 || colors.length === 0) return MISSING_COLOR;
+  let colorIndex = 0;
+  while (colorIndex < breakpoints.length && value >= breakpoints[colorIndex]) {
+    colorIndex += 1;
+  }
+  return colors[colorIndex] ?? MISSING_COLOR;
+}
+
+// Retained for the Standard-view selected-value swatch; Lens rendering uses the discrete lookup.
 export function updraftLensColor(
   value: number | null,
   rangeMinimum: number,
@@ -251,10 +302,82 @@ export function updraftLensColor(
   if (value === null || !Number.isFinite(value)) return MISSING_COLOR;
   if (value <= 0) {
     const denominator = Math.max(Number.EPSILON, Math.abs(rangeMinimum));
-    return interpolateHex(DOWNDRAFT_COLOR, NEUTRAL_COLOR, 1 - clamp(Math.abs(value) / denominator));
+    return interpolateHex(
+      LEGACY_DOWNDRAFT_COLOR,
+      LEGACY_NEUTRAL_COLOR,
+      1 - clamp(Math.abs(value) / denominator),
+    );
   }
   const denominator = Math.max(Number.EPSILON, Math.abs(rangeMaximum));
-  return interpolateHex(NEUTRAL_COLOR, UPDRAFT_COLOR, clamp(value / denominator));
+  return interpolateHex(LEGACY_NEUTRAL_COLOR, LEGACY_UPDRAFT_COLOR, clamp(value / denominator));
+}
+
+export function UpdraftLensScaleLegend({
+  frame,
+  viewLabel,
+}: {
+  frame: UpdraftLensFrame;
+  viewLabel: "2-D inspector" | "3-D viewer";
+}) {
+  const intervals = updraftLensScaleIntervals(frame.w_scale_breakpoints_m_s, frame.w_scale_colors);
+  const finiteValues = frame.w_values_m_s
+    .flat()
+    .filter((value): value is number => value !== null && Number.isFinite(value));
+  const sliceMinimum = finiteValues.length > 0 ? Math.min(...finiteValues) : null;
+  const sliceMaximum = finiteValues.length > 0 ? Math.max(...finiteValues) : null;
+  const viewClass = viewLabel === "2-D inspector" ? "2d" : "3d";
+  return (
+    <section
+      className={`updraft-lens-scale-legend updraft-lens-scale-legend-${viewClass}`}
+      aria-label={`${viewLabel} ${SCALE_TITLE}; ${frame.w_scale_id}`}
+    >
+      <div className="updraft-lens-scale-heading">
+        <strong>{SCALE_TITLE}</strong>
+      </div>
+      <p className="updraft-lens-slice-range updraft-lens-slice-range-maximum">
+        Slice maximum {sliceMaximum === null ? "unavailable" : `${sliceMaximum.toFixed(2)} m/s`}.
+      </p>
+      <ol className="updraft-lens-scale-intervals" aria-label="Exact vertical velocity intervals">
+        {[...intervals].reverse().map((interval, reversedIndex) => {
+          const index = intervals.length - 1 - reversedIndex;
+          return (
+            <li
+              key={`${interval.label}-${interval.color}`}
+              aria-label={`${interval.label} ${frame.w_scale_units}; ${INTERVAL_MEANINGS[index]}; color ${interval.color}`}
+            >
+              <span
+                className="updraft-lens-scale-swatch"
+                style={{ backgroundColor: interval.color }}
+                aria-hidden="true"
+              />
+              <span>
+                {interval.label} {frame.w_scale_units}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+      <p className="updraft-lens-slice-range updraft-lens-slice-range-minimum">
+        Slice minimum {sliceMinimum === null ? "unavailable" : `${sliceMinimum.toFixed(2)} m/s`}.
+      </p>
+    </section>
+  );
+}
+
+export function updraftLensScaleIntervals(
+  breakpoints: number[],
+  colors: string[],
+): Array<{ label: string; color: string }> {
+  return colors.map((color, index) => {
+    if (index === 0) return { label: `< ${formatVelocity(breakpoints[0])}`, color };
+    if (index === colors.length - 1) {
+      return { label: `>= ${formatVelocity(breakpoints.at(-1))}`, color };
+    }
+    return {
+      label: `${formatVelocity(breakpoints[index - 1])} to < ${formatVelocity(breakpoints[index])}`,
+      color,
+    };
+  });
 }
 
 export function updraftLensCellGeometry(
@@ -400,6 +523,10 @@ function clamp(value: number): number {
 
 function formatKilometers(value: number): string {
   return `${Number(value.toFixed(2))}`;
+}
+
+function formatVelocity(value: number | undefined): string {
+  return Number.isFinite(value) ? Number(value).toFixed(1) : "unavailable";
 }
 
 function updraftLensAccessibleSummary(frame: UpdraftLensFrame): string {

--- a/docs/product/TRADE_CUMULUS_PRODUCT_SLICE.md
+++ b/docs/product/TRADE_CUMULUS_PRODUCT_SLICE.md
@@ -154,10 +154,10 @@ It represents the rate at which the idealized lower boundary supplies water vapo
 
 The first validation exposes exactly two states:
 
-| State | Product meaning | CM1-facing moisture flux |
-| --- | --- | ---: |
-| Baseline | Canonical BOMEX surface moisture supply | `5.2e-5 g/g m/s` |
-| More moisture | Fifty percent stronger surface moisture supply | `7.8e-5 g/g m/s` |
+| State         | Product meaning                                | CM1-facing moisture flux |
+| ------------- | ---------------------------------------------- | -----------------------: |
+| Baseline      | Canonical BOMEX surface moisture supply        |         `5.2e-5 g/g m/s` |
+| More moisture | Fifty percent stronger surface moisture supply |         `7.8e-5 g/g m/s` |
 
 The product should present understandable states, not a raw free-form CM1 parameter.
 
@@ -269,26 +269,34 @@ For a single Simulation:
 
 If no qualifying overlap exists, fall back first to a plane through the largest coherent cloud-liquid object, then to the domain midpoint.
 
-### Vertical-velocity palette
+### Fixed Trade Cumulus vertical-velocity scale
 
-Use a divergent palette with a physically meaningful zero:
+The Updraft Lens uses the world-owned fixed scale:
 
 ```text
-negative vertical velocity → blue
-near zero → neutral
-positive vertical velocity → red
+trade_cumulus_updraft_velocity_v1
 ```
 
-The default range must:
+Every eligible Trade Cumulus Simulation, frame, slice orientation, and Comparison uses the same discrete vertical-velocity encoding:
 
-- be symmetric about zero;
-- be robust to isolated extrema;
-- remain fixed through playback;
-- be visibly labeled in `m/s`.
+| Vertical velocity    | Color     | Interpretation                 |
+| -------------------- | --------- | ------------------------------ |
+| `< -1.0 m/s`         | `#4b0082` | strongest or clipped downdraft |
+| `-1.0 to < -0.5 m/s` | `#0057d9` | downdraft                      |
+| `-0.5 to < -0.1 m/s` | `#00c9d8` | weak downdraft                 |
+| `-0.1 to < 0.1 m/s`  | `#ffffff` | near-neutral motion            |
+| `0.1 to < 0.5 m/s`   | `#00d63b` | weak updraft                   |
+| `0.5 to < 1.0 m/s`   | `#8fe000` | moderate updraft               |
+| `1.0 to < 2.0 m/s`   | `#ffe000` | active updraft                 |
+| `2.0 to < 3.0 m/s`   | `#ff9800` | strong updraft                 |
+| `3.0 to < 5.0 m/s`   | `#ff3b00` | very strong updraft            |
+| `>= 5.0 m/s`         | `#c40000` | exceptional or clipped updraft |
 
-For a Comparison, derive one shared symmetric range from both Simulations and keep it fixed across both views and all synchronized frames.
+Values outside the finite outer breakpoints use the endpoint colors. Per-slice clipping counts remain available in the Lens payload for technical diagnostics, while the visible legend reports the current slice minimum and maximum. Missing values remain distinct from neutral motion.
 
-Do not rescale each frame independently.
+This scale is specific to the Trade Cumulus Cloud World. It is not a universal Cloud Chamber vertical-velocity scale and does not determine the appropriate Updraft Lens scale for deep convection or another Cloud World.
+
+The scale remains fixed through playback and is shared across Comparisons. It is never rescaled independently by frame, plane, Simulation, or viewer session.
 
 ### Slice rendering
 
@@ -347,7 +355,7 @@ The Comparison contains:
 - the meaningful changed condition stated plainly;
 - synchronized model time;
 - a shared default vertical plane;
-- a shared `w` range;
+- the shared fixed Trade Cumulus Updraft Scale v1;
 - a shared cloud threshold;
 - shared horizontal-wind overlay settings;
 - the same scientific and numerical assumptions except for surface moisture supply.
@@ -430,12 +438,12 @@ Automated causal reasoning is not required.
 
 ## 9. Candidate status and graduation
 
-| Product element | Current status |
-| --- | --- |
-| Trade Cumulus Cloud World | Candidate |
-| Canonical BOMEX Baseline Recipe | Candidate |
-| Surface moisture supply Control | Experimental |
-| Updraft Lens for Trade Cumulus | Candidate |
+| Product element                          | Current status     |
+| ---------------------------------------- | ------------------ |
+| Trade Cumulus Cloud World                | Candidate          |
+| Canonical BOMEX Baseline Recipe          | Candidate          |
+| Surface moisture supply Control          | Experimental       |
+| Updraft Lens for Trade Cumulus           | Candidate          |
 | Baseline versus More Moisture Comparison | Planned validation |
 
 The slice may advance only when the matched implementation demonstrates:

--- a/docs/research/trade-cumulus/trade-cumulus-updraft-scale-calibration.md
+++ b/docs/research/trade-cumulus/trade-cumulus-updraft-scale-calibration.md
@@ -1,0 +1,157 @@
+# Trade Cumulus Updraft Scale Calibration
+
+## Status and authority boundary
+
+This document records calibration and implementation evidence for the candidate
+Trade Cumulus Updraft Lens. It is not general product authority and does not
+graduate the Cloud World, Recipe, Control, Lens, or MVP. The exact scale
+decision came from the PM activation comment on issue #379; issue #377 supplied
+the numerical evidence. No CM1 run occurred under issue #379.
+
+## Decision and fixed scale
+
+The PM-approved world-owned scale is
+`trade_cumulus_updraft_velocity_v1` (`fixed_discrete`, `m/s`). It is specific to
+Trade Cumulus and uses these exact half-open intervals:
+
+| Vertical velocity | Color     | Interpretation                 |
+| ----------------- | --------- | ------------------------------ |
+| `< -1.0`          | `#4b0082` | strongest or clipped downdraft |
+| `-1.0 to < -0.5`  | `#0057d9` | downdraft                      |
+| `-0.5 to < -0.1`  | `#00c9d8` | weak downdraft                 |
+| `-0.1 to < 0.1`   | `#ffffff` | near-neutral motion            |
+| `0.1 to < 0.5`    | `#00d63b` | weak updraft                   |
+| `0.5 to < 1.0`    | `#8fe000` | moderate updraft               |
+| `1.0 to < 2.0`    | `#ffe000` | active updraft                 |
+| `2.0 to < 3.0`    | `#ff9800` | strong updraft                 |
+| `3.0 to < 5.0`    | `#ff3b00` | very strong updraft            |
+| `>= 5.0`          | `#c40000` | exceptional or clipped updraft |
+
+Values below `-1.0 m/s` and at or above `5.0 m/s` use endpoint colors. Clipping
+counts remain in the Lens payload for technical diagnostics; the visible legend
+reports the current slice minimum and maximum instead. The neutral interval is
+exactly `[-0.1, 0.1) m/s`.
+
+## Evidence sources
+
+The read-only calibration inputs were:
+
+- `result-bomex-370-full-20260719`, the preserved Stage 4 BOMEX result;
+- `result-trade-cumulus-5b-full-baseline-20260720T162342Z`, the #377 Baseline;
+- `result-trade-cumulus-5b-full-more_moisture-20260720T162342Z`, the #377 More Moisture Simulation.
+
+The #377 matched-run report supplied the distribution evidence and traceability.
+Figure 5 of [Morrison et al. (2026)](https://doi.org/10.1175/BAMS-D-25-0026.1)
+supplied discrete signed-flow visual logic only. Its stronger congestus velocity
+range and cloud-water boundary were not copied.
+
+## Calibration method
+
+Every saved model-output frame was read without scientific interpolation or
+subsampling. The merged public
+`center_vertical_velocity_to_scalar_grid(...)` method was applied exactly: a
+vertical-face `w` grid with one extra level was centered by the arithmetic mean
+of each adjacent face pair; an already scalar-level grid was used directly.
+Finite statistics used the resulting scalar cells. Cloud-conditioned statistics
+used the unchanged `ql >= 1e-6 kg/kg` mask.
+
+Low clipping is `w < -1.0 m/s`; high clipping is `w >= 5.0 m/s`. Missing and
+non-finite values are excluded from finite and clipping denominators.
+
+## Distribution context from Stage 5B-2
+
+The #377 pair-wide finite count was `111,206,400`, with extrema
+`-6.159492 / 9.343031 m/s`.
+
+Negative-subset quantiles (`m/s`):
+
+| Dataset       |        p1 |        p5 |       p10 |       p25 |       p50 |       p75 |       p90 |       p95 |       p99 |
+| ------------- | --------: | --------: | --------: | --------: | --------: | --------: | --------: | --------: | --------: |
+| Baseline      | -0.662683 | -0.394454 | -0.296529 | -0.169646 | -0.072893 | -0.021260 | -0.004710 | -0.001585 | -0.000151 |
+| More Moisture | -0.786535 | -0.466533 | -0.353980 | -0.208470 | -0.093865 | -0.028284 | -0.006086 | -0.001980 | -0.000170 |
+| Pair          | -0.729601 | -0.432517 | -0.326226 | -0.188851 | -0.082705 | -0.024392 | -0.005320 | -0.001760 | -0.000160 |
+
+Positive-subset quantiles (`m/s`):
+
+| Dataset       |       p1 |       p5 |      p10 |      p25 |      p50 |      p75 |      p90 |      p95 |      p99 |
+| ------------- | -------: | -------: | -------: | -------: | -------: | -------: | -------: | -------: | -------: |
+| Baseline      | 0.000140 | 0.001356 | 0.003995 | 0.018010 | 0.064116 | 0.159325 | 0.323232 | 0.505377 | 1.051013 |
+| More Moisture | 0.000155 | 0.001641 | 0.005014 | 0.023763 | 0.083693 | 0.200694 | 0.394275 | 0.596454 | 1.216397 |
+| Pair          | 0.000147 | 0.001485 | 0.004450 | 0.020558 | 0.073159 | 0.179692 | 0.360132 | 0.553657 | 1.133881 |
+
+Positive-`w` cloudy-cell quantiles (`m/s`):
+
+| Dataset       |      p25 |      p50 |      p75 |      p90 |      p95 |      p99 |
+| ------------- | -------: | -------: | -------: | -------: | -------: | -------: |
+| Baseline      | 0.347638 | 0.715970 | 1.342463 | 2.223742 | 2.924758 | 4.492927 |
+| More Moisture | 0.410502 | 0.829783 | 1.516918 | 2.481667 | 3.241838 | 4.826632 |
+| Pair          | 0.381276 | 0.778887 | 1.441908 | 2.373120 | 3.111509 | 4.699079 |
+
+The selected round categories suppress weak background motion around zero while
+separating weak, active, strong, very strong, and exceptional Trade Cumulus
+updrafts. They were not copied from the stronger congestus reference.
+
+## Clipping results
+
+All finite-cell measurements:
+
+| Dataset            | Frames | Finite cells |      Min / max (m/s) |      Low count (%) |   High count (%) | Max-frame low / high (%) |
+| ------------------ | -----: | -----------: | -------------------: | -----------------: | ---------------: | -----------------------: |
+| Stage 4            |     73 |   22,425,600 | -5.225891 / 8.258350 |  32,979 (0.147060) |   899 (0.004009) |      0.574219 / 0.035156 |
+| #377 Baseline      |    181 |   55,603,200 | -5.438223 / 9.082246 |  80,258 (0.144341) | 2,343 (0.004214) |      0.574219 / 0.045898 |
+| #377 More Moisture |    181 |   55,603,200 | -6.159492 / 9.343031 | 138,533 (0.249146) | 4,217 (0.007584) |      0.814453 / 0.069987 |
+| #377 pair          |    362 |  111,206,400 | -6.159492 / 9.343031 | 218,791 (0.196743) | 6,560 (0.005899) |      0.814453 / 0.069987 |
+
+Cloud-conditioned finite-cell measurements using `ql >= 1e-6 kg/kg`:
+
+| Dataset            | Cloudy finite cells |    Low count (%) |   High count (%) | Max-frame low / high (%) |
+| ------------------ | ------------------: | ---------------: | ---------------: | -----------------------: |
+| Stage 4            |             172,011 | 1,087 (0.631936) |   899 (0.522641) |      5.268390 / 3.292683 |
+| #377 Baseline      |             427,626 | 2,643 (0.618063) | 2,343 (0.547909) |      5.268390 / 4.728370 |
+| #377 More Moisture |             561,978 | 4,120 (0.733125) | 4,217 (0.750385) |      4.653313 / 4.599914 |
+| #377 pair          |             989,604 | 6,763 (0.683405) | 6,560 (0.662891) |      5.268390 / 4.728370 |
+
+## Interval occupancy
+
+Each cell gives count and percent of all finite scalar-centered `w` cells.
+
+| Interval (m/s)   |                 Stage 4 |           #377 Baseline |      #377 More Moisture |               #377 pair |
+| ---------------- | ----------------------: | ----------------------: | ----------------------: | ----------------------: |
+| `< -1.0`         |      32,979 (0.147060%) |      80,258 (0.144341%) |     138,533 (0.249146%) |     218,791 (0.196743%) |
+| `-1.0 to < -0.5` |     258,887 (1.154426%) |     645,777 (1.161403%) |   1,059,776 (1.905962%) |   1,705,553 (1.533682%) |
+| `-0.5 to < -0.1` |  4,507,240 (20.098637%) | 11,258,020 (20.247072%) | 12,878,434 (23.161318%) | 24,136,454 (21.704195%) |
+| `-0.1 to < 0.1`  | 13,648,140 (60.859643%) | 33,685,549 (60.582033%) | 29,736,796 (53.480368%) | 63,422,345 (57.031201%) |
+| `0.1 to < 0.5`   |  3,441,252 (15.345195%) |  8,602,994 (15.472120%) | 10,015,809 (18.013008%) | 18,618,803 (16.742564%) |
+| `0.5 to < 1.0`   |     414,452 (1.848120%) |   1,027,287 (1.847532%) |   1,336,424 (2.403502%) |   2,363,711 (2.125517%) |
+| `1.0 to < 2.0`   |     102,878 (0.458752%) |     253,876 (0.456585%) |     355,714 (0.639737%) |     609,590 (0.548161%) |
+| `2.0 to < 3.0`   |      12,571 (0.056056%) |      31,385 (0.056445%) |      49,601 (0.089205%) |      80,986 (0.072825%) |
+| `3.0 to < 5.0`   |       6,302 (0.028102%) |      15,711 (0.028256%) |      27,896 (0.050170%) |      43,607 (0.039213%) |
+| `>= 5.0`         |         899 (0.004009%) |       2,343 (0.004214%) |       4,217 (0.007584%) |       6,560 (0.005899%) |
+
+## Visual-reference boundary
+
+The AMS figure supports a discrete signed-flow palette, visible near-zero class,
+and black cloud boundary as visual logic. It does not numerically govern this
+scale. Its precipitating cumulus congestus has stronger motion and uses a
+different cloud-water boundary definition.
+
+## Limits
+
+This calibration covers one preserved Stage 4 result and one deterministic
+Stage 5B-2 realization per Control state. It does not establish universal
+shallow-cloud statistics, response uncertainty, causation, or suitability for
+deep convection or another Cloud World. The cloud threshold remains exactly
+`ql >= 1e-6 kg/kg`.
+
+## Verification targets
+
+The fixed scale must remain identical across eligible Trade Cumulus results,
+saved frames, planes, orientations, two-dimensional and three-dimensional
+views, and future synchronized Comparisons. Endpoint clipping telemetry must
+remain available in the payload, missing values must remain distinct from
+neutral motion, and no per-result percentile may control the Lens color scale.
+
+All PM clipping stop thresholds passed: each #377 full-run finite-side fraction
+was below 1%, every saved-frame finite-side fraction was below 5%, each #377
+full-run cloudy-side fraction was below 5%, and every saved-frame cloudy-side
+fraction was below 15%.


### PR DESCRIPTION
## Summary

- Replace result-derived Updraft Lens scaling with the PM-approved, world-owned `trade_cumulus_updraft_velocity_v1` fixed discrete scale.
- Return exact scale metadata and finite-cell clipping telemetry from the backend while removing the obsolete all-frame `w` range scan.
- Use one shared half-open color lookup in the 2-D slice and 3-D plane, with missing values distinct from neutral motion.
- Present a right-side `Vertical velocity (w), m/s` legend in both views: slice maximum above the red updraft classes, slice minimum below the dark downdraft classes, and no visible clipping warning.
- Record the Stage 4 and Stage 5B-2 calibration evidence and update the approved Trade Cumulus product slice.

## Scope

Related issue: Closes #379

Files or systems changed: the bounded Trade Cumulus Updraft Lens backend models and response generation; shared 2-D/3-D Lens rendering; focused frontend, backend, and mocked-browser tests; the approved product slice; and one calibration evidence document.

Explicitly out of scope: CM1 execution, Cloud World or Recipe graduation, cloud threshold changes, default time or plane selection, horizontal-wind defaults, Standard Explore, Control semantics, Comparison implementation, and any scale for another Cloud World.

## Product and science impact

This changes user-facing scientific rendering and language exactly as approved in the issue #379 activation prompt and subsequent PM live-review comments. The scale is fixed for Trade Cumulus, uses the approved ten colors and nine half-open breakpoints, and remains stable across results, frames, planes, orientations, and both viewers.

Clipping counts remain additive technical payload fields. The visible legends instead report the current slice minimum and maximum, per PM direction.

This PR does not establish a universal vertical-velocity scale, validate a recipe, change scientific interpretation outside the approved scale, or graduate the candidate Trade Cumulus slice.

## Verification

Commands and manual checks performed:

```text
BACKEND_PYTHON=app/backend/.venv/bin/python scripts/check.sh
scripts/check-e2e.sh
npx playwright test e2e/mocked-smoke/build-results-explore.spec.ts --project=chromium --grep "Trade Cumulus activates" --timeout=120000
```

- `scripts/check.sh`: 91 frontend tests and 510 backend tests passed, plus lint, build, formatting, mypy, script syntax, artifact guards, and docs checks.
- `scripts/check-e2e.sh`: all 24 mocked Chromium smoke tests passed.
- Live Playwright review covered `result-bomex-370-full-20260719`, `result-trade-cumulus-5b-full-baseline-20260720T162342Z`, and `result-trade-cumulus-5b-full-more_moisture-20260720T162342Z` in all three slice orientations.
- Live interaction covered frame and plane changes, scalar-field changes, perturbation and total wind, playback, cloud-boundary and wind toggles, desktop layout, 390 px layout, and clean browser console output.
- Desktop and mobile screenshot pixel checks confirmed the Three.js scene was nonblank and materially rendered.
- No CM1 run occurred for this issue.

The calibration stop thresholds all passed. For the matched Stage 5B-2 pair, finite-cell clipping was 0.196743% low and 0.005899% high; cloudy-cell clipping was 0.683405% low and 0.662891% high.

## Risks and review focus

Review the exact breakpoint boundary behavior, fixed metadata values, consistent 2-D/3-D color lookup, red-to-downdraft legend order, slice min/max placement, and the claim boundaries in the calibration document.

## Artifact check

- [x] No CM1 source or binaries were committed.
- [x] No NetCDF output, generated run directories, runtime data, or sounding caches were committed.
- [x] No machine-private paths, settings, logs, screenshots, videos, traces, or large generated artifacts were committed unless explicitly approved.

## Merge posture

- [x] Manual review required.
- [x] Auto-merge is not enabled.
