### PR TITLE
Stage 5B-4: implement the curated Trade Cumulus comparison story

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -85,6 +85,11 @@ from cloud_chamber.sounding_candidates import (
     screen_cached_soundings,
     update_saved_candidate,
 )
+from cloud_chamber.trade_cumulus_comparison_story import (
+    TradeCumulusComparisonStoryConflict,
+    TradeCumulusComparisonStoryNotFound,
+    trade_cumulus_moisture_comparison_story,
+)
 from cloud_chamber.trade_cumulus_updraft_lens import (
     LensOrientation,
     TradeCumulusUpdraftLensError,
@@ -568,6 +573,17 @@ def list_results() -> dict[str, object]:
     return {
         "results": [card.model_dump(mode="json") for card in list_result_cards(load_settings())]
     }
+
+
+@app.get("/api/comparisons/trade-cumulus-moisture-v1")
+def get_trade_cumulus_moisture_comparison_story() -> dict[str, object]:
+    try:
+        story = trade_cumulus_moisture_comparison_story(load_settings())
+    except TradeCumulusComparisonStoryNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except TradeCumulusComparisonStoryConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return story.model_dump(mode="json")
 
 
 @app.get("/api/results/{result_id}")

--- a/app/backend/cloud_chamber/trade_cumulus_comparison_story.py
+++ b/app/backend/cloud_chamber/trade_cumulus_comparison_story.py
@@ -46,6 +46,11 @@ MORE_MOISTURE_RUN_ID = "trade-cumulus-5b-full-more_moisture-20260720T162342Z"
 EXPECTED_FIXED_ASSUMPTIONS_SHA256 = (
     "71d746b110fb1310ebb6dafbef4cfa4bd44c379fc6964ed1787deaf45e422535"
 )
+EXPECTED_IMPLEMENTATION_COMMIT = "49da1defc9914d3cc903ed9589c1312ddd843726"
+EXPECTED_CM1_SOURCE_MANIFEST_SHA256 = (
+    "fbe2367dfcd6d8c55cac4bd03362d8d49f13f80cebd13b36230c20d71119a84e"
+)
+EXPECTED_CM1_EXECUTABLE_SHA256 = "5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1"
 COMPARISON_EVIDENCE_RELATIVE_PATH = (
     "comparisons/trade-cumulus-moisture-20260720T162342Z/comparison_evidence.json"
 )
@@ -326,6 +331,7 @@ def trade_cumulus_moisture_comparison_story(
         control_state="more_moisture",
         control_value=7.8e-5,
     )
+    _validate_shared_cm1_provenance(baseline_metadata, more_metadata)
     baseline_view = _validated_curated_view(settings, BASELINE_VIEW)
     more_view = _validated_curated_view(settings, MORE_MOISTURE_VIEW)
     metrics = {key: _validated_metric(evidence, spec) for key, spec in _METRIC_SPECS.items()}
@@ -511,14 +517,18 @@ def _load_and_validate_evidence(settings: CloudChamberSettings) -> TradeCumulusP
 
     _require_equal(evidence.evidence_version, COMPARISON_EVIDENCE_VERSION, "evidence version")
     _require_equal(evidence.evidence_state, "matched_runs_valid", "evidence state")
-    if not evidence.implementation_commit.strip():
-        _conflict("implementation commit")
+    _require_equal(
+        evidence.implementation_commit,
+        EXPECTED_IMPLEMENTATION_COMMIT,
+        "implementation commit",
+    )
     _validate_evidence_member(
         evidence.baseline,
         result_id=BASELINE_RESULT_ID,
         run_id=BASELINE_RUN_ID,
         control_state="baseline",
         control_value=5.2e-5,
+        implementation_commit=evidence.implementation_commit,
     )
     _validate_evidence_member(
         evidence.more_moisture,
@@ -526,6 +536,7 @@ def _load_and_validate_evidence(settings: CloudChamberSettings) -> TradeCumulusP
         run_id=MORE_MOISTURE_RUN_ID,
         control_state="more_moisture",
         control_value=7.8e-5,
+        implementation_commit=evidence.implementation_commit,
     )
     if not evidence.stage4_consistency.passed:
         _conflict("Stage 4 consistency")
@@ -544,6 +555,7 @@ def _validate_evidence_member(
     run_id: str,
     control_state: str,
     control_value: float,
+    implementation_commit: str,
 ) -> None:
     expected = {
         "run evidence version": (member.evidence_version, RUN_EVIDENCE_VERSION),
@@ -555,6 +567,8 @@ def _validate_evidence_member(
         "run length": (member.run_length, "full"),
         "run identity": (member.run_id, run_id),
         "result identity": (member.result_id, result_id),
+        "run implementation commit": (member.app_commit, EXPECTED_IMPLEMENTATION_COMMIT),
+        "run/top-level implementation commit": (member.app_commit, implementation_commit),
         "run lifecycle": (member.gate.lifecycle_state, "completed"),
         "run product state": (member.gate.product_state, "completed_cm1_result"),
     }
@@ -626,6 +640,49 @@ def _validate_result_metadata(
         EXPECTED_FIXED_ASSUMPTIONS_SHA256,
         "fixed assumptions hash",
     )
+
+
+def _validate_shared_cm1_provenance(
+    baseline: ResultMetadata,
+    more_moisture: ResultMetadata,
+) -> None:
+    baseline_source, baseline_executable = _cm1_provenance_hashes(baseline, "Baseline")
+    more_source, more_executable = _cm1_provenance_hashes(more_moisture, "More Moisture")
+    _require_equal(baseline_source, more_source, "paired CM1 source manifest hash")
+    _require_equal(baseline_executable, more_executable, "paired CM1 executable hash")
+    _require_equal(
+        baseline_source,
+        EXPECTED_CM1_SOURCE_MANIFEST_SHA256,
+        "Baseline CM1 source manifest hash",
+    )
+    _require_equal(
+        more_source,
+        EXPECTED_CM1_SOURCE_MANIFEST_SHA256,
+        "More Moisture CM1 source manifest hash",
+    )
+    _require_equal(
+        baseline_executable,
+        EXPECTED_CM1_EXECUTABLE_SHA256,
+        "Baseline CM1 executable hash",
+    )
+    _require_equal(
+        more_executable,
+        EXPECTED_CM1_EXECUTABLE_SHA256,
+        "More Moisture CM1 executable hash",
+    )
+
+
+def _cm1_provenance_hashes(metadata: ResultMetadata, member_label: str) -> tuple[str, str]:
+    provenance = metadata.run_configuration.get("cm1_provenance")
+    if not isinstance(provenance, dict):
+        _conflict(f"{member_label} CM1 provenance")
+    source_hash = provenance.get("source_manifest_sha256")
+    executable_hash = provenance.get("executable_sha256")
+    if not isinstance(source_hash, str) or not source_hash:
+        _conflict(f"{member_label} CM1 source manifest hash")
+    if not isinstance(executable_hash, str) or not executable_hash:
+        _conflict(f"{member_label} CM1 executable hash")
+    return source_hash, executable_hash
 
 
 def _validated_curated_view(

--- a/app/backend/cloud_chamber/trade_cumulus_comparison_story.py
+++ b/app/backend/cloud_chamber/trade_cumulus_comparison_story.py
@@ -1,0 +1,885 @@
+"""Curated Trade Cumulus moisture-comparison story."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from typing import Literal, NoReturn, cast
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from cloud_chamber.result_ingest import (
+    ResultIngestError,
+    ResultMetadata,
+)
+from cloud_chamber.result_ingest import (
+    get_result_metadata as get_result_metadata,
+)
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.trade_cumulus_moisture_comparison import (
+    PairedScalarMetric,
+    TimedValue,
+    TradeCumulusPairedEvidence,
+    TradeCumulusRunEvidence,
+)
+from cloud_chamber.trade_cumulus_updraft_lens import (
+    CLOUD_THRESHOLD_KG_KG,
+    TRADE_CUMULUS_UPDRAFT_SCALE_BREAKPOINTS_M_S,
+    TRADE_CUMULUS_UPDRAFT_SCALE_COLORS,
+    TRADE_CUMULUS_UPDRAFT_SCALE_ID,
+    TradeCumulusUpdraftLensDefaults,
+    TradeCumulusUpdraftLensError,
+    TradeCumulusUpdraftLensFrame,
+    trade_cumulus_updraft_lens_defaults,
+    trade_cumulus_updraft_lens_frame,
+)
+
+COMPARISON_ID: Literal["trade_cumulus_moisture_v1"] = "trade_cumulus_moisture_v1"
+COMPARISON_GROUP_ID: Literal["trade_cumulus_moisture_v1"] = "trade_cumulus_moisture_v1"
+PRODUCT_SLICE_ID: Literal["trade_cumulus_v1"] = "trade_cumulus_v1"
+CASE_ID: Literal["bomex_trade_cumulus_baseline_v0"] = "bomex_trade_cumulus_baseline_v0"
+BASELINE_RESULT_ID = "result-trade-cumulus-5b-full-baseline-20260720T162342Z"
+MORE_MOISTURE_RESULT_ID = "result-trade-cumulus-5b-full-more_moisture-20260720T162342Z"
+BASELINE_RUN_ID = "trade-cumulus-5b-full-baseline-20260720T162342Z"
+MORE_MOISTURE_RUN_ID = "trade-cumulus-5b-full-more_moisture-20260720T162342Z"
+EXPECTED_FIXED_ASSUMPTIONS_SHA256 = (
+    "71d746b110fb1310ebb6dafbef4cfa4bd44c379fc6964ed1787deaf45e422535"
+)
+COMPARISON_EVIDENCE_RELATIVE_PATH = (
+    "comparisons/trade-cumulus-moisture-20260720T162342Z/comparison_evidence.json"
+)
+COMPARISON_EVIDENCE_VERSION = "trade_cumulus_moisture_comparison_evidence_v1"
+RUN_EVIDENCE_VERSION = "trade_cumulus_moisture_run_evidence_v1"
+FINAL_THREE_HOUR_START_SECONDS = 10_800.0
+
+
+class TradeCumulusComparisonStoryNotFound(RuntimeError):
+    """Raised when an approved comparison artifact is unavailable."""
+
+
+class TradeCumulusComparisonStoryConflict(RuntimeError):
+    """Raised when runtime evidence contradicts the approved comparison."""
+
+
+class CuratedView(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    time_index: int
+    time_seconds: float
+    orientation: Literal["vertical_x"]
+    plane_dimension: Literal["y"]
+    plane_index: int
+    plane_coordinate: float
+    plane_units: Literal["km"]
+    camera_preset: Literal["overview"]
+    cloud_field: Literal["ql"]
+    cloud_threshold_kg_kg: float
+    lens_id: Literal["updraft"]
+    scale_id: Literal["trade_cumulus_updraft_velocity_v1"]
+    wind_mode: Literal["perturbation"]
+    show_wind: Literal[True]
+    show_cloud_boundary: Literal[True]
+    opacity: float
+    point_size: int
+    caption: str
+
+
+class ComparisonMember(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    result_id: str
+    run_id: str
+    display_name: str
+    control_state: Literal["baseline", "more_moisture"]
+    control_label: Literal["Surface moisture supply"]
+    control_value: float
+    control_units: Literal["g/g m/s"]
+    control_display: str
+    curated_view: CuratedView
+
+
+class ChangedCondition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: Literal["Surface moisture supply"]
+    baseline_display: str
+    more_moisture_display: str
+    change_display: Literal["+50%"]
+
+
+class MaterialResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    metric_id: str
+    label: str
+    baseline_value: float
+    more_moisture_value: float
+    absolute_delta: float
+    percent_delta: float
+    units: str
+    method: str
+    window: str
+    baseline_display: str
+    more_moisture_display: str
+    change_display: str
+
+
+class AuthoredResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    body: str
+
+
+class HeldFixedGroup(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    body: str
+
+
+class HeldFixedByDesign(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lead: Literal["Only surface moisture supply changed."]
+    groups: list[HeldFixedGroup]
+
+
+class EvidenceSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    analysis_window: Literal["time >= 10800 s"]
+    analysis_start_seconds: float
+    analysis_end_seconds: float
+    output_cadence_seconds: int
+    paired_saved_frame_count: int
+
+
+class ComparisonProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evidence_state: Literal["matched_runs_valid"]
+    evidence_version: str
+    implementation_commit: str
+    fixed_assumptions_sha256: str
+    baseline_run_id: str
+    baseline_result_id: str
+    more_moisture_run_id: str
+    more_moisture_result_id: str
+    scale_id: Literal["trade_cumulus_updraft_velocity_v1"]
+    comparison_source: Literal["runtime_matched_pair_evidence"]
+
+
+class TradeCumulusComparisonStory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    comparison_id: Literal["trade_cumulus_moisture_v1"]
+    comparison_group_id: Literal["trade_cumulus_moisture_v1"]
+    product_slice_id: Literal["trade_cumulus_v1"]
+    case_id: Literal["bomex_trade_cumulus_baseline_v0"]
+    title: str
+    question: str
+    illustrative_view_note: str
+    baseline: ComparisonMember
+    more_moisture: ComparisonMember
+    changed_condition: ChangedCondition
+    material_responses: list[MaterialResponse]
+    small_or_mixed_responses: list[AuthoredResponse]
+    held_fixed_by_design: HeldFixedByDesign
+    explanation_paragraphs: list[str]
+    evidence_summary: EvidenceSummary
+    provenance: ComparisonProvenance
+    caveats: list[str]
+
+
+@dataclass(frozen=True)
+class _CuratedViewSpec:
+    result_id: str
+    time_index: int
+    time_seconds: float
+    plane_index: int
+    plane_coordinate: float
+    caption: str
+
+
+@dataclass(frozen=True)
+class _MetricSpec:
+    key: str
+    units: str
+    method: str
+    window: str
+    baseline: float
+    more_moisture: float
+    absolute_delta: float
+    percent_delta: float
+
+
+BASELINE_VIEW = _CuratedViewSpec(
+    result_id=BASELINE_RESULT_ID,
+    time_index=152,
+    time_seconds=18_240.0,
+    plane_index=5,
+    plane_coordinate=-2.6500000953674316,
+    caption=(
+        "This illustrative Baseline view shows one concentrated active cloud reaching about "
+        "2 km, with a strong rising core bordered by sinking air."
+    ),
+)
+MORE_MOISTURE_VIEW = _CuratedViewSpec(
+    result_id=MORE_MOISTURE_RESULT_ID,
+    time_index=169,
+    time_seconds=20_280.0,
+    plane_index=51,
+    plane_coordinate=1.9500000476837158,
+    caption=(
+        "This illustrative More Moisture view shows several active clouds across the slice, "
+        "with rising cores distributed through a broader cloud-filled region reaching just "
+        "above 2 km."
+    ),
+)
+
+_METRIC_SPECS = {
+    "mean_total_cloud_cover_final_three_hours": _MetricSpec(
+        key="mean_total_cloud_cover_final_three_hours",
+        units="%",
+        method="time mean of horizontal columns containing ql >= 1e-6 kg/kg",
+        window="time >= 10800 s",
+        baseline=10.596239697802197,
+        more_moisture=12.710873111263735,
+        absolute_delta=2.1146334134615383,
+        percent_delta=19.956451286206196,
+    ),
+    "domain_mean_cwp_final_three_hour_mean": _MetricSpec(
+        key="domain_mean_cwp_final_three_hour_mean",
+        units="kg/m^2",
+        method="time mean of horizontal domain-mean cwp",
+        window="time >= 10800 s",
+        baseline=0.006351999299305916,
+        more_moisture=0.009071426778155891,
+        absolute_delta=0.0027194274788499753,
+        percent_delta=42.81215017053178,
+    ),
+    "coherent_cloud_top_final_three_hour_mean": _MetricSpec(
+        key="coherent_cloud_top_final_three_hour_mean",
+        units="m",
+        method="mean supported coherent cloud-object top",
+        window="time >= 10800 s",
+        baseline=1668.3517340775375,
+        more_moisture=1805.0550379595913,
+        absolute_delta=136.7033038820539,
+        percent_delta=8.193913854600911,
+    ),
+    "first_isolated_cloud_liquid_time": _MetricSpec(
+        key="first_isolated_cloud_liquid_time",
+        units="s",
+        method="first model frame with any finite ql >= 1e-6 kg/kg",
+        window="full run",
+        baseline=1080.0,
+        more_moisture=1080.0,
+        absolute_delta=0.0,
+        percent_delta=0.0,
+    ),
+    "time_mean_cloud_fraction_profile_peak_height": _MetricSpec(
+        key="time_mean_cloud_fraction_profile_peak_height",
+        units="m",
+        method="height of first maximum in final-three-hour time-mean cloud-fraction profile",
+        window="time >= 10800 s",
+        baseline=620.0000047683716,
+        more_moisture=620.0000047683716,
+        absolute_delta=0.0,
+        percent_delta=0.0,
+    ),
+    "cloudy_scalar_cells_with_positive_centered_w": _MetricSpec(
+        key="cloudy_scalar_cells_with_positive_centered_w",
+        units="%",
+        method="pooled fraction of cloudy scalar cells with centered w > 0",
+        window="time >= 10800 s",
+        baseline=90.3791231845806,
+        more_moisture=90.45123498042852,
+        absolute_delta=0.07211179584791694,
+        percent_delta=0.0797881117972826,
+    ),
+}
+
+
+def trade_cumulus_moisture_comparison_story(
+    settings: CloudChamberSettings,
+) -> TradeCumulusComparisonStory:
+    """Return the one approved, evidence-backed Trade Cumulus comparison story."""
+    evidence = _load_and_validate_evidence(settings)
+    baseline_metadata = _load_result(settings, BASELINE_RESULT_ID)
+    more_metadata = _load_result(settings, MORE_MOISTURE_RESULT_ID)
+    _validate_result_metadata(
+        baseline_metadata,
+        evidence.baseline,
+        result_id=BASELINE_RESULT_ID,
+        run_id=BASELINE_RUN_ID,
+        control_state="baseline",
+        control_value=5.2e-5,
+    )
+    _validate_result_metadata(
+        more_metadata,
+        evidence.more_moisture,
+        result_id=MORE_MOISTURE_RESULT_ID,
+        run_id=MORE_MOISTURE_RUN_ID,
+        control_state="more_moisture",
+        control_value=7.8e-5,
+    )
+    baseline_view = _validated_curated_view(settings, BASELINE_VIEW)
+    more_view = _validated_curated_view(settings, MORE_MOISTURE_VIEW)
+    metrics = {key: _validated_metric(evidence, spec) for key, spec in _METRIC_SPECS.items()}
+    paired_frame_count = _validate_mixed_time_series(evidence)
+
+    return TradeCumulusComparisonStory(
+        comparison_id=COMPARISON_ID,
+        comparison_group_id=COMPARISON_GROUP_ID,
+        product_slice_id=PRODUCT_SLICE_ID,
+        case_id=CASE_ID,
+        title="Trade Cumulus: Baseline and More Moisture",
+        question="How does stronger surface moisture supply change the trade-cumulus field?",
+        illustrative_view_note=(
+            "Illustrative views: selected to help show the response measured across the full "
+            "simulations. Times and locations may differ, and these are not corresponding "
+            "individual clouds."
+        ),
+        baseline=_member(
+            evidence.baseline,
+            baseline_view,
+            display_name="Canonical BOMEX Baseline",
+            control_display="5.2 × 10⁻⁵ g/g m/s",
+        ),
+        more_moisture=_member(
+            evidence.more_moisture,
+            more_view,
+            display_name="More Moisture",
+            control_display="7.8 × 10⁻⁵ g/g m/s",
+        ),
+        changed_condition=ChangedCondition(
+            label="Surface moisture supply",
+            baseline_display="5.2 × 10⁻⁵ g/g m/s",
+            more_moisture_display="7.8 × 10⁻⁵ g/g m/s",
+            change_display="+50%",
+        ),
+        material_responses=[
+            _material_response(
+                metrics["mean_total_cloud_cover_final_three_hours"],
+                metric_id="mean_cloud_cover_final_three_hours",
+                label="Mean cloud cover, final three hours",
+                baseline_display="10.596%",
+                more_display="12.711%",
+                change_display="+2.115 percentage points",
+            ),
+            _material_response(
+                metrics["domain_mean_cwp_final_three_hour_mean"],
+                metric_id="mean_cloud_water_path_final_three_hours",
+                label="Mean cloud-water path, final three hours",
+                baseline_display="0.006352 kg/m²",
+                more_display="0.009071 kg/m²",
+                change_display="+42.812%",
+            ),
+            _material_response(
+                metrics["coherent_cloud_top_final_three_hour_mean"],
+                metric_id="mean_coherent_cloud_top_final_three_hours",
+                label="Mean coherent cloud top, final three hours",
+                baseline_display="1,668 m",
+                more_display="1,805 m",
+                change_display="+137 m",
+            ),
+        ],
+        small_or_mixed_responses=[
+            AuthoredResponse(
+                title="Initial cloud-liquid onset was unchanged.",
+                body="Both simulations first reached the cloud-liquid threshold at 1,080 s.",
+            ),
+            AuthoredResponse(
+                title="The cloud-fraction peak stayed at the same height.",
+                body="Both final-three-hour profiles peaked near 620 m.",
+            ),
+            AuthoredResponse(
+                title="The fraction of cloudy air rising changed very little.",
+                body="It was 90.379% in Baseline and 90.451% in More Moisture.",
+            ),
+            AuthoredResponse(
+                title="The response varied through time.",
+                body=(
+                    "More Moisture was not cloudier or wetter than Baseline at every individual "
+                    "saved frame."
+                ),
+            ),
+        ],
+        held_fixed_by_design=HeldFixedByDesign(
+            lead="Only surface moisture supply changed.",
+            groups=[
+                HeldFixedGroup(
+                    title="Initial atmosphere",
+                    body=(
+                        "Thermodynamic, moisture, and wind profiles, including the deterministic "
+                        "perturbation."
+                    ),
+                ),
+                HeldFixedGroup(
+                    title="Forcing",
+                    body=(
+                        "Sensible heat supply, friction velocity, large-scale forcing, "
+                        "geostrophic wind, and Coriolis treatment."
+                    ),
+                ),
+                HeldFixedGroup(
+                    title="Model setup",
+                    body=(
+                        "Moist physics, turbulence, boundaries, domain, grid, and timestep "
+                        "strategy."
+                    ),
+                ),
+                HeldFixedGroup(
+                    title="Execution and outputs",
+                    body=(
+                        "Duration, output cadence, requested fields, CM1 source and executable, "
+                        "and the Cloud Chamber implementation commit."
+                    ),
+                ),
+            ],
+        ),
+        explanation_paragraphs=[
+            (
+                "More surface moisture produced a cloudier, wetter, somewhat deeper "
+                "trade-cumulus field."
+            ),
+            (
+                "Only the lower-boundary moisture supply changed. Over the final three hours, "
+                "More Moisture covered more of the domain with cloud, held about 43 percent more "
+                "mean cloud-water path, and produced coherent clouds averaging 137 meters taller."
+            ),
+            (
+                "It did not create a completely different circulation regime. Initial "
+                "cloud-liquid onset and the height of the cloud-fraction maximum were unchanged, "
+                "and about 90 percent of cloudy cells were rising in both simulations."
+            ),
+            (
+                "The illustrative Lens views are selected to help show the measured response. "
+                "They show different times and locations and are not one-to-one matches of "
+                "individual clouds. More Moisture was also not cloudier at every saved frame, so "
+                "the result is a change in the evolving cloud field rather than a rule that every "
+                "moment must look larger."
+            ),
+        ],
+        evidence_summary=EvidenceSummary(
+            analysis_window="time >= 10800 s",
+            analysis_start_seconds=FINAL_THREE_HOUR_START_SECONDS,
+            analysis_end_seconds=float(evidence.baseline.duration_seconds),
+            output_cadence_seconds=evidence.baseline.output_cadence_seconds,
+            paired_saved_frame_count=paired_frame_count,
+        ),
+        provenance=ComparisonProvenance(
+            evidence_state="matched_runs_valid",
+            evidence_version=evidence.evidence_version,
+            implementation_commit=evidence.implementation_commit,
+            fixed_assumptions_sha256=EXPECTED_FIXED_ASSUMPTIONS_SHA256,
+            baseline_run_id=evidence.baseline.run_id,
+            baseline_result_id=evidence.baseline.result_id,
+            more_moisture_run_id=evidence.more_moisture.run_id,
+            more_moisture_result_id=evidence.more_moisture.result_id,
+            scale_id=cast(
+                Literal["trade_cumulus_updraft_velocity_v1"],
+                TRADE_CUMULUS_UPDRAFT_SCALE_ID,
+            ),
+            comparison_source="runtime_matched_pair_evidence",
+        ),
+        caveats=[
+            "one_deterministic_les_realization_per_control_state",
+            "illustrative_views_are_not_direct_frame_matches",
+            "individual_clouds_are_not_paired_one_to_one",
+            "candidate_product_slice_not_supported_status",
+        ],
+    )
+
+
+def _load_and_validate_evidence(settings: CloudChamberSettings) -> TradeCumulusPairedEvidence:
+    path = settings.runtime_home.expanduser() / COMPARISON_EVIDENCE_RELATIVE_PATH
+    if not path.is_file():
+        raise TradeCumulusComparisonStoryNotFound("Comparison evidence is unavailable.")
+    try:
+        payload = json.loads(path.read_text())
+        evidence = TradeCumulusPairedEvidence.model_validate(payload)
+    except OSError as exc:
+        raise TradeCumulusComparisonStoryNotFound("Comparison evidence is unavailable.") from exc
+    except (json.JSONDecodeError, ValidationError, ValueError, TypeError) as exc:
+        raise TradeCumulusComparisonStoryConflict(
+            "Comparison evidence does not match the required schema."
+        ) from exc
+
+    _require_equal(evidence.evidence_version, COMPARISON_EVIDENCE_VERSION, "evidence version")
+    _require_equal(evidence.evidence_state, "matched_runs_valid", "evidence state")
+    if not evidence.implementation_commit.strip():
+        _conflict("implementation commit")
+    _validate_evidence_member(
+        evidence.baseline,
+        result_id=BASELINE_RESULT_ID,
+        run_id=BASELINE_RUN_ID,
+        control_state="baseline",
+        control_value=5.2e-5,
+    )
+    _validate_evidence_member(
+        evidence.more_moisture,
+        result_id=MORE_MOISTURE_RESULT_ID,
+        run_id=MORE_MOISTURE_RUN_ID,
+        control_state="more_moisture",
+        control_value=7.8e-5,
+    )
+    if not evidence.stage4_consistency.passed:
+        _conflict("Stage 4 consistency")
+    _require_equal(
+        evidence.stage4_consistency.new_baseline_result_id,
+        BASELINE_RESULT_ID,
+        "Stage 4 baseline identity",
+    )
+    return evidence
+
+
+def _validate_evidence_member(
+    member: TradeCumulusRunEvidence,
+    *,
+    result_id: str,
+    run_id: str,
+    control_state: str,
+    control_value: float,
+) -> None:
+    expected = {
+        "run evidence version": (member.evidence_version, RUN_EVIDENCE_VERSION),
+        "product slice": (member.product_slice_id, PRODUCT_SLICE_ID),
+        "comparison group": (member.comparison_group_id, COMPARISON_GROUP_ID),
+        "case identity": (member.case_id, CASE_ID),
+        "control identity": (member.control_id, "surface_moisture_supply"),
+        "control state": (member.control_state, control_state),
+        "run length": (member.run_length, "full"),
+        "run identity": (member.run_id, run_id),
+        "result identity": (member.result_id, result_id),
+        "run lifecycle": (member.gate.lifecycle_state, "completed"),
+        "run product state": (member.gate.product_state, "completed_cm1_result"),
+    }
+    for label, (actual, wanted) in expected.items():
+        _require_equal(actual, wanted, label)
+    _require_exact_float(member.surface_moisture_flux_g_g_m_s, control_value, "surface moisture")
+    _require_exact_float(
+        member.gate.intended_surface_moisture_flux_g_g_m_s,
+        control_value,
+        "gated surface moisture",
+    )
+    if not member.gate.valid or member.gate.failures:
+        _conflict("run gate")
+
+
+def _load_result(settings: CloudChamberSettings, result_id: str) -> ResultMetadata:
+    try:
+        return get_result_metadata(settings, result_id)
+    except (ResultIngestError, OSError) as exc:
+        raise TradeCumulusComparisonStoryNotFound(
+            "An approved comparison result is unavailable."
+        ) from exc
+
+
+def _validate_result_metadata(
+    metadata: ResultMetadata,
+    evidence: TradeCumulusRunEvidence,
+    *,
+    result_id: str,
+    run_id: str,
+    control_state: str,
+    control_value: float,
+) -> None:
+    controls = metadata.controls
+    configuration = metadata.run_configuration
+    expected = {
+        "persisted result identity": (metadata.result_id, result_id),
+        "persisted run identity": (metadata.run_id, run_id),
+        "persisted scenario identity": (metadata.scenario_id, CASE_ID),
+        "persisted lifecycle": (metadata.source_lifecycle_state, "completed"),
+        "persisted product state": (metadata.source_product_state, "completed_cm1_result"),
+        "persisted case identity": (configuration.get("case_id"), CASE_ID),
+        "persisted product slice": (configuration.get("product_slice_id"), PRODUCT_SLICE_ID),
+        "persisted comparison group": (
+            configuration.get("comparison_group_id"),
+            COMPARISON_GROUP_ID,
+        ),
+        "persisted control identity": (controls.get("control_id"), "surface_moisture_supply"),
+        "persisted control state": (controls.get("control_state"), control_state),
+        "configured control identity": (
+            configuration.get("control_id"),
+            "surface_moisture_supply",
+        ),
+        "configured control state": (configuration.get("control_state"), control_state),
+        "result/evidence run identity": (metadata.run_id, evidence.run_id),
+    }
+    for label, (actual, wanted) in expected.items():
+        _require_equal(actual, wanted, label)
+    _require_exact_float(
+        controls.get("surface_moisture_flux_g_g_m_s"), control_value, "control value"
+    )
+    _require_exact_float(
+        configuration.get("surface_moisture_flux_g_g_m_s"),
+        control_value,
+        "configured control value",
+    )
+    _require_equal(
+        configuration.get("fixed_assumptions_sha256"),
+        EXPECTED_FIXED_ASSUMPTIONS_SHA256,
+        "fixed assumptions hash",
+    )
+
+
+def _validated_curated_view(
+    settings: CloudChamberSettings,
+    spec: _CuratedViewSpec,
+) -> CuratedView:
+    try:
+        defaults = trade_cumulus_updraft_lens_defaults(settings, spec.result_id)
+        _validate_scale(defaults)
+        frame = trade_cumulus_updraft_lens_frame(
+            settings,
+            spec.result_id,
+            time_index=spec.time_index,
+            orientation="vertical_x",
+            plane_index=spec.plane_index,
+            wind_mode="perturbation",
+        )
+    except (ResultIngestError, OSError) as exc:
+        raise TradeCumulusComparisonStoryNotFound(
+            "A curated comparison view artifact is unavailable."
+        ) from exc
+    except TradeCumulusUpdraftLensError as exc:
+        message = str(exc).lower()
+        if "unavailable" in message or "no readable" in message or "no netcdf" in message:
+            raise TradeCumulusComparisonStoryNotFound(
+                "A curated comparison view artifact is unavailable."
+            ) from exc
+        raise TradeCumulusComparisonStoryConflict(
+            "A curated comparison view could not be reproduced."
+        ) from exc
+    _validate_frame(frame, spec)
+    return CuratedView(
+        time_index=spec.time_index,
+        time_seconds=spec.time_seconds,
+        orientation="vertical_x",
+        plane_dimension="y",
+        plane_index=spec.plane_index,
+        plane_coordinate=spec.plane_coordinate,
+        plane_units="km",
+        camera_preset="overview",
+        cloud_field="ql",
+        cloud_threshold_kg_kg=CLOUD_THRESHOLD_KG_KG,
+        lens_id="updraft",
+        scale_id=cast(
+            Literal["trade_cumulus_updraft_velocity_v1"],
+            TRADE_CUMULUS_UPDRAFT_SCALE_ID,
+        ),
+        wind_mode="perturbation",
+        show_wind=True,
+        show_cloud_boundary=True,
+        opacity=0.68,
+        point_size=11,
+        caption=spec.caption,
+    )
+
+
+def _validate_scale(
+    scale: TradeCumulusUpdraftLensDefaults | TradeCumulusUpdraftLensFrame,
+) -> None:
+    _require_equal(scale.w_scale_id, TRADE_CUMULUS_UPDRAFT_SCALE_ID, "updraft scale")
+    _require_equal(
+        scale.w_scale_breakpoints_m_s,
+        list(TRADE_CUMULUS_UPDRAFT_SCALE_BREAKPOINTS_M_S),
+        "updraft scale breakpoints",
+    )
+    _require_equal(
+        scale.w_scale_colors,
+        list(TRADE_CUMULUS_UPDRAFT_SCALE_COLORS),
+        "updraft scale colors",
+    )
+    _require_exact_float(
+        scale.cloud_threshold_kg_kg,
+        CLOUD_THRESHOLD_KG_KG,
+        "cloud threshold",
+    )
+
+
+def _validate_frame(frame: TradeCumulusUpdraftLensFrame, spec: _CuratedViewSpec) -> None:
+    _validate_scale(frame)
+    expected = {
+        "curated result": (frame.result_id, spec.result_id),
+        "curated time index": (frame.time_index, spec.time_index),
+        "curated orientation": (frame.orientation, "vertical_x"),
+        "curated plane dimension": (frame.plane_dimension, "y"),
+        "curated plane index": (frame.plane_index, spec.plane_index),
+        "curated plane units": (frame.plane_units, "km"),
+        "curated wind mode": (frame.wind_mode, "perturbation"),
+    }
+    for label, (actual, wanted) in expected.items():
+        _require_equal(actual, wanted, label)
+    _require_exact_float(frame.time_seconds, spec.time_seconds, "curated time")
+    _require_close(
+        frame.plane_coordinate,
+        spec.plane_coordinate,
+        "curated plane coordinate",
+        abs_tol=1e-9,
+    )
+    if frame.w_finite_count <= 0:
+        _conflict("curated vertical velocity")
+    if not any(any(row) for row in frame.cloud_mask):
+        _conflict("curated cloud boundary")
+    if not frame.wind_vectors:
+        _conflict("curated wind vectors")
+
+
+def _validated_metric(
+    evidence: TradeCumulusPairedEvidence,
+    spec: _MetricSpec,
+) -> PairedScalarMetric:
+    metric = evidence.scalar_metrics.get(spec.key)
+    if metric is None:
+        _conflict(f"metric {spec.key}")
+    assert metric is not None
+    _require_equal(metric.units, spec.units, f"metric {spec.key} units")
+    _require_equal(metric.method, spec.method, f"metric {spec.key} method")
+    _require_equal(metric.window, spec.window, f"metric {spec.key} window")
+    _require_equal(metric.quality, "trusted", f"metric {spec.key} quality")
+    _require_close(metric.baseline, spec.baseline, f"metric {spec.key} Baseline")
+    _require_close(
+        metric.more_moisture,
+        spec.more_moisture,
+        f"metric {spec.key} More Moisture",
+    )
+    _require_close(metric.absolute_delta, spec.absolute_delta, f"metric {spec.key} delta")
+    _require_close(metric.percent_delta, spec.percent_delta, f"metric {spec.key} percent delta")
+    return metric
+
+
+def _validate_mixed_time_series(evidence: TradeCumulusPairedEvidence) -> int:
+    counts = []
+    for key in ("domain_mean_cwp", "total_cloud_cover_percent"):
+        baseline = evidence.baseline.time_series.get(key)
+        more = evidence.more_moisture.time_series.get(key)
+        paired = evidence.exact_time_pairing.get(key)
+        if baseline is None or more is None or paired is None:
+            _conflict(f"exact-time {key}")
+        assert baseline is not None and more is not None and paired is not None
+        _validate_paired_series(key, baseline, more, paired)
+        counts.append(len(paired))
+    if counts[0] != counts[1]:
+        _conflict("exact-time pairing length")
+    return counts[0]
+
+
+def _validate_paired_series(
+    key: str,
+    baseline: list[TimedValue],
+    more: list[TimedValue],
+    paired: list[TimedValue],
+) -> None:
+    if not baseline or len(baseline) != len(more) or len(baseline) != len(paired):
+        _conflict(f"exact-time {key} length")
+    has_not_greater = False
+    for baseline_value, more_value, paired_value in zip(baseline, more, paired, strict=True):
+        _require_exact_float(
+            more_value.time_seconds,
+            baseline_value.time_seconds,
+            f"exact-time {key} member time",
+        )
+        _require_exact_float(
+            paired_value.time_seconds,
+            baseline_value.time_seconds,
+            f"exact-time {key} paired time",
+        )
+        if baseline_value.value is None or more_value.value is None:
+            if paired_value.value is not None:
+                _conflict(f"exact-time {key} unavailable value")
+            continue
+        expected_delta = more_value.value - baseline_value.value
+        _require_close(paired_value.value, expected_delta, f"exact-time {key} delta")
+        if more_value.value <= baseline_value.value:
+            has_not_greater = True
+    if not has_not_greater:
+        _conflict(f"exact-time {key} mixed response")
+
+
+def _member(
+    evidence: TradeCumulusRunEvidence,
+    view: CuratedView,
+    *,
+    display_name: str,
+    control_display: str,
+) -> ComparisonMember:
+    return ComparisonMember(
+        result_id=evidence.result_id,
+        run_id=evidence.run_id,
+        display_name=display_name,
+        control_state=cast(Literal["baseline", "more_moisture"], evidence.control_state),
+        control_label="Surface moisture supply",
+        control_value=evidence.surface_moisture_flux_g_g_m_s,
+        control_units="g/g m/s",
+        control_display=control_display,
+        curated_view=view,
+    )
+
+
+def _material_response(
+    metric: PairedScalarMetric,
+    *,
+    metric_id: str,
+    label: str,
+    baseline_display: str,
+    more_display: str,
+    change_display: str,
+) -> MaterialResponse:
+    if (
+        metric.baseline is None
+        or metric.more_moisture is None
+        or metric.absolute_delta is None
+        or metric.percent_delta is None
+    ):
+        _conflict(f"material response {metric_id}")
+    return MaterialResponse(
+        metric_id=metric_id,
+        label=label,
+        baseline_value=metric.baseline,
+        more_moisture_value=metric.more_moisture,
+        absolute_delta=metric.absolute_delta,
+        percent_delta=metric.percent_delta,
+        units=metric.units,
+        method=metric.method,
+        window=metric.window,
+        baseline_display=baseline_display,
+        more_moisture_display=more_display,
+        change_display=change_display,
+    )
+
+
+def _require_equal(actual: object, expected: object, label: str) -> None:
+    if actual != expected:
+        _conflict(label)
+
+
+def _require_exact_float(actual: object, expected: float, label: str) -> None:
+    if isinstance(actual, bool) or not isinstance(actual, (int, float)):
+        _conflict(label)
+    if float(actual) != expected:
+        _conflict(label)
+
+
+def _require_close(
+    actual: float | None,
+    expected: float,
+    label: str,
+    *,
+    abs_tol: float = 1e-12,
+) -> None:
+    if actual is None or not math.isfinite(actual):
+        _conflict(label)
+    if not math.isclose(actual, expected, rel_tol=0, abs_tol=abs_tol):
+        _conflict(label)
+
+
+def _conflict(label: str) -> NoReturn:
+    raise TradeCumulusComparisonStoryConflict(
+        f"Comparison evidence conflicts with the approved {label}."
+    )

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -1,6 +1,7 @@
 import json
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import xarray as xr
@@ -28,9 +29,56 @@ from cloud_chamber.run_manifest import (
     load_run_manifest,
     write_run_manifest,
 )
+from cloud_chamber.trade_cumulus_comparison_story import (
+    TradeCumulusComparisonStoryConflict,
+    TradeCumulusComparisonStoryNotFound,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
+
+
+def test_trade_cumulus_comparison_story_api_returns_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    story = SimpleNamespace(
+        model_dump=lambda **_kwargs: {"comparison_id": "trade_cumulus_moisture_v1"}
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.app.trade_cumulus_moisture_comparison_story",
+        lambda _settings: story,
+    )
+
+    response = TestClient(app).get("/api/comparisons/trade-cumulus-moisture-v1")
+
+    assert response.status_code == 200
+    assert response.json() == {"comparison_id": "trade_cumulus_moisture_v1"}
+
+
+@pytest.mark.parametrize(
+    ("error", "status_code"),
+    [
+        (TradeCumulusComparisonStoryNotFound("Comparison unavailable."), 404),
+        (TradeCumulusComparisonStoryConflict("Comparison conflicts."), 409),
+    ],
+)
+def test_trade_cumulus_comparison_story_api_maps_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    error: RuntimeError,
+    status_code: int,
+) -> None:
+    def raise_error(_settings: object) -> object:
+        raise error
+
+    monkeypatch.setattr(
+        "cloud_chamber.app.trade_cumulus_moisture_comparison_story",
+        raise_error,
+    )
+
+    response = TestClient(app).get("/api/comparisons/trade-cumulus-moisture-v1")
+
+    assert response.status_code == status_code
+    assert "/Users/" not in response.text
 
 
 class FakeRunManager:

--- a/app/backend/tests/test_trade_cumulus_comparison_story.py
+++ b/app/backend/tests/test_trade_cumulus_comparison_story.py
@@ -1,0 +1,582 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import cloud_chamber.trade_cumulus_comparison_story as comparison_story
+from cloud_chamber.result_ingest import ResultIngestError, ResultMetadata
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.trade_cumulus_comparison_story import (
+    BASELINE_RESULT_ID,
+    BASELINE_RUN_ID,
+    MORE_MOISTURE_RESULT_ID,
+    MORE_MOISTURE_RUN_ID,
+    TradeCumulusComparisonStoryConflict,
+    TradeCumulusComparisonStoryNotFound,
+    trade_cumulus_moisture_comparison_story,
+)
+from cloud_chamber.trade_cumulus_updraft_lens import (
+    TRADE_CUMULUS_UPDRAFT_SCALE_BREAKPOINTS_M_S,
+    TRADE_CUMULUS_UPDRAFT_SCALE_COLORS,
+    TRADE_CUMULUS_UPDRAFT_SCALE_ID,
+    TradeCumulusUpdraftLensError,
+)
+
+
+def _settings(tmp_path: Path) -> CloudChamberSettings:
+    return CloudChamberSettings(
+        runtime_home=tmp_path,
+        cm1_root=None,
+        cm1_run_dir=None,
+        cache_dir=tmp_path / "cache",
+        log_dir=tmp_path / "logs",
+    )
+
+
+def _gate(control_value: float) -> dict[str, Any]:
+    return {
+        "valid": True,
+        "lifecycle_state": "completed",
+        "product_state": "completed_cm1_result",
+        "exit_code": 0,
+        "normal_completion_reported": True,
+        "runtime_integrity_state": "caveated",
+        "runtime_integrity_reason": "runtime_integrity_caveated_evidence_present",
+        "runtime_integrity_caveats": ["runtime_integrity_caveated_underflow_only"],
+        "model_output_count": 181,
+        "expected_model_output_count": 181,
+        "diagnostic_output_count": 361,
+        "expected_diagnostic_output_count": 361,
+        "missing_required_fields": [],
+        "required_field_non_finite_counts": {"ql": 0, "w": 0, "u": 0, "v": 0},
+        "intended_surface_moisture_flux_g_g_m_s": control_value,
+        "emitted_surface_moisture_flux_min_g_g_m_s": control_value,
+        "emitted_surface_moisture_flux_max_g_g_m_s": control_value,
+        "failures": [],
+    }
+
+
+def _run_evidence(
+    *, result_id: str, run_id: str, control_state: str, control_value: float
+) -> dict[str, Any]:
+    cwp_values = [
+        {"time_seconds": 10_800.0, "value": 0.007},
+        {"time_seconds": 10_920.0, "value": 0.009},
+    ]
+    cover_values = [
+        {"time_seconds": 10_800.0, "value": 10.0},
+        {"time_seconds": 10_920.0, "value": 12.0},
+    ]
+    if control_state == "more_moisture":
+        cwp_values = [
+            {"time_seconds": 10_800.0, "value": 0.008},
+            {"time_seconds": 10_920.0, "value": 0.008},
+        ]
+        cover_values = [
+            {"time_seconds": 10_800.0, "value": 11.0},
+            {"time_seconds": 10_920.0, "value": 11.0},
+        ]
+    return {
+        "evidence_version": "trade_cumulus_moisture_run_evidence_v1",
+        "product_slice_id": "trade_cumulus_v1",
+        "comparison_group_id": "trade_cumulus_moisture_v1",
+        "case_id": "bomex_trade_cumulus_baseline_v0",
+        "recipe_candidate_id": "canonical_bomex_baseline",
+        "control_id": "surface_moisture_supply",
+        "control_state": control_state,
+        "run_length": "full",
+        "run_id": run_id,
+        "result_id": result_id,
+        "app_commit": "49da1defc9914d3cc903ed9589c1312ddd843726",
+        "surface_moisture_flux_g_g_m_s": control_value,
+        "duration_seconds": 21_600,
+        "output_cadence_seconds": 120,
+        "diagnostic_cadence_seconds": 60,
+        "wall_clock_seconds": 1_300.0,
+        "cm1_reported_runtime_seconds": 1_299.0,
+        "output_bytes": 1_000,
+        "gate": _gate(control_value),
+        "scalar_metrics": {},
+        "time_series": {
+            "domain_mean_cwp": cwp_values,
+            "total_cloud_cover_percent": cover_values,
+        },
+        "vertical_profiles": {},
+        "final_domain_mean_profiles": {},
+        "forcing_diagnostics": {},
+        "forcing_and_transport_fields_available": [],
+        "available_fields": ["cwp", "ql", "u", "v", "w"],
+        "caveats": [],
+    }
+
+
+def _metric(
+    units: str,
+    method: str,
+    window: str,
+    baseline: float,
+    more: float,
+    absolute_delta: float,
+    percent_delta: float,
+) -> dict[str, Any]:
+    return {
+        "units": units,
+        "method": method,
+        "window": window,
+        "baseline": baseline,
+        "more_moisture": more,
+        "absolute_delta": absolute_delta,
+        "percent_delta": percent_delta,
+        "percent_delta_unavailable_reason": None,
+        "quality": "trusted",
+        "caveats": [],
+    }
+
+
+def _evidence() -> dict[str, Any]:
+    return {
+        "evidence_version": "trade_cumulus_moisture_comparison_evidence_v1",
+        "evidence_state": "matched_runs_valid",
+        "implementation_commit": "49da1defc9914d3cc903ed9589c1312ddd843726",
+        "baseline": _run_evidence(
+            result_id=BASELINE_RESULT_ID,
+            run_id=BASELINE_RUN_ID,
+            control_state="baseline",
+            control_value=5.2e-5,
+        ),
+        "more_moisture": _run_evidence(
+            result_id=MORE_MOISTURE_RESULT_ID,
+            run_id=MORE_MOISTURE_RUN_ID,
+            control_state="more_moisture",
+            control_value=7.8e-5,
+        ),
+        "scalar_metrics": {
+            "mean_total_cloud_cover_final_three_hours": _metric(
+                "%",
+                "time mean of horizontal columns containing ql >= 1e-6 kg/kg",
+                "time >= 10800 s",
+                10.596239697802197,
+                12.710873111263735,
+                2.1146334134615383,
+                19.956451286206196,
+            ),
+            "domain_mean_cwp_final_three_hour_mean": _metric(
+                "kg/m^2",
+                "time mean of horizontal domain-mean cwp",
+                "time >= 10800 s",
+                0.006351999299305916,
+                0.009071426778155891,
+                0.0027194274788499753,
+                42.81215017053178,
+            ),
+            "coherent_cloud_top_final_three_hour_mean": _metric(
+                "m",
+                "mean supported coherent cloud-object top",
+                "time >= 10800 s",
+                1668.3517340775375,
+                1805.0550379595913,
+                136.7033038820539,
+                8.193913854600911,
+            ),
+            "first_isolated_cloud_liquid_time": _metric(
+                "s",
+                "first model frame with any finite ql >= 1e-6 kg/kg",
+                "full run",
+                1080.0,
+                1080.0,
+                0.0,
+                0.0,
+            ),
+            "time_mean_cloud_fraction_profile_peak_height": _metric(
+                "m",
+                "height of first maximum in final-three-hour time-mean cloud-fraction profile",
+                "time >= 10800 s",
+                620.0000047683716,
+                620.0000047683716,
+                0.0,
+                0.0,
+            ),
+            "cloudy_scalar_cells_with_positive_centered_w": _metric(
+                "%",
+                "pooled fraction of cloudy scalar cells with centered w > 0",
+                "time >= 10800 s",
+                90.3791231845806,
+                90.45123498042852,
+                0.07211179584791694,
+                0.0797881117972826,
+            ),
+        },
+        "exact_time_pairing": {
+            "domain_mean_cwp": [
+                {"time_seconds": 10_800.0, "value": 0.001},
+                {"time_seconds": 10_920.0, "value": -0.001},
+            ],
+            "total_cloud_cover_percent": [
+                {"time_seconds": 10_800.0, "value": 1.0},
+                {"time_seconds": 10_920.0, "value": -1.0},
+            ],
+        },
+        "stage4_consistency": {
+            "preserved_result_id": "result-bomex-370-full-20260719",
+            "new_baseline_result_id": BASELINE_RESULT_ID,
+            "common_times_seconds": [10_800.0],
+            "absolute_tolerance": 1e-10,
+            "relative_tolerance": 1e-6,
+            "field_differences": [],
+            "first_failure": None,
+            "passed": True,
+        },
+        "lens_preparation": {
+            "baseline_result_id": BASELINE_RESULT_ID,
+            "more_moisture_result_id": MORE_MOISTURE_RESULT_ID,
+            "baseline_default_time_index": 152,
+            "baseline_default_time_seconds": 18_240.0,
+            "baseline_default_plane_index": 5,
+            "baseline_default_plane_coordinate": -2.6500000953674316,
+            "baseline_default_plane_units": "km",
+            "inherited_variant_time_index": 152,
+            "inherited_variant_plane_index": 5,
+            "wind_target_level_m": 600.0,
+            "wind_level_index": 14,
+            "wind_actual_level_m": 580.0,
+            "wind_stride": 8,
+            "cloud_threshold_kg_kg": 1e-6,
+            "joint_w_range_min_m_s": -1.0,
+            "joint_w_range_max_m_s": 1.0,
+            "joint_perturbation_wind_reference_m_s": 0.9,
+            "joint_total_wind_reference_m_s": 8.8,
+            "coordinate_compatibility": "exact_scalar_grid_coordinates_match",
+            "field_availability": {
+                BASELINE_RESULT_ID: ["cwp", "ql", "u", "v", "w"],
+                MORE_MOISTURE_RESULT_ID: ["cwp", "ql", "u", "v", "w"],
+            },
+        },
+        "estimated_full_pair_bytes": 2_000,
+        "actual_full_pair_bytes": 2_100,
+        "runtime_local_evidence_path": "/machine/private/comparison_evidence.json",
+        "caveats": [],
+    }
+
+
+def _metadata(
+    result_id: str,
+    run_id: str,
+    control_state: str,
+    control_value: float,
+) -> ResultMetadata:
+    now = datetime(2026, 7, 20, tzinfo=UTC)
+    return ResultMetadata(
+        result_id=result_id,
+        run_id=run_id,
+        scenario_id="bomex_trade_cumulus_baseline_v0",
+        physical_question="How does stronger surface moisture supply change the field?",
+        controls={
+            "control_id": "surface_moisture_supply",
+            "control_state": control_state,
+            "surface_moisture_flux_g_g_m_s": control_value,
+        },
+        run_configuration={
+            "case_id": "bomex_trade_cumulus_baseline_v0",
+            "product_slice_id": "trade_cumulus_v1",
+            "comparison_group_id": "trade_cumulus_moisture_v1",
+            "control_id": "surface_moisture_supply",
+            "control_state": control_state,
+            "surface_moisture_flux_g_g_m_s": control_value,
+            "fixed_assumptions_sha256": (
+                "71d746b110fb1310ebb6dafbef4cfa4bd44c379fc6964ed1787deaf45e422535"
+            ),
+        },
+        source_lifecycle_state="completed",
+        source_product_state="completed_cm1_result",
+        source_model="CM1",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _scale(**updates: Any) -> SimpleNamespace:
+    values = {
+        "w_scale_id": TRADE_CUMULUS_UPDRAFT_SCALE_ID,
+        "w_scale_breakpoints_m_s": list(TRADE_CUMULUS_UPDRAFT_SCALE_BREAKPOINTS_M_S),
+        "w_scale_colors": list(TRADE_CUMULUS_UPDRAFT_SCALE_COLORS),
+        "cloud_threshold_kg_kg": 1e-6,
+    }
+    values.update(updates)
+    return SimpleNamespace(**values)
+
+
+def _frame(result_id: str, **updates: Any) -> SimpleNamespace:
+    if result_id == BASELINE_RESULT_ID:
+        values = {
+            "result_id": result_id,
+            "time_index": 152,
+            "time_seconds": 18_240.0,
+            "plane_index": 5,
+            "plane_coordinate": -2.6500000953674316,
+        }
+    else:
+        values = {
+            "result_id": result_id,
+            "time_index": 169,
+            "time_seconds": 20_280.0,
+            "plane_index": 51,
+            "plane_coordinate": 1.9500000476837158,
+        }
+    values.update(
+        {
+            "orientation": "vertical_x",
+            "plane_dimension": "y",
+            "plane_units": "km",
+            "wind_mode": "perturbation",
+            "w_finite_count": 4,
+            "cloud_mask": [[True, False]],
+            "wind_vectors": [object()],
+        }
+    )
+    values.update(vars(_scale()))
+    values.update(updates)
+    return SimpleNamespace(**values)
+
+
+def _install_valid_dependencies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    evidence: dict[str, Any] | None = None,
+    frame_factory: Callable[[str], SimpleNamespace] = _frame,
+) -> CloudChamberSettings:
+    evidence_path = (
+        tmp_path
+        / "comparisons"
+        / "trade-cumulus-moisture-20260720T162342Z"
+        / "comparison_evidence.json"
+    )
+    evidence_path.parent.mkdir(parents=True)
+    evidence_path.write_text(json.dumps(evidence or _evidence()))
+    metadata = {
+        BASELINE_RESULT_ID: _metadata(BASELINE_RESULT_ID, BASELINE_RUN_ID, "baseline", 5.2e-5),
+        MORE_MOISTURE_RESULT_ID: _metadata(
+            MORE_MOISTURE_RESULT_ID,
+            MORE_MOISTURE_RUN_ID,
+            "more_moisture",
+            7.8e-5,
+        ),
+    }
+    monkeypatch.setattr(
+        comparison_story,
+        "get_result_metadata",
+        lambda _settings, result_id: metadata[result_id],
+    )
+    monkeypatch.setattr(
+        comparison_story,
+        "trade_cumulus_updraft_lens_defaults",
+        lambda _settings, _result_id: _scale(),
+    )
+    monkeypatch.setattr(
+        comparison_story,
+        "trade_cumulus_updraft_lens_frame",
+        lambda _settings, result_id, **_kwargs: frame_factory(result_id),
+    )
+    return _settings(tmp_path)
+
+
+def test_story_returns_exact_authored_payload_and_curated_views(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _install_valid_dependencies(tmp_path, monkeypatch)
+
+    payload = trade_cumulus_moisture_comparison_story(settings).model_dump(mode="json")
+
+    assert payload["title"] == "Trade Cumulus: Baseline and More Moisture"
+    assert payload["question"] == (
+        "How does stronger surface moisture supply change the trade-cumulus field?"
+    )
+    assert payload["illustrative_view_note"].startswith("Illustrative views: selected")
+    assert payload["baseline"]["display_name"] == "Canonical BOMEX Baseline"
+    assert payload["baseline"]["control_display"] == "5.2 × 10⁻⁵ g/g m/s"
+    assert payload["baseline"]["curated_view"] == {
+        "time_index": 152,
+        "time_seconds": 18_240.0,
+        "orientation": "vertical_x",
+        "plane_dimension": "y",
+        "plane_index": 5,
+        "plane_coordinate": -2.6500000953674316,
+        "plane_units": "km",
+        "camera_preset": "overview",
+        "cloud_field": "ql",
+        "cloud_threshold_kg_kg": 1e-6,
+        "lens_id": "updraft",
+        "scale_id": "trade_cumulus_updraft_velocity_v1",
+        "wind_mode": "perturbation",
+        "show_wind": True,
+        "show_cloud_boundary": True,
+        "opacity": 0.68,
+        "point_size": 11,
+        "caption": (
+            "This illustrative Baseline view shows one concentrated active cloud reaching about "
+            "2 km, with a strong rising core bordered by sinking air."
+        ),
+    }
+    assert payload["more_moisture"]["curated_view"]["time_index"] == 169
+    assert payload["more_moisture"]["curated_view"]["plane_index"] == 51
+    assert payload["more_moisture"]["curated_view"]["caption"].startswith(
+        "This illustrative More Moisture view"
+    )
+    assert payload["changed_condition"] == {
+        "label": "Surface moisture supply",
+        "baseline_display": "5.2 × 10⁻⁵ g/g m/s",
+        "more_moisture_display": "7.8 × 10⁻⁵ g/g m/s",
+        "change_display": "+50%",
+    }
+    assert [item["metric_id"] for item in payload["material_responses"]] == [
+        "mean_cloud_cover_final_three_hours",
+        "mean_cloud_water_path_final_three_hours",
+        "mean_coherent_cloud_top_final_three_hours",
+    ]
+    assert [item["change_display"] for item in payload["material_responses"]] == [
+        "+2.115 percentage points",
+        "+42.812%",
+        "+137 m",
+    ]
+    assert len(payload["small_or_mixed_responses"]) == 4
+    assert payload["small_or_mixed_responses"][3]["body"].endswith("saved frame.")
+    assert payload["held_fixed_by_design"]["lead"] == "Only surface moisture supply changed."
+    assert [group["title"] for group in payload["held_fixed_by_design"]["groups"]] == [
+        "Initial atmosphere",
+        "Forcing",
+        "Model setup",
+        "Execution and outputs",
+    ]
+    assert len(payload["explanation_paragraphs"]) == 4
+    assert payload["provenance"]["comparison_source"] == "runtime_matched_pair_evidence"
+    assert payload["caveats"] == [
+        "one_deterministic_les_realization_per_control_state",
+        "illustrative_views_are_not_direct_frame_matches",
+        "individual_clouds_are_not_paired_one_to_one",
+        "candidate_product_slice_not_supported_status",
+    ]
+    serialized = json.dumps(payload)
+    assert "/machine/private" not in serialized
+    assert "/Users/" not in serialized
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda payload: payload.update(evidence_state="baseline_invalid"),
+        lambda payload: payload["baseline"].update(result_id="wrong-result"),
+        lambda payload: payload["more_moisture"].update(surface_moisture_flux_g_g_m_s=7.9e-5),
+        lambda payload: payload["baseline"]["gate"].update(valid=False),
+        lambda payload: payload["stage4_consistency"].update(passed=False),
+        lambda payload: payload["scalar_metrics"]["domain_mean_cwp_final_three_hour_mean"].update(
+            method="different method"
+        ),
+        lambda payload: payload["scalar_metrics"][
+            "coherent_cloud_top_final_three_hour_mean"
+        ].update(baseline=1700.0),
+        lambda payload: payload["exact_time_pairing"]["domain_mean_cwp"].__setitem__(
+            1, {"time_seconds": 10_920.0, "value": 0.5}
+        ),
+    ],
+)
+def test_story_rejects_conflicting_runtime_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutate: Callable[[dict[str, Any]], None],
+) -> None:
+    evidence = _evidence()
+    mutate(evidence)
+    settings = _install_valid_dependencies(tmp_path, monkeypatch, evidence=evidence)
+
+    with pytest.raises(TradeCumulusComparisonStoryConflict):
+        trade_cumulus_moisture_comparison_story(settings)
+
+
+def test_story_rejects_wrong_result_hash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _install_valid_dependencies(tmp_path, monkeypatch)
+    original = comparison_story.get_result_metadata
+
+    def wrong_hash(_settings: CloudChamberSettings, result_id: str) -> ResultMetadata:
+        metadata = original(_settings, result_id)
+        if result_id == BASELINE_RESULT_ID:
+            metadata.run_configuration["fixed_assumptions_sha256"] = "wrong"
+        return metadata
+
+    monkeypatch.setattr(comparison_story, "get_result_metadata", wrong_hash)
+
+    with pytest.raises(TradeCumulusComparisonStoryConflict, match="fixed assumptions hash"):
+        trade_cumulus_moisture_comparison_story(settings)
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"w_scale_id": "wrong-scale"},
+        {"w_scale_breakpoints_m_s": [-1.0, 1.0]},
+        {"time_seconds": 18_360.0},
+        {"plane_index": 6},
+        {"plane_coordinate": -2.64},
+        {"w_finite_count": 0},
+        {"cloud_mask": [[False, False]]},
+        {"wind_vectors": []},
+    ],
+)
+def test_story_rejects_conflicting_scale_or_curated_frame(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    updates: dict[str, Any],
+) -> None:
+    settings = _install_valid_dependencies(
+        tmp_path,
+        monkeypatch,
+        frame_factory=lambda result_id: _frame(
+            result_id,
+            **(updates if result_id == BASELINE_RESULT_ID else {}),
+        ),
+    )
+
+    with pytest.raises(TradeCumulusComparisonStoryConflict):
+        trade_cumulus_moisture_comparison_story(settings)
+
+
+def test_story_returns_not_found_for_missing_evidence(tmp_path: Path) -> None:
+    with pytest.raises(TradeCumulusComparisonStoryNotFound, match="evidence is unavailable"):
+        trade_cumulus_moisture_comparison_story(_settings(tmp_path))
+
+
+def test_story_returns_not_found_for_missing_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _install_valid_dependencies(tmp_path, monkeypatch)
+
+    def missing_result(_settings: CloudChamberSettings, _result_id: str) -> ResultMetadata:
+        raise ResultIngestError("Result metadata not found at /machine/private/result.json")
+
+    monkeypatch.setattr(comparison_story, "get_result_metadata", missing_result)
+
+    with pytest.raises(TradeCumulusComparisonStoryNotFound) as caught:
+        trade_cumulus_moisture_comparison_story(settings)
+    assert "/machine/private" not in str(caught.value)
+
+
+def test_story_returns_not_found_for_missing_model_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _install_valid_dependencies(tmp_path, monkeypatch)
+
+    def missing_frame(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        raise TradeCumulusUpdraftLensError(
+            "Model-output file is unavailable: /machine/private/cm1out.nc"
+        )
+
+    monkeypatch.setattr(comparison_story, "trade_cumulus_updraft_lens_frame", missing_frame)
+
+    with pytest.raises(TradeCumulusComparisonStoryNotFound) as caught:
+        trade_cumulus_moisture_comparison_story(settings)
+    assert "/machine/private" not in str(caught.value)

--- a/app/backend/tests/test_trade_cumulus_comparison_story.py
+++ b/app/backend/tests/test_trade_cumulus_comparison_story.py
@@ -291,6 +291,14 @@ def _metadata(
             "fixed_assumptions_sha256": (
                 "71d746b110fb1310ebb6dafbef4cfa4bd44c379fc6964ed1787deaf45e422535"
             ),
+            "cm1_provenance": {
+                "source_manifest_sha256": (
+                    "fbe2367dfcd6d8c55cac4bd03362d8d49f13f80cebd13b36230c20d71119a84e"
+                ),
+                "executable_sha256": (
+                    "5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1"
+                ),
+            },
         },
         source_lifecycle_state="completed",
         source_product_state="completed_cm1_result",
@@ -498,6 +506,23 @@ def test_story_rejects_conflicting_runtime_evidence(
         trade_cumulus_moisture_comparison_story(settings)
 
 
+@pytest.mark.parametrize("target", ["top_level", "baseline", "more_moisture"])
+def test_story_rejects_mismatched_implementation_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    target: str,
+) -> None:
+    evidence = _evidence()
+    if target == "top_level":
+        evidence["implementation_commit"] = "wrong"
+    else:
+        evidence[target]["app_commit"] = "wrong"
+    settings = _install_valid_dependencies(tmp_path, monkeypatch, evidence=evidence)
+
+    with pytest.raises(TradeCumulusComparisonStoryConflict, match="implementation commit"):
+        trade_cumulus_moisture_comparison_story(settings)
+
+
 def test_story_rejects_wrong_result_hash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _install_valid_dependencies(tmp_path, monkeypatch)
     original = comparison_story.get_result_metadata
@@ -511,6 +536,36 @@ def test_story_rejects_wrong_result_hash(tmp_path: Path, monkeypatch: pytest.Mon
     monkeypatch.setattr(comparison_story, "get_result_metadata", wrong_hash)
 
     with pytest.raises(TradeCumulusComparisonStoryConflict, match="fixed assumptions hash"):
+        trade_cumulus_moisture_comparison_story(settings)
+
+
+@pytest.mark.parametrize(
+    ("result_id", "hash_key"),
+    [
+        (BASELINE_RESULT_ID, "source_manifest_sha256"),
+        (MORE_MOISTURE_RESULT_ID, "source_manifest_sha256"),
+        (BASELINE_RESULT_ID, "executable_sha256"),
+        (MORE_MOISTURE_RESULT_ID, "executable_sha256"),
+    ],
+)
+def test_story_rejects_mismatched_persisted_cm1_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    result_id: str,
+    hash_key: str,
+) -> None:
+    settings = _install_valid_dependencies(tmp_path, monkeypatch)
+    original = comparison_story.get_result_metadata
+
+    def wrong_provenance(_settings: CloudChamberSettings, requested_id: str) -> ResultMetadata:
+        metadata = original(_settings, requested_id)
+        if requested_id == result_id:
+            metadata.run_configuration["cm1_provenance"][hash_key] = "wrong"
+        return metadata
+
+    monkeypatch.setattr(comparison_story, "get_result_metadata", wrong_provenance)
+
+    with pytest.raises(TradeCumulusComparisonStoryConflict, match="CM1"):
         trade_cumulus_moisture_comparison_story(settings)
 
 

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -3,9 +3,425 @@ import { expect, test } from "@playwright/test";
 import { gotoApp, gotoBuild, gotoResults, openRunMonitor } from "../helpers";
 import { mockCloudChamberApis, results } from "../fixtures";
 
+const comparisonBaselineId = "result-trade-cumulus-5b-full-baseline-20260720T162342Z";
+const comparisonMoreMoistureId = "result-trade-cumulus-5b-full-more_moisture-20260720T162342Z";
+
+const comparisonBaselineResult = {
+  ...results[0],
+  result_id: comparisonBaselineId,
+  run_id: "trade-cumulus-5b-full-baseline-20260720T162342Z",
+  name: "Canonical BOMEX Baseline",
+  scenario_id: "bomex_trade_cumulus_baseline_v0",
+  scenario_name: "Trade Cumulus",
+  run_configuration: {
+    ...results[0].run_configuration,
+    case_id: "bomex_trade_cumulus_baseline_v0",
+  },
+};
+
+const comparisonMoreMoistureResult = {
+  ...comparisonBaselineResult,
+  result_id: comparisonMoreMoistureId,
+  run_id: "trade-cumulus-5b-full-more_moisture-20260720T162342Z",
+  name: "More Moisture",
+};
+
+const comparisonStory = {
+  comparison_id: "trade_cumulus_moisture_v1",
+  comparison_group_id: "trade_cumulus_moisture_v1",
+  product_slice_id: "trade_cumulus_v1",
+  case_id: "bomex_trade_cumulus_baseline_v0",
+  title: "Trade Cumulus: Baseline and More Moisture",
+  question: "How does stronger surface moisture supply change the trade-cumulus field?",
+  illustrative_view_note:
+    "Illustrative views: selected to help show the response measured across the full simulations. Times and locations may differ, and these are not corresponding individual clouds.",
+  baseline: {
+    result_id: comparisonBaselineId,
+    run_id: comparisonBaselineResult.run_id,
+    display_name: "Canonical BOMEX Baseline",
+    control_state: "baseline",
+    control_label: "Surface moisture supply",
+    control_value: 5.2e-5,
+    control_units: "g/g m/s",
+    control_display: "5.2 × 10⁻⁵ g/g m/s",
+    curated_view: {
+      time_index: 152,
+      time_seconds: 18_240,
+      orientation: "vertical_x",
+      plane_dimension: "y",
+      plane_index: 5,
+      plane_coordinate: -2.6500000953674316,
+      plane_units: "km",
+      camera_preset: "overview",
+      cloud_field: "ql",
+      cloud_threshold_kg_kg: 1e-6,
+      lens_id: "updraft",
+      scale_id: "trade_cumulus_updraft_velocity_v1",
+      wind_mode: "perturbation",
+      show_wind: true,
+      show_cloud_boundary: true,
+      opacity: 0.68,
+      point_size: 11,
+      caption:
+        "This illustrative Baseline view shows one concentrated active cloud reaching about 2 km, with a strong rising core bordered by sinking air.",
+    },
+  },
+  more_moisture: {
+    result_id: comparisonMoreMoistureId,
+    run_id: comparisonMoreMoistureResult.run_id,
+    display_name: "More Moisture",
+    control_state: "more_moisture",
+    control_label: "Surface moisture supply",
+    control_value: 7.8e-5,
+    control_units: "g/g m/s",
+    control_display: "7.8 × 10⁻⁵ g/g m/s",
+    curated_view: {
+      time_index: 169,
+      time_seconds: 20_280,
+      orientation: "vertical_x",
+      plane_dimension: "y",
+      plane_index: 51,
+      plane_coordinate: 1.9500000476837158,
+      plane_units: "km",
+      camera_preset: "overview",
+      cloud_field: "ql",
+      cloud_threshold_kg_kg: 1e-6,
+      lens_id: "updraft",
+      scale_id: "trade_cumulus_updraft_velocity_v1",
+      wind_mode: "perturbation",
+      show_wind: true,
+      show_cloud_boundary: true,
+      opacity: 0.68,
+      point_size: 11,
+      caption:
+        "This illustrative More Moisture view shows several active clouds across the slice, with rising cores distributed through a broader cloud-filled region reaching just above 2 km.",
+    },
+  },
+  changed_condition: {
+    label: "Surface moisture supply",
+    baseline_display: "5.2 × 10⁻⁵ g/g m/s",
+    more_moisture_display: "7.8 × 10⁻⁵ g/g m/s",
+    change_display: "+50%",
+  },
+  material_responses: [
+    {
+      metric_id: "mean_cloud_cover_final_three_hours",
+      label: "Mean cloud cover, final three hours",
+      baseline_value: 10.596239697802197,
+      more_moisture_value: 12.710873111263735,
+      absolute_delta: 2.1146334134615383,
+      percent_delta: 19.956451286206196,
+      units: "%",
+      method: "time mean of horizontal columns containing ql >= 1e-6 kg/kg",
+      window: "time >= 10800 s",
+      baseline_display: "10.596%",
+      more_moisture_display: "12.711%",
+      change_display: "+2.115 percentage points",
+    },
+    {
+      metric_id: "mean_cloud_water_path_final_three_hours",
+      label: "Mean cloud-water path, final three hours",
+      baseline_value: 0.006351999299305916,
+      more_moisture_value: 0.009071426778155891,
+      absolute_delta: 0.0027194274788499753,
+      percent_delta: 42.81215017053178,
+      units: "kg/m^2",
+      method: "time mean of horizontal domain-mean cwp",
+      window: "time >= 10800 s",
+      baseline_display: "0.006352 kg/m²",
+      more_moisture_display: "0.009071 kg/m²",
+      change_display: "+42.812%",
+    },
+    {
+      metric_id: "mean_coherent_cloud_top_final_three_hours",
+      label: "Mean coherent cloud top, final three hours",
+      baseline_value: 1668.3517340775375,
+      more_moisture_value: 1805.0550379595913,
+      absolute_delta: 136.7033038820539,
+      percent_delta: 8.193913854600911,
+      units: "m",
+      method: "mean supported coherent cloud-object top",
+      window: "time >= 10800 s",
+      baseline_display: "1,668 m",
+      more_moisture_display: "1,805 m",
+      change_display: "+137 m",
+    },
+  ],
+  small_or_mixed_responses: [
+    {
+      title: "Initial cloud-liquid onset was unchanged.",
+      body: "Both simulations first reached the cloud-liquid threshold at 1,080 s.",
+    },
+    {
+      title: "The cloud-fraction peak stayed at the same height.",
+      body: "Both final-three-hour profiles peaked near 620 m.",
+    },
+    {
+      title: "The fraction of cloudy air rising changed very little.",
+      body: "It was 90.379% in Baseline and 90.451% in More Moisture.",
+    },
+    {
+      title: "The response varied through time.",
+      body: "More Moisture was not cloudier or wetter than Baseline at every individual saved frame.",
+    },
+  ],
+  held_fixed_by_design: {
+    lead: "Only surface moisture supply changed.",
+    groups: [
+      {
+        title: "Initial atmosphere",
+        body: "Thermodynamic, moisture, and wind profiles, including the deterministic perturbation.",
+      },
+      {
+        title: "Forcing",
+        body: "Sensible heat supply, friction velocity, large-scale forcing, geostrophic wind, and Coriolis treatment.",
+      },
+      {
+        title: "Model setup",
+        body: "Moist physics, turbulence, boundaries, domain, grid, and timestep strategy.",
+      },
+      {
+        title: "Execution and outputs",
+        body: "Duration, output cadence, requested fields, CM1 source and executable, and the Cloud Chamber implementation commit.",
+      },
+    ],
+  },
+  explanation_paragraphs: [
+    "More surface moisture produced a cloudier, wetter, somewhat deeper trade-cumulus field.",
+    "Only the lower-boundary moisture supply changed. Over the final three hours, More Moisture covered more of the domain with cloud, held about 43 percent more mean cloud-water path, and produced coherent clouds averaging 137 meters taller.",
+    "It did not create a completely different circulation regime. Initial cloud-liquid onset and the height of the cloud-fraction maximum were unchanged, and about 90 percent of cloudy cells were rising in both simulations.",
+    "The illustrative Lens views are selected to help show the measured response. They show different times and locations and are not one-to-one matches of individual clouds. More Moisture was also not cloudier at every saved frame, so the result is a change in the evolving cloud field rather than a rule that every moment must look larger.",
+  ],
+  evidence_summary: {
+    analysis_window: "time >= 10800 s",
+    analysis_start_seconds: 10_800,
+    analysis_end_seconds: 21_600,
+    output_cadence_seconds: 120,
+    paired_saved_frame_count: 181,
+  },
+  provenance: {
+    evidence_state: "matched_runs_valid",
+    evidence_version: "trade_cumulus_moisture_comparison_evidence_v1",
+    implementation_commit: "49da1defc9914d3cc903ed9589c1312ddd843726",
+    fixed_assumptions_sha256: "71d746b110fb1310ebb6dafbef4cfa4bd44c379fc6964ed1787deaf45e422535",
+    baseline_run_id: comparisonBaselineResult.run_id,
+    baseline_result_id: comparisonBaselineId,
+    more_moisture_run_id: comparisonMoreMoistureResult.run_id,
+    more_moisture_result_id: comparisonMoreMoistureId,
+    scale_id: "trade_cumulus_updraft_velocity_v1",
+    comparison_source: "runtime_matched_pair_evidence",
+  },
+  caveats: [
+    "one_deterministic_les_realization_per_control_state",
+    "illustrative_views_are_not_direct_frame_matches",
+    "individual_clouds_are_not_paired_one_to_one",
+    "candidate_product_slice_not_supported_status",
+  ],
+};
+
+const comparisonUpdraftScale = {
+  w_range_min_m_s: -1,
+  w_range_max_m_s: 5,
+  w_range_method: "fixed_trade_cumulus_updraft_velocity_v1",
+  w_scale_id: "trade_cumulus_updraft_velocity_v1",
+  w_scale_owner: "trade_cumulus",
+  w_scale_type: "fixed_discrete",
+  w_scale_units: "m/s",
+  w_scale_breakpoints_m_s: [-1, -0.5, -0.1, 0.1, 0.5, 1, 2, 3, 5],
+  w_scale_colors: [
+    "#4b0082",
+    "#0057d9",
+    "#00c9d8",
+    "#ffffff",
+    "#00d63b",
+    "#8fe000",
+    "#ffe000",
+    "#ff9800",
+    "#ff3b00",
+    "#c40000",
+  ],
+  w_scale_neutral_interval_m_s: [-0.1, 0.1],
+  w_scale_source: "pm_approved_issue_379_from_stage5b2_matched_pair",
+  w_scale_clipping_behavior:
+    "values_below_-1.0_and_at_or_above_5.0_use_endpoint_colors_and_are_reported_as_clipped",
+};
+
+type ComparisonMember = typeof comparisonStory.baseline;
+
+function comparisonPointCloud(member: ComparisonMember) {
+  const offset = member.control_state === "baseline" ? 0 : 0.45;
+  const points: Array<[number, number, number, number]> = [
+    [-1.8 + offset, -0.8, 0.5, 0.00035],
+    [-1.2 + offset, -0.4, 0.9, 0.0008],
+    [-0.5 + offset, 0.1, 1.35, 0.0012],
+    [0.3 + offset, 0.6, 1.8, 0.00095],
+    [1.4 + offset, 1.1, 1.15, 0.0005],
+  ];
+  return {
+    result_id: member.result_id,
+    run_id: member.run_id,
+    scenario_id: "bomex_trade_cumulus_baseline_v0",
+    field: { raw_field_name: "ql", display_name: "Cloud water", units: "kg/kg" },
+    selection: {
+      field: "ql",
+      time_index: member.curated_view.time_index,
+      time_seconds: member.curated_view.time_seconds,
+      threshold: 1e-6,
+      max_points: 50_000,
+    },
+    coordinate_units: { xh: "km", yh: "km", zh: "km" },
+    coordinate_extents: {
+      xh: { min: -3.2, max: 3.2, units: "km" },
+      yh: { min: -3.2, max: 3.2, units: "km" },
+      zh: { min: 0, max: 3, units: "km" },
+    },
+    points,
+    stats: {
+      source_count: points.length,
+      returned_count: points.length,
+      field_min_value: 0,
+      field_max_value: 0.0012,
+      field_mean_value: 0.00076,
+      field_finite_count: points.length,
+      field_non_finite_count: 0,
+      min_value: 0.00035,
+      max_value: 0.0012,
+      active_z_min: 0.5,
+      active_z_max: 1.8,
+      downsampled: false,
+      downsample_stride: 1,
+    },
+    provenance: {
+      source_model: "CM1",
+      result_id: member.result_id,
+      run_id: member.run_id,
+      scenario_id: "bomex_trade_cumulus_baseline_v0",
+      processing_method: "backend_xarray_native_grid_threshold",
+      rendering_method: "thresholded_point_cloud",
+      provenance_label: "CM1-derived cloud water point cloud",
+    },
+    caveats: [],
+  };
+}
+
+function comparisonLensFrame(member: ComparisonMember) {
+  const values =
+    member.control_state === "baseline"
+      ? [
+          [-0.6, -0.2, 0.3, 0.6],
+          [-0.3, 0.1, 0.9, 1.4],
+          [-0.1, 0.4, 1.8, 2.5],
+          [0, 0.2, 0.8, 0.4],
+        ]
+      : [
+          [-0.5, -0.1, 0.4, 0.8],
+          [-0.2, 0.5, 1.5, 2.2],
+          [0.1, 0.9, 2.8, 4.1],
+          [0.2, 0.6, 1.7, 0.7],
+        ];
+  return {
+    result_id: member.result_id,
+    time_index: member.curated_view.time_index,
+    time_seconds: member.curated_view.time_seconds,
+    orientation: "vertical_x",
+    plane_dimension: "y",
+    plane_index: member.curated_view.plane_index,
+    plane_coordinate: member.curated_view.plane_coordinate,
+    plane_units: "km",
+    dimension_order: ["z", "x"],
+    x_indices: [0, 1, 2, 3],
+    x_values_km: [-3.2, -1.1, 1.1, 3.2],
+    y_indices: [0, 1],
+    y_values_km: [-3.2, 3.2],
+    z_indices: [0, 1, 2, 3],
+    z_values_km: [0, 1, 2, 3],
+    w_values_m_s: values,
+    cloud_mask: [
+      [false, true, true, false],
+      [true, true, true, false],
+      [false, true, true, true],
+      [false, false, true, false],
+    ],
+    cloud_threshold_kg_kg: 1e-6,
+    ...comparisonUpdraftScale,
+    w_finite_count: 16,
+    w_low_clipped_count: 0,
+    w_high_clipped_count: 0,
+    w_low_clipped_fraction: 0,
+    w_high_clipped_fraction: 0,
+    wind_mode: "perturbation",
+    wind_target_level_m: 600,
+    wind_actual_level_m: 580,
+    wind_level_index: 14,
+    wind_stride: 8,
+    wind_reference_m_s: 0.9,
+    wind_arrow_domain_fraction: 0.08,
+    domain_mean_u_m_s: 0,
+    domain_mean_v_m_s: 0,
+    wind_vectors: [
+      { x_km: -2, y_km: 0, z_km: 0.58, u_m_s: 0.4, v_m_s: 0.2, magnitude_m_s: 0.45 },
+      { x_km: 0, y_km: 0, z_km: 0.58, u_m_s: -0.3, v_m_s: 0.4, magnitude_m_s: 0.5 },
+      { x_km: 2, y_km: 0, z_km: 0.58, u_m_s: 0.2, v_m_s: -0.4, magnitude_m_s: 0.45 },
+    ],
+    provenance: {
+      source_model: "CM1",
+      result_id: member.result_id,
+      run_id: member.run_id,
+      scenario_id: "bomex_trade_cumulus_baseline_v0",
+      processing_method: "trade_cumulus_updraft_lens_frame",
+      rendering_method: "native_grid_slice",
+      provenance_label: "CM1-derived Updraft Lens frame",
+    },
+    caveats: [],
+  };
+}
+
+async function mockTradeCumulusComparison(page: Parameters<typeof mockCloudChamberApis>[0]) {
+  await page.route("**/api/results", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        results: [comparisonBaselineResult, comparisonMoreMoistureResult, results[0]],
+      }),
+    }),
+  );
+  await page.route("**/api/comparisons/trade-cumulus-moisture-v1", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(comparisonStory),
+    }),
+  );
+  await page.route("**/api/results/*/visualization/point-cloud**", (route) => {
+    const url = route.request().url();
+    const member = url.includes(comparisonMoreMoistureId)
+      ? comparisonStory.more_moisture
+      : comparisonStory.baseline;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(comparisonPointCloud(member)),
+    });
+  });
+  await page.route("**/api/results/*/visualization/trade-cumulus-updraft-lens/frame**", (route) => {
+    const member = route.request().url().includes(comparisonMoreMoistureId)
+      ? comparisonStory.more_moisture
+      : comparisonStory.baseline;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(comparisonLensFrame(member)),
+    });
+  });
+}
+
 test.describe("mocked smoke: Build, Results, Explore path", () => {
   test.beforeEach(async ({ page }) => {
     await mockCloudChamberApis(page);
+    await page.route("**/api/comparisons/trade-cumulus-moisture-v1", (route) =>
+      route.fulfill({ status: 404, contentType: "application/json", body: "{}" }),
+    );
     await gotoApp(page);
   });
 
@@ -243,6 +659,117 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(resultDetail.getByText("Local data")).toBeVisible();
     await expect(page.getByRole("tab", { name: "Compare" })).toHaveCount(0);
     await expect(page.getByRole("tab", { name: "Storage" })).toHaveCount(0);
+  });
+
+  test("Results opens the complete curated Trade Cumulus comparison story", async ({ page }) => {
+    const browserErrors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") browserErrors.push(`console: ${message.text()}`);
+    });
+    page.on("pageerror", (error) => browserErrors.push(`page: ${error.message}`));
+    page.on("requestfailed", (request) => {
+      const failure = request.failure()?.errorText ?? "unknown failure";
+      if (request.url().includes("/api/") && !failure.includes("ERR_ABORTED")) {
+        browserErrors.push(`request: ${request.method()} ${request.url()} (${failure})`);
+      }
+    });
+
+    await mockTradeCumulusComparison(page);
+    await page.reload();
+    await gotoResults(page);
+    browserErrors.length = 0;
+
+    await page.getByRole("button", { name: "Canonical BOMEX Baseline" }).click();
+    const resultDetail = page.getByLabel("Result detail");
+    await resultDetail.getByRole("button", { name: "Compare Baseline and More Moisture" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Trade Cumulus: Baseline and More Moisture" }),
+    ).toBeVisible();
+    await expect(page.getByText(comparisonStory.question)).toBeVisible();
+    await expect(page.getByLabel("Changed condition")).toContainText("+50%");
+    await expect(page.getByText(comparisonStory.illustrative_view_note)).toBeVisible();
+
+    const simulations = page.locator("article.comparison-simulation");
+    await expect(simulations).toHaveCount(2);
+    await expect(simulations.nth(0)).toContainText("18,240 s · 05:04:00");
+    await expect(simulations.nth(0)).toContainText("Vertical x-z slice at y = -2.65 km");
+    await expect(simulations.nth(1)).toContainText("20,280 s · 05:38:00");
+    await expect(simulations.nth(1)).toContainText("Vertical x-z slice at y = 1.95 km");
+    await expect(page.getByRole("img", { name: /Updraft Lens vertical x-z slice/ })).toHaveCount(2);
+    await expect(page.getByTestId("updraft-lens-cloud-boundary")).toHaveCount(2);
+    await expect(page.getByLabel(/3-D viewer Vertical velocity \(w\), m\/s/)).toHaveCount(2);
+    await expect(page.getByLabel(/2-D inspector Vertical velocity \(w\), m\/s/)).toHaveCount(2);
+    await expect(page.getByRole("heading", { name: "What responded materially" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "What changed little or varied" }),
+    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "What stayed fixed" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "What this comparison suggests" }),
+    ).toBeVisible();
+
+    const canvases = page.locator("canvas.true3d-canvas");
+    await expect(canvases).toHaveCount(2);
+    for (let index = 0; index < 2; index += 1) {
+      await expect(canvases.nth(index)).toBeVisible();
+      const dimensions = await canvases.nth(index).evaluate((canvas: HTMLCanvasElement) => ({
+        displayWidth: canvas.clientWidth,
+        displayHeight: canvas.clientHeight,
+        renderWidth: canvas.width,
+        renderHeight: canvas.height,
+      }));
+      expect(dimensions.displayWidth).toBeGreaterThan(100);
+      expect(dimensions.displayHeight).toBeGreaterThan(100);
+      expect(dimensions.renderWidth).toBeGreaterThan(100);
+      expect(dimensions.renderHeight).toBeGreaterThan(100);
+      const renderedPixels = await canvases.nth(index).screenshot();
+      expect(renderedPixels.byteLength).toBeGreaterThan(5_000);
+    }
+
+    const baselineControls = simulations.nth(0).getByLabel("3-D camera controls");
+    const moreMoistureControls = simulations.nth(1).getByLabel("3-D camera controls");
+    await baselineControls.getByRole("button", { name: "Look along x" }).click();
+    await expect(baselineControls).toContainText("Camera looking along the x axis");
+    await expect(moreMoistureControls).toContainText("Camera ready");
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(simulations.nth(0)).toBeVisible();
+    await expect(simulations.nth(1)).toBeVisible();
+    const mobileLayout = await simulations.evaluateAll((cards) => {
+      const first = cards[0].getBoundingClientRect();
+      const second = cards[1].getBoundingClientRect();
+      return {
+        stacked: second.top >= first.bottom,
+        fitsViewport: document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+      };
+    });
+    expect(mobileLayout).toEqual({ stacked: true, fitsViewport: true });
+
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await simulations.nth(1).getByRole("button", { name: "Open More Moisture in Explore" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Trade Cumulus: Baseline and More Moisture" }),
+    ).toHaveCount(0);
+    await expect(page.getByLabel("Explore viewer controls")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("More Moisture").first()).toBeVisible();
+
+    await page
+      .getByRole("navigation", { name: "Cloud Chamber workspace" })
+      .getByRole("button", { name: "Results" })
+      .click();
+    await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
+    await page.getByRole("button", { name: "More Moisture", exact: true }).click();
+    await page
+      .getByLabel("Result detail")
+      .getByRole("button", { name: "Compare Baseline and More Moisture" })
+      .click();
+    await expect(
+      page.getByRole("heading", { name: "Trade Cumulus: Baseline and More Moisture" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Back to Results" }).click();
+    await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
+    expect(browserErrors).toEqual([]);
   });
 
   test("Results filters and sorts by science metadata", async ({ page }) => {
@@ -730,18 +1257,17 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
 
     await expect(page.getByLabel("Explore viewer controls")).toBeVisible();
     await expect(page.getByLabel("Timelapse playback controls")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Play time" })).toBeVisible();
+    const playbackButton = page.getByLabel("Timelapse playback controls").getByRole("button");
+    await expect(playbackButton).toHaveText("Play time");
     await expect(page.getByLabel("Playback speed")).toHaveValue("1");
     await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
 
     await page.locator("#explore-time").selectOption("1");
-    await page.getByLabel("Playback speed").selectOption("2");
-    await page.getByRole("button", { name: "Play time" }).click();
+    await page.getByLabel("Playback speed").selectOption("0.5");
+    await playbackButton.click();
 
-    await expect(page.getByRole("button", { name: "Pause time" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    await expect(playbackButton).toHaveText("Pause time");
+    await expect(playbackButton).toHaveAttribute("aria-pressed", "true");
     await expect(
       page.getByText("Pause playback to select a cell and explain this time step."),
     ).toBeVisible();
@@ -750,22 +1276,17 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
         /Animating 3-D scene at .*; slice and evidence remain at .* until playback is paused\./,
       ),
     ).toBeVisible();
-    await expect(page.locator("#explore-time")).toHaveValue("2", { timeout: 2_000 });
-
-    await page.getByRole("button", { name: "Pause time" }).click();
-    await expect(page.getByRole("button", { name: "Play time" })).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
+    await expect(page.locator("#explore-time")).toHaveValue("2", { timeout: 4_000 });
+    await expect(playbackButton).toHaveText("Play time", { timeout: 4_000 });
+    await expect(playbackButton).toHaveAttribute("aria-pressed", "false");
+    await expect(page.locator("#explore-time")).toHaveValue("0");
 
     await page.getByRole("button", { name: "Last frame" }).click();
     await expect(page.locator("#explore-time")).toHaveValue("2");
-    await page.getByRole("button", { name: "Play time" }).click();
-    await expect(page.locator("#explore-time")).toHaveValue("0", { timeout: 2_000 });
-    await expect(page.getByRole("button", { name: "Play time" })).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
+    await playbackButton.click();
+    await expect(page.locator("#explore-time")).toHaveValue("0", { timeout: 4_000 });
+    await expect(playbackButton).toHaveText("Play time");
+    await expect(playbackButton).toHaveAttribute("aria-pressed", "false");
   });
 
   test("Explore process evidence offers useful modes and moves unsupported modes secondary", async ({

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -3189,6 +3189,279 @@ details[open] > summary {
   padding-top: 0.4rem;
 }
 
+.trade-cumulus-comparison {
+  display: grid;
+  gap: 1.25rem;
+  min-width: 0;
+}
+
+.comparison-story-header,
+.comparison-story-section {
+  display: grid;
+  gap: 0.85rem;
+  min-width: 0;
+  border-top: 1px solid var(--color-border);
+  padding-top: 1rem;
+}
+
+.comparison-story-header {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.comparison-story-heading-row,
+.comparison-simulation-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.comparison-story-heading-row h2 {
+  margin-bottom: 0.35rem;
+}
+
+.comparison-story-question {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: 1.05rem;
+  font-weight: 750;
+}
+
+.comparison-changed-condition {
+  margin: 0;
+  border: 1px solid var(--color-border-strong);
+  border-left: 4px solid var(--color-accent-primary);
+  border-radius: 6px;
+  padding: 0.75rem 0.85rem;
+  background: var(--color-surface);
+}
+
+.comparison-changed-condition dt,
+.comparison-simulation-header dt,
+.comparison-material-responses dt,
+.comparison-held-fixed dt {
+  color: var(--color-text-primary);
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.comparison-changed-condition dd {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  align-items: baseline;
+  margin: 0.3rem 0 0;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.comparison-changed-condition strong {
+  color: var(--color-success);
+}
+
+.comparison-illustrative-note {
+  margin: 0;
+  border-left: 3px solid var(--color-border-strong);
+  padding: 0.2rem 0 0.2rem 0.75rem;
+  color: var(--color-text-primary);
+}
+
+.comparison-story-load-state {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 1rem;
+  background: var(--color-surface);
+}
+
+.comparison-story-load-state > :last-child {
+  margin-bottom: 0;
+}
+
+.comparison-simulation-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  align-items: start;
+  min-width: 0;
+}
+
+.comparison-simulation {
+  display: grid;
+  gap: 0.85rem;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.85rem;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: var(--shadow-subtle);
+}
+
+.comparison-simulation-header h3,
+.comparison-lens-heading h4 {
+  margin-bottom: 0.2rem;
+}
+
+.comparison-simulation-header > * {
+  min-width: 0;
+}
+
+.comparison-simulation-header p {
+  margin: 0;
+}
+
+.comparison-simulation-header dl {
+  display: grid;
+  flex: 0 1 13rem;
+  gap: 0.4rem;
+  min-width: 0;
+  margin: 0;
+  text-align: right;
+}
+
+.comparison-simulation-header dd {
+  margin: 0.08rem 0 0;
+  color: var(--color-text-primary);
+  font-size: 0.84rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.comparison-view-caption {
+  min-height: 4.5rem;
+  margin: 0;
+  color: var(--color-text-primary);
+  overflow-wrap: anywhere;
+}
+
+.comparison-simulation .true3d-viewer,
+.comparison-simulation .true3d-controls,
+.comparison-simulation .true3d-control-section {
+  min-width: 0;
+}
+
+.comparison-simulation .true3d-scene-frame {
+  min-height: clamp(22rem, 28vw, 31rem);
+}
+
+.comparison-simulation .true3d-scene-label {
+  display: none;
+}
+
+.comparison-simulation .true3d-slice-label-updraft-lens {
+  display: none;
+}
+
+.comparison-simulation .true3d-field-legend {
+  min-width: 0;
+  max-width: min(11rem, calc(100% - 1.5rem));
+}
+
+.comparison-simulation .true3d-field-legend-row {
+  grid-template-columns: auto minmax(2.5rem, 1fr) auto;
+}
+
+.comparison-simulation .true3d-controls {
+  grid-template-columns: 1fr;
+  align-items: start;
+}
+
+.comparison-lens-view {
+  display: grid;
+  gap: 0.55rem;
+  min-width: 0;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.85rem;
+}
+
+.comparison-lens-heading .eyebrow {
+  margin-bottom: 0.15rem;
+}
+
+.comparison-simulation-action {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.comparison-story-section h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.comparison-material-responses,
+.comparison-held-fixed {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.comparison-material-responses {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.comparison-material-responses > div,
+.comparison-held-fixed > div {
+  border-left: 3px solid var(--color-border-strong);
+  padding-left: 0.75rem;
+}
+
+.comparison-material-responses dd {
+  display: grid;
+  gap: 0.2rem;
+  margin: 0.45rem 0 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.comparison-material-responses strong {
+  margin-top: 0.15rem;
+  color: var(--color-success);
+}
+
+.comparison-authored-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.comparison-authored-list li {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.comparison-authored-list strong {
+  color: var(--color-text-primary);
+}
+
+.comparison-section-lead {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.comparison-held-fixed {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.comparison-held-fixed dd {
+  margin: 0.35rem 0 0;
+}
+
+.comparison-explanation {
+  max-width: 78rem;
+}
+
+.comparison-explanation p {
+  color: var(--color-text-primary);
+}
+
+.comparison-explanation p:last-child {
+  margin-bottom: 0;
+}
+
 @media (max-width: 860px) {
   .topbar,
   .builder-layout,
@@ -3203,6 +3476,48 @@ details[open] > summary {
   .explore-result-summary,
   .embedded-run-configuration-panel .run-configuration-grid {
     grid-template-columns: 1fr;
+  }
+
+  .comparison-simulation-grid,
+  .comparison-material-responses,
+  .comparison-authored-list,
+  .comparison-held-fixed {
+    grid-template-columns: 1fr;
+  }
+
+  .comparison-story-heading-row,
+  .comparison-simulation-header {
+    display: grid;
+  }
+
+  .comparison-simulation-header dl {
+    min-width: 0;
+    text-align: left;
+  }
+
+  .comparison-simulation-action {
+    justify-content: flex-start;
+  }
+
+  .comparison-simulation .true3d-scene-frame {
+    min-height: 24rem;
+  }
+
+  .comparison-simulation .true3d-wind-legend,
+  .comparison-simulation .true3d-field-legend {
+    box-sizing: border-box;
+    width: 7.5rem;
+    max-width: calc(100% - 11.25rem);
+    overflow-wrap: anywhere;
+  }
+
+  .comparison-simulation .true3d-field-legend-row {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
+  }
+
+  .comparison-simulation .true3d-field-legend-row small:last-child {
+    text-align: right;
   }
 
   .visualizer-workbench {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3179,6 +3179,129 @@ const tradeCumulusResultCard = {
   },
 };
 
+const comparisonBaselineResultCard = {
+  ...tradeCumulusResultCard,
+  result_id: "result-trade-cumulus-5b-full-baseline-20260720T162342Z",
+  run_id: "trade-cumulus-5b-full-baseline-20260720T162342Z",
+  name: "Canonical BOMEX Baseline",
+};
+
+const comparisonMoreResultCard = {
+  ...tradeCumulusResultCard,
+  result_id: "result-trade-cumulus-5b-full-more_moisture-20260720T162342Z",
+  run_id: "trade-cumulus-5b-full-more_moisture-20260720T162342Z",
+  name: "More Moisture",
+};
+
+const tradeCumulusComparisonStoryResponse = {
+  comparison_id: "trade_cumulus_moisture_v1",
+  comparison_group_id: "trade_cumulus_moisture_v1",
+  product_slice_id: "trade_cumulus_v1",
+  case_id: "bomex_trade_cumulus_baseline_v0",
+  title: "Trade Cumulus: Baseline and More Moisture",
+  question: "How does stronger surface moisture supply change the trade-cumulus field?",
+  illustrative_view_note:
+    "Illustrative views: selected to help show the response measured across the full simulations. Times and locations may differ, and these are not corresponding individual clouds.",
+  baseline: {
+    result_id: comparisonBaselineResultCard.result_id,
+    run_id: comparisonBaselineResultCard.run_id,
+    display_name: "Canonical BOMEX Baseline",
+    control_state: "baseline",
+    control_label: "Surface moisture supply",
+    control_value: 5.2e-5,
+    control_units: "g/g m/s",
+    control_display: "5.2 × 10⁻⁵ g/g m/s",
+    curated_view: {
+      time_index: 152,
+      time_seconds: 18240,
+      orientation: "vertical_x",
+      plane_dimension: "y",
+      plane_index: 5,
+      plane_coordinate: -2.6500000953674316,
+      plane_units: "km",
+      camera_preset: "overview",
+      cloud_field: "ql",
+      cloud_threshold_kg_kg: 1e-6,
+      lens_id: "updraft",
+      scale_id: "trade_cumulus_updraft_velocity_v1",
+      wind_mode: "perturbation",
+      show_wind: true,
+      show_cloud_boundary: true,
+      opacity: 0.68,
+      point_size: 11,
+      caption: "Baseline curated view.",
+    },
+  },
+  more_moisture: {
+    result_id: comparisonMoreResultCard.result_id,
+    run_id: comparisonMoreResultCard.run_id,
+    display_name: "More Moisture",
+    control_state: "more_moisture",
+    control_label: "Surface moisture supply",
+    control_value: 7.8e-5,
+    control_units: "g/g m/s",
+    control_display: "7.8 × 10⁻⁵ g/g m/s",
+    curated_view: {
+      time_index: 169,
+      time_seconds: 20280,
+      orientation: "vertical_x",
+      plane_dimension: "y",
+      plane_index: 51,
+      plane_coordinate: 1.9500000476837158,
+      plane_units: "km",
+      camera_preset: "overview",
+      cloud_field: "ql",
+      cloud_threshold_kg_kg: 1e-6,
+      lens_id: "updraft",
+      scale_id: "trade_cumulus_updraft_velocity_v1",
+      wind_mode: "perturbation",
+      show_wind: true,
+      show_cloud_boundary: true,
+      opacity: 0.68,
+      point_size: 11,
+      caption: "More Moisture curated view.",
+    },
+  },
+  changed_condition: {
+    label: "Surface moisture supply",
+    baseline_display: "5.2 × 10⁻⁵ g/g m/s",
+    more_moisture_display: "7.8 × 10⁻⁵ g/g m/s",
+    change_display: "+50%",
+  },
+  material_responses: [],
+  small_or_mixed_responses: [],
+  held_fixed_by_design: {
+    lead: "Only surface moisture supply changed.",
+    groups: [],
+  },
+  explanation_paragraphs: [],
+  evidence_summary: {
+    analysis_window: "time >= 10800 s",
+    analysis_start_seconds: 10800,
+    analysis_end_seconds: 21600,
+    output_cadence_seconds: 120,
+    paired_saved_frame_count: 181,
+  },
+  provenance: {
+    evidence_state: "matched_runs_valid",
+    evidence_version: "trade_cumulus_moisture_comparison_evidence_v1",
+    implementation_commit: "49da1defc9914d3cc903ed9589c1312ddd843726",
+    fixed_assumptions_sha256: "71d746b110fb1310ebb6dafbef4cfa4bd44c379fc6964ed1787deaf45e422535",
+    baseline_run_id: comparisonBaselineResultCard.run_id,
+    baseline_result_id: comparisonBaselineResultCard.result_id,
+    more_moisture_run_id: comparisonMoreResultCard.run_id,
+    more_moisture_result_id: comparisonMoreResultCard.result_id,
+    scale_id: "trade_cumulus_updraft_velocity_v1",
+    comparison_source: "runtime_matched_pair_evidence",
+  },
+  caveats: [
+    "one_deterministic_les_realization_per_control_state",
+    "illustrative_views_are_not_direct_frame_matches",
+    "individual_clouds_are_not_paired_one_to_one",
+    "candidate_product_slice_not_supported_status",
+  ],
+};
+
 const tradeCumulusFieldCatalog = {
   ...fieldCatalogResponse,
   result_id: "result-trade-cumulus",
@@ -4016,6 +4139,94 @@ function mockTradeCumulusVisualizer(
       return Promise.resolve(
         new Response(JSON.stringify(tradeCumulusSliceResponse(url)), { status: 200 }),
       );
+    }
+    return (
+      defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+    );
+  });
+}
+
+function comparisonPointCloud(member: typeof tradeCumulusComparisonStoryResponse.baseline) {
+  const response = tradeCumulusPointCloudResponse();
+  return {
+    ...response,
+    result_id: member.result_id,
+    run_id: member.run_id,
+    selection: {
+      ...response.selection,
+      field: "ql",
+      time_index: member.curated_view.time_index,
+      time_seconds: member.curated_view.time_seconds,
+      threshold: member.curated_view.cloud_threshold_kg_kg,
+      max_points: 50000,
+    },
+    provenance: {
+      ...response.provenance,
+      result_id: member.result_id,
+      run_id: member.run_id,
+    },
+  };
+}
+
+function comparisonFrame(member: typeof tradeCumulusComparisonStoryResponse.baseline) {
+  const response = tradeCumulusUpdraftLensFrame({
+    timeIndex: member.curated_view.time_index,
+    planeIndex: member.curated_view.plane_index,
+    orientation: "vertical_x",
+    windMode: "perturbation",
+  });
+  return {
+    ...response,
+    result_id: member.result_id,
+    time_seconds: member.curated_view.time_seconds,
+    plane_coordinate: member.curated_view.plane_coordinate,
+    provenance: {
+      ...response.provenance,
+      result_id: member.result_id,
+      run_id: member.run_id,
+    },
+  };
+}
+
+function mockTradeCumulusComparisonApp(storyStatus = 200) {
+  const defaultFetch = vi.mocked(fetch).getMockImplementation();
+  vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === "/api/results") {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            results: [comparisonBaselineResultCard, comparisonMoreResultCard, resultCard],
+          }),
+          { status: 200 },
+        ),
+      );
+    }
+    if (url === "/api/comparisons/trade-cumulus-moisture-v1") {
+      return Promise.resolve(
+        new Response(
+          storyStatus === 200 ? JSON.stringify(tradeCumulusComparisonStoryResponse) : "unavailable",
+          { status: storyStatus },
+        ),
+      );
+    }
+    if (
+      url.includes(comparisonBaselineResultCard.result_id) ||
+      url.includes(comparisonMoreResultCard.result_id)
+    ) {
+      const member = url.includes(comparisonMoreResultCard.result_id)
+        ? tradeCumulusComparisonStoryResponse.more_moisture
+        : tradeCumulusComparisonStoryResponse.baseline;
+      if (url.includes("/visualization/point-cloud")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(comparisonPointCloud(member)), { status: 200 }),
+        );
+      }
+      if (url.includes("/trade-cumulus-updraft-lens/frame")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(comparisonFrame(member)), { status: 200 }),
+        );
+      }
     }
     return (
       defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
@@ -6109,6 +6320,59 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getAllByText("Completed CM1 result").length).toBeGreaterThan(0);
     expect(within(resultDetail).getByRole("button", { name: "Open in Explore" })).toBeEnabled();
+  });
+
+  it("opens the curated comparison from either approved member inside Explore", async () => {
+    mockTradeCumulusComparisonApp();
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Canonical BOMEX Baseline" }));
+    const baselineDetail = await screen.findByLabelText("Result detail");
+    const compareButton = await within(baselineDetail).findByRole("button", {
+      name: "Compare Baseline and More Moisture",
+    });
+    fireEvent.click(compareButton);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Trade Cumulus: Baseline and More Moisture",
+      }),
+    ).toBeInTheDocument();
+    const topNav = screen.getByRole("navigation", { name: "Cloud Chamber workspace" });
+    expect(within(topNav).getByRole("button", { name: "Explore" })).toHaveClass("active-control");
+    expect(within(topNav).getAllByRole("button")).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to Results" }));
+    expect(await screen.findByRole("heading", { name: "Experiment Notebook" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Trade Cumulus: Baseline and More Moisture" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "More Moisture" }));
+    expect(
+      await within(screen.getByLabelText("Result detail")).findByRole("button", {
+        name: "Compare Baseline and More Moisture",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not expose comparison for unrelated results or unavailable story evidence", async () => {
+    mockTradeCumulusComparisonApp(409);
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Canonical BOMEX Baseline" }));
+    expect(
+      within(await screen.findByLabelText("Result detail")).queryByRole("button", {
+        name: "Compare Baseline and More Moisture",
+      }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Quick-look shallow cumulus" }));
+    expect(
+      within(await screen.findByLabelText("Result detail")).queryByRole("button", {
+        name: "Compare Baseline and More Moisture",
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders result cards with case-manifest run configurations", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import type { CSSProperties, FormEvent } from "react";
 
 import "./App.css";
+import {
+  TradeCumulusComparisonStory,
+  type TradeCumulusComparisonStoryResponse,
+} from "./TradeCumulusComparisonStory";
 import { True3DViewer } from "./True3DViewer";
 import {
   type UpdraftLensDefaults,
@@ -1992,6 +1996,35 @@ async function fetchResults(): Promise<ResultsResponse> {
   return normalizeResultsResponse(await response.json());
 }
 
+type ComparisonStoryLoadResult = {
+  story: TradeCumulusComparisonStoryResponse | null;
+  status: string | null;
+};
+
+async function fetchTradeCumulusComparisonStory(): Promise<ComparisonStoryLoadResult> {
+  try {
+    const response = await fetch("/api/comparisons/trade-cumulus-moisture-v1");
+    if (response.status === 404 || response.status === 409) {
+      return { story: null, status: null };
+    }
+    if (!response.ok) {
+      return {
+        story: null,
+        status: "The curated comparison is temporarily unavailable.",
+      };
+    }
+    return {
+      story: (await response.json()) as TradeCumulusComparisonStoryResponse,
+      status: null,
+    };
+  } catch {
+    return {
+      story: null,
+      status: "The curated comparison is temporarily unavailable.",
+    };
+  }
+}
+
 function normalizeResultsResponse(payload: unknown): ResultsResponse {
   if (Array.isArray(payload)) {
     return { results: payload as ResultCard[] };
@@ -2304,6 +2337,11 @@ export function App() {
   const [results, setResults] = useState<ResultCard[]>([]);
   const [selectedResultId, setSelectedResultId] = useState<string | null>(null);
   const selectedResultIdRef = useRef<string | null>(null);
+  const [comparisonStory, setComparisonStory] =
+    useState<TradeCumulusComparisonStoryResponse | null>(null);
+  const [comparisonStoryStatus, setComparisonStoryStatus] = useState<string | null>(null);
+  const [comparisonStoryMemberIds, setComparisonStoryMemberIds] = useState<string[]>([]);
+  const [comparisonStoryActive, setComparisonStoryActive] = useState(false);
   const [resultDraft, setResultDraft] = useState({ name: "", tags: "", notes: "" });
   const [resultsStatus, setResultsStatus] = useState("Loading results...");
   const [storageInventory, setStorageInventory] = useState<StorageInventoryResponse | null>(null);
@@ -2366,6 +2404,7 @@ export function App() {
 
   useEffect(() => {
     let active = true;
+    let resultsFailed = false;
     fetchResults()
       .then((payload) => {
         if (!active) return;
@@ -2376,11 +2415,29 @@ export function App() {
       })
       .catch((caught: unknown) => {
         if (!active) return;
+        resultsFailed = true;
         setResults([]);
         setSelectedResultId(null);
+        setComparisonStory(null);
+        setComparisonStoryStatus(null);
+        setComparisonStoryMemberIds([]);
+        setComparisonStoryActive(false);
         setResultsError(caught instanceof Error ? caught.message : "Could not load results.");
         setResultsStatus("Results unavailable");
       });
+    fetchTradeCumulusComparisonStory().then((comparison) => {
+      if (!active || resultsFailed) return;
+      setComparisonStory(comparison.story);
+      setComparisonStoryStatus(comparison.status);
+      if (comparison.story) {
+        setComparisonStoryMemberIds([
+          comparison.story.baseline.result_id,
+          comparison.story.more_moisture.result_id,
+        ]);
+      } else if (!comparison.status) {
+        setComparisonStoryMemberIds([]);
+      }
+    });
     return () => {
       active = false;
     };
@@ -2454,6 +2511,7 @@ export function App() {
   useEffect(() => {
     selectedResultIdRef.current = selectedResultId;
     setResultDeletePreview(null);
+    setComparisonStoryActive(false);
   }, [selectedResultId]);
   const autoFinalizingWorkerRunIdSet = useMemo(
     () => new Set(autoFinalizingWorkerRunIds),
@@ -3526,6 +3584,7 @@ export function App() {
   }
 
   async function refreshResults(selectResultId?: string) {
+    const comparisonRequest = fetchTradeCumulusComparisonStory();
     const payload = await fetchResults();
     const prioritized = prioritizeResults(payload.results);
     setResults(prioritized);
@@ -3535,7 +3594,35 @@ export function App() {
       return prioritized[0]?.result_id ?? null;
     });
     setResultsStatus(payload.results.length > 0 ? "Results loaded" : "No ingested results");
+    void comparisonRequest.then((comparison) => {
+      setComparisonStory(comparison.story);
+      setComparisonStoryStatus(comparison.status);
+      if (comparison.story) {
+        setComparisonStoryMemberIds([
+          comparison.story.baseline.result_id,
+          comparison.story.more_moisture.result_id,
+        ]);
+      } else if (!comparison.status) {
+        setComparisonStoryMemberIds([]);
+      }
+      if (!comparison.story) setComparisonStoryActive(false);
+    });
     return prioritized;
+  }
+
+  function selectOrdinaryResult(resultId: string) {
+    setComparisonStoryActive(false);
+    setSelectedResultId(resultId);
+  }
+
+  function openOrdinaryResult(resultId: string, section: "results" | "explore") {
+    selectOrdinaryResult(resultId);
+    setActiveSection(section);
+  }
+
+  function handleWorkspaceNavigation(section: WorkspaceSection) {
+    if (section !== "explore") setComparisonStoryActive(false);
+    setActiveSection(section);
   }
 
   async function handleRefreshResults() {
@@ -3546,6 +3633,10 @@ export function App() {
     } catch (caught) {
       setResults([]);
       setSelectedResultId(null);
+      setComparisonStory(null);
+      setComparisonStoryStatus(null);
+      setComparisonStoryMemberIds([]);
+      setComparisonStoryActive(false);
       setResultsError(caught instanceof Error ? caught.message : "Could not load results.");
       setResultsStatus("Results unavailable");
     }
@@ -3793,7 +3884,7 @@ export function App() {
               key={section}
               type="button"
               className={activeSection === section ? "active-control" : ""}
-              onClick={() => setActiveSection(section)}
+              onClick={() => handleWorkspaceNavigation(section)}
             >
               {sectionLabel(section)}
             </button>
@@ -3916,20 +4007,18 @@ export function App() {
           onFinalizeStoredLanWorkerRun={handleFinalizeStoredLanWorkerRun}
           onIngestStoredRun={handleIngestStoredRun}
           onOpenInResults={() => {
-            if (ingestedResultId) setSelectedResultId(ingestedResultId);
-            setActiveSection("results");
+            if (ingestedResultId) openOrdinaryResult(ingestedResultId, "results");
+            else handleWorkspaceNavigation("results");
           }}
           onInspectIngested={() => {
-            if (ingestedResultId) setSelectedResultId(ingestedResultId);
-            setActiveSection("explore");
+            if (ingestedResultId) openOrdinaryResult(ingestedResultId, "explore");
+            else handleWorkspaceNavigation("explore");
           }}
           onOpenStoredResult={(resultId) => {
-            setSelectedResultId(resultId);
-            setActiveSection("results");
+            openOrdinaryResult(resultId, "results");
           }}
           onExploreStoredResult={(resultId) => {
-            setSelectedResultId(resultId);
-            setActiveSection("explore");
+            openOrdinaryResult(resultId, "explore");
           }}
           onRefreshStorage={handleRefreshStorage}
           onPreviewRunDelete={handlePreviewRunDelete}
@@ -3949,11 +4038,22 @@ export function App() {
           resultsError={resultsError}
           resultDeletePreview={resultDeletePreview}
           draft={resultDraft}
-          onSelectResult={setSelectedResultId}
+          comparisonStory={comparisonStory}
+          comparisonStoryStatus={
+            selectedResultId && comparisonStoryMemberIds.includes(selectedResultId)
+              ? comparisonStoryStatus
+              : null
+          }
+          onSelectResult={selectOrdinaryResult}
           onDraftChange={setResultDraft}
           onSubmit={handleResultUpdate}
           onRefreshResults={handleRefreshResults}
           onInspect={() => {
+            setComparisonStoryActive(false);
+            setActiveSection("explore");
+          }}
+          onCompare={() => {
+            setComparisonStoryActive(true);
             setActiveSection("explore");
           }}
           onPreviewResultDelete={handlePreviewResultDelete}
@@ -3965,7 +4065,17 @@ export function App() {
         />
       )}
 
-      {activeSection === "explore" && <ExploreWorkspace selectedResult={selectedResult} />}
+      {activeSection === "explore" && (
+        <ExploreWorkspace
+          selectedResult={selectedResult}
+          comparisonStory={comparisonStoryActive ? comparisonStory : null}
+          onBackToResults={() => {
+            setComparisonStoryActive(false);
+            setActiveSection("results");
+          }}
+          onOpenResult={(resultId) => openOrdinaryResult(resultId, "explore")}
+        />
+      )}
     </main>
   );
 }
@@ -6960,11 +7070,14 @@ function ResultsWorkspace({
   resultsError,
   resultDeletePreview,
   draft,
+  comparisonStory,
+  comparisonStoryStatus,
   onSelectResult,
   onDraftChange,
   onSubmit,
   onRefreshResults,
   onInspect,
+  onCompare,
   onPreviewResultDelete,
   onConfirmResultDelete,
   onCancelResultDelete,
@@ -6976,11 +7089,14 @@ function ResultsWorkspace({
   resultsError: string | null;
   resultDeletePreview: DeleteResultResponse | null;
   draft: { name: string; tags: string; notes: string };
+  comparisonStory: TradeCumulusComparisonStoryResponse | null;
+  comparisonStoryStatus: string | null;
   onSelectResult: (resultId: string) => void;
   onDraftChange: (draft: { name: string; tags: string; notes: string }) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onRefreshResults: () => void;
   onInspect: () => void;
+  onCompare: () => void;
   onPreviewResultDelete: (resultId: string) => void;
   onConfirmResultDelete: (resultId: string) => void;
   onCancelResultDelete: () => void;
@@ -7011,10 +7127,13 @@ function ResultsWorkspace({
         selectedResult={selectedResult}
         selectedResultId={selectedResultId}
         draft={draft}
+        comparisonStory={comparisonStory}
+        comparisonStoryStatus={comparisonStoryStatus}
         onSelectResult={onSelectResult}
         onDraftChange={onDraftChange}
         onSubmit={onSubmit}
         onInspect={onInspect}
+        onCompare={onCompare}
         onOpenResultInExplore={(resultId) => {
           onSelectResult(resultId);
           onInspect();
@@ -7033,10 +7152,13 @@ function NotebookWorkspace({
   selectedResult,
   selectedResultId,
   draft,
+  comparisonStory,
+  comparisonStoryStatus,
   onSelectResult,
   onDraftChange,
   onSubmit,
   onInspect,
+  onCompare,
   onOpenResultInExplore,
   deletePreview,
   onPreviewDelete,
@@ -7047,10 +7169,13 @@ function NotebookWorkspace({
   selectedResult: ResultCard | undefined;
   selectedResultId: string | null;
   draft: { name: string; tags: string; notes: string };
+  comparisonStory: TradeCumulusComparisonStoryResponse | null;
+  comparisonStoryStatus: string | null;
   onSelectResult: (resultId: string) => void;
   onDraftChange: (draft: { name: string; tags: string; notes: string }) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onInspect: () => void;
+  onCompare: () => void;
   onOpenResultInExplore: (resultId: string) => void;
   deletePreview: DeleteResultResponse | null;
   onPreviewDelete: (resultId: string) => void;
@@ -7085,9 +7210,12 @@ function NotebookWorkspace({
         <ResultNotebookCard
           result={selectedResult}
           draft={draft}
+          comparisonStory={comparisonStory}
+          comparisonStoryStatus={comparisonStoryStatus}
           onDraftChange={onDraftChange}
           onSubmit={onSubmit}
           onInspect={onInspect}
+          onCompare={onCompare}
           deletePreview={deletePreview}
           onPreviewDelete={onPreviewDelete}
           onConfirmDelete={onConfirmDelete}
@@ -7098,16 +7226,34 @@ function NotebookWorkspace({
   );
 }
 
-function ExploreWorkspace({ selectedResult }: { selectedResult: ResultCard | undefined }) {
+function ExploreWorkspace({
+  selectedResult,
+  comparisonStory,
+  onOpenResult,
+  onBackToResults,
+}: {
+  selectedResult: ResultCard | undefined;
+  comparisonStory: TradeCumulusComparisonStoryResponse | null;
+  onOpenResult: (resultId: string) => void;
+  onBackToResults: () => void;
+}) {
   return (
     <section className="workspace-section explore-workspace" aria-label="Explore this result">
-      {!selectedResult && (
+      {comparisonStory && (
+        <TradeCumulusComparisonStory
+          story={comparisonStory}
+          onOpenResult={onOpenResult}
+          onBackToResults={onBackToResults}
+        />
+      )}
+
+      {!comparisonStory && !selectedResult && (
         <section className="status-panel">
           <p>Select an ingested result from Results to inspect or visualize it.</p>
         </section>
       )}
 
-      {selectedResult && (
+      {!comparisonStory && selectedResult && (
         <section className="explore-result-view">
           <ExploreResultSummary result={selectedResult} />
           <VisualizerSceneShell result={selectedResult} />
@@ -8792,9 +8938,12 @@ function ExperimentNotebookList({
 function ResultNotebookCard({
   result,
   draft,
+  comparisonStory,
+  comparisonStoryStatus,
   onDraftChange,
   onSubmit,
   onInspect,
+  onCompare,
   deletePreview,
   onPreviewDelete,
   onConfirmDelete,
@@ -8802,9 +8951,12 @@ function ResultNotebookCard({
 }: {
   result: ResultCard | undefined;
   draft: { name: string; tags: string; notes: string };
+  comparisonStory: TradeCumulusComparisonStoryResponse | null;
+  comparisonStoryStatus: string | null;
   onDraftChange: (draft: { name: string; tags: string; notes: string }) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onInspect: () => void;
+  onCompare: () => void;
   deletePreview: DeleteResultResponse | null;
   onPreviewDelete: (resultId: string) => void;
   onConfirmDelete: (resultId: string) => void;
@@ -8819,6 +8971,11 @@ function ResultNotebookCard({
   }
 
   const visibleDeletePreview = deletePreview?.result_id === result.result_id ? deletePreview : null;
+  const comparisonMemberSelected = Boolean(
+    comparisonStory &&
+    (result.result_id === comparisonStory.baseline.result_id ||
+      result.result_id === comparisonStory.more_moisture.result_id),
+  );
 
   return (
     <section className="notebook-card" aria-label="Result detail">
@@ -9025,6 +9182,11 @@ function ResultNotebookCard({
         />
 
         <div className="button-row">
+          {comparisonMemberSelected && (
+            <button type="button" onClick={onCompare}>
+              Compare Baseline and More Moisture
+            </button>
+          )}
           <button type="button" onClick={onInspect}>
             Open in Explore
           </button>
@@ -9039,6 +9201,11 @@ function ResultNotebookCard({
             Save changes
           </button>
         </div>
+        {!comparisonStory && comparisonStoryStatus && (
+          <p className="inline-status" role="status">
+            {comparisonStoryStatus}
+          </p>
+        )}
       </form>
     </section>
   );

--- a/app/frontend/src/TradeCumulusComparisonStory.test.tsx
+++ b/app/frontend/src/TradeCumulusComparisonStory.test.tsx
@@ -440,6 +440,42 @@ describe("TradeCumulusComparisonStory", () => {
     expect(screen.queryByTestId("comparison-updraft-lens-slice")).not.toBeInTheDocument();
   });
 
+  it.each([
+    { caseName: "empty", points: [] as number[][], returnedCount: 0 },
+    { caseName: "count-inconsistent", points: [[0, 0, 1, 0.001]], returnedCount: 2 },
+  ])("fails closed when a point cloud is $caseName", async ({ points, returnedCount }) => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      const member = url.includes(moreId) ? story.more_moisture : story.baseline;
+      let payload = url.includes("point-cloud") ? pointCloud(member) : frame(member);
+      if (url.includes("point-cloud") && member === story.baseline) {
+        payload = {
+          ...pointCloud(member),
+          points,
+          stats: {
+            ...pointCloud(member).stats,
+            returned_count: returnedCount,
+          },
+        };
+      }
+      return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }));
+    });
+
+    render(
+      <TradeCumulusComparisonStory
+        story={story}
+        onOpenResult={vi.fn()}
+        onBackToResults={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Curated point-cloud data conflicts with the comparison story.",
+    );
+    expect(screen.queryByTestId("comparison-true3d-viewer")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("comparison-updraft-lens-slice")).not.toBeInTheDocument();
+  });
+
   it("routes Back and both member actions without adding comparison controls", async () => {
     const onOpenResult = vi.fn();
     const onBackToResults = vi.fn();

--- a/app/frontend/src/TradeCumulusComparisonStory.test.tsx
+++ b/app/frontend/src/TradeCumulusComparisonStory.test.tsx
@@ -1,0 +1,468 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  TradeCumulusComparisonStory,
+  type TradeCumulusComparisonStoryResponse,
+} from "./TradeCumulusComparisonStory";
+
+vi.mock("./True3DViewer", () => ({
+  True3DViewer: ({ resultName }: { resultName: string }) => (
+    <div data-testid="comparison-true3d-viewer">{resultName} 3-D viewer</div>
+  ),
+}));
+
+vi.mock("./UpdraftLensSlice", () => ({
+  UpdraftLensSlice: ({ frame }: { frame: { result_id: string } }) => (
+    <div data-testid="comparison-updraft-lens-slice">{frame.result_id} Lens slice</div>
+  ),
+}));
+
+const baselineId = "result-trade-cumulus-5b-full-baseline-20260720T162342Z";
+const moreId = "result-trade-cumulus-5b-full-more_moisture-20260720T162342Z";
+
+const story: TradeCumulusComparisonStoryResponse = {
+  comparison_id: "trade_cumulus_moisture_v1",
+  comparison_group_id: "trade_cumulus_moisture_v1",
+  product_slice_id: "trade_cumulus_v1",
+  case_id: "bomex_trade_cumulus_baseline_v0",
+  title: "Trade Cumulus: Baseline and More Moisture",
+  question: "How does stronger surface moisture supply change the trade-cumulus field?",
+  illustrative_view_note:
+    "Illustrative views: selected to help show the response measured across the full simulations. Times and locations may differ, and these are not corresponding individual clouds.",
+  baseline: {
+    result_id: baselineId,
+    run_id: "trade-cumulus-5b-full-baseline-20260720T162342Z",
+    display_name: "Canonical BOMEX Baseline",
+    control_state: "baseline",
+    control_label: "Surface moisture supply",
+    control_value: 5.2e-5,
+    control_units: "g/g m/s",
+    control_display: "5.2 × 10⁻⁵ g/g m/s",
+    curated_view: {
+      time_index: 152,
+      time_seconds: 18_240,
+      orientation: "vertical_x",
+      plane_dimension: "y",
+      plane_index: 5,
+      plane_coordinate: -2.6500000953674316,
+      plane_units: "km",
+      camera_preset: "overview",
+      cloud_field: "ql",
+      cloud_threshold_kg_kg: 1e-6,
+      lens_id: "updraft",
+      scale_id: "trade_cumulus_updraft_velocity_v1",
+      wind_mode: "perturbation",
+      show_wind: true,
+      show_cloud_boundary: true,
+      opacity: 0.68,
+      point_size: 11,
+      caption:
+        "This illustrative Baseline view shows one concentrated active cloud reaching about 2 km, with a strong rising core bordered by sinking air.",
+    },
+  },
+  more_moisture: {
+    result_id: moreId,
+    run_id: "trade-cumulus-5b-full-more_moisture-20260720T162342Z",
+    display_name: "More Moisture",
+    control_state: "more_moisture",
+    control_label: "Surface moisture supply",
+    control_value: 7.8e-5,
+    control_units: "g/g m/s",
+    control_display: "7.8 × 10⁻⁵ g/g m/s",
+    curated_view: {
+      time_index: 169,
+      time_seconds: 20_280,
+      orientation: "vertical_x",
+      plane_dimension: "y",
+      plane_index: 51,
+      plane_coordinate: 1.9500000476837158,
+      plane_units: "km",
+      camera_preset: "overview",
+      cloud_field: "ql",
+      cloud_threshold_kg_kg: 1e-6,
+      lens_id: "updraft",
+      scale_id: "trade_cumulus_updraft_velocity_v1",
+      wind_mode: "perturbation",
+      show_wind: true,
+      show_cloud_boundary: true,
+      opacity: 0.68,
+      point_size: 11,
+      caption:
+        "This illustrative More Moisture view shows several active clouds across the slice, with rising cores distributed through a broader cloud-filled region reaching just above 2 km.",
+    },
+  },
+  changed_condition: {
+    label: "Surface moisture supply",
+    baseline_display: "5.2 × 10⁻⁵ g/g m/s",
+    more_moisture_display: "7.8 × 10⁻⁵ g/g m/s",
+    change_display: "+50%",
+  },
+  material_responses: [
+    {
+      metric_id: "mean_cloud_cover_final_three_hours",
+      label: "Mean cloud cover, final three hours",
+      baseline_value: 10.596239697802197,
+      more_moisture_value: 12.710873111263735,
+      absolute_delta: 2.1146334134615383,
+      percent_delta: 19.956451286206196,
+      units: "%",
+      method: "time mean of horizontal columns containing ql >= 1e-6 kg/kg",
+      window: "time >= 10800 s",
+      baseline_display: "10.596%",
+      more_moisture_display: "12.711%",
+      change_display: "+2.115 percentage points",
+    },
+    {
+      metric_id: "mean_cloud_water_path_final_three_hours",
+      label: "Mean cloud-water path, final three hours",
+      baseline_value: 0.006351999299305916,
+      more_moisture_value: 0.009071426778155891,
+      absolute_delta: 0.0027194274788499753,
+      percent_delta: 42.81215017053178,
+      units: "kg/m^2",
+      method: "time mean of horizontal domain-mean cwp",
+      window: "time >= 10800 s",
+      baseline_display: "0.006352 kg/m²",
+      more_moisture_display: "0.009071 kg/m²",
+      change_display: "+42.812%",
+    },
+    {
+      metric_id: "mean_coherent_cloud_top_final_three_hours",
+      label: "Mean coherent cloud top, final three hours",
+      baseline_value: 1668.3517340775375,
+      more_moisture_value: 1805.0550379595913,
+      absolute_delta: 136.7033038820539,
+      percent_delta: 8.193913854600911,
+      units: "m",
+      method: "mean supported coherent cloud-object top",
+      window: "time >= 10800 s",
+      baseline_display: "1,668 m",
+      more_moisture_display: "1,805 m",
+      change_display: "+137 m",
+    },
+  ],
+  small_or_mixed_responses: [
+    {
+      title: "Initial cloud-liquid onset was unchanged.",
+      body: "Both simulations first reached the cloud-liquid threshold at 1,080 s.",
+    },
+    {
+      title: "The cloud-fraction peak stayed at the same height.",
+      body: "Both final-three-hour profiles peaked near 620 m.",
+    },
+    {
+      title: "The fraction of cloudy air rising changed very little.",
+      body: "It was 90.379% in Baseline and 90.451% in More Moisture.",
+    },
+    {
+      title: "The response varied through time.",
+      body: "More Moisture was not cloudier or wetter than Baseline at every individual saved frame.",
+    },
+  ],
+  held_fixed_by_design: {
+    lead: "Only surface moisture supply changed.",
+    groups: [
+      {
+        title: "Initial atmosphere",
+        body: "Thermodynamic, moisture, and wind profiles, including the deterministic perturbation.",
+      },
+      {
+        title: "Forcing",
+        body: "Sensible heat supply, friction velocity, large-scale forcing, geostrophic wind, and Coriolis treatment.",
+      },
+      {
+        title: "Model setup",
+        body: "Moist physics, turbulence, boundaries, domain, grid, and timestep strategy.",
+      },
+      {
+        title: "Execution and outputs",
+        body: "Duration, output cadence, requested fields, CM1 source and executable, and the Cloud Chamber implementation commit.",
+      },
+    ],
+  },
+  explanation_paragraphs: [
+    "More surface moisture produced a cloudier, wetter, somewhat deeper trade-cumulus field.",
+    "Only the lower-boundary moisture supply changed. Over the final three hours, More Moisture covered more of the domain with cloud, held about 43 percent more mean cloud-water path, and produced coherent clouds averaging 137 meters taller.",
+    "It did not create a completely different circulation regime. Initial cloud-liquid onset and the height of the cloud-fraction maximum were unchanged, and about 90 percent of cloudy cells were rising in both simulations.",
+    "The illustrative Lens views are selected to help show the measured response. They show different times and locations and are not one-to-one matches of individual clouds. More Moisture was also not cloudier at every saved frame, so the result is a change in the evolving cloud field rather than a rule that every moment must look larger.",
+  ],
+  evidence_summary: {
+    analysis_window: "time >= 10800 s",
+    analysis_start_seconds: 10_800,
+    analysis_end_seconds: 21_600,
+    output_cadence_seconds: 120,
+    paired_saved_frame_count: 181,
+  },
+  provenance: {
+    evidence_state: "matched_runs_valid",
+    evidence_version: "trade_cumulus_moisture_comparison_evidence_v1",
+    implementation_commit: "49da1defc9914d3cc903ed9589c1312ddd843726",
+    fixed_assumptions_sha256: "71d746b110fb1310ebb6dafbef4cfa4bd44c379fc6964ed1787deaf45e422535",
+    baseline_run_id: "trade-cumulus-5b-full-baseline-20260720T162342Z",
+    baseline_result_id: baselineId,
+    more_moisture_run_id: "trade-cumulus-5b-full-more_moisture-20260720T162342Z",
+    more_moisture_result_id: moreId,
+    scale_id: "trade_cumulus_updraft_velocity_v1",
+    comparison_source: "runtime_matched_pair_evidence",
+  },
+  caveats: [
+    "one_deterministic_les_realization_per_control_state",
+    "illustrative_views_are_not_direct_frame_matches",
+    "individual_clouds_are_not_paired_one_to_one",
+    "candidate_product_slice_not_supported_status",
+  ],
+};
+
+function pointCloud(member: TradeCumulusComparisonStoryResponse["baseline"]) {
+  return {
+    result_id: member.result_id,
+    run_id: member.run_id,
+    scenario_id: "bomex_trade_cumulus_baseline_v0",
+    field: { raw_field_name: "ql", display_name: "Cloud water", units: "kg/kg" },
+    selection: {
+      field: "ql",
+      time_index: member.curated_view.time_index,
+      time_seconds: member.curated_view.time_seconds,
+      threshold: 1e-6,
+      max_points: 50_000,
+    },
+    coordinate_units: { xh: "km", yh: "km", zh: "km" },
+    coordinate_extents: {
+      xh: { min: -3.2, max: 3.2, units: "km" },
+      yh: { min: -3.2, max: 3.2, units: "km" },
+      zh: { min: 0, max: 3, units: "km" },
+    },
+    points: [[0, 0, 1, 0.001]],
+    stats: {
+      source_count: 1,
+      returned_count: 1,
+      field_min_value: 0,
+      field_max_value: 0.001,
+      field_mean_value: 0.0001,
+      field_finite_count: 1,
+      field_non_finite_count: 0,
+      min_value: 0.001,
+      max_value: 0.001,
+      active_z_min: 1,
+      active_z_max: 1,
+      downsampled: false,
+      downsample_stride: 1,
+    },
+    provenance: {
+      source_model: "CM1",
+      result_id: member.result_id,
+      run_id: member.run_id,
+      scenario_id: "bomex_trade_cumulus_baseline_v0",
+      processing_method: "backend_xarray_native_grid_threshold",
+      rendering_method: "thresholded_point_cloud",
+      provenance_label: "CM1-derived cloud water point cloud",
+    },
+    caveats: [],
+  };
+}
+
+function frame(member: TradeCumulusComparisonStoryResponse["baseline"]) {
+  return {
+    result_id: member.result_id,
+    time_index: member.curated_view.time_index,
+    time_seconds: member.curated_view.time_seconds,
+    orientation: "vertical_x",
+    plane_dimension: "y",
+    plane_index: member.curated_view.plane_index,
+    plane_coordinate: member.curated_view.plane_coordinate,
+    plane_units: "km",
+    dimension_order: ["z", "x"],
+    x_indices: [0, 1],
+    x_values_km: [-0.05, 0.05],
+    y_indices: [0, 1],
+    y_values_km: [-0.05, 0.05],
+    z_indices: [0, 1],
+    z_values_km: [0.02, 0.06],
+    w_values_m_s: [[-0.5, 1]],
+    cloud_mask: [[true, false]],
+    cloud_threshold_kg_kg: 1e-6,
+    w_range_min_m_s: -1,
+    w_range_max_m_s: 5,
+    w_range_method: "fixed_trade_cumulus_updraft_velocity_v1",
+    w_scale_id: "trade_cumulus_updraft_velocity_v1",
+    w_scale_owner: "trade_cumulus",
+    w_scale_type: "fixed_discrete",
+    w_scale_units: "m/s",
+    w_scale_breakpoints_m_s: [-1, -0.5, -0.1, 0.1, 0.5, 1, 2, 3, 5],
+    w_scale_colors: [
+      "#4b0082",
+      "#0057d9",
+      "#00c9d8",
+      "#ffffff",
+      "#00d63b",
+      "#8fe000",
+      "#ffe000",
+      "#ff9800",
+      "#ff3b00",
+      "#c40000",
+    ],
+    w_scale_neutral_interval_m_s: [-0.1, 0.1],
+    w_scale_source: "pm_approved_issue_379_from_stage5b2_matched_pair",
+    w_scale_clipping_behavior: "endpoint colors",
+    w_finite_count: 2,
+    w_low_clipped_count: 0,
+    w_high_clipped_count: 0,
+    w_low_clipped_fraction: 0,
+    w_high_clipped_fraction: 0,
+    wind_mode: "perturbation",
+    wind_target_level_m: 600,
+    wind_actual_level_m: 580,
+    wind_level_index: 14,
+    wind_stride: 8,
+    wind_reference_m_s: 0.9,
+    wind_arrow_domain_fraction: 0.08,
+    domain_mean_u_m_s: 0,
+    domain_mean_v_m_s: 0,
+    wind_vectors: [{ x_km: 0, y_km: 0, z_km: 0.58, u_m_s: 0.4, v_m_s: 0.2, magnitude_m_s: 0.45 }],
+    provenance: {
+      source_model: "CM1",
+      result_id: member.result_id,
+      run_id: member.run_id,
+      scenario_id: "bomex_trade_cumulus_baseline_v0",
+      processing_method: "trade_cumulus_updraft_lens_frame",
+      rendering_method: "native_grid_slice",
+      provenance_label: "CM1-derived Updraft Lens frame",
+    },
+    caveats: [],
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      const member = url.includes(moreId) ? story.more_moisture : story.baseline;
+      const payload = url.includes("point-cloud") ? pointCloud(member) : frame(member);
+      return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }));
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("TradeCumulusComparisonStory", () => {
+  it("loads both exact views and renders the complete authored story", async () => {
+    render(
+      <TradeCumulusComparisonStory
+        story={story}
+        onOpenResult={vi.fn()}
+        onBackToResults={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Trade Cumulus: Baseline and More Moisture" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(story.question)).toBeInTheDocument();
+    expect(screen.getByText(story.illustrative_view_note)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("comparison-true3d-viewer")).toHaveLength(2);
+    });
+    expect(screen.getAllByTestId("comparison-updraft-lens-slice")).toHaveLength(2);
+    expect(screen.getByText("18,240 s · 05:04:00")).toBeInTheDocument();
+    expect(screen.getByText("20,280 s · 05:38:00")).toBeInTheDocument();
+    expect(screen.getAllByText("Vertical x-z slice at y = -2.65 km")).toHaveLength(2);
+    expect(screen.getAllByText("Vertical x-z slice at y = 1.95 km")).toHaveLength(2);
+    expect(screen.getByText(story.baseline.curated_view.caption)).toBeInTheDocument();
+    expect(screen.getByText(story.more_moisture.curated_view.caption)).toBeInTheDocument();
+    expect(screen.getByText("+50%")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "What responded materially" })).toBeInTheDocument();
+    expect(screen.getByText("+2.115 percentage points")).toBeInTheDocument();
+    expect(screen.getByText("+42.812%")).toBeInTheDocument();
+    expect(screen.getByText("+137 m")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "What changed little or varied" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(story.small_or_mixed_responses[3].body)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "What stayed fixed" })).toBeInTheDocument();
+    expect(screen.getByText("Execution and outputs")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "What this comparison suggests" }),
+    ).toBeInTheDocument();
+    story.explanation_paragraphs.forEach((paragraph) => {
+      expect(screen.getByText(paragraph)).toBeInTheDocument();
+    });
+
+    const requestedUrls = vi.mocked(fetch).mock.calls.map(([input]) => String(input));
+    expect(requestedUrls).toContain(
+      `/api/results/${baselineId}/visualization/point-cloud?field=ql&time_index=152&threshold=0.000001&max_points=50000&encoding=json`,
+    );
+    expect(requestedUrls).toContain(
+      `/api/results/${baselineId}/visualization/trade-cumulus-updraft-lens/frame?time_index=152&plane_index=5&orientation=vertical_x&wind_mode=perturbation`,
+    );
+    expect(requestedUrls).toContain(
+      `/api/results/${moreId}/visualization/point-cloud?field=ql&time_index=169&threshold=0.000001&max_points=50000&encoding=json`,
+    );
+    expect(requestedUrls).toContain(
+      `/api/results/${moreId}/visualization/trade-cumulus-updraft-lens/frame?time_index=169&plane_index=51&orientation=vertical_x&wind_mode=perturbation`,
+    );
+    expect(screen.queryByRole("button", { name: "Play time" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Position")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("2-D slice field")).not.toBeInTheDocument();
+  });
+
+  it("fails closed when either returned frame conflicts with the story", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      const member = url.includes(moreId) ? story.more_moisture : story.baseline;
+      const payload = url.includes("point-cloud")
+        ? pointCloud(member)
+        : {
+            ...frame(member),
+            time_seconds:
+              member === story.more_moisture ? 20_400 : member.curated_view.time_seconds,
+          };
+      return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }));
+    });
+
+    render(
+      <TradeCumulusComparisonStory
+        story={story}
+        onOpenResult={vi.fn()}
+        onBackToResults={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Curated Updraft Lens data conflicts with the comparison story.",
+    );
+    expect(screen.queryByTestId("comparison-true3d-viewer")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("comparison-updraft-lens-slice")).not.toBeInTheDocument();
+  });
+
+  it("routes Back and both member actions without adding comparison controls", async () => {
+    const onOpenResult = vi.fn();
+    const onBackToResults = vi.fn();
+    render(
+      <TradeCumulusComparisonStory
+        story={story}
+        onOpenResult={onOpenResult}
+        onBackToResults={onBackToResults}
+      />,
+    );
+    await screen.findAllByTestId("comparison-true3d-viewer");
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Baseline in Explore" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open More Moisture in Explore" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back to Results" }));
+
+    expect(onOpenResult).toHaveBeenNthCalledWith(1, baselineId);
+    expect(onOpenResult).toHaveBeenNthCalledWith(2, moreId);
+    expect(onBackToResults).toHaveBeenCalledOnce();
+    const storyRegion = screen.getByRole("heading", {
+      name: "Trade Cumulus: Baseline and More Moisture",
+    }).parentElement?.parentElement;
+    expect(storyRegion).not.toBeNull();
+    expect(within(storyRegion!).queryByRole("button", { name: /orientation/i })).toBeNull();
+  });
+});

--- a/app/frontend/src/TradeCumulusComparisonStory.tsx
+++ b/app/frontend/src/TradeCumulusComparisonStory.tsx
@@ -1,0 +1,490 @@
+import { useEffect, useState } from "react";
+
+import { True3DViewer } from "./True3DViewer";
+import { type UpdraftLensFrame, UpdraftLensSlice } from "./UpdraftLensSlice";
+
+export type TradeCumulusCuratedView = {
+  time_index: number;
+  time_seconds: number;
+  orientation: "vertical_x";
+  plane_dimension: "y";
+  plane_index: number;
+  plane_coordinate: number;
+  plane_units: "km";
+  camera_preset: "overview";
+  cloud_field: "ql";
+  cloud_threshold_kg_kg: number;
+  lens_id: "updraft";
+  scale_id: "trade_cumulus_updraft_velocity_v1";
+  wind_mode: "perturbation";
+  show_wind: true;
+  show_cloud_boundary: true;
+  opacity: number;
+  point_size: number;
+  caption: string;
+};
+
+export type TradeCumulusComparisonMember = {
+  result_id: string;
+  run_id: string;
+  display_name: string;
+  control_state: "baseline" | "more_moisture";
+  control_label: "Surface moisture supply";
+  control_value: number;
+  control_units: "g/g m/s";
+  control_display: string;
+  curated_view: TradeCumulusCuratedView;
+};
+
+export type TradeCumulusMaterialResponse = {
+  metric_id: string;
+  label: string;
+  baseline_value: number;
+  more_moisture_value: number;
+  absolute_delta: number;
+  percent_delta: number;
+  units: string;
+  method: string;
+  window: string;
+  baseline_display: string;
+  more_moisture_display: string;
+  change_display: string;
+};
+
+export type TradeCumulusComparisonStoryResponse = {
+  comparison_id: "trade_cumulus_moisture_v1";
+  comparison_group_id: "trade_cumulus_moisture_v1";
+  product_slice_id: "trade_cumulus_v1";
+  case_id: "bomex_trade_cumulus_baseline_v0";
+  title: string;
+  question: string;
+  illustrative_view_note: string;
+  baseline: TradeCumulusComparisonMember;
+  more_moisture: TradeCumulusComparisonMember;
+  changed_condition: {
+    label: "Surface moisture supply";
+    baseline_display: string;
+    more_moisture_display: string;
+    change_display: "+50%";
+  };
+  material_responses: TradeCumulusMaterialResponse[];
+  small_or_mixed_responses: Array<{ title: string; body: string }>;
+  held_fixed_by_design: {
+    lead: "Only surface moisture supply changed.";
+    groups: Array<{ title: string; body: string }>;
+  };
+  explanation_paragraphs: string[];
+  evidence_summary: {
+    analysis_window: "time >= 10800 s";
+    analysis_start_seconds: number;
+    analysis_end_seconds: number;
+    output_cadence_seconds: number;
+    paired_saved_frame_count: number;
+  };
+  provenance: {
+    evidence_state: "matched_runs_valid";
+    evidence_version: string;
+    implementation_commit: string;
+    fixed_assumptions_sha256: string;
+    baseline_run_id: string;
+    baseline_result_id: string;
+    more_moisture_run_id: string;
+    more_moisture_result_id: string;
+    scale_id: "trade_cumulus_updraft_velocity_v1";
+    comparison_source: "runtime_matched_pair_evidence";
+  };
+  caveats: string[];
+};
+
+type PointCloudResponse = {
+  result_id: string;
+  run_id: string;
+  scenario_id: string;
+  field: {
+    raw_field_name: string;
+    display_name: string;
+    units: string | null;
+  };
+  selection: {
+    field: string;
+    time_index: number;
+    time_seconds: number | null;
+    threshold: number;
+    max_points: number;
+  };
+  coordinate_units: Record<string, string | null>;
+  coordinate_extents: Record<string, { min: number; max: number; units: string | null }>;
+  points: Array<[number, number, number, number]>;
+  stats: {
+    source_count: number;
+    returned_count: number;
+    field_min_value: number | null;
+    field_max_value: number | null;
+    field_mean_value: number | null;
+    field_finite_count: number;
+    field_non_finite_count: number;
+    min_value: number | null;
+    max_value: number | null;
+    active_z_min: number | null;
+    active_z_max: number | null;
+    downsampled: boolean;
+    downsample_stride: number;
+  };
+  provenance: {
+    source_model: string;
+    result_id: string;
+    run_id: string;
+    scenario_id: string;
+    processing_method: string;
+    rendering_method: string;
+    provenance_label: string;
+  };
+  caveats: string[];
+};
+
+type CuratedMemberData = {
+  member: TradeCumulusComparisonMember;
+  pointCloud: PointCloudResponse;
+  frame: UpdraftLensFrame;
+};
+
+type ComparisonData = {
+  baseline: CuratedMemberData;
+  moreMoisture: CuratedMemberData;
+};
+
+export function TradeCumulusComparisonStory({
+  story,
+  onOpenResult,
+  onBackToResults,
+}: {
+  story: TradeCumulusComparisonStoryResponse;
+  onOpenResult: (resultId: string) => void;
+  onBackToResults: () => void;
+}) {
+  const [data, setData] = useState<ComparisonData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+    setData(null);
+    setError(null);
+
+    Promise.all([
+      loadCuratedMember(story.baseline, controller.signal),
+      loadCuratedMember(story.more_moisture, controller.signal),
+    ])
+      .then(([baseline, moreMoisture]) => {
+        if (!active) return;
+        setData({ baseline, moreMoisture });
+      })
+      .catch((caught: unknown) => {
+        if (!active || controller.signal.aborted) return;
+        setData(null);
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : "The curated comparison views could not be loaded.",
+        );
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [story]);
+
+  return (
+    <section className="trade-cumulus-comparison" aria-labelledby="comparison-story-title">
+      <header className="comparison-story-header">
+        <div className="comparison-story-heading-row">
+          <div>
+            <p className="eyebrow">Curated comparison</p>
+            <h2 id="comparison-story-title">{story.title}</h2>
+            <p className="comparison-story-question">{story.question}</p>
+          </div>
+          <button type="button" className="secondary-button" onClick={onBackToResults}>
+            Back to Results
+          </button>
+        </div>
+
+        <dl className="comparison-changed-condition" aria-label="Changed condition">
+          <div>
+            <dt>{story.changed_condition.label}</dt>
+            <dd>
+              <span>{story.changed_condition.baseline_display}</span>
+              <span aria-hidden="true">to</span>
+              <span>{story.changed_condition.more_moisture_display}</span>
+              <strong>{story.changed_condition.change_display}</strong>
+            </dd>
+          </div>
+        </dl>
+        <p className="comparison-illustrative-note">{story.illustrative_view_note}</p>
+      </header>
+
+      {error && (
+        <section className="comparison-story-load-state" role="alert">
+          <h3>Curated views unavailable</h3>
+          <p>{error}</p>
+        </section>
+      )}
+
+      {!data && !error && (
+        <section className="comparison-story-load-state" role="status">
+          <p>Loading both curated simulation views...</p>
+        </section>
+      )}
+
+      {data && (
+        <>
+          <div className="comparison-simulation-grid" aria-label="Curated simulation views">
+            <SimulationView
+              data={data.baseline}
+              actionLabel="Open Baseline in Explore"
+              onOpenResult={onOpenResult}
+            />
+            <SimulationView
+              data={data.moreMoisture}
+              actionLabel="Open More Moisture in Explore"
+              onOpenResult={onOpenResult}
+            />
+          </div>
+
+          <section className="comparison-story-section" aria-labelledby="material-response-title">
+            <h3 id="material-response-title">What responded materially</h3>
+            <dl className="comparison-material-responses">
+              {story.material_responses.map((response) => (
+                <div key={response.metric_id}>
+                  <dt>{response.label}</dt>
+                  <dd>
+                    <span>Baseline {response.baseline_display}</span>
+                    <span>More Moisture {response.more_moisture_display}</span>
+                    <strong>{response.change_display}</strong>
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <section className="comparison-story-section" aria-labelledby="mixed-response-title">
+            <h3 id="mixed-response-title">What changed little or varied</h3>
+            <ul className="comparison-authored-list">
+              {story.small_or_mixed_responses.map((response) => (
+                <li key={response.title}>
+                  <strong>{response.title}</strong>
+                  <span>{response.body}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="comparison-story-section" aria-labelledby="held-fixed-title">
+            <h3 id="held-fixed-title">What stayed fixed</h3>
+            <p className="comparison-section-lead">{story.held_fixed_by_design.lead}</p>
+            <dl className="comparison-held-fixed">
+              {story.held_fixed_by_design.groups.map((group) => (
+                <div key={group.title}>
+                  <dt>{group.title}</dt>
+                  <dd>{group.body}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <section className="comparison-story-section" aria-labelledby="comparison-suggests-title">
+            <h3 id="comparison-suggests-title">What this comparison suggests</h3>
+            <div className="comparison-explanation">
+              {story.explanation_paragraphs.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          </section>
+        </>
+      )}
+    </section>
+  );
+}
+
+function SimulationView({
+  data,
+  actionLabel,
+  onOpenResult,
+}: {
+  data: CuratedMemberData;
+  actionLabel: string;
+  onOpenResult: (resultId: string) => void;
+}) {
+  const { member, pointCloud, frame } = data;
+  const timeLabel = `${formatSeconds(member.curated_view.time_seconds)} · ${formatClock(
+    member.curated_view.time_seconds,
+  )}`;
+  const planeLabel = `Vertical x-z slice at y = ${formatCoordinate(
+    member.curated_view.plane_coordinate,
+  )} km`;
+
+  return (
+    <article
+      className="comparison-simulation"
+      aria-labelledby={`comparison-simulation-${member.control_state}`}
+      data-result-id={member.result_id}
+    >
+      <header className="comparison-simulation-header">
+        <div>
+          <p className="eyebrow">Simulation</p>
+          <h3 id={`comparison-simulation-${member.control_state}`}>{member.display_name}</h3>
+          <p>{member.control_display}</p>
+        </div>
+        <dl>
+          <div>
+            <dt>Model time</dt>
+            <dd>{timeLabel}</dd>
+          </div>
+          <div>
+            <dt>Lens plane</dt>
+            <dd>{planeLabel}</dd>
+          </div>
+        </dl>
+      </header>
+
+      <p className="comparison-view-caption">{member.curated_view.caption}</p>
+
+      <True3DViewer
+        resultName={member.display_name}
+        pointCloud={pointCloud}
+        fieldLabel="ql — Cloud water"
+        valueChannelLabel="Cloud water above the fixed threshold."
+        activeSlice={null}
+        activeSliceLabel={planeLabel}
+        showSlicePlane={false}
+        selectedRegion={null}
+        coordinateSizes={{
+          x: frame.x_indices.length,
+          y: frame.y_indices.length,
+          z: frame.z_indices.length,
+        }}
+        selectedTimeLabel={timeLabel}
+        sceneTimeLabel={timeLabel}
+        thresholdLabel="1.000e-6 kg/kg"
+        opacity={member.curated_view.opacity}
+        pointSize={member.curated_view.point_size}
+        status="Curated view loaded"
+        provenanceLabel={frame.provenance.provenance_label}
+        noCloudMessage="No cloud water is visible in this curated frame."
+        windVectors={frame.wind_vectors}
+        showWindVectors={member.curated_view.show_wind}
+        windMode={member.curated_view.wind_mode}
+        windReferenceMps={frame.wind_reference_m_s}
+        windArrowDomainFraction={frame.wind_arrow_domain_fraction}
+        updraftLensFrame={frame}
+      />
+
+      <section className="comparison-lens-view" aria-label={`${member.display_name} Lens slice`}>
+        <div className="comparison-lens-heading">
+          <p className="eyebrow">Updraft Lens</p>
+          <h4>{planeLabel}</h4>
+        </div>
+        <UpdraftLensSlice frame={frame} showCloudBoundary selectedPoint={null} />
+      </section>
+
+      <div className="comparison-simulation-action">
+        <button type="button" onClick={() => onOpenResult(member.result_id)}>
+          {actionLabel}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+async function loadCuratedMember(
+  member: TradeCumulusComparisonMember,
+  signal: AbortSignal,
+): Promise<CuratedMemberData> {
+  const view = member.curated_view;
+  const pointCloudQuery = new URLSearchParams({
+    field: view.cloud_field,
+    time_index: String(view.time_index),
+    threshold: String(view.cloud_threshold_kg_kg),
+    max_points: "50000",
+    encoding: "json",
+  });
+  const frameQuery = new URLSearchParams({
+    time_index: String(view.time_index),
+    plane_index: String(view.plane_index),
+    orientation: view.orientation,
+    wind_mode: view.wind_mode,
+  });
+  const [pointCloudResponse, frameResponse] = await Promise.all([
+    fetch(
+      `/api/results/${member.result_id}/visualization/point-cloud?${pointCloudQuery.toString()}`,
+      { signal },
+    ),
+    fetch(
+      `/api/results/${member.result_id}/visualization/trade-cumulus-updraft-lens/frame?${frameQuery.toString()}`,
+      { signal },
+    ),
+  ]);
+  if (!pointCloudResponse.ok || !frameResponse.ok) {
+    throw new Error("Both curated simulation views must load before comparison.");
+  }
+  const pointCloud = (await pointCloudResponse.json()) as PointCloudResponse;
+  const frame = (await frameResponse.json()) as UpdraftLensFrame;
+  validatePointCloud(member, pointCloud);
+  validateFrame(member, frame);
+  return { member, pointCloud, frame };
+}
+
+function validatePointCloud(member: TradeCumulusComparisonMember, pointCloud: PointCloudResponse) {
+  const view = member.curated_view;
+  if (
+    pointCloud.result_id !== member.result_id ||
+    pointCloud.provenance.result_id !== member.result_id ||
+    pointCloud.field.raw_field_name !== view.cloud_field ||
+    pointCloud.selection.field !== view.cloud_field ||
+    pointCloud.selection.time_index !== view.time_index ||
+    !numbersMatch(pointCloud.selection.time_seconds, view.time_seconds) ||
+    !numbersMatch(pointCloud.selection.threshold, view.cloud_threshold_kg_kg)
+  ) {
+    throw new Error("Curated point-cloud data conflicts with the comparison story.");
+  }
+}
+
+function validateFrame(member: TradeCumulusComparisonMember, frame: UpdraftLensFrame) {
+  const view = member.curated_view;
+  if (
+    frame.result_id !== member.result_id ||
+    frame.time_index !== view.time_index ||
+    !numbersMatch(frame.time_seconds, view.time_seconds) ||
+    frame.orientation !== view.orientation ||
+    frame.plane_dimension !== view.plane_dimension ||
+    frame.plane_index !== view.plane_index ||
+    !numbersMatch(frame.plane_coordinate, view.plane_coordinate, 1e-9) ||
+    frame.plane_units !== view.plane_units ||
+    frame.w_scale_id !== view.scale_id ||
+    !numbersMatch(frame.cloud_threshold_kg_kg, view.cloud_threshold_kg_kg)
+  ) {
+    throw new Error("Curated Updraft Lens data conflicts with the comparison story.");
+  }
+}
+
+function numbersMatch(left: number | null, right: number, tolerance = 1e-12): boolean {
+  return left !== null && Number.isFinite(left) && Math.abs(left - right) <= tolerance;
+}
+
+function formatSeconds(seconds: number): string {
+  return `${seconds.toLocaleString("en-US", { maximumFractionDigits: 0 })} s`;
+}
+
+function formatClock(seconds: number): string {
+  const rounded = Math.round(seconds);
+  const hours = Math.floor(rounded / 3600);
+  const minutes = Math.floor((rounded % 3600) / 60);
+  const remainingSeconds = rounded % 60;
+  return [hours, minutes, remainingSeconds]
+    .map((value) => String(value).padStart(2, "0"))
+    .join(":");
+}
+
+function formatCoordinate(value: number): string {
+  return Number(value.toFixed(2)).toString();
+}

--- a/app/frontend/src/TradeCumulusComparisonStory.tsx
+++ b/app/frontend/src/TradeCumulusComparisonStory.tsx
@@ -443,7 +443,11 @@ function validatePointCloud(member: TradeCumulusComparisonMember, pointCloud: Po
     pointCloud.selection.field !== view.cloud_field ||
     pointCloud.selection.time_index !== view.time_index ||
     !numbersMatch(pointCloud.selection.time_seconds, view.time_seconds) ||
-    !numbersMatch(pointCloud.selection.threshold, view.cloud_threshold_kg_kg)
+    !numbersMatch(pointCloud.selection.threshold, view.cloud_threshold_kg_kg) ||
+    pointCloud.points.length === 0 ||
+    !Number.isInteger(pointCloud.stats.returned_count) ||
+    pointCloud.stats.returned_count <= 0 ||
+    pointCloud.stats.returned_count !== pointCloud.points.length
   ) {
     throw new Error("Curated point-cloud data conflicts with the comparison story.");
   }

--- a/docs/product/TRADE_CUMULUS_PRODUCT_SLICE.md
+++ b/docs/product/TRADE_CUMULUS_PRODUCT_SLICE.md
@@ -342,7 +342,7 @@ For a Comparison, both Simulations must use the same arrow mode, height, density
 
 This is flow context within the Updraft Lens. It does not establish a generalized vector-rendering platform or a separate Wind Lens.
 
-## 6. First matched Comparison
+## 6. First curated Comparison
 
 The first deliberate question is:
 
@@ -353,38 +353,39 @@ The Comparison contains:
 - one Canonical BOMEX Baseline Simulation;
 - one More Moisture Simulation;
 - the meaningful changed condition stated plainly;
-- synchronized model time;
-- a shared default vertical plane;
+- one independently curated illustrative Updraft Lens view from each Simulation;
 - the shared fixed Trade Cumulus Updraft Scale v1;
-- a shared cloud threshold;
-- shared horizontal-wind overlay settings;
-- the same scientific and numerical assumptions except for surface moisture supply.
+- the same cloud threshold and horizontal-wind treatment;
+- a concise account of what responded materially, what changed little or varied, and what remained fixed by design;
+- an authored explanation grounded in the full-run evidence.
 
-### Reference ownership
+### Illustrative views
 
-The baseline is the reference Simulation.
+The two default views may use different model times and slice positions.
 
-Its default time and plane are selected once and inherited by the variant.
+They are selected to help a person see and understand the response measured across the full simulations. They are not corresponding individual clouds, and the images do not establish the response on their own.
 
-Do not independently pick the most flattering time or plane from each Simulation.
+Each view must identify its exact Simulation, time, orientation, and position. Both use the same world-owned vertical-velocity scale, cloud threshold, perturbation-wind treatment, and scientific rendering conventions.
 
-The user may move the shared time or plane, but the Comparison should remain synchronized.
+The selected views are authored defaults for this one Comparison. This does not establish an automatic view-ranking system, arbitrary result pairing, or Saved View persistence.
 
-### Honest comparability
+### Evidence summary
 
-The two runs use the same deterministic perturbation seed and differ only in surface moisture supply.
+The Comparison should state:
 
-Even so, large-eddy simulations can diverge through time.
+- the one Control that changed;
+- the major aggregate responses measured across the final three hours;
+- important outcomes that did not change or changed only slightly;
+- time-dependent behavior that prevents a simplistic every-frame claim;
+- the scientific and numerical assumptions held fixed.
 
-The product must not imply that one individual baseline cloud retains one-to-one identity with one individual variant cloud through the full six hours.
+One deterministic realization per state does not support statistical-significance language or a general uncertainty estimate.
 
-Compare:
+### Honest comparison boundary
 
-- field-level behavior;
-- cloud population and lifecycle;
-- process patterns;
-- aggregate and time-dependent response;
-- representative aligned views.
+The two large-eddy simulations share the same deterministic perturbation and differ only in surface moisture supply, but their individual cloud populations diverge through time.
+
+The product must not imply one-to-one identity between clouds or describe the curated images as a direct frame-for-frame comparison. The images illustrate the evidence; the complete matched-run analysis supports the interpretation.
 
 ## 7. Output cadence and required evidence
 


### PR DESCRIPTION
## Summary

Implements the one approved Trade Cumulus moisture comparison story from issue #381. The existing Results workspace exposes the story only for the two approved full-run results, and the existing Explore workspace renders the exact independently curated Baseline and More Moisture views alongside the approved full-run evidence narrative.

The backend validates runtime comparison evidence, persisted result identity and controls, the fixed assumptions hash, run gates, exact metrics and time-series conditions, and both curated Updraft Lens frames before returning the strict story payload. Missing artifacts return 404; contradictory evidence returns 409; ordinary Results and Explore remain usable when the story is unavailable.

PM review follow-up also validates the exact top-level and member implementation commits, the exact and shared persisted CM1 source-manifest and executable hashes, and rejects empty or count-inconsistent curated point-cloud payloads before either source view can report loaded.

## Scope

Related issue: #381

Files or systems changed:

- `docs/product/TRADE_CUMULUS_PRODUCT_SLICE.md`
- `app/backend/cloud_chamber/trade_cumulus_comparison_story.py`
- `app/backend/cloud_chamber/app.py`
- `app/backend/tests/test_trade_cumulus_comparison_story.py`
- `app/backend/tests/test_app.py`
- `app/frontend/src/TradeCumulusComparisonStory.tsx`
- `app/frontend/src/TradeCumulusComparisonStory.test.tsx`
- `app/frontend/src/App.tsx`
- `app/frontend/src/App.test.tsx`
- `app/frontend/src/App.css`
- `app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts`

Curated views implemented exactly:

- Baseline B5: result `result-trade-cumulus-5b-full-baseline-20260720T162342Z`, time index 152 / 18,240 s, vertical x-z plane at y index 5 / -2.6500000953674316 km, Overview camera.
- More Moisture M5: result `result-trade-cumulus-5b-full-more_moisture-20260720T162342Z`, time index 169 / 20,280 s, vertical x-z plane at y index 51 / 1.9500000476837158 km, Overview camera.
- Both use ql at `1e-6 kg/kg`, the fixed Trade Cumulus Updraft Scale v1, perturbation wind, cloud boundary, opacity 0.68, and point size 11.

Explicitly out of scope:

- Generic comparison APIs, arbitrary pairing, saved views, automatic view selection, editors, or persistence.
- Comparison playback, synchronized cameras, same-time alignment, or editable scientific/rendering controls.
- Changes to the fixed scale, threshold, Lens behavior, source results, manifests, NetCDF, or runtime evidence.
- Real CM1 execution, new product concepts, recipes, Controls, Lenses, metrics, or workspaces.

## Product and science impact

Yes. This adds the exact user-facing comparison story, scientific language, and product-document correction explicitly approved in issue #381 and its activation/implementation comments.

The story keeps illustrative views distinct from evidence. Its three material responses are validated against full-run runtime evidence; four small or mixed responses are returned only after validating their associated values and time-series condition. It states that the views differ in time and location and are not corresponding individual clouds.

What this PR does **not** establish:

- It does not establish statistical significance or causal proof.
- It does not promote the candidate Trade Cumulus slice to supported status.
- It does not create a generalized Comparison platform or permanent fourth workspace.
- It does not alter product direction, recipe/scenario status, destructive cleanup, real CM1 behavior, or any manifest/result/scenario schema.

## Verification

Commands and manual checks performed:

```text
scripts/check.sh
scripts/check-e2e.sh
app/backend/.venv/bin/python -m mypy cloud_chamber/trade_cumulus_comparison_story.py tests/test_trade_cumulus_comparison_story.py
app/backend/.venv/bin/python -m pytest tests/test_trade_cumulus_comparison_story.py tests/test_app.py -q
npx playwright test e2e/mocked-smoke/build-results-explore.spec.ts --project=chromium --workers=1 --grep "Unified Explore plays through saved output times"
git diff --check main...HEAD
```

Results:

- 98 frontend unit tests passed.
- Frontend lint and production build passed.
- Ruff formatting/check and mypy passed across 65 backend source files.
- 541 backend tests passed; one existing NumPy binary-compatibility warning remains.
- Script syntax, forbidden tracked artifact, and docs/JSON/YAML checks passed.
- All 25 Chromium mocked-smoke Playwright tests passed.
- The exact comparison Playwright journey passed with both approved members, curated point clouds and Lens frames, fixed legends, cloud boundaries, perturbation-wind context, navigation, and evidence copy.
- Live desktop review at 1440 x 1000 confirmed both nonblank 3-D scenes, proportioned slices, independent camera controls, complete evidence sections, no horizontal overflow, and no browser errors or warnings.
- The live backend story endpoint returned HTTP 200 from the preserved runtime evidence and source results without running CM1.

Known non-blocking output: existing React `act(...)` test warnings, the existing Vite chunk-size warning, and the existing backend NumPy ABI warning.

## Risks and review focus

- Review the strict evidence and persisted-result validation, especially 404 versus 409 behavior and the no-fallback curated-frame checks.
- Confirm the B5/M5 identities, times, planes, rendering defaults, captions, approved metric copy, and evidence/illustration distinction.
- Inspect the Results entry condition and all exits from the dedicated Explore comparison state so unrelated results retain ordinary behavior.
- Inspect the desktop two-column composition, fixed legends, source-view readability, and downstream evidence hierarchy.

## Artifact check

- [x] No CM1 source or binaries were committed.
- [x] No NetCDF output, generated run directories, runtime data, or sounding caches were committed.
- [x] No machine-private paths, settings, logs, screenshots, videos, traces, or large generated artifacts were committed unless explicitly approved.

## Merge posture

- [x] Manual review required.
- [x] Auto-merge is not enabled.

This PR is intentionally draft and has not been merged.
