### PR TITLE
MVP Increment 2: build the integrated Explore workspace

### DIFF
--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -1511,6 +1511,30 @@ export async function mockCloudChamberApis(page: Page) {
 
   await page.route("**/api/results", (route) => json(route, { results: currentResults }));
 
+  await page.route("**/api/results/*", async (route) => {
+    if (route.request().method() !== "PATCH") {
+      await route.fallback();
+      return;
+    }
+    const resultId = resultIdFromUrl(route.request().url());
+    const body = (route.request().postDataJSON() ?? {}) as {
+      name?: string;
+      tags?: string[];
+      notes?: string | null;
+    };
+    const current = currentResults.find((item) => item.result_id === resultId) ?? results[0];
+    const updated = {
+      ...current,
+      ...(body.name !== undefined ? { name: body.name } : {}),
+      ...(body.tags !== undefined ? { tags: body.tags } : {}),
+      ...(body.notes !== undefined ? { notes: body.notes } : {}),
+    };
+    currentResults = currentResults.map((item) =>
+      item.result_id === resultId ? updated : item,
+    );
+    await json(route, updated);
+  });
+
   await page.route("**/api/results/*/delete-preview", (route) => {
     const resultId = resultIdFromUrl(route.request().url());
     const result = currentResults.find((item) => item.result_id === resultId) ?? results[0];

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -578,12 +578,35 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       .getByLabel("Canonical BOMEX Baseline Simulation")
       .getByRole("button", { name: "Explore" })
       .click();
+    await expect(
+      page.getByRole("heading", { name: "Trade Cumulus / Canonical BOMEX Baseline" }),
+    ).toBeVisible();
     await expect(page.getByRole("button", { name: "Back to Trade Cumulus" })).toBeVisible();
     await expect(page.getByLabel("Canonical BOMEX Baseline workspace")).toBeVisible();
+    await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible();
+    await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Explore inspector" })).toBeVisible();
+    await expect(page.getByText("Cloud formed in this result")).toBeVisible();
+    await expect(page.getByText("Deep convection not detected")).toHaveCount(0);
     await expect(page.getByRole("heading", { name: "Field Slice" })).toBeVisible({
       timeout: 12_000,
     });
-    await expect(page.getByText("Updraft Lens", { exact: true }).first()).toBeVisible();
+    const lensButton = page.getByRole("button", { name: "Updraft Lens" });
+    await expect(lensButton).toBeEnabled();
+    await lensButton.click();
+    await expect(page.getByRole("img", { name: /Updraft Lens vertical x-z slice/ })).toBeVisible();
+    await page.getByRole("button", { name: "Previous" }).click();
+    await page.getByLabel("Updraft Lens slice position").fill("3");
+    await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("3");
+    await page.getByRole("button", { name: "Science" }).click();
+    await expect(page.getByRole("heading", { name: "Science at this time" })).toBeVisible();
+    await page.getByRole("button", { name: "Details" }).click();
+    await expect(page.getByRole("heading", { name: "Simulation details" })).toBeVisible();
+    await page.getByRole("button", { name: "Collapse inspector" }).click();
+    await expect(page.getByRole("button", { name: "Open inspector" })).toBeVisible();
+    await page.getByRole("button", { name: "Open inspector" }).click();
+    await expect(page.getByRole("heading", { name: "Simulation details" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Compare" })).toHaveCount(0);
     await page.getByRole("button", { name: "Back to Trade Cumulus" }).click();
 
     await page.getByRole("button", { name: "Open Comparison" }).click();
@@ -1042,7 +1065,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
 
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
-    await expect(page.getByText(/what happened in this result/i).first()).toBeVisible();
+    await expect(page.getByLabel("Integrated Explore workspace")).toBeVisible();
   });
 
   test("Results notebook remains card-first on mobile", async ({ page }) => {
@@ -1066,7 +1089,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
-    await expect(page.getByText(/what happened in this result/i).first()).toBeVisible({
+    await expect(page.getByLabel("Integrated Explore workspace")).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.getByLabel("Explore viewer controls")).toBeVisible();
@@ -1113,6 +1136,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       );
     });
     expect(fieldControlsPrecedeHeatmap).toBe(true);
+    await expect(page.getByText("Cloud formed in this result")).toBeVisible();
+    await expect(page.getByText("Cloud formed here")).toHaveCount(0);
+    await page.getByRole("button", { name: "Science" }).click();
     await page
       .getByRole("button", { name: /inspect .*row 2, column 2/i })
       .first()
@@ -1125,8 +1151,6 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/finite values/i).first()).toBeVisible();
     await expect(page.getByText(/\[\[[\d.,\s]+\]\]/)).not.toBeVisible();
 
-    await expect(page.getByText("Cloud formed in this result")).toBeVisible();
-    await expect(page.getByText("Cloud formed here")).toHaveCount(0);
     await expect(page.getByRole("button", { name: /reset camera/i })).toBeVisible();
     await expect(page.getByText(/selected point: x/i)).toBeVisible();
   });
@@ -1352,13 +1376,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByLabel("Horizontal wind overlay legend")).toContainText(
       "0.9 m/s reference",
     );
-    const inspectorLegend = page.getByLabel(/2-D inspector Vertical velocity \(w\), m\/s/);
-    const viewerLegend = page.getByLabel(/3-D viewer Vertical velocity \(w\), m\/s/);
+    const inspectorLegend = page.getByLabel(/Explore workspace Vertical velocity \(w\), m\/s/);
     await expect(inspectorLegend).toContainText("Vertical velocity (w), m/s");
-    await expect(viewerLegend).toContainText("-0.1 to < 0.1");
-    await expect(page.locator(".updraft-lens-scale-swatch")).toHaveCount(20);
-    await expect(page.getByText("Slice maximum 5.20 m/s.")).toHaveCount(2);
-    await expect(page.getByText("Slice minimum -1.20 m/s.")).toHaveCount(2);
+    await expect(inspectorLegend).toContainText("-0.1 to < 0.1");
+    await expect(page.locator(".updraft-lens-scale-swatch")).toHaveCount(10);
+    await expect(page.getByText("Slice maximum 5.20 m/s.")).toHaveCount(1);
+    await expect(page.getByText("Slice minimum -1.20 m/s.")).toHaveCount(1);
     await expect(page.getByText(/Clipped in this slice/)).toHaveCount(0);
     await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("2");
     await expect(page.getByRole("button", { name: "Vertical x-z" })).toHaveAttribute(
@@ -1425,12 +1448,6 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
         () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
       ),
     ).toBe(true);
-    await page.setViewportSize({ width: 390, height: 844 });
-    expect(
-      await page.evaluate(
-        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
-      ),
-    ).toBe(true);
     await viewMode.getByRole("button", { name: "Standard" }).click();
     await expect(page.getByRole("heading", { name: "Field Slice" })).toBeVisible();
     await expect(page.getByLabel("Slice field")).toBeVisible();
@@ -1454,14 +1471,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
 
     await expect(playbackButton).toHaveText("Pause time");
     await expect(playbackButton).toHaveAttribute("aria-pressed", "true");
-    await expect(
-      page.getByText("Pause playback to select a cell and explain this time step."),
-    ).toBeVisible();
-    await expect(
-      page.getByText(
-        /Animating 3-D scene at .*; slice and evidence remain at .* until playback is paused\./,
-      ),
-    ).toBeVisible();
+    await expect(page.getByText(/Animating the coordinated scene and slice at .*/i)).toBeVisible();
     await expect(page.locator("#explore-time")).toHaveValue("2", { timeout: 4_000 });
     await expect(playbackButton).toHaveText("Play time", { timeout: 4_000 });
     await expect(playbackButton).toHaveAttribute("aria-pressed", "false");
@@ -1481,10 +1491,11 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
-    await expect(page.getByText(/what happened in this result/i).first()).toBeVisible({
+    await expect(page.getByLabel("Integrated Explore workspace")).toBeVisible({
       timeout: 10_000,
     });
-    await page.getByText("Process evidence details").click();
+    await page.getByRole("button", { name: "Science" }).click();
+    await page.getByText("Process evidence").click();
 
     const processMode = page.getByLabel("Process mode");
     await expect(processMode).toBeVisible();
@@ -1617,10 +1628,52 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText("Loading fields...", { exact: true })).not.toBeVisible();
   });
 
-  test("Explore mobile puts visualization and explanation before technical controls", async ({
+  test("Explore isolates a failed 3-D layer from the slice timeline and inspector", async ({
     page,
   }) => {
-    await page.setViewportSize({ width: 390, height: 844 });
+    await page.route("**/api/results/*/visualization/point-cloud**", (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Point cloud temporarily unavailable." }),
+      }),
+    );
+
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+
+    await expect(page.getByText("3-D cloud layer unavailable")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Retry 3-D layer" })).toBeVisible();
+    await expect(page.getByText("Slice synced")).toBeVisible();
+    await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Explore inspector" })).toBeVisible();
+  });
+
+  test("Explore isolates a failed slice from the 3-D scene timeline and inspector", async ({
+    page,
+  }) => {
+    await page.route("**/api/results/*/visualization/slice**", (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Slice temporarily unavailable." }),
+      }),
+    );
+
+    await gotoResults(page);
+    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+
+    await expect(page.getByText("Field Slice unavailable")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Retry Field Slice" })).toBeVisible();
+    await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible();
+    await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Explore inspector" })).toBeVisible();
+  });
+
+  test("Explore narrow desktop keeps visualization and inspector ahead of technical details", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
@@ -1643,15 +1696,16 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     expect(heatmapPrecedesTechnicalDetails).toBe(true);
 
     const scene = page.getByLabel("True 3-D scalar field viewer");
-    const explanation = page.getByLabel("Visualization details");
+    const explanation = page.getByRole("complementary", { name: "Explore inspector" });
     await expect(scene).toBeVisible({ timeout: 12_000 });
     await expect(explanation).toBeVisible();
-    const scenePrecedesExplanation = await scene.evaluate((element) => {
-      const details = document.querySelector('[aria-label="Visualization details"]');
-      return Boolean(
-        details && element.compareDocumentPosition(details) & Node.DOCUMENT_POSITION_FOLLOWING,
-      );
-    });
-    expect(scenePrecedesExplanation).toBe(true);
+    await expect(explanation.getByRole("button", { name: "Explain" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(explanation.getByRole("button", { name: "Details" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
   });
 });

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -587,12 +587,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("complementary", { name: "Explore inspector" })).toBeVisible();
     await expect(page.getByText("Cloud formed")).toBeVisible();
     await expect(page.getByText("Deep convection not detected")).toHaveCount(0);
-    await expect(page.getByRole("heading", { name: "Field Slice" })).toBeVisible({
+    await expect(page.getByRole("heading", { name: "Updraft Lens" })).toBeVisible({
       timeout: 12_000,
     });
     const lensButton = page.getByRole("button", { name: "Updraft Lens" });
     await expect(lensButton).toBeEnabled();
-    await lensButton.click();
+    await expect(lensButton).toHaveAttribute("aria-pressed", "true");
     await expect(page.getByRole("img", { name: /Updraft Lens vertical x-z slice/ })).toBeVisible();
     await page.getByRole("button", { name: "Previous" }).click();
     await page.getByLabel("Updraft Lens slice position").fill("3");
@@ -1087,7 +1087,8 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
         renderedWidth: bounds.width,
         renderedHeight: bounds.height,
         contentFits:
-          element.scrollWidth <= element.clientWidth && element.scrollHeight <= element.clientHeight,
+          element.scrollWidth <= element.clientWidth &&
+          element.scrollHeight <= element.clientHeight,
         gridGap: grid ? getComputedStyle(grid).gap : null,
         rowGap: row ? getComputedStyle(row).gap : null,
         padding: getComputedStyle(element).padding,
@@ -1333,11 +1334,17 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
     const savedTime = page.getByRole("slider", { name: "Saved output time" });
-    const ordinaryTimeValue = await savedTime.inputValue();
     const viewMode = page.getByLabel("Explore view mode");
     await expect(viewMode).toBeVisible();
     const lensToggle = viewMode.getByRole("button", { name: "Updraft Lens" });
     await expect(lensToggle).toBeEnabled();
+    await expect(lensToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(viewMode.getByRole("button").allTextContents()).resolves.toEqual([
+      "Updraft Lens",
+      "Field",
+    ]);
+    await viewMode.getByRole("button", { name: "Field" }).click();
+    await expect(page.getByRole("heading", { name: "Field Slice" })).toBeVisible();
     await lensToggle.click();
     await expect(page.getByRole("heading", { name: "Updraft Lens" })).toBeVisible();
     await expect(page.getByRole("img", { name: /Updraft Lens vertical x-z slice/ })).toBeVisible();
@@ -1351,12 +1358,31 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       "0.9 m/s reference",
     );
     const inspectorLegend = page.getByLabel(/Explore workspace Vertical velocity \(w\), m\/s/);
-    await expect(inspectorLegend).toContainText("Vertical velocity (w), m/s");
+    await expect(inspectorLegend).toContainText("w (m/s)");
     await expect(inspectorLegend).toContainText("-0.1 to < 0.1");
     await expect(page.locator(".updraft-lens-scale-swatch")).toHaveCount(10);
-    await expect(page.getByText("Slice maximum 5.20 m/s.")).toHaveCount(1);
-    await expect(page.getByText("Slice minimum -1.20 m/s.")).toHaveCount(1);
+    await expect(inspectorLegend.getByRole("listitem").first()).not.toContainText("m/s");
+    await expect(page.getByText("Slice maximum 5.20 m/s.")).toHaveCount(0);
+    await expect(page.getByText("Slice minimum -1.20 m/s.")).toHaveCount(0);
     await expect(page.getByText(/Clipped in this slice/)).toHaveCount(0);
+    const compactLensLayout = await page
+      .locator(".updraft-lens-instrument-body-compact")
+      .evaluate((body) => {
+        const svg = body.querySelector<SVGElement>(".updraft-lens-svg");
+        const legend = body.querySelector<HTMLElement>(".updraft-lens-scale-legend-compact");
+        const svgBounds = svg?.getBoundingClientRect();
+        const legendBounds = legend?.getBoundingClientRect();
+        return {
+          plotWidth: svgBounds?.width ?? 0,
+          plotHeight: svgBounds?.height ?? 0,
+          legendBelowPlot: Boolean(
+            svgBounds && legendBounds && legendBounds.top >= svgBounds.bottom,
+          ),
+        };
+      });
+    expect(compactLensLayout.plotWidth).toBeGreaterThan(100);
+    expect(compactLensLayout.plotHeight).toBeGreaterThan(200);
+    expect(compactLensLayout.legendBelowPlot).toBe(true);
     await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("2");
     await expect(page.getByRole("button", { name: "Vertical x-z" })).toHaveAttribute(
       "aria-pressed",
@@ -1367,6 +1393,19 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     ).toBeVisible();
     await expect(page.getByLabel("Slice field")).toHaveCount(0);
     await page.locator("details.true3d-display-control > summary").click();
+    const displayAlignment = await page.locator(".true3d-controls-compact").evaluate((controls) => {
+      const elements = [
+        controls.querySelector(".true3d-display-control > summary"),
+        controls.querySelector("select[aria-label='Camera view']"),
+        ...controls.querySelectorAll(":scope > button"),
+      ].filter((element): element is Element => element !== null);
+      const centers = elements.map((element) => {
+        const bounds = element.getBoundingClientRect();
+        return bounds.top + bounds.height / 2;
+      });
+      return Math.max(...centers) - Math.min(...centers);
+    });
+    expect(displayAlignment).toBeLessThan(1.5);
     const scalarField = page.getByLabel("3-D scalar field", { exact: true });
     await expect(scalarField).toBeVisible();
     await scalarField.selectOption("qv");
@@ -1375,8 +1414,14 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("img", { name: /y index 2/ })).toBeVisible();
     await page.getByLabel("Layer opacity").fill("0.45");
     await page.getByLabel("Point size").fill("14");
+    await page.getByLabel("Lens opacity").fill("0.6");
     await expect(page.getByLabel("Layer opacity")).toHaveValue("0.45");
     await expect(page.getByLabel("Point size")).toHaveValue("14");
+    await expect(page.getByLabel("Lens opacity")).toHaveValue("0.6");
+    await expect(page.getByLabel("True 3-D scalar field viewer")).toHaveAttribute(
+      "data-updraft-lens-opacity",
+      "0.6",
+    );
     const sliceAspect = await page.locator(".updraft-lens-svg").evaluate((element) => {
       const bounds = element.getBoundingClientRect();
       return {
@@ -1405,7 +1450,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     ).toBeVisible();
     await savedTime.fill("2");
     await expect(page.getByText("3,600 s · frame 3 of 3", { exact: true })).toBeVisible();
-    await expect(inspectorLegend).toContainText("Vertical velocity (w), m/s");
+    await expect(inspectorLegend).toContainText("w (m/s)");
     await expect(inspectorLegend).toContainText(">= 5.0");
 
     await page.getByRole("button", { name: "Total wind" }).click();
@@ -1414,6 +1459,10 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     );
     await page.getByLabel("Cloud boundary").uncheck();
     await expect(page.getByTestId("updraft-lens-cloud-boundary")).toHaveCount(0);
+    await expect(page.getByLabel("True 3-D scalar field viewer")).toHaveAttribute(
+      "data-updraft-lens-cloud-boundary",
+      "false",
+    );
     await page.getByRole("checkbox", { name: "Horizontal wind" }).uncheck();
     await expect(page.getByLabel("Horizontal wind overlay legend")).toHaveCount(0);
     expect(
@@ -1423,26 +1472,89 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     ).toBe(true);
 
     await page.getByRole("button", { name: "Maximize slice viewer" }).click();
+    await expect(inspectorLegend).toContainText("Vertical velocity (w), m/s");
+    await expect(inspectorLegend).toContainText("Slice maximum 5.20 m/s.");
+    await expect(inspectorLegend).toContainText("Slice minimum -1.20 m/s.");
     const focusedLensFit = await page.locator(".updraft-lens-instrument-body").evaluate((body) => {
       const svg = body.querySelector<SVGElement>(".updraft-lens-svg");
+      const xLabels = body.querySelectorAll<HTMLElement>(".updraft-lens-axis-x span");
+      const zLabels = body.querySelectorAll<HTMLElement>(".updraft-lens-axis-z span");
       const bodyBounds = body.getBoundingClientRect();
       const svgBounds = svg?.getBoundingClientRect();
       return {
-        bodyFits:
-          body.scrollWidth <= body.clientWidth && body.scrollHeight <= body.clientHeight,
+        bodyFits: body.scrollWidth <= body.clientWidth && body.scrollHeight <= body.clientHeight,
+        expands: Boolean(svgBounds) && svgBounds!.height >= 420,
         svgFits:
           Boolean(svgBounds) &&
           svgBounds!.right <= bodyBounds.right + 1 &&
           svgBounds!.bottom <= bodyBounds.bottom + 1,
+        axesAlign:
+          Boolean(svgBounds) &&
+          Math.abs(xLabels[0].getBoundingClientRect().left - svgBounds!.left) < 4 &&
+          Math.abs(xLabels[1].getBoundingClientRect().right - svgBounds!.right) < 4 &&
+          Math.abs(zLabels[0].getBoundingClientRect().top - svgBounds!.top) < 4 &&
+          Math.abs(zLabels[1].getBoundingClientRect().bottom - svgBounds!.bottom) < 4,
+        axisDeltas: svgBounds
+          ? {
+              xStart: xLabels[0].getBoundingClientRect().left - svgBounds.left,
+              xEnd: xLabels[1].getBoundingClientRect().right - svgBounds.right,
+              zTop: zLabels[0].getBoundingClientRect().top - svgBounds.top,
+              zBottom: zLabels[1].getBoundingClientRect().bottom - svgBounds.bottom,
+            }
+          : null,
       };
     });
-    expect(focusedLensFit).toEqual({ bodyFits: true, svgFits: true });
+    expect(focusedLensFit).toMatchObject({
+      bodyFits: true,
+      expands: true,
+      svgFits: true,
+      axesAlign: true,
+    });
+
+    await page.getByRole("button", { name: "Horizontal x-y" }).click();
+    await expect(
+      page.getByRole("img", { name: /Updraft Lens horizontal x-y slice/ }),
+    ).toBeVisible();
+    const focusedTopDownFit = await page
+      .locator(".updraft-lens-instrument-body")
+      .evaluate((body) => {
+        const svg = body.querySelector<SVGElement>(".updraft-lens-svg");
+        const bounds = svg?.getBoundingClientRect();
+        return {
+          expands: Boolean(bounds) && bounds!.height >= 420,
+          preservesAspect:
+            Boolean(bounds) &&
+            Math.abs(
+              bounds!.width / bounds!.height - Number(svg!.getAttribute("data-domain-aspect")),
+            ) < 0.03,
+          noOverflow:
+            body.scrollWidth <= body.clientWidth && body.scrollHeight <= body.clientHeight,
+        };
+      });
+    expect(focusedTopDownFit).toEqual({
+      expands: true,
+      preservesAspect: true,
+      noOverflow: true,
+    });
+    await page.getByRole("button", { name: "Vertical x-z" }).click();
     await page.getByRole("button", { name: "Restore slice viewer" }).click();
 
     await viewMode.getByRole("button", { name: "Field" }).click();
     await expect(page.getByRole("heading", { name: "Field Slice" })).toBeVisible();
     await expect(page.getByLabel("Slice field")).toBeVisible();
-    await expect(savedTime).toHaveValue(ordinaryTimeValue);
+    await expect(savedTime).toHaveValue("2");
+    await expect(page.getByLabel("Slice position")).toHaveValue("3");
+    await expect(page.getByRole("button", { name: "Vertical x-z slice", exact: true })).toHaveClass(
+      /active-control/,
+    );
+
+    await lensToggle.click();
+    await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("3");
+    await expect(savedTime).toHaveValue("2");
+    await expect(page.getByRole("button", { name: "Vertical x-z" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 
   test("Unified Explore plays through saved output times", async ({ page }) => {
@@ -1452,7 +1564,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByLabel("Explore viewer controls")).toBeVisible();
     await expect(page.getByLabel("Timelapse playback controls")).toBeVisible();
     const playbackButton = page.getByLabel("Timelapse playback controls").getByRole("button");
-    await expect(playbackButton).toHaveText("Play time");
+    await expect(playbackButton).toHaveAccessibleName("Play");
     await expect(page.getByLabel("Playback speed")).toHaveValue("1");
     await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
 
@@ -1461,10 +1573,10 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await page.getByLabel("Playback speed").selectOption("0.5");
     await playbackButton.click();
 
-    await expect(playbackButton).toHaveText("Pause time");
+    await expect(playbackButton).toHaveAccessibleName("Pause");
     await expect(playbackButton).toHaveAttribute("aria-pressed", "true");
     await expect(savedTime).toHaveValue("2", { timeout: 4_000 });
-    await expect(playbackButton).toHaveText("Play time", { timeout: 4_000 });
+    await expect(playbackButton).toHaveAccessibleName("Play", { timeout: 4_000 });
     await expect(playbackButton).toHaveAttribute("aria-pressed", "false");
     await expect(savedTime).toHaveValue("0");
 
@@ -1472,7 +1584,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(savedTime).toHaveValue("2");
     await playbackButton.click();
     await expect(savedTime).toHaveValue("0", { timeout: 4_000 });
-    await expect(playbackButton).toHaveText("Play time");
+    await expect(playbackButton).toHaveAccessibleName("Play");
     await expect(playbackButton).toHaveAttribute("aria-pressed", "false");
   });
 
@@ -1696,7 +1808,8 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
           timeline!.scrollHeight <= timeline!.clientHeight,
         notebookBelowScene:
           Boolean(notebookRegion && sceneRegion) &&
-          notebookRegion!.getBoundingClientRect().top >= sceneRegion!.getBoundingClientRect().bottom,
+          notebookRegion!.getBoundingClientRect().top >=
+            sceneRegion!.getBoundingClientRect().bottom,
         shell: rect(".visualizer-shell")?.width ?? 0,
       };
     });

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -539,6 +539,7 @@ async function mockTradeCumulusWorld(page: Parameters<typeof mockCloudChamberApi
 
 test.describe("mocked smoke: Build, Results, Explore path", () => {
   test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
     await mockCloudChamberApis(page);
     await page.route("**/api/comparisons/trade-cumulus-moisture-v1", (route) =>
       route.fulfill({ status: 404, contentType: "application/json", body: "{}" }),
@@ -578,15 +579,13 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       .getByLabel("Canonical BOMEX Baseline Simulation")
       .getByRole("button", { name: "Explore" })
       .click();
-    await expect(
-      page.getByRole("heading", { name: "Trade Cumulus / Canonical BOMEX Baseline" }),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Canonical BOMEX Baseline" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Back to Trade Cumulus" })).toBeVisible();
     await expect(page.getByLabel("Canonical BOMEX Baseline workspace")).toBeVisible();
     await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible();
     await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
     await expect(page.getByRole("complementary", { name: "Explore inspector" })).toBeVisible();
-    await expect(page.getByText("Cloud formed in this result")).toBeVisible();
+    await expect(page.getByText("Cloud formed")).toBeVisible();
     await expect(page.getByText("Deep convection not detected")).toHaveCount(0);
     await expect(page.getByRole("heading", { name: "Field Slice" })).toBeVisible({
       timeout: 12_000,
@@ -598,14 +597,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await page.getByRole("button", { name: "Previous" }).click();
     await page.getByLabel("Updraft Lens slice position").fill("3");
     await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("3");
-    await page.getByRole("button", { name: "Science" }).click();
-    await expect(page.getByRole("heading", { name: "Science at this time" })).toBeVisible();
-    await page.getByRole("button", { name: "Details" }).click();
+    await expect(page.getByRole("heading", { name: "What am I seeing?" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Simulation details" })).toBeVisible();
     await page.getByRole("button", { name: "Collapse inspector" }).click();
     await expect(page.getByRole("button", { name: "Open inspector" })).toBeVisible();
     await page.getByRole("button", { name: "Open inspector" }).click();
-    await expect(page.getByRole("heading", { name: "Simulation details" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "What am I seeing?" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Compare" })).toHaveCount(0);
     await page.getByRole("button", { name: "Back to Trade Cumulus" }).click();
 
@@ -942,19 +939,6 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(baselineControls).toContainText("Camera looking along the x axis");
     await expect(moreMoistureControls).toContainText("Camera ready");
 
-    await page.setViewportSize({ width: 390, height: 844 });
-    await expect(simulations.nth(0)).toBeVisible();
-    await expect(simulations.nth(1)).toBeVisible();
-    const mobileLayout = await simulations.evaluateAll((cards) => {
-      const first = cards[0].getBoundingClientRect();
-      const second = cards[1].getBoundingClientRect();
-      return {
-        stacked: second.top >= first.bottom,
-        fitsViewport: document.documentElement.scrollWidth <= document.documentElement.clientWidth,
-      };
-    });
-    expect(mobileLayout).toEqual({ stacked: true, fitsViewport: true });
-
     await page.setViewportSize({ width: 1440, height: 1000 });
     await simulations.nth(1).getByRole("button", { name: "Open More Moisture in Explore" }).click();
     await expect(
@@ -1068,21 +1052,6 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByLabel("Integrated Explore workspace")).toBeVisible();
   });
 
-  test("Results notebook remains card-first on mobile", async ({ page }) => {
-    await page.setViewportSize({ width: 390, height: 844 });
-    await gotoResults(page);
-
-    await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
-    const resultsList = page.getByLabel("Results list");
-    await expect(resultsList).toBeVisible();
-    await expect(page.getByText("Baseline Shallow Cumulus — Quick Look").first()).toBeVisible();
-    await expect(
-      resultsList.getByText(/Cloud water formed in the validated reference baseline/i),
-    ).toBeVisible();
-    await expect(page.getByLabel("Result detail")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Open in Explore" }).first()).toBeVisible();
-  });
-
   test("Unified Explore renders cloud context, slice inspector, and explanation", async ({
     page,
   }) => {
@@ -1105,8 +1074,6 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("heading", { name: "Field Slice" })).toBeVisible();
     await expect(page.getByText(/Horizontal layer at z = /i).first()).toBeVisible();
     await expect(page.getByLabel("Slice position")).toBeVisible();
-    await expect(page.getByRole("button", { name: /move down/i })).toBeVisible();
-    await expect(page.getByRole("button", { name: /move up/i })).toBeVisible();
     const heatmap = page.getByRole("img", { name: /heatmap/i });
     await expect(heatmap).toBeVisible();
     await expect(page.getByTestId("slice-cloud-boundary")).toBeVisible();
@@ -1117,6 +1084,10 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       return {
         declaredAspect: Number(element.getAttribute("data-domain-aspect")),
         renderedAspect: bounds.width / bounds.height,
+        renderedWidth: bounds.width,
+        renderedHeight: bounds.height,
+        contentFits:
+          element.scrollWidth <= element.clientWidth && element.scrollHeight <= element.clientHeight,
         gridGap: grid ? getComputedStyle(grid).gap : null,
         rowGap: row ? getComputedStyle(row).gap : null,
         padding: getComputedStyle(element).padding,
@@ -1125,6 +1096,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     expect(Math.abs(heatmapLayout.declaredAspect - heatmapLayout.renderedAspect)).toBeLessThan(
       0.03,
     );
+    expect(heatmapLayout.renderedWidth).toBeGreaterThan(220);
+    expect(heatmapLayout.renderedHeight).toBeGreaterThan(220);
+    expect(heatmapLayout.contentFits).toBe(true);
     expect(heatmapLayout.gridGap).toBe("0px");
     expect(heatmapLayout.rowGap).toBe("0px");
     expect(heatmapLayout.padding).toBe("0px");
@@ -1136,15 +1110,14 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       );
     });
     expect(fieldControlsPrecedeHeatmap).toBe(true);
-    await expect(page.getByText("Cloud formed in this result")).toBeVisible();
+    await expect(page.getByText("Cloud formed")).toBeVisible();
     await expect(page.getByText("Cloud formed here")).toHaveCount(0);
-    await page.getByRole("button", { name: "Science" }).click();
     await page
       .getByRole("button", { name: /inspect .*row 2, column 2/i })
       .first()
       .click();
     await expect(page.getByText(/what happened here/i).first()).toBeVisible();
-    await expect(page.getByText(/selected-point diagnostics loaded/i)).toBeVisible();
+    await expect(page.getByText("Point ready")).toBeVisible();
     await expect(page.getByText(/cloud water appeared locally/i)).toBeVisible();
     await expect(page.getByText(/local max w/i)).toBeVisible();
     await page.getByText("Technical slice details").first().click();
@@ -1152,10 +1125,10 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/\[\[[\d.,\s]+\]\]/)).not.toBeVisible();
 
     await expect(page.getByRole("button", { name: /reset camera/i })).toBeVisible();
-    await expect(page.getByText(/selected point: x/i)).toBeVisible();
+    await expect(page.getByText(/selected: x/i)).toBeVisible();
   });
 
-  test("Trade Cumulus activates the Updraft Lens with bounded process controls", async ({
+  test("Trade Cumulus activates the Updraft Lens with coordinated rendering controls", async ({
     page,
   }) => {
     const catalog = await page.evaluate(async () =>
@@ -1359,7 +1332,8 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
-    const ordinaryTimeValue = await page.getByRole("combobox", { name: "Time" }).inputValue();
+    const savedTime = page.getByRole("slider", { name: "Saved output time" });
+    const ordinaryTimeValue = await savedTime.inputValue();
     const viewMode = page.getByLabel("Explore view mode");
     await expect(viewMode).toBeVisible();
     const lensToggle = viewMode.getByRole("button", { name: "Updraft Lens" });
@@ -1389,9 +1363,10 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       "true",
     );
     await expect(
-      page.getByText("Updraft Lens slice: Vertical x-z slice at y = 0.05 km", { exact: true }),
+      page.getByText("Updraft Lens: Vertical x-z slice at y = 0.05 km", { exact: true }),
     ).toBeVisible();
     await expect(page.getByLabel("Slice field")).toHaveCount(0);
+    await page.locator("details.true3d-display-control > summary").click();
     const scalarField = page.getByLabel("3-D scalar field", { exact: true });
     await expect(scalarField).toBeVisible();
     await scalarField.selectOption("qv");
@@ -1415,10 +1390,10 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(
       page.getByRole("img", { name: /Updraft Lens horizontal x-y slice/ }),
     ).toBeVisible();
-    await expect(page.getByText(/Updraft Lens slice: Horizontal x-y layer at z =/)).toBeVisible();
+    await expect(page.getByText(/Updraft Lens: Horizontal x-y layer at z =/)).toBeVisible();
     await page.getByRole("button", { name: "Vertical y-z" }).click();
     await expect(page.getByRole("img", { name: /Updraft Lens vertical y-z slice/ })).toBeVisible();
-    await expect(page.getByText(/Updraft Lens slice: Vertical y-z slice at x =/)).toBeVisible();
+    await expect(page.getByText(/Updraft Lens: Vertical y-z slice at x =/)).toBeVisible();
     await page.getByRole("button", { name: "Vertical x-z" }).click();
     await expect(page.getByRole("img", { name: /Updraft Lens vertical x-z slice/ })).toBeVisible();
 
@@ -1426,12 +1401,10 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("3");
     await expect(page.getByRole("img", { name: /y index 3/ })).toBeVisible();
     await expect(
-      page.getByText("Updraft Lens slice: Vertical x-z slice at y = 0.15 km", { exact: true }),
+      page.getByText("Updraft Lens: Vertical x-z slice at y = 0.15 km", { exact: true }),
     ).toBeVisible();
-    await page.getByRole("combobox", { name: "Time" }).selectOption({ label: "3,600 s" });
-    await expect(
-      page.getByText("Vertical x-z slice at y = 0.15 km · w · 3,600 s", { exact: true }),
-    ).toBeVisible();
+    await savedTime.fill("2");
+    await expect(page.getByText("3,600 s · frame 3 of 3", { exact: true })).toBeVisible();
     await expect(inspectorLegend).toContainText("Vertical velocity (w), m/s");
     await expect(inspectorLegend).toContainText(">= 5.0");
 
@@ -1448,10 +1421,28 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
         () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
       ),
     ).toBe(true);
-    await viewMode.getByRole("button", { name: "Standard" }).click();
+
+    await page.getByRole("button", { name: "Maximize slice viewer" }).click();
+    const focusedLensFit = await page.locator(".updraft-lens-instrument-body").evaluate((body) => {
+      const svg = body.querySelector<SVGElement>(".updraft-lens-svg");
+      const bodyBounds = body.getBoundingClientRect();
+      const svgBounds = svg?.getBoundingClientRect();
+      return {
+        bodyFits:
+          body.scrollWidth <= body.clientWidth && body.scrollHeight <= body.clientHeight,
+        svgFits:
+          Boolean(svgBounds) &&
+          svgBounds!.right <= bodyBounds.right + 1 &&
+          svgBounds!.bottom <= bodyBounds.bottom + 1,
+      };
+    });
+    expect(focusedLensFit).toEqual({ bodyFits: true, svgFits: true });
+    await page.getByRole("button", { name: "Restore slice viewer" }).click();
+
+    await viewMode.getByRole("button", { name: "Field" }).click();
     await expect(page.getByRole("heading", { name: "Field Slice" })).toBeVisible();
     await expect(page.getByLabel("Slice field")).toBeVisible();
-    await expect(page.getByRole("combobox", { name: "Time" })).toHaveValue(ordinaryTimeValue);
+    await expect(savedTime).toHaveValue(ordinaryTimeValue);
   });
 
   test("Unified Explore plays through saved output times", async ({ page }) => {
@@ -1465,27 +1456,27 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByLabel("Playback speed")).toHaveValue("1");
     await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
 
-    await page.locator("#explore-time").selectOption("1");
+    const savedTime = page.getByRole("slider", { name: "Saved output time" });
+    await savedTime.fill("1");
     await page.getByLabel("Playback speed").selectOption("0.5");
     await playbackButton.click();
 
     await expect(playbackButton).toHaveText("Pause time");
     await expect(playbackButton).toHaveAttribute("aria-pressed", "true");
-    await expect(page.getByText(/Animating the coordinated scene and slice at .*/i)).toBeVisible();
-    await expect(page.locator("#explore-time")).toHaveValue("2", { timeout: 4_000 });
+    await expect(savedTime).toHaveValue("2", { timeout: 4_000 });
     await expect(playbackButton).toHaveText("Play time", { timeout: 4_000 });
     await expect(playbackButton).toHaveAttribute("aria-pressed", "false");
-    await expect(page.locator("#explore-time")).toHaveValue("0");
+    await expect(savedTime).toHaveValue("0");
 
-    await page.getByRole("button", { name: "Last frame" }).click();
-    await expect(page.locator("#explore-time")).toHaveValue("2");
+    await page.getByLabel("Key moments").selectOption({ label: "Last frame" });
+    await expect(savedTime).toHaveValue("2");
     await playbackButton.click();
-    await expect(page.locator("#explore-time")).toHaveValue("0", { timeout: 4_000 });
+    await expect(savedTime).toHaveValue("0", { timeout: 4_000 });
     await expect(playbackButton).toHaveText("Play time");
     await expect(playbackButton).toHaveAttribute("aria-pressed", "false");
   });
 
-  test("Explore process evidence offers useful modes and moves unsupported modes secondary", async ({
+  test("Explore keeps current context primary and persists notes below the viewers", async ({
     page,
   }) => {
     await gotoResults(page);
@@ -1494,25 +1485,19 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByLabel("Integrated Explore workspace")).toBeVisible({
       timeout: 10_000,
     });
-    await page.getByRole("button", { name: "Science" }).click();
-    await page.getByText("Process evidence").click();
+    await expect(page.getByRole("heading", { name: "What am I seeing?" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Science" })).toHaveCount(0);
+    await expect(page.getByText("Process evidence")).toHaveCount(0);
 
-    const processMode = page.getByLabel("Process mode");
-    await expect(processMode).toBeVisible();
-    await expect(processMode.locator("option", { hasText: "Thermal Fate summary" })).toHaveCount(1);
-    await expect(processMode.locator("option", { hasText: "Cloud Water" })).toHaveCount(1);
-    await expect(processMode.locator("option", { hasText: "Updrafts" })).toHaveCount(1);
-    await expect(processMode.locator("option", { hasText: "Moisture" })).toHaveCount(0);
-    await expect(processMode.locator("option", { hasText: "Buoyancy" })).toHaveCount(0);
-    await expect(processMode.locator("option", { hasText: "Deep Breakthrough" })).toHaveCount(0);
-    await expect(processMode.locator("option", { hasText: "Precipitation Feedback" })).toHaveCount(
-      0,
-    );
-
-    await page.getByText("Not available for this result").click();
-    await expect(page.getByText("Moisture / Saturation", { exact: true })).toBeVisible();
-    await expect(page.getByText("Deep Breakthrough", { exact: true })).toBeVisible();
-    await expect(page.getByText(/missing required CM1 fields/i)).toBeVisible();
+    const notebook = page.getByLabel("Simulation notebook", { exact: true });
+    await notebook.scrollIntoViewIfNeeded();
+    const notes = notebook.getByRole("textbox", { name: "Simulation notes" });
+    await notes.fill("Watch the western cloud turret.");
+    await notebook.getByRole("button", { name: "Save note" }).click();
+    await expect(notebook.getByText("Note saved")).toBeVisible();
+    await expect(notes).toHaveValue("Watch the western cloud turret.");
+    await expect(page.getByRole("heading", { name: "Simulation details" })).toBeVisible();
+    await expect(page.getByText("Visualization details")).toBeVisible();
   });
 
   test("Results to Explore loads cloud-forming qc and w fields", async ({ page }) => {
@@ -1546,6 +1531,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByText(/cloud-water point layer loaded/i).first()).toBeVisible({
       timeout: 12_000,
     });
+    await page.locator("details.true3d-display-control > summary").click();
     const threeDField = page.locator("#explore-3d-field");
     await expect(threeDField).toBeVisible();
     await expect(threeDField.locator("option", { hasText: "qc - Cloud water" })).toHaveCount(1);
@@ -1597,7 +1583,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(
       page.getByText(/No cloud water formed in this result; vertical velocity is available/i),
     ).toBeVisible();
-    await expect(page.getByText("No cloud formed in this result")).toBeVisible();
+    await expect(page.getByText(/For this no-cloud result, use vertical velocity/)).toBeVisible();
     await expect(page.getByText("No cloud formed here")).toHaveCount(0);
 
     await expect(page.getByText(/slice synced/i).first()).toBeVisible({ timeout: 10_000 });
@@ -1670,10 +1656,10 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("complementary", { name: "Explore inspector" })).toBeVisible();
   });
 
-  test("Explore narrow desktop keeps visualization and inspector ahead of technical details", async ({
+  test("Explore desktop cockpit prioritizes viewers and supports either maximized view", async ({
     page,
   }) => {
-    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.setViewportSize({ width: 1440, height: 900 });
     await gotoResults(page);
     await page.getByRole("button", { name: "Open in Explore" }).first().click();
 
@@ -1684,28 +1670,62 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     const heatmap = page.getByRole("img", { name: /heatmap/i });
     await expect(heatmap).toBeVisible({ timeout: 10_000 });
 
-    const heatmapPrecedesTechnicalDetails = await heatmap.evaluate((element) => {
-      const technicalSummary = Array.from(document.querySelectorAll("summary")).find((summary) =>
-        summary.textContent?.includes("Technical slice details"),
-      );
-      return Boolean(
-        technicalSummary &&
-        element.compareDocumentPosition(technicalSummary) & Node.DOCUMENT_POSITION_FOLLOWING,
-      );
-    });
-    expect(heatmapPrecedesTechnicalDetails).toBe(true);
-
     const scene = page.getByLabel("True 3-D scalar field viewer");
-    const explanation = page.getByRole("complementary", { name: "Explore inspector" });
+    const slice = page.getByLabel("Field Slice");
+    const context = page.getByRole("complementary", { name: "Explore inspector" });
+    const notebook = page.getByLabel("Simulation notebook and details");
     await expect(scene).toBeVisible({ timeout: 12_000 });
-    await expect(explanation).toBeVisible();
-    await expect(explanation.getByRole("button", { name: "Explain" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
+    await expect(slice).toBeVisible();
+    await expect(context).toBeVisible();
+
+    const cockpitGeometry = await page.evaluate(() => {
+      const rect = (selector: string) => document.querySelector(selector)?.getBoundingClientRect();
+      const sliceControls = document.querySelector<HTMLElement>(".explore-control-card-slice");
+      const timeline = document.querySelector<HTMLElement>(".explore-control-card-time");
+      const notebookRegion = document.querySelector<HTMLElement>(".explore-secondary-content");
+      const sceneRegion = document.querySelector<HTMLElement>(".true3d-viewer");
+      return {
+        documentFits: document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+        sliceControlsFit:
+          Boolean(sliceControls) &&
+          sliceControls!.scrollWidth <= sliceControls!.clientWidth &&
+          sliceControls!.scrollHeight <= sliceControls!.clientHeight,
+        timelineFits:
+          Boolean(timeline) &&
+          timeline!.scrollWidth <= timeline!.clientWidth &&
+          timeline!.scrollHeight <= timeline!.clientHeight,
+        notebookBelowScene:
+          Boolean(notebookRegion && sceneRegion) &&
+          notebookRegion!.getBoundingClientRect().top >= sceneRegion!.getBoundingClientRect().bottom,
+        shell: rect(".visualizer-shell")?.width ?? 0,
+      };
+    });
+    expect(cockpitGeometry).toEqual({
+      documentFits: true,
+      sliceControlsFit: true,
+      timelineFits: true,
+      notebookBelowScene: true,
+      shell: expect.any(Number),
+    });
+    expect(cockpitGeometry.shell).toBeGreaterThan(1200);
+
+    await page.getByRole("button", { name: "Maximize 3-D viewer" }).click();
+    await expect(page.getByLabel("Integrated Explore workspace")).toHaveClass(
+      /visualizer-shell-focused-scene/,
     );
-    await expect(explanation.getByRole("button", { name: "Details" })).toHaveAttribute(
-      "aria-pressed",
-      "false",
+    await expect(page.getByRole("button", { name: "Restore 3-D viewer" })).toBeVisible();
+    await page.getByRole("button", { name: "Restore 3-D viewer" }).click();
+
+    await page.getByRole("button", { name: "Maximize slice viewer" }).click();
+    await expect(page.getByLabel("Integrated Explore workspace")).toHaveClass(
+      /visualizer-shell-focused-slice/,
     );
+    await expect(page.getByRole("button", { name: "Restore slice viewer" })).toBeVisible();
+    const focusedHeatmap = page.getByRole("img", { name: /heatmap/i });
+    const focusedHeatmapBox = await focusedHeatmap.boundingBox();
+    expect(focusedHeatmapBox?.width ?? 0).toBeGreaterThan(280);
+    expect(focusedHeatmapBox?.height ?? 0).toBeGreaterThan(280);
+    await page.getByRole("button", { name: "Restore slice viewer" }).click();
+    await expect(notebook).toBeAttached();
   });
 });

--- a/app/frontend/e2e/mocked-smoke/navigation.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/navigation.spec.ts
@@ -106,11 +106,7 @@ test.describe("mocked smoke: app shell", () => {
     await expect(page.getByText("Scenario setup")).toHaveCount(0);
   });
 
-  for (const viewport of [
-    { width: 390, height: 844 },
-    { width: 1024, height: 768 },
-    { width: 1440, height: 900 },
-  ]) {
+  for (const viewport of [{ width: 1440, height: 900 }]) {
     test(`keeps Build Results Explore reachable at ${viewport.width}x${viewport.height}`, async ({
       page,
     }) => {
@@ -129,7 +125,7 @@ test.describe("mocked smoke: app shell", () => {
       await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
       await gotoExplore(page);
       await expect(page.getByLabel("Explore this result")).toBeVisible();
-      await expect(page.getByRole("heading", { name: "What happened in this result?" }))
+      await expect(page.getByRole("heading", { name: "What am I seeing?" }))
         .toBeVisible();
     });
   }

--- a/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
@@ -52,6 +52,7 @@ async function expectInside(container: Locator, target: Locator, label: string) 
 
 test.describe("mocked smoke: visualizer occlusion regression", () => {
   test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
     await mockCloudChamberApis(page);
     await gotoApp(page);
     await gotoResults(page);
@@ -60,7 +61,7 @@ test.describe("mocked smoke: visualizer occlusion regression", () => {
   });
 
   test("3-D scene does not cover its primary controls", async ({ page }) => {
-    await expect(page.getByText(/what happened in this result/i).first()).toBeVisible({
+    await expect(page.getByText(/what am i seeing/i).first()).toBeVisible({
       timeout: 12_000,
     });
     await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible({
@@ -68,13 +69,13 @@ test.describe("mocked smoke: visualizer occlusion regression", () => {
     });
     await expect(page.getByLabel("3-D camera controls")).toBeVisible();
 
+    await expectClickableCenter(page, page.getByRole("button", { name: "Reset camera" }), "Reset");
+    await expectClickableCenter(page, page.getByLabel("Camera view"), "Camera view");
     await expectClickableCenter(
       page,
-      page.getByRole("button", { name: /reset camera/i }),
-      "Reset camera",
+      page.locator("details.true3d-display-control > summary"),
+      "Display controls",
     );
-    await expectClickableCenter(page, page.getByRole("button", { name: /zoom in/i }), "Zoom in");
-    await expectClickableCenter(page, page.getByRole("button", { name: /zoom out/i }), "Zoom out");
     await expectClickableCenter(page, page.getByLabel("Slice position"), "Slice position slider");
     await expectClickableCenter(
       page,
@@ -82,24 +83,47 @@ test.describe("mocked smoke: visualizer occlusion regression", () => {
       "Vertical x-z slice control",
     );
     await expect(page.getByRole("heading", { name: "Field Slice" })).toBeVisible();
+
+    await page.locator("details.true3d-display-control > summary").click();
+    await expect(page.getByLabel("3-D scalar field", { exact: true })).toBeVisible();
+    await expect(page.getByLabel("Layer opacity")).toBeVisible();
+    await expect(page.getByLabel("Point size")).toBeVisible();
   });
 
-  test("true 3-D scene labels stay inside the viewer frame", async ({ page }) => {
+  test("true 3-D overlays stay inside the viewer without collisions", async ({ page }) => {
     const scene = page.getByLabel("True 3-D scalar field viewer");
     const canvasMount = page.getByLabel(
       "Interactive Three.js scene showing a CM1 scalar field, domain bounds, slice plane, and selected point",
     );
-    const contextLabel = page.locator(".true3d-scene-label").first();
-    const sliceLabel = page.locator(".true3d-slice-label").first();
+    const contextStack = page.getByLabel("3-D scene context");
+    const fieldLegend = page.getByLabel("3-D field color legend");
     const cameraControls = page.getByLabel("3-D camera controls");
+    const canvas = page.locator("canvas.true3d-canvas");
 
     await expect(scene).toBeVisible();
     await expect(canvasMount).toBeVisible();
-    await expect(contextLabel).toBeVisible();
-    await expect(sliceLabel).toBeVisible();
+    await expect(contextStack).toBeVisible();
+    await expect(fieldLegend).toBeVisible();
     await expect(cameraControls).toBeVisible();
-    await expectInside(scene, contextLabel, "Scene context label");
-    await expectInside(scene, sliceLabel, "Slice plane label");
-    await expectNoOverlap(canvasMount, cameraControls, "Canvas mount and camera controls");
+    await expectInside(scene, contextStack, "Scene context stack");
+    await expectInside(scene, fieldLegend, "Field legend");
+    await expectInside(scene, cameraControls, "Camera controls");
+    await expectNoOverlap(contextStack, fieldLegend, "Context stack and field legend");
+    await expectNoOverlap(contextStack, cameraControls, "Context stack and camera controls");
+    await expectNoOverlap(fieldLegend, cameraControls, "Field legend and camera controls");
+
+    await expect(canvas).toBeVisible();
+    const dimensions = await canvas.evaluate((element: HTMLCanvasElement) => ({
+      displayWidth: element.clientWidth,
+      displayHeight: element.clientHeight,
+      renderWidth: element.width,
+      renderHeight: element.height,
+    }));
+    expect(dimensions.displayWidth).toBeGreaterThan(300);
+    expect(dimensions.displayHeight).toBeGreaterThan(300);
+    expect(dimensions.renderWidth).toBeGreaterThan(300);
+    expect(dimensions.renderHeight).toBeGreaterThan(300);
+    const renderedPixels = await canvas.screenshot();
+    expect(renderedPixels.byteLength).toBeGreaterThan(5_000);
   });
 });

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -2715,42 +2715,6 @@ details[open] > summary {
   font-weight: 850;
 }
 
-.process-mode-control {
-  display: grid;
-  gap: 0.55rem;
-  grid-column: 1 / -1;
-  margin: 0;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 0.75rem;
-}
-
-.process-mode-control legend {
-  color: var(--color-text-primary);
-  font-weight: 850;
-}
-
-.process-mode-helper {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-  margin: 0;
-  color: var(--color-text-muted);
-  font-size: 0.9rem;
-}
-
-.unavailable-diagnostics {
-  border-top: 1px solid var(--color-border);
-  padding-top: 0.55rem;
-}
-
-.unavailable-diagnostics summary {
-  color: var(--color-text-muted);
-  font-size: 0.92rem;
-  font-weight: 800;
-}
-
 .muted-text {
   color: var(--color-text-muted);
 }
@@ -2760,16 +2724,6 @@ details[open] > summary {
   gap: 0.4rem;
   color: var(--color-text-primary);
   font-weight: 800;
-}
-
-.process-overlay-panel {
-  display: grid;
-  gap: 0.75rem;
-  border: 1px solid rgba(76, 127, 164, 0.24);
-  border-radius: 8px;
-  margin-top: 0.75rem;
-  padding: 0.75rem;
-  background: rgba(232, 242, 248, 0.72);
 }
 
 .slice-orientation-summary {
@@ -2908,7 +2862,7 @@ details[open] > summary {
 
 .heatmap-row {
   display: grid;
-  grid-auto-columns: minmax(0.44rem, 1fr);
+  grid-auto-columns: minmax(0, 1fr);
   grid-auto-flow: column;
   gap: 0;
   min-height: 0;
@@ -3092,7 +3046,13 @@ details[open] > summary {
 }
 
 .updraft-lens-axis-x {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
+}
+
+.updraft-lens-axis-x span:last-child {
+  text-align: right;
 }
 
 .updraft-lens-scale-legend {
@@ -3942,13 +3902,18 @@ details[open] > summary {
   }
 
   .integrated-explore-workspace .slice-map-frame {
-    width: min(100%, calc(12rem * var(--slice-domain-aspect) + 4rem));
+    --slice-plot-size: clamp(10rem, calc(100vh - 39rem), 17.25rem);
+
+    width: min(100%, calc(var(--slice-plot-size) * var(--slice-domain-aspect) + 6rem));
     max-width: none;
     margin-inline: auto;
   }
 
   .integrated-explore-workspace .slice-map-frame .slice-heatmap {
-    width: min(calc(12rem * var(--slice-domain-aspect)), calc(100% - 4rem));
+    width: min(
+      calc(var(--slice-plot-size) * var(--slice-domain-aspect)),
+      100%
+    );
     max-width: none !important;
   }
 
@@ -4118,6 +4083,1086 @@ details[open] > summary {
 
   .integrated-explore-workspace .workspace-catalog-error {
     grid-column: 1 / -1;
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+/* Integrated Explore uses a fixed desktop cockpit instead of the legacy stacked workbench. */
+@media (min-width: 1100px) {
+  .app-shell-explore {
+    height: auto;
+    min-height: 100vh;
+    gap: 0;
+    overflow: visible;
+    padding: 0 12px;
+  }
+
+  .app-shell-explore .topbar {
+    height: 48px;
+    box-sizing: border-box;
+    padding: 0;
+  }
+
+  .app-shell-explore .topbar h1 {
+    font-size: 1.1rem;
+  }
+
+  .app-shell-explore .topbar .secondary-button {
+    border: 0;
+    padding: 0.3rem 0.45rem;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .app-shell-explore > .world-context-workspace {
+    height: auto;
+    min-height: calc(100vh - 48px);
+    gap: 0;
+    align-content: stretch;
+    grid-template-rows: minmax(0, 1fr);
+  }
+
+  .app-shell-explore .explore-workspace,
+  .app-shell-explore .explore-result-view {
+    min-height: 0;
+  }
+
+  .app-shell-explore .integrated-explore-workspace {
+    height: auto;
+    min-height: calc(100vh - 48px);
+    gap: 0;
+    grid-template-rows: 56px auto;
+  }
+
+  .app-shell-explore .integrated-explore-header {
+    height: 56px;
+    box-sizing: border-box;
+    padding: 0;
+  }
+
+  .integrated-explore-identity {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    min-width: 0;
+  }
+
+  .integrated-explore-identity h2 {
+    overflow: hidden;
+    margin: 0;
+    font-size: 1.05rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .integrated-explore-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.32rem;
+    border: 0;
+    padding: 0.3rem 0.2rem;
+    background: transparent;
+    color: var(--color-accent-primary);
+    box-shadow: none;
+    white-space: nowrap;
+  }
+
+  .integrated-explore-back span {
+    font-size: 1.35rem;
+    line-height: 0.8;
+  }
+
+  .integrated-explore-actions button {
+    padding: 0.42rem 0.75rem;
+  }
+
+  .integrated-explore-workspace .visualizer-shell {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 680fr) minmax(360px, 392fr) minmax(280px, 300fr);
+    grid-template-rows: minmax(22.5rem, calc(100vh - 360px)) 152px 64px auto;
+    gap: 8px;
+    height: auto;
+    min-height: 0;
+    box-sizing: border-box;
+    overflow: visible;
+    padding: 12px 0;
+  }
+
+  .integrated-explore-workspace .visualizer-workbench,
+  .integrated-explore-workspace .visualizer-stage,
+  .integrated-explore-workspace .explore-control-deck {
+    display: contents;
+  }
+
+  .integrated-explore-workspace .true3d-viewer {
+    position: relative;
+    grid-column: 1;
+    grid-row: 1 / 3;
+    display: block;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    background: var(--color-visualization-background);
+  }
+
+  .integrated-explore-workspace .true3d-scene-frame,
+  .integrated-explore-workspace .true3d-scene-frame-tall {
+    height: 100%;
+    min-height: 0;
+    border-radius: 4px;
+  }
+
+  .integrated-explore-workspace .true3d-field-legend {
+    top: 0.75rem;
+    right: 0.75rem;
+    bottom: auto;
+    left: auto;
+    min-width: min(15rem, calc(100% - 1.5rem));
+    max-width: 18rem;
+  }
+
+  .integrated-explore-workspace .true3d-context-stack {
+    position: absolute;
+    z-index: 3;
+    top: 0.75rem;
+    left: 0.75rem;
+    display: grid;
+    gap: 0.28rem;
+    width: fit-content;
+    max-width: min(30rem, calc(100% - 1.5rem));
+    pointer-events: none;
+  }
+
+  .integrated-explore-workspace .true3d-context-stack .true3d-slice-label,
+  .integrated-explore-workspace .true3d-context-stack .true3d-selected-point-label,
+  .integrated-explore-workspace .true3d-context-stack .true3d-wind-legend {
+    position: static;
+    width: fit-content;
+    max-width: 100%;
+    box-sizing: border-box;
+    margin: 0;
+    border: 1px solid rgba(120, 150, 166, 0.42);
+    border-radius: 4px;
+    padding: 0.34rem 0.45rem;
+    background: rgba(255, 255, 255, 0.84);
+    box-shadow: 0 4px 12px rgba(36, 63, 82, 0.08);
+    color: var(--color-text-primary);
+    font-size: 0.72rem;
+    line-height: 1.25;
+  }
+
+  .integrated-explore-workspace .true3d-context-stack .true3d-slice-label {
+    border-left: 3px solid var(--color-accent-primary);
+  }
+
+  .integrated-explore-workspace .true3d-context-stack .true3d-selected-point-label {
+    border-left: 3px solid #d97706;
+  }
+
+  .integrated-explore-workspace .true3d-context-stack .true3d-wind-legend {
+    border-left: 3px solid #263238;
+  }
+
+  .integrated-explore-workspace .true3d-context-stack .true3d-wind-legend span {
+    font-size: 0.68rem;
+  }
+
+  .integrated-explore-workspace .true3d-controls-compact {
+    position: absolute;
+    z-index: 4;
+    bottom: 0.75rem;
+    left: 0.75rem;
+    display: flex;
+    width: auto;
+    max-width: calc(100% - 1.5rem);
+    gap: 0;
+    align-items: center;
+    border: 1px solid rgba(91, 125, 145, 0.56);
+    border-radius: 4px;
+    padding: 0.2rem;
+    background: rgba(250, 253, 254, 0.94);
+    box-shadow: 0 5px 16px rgba(36, 63, 82, 0.14);
+  }
+
+  .integrated-explore-workspace .true3d-controls-compact:has(.true3d-display-control[open]) {
+    width: 24rem;
+    box-sizing: border-box;
+    border-radius: 0 0 4px 4px;
+    background: rgba(250, 253, 254, 0.98);
+  }
+
+  .integrated-explore-workspace .true3d-controls-compact > label {
+    display: flex;
+    gap: 0.28rem;
+    align-items: center;
+    border-left: 1px solid var(--color-border);
+    padding-left: 0.2rem;
+    color: var(--color-text-primary);
+    font-size: 0.72rem;
+    font-weight: 800;
+  }
+
+  .integrated-explore-workspace .true3d-controls-compact > label select,
+  .integrated-explore-workspace .true3d-controls-compact > button {
+    min-height: 1.8rem;
+    border: 0;
+    border-radius: 2px;
+    padding: 0.2rem 0.45rem;
+    background: transparent;
+    color: var(--color-text-primary);
+    font-size: 0.72rem;
+    box-shadow: none;
+  }
+
+  .integrated-explore-workspace .true3d-controls-compact > label select:hover,
+  .integrated-explore-workspace .true3d-controls-compact > button:hover,
+  .integrated-explore-workspace .true3d-display-control > summary:hover {
+    background: var(--color-accent-soft);
+  }
+
+  .integrated-explore-workspace .true3d-controls-compact > button {
+    width: 2rem;
+    border-left: 1px solid var(--color-border);
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .true3d-display-control {
+    position: static;
+  }
+
+  .true3d-display-control > summary {
+    display: flex;
+    gap: 0.35rem;
+    align-items: center;
+    min-height: 1.8rem;
+    box-sizing: border-box;
+    border: 0;
+    border-radius: 2px;
+    padding: 0.28rem 0.5rem;
+    background: transparent;
+    color: var(--color-text-primary);
+    font-size: 0.72rem;
+    font-weight: 800;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .true3d-display-control > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .true3d-display-control[open] > summary {
+    background: var(--color-accent-soft);
+    color: var(--color-accent-primary);
+  }
+
+  .true3d-display-panel {
+    position: absolute;
+    bottom: 100%;
+    left: -1px;
+    width: calc(100% + 2px);
+    box-sizing: border-box;
+    border: 1px solid var(--color-border-strong);
+    border-bottom: 0;
+    border-radius: 4px 4px 0 0;
+    padding: 0.7rem;
+    background: rgba(255, 255, 255, 0.97);
+    box-shadow: 0 -7px 20px rgba(36, 63, 82, 0.14);
+  }
+
+  .true3d-display-panel .inspector-rendering-controls-compact {
+    grid-template-columns: minmax(0, 1fr) 8.5rem;
+    gap: 0.7rem 0.75rem;
+    border: 0;
+    padding: 0;
+  }
+
+  .true3d-display-panel .inspector-rendering-controls-compact > label {
+    font-size: 0.7rem;
+  }
+
+  .true3d-display-panel .inspector-rendering-controls-compact > label:first-of-type {
+    grid-column: 1;
+  }
+
+  .true3d-display-panel .inspector-rendering-controls-compact > label:nth-of-type(2) {
+    grid-column: 2;
+  }
+
+  .true3d-display-panel .rendering-range-controls {
+    grid-column: 1 / -1;
+    gap: 0.75rem;
+  }
+
+  .true3d-display-panel .rendering-range-controls label {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 0.38rem;
+    align-items: center;
+    white-space: nowrap;
+  }
+
+  .integrated-explore-workspace .unified-slice-inspector {
+    grid-column: 2;
+    grid-row: 1;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: 0.45rem;
+    min-width: 0;
+    min-height: 0;
+    max-height: none;
+    overflow: hidden;
+    border: 0;
+    border-left: 1px solid var(--color-border);
+    border-radius: 0;
+    padding: 0 0 0 8px;
+    background: transparent;
+  }
+
+  .instrument-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.55rem;
+    min-height: 42px;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 0.35rem;
+  }
+
+  .instrument-header h2,
+  .instrument-header p {
+    margin: 0;
+  }
+
+  .instrument-header > div:first-child {
+    min-width: 0;
+  }
+
+  .instrument-header h2 {
+    font-size: 0.98rem;
+  }
+
+  .instrument-header p {
+    overflow: hidden;
+    font-size: 0.72rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .instrument-actions {
+    display: flex;
+    gap: 0.2rem;
+    align-items: center;
+    flex: 0 0 auto;
+  }
+
+  .viewer-maximize-button {
+    width: 1.75rem;
+    min-width: 1.75rem;
+    height: 1.75rem;
+    min-height: 1.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    padding: 0;
+    background: transparent;
+    color: var(--color-text-primary);
+    font-size: 1rem;
+    line-height: 1;
+    box-shadow: none;
+  }
+
+  .viewer-maximize-button:hover,
+  .viewer-maximize-button:focus-visible {
+    border-color: var(--color-accent-primary);
+    background: var(--color-accent-soft);
+    color: var(--color-accent-primary);
+  }
+
+  .instrument-view-toggle {
+    display: flex;
+    gap: 0.18rem;
+    flex: 0 0 auto;
+  }
+
+  .instrument-view-toggle button {
+    padding: 0.27rem 0.38rem;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 0.7rem;
+    box-shadow: none;
+  }
+
+  .instrument-view-toggle .active-control {
+    background: var(--color-accent-soft);
+    color: var(--color-accent-primary);
+  }
+
+  .integrated-explore-workspace .unified-slice-inspector > .updraft-lens-slice,
+  .integrated-explore-workspace .unified-slice-inspector > .slice-panel {
+    align-self: center;
+    min-height: 0;
+  }
+
+  .integrated-explore-workspace .updraft-lens-slice-without-legend {
+    width: 100%;
+    max-width: none;
+  }
+
+  .updraft-lens-instrument-body {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 8.8rem;
+    gap: 0.55rem;
+    align-items: center;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .updraft-lens-instrument-body .updraft-lens-slice-without-legend {
+    align-self: center;
+    min-width: 0;
+  }
+
+  .integrated-explore-workspace .updraft-lens-slice-without-legend .updraft-lens-svg {
+    width: 100%;
+    height: auto;
+    max-width: 100%;
+    max-height: none;
+  }
+
+  .integrated-explore-workspace .updraft-lens-scale-legend-workspace {
+    align-self: center;
+    gap: 0.18rem;
+    border: 0;
+    border-left: 1px solid var(--color-border);
+    border-radius: 0;
+    padding: 0.1rem 0 0.1rem 0.55rem;
+    background: transparent;
+  }
+
+  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-scale-intervals {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.06rem;
+  }
+
+  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-scale-intervals li {
+    grid-template-columns: 0.55rem minmax(0, 1fr);
+    gap: 0.22rem;
+    font-size: 0.6rem;
+    line-height: 1.1;
+  }
+
+  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-scale-swatch {
+    width: 0.5rem;
+    min-height: 0.82rem;
+  }
+
+  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-slice-range,
+  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-scale-heading strong {
+    font-size: 0.62rem;
+    line-height: 1.15;
+  }
+
+  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-slice-range-maximum {
+    padding-bottom: 0.22rem;
+  }
+
+  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-slice-range-minimum {
+    padding-top: 0.22rem;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens,
+  .integrated-explore-workspace .explore-control-card-slice {
+    grid-column: 2;
+    grid-row: 2;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    gap: 0.32rem 0.45rem;
+    min-width: 0;
+    height: 152px;
+    box-sizing: border-box;
+    max-height: none;
+    overflow: hidden;
+    border: 0;
+    border-top: 1px solid var(--color-border);
+    border-radius: 0;
+    padding: 0.45rem 0 0 8px;
+    background: transparent;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens select,
+  .integrated-explore-workspace .explore-control-card-slice select,
+  .integrated-explore-workspace .explore-control-card-updraft-lens input[type="range"],
+  .integrated-explore-workspace .explore-control-card-slice input[type="range"] {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens legend,
+  .integrated-explore-workspace .explore-control-card-slice legend {
+    display: none;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens > .segmented-buttons,
+  .integrated-explore-workspace .explore-control-card-slice > .segmented-buttons,
+  .integrated-explore-workspace .explore-control-card-updraft-lens > label[for="updraft-lens-plane-position"],
+  .integrated-explore-workspace .explore-control-card-slice > label[for="explore-slice-field"],
+  .integrated-explore-workspace .explore-control-card-slice > label[for="explore-slice-position"] {
+    grid-column: 1 / -1;
+  }
+
+  .integrated-explore-workspace .explore-control-card-slice > label[for="explore-slice-field"] {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens > label[for="updraft-lens-plane-position"],
+  .integrated-explore-workspace .explore-control-card-slice > label[for="explore-slice-position"] {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 0.45rem;
+    align-items: center;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens > label[for="updraft-lens-plane-position"] .slice-position-label,
+  .integrated-explore-workspace .explore-control-card-slice > label[for="explore-slice-position"] .slice-position-label {
+    display: flex;
+    gap: 0.25rem;
+    align-items: baseline;
+    white-space: nowrap;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens .segmented-buttons,
+  .integrated-explore-workspace .explore-control-card-slice .segmented-buttons {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.2rem;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens button,
+  .integrated-explore-workspace .explore-control-card-slice button,
+  .integrated-explore-workspace .explore-control-card-updraft-lens label,
+  .integrated-explore-workspace .explore-control-card-slice label,
+  .integrated-explore-workspace .explore-control-card-updraft-lens select,
+  .integrated-explore-workspace .explore-control-card-slice select {
+    font-size: 0.68rem;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens button,
+  .integrated-explore-workspace .explore-control-card-slice button {
+    min-width: 0;
+    padding: 0.24rem 0.34rem;
+    white-space: nowrap;
+  }
+
+  .integrated-explore-workspace .slice-move-buttons {
+    display: none;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens .control-help {
+    display: none;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens .updraft-lens-mode-control {
+    display: flex;
+    grid-column: 1 / -1;
+    gap: 0.4rem;
+    align-items: center;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens .updraft-lens-mode-control > span {
+    white-space: nowrap;
+  }
+
+  .integrated-explore-workspace .explore-control-card-updraft-lens .updraft-lens-mode-control .segmented-buttons {
+    display: flex;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time {
+    grid-column: 1 / 3;
+    grid-row: 3;
+    display: grid;
+    grid-template-columns: auto auto minmax(12rem, 1fr) minmax(7rem, auto);
+    gap: 0.55rem;
+    align-items: center;
+    height: 64px;
+    box-sizing: border-box;
+    overflow: hidden;
+    border: 0;
+    border-top: 1px solid var(--color-border);
+    border-radius: 0;
+    padding: 0.42rem 0;
+    background: transparent;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time label[for="explore-time"] {
+    display: none;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time legend,
+  .integrated-explore-workspace .explore-control-card-time .control-help {
+    display: none;
+  }
+
+  .integrated-explore-workspace .frame-step-controls,
+  .integrated-explore-workspace .timelapse-controls {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+  }
+
+  .integrated-explore-workspace .frame-step-controls button {
+    width: 2rem;
+    min-height: 2rem;
+    padding: 0;
+    font-size: 1.05rem;
+  }
+
+  .integrated-explore-workspace .timelapse-controls > button {
+    min-width: 5.2rem;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time label {
+    gap: 0.15rem;
+    margin: 0;
+    font-size: 0.65rem;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time label[for="explore-time-scrubber"] {
+    display: grid;
+    grid-column: auto;
+    grid-template-columns: auto minmax(8rem, 1fr) auto;
+    gap: 0.45rem;
+    align-items: center;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time label[for="explore-time-scrubber"] input {
+    width: 100%;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time .timeline-label {
+    white-space: nowrap;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time .slice-position-label {
+    display: grid;
+    justify-items: end;
+    font-size: 0.68rem;
+    white-space: nowrap;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time .slice-position-label small {
+    font-size: 0.6rem;
+    white-space: nowrap;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time select,
+  .integrated-explore-workspace .explore-control-card-time button {
+    min-height: 1.9rem;
+    padding: 0.25rem 0.36rem;
+    font-size: 0.7rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector {
+    grid-column: 3;
+    grid-row: 1 / 4;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    width: auto;
+    min-width: 0;
+    min-height: 0;
+    max-height: none;
+    overflow: hidden;
+    border: 0;
+    border-left: 1px solid var(--color-border);
+    border-radius: 0;
+    background: transparent;
+  }
+
+  .integrated-explore-workspace .explore-inspector-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.45rem;
+    align-items: stretch;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0 0 0 8px;
+  }
+
+  .integrated-explore-workspace .explore-inspector-header > strong {
+    align-self: center;
+    color: var(--color-text-primary);
+    font-size: 0.78rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-tabs {
+    position: static;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0;
+    border: 0;
+    padding: 0;
+    background: transparent;
+  }
+
+  .integrated-explore-workspace .explore-inspector-tabs button {
+    border: 0;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    padding: 0.58rem 0.18rem 0.48rem;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 0.7rem;
+    box-shadow: none;
+  }
+
+  .integrated-explore-workspace .explore-inspector-tabs .active-control {
+    border-bottom-color: var(--color-accent-primary);
+    background: transparent;
+    color: var(--color-accent-primary);
+  }
+
+  .integrated-explore-workspace .explore-inspector-toggle {
+    align-self: center;
+    width: 1.85rem;
+    height: 1.85rem;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 0;
+    background: transparent;
+    color: var(--color-accent-primary);
+    font-size: 1.05rem;
+    line-height: 1;
+    box-shadow: none;
+  }
+
+  .integrated-explore-workspace .explore-inspector > div {
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel {
+    gap: 0.45rem;
+    min-width: 0;
+    padding: 0.55rem 0.2rem 0.65rem 8px;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel > *,
+  .integrated-explore-workspace .explore-inspector-panel section,
+  .integrated-explore-workspace .explore-inspector-panel details,
+  .integrated-explore-workspace .explore-inspector-panel dl,
+  .integrated-explore-workspace .explore-inspector-panel div {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel .section-heading {
+    align-items: start;
+  }
+
+  .integrated-explore-workspace .selected-region-inspector .section-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.3rem;
+  }
+
+  .integrated-explore-workspace .selected-region-inspector .state-chip {
+    justify-self: start;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel .section-heading h3 {
+    font-size: 0.92rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel .eyebrow {
+    font-size: 0.64rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel p,
+  .integrated-explore-workspace .explore-inspector-panel dd,
+  .integrated-explore-workspace .explore-inspector-panel li {
+    line-height: 1.35;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel .metric-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.3rem;
+  }
+
+  .context-metrics {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0;
+    margin: 0;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .context-metrics > div {
+    min-width: 0;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0.45rem 0.35rem 0.45rem 0;
+  }
+
+  .context-metrics > div:last-child {
+    grid-column: 1 / -1;
+  }
+
+  .context-metrics dt,
+  .context-metrics dd {
+    margin: 0;
+  }
+
+  .context-metrics dt {
+    color: var(--color-text-primary);
+    font-size: 0.68rem;
+    font-weight: 800;
+  }
+
+  .context-metrics dd {
+    margin-top: 0.12rem;
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel .metric-grid div {
+    border: 0;
+    border-top: 1px solid var(--color-border);
+    border-radius: 0;
+    padding: 0.32rem 0;
+    background: transparent;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel dd,
+  .integrated-explore-workspace .explore-inspector-panel code,
+  .integrated-explore-workspace .explore-inspector-panel pre {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .integrated-explore-workspace .explore-inspector-collapsed {
+    max-height: none;
+  }
+
+  .integrated-explore-workspace .visualizer-shell:has(.explore-inspector-collapsed) {
+    grid-template-columns: minmax(0, 680fr) minmax(0, 392fr) 3rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-collapsed .explore-inspector-header {
+    display: grid;
+    grid-template-columns: 1fr;
+    justify-items: center;
+    border-bottom: 0;
+    padding: 0.2rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-collapsed .explore-inspector-header button {
+    writing-mode: horizontal-tb;
+  }
+
+  .simulation-notes-form {
+    display: grid;
+    gap: 0.6rem;
+  }
+
+  .simulation-notes-form textarea {
+    width: 100%;
+    min-height: 11rem;
+    box-sizing: border-box;
+    resize: vertical;
+    line-height: 1.45;
+  }
+
+  .simulation-notes-actions {
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+  }
+
+  .simulation-notes-actions p {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+  }
+
+  .explore-secondary-content {
+    grid-column: 1 / -1;
+    grid-row: 4;
+    display: grid;
+    grid-template-columns: minmax(18rem, 0.8fr) minmax(0, 1.2fr);
+    gap: 1.5rem;
+    border-top: 1px solid var(--color-border-strong);
+    padding: 1.15rem 0 2rem;
+  }
+
+  .explore-secondary-content > section {
+    min-width: 0;
+  }
+
+  .explore-secondary-content > section + section {
+    border-left: 1px solid var(--color-border);
+    padding-left: 1.5rem;
+  }
+
+  .explore-secondary-content .metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .explore-secondary-content dd,
+  .explore-secondary-content code,
+  .explore-secondary-content pre {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-scene .true3d-viewer {
+    grid-column: 1 / -1;
+    grid-row: 1 / 3;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-scene .unified-slice-inspector,
+  .integrated-explore-workspace .visualizer-shell-focused-scene .explore-control-card-slice,
+  .integrated-explore-workspace .visualizer-shell-focused-scene .explore-control-card-updraft-lens,
+  .integrated-explore-workspace .visualizer-shell-focused-scene .explore-inspector {
+    display: none;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-scene .explore-control-card-time {
+    grid-column: 1 / -1;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-slice .true3d-viewer,
+  .integrated-explore-workspace .visualizer-shell-focused-slice .explore-inspector {
+    display: none;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-slice .unified-slice-inspector {
+    grid-column: 1 / -1;
+    grid-row: 1;
+    border-left: 0;
+    padding-left: 0;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-slice .explore-control-card-slice,
+  .integrated-explore-workspace .visualizer-shell-focused-slice .explore-control-card-updraft-lens {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    border-left: 0;
+    padding-left: 0;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-slice .explore-control-card-time {
+    grid-column: 1 / -1;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-slice .updraft-lens-instrument-body {
+    grid-template-columns: minmax(0, 1fr) 10rem;
+    width: min(74rem, 100%);
+    margin-inline: auto;
+  }
+
+  .integrated-explore-workspace
+    .visualizer-shell-focused-slice
+    .updraft-lens-slice-without-legend,
+  .integrated-explore-workspace
+    .visualizer-shell-focused-slice
+    .updraft-lens-plot-column {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .integrated-explore-workspace
+    .visualizer-shell-focused-slice
+    .updraft-lens-slice-without-legend
+    .updraft-lens-svg {
+    width: auto;
+    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-slice .slice-panel {
+    width: min(74rem, 100%);
+    margin-inline: auto;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-slice .slice-map-frame {
+    --focused-slice-plot-size: min(20rem, calc(100vh - 32rem));
+
+    width: min(
+      100%,
+      calc(var(--focused-slice-plot-size) * var(--slice-domain-aspect) + 8rem)
+    );
+  }
+
+  .integrated-explore-workspace
+    .visualizer-shell-focused-slice
+    .slice-map-frame
+    .slice-heatmap {
+    width: calc(var(--focused-slice-plot-size) * var(--slice-domain-aspect));
+  }
+
+  .inspector-rendering-controls {
+    display: grid;
+    gap: 0.42rem;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 0.55rem;
+  }
+
+  .inspector-rendering-controls h3,
+  .inspector-rendering-controls p {
+    margin: 0;
+  }
+
+  .inspector-rendering-controls label {
+    display: grid;
+    gap: 0.18rem;
+    color: var(--color-text-primary);
+    font-size: 0.7rem;
+    font-weight: 800;
+  }
+
+  .rendering-range-controls {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+
+  .rendering-range-controls output {
+    font-size: 0.65rem;
+  }
+
+  .integrated-explore-workspace .layer-local-error-3d {
+    z-index: 8;
+    grid-column: 1;
+    grid-row: 1;
+    align-self: start;
+    justify-self: center;
+    margin-top: 3.5rem;
+  }
+
+  .integrated-explore-workspace .workspace-catalog-error {
+    position: absolute;
+    z-index: 10;
+    top: 1rem;
+    left: 50%;
+    width: min(34rem, calc(100% - 2rem));
+    transform: translateX(-50%);
   }
 }
 

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -2982,6 +2982,7 @@ details[open] > summary {
 .updraft-lens-slice {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) minmax(12.5rem, 15rem);
+  grid-template-rows: auto auto;
   gap: 0.55rem;
   align-items: stretch;
   width: 100%;
@@ -2991,12 +2992,12 @@ details[open] > summary {
 }
 
 .updraft-lens-plot-column {
-  display: grid;
-  gap: 0.38rem;
-  min-width: 0;
+  display: contents;
 }
 
 .updraft-lens-svg {
+  grid-column: 2;
+  grid-row: 1;
   display: block;
   width: 100%;
   height: auto;
@@ -3035,9 +3036,11 @@ details[open] > summary {
 }
 
 .updraft-lens-axis-z {
+  grid-column: 1;
+  grid-row: 1;
   flex-direction: column;
   align-items: center;
-  padding: 0.1rem 0 1.75rem;
+  padding: 0.1rem 0;
 }
 
 .updraft-lens-axis-z strong {
@@ -3047,8 +3050,11 @@ details[open] > summary {
 
 .updraft-lens-axis-x {
   display: grid;
+  grid-column: 2;
+  grid-row: 2;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
+  width: 100%;
 }
 
 .updraft-lens-axis-x span:last-child {
@@ -3056,6 +3062,8 @@ details[open] > summary {
 }
 
 .updraft-lens-scale-legend {
+  grid-column: 3;
+  grid-row: 1 / span 2;
   box-sizing: border-box;
   display: grid;
   gap: 0.5rem;
@@ -3910,10 +3918,7 @@ details[open] > summary {
   }
 
   .integrated-explore-workspace .slice-map-frame .slice-heatmap {
-    width: min(
-      calc(var(--slice-plot-size) * var(--slice-domain-aspect)),
-      100%
-    );
+    width: min(calc(var(--slice-plot-size) * var(--slice-domain-aspect)), 100%);
     max-width: none !important;
   }
 
@@ -4317,7 +4322,9 @@ details[open] > summary {
 
   .integrated-explore-workspace .true3d-controls-compact > label select,
   .integrated-explore-workspace .true3d-controls-compact > button {
-    min-height: 1.8rem;
+    width: auto;
+    height: 2rem;
+    min-height: 2rem;
     border: 0;
     border-radius: 2px;
     padding: 0.2rem 0.45rem;
@@ -4342,21 +4349,30 @@ details[open] > summary {
 
   .true3d-display-control {
     position: static;
+    display: flex;
+    height: 2rem;
+    align-self: center;
+    align-items: center;
   }
 
   .true3d-display-control > summary {
     display: flex;
     gap: 0.35rem;
+    align-self: center;
     align-items: center;
-    min-height: 1.8rem;
+    justify-content: center;
+    height: 2rem;
+    min-height: 2rem;
     box-sizing: border-box;
+    margin: 0;
     border: 0;
     border-radius: 2px;
-    padding: 0.28rem 0.5rem;
+    padding: 0 0.5rem;
     background: transparent;
     color: var(--color-text-primary);
     font-size: 0.72rem;
     font-weight: 800;
+    line-height: 1;
     cursor: pointer;
     list-style: none;
   }
@@ -4366,6 +4382,7 @@ details[open] > summary {
   }
 
   .true3d-display-control[open] > summary {
+    margin: 0;
     background: var(--color-accent-soft);
     color: var(--color-accent-primary);
   }
@@ -4413,6 +4430,10 @@ details[open] > summary {
     gap: 0.38rem;
     align-items: center;
     white-space: nowrap;
+  }
+
+  .true3d-display-panel .rendering-range-controls .lens-opacity-control {
+    grid-column: 1 / -1;
   }
 
   .integrated-explore-workspace .unified-slice-inspector {
@@ -4523,12 +4544,36 @@ details[open] > summary {
 
   .updraft-lens-instrument-body {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 8.8rem;
+    grid-template-columns: minmax(0, 1fr) 10rem;
     gap: 0.55rem;
     align-items: center;
     min-width: 0;
     min-height: 0;
     overflow: hidden;
+  }
+
+  .updraft-lens-instrument-body-compact {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto auto;
+    gap: 0.4rem;
+    align-items: start;
+    align-content: center;
+  }
+
+  .updraft-lens-instrument-body-compact .updraft-lens-slice-without-legend {
+    --compact-lens-plot-height: 15rem;
+
+    grid-column: 1;
+    grid-row: 1;
+    justify-self: center;
+    width: min(
+      100%,
+      calc(var(--compact-lens-plot-height) * var(--updraft-lens-domain-aspect) + 2.5rem)
+    );
+  }
+
+  .updraft-lens-instrument-body-compact .updraft-lens-slice-top-down {
+    --compact-lens-plot-height: 14rem;
   }
 
   .updraft-lens-instrument-body .updraft-lens-slice-without-legend {
@@ -4544,6 +4589,8 @@ details[open] > summary {
   }
 
   .integrated-explore-workspace .updraft-lens-scale-legend-workspace {
+    grid-column: 2;
+    grid-row: 1;
     align-self: center;
     gap: 0.18rem;
     border: 0;
@@ -4558,7 +4605,10 @@ details[open] > summary {
     gap: 0.06rem;
   }
 
-  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-scale-intervals li {
+  .integrated-explore-workspace
+    .updraft-lens-scale-legend-workspace
+    .updraft-lens-scale-intervals
+    li {
     grid-template-columns: 0.55rem minmax(0, 1fr);
     gap: 0.22rem;
     font-size: 0.6rem;
@@ -4570,17 +4620,61 @@ details[open] > summary {
     min-height: 0.82rem;
   }
 
+  .integrated-explore-workspace .updraft-lens-scale-legend-compact {
+    grid-column: 1;
+    grid-row: 2;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.5rem;
+    align-items: center;
+    border-top: 1px solid var(--color-border);
+    border-left: 0;
+    padding: 0.32rem 0 0;
+  }
+
+  .integrated-explore-workspace .updraft-lens-scale-legend-compact .updraft-lens-scale-intervals {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.14rem 0.35rem;
+  }
+
+  .integrated-explore-workspace
+    .updraft-lens-scale-legend-compact
+    .updraft-lens-scale-heading
+    strong {
+    font-size: 0.68rem;
+  }
+
+  .integrated-explore-workspace
+    .updraft-lens-scale-legend-compact
+    .updraft-lens-scale-intervals
+    li {
+    grid-template-columns: 0.42rem minmax(0, 1fr);
+    gap: 0.18rem;
+    font-size: 0.56rem;
+  }
+
+  .integrated-explore-workspace .updraft-lens-scale-legend-compact .updraft-lens-scale-swatch {
+    width: 0.4rem;
+    min-height: 0.72rem;
+  }
+
   .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-slice-range,
-  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-scale-heading strong {
+  .integrated-explore-workspace
+    .updraft-lens-scale-legend-workspace
+    .updraft-lens-scale-heading
+    strong {
     font-size: 0.62rem;
     line-height: 1.15;
   }
 
-  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-slice-range-maximum {
+  .integrated-explore-workspace
+    .updraft-lens-scale-legend-workspace
+    .updraft-lens-slice-range-maximum {
     padding-bottom: 0.22rem;
   }
 
-  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-slice-range-minimum {
+  .integrated-explore-workspace
+    .updraft-lens-scale-legend-workspace
+    .updraft-lens-slice-range-minimum {
     padding-top: 0.22rem;
   }
 
@@ -4618,7 +4712,9 @@ details[open] > summary {
 
   .integrated-explore-workspace .explore-control-card-updraft-lens > .segmented-buttons,
   .integrated-explore-workspace .explore-control-card-slice > .segmented-buttons,
-  .integrated-explore-workspace .explore-control-card-updraft-lens > label[for="updraft-lens-plane-position"],
+  .integrated-explore-workspace
+    .explore-control-card-updraft-lens
+    > label[for="updraft-lens-plane-position"],
   .integrated-explore-workspace .explore-control-card-slice > label[for="explore-slice-field"],
   .integrated-explore-workspace .explore-control-card-slice > label[for="explore-slice-position"] {
     grid-column: 1 / -1;
@@ -4631,7 +4727,9 @@ details[open] > summary {
     align-items: center;
   }
 
-  .integrated-explore-workspace .explore-control-card-updraft-lens > label[for="updraft-lens-plane-position"],
+  .integrated-explore-workspace
+    .explore-control-card-updraft-lens
+    > label[for="updraft-lens-plane-position"],
   .integrated-explore-workspace .explore-control-card-slice > label[for="explore-slice-position"] {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
@@ -4639,8 +4737,14 @@ details[open] > summary {
     align-items: center;
   }
 
-  .integrated-explore-workspace .explore-control-card-updraft-lens > label[for="updraft-lens-plane-position"] .slice-position-label,
-  .integrated-explore-workspace .explore-control-card-slice > label[for="explore-slice-position"] .slice-position-label {
+  .integrated-explore-workspace
+    .explore-control-card-updraft-lens
+    > label[for="updraft-lens-plane-position"]
+    .slice-position-label,
+  .integrated-explore-workspace
+    .explore-control-card-slice
+    > label[for="explore-slice-position"]
+    .slice-position-label {
     display: flex;
     gap: 0.25rem;
     align-items: baseline;
@@ -4685,11 +4789,17 @@ details[open] > summary {
     align-items: center;
   }
 
-  .integrated-explore-workspace .explore-control-card-updraft-lens .updraft-lens-mode-control > span {
+  .integrated-explore-workspace
+    .explore-control-card-updraft-lens
+    .updraft-lens-mode-control
+    > span {
     white-space: nowrap;
   }
 
-  .integrated-explore-workspace .explore-control-card-updraft-lens .updraft-lens-mode-control .segmented-buttons {
+  .integrated-explore-workspace
+    .explore-control-card-updraft-lens
+    .updraft-lens-mode-control
+    .segmented-buttons {
     display: flex;
   }
 
@@ -4734,7 +4844,47 @@ details[open] > summary {
   }
 
   .integrated-explore-workspace .timelapse-controls > button {
-    min-width: 5.2rem;
+    width: 2rem;
+    min-width: 2rem;
+    min-height: 2rem;
+    padding: 0;
+  }
+
+  .integrated-explore-workspace .timelapse-controls label {
+    display: block;
+  }
+
+  .integrated-explore-workspace .timelapse-controls select {
+    height: 2rem;
+    min-height: 2rem;
+  }
+
+  .timelapse-icon {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 0.8rem;
+    height: 0.8rem;
+  }
+
+  .timelapse-icon-play > span {
+    width: 0;
+    height: 0;
+    border-top: 0.36rem solid transparent;
+    border-bottom: 0.36rem solid transparent;
+    border-left: 0.58rem solid currentColor;
+    transform: translateX(0.05rem);
+  }
+
+  .timelapse-icon-pause {
+    gap: 0.18rem;
+  }
+
+  .timelapse-icon-pause > span {
+    width: 0.18rem;
+    height: 0.72rem;
+    border-radius: 1px;
+    background: currentColor;
   }
 
   .integrated-explore-workspace .explore-control-card-time label {
@@ -4751,7 +4901,10 @@ details[open] > summary {
     align-items: center;
   }
 
-  .integrated-explore-workspace .explore-control-card-time label[for="explore-time-scrubber"] input {
+  .integrated-explore-workspace
+    .explore-control-card-time
+    label[for="explore-time-scrubber"]
+    input {
     width: 100%;
   }
 
@@ -5070,30 +5223,36 @@ details[open] > summary {
     grid-column: 1 / -1;
   }
 
+  .integrated-explore-workspace .visualizer-shell-focused-slice {
+    grid-template-rows: minmax(36rem, calc(100vh - 10rem)) 152px 64px auto;
+  }
+
   .integrated-explore-workspace .visualizer-shell-focused-slice .updraft-lens-instrument-body {
     grid-template-columns: minmax(0, 1fr) 10rem;
-    width: min(74rem, 100%);
+    justify-content: center;
+    width: min(84rem, 100%);
     margin-inline: auto;
   }
 
   .integrated-explore-workspace
     .visualizer-shell-focused-slice
-    .updraft-lens-slice-without-legend,
-  .integrated-explore-workspace
-    .visualizer-shell-focused-slice
-    .updraft-lens-plot-column {
-    height: 100%;
-    min-height: 0;
+    .updraft-lens-instrument-body:has(.updraft-lens-slice-top-down) {
+    grid-template-columns: minmax(0, 40rem) 10rem;
   }
 
-  .integrated-explore-workspace
-    .visualizer-shell-focused-slice
-    .updraft-lens-slice-without-legend
-    .updraft-lens-svg {
-    width: auto;
-    height: 100%;
+  .integrated-explore-workspace .visualizer-shell-focused-slice .updraft-lens-slice-without-legend {
+    --focused-lens-plot-height: clamp(28rem, calc(100vh - 22rem), 32rem);
+
+    justify-self: center;
+    width: min(
+      100%,
+      calc(var(--focused-lens-plot-height) * var(--updraft-lens-domain-aspect) + 2.5rem)
+    );
     max-width: 100%;
-    max-height: 100%;
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-slice .updraft-lens-slice-top-down {
+    --focused-lens-plot-height: clamp(28rem, calc(100vh - 21rem), 36rem);
   }
 
   .integrated-explore-workspace .visualizer-shell-focused-slice .slice-panel {
@@ -5102,18 +5261,18 @@ details[open] > summary {
   }
 
   .integrated-explore-workspace .visualizer-shell-focused-slice .slice-map-frame {
-    --focused-slice-plot-size: min(20rem, calc(100vh - 32rem));
+    --focused-slice-plot-size: clamp(28rem, calc(100vh - 22rem), 32rem);
 
-    width: min(
-      100%,
-      calc(var(--focused-slice-plot-size) * var(--slice-domain-aspect) + 8rem)
-    );
+    width: min(100%, calc(var(--focused-slice-plot-size) * var(--slice-domain-aspect) + 8rem));
   }
 
   .integrated-explore-workspace
     .visualizer-shell-focused-slice
-    .slice-map-frame
-    .slice-heatmap {
+    .slice-map-frame[data-orientation="horizontal"] {
+    --focused-slice-plot-size: clamp(32rem, calc(100vh - 18rem), 38rem);
+  }
+
+  .integrated-explore-workspace .visualizer-shell-focused-slice .slice-map-frame .slice-heatmap {
     width: calc(var(--focused-slice-plot-size) * var(--slice-domain-aspect));
   }
 

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -3781,6 +3781,346 @@ details[open] > summary {
   display: none;
 }
 
+@media (min-width: 1100px) {
+  .world-context-workspace:has(.integrated-explore-workspace) {
+    gap: 0.45rem;
+  }
+
+  .integrated-explore-workspace {
+    display: grid;
+    gap: 0.45rem;
+    min-width: 0;
+  }
+
+  .integrated-explore-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0 0.15rem 0.45rem;
+  }
+
+  .integrated-explore-header .eyebrow,
+  .integrated-explore-header h2 {
+    margin-bottom: 0;
+  }
+
+  .integrated-explore-header h2 {
+    font-size: 1.25rem;
+  }
+
+  .integrated-explore-actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+
+  .integrated-explore-workspace .visualizer-shell {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 21rem;
+    grid-template-areas:
+      "scene inspector"
+      "slice inspector"
+      "controls controls";
+    grid-template-rows: auto auto auto;
+    gap: 0.45rem;
+    min-width: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .integrated-explore-workspace .visualizer-workbench,
+  .integrated-explore-workspace .visualizer-stage {
+    display: contents;
+  }
+
+  .integrated-explore-workspace .true3d-viewer {
+    grid-area: scene;
+    gap: 0.3rem;
+    min-width: 0;
+    padding: 0.45rem;
+  }
+
+  .integrated-explore-workspace .true3d-scene-header .eyebrow {
+    margin-bottom: 0.08rem;
+  }
+
+  .integrated-explore-workspace .true3d-scene-header h3 {
+    font-size: 0.95rem;
+  }
+
+  .integrated-explore-workspace .true3d-scene-frame,
+  .integrated-explore-workspace .true3d-scene-frame-tall {
+    height: 18rem;
+    min-height: 18rem;
+  }
+
+  .integrated-explore-workspace .true3d-controls {
+    grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1.4fr);
+    gap: 0.3rem 0.45rem;
+    align-items: center;
+    padding: 0.3rem 0.4rem;
+  }
+
+  .integrated-explore-workspace .true3d-control-section {
+    display: contents;
+  }
+
+  .integrated-explore-workspace .true3d-controls > p {
+    display: none;
+  }
+
+  .integrated-explore-workspace .true3d-preset-buttons {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+
+  .integrated-explore-workspace .true3d-preset-buttons button {
+    padding: 0.28rem 0.4rem;
+    font-size: 0.76rem;
+    white-space: nowrap;
+  }
+
+  .integrated-explore-workspace .true3d-provenance {
+    display: none;
+  }
+
+  .integrated-explore-workspace .unified-slice-inspector {
+    grid-area: slice;
+    align-content: start;
+    gap: 0.35rem;
+    min-width: 0;
+    min-height: 14.5rem;
+    max-height: 16.5rem;
+    overflow: auto;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 0.45rem;
+    background: var(--color-surface);
+  }
+
+  .integrated-explore-workspace .unified-slice-inspector .section-heading h2 {
+    margin-bottom: 0.1rem;
+    font-size: 1rem;
+  }
+
+  .integrated-explore-workspace .unified-slice-inspector .section-heading p {
+    margin-bottom: 0;
+    font-size: 0.78rem;
+  }
+
+  .integrated-explore-workspace .updraft-lens-slice-without-legend {
+    grid-template-columns: auto minmax(0, 1fr);
+    width: min(100%, 47rem);
+  }
+
+  .integrated-explore-workspace .updraft-lens-slice-without-legend .updraft-lens-svg {
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 12.25rem;
+  }
+
+  .integrated-explore-workspace .updraft-lens-slice-without-legend .updraft-lens-plot-column {
+    justify-items: center;
+  }
+
+  .integrated-explore-workspace .slice-panel {
+    padding: 0.2rem;
+    box-shadow: none;
+  }
+
+  .integrated-explore-workspace .slice-panel > .section-heading {
+    display: none;
+  }
+
+  .integrated-explore-workspace .unified-slice-inspector .slice-panel > h3,
+  .integrated-explore-workspace .unified-slice-inspector .slice-axis-summary {
+    display: none;
+  }
+
+  .integrated-explore-workspace .slice-map-frame {
+    width: min(100%, calc(12rem * var(--slice-domain-aspect) + 4rem));
+    max-width: none;
+    margin-inline: auto;
+  }
+
+  .integrated-explore-workspace .slice-map-frame .slice-heatmap {
+    width: min(calc(12rem * var(--slice-domain-aspect)), calc(100% - 4rem));
+    max-width: none !important;
+  }
+
+  .integrated-explore-workspace .explore-control-deck {
+    grid-area: controls;
+    grid-template-columns: minmax(8.5rem, 0.45fr) minmax(20rem, 1.05fr) minmax(28rem, 1.5fr) minmax(
+        14rem,
+        0.8fr
+      );
+    gap: 0.4rem;
+    max-height: 12.5rem;
+    overflow: auto;
+  }
+
+  .integrated-explore-workspace .explore-control-deck:not(.explore-control-deck-has-view-mode) {
+    grid-template-columns: minmax(20rem, 0.8fr) minmax(28rem, 1.2fr) minmax(14rem, 0.7fr);
+  }
+
+  .integrated-explore-workspace .explore-control-card {
+    gap: 0.28rem;
+    padding: 0.38rem;
+  }
+
+  .integrated-explore-workspace .explore-control-card legend,
+  .integrated-explore-workspace .explore-control-card label,
+  .integrated-explore-workspace .explore-control-card button,
+  .integrated-explore-workspace .explore-control-card select,
+  .integrated-explore-workspace .explore-control-card input {
+    font-size: 0.76rem;
+  }
+
+  .integrated-explore-workspace .frame-step-controls {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .integrated-explore-workspace .explore-control-card-time {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .integrated-explore-workspace .explore-control-card-time legend,
+  .integrated-explore-workspace .explore-control-card-time label[for="explore-time-scrubber"],
+  .integrated-explore-workspace .explore-control-card-time .time-preset-buttons,
+  .integrated-explore-workspace .explore-control-card-time .control-help {
+    grid-column: 1 / -1;
+  }
+
+  .integrated-explore-workspace .explore-inspector {
+    grid-area: inspector;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    min-width: 0;
+    min-height: 0;
+    max-height: 39rem;
+    overflow: hidden;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-surface);
+  }
+
+  .integrated-explore-workspace .explore-inspector-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0.45rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-header button {
+    padding: 0.28rem 0.42rem;
+    font-size: 0.74rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector > div {
+    min-height: 0;
+    overflow: auto;
+  }
+
+  .integrated-explore-workspace .explore-inspector-tabs {
+    position: sticky;
+    z-index: 3;
+    top: 0;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.2rem;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0.35rem;
+    background: var(--color-surface);
+  }
+
+  .integrated-explore-workspace .explore-inspector-tabs button {
+    padding: 0.34rem 0.2rem;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 0.74rem;
+    box-shadow: none;
+  }
+
+  .integrated-explore-workspace .explore-inspector-tabs .active-control {
+    background: var(--color-accent-soft);
+    color: var(--color-accent-primary);
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel {
+    display: grid;
+    gap: 0.65rem;
+    padding: 0.55rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel[hidden] {
+    display: none;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel h3,
+  .integrated-explore-workspace .explore-inspector-panel h4,
+  .integrated-explore-workspace .explore-inspector-panel p {
+    margin-bottom: 0.35rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel .selected-region-inspector {
+    gap: 0.55rem;
+    border: 0;
+    padding: 0;
+    background: transparent;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel .metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.38rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-panel .metric-grid div {
+    padding: 0.38rem;
+  }
+
+  .integrated-explore-workspace .updraft-lens-scale-legend-workspace .updraft-lens-scale-intervals {
+    grid-template-columns: 1fr;
+  }
+
+  .integrated-explore-workspace .inspector-code-block {
+    max-width: 100%;
+    overflow: auto;
+    font-size: 0.72rem;
+    white-space: pre-wrap;
+  }
+
+  .integrated-explore-workspace .explore-inspector-collapsed {
+    max-height: 3rem;
+  }
+
+  .integrated-explore-workspace .explore-inspector-collapsed .explore-inspector-header strong {
+    writing-mode: vertical-rl;
+  }
+
+  .integrated-explore-workspace .visualizer-shell:has(.explore-inspector-collapsed) {
+    grid-template-columns: minmax(0, 1fr) 4.5rem;
+  }
+
+  .integrated-explore-workspace .layer-local-error-3d {
+    z-index: 8;
+    grid-area: scene;
+    align-self: start;
+    justify-self: center;
+    margin-top: 3.5rem;
+  }
+
+  .integrated-explore-workspace .workspace-catalog-error {
+    grid-column: 1 / -1;
+  }
+}
+
 @media (max-width: 860px) {
   .topbar,
   .builder-layout,

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -4463,8 +4463,9 @@ describe("App", () => {
       expect(
         await screen.findByLabelText(`${resultName} Lab result workspace`),
       ).toBeInTheDocument();
-      const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
-      expect(within(breadcrumb).getByRole("button", { name: "Lab" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: `Trade Cumulus Lab / ${resultName}` }),
+      ).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: "Back to Lab Results" }));
       expect(
         await screen.findByRole("heading", { name: "Experiment Notebook" }),
@@ -6738,7 +6739,9 @@ describe("App", () => {
     expect(await screen.findByLabelText("Explore viewer controls")).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.getByLabelText("Time")).toHaveValue("2");
-    expect(screen.getByText(/Supercell-like environment · Supported/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Science" }));
+    fireEvent.click(screen.getByText("Process evidence"));
+    expect(screen.getByLabelText("Process mode")).toHaveValue("thermal_fate");
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -7335,13 +7338,10 @@ describe("App", () => {
     expect(screen.getByLabelText("Horizontal wind overlay legend")).toHaveTextContent(
       "0.9 m/s reference",
     );
-    expect(screen.getAllByText("Vertical velocity (w), m/s")).toHaveLength(2);
-    expect(screen.getByLabelText(/2-D inspector Vertical velocity \(w\), m\/s/)).toHaveTextContent(
-      "-0.1 to < 0.1",
-    );
-    expect(screen.getByLabelText(/3-D viewer Vertical velocity \(w\), m\/s/)).toHaveTextContent(
-      "m/s",
-    );
+    expect(screen.getAllByText("Vertical velocity (w), m/s")).toHaveLength(1);
+    expect(
+      screen.getByLabelText(/Explore workspace Vertical velocity \(w\), m\/s/),
+    ).toHaveTextContent("-0.1 to < 0.1");
     expect(screen.getByText(/Updraft Lens slice: Vertical x-z slice at y =/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Horizontal x-y" }));
@@ -7425,10 +7425,10 @@ describe("App", () => {
         ),
       );
     });
-    const legend = await screen.findByLabelText(/2-D inspector Vertical velocity \(w\), m\/s/);
+    const legend = await screen.findByLabelText(/Explore workspace Vertical velocity \(w\), m\/s/);
     expect(legend).toHaveTextContent("Vertical velocity (w), m/s");
-    expect(screen.getAllByText("Slice maximum 1.40 m/s.")).toHaveLength(2);
-    expect(screen.getAllByText("Slice minimum -1.40 m/s.")).toHaveLength(2);
+    expect(screen.getAllByText("Slice maximum 1.40 m/s.")).toHaveLength(1);
+    expect(screen.getAllByText("Slice minimum -1.40 m/s.")).toHaveLength(1);
 
     await act(async () => {
       resolveFirst?.(
@@ -7439,8 +7439,8 @@ describe("App", () => {
       );
     });
     expect(legend).toHaveTextContent("Vertical velocity (w), m/s");
-    expect(screen.getAllByText("Slice maximum 1.40 m/s.")).toHaveLength(2);
-    expect(screen.getAllByText("Slice minimum -1.40 m/s.")).toHaveLength(2);
+    expect(screen.getAllByText("Slice maximum 1.40 m/s.")).toHaveLength(1);
+    expect(screen.getAllByText("Slice minimum -1.40 m/s.")).toHaveLength(1);
     expect(screen.queryByText("Slice maximum 0.90 m/s.")).not.toBeInTheDocument();
     expect(screen.queryByText("Slice minimum -0.90 m/s.")).not.toBeInTheDocument();
     expect(screen.queryByText(/Clipped in this slice/)).not.toBeInTheDocument();
@@ -7451,9 +7451,7 @@ describe("App", () => {
 
     await openSelectedResultInExplore();
 
-    expect(
-      await screen.findByRole("heading", { name: "What happened in this result?" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     expect(await screen.findByLabelText("Explore viewer controls")).toBeInTheDocument();
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
@@ -7566,7 +7564,7 @@ describe("App", () => {
     ).toBe(false);
   });
 
-  it("plays saved output times without refetching fields until pause and resets at the end", async () => {
+  it("plays coordinated saved output times and resets at the end", async () => {
     render(<App />);
 
     await openSelectedResultInExplore();
@@ -7599,9 +7597,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Selected point")).not.toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Animating 3-D scene at 900 s; slice and evidence remain at 900 s until playback is paused.",
-      ),
+      screen.getByText("Animating the coordinated scene and slice at 900 s."),
     ).toBeInTheDocument();
 
     await act(async () => {
@@ -7611,9 +7607,7 @@ describe("App", () => {
     expect(screen.getByLabelText("Time")).toHaveValue("2");
     expect(screen.getByLabelText("Saved output time")).toHaveValue("2");
     expect(
-      screen.getByText(
-        "Animating 3-D scene at 1,800 s; slice and evidence remain at 900 s until playback is paused.",
-      ),
+      screen.getByText("Animating the coordinated scene and slice at 1,800 s."),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Slice position")).toHaveValue("0");
     expect(
@@ -7628,13 +7622,13 @@ describe("App", () => {
         ([url]) =>
           String(url).includes("/visualization/slice") && String(url).includes("time_index=2"),
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       fetchMock.mock.calls.some(
         ([url]) =>
           String(url).includes("/visualization/defaults") && String(url).includes("time_index=2"),
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       screen.getByText("Pause playback to select a cell and explain this time step."),
     ).toBeInTheDocument();
@@ -7689,6 +7683,7 @@ describe("App", () => {
 
     await openSelectedResultInExplore();
     await screen.findByText("Slice synced");
+    fireEvent.click(screen.getByRole("button", { name: "Science" }));
 
     const heatmap = screen.getAllByRole("img", { name: /heatmap/i })[0];
     fireEvent.click(within(heatmap).getByRole("button", { name: /row 1, column 2/i }));
@@ -7827,6 +7822,7 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
     await screen.findByText("Slice synced");
+    fireEvent.click(screen.getByRole("button", { name: "Science" }));
     fireEvent.click(
       within(screen.getAllByRole("img", { name: /heatmap/i })[0]).getByRole("button", {
         name: /row 1, column 1/i,
@@ -7861,16 +7857,15 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(
-      await screen.findByRole("heading", { name: "What happened in this result?" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findAllByText("Cloud-water point layer loaded");
-    expect(screen.getByText("Result explanation")).toBeInTheDocument();
+    expect(screen.getByText("What happened in this result?")).toBeInTheDocument();
     expect(
       screen.getAllByText(/Cloud water formed in the validated reference baseline/).length,
     ).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByText("Process evidence details"));
+    fireEvent.click(screen.getByRole("button", { name: "Science" }));
+    fireEvent.click(screen.getByText("Process evidence"));
     const processMode = screen.getByLabelText("Process mode");
     expect(processMode).toHaveValue("thermal_fate");
     expect(
@@ -7910,11 +7905,10 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(
-      await screen.findByRole("heading", { name: "What happened in this result?" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findByText("Slice synced");
-    fireEvent.click(screen.getByText("Process evidence details"));
+    fireEvent.click(screen.getByRole("button", { name: "Science" }));
+    fireEvent.click(screen.getByText("Process evidence"));
     const processMode = screen.getByLabelText("Process mode");
     expect(
       within(processMode).getByRole("option", { name: /Moisture \/ Saturation \(candidate\)/ }),
@@ -7940,11 +7934,10 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(
-      await screen.findByRole("heading", { name: "What happened in this result?" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findByText("Slice synced");
-    fireEvent.click(screen.getByText("Process evidence details"));
+    fireEvent.click(screen.getByRole("button", { name: "Science" }));
+    fireEvent.click(screen.getByText("Process evidence"));
     const processMode = screen.getByLabelText("Process mode");
     expect(
       within(processMode).getByRole("option", { name: /Cap \/ Inversion \(candidate\)/ }),
@@ -7964,9 +7957,7 @@ describe("App", () => {
     const resultDetail = screen.getByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(
-      await screen.findByRole("heading", { name: "What happened in this result?" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.queryByRole("option", { name: /qc/ })).not.toBeInTheDocument();
@@ -7980,9 +7971,7 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(
-      await screen.findByRole("heading", { name: "What happened in this result?" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("True 3-D scalar field viewer")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Field Slice" })).toBeInTheDocument();
@@ -8164,9 +8153,7 @@ describe("App", () => {
       }),
     );
 
-    expect(
-      await screen.findByRole("heading", { name: "What happened in this result?" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findAllByText("Cloud water max is 0 kg/kg; no points are above 1.000e-6 kg/kg");
     expect(screen.getByRole("heading", { name: "Field Slice" })).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
@@ -8280,14 +8267,76 @@ describe("App", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
+  it("keeps the slice timeline and inspector usable when the 3-D layer fails", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let allowPointCloud = false;
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/visualization/point-cloud") && !allowPointCloud) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ detail: "Point cloud temporarily unavailable." }), {
+            status: 503,
+          }),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+    await openSelectedResultInExplore();
+
+    expect(await screen.findByText("3-D cloud layer unavailable")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Field Slice" })).toBeInTheDocument();
+    expect(screen.getByRole("slider", { name: "Saved output time" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Explore inspector")).toBeInTheDocument();
+    expect(await screen.findByText("Slice synced")).toBeInTheDocument();
+
+    allowPointCloud = true;
+    fireEvent.click(screen.getByRole("button", { name: "Retry 3-D layer" }));
+    await screen.findAllByText("Cloud-water point layer loaded");
+    expect(screen.queryByText("3-D cloud layer unavailable")).not.toBeInTheDocument();
+  });
+
+  it("keeps the 3-D scene timeline and inspector usable when the slice fails", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let allowSlice = false;
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/visualization/slice") && !allowSlice) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ detail: "Slice temporarily unavailable." }), {
+            status: 503,
+          }),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+    await openSelectedResultInExplore();
+
+    expect(await screen.findByText("Field Slice unavailable")).toBeInTheDocument();
+    expect(screen.getByLabelText("True 3-D scalar field viewer")).toBeInTheDocument();
+    expect(screen.getByRole("slider", { name: "Saved output time" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Explore inspector")).toBeInTheDocument();
+    await screen.findAllByText("Cloud-water point layer loaded");
+
+    allowSlice = true;
+    fireEvent.click(screen.getByRole("button", { name: "Retry Field Slice" }));
+    expect(await screen.findByText("Slice synced")).toBeInTheDocument();
+    expect(screen.queryByText("Field Slice unavailable")).not.toBeInTheDocument();
+  });
+
   it("renders cloud-water context in unified Explore", async () => {
     render(<App />);
 
     await openSelectedResultInExplore();
 
-    expect(
-      await screen.findByRole("heading", { name: "What happened in this result?" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findAllByText("Cloud-water point layer loaded");
     expect(screen.getByText("Cloud formed in this result")).toBeInTheDocument();
     expect(screen.queryByText("Cloud formed here")).not.toBeInTheDocument();
@@ -8300,7 +8349,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Scientific visualization workbench")).toBeInTheDocument();
     expect(screen.getByLabelText("Fixed visualization viewport region")).toBeInTheDocument();
-    expect(screen.getByLabelText("Visualization details")).toBeInTheDocument();
+    expect(screen.getByLabelText("Explore inspector")).toBeInTheDocument();
     expect(screen.getByLabelText("Explore viewer controls")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Field Slice" })).toBeInTheDocument();
     expect(within(viewer).getByText("True 3-D scene")).toBeInTheDocument();
@@ -8520,9 +8569,7 @@ describe("App", () => {
     const resultDetail = screen.getByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(
-      await screen.findByRole("heading", { name: "What happened in this result?" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findAllByText("Slice fields ready; no 3-D scalar field available");
     expect(screen.getByText("No supported 3-D scalar field")).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
@@ -8536,9 +8583,7 @@ describe("App", () => {
     const resultDetail = screen.getByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
 
-    expect(
-      await screen.findByRole("heading", { name: "What happened in this result?" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findAllByText("No fields available");
     expect(
       screen.getByText("No visualization-ready fields are available for this result."),

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -7285,7 +7285,7 @@ describe("App", () => {
     expect(screen.queryByLabelText("Explore view mode")).not.toBeInTheDocument();
   });
 
-  it("activates the Updraft Lens, applies defaults, controls overlays, and restores Explore", async () => {
+  it("opens in the Updraft Lens, applies defaults, controls overlays, and restores Explore", async () => {
     mockTradeCumulusVisualizer();
     const visualizerResult = tradeCumulusResultCard as unknown as Parameters<
       typeof VisualizerSceneShell
@@ -7295,12 +7295,12 @@ describe("App", () => {
     const viewMode = await screen.findByLabelText("Explore view mode");
     const lensToggle = within(viewMode).getByRole("button", { name: "Updraft Lens" });
     await waitFor(() => expect(lensToggle).toBeEnabled());
-    expect(within(viewMode).getByRole("button", { name: "Field" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    expect(screen.queryByRole("heading", { name: "Updraft Lens" })).not.toBeInTheDocument();
-    fireEvent.click(lensToggle);
+    expect(
+      within(viewMode)
+        .getAllByRole("button")
+        .map((button) => button.textContent),
+    ).toEqual(["Updraft Lens", "Field"]);
+    await waitFor(() => expect(lensToggle).toHaveAttribute("aria-pressed", "true"));
 
     expect(await screen.findByRole("heading", { name: "Updraft Lens" })).toBeInTheDocument();
     expect(
@@ -7331,15 +7331,22 @@ describe("App", () => {
     );
     fireEvent.change(screen.getByLabelText("Layer opacity"), { target: { value: "0.45" } });
     fireEvent.change(screen.getByLabelText("Point size"), { target: { value: "14" } });
+    fireEvent.change(screen.getByLabelText("Lens opacity"), { target: { value: "0.75" } });
     expect(screen.getByLabelText("Layer opacity")).toHaveValue("0.45");
     expect(screen.getByLabelText("Point size")).toHaveValue("14");
+    expect(screen.getByLabelText("Lens opacity")).toHaveValue("0.75");
+    expect(screen.getByLabelText("True 3-D scalar field viewer")).toHaveAttribute(
+      "data-updraft-lens-opacity",
+      "0.75",
+    );
     expect(screen.getByLabelText("Horizontal wind overlay legend")).toHaveTextContent(
       "0.9 m/s reference",
     );
-    expect(screen.getAllByText("Vertical velocity (w), m/s")).toHaveLength(1);
+    expect(screen.getByText("w (m/s)")).toBeInTheDocument();
     expect(
       screen.getByLabelText(/Explore workspace Vertical velocity \(w\), m\/s/),
     ).toHaveTextContent("-0.1 to < 0.1");
+    expect(screen.queryByText(/Slice maximum/)).not.toBeInTheDocument();
     expect(screen.getByText(/Updraft Lens: Vertical x-z slice at y =/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Horizontal x-y" }));
@@ -7372,6 +7379,10 @@ describe("App", () => {
 
     fireEvent.click(screen.getByLabelText("Cloud boundary"));
     expect(screen.queryByTestId("updraft-lens-cloud-boundary")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("True 3-D scalar field viewer")).toHaveAttribute(
+      "data-updraft-lens-cloud-boundary",
+      "false",
+    );
     fireEvent.click(screen.getByLabelText("Horizontal wind"));
     expect(screen.queryByLabelText("Horizontal wind overlay legend")).not.toBeInTheDocument();
 
@@ -7388,8 +7399,20 @@ describe("App", () => {
     fireEvent.click(within(viewMode).getByRole("button", { name: "Field" }));
     expect(await screen.findByLabelText("Slice field")).toBeInTheDocument();
     expect(screen.getByLabelText("3-D scalar field")).toBeInTheDocument();
-    expect(screen.getByLabelText("Time")).toHaveValue("3");
+    expect(screen.getByLabelText("Time")).toHaveValue("2");
+    expect(screen.getByLabelText("Slice position")).toHaveValue("0");
+    expect(screen.getByRole("button", { name: "Vertical x-z slice" })).toHaveClass(
+      "active-control",
+    );
     expect(screen.queryByRole("heading", { name: "Updraft Lens" })).not.toBeInTheDocument();
+
+    fireEvent.click(within(viewMode).getByRole("button", { name: "Updraft Lens" }));
+    expect(await screen.findByLabelText("Updraft Lens slice position")).toHaveValue("0");
+    expect(screen.getByLabelText("Time")).toHaveValue("2");
+    expect(screen.getByRole("button", { name: "Vertical x-z" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 
   it("ignores stale Updraft Lens frame responses", async () => {
@@ -7409,8 +7432,8 @@ describe("App", () => {
     render(<VisualizerSceneShell result={visualizerResult} />);
 
     const lensToggle = await screen.findByRole("button", { name: "Updraft Lens" });
-    await waitFor(() => expect(lensToggle).toBeEnabled());
-    fireEvent.click(lensToggle);
+    await waitFor(() => expect(lensToggle).toHaveAttribute("aria-pressed", "true"));
+    fireEvent.click(screen.getByRole("button", { name: "Maximize slice viewer" }));
     await waitFor(() => expect(resolveFirst).toBeDefined());
     fireEvent.change(screen.getByLabelText("Time"), { target: { value: "1" } });
     await waitFor(() => expect(resolveSecond).toBeDefined());
@@ -7584,12 +7607,9 @@ describe("App", () => {
     expect(await screen.findByText("Point ready")).toBeInTheDocument();
 
     vi.useFakeTimers();
-    fireEvent.click(screen.getByRole("button", { name: "Play time" }));
+    fireEvent.click(screen.getByRole("button", { name: "Play" }));
 
-    expect(screen.getByRole("button", { name: "Pause time" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    expect(screen.getByRole("button", { name: "Pause" })).toHaveAttribute("aria-pressed", "true");
     expect(
       screen.getByText("Pause playback to select a cell and explain this time step."),
     ).toBeInTheDocument();
@@ -7631,11 +7651,8 @@ describe("App", () => {
       screen.getByText("Pause playback to select a cell and explain this time step."),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Pause time" }));
-    expect(screen.getByRole("button", { name: "Play time" })).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Pause" }));
+    expect(screen.getByRole("button", { name: "Play" })).toHaveAttribute("aria-pressed", "false");
     vi.useRealTimers();
     await waitFor(() =>
       expect(
@@ -7660,14 +7677,11 @@ describe("App", () => {
     fetchMock.mockClear();
 
     vi.useFakeTimers();
-    fireEvent.click(screen.getByRole("button", { name: "Play time" }));
+    fireEvent.click(screen.getByRole("button", { name: "Play" }));
     await act(async () => {
       vi.advanceTimersByTime(900);
     });
-    expect(screen.getByRole("button", { name: "Play time" })).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
+    expect(screen.getByRole("button", { name: "Play" })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByLabelText("Time")).toHaveValue("0");
     expect(screen.getByLabelText("Saved output time")).toHaveValue("0");
     vi.useRealTimers();
@@ -8290,9 +8304,8 @@ describe("App", () => {
     expect(screen.getByLabelText("Time")).toBeInTheDocument();
     expect(screen.getByLabelText("Show slice plane")).toBeChecked();
     expect(
-      screen.getAllByText(
-        "Current field max: 0.008 g/kg. Visible points above 0.001 g/kg: 3.",
-      ).length,
+      screen.getAllByText("Current field max: 0.008 g/kg. Visible points above 0.001 g/kg: 3.")
+        .length,
     ).toBeGreaterThan(0);
     expect(screen.getByText("0 to 3 km")).toBeInTheDocument();
     expect(screen.getByText("0.8 km to 1.2 km")).toBeInTheDocument();
@@ -8369,9 +8382,7 @@ describe("App", () => {
 
     const viewer = screen.getByLabelText("True 3-D scalar field viewer");
     expect(within(viewer).getByText(/Slice: Horizontal layer at z = /)).toBeInTheDocument();
-    expect(
-      within(viewer).queryByText(/Slice: Vertical x-z slice at y = /),
-    ).not.toBeInTheDocument();
+    expect(within(viewer).queryByText(/Slice: Vertical x-z slice at y = /)).not.toBeInTheDocument();
     expect(screen.getAllByText("qc (Cloud water)").length).toBeGreaterThan(0);
     expect(screen.getAllByText("native_grid_view_no_interpolation").length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: "Move down" }));
@@ -8387,9 +8398,7 @@ describe("App", () => {
     );
     expect(screen.getByLabelText("Slice position")).toBeInTheDocument();
     await waitFor(() => {
-      expect(
-        within(viewer).getByText(/Slice: Vertical x-z slice at y = /),
-      ).toBeInTheDocument();
+      expect(within(viewer).getByText(/Slice: Vertical x-z slice at y = /)).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Vertical y-z slice" }));
@@ -8399,9 +8408,7 @@ describe("App", () => {
     expect(screen.getByLabelText("Slice position")).toBeInTheDocument();
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(expect.stringContaining("orientation=vertical_y"));
-      expect(
-        within(viewer).getByText(/Slice: Vertical y-z slice at x = /),
-      ).toBeInTheDocument();
+      expect(within(viewer).getByText(/Slice: Vertical y-z slice at x = /)).toBeInTheDocument();
     });
     fireEvent.click(screen.getByRole("button", { name: "Move back" }));
     await waitFor(() => {
@@ -8431,9 +8438,7 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Vertical x-z slice" }));
     const viewer = screen.getByLabelText("True 3-D scalar field viewer");
     await waitFor(() => {
-      expect(
-        within(viewer).getByText(/Slice: Vertical x-z slice at y = /),
-      ).toBeInTheDocument();
+      expect(within(viewer).getByText(/Slice: Vertical x-z slice at y = /)).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Horizontal layer" }));

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3099,9 +3099,10 @@ function pointCloudResponse({
     fieldCatalogResponse.available_fields.find((candidate) => candidate.raw_field_name === field) ??
     fieldCatalogResponse.available_fields[0];
   const isSurface = field === "rain";
+  const resolvedFieldRange = fieldRange ?? mockFieldRange(field);
   const returnedPoints =
     points ??
-    (threshold >= 1 || timeIndex === 0
+    (threshold >= resolvedFieldRange.max || timeIndex === 0
       ? []
       : [
           [0, 0, field === "rain" ? 0 : 0.8, mockPointValue(field, 0)],
@@ -3136,9 +3137,9 @@ function pointCloudResponse({
     stats: {
       source_count: returnedPoints.length,
       returned_count: returnedPoints.length,
-      field_min_value: (fieldRange ?? mockFieldRange(field)).min,
-      field_max_value: (fieldRange ?? mockFieldRange(field)).max,
-      field_mean_value: (fieldRange ?? mockFieldRange(field)).mean,
+      field_min_value: resolvedFieldRange.min,
+      field_max_value: resolvedFieldRange.max,
+      field_mean_value: resolvedFieldRange.mean,
       field_finite_count: 24,
       field_non_finite_count: 0,
       min_value: values.length ? Math.min(...values) : null,
@@ -4463,9 +4464,7 @@ describe("App", () => {
       expect(
         await screen.findByLabelText(`${resultName} Lab result workspace`),
       ).toBeInTheDocument();
-      expect(
-        screen.getByRole("heading", { name: `Trade Cumulus Lab / ${resultName}` }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: resultName })).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: "Back to Lab Results" }));
       expect(
         await screen.findByRole("heading", { name: "Experiment Notebook" }),
@@ -6739,9 +6738,8 @@ describe("App", () => {
     expect(await screen.findByLabelText("Explore viewer controls")).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.getByLabelText("Time")).toHaveValue("2");
-    fireEvent.click(screen.getByRole("button", { name: "Science" }));
-    fireEvent.click(screen.getByText("Process evidence"));
-    expect(screen.getByLabelText("Process mode")).toHaveValue("thermal_fate");
+    expect(screen.getByRole("heading", { name: "What am I seeing?" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Process mode")).not.toBeInTheDocument();
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -7297,7 +7295,7 @@ describe("App", () => {
     const viewMode = await screen.findByLabelText("Explore view mode");
     const lensToggle = within(viewMode).getByRole("button", { name: "Updraft Lens" });
     await waitFor(() => expect(lensToggle).toBeEnabled());
-    expect(within(viewMode).getByRole("button", { name: "Standard" })).toHaveAttribute(
+    expect(within(viewMode).getByRole("button", { name: "Field" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
@@ -7342,7 +7340,7 @@ describe("App", () => {
     expect(
       screen.getByLabelText(/Explore workspace Vertical velocity \(w\), m\/s/),
     ).toHaveTextContent("-0.1 to < 0.1");
-    expect(screen.getByText(/Updraft Lens slice: Vertical x-z slice at y =/)).toBeInTheDocument();
+    expect(screen.getByText(/Updraft Lens: Vertical x-z slice at y =/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Horizontal x-y" }));
     expect(
@@ -7387,7 +7385,7 @@ describe("App", () => {
       ),
     );
 
-    fireEvent.click(within(viewMode).getByRole("button", { name: "Standard" }));
+    fireEvent.click(within(viewMode).getByRole("button", { name: "Field" }));
     expect(await screen.findByLabelText("Slice field")).toBeInTheDocument();
     expect(screen.getByLabelText("3-D scalar field")).toBeInTheDocument();
     expect(screen.getByLabelText("Time")).toHaveValue("3");
@@ -7456,7 +7454,7 @@ describe("App", () => {
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
     expect(screen.getAllByText("qc (Cloud water)").length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/kg\/kg/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/g\/kg/).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Horizontal layer" })).toHaveClass("active-control");
     expect(screen.getByRole("heading", { name: "Field Slice" })).toBeInTheDocument();
     expect(screen.getAllByText(/Horizontal layer at z = /).length).toBeGreaterThan(0);
@@ -7485,7 +7483,7 @@ describe("App", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
       ),
     ).toBe(true);
-    expect(screen.getAllByText("2.000e-5 kg/kg").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("0.02 g/kg").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Technical slice details").length).toBeGreaterThan(0);
     expect(screen.getAllByText("native_grid_view_no_interpolation").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/CM1-derived visualization-ready data/).length).toBeGreaterThan(0);
@@ -7583,7 +7581,7 @@ describe("App", () => {
 
     const heatmap = screen.getAllByRole("img", { name: /heatmap/i })[0];
     fireEvent.click(within(heatmap).getByRole("button", { name: /row 1, column 2/i }));
-    expect(await screen.findByText("Selected-point diagnostics loaded")).toBeInTheDocument();
+    expect(await screen.findByText("Point ready")).toBeInTheDocument();
 
     vi.useFakeTimers();
     fireEvent.click(screen.getByRole("button", { name: "Play time" }));
@@ -7655,7 +7653,7 @@ describe("App", () => {
     ).toBe(true);
     expect(screen.getByLabelText("Slice position")).toHaveValue("0");
 
-    fireEvent.click(screen.getByRole("button", { name: "Last frame" }));
+    fireEvent.change(screen.getByLabelText("Key moments"), { target: { value: "3" } });
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("time_index=3")),
     );
@@ -7683,12 +7681,11 @@ describe("App", () => {
 
     await openSelectedResultInExplore();
     await screen.findByText("Slice synced");
-    fireEvent.click(screen.getByRole("button", { name: "Science" }));
 
     const heatmap = screen.getAllByRole("img", { name: /heatmap/i })[0];
     fireEvent.click(within(heatmap).getByRole("button", { name: /row 1, column 2/i }));
 
-    expect(await screen.findByText("Selected-point diagnostics loaded")).toBeInTheDocument();
+    expect(await screen.findByText("Point ready")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "What happened here?" })).toBeInTheDocument();
     expect(screen.getAllByText("Growing cumulus").length).toBeGreaterThan(0);
     expect(
@@ -7696,7 +7693,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("First local cloud time")).toBeInTheDocument();
     expect(screen.getByText("Local max qc")).toBeInTheDocument();
-    expect(screen.getAllByText("2.000e-5 kg/kg").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("2.000e-2 g/kg").length).toBeGreaterThan(0);
     expect(screen.getByText("Local max w")).toBeInTheDocument();
     expect(screen.getByText("4.5 m/s")).toBeInTheDocument();
     expect(screen.getByText("Local rain")).toBeInTheDocument();
@@ -7706,8 +7703,7 @@ describe("App", () => {
     expect(screen.getAllByText("zh[15]; 0.62 km").length).toBeGreaterThan(0);
     expect(screen.queryByText(/0\.05000000074505806/)).not.toBeInTheDocument();
     expect(screen.queryByText(/-1\.5500000715255737/)).not.toBeInTheDocument();
-    expect(screen.getByText("Technical details and provenance")).toBeInTheDocument();
-    expect(screen.getByText(/backend xarray selected-region diagnostics/i)).toBeInTheDocument();
+    expect(screen.getByText("Selected-point details")).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining(
         "/api/results/result-dry-run-quicklook/diagnostics/selected-region?region_type=point",
@@ -7741,9 +7737,9 @@ describe("App", () => {
       }),
     );
 
-    expect(await screen.findByText("Selected-point diagnostics loaded")).toBeInTheDocument();
+    expect(await screen.findByText("Point ready")).toBeInTheDocument();
     const selectedPoint = screen.getByLabelText("Selected point context");
-    expect(within(selectedPoint).getByText("5.000e-6 kg/kg")).toBeInTheDocument();
+    expect(within(selectedPoint).getByText("0.005 g/kg")).toBeInTheDocument();
     expect(within(selectedPoint).queryByText("0 kg/kg")).not.toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining("x_index=1&y_index=0&z_index=1"));
   });
@@ -7822,7 +7818,6 @@ describe("App", () => {
     const resultDetail = await screen.findByLabelText("Result detail");
     fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
     await screen.findByText("Slice synced");
-    fireEvent.click(screen.getByRole("button", { name: "Science" }));
     fireEvent.click(
       within(screen.getAllByRole("img", { name: /heatmap/i })[0]).getByRole("button", {
         name: /row 1, column 1/i,
@@ -7830,7 +7825,7 @@ describe("App", () => {
     );
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Unsupported selected region.");
-    expect(screen.getByText("Selected-point request failed")).toBeInTheDocument();
+    expect(screen.getByText("Point unavailable")).toBeInTheDocument();
   });
 
   it("supports field and time selection through visualization-ready APIs", async () => {
@@ -7851,7 +7846,7 @@ describe("App", () => {
     );
   });
 
-  it("keeps only supported process evidence modes in the Baseline primary focus control", async () => {
+  it("keeps retired process-model controls out of the primary Explore context", async () => {
     render(<App />);
 
     const resultDetail = await screen.findByLabelText("Result detail");
@@ -7859,95 +7854,13 @@ describe("App", () => {
 
     expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findAllByText("Cloud-water point layer loaded");
-    expect(screen.getByText("What happened in this result?")).toBeInTheDocument();
-    expect(
-      screen.getAllByText(/Cloud water formed in the validated reference baseline/).length,
-    ).toBeGreaterThan(0);
-
-    fireEvent.click(screen.getByRole("button", { name: "Science" }));
-    fireEvent.click(screen.getByText("Process evidence"));
-    const processMode = screen.getByLabelText("Process mode");
-    expect(processMode).toHaveValue("thermal_fate");
-    expect(
-      within(processMode).getByRole("option", { name: /Thermal Fate summary/ }),
-    ).toBeInTheDocument();
-    expect(within(processMode).getByRole("option", { name: "Cloud Water" })).toBeInTheDocument();
-    expect(within(processMode).getByRole("option", { name: "Updrafts" })).toBeInTheDocument();
-    expect(
-      within(processMode).getByRole("option", { name: /Cloud Lifecycle/ }),
-    ).toBeInTheDocument();
-    expect(within(processMode).queryByRole("option", { name: /Moisture/ })).not.toBeInTheDocument();
-    expect(within(processMode).queryByRole("option", { name: /Buoyancy/ })).not.toBeInTheDocument();
-    expect(
-      within(processMode).queryByRole("option", { name: /Deep Breakthrough/ }),
-    ).not.toBeInTheDocument();
-    expect(
-      within(processMode).queryByRole("option", { name: /Precipitation Feedback/ }),
-    ).not.toBeInTheDocument();
-
-    fireEvent.change(processMode, { target: { value: "cloud_water" } });
-
-    expect(processMode).toHaveValue("cloud_water");
-    expect(screen.getByRole("heading", { name: "Cloud Water" })).toBeInTheDocument();
-
-    expect(screen.getByText("Not available for this result")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Not available for this result"));
-    expect(screen.getByText(/Moisture \/ Saturation/)).toBeInTheDocument();
-    expect(screen.getByText(/missing required CM1 fields/i)).toBeInTheDocument();
-    expect(screen.getByText(/Deep Breakthrough/)).toBeInTheDocument();
-    expect(screen.getAllByText(/Future diagnostic/i).length).toBeGreaterThan(0);
-  });
-
-  it("shows Dry Failed moisture limitation as a candidate focus instead of a dead-end", async () => {
-    render(<App />);
-
-    fireEvent.click(await screen.findByRole("button", { name: "Dry Failed Cumulus quick-look" }));
-    const resultDetail = await screen.findByLabelText("Result detail");
-    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
-
-    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
-    await screen.findByText("Slice synced");
-    fireEvent.click(screen.getByRole("button", { name: "Science" }));
-    fireEvent.click(screen.getByText("Process evidence"));
-    const processMode = screen.getByLabelText("Process mode");
-    expect(
-      within(processMode).getByRole("option", { name: /Moisture \/ Saturation \(candidate\)/ }),
-    ).toBeInTheDocument();
-    expect(within(processMode).queryByRole("option", { name: /Buoyancy/ })).not.toBeInTheDocument();
-
-    fireEvent.change(processMode, { target: { value: "moisture" } });
-
-    expect(processMode).toHaveValue("moisture");
-    expect(screen.getByRole("heading", { name: "Moisture / Saturation" })).toBeInTheDocument();
-    expect(screen.getAllByText("Candidate").length).toBeGreaterThan(0);
-    expect(
-      screen.getByText(/thermals are present while cloud water and rain stay below threshold/i),
-    ).toBeInTheDocument();
-  });
-
-  it("shows capped-style results with cap inversion as a candidate focus", async () => {
-    render(<App />);
-
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Capped / Suppressed Cumulus quick-look" }),
-    );
-    const resultDetail = await screen.findByLabelText("Result detail");
-    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
-
-    expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
-    await screen.findByText("Slice synced");
-    fireEvent.click(screen.getByRole("button", { name: "Science" }));
-    fireEvent.click(screen.getByText("Process evidence"));
-    const processMode = screen.getByLabelText("Process mode");
-    expect(
-      within(processMode).getByRole("option", { name: /Cap \/ Inversion \(candidate\)/ }),
-    ).toBeInTheDocument();
-
-    fireEvent.change(processMode, { target: { value: "cap" } });
-
-    expect(processMode).toHaveValue("cap");
-    expect(screen.getByRole("heading", { name: "Cap / Inversion" })).toBeInTheDocument();
-    expect(screen.getByText(/candidate process view/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "What am I seeing?" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Current context")).toBeInTheDocument();
+    expect(screen.getByLabelText("Simulation notebook and details")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Science" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Process evidence")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Process mode")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Thermal Fate/)).not.toBeInTheDocument();
   });
 
   it("handles missing qc fields without treating no-qc as a broken Explore state", async () => {
@@ -8154,18 +8067,19 @@ describe("App", () => {
     );
 
     expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
-    await screen.findAllByText("Cloud water max is 0 kg/kg; no points are above 1.000e-6 kg/kg");
+    await screen.findAllByText("Cloud water max is 0 g/kg; no points are above 0.001 g/kg");
     expect(screen.getByRole("heading", { name: "Field Slice" })).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
     expect(
       screen.getAllByRole("option", { name: "w - Vertical velocity (slice only)" }).length,
     ).toBeGreaterThan(0);
+    expect(screen.getByText("No cloud formed")).toBeInTheDocument();
     expect(
-      screen.getAllByText(
-        "Thermals rose, but low-level moisture stayed too dry for meaningful cloud water or rain.",
-      ).length,
-    ).toBeGreaterThan(0);
+      screen.getByText(
+        "For this no-cloud result, use vertical velocity (w) slices to inspect the thermals.",
+      ),
+    ).toBeInTheDocument();
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
   });
@@ -8338,7 +8252,7 @@ describe("App", () => {
 
     expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findAllByText("Cloud-water point layer loaded");
-    expect(screen.getByText("Cloud formed in this result")).toBeInTheDocument();
+    expect(screen.getByText("Cloud formed")).toBeInTheDocument();
     expect(screen.queryByText("Cloud formed here")).not.toBeInTheDocument();
     const viewer = screen.getByLabelText("True 3-D scalar field viewer");
     expect(viewer).toBeInTheDocument();
@@ -8352,7 +8266,7 @@ describe("App", () => {
     expect(screen.getByLabelText("Explore inspector")).toBeInTheDocument();
     expect(screen.getByLabelText("Explore viewer controls")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Field Slice" })).toBeInTheDocument();
-    expect(within(viewer).getByText("True 3-D scene")).toBeInTheDocument();
+    expect(within(viewer).queryByText("True 3-D scene")).not.toBeInTheDocument();
     expect(within(viewer).getByText("Cloud water")).toBeInTheDocument();
     const axisLabels = within(viewer).getByLabelText("3-D axis tick labels");
     expect(within(axisLabels).getByText("x -3 km")).toBeInTheDocument();
@@ -8363,14 +8277,10 @@ describe("App", () => {
     expect(within(axisLabels).getByText("y +3 km")).toBeInTheDocument();
     expect(within(axisLabels).getByText("z 0 km")).toBeInTheDocument();
     expect(within(axisLabels).getByText("z +1 km")).toBeInTheDocument();
-    expect(within(viewer).getByText(/Slice plane: Horizontal layer at z = /)).toBeInTheDocument();
+    expect(within(viewer).getByText(/Slice: Horizontal layer at z = /)).toBeInTheDocument();
     expect(screen.getByLabelText(/Horizontal layer at z = .* heatmap/)).toBeInTheDocument();
-    expect(within(viewer).getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
-    expect(within(viewer).getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
+    expect(within(viewer).getByLabelText("Camera view")).toBeInTheDocument();
     expect(within(viewer).getByRole("button", { name: "Reset camera" })).toBeInTheDocument();
-    expect(within(viewer).getByRole("button", { name: "Top-down x-y" })).toBeInTheDocument();
-    expect(within(viewer).getByRole("button", { name: "Look along x" })).toBeInTheDocument();
-    expect(within(viewer).getByRole("button", { name: "Look along y" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Oblique" })).not.toBeInTheDocument();
     expect(screen.queryByRole("slider", { name: "Zoom" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
@@ -8381,32 +8291,74 @@ describe("App", () => {
     expect(screen.getByLabelText("Show slice plane")).toBeChecked();
     expect(
       screen.getAllByText(
-        "Current field max: 8.000e-6 kg/kg. Visible points above 1.000e-6 kg/kg: 3.",
+        "Current field max: 0.008 g/kg. Visible points above 0.001 g/kg: 3.",
       ).length,
     ).toBeGreaterThan(0);
     expect(screen.getByText("0 to 3 km")).toBeInTheDocument();
     expect(screen.getByText("0.8 km to 1.2 km")).toBeInTheDocument();
-    expect(screen.getByText("x 2, y 1, z 1.2 km, value 8.000e-6")).toBeInTheDocument();
-    expect(
-      screen.getByText("Slice planes: native-grid JSON slices from the backend"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("x 2, y 1, z 1.2 km, value 0.008 g/kg")).toBeInTheDocument();
     expect(screen.getByText("3 of 3")).toBeInTheDocument();
     expect(screen.getAllByText("2,700 s").length).toBeGreaterThan(0);
-    expect(screen.getByText("2.000e-6 kg/kg to 8.000e-6 kg/kg")).toBeInTheDocument();
-    expect(screen.getByText("Visualizer interpretation of CM1-derived output")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Processing method: backend native-grid thresholded point cloud for supported scalar fields",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Rendering method: direct Three.js scalar point cloud"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("No raw NetCDF parsing in the browser")).toBeInTheDocument();
+    expect(screen.getByText("0.002 g/kg to 0.008 g/kg")).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining("time_index=3"));
     expect(fetch).toHaveBeenCalledWith(
       "/api/results/result-dry-run-quicklook/visualization/defaults?time_index=3",
     );
+  });
+
+  it("saves Simulation notes from Explore through the result API", async () => {
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/results/result-dry-run-quicklook" && init?.method === "PATCH") {
+        const body = JSON.parse(String(init.body ?? "{}")) as { notes?: string | null };
+        return Promise.resolve(
+          new Response(JSON.stringify({ ...resultCard, notes: body.notes ?? null }), {
+            status: 200,
+          }),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+    await openSelectedResultInExplore();
+
+    const notes = await screen.findByRole("textbox", { name: "Simulation notes" });
+    expect(notes).toHaveValue("Reference-derived quick-look result.");
+    fireEvent.change(notes, { target: { value: "Watch the western cloud turret." } });
+    fireEvent.click(screen.getByRole("button", { name: "Save note" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Note saved")).toBeInTheDocument();
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/results/result-dry-run-quicklook",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ notes: "Watch the western cloud turret." }),
+      }),
+    );
+    expect(notes).toHaveValue("Watch the western cloud turret.");
+  });
+
+  it("maximizes and restores either Explore viewer", async () => {
+    render(<App />);
+    await openSelectedResultInExplore();
+    await screen.findAllByText("Cloud-water point layer loaded");
+
+    const workspace = screen.getByLabelText("Integrated Explore workspace");
+    fireEvent.click(screen.getByRole("button", { name: "Maximize 3-D viewer" }));
+    expect(workspace).toHaveClass("visualizer-shell-focused-scene");
+    fireEvent.click(screen.getByRole("button", { name: "Restore 3-D viewer" }));
+    expect(workspace).not.toHaveClass("visualizer-shell-focused-scene");
+
+    fireEvent.click(screen.getByRole("button", { name: "Maximize slice viewer" }));
+    expect(workspace).toHaveClass("visualizer-shell-focused-slice");
+    fireEvent.click(screen.getByRole("button", { name: "Restore slice viewer" }));
+    expect(workspace).not.toHaveClass("visualizer-shell-focused-slice");
   });
 
   it("supports qc and w slice planes synced to Explore time", async () => {
@@ -8416,9 +8368,9 @@ describe("App", () => {
     await screen.findAllByText("Cloud-water point layer loaded");
 
     const viewer = screen.getByLabelText("True 3-D scalar field viewer");
-    expect(within(viewer).getByText(/Slice plane: Horizontal layer at z = /)).toBeInTheDocument();
+    expect(within(viewer).getByText(/Slice: Horizontal layer at z = /)).toBeInTheDocument();
     expect(
-      within(viewer).queryByText(/Slice plane: Vertical x-z slice at y = /),
+      within(viewer).queryByText(/Slice: Vertical x-z slice at y = /),
     ).not.toBeInTheDocument();
     expect(screen.getAllByText("qc (Cloud water)").length).toBeGreaterThan(0);
     expect(screen.getAllByText("native_grid_view_no_interpolation").length).toBeGreaterThan(0);
@@ -8436,7 +8388,7 @@ describe("App", () => {
     expect(screen.getByLabelText("Slice position")).toBeInTheDocument();
     await waitFor(() => {
       expect(
-        within(viewer).getByText(/Slice plane: Vertical x-z slice at y = /),
+        within(viewer).getByText(/Slice: Vertical x-z slice at y = /),
       ).toBeInTheDocument();
     });
 
@@ -8448,7 +8400,7 @@ describe("App", () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(expect.stringContaining("orientation=vertical_y"));
       expect(
-        within(viewer).getByText(/Slice plane: Vertical y-z slice at x = /),
+        within(viewer).getByText(/Slice: Vertical y-z slice at x = /),
       ).toBeInTheDocument();
     });
     fireEvent.click(screen.getByRole("button", { name: "Move back" }));
@@ -8480,13 +8432,13 @@ describe("App", () => {
     const viewer = screen.getByLabelText("True 3-D scalar field viewer");
     await waitFor(() => {
       expect(
-        within(viewer).getByText(/Slice plane: Vertical x-z slice at y = /),
+        within(viewer).getByText(/Slice: Vertical x-z slice at y = /),
       ).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Horizontal layer" }));
     await waitFor(() => {
-      expect(within(viewer).getByText(/Slice plane: Horizontal layer at z = /)).toBeInTheDocument();
+      expect(within(viewer).getByText(/Slice: Horizontal layer at z = /)).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByLabelText("Slice field"), { target: { value: "w" } });
@@ -8507,32 +8459,18 @@ describe("App", () => {
     await screen.findAllByText("Cloud-water point layer loaded");
 
     const cameraControls = screen.getByLabelText("3-D camera controls");
-    expect(within(cameraControls).getByText(/Camera ready/)).toBeInTheDocument();
-    fireEvent.click(within(cameraControls).getByRole("button", { name: "Top-down x-y" }));
-    expect(within(cameraControls).getByText(/Camera set to top-down x-y view/)).toBeInTheDocument();
-    fireEvent.click(within(cameraControls).getByRole("button", { name: "Look along x" }));
-    expect(within(cameraControls).getByText(/Camera looking along the x axis/)).toBeInTheDocument();
-    fireEvent.click(within(cameraControls).getByRole("button", { name: "Look along y" }));
-    expect(within(cameraControls).getByText(/Camera looking along the y axis/)).toBeInTheDocument();
-    fireEvent.click(within(cameraControls).getByRole("button", { name: "Zoom in" }));
-    expect(within(cameraControls).getByText(/Camera zoomed in/)).toBeInTheDocument();
-    fireEvent.click(within(cameraControls).getByRole("button", { name: "Zoom out" }));
-    expect(within(cameraControls).getByText(/Camera zoomed out/)).toBeInTheDocument();
-    fireEvent.click(within(cameraControls).getByRole("button", { name: "Pan view up" }));
-    expect(within(cameraControls).getByText(/Camera moved up/)).toBeInTheDocument();
-    fireEvent.click(within(cameraControls).getByRole("button", { name: "Pan view down" }));
-    expect(within(cameraControls).getByText(/Camera moved down/)).toBeInTheDocument();
-    fireEvent.click(within(cameraControls).getByRole("button", { name: "Taller viewport" }));
-    expect(within(cameraControls).getByText(/Viewport set taller/)).toBeInTheDocument();
-    expect(
-      within(cameraControls).getByRole("button", { name: "Standard viewport" }),
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Technical visualization details"));
+    const cameraView = within(cameraControls).getByLabelText("Camera view");
+    expect(cameraView).toHaveValue("overview");
+    fireEvent.change(cameraView, { target: { value: "top_down_xy" } });
+    expect(cameraView).toHaveValue("top_down_xy");
+    fireEvent.change(cameraView, { target: { value: "look_along_x" } });
+    expect(cameraView).toHaveValue("look_along_x");
+    fireEvent.change(cameraView, { target: { value: "look_along_y" } });
+    expect(cameraView).toHaveValue("look_along_y");
+    fireEvent.click(screen.getByText("Visualization details"));
     expect(screen.getByText("Direct Three.js point cloud")).toBeInTheDocument();
 
     fireEvent.click(within(cameraControls).getByRole("button", { name: "Reset camera" }));
-
-    expect(within(cameraControls).getByText(/Camera reset to overview/)).toBeInTheDocument();
   });
 
   it("updates cloud-water threshold opacity point size and time requests", async () => {
@@ -8543,13 +8481,12 @@ describe("App", () => {
 
     fireEvent.change(screen.getByLabelText("Cloud-water threshold"), { target: { value: "1" } });
 
-    await screen.findAllByText(
-      "Cloud water max is 8.000e-6 kg/kg; no points are above 1.000e+0 kg/kg",
-    );
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining("threshold=0.001"));
+    });
     expect(
       screen.getByText("No cloud water above the selected threshold at this time."),
     ).toBeInTheDocument();
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("threshold=1"));
 
     fireEvent.change(screen.getByLabelText("Layer opacity"), { target: { value: "0.8" } });
     fireEvent.change(screen.getByLabelText("Point size"), { target: { value: "14" } });
@@ -8571,7 +8508,11 @@ describe("App", () => {
 
     expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findAllByText("Slice fields ready; no 3-D scalar field available");
-    expect(screen.getByText("No supported 3-D scalar field")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No supported 3-D scalar field is available for this result. Use Field Slice for available fields.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.getByLabelText("3-D scalar field")).toBeDisabled();
   });
@@ -8588,6 +8529,10 @@ describe("App", () => {
     expect(
       screen.getByText("No visualization-ready fields are available for this result."),
     ).toBeInTheDocument();
-    expect(screen.getByText("No supported 3-D scalar field")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No supported 3-D scalar field is available for this result. Use Field Slice for available fields.",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties, FormEvent } from "react";
 
 import "./App.css";
 import { CloudWorldsHome } from "./CloudWorldsHome";
+import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
 import {
   TradeCumulusComparisonStory,
   type TradeCumulusComparisonStoryResponse,
@@ -22,6 +23,7 @@ import {
   type UpdraftLensPointSelection,
   type UpdraftLensWindMode,
   UpdraftLensSlice,
+  UpdraftLensScaleLegend,
   updraftLensBoundaryPath,
   updraftLensColor,
 } from "./UpdraftLensSlice";
@@ -4207,6 +4209,18 @@ export function App() {
         worldSimulationDisplayName(selectedResult?.result_id, selectedResult?.name));
   const labResultContext =
     productLocation === "explore" && worldExploreContext?.kind === "lab_result";
+  const activeWorldSimulation =
+    productLocation === "explore" && worldExploreContext?.kind === "simulation"
+      ? (worldDetail?.simulations.find(
+          (simulation) => simulation.result_id === selectedResult?.result_id,
+        ) ?? null)
+      : null;
+  const activeResultAssetPath =
+    storageInventory?.runs.find((run) => run.run_id === selectedResult?.run_id)?.path ?? null;
+  const worldCompareAvailable = Boolean(
+    activeWorldSimulation?.compare_suggestions.length &&
+    worldDetail?.featured_comparison.open_available,
+  );
 
   return (
     <main className="app-shell">
@@ -4255,33 +4269,24 @@ export function App() {
           className="world-context-workspace"
           aria-label={`${worldContextName}${labResultContext ? " Lab result" : ""} workspace`}
         >
-          <header className="world-context-header">
-            <nav className="world-breadcrumb" aria-label="Breadcrumb">
-              <button type="button" onClick={() => setProductLocation("worlds")}>
-                Cloud Worlds
-              </button>
-              <span aria-hidden="true">/</span>
+          {productLocation === "comparison" && (
+            <header className="world-context-header">
+              <nav className="world-breadcrumb" aria-label="Breadcrumb">
+                <button type="button" onClick={() => setProductLocation("worlds")}>
+                  Cloud Worlds
+                </button>
+                <span aria-hidden="true">/</span>
+                <button type="button" onClick={returnToTradeCumulus}>
+                  Trade Cumulus
+                </button>
+                <span aria-hidden="true">/</span>
+                <span>{worldContextName}</span>
+              </nav>
               <button type="button" onClick={returnToTradeCumulus}>
-                Trade Cumulus
+                Back to Trade Cumulus
               </button>
-              {labResultContext && (
-                <>
-                  <span aria-hidden="true">/</span>
-                  <button type="button" onClick={returnToLabResults}>
-                    Lab
-                  </button>
-                </>
-              )}
-              <span aria-hidden="true">/</span>
-              <span>{worldContextName}</span>
-            </nav>
-            <button
-              type="button"
-              onClick={labResultContext ? returnToLabResults : returnToTradeCumulus}
-            >
-              {labResultContext ? "Back to Lab Results" : "Back to Trade Cumulus"}
-            </button>
-          </header>
+            </header>
+          )}
           {productLocation === "comparison" && (!comparisonStoryActive || !comparisonStory) ? (
             <section className="status-panel" role="status">
               <p>{worldComparisonStatus ?? "Loading featured Comparison..."}</p>
@@ -4295,6 +4300,13 @@ export function App() {
                 selectOrdinaryResult(resultId);
                 enterWorldExplore(resultId);
               }}
+              worldName={labResultContext ? "Trade Cumulus Lab" : "Trade Cumulus"}
+              simulationName={worldContextName}
+              simulationRecord={activeWorldSimulation}
+              assetPath={activeResultAssetPath}
+              backLabel={labResultContext ? "Back to Lab Results" : "Back to Trade Cumulus"}
+              onBack={labResultContext ? returnToLabResults : returnToTradeCumulus}
+              onCompare={worldCompareAvailable ? () => void openWorldComparison() : undefined}
             />
           )}
         </section>
@@ -7452,11 +7464,25 @@ function ExploreWorkspace({
   comparisonStory,
   onOpenResult,
   onBackToResults,
+  worldName,
+  simulationName,
+  simulationRecord,
+  assetPath,
+  backLabel,
+  onBack,
+  onCompare,
 }: {
   selectedResult: ResultCard | undefined;
   comparisonStory: TradeCumulusComparisonStoryResponse | null;
   onOpenResult: (resultId: string) => void;
   onBackToResults: () => void;
+  worldName?: string;
+  simulationName?: string;
+  simulationRecord?: SimulationRecord | null;
+  assetPath?: string | null;
+  backLabel?: string;
+  onBack?: () => void;
+  onCompare?: () => void;
 }) {
   return (
     <section className="workspace-section explore-workspace" aria-label="Explore this result">
@@ -7476,39 +7502,18 @@ function ExploreWorkspace({
 
       {!comparisonStory && selectedResult && (
         <section className="explore-result-view">
-          <ExploreResultSummary result={selectedResult} />
-          <VisualizerSceneShell result={selectedResult} />
+          <VisualizerSceneShell
+            result={selectedResult}
+            worldName={worldName}
+            simulationName={simulationName}
+            simulationRecord={simulationRecord}
+            assetPath={assetPath}
+            backLabel={backLabel}
+            onBack={onBack}
+            onCompare={onCompare}
+          />
         </section>
       )}
-    </section>
-  );
-}
-
-function ExploreResultSummary({ result }: { result: ResultCard }) {
-  return (
-    <section className="explore-result-summary" aria-label="Selected Explore result">
-      <div>
-        <h3>{result.name}</h3>
-        <p>
-          {result.scenario_name ?? humanize(result.scenario_id)} ·{" "}
-          {resultRunConfigurationLabel(result.run_configuration)}
-          {result.completed_at ? ` · ${formatDate(result.completed_at)}` : ""}
-        </p>
-        <p>{resultStory(result)}</p>
-        {result.candidate_hypothesis_comparison && (
-          <p className="secondary-result-note">
-            {result.candidate_hypothesis_comparison.screened_as ?? "Screened candidate"} ·{" "}
-            {result.candidate_hypothesis_comparison.match_status_label}:{" "}
-            {result.candidate_hypothesis_comparison.cm1_outcome}
-          </p>
-        )}
-      </div>
-      <div className="badge-row">
-        <OutcomeBadge result={result} />
-        <StatusBadge label={rainWaterOutcome(result)} tone="neutral" />
-        <StatusBadge label={resultInputSourceLabel(result)} tone="neutral" />
-        <StatusBadge label={scienceSupportLabel(result)} tone="neutral" />
-      </div>
     </section>
   );
 }
@@ -9739,9 +9744,30 @@ function tradeCumulusUpdraftLensEligible(result: ResultCard): boolean {
   );
 }
 
-export function VisualizerSceneShell({ result }: { result: ResultCard }) {
+export function VisualizerSceneShell({
+  result,
+  worldName,
+  simulationName,
+  simulationRecord = null,
+  assetPath = null,
+  backLabel,
+  onBack,
+  onCompare,
+}: {
+  result: ResultCard;
+  worldName?: string;
+  simulationName?: string;
+  simulationRecord?: SimulationRecord | null;
+  assetPath?: string | null;
+  backLabel?: string;
+  onBack?: () => void;
+  onCompare?: () => void;
+}) {
   const resultId = result.result_id;
   const updraftLensEligible = tradeCumulusUpdraftLensEligible(result);
+  const productWorldName = worldName ?? (updraftLensEligible ? "Trade Cumulus" : "Cloud Chamber");
+  const productSimulationName =
+    simulationName ?? worldSimulationDisplayName(result.result_id, result.name);
   const initialResultRef = useRef(result);
   if (initialResultRef.current.result_id !== resultId) {
     initialResultRef.current = result;
@@ -9776,9 +9802,13 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
   );
   const [sceneStatus, setSceneStatus] = useState("Loading scene data...");
   const [sceneError, setSceneError] = useState<string | null>(null);
+  const [pointCloudError, setPointCloudError] = useState<string | null>(null);
   const [sliceLoading, setSliceLoading] = useState(false);
   const [sliceError, setSliceError] = useState<string | null>(null);
   const [fieldLoadAttempt, setFieldLoadAttempt] = useState(0);
+  const [pointCloudLoadAttempt, setPointCloudLoadAttempt] = useState(0);
+  const [sliceLoadAttempt, setSliceLoadAttempt] = useState(0);
+  const [updraftLensLoadAttempt, setUpdraftLensLoadAttempt] = useState(0);
   const [selectedRegion, setSelectedRegion] = useState<SelectedRegionRequest | null>(null);
   const [regionDiagnostics, setRegionDiagnostics] =
     useState<SelectedRegionDiagnosticsResponse | null>(null);
@@ -9803,6 +9833,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setViewDefaults(null);
     setSelectedTimeDefaults(null);
     setSceneError(null);
+    setPointCloudError(null);
     setSelectedFieldName("");
     setTimeIndex(0);
     setPlaybackTimeIndex(0);
@@ -9824,6 +9855,9 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setSceneCloudBoundarySlice(null);
     setSliceLoading(false);
     setSliceError(null);
+    setPointCloudLoadAttempt(0);
+    setSliceLoadAttempt(0);
+    setUpdraftLensLoadAttempt(0);
     setSelectedRegion(null);
     setRegionDiagnostics(null);
     setRegionError(null);
@@ -9994,7 +10028,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
   const selectedDefaults = defaultsForField(viewDefaults, selectedFieldName);
   const selectedTimeFieldDefaults = defaultsForField(selectedTimeDefaults, selectedFieldName);
   const selectedTimeSliceDefaults = defaultsForField(selectedTimeDefaults, sliceFieldName);
-  const selectedTimeValue = timeOptions[resolvedTimeIndex] ?? null;
+  const selectedTimeValue = timeOptions[displayTimeIndex] ?? null;
   const selectedTimeLabel = formatTimeValue(selectedTimeValue);
   const displayTimeValue = timeOptions[displayTimeIndex] ?? null;
   const displayTimeLabel = formatTimeValue(displayTimeValue);
@@ -10211,10 +10245,11 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
   useEffect(() => {
     if (!selectedEncoding) {
       setPointCloud(null);
+      setPointCloudError(null);
       return;
     }
     let active = true;
-    setSceneError(null);
+    setPointCloudError(null);
     setSceneStatus(`Loading ${selectedEncoding.field.display_name.toLowerCase()} points...`);
     fetchVisualizationPointCloud(result.result_id, {
       field: selectedEncoding.field.raw_field_name,
@@ -10234,7 +10269,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
       .catch((caught: unknown) => {
         if (!active) return;
         setPointCloud(null);
-        setSceneError(
+        setPointCloudError(
           caught instanceof Error ? caught.message : "Unable to load 3-D scalar point layer.",
         );
         setSceneStatus("3-D scalar layer unavailable");
@@ -10242,7 +10277,14 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     return () => {
       active = false;
     };
-  }, [maxPoints, result.result_id, sceneTimeIndex, selectedEncoding, threshold]);
+  }, [
+    maxPoints,
+    pointCloudLoadAttempt,
+    result.result_id,
+    sceneTimeIndex,
+    selectedEncoding,
+    threshold,
+  ]);
 
   useEffect(() => {
     if (!catalog) {
@@ -10250,7 +10292,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
       return;
     }
     let active = true;
-    fetchVisualizationDefaults(result.result_id, resolvedTimeIndex)
+    fetchVisualizationDefaults(result.result_id, displayTimeIndex)
       .then((defaults) => {
         if (!active) return;
         setSelectedTimeDefaults(defaults);
@@ -10261,7 +10303,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     return () => {
       active = false;
     };
-  }, [catalog, result.result_id, resolvedTimeIndex]);
+  }, [catalog, displayTimeIndex, result.result_id]);
 
   useEffect(() => {
     if (!sliceField) {
@@ -10282,14 +10324,14 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setSliceError(null);
     const horizontalPromise = fetchVisualizationSlice(result.result_id, {
       field: sliceField.raw_field_name,
-      timeIndex: resolvedTimeIndex,
+      timeIndex: displayTimeIndex,
       orientation: "horizontal",
       levelIndex: horizontalSliceLevel,
     });
     const verticalPromise = sliceSupportsVertical
       ? fetchVisualizationSlice(result.result_id, {
           field: sliceField.raw_field_name,
-          timeIndex: resolvedTimeIndex,
+          timeIndex: displayTimeIndex,
           orientation: sliceOrientation,
           levelIndex: verticalSliceIndex,
         })
@@ -10313,8 +10355,9 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     };
   }, [
     horizontalSliceLevel,
+    displayTimeIndex,
     result.result_id,
-    resolvedTimeIndex,
+    sliceLoadAttempt,
     sliceField,
     sliceSupportsVertical,
     sliceOrientation,
@@ -10331,7 +10374,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     setSceneCloudBoundarySlice(null);
     fetchVisualizationSlice(result.result_id, {
       field: cloudBoundaryField.raw_field_name,
-      timeIndex: resolvedTimeIndex,
+      timeIndex: displayTimeIndex,
       orientation: activeSlicePlane,
       levelIndex: activeSliceIndex,
     })
@@ -10348,7 +10391,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     activeSliceIndex,
     activeSlicePlane,
     cloudBoundaryField,
-    resolvedTimeIndex,
+    displayTimeIndex,
     result.result_id,
     sliceField,
     updraftLensActive,
@@ -10368,7 +10411,7 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
     fetchTradeCumulusUpdraftLensFrame(
       result.result_id,
       {
-        timeIndex: resolvedTimeIndex,
+        timeIndex: displayTimeIndex,
         orientation: activeSlicePlane,
         planeIndex: activeSliceIndex,
         windMode: updraftLensWindMode,
@@ -10394,10 +10437,11 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
   }, [
     activeSliceIndex,
     activeSlicePlane,
-    resolvedTimeIndex,
+    displayTimeIndex,
     result.result_id,
     updraftLensActive,
     updraftLensDefaults,
+    updraftLensLoadAttempt,
     updraftLensWindMode,
   ]);
 
@@ -10457,871 +10501,1014 @@ export function VisualizerSceneShell({ result }: { result: ResultCard }) {
   }
 
   return (
-    <section className="visualizer-shell" aria-labelledby="visualizer-shell-title">
-      <div className="section-heading">
-        <div>
-          <p className="eyebrow">Field view</p>
-          <h2 id="visualizer-shell-title">What happened in this result?</h2>
-        </div>
-        <div className="visualizer-heading-actions">
-          <p className="state-chip">
-            {updraftLensActive
-              ? updraftLensLoading
-                ? "Loading Updraft Lens"
-                : "Updraft Lens active"
-              : sceneStatus}
-          </p>
-        </div>
-      </div>
+    <IntegratedExploreWorkspace
+      worldName={productWorldName}
+      simulationName={productSimulationName}
+      backLabel={backLabel}
+      onBack={onBack}
+      onCompare={onCompare}
+    >
+      <section className="visualizer-shell" aria-label="Integrated Explore workspace">
+        {sceneError && (
+          <div className="workspace-catalog-error" role="alert">
+            <p>{sceneError}</p>
+            <button type="button" onClick={() => setFieldLoadAttempt((current) => current + 1)}>
+              Retry loading fields
+            </button>
+          </div>
+        )}
 
-      {sceneError && (
-        <div role="alert">
-          <p>{sceneError}</p>
-          <button type="button" onClick={() => setFieldLoadAttempt((current) => current + 1)}>
-            Retry loading fields
-          </button>
-        </div>
-      )}
+        {catalog && catalog.available_fields.length === 0 && (
+          <p role="status">No visualization-ready fields are available for this result.</p>
+        )}
 
-      {catalog && catalog.available_fields.length === 0 && (
-        <p role="status">No visualization-ready fields are available for this result.</p>
-      )}
+        {updraftLensEligible && !updraftLensActive && updraftLensError && (
+          <p role="alert">{updraftLensError}</p>
+        )}
 
-      {updraftLensEligible && !updraftLensActive && updraftLensError && (
-        <p role="alert">{updraftLensError}</p>
-      )}
-
-      <div className="visualizer-workbench" aria-label="Scientific visualization workbench">
-        <div className="visualizer-stage" aria-label="Fixed visualization viewport region">
-          <True3DViewer
-            resultName={result.name}
-            pointCloud={pointCloud}
-            fieldLabel={
-              selectedEncoding
-                ? `${selectedEncoding.field.raw_field_name} — ${selectedEncoding.field.display_name}`
-                : "No supported 3-D scalar field"
-            }
-            valueChannelLabel={
-              selectedEncoding?.valueChannel ?? "3-D scalar rendering unavailable."
-            }
-            activeSlice={
-              updraftLensActive
-                ? null
-                : activeSlicePlane === "horizontal"
-                  ? sceneHorizontalSlice
-                  : sceneVerticalSlice
-            }
-            activeSliceLabel={activeSliceLabel}
-            showSlicePlane={!updraftLensActive && showSlicePlanes}
-            selectedRegion={selectedRegion}
-            coordinateSizes={{ x: sliceXSize, y: sliceYSize, z: sliceVerticalSize }}
-            selectedTimeLabel={selectedTimeLabel}
-            sceneTimeLabel={sceneTimeLabel}
-            thresholdLabel={formatScientific(threshold, selectedEncoding?.field.units ?? "")}
-            opacity={opacity}
-            pointSize={pointSize}
-            status={sceneStatus}
-            provenanceLabel={provenanceLabel}
-            noCloudMessage={
-              !selectedEncoding
-                ? "No supported 3-D scalar field is available for this result. Use Field Slice for available fields."
-                : selectedEncoding.field.raw_field_name === "qc" && isNoCloudWithUpdraft
-                  ? "No cloud water formed in this result; vertical velocity is available in Field Slice."
-                  : selectedEncoding.emptyStateTitle
-            }
-            windVectors={updraftLensFrame?.wind_vectors ?? []}
-            showWindVectors={updraftLensActive && showUpdraftLensWind && Boolean(updraftLensFrame)}
-            windMode={updraftLensWindMode}
-            windReferenceMps={updraftLensFrame?.wind_reference_m_s ?? 0}
-            windArrowDomainFraction={updraftLensFrame?.wind_arrow_domain_fraction ?? 0.08}
-            updraftLensFrame={updraftLensActive ? updraftLensFrame : null}
-          />
-          {catalog && sliceField && (
-            <section
-              className={`explore-control-deck${
-                updraftLensEligible ? " explore-control-deck-has-view-mode" : ""
-              }${updraftLensActive ? " explore-control-deck-lens" : ""}`}
-              aria-label="Explore viewer controls"
-            >
-              {updraftLensEligible && (
-                <fieldset className="explore-control-card explore-control-card-view-mode">
-                  <legend>View</legend>
-                  <div className="segmented-buttons" aria-label="Explore view mode">
-                    <button
-                      type="button"
-                      className={!updraftLensActive ? "active-control" : ""}
-                      aria-pressed={!updraftLensActive}
-                      onClick={() => {
-                        if (updraftLensActive) handleUpdraftLensToggle();
-                      }}
-                    >
-                      Standard
-                    </button>
-                    <button
-                      type="button"
-                      className={updraftLensActive ? "active-control" : ""}
-                      aria-pressed={updraftLensActive}
-                      disabled={!updraftLensActive && !updraftLensDefaults}
-                      onClick={() => {
-                        if (!updraftLensActive) handleUpdraftLensToggle();
-                      }}
-                    >
-                      Updraft Lens
-                    </button>
-                  </div>
-                </fieldset>
-              )}
-
-              <fieldset className="explore-control-card explore-control-card-time">
-                <legend>Time</legend>
-                <div className="timelapse-controls" aria-label="Timelapse playback controls">
-                  <button
-                    type="button"
-                    disabled={!canPlayTimelapse}
-                    aria-pressed={isPlaybackRunning}
-                    onClick={handlePlaybackToggle}
-                  >
-                    {isPlaybackRunning ? "Pause time" : "Play time"}
-                  </button>
-                  <label htmlFor="explore-playback-speed">
-                    Speed
-                    <select
-                      id="explore-playback-speed"
-                      aria-label="Playback speed"
-                      value={playbackSpeed}
-                      onChange={(event) => setPlaybackSpeed(Number(event.target.value))}
-                    >
-                      {playbackSpeedOptions.map((speed) => (
-                        <option key={speed} value={speed}>
-                          {speed}x
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                </div>
-                <label htmlFor="explore-time-scrubber">
-                  Saved output time
-                  <input
-                    id="explore-time-scrubber"
-                    aria-label="Saved output time"
-                    type="range"
-                    min={0}
-                    max={timeMax}
-                    value={displayTimeIndex}
-                    disabled={timeMax === 0}
-                    onChange={(event) => handleTimeIndexChange(Number(event.target.value))}
-                  />
-                  <span className="slice-position-label">
-                    <span>{displayTimeLabel}</span>
-                    <small>
-                      frame {displayTimeIndex + 1} of {Math.max(1, timeOptions.length)}
-                    </small>
-                  </span>
-                </label>
-                <label htmlFor="explore-time">
-                  Output time
-                  <select
-                    id="explore-time"
-                    aria-label="Time"
-                    value={displayTimeIndex}
-                    onChange={(event) => handleTimeIndexChange(Number(event.target.value))}
-                  >
-                    {timeOptions.map((value, index) => (
-                      <option key={`${value}-${index}`} value={index}>
-                        {formatTimeValue(value)}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-
-                <div className="time-preset-buttons" aria-label="Time presets">
-                  {timePresets.map((preset) => (
-                    <button
-                      key={preset.label}
-                      type="button"
-                      onClick={() =>
-                        handleTimeIndexChange(closestTimeIndex(timeOptions, preset.seconds))
-                      }
-                    >
-                      {preset.label}
-                    </button>
-                  ))}
-                  <button type="button" onClick={() => handleTimeIndexChange(timeMax)}>
-                    Last frame
-                  </button>
-                </div>
-                {isPlaybackRunning && (
-                  <p className="control-help">
-                    Animating 3-D scene at {sceneTimeLabel}; slice and evidence remain at{" "}
-                    {selectedTimeLabel} until playback is paused.
-                  </p>
-                )}
-              </fieldset>
-
-              {updraftLensActive ? (
-                <fieldset className="explore-control-card explore-control-card-updraft-lens">
-                  <legend>Updraft Lens</legend>
-                  <div className="segmented-buttons" aria-label="Updraft Lens slice orientation">
-                    <button
-                      type="button"
-                      className={activeSlicePlane === "horizontal" ? "active-control" : ""}
-                      aria-pressed={activeSlicePlane === "horizontal"}
-                      onClick={() => {
-                        setActiveSlicePlane("horizontal");
-                        setHorizontalSliceLevel((current) =>
-                          Math.min(current, Math.max(0, sliceVerticalSize - 1)),
-                        );
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      Horizontal x-y
-                    </button>
-                    <button
-                      type="button"
-                      className={activeSlicePlane === "vertical_x" ? "active-control" : ""}
-                      aria-pressed={activeSlicePlane === "vertical_x"}
-                      onClick={() => {
-                        setActiveSlicePlane("vertical_x");
-                        setSliceOrientation("vertical_x");
-                        setVerticalSliceIndex((current) =>
-                          Math.min(current, Math.max(0, sliceYSize - 1)),
-                        );
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      Vertical x-z
-                    </button>
-                    <button
-                      type="button"
-                      className={activeSlicePlane === "vertical_y" ? "active-control" : ""}
-                      aria-pressed={activeSlicePlane === "vertical_y"}
-                      onClick={() => {
-                        setActiveSlicePlane("vertical_y");
-                        setSliceOrientation("vertical_y");
-                        setVerticalSliceIndex((current) =>
-                          Math.min(current, Math.max(0, sliceXSize - 1)),
-                        );
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      Vertical y-z
-                    </button>
-                  </div>
-
-                  <label htmlFor="updraft-lens-plane-position">
-                    Position
-                    <input
-                      id="updraft-lens-plane-position"
-                      aria-label="Updraft Lens slice position"
-                      type="range"
-                      min={0}
-                      max={Math.max(0, activeSliceMax - 1)}
-                      value={activeSliceIndex}
-                      onChange={(event) => {
-                        const nextIndex = Number(event.target.value);
-                        if (activeSlicePlane === "horizontal") {
-                          setHorizontalSliceLevel(nextIndex);
-                        } else {
-                          setVerticalSliceIndex(nextIndex);
-                        }
-                        setSelectedRegion(null);
-                      }}
-                    />
-                    <span className="slice-position-label">
-                      <span>{updraftLensPlaneLabel}</span>
-                      <small>index {activeSliceIndex}</small>
-                    </span>
-                  </label>
-
-                  <div className="button-row slice-move-buttons">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const nextIndex = Math.max(0, activeSliceIndex - 1);
-                        if (activeSlicePlane === "horizontal") {
-                          setHorizontalSliceLevel(nextIndex);
-                        } else {
-                          setVerticalSliceIndex(nextIndex);
-                        }
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const nextIndex = Math.min(
-                          Math.max(0, activeSliceMax - 1),
-                          activeSliceIndex + 1,
-                        );
-                        if (activeSlicePlane === "horizontal") {
-                          setHorizontalSliceLevel(nextIndex);
-                        } else {
-                          setVerticalSliceIndex(nextIndex);
-                        }
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
-                    </button>
-                  </div>
-
-                  <label className="checkbox-label" htmlFor="updraft-lens-cloud-boundary">
-                    <input
-                      id="updraft-lens-cloud-boundary"
-                      type="checkbox"
-                      checked={showUpdraftLensBoundary}
-                      onChange={(event) => setShowUpdraftLensBoundary(event.target.checked)}
-                    />
-                    Cloud boundary
-                  </label>
-
-                  <label className="checkbox-label" htmlFor="updraft-lens-wind-overlay">
-                    <input
-                      id="updraft-lens-wind-overlay"
-                      type="checkbox"
-                      checked={showUpdraftLensWind}
-                      onChange={(event) => setShowUpdraftLensWind(event.target.checked)}
-                    />
-                    Horizontal wind
-                  </label>
-
-                  <div className="updraft-lens-mode-control">
-                    <span>Wind mode</span>
-                    <div className="segmented-buttons" aria-label="Updraft Lens wind mode">
+        <div className="visualizer-workbench" aria-label="Scientific visualization workbench">
+          <div className="visualizer-stage" aria-label="Fixed visualization viewport region">
+            {pointCloudError && (
+              <div className="layer-local-error layer-local-error-3d" role="alert">
+                <strong>3-D cloud layer unavailable</strong>
+                <span>{pointCloudError}</span>
+                <button
+                  type="button"
+                  onClick={() => setPointCloudLoadAttempt((current) => current + 1)}
+                >
+                  Retry 3-D layer
+                </button>
+              </div>
+            )}
+            <True3DViewer
+              resultName={productSimulationName}
+              pointCloud={pointCloud}
+              fieldLabel={
+                selectedEncoding
+                  ? `${selectedEncoding.field.raw_field_name} — ${selectedEncoding.field.display_name}`
+                  : "No supported 3-D scalar field"
+              }
+              valueChannelLabel={
+                selectedEncoding?.valueChannel ?? "3-D scalar rendering unavailable."
+              }
+              activeSlice={
+                updraftLensActive
+                  ? null
+                  : activeSlicePlane === "horizontal"
+                    ? sceneHorizontalSlice
+                    : sceneVerticalSlice
+              }
+              activeSliceLabel={activeSliceLabel}
+              showSlicePlane={!updraftLensActive && showSlicePlanes}
+              selectedRegion={selectedRegion}
+              coordinateSizes={{ x: sliceXSize, y: sliceYSize, z: sliceVerticalSize }}
+              selectedTimeLabel={selectedTimeLabel}
+              sceneTimeLabel={sceneTimeLabel}
+              thresholdLabel={formatScientific(threshold, selectedEncoding?.field.units ?? "")}
+              opacity={opacity}
+              pointSize={pointSize}
+              status={sceneStatus}
+              provenanceLabel={provenanceLabel}
+              noCloudMessage={
+                !selectedEncoding
+                  ? "No supported 3-D scalar field is available for this result. Use Field Slice for available fields."
+                  : selectedEncoding.field.raw_field_name === "qc" && isNoCloudWithUpdraft
+                    ? "No cloud water formed in this result; vertical velocity is available in Field Slice."
+                    : selectedEncoding.emptyStateTitle
+              }
+              windVectors={updraftLensFrame?.wind_vectors ?? []}
+              showWindVectors={
+                updraftLensActive && showUpdraftLensWind && Boolean(updraftLensFrame)
+              }
+              windMode={updraftLensWindMode}
+              windReferenceMps={updraftLensFrame?.wind_reference_m_s ?? 0}
+              windArrowDomainFraction={updraftLensFrame?.wind_arrow_domain_fraction ?? 0.08}
+              updraftLensFrame={updraftLensActive ? updraftLensFrame : null}
+              showUpdraftLensLegend={false}
+            />
+            {catalog && sliceField && (
+              <section
+                className={`explore-control-deck${
+                  updraftLensEligible ? " explore-control-deck-has-view-mode" : ""
+                }${updraftLensActive ? " explore-control-deck-lens" : ""}`}
+                aria-label="Explore viewer controls"
+              >
+                {updraftLensEligible && (
+                  <fieldset className="explore-control-card explore-control-card-view-mode">
+                    <legend>View</legend>
+                    <div className="segmented-buttons" aria-label="Explore view mode">
                       <button
                         type="button"
-                        className={updraftLensWindMode === "perturbation" ? "active-control" : ""}
-                        aria-pressed={updraftLensWindMode === "perturbation"}
-                        onClick={() => setUpdraftLensWindMode("perturbation")}
+                        className={!updraftLensActive ? "active-control" : ""}
+                        aria-pressed={!updraftLensActive}
+                        onClick={() => {
+                          if (updraftLensActive) handleUpdraftLensToggle();
+                        }}
                       >
-                        Local departures
+                        Standard
                       </button>
                       <button
                         type="button"
-                        className={updraftLensWindMode === "total" ? "active-control" : ""}
-                        aria-pressed={updraftLensWindMode === "total"}
-                        onClick={() => setUpdraftLensWindMode("total")}
+                        className={updraftLensActive ? "active-control" : ""}
+                        aria-pressed={updraftLensActive}
+                        disabled={!updraftLensActive && !updraftLensDefaults}
+                        onClick={() => {
+                          if (!updraftLensActive) handleUpdraftLensToggle();
+                        }}
                       >
-                        Total wind
+                        Updraft Lens
                       </button>
                     </div>
-                  </div>
-                  {updraftLensFrame && (
-                    <p className="control-help">
-                      Wind level {Math.round(updraftLensFrame.wind_actual_level_m)} m · reference{" "}
-                      {updraftLensFrame.wind_reference_m_s.toFixed(1)} m/s
-                    </p>
-                  )}
-                  {updraftLensError && <p role="alert">{updraftLensError}</p>}
-                </fieldset>
-              ) : (
-                <fieldset className="explore-control-card explore-control-card-slice">
-                  <legend>Slice</legend>
-                  <label htmlFor="explore-slice-field">
-                    Field Slice field
-                    <select
-                      id="explore-slice-field"
-                      aria-label="Slice field"
-                      value={sliceFieldName}
-                      onChange={(event) => {
-                        const nextField = catalog.available_fields.find(
-                          (field) => field.raw_field_name === event.target.value,
-                        );
-                        setSliceFieldName(event.target.value);
-                        const nextDefaults = defaultsForField(viewDefaults, event.target.value);
-                        setHorizontalSliceLevel(defaultHorizontalLevel(nextField, nextDefaults));
-                        setVerticalSliceIndex(
-                          defaultVerticalIndex(nextField, sliceOrientation, nextDefaults),
-                        );
-                        if (!nextField?.coordinate_names.vertical) {
-                          setActiveSlicePlane("horizontal");
-                        }
-                        setSelectedRegion(null);
-                      }}
+                  </fieldset>
+                )}
+
+                <fieldset className="explore-control-card explore-control-card-time">
+                  <legend>Time</legend>
+                  <div className="frame-step-controls" aria-label="Saved frame step controls">
+                    <button
+                      type="button"
+                      disabled={displayTimeIndex <= 0}
+                      onClick={() => handleTimeIndexChange(displayTimeIndex - 1)}
                     >
-                      {catalog.available_fields.map((field) => (
-                        <option key={field.raw_field_name} value={field.raw_field_name}>
-                          {sliceFieldOptionLabel(field)}
+                      Previous
+                    </button>
+                    <button
+                      type="button"
+                      disabled={displayTimeIndex >= timeMax}
+                      onClick={() => handleTimeIndexChange(displayTimeIndex + 1)}
+                    >
+                      Next
+                    </button>
+                  </div>
+                  <div className="timelapse-controls" aria-label="Timelapse playback controls">
+                    <button
+                      type="button"
+                      disabled={!canPlayTimelapse}
+                      aria-pressed={isPlaybackRunning}
+                      onClick={handlePlaybackToggle}
+                    >
+                      {isPlaybackRunning ? "Pause time" : "Play time"}
+                    </button>
+                    <label htmlFor="explore-playback-speed">
+                      Speed
+                      <select
+                        id="explore-playback-speed"
+                        aria-label="Playback speed"
+                        value={playbackSpeed}
+                        onChange={(event) => setPlaybackSpeed(Number(event.target.value))}
+                      >
+                        {playbackSpeedOptions.map((speed) => (
+                          <option key={speed} value={speed}>
+                            {speed}x
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+                  <label htmlFor="explore-time-scrubber">
+                    Saved output time
+                    <input
+                      id="explore-time-scrubber"
+                      aria-label="Saved output time"
+                      type="range"
+                      min={0}
+                      max={timeMax}
+                      value={displayTimeIndex}
+                      disabled={timeMax === 0}
+                      onChange={(event) => handleTimeIndexChange(Number(event.target.value))}
+                    />
+                    <span className="slice-position-label">
+                      <span>{displayTimeLabel}</span>
+                      <small>
+                        frame {displayTimeIndex + 1} of {Math.max(1, timeOptions.length)}
+                      </small>
+                    </span>
+                  </label>
+                  <label htmlFor="explore-time">
+                    Output time
+                    <select
+                      id="explore-time"
+                      aria-label="Time"
+                      value={displayTimeIndex}
+                      onChange={(event) => handleTimeIndexChange(Number(event.target.value))}
+                    >
+                      {timeOptions.map((value, index) => (
+                        <option key={`${value}-${index}`} value={index}>
+                          {formatTimeValue(value)}
                         </option>
                       ))}
                     </select>
                   </label>
 
-                  <div className="segmented-buttons" aria-label="Slice orientation">
-                    <button
-                      type="button"
-                      className={activeSlicePlane === "horizontal" ? "active-control" : ""}
-                      onClick={() => {
-                        setActiveSlicePlane("horizontal");
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      Horizontal layer
-                    </button>
-                    <button
-                      type="button"
-                      className={activeSlicePlane === "vertical_x" ? "active-control" : ""}
-                      disabled={!sliceSupportsVertical}
-                      onClick={() => {
-                        setActiveSlicePlane("vertical_x");
-                        setSliceOrientation("vertical_x");
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      Vertical x-z slice
-                    </button>
-                    <button
-                      type="button"
-                      className={activeSlicePlane === "vertical_y" ? "active-control" : ""}
-                      disabled={!sliceSupportsVertical}
-                      onClick={() => {
-                        setActiveSlicePlane("vertical_y");
-                        setSliceOrientation("vertical_y");
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      Vertical y-z slice
+                  <div className="time-preset-buttons" aria-label="Time presets">
+                    {timePresets.map((preset) => (
+                      <button
+                        key={preset.label}
+                        type="button"
+                        onClick={() =>
+                          handleTimeIndexChange(closestTimeIndex(timeOptions, preset.seconds))
+                        }
+                      >
+                        {preset.label}
+                      </button>
+                    ))}
+                    <button type="button" onClick={() => handleTimeIndexChange(timeMax)}>
+                      Last frame
                     </button>
                   </div>
-
-                  <label htmlFor="explore-slice-position">
-                    Position
-                    <input
-                      id="explore-slice-position"
-                      aria-label="Slice position"
-                      type="range"
-                      min={0}
-                      max={Math.max(0, activeSliceMax - 1)}
-                      value={activeSliceIndex}
-                      onChange={(event) => {
-                        const nextIndex = Number(event.target.value);
-                        if (activeSlicePlane === "horizontal") {
-                          setHorizontalSliceLevel(nextIndex);
-                        } else {
-                          setVerticalSliceIndex(nextIndex);
-                        }
-                        setSelectedRegion(null);
-                      }}
-                    />
-                    <span className="slice-position-label">
-                      {activeSlicePositionLabel || `index ${activeSliceIndex}`}{" "}
-                      <small>index {activeSliceIndex}</small>
-                    </span>
-                  </label>
-
-                  <div className="button-row slice-move-buttons">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const nextIndex = Math.max(0, activeSliceIndex - 1);
-                        if (activeSlicePlane === "horizontal") {
-                          setHorizontalSliceLevel(nextIndex);
-                        } else {
-                          setVerticalSliceIndex(nextIndex);
-                        }
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const nextIndex = Math.min(
-                          Math.max(0, activeSliceMax - 1),
-                          activeSliceIndex + 1,
-                        );
-                        if (activeSlicePlane === "horizontal") {
-                          setHorizontalSliceLevel(nextIndex);
-                        } else {
-                          setVerticalSliceIndex(nextIndex);
-                        }
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
-                    </button>
-                  </div>
-
-                  <label className="checkbox-label" htmlFor="show-slice-plane">
-                    <input
-                      id="show-slice-plane"
-                      type="checkbox"
-                      checked={showSlicePlanes}
-                      onChange={(event) => setShowSlicePlanes(event.target.checked)}
-                    />
-                    Show slice plane
-                  </label>
+                  {isPlaybackRunning && (
+                    <p className="control-help">
+                      Animating the coordinated scene and slice at {sceneTimeLabel}.
+                    </p>
+                  )}
                 </fieldset>
-              )}
 
-              <fieldset className="explore-control-card explore-control-card-rendering">
-                <legend>3-D scalar layer</legend>
-                <label htmlFor="explore-3d-field">
-                  3-D field
-                  <select
-                    id="explore-3d-field"
-                    aria-label="3-D scalar field"
-                    value={selectedFieldName}
-                    disabled={threeDScalarEncodings.length === 0}
-                    onChange={(event) => {
-                      const nextEncoding =
-                        threeDScalarEncodings.find(
-                          (encoding) => encoding.field.raw_field_name === event.target.value,
-                        ) ?? null;
-                      setSelectedFieldName(event.target.value);
-                      if (nextEncoding) {
-                        setThreshold(nextEncoding.defaultThreshold);
-                        if (!updraftLensActive) {
-                          setSliceFieldName(nextEncoding.field.raw_field_name);
-                          if (!nextEncoding.field.coordinate_names.vertical) {
+                {updraftLensActive ? (
+                  <fieldset className="explore-control-card explore-control-card-updraft-lens">
+                    <legend>Updraft Lens</legend>
+                    <div className="segmented-buttons" aria-label="Updraft Lens slice orientation">
+                      <button
+                        type="button"
+                        className={activeSlicePlane === "horizontal" ? "active-control" : ""}
+                        aria-pressed={activeSlicePlane === "horizontal"}
+                        onClick={() => {
+                          setActiveSlicePlane("horizontal");
+                          setHorizontalSliceLevel((current) =>
+                            Math.min(current, Math.max(0, sliceVerticalSize - 1)),
+                          );
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        Horizontal x-y
+                      </button>
+                      <button
+                        type="button"
+                        className={activeSlicePlane === "vertical_x" ? "active-control" : ""}
+                        aria-pressed={activeSlicePlane === "vertical_x"}
+                        onClick={() => {
+                          setActiveSlicePlane("vertical_x");
+                          setSliceOrientation("vertical_x");
+                          setVerticalSliceIndex((current) =>
+                            Math.min(current, Math.max(0, sliceYSize - 1)),
+                          );
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        Vertical x-z
+                      </button>
+                      <button
+                        type="button"
+                        className={activeSlicePlane === "vertical_y" ? "active-control" : ""}
+                        aria-pressed={activeSlicePlane === "vertical_y"}
+                        onClick={() => {
+                          setActiveSlicePlane("vertical_y");
+                          setSliceOrientation("vertical_y");
+                          setVerticalSliceIndex((current) =>
+                            Math.min(current, Math.max(0, sliceXSize - 1)),
+                          );
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        Vertical y-z
+                      </button>
+                    </div>
+
+                    <label htmlFor="updraft-lens-plane-position">
+                      Position
+                      <input
+                        id="updraft-lens-plane-position"
+                        aria-label="Updraft Lens slice position"
+                        type="range"
+                        min={0}
+                        max={Math.max(0, activeSliceMax - 1)}
+                        value={activeSliceIndex}
+                        onChange={(event) => {
+                          const nextIndex = Number(event.target.value);
+                          if (activeSlicePlane === "horizontal") {
+                            setHorizontalSliceLevel(nextIndex);
+                          } else {
+                            setVerticalSliceIndex(nextIndex);
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      />
+                      <span className="slice-position-label">
+                        <span>{updraftLensPlaneLabel}</span>
+                        <small>index {activeSliceIndex}</small>
+                      </span>
+                    </label>
+
+                    <div className="button-row slice-move-buttons">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const nextIndex = Math.max(0, activeSliceIndex - 1);
+                          if (activeSlicePlane === "horizontal") {
+                            setHorizontalSliceLevel(nextIndex);
+                          } else {
+                            setVerticalSliceIndex(nextIndex);
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const nextIndex = Math.min(
+                            Math.max(0, activeSliceMax - 1),
+                            activeSliceIndex + 1,
+                          );
+                          if (activeSlicePlane === "horizontal") {
+                            setHorizontalSliceLevel(nextIndex);
+                          } else {
+                            setVerticalSliceIndex(nextIndex);
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
+                      </button>
+                    </div>
+
+                    <label className="checkbox-label" htmlFor="updraft-lens-cloud-boundary">
+                      <input
+                        id="updraft-lens-cloud-boundary"
+                        type="checkbox"
+                        checked={showUpdraftLensBoundary}
+                        onChange={(event) => setShowUpdraftLensBoundary(event.target.checked)}
+                      />
+                      Cloud boundary
+                    </label>
+
+                    <label className="checkbox-label" htmlFor="updraft-lens-wind-overlay">
+                      <input
+                        id="updraft-lens-wind-overlay"
+                        type="checkbox"
+                        checked={showUpdraftLensWind}
+                        onChange={(event) => setShowUpdraftLensWind(event.target.checked)}
+                      />
+                      Horizontal wind
+                    </label>
+
+                    <div className="updraft-lens-mode-control">
+                      <span>Wind mode</span>
+                      <div className="segmented-buttons" aria-label="Updraft Lens wind mode">
+                        <button
+                          type="button"
+                          className={updraftLensWindMode === "perturbation" ? "active-control" : ""}
+                          aria-pressed={updraftLensWindMode === "perturbation"}
+                          onClick={() => setUpdraftLensWindMode("perturbation")}
+                        >
+                          Local departures
+                        </button>
+                        <button
+                          type="button"
+                          className={updraftLensWindMode === "total" ? "active-control" : ""}
+                          aria-pressed={updraftLensWindMode === "total"}
+                          onClick={() => setUpdraftLensWindMode("total")}
+                        >
+                          Total wind
+                        </button>
+                      </div>
+                    </div>
+                    {updraftLensFrame && (
+                      <p className="control-help">
+                        Wind level {Math.round(updraftLensFrame.wind_actual_level_m)} m · reference{" "}
+                        {updraftLensFrame.wind_reference_m_s.toFixed(1)} m/s
+                      </p>
+                    )}
+                  </fieldset>
+                ) : (
+                  <fieldset className="explore-control-card explore-control-card-slice">
+                    <legend>Slice</legend>
+                    <label htmlFor="explore-slice-field">
+                      Field Slice field
+                      <select
+                        id="explore-slice-field"
+                        aria-label="Slice field"
+                        value={sliceFieldName}
+                        onChange={(event) => {
+                          const nextField = catalog.available_fields.find(
+                            (field) => field.raw_field_name === event.target.value,
+                          );
+                          setSliceFieldName(event.target.value);
+                          const nextDefaults = defaultsForField(viewDefaults, event.target.value);
+                          setHorizontalSliceLevel(defaultHorizontalLevel(nextField, nextDefaults));
+                          setVerticalSliceIndex(
+                            defaultVerticalIndex(nextField, sliceOrientation, nextDefaults),
+                          );
+                          if (!nextField?.coordinate_names.vertical) {
                             setActiveSlicePlane("horizontal");
                           }
-                          const nextDefaults =
-                            defaultsForField(
-                              selectedTimeDefaults,
-                              nextEncoding.field.raw_field_name,
-                            ) ?? defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
-                          setHorizontalSliceLevel(
-                            defaultHorizontalLevel(nextEncoding.field, nextDefaults),
-                          );
-                          setVerticalSliceIndex(
-                            defaultVerticalIndex(
-                              nextEncoding.field,
-                              sliceOrientation,
-                              nextDefaults,
-                            ),
-                          );
-                        }
-                      }
-                      setSelectedRegion(null);
-                    }}
-                  >
-                    {threeDScalarEncodings.length === 0 && (
-                      <option value="">No 3-D scalar fields</option>
-                    )}
-                    {threeDScalarEncodings.map((encoding) => (
-                      <option
-                        key={encoding.field.raw_field_name}
-                        value={encoding.field.raw_field_name}
+                          setSelectedRegion(null);
+                        }}
                       >
-                        {encoding.field.raw_field_name} - {encoding.field.display_name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <p className="control-help">
-                  {selectedEncoding
-                    ? selectedEncoding.valueChannel
-                    : "Only fields with a defined 3-D scalar encoding appear here; vertical velocity remains slice-only."}
-                </p>
-                {pointCloud && selectedEncoding && (
-                  <p className="control-help">
-                    {pointCloudFieldSummary(pointCloud)}
-                    {selectedEncoding.field.raw_field_name === "dbz"
-                      ? " Weather-radar colors use a fixed 0 to 60+ dBZ scale."
-                      : ""}
-                  </p>
+                        {catalog.available_fields.map((field) => (
+                          <option key={field.raw_field_name} value={field.raw_field_name}>
+                            {sliceFieldOptionLabel(field)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+
+                    <div className="segmented-buttons" aria-label="Slice orientation">
+                      <button
+                        type="button"
+                        className={activeSlicePlane === "horizontal" ? "active-control" : ""}
+                        onClick={() => {
+                          setActiveSlicePlane("horizontal");
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        Horizontal layer
+                      </button>
+                      <button
+                        type="button"
+                        className={activeSlicePlane === "vertical_x" ? "active-control" : ""}
+                        disabled={!sliceSupportsVertical}
+                        onClick={() => {
+                          setActiveSlicePlane("vertical_x");
+                          setSliceOrientation("vertical_x");
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        Vertical x-z slice
+                      </button>
+                      <button
+                        type="button"
+                        className={activeSlicePlane === "vertical_y" ? "active-control" : ""}
+                        disabled={!sliceSupportsVertical}
+                        onClick={() => {
+                          setActiveSlicePlane("vertical_y");
+                          setSliceOrientation("vertical_y");
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        Vertical y-z slice
+                      </button>
+                    </div>
+
+                    <label htmlFor="explore-slice-position">
+                      Position
+                      <input
+                        id="explore-slice-position"
+                        aria-label="Slice position"
+                        type="range"
+                        min={0}
+                        max={Math.max(0, activeSliceMax - 1)}
+                        value={activeSliceIndex}
+                        onChange={(event) => {
+                          const nextIndex = Number(event.target.value);
+                          if (activeSlicePlane === "horizontal") {
+                            setHorizontalSliceLevel(nextIndex);
+                          } else {
+                            setVerticalSliceIndex(nextIndex);
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      />
+                      <span className="slice-position-label">
+                        {activeSlicePositionLabel || `index ${activeSliceIndex}`}{" "}
+                        <small>index {activeSliceIndex}</small>
+                      </span>
+                    </label>
+
+                    <div className="button-row slice-move-buttons">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const nextIndex = Math.max(0, activeSliceIndex - 1);
+                          if (activeSlicePlane === "horizontal") {
+                            setHorizontalSliceLevel(nextIndex);
+                          } else {
+                            setVerticalSliceIndex(nextIndex);
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const nextIndex = Math.min(
+                            Math.max(0, activeSliceMax - 1),
+                            activeSliceIndex + 1,
+                          );
+                          if (activeSlicePlane === "horizontal") {
+                            setHorizontalSliceLevel(nextIndex);
+                          } else {
+                            setVerticalSliceIndex(nextIndex);
+                          }
+                          setSelectedRegion(null);
+                        }}
+                      >
+                        {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
+                      </button>
+                    </div>
+
+                    <label className="checkbox-label" htmlFor="show-slice-plane">
+                      <input
+                        id="show-slice-plane"
+                        type="checkbox"
+                        checked={showSlicePlanes}
+                        onChange={(event) => setShowSlicePlanes(event.target.checked)}
+                      />
+                      Show slice plane
+                    </label>
+                  </fieldset>
                 )}
-                {selectedEncoding?.field.raw_field_name === "qc" &&
-                  cloudTopMismatchNotice(result) && (
-                    <p className="control-help">{cloudTopMismatchNotice(result)}</p>
+
+                <fieldset className="explore-control-card explore-control-card-rendering">
+                  <legend>3-D scalar layer</legend>
+                  <label htmlFor="explore-3d-field">
+                    3-D field
+                    <select
+                      id="explore-3d-field"
+                      aria-label="3-D scalar field"
+                      value={selectedFieldName}
+                      disabled={threeDScalarEncodings.length === 0}
+                      onChange={(event) => {
+                        const nextEncoding =
+                          threeDScalarEncodings.find(
+                            (encoding) => encoding.field.raw_field_name === event.target.value,
+                          ) ?? null;
+                        setSelectedFieldName(event.target.value);
+                        if (nextEncoding) {
+                          setThreshold(nextEncoding.defaultThreshold);
+                          if (!updraftLensActive) {
+                            setSliceFieldName(nextEncoding.field.raw_field_name);
+                            if (!nextEncoding.field.coordinate_names.vertical) {
+                              setActiveSlicePlane("horizontal");
+                            }
+                            const nextDefaults =
+                              defaultsForField(
+                                selectedTimeDefaults,
+                                nextEncoding.field.raw_field_name,
+                              ) ??
+                              defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
+                            setHorizontalSliceLevel(
+                              defaultHorizontalLevel(nextEncoding.field, nextDefaults),
+                            );
+                            setVerticalSliceIndex(
+                              defaultVerticalIndex(
+                                nextEncoding.field,
+                                sliceOrientation,
+                                nextDefaults,
+                              ),
+                            );
+                          }
+                        }
+                        setSelectedRegion(null);
+                      }}
+                    >
+                      {threeDScalarEncodings.length === 0 && (
+                        <option value="">No 3-D scalar fields</option>
+                      )}
+                      {threeDScalarEncodings.map((encoding) => (
+                        <option
+                          key={encoding.field.raw_field_name}
+                          value={encoding.field.raw_field_name}
+                        >
+                          {encoding.field.raw_field_name} - {encoding.field.display_name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <p className="control-help">
+                    {selectedEncoding
+                      ? selectedEncoding.valueChannel
+                      : "Only fields with a defined 3-D scalar encoding appear here; vertical velocity remains slice-only."}
+                  </p>
+                  {pointCloud && selectedEncoding && (
+                    <p className="control-help">
+                      {pointCloudFieldSummary(pointCloud)}
+                      {selectedEncoding.field.raw_field_name === "dbz"
+                        ? " Weather-radar colors use a fixed 0 to 60+ dBZ scale."
+                        : ""}
+                    </p>
                   )}
-                <label htmlFor="cloud-threshold">
-                  {selectedEncoding?.thresholdLabel ?? "Visible minimum"}
-                  <input
-                    id="cloud-threshold"
-                    aria-label={selectedEncoding?.thresholdAriaLabel ?? "3-D scalar threshold"}
-                    type="number"
-                    min={0}
-                    step={selectedEncoding?.thresholdStep ?? 0.000001}
-                    value={threshold}
-                    onChange={(event) => setThreshold(Number(event.target.value))}
-                    disabled={!selectedEncoding}
-                  />
-                </label>
-                <label htmlFor="cloud-opacity">
-                  Opacity
-                  <input
-                    id="cloud-opacity"
-                    aria-label="Layer opacity"
-                    type="range"
-                    min={0.1}
-                    max={1}
-                    step={0.05}
-                    value={opacity}
-                    onChange={(event) => setOpacity(Number(event.target.value))}
-                  />
-                  <output htmlFor="cloud-opacity">{opacity}</output>
-                </label>
-                <label htmlFor="cloud-point-size">
-                  Point size
-                  <input
-                    id="cloud-point-size"
-                    aria-label="Point size"
-                    type="range"
-                    min={3}
-                    max={18}
-                    value={pointSize}
-                    onChange={(event) => setPointSize(Number(event.target.value))}
-                  />
-                  <output htmlFor="cloud-point-size">{pointSize}px</output>
-                </label>
-              </fieldset>
-            </section>
-          )}
-        </div>
-
-        <aside className="visualizer-details-panel" aria-label="Visualization details">
-          <ResultExplanationPanel result={result} isNoCloudWithUpdraft={isNoCloudWithUpdraft} />
-
-          <details className="technical-details">
-            <summary>Process evidence details</summary>
-            <ProcessModeControl
-              processMode={activeProcessMode}
-              processModeStates={primaryProcessModes}
-              activeProcessModeState={activeProcessModeState}
-              unavailableProcessModes={unavailableProcessModes}
-              onProcessModeChange={setProcessMode}
-            />
-            <ProcessOverlayPanel
-              result={result}
-              catalog={catalog}
-              selectedField={sliceField}
-              processMode={activeProcessMode}
-              slice={activeSlicePlane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice}
-            />
-          </details>
-
-          {sliceError && <p role="alert">{sliceError}</p>}
-
-          <details className="technical-details">
-            <summary>Technical visualization details</summary>
-            <dl className="metric-grid">
-              <Metric label="Run ID" value={result.run_id} />
-              <Metric label="Renderer" value="Direct Three.js point cloud" />
-              <Metric
-                label="3-D field"
-                value={
-                  selectedField
-                    ? `${selectedField.raw_field_name} (${selectedField.display_name})`
-                    : "Unavailable"
-                }
-              />
-              <Metric label="3-D scene time" value={sceneTimeLabel} />
-              <Metric label="Slice/evidence time" value={selectedTimeLabel} />
-              <Metric label="Slice plane" value={activeSliceLabel} />
-              <Metric label="Slice plane visible" value={showSlicePlanes ? "Yes" : "No"} />
-              <Metric
-                label={selectedEncoding?.thresholdLabel ?? "Visible threshold"}
-                value={formatScientific(threshold, selectedField?.units ?? "")}
-              />
-              <Metric label="Opacity" value={String(opacity)} />
-              <Metric label="Point size" value={`${pointSize}px`} />
-              <Metric
-                label="Point count"
-                value={
-                  pointCloud
-                    ? `${pointCloud.stats.returned_count.toLocaleString()} of ${pointCloud.stats.source_count.toLocaleString()}`
-                    : "Unavailable"
-                }
-              />
-              <Metric
-                label={selectedEncoding?.rangeLabel ?? "3-D field range"}
-                value={
-                  pointCloud
-                    ? `${formatMaybeNumber(pointCloud.stats.min_value, selectedField?.units ?? "kg/kg")} to ${formatMaybeNumber(
-                        pointCloud.stats.max_value,
-                        selectedField?.units ?? "kg/kg",
-                      )}`
-                    : "Unavailable"
-                }
-              />
-              <Metric
-                label="Selected-field range"
-                value={
-                  pointCloud
-                    ? `${formatMaybeNumber(
-                        pointCloud.stats.field_min_value,
-                        selectedField?.units ?? "kg/kg",
-                      )} to ${formatMaybeNumber(
-                        pointCloud.stats.field_max_value,
-                        selectedField?.units ?? "kg/kg",
-                      )}`
-                    : "Unavailable"
-                }
-              />
-              <Metric
-                label="Downsampling"
-                value={
-                  pointCloud?.stats.downsampled
-                    ? `Deterministic stride ${pointCloud.stats.downsample_stride}`
-                    : "Not applied"
-                }
-              />
-              <Metric
-                label="Default source"
-                value={
-                  selectedTimeFieldDefaults?.source ??
-                  selectedDefaults?.source ??
-                  "domain center fallback"
-                }
-              />
-              <Metric
-                label="Slice source"
-                value={
-                  sliceField
-                    ? `${sliceField.raw_field_name} (${sliceField.display_name})`
-                    : "Unavailable"
-                }
-              />
-              <Metric
-                label="Slice orientation"
-                value={
-                  activeSlicePlane === "horizontal" && sceneHorizontalSlice
-                    ? `${sceneHorizontalSlice.selection.orientation} at ${sceneHorizontalSlice.selection.selected_dimension}[${sceneHorizontalSlice.selection.selected_index}]`
-                    : sceneVerticalSlice
-                      ? `${sceneVerticalSlice.selection.orientation} at ${sceneVerticalSlice.selection.selected_dimension}[${sceneVerticalSlice.selection.selected_index}]`
-                      : "Unavailable"
-                }
-              />
-              <Metric label="Domain x extent" value={extentLabel(pointCloud, "xh")} />
-              <Metric label="Domain y extent" value={extentLabel(pointCloud, "yh")} />
-              <Metric label="Domain z extent" value={verticalExtentLabel(pointCloud)} />
-              <Metric
-                label="Active cloud z range"
-                value={
-                  pointCloud
-                    ? `${formatMaybeNumber(pointCloud.stats.active_z_min, verticalCoordinateUnit(pointCloud))} to ${formatMaybeNumber(
-                        pointCloud.stats.active_z_max,
-                        verticalCoordinateUnit(pointCloud),
-                      )}`
-                    : "Unavailable"
-                }
-              />
-              <Metric label="Max 3-D field location" value={maxPointLocationLabel(pointCloud)} />
-              <Metric
-                label="Selected-time slice default"
-                value={selectedTimeSliceDefaults?.source ?? "Unavailable"}
-              />
-            </dl>
-
-            <section aria-labelledby="visualizer-provenance-title">
-              <h3 id="visualizer-provenance-title">Provenance / rendering labels</h3>
-              <ul className="compact-list">
-                <li>{provenanceLabel}</li>
-                <li>Visualizer interpretation of CM1-derived output</li>
-                <li>
-                  Value channel:{" "}
-                  {selectedEncoding?.valueChannel ?? "3-D scalar rendering unavailable"}
-                </li>
-                <li>
-                  Processing method: backend native-grid thresholded point cloud for supported
-                  scalar fields
-                </li>
-                <li>Rendering method: direct Three.js scalar point cloud</li>
-                <li>Slice planes: native-grid JSON slices from the backend</li>
-                <li>No raw NetCDF parsing in the browser</li>
-                <li>
-                  No interpolation, ray marching, isosurface extraction, or synthetic cloud physics
-                </li>
-              </ul>
-            </section>
-          </details>
-        </aside>
-      </div>
-
-      {catalog && sliceField && (
-        <section className="unified-slice-inspector" aria-labelledby="unified-slice-title">
-          <div className="section-heading compact-heading">
-            <div>
-              <p className="eyebrow">Field Slice</p>
-              <h2 id="unified-slice-title">{updraftLensActive ? "Updraft Lens" : "Field Slice"}</h2>
-              <p>
-                {activeSliceLabel} · {updraftLensActive ? "w" : sliceField.raw_field_name} ·{" "}
-                {selectedTimeLabel}
-              </p>
-            </div>
-            <p className="state-chip">
-              {updraftLensActive
-                ? updraftLensError
-                  ? "Lens unavailable"
-                  : updraftLensLoading || !updraftLensFrame
-                    ? "Loading Lens"
-                    : "Lens synced"
-                : sliceError
-                  ? "Slice unavailable"
-                  : sliceLoading || !activeSlice
-                    ? "Loading slice"
-                    : "Slice synced"}
-            </p>
+                  {selectedEncoding?.field.raw_field_name === "qc" &&
+                    cloudTopMismatchNotice(result) && (
+                      <p className="control-help">{cloudTopMismatchNotice(result)}</p>
+                    )}
+                  <label htmlFor="cloud-threshold">
+                    {selectedEncoding?.thresholdLabel ?? "Visible minimum"}
+                    <input
+                      id="cloud-threshold"
+                      aria-label={selectedEncoding?.thresholdAriaLabel ?? "3-D scalar threshold"}
+                      type="number"
+                      min={0}
+                      step={selectedEncoding?.thresholdStep ?? 0.000001}
+                      value={threshold}
+                      onChange={(event) => setThreshold(Number(event.target.value))}
+                      disabled={!selectedEncoding}
+                    />
+                  </label>
+                  <label htmlFor="cloud-opacity">
+                    Opacity
+                    <input
+                      id="cloud-opacity"
+                      aria-label="Layer opacity"
+                      type="range"
+                      min={0.1}
+                      max={1}
+                      step={0.05}
+                      value={opacity}
+                      onChange={(event) => setOpacity(Number(event.target.value))}
+                    />
+                    <output htmlFor="cloud-opacity">{opacity}</output>
+                  </label>
+                  <label htmlFor="cloud-point-size">
+                    Point size
+                    <input
+                      id="cloud-point-size"
+                      aria-label="Point size"
+                      type="range"
+                      min={3}
+                      max={18}
+                      value={pointSize}
+                      onChange={(event) => setPointSize(Number(event.target.value))}
+                    />
+                    <output htmlFor="cloud-point-size">{pointSize}px</output>
+                  </label>
+                </fieldset>
+              </section>
+            )}
           </div>
 
-          {sliceError && <p role="alert">{sliceError}</p>}
-
-          {updraftLensActive ? (
-            updraftLensFrame ? (
-              <UpdraftLensSlice
-                frame={updraftLensFrame}
-                showCloudBoundary={showUpdraftLensBoundary}
-                selectedPoint={
-                  selectedRegion?.xIndex !== undefined &&
-                  selectedRegion.yIndex !== undefined &&
-                  selectedRegion.zIndex !== undefined
-                    ? {
-                        xIndex: selectedRegion.xIndex,
-                        yIndex: selectedRegion.yIndex,
-                        zIndex: selectedRegion.zIndex,
+          <ExploreInspector
+            sections={{
+              explain: (
+                <>
+                  <ResultExplanationPanel
+                    result={result}
+                    tradeCumulus={updraftLensEligible}
+                    isNoCloudWithUpdraft={isNoCloudWithUpdraft}
+                    updraftLensActive={updraftLensActive}
+                    updraftLensFrame={updraftLensFrame}
+                  />
+                  {updraftLensActive && updraftLensFrame && (
+                    <section className="integrated-lens-legend" aria-label="Updraft Lens context">
+                      <p>
+                        The Updraft Lens relates rising and sinking air to the visible cloud
+                        boundary.
+                      </p>
+                      <UpdraftLensScaleLegend
+                        frame={updraftLensFrame}
+                        viewLabel="Explore workspace"
+                      />
+                      <dl className="metric-grid compact-metric-grid">
+                        <Metric label="Plane" value={activeSliceLabel} />
+                        <Metric
+                          label="Cloud boundary"
+                          value={showUpdraftLensBoundary ? "Visible" : "Hidden"}
+                        />
+                        <Metric
+                          label="Horizontal wind"
+                          value={
+                            showUpdraftLensWind ? windModeLabel(updraftLensWindMode) : "Hidden"
+                          }
+                        />
+                        <Metric
+                          label="Wind reference"
+                          value={`${updraftLensFrame.wind_reference_m_s.toFixed(1)} m/s at ${Math.round(
+                            updraftLensFrame.wind_actual_level_m,
+                          )} m`}
+                        />
+                      </dl>
+                    </section>
+                  )}
+                </>
+              ),
+              science: (
+                <>
+                  <ExploreSciencePanel
+                    result={result}
+                    tradeCumulus={updraftLensEligible}
+                    pointCloud={pointCloud}
+                    updraftLensFrame={updraftLensFrame}
+                    selectedTimeLabel={selectedTimeLabel}
+                  />
+                  <details className="technical-details">
+                    <summary>Process evidence</summary>
+                    <ProcessModeControl
+                      processMode={activeProcessMode}
+                      processModeStates={primaryProcessModes}
+                      activeProcessModeState={activeProcessModeState}
+                      unavailableProcessModes={unavailableProcessModes}
+                      onProcessModeChange={setProcessMode}
+                    />
+                    <ProcessOverlayPanel
+                      result={result}
+                      catalog={catalog}
+                      selectedField={sliceField}
+                      processMode={activeProcessMode}
+                      slice={
+                        activeSlicePlane === "horizontal"
+                          ? sceneHorizontalSlice
+                          : sceneVerticalSlice
                       }
-                    : null
-                }
-                onSelectPoint={selectPointFromUpdraftLens}
-              />
-            ) : (
-              !updraftLensError && <p role="status">Loading Updraft Lens frame...</p>
-            )
-          ) : (
-            <SlicePanel
-              title={activeSliceLabel}
-              slice={activeSlice}
-              pointCloud={pointCloud}
-              cloudBoundarySlice={activeCloudBoundarySlice}
-              selectedRegion={selectedRegion}
-              onSelectRegion={selectPointFromSlice}
-            />
-          )}
+                    />
+                  </details>
+                  <SelectedRegionInspector
+                    selectedRegion={selectedRegion}
+                    slice={updraftLensActive ? null : activeSlice}
+                    selectedValue={selectedSliceValue}
+                    diagnostics={regionDiagnostics}
+                    status={regionStatus}
+                    error={regionError}
+                    playbackRunning={isPlaybackRunning}
+                  />
+                </>
+              ),
+              notes: <SimulationNotesPanel result={result} />,
+              details: (
+                <>
+                  <SimulationDetailsPanel
+                    result={result}
+                    simulationRecord={simulationRecord}
+                    assetPath={assetPath}
+                    selectedField={selectedField}
+                    sliceField={sliceField}
+                    selectedTimeLabel={selectedTimeLabel}
+                    activeSliceLabel={activeSliceLabel}
+                  />
+                  <details className="technical-details">
+                    <summary>Technical visualization details</summary>
+                    <dl className="metric-grid">
+                      <Metric label="Run ID" value={result.run_id} />
+                      <Metric label="Renderer" value="Direct Three.js point cloud" />
+                      <Metric
+                        label="3-D field"
+                        value={
+                          selectedField
+                            ? `${selectedField.raw_field_name} (${selectedField.display_name})`
+                            : "Unavailable"
+                        }
+                      />
+                      <Metric label="3-D scene time" value={sceneTimeLabel} />
+                      <Metric label="Slice/evidence time" value={selectedTimeLabel} />
+                      <Metric label="Slice plane" value={activeSliceLabel} />
+                      <Metric label="Slice plane visible" value={showSlicePlanes ? "Yes" : "No"} />
+                      <Metric
+                        label={selectedEncoding?.thresholdLabel ?? "Visible threshold"}
+                        value={formatScientific(threshold, selectedField?.units ?? "")}
+                      />
+                      <Metric label="Opacity" value={String(opacity)} />
+                      <Metric label="Point size" value={`${pointSize}px`} />
+                      <Metric
+                        label="Point count"
+                        value={
+                          pointCloud
+                            ? `${pointCloud.stats.returned_count.toLocaleString()} of ${pointCloud.stats.source_count.toLocaleString()}`
+                            : "Unavailable"
+                        }
+                      />
+                      <Metric
+                        label={selectedEncoding?.rangeLabel ?? "3-D field range"}
+                        value={
+                          pointCloud
+                            ? `${formatMaybeNumber(pointCloud.stats.min_value, selectedField?.units ?? "kg/kg")} to ${formatMaybeNumber(
+                                pointCloud.stats.max_value,
+                                selectedField?.units ?? "kg/kg",
+                              )}`
+                            : "Unavailable"
+                        }
+                      />
+                      <Metric
+                        label="Selected-field range"
+                        value={
+                          pointCloud
+                            ? `${formatMaybeNumber(
+                                pointCloud.stats.field_min_value,
+                                selectedField?.units ?? "kg/kg",
+                              )} to ${formatMaybeNumber(
+                                pointCloud.stats.field_max_value,
+                                selectedField?.units ?? "kg/kg",
+                              )}`
+                            : "Unavailable"
+                        }
+                      />
+                      <Metric
+                        label="Downsampling"
+                        value={
+                          pointCloud?.stats.downsampled
+                            ? `Deterministic stride ${pointCloud.stats.downsample_stride}`
+                            : "Not applied"
+                        }
+                      />
+                      <Metric
+                        label="Default source"
+                        value={
+                          selectedTimeFieldDefaults?.source ??
+                          selectedDefaults?.source ??
+                          "domain center fallback"
+                        }
+                      />
+                      <Metric
+                        label="Slice source"
+                        value={
+                          sliceField
+                            ? `${sliceField.raw_field_name} (${sliceField.display_name})`
+                            : "Unavailable"
+                        }
+                      />
+                      <Metric
+                        label="Slice orientation"
+                        value={
+                          activeSlicePlane === "horizontal" && sceneHorizontalSlice
+                            ? `${sceneHorizontalSlice.selection.orientation} at ${sceneHorizontalSlice.selection.selected_dimension}[${sceneHorizontalSlice.selection.selected_index}]`
+                            : sceneVerticalSlice
+                              ? `${sceneVerticalSlice.selection.orientation} at ${sceneVerticalSlice.selection.selected_dimension}[${sceneVerticalSlice.selection.selected_index}]`
+                              : "Unavailable"
+                        }
+                      />
+                      <Metric label="Domain x extent" value={extentLabel(pointCloud, "xh")} />
+                      <Metric label="Domain y extent" value={extentLabel(pointCloud, "yh")} />
+                      <Metric label="Domain z extent" value={verticalExtentLabel(pointCloud)} />
+                      <Metric
+                        label="Active cloud z range"
+                        value={
+                          pointCloud
+                            ? `${formatMaybeNumber(pointCloud.stats.active_z_min, verticalCoordinateUnit(pointCloud))} to ${formatMaybeNumber(
+                                pointCloud.stats.active_z_max,
+                                verticalCoordinateUnit(pointCloud),
+                              )}`
+                            : "Unavailable"
+                        }
+                      />
+                      <Metric
+                        label="Max 3-D field location"
+                        value={maxPointLocationLabel(pointCloud)}
+                      />
+                      <Metric
+                        label="Selected-time slice default"
+                        value={selectedTimeSliceDefaults?.source ?? "Unavailable"}
+                      />
+                    </dl>
 
-          <SelectedRegionInspector
-            selectedRegion={selectedRegion}
-            slice={updraftLensActive ? null : activeSlice}
-            selectedValue={selectedSliceValue}
-            diagnostics={regionDiagnostics}
-            status={regionStatus}
-            error={regionError}
-            playbackRunning={isPlaybackRunning}
+                    <section aria-labelledby="visualizer-provenance-title">
+                      <h3 id="visualizer-provenance-title">Provenance / rendering labels</h3>
+                      <ul className="compact-list">
+                        <li>{provenanceLabel}</li>
+                        <li>Visualizer interpretation of CM1-derived output</li>
+                        <li>
+                          Value channel:{" "}
+                          {selectedEncoding?.valueChannel ?? "3-D scalar rendering unavailable"}
+                        </li>
+                        <li>
+                          Processing method: backend native-grid thresholded point cloud for
+                          supported scalar fields
+                        </li>
+                        <li>Rendering method: direct Three.js scalar point cloud</li>
+                        <li>Slice planes: native-grid JSON slices from the backend</li>
+                        <li>No raw NetCDF parsing in the browser</li>
+                        <li>
+                          No interpolation, ray marching, isosurface extraction, or synthetic cloud
+                          physics
+                        </li>
+                      </ul>
+                    </section>
+                  </details>
+                </>
+              ),
+            }}
           />
-        </section>
-      )}
-    </section>
+        </div>
+
+        {catalog && sliceField && (
+          <section className="unified-slice-inspector" aria-labelledby="unified-slice-title">
+            <div className="section-heading compact-heading">
+              <div>
+                <p className="eyebrow">Field Slice</p>
+                <h2 id="unified-slice-title">
+                  {updraftLensActive ? "Updraft Lens" : "Field Slice"}
+                </h2>
+                <p>
+                  {activeSliceLabel} · {updraftLensActive ? "w" : sliceField.raw_field_name} ·{" "}
+                  {selectedTimeLabel}
+                </p>
+              </div>
+              <p className="state-chip">
+                {updraftLensActive
+                  ? updraftLensError
+                    ? "Lens unavailable"
+                    : updraftLensLoading || !updraftLensFrame
+                      ? "Loading Lens"
+                      : "Lens synced"
+                  : sliceError
+                    ? "Slice unavailable"
+                    : sliceLoading || !activeSlice
+                      ? "Loading slice"
+                      : "Slice synced"}
+              </p>
+            </div>
+
+            {(updraftLensActive ? updraftLensError : sliceError) && (
+              <div className="layer-local-error layer-local-error-slice" role="alert">
+                <strong>
+                  {updraftLensActive ? "Updraft Lens slice unavailable" : "Field Slice unavailable"}
+                </strong>
+                <span>{updraftLensActive ? updraftLensError : sliceError}</span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (updraftLensActive) {
+                      setUpdraftLensLoadAttempt((current) => current + 1);
+                    } else {
+                      setSliceLoadAttempt((current) => current + 1);
+                    }
+                  }}
+                >
+                  {updraftLensActive ? "Retry Lens slice" : "Retry Field Slice"}
+                </button>
+              </div>
+            )}
+
+            {updraftLensActive ? (
+              updraftLensFrame ? (
+                <UpdraftLensSlice
+                  frame={updraftLensFrame}
+                  showCloudBoundary={showUpdraftLensBoundary}
+                  showLegend={false}
+                  selectedPoint={
+                    selectedRegion?.xIndex !== undefined &&
+                    selectedRegion.yIndex !== undefined &&
+                    selectedRegion.zIndex !== undefined
+                      ? {
+                          xIndex: selectedRegion.xIndex,
+                          yIndex: selectedRegion.yIndex,
+                          zIndex: selectedRegion.zIndex,
+                        }
+                      : null
+                  }
+                  onSelectPoint={selectPointFromUpdraftLens}
+                />
+              ) : (
+                !updraftLensError && <p role="status">Loading Updraft Lens frame...</p>
+              )
+            ) : (
+              <SlicePanel
+                title={activeSliceLabel}
+                slice={activeSlice}
+                pointCloud={pointCloud}
+                cloudBoundarySlice={activeCloudBoundarySlice}
+                selectedRegion={selectedRegion}
+                onSelectRegion={selectPointFromSlice}
+              />
+            )}
+          </section>
+        )}
+      </section>
+    </IntegratedExploreWorkspace>
   );
 }
 
 function ResultExplanationPanel({
   result,
+  tradeCumulus,
   isNoCloudWithUpdraft,
+  updraftLensActive,
+  updraftLensFrame,
 }: {
   result: ResultCard;
+  tradeCumulus: boolean;
   isNoCloudWithUpdraft: boolean;
+  updraftLensActive: boolean;
+  updraftLensFrame: UpdraftLensFrame | null;
 }) {
-  const cloudLabel = cloudOutcome(result);
+  const cloudLabel = tradeCumulus
+    ? fieldQualityBlocksEvidence(result, "qc")
+      ? "Cloud unavailable"
+      : resultFirstCloudTime(result) !== null || (resultMaxQc(result) ?? 0) > 0
+        ? "Cloud formed"
+        : "No cloud formed"
+    : cloudOutcome(result);
+  const explanation = tradeCumulus
+    ? `Cloud water first appeared at ${formatSeconds(resultFirstCloudTime(result))}. The Simulation reached ${formatNumber(
+        resultMaxUpdraft(result),
+        "m/s",
+      )} maximum upward motion and ${formatNumber(
+        resultMinDowndraft(result),
+        "m/s",
+      )} minimum vertical motion.${
+        updraftLensActive && updraftLensFrame
+          ? ` The active Lens shows ${formatNumber(updraftLensFrame.w_range_min_m_s, "m/s")} to ${formatNumber(
+              updraftLensFrame.w_range_max_m_s,
+              "m/s",
+            )} on the selected plane.`
+          : " Activate the Updraft Lens to relate that motion to the cloud boundary."
+      }`
+    : resultStory(result);
   return (
     <section className="selected-region-inspector" aria-label="Result-level explanation panel">
       <div className="section-heading compact-heading">
         <div>
           <p className="eyebrow">Explanation</p>
-          <h3>Result explanation</h3>
+          <h3>What happened in this result?</h3>
         </div>
         <StatusBadge
           label={
@@ -11334,16 +11521,25 @@ function ResultExplanationPanel({
           tone={cloudLabel === "Cloud formed" ? "good" : "warning"}
         />
       </div>
-      <p>{resultStory(result)}</p>
+      <p>{explanation}</p>
       <section aria-label="Evidence">
         <h4>Evidence</h4>
         <dl className="metric-grid">
-          <Metric label="First cloud time" value={formatSeconds(result.first_cloud_time_seconds)} />
-          <Metric label="Max qc" value={formatScientific(result.max_qc_kg_kg, "kg/kg")} />
-          <Metric label="Max w" value={formatNumber(result.max_w_m_s, "m/s")} />
-          <Metric label="Rain water aloft" value={rainWaterOutcome(result)} />
-          <Metric label="Surface rain" value={surfaceRainOutcome(result)} />
-          <Metric label="Reflectivity" value={reflectivityOutcome(result)} />
+          <Metric label="First cloud" value={formatSeconds(resultFirstCloudTime(result))} />
+          <Metric label="Max cloud water" value={formatScientific(resultMaxQc(result), "kg/kg")} />
+          <Metric
+            label="Max vertical velocity"
+            value={formatNumber(resultMaxUpdraft(result), "m/s")}
+          />
+          <Metric
+            label="Min vertical velocity"
+            value={formatNumber(resultMinDowndraft(result), "m/s")}
+          />
+          <Metric
+            label="Coherent cloud top"
+            value={formatNumber(resultCloudTopMeters(result), "m")}
+          />
+          <Metric label="Latest output" value={formatSeconds(resultLatestOutputTime(result))} />
         </dl>
       </section>
       {isNoCloudWithUpdraft && (
@@ -11362,6 +11558,204 @@ function ResultExplanationPanel({
       </details>
     </section>
   );
+}
+
+function ExploreSciencePanel({
+  result,
+  tradeCumulus,
+  pointCloud,
+  updraftLensFrame,
+  selectedTimeLabel,
+}: {
+  result: ResultCard;
+  tradeCumulus: boolean;
+  pointCloud: PointCloudResponse | null;
+  updraftLensFrame: UpdraftLensFrame | null;
+  selectedTimeLabel: string;
+}) {
+  return (
+    <section aria-labelledby="explore-science-title">
+      <h3 id="explore-science-title">Science at this time</h3>
+      <dl className="metric-grid compact-metric-grid">
+        <Metric label="Model time" value={selectedTimeLabel} />
+        <Metric label="Max cloud water" value={formatScientific(resultMaxQc(result), "kg/kg")} />
+        <Metric
+          label="Coherent cloud top"
+          value={formatNumber(resultCloudTopMeters(result), "m")}
+        />
+        <Metric
+          label="Max vertical velocity"
+          value={formatNumber(resultMaxUpdraft(result), "m/s")}
+        />
+        <Metric
+          label="Min vertical velocity"
+          value={formatNumber(resultMinDowndraft(result), "m/s")}
+        />
+        <Metric
+          label="Visible 3-D points"
+          value={pointCloud ? pointCloud.stats.returned_count.toLocaleString() : "Unavailable"}
+        />
+        <Metric
+          label="Current 3-D field range"
+          value={
+            pointCloud
+              ? `${formatMaybeNumber(pointCloud.stats.field_min_value, pointCloud.field.units ?? "")} to ${formatMaybeNumber(
+                  pointCloud.stats.field_max_value,
+                  pointCloud.field.units ?? "",
+                )}`
+              : "Unavailable"
+          }
+        />
+        <Metric
+          label="Current Lens range"
+          value={
+            updraftLensFrame
+              ? `${formatNumber(updraftLensFrame.w_range_min_m_s, "m/s")} to ${formatNumber(
+                  updraftLensFrame.w_range_max_m_s,
+                  "m/s",
+                )}`
+              : "Lens inactive"
+          }
+        />
+        {!tradeCumulus && (
+          <>
+            <Metric label="Rain water aloft" value={rainWaterOutcome(result)} />
+            <Metric label="Reflectivity" value={reflectivityOutcome(result)} />
+          </>
+        )}
+      </dl>
+    </section>
+  );
+}
+
+function SimulationNotesPanel({ result }: { result: ResultCard }) {
+  return (
+    <section aria-labelledby="simulation-notes-title">
+      <h3 id="simulation-notes-title">Simulation notes</h3>
+      <p>{result.notes?.trim() || "No note recorded for this Simulation."}</p>
+    </section>
+  );
+}
+
+function SimulationDetailsPanel({
+  result,
+  simulationRecord,
+  assetPath,
+  selectedField,
+  sliceField,
+  selectedTimeLabel,
+  activeSliceLabel,
+}: {
+  result: ResultCard;
+  simulationRecord: SimulationRecord | null;
+  assetPath: string | null;
+  selectedField: VisualizableField | undefined;
+  sliceField: VisualizableField | undefined;
+  selectedTimeLabel: string;
+  activeSliceLabel: string;
+}) {
+  const differences = simulationRecord?.configuration_difference_from_reference ?? [];
+  const controls = Object.entries(result.controls).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  return (
+    <section aria-labelledby="simulation-details-title">
+      <h3 id="simulation-details-title">Simulation details</h3>
+      <dl className="metric-grid compact-metric-grid">
+        <Metric label="Result ID" value={result.result_id} />
+        <Metric label="Run ID" value={result.run_id} />
+        <Metric label="Model" value={result.source_model} />
+        <Metric label="Model time" value={selectedTimeLabel} />
+        <Metric
+          label="3-D field"
+          value={
+            selectedField
+              ? `${selectedField.display_name} (${selectedField.units ?? "unitless"})`
+              : "Unavailable"
+          }
+        />
+        <Metric
+          label="Slice field"
+          value={
+            sliceField
+              ? `${sliceField.display_name} (${sliceField.units ?? "unitless"})`
+              : "Unavailable"
+          }
+        />
+        <Metric label="Slice plane" value={activeSliceLabel} />
+        <Metric
+          label="Recipe"
+          value={
+            result.recipe_display_name ??
+            result.run_recipe_display_name ??
+            result.run_recipe ??
+            "Unavailable"
+          }
+        />
+        <Metric
+          label="Runtime integrity"
+          value={humanize(result.runtime_integrity?.state ?? "not_assessed")}
+        />
+        <Metric label="Output inventory" value={outputSummary(result.output_file_summary)} />
+        <Metric label="Local asset path" value={assetPath ?? "Unavailable"} />
+        <Metric
+          label="Lineage"
+          value={simulationRecord ? humanize(simulationRecord.lineage_state) : "Unavailable"}
+        />
+        <Metric label="Rain water aloft" value={rainWaterOutcome(result)} />
+        <Metric label="Surface rain" value={surfaceRainOutcome(result)} />
+        <Metric label="Reflectivity" value={reflectivityOutcome(result)} />
+      </dl>
+      {controls.length > 0 && (
+        <details>
+          <summary>Configured controls</summary>
+          <dl className="metric-grid compact-metric-grid">
+            {controls.map(([key, value]) => (
+              <Metric key={key} label={humanize(key)} value={formatDetailValue(value)} />
+            ))}
+          </dl>
+        </details>
+      )}
+      {result.run_configuration?.cm1_values && (
+        <details>
+          <summary>Resolved CM1 configuration</summary>
+          <pre className="inspector-code-block">
+            {JSON.stringify(result.run_configuration.cm1_values, null, 2)}
+          </pre>
+        </details>
+      )}
+      {differences.length > 0 && (
+        <details>
+          <summary>Differences from reference</summary>
+          <dl className="metric-grid compact-metric-grid">
+            {differences.map((difference) => (
+              <Metric
+                key={difference.path}
+                label={difference.label}
+                value={`${formatDetailValue(difference.left_value)} to ${formatDetailValue(
+                  difference.right_value,
+                )}${difference.units ? ` ${difference.units}` : ""}`}
+              />
+            ))}
+          </dl>
+        </details>
+      )}
+      <RuntimeIntegritySummary runtimeIntegrity={result.runtime_integrity ?? null} />
+      <FieldQualitySummary result={result} />
+    </section>
+  );
+}
+
+function formatDetailValue(value: unknown): string {
+  if (value === null || value === undefined || value === "") return "Unavailable";
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+function windModeLabel(mode: UpdraftLensWindMode): string {
+  return mode === "perturbation" ? "Local departures" : "Total wind";
 }
 
 function activeSlicePosition(
@@ -11514,12 +11908,18 @@ function SlicePanel({
   }
 
   const anchors = sliceAnchorLabels(slice, pointCloud);
+  const fallbackAspect = (slice.values[0]?.length ?? 1) / Math.max(1, slice.values.length);
+  const domainAspect = slicePhysicalAspect(slice, pointCloud, fallbackAspect);
 
   return (
     <section className="slice-panel" aria-label={title}>
       <h3>{title}</h3>
       <p className="slice-axis-summary">{sliceAxisSummary(slice, slice.selection.orientation)}</p>
-      <div className="slice-map-frame" aria-label={`${title} orientation map`}>
+      <div
+        className="slice-map-frame"
+        aria-label={`${title} orientation map`}
+        style={{ "--slice-domain-aspect": String(domainAspect) } as CSSProperties}
+      >
         <span className="slice-map-anchor slice-map-anchor-top">{anchors.top}</span>
         <span className="slice-map-anchor slice-map-anchor-left">{anchors.left}</span>
         <SliceHeatmap

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1510,11 +1510,6 @@ type SceneSlicePlane = "horizontal" | "vertical_x" | "vertical_y";
 type OrdinaryExploreState = {
   selectedFieldName: string;
   sliceFieldName: string;
-  timeIndex: number;
-  activeSlicePlane: SceneSlicePlane;
-  sliceOrientation: "vertical_x" | "vertical_y";
-  horizontalSliceLevel: number;
-  verticalSliceIndex: number;
   showSlicePlanes: boolean;
   threshold: number;
 };
@@ -9816,12 +9811,14 @@ export function VisualizerSceneShell({
   const [updraftLensFrame, setUpdraftLensFrame] = useState<UpdraftLensFrame | null>(null);
   const [updraftLensLoading, setUpdraftLensLoading] = useState(false);
   const [updraftLensError, setUpdraftLensError] = useState<string | null>(null);
+  const [updraftLensOpacity, setUpdraftLensOpacity] = useState(0.9);
   const [showUpdraftLensBoundary, setShowUpdraftLensBoundary] = useState(true);
   const [showUpdraftLensWind, setShowUpdraftLensWind] = useState(true);
   const [updraftLensWindMode, setUpdraftLensWindMode] =
     useState<UpdraftLensWindMode>("perturbation");
   const ordinaryExploreStateRef = useRef<OrdinaryExploreState | null>(null);
   const updraftLensRequestRef = useRef(0);
+  const autoActivatedUpdraftLensResultRef = useRef<string | null>(null);
   const maxPoints = 50_000;
 
   useEffect(() => {
@@ -9863,10 +9860,12 @@ export function VisualizerSceneShell({
     setUpdraftLensFrame(null);
     setUpdraftLensLoading(false);
     setUpdraftLensError(null);
+    setUpdraftLensOpacity(0.9);
     setShowUpdraftLensBoundary(true);
     setShowUpdraftLensWind(true);
     setUpdraftLensWindMode("perturbation");
     ordinaryExploreStateRef.current = null;
+    autoActivatedUpdraftLensResultRef.current = null;
     updraftLensRequestRef.current += 1;
     setSceneStatus("Loading scene data...");
     withTimeout(
@@ -10106,81 +10105,99 @@ export function VisualizerSceneShell({
     timeOptions.length,
   ]);
 
-  const handleUpdraftLensToggle = useCallback(() => {
-    if (updraftLensActive) {
-      const ordinary = ordinaryExploreStateRef.current;
-      setUpdraftLensActive(false);
-      setUpdraftLensFrame(null);
-      setUpdraftLensLoading(false);
-      setUpdraftLensError(null);
-      updraftLensRequestRef.current += 1;
-      if (ordinary) {
-        setSelectedFieldName(ordinary.selectedFieldName);
-        setSliceFieldName(ordinary.sliceFieldName);
-        setTimeIndex(ordinary.timeIndex);
-        setPlaybackTimeIndex(ordinary.timeIndex);
-        setActiveSlicePlane(ordinary.activeSlicePlane);
-        setSliceOrientation(ordinary.sliceOrientation);
-        setHorizontalSliceLevel(ordinary.horizontalSliceLevel);
-        setVerticalSliceIndex(ordinary.verticalSliceIndex);
-        setShowSlicePlanes(ordinary.showSlicePlanes);
-        setThreshold(ordinary.threshold);
+  const handleUpdraftLensToggle = useCallback(
+    (useCandidateDefaults = false) => {
+      if (updraftLensActive) {
+        const ordinary = ordinaryExploreStateRef.current;
+        setUpdraftLensActive(false);
+        setUpdraftLensFrame(null);
+        setUpdraftLensLoading(false);
+        setUpdraftLensError(null);
+        updraftLensRequestRef.current += 1;
+        if (ordinary) {
+          setSelectedFieldName(ordinary.selectedFieldName);
+          setSliceFieldName(ordinary.sliceFieldName);
+          setShowSlicePlanes(ordinary.showSlicePlanes);
+          setThreshold(ordinary.threshold);
+        }
+        ordinaryExploreStateRef.current = null;
+        clearSelectedRegionForTimeChange();
+        return;
       }
-      ordinaryExploreStateRef.current = null;
+      if (
+        !updraftLensDefaults ||
+        !catalog ||
+        updraftLensDefaults.result_id !== resultId ||
+        catalog.result_id !== resultId
+      ) {
+        return;
+      }
+      ordinaryExploreStateRef.current = {
+        selectedFieldName,
+        sliceFieldName,
+        showSlicePlanes,
+        threshold,
+      };
+      const cloudField = catalog.available_fields.find(
+        (field) => field.raw_field_name === updraftLensDefaults.cloud_field,
+      );
+      const primaryField = catalog.available_fields.find(
+        (field) => field.raw_field_name === updraftLensDefaults.primary_field,
+      );
+      setSelectedFieldName(cloudField?.raw_field_name ?? selectedFieldName);
+      setSliceFieldName(primaryField?.raw_field_name ?? sliceFieldName);
+      setIsPlaybackRunning(false);
+      if (useCandidateDefaults) {
+        const primaryDefaults = defaultsForField(viewDefaults, primaryField?.raw_field_name ?? "");
+        setTimeIndex(updraftLensDefaults.default_time_index);
+        setPlaybackTimeIndex(updraftLensDefaults.default_time_index);
+        setActiveSlicePlane("vertical_x");
+        setSliceOrientation("vertical_x");
+        setHorizontalSliceLevel(defaultHorizontalLevel(primaryField, primaryDefaults));
+        setVerticalSliceIndex(updraftLensDefaults.default_plane_index);
+      }
+      setShowSlicePlanes(true);
+      setThreshold(updraftLensDefaults.cloud_threshold_kg_kg);
+      setShowUpdraftLensBoundary(true);
+      setShowUpdraftLensWind(updraftLensDefaults.wind_shown_by_default);
+      setUpdraftLensWindMode(updraftLensDefaults.wind_default_mode);
+      setUpdraftLensError(null);
+      setUpdraftLensActive(true);
       clearSelectedRegionForTimeChange();
+    },
+    [
+      catalog,
+      clearSelectedRegionForTimeChange,
+      resultId,
+      selectedFieldName,
+      showSlicePlanes,
+      sliceFieldName,
+      threshold,
+      updraftLensActive,
+      updraftLensDefaults,
+      viewDefaults,
+    ],
+  );
+
+  useEffect(() => {
+    if (
+      !updraftLensEligible ||
+      updraftLensActive ||
+      !updraftLensDefaults ||
+      !catalog ||
+      autoActivatedUpdraftLensResultRef.current === resultId
+    ) {
       return;
     }
-    if (!updraftLensDefaults || !catalog) return;
-    ordinaryExploreStateRef.current = {
-      selectedFieldName,
-      sliceFieldName,
-      timeIndex: resolvedTimeIndex,
-      activeSlicePlane,
-      sliceOrientation,
-      horizontalSliceLevel,
-      verticalSliceIndex,
-      showSlicePlanes,
-      threshold,
-    };
-    const cloudField = catalog.available_fields.find(
-      (field) => field.raw_field_name === updraftLensDefaults.cloud_field,
-    );
-    const primaryField = catalog.available_fields.find(
-      (field) => field.raw_field_name === updraftLensDefaults.primary_field,
-    );
-    const primaryDefaults = defaultsForField(viewDefaults, primaryField?.raw_field_name ?? "");
-    setSelectedFieldName(cloudField?.raw_field_name ?? selectedFieldName);
-    setSliceFieldName(primaryField?.raw_field_name ?? sliceFieldName);
-    setTimeIndex(updraftLensDefaults.default_time_index);
-    setPlaybackTimeIndex(updraftLensDefaults.default_time_index);
-    setIsPlaybackRunning(false);
-    setActiveSlicePlane("vertical_x");
-    setSliceOrientation("vertical_x");
-    setHorizontalSliceLevel(defaultHorizontalLevel(primaryField, primaryDefaults));
-    setVerticalSliceIndex(updraftLensDefaults.default_plane_index);
-    setShowSlicePlanes(true);
-    setThreshold(updraftLensDefaults.cloud_threshold_kg_kg);
-    setShowUpdraftLensBoundary(true);
-    setShowUpdraftLensWind(updraftLensDefaults.wind_shown_by_default);
-    setUpdraftLensWindMode(updraftLensDefaults.wind_default_mode);
-    setUpdraftLensError(null);
-    setUpdraftLensActive(true);
-    clearSelectedRegionForTimeChange();
+    autoActivatedUpdraftLensResultRef.current = resultId;
+    handleUpdraftLensToggle(true);
   }, [
-    activeSlicePlane,
     catalog,
-    clearSelectedRegionForTimeChange,
-    horizontalSliceLevel,
-    resolvedTimeIndex,
-    selectedFieldName,
-    showSlicePlanes,
-    sliceFieldName,
-    sliceOrientation,
-    threshold,
+    handleUpdraftLensToggle,
+    resultId,
     updraftLensActive,
     updraftLensDefaults,
-    verticalSliceIndex,
-    viewDefaults,
+    updraftLensEligible,
   ]);
 
   useEffect(() => {
@@ -10482,9 +10499,8 @@ export function VisualizerSceneShell({
 
   function handleThreeDFieldChange(nextFieldName: string) {
     const nextEncoding =
-      threeDScalarEncodings.find(
-        (encoding) => encoding.field.raw_field_name === nextFieldName,
-      ) ?? null;
+      threeDScalarEncodings.find((encoding) => encoding.field.raw_field_name === nextFieldName) ??
+      null;
     setSelectedFieldName(nextFieldName);
     if (nextEncoding) {
       setThreshold(nextEncoding.defaultThreshold);
@@ -10595,6 +10611,8 @@ export function VisualizerSceneShell({
               windReferenceMps={updraftLensFrame?.wind_reference_m_s ?? 0}
               windArrowDomainFraction={updraftLensFrame?.wind_arrow_domain_fraction ?? 0.08}
               updraftLensFrame={updraftLensActive ? updraftLensFrame : null}
+              updraftLensOpacity={updraftLensOpacity}
+              showUpdraftLensBoundary={updraftLensActive && showUpdraftLensBoundary}
               showUpdraftLensLegend={false}
               compactWorkspace
               maximized={focusedViewer === "scene"}
@@ -10612,10 +10630,12 @@ export function VisualizerSceneShell({
                   threshold={threshold}
                   opacity={opacity}
                   pointSize={pointSize}
+                  lensOpacity={updraftLensActive ? updraftLensOpacity : undefined}
                   onFieldChange={handleThreeDFieldChange}
                   onThresholdChange={setThreshold}
                   onOpacityChange={setOpacity}
                   onPointSizeChange={setPointSize}
+                  onLensOpacityChange={setUpdraftLensOpacity}
                 />
               }
             />
@@ -10651,14 +10671,31 @@ export function VisualizerSceneShell({
                   <div className="timelapse-controls" aria-label="Timelapse playback controls">
                     <button
                       type="button"
+                      className="timelapse-toggle"
                       disabled={!canPlayTimelapse}
                       aria-pressed={isPlaybackRunning}
+                      aria-label={isPlaybackRunning ? "Pause" : "Play"}
+                      title={isPlaybackRunning ? "Pause" : "Play"}
                       onClick={handlePlaybackToggle}
                     >
-                      {isPlaybackRunning ? "Pause time" : "Play time"}
+                      <span
+                        className={`timelapse-icon timelapse-icon-${
+                          isPlaybackRunning ? "pause" : "play"
+                        }`}
+                        aria-hidden="true"
+                      >
+                        {isPlaybackRunning ? (
+                          <>
+                            <span />
+                            <span />
+                          </>
+                        ) : (
+                          <span />
+                        )}
+                      </span>
                     </button>
                     <label htmlFor="explore-playback-speed">
-                      Speed
+                      <span className="sr-only">Playback speed</span>
                       <select
                         id="explore-playback-speed"
                         aria-label="Playback speed"
@@ -11038,14 +11075,13 @@ export function VisualizerSceneShell({
                     </label>
                   </fieldset>
                 )}
-
               </section>
             )}
           </div>
 
           <ExploreInspector
             sections={{
-              explain: (
+              explain:
                 selectedRegion || regionError || isPlaybackRunning ? (
                   <SelectedRegionInspector
                     selectedRegion={selectedRegion}
@@ -11066,11 +11102,8 @@ export function VisualizerSceneShell({
                     selectedTimeLabel={selectedTimeLabel}
                     activeSliceLabel={activeSliceLabel}
                   />
-                )
-              ),
-              notes: (
-                <SimulationNotesPanel result={result} onResultUpdated={onResultUpdated} />
-              ),
+                ),
+              notes: <SimulationNotesPanel result={result} onResultUpdated={onResultUpdated} />,
               details: (
                 <>
                   <SimulationDetailsPanel
@@ -11195,7 +11228,6 @@ export function VisualizerSceneShell({
                         value={selectedTimeSliceDefaults?.source ?? "Unavailable"}
                       />
                     </dl>
-
                   </details>
                 </>
               ),
@@ -11219,16 +11251,6 @@ export function VisualizerSceneShell({
                   <div className="instrument-view-toggle" aria-label="Explore view mode">
                     <button
                       type="button"
-                      className={!updraftLensActive ? "active-control" : ""}
-                      aria-pressed={!updraftLensActive}
-                      onClick={() => {
-                        if (updraftLensActive) handleUpdraftLensToggle();
-                      }}
-                    >
-                      Field
-                    </button>
-                    <button
-                      type="button"
                       className={updraftLensActive ? "active-control" : ""}
                       aria-pressed={updraftLensActive}
                       disabled={!updraftLensActive && !updraftLensDefaults}
@@ -11237,6 +11259,16 @@ export function VisualizerSceneShell({
                       }}
                     >
                       Updraft Lens
+                    </button>
+                    <button
+                      type="button"
+                      className={!updraftLensActive ? "active-control" : ""}
+                      aria-pressed={!updraftLensActive}
+                      onClick={() => {
+                        if (updraftLensActive) handleUpdraftLensToggle();
+                      }}
+                    >
+                      Field
                     </button>
                   </div>
                 )}
@@ -11294,7 +11326,11 @@ export function VisualizerSceneShell({
 
             {updraftLensActive ? (
               updraftLensFrame ? (
-                <div className="updraft-lens-instrument-body">
+                <div
+                  className={`updraft-lens-instrument-body${
+                    focusedViewer === "slice" ? "" : " updraft-lens-instrument-body-compact"
+                  }`}
+                >
                   <UpdraftLensSlice
                     frame={updraftLensFrame}
                     showCloudBoundary={showUpdraftLensBoundary}
@@ -11315,6 +11351,7 @@ export function VisualizerSceneShell({
                   <UpdraftLensScaleLegend
                     frame={updraftLensFrame}
                     viewLabel="Explore workspace"
+                    compact={focusedViewer !== "slice"}
                   />
                 </div>
               ) : (
@@ -11347,10 +11384,12 @@ function ExploreRenderingControls({
   threshold,
   opacity,
   pointSize,
+  lensOpacity,
   onFieldChange,
   onThresholdChange,
   onOpacityChange,
   onPointSizeChange,
+  onLensOpacityChange,
 }: {
   compact?: boolean;
   encodings: ThreeDScalarEncoding[];
@@ -11361,10 +11400,12 @@ function ExploreRenderingControls({
   threshold: number;
   opacity: number;
   pointSize: number;
+  lensOpacity?: number;
   onFieldChange: (fieldName: string) => void;
   onThresholdChange: (value: number) => void;
   onOpacityChange: (value: number) => void;
   onPointSizeChange: (value: number) => void;
+  onLensOpacityChange?: (value: number) => void;
 }) {
   const thresholdScale = scalarDisplayScale(selectedEncoding?.field);
   const thresholdUnits = scalarDisplayUnits(selectedEncoding?.field);
@@ -11408,7 +11449,7 @@ function ExploreRenderingControls({
       </label>
       <div className="rendering-range-controls">
         <label htmlFor="cloud-opacity">
-          Opacity
+          Cloud opacity
           <input
             id="cloud-opacity"
             aria-label="Layer opacity"
@@ -11421,6 +11462,22 @@ function ExploreRenderingControls({
           />
           <output htmlFor="cloud-opacity">{opacity}</output>
         </label>
+        {lensOpacity !== undefined && onLensOpacityChange && (
+          <label className="lens-opacity-control" htmlFor="updraft-lens-opacity">
+            Lens opacity
+            <input
+              id="updraft-lens-opacity"
+              aria-label="Lens opacity"
+              type="range"
+              min={0.15}
+              max={1}
+              step={0.05}
+              value={lensOpacity}
+              onChange={(event) => onLensOpacityChange(Number(event.target.value))}
+            />
+            <output htmlFor="updraft-lens-opacity">{lensOpacity}</output>
+          </label>
+        )}
         <label htmlFor="cloud-point-size">
           Point size
           <input
@@ -11508,10 +11565,7 @@ function ResultExplanationPanel({
         <dl className="context-metrics">
           <Metric label="Model time" value={selectedTimeLabel} />
           <Metric label="First cloud" value={formatSeconds(resultFirstCloudTime(result))} />
-          <Metric
-            label="Cloud water max"
-            value={formatMixingRatio(resultMaxQc(result))}
-          />
+          <Metric label="Cloud water max" value={formatMixingRatio(resultMaxQc(result))} />
           <Metric
             label="Vertical velocity"
             value={`${formatNumber(resultMinDowndraft(result), "m/s")} to ${formatNumber(
@@ -11872,6 +11926,7 @@ function SlicePanel({
       <div
         className="slice-map-frame"
         aria-label={`${title} orientation map`}
+        data-orientation={slice.selection.orientation}
         style={{ "--slice-domain-aspect": String(domainAspect) } as CSSProperties}
       >
         <span className="slice-map-anchor slice-map-anchor-top">{anchors.top}</span>

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1505,16 +1505,6 @@ type ViewDefaultsResponse = {
   caveats: string[];
 };
 
-type ProcessMode =
-  | "thermal_fate"
-  | "cloud_water"
-  | "updrafts"
-  | "moisture"
-  | "buoyancy"
-  | "cap"
-  | "cloud_lifecycle"
-  | "deep_breakthrough"
-  | "precipitation_feedback";
 type SceneSlicePlane = "horizontal" | "vertical_x" | "vertical_y";
 
 type OrdinaryExploreState = {
@@ -4174,6 +4164,7 @@ export function App() {
     <ExploreWorkspace
       selectedResult={selectedResult}
       comparisonStory={comparisonStoryActive ? comparisonStory : null}
+      onResultUpdated={updateResultInList}
       onBackToResults={() => {
         setComparisonStoryActive(false);
         setActiveSection("results");
@@ -4223,7 +4214,7 @@ export function App() {
   );
 
   return (
-    <main className="app-shell">
+    <main className={`app-shell${productLocation === "explore" ? " app-shell-explore" : ""}`}>
       <header className="topbar">
         <div className="brand-mark">
           <h1>Cloud Chamber</h1>
@@ -4234,7 +4225,7 @@ export function App() {
             className="secondary-button"
             onClick={() => setProductLocation("worlds")}
           >
-            Cloud Worlds
+            Home
           </button>
         )}
       </header>
@@ -4295,6 +4286,7 @@ export function App() {
             <ExploreWorkspace
               selectedResult={selectedResult}
               comparisonStory={productLocation === "comparison" ? comparisonStory : null}
+              onResultUpdated={updateResultInList}
               onBackToResults={returnToTradeCumulus}
               onOpenResult={(resultId) => {
                 selectOrdinaryResult(resultId);
@@ -7462,6 +7454,7 @@ function NotebookWorkspace({
 function ExploreWorkspace({
   selectedResult,
   comparisonStory,
+  onResultUpdated,
   onOpenResult,
   onBackToResults,
   worldName,
@@ -7474,6 +7467,7 @@ function ExploreWorkspace({
 }: {
   selectedResult: ResultCard | undefined;
   comparisonStory: TradeCumulusComparisonStoryResponse | null;
+  onResultUpdated: (result: ResultCard) => void;
   onOpenResult: (resultId: string) => void;
   onBackToResults: () => void;
   worldName?: string;
@@ -7511,6 +7505,7 @@ function ExploreWorkspace({
             backLabel={backLabel}
             onBack={onBack}
             onCompare={onCompare}
+            onResultUpdated={onResultUpdated}
           />
         </section>
       )}
@@ -9753,6 +9748,7 @@ export function VisualizerSceneShell({
   backLabel,
   onBack,
   onCompare,
+  onResultUpdated,
 }: {
   result: ResultCard;
   worldName?: string;
@@ -9762,6 +9758,7 @@ export function VisualizerSceneShell({
   backLabel?: string;
   onBack?: () => void;
   onCompare?: () => void;
+  onResultUpdated?: (result: ResultCard) => void;
 }) {
   const resultId = result.result_id;
   const updraftLensEligible = tradeCumulusUpdraftLensEligible(result);
@@ -9785,8 +9782,8 @@ export function VisualizerSceneShell({
   const [threshold, setThreshold] = useState(1e-6);
   const [opacity, setOpacity] = useState(0.68);
   const [pointSize, setPointSize] = useState(11);
+  const [focusedViewer, setFocusedViewer] = useState<"scene" | "slice" | null>(null);
   const [pointCloud, setPointCloud] = useState<PointCloudResponse | null>(null);
-  const [processMode, setProcessMode] = useState<ProcessMode>("thermal_fate");
   const [showSlicePlanes, setShowSlicePlanes] = useState(true);
   const [sliceFieldName, setSliceFieldName] = useState("qc");
   const [activeSlicePlane, setActiveSlicePlane] = useState<SceneSlicePlane>("horizontal");
@@ -9843,7 +9840,6 @@ export function VisualizerSceneShell({
     setOpacity(0.68);
     setPointSize(11);
     setPointCloud(null);
-    setProcessMode("thermal_fate");
     setShowSlicePlanes(true);
     setSliceFieldName("qc");
     setActiveSlicePlane("horizontal");
@@ -10032,6 +10028,8 @@ export function VisualizerSceneShell({
   const selectedTimeLabel = formatTimeValue(selectedTimeValue);
   const displayTimeValue = timeOptions[displayTimeIndex] ?? null;
   const displayTimeLabel = formatTimeValue(displayTimeValue);
+  const displayClockLabel = formatClockTime(displayTimeValue);
+  const finalClockLabel = formatClockTime(timeOptions.at(-1) ?? null);
   const sceneTimeValue = timeOptions[sceneTimeIndex] ?? null;
   const sceneTimeLabel = formatTimeValue(sceneTimeValue);
   const playbackSpeedOptions = [0.5, 1, 2, 4];
@@ -10052,18 +10050,6 @@ export function VisualizerSceneShell({
   const selectedSliceValue = updraftLensActive
     ? selectedUpdraftLensValue(updraftLensFrame, selectedRegion)
     : selectedSliceCellValue(activeSlice, selectedRegion);
-  const processModeStates = useMemo(
-    () => processModeClassifications(result, catalog, sliceField, activeSlice),
-    [activeSlice, catalog, result, sliceField],
-  );
-  const primaryProcessModes = processModeStates.filter((state) => state.primary);
-  const unavailableProcessModes = processModeStates.filter((state) => !state.primary);
-  const activeProcessMode = primaryProcessModes.some((state) => state.mode === processMode)
-    ? processMode
-    : (primaryProcessModes[0]?.mode ?? "thermal_fate");
-  const activeProcessModeState =
-    primaryProcessModes.find((state) => state.mode === activeProcessMode) ??
-    processModeStates.find((state) => state.mode === activeProcessMode);
   const timePresets = [
     result.time_of_max_qc_seconds !== null && result.time_of_max_qc_seconds !== undefined
       ? { label: "Max cloud water", seconds: result.time_of_max_qc_seconds }
@@ -10196,12 +10182,6 @@ export function VisualizerSceneShell({
     verticalSliceIndex,
     viewDefaults,
   ]);
-
-  useEffect(() => {
-    if (processMode !== activeProcessMode) {
-      setProcessMode(activeProcessMode);
-    }
-  }, [activeProcessMode, processMode]);
 
   useEffect(() => {
     if (!canPlayTimelapse && isPlaybackRunning) {
@@ -10460,7 +10440,7 @@ export function VisualizerSceneShell({
       .then((payload) => {
         if (!active) return;
         setRegionDiagnostics(payload);
-        setRegionStatus("Selected-point diagnostics loaded");
+        setRegionStatus("Point ready");
       })
       .catch((caught: unknown) => {
         if (!active) return;
@@ -10468,7 +10448,7 @@ export function VisualizerSceneShell({
         setRegionError(
           caught instanceof Error ? caught.message : "Unable to inspect the selected point.",
         );
-        setRegionStatus("Selected-point request failed");
+        setRegionStatus("Point unavailable");
       });
     return () => {
       active = false;
@@ -10500,6 +10480,31 @@ export function VisualizerSceneShell({
     });
   }
 
+  function handleThreeDFieldChange(nextFieldName: string) {
+    const nextEncoding =
+      threeDScalarEncodings.find(
+        (encoding) => encoding.field.raw_field_name === nextFieldName,
+      ) ?? null;
+    setSelectedFieldName(nextFieldName);
+    if (nextEncoding) {
+      setThreshold(nextEncoding.defaultThreshold);
+      if (!updraftLensActive) {
+        setSliceFieldName(nextEncoding.field.raw_field_name);
+        if (!nextEncoding.field.coordinate_names.vertical) {
+          setActiveSlicePlane("horizontal");
+        }
+        const nextDefaults =
+          defaultsForField(selectedTimeDefaults, nextEncoding.field.raw_field_name) ??
+          defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
+        setHorizontalSliceLevel(defaultHorizontalLevel(nextEncoding.field, nextDefaults));
+        setVerticalSliceIndex(
+          defaultVerticalIndex(nextEncoding.field, sliceOrientation, nextDefaults),
+        );
+      }
+    }
+    setSelectedRegion(null);
+  }
+
   return (
     <IntegratedExploreWorkspace
       worldName={productWorldName}
@@ -10508,7 +10513,10 @@ export function VisualizerSceneShell({
       onBack={onBack}
       onCompare={onCompare}
     >
-      <section className="visualizer-shell" aria-label="Integrated Explore workspace">
+      <section
+        className={`visualizer-shell${focusedViewer ? ` visualizer-shell-focused-${focusedViewer}` : ""}`}
+        aria-label="Integrated Explore workspace"
+      >
         {sceneError && (
           <div className="workspace-catalog-error" role="alert">
             <p>{sceneError}</p>
@@ -10564,7 +10572,10 @@ export function VisualizerSceneShell({
               coordinateSizes={{ x: sliceXSize, y: sliceYSize, z: sliceVerticalSize }}
               selectedTimeLabel={selectedTimeLabel}
               sceneTimeLabel={sceneTimeLabel}
-              thresholdLabel={formatScientific(threshold, selectedEncoding?.field.units ?? "")}
+              thresholdLabel={formatScientific(
+                threshold * scalarDisplayScale(selectedEncoding?.field),
+                scalarDisplayUnits(selectedEncoding?.field),
+              )}
               opacity={opacity}
               pointSize={pointSize}
               status={sceneStatus}
@@ -10585,6 +10596,28 @@ export function VisualizerSceneShell({
               windArrowDomainFraction={updraftLensFrame?.wind_arrow_domain_fraction ?? 0.08}
               updraftLensFrame={updraftLensActive ? updraftLensFrame : null}
               showUpdraftLensLegend={false}
+              compactWorkspace
+              maximized={focusedViewer === "scene"}
+              onToggleMaximize={() =>
+                setFocusedViewer((current) => (current === "scene" ? null : "scene"))
+              }
+              compactDisplayControls={
+                <ExploreRenderingControls
+                  compact
+                  encodings={threeDScalarEncodings}
+                  selectedFieldName={selectedFieldName}
+                  selectedEncoding={selectedEncoding}
+                  pointCloud={pointCloud}
+                  result={result}
+                  threshold={threshold}
+                  opacity={opacity}
+                  pointSize={pointSize}
+                  onFieldChange={handleThreeDFieldChange}
+                  onThresholdChange={setThreshold}
+                  onOpacityChange={setOpacity}
+                  onPointSizeChange={setPointSize}
+                />
+              }
             />
             {catalog && sliceField && (
               <section
@@ -10593,51 +10626,26 @@ export function VisualizerSceneShell({
                 }${updraftLensActive ? " explore-control-deck-lens" : ""}`}
                 aria-label="Explore viewer controls"
               >
-                {updraftLensEligible && (
-                  <fieldset className="explore-control-card explore-control-card-view-mode">
-                    <legend>View</legend>
-                    <div className="segmented-buttons" aria-label="Explore view mode">
-                      <button
-                        type="button"
-                        className={!updraftLensActive ? "active-control" : ""}
-                        aria-pressed={!updraftLensActive}
-                        onClick={() => {
-                          if (updraftLensActive) handleUpdraftLensToggle();
-                        }}
-                      >
-                        Standard
-                      </button>
-                      <button
-                        type="button"
-                        className={updraftLensActive ? "active-control" : ""}
-                        aria-pressed={updraftLensActive}
-                        disabled={!updraftLensActive && !updraftLensDefaults}
-                        onClick={() => {
-                          if (!updraftLensActive) handleUpdraftLensToggle();
-                        }}
-                      >
-                        Updraft Lens
-                      </button>
-                    </div>
-                  </fieldset>
-                )}
-
                 <fieldset className="explore-control-card explore-control-card-time">
                   <legend>Time</legend>
                   <div className="frame-step-controls" aria-label="Saved frame step controls">
                     <button
                       type="button"
+                      aria-label="Previous"
+                      title="Previous saved frame"
                       disabled={displayTimeIndex <= 0}
                       onClick={() => handleTimeIndexChange(displayTimeIndex - 1)}
                     >
-                      Previous
+                      <span aria-hidden="true">&lsaquo;</span>
                     </button>
                     <button
                       type="button"
+                      aria-label="Next"
+                      title="Next saved frame"
                       disabled={displayTimeIndex >= timeMax}
                       onClick={() => handleTimeIndexChange(displayTimeIndex + 1)}
                     >
-                      Next
+                      <span aria-hidden="true">&rsaquo;</span>
                     </button>
                   </div>
                   <div className="timelapse-controls" aria-label="Timelapse playback controls">
@@ -10666,7 +10674,7 @@ export function VisualizerSceneShell({
                     </label>
                   </div>
                   <label htmlFor="explore-time-scrubber">
-                    Saved output time
+                    <span className="timeline-label">Saved output time</span>
                     <input
                       id="explore-time-scrubber"
                       aria-label="Saved output time"
@@ -10678,9 +10686,12 @@ export function VisualizerSceneShell({
                       onChange={(event) => handleTimeIndexChange(Number(event.target.value))}
                     />
                     <span className="slice-position-label">
-                      <span>{displayTimeLabel}</span>
+                      <span>
+                        {displayClockLabel} / {finalClockLabel}
+                      </span>
                       <small>
-                        frame {displayTimeIndex + 1} of {Math.max(1, timeOptions.length)}
+                        {displayTimeLabel} · frame {displayTimeIndex + 1} of{" "}
+                        {Math.max(1, timeOptions.length)}
                       </small>
                     </span>
                   </label>
@@ -10700,22 +10711,29 @@ export function VisualizerSceneShell({
                     </select>
                   </label>
 
-                  <div className="time-preset-buttons" aria-label="Time presets">
-                    {timePresets.map((preset) => (
-                      <button
-                        key={preset.label}
-                        type="button"
-                        onClick={() =>
-                          handleTimeIndexChange(closestTimeIndex(timeOptions, preset.seconds))
+                  <label className="timeline-key-moments">
+                    Moment
+                    <select
+                      aria-label="Key moments"
+                      value=""
+                      onChange={(event) => {
+                        if (event.target.value !== "") {
+                          handleTimeIndexChange(Number(event.target.value));
                         }
-                      >
-                        {preset.label}
-                      </button>
-                    ))}
-                    <button type="button" onClick={() => handleTimeIndexChange(timeMax)}>
-                      Last frame
-                    </button>
-                  </div>
+                      }}
+                    >
+                      <option value="">Choose</option>
+                      {timePresets.map((preset) => (
+                        <option
+                          key={preset.label}
+                          value={closestTimeIndex(timeOptions, preset.seconds)}
+                        >
+                          {preset.label}
+                        </option>
+                      ))}
+                      <option value={timeMax}>Last frame</option>
+                    </select>
+                  </label>
                   {isPlaybackRunning && (
                     <p className="control-help">
                       Animating the coordinated scene and slice at {sceneTimeLabel}.
@@ -11021,120 +11039,6 @@ export function VisualizerSceneShell({
                   </fieldset>
                 )}
 
-                <fieldset className="explore-control-card explore-control-card-rendering">
-                  <legend>3-D scalar layer</legend>
-                  <label htmlFor="explore-3d-field">
-                    3-D field
-                    <select
-                      id="explore-3d-field"
-                      aria-label="3-D scalar field"
-                      value={selectedFieldName}
-                      disabled={threeDScalarEncodings.length === 0}
-                      onChange={(event) => {
-                        const nextEncoding =
-                          threeDScalarEncodings.find(
-                            (encoding) => encoding.field.raw_field_name === event.target.value,
-                          ) ?? null;
-                        setSelectedFieldName(event.target.value);
-                        if (nextEncoding) {
-                          setThreshold(nextEncoding.defaultThreshold);
-                          if (!updraftLensActive) {
-                            setSliceFieldName(nextEncoding.field.raw_field_name);
-                            if (!nextEncoding.field.coordinate_names.vertical) {
-                              setActiveSlicePlane("horizontal");
-                            }
-                            const nextDefaults =
-                              defaultsForField(
-                                selectedTimeDefaults,
-                                nextEncoding.field.raw_field_name,
-                              ) ??
-                              defaultsForField(viewDefaults, nextEncoding.field.raw_field_name);
-                            setHorizontalSliceLevel(
-                              defaultHorizontalLevel(nextEncoding.field, nextDefaults),
-                            );
-                            setVerticalSliceIndex(
-                              defaultVerticalIndex(
-                                nextEncoding.field,
-                                sliceOrientation,
-                                nextDefaults,
-                              ),
-                            );
-                          }
-                        }
-                        setSelectedRegion(null);
-                      }}
-                    >
-                      {threeDScalarEncodings.length === 0 && (
-                        <option value="">No 3-D scalar fields</option>
-                      )}
-                      {threeDScalarEncodings.map((encoding) => (
-                        <option
-                          key={encoding.field.raw_field_name}
-                          value={encoding.field.raw_field_name}
-                        >
-                          {encoding.field.raw_field_name} - {encoding.field.display_name}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <p className="control-help">
-                    {selectedEncoding
-                      ? selectedEncoding.valueChannel
-                      : "Only fields with a defined 3-D scalar encoding appear here; vertical velocity remains slice-only."}
-                  </p>
-                  {pointCloud && selectedEncoding && (
-                    <p className="control-help">
-                      {pointCloudFieldSummary(pointCloud)}
-                      {selectedEncoding.field.raw_field_name === "dbz"
-                        ? " Weather-radar colors use a fixed 0 to 60+ dBZ scale."
-                        : ""}
-                    </p>
-                  )}
-                  {selectedEncoding?.field.raw_field_name === "qc" &&
-                    cloudTopMismatchNotice(result) && (
-                      <p className="control-help">{cloudTopMismatchNotice(result)}</p>
-                    )}
-                  <label htmlFor="cloud-threshold">
-                    {selectedEncoding?.thresholdLabel ?? "Visible minimum"}
-                    <input
-                      id="cloud-threshold"
-                      aria-label={selectedEncoding?.thresholdAriaLabel ?? "3-D scalar threshold"}
-                      type="number"
-                      min={0}
-                      step={selectedEncoding?.thresholdStep ?? 0.000001}
-                      value={threshold}
-                      onChange={(event) => setThreshold(Number(event.target.value))}
-                      disabled={!selectedEncoding}
-                    />
-                  </label>
-                  <label htmlFor="cloud-opacity">
-                    Opacity
-                    <input
-                      id="cloud-opacity"
-                      aria-label="Layer opacity"
-                      type="range"
-                      min={0.1}
-                      max={1}
-                      step={0.05}
-                      value={opacity}
-                      onChange={(event) => setOpacity(Number(event.target.value))}
-                    />
-                    <output htmlFor="cloud-opacity">{opacity}</output>
-                  </label>
-                  <label htmlFor="cloud-point-size">
-                    Point size
-                    <input
-                      id="cloud-point-size"
-                      aria-label="Point size"
-                      type="range"
-                      min={3}
-                      max={18}
-                      value={pointSize}
-                      onChange={(event) => setPointSize(Number(event.target.value))}
-                    />
-                    <output htmlFor="cloud-point-size">{pointSize}px</output>
-                  </label>
-                </fieldset>
               </section>
             )}
           </div>
@@ -11142,77 +11046,7 @@ export function VisualizerSceneShell({
           <ExploreInspector
             sections={{
               explain: (
-                <>
-                  <ResultExplanationPanel
-                    result={result}
-                    tradeCumulus={updraftLensEligible}
-                    isNoCloudWithUpdraft={isNoCloudWithUpdraft}
-                    updraftLensActive={updraftLensActive}
-                    updraftLensFrame={updraftLensFrame}
-                  />
-                  {updraftLensActive && updraftLensFrame && (
-                    <section className="integrated-lens-legend" aria-label="Updraft Lens context">
-                      <p>
-                        The Updraft Lens relates rising and sinking air to the visible cloud
-                        boundary.
-                      </p>
-                      <UpdraftLensScaleLegend
-                        frame={updraftLensFrame}
-                        viewLabel="Explore workspace"
-                      />
-                      <dl className="metric-grid compact-metric-grid">
-                        <Metric label="Plane" value={activeSliceLabel} />
-                        <Metric
-                          label="Cloud boundary"
-                          value={showUpdraftLensBoundary ? "Visible" : "Hidden"}
-                        />
-                        <Metric
-                          label="Horizontal wind"
-                          value={
-                            showUpdraftLensWind ? windModeLabel(updraftLensWindMode) : "Hidden"
-                          }
-                        />
-                        <Metric
-                          label="Wind reference"
-                          value={`${updraftLensFrame.wind_reference_m_s.toFixed(1)} m/s at ${Math.round(
-                            updraftLensFrame.wind_actual_level_m,
-                          )} m`}
-                        />
-                      </dl>
-                    </section>
-                  )}
-                </>
-              ),
-              science: (
-                <>
-                  <ExploreSciencePanel
-                    result={result}
-                    tradeCumulus={updraftLensEligible}
-                    pointCloud={pointCloud}
-                    updraftLensFrame={updraftLensFrame}
-                    selectedTimeLabel={selectedTimeLabel}
-                  />
-                  <details className="technical-details">
-                    <summary>Process evidence</summary>
-                    <ProcessModeControl
-                      processMode={activeProcessMode}
-                      processModeStates={primaryProcessModes}
-                      activeProcessModeState={activeProcessModeState}
-                      unavailableProcessModes={unavailableProcessModes}
-                      onProcessModeChange={setProcessMode}
-                    />
-                    <ProcessOverlayPanel
-                      result={result}
-                      catalog={catalog}
-                      selectedField={sliceField}
-                      processMode={activeProcessMode}
-                      slice={
-                        activeSlicePlane === "horizontal"
-                          ? sceneHorizontalSlice
-                          : sceneVerticalSlice
-                      }
-                    />
-                  </details>
+                selectedRegion || regionError || isPlaybackRunning ? (
                   <SelectedRegionInspector
                     selectedRegion={selectedRegion}
                     slice={updraftLensActive ? null : activeSlice}
@@ -11222,9 +11056,21 @@ export function VisualizerSceneShell({
                     error={regionError}
                     playbackRunning={isPlaybackRunning}
                   />
-                </>
+                ) : (
+                  <ResultExplanationPanel
+                    result={result}
+                    tradeCumulus={updraftLensEligible}
+                    isNoCloudWithUpdraft={isNoCloudWithUpdraft}
+                    updraftLensActive={updraftLensActive}
+                    updraftLensFrame={updraftLensFrame}
+                    selectedTimeLabel={selectedTimeLabel}
+                    activeSliceLabel={activeSliceLabel}
+                  />
+                )
               ),
-              notes: <SimulationNotesPanel result={result} />,
+              notes: (
+                <SimulationNotesPanel result={result} onResultUpdated={onResultUpdated} />
+              ),
               details: (
                 <>
                   <SimulationDetailsPanel
@@ -11237,7 +11083,7 @@ export function VisualizerSceneShell({
                     activeSliceLabel={activeSliceLabel}
                   />
                   <details className="technical-details">
-                    <summary>Technical visualization details</summary>
+                    <summary>Visualization details</summary>
                     <dl className="metric-grid">
                       <Metric label="Run ID" value={result.run_id} />
                       <Metric label="Renderer" value="Direct Three.js point cloud" />
@@ -11250,12 +11096,15 @@ export function VisualizerSceneShell({
                         }
                       />
                       <Metric label="3-D scene time" value={sceneTimeLabel} />
-                      <Metric label="Slice/evidence time" value={selectedTimeLabel} />
+                      <Metric label="Slice time" value={selectedTimeLabel} />
                       <Metric label="Slice plane" value={activeSliceLabel} />
                       <Metric label="Slice plane visible" value={showSlicePlanes ? "Yes" : "No"} />
                       <Metric
                         label={selectedEncoding?.thresholdLabel ?? "Visible threshold"}
-                        value={formatScientific(threshold, selectedField?.units ?? "")}
+                        value={formatScientific(
+                          threshold * scalarDisplayScale(selectedField),
+                          scalarDisplayUnits(selectedField),
+                        )}
                       />
                       <Metric label="Opacity" value={String(opacity)} />
                       <Metric label="Point size" value={`${pointSize}px`} />
@@ -11271,9 +11120,9 @@ export function VisualizerSceneShell({
                         label={selectedEncoding?.rangeLabel ?? "3-D field range"}
                         value={
                           pointCloud
-                            ? `${formatMaybeNumber(pointCloud.stats.min_value, selectedField?.units ?? "kg/kg")} to ${formatMaybeNumber(
+                            ? `${formatFieldMaybeNumber(pointCloud.stats.min_value, selectedField)} to ${formatFieldMaybeNumber(
                                 pointCloud.stats.max_value,
-                                selectedField?.units ?? "kg/kg",
+                                selectedField,
                               )}`
                             : "Unavailable"
                         }
@@ -11282,12 +11131,9 @@ export function VisualizerSceneShell({
                         label="Selected-field range"
                         value={
                           pointCloud
-                            ? `${formatMaybeNumber(
-                                pointCloud.stats.field_min_value,
-                                selectedField?.units ?? "kg/kg",
-                              )} to ${formatMaybeNumber(
+                            ? `${formatFieldMaybeNumber(pointCloud.stats.field_min_value, selectedField)} to ${formatFieldMaybeNumber(
                                 pointCloud.stats.field_max_value,
-                                selectedField?.units ?? "kg/kg",
+                                selectedField,
                               )}`
                             : "Unavailable"
                         }
@@ -11350,28 +11196,6 @@ export function VisualizerSceneShell({
                       />
                     </dl>
 
-                    <section aria-labelledby="visualizer-provenance-title">
-                      <h3 id="visualizer-provenance-title">Provenance / rendering labels</h3>
-                      <ul className="compact-list">
-                        <li>{provenanceLabel}</li>
-                        <li>Visualizer interpretation of CM1-derived output</li>
-                        <li>
-                          Value channel:{" "}
-                          {selectedEncoding?.valueChannel ?? "3-D scalar rendering unavailable"}
-                        </li>
-                        <li>
-                          Processing method: backend native-grid thresholded point cloud for
-                          supported scalar fields
-                        </li>
-                        <li>Rendering method: direct Three.js scalar point cloud</li>
-                        <li>Slice planes: native-grid JSON slices from the backend</li>
-                        <li>No raw NetCDF parsing in the browser</li>
-                        <li>
-                          No interpolation, ray marching, isosurface extraction, or synthetic cloud
-                          physics
-                        </li>
-                      </ul>
-                    </section>
                   </details>
                 </>
               ),
@@ -11381,18 +11205,58 @@ export function VisualizerSceneShell({
 
         {catalog && sliceField && (
           <section className="unified-slice-inspector" aria-labelledby="unified-slice-title">
-            <div className="section-heading compact-heading">
+            <div className="instrument-header">
               <div>
-                <p className="eyebrow">Field Slice</p>
                 <h2 id="unified-slice-title">
                   {updraftLensActive ? "Updraft Lens" : "Field Slice"}
                 </h2>
                 <p>
-                  {activeSliceLabel} · {updraftLensActive ? "w" : sliceField.raw_field_name} ·{" "}
-                  {selectedTimeLabel}
+                  {activeSliceLabel} · {updraftLensActive ? "w" : sliceField.raw_field_name}
                 </p>
               </div>
-              <p className="state-chip">
+              <div className="instrument-actions">
+                {updraftLensEligible && (
+                  <div className="instrument-view-toggle" aria-label="Explore view mode">
+                    <button
+                      type="button"
+                      className={!updraftLensActive ? "active-control" : ""}
+                      aria-pressed={!updraftLensActive}
+                      onClick={() => {
+                        if (updraftLensActive) handleUpdraftLensToggle();
+                      }}
+                    >
+                      Field
+                    </button>
+                    <button
+                      type="button"
+                      className={updraftLensActive ? "active-control" : ""}
+                      aria-pressed={updraftLensActive}
+                      disabled={!updraftLensActive && !updraftLensDefaults}
+                      onClick={() => {
+                        if (!updraftLensActive) handleUpdraftLensToggle();
+                      }}
+                    >
+                      Updraft Lens
+                    </button>
+                  </div>
+                )}
+                <button
+                  type="button"
+                  className="viewer-maximize-button"
+                  aria-label={
+                    focusedViewer === "slice" ? "Restore slice viewer" : "Maximize slice viewer"
+                  }
+                  title={
+                    focusedViewer === "slice" ? "Restore slice viewer" : "Maximize slice viewer"
+                  }
+                  onClick={() =>
+                    setFocusedViewer((current) => (current === "slice" ? null : "slice"))
+                  }
+                >
+                  <span aria-hidden="true">{"\u26f6"}</span>
+                </button>
+              </div>
+              <p className="sr-only" role="status">
                 {updraftLensActive
                   ? updraftLensError
                     ? "Lens unavailable"
@@ -11430,23 +11294,29 @@ export function VisualizerSceneShell({
 
             {updraftLensActive ? (
               updraftLensFrame ? (
-                <UpdraftLensSlice
-                  frame={updraftLensFrame}
-                  showCloudBoundary={showUpdraftLensBoundary}
-                  showLegend={false}
-                  selectedPoint={
-                    selectedRegion?.xIndex !== undefined &&
-                    selectedRegion.yIndex !== undefined &&
-                    selectedRegion.zIndex !== undefined
-                      ? {
-                          xIndex: selectedRegion.xIndex,
-                          yIndex: selectedRegion.yIndex,
-                          zIndex: selectedRegion.zIndex,
-                        }
-                      : null
-                  }
-                  onSelectPoint={selectPointFromUpdraftLens}
-                />
+                <div className="updraft-lens-instrument-body">
+                  <UpdraftLensSlice
+                    frame={updraftLensFrame}
+                    showCloudBoundary={showUpdraftLensBoundary}
+                    showLegend={false}
+                    selectedPoint={
+                      selectedRegion?.xIndex !== undefined &&
+                      selectedRegion.yIndex !== undefined &&
+                      selectedRegion.zIndex !== undefined
+                        ? {
+                            xIndex: selectedRegion.xIndex,
+                            yIndex: selectedRegion.yIndex,
+                            zIndex: selectedRegion.zIndex,
+                          }
+                        : null
+                    }
+                    onSelectPoint={selectPointFromUpdraftLens}
+                  />
+                  <UpdraftLensScaleLegend
+                    frame={updraftLensFrame}
+                    viewLabel="Explore workspace"
+                  />
+                </div>
               ) : (
                 !updraftLensError && <p role="status">Loading Updraft Lens frame...</p>
               )
@@ -11467,18 +11337,137 @@ export function VisualizerSceneShell({
   );
 }
 
+function ExploreRenderingControls({
+  compact = false,
+  encodings,
+  selectedFieldName,
+  selectedEncoding,
+  pointCloud,
+  result,
+  threshold,
+  opacity,
+  pointSize,
+  onFieldChange,
+  onThresholdChange,
+  onOpacityChange,
+  onPointSizeChange,
+}: {
+  compact?: boolean;
+  encodings: ThreeDScalarEncoding[];
+  selectedFieldName: string;
+  selectedEncoding: ThreeDScalarEncoding | null;
+  pointCloud: PointCloudResponse | null;
+  result: ResultCard;
+  threshold: number;
+  opacity: number;
+  pointSize: number;
+  onFieldChange: (fieldName: string) => void;
+  onThresholdChange: (value: number) => void;
+  onOpacityChange: (value: number) => void;
+  onPointSizeChange: (value: number) => void;
+}) {
+  const thresholdScale = scalarDisplayScale(selectedEncoding?.field);
+  const thresholdUnits = scalarDisplayUnits(selectedEncoding?.field);
+  return (
+    <section
+      className={`inspector-rendering-controls${compact ? " inspector-rendering-controls-compact" : ""}`}
+      aria-label={compact ? "3-D display controls" : undefined}
+      aria-labelledby={compact ? undefined : "rendering-controls-title"}
+    >
+      {!compact && <h3 id="rendering-controls-title">3-D layer</h3>}
+      <label htmlFor="explore-3d-field">
+        Field
+        <select
+          id="explore-3d-field"
+          aria-label="3-D scalar field"
+          value={selectedFieldName}
+          disabled={encodings.length === 0}
+          onChange={(event) => onFieldChange(event.target.value)}
+        >
+          {encodings.length === 0 && <option value="">No 3-D scalar fields</option>}
+          {encodings.map((encoding) => (
+            <option key={encoding.field.raw_field_name} value={encoding.field.raw_field_name}>
+              {encoding.field.raw_field_name} - {encoding.field.display_name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label htmlFor="cloud-threshold">
+        {selectedEncoding?.thresholdLabel ?? "Visible minimum"}
+        {thresholdUnits ? ` (${thresholdUnits})` : ""}
+        <input
+          id="cloud-threshold"
+          aria-label={selectedEncoding?.thresholdAriaLabel ?? "3-D scalar threshold"}
+          type="number"
+          min={0}
+          step={(selectedEncoding?.thresholdStep ?? 0.000001) * thresholdScale}
+          value={threshold * thresholdScale}
+          onChange={(event) => onThresholdChange(Number(event.target.value) / thresholdScale)}
+          disabled={!selectedEncoding}
+        />
+      </label>
+      <div className="rendering-range-controls">
+        <label htmlFor="cloud-opacity">
+          Opacity
+          <input
+            id="cloud-opacity"
+            aria-label="Layer opacity"
+            type="range"
+            min={0.1}
+            max={1}
+            step={0.05}
+            value={opacity}
+            onChange={(event) => onOpacityChange(Number(event.target.value))}
+          />
+          <output htmlFor="cloud-opacity">{opacity}</output>
+        </label>
+        <label htmlFor="cloud-point-size">
+          Point size
+          <input
+            id="cloud-point-size"
+            aria-label="Point size"
+            type="range"
+            min={3}
+            max={18}
+            value={pointSize}
+            onChange={(event) => onPointSizeChange(Number(event.target.value))}
+          />
+          <output htmlFor="cloud-point-size">{pointSize}px</output>
+        </label>
+      </div>
+      <div className={compact ? "sr-only" : undefined}>
+        <p className="control-help">
+          {selectedEncoding
+            ? selectedEncoding.valueChannel
+            : "Only fields with a defined 3-D scalar encoding appear here."}
+        </p>
+        {pointCloud && selectedEncoding && (
+          <p className="control-help">{pointCloudFieldSummary(pointCloud)}</p>
+        )}
+        {selectedEncoding?.field.raw_field_name === "qc" && cloudTopMismatchNotice(result) && (
+          <p className="control-help">{cloudTopMismatchNotice(result)}</p>
+        )}
+      </div>
+    </section>
+  );
+}
+
 function ResultExplanationPanel({
   result,
   tradeCumulus,
   isNoCloudWithUpdraft,
   updraftLensActive,
   updraftLensFrame,
+  selectedTimeLabel,
+  activeSliceLabel,
 }: {
   result: ResultCard;
   tradeCumulus: boolean;
   isNoCloudWithUpdraft: boolean;
   updraftLensActive: boolean;
   updraftLensFrame: UpdraftLensFrame | null;
+  selectedTimeLabel: string;
+  activeSliceLabel: string;
 }) {
   const cloudLabel = tradeCumulus
     ? fieldQualityBlocksEvidence(result, "qc")
@@ -11487,152 +11476,121 @@ function ResultExplanationPanel({
         ? "Cloud formed"
         : "No cloud formed"
     : cloudOutcome(result);
-  const explanation = tradeCumulus
-    ? `Cloud water first appeared at ${formatSeconds(resultFirstCloudTime(result))}. The Simulation reached ${formatNumber(
-        resultMaxUpdraft(result),
-        "m/s",
-      )} maximum upward motion and ${formatNumber(
-        resultMinDowndraft(result),
-        "m/s",
-      )} minimum vertical motion.${
-        updraftLensActive && updraftLensFrame
-          ? ` The active Lens shows ${formatNumber(updraftLensFrame.w_range_min_m_s, "m/s")} to ${formatNumber(
-              updraftLensFrame.w_range_max_m_s,
-              "m/s",
-            )} on the selected plane.`
-          : " Activate the Updraft Lens to relate that motion to the cloud boundary."
-      }`
-    : resultStory(result);
+  const currentViewExplanation =
+    updraftLensActive && updraftLensFrame
+      ? `At model time ${selectedTimeLabel}, the ${activeSliceLabel} shows vertical velocity from ${formatNumber(
+          updraftLensFrame.w_range_min_m_s,
+          "m/s",
+        )} to ${formatNumber(
+          updraftLensFrame.w_range_max_m_s,
+          "m/s",
+        )}. Warm colors mark rising air, cool colors mark sinking air, and the black outline marks cloud water.`
+      : `At model time ${selectedTimeLabel}, the 3-D cloud field and ${activeSliceLabel} show the same saved model state. The plane in the scene locates the Field Slice in the cloud domain.`;
   return (
     <section className="selected-region-inspector" aria-label="Result-level explanation panel">
       <div className="section-heading compact-heading">
         <div>
-          <p className="eyebrow">Explanation</p>
-          <h3>What happened in this result?</h3>
+          <h3>What am I seeing?</h3>
         </div>
         <StatusBadge
           label={
             cloudLabel === "Cloud formed"
-              ? "Cloud formed in this result"
+              ? "Cloud formed"
               : cloudLabel === "No cloud formed"
-                ? "No cloud formed in this result"
+                ? "No cloud formed"
                 : cloudLabel
           }
           tone={cloudLabel === "Cloud formed" ? "good" : "warning"}
         />
       </div>
-      <p>{explanation}</p>
-      <section aria-label="Evidence">
-        <h4>Evidence</h4>
-        <dl className="metric-grid">
+      <p>{currentViewExplanation}</p>
+      <section aria-label="Current context">
+        <dl className="context-metrics">
+          <Metric label="Model time" value={selectedTimeLabel} />
           <Metric label="First cloud" value={formatSeconds(resultFirstCloudTime(result))} />
-          <Metric label="Max cloud water" value={formatScientific(resultMaxQc(result), "kg/kg")} />
           <Metric
-            label="Max vertical velocity"
-            value={formatNumber(resultMaxUpdraft(result), "m/s")}
+            label="Cloud water max"
+            value={formatMixingRatio(resultMaxQc(result))}
           />
           <Metric
-            label="Min vertical velocity"
-            value={formatNumber(resultMinDowndraft(result), "m/s")}
+            label="Vertical velocity"
+            value={`${formatNumber(resultMinDowndraft(result), "m/s")} to ${formatNumber(
+              resultMaxUpdraft(result),
+              "m/s",
+            )}`}
           />
-          <Metric
-            label="Coherent cloud top"
-            value={formatNumber(resultCloudTopMeters(result), "m")}
-          />
-          <Metric label="Latest output" value={formatSeconds(resultLatestOutputTime(result))} />
         </dl>
       </section>
       {isNoCloudWithUpdraft && (
         <p>For this no-cloud result, use vertical velocity (w) slices to inspect the thermals.</p>
       )}
-      <details>
-        <summary>Technical details</summary>
-        <ul className="compact-list">
-          <li>Thermal Fate is the internal explanation model.</li>
-          <li>Evidence comes from ingested CM1 diagnostics and visualization-ready fields.</li>
-          <li>No raw NetCDF parsing in the browser.</li>
-          {result.caveats.map((caveat) => (
-            <li key={caveat}>{caveat}</li>
-          ))}
-        </ul>
-      </details>
     </section>
   );
 }
 
-function ExploreSciencePanel({
+function SimulationNotesPanel({
   result,
-  tradeCumulus,
-  pointCloud,
-  updraftLensFrame,
-  selectedTimeLabel,
+  onResultUpdated,
 }: {
   result: ResultCard;
-  tradeCumulus: boolean;
-  pointCloud: PointCloudResponse | null;
-  updraftLensFrame: UpdraftLensFrame | null;
-  selectedTimeLabel: string;
+  onResultUpdated?: (result: ResultCard) => void;
 }) {
-  return (
-    <section aria-labelledby="explore-science-title">
-      <h3 id="explore-science-title">Science at this time</h3>
-      <dl className="metric-grid compact-metric-grid">
-        <Metric label="Model time" value={selectedTimeLabel} />
-        <Metric label="Max cloud water" value={formatScientific(resultMaxQc(result), "kg/kg")} />
-        <Metric
-          label="Coherent cloud top"
-          value={formatNumber(resultCloudTopMeters(result), "m")}
-        />
-        <Metric
-          label="Max vertical velocity"
-          value={formatNumber(resultMaxUpdraft(result), "m/s")}
-        />
-        <Metric
-          label="Min vertical velocity"
-          value={formatNumber(resultMinDowndraft(result), "m/s")}
-        />
-        <Metric
-          label="Visible 3-D points"
-          value={pointCloud ? pointCloud.stats.returned_count.toLocaleString() : "Unavailable"}
-        />
-        <Metric
-          label="Current 3-D field range"
-          value={
-            pointCloud
-              ? `${formatMaybeNumber(pointCloud.stats.field_min_value, pointCloud.field.units ?? "")} to ${formatMaybeNumber(
-                  pointCloud.stats.field_max_value,
-                  pointCloud.field.units ?? "",
-                )}`
-              : "Unavailable"
-          }
-        />
-        <Metric
-          label="Current Lens range"
-          value={
-            updraftLensFrame
-              ? `${formatNumber(updraftLensFrame.w_range_min_m_s, "m/s")} to ${formatNumber(
-                  updraftLensFrame.w_range_max_m_s,
-                  "m/s",
-                )}`
-              : "Lens inactive"
-          }
-        />
-        {!tradeCumulus && (
-          <>
-            <Metric label="Rain water aloft" value={rainWaterOutcome(result)} />
-            <Metric label="Reflectivity" value={reflectivityOutcome(result)} />
-          </>
-        )}
-      </dl>
-    </section>
-  );
-}
+  const [draft, setDraft] = useState(result.notes ?? "");
+  const [status, setStatus] = useState("");
+  const [saving, setSaving] = useState(false);
+  const statusResultIdRef = useRef(result.result_id);
 
-function SimulationNotesPanel({ result }: { result: ResultCard }) {
+  useEffect(() => {
+    const resultChanged = statusResultIdRef.current !== result.result_id;
+    statusResultIdRef.current = result.result_id;
+    setDraft(result.notes ?? "");
+    if (resultChanged) setStatus("");
+  }, [result.result_id, result.notes]);
+
+  async function saveNote(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaving(true);
+    setStatus("Saving note...");
+    try {
+      const updated = await patchResultCard(result.result_id, {
+        notes: draft.trim() || null,
+      });
+      setDraft(updated.notes ?? "");
+      onResultUpdated?.(updated);
+      setStatus("Note saved");
+    } catch (caught) {
+      setStatus(caught instanceof Error ? caught.message : "Unable to save note.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const savedNote = result.notes ?? "";
   return (
     <section aria-labelledby="simulation-notes-title">
       <h3 id="simulation-notes-title">Simulation notes</h3>
-      <p>{result.notes?.trim() || "No note recorded for this Simulation."}</p>
+      <form className="simulation-notes-form" onSubmit={(event) => void saveNote(event)}>
+        <label htmlFor={`simulation-notes-${result.result_id}`}>
+          <span className="sr-only">Notes for {result.name}</span>
+          <textarea
+            id={`simulation-notes-${result.result_id}`}
+            aria-label="Simulation notes"
+            rows={9}
+            placeholder="Record observations, questions, or follow-up ideas."
+            value={draft}
+            onChange={(event) => {
+              setDraft(event.target.value);
+              setStatus("");
+            }}
+          />
+        </label>
+        <div className="simulation-notes-actions">
+          <button type="submit" disabled={saving || draft === savedNote}>
+            {saving ? "Saving..." : "Save note"}
+          </button>
+          {status && <p role="status">{status}</p>}
+        </div>
+      </form>
     </section>
   );
 }
@@ -11670,7 +11628,7 @@ function SimulationDetailsPanel({
           label="3-D field"
           value={
             selectedField
-              ? `${selectedField.display_name} (${selectedField.units ?? "unitless"})`
+              ? `${selectedField.display_name} (${scalarDisplayUnits(selectedField)})`
               : "Unavailable"
           }
         />
@@ -11678,7 +11636,7 @@ function SimulationDetailsPanel({
           label="Slice field"
           value={
             sliceField
-              ? `${sliceField.display_name} (${sliceField.units ?? "unitless"})`
+              ? `${sliceField.display_name} (${scalarDisplayUnits(sliceField)})`
               : "Unavailable"
           }
         />
@@ -11752,10 +11710,6 @@ function formatDetailValue(value: unknown): string {
     return String(value);
   }
   return JSON.stringify(value);
-}
-
-function windModeLabel(mode: UpdraftLensWindMode): string {
-  return mode === "perturbation" ? "Local departures" : "Total wind";
 }
 
 function activeSlicePosition(
@@ -11945,8 +11899,8 @@ function SlicePanel({
           <Metric label="Time" value={formatSeconds(slice.selection.time_seconds)} />
           <Metric label="Shape" value={slice.shape.join(" x ")} />
           <Metric label="Dimensions" value={slice.dimension_order.join(", ")} />
-          <Metric label="Min" value={formatMaybeNumber(slice.stats.min, slice.field.units)} />
-          <Metric label="Max" value={formatMaybeNumber(slice.stats.max, slice.field.units)} />
+          <Metric label="Min" value={formatFieldMaybeNumber(slice.stats.min, slice.field)} />
+          <Metric label="Max" value={formatFieldMaybeNumber(slice.stats.max, slice.field)} />
           <Metric label="Finite values" value={String(slice.stats.finite_count)} />
           <Metric label="Non-finite values" value={String(slice.stats.non_finite_count)} />
         </dl>
@@ -12046,134 +12000,6 @@ function axisSize(slice: SliceResponse, dimension: string | null): number {
   return index >= 0 ? (slice.field.shape[index] ?? 1) : 1;
 }
 
-function ProcessModeControl({
-  processMode,
-  processModeStates,
-  activeProcessModeState,
-  unavailableProcessModes,
-  onProcessModeChange,
-}: {
-  processMode: ProcessMode;
-  processModeStates: ProcessModeClassification[];
-  activeProcessModeState: ProcessModeClassification | undefined;
-  unavailableProcessModes: ProcessModeClassification[];
-  onProcessModeChange: (mode: ProcessMode) => void;
-}) {
-  return (
-    <fieldset className="process-mode-control">
-      <legend>Explanation focus</legend>
-      {processModeStates.length > 0 ? (
-        <>
-          <select
-            aria-label="Process mode"
-            value={processMode}
-            onChange={(event) => onProcessModeChange(event.target.value as ProcessMode)}
-          >
-            {processModeStates.map((state) => (
-              <option key={state.mode} value={state.mode}>
-                {processModeLabel(state.mode)}
-                {state.support === "candidate" ? " (candidate)" : ""}
-              </option>
-            ))}
-          </select>
-          {activeProcessModeState && (
-            <p className="process-mode-helper">
-              <StatusBadge
-                label={processSupportLabel(activeProcessModeState.support)}
-                tone={
-                  activeProcessModeState.support === "supported"
-                    ? "good"
-                    : activeProcessModeState.support === "candidate"
-                      ? "neutral"
-                      : "warning"
-                }
-              />
-              <span>{activeProcessModeState.primaryReason}</span>
-            </p>
-          )}
-        </>
-      ) : (
-        <p>No supported process evidence focus is available for this result yet.</p>
-      )}
-      {unavailableProcessModes.length > 0 && (
-        <details className="unavailable-diagnostics">
-          <summary>Not available for this result</summary>
-          <ul className="compact-list">
-            {unavailableProcessModes.map((state) => (
-              <li key={state.mode}>
-                <strong>{processModeLabel(state.mode)}</strong>{" "}
-                <span className="muted-text">
-                  {processSupportLabel(state.support)}. {state.primaryReason} {state.description}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </details>
-      )}
-    </fieldset>
-  );
-}
-
-function ProcessOverlayPanel({
-  result,
-  catalog,
-  selectedField,
-  processMode,
-  slice,
-}: {
-  result: ResultCard;
-  catalog: FieldCatalogResponse | null;
-  selectedField: VisualizableField | undefined;
-  processMode: ProcessMode;
-  slice?: SliceResponse | null;
-}) {
-  const summary = processModeSummary(processMode, result, catalog, selectedField, slice ?? null);
-  return (
-    <section className="process-overlay-panel" aria-label="Explanation evidence">
-      <div className="section-heading compact-heading">
-        <div>
-          <p className="eyebrow">Evidence</p>
-          <h3>{processModeLabel(processMode)}</h3>
-        </div>
-        <StatusBadge
-          label={processSupportLabel(summary.support)}
-          tone={
-            summary.support === "supported"
-              ? "good"
-              : summary.support === "candidate"
-                ? "neutral"
-                : "warning"
-          }
-        />
-      </div>
-      <p>{summary.description}</p>
-      <dl className="metric-grid">
-        <Metric label="Evidence type" value={summary.evidenceType} />
-        <Metric label="Source" value={summary.source} />
-        <Metric label="Process confidence" value={processSupportLabel(summary.support)} />
-        <Metric label="Selected field" value={selectedField?.raw_field_name ?? "Unavailable"} />
-      </dl>
-      {summary.annotations.length > 0 && (
-        <ul className="compact-list">
-          {summary.annotations.map((annotation) => (
-            <li key={annotation}>{annotation}</li>
-          ))}
-        </ul>
-      )}
-      {summary.caveats.length > 0 && (
-        <details>
-          <summary>Process caveats</summary>
-          <ul className="compact-list">
-            {_dedupeStrings(summary.caveats).map((caveat) => (
-              <li key={caveat}>{caveat}</li>
-            ))}
-          </ul>
-        </details>
-      )}
-    </section>
-  );
-}
-
 function SelectedRegionInspector({
   selectedRegion,
   slice,
@@ -12253,7 +12079,7 @@ function SelectedRegionInspector({
             />
             <Metric
               label="Local max qc"
-              value={formatScientific(diagnostics.diagnostics.local_max_qc_kg_kg, "kg/kg")}
+              value={formatMixingRatio(diagnostics.diagnostics.local_max_qc_kg_kg)}
             />
             <Metric
               label="Local max w"
@@ -12274,7 +12100,7 @@ function SelectedRegionInspector({
           </dl>
 
           <details>
-            <summary>Technical details and provenance</summary>
+            <summary>Selected-point details</summary>
             <dl className="metric-grid">
               <Metric label="Region type" value={humanize(diagnostics.region.region_type)} />
               <Metric label="Native grid" value={diagnostics.region.native_grid ?? "Unavailable"} />
@@ -12308,10 +12134,7 @@ function SelectedRegionInspector({
                 )}
               />
             </dl>
-            <p>{diagnostics.provenance.provenance_label}</p>
             <ul className="compact-list">
-              <li>Backend xarray selected-region diagnostics; no raw NetCDF parsing in browser.</li>
-              <li>Selected region is not cloud-object tracking.</li>
               {_dedupeStrings([
                 ...diagnostics.caveats,
                 ...diagnostics.interpretation.caveats,
@@ -12368,7 +12191,7 @@ function SelectedPointContext({
         />
         <Metric
           label="Selected field value"
-          value={formatMaybeNumber(selectedValue, slice?.field.units ?? null)}
+          value={formatFieldMaybeNumber(selectedValue, slice?.field)}
         />
         <Metric label="x" value={x} />
         <Metric label="y" value={y} />
@@ -12426,7 +12249,7 @@ function SliceHeatmap({
                   title={
                     cell.value === null
                       ? "missing"
-                      : formatMaybeNumber(cell.value, slice.field.units)
+                      : formatFieldMaybeNumber(cell.value, slice.field)
                   }
                   aria-label={`Inspect ${title} row ${displayRowIndex + 1}, column ${displayColumnIndex + 1}`}
                   style={sliceCellStyle(cell.value, slice)}
@@ -13839,305 +13662,12 @@ function Metric({ label, value }: { label: string; value: string }) {
   );
 }
 
-const PROCESS_MODES: ProcessMode[] = [
-  "thermal_fate",
-  "cloud_water",
-  "updrafts",
-  "cloud_lifecycle",
-  "cap",
-  "moisture",
-  "buoyancy",
-  "deep_breakthrough",
-  "precipitation_feedback",
-];
-
 type ProcessSupport =
   | "supported"
   | "candidate"
   | "insufficient_evidence"
   | "unsupported_missing_fields"
   | "future";
-
-type ProcessModeSummary = {
-  support: ProcessSupport;
-  evidenceType: string;
-  source: string;
-  description: string;
-  annotations: string[];
-  caveats: string[];
-};
-
-type ProcessModeClassification = ProcessModeSummary & {
-  mode: ProcessMode;
-  primary: boolean;
-  primaryReason: string;
-};
-
-function processModeSummary(
-  mode: ProcessMode,
-  result: ResultCard,
-  catalog: FieldCatalogResponse | null,
-  selectedField: VisualizableField | undefined,
-  slice: SliceResponse | null,
-): ProcessModeSummary {
-  const fields = new Set(catalog?.available_fields.map((field) => field.raw_field_name) ?? []);
-  const caveats = [...result.caveats];
-  const thermalLabel = result.thermal_fate_label ?? "Insufficient evidence";
-  const confidence = normalizeProcessSupport(result.thermal_fate_confidence);
-  const fieldSource = selectedField
-    ? `${selectedField.raw_field_name} on native ${selectedField.native_grid}`
-    : "No selected field";
-  const sliceAnnotation = slice
-    ? `Active slice ${slice.selection.orientation} shows ${slice.field.raw_field_name} min ${formatMaybeNumber(
-        slice.stats.min,
-        slice.field.units,
-      )}, max ${formatMaybeNumber(slice.stats.max, slice.field.units)}.`
-    : "No active slice summary is available yet.";
-
-  if (mode === "thermal_fate") {
-    const hasResultSummary = Boolean(result.thermal_fate_label || result.diagnostics_summary);
-    const summarySupport =
-      confidence === "insufficient_evidence" && hasResultSummary ? "candidate" : confidence;
-    return {
-      support: summarySupport,
-      evidenceType: "backend process diagnostics",
-      source: "Result Card process fields from ingested CM1 output",
-      description: `${thermalLabel}. ${
-        result.main_limiting_factor && result.main_limiting_factor !== "unknown"
-          ? `Main limiting factor: ${result.main_limiting_factor}.`
-          : "No supported main limiting factor is available yet."
-      }`,
-      annotations: [
-        `Diagnostics summary: ${result.diagnostics_summary ?? "Unavailable"}`,
-        `Cloud: ${cloudOutcome(result)}; rain water aloft: ${rainWaterOutcome(result)}`,
-      ],
-      caveats,
-    };
-  }
-
-  if (mode === "cloud_water") {
-    return {
-      support: fields.has("qc") ? "supported" : "unsupported_missing_fields",
-      evidenceType: "direct CM1 field plus derived threshold diagnostics",
-      source: fieldSource,
-      description: fields.has("qc")
-        ? "Cloud-water overlay uses direct qc output with the documented cloud threshold."
-        : "Cloud-water overlay is unavailable because qc is missing for this result.",
-      annotations: [
-        `Max qc: ${formatScientific(result.max_qc_kg_kg, "kg/kg")}`,
-        `First cloud time: ${formatSeconds(result.first_cloud_time_seconds)}`,
-        sliceAnnotation,
-      ],
-      caveats: fields.has("qc") ? caveats : [...caveats, "missing_visualization_field:qc"],
-    };
-  }
-
-  if (mode === "updrafts") {
-    return {
-      support: fields.has("w") ? "supported" : "unsupported_missing_fields",
-      evidenceType: "direct CM1 vertical-velocity field",
-      source: fieldSource,
-      description: fields.has("w")
-        ? "Updraft overlay uses direct w output and max/min vertical velocity summaries."
-        : "Updraft overlay is unavailable because w is missing for this result.",
-      annotations: [
-        `Max w: ${formatNumber(result.max_w_m_s, "m/s")}`,
-        `Min w: ${formatNumber(result.min_w_m_s, "m/s")}`,
-        sliceAnnotation,
-      ],
-      caveats: fields.has("w") ? caveats : [...caveats, "missing_visualization_field:w"],
-    };
-  }
-
-  if (mode === "cloud_lifecycle") {
-    const available = result.first_cloud_time_seconds !== null || result.max_qc_kg_kg !== null;
-    return {
-      support: available ? "candidate" : "insufficient_evidence",
-      evidenceType: "derived cloud lifecycle diagnostics",
-      source: "Ingested result diagnostics",
-      description: available
-        ? "Cloud lifecycle uses first cloud time, qc summaries, cloud fraction, and slice annotations where available."
-        : "Cloud lifecycle diagnostics are not available for this result.",
-      annotations: [
-        `First cloud time: ${formatSeconds(result.first_cloud_time_seconds)}`,
-        `Max qc: ${formatScientific(result.max_qc_kg_kg, "kg/kg")}`,
-        sliceAnnotation,
-      ],
-      caveats,
-    };
-  }
-
-  if (mode === "cap") {
-    const capped =
-      result.scenario_id.includes("capped") || result.controls.cap_strength === "stronger";
-    return {
-      support: capped ? "candidate" : "insufficient_evidence",
-      evidenceType: "scenario/control proxy plus cloud-top diagnostics",
-      source: "Scenario metadata and derived diagnostics",
-      description: capped
-        ? "Cap/inversion overlay is a candidate process view; current data suggests cap context but does not directly diagnose inhibition."
-        : "Cap/inversion overlay needs stronger-cap metadata or cap-relative diagnostics before making a process claim.",
-      annotations: [
-        `Cap strength: ${String(result.controls.cap_strength ?? "not recorded")}`,
-        `Thermal Fate label: ${thermalLabel}`,
-      ],
-      caveats: [...caveats, "cap_layer_annotation_is_proxy_without_full_cap_diagnostics"],
-    };
-  }
-
-  if (mode === "moisture") {
-    const moistureLimited =
-      result.main_limiting_factor === "moisture" ||
-      result.scenario_id.includes("dry-failed") ||
-      result.caveats.some((caveat) => caveat.includes("moisture"));
-    return {
-      support: moistureLimited ? "candidate" : "unsupported_missing_fields",
-      evidenceType: moistureLimited
-        ? "scenario/control proxy plus cloud-water and updraft diagnostics"
-        : "unavailable moisture diagnostic group",
-      source: moistureLimited
-        ? "Dry Failed / moisture-limited result metadata and derived diagnostics"
-        : "Required humidity, qv, RH, or saturation-deficit fields were not ingested",
-      description: moistureLimited
-        ? "Moisture limitation is a candidate explanation for this contrast case because thermals are present while cloud water and rain stay below threshold."
-        : "Moisture / saturation diagnostics need qv, RH, or saturation-deficit fields before they can be selected as a focus.",
-      annotations: [
-        `Main limiting factor: ${String(result.main_limiting_factor ?? "not recorded")}`,
-        `Cloud: ${cloudOutcome(result)}; max w: ${formatNumber(result.max_w_m_s, "m/s")}`,
-      ],
-      caveats: moistureLimited
-        ? [...caveats, "moisture_limitation_is_candidate_without_direct_qv_or_rh_diagnostics"]
-        : [...caveats, "moisture_unsupported_missing_fields"],
-    };
-  }
-
-  if (mode === "precipitation_feedback") {
-    const rainWaterDetected = rainWaterOutcome(result) === "Rain water aloft detected";
-    return {
-      support: "future",
-      evidenceType: "qr/rain and downdraft proxy diagnostics",
-      source: rainWaterDetected
-        ? "Rain-water aloft summary exists, but cold-pool/outflow evidence is not available"
-        : "Required rain, downdraft, cold-pool, and outflow evidence is not available",
-      description: rainWaterDetected
-        ? "Rain water aloft is present, but precipitation-feedback needs downdraft/cold-pool evidence before it can be selected as a normal focus."
-        : "Precipitation feedback is future work for this result because rain-water, cold-pool, and outflow diagnostics are not available.",
-      annotations: [
-        `Rain water aloft: ${rainWaterOutcome(result)}`,
-        `Min w: ${formatNumber(result.min_w_m_s, "m/s")}`,
-      ],
-      caveats: [...caveats, "precipitation_feedback_requires_downdraft_and_cold_pool_diagnostics"],
-    };
-  }
-
-  const unavailableLabels: Record<ProcessMode, string> = {
-    thermal_fate: "",
-    cloud_water: "",
-    updrafts: "",
-    cloud_lifecycle: "",
-    cap: "",
-    moisture: "Moisture / saturation diagnostics need qv/RH or saturation-deficit fields.",
-    buoyancy: "Buoyancy diagnostics need thermodynamic fields and a documented buoyancy method.",
-    deep_breakthrough:
-      "Deep-breakthrough diagnostics need CAPE/CIN/LFC/EL and sustained-updraft context.",
-    precipitation_feedback:
-      "Precipitation-feedback diagnostics need rain, downdraft, cold-pool, and outflow evidence.",
-  };
-  return {
-    support:
-      mode === "buoyancy" || mode === "deep_breakthrough" ? "future" : "unsupported_missing_fields",
-    evidenceType: "unavailable diagnostic group",
-    source: "Required source fields were not ingested",
-    description: unavailableLabels[mode],
-    annotations: ["Unavailable diagnostics are shown explicitly rather than hidden."],
-    caveats: [...caveats, `${mode}_unsupported_missing_fields`],
-  };
-}
-
-function processModeClassifications(
-  result: ResultCard,
-  catalog: FieldCatalogResponse | null,
-  selectedField: VisualizableField | undefined,
-  slice: SliceResponse | null,
-): ProcessModeClassification[] {
-  return PROCESS_MODES.map((mode) => {
-    const summary = processModeSummary(mode, result, catalog, selectedField, slice);
-    const primary = processModeIsPrimary(mode, summary, result);
-    return {
-      mode,
-      ...summary,
-      primary,
-      primaryReason: primary
-        ? "Supported or useful candidate for this result."
-        : unavailableProcessReason(mode, summary),
-    };
-  });
-}
-
-function processModeIsPrimary(
-  mode: ProcessMode,
-  summary: ProcessModeSummary,
-  result: ResultCard,
-): boolean {
-  if (summary.support === "supported") return true;
-  if (summary.support !== "candidate") return false;
-  if (mode === "precipitation_feedback") return false;
-  if (mode === "cap") {
-    return result.scenario_id.includes("capped") || result.controls.cap_strength === "stronger";
-  }
-  if (mode === "moisture") {
-    return (
-      result.main_limiting_factor === "moisture" ||
-      result.scenario_id.includes("dry-failed") ||
-      result.caveats.some((caveat) => caveat.includes("moisture"))
-    );
-  }
-  return true;
-}
-
-function unavailableProcessReason(mode: ProcessMode, summary: ProcessModeSummary): string {
-  if (summary.support === "future") {
-    return "Future diagnostic: required backend evidence is not implemented for this result family.";
-  }
-  if (summary.support === "unsupported_missing_fields") {
-    return "Missing required CM1 fields or derived diagnostics for this selected result.";
-  }
-  if (summary.support === "insufficient_evidence") {
-    return "Evidence is present but not enough to make this a useful primary focus.";
-  }
-  if (summary.support === "candidate" && mode === "precipitation_feedback") {
-    return "Rain alone is not enough to select precipitation feedback without downdraft/cold-pool evidence.";
-  }
-  return "Not useful as a primary focus for this selected result.";
-}
-
-function processModeLabel(mode: ProcessMode): string {
-  const labels: Record<ProcessMode, string> = {
-    thermal_fate: "Thermal Fate summary",
-    cloud_water: "Cloud Water",
-    updrafts: "Updrafts",
-    moisture: "Moisture / Saturation",
-    buoyancy: "Buoyancy",
-    cap: "Cap / Inversion",
-    cloud_lifecycle: "Cloud Lifecycle",
-    deep_breakthrough: "Deep Breakthrough",
-    precipitation_feedback: "Precipitation Feedback",
-  };
-  return labels[mode];
-}
-
-function normalizeProcessSupport(value: string | null | undefined): ProcessSupport {
-  if (
-    value === "supported" ||
-    value === "candidate" ||
-    value === "insufficient_evidence" ||
-    value === "unsupported_missing_fields" ||
-    value === "future"
-  ) {
-    return value;
-  }
-  return "insufficient_evidence";
-}
 
 function processSupportLabel(value: ProcessSupport): string {
   const labels: Record<ProcessSupport, string> = {
@@ -14764,6 +14294,28 @@ function formatScientific(value: number | null, units: string): string {
   return `${value.toExponential(3)}${units ? ` ${units}` : ""}`;
 }
 
+function scalarDisplayScale(field: VisualizableField | undefined): number {
+  return field?.units === "kg/kg" ? 1000 : 1;
+}
+
+function scalarDisplayUnits(field: VisualizableField | undefined): string {
+  return field?.units === "kg/kg" ? "g/kg" : (field?.units ?? "");
+}
+
+function formatFieldMaybeNumber(
+  value: number | null,
+  field: VisualizableField | undefined,
+): string {
+  return formatMaybeNumber(
+    value === null ? null : value * scalarDisplayScale(field),
+    scalarDisplayUnits(field),
+  );
+}
+
+function formatMixingRatio(value: number | null): string {
+  return formatScientific(value === null ? null : value * 1000, "g/kg");
+}
+
 function formatNumber(value: number | null, units: string): string {
   if (value === null) return "Unavailable";
   const formatted = Number(value.toFixed(3)).toLocaleString();
@@ -14800,6 +14352,15 @@ function formatTimeValue(value: number | string | null): string {
   if (value === null) return "Time unavailable";
   if (typeof value === "number") return `${value.toLocaleString()} s`;
   return value;
+}
+
+function formatClockTime(value: number | string | null): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return formatTimeValue(value);
+  const totalSeconds = Math.max(0, Math.round(value));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return [hours, minutes, seconds].map((part) => String(part).padStart(2, "0")).join(":");
 }
 
 function runIdFromPackage(dryRun: DryRunResponse): string {
@@ -14851,9 +14412,8 @@ function verticalCoordinateUnit(pointCloud: PointCloudResponse | null): string |
 }
 
 function pointCloudFieldSummary(pointCloud: PointCloudResponse): string {
-  const units = pointCloud.field.units ?? "";
-  const maxValue = formatMaybeNumber(pointCloud.stats.field_max_value, units);
-  const threshold = formatScientific(pointCloud.selection.threshold, units);
+  const maxValue = formatFieldMaybeNumber(pointCloud.stats.field_max_value, pointCloud.field);
+  const threshold = formatFieldMaybeNumber(pointCloud.selection.threshold, pointCloud.field);
   return `Current field max: ${maxValue}. Visible points above ${threshold}: ${pointCloud.stats.source_count.toLocaleString()}.`;
 }
 
@@ -14861,14 +14421,8 @@ function emptyPointCloudStatus(
   pointCloud: PointCloudResponse,
   selectedEncoding: ThreeDScalarEncoding,
 ): string {
-  const maxValue = formatMaybeNumber(
-    pointCloud.stats.field_max_value,
-    selectedEncoding.field.units ?? "",
-  );
-  const threshold = formatScientific(
-    pointCloud.selection.threshold,
-    selectedEncoding.field.units ?? "",
-  );
+  const maxValue = formatFieldMaybeNumber(pointCloud.stats.field_max_value, selectedEncoding.field);
+  const threshold = formatFieldMaybeNumber(pointCloud.selection.threshold, selectedEncoding.field);
   return `${selectedEncoding.field.display_name} max is ${maxValue}; no points are above ${threshold}`;
 }
 
@@ -14878,7 +14432,7 @@ function maxPointLocationLabel(pointCloud: PointCloudResponse | null): string {
   const units = verticalCoordinateUnit(pointCloud) ?? "";
   return `x ${formatCompactNumber(location.x)}, y ${formatCompactNumber(location.y)}, z ${formatCompactNumber(
     location.z,
-  )}${units ? ` ${units}` : ""}, value ${formatCompactNumber(location.value)}`;
+  )}${units ? ` ${units}` : ""}, value ${formatFieldMaybeNumber(location.value, pointCloud?.field)}`;
 }
 
 function heatmapScaleClass(field: VisualizableField): string {
@@ -14948,14 +14502,14 @@ function sliceLegendMinimum(slice: SliceResponse): string {
   if (slice.field.raw_field_name === "dbz" || slice.field.canonical_field_name === "reflectivity") {
     return "0 dBZ";
   }
-  return formatMaybeNumber(slice.stats.min, slice.field.units);
+  return formatFieldMaybeNumber(slice.stats.min, slice.field);
 }
 
 function sliceLegendMaximum(slice: SliceResponse): string {
   if (slice.field.raw_field_name === "dbz" || slice.field.canonical_field_name === "reflectivity") {
     return "60+ dBZ";
   }
-  return formatMaybeNumber(slice.stats.max, slice.field.units);
+  return formatFieldMaybeNumber(slice.stats.max, slice.field);
 }
 
 function radarReflectivityBackground(dbz: number): string {

--- a/app/frontend/src/CloudWorldsHome.tsx
+++ b/app/frontend/src/CloudWorldsHome.tsx
@@ -97,18 +97,22 @@ export function CloudWorldsHome({
                 <p className="eyebrow">Installed World</p>
                 <h2 id="trade-cumulus-world-title">{tradeCumulus.display_name}</h2>
               </div>
-              <span className={`world-availability ${tradeCumulus.availability_state}`}>
-                {availabilityLabel(tradeCumulus.availability_state)}
-              </span>
+              {tradeCumulus.availability_state !== "available" && (
+                <span className={`world-availability ${tradeCumulus.availability_state}`}>
+                  {availabilityLabel(tradeCumulus.availability_state)}
+                </span>
+              )}
             </div>
             <p className="world-description">{tradeCumulus.short_description}</p>
-            <p className="world-availability-message">{tradeCumulus.availability_message}</p>
+            {tradeCumulus.availability_state !== "available" && (
+              <p className="world-availability-message">{tradeCumulus.availability_message}</p>
+            )}
           </div>
 
           <dl className="world-card-metrics">
             <div>
               <dt>Reference</dt>
-              <dd>{tradeCumulus.reference_available ? "Available" : "Unavailable"}</dd>
+              <dd>{tradeCumulus.reference_available ? "Canonical BOMEX" : "Unavailable"}</dd>
             </div>
             <div>
               <dt>Simulations</dt>

--- a/app/frontend/src/IntegratedExploreWorkspace.test.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.test.tsx
@@ -18,21 +18,19 @@ describe("IntegratedExploreWorkspace", () => {
       </IntegratedExploreWorkspace>,
     );
 
-    expect(
-      screen.getByRole("heading", { name: "Trade Cumulus / Canonical BOMEX Baseline" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Canonical BOMEX Baseline" })).toBeInTheDocument();
+    expect(screen.queryByText("Trade Cumulus / Canonical BOMEX Baseline")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Back to Trade Cumulus" }));
     fireEvent.click(screen.getByRole("button", { name: "Compare" }));
     expect(onBack).toHaveBeenCalledOnce();
     expect(onCompare).toHaveBeenCalledOnce();
   });
 
-  it("switches inspector sections and preserves the active section across collapse", () => {
+  it("keeps current context primary and places notes and details in secondary content", () => {
     render(
       <ExploreInspector
         sections={{
           explain: <p>Authored explanation</p>,
-          science: <p>Shallow-cloud evidence</p>,
           notes: <p>No note recorded</p>,
           details: <p>Technical provenance</p>,
         }}
@@ -40,11 +38,14 @@ describe("IntegratedExploreWorkspace", () => {
     );
 
     expect(screen.getByText("Authored explanation")).toBeVisible();
-    fireEvent.click(screen.getByRole("button", { name: "Science" }));
-    expect(screen.getByText("Shallow-cloud evidence")).toBeVisible();
+    expect(screen.getByLabelText("Simulation notebook")).toHaveTextContent("No note recorded");
+    expect(screen.getByLabelText("Simulation technical details")).toHaveTextContent(
+      "Technical provenance",
+    );
     fireEvent.click(screen.getByRole("button", { name: "Collapse inspector" }));
     expect(screen.getByLabelText("Explore inspector")).toHaveAttribute("data-collapsed", "true");
+    expect(screen.getByLabelText("Simulation notebook")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Open inspector" }));
-    expect(screen.getByText("Shallow-cloud evidence")).toBeVisible();
+    expect(screen.getByText("Authored explanation")).toBeVisible();
   });
 });

--- a/app/frontend/src/IntegratedExploreWorkspace.test.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
+
+describe("IntegratedExploreWorkspace", () => {
+  it("leads with stable product identity and bounded actions", () => {
+    const onBack = vi.fn();
+    const onCompare = vi.fn();
+    render(
+      <IntegratedExploreWorkspace
+        worldName="Trade Cumulus"
+        simulationName="Canonical BOMEX Baseline"
+        onBack={onBack}
+        onCompare={onCompare}
+      >
+        <p>Coordinated views</p>
+      </IntegratedExploreWorkspace>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Trade Cumulus / Canonical BOMEX Baseline" }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Back to Trade Cumulus" }));
+    fireEvent.click(screen.getByRole("button", { name: "Compare" }));
+    expect(onBack).toHaveBeenCalledOnce();
+    expect(onCompare).toHaveBeenCalledOnce();
+  });
+
+  it("switches inspector sections and preserves the active section across collapse", () => {
+    render(
+      <ExploreInspector
+        sections={{
+          explain: <p>Authored explanation</p>,
+          science: <p>Shallow-cloud evidence</p>,
+          notes: <p>No note recorded</p>,
+          details: <p>Technical provenance</p>,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Authored explanation")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Science" }));
+    expect(screen.getByText("Shallow-cloud evidence")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Collapse inspector" }));
+    expect(screen.getByLabelText("Explore inspector")).toHaveAttribute("data-collapsed", "true");
+    fireEvent.click(screen.getByRole("button", { name: "Open inspector" }));
+    expect(screen.getByText("Shallow-cloud evidence")).toBeVisible();
+  });
+});

--- a/app/frontend/src/IntegratedExploreWorkspace.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.tsx
@@ -1,0 +1,108 @@
+import { type ReactNode, useState } from "react";
+
+export type ExploreInspectorSection = "explain" | "science" | "notes" | "details";
+
+type InspectorSections = Record<ExploreInspectorSection, ReactNode>;
+
+export function IntegratedExploreWorkspace({
+  worldName,
+  simulationName,
+  backLabel,
+  onBack,
+  onCompare,
+  children,
+}: {
+  worldName: string;
+  simulationName: string;
+  backLabel?: string;
+  onBack?: () => void;
+  onCompare?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <section className="integrated-explore-workspace" aria-label={`${simulationName} Explore`}>
+      <header className="integrated-explore-header">
+        <div>
+          <p className="eyebrow">Explore</p>
+          <h2>
+            <span>{worldName}</span>
+            <span> / </span>
+            <span>{simulationName}</span>
+          </h2>
+        </div>
+        {(onBack || onCompare) && (
+          <div className="integrated-explore-actions">
+            {onBack && (
+              <button type="button" className="secondary-button" onClick={onBack}>
+                {backLabel ?? `Back to ${worldName}`}
+              </button>
+            )}
+            {onCompare && (
+              <button type="button" onClick={onCompare}>
+                Compare
+              </button>
+            )}
+          </div>
+        )}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+export function ExploreInspector({ sections }: { sections: InspectorSections }) {
+  const [activeSection, setActiveSection] = useState<ExploreInspectorSection>("explain");
+  const [collapsed, setCollapsed] = useState(false);
+  const labels: Array<{ id: ExploreInspectorSection; label: string }> = [
+    { id: "explain", label: "Explain" },
+    { id: "science", label: "Science" },
+    { id: "notes", label: "Notes" },
+    { id: "details", label: "Details" },
+  ];
+
+  return (
+    <aside
+      className={`explore-inspector${collapsed ? " explore-inspector-collapsed" : ""}`}
+      aria-label="Explore inspector"
+      data-collapsed={collapsed ? "true" : "false"}
+    >
+      <header className="explore-inspector-header">
+        <strong>Inspector</strong>
+        <button
+          type="button"
+          className="secondary-button"
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? "Open inspector" : "Collapse inspector"}
+          onClick={() => setCollapsed((current) => !current)}
+        >
+          {collapsed ? "Open" : "Collapse"}
+        </button>
+      </header>
+      <div hidden={collapsed}>
+        <nav className="explore-inspector-tabs" aria-label="Explore inspector sections">
+          {labels.map(({ id, label }) => (
+            <button
+              key={id}
+              type="button"
+              className={activeSection === id ? "active-control" : ""}
+              aria-pressed={activeSection === id}
+              onClick={() => setActiveSection(id)}
+            >
+              {label}
+            </button>
+          ))}
+        </nav>
+        {labels.map(({ id, label }) => (
+          <section
+            key={id}
+            className="explore-inspector-panel"
+            aria-label={`${label} inspector`}
+            hidden={activeSection !== id}
+          >
+            {sections[id]}
+          </section>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/app/frontend/src/IntegratedExploreWorkspace.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.tsx
@@ -1,8 +1,10 @@
 import { type ReactNode, useState } from "react";
 
-export type ExploreInspectorSection = "explain" | "science" | "notes" | "details";
-
-type InspectorSections = Record<ExploreInspectorSection, ReactNode>;
+type InspectorSections = {
+  explain: ReactNode;
+  notes: ReactNode;
+  details: ReactNode;
+};
 
 export function IntegratedExploreWorkspace({
   worldName,
@@ -22,26 +24,24 @@ export function IntegratedExploreWorkspace({
   return (
     <section className="integrated-explore-workspace" aria-label={`${simulationName} Explore`}>
       <header className="integrated-explore-header">
-        <div>
-          <p className="eyebrow">Explore</p>
-          <h2>
-            <span>{worldName}</span>
-            <span> / </span>
-            <span>{simulationName}</span>
-          </h2>
+        <div className="integrated-explore-identity">
+          {onBack && (
+            <button
+              type="button"
+              className="integrated-explore-back"
+              aria-label={backLabel ?? `Back to ${worldName}`}
+              onClick={onBack}
+            >
+              <span aria-hidden="true">&lsaquo;</span> {worldName}
+            </button>
+          )}
+          <h2>{simulationName}</h2>
         </div>
-        {(onBack || onCompare) && (
+        {onCompare && (
           <div className="integrated-explore-actions">
-            {onBack && (
-              <button type="button" className="secondary-button" onClick={onBack}>
-                {backLabel ?? `Back to ${worldName}`}
-              </button>
-            )}
-            {onCompare && (
-              <button type="button" onClick={onCompare}>
-                Compare
-              </button>
-            )}
+            <button type="button" onClick={onCompare}>
+              Compare
+            </button>
           </div>
         )}
       </header>
@@ -51,58 +51,38 @@ export function IntegratedExploreWorkspace({
 }
 
 export function ExploreInspector({ sections }: { sections: InspectorSections }) {
-  const [activeSection, setActiveSection] = useState<ExploreInspectorSection>("explain");
   const [collapsed, setCollapsed] = useState(false);
-  const labels: Array<{ id: ExploreInspectorSection; label: string }> = [
-    { id: "explain", label: "Explain" },
-    { id: "science", label: "Science" },
-    { id: "notes", label: "Notes" },
-    { id: "details", label: "Details" },
-  ];
 
   return (
-    <aside
-      className={`explore-inspector${collapsed ? " explore-inspector-collapsed" : ""}`}
-      aria-label="Explore inspector"
-      data-collapsed={collapsed ? "true" : "false"}
-    >
-      <header className="explore-inspector-header">
-        <strong>Inspector</strong>
-        <button
-          type="button"
-          className="secondary-button"
-          aria-expanded={!collapsed}
-          aria-label={collapsed ? "Open inspector" : "Collapse inspector"}
-          onClick={() => setCollapsed((current) => !current)}
-        >
-          {collapsed ? "Open" : "Collapse"}
-        </button>
-      </header>
-      <div hidden={collapsed}>
-        <nav className="explore-inspector-tabs" aria-label="Explore inspector sections">
-          {labels.map(({ id, label }) => (
-            <button
-              key={id}
-              type="button"
-              className={activeSection === id ? "active-control" : ""}
-              aria-pressed={activeSection === id}
-              onClick={() => setActiveSection(id)}
-            >
-              {label}
-            </button>
-          ))}
-        </nav>
-        {labels.map(({ id, label }) => (
-          <section
-            key={id}
-            className="explore-inspector-panel"
-            aria-label={`${label} inspector`}
-            hidden={activeSection !== id}
+    <>
+      <aside
+        className={`explore-inspector${collapsed ? " explore-inspector-collapsed" : ""}`}
+        aria-label="Explore inspector"
+        data-collapsed={collapsed ? "true" : "false"}
+      >
+        <header className="explore-inspector-header">
+          {!collapsed && <strong>Context</strong>}
+          <button
+            type="button"
+            className="explore-inspector-toggle"
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? "Open inspector" : "Collapse inspector"}
+            title={collapsed ? "Open inspector" : "Collapse inspector"}
+            onClick={() => setCollapsed((current) => !current)}
           >
-            {sections[id]}
+            <span aria-hidden="true">{collapsed ? "\u00ab" : "\u00bb"}</span>
+          </button>
+        </header>
+        <div hidden={collapsed}>
+          <section className="explore-inspector-panel" aria-label="Context inspector">
+            {sections.explain}
           </section>
-        ))}
-      </div>
-    </aside>
+        </div>
+      </aside>
+      <section className="explore-secondary-content" aria-label="Simulation notebook and details">
+        <section aria-label="Simulation notebook">{sections.notes}</section>
+        <section aria-label="Simulation technical details">{sections.details}</section>
+      </section>
+    </>
   );
 }

--- a/app/frontend/src/TradeCumulusComparisonStory.test.tsx
+++ b/app/frontend/src/TradeCumulusComparisonStory.test.tsx
@@ -406,7 +406,7 @@ describe("TradeCumulusComparisonStory", () => {
     expect(requestedUrls).toContain(
       `/api/results/${moreId}/visualization/trade-cumulus-updraft-lens/frame?time_index=169&plane_index=51&orientation=vertical_x&wind_mode=perturbation`,
     );
-    expect(screen.queryByRole("button", { name: "Play time" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Play" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Position")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("2-D slice field")).not.toBeInTheDocument();
   });

--- a/app/frontend/src/TradeCumulusWorld.tsx
+++ b/app/frontend/src/TradeCumulusWorld.tsx
@@ -384,13 +384,15 @@ function SimulationCard({
           <p className="eyebrow">{roleLabel(simulation.role)}</p>
           <h3>{simulation.display_name}</h3>
         </div>
-        <div className="simulation-state-row">
-          <span className={`technical-state ${simulation.technical_state}`}>
-            {technicalStateLabel(simulation.technical_state)}
-          </span>
-        </div>
+        {simulation.technical_state !== "available" && (
+          <div className="simulation-state-row">
+            <span className={`technical-state ${simulation.technical_state}`}>
+              {technicalStateLabel(simulation.technical_state)}
+            </span>
+          </div>
+        )}
       </header>
-      <p>{simulation.technical_state_message}</p>
+      {simulation.technical_state !== "available" && <p>{simulation.technical_state_message}</p>}
       {simulation.parent_simulation_id && (
         <p className="simulation-relationship">
           Parent: {relationshipName(simulation.parent_simulation_id)}
@@ -495,11 +497,13 @@ function ComparisonCard({
           <p className="eyebrow">Featured Comparison</p>
           <h3>{comparison.display_name}</h3>
         </div>
-        <span className={`technical-state ${comparison.availability_state}`}>
-          {technicalStateLabel(comparison.availability_state)}
-        </span>
+        {comparison.availability_state !== "available" && (
+          <span className={`technical-state ${comparison.availability_state}`}>
+            {technicalStateLabel(comparison.availability_state)}
+          </span>
+        )}
       </header>
-      <p>{comparison.availability_message}</p>
+      {comparison.availability_state !== "available" && <p>{comparison.availability_message}</p>}
       <button type="button" disabled={!comparison.open_available} onClick={onOpen}>
         Open Comparison
       </button>

--- a/app/frontend/src/True3DViewer.test.tsx
+++ b/app/frontend/src/True3DViewer.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  axisAlignedPlaneOccludesPoint,
   cameraDistanceLimits,
   scalarPointPixelSize,
+  updraftLensPlaneTextureData,
   updraftLensTextureData,
   windArrowLength,
 } from "./True3DViewer.utils";
@@ -77,5 +79,59 @@ describe("True3DViewer Updraft Lens texture", () => {
       }),
     );
     expect(textureBytes).toEqual(sliceBytes);
+  });
+
+  it("burns a stable black cloud boundary into the higher-resolution plane texture", () => {
+    const withBoundary = updraftLensPlaneTextureData(
+      [[0, 0]],
+      2,
+      1,
+      [-0.1],
+      ["#ffffff", "#00d63b"],
+      [[true, false]],
+      true,
+    );
+    const withoutBoundary = updraftLensPlaneTextureData(
+      [[0, 0]],
+      2,
+      1,
+      [-0.1],
+      ["#ffffff", "#00d63b"],
+      [[true, false]],
+      false,
+    );
+    const countBlackPixels = (data: Uint8Array) => {
+      let count = 0;
+      for (let index = 0; index < data.length; index += 4) {
+        if (data[index] === 0x0b && data[index + 1] === 0x0c && data[index + 2] === 0x0c) {
+          count += 1;
+        }
+      }
+      return count;
+    };
+    expect(withBoundary.width).toBe(12);
+    expect(withBoundary.height).toBe(6);
+    expect(countBlackPixels(withBoundary.data)).toBeGreaterThan(0);
+    expect(countBlackPixels(withoutBoundary.data)).toBe(0);
+  });
+});
+
+describe("True3DViewer Lens occlusion", () => {
+  const bounds = {
+    x: { min: -1, max: 1 },
+    y: { min: -1, max: 1 },
+    z: { min: -1, max: 1 },
+  };
+
+  it("recognizes a point behind the bounded Lens plane", () => {
+    expect(
+      axisAlignedPlaneOccludesPoint({ x: 0, y: 0, z: 10 }, { x: 0, y: 0, z: -5 }, "z", 0, bounds),
+    ).toBe(true);
+    expect(
+      axisAlignedPlaneOccludesPoint({ x: 0, y: 0, z: 10 }, { x: 4, y: 0, z: -5 }, "z", 0, bounds),
+    ).toBe(false);
+    expect(
+      axisAlignedPlaneOccludesPoint({ x: 0, y: 0, z: 10 }, { x: 0, y: 0, z: 5 }, "z", 0, bounds),
+    ).toBe(false);
   });
 });

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -100,6 +100,7 @@ type True3DViewerProps = {
   windReferenceMps?: number;
   windArrowDomainFraction?: number;
   updraftLensFrame?: UpdraftLensFrame | null;
+  showUpdraftLensLegend?: boolean;
 };
 
 type SceneRefs = {
@@ -163,6 +164,7 @@ export function True3DViewer({
   windReferenceMps = 0,
   windArrowDomainFraction = 0.08,
   updraftLensFrame = null,
+  showUpdraftLensLegend = true,
 }: True3DViewerProps) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const axisLabelLayerRef = useRef<HTMLDivElement | null>(null);
@@ -386,7 +388,7 @@ export function True3DViewer({
             <span>{windReferenceMps.toFixed(1)} m/s reference = 8% domain width</span>
           </div>
         )}
-        {updraftLensFrame && (
+        {updraftLensFrame && showUpdraftLensLegend && (
           <UpdraftLensScaleLegend frame={updraftLensFrame} viewLabel="3-D viewer" />
         )}
         <div

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -9,9 +9,10 @@ import type {
 } from "./UpdraftLensSlice";
 import { UpdraftLensScaleLegend } from "./UpdraftLensSlice";
 import {
+  axisAlignedPlaneOccludesPoint,
   cameraDistanceLimits,
   scalarPointPixelSize,
-  updraftLensTextureData,
+  updraftLensPlaneTextureData,
   windArrowLength,
 } from "./True3DViewer.utils";
 
@@ -100,6 +101,8 @@ type True3DViewerProps = {
   windReferenceMps?: number;
   windArrowDomainFraction?: number;
   updraftLensFrame?: UpdraftLensFrame | null;
+  updraftLensOpacity?: number;
+  showUpdraftLensBoundary?: boolean;
   showUpdraftLensLegend?: boolean;
   compactWorkspace?: boolean;
   compactDisplayControls?: ReactNode;
@@ -168,6 +171,8 @@ export function True3DViewer({
   windReferenceMps = 0,
   windArrowDomainFraction = 0.08,
   updraftLensFrame = null,
+  updraftLensOpacity = 0.9,
+  showUpdraftLensBoundary = true,
   showUpdraftLensLegend = true,
   compactWorkspace = false,
   compactDisplayControls,
@@ -177,6 +182,8 @@ export function True3DViewer({
   const mountRef = useRef<HTMLDivElement | null>(null);
   const axisLabelLayerRef = useRef<HTMLDivElement | null>(null);
   const refs = useRef<SceneRefs | null>(null);
+  const axisOcclusionRef = useRef({ frame: updraftLensFrame, opacity: updraftLensOpacity });
+  axisOcclusionRef.current = { frame: updraftLensFrame, opacity: updraftLensOpacity };
   const [renderError, setRenderError] = useState<string | null>(null);
   const [cameraStatus, setCameraStatus] = useState("Camera ready");
   const [tallViewport, setTallViewport] = useState(false);
@@ -284,7 +291,14 @@ export function True3DViewer({
       const animate = () => {
         controls.update();
         renderer.render(scene, camera);
-        positionAxisLabels(axisLabelLayerRef.current, renderer.domElement, camera, axisLabels);
+        positionAxisLabels(
+          axisLabelLayerRef.current,
+          renderer.domElement,
+          camera,
+          axisLabels,
+          bounds,
+          axisOcclusionRef.current,
+        );
         const current = refs.current;
         if (current) current.animationFrame = window.requestAnimationFrame(animate);
       };
@@ -337,6 +351,8 @@ export function True3DViewer({
       windReferenceMps,
       windArrowDomainFraction,
       updraftLensFrame,
+      updraftLensOpacity,
+      showUpdraftLensBoundary,
     });
   }, [
     activeSlice,
@@ -352,6 +368,8 @@ export function True3DViewer({
     windReferenceMps,
     windVectors,
     updraftLensFrame,
+    updraftLensOpacity,
+    showUpdraftLensBoundary,
   ]);
 
   return (
@@ -359,6 +377,8 @@ export function True3DViewer({
       className={`true3d-viewer${compactWorkspace ? " true3d-viewer-compact" : ""}`}
       aria-label="True 3-D scalar field viewer"
       data-result-name={resultName}
+      data-updraft-lens-opacity={updraftLensFrame ? updraftLensOpacity : undefined}
+      data-updraft-lens-cloud-boundary={updraftLensFrame ? showUpdraftLensBoundary : undefined}
     >
       {!compactWorkspace && (
         <div className="true3d-scene-header">
@@ -446,9 +466,7 @@ export function True3DViewer({
             )}
             {showWindVectors && windVectors.length > 0 && (
               <div className="true3d-wind-legend" aria-label="Horizontal wind overlay legend">
-                <strong>
-                  {windMode === "perturbation" ? "Local departures" : "Total wind"}
-                </strong>
+                <strong>{windMode === "perturbation" ? "Local departures" : "Total wind"}</strong>
                 <span>{windReferenceMps.toFixed(1)} m/s reference</span>
               </div>
             )}
@@ -605,6 +623,8 @@ function rebuildScene(
     windReferenceMps,
     windArrowDomainFraction,
     updraftLensFrame,
+    updraftLensOpacity,
+    showUpdraftLensBoundary,
   }: {
     bounds: SceneBounds;
     pointCloud: PointCloudResponse | null;
@@ -619,6 +639,8 @@ function rebuildScene(
     windReferenceMps: number;
     windArrowDomainFraction: number;
     updraftLensFrame: UpdraftLensFrame | null;
+    updraftLensOpacity: number;
+    showUpdraftLensBoundary: boolean;
   },
 ) {
   disposeScene(scene);
@@ -633,7 +655,7 @@ function rebuildScene(
   scene.add(axisTickMarks(bounds));
 
   if (pointCloud?.points.length) {
-    scene.add(cloudPointLayer(pointCloud, bounds, opacity, pointSize));
+    scene.add(cloudPointLayer(pointCloud, bounds, opacity, pointSize, Boolean(updraftLensFrame)));
   }
 
   if (showWindVectors && windVectors.length) {
@@ -641,7 +663,9 @@ function rebuildScene(
   }
 
   if (updraftLensFrame) {
-    scene.add(updraftLensSlicePlane(updraftLensFrame, bounds));
+    scene.add(
+      updraftLensSlicePlane(updraftLensFrame, bounds, updraftLensOpacity, showUpdraftLensBoundary),
+    );
   }
 
   if (showSlicePlane && activeSlice) {
@@ -653,19 +677,27 @@ function rebuildScene(
   }
 }
 
-function updraftLensSlicePlane(frame: UpdraftLensFrame, bounds: SceneBounds): THREE.Group {
+function updraftLensSlicePlane(
+  frame: UpdraftLensFrame,
+  bounds: SceneBounds,
+  opacity: number,
+  showCloudBoundary: boolean,
+): THREE.Group {
   const width = Math.max(1, frame.w_values_m_s[0]?.length ?? 0);
   const height = Math.max(1, frame.w_values_m_s.length);
-  const texture = new THREE.DataTexture(
-    updraftLensTextureData(
-      frame.w_values_m_s,
-      width,
-      height,
-      frame.w_scale_breakpoints_m_s,
-      frame.w_scale_colors,
-    ),
+  const texturePayload = updraftLensPlaneTextureData(
+    frame.w_values_m_s,
     width,
     height,
+    frame.w_scale_breakpoints_m_s,
+    frame.w_scale_colors,
+    frame.cloud_mask,
+    showCloudBoundary,
+  );
+  const texture = new THREE.DataTexture(
+    texturePayload.data,
+    texturePayload.width,
+    texturePayload.height,
     THREE.RGBAFormat,
     THREE.UnsignedByteType,
   );
@@ -675,18 +707,23 @@ function updraftLensSlicePlane(frame: UpdraftLensFrame, bounds: SceneBounds): TH
   texture.generateMipmaps = false;
   texture.needsUpdate = true;
 
-  let geometry: THREE.PlaneGeometry;
+  let planeWidth: number;
+  let planeHeight: number;
   if (frame.orientation === "horizontal") {
-    geometry = new THREE.PlaneGeometry(bounds.xRange, bounds.yRange);
+    planeWidth = bounds.xRange;
+    planeHeight = bounds.yRange;
   } else if (frame.orientation === "vertical_y") {
-    geometry = new THREE.PlaneGeometry(bounds.yRange, bounds.zRange);
+    planeWidth = bounds.yRange;
+    planeHeight = bounds.zRange;
   } else {
-    geometry = new THREE.PlaneGeometry(bounds.xRange, bounds.zRange);
+    planeWidth = bounds.xRange;
+    planeHeight = bounds.zRange;
   }
+  const geometry = new THREE.PlaneGeometry(planeWidth, planeHeight);
   const material = new THREE.MeshBasicMaterial({
     map: texture,
     transparent: true,
-    opacity: 0.68,
+    opacity: Math.min(1, Math.max(0.15, opacity)),
     side: THREE.DoubleSide,
     depthWrite: false,
   });
@@ -701,7 +738,7 @@ function updraftLensSlicePlane(frame: UpdraftLensFrame, bounds: SceneBounds): TH
   } else {
     plane.position.z = centeredCoordinate(frame.plane_coordinate ?? 0, bounds.y);
   }
-  plane.renderOrder = 10;
+  plane.renderOrder = 30;
 
   const outline = new THREE.LineSegments(
     new THREE.EdgesGeometry(geometry),
@@ -710,7 +747,7 @@ function updraftLensSlicePlane(frame: UpdraftLensFrame, bounds: SceneBounds): TH
   outline.name = "Updraft Lens plane outline";
   outline.position.copy(plane.position);
   outline.rotation.copy(plane.rotation);
-  outline.renderOrder = 11;
+  outline.renderOrder = 31;
 
   const group = new THREE.Group();
   group.name = "trade-cumulus-updraft-lens-slice-plane";
@@ -936,6 +973,8 @@ function positionAxisLabels(
   canvas: HTMLCanvasElement,
   camera: THREE.Camera,
   labels: AxisLabel[],
+  bounds: SceneBounds,
+  updraftLens: { frame: UpdraftLensFrame | null; opacity: number },
 ) {
   if (!layer) return;
   const width = canvas.clientWidth;
@@ -959,9 +998,54 @@ function positionAxisLabels(
       x <= width + 24 &&
       y >= -24 &&
       y <= height + 24;
+    const occluded =
+      updraftLens.frame !== null &&
+      updraftLensOccludesAxisLabel(camera.position, label.position, updraftLens.frame, bounds);
+    const lensVisibility = occluded ? (1 - updraftLens.opacity) ** 2 : 1;
     element.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%)`;
-    element.style.opacity = visible ? "1" : "0";
+    element.style.opacity = visible ? String(lensVisibility) : "0";
   });
+}
+
+function updraftLensOccludesAxisLabel(
+  camera: THREE.Vector3,
+  label: THREE.Vector3,
+  frame: UpdraftLensFrame,
+  bounds: SceneBounds,
+): boolean {
+  const halfX = bounds.xRange / 2;
+  const halfY = bounds.yRange / 2;
+  const halfZ = bounds.zRange / 2;
+  const planeBounds = {
+    x: { min: -halfX, max: halfX },
+    y: { min: -halfZ, max: halfZ },
+    z: { min: -halfY, max: halfY },
+  };
+  if (frame.orientation === "horizontal") {
+    return axisAlignedPlaneOccludesPoint(
+      camera,
+      label,
+      "y",
+      centeredCoordinate(frame.plane_coordinate ?? 0, bounds.z),
+      planeBounds,
+    );
+  }
+  if (frame.orientation === "vertical_y") {
+    return axisAlignedPlaneOccludesPoint(
+      camera,
+      label,
+      "x",
+      centeredCoordinate(frame.plane_coordinate ?? 0, bounds.x),
+      planeBounds,
+    );
+  }
+  return axisAlignedPlaneOccludesPoint(
+    camera,
+    label,
+    "z",
+    centeredCoordinate(frame.plane_coordinate ?? 0, bounds.y),
+    planeBounds,
+  );
 }
 
 function cloudPointLayer(
@@ -969,6 +1053,7 @@ function cloudPointLayer(
   bounds: SceneBounds,
   opacity: number,
   pointSize: number,
+  depthWrite: boolean,
 ): THREE.Points {
   const positions = new Float32Array(pointCloud.points.length * 3);
   const colors = new Float32Array(pointCloud.points.length * 3);
@@ -994,7 +1079,7 @@ function cloudPointLayer(
     vertexColors: true,
     transparent: true,
     opacity,
-    depthWrite: false,
+    depthWrite,
     sizeAttenuation: false,
   });
   const layer = new THREE.Points(geometry, material);
@@ -1084,7 +1169,9 @@ function fieldLegendMaximum(pointCloud: PointCloudResponse): string {
 }
 
 function formatFieldLegendValue(value: number | null, units: string | null): string {
-  return units === "kg/kg" ? formatValue(value === null ? null : value * 1000, "g/kg") : formatValue(value, units);
+  return units === "kg/kg"
+    ? formatValue(value === null ? null : value * 1000, "g/kg")
+    : formatValue(value, units);
 }
 
 function slicePlane(slice: SliceResponse, label: string, bounds: SceneBounds): THREE.Group {

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
@@ -101,6 +101,10 @@ type True3DViewerProps = {
   windArrowDomainFraction?: number;
   updraftLensFrame?: UpdraftLensFrame | null;
   showUpdraftLensLegend?: boolean;
+  compactWorkspace?: boolean;
+  compactDisplayControls?: ReactNode;
+  maximized?: boolean;
+  onToggleMaximize?: () => void;
 };
 
 type SceneRefs = {
@@ -165,6 +169,10 @@ export function True3DViewer({
   windArrowDomainFraction = 0.08,
   updraftLensFrame = null,
   showUpdraftLensLegend = true,
+  compactWorkspace = false,
+  compactDisplayControls,
+  maximized = false,
+  onToggleMaximize,
 }: True3DViewerProps) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const axisLabelLayerRef = useRef<HTMLDivElement | null>(null);
@@ -347,14 +355,20 @@ export function True3DViewer({
   ]);
 
   return (
-    <section className="true3d-viewer" aria-label="True 3-D scalar field viewer">
-      <div className="true3d-scene-header">
-        <div>
-          <p className="eyebrow">True 3-D scene</p>
-          <h3>{resultName}</h3>
+    <section
+      className={`true3d-viewer${compactWorkspace ? " true3d-viewer-compact" : ""}`}
+      aria-label="True 3-D scalar field viewer"
+      data-result-name={resultName}
+    >
+      {!compactWorkspace && (
+        <div className="true3d-scene-header">
+          <div>
+            <p className="eyebrow">True 3-D scene</p>
+            <h3>{resultName}</h3>
+          </div>
+          <p className="state-chip">{status}</p>
         </div>
-        <p className="state-chip">{status}</p>
-      </div>
+      )}
 
       <div className={`true3d-scene-frame${tallViewport ? " true3d-scene-frame-tall" : ""}`}>
         <div
@@ -363,11 +377,18 @@ export function True3DViewer({
           role="img"
           aria-label="Interactive Three.js scene showing a CM1 scalar field, domain bounds, slice plane, and selected point"
         />
-        <div className="true3d-scene-label true3d-scene-label-context">
-          <strong>{fieldLabel}</strong>
-          <span>{sceneTimeLabel || selectedTimeLabel}</span>
-          <span>Threshold {thresholdLabel}</span>
-        </div>
+        {compactWorkspace && (
+          <p className="sr-only" role="status">
+            {status}
+          </p>
+        )}
+        {!compactWorkspace && (
+          <div className="true3d-scene-label true3d-scene-label-context">
+            <strong>{fieldLabel}</strong>
+            <span>{sceneTimeLabel || selectedTimeLabel}</span>
+            <span>Threshold {thresholdLabel}</span>
+          </div>
+        )}
         {pointCloud && (
           <div className="true3d-field-legend" aria-label="3-D field color legend">
             <span>{pointCloud.field.display_name}</span>
@@ -382,7 +403,7 @@ export function True3DViewer({
             </div>
           </div>
         )}
-        {showWindVectors && windVectors.length > 0 && (
+        {!compactWorkspace && showWindVectors && windVectors.length > 0 && (
           <div className="true3d-wind-legend" aria-label="Horizontal wind overlay legend">
             <strong>{windMode === "perturbation" ? "Local departures" : "Total wind"}</strong>
             <span>{windReferenceMps.toFixed(1)} m/s reference = 8% domain width</span>
@@ -406,20 +427,50 @@ export function True3DViewer({
             </span>
           ))}
         </div>
-        {updraftLensFrame ? (
-          <p className="true3d-slice-label true3d-slice-label-updraft-lens">
-            Updraft Lens slice: {activeSliceLabel}
-          </p>
+        {compactWorkspace ? (
+          <div className="true3d-context-stack" aria-label="3-D scene context">
+            {updraftLensFrame ? (
+              <p className="true3d-slice-label true3d-slice-label-updraft-lens">
+                Updraft Lens: {activeSliceLabel}
+              </p>
+            ) : (
+              showSlicePlane &&
+              activeSlice && <p className="true3d-slice-label">Slice: {activeSliceLabel}</p>
+            )}
+            {selectedPoint && (
+              <p className="true3d-selected-point-label">
+                Selected: x {formatCoordinate(selectedPoint.x, bounds.x.units)}, y{" "}
+                {formatCoordinate(selectedPoint.y, bounds.y.units)}, z{" "}
+                {formatCoordinate(selectedPoint.z, bounds.z.units)}
+              </p>
+            )}
+            {showWindVectors && windVectors.length > 0 && (
+              <div className="true3d-wind-legend" aria-label="Horizontal wind overlay legend">
+                <strong>
+                  {windMode === "perturbation" ? "Local departures" : "Total wind"}
+                </strong>
+                <span>{windReferenceMps.toFixed(1)} m/s reference</span>
+              </div>
+            )}
+          </div>
         ) : (
-          showSlicePlane &&
-          activeSlice && <p className="true3d-slice-label">Slice plane: {activeSliceLabel}</p>
-        )}
-        {selectedPoint && (
-          <p className="true3d-selected-point-label">
-            Selected point: x {formatCoordinate(selectedPoint.x, bounds.x.units)}, y{" "}
-            {formatCoordinate(selectedPoint.y, bounds.y.units)}, z{" "}
-            {formatCoordinate(selectedPoint.z, bounds.z.units)}
-          </p>
+          <>
+            {updraftLensFrame ? (
+              <p className="true3d-slice-label true3d-slice-label-updraft-lens">
+                Updraft Lens slice: {activeSliceLabel}
+              </p>
+            ) : (
+              showSlicePlane &&
+              activeSlice && <p className="true3d-slice-label">Slice plane: {activeSliceLabel}</p>
+            )}
+            {selectedPoint && (
+              <p className="true3d-selected-point-label">
+                Selected point: x {formatCoordinate(selectedPoint.x, bounds.x.units)}, y{" "}
+                {formatCoordinate(selectedPoint.y, bounds.y.units)}, z{" "}
+                {formatCoordinate(selectedPoint.z, bounds.z.units)}
+              </p>
+            )}
+          </>
         )}
         {renderError && (
           <p className="true3d-render-error" role="status">
@@ -435,53 +486,101 @@ export function True3DViewer({
         )}
       </div>
 
-      <div className="true3d-controls" aria-label="3-D camera controls">
-        <div className="true3d-control-section">
-          <span>Camera</span>
-          <div className="true3d-preset-buttons" aria-label="3-D camera presets">
-            <button type="button" onClick={() => setCameraPreset("overview")}>
-              Overview
+      {compactWorkspace ? (
+        <div className="true3d-controls true3d-controls-compact" aria-label="3-D camera controls">
+          {compactDisplayControls && (
+            <details className="true3d-display-control">
+              <summary>
+                <span>Display</span>
+              </summary>
+              <div className="true3d-display-panel">{compactDisplayControls}</div>
+            </details>
+          )}
+          <label>
+            <span className="sr-only">Camera view</span>
+            <select
+              aria-label="Camera view"
+              defaultValue="overview"
+              onChange={(event) => setCameraPreset(event.target.value as CameraPreset)}
+            >
+              <option value="overview">Overview</option>
+              <option value="top_down_xy">Top-down x-y</option>
+              <option value="look_along_x">Look along x</option>
+              <option value="look_along_y">Look along y</option>
+            </select>
+          </label>
+          <button
+            type="button"
+            className="true3d-icon-command"
+            aria-label="Reset camera"
+            title="Reset camera"
+            onClick={resetCamera}
+          >
+            <span aria-hidden="true">{"\u21ba"}</span>
+          </button>
+          {onToggleMaximize && (
+            <button
+              type="button"
+              className="viewer-maximize-button"
+              aria-label={maximized ? "Restore 3-D viewer" : "Maximize 3-D viewer"}
+              title={maximized ? "Restore 3-D viewer" : "Maximize 3-D viewer"}
+              onClick={onToggleMaximize}
+            >
+              <span aria-hidden="true">{"\u26f6"}</span>
             </button>
-            <button type="button" onClick={() => setCameraPreset("top_down_xy")}>
-              Top-down x-y
-            </button>
-            <button type="button" onClick={() => setCameraPreset("look_along_x")}>
-              Look along x
-            </button>
-            <button type="button" onClick={() => setCameraPreset("look_along_y")}>
-              Look along y
-            </button>
-          </div>
+          )}
         </div>
-        <div className="true3d-control-section">
-          <span>View</span>
-          <div className="true3d-preset-buttons" aria-label="3-D view actions">
-            <button type="button" onClick={() => zoomCamera("in")}>
-              Zoom in
-            </button>
-            <button type="button" onClick={() => zoomCamera("out")}>
-              Zoom out
-            </button>
-            <button type="button" onClick={() => moveCameraVertical("up")}>
-              Pan view up
-            </button>
-            <button type="button" onClick={() => moveCameraVertical("down")}>
-              Pan view down
-            </button>
-            <button type="button" onClick={resetCamera}>
-              Reset camera
-            </button>
-            <button type="button" onClick={toggleViewportHeight}>
-              {tallViewport ? "Standard viewport" : "Taller viewport"}
-            </button>
+      ) : (
+        <>
+          <div className="true3d-controls" aria-label="3-D camera controls">
+            <div className="true3d-control-section">
+              <span>Camera</span>
+              <div className="true3d-preset-buttons" aria-label="3-D camera presets">
+                <button type="button" onClick={() => setCameraPreset("overview")}>
+                  Overview
+                </button>
+                <button type="button" onClick={() => setCameraPreset("top_down_xy")}>
+                  Top-down x-y
+                </button>
+                <button type="button" onClick={() => setCameraPreset("look_along_x")}>
+                  Look along x
+                </button>
+                <button type="button" onClick={() => setCameraPreset("look_along_y")}>
+                  Look along y
+                </button>
+              </div>
+            </div>
+            <div className="true3d-control-section">
+              <span>View</span>
+              <div className="true3d-preset-buttons" aria-label="3-D view actions">
+                <button type="button" onClick={() => zoomCamera("in")}>
+                  Zoom in
+                </button>
+                <button type="button" onClick={() => zoomCamera("out")}>
+                  Zoom out
+                </button>
+                <button type="button" onClick={() => moveCameraVertical("up")}>
+                  Pan view up
+                </button>
+                <button type="button" onClick={() => moveCameraVertical("down")}>
+                  Pan view down
+                </button>
+                <button type="button" onClick={resetCamera}>
+                  Reset camera
+                </button>
+                <button type="button" onClick={toggleViewportHeight}>
+                  {tallViewport ? "Standard viewport" : "Taller viewport"}
+                </button>
+              </div>
+            </div>
+            <p>{cameraStatus}. Drag to orbit, right-drag to pan, scroll to zoom.</p>
           </div>
-        </div>
-        <p>{cameraStatus}. Drag to orbit, right-drag to pan, scroll to zoom.</p>
-      </div>
-      <p className="true3d-provenance" aria-label="3-D provenance labels">
-        {valueChannelLabel} CM1-derived visualization-ready scalar points and native-grid slice
-        plane; rendered with direct Three.js. {provenanceLabel}
-      </p>
+          <p className="true3d-provenance" aria-label="3-D provenance labels">
+            {valueChannelLabel} CM1-derived visualization-ready scalar points and native-grid slice
+            plane; rendered with direct Three.js. {provenanceLabel}
+          </p>
+        </>
+      )}
     </section>
   );
 }
@@ -976,12 +1075,16 @@ function scalarRampKey(fieldName: string): string {
 
 function fieldLegendMinimum(pointCloud: PointCloudResponse): string {
   if (pointCloud.field.raw_field_name === "dbz") return "0 dBZ";
-  return formatValue(pointCloud.stats.min_value, pointCloud.field.units);
+  return formatFieldLegendValue(pointCloud.stats.min_value, pointCloud.field.units);
 }
 
 function fieldLegendMaximum(pointCloud: PointCloudResponse): string {
   if (pointCloud.field.raw_field_name === "dbz") return "60+ dBZ";
-  return formatValue(pointCloud.stats.max_value, pointCloud.field.units);
+  return formatFieldLegendValue(pointCloud.stats.max_value, pointCloud.field.units);
+}
+
+function formatFieldLegendValue(value: number | null, units: string | null): string {
+  return units === "kg/kg" ? formatValue(value === null ? null : value * 1000, "g/kg") : formatValue(value, units);
 }
 
 function slicePlane(slice: SliceResponse, label: string, bounds: SceneBounds): THREE.Group {

--- a/app/frontend/src/True3DViewer.utils.ts
+++ b/app/frontend/src/True3DViewer.utils.ts
@@ -4,6 +4,10 @@ const DEFAULT_SCALAR_POINT_PIXEL_SIZE = 11;
 const MIN_SCALAR_POINT_PIXEL_SIZE = 3;
 const MAX_SCALAR_POINT_PIXEL_SIZE = 18;
 const DEFAULT_MAX_RANGE = 6.4;
+const UPDRAFT_LENS_TEXTURE_CELL_SCALE = 6;
+
+type Point3 = { x: number; y: number; z: number };
+type Axis3 = keyof Point3;
 
 export function scalarPointPixelSize(pointSize: number): number {
   const resolved = Number.isFinite(pointSize) ? pointSize : DEFAULT_SCALAR_POINT_PIXEL_SIZE;
@@ -19,6 +23,28 @@ export function cameraDistanceLimits(maxRange: number): {
     minDistance: Math.max(1.5, resolvedMaxRange * 0.015),
     maxDistance: Math.max(40, resolvedMaxRange * 3),
   };
+}
+
+export function axisAlignedPlaneOccludesPoint(
+  camera: Point3,
+  point: Point3,
+  planeAxis: Axis3,
+  planeCoordinate: number,
+  planeBounds: Record<Axis3, { min: number; max: number }>,
+): boolean {
+  const denominator = point[planeAxis] - camera[planeAxis];
+  if (Math.abs(denominator) < Number.EPSILON) return false;
+  const amount = (planeCoordinate - camera[planeAxis]) / denominator;
+  if (amount <= 0 || amount >= 1) return false;
+  const intersection = {
+    x: camera.x + (point.x - camera.x) * amount,
+    y: camera.y + (point.y - camera.y) * amount,
+    z: camera.z + (point.z - camera.z) * amount,
+  };
+  return (Object.keys(planeBounds) as Axis3[]).every(
+    (axis) =>
+      intersection[axis] >= planeBounds[axis].min && intersection[axis] <= planeBounds[axis].max,
+  );
 }
 
 export function windArrowLength(
@@ -64,6 +90,51 @@ export function updraftLensTextureData(
     }
   }
   return data;
+}
+
+export function updraftLensPlaneTextureData(
+  values: Array<Array<number | null>>,
+  width: number,
+  height: number,
+  breakpoints: number[],
+  colors: string[],
+  cloudMask: boolean[][],
+  showCloudBoundary: boolean,
+): { data: Uint8Array; width: number; height: number } {
+  const sourceWidth = Math.max(1, Math.trunc(width));
+  const sourceHeight = Math.max(1, Math.trunc(height));
+  const textureWidth = sourceWidth * UPDRAFT_LENS_TEXTURE_CELL_SCALE;
+  const textureHeight = sourceHeight * UPDRAFT_LENS_TEXTURE_CELL_SCALE;
+  const data = new Uint8Array(textureWidth * textureHeight * 4);
+  const cloudy = (row: number, column: number) => Boolean(cloudMask[row]?.[column]);
+
+  for (let row = 0; row < sourceHeight; row += 1) {
+    for (let column = 0; column < sourceWidth; column += 1) {
+      const baseColor = hexColorChannels(
+        updraftLensDiscreteColor(values[row]?.[column] ?? null, breakpoints, colors),
+      );
+      for (let cellY = 0; cellY < UPDRAFT_LENS_TEXTURE_CELL_SCALE; cellY += 1) {
+        for (let cellX = 0; cellX < UPDRAFT_LENS_TEXTURE_CELL_SCALE; cellX += 1) {
+          const boundaryPixel =
+            showCloudBoundary &&
+            cloudy(row, column) &&
+            ((cellX === 0 && !cloudy(row, column - 1)) ||
+              (cellX === UPDRAFT_LENS_TEXTURE_CELL_SCALE - 1 && !cloudy(row, column + 1)) ||
+              (cellY === 0 && !cloudy(row - 1, column)) ||
+              (cellY === UPDRAFT_LENS_TEXTURE_CELL_SCALE - 1 && !cloudy(row + 1, column)));
+          const [red, green, blue] = boundaryPixel ? [0x0b, 0x0c, 0x0c] : baseColor;
+          const textureX = column * UPDRAFT_LENS_TEXTURE_CELL_SCALE + cellX;
+          const textureY = row * UPDRAFT_LENS_TEXTURE_CELL_SCALE + cellY;
+          const offset = (textureY * textureWidth + textureX) * 4;
+          data[offset] = red;
+          data[offset + 1] = green;
+          data[offset + 2] = blue;
+          data[offset + 3] = 255;
+        }
+      }
+    }
+  }
+  return { data, width: textureWidth, height: textureHeight };
 }
 
 function hexColorChannels(color: string): [number, number, number] {

--- a/app/frontend/src/UpdraftLensSlice.test.tsx
+++ b/app/frontend/src/UpdraftLensSlice.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   type UpdraftLensFrame,
+  UpdraftLensScaleLegend,
   UpdraftLensSlice,
   updraftLensBoundaryPath,
   updraftLensCellGeometry,
@@ -183,6 +184,16 @@ describe("UpdraftLensSlice rendering", () => {
     expect(legend).toHaveTextContent("Slice minimum -1.00 m/s.");
     expect(screen.queryByText(/Clipped in this slice/)).not.toBeInTheDocument();
     expect(screen.getByTestId("updraft-lens-cloud-boundary")).toBeInTheDocument();
+  });
+
+  it("uses a compact unit-once legend outside the maximized Lens", () => {
+    render(<UpdraftLensScaleLegend frame={frame} viewLabel="Explore workspace" compact />);
+    const legend = screen.getByLabelText(/Explore workspace Vertical velocity \(w\), m\/s/);
+    expect(legend).toHaveTextContent("w (m/s)");
+    expect(legend).toHaveTextContent("3.0 to < 5.0");
+    expect(legend).not.toHaveTextContent("3.0 to < 5.0 m/s");
+    expect(legend).not.toHaveTextContent("Slice maximum");
+    expect(legend).not.toHaveTextContent("Slice minimum");
   });
 
   it.each([

--- a/app/frontend/src/UpdraftLensSlice.tsx
+++ b/app/frontend/src/UpdraftLensSlice.tsx
@@ -122,6 +122,7 @@ export type UpdraftLensDefaults = {
 type UpdraftLensSliceProps = {
   frame: UpdraftLensFrame;
   showCloudBoundary?: boolean;
+  showLegend?: boolean;
   selectedPoint?: UpdraftLensPointSelection | null;
   onSelectPoint?: (selection: UpdraftLensPointSelection) => void;
 };
@@ -154,6 +155,7 @@ const INTERVAL_MEANINGS = [
 export function UpdraftLensSlice({
   frame,
   showCloudBoundary = true,
+  showLegend = true,
   selectedPoint = null,
   onSelectPoint,
 }: UpdraftLensSliceProps) {
@@ -208,7 +210,10 @@ export function UpdraftLensSlice({
   }
 
   return (
-    <section className="updraft-lens-slice" aria-label="Updraft Lens vertical slice">
+    <section
+      className={`updraft-lens-slice${showLegend ? "" : " updraft-lens-slice-without-legend"}`}
+      aria-label="Updraft Lens slice"
+    >
       <div className="updraft-lens-axis updraft-lens-axis-z" aria-hidden="true">
         <span>{formatKilometers(rowMax)}</span>
         <strong>{rowDimension} (km)</strong>
@@ -274,7 +279,7 @@ export function UpdraftLensSlice({
           <span>{formatKilometers(columnMax)}</span>
         </div>
       </div>
-      <UpdraftLensScaleLegend frame={frame} viewLabel="2-D inspector" />
+      {showLegend && <UpdraftLensScaleLegend frame={frame} viewLabel="2-D inspector" />}
     </section>
   );
 }
@@ -317,7 +322,7 @@ export function UpdraftLensScaleLegend({
   viewLabel,
 }: {
   frame: UpdraftLensFrame;
-  viewLabel: "2-D inspector" | "3-D viewer";
+  viewLabel: "2-D inspector" | "3-D viewer" | "Explore workspace";
 }) {
   const intervals = updraftLensScaleIntervals(frame.w_scale_breakpoints_m_s, frame.w_scale_colors);
   const finiteValues = frame.w_values_m_s
@@ -325,7 +330,8 @@ export function UpdraftLensScaleLegend({
     .filter((value): value is number => value !== null && Number.isFinite(value));
   const sliceMinimum = finiteValues.length > 0 ? Math.min(...finiteValues) : null;
   const sliceMaximum = finiteValues.length > 0 ? Math.max(...finiteValues) : null;
-  const viewClass = viewLabel === "2-D inspector" ? "2d" : "3d";
+  const viewClass =
+    viewLabel === "2-D inspector" ? "2d" : viewLabel === "3-D viewer" ? "3d" : "workspace";
   return (
     <section
       className={`updraft-lens-scale-legend updraft-lens-scale-legend-${viewClass}`}

--- a/app/frontend/src/UpdraftLensSlice.tsx
+++ b/app/frontend/src/UpdraftLensSlice.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import type { MouseEvent as ReactMouseEvent } from "react";
+import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
 
 export type UpdraftLensWindMode = "perturbation" | "total";
 export type UpdraftLensOrientation = "horizontal" | "vertical_x" | "vertical_y";
@@ -211,8 +211,12 @@ export function UpdraftLensSlice({
 
   return (
     <section
-      className={`updraft-lens-slice${showLegend ? "" : " updraft-lens-slice-without-legend"}`}
+      className={`updraft-lens-slice updraft-lens-slice-${
+        frame.orientation === "horizontal" ? "top-down" : "side-on"
+      }${showLegend ? "" : " updraft-lens-slice-without-legend"}`}
       aria-label="Updraft Lens slice"
+      data-orientation={frame.orientation}
+      style={{ "--updraft-lens-domain-aspect": String(width / height) } as CSSProperties}
     >
       <div className="updraft-lens-axis updraft-lens-axis-z" aria-hidden="true">
         <span>{formatKilometers(rowMax)}</span>
@@ -320,9 +324,11 @@ export function updraftLensColor(
 export function UpdraftLensScaleLegend({
   frame,
   viewLabel,
+  compact = false,
 }: {
   frame: UpdraftLensFrame;
   viewLabel: "2-D inspector" | "3-D viewer" | "Explore workspace";
+  compact?: boolean;
 }) {
   const intervals = updraftLensScaleIntervals(frame.w_scale_breakpoints_m_s, frame.w_scale_colors);
   const finiteValues = frame.w_values_m_s
@@ -334,15 +340,19 @@ export function UpdraftLensScaleLegend({
     viewLabel === "2-D inspector" ? "2d" : viewLabel === "3-D viewer" ? "3d" : "workspace";
   return (
     <section
-      className={`updraft-lens-scale-legend updraft-lens-scale-legend-${viewClass}`}
+      className={`updraft-lens-scale-legend updraft-lens-scale-legend-${viewClass}${
+        compact ? " updraft-lens-scale-legend-compact" : ""
+      }`}
       aria-label={`${viewLabel} ${SCALE_TITLE}; ${frame.w_scale_id}`}
     >
       <div className="updraft-lens-scale-heading">
-        <strong>{SCALE_TITLE}</strong>
+        <strong>{compact ? "w (m/s)" : SCALE_TITLE}</strong>
       </div>
-      <p className="updraft-lens-slice-range updraft-lens-slice-range-maximum">
-        Slice maximum {sliceMaximum === null ? "unavailable" : `${sliceMaximum.toFixed(2)} m/s`}.
-      </p>
+      {!compact && (
+        <p className="updraft-lens-slice-range updraft-lens-slice-range-maximum">
+          Slice maximum {sliceMaximum === null ? "unavailable" : `${sliceMaximum.toFixed(2)} m/s`}.
+        </p>
+      )}
       <ol className="updraft-lens-scale-intervals" aria-label="Exact vertical velocity intervals">
         {[...intervals].reverse().map((interval, reversedIndex) => {
           const index = intervals.length - 1 - reversedIndex;
@@ -356,16 +366,16 @@ export function UpdraftLensScaleLegend({
                 style={{ backgroundColor: interval.color }}
                 aria-hidden="true"
               />
-              <span>
-                {interval.label} {frame.w_scale_units}
-              </span>
+              <span>{compact ? interval.label : `${interval.label} ${frame.w_scale_units}`}</span>
             </li>
           );
         })}
       </ol>
-      <p className="updraft-lens-slice-range updraft-lens-slice-range-minimum">
-        Slice minimum {sliceMinimum === null ? "unavailable" : `${sliceMinimum.toFixed(2)} m/s`}.
-      </p>
+      {!compact && (
+        <p className="updraft-lens-slice-range updraft-lens-slice-range-minimum">
+          Slice minimum {sliceMinimum === null ? "unavailable" : `${sliceMinimum.toFixed(2)} m/s`}.
+        </p>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Closes #388

## Scope

Builds the World-scoped single-Simulation Explore workspace for Trade Cumulus and incorporates the PM's direct visual-review corrections.

Exact changed files:

- `app/frontend/e2e/fixtures.ts`
- `app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts`
- `app/frontend/e2e/mocked-smoke/navigation.spec.ts`
- `app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts`
- `app/frontend/src/App.css`
- `app/frontend/src/App.test.tsx`
- `app/frontend/src/App.tsx`
- `app/frontend/src/CloudWorldsHome.tsx`
- `app/frontend/src/IntegratedExploreWorkspace.test.tsx`
- `app/frontend/src/IntegratedExploreWorkspace.tsx`
- `app/frontend/src/TradeCumulusComparisonStory.test.tsx`
- `app/frontend/src/TradeCumulusWorld.tsx`
- `app/frontend/src/True3DViewer.test.tsx`
- `app/frontend/src/True3DViewer.tsx`
- `app/frontend/src/True3DViewer.utils.ts`
- `app/frontend/src/UpdraftLensSlice.test.tsx`
- `app/frontend/src/UpdraftLensSlice.tsx`

## Before and after

Before, Explore compressed the 3-D scene, slice, controls, multiple inspector tabs, legends, and technical details into competing panels. Important controls were hard to recover, slice geometry could overflow or appear distorted, selected-point labels collided, and Explain/Science repeated or exposed outdated process-model copy.

After, the 1440 x 900 desktop workspace leads with a compact Simulation identity bar and one coordinated scientific cockpit: a large 3-D scene, a useful Field Slice or Updraft Lens, a bounded Context rail, and a persistent timeline. Notes and technical details remain available below the primary viewing loop.

## Behavior

- Keeps 3-D, slice, time, plane, Lens state, cloud boundary, horizontal wind, and selected point synchronized.
- Adds compact previous/next, play/pause, speed, saved-output time, and key-moment controls.
- Replaces the redundant Explain/Science tabs with one stateful Context panel:
  - general view context when no point is selected;
  - selected-point evidence when a slice cell is selected.
- Removes the obsolete Thermal Fate/process-focus UI and its stale technical explanation copy.
- Adds editable Simulation notes using the existing result metadata PATCH path; no backend endpoint changed.
- Moves Notes and Details below the primary viewing loop.
- Adds maximize/restore controls for either the 3-D viewer or the slice/Lens viewer.
- Consolidates 3-D field, threshold, opacity, point-size, camera preset, reset, and maximize controls into one attached tool dock.
- Preserves Field Slice x-y, x-z, and y-z inspection with physical aspect, stronger contrast, and black cloud boundary.
- Preserves Updraft Lens x-y, x-z, and y-z inspection with the approved fixed scale, red-up/blue-down vertical legend, slice maximum above, slice minimum below, cloud boundary, and horizontal wind.
- Uses `g/kg` for displayed cloud water and `g/kg m/s` for the World moisture-flux difference while retaining source/API units internally.
- Removes normal-state availability clutter and the redundant World/overview labels requested during PM review.
- Keeps 3-D and slice load failures local, with compact retry controls and no silent field, time, plane, or Lens fallback.

## Non-implications

- No backend or scientific-calculation changes.
- No CM1 execution or generated run artifacts.
- No ordinary two-Simulation Compare, Save View, new Lens, new World, routing framework, or visualization framework.
- Issue #399 still owns the broader shared Explore/Compare multi-window geometry and required real-window validation. This PR does not claim #399 acceptance or activate that queued issue.

## Verification

- `git diff --check`: passed.
- `scripts/check.sh`: passed.
  - 119 frontend tests passed.
  - 558 backend tests passed.
  - Production build passed.
  - Existing NumPy ABI and Vite chunk-size warnings remain non-blocking.
- `scripts/check-e2e.sh`: passed, 25 mocked Chromium tests.
- Focused desktop Playwright coverage verifies:
  - simultaneous 3-D and slice;
  - notes persistence;
  - Field and Updraft Lens orientation/state changes;
  - 3-D and slice maximize/restore;
  - no horizontal document overflow;
  - no nested slice-control overflow;
  - 3-D overlay collision prevention;
  - local 3-D and slice failure isolation.
- Real preserved Canonical BOMEX Baseline reviewed in Chromium at 1440 x 900:
  - Field, Lens, selected-point, display controls, maximized 3-D, and maximized Lens states inspected;
  - document width remained bounded;
  - slice grids fit their viewports;
  - no browser console errors observed.
- Supplementary live in-app Browser review completed in the current desktop window.
- Mobile was not tested, per PM direction.
- No CM1 process was started.

## Review posture

Approved by the PM for manual merge after green verification. Auto-merge is not enabled.