### PR TITLE
Research: validate terrain-aware mountain-wave visualization

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -39,6 +39,11 @@ from cloud_chamber.lan_worker import (
 )
 from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError, RunStatus
 from cloud_chamber.local_run_queue import LocalRunQueueError, LocalRunQueueManager
+from cloud_chamber.mountain_wave_terrain_visualization import (
+    MountainWaveTerrainField,
+    MountainWaveTerrainVisualizationError,
+    preserved_mountain_wave_terrain_frame,
+)
 from cloud_chamber.observed_sounding import ObservedSoundingError, parse_igra_station_text
 from cloud_chamber.result_cards import (
     ResultCardUpdate,
@@ -759,6 +764,22 @@ def get_trade_cumulus_updraft_lens_defaults(result_id: str) -> dict[str, object]
     except ResultIngestError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except TradeCumulusUpdraftLensError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return result.model_dump(mode="json")
+
+
+@app.get("/api/research/mountain-wave-terrain")
+def get_mountain_wave_terrain_frame(
+    field: MountainWaveTerrainField = "w",
+    time_index: int = 0,
+) -> dict[str, object]:
+    try:
+        result = preserved_mountain_wave_terrain_frame(
+            load_settings(),
+            field=field,
+            time_index=time_index,
+        )
+    except MountainWaveTerrainVisualizationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return result.model_dump(mode="json")
 

--- a/app/backend/cloud_chamber/mountain_wave_terrain_visualization.py
+++ b/app/backend/cloud_chamber/mountain_wave_terrain_visualization.py
@@ -1,0 +1,645 @@
+"""Terrain-aware browser payload for the preserved Gate B mountain-wave run."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Literal
+
+import numpy as np
+import xarray as xr
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.mountain_wave_case import (
+    EXPECTED_OUTPUT_TIMES_SECONDS,
+    PRESERVED_GATE_B_EVALUATION_INPUT_SHA256,
+    PRESERVED_GATE_B_IMPLEMENTATION_COMMIT,
+    PRESERVED_GATE_B_RUN_ID,
+    MountainWaveCaseError,
+    accepted_model_output_paths,
+    load_completed_mountain_wave_package_for_evaluation,
+    normalize_length_to_m,
+    normalize_time_to_seconds,
+    parse_namelist_assignments,
+    reconstruct_physical_heights,
+    resolve_active_top_evidence,
+    verify_evaluation_input_identity,
+)
+from cloud_chamber.settings import CloudChamberSettings
+
+MountainWaveTerrainField = Literal["w", "theta_perturbation"]
+
+
+class MountainWaveTerrainVisualizationError(RuntimeError):
+    """Raised when the bounded terrain-aware payload cannot be represented honestly."""
+
+
+class TerrainFieldMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: MountainWaveTerrainField
+    display_name: str
+    units: str
+    native_dimensions: list[str]
+    vertical_grid: Literal["physical_full_levels", "physical_scalar_levels"]
+    derivation: str
+
+
+class TerrainGeometry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    x_center_m: list[float]
+    x_edge_m: list[float]
+    terrain_m: list[float]
+    scalar_height_m: list[list[float]]
+    full_height_m: list[list[float]]
+    nominal_scalar_height_m: list[float]
+    nominal_full_height_m: list[float]
+    active_top_m: float
+    singleton_y_m: float
+    horizontal_units: str = "m"
+    vertical_units: str = "m"
+
+
+class TerrainActiveTopEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    transform_top_source: str
+    final_nominal_zf_m: float
+    runtime_ztop_m: float
+    configured_nz: int
+    configured_dz_m: float
+    nz_times_dz_m: float
+    all_sources_agree: bool
+    inactive_namelist_ztop_m: float
+
+
+class TerrainVerticalReferences(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    physical_model_height: str = "terrain-following geometric height above model datum"
+    local_agl: str = "physical model height minus native terrain height at the same x cell"
+    nominal_coordinate: str = "terrain coordinate used by CM1; not physical altitude over terrain"
+    model_height_is_msl: bool = False
+
+
+class TerrainScale(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    fixed_across_all_times: bool = True
+    minimum: float
+    maximum: float
+    selected_time_minimum: float
+    selected_time_maximum: float
+    palette: str = "blue_white_red_diverging"
+
+
+class TerrainProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_history_file: str
+    reference_history_file: str | None = None
+    source_kind: str = "native_cm1_numbered_history"
+    topology: str = "native_2d_x_z_singleton_y"
+    horizontal_collocation: str = "none"
+    interpolation: str = "none"
+    display_binning: str
+    physical_height_source: str
+    full_height_source: str
+    masked_below_terrain: bool = True
+
+
+class TerrainIdentity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    implementation_commit: str
+    verification_mode: str
+    verified_file_count: int
+    verified_before_and_after_extraction: bool
+
+
+class TerrainPerformance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    extraction_ms: float
+    serialization_ms: float = 0.0
+    serialized_payload_bytes: int = 0
+
+
+class MountainWaveTerrainFrame(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = "mountain_wave_terrain_research_v1"
+    run_id: str
+    case_label: str = "CM1 r21.1 dry mountain-wave benchmark"
+    time_index: int
+    time_seconds: int
+    times_seconds: list[int]
+    dimensionality: str = "2-D x-z cross-section"
+    singleton_y: bool = True
+    dry_case: bool = True
+    field: TerrainFieldMetadata
+    values: list[list[float]]
+    geometry: TerrainGeometry
+    active_top_evidence: TerrainActiveTopEvidence
+    vertical_references: TerrainVerticalReferences = Field(
+        default_factory=TerrainVerticalReferences
+    )
+    scale: TerrainScale
+    provenance: TerrainProvenance
+    identity: TerrainIdentity
+    performance: TerrainPerformance
+    caveats: list[str] = Field(
+        default_factory=lambda: [
+            "This dry two-dimensional benchmark does not simulate moisture or cloud formation.",
+            (
+                "The singleton y dimension is native CM1 output, not an extruded "
+                "three-dimensional field."
+            ),
+        ]
+    )
+
+
+def terrain_frame_from_native_outputs(
+    *,
+    output_paths: list[Path],
+    namelist_path: Path,
+    field: MountainWaveTerrainField,
+    time_index: int,
+    run_id: str = PRESERVED_GATE_B_RUN_ID,
+    implementation_commit: str = PRESERVED_GATE_B_IMPLEMENTATION_COMMIT,
+    expected_times_seconds: tuple[int, ...] = EXPECTED_OUTPUT_TIMES_SECONDS,
+    identity_verified: bool = False,
+    verified_file_count: int = 0,
+) -> MountainWaveTerrainFrame:
+    """Extract one native-topology frame while validating every history's geometry."""
+    started = perf_counter()
+    paths = accepted_model_output_paths(output_paths)
+    if len(paths) != len(expected_times_seconds):
+        raise MountainWaveTerrainVisualizationError(
+            f"Expected {len(expected_times_seconds)} numbered histories; found {len(paths)}."
+        )
+    if not 0 <= time_index < len(paths):
+        raise MountainWaveTerrainVisualizationError(
+            f"Time index {time_index} is outside 0..{len(paths) - 1}."
+        )
+
+    assignments = parse_namelist_assignments(namelist_path.read_text())
+    configured_nz = _namelist_int(assignments, "nz")
+    configured_dz_m = _namelist_float(assignments, "dz")
+    if _namelist_int(assignments, "ny") != 1:
+        raise MountainWaveTerrainVisualizationError(
+            "The bounded terrain viewer requires the native singleton y dimension."
+        )
+    if _namelist_int(assignments, "stretch_z") != 0:
+        raise MountainWaveTerrainVisualizationError(
+            "This bounded validator supports only the preserved unstretched vertical setup."
+        )
+
+    times: list[int] = []
+    frames: list[np.ndarray[Any, np.dtype[np.float64]]] = []
+    reference_theta: np.ndarray[Any, np.dtype[np.float64]] | None = None
+    expected_geometry: tuple[np.ndarray[Any, np.dtype[np.float64]], ...] | None = None
+    selected_geometry: tuple[np.ndarray[Any, np.dtype[np.float64]], ...] | None = None
+    selected_y_m = 0.0
+    selected_active_top = None
+
+    for path_index, path in enumerate(paths):
+        try:
+            with xr.open_dataset(path, decode_times=False) as dataset:
+                _require_native_semantics(dataset)
+                time_seconds = _single_time_seconds(dataset)
+                rounded_time = int(round(time_seconds))
+                if not math.isclose(time_seconds, rounded_time, rel_tol=0.0, abs_tol=0.01):
+                    raise MountainWaveTerrainVisualizationError(
+                        "Native history time is not an integral second."
+                    )
+                times.append(rounded_time)
+
+                x_center_m = _length_coordinate(dataset, "xh")
+                x_edge_m = _length_coordinate(dataset, "xf")
+                y_center_m = _length_coordinate(dataset, "yh")
+                nominal_scalar_m = _length_coordinate(dataset, "zh")
+                nominal_full_m = _length_coordinate(dataset, "zf")
+                if y_center_m.size != 1 or int(dataset.sizes.get("yh", 0)) != 1:
+                    raise MountainWaveTerrainVisualizationError(
+                        "Native output is not a singleton-y two-dimensional cross-section."
+                    )
+                if x_edge_m.size != x_center_m.size + 1:
+                    raise MountainWaveTerrainVisualizationError(
+                        "Native x edges do not bound the scalar x centers."
+                    )
+                terrain_m = _field_2d(dataset, "zs", ("yh", "xh"))[0]
+                scalar_height_m = _field_3d(dataset, "zhval", ("zh", "yh", "xh"))[:, 0, :]
+                active_top = resolve_active_top_evidence(
+                    nominal_full_m,
+                    "m",
+                    dataset["ztop"].values,
+                    str(dataset["ztop"].attrs.get("units", "")),
+                    configured_nz=configured_nz,
+                    configured_dz_m=configured_dz_m,
+                )
+                full_height_m = reconstruct_physical_heights(
+                    terrain_m[None, :],
+                    nominal_full_m,
+                    active_top_m=active_top.final_nominal_zf_m,
+                )[:, 0, :]
+                reconstructed_scalar_m = reconstruct_physical_heights(
+                    terrain_m[None, :],
+                    nominal_scalar_m,
+                    active_top_m=active_top.final_nominal_zf_m,
+                )[:, 0, :]
+                if scalar_height_m.shape != reconstructed_scalar_m.shape or not np.allclose(
+                    scalar_height_m, reconstructed_scalar_m, rtol=0.0, atol=0.02
+                ):
+                    raise MountainWaveTerrainVisualizationError(
+                        "Native physical scalar heights disagree with CM1 "
+                        "terrain-following semantics."
+                    )
+                _require_geometry_invariants(
+                    terrain_m=terrain_m,
+                    scalar_height_m=scalar_height_m,
+                    full_height_m=full_height_m,
+                    active_top_m=active_top.final_nominal_zf_m,
+                )
+
+                geometry = (
+                    x_center_m,
+                    x_edge_m,
+                    terrain_m,
+                    scalar_height_m,
+                    full_height_m,
+                    nominal_scalar_m,
+                    nominal_full_m,
+                )
+                if expected_geometry is None:
+                    expected_geometry = tuple(item.copy() for item in geometry)
+                else:
+                    _require_same_geometry(expected_geometry, geometry)
+
+                if field == "w":
+                    _require_units(dataset, "w", {"m/s", "m s-1", "m s^-1"})
+                    values = _field_3d(dataset, "w", ("zf", "yh", "xh"))[:, 0, :]
+                else:
+                    _require_units(dataset, "th", {"k", "kelvin"})
+                    theta = _field_3d(dataset, "th", ("zh", "yh", "xh"))[:, 0, :]
+                    if reference_theta is None:
+                        reference_theta = theta.copy()
+                    values = theta - reference_theta
+                if not np.isfinite(values).all():
+                    raise MountainWaveTerrainVisualizationError(
+                        f"Field {field} contains non-finite values."
+                    )
+                frames.append(values)
+                if path_index == time_index:
+                    selected_geometry = geometry
+                    selected_y_m = float(y_center_m[0])
+                    selected_active_top = active_top
+        except MountainWaveTerrainVisualizationError:
+            raise
+        except MountainWaveCaseError as exc:
+            raise MountainWaveTerrainVisualizationError(str(exc)) from exc
+        except (OSError, ValueError, KeyError) as exc:
+            raise MountainWaveTerrainVisualizationError(
+                f"Native history {path.name} could not be decoded with required terrain semantics."
+            ) from exc
+
+    if times != list(expected_times_seconds):
+        raise MountainWaveTerrainVisualizationError(
+            f"Native history times differ from the required exact sequence: {times}."
+        )
+    if selected_geometry is None or selected_active_top is None:
+        raise MountainWaveTerrainVisualizationError("Selected terrain geometry was not extracted.")
+
+    global_max_abs = max(float(np.max(np.abs(values))) for values in frames)
+    if global_max_abs == 0.0:
+        global_max_abs = 1.0
+    selected = frames[time_index]
+    (
+        x_center_m,
+        x_edge_m,
+        terrain_m,
+        scalar_height_m,
+        full_height_m,
+        nominal_scalar_m,
+        nominal_full_m,
+    ) = selected_geometry
+    metadata = _field_metadata(field)
+    response = MountainWaveTerrainFrame(
+        run_id=run_id,
+        time_index=time_index,
+        time_seconds=times[time_index],
+        times_seconds=times,
+        field=metadata,
+        values=selected.tolist(),
+        geometry=TerrainGeometry(
+            x_center_m=x_center_m.tolist(),
+            x_edge_m=x_edge_m.tolist(),
+            terrain_m=terrain_m.tolist(),
+            scalar_height_m=scalar_height_m.tolist(),
+            full_height_m=full_height_m.tolist(),
+            nominal_scalar_height_m=nominal_scalar_m.tolist(),
+            nominal_full_height_m=nominal_full_m.tolist(),
+            active_top_m=float(full_height_m[-1, 0]),
+            singleton_y_m=selected_y_m,
+        ),
+        active_top_evidence=TerrainActiveTopEvidence(
+            transform_top_source=selected_active_top.transform_top_source,
+            final_nominal_zf_m=selected_active_top.final_nominal_zf_m,
+            runtime_ztop_m=selected_active_top.runtime_ztop_m,
+            configured_nz=selected_active_top.configured_nz,
+            configured_dz_m=selected_active_top.configured_dz_m,
+            nz_times_dz_m=selected_active_top.nz_times_dz_m,
+            all_sources_agree=selected_active_top.all_active_top_sources_agree,
+            inactive_namelist_ztop_m=selected_active_top.inactive_namelist_ztop_m,
+        ),
+        scale=TerrainScale(
+            minimum=-global_max_abs,
+            maximum=global_max_abs,
+            selected_time_minimum=float(np.min(selected)),
+            selected_time_maximum=float(np.max(selected)),
+        ),
+        provenance=TerrainProvenance(
+            source_history_file=paths[time_index].name,
+            reference_history_file=paths[0].name if field == "theta_perturbation" else None,
+            display_binning=(
+                "Native full-level samples painted between physical vertical midpoints and "
+                "adjacent center-height midpoints at interior x edges, clamped to terrain and "
+                "active top; native field values are not interpolated."
+                if field == "w"
+                else (
+                    "Native scalar samples painted between physical full-level bounds and "
+                    "adjacent center-height midpoints at interior x edges; native field values "
+                    "are not interpolated."
+                )
+            ),
+            physical_height_source=(
+                "native zhval verified against CM1 terrain-following reconstruction"
+            ),
+            full_height_source=(
+                "reconstructed from native zs, nominal zf, and independently agreed active top"
+            ),
+        ),
+        identity=TerrainIdentity(
+            implementation_commit=implementation_commit,
+            verification_mode="pinned_sha256_before_and_after_extraction",
+            verified_file_count=verified_file_count,
+            verified_before_and_after_extraction=identity_verified,
+        ),
+        performance=TerrainPerformance(extraction_ms=(perf_counter() - started) * 1_000.0),
+    )
+    return _measure_serialization(response)
+
+
+def preserved_mountain_wave_terrain_frame(
+    settings: CloudChamberSettings,
+    *,
+    field: MountainWaveTerrainField,
+    time_index: int,
+) -> MountainWaveTerrainFrame:
+    """Return one frame only after before-and-after verification of the preserved run."""
+    try:
+        package = load_completed_mountain_wave_package_for_evaluation(
+            settings=settings,
+            run_id=PRESERVED_GATE_B_RUN_ID,
+            expected_implementation_commit=PRESERVED_GATE_B_IMPLEMENTATION_COMMIT,
+        )
+        before = verify_evaluation_input_identity(
+            package,
+            expected_run_id=PRESERVED_GATE_B_RUN_ID,
+            expected_implementation_commit=PRESERVED_GATE_B_IMPLEMENTATION_COMMIT,
+            expected_file_sha256=PRESERVED_GATE_B_EVALUATION_INPUT_SHA256,
+        )
+        response = terrain_frame_from_native_outputs(
+            output_paths=list(package.package_dir.glob("cm1out_*.nc*")),
+            namelist_path=package.package_dir / "namelist.input",
+            field=field,
+            time_index=time_index,
+            identity_verified=True,
+            verified_file_count=len(before["file_sha256"]),
+        )
+        after = verify_evaluation_input_identity(
+            package,
+            expected_run_id=PRESERVED_GATE_B_RUN_ID,
+            expected_implementation_commit=PRESERVED_GATE_B_IMPLEMENTATION_COMMIT,
+            expected_file_sha256=PRESERVED_GATE_B_EVALUATION_INPUT_SHA256,
+        )
+        if before["file_sha256"] != after["file_sha256"]:
+            raise MountainWaveTerrainVisualizationError(
+                "Preserved evaluation inputs changed during terrain extraction."
+            )
+        return response
+    except MountainWaveTerrainVisualizationError:
+        raise
+    except MountainWaveCaseError as exc:
+        raise MountainWaveTerrainVisualizationError(str(exc)) from exc
+    except OSError as exc:
+        raise MountainWaveTerrainVisualizationError(
+            "The preserved mountain-wave result is not available for local terrain validation."
+        ) from exc
+
+
+def local_agl_m(*, model_height_m: float, terrain_height_m: float) -> float:
+    agl = model_height_m - terrain_height_m
+    if agl < -0.01:
+        raise MountainWaveTerrainVisualizationError(
+            "A point below local terrain has no visible AGL."
+        )
+    return max(0.0, agl)
+
+
+def _field_metadata(field: MountainWaveTerrainField) -> TerrainFieldMetadata:
+    if field == "w":
+        return TerrainFieldMetadata(
+            key=field,
+            display_name="Vertical velocity",
+            units="m/s",
+            native_dimensions=["zf", "yh", "xh"],
+            vertical_grid="physical_full_levels",
+            derivation="native CM1 w; no interpolation or collocation",
+        )
+    return TerrainFieldMetadata(
+        key=field,
+        display_name="Potential-temperature perturbation",
+        units="K",
+        native_dimensions=["zh", "yh", "xh"],
+        vertical_grid="physical_scalar_levels",
+        derivation="native CM1 th minus the same native scalar cell at t=0 s",
+    )
+
+
+def _measure_serialization(response: MountainWaveTerrainFrame) -> MountainWaveTerrainFrame:
+    started = perf_counter()
+    response.model_dump_json()
+    elapsed_ms = (perf_counter() - started) * 1_000.0
+    measured = response.model_copy(
+        update={
+            "performance": response.performance.model_copy(
+                update={
+                    "serialization_ms": elapsed_ms,
+                    "serialized_payload_bytes": 0,
+                }
+            )
+        }
+    )
+    for _attempt in range(4):
+        payload_bytes = len(measured.model_dump_json().encode("utf-8"))
+        if payload_bytes == measured.performance.serialized_payload_bytes:
+            break
+        measured = measured.model_copy(
+            update={
+                "performance": measured.performance.model_copy(
+                    update={"serialized_payload_bytes": payload_bytes}
+                )
+            }
+        )
+    return measured
+
+
+def _namelist_float(assignments: dict[str, str], name: str) -> float:
+    try:
+        return float(assignments[name].lower().replace("d", "e"))
+    except (KeyError, ValueError) as exc:
+        raise MountainWaveTerrainVisualizationError(
+            f"Namelist lacks a numeric {name} assignment."
+        ) from exc
+
+
+def _namelist_int(assignments: dict[str, str], name: str) -> int:
+    value = _namelist_float(assignments, name)
+    if not value.is_integer():
+        raise MountainWaveTerrainVisualizationError(f"Namelist {name} must be integral.")
+    return int(value)
+
+
+def _single_time_seconds(dataset: xr.Dataset) -> float:
+    if "time" not in dataset:
+        raise MountainWaveTerrainVisualizationError("Native output lacks the time coordinate.")
+    values = normalize_time_to_seconds(
+        dataset["time"].values,
+        str(dataset["time"].attrs.get("units", "")),
+    ).reshape(-1)
+    if values.size != 1:
+        raise MountainWaveTerrainVisualizationError(
+            "Each numbered native history must contain exactly one time."
+        )
+    return float(values[0])
+
+
+def _length_coordinate(dataset: xr.Dataset, name: str) -> np.ndarray[Any, np.dtype[np.float64]]:
+    if name not in dataset:
+        raise MountainWaveTerrainVisualizationError(f"Native output lacks coordinate {name}.")
+    values = normalize_length_to_m(
+        dataset[name].values,
+        str(dataset[name].attrs.get("units", "")),
+    )
+    if values.ndim != 1 or values.size < 1 or not np.isfinite(values).all():
+        raise MountainWaveTerrainVisualizationError(f"Coordinate {name} is not finite and 1-D.")
+    if values.size > 1 and not np.all(np.diff(values) > 0.0):
+        raise MountainWaveTerrainVisualizationError(
+            f"Coordinate {name} is not strictly increasing."
+        )
+    return values
+
+
+def _field_2d(
+    dataset: xr.Dataset, name: str, dimensions: tuple[str, str]
+) -> np.ndarray[Any, np.dtype[np.float64]]:
+    return _field_array(dataset, name, dimensions)
+
+
+def _field_3d(
+    dataset: xr.Dataset, name: str, dimensions: tuple[str, str, str]
+) -> np.ndarray[Any, np.dtype[np.float64]]:
+    return _field_array(dataset, name, dimensions)
+
+
+def _field_array(
+    dataset: xr.Dataset, name: str, dimensions: tuple[str, ...]
+) -> np.ndarray[Any, np.dtype[np.float64]]:
+    if name not in dataset:
+        raise MountainWaveTerrainVisualizationError(f"Native output lacks required field {name}.")
+    item = dataset[name]
+    if "time" in item.dims:
+        if item.sizes["time"] != 1:
+            raise MountainWaveTerrainVisualizationError(
+                f"Field {name} has more than one time in a numbered history."
+            )
+        item = item.isel(time=0)
+    for dimension in list(item.dims):
+        if dimension not in dimensions:
+            if item.sizes[dimension] != 1:
+                raise MountainWaveTerrainVisualizationError(
+                    f"Field {name} has unsupported dimension {dimension}."
+                )
+            item = item.isel({dimension: 0})
+    if set(item.dims) != set(dimensions):
+        raise MountainWaveTerrainVisualizationError(
+            f"Field {name} dimensions are {item.dims}; expected {dimensions}."
+        )
+    values = np.asarray(item.transpose(*dimensions).values, dtype=np.float64)
+    if not np.isfinite(values).all():
+        raise MountainWaveTerrainVisualizationError(f"Field {name} contains non-finite values.")
+    return values
+
+
+def _require_native_semantics(dataset: xr.Dataset) -> None:
+    for name in ("time", "xh", "xf", "yh", "zh", "zf", "zs", "zhval", "th", "w", "ztop"):
+        if name not in dataset:
+            raise MountainWaveTerrainVisualizationError(
+                f"Native output lacks required terrain semantic {name}."
+            )
+    _require_units(dataset, "zs", {"m", "meter", "meters"})
+    _require_units(dataset, "zhval", {"m", "meter", "meters"})
+
+
+def _require_units(dataset: xr.Dataset, name: str, accepted: set[str]) -> None:
+    actual = str(dataset[name].attrs.get("units", "")).strip().lower()
+    normalized = actual.replace(" ", "")
+    if normalized not in {unit.replace(" ", "") for unit in accepted}:
+        raise MountainWaveTerrainVisualizationError(
+            f"Required field {name} has unsupported units {actual!r}."
+        )
+
+
+def _require_geometry_invariants(
+    *,
+    terrain_m: np.ndarray[Any, np.dtype[np.float64]],
+    scalar_height_m: np.ndarray[Any, np.dtype[np.float64]],
+    full_height_m: np.ndarray[Any, np.dtype[np.float64]],
+    active_top_m: float,
+) -> None:
+    if float(np.ptp(terrain_m)) <= 0.0:
+        raise MountainWaveTerrainVisualizationError(
+            "The preserved terrain-aware validation requires curved, non-flat terrain."
+        )
+    if scalar_height_m.shape[1] != terrain_m.size or full_height_m.shape[1] != terrain_m.size:
+        raise MountainWaveTerrainVisualizationError("Physical height meshes do not match x cells.")
+    if not np.all(np.diff(scalar_height_m, axis=0) > 0.0) or not np.all(
+        np.diff(full_height_m, axis=0) > 0.0
+    ):
+        raise MountainWaveTerrainVisualizationError("Physical model columns are not monotonic.")
+    if np.any(scalar_height_m < terrain_m[None, :] - 0.01) or np.any(
+        full_height_m < terrain_m[None, :] - 0.01
+    ):
+        raise MountainWaveTerrainVisualizationError("Physical grid contains heights below terrain.")
+    if not np.allclose(full_height_m[0], terrain_m, rtol=0.0, atol=0.01):
+        raise MountainWaveTerrainVisualizationError(
+            "Full-level bottom does not equal local terrain."
+        )
+    if not np.allclose(full_height_m[-1], active_top_m, rtol=0.0, atol=0.01):
+        raise MountainWaveTerrainVisualizationError("Full-level top is not constant at active top.")
+
+
+def _require_same_geometry(
+    expected: tuple[np.ndarray[Any, np.dtype[np.float64]], ...],
+    actual: tuple[np.ndarray[Any, np.dtype[np.float64]], ...],
+) -> None:
+    for expected_values, actual_values in zip(expected, actual, strict=True):
+        if expected_values.shape != actual_values.shape or not np.allclose(
+            expected_values, actual_values, rtol=0.0, atol=0.01
+        ):
+            raise MountainWaveTerrainVisualizationError(
+                "Terrain-aware coordinates change between native histories."
+            )

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -142,6 +142,44 @@ def test_world_endpoints_return_typed_payloads(monkeypatch: pytest.MonkeyPatch) 
     )
 
 
+def test_mountain_wave_terrain_research_api_returns_bounded_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, int]] = []
+
+    def frame(_settings: object, *, field: str, time_index: int) -> SimpleNamespace:
+        calls.append((field, time_index))
+        return SimpleNamespace(
+            model_dump=lambda **_kwargs: {
+                "run_id": "dry-mountain-wave-official-20260721T183530Z",
+                "field": {"key": field},
+                "time_index": time_index,
+                "singleton_y": True,
+            }
+        )
+
+    monkeypatch.setattr("cloud_chamber.app.preserved_mountain_wave_terrain_frame", frame)
+
+    response = TestClient(app).get(
+        "/api/research/mountain-wave-terrain",
+        params={"field": "theta_perturbation", "time_index": 4},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["field"]["key"] == "theta_perturbation"
+    assert response.json()["singleton_y"] is True
+    assert calls == [("theta_perturbation", 4)]
+
+
+def test_mountain_wave_terrain_research_api_rejects_unknown_fields() -> None:
+    response = TestClient(app).get(
+        "/api/research/mountain-wave-terrain",
+        params={"field": "cloud_water", "time_index": 0},
+    )
+
+    assert response.status_code == 422
+
+
 @pytest.mark.parametrize(
     ("path", "attribute"),
     [

--- a/app/backend/tests/test_mountain_wave_terrain_visualization.py
+++ b/app/backend/tests/test_mountain_wave_terrain_visualization.py
@@ -1,0 +1,184 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from cloud_chamber.mountain_wave_case import EXPECTED_OUTPUT_TIMES_SECONDS
+from cloud_chamber.mountain_wave_terrain_visualization import (
+    MountainWaveTerrainVisualizationError,
+    local_agl_m,
+    terrain_frame_from_native_outputs,
+)
+
+
+def test_native_w_payload_preserves_curved_terrain_and_full_level_placement(
+    tmp_path: Path,
+) -> None:
+    paths, namelist = _write_native_histories(tmp_path)
+
+    frame = terrain_frame_from_native_outputs(
+        output_paths=paths,
+        namelist_path=namelist,
+        field="w",
+        time_index=10,
+    )
+
+    assert frame.times_seconds == list(EXPECTED_OUTPUT_TIMES_SECONDS)
+    assert frame.time_seconds == 2160
+    assert frame.singleton_y is True
+    assert frame.geometry.singleton_y_m == pytest.approx(0.0)
+    assert frame.geometry.terrain_m == pytest.approx([0.0, 400.0, 100.0])
+    assert frame.geometry.full_height_m[0] == pytest.approx(frame.geometry.terrain_m)
+    assert frame.geometry.full_height_m[-1] == pytest.approx([20_000.0] * 3)
+    assert frame.geometry.horizontal_units == "m"
+    assert frame.geometry.vertical_units == "m"
+    assert np.min(np.asarray(frame.geometry.full_height_m) - frame.geometry.terrain_m) >= 0.0
+    assert frame.active_top_evidence.final_nominal_zf_m == pytest.approx(20_000.0)
+    assert frame.active_top_evidence.runtime_ztop_m == pytest.approx(20_000.0)
+    assert frame.active_top_evidence.nz_times_dz_m == pytest.approx(20_000.0)
+    assert frame.active_top_evidence.all_sources_agree is True
+    assert frame.vertical_references.model_height_is_msl is False
+    assert frame.field.native_dimensions == ["zf", "yh", "xh"]
+    assert frame.field.vertical_grid == "physical_full_levels"
+    assert len(frame.values) == 3
+    assert len(frame.values[0]) == 3
+    assert frame.scale.fixed_across_all_times is True
+    assert frame.scale.minimum == pytest.approx(-frame.scale.maximum)
+    assert frame.provenance.interpolation == "none"
+    assert frame.provenance.masked_below_terrain is True
+
+
+def test_theta_perturbation_uses_native_scalar_cells_and_t0_reference(tmp_path: Path) -> None:
+    paths, namelist = _write_native_histories(tmp_path)
+
+    frame = terrain_frame_from_native_outputs(
+        output_paths=paths,
+        namelist_path=namelist,
+        field="theta_perturbation",
+        time_index=2,
+    )
+
+    assert frame.field.units == "K"
+    assert frame.field.native_dimensions == ["zh", "yh", "xh"]
+    assert frame.field.vertical_grid == "physical_scalar_levels"
+    assert np.asarray(frame.values) == pytest.approx(np.full((2, 3), 0.5))
+    assert frame.provenance.reference_history_file == "cm1out_000001.nc"
+    assert len(frame.geometry.scalar_height_m) == 2
+    assert np.all(
+        np.asarray(frame.geometry.scalar_height_m) > np.asarray(frame.geometry.terrain_m)[None, :]
+    )
+
+
+def test_active_top_mismatch_fails_closed(tmp_path: Path) -> None:
+    paths, namelist = _write_native_histories(tmp_path, runtime_top_m=19_000.0)
+
+    with pytest.raises(
+        MountainWaveTerrainVisualizationError, match="Active-top evidence disagrees"
+    ):
+        terrain_frame_from_native_outputs(
+            output_paths=paths,
+            namelist_path=namelist,
+            field="w",
+            time_index=0,
+        )
+
+
+def test_missing_physical_height_semantics_fail_closed(tmp_path: Path) -> None:
+    paths, namelist = _write_native_histories(tmp_path, include_zhval=False)
+
+    with pytest.raises(MountainWaveTerrainVisualizationError, match="zhval"):
+        terrain_frame_from_native_outputs(
+            output_paths=paths,
+            namelist_path=namelist,
+            field="w",
+            time_index=0,
+        )
+
+
+def test_exact_output_time_sequence_is_required(tmp_path: Path) -> None:
+    paths, namelist = _write_native_histories(tmp_path, time_offset_seconds=1)
+
+    with pytest.raises(MountainWaveTerrainVisualizationError, match="exact sequence"):
+        terrain_frame_from_native_outputs(
+            output_paths=paths,
+            namelist_path=namelist,
+            field="w",
+            time_index=0,
+        )
+
+
+def test_local_agl_uses_local_terrain_and_rejects_below_ground() -> None:
+    assert local_agl_m(model_height_m=1_250.0, terrain_height_m=400.0) == pytest.approx(850.0)
+    with pytest.raises(MountainWaveTerrainVisualizationError, match="below local terrain"):
+        local_agl_m(model_height_m=399.0, terrain_height_m=400.0)
+
+
+def _write_native_histories(
+    root: Path,
+    *,
+    runtime_top_m: float = 20_000.0,
+    include_zhval: bool = True,
+    time_offset_seconds: int = 0,
+) -> tuple[list[Path], Path]:
+    namelist = root / "namelist.input"
+    namelist.write_text(
+        """ &param0
+ nx = 3,
+ ny = 1,
+ nz = 2,
+ dx = 1000.0,
+ dy = 1000.0,
+ dz = 10000.0,
+ /
+ &param6
+ stretch_z = 0,
+ /
+"""
+    )
+    xh_m = np.asarray([-1_000.0, 0.0, 1_000.0])
+    xf_m = np.asarray([-1_500.0, -500.0, 500.0, 1_500.0])
+    terrain_m = np.asarray([0.0, 400.0, 100.0])
+    nominal_scalar_m = np.asarray([5_000.0, 15_000.0])
+    nominal_full_m = np.asarray([0.0, 10_000.0, 20_000.0])
+    scalar_height_m = (
+        terrain_m[None, :] + nominal_scalar_m[:, None] * (20_000.0 - terrain_m[None, :]) / 20_000.0
+    )
+    paths: list[Path] = []
+    for index, expected_time in enumerate(EXPECTED_OUTPUT_TIMES_SECONDS):
+        theta = 300.0 + np.arange(6, dtype=np.float64).reshape(2, 1, 3)
+        theta += index * 0.25
+        w = np.linspace(-1.0, 1.0, 9, dtype=np.float64).reshape(3, 1, 3)
+        w *= index + 1
+        data_vars: dict[str, tuple[tuple[str, ...], object, dict[str, str]]] = {
+            "zs": (("time", "yh", "xh"), terrain_m.reshape(1, 1, 3), {"units": "m"}),
+            "th": (("time", "zh", "yh", "xh"), theta[None, ...], {"units": "K"}),
+            "w": (("time", "zf", "yh", "xh"), w[None, ...], {"units": "m/s"}),
+            "ztop": (("one",), [runtime_top_m], {"units": "m"}),
+        }
+        if include_zhval:
+            data_vars["zhval"] = (
+                ("time", "zh", "yh", "xh"),
+                scalar_height_m.reshape(1, 2, 1, 3),
+                {"units": "m"},
+            )
+        dataset = xr.Dataset(
+            data_vars=data_vars,
+            coords={
+                "time": (
+                    "time",
+                    [expected_time + time_offset_seconds],
+                    {"units": "seconds"},
+                ),
+                "xh": ("xh", xh_m / 1_000.0, {"units": "km"}),
+                "xf": ("xf", xf_m / 1_000.0, {"units": "km"}),
+                "yh": ("yh", [0.0], {"units": "km"}),
+                "zh": ("zh", nominal_scalar_m / 1_000.0, {"units": "km"}),
+                "zf": ("zf", nominal_full_m / 1_000.0, {"units": "km"}),
+                "one": ("one", [1]),
+            },
+        )
+        path = root / f"cm1out_{index + 1:06d}.nc"
+        dataset.to_netcdf(path)
+        paths.append(path)
+    return paths, namelist

--- a/app/frontend/src/CloudWorldsHome.test.tsx
+++ b/app/frontend/src/CloudWorldsHome.test.tsx
@@ -37,6 +37,8 @@ describe("CloudWorldsHome", () => {
     expect(await screen.findByRole("heading", { name: "Trade Cumulus" })).toBeInTheDocument();
     expect(screen.getByText(summary.short_description)).toBeInTheDocument();
     expect(screen.getByText("2 awaiting inspection")).toBeInTheDocument();
+    expect(screen.queryByText(/mountain-wave/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /terrain/i })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Enter Trade Cumulus" }));
     expect(onEnter).toHaveBeenCalledOnce();
   });

--- a/app/frontend/src/MountainWaveTerrainResearch.css
+++ b/app/frontend/src/MountainWaveTerrainResearch.css
@@ -1,0 +1,380 @@
+.mw-research-shell {
+  min-width: 1100px;
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding: 20px 24px 26px;
+  background: #f2f6f8;
+  color: var(--color-text-primary);
+}
+
+.mw-research-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--color-border-strong);
+  padding-bottom: 15px;
+}
+
+.mw-research-header h1 {
+  font-size: 28px;
+  line-height: 1.1;
+}
+
+.mw-research-kicker {
+  margin: 0 0 4px;
+  color: #2f74a8;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.mw-research-subtitle {
+  margin: 5px 0 0;
+  font-size: 14px;
+}
+
+.mw-research-header-facts {
+  display: grid;
+  gap: 2px;
+  min-width: 290px;
+  text-align: right;
+}
+
+.mw-research-header-facts strong {
+  font-size: 14px;
+}
+
+.mw-research-header-facts span {
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.mw-research-workspace {
+  display: grid;
+  grid-template-columns: minmax(700px, 1fr) 320px;
+  min-height: 690px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface);
+}
+
+.mw-plot-panel {
+  position: relative;
+  min-width: 0;
+  border-right: 1px solid var(--color-border-strong);
+  background: #f8fbfc;
+}
+
+.mw-plot-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  height: 60px;
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--color-border);
+  padding: 10px 18px;
+}
+
+.mw-plot-heading > div {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.mw-plot-heading span {
+  font-size: 17px;
+  font-weight: 800;
+}
+
+.mw-plot-heading strong,
+.mw-plot-heading p {
+  margin: 0;
+  font-size: 13px;
+}
+
+.mw-terrain-canvas {
+  display: block;
+  width: calc(100% - 92px);
+  height: 628px;
+  cursor: crosshair;
+}
+
+.mw-plot-loading {
+  display: grid;
+  width: calc(100% - 92px);
+  height: 628px;
+  place-items: center;
+  color: var(--color-text-muted);
+  font-weight: 700;
+}
+
+.mw-color-legend {
+  position: absolute;
+  top: 84px;
+  right: 14px;
+  bottom: 44px;
+  display: grid;
+  grid-template-columns: 18px 46px;
+  grid-template-rows: auto auto 1fr auto auto;
+  gap: 5px 8px;
+  width: 66px;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.mw-color-legend strong,
+.mw-color-legend > span,
+.mw-color-legend > p {
+  grid-column: 1 / -1;
+}
+
+.mw-color-legend strong {
+  color: var(--color-text-primary);
+  font-size: 12px;
+}
+
+.mw-color-legend > span {
+  font-weight: 700;
+}
+
+.mw-color-ramp {
+  grid-column: 1;
+  grid-row: 3;
+  min-height: 350px;
+  border: 1px solid #9aaab3;
+  background: linear-gradient(to bottom, #9d1d20, #ef8a62 25%, #f7f7f2 50%, #6aaed6 75%, #173f8a);
+}
+
+.mw-color-ticks {
+  grid-column: 2;
+  grid-row: 3;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  font-size: 10px;
+}
+
+.mw-color-legend > p {
+  margin: 2px 0 0;
+  line-height: 1.25;
+}
+
+.mw-control-rail {
+  min-width: 0;
+  background: #fbfdfe;
+}
+
+.mw-control-section,
+.mw-readout-section,
+.mw-native-facts {
+  border-bottom: 1px solid var(--color-border);
+  padding: 17px 18px;
+}
+
+.mw-control-rail h2 {
+  margin: 0 0 10px;
+  font-size: 13px;
+  text-transform: uppercase;
+}
+
+.mw-segmented-control {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border: 1px solid var(--color-border-strong);
+  padding: 3px;
+  background: #eef4f7;
+}
+
+.mw-segmented-control button {
+  min-height: 36px;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.mw-segmented-control button[aria-pressed="true"] {
+  background: #ffffff;
+  color: #216b9e;
+  box-shadow: 0 1px 4px rgba(44, 79, 104, 0.15);
+}
+
+.mw-field-note,
+.mw-readout-section > p {
+  margin: 9px 0 0;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.mw-control-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.mw-control-heading h2 {
+  margin-bottom: 0;
+}
+
+.mw-control-heading strong {
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+
+.mw-time-commands {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.mw-icon-button {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid var(--color-border-strong);
+  background: #ffffff;
+  color: #255f87;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.mw-icon-button:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.mw-play-button {
+  border-color: #2f74a8;
+  background: #2f74a8;
+  color: white;
+}
+
+.mw-play-icon {
+  width: 0;
+  height: 0;
+  margin-left: 2px;
+  border-top: 7px solid transparent;
+  border-bottom: 7px solid transparent;
+  border-left: 11px solid currentColor;
+}
+
+.mw-pause-icon {
+  width: 11px;
+  height: 15px;
+  border-right: 4px solid currentColor;
+  border-left: 4px solid currentColor;
+}
+
+.mw-time-slider {
+  width: 100%;
+  margin: 15px 0 0;
+}
+
+.mw-time-range {
+  display: flex;
+  justify-content: space-between;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.mw-readout-section {
+  min-height: 170px;
+  background: #f4f8fa;
+}
+
+.mw-readout-grid,
+.mw-native-facts dl,
+.mw-research-footer dl {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 14px;
+  margin: 0;
+}
+
+.mw-readout-grid div,
+.mw-native-facts dl div,
+.mw-research-footer dl div {
+  min-width: 0;
+}
+
+.mw-readout-grid dt,
+.mw-native-facts dt,
+.mw-research-footer dt {
+  color: var(--color-text-muted);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.mw-readout-grid dd,
+.mw-native-facts dd,
+.mw-research-footer dd {
+  margin: 2px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.mw-readout-wide {
+  grid-column: 1 / -1;
+}
+
+.mw-native-facts dl div {
+  border-top: 1px solid var(--color-border);
+  padding-top: 8px;
+}
+
+.mw-research-footer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(420px, 0.8fr);
+  gap: 28px;
+  border: 1px solid var(--color-border-strong);
+  border-top: 0;
+  padding: 16px 18px;
+  background: #fbfdfe;
+}
+
+.mw-research-footer strong,
+.mw-research-footer summary {
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.mw-research-footer p {
+  margin: 4px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.mw-research-footer details[open] summary {
+  margin-bottom: 12px;
+}
+
+.mw-research-error {
+  display: grid;
+  justify-items: start;
+  gap: 8px;
+  border: 1px solid #d49b91;
+  padding: 20px;
+  background: #fff4f1;
+}
+
+.mw-research-error button {
+  border: 1px solid var(--color-border-strong);
+  padding: 7px 12px;
+  background: #fff;
+  color: #2f74a8;
+  font-weight: 800;
+}

--- a/app/frontend/src/MountainWaveTerrainResearch.test.tsx
+++ b/app/frontend/src/MountainWaveTerrainResearch.test.tsx
@@ -1,0 +1,209 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type MountainWaveTerrainFrame,
+  MountainWaveTerrainResearch,
+  buildTerrainDisplayCells,
+  centerValuesToEdges,
+  terrainReadoutForCell,
+  terrainFieldColor,
+} from "./MountainWaveTerrainResearch";
+
+const frame: MountainWaveTerrainFrame = {
+  schema_version: "mountain_wave_terrain_research_v1",
+  run_id: "dry-mountain-wave-official-20260721T183530Z",
+  case_label: "CM1 r21.1 dry mountain-wave benchmark",
+  time_index: 0,
+  time_seconds: 0,
+  times_seconds: [0, 216, 432, 648, 864, 1080, 1296, 1512, 1728, 1944, 2160],
+  dimensionality: "2-D x-z cross-section",
+  singleton_y: true,
+  dry_case: true,
+  field: {
+    key: "w",
+    display_name: "Vertical velocity",
+    units: "m/s",
+    native_dimensions: ["zf", "yh", "xh"],
+    vertical_grid: "physical_full_levels",
+    derivation: "native CM1 w; no interpolation or collocation",
+  },
+  values: [
+    [-0.2, 0.1],
+    [-1.0, 1.0],
+    [-0.1, 0.2],
+  ],
+  geometry: {
+    x_center_m: [-500, 500],
+    x_edge_m: [-1000, 0, 1000],
+    terrain_m: [0, 400],
+    scalar_height_m: [
+      [5000, 5300],
+      [15000, 15100],
+    ],
+    full_height_m: [
+      [0, 400],
+      [10000, 10200],
+      [20000, 20000],
+    ],
+    nominal_scalar_height_m: [5000, 15000],
+    nominal_full_height_m: [0, 10000, 20000],
+    active_top_m: 20000,
+    singleton_y_m: 0,
+    horizontal_units: "m",
+    vertical_units: "m",
+  },
+  active_top_evidence: {
+    transform_top_source: "final_nominal_zf",
+    final_nominal_zf_m: 20000,
+    runtime_ztop_m: 20000,
+    configured_nz: 2,
+    configured_dz_m: 10000,
+    nz_times_dz_m: 20000,
+    all_sources_agree: true,
+    inactive_namelist_ztop_m: 18000,
+  },
+  vertical_references: {
+    physical_model_height: "terrain-following geometric height above model datum",
+    local_agl: "physical model height minus native terrain height at the same x cell",
+    nominal_coordinate: "terrain coordinate used by CM1; not physical altitude over terrain",
+    model_height_is_msl: false,
+  },
+  scale: {
+    fixed_across_all_times: true,
+    minimum: -3.1,
+    maximum: 3.1,
+    selected_time_minimum: -1,
+    selected_time_maximum: 1,
+    palette: "blue_white_red_diverging",
+  },
+  provenance: {
+    source_history_file: "cm1out_000001.nc",
+    reference_history_file: null,
+    source_kind: "native_cm1_numbered_history",
+    topology: "native_2d_x_z_singleton_y",
+    horizontal_collocation: "none",
+    interpolation: "none",
+    display_binning: "Native full-level samples painted between physical vertical midpoints.",
+    physical_height_source: "native zhval",
+    full_height_source: "reconstructed",
+    masked_below_terrain: true,
+  },
+  identity: {
+    implementation_commit: "9ff73ff244c393bee2a2e93a851ad1ba2dc16287",
+    verification_mode: "pinned_sha256_before_and_after_extraction",
+    verified_file_count: 23,
+    verified_before_and_after_extraction: true,
+  },
+  performance: {
+    extraction_ms: 31.2,
+    serialization_ms: 1.1,
+    serialized_payload_bytes: 160000,
+  },
+  caveats: [
+    "This dry two-dimensional benchmark does not simulate moisture or cloud formation.",
+    "The singleton y dimension is native CM1 output, not an extruded three-dimensional field.",
+  ],
+};
+
+describe("terrain-aware display geometry", () => {
+  it("places full-level samples between physical midpoints without cells below terrain", () => {
+    const cells = buildTerrainDisplayCells(frame);
+    expect(cells).toHaveLength(6);
+    expect(cells[0]?.nominalHeightM).toBe(0);
+    expect(cells[0]?.corners[0]).toEqual({ x: -1000, z: 0 });
+    expect(cells[1]?.corners[0]?.z).toBe(200);
+    expect(cells.every((cell) => cell.corners.every((corner) => corner.z >= 0))).toBe(true);
+    expect(cells.at(-1)?.corners[2]?.z).toBe(20000);
+    expect(terrainReadoutForCell(frame, cells[1]!)).toMatchObject({
+      xM: 500,
+      modelHeightM: 400,
+      terrainHeightM: 400,
+      aglM: 0,
+    });
+  });
+
+  it("uses physical full-level bounds for scalar theta cells", () => {
+    const thetaFrame: MountainWaveTerrainFrame = {
+      ...frame,
+      field: {
+        ...frame.field,
+        key: "theta_perturbation",
+        units: "K",
+        native_dimensions: ["zh", "yh", "xh"],
+        vertical_grid: "physical_scalar_levels",
+      },
+      values: [
+        [0.1, 0.2],
+        [-0.1, -0.2],
+      ],
+    };
+    const cells = buildTerrainDisplayCells(thetaFrame);
+    expect(cells).toHaveLength(4);
+    expect(cells[0]?.nominalHeightM).toBe(5000);
+    expect(cells[2]?.corners[0]?.z).toBe(10000);
+  });
+
+  it("derives continuous geometry edges and a deterministic diverging scale", () => {
+    expect(centerValuesToEdges([0, 400, 100])).toEqual([0, 200, 250, 100]);
+    expect(terrainFieldColor(-1, -1, 1)).toBe("#173f8a");
+    expect(terrainFieldColor(0, -1, 1)).toBe("#f7f7f2");
+    expect(terrainFieldColor(1, -1, 1)).toBe("#9d1d20");
+  });
+});
+
+describe("MountainWaveTerrainResearch", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(ok(frame)));
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("opens on native w with exact-time controls and explicit dry singleton-y scope", async () => {
+    render(<MountainWaveTerrainResearch />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Dry mountain-wave cross-section" }),
+    ).toBeInTheDocument();
+    await screen.findByRole("img", { name: /Vertical velocity over native curved terrain/ });
+    expect(screen.getByText("Dry 2-D x-z cross-section · singleton y")).toBeInTheDocument();
+    expect(screen.getByText(/does not simulate moisture or cloud formation/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Vertical velocity" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("slider", { name: "Saved output time" })).toHaveAttribute("max", "10");
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/research/mountain-wave-terrain?field=w&time_index=10",
+      expect.any(Object),
+    );
+  });
+
+  it("requests the selected field and exact previous history", async () => {
+    render(<MountainWaveTerrainResearch />);
+    await screen.findByRole("img", { name: /Vertical velocity over native curved terrain/ });
+
+    fireEvent.click(screen.getByRole("button", { name: "θ perturbation" }));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/research/mountain-wave-terrain?field=theta_perturbation&time_index=10",
+        expect.any(Object),
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Previous output" }));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/research/mountain-wave-terrain?field=theta_perturbation&time_index=9",
+        expect.any(Object),
+      ),
+    );
+  });
+});
+
+function ok(payload: unknown): Response {
+  return { ok: true, json: async () => payload } as Response;
+}

--- a/app/frontend/src/MountainWaveTerrainResearch.tsx
+++ b/app/frontend/src/MountainWaveTerrainResearch.tsx
@@ -1,0 +1,716 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+
+import "./App.css";
+import "./MountainWaveTerrainResearch.css";
+
+export type MountainWaveTerrainField = "w" | "theta_perturbation";
+
+export type MountainWaveTerrainFrame = {
+  schema_version: string;
+  run_id: string;
+  case_label: string;
+  time_index: number;
+  time_seconds: number;
+  times_seconds: number[];
+  dimensionality: string;
+  singleton_y: boolean;
+  dry_case: boolean;
+  field: {
+    key: MountainWaveTerrainField;
+    display_name: string;
+    units: string;
+    native_dimensions: string[];
+    vertical_grid: "physical_full_levels" | "physical_scalar_levels";
+    derivation: string;
+  };
+  values: number[][];
+  geometry: {
+    x_center_m: number[];
+    x_edge_m: number[];
+    terrain_m: number[];
+    scalar_height_m: number[][];
+    full_height_m: number[][];
+    nominal_scalar_height_m: number[];
+    nominal_full_height_m: number[];
+    active_top_m: number;
+    singleton_y_m: number;
+    horizontal_units: string;
+    vertical_units: string;
+  };
+  active_top_evidence: {
+    transform_top_source: string;
+    final_nominal_zf_m: number;
+    runtime_ztop_m: number;
+    configured_nz: number;
+    configured_dz_m: number;
+    nz_times_dz_m: number;
+    all_sources_agree: boolean;
+    inactive_namelist_ztop_m: number;
+  };
+  vertical_references: {
+    physical_model_height: string;
+    local_agl: string;
+    nominal_coordinate: string;
+    model_height_is_msl: boolean;
+  };
+  scale: {
+    fixed_across_all_times: boolean;
+    minimum: number;
+    maximum: number;
+    selected_time_minimum: number;
+    selected_time_maximum: number;
+    palette: string;
+  };
+  provenance: {
+    source_history_file: string;
+    reference_history_file: string | null;
+    source_kind: string;
+    topology: string;
+    horizontal_collocation: string;
+    interpolation: string;
+    display_binning: string;
+    physical_height_source: string;
+    full_height_source: string;
+    masked_below_terrain: boolean;
+  };
+  identity: {
+    implementation_commit: string;
+    verification_mode: string;
+    verified_file_count: number;
+    verified_before_and_after_extraction: boolean;
+  };
+  performance: {
+    extraction_ms: number;
+    serialization_ms: number;
+    serialized_payload_bytes: number;
+  };
+  caveats: string[];
+};
+
+export type TerrainDisplayCell = {
+  row: number;
+  column: number;
+  value: number;
+  nominalHeightM: number;
+  corners: Array<{ x: number; z: number }>;
+};
+
+export type TerrainReadout = {
+  xM: number;
+  modelHeightM: number;
+  terrainHeightM: number;
+  aglM: number;
+  value: number;
+  nominalHeightM: number;
+};
+
+const COLOR_STOPS = ["#173f8a", "#6aaed6", "#f7f7f2", "#ef8a62", "#9d1d20"];
+
+export function MountainWaveTerrainResearch() {
+  const [field, setField] = useState<MountainWaveTerrainField>("w");
+  const [timeIndex, setTimeIndex] = useState(10);
+  const [frame, setFrame] = useState<MountainWaveTerrainFrame | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [requestMs, setRequestMs] = useState<number | null>(null);
+  const [readout, setReadout] = useState<TerrainReadout | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const started = performance.now();
+    setLoading(true);
+    setError(null);
+    fetch(`/api/research/mountain-wave-terrain?field=${field}&time_index=${timeIndex}`, {
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          const payload = (await response.json().catch(() => null)) as { detail?: string } | null;
+          throw new Error(payload?.detail ?? `Terrain payload failed (${response.status}).`);
+        }
+        return (await response.json()) as MountainWaveTerrainFrame;
+      })
+      .then((payload) => {
+        setFrame(payload);
+        setRequestMs(performance.now() - started);
+        setReadout(null);
+      })
+      .catch((reason: unknown) => {
+        if (!controller.signal.aborted) {
+          setError(reason instanceof Error ? reason.message : "Terrain payload failed.");
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [field, retryNonce, timeIndex]);
+
+  useEffect(() => {
+    if (!playing) return;
+    const timer = window.setInterval(() => {
+      setTimeIndex((current) => (current >= 10 ? 0 : current + 1));
+    }, 900);
+    return () => window.clearInterval(timer);
+  }, [playing]);
+
+  const times = frame?.times_seconds ?? Array.from({ length: 11 }, (_unused, index) => index * 216);
+  const moveTime = useCallback((delta: number) => {
+    setPlaying(false);
+    setTimeIndex((current) => Math.max(0, Math.min(10, current + delta)));
+  }, []);
+
+  return (
+    <main className="mw-research-shell">
+      <header className="mw-research-header">
+        <div>
+          <p className="mw-research-kicker">Terrain-aware validation</p>
+          <h1>Dry mountain-wave cross-section</h1>
+          <p className="mw-research-subtitle">
+            Native CM1 terrain-following output at y ={" "}
+            {formatDistance(frame?.geometry.singleton_y_m ?? 0)}
+          </p>
+        </div>
+        <div className="mw-research-header-facts" aria-label="Research surface status">
+          <strong>Preserved Gate B result</strong>
+          <span>Dry 2-D x-z cross-section · singleton y</span>
+        </div>
+      </header>
+
+      {error ? (
+        <section className="mw-research-error" role="alert">
+          <strong>Terrain view unavailable</strong>
+          <span>{error}</span>
+          <button type="button" onClick={() => setRetryNonce((current) => current + 1)}>
+            Retry
+          </button>
+        </section>
+      ) : (
+        <div className="mw-research-workspace" aria-busy={loading}>
+          <section className="mw-plot-panel" aria-label="Terrain-following field view">
+            <div className="mw-plot-heading">
+              <div>
+                <span>{frame?.field.display_name ?? "Vertical velocity"}</span>
+                <strong>{formatModelTime(frame?.time_seconds ?? times[timeIndex] ?? 0)}</strong>
+              </div>
+              <p>{loading ? "Loading native history…" : "Physical height · native x-z topology"}</p>
+            </div>
+            {frame ? (
+              <TerrainCanvas frame={frame} onReadout={setReadout} />
+            ) : (
+              <div className="mw-plot-loading">Loading verified terrain geometry…</div>
+            )}
+            {frame && <TerrainLegend frame={frame} />}
+          </section>
+
+          <aside className="mw-control-rail" aria-label="Terrain view controls">
+            <section className="mw-control-section">
+              <h2>Field</h2>
+              <div className="mw-segmented-control" aria-label="Field selection">
+                <button type="button" aria-pressed={field === "w"} onClick={() => setField("w")}>
+                  Vertical velocity
+                </button>
+                <button
+                  type="button"
+                  aria-pressed={field === "theta_perturbation"}
+                  onClick={() => setField("theta_perturbation")}
+                >
+                  θ perturbation
+                </button>
+              </div>
+              <p className="mw-field-note">{frame?.field.derivation ?? "Native CM1 field."}</p>
+            </section>
+
+            <section className="mw-control-section">
+              <div className="mw-control-heading">
+                <h2>Model time</h2>
+                <strong>{formatModelTime(times[timeIndex] ?? 0)}</strong>
+              </div>
+              <div className="mw-time-commands">
+                <button
+                  type="button"
+                  className="mw-icon-button"
+                  aria-label="Previous output"
+                  title="Previous output"
+                  disabled={timeIndex === 0}
+                  onClick={() => moveTime(-1)}
+                >
+                  ‹
+                </button>
+                <button
+                  type="button"
+                  className="mw-icon-button mw-play-button"
+                  aria-label={playing ? "Pause" : "Play"}
+                  title={playing ? "Pause" : "Play"}
+                  onClick={() => setPlaying((current) => !current)}
+                >
+                  <span aria-hidden="true" className={playing ? "mw-pause-icon" : "mw-play-icon"} />
+                </button>
+                <button
+                  type="button"
+                  className="mw-icon-button"
+                  aria-label="Next output"
+                  title="Next output"
+                  disabled={timeIndex === times.length - 1}
+                  onClick={() => moveTime(1)}
+                >
+                  ›
+                </button>
+              </div>
+              <input
+                className="mw-time-slider"
+                type="range"
+                min={0}
+                max={times.length - 1}
+                value={timeIndex}
+                aria-label="Saved output time"
+                onChange={(event) => {
+                  setPlaying(false);
+                  setTimeIndex(Number(event.currentTarget.value));
+                }}
+              />
+              <div className="mw-time-range" aria-hidden="true">
+                <span>0:00</span>
+                <span>36:00</span>
+              </div>
+            </section>
+
+            <section className="mw-readout-section" aria-live="polite">
+              <h2>Pointer</h2>
+              {readout ? (
+                <dl className="mw-readout-grid">
+                  <div>
+                    <dt>x</dt>
+                    <dd>{formatDistance(readout.xM)}</dd>
+                  </div>
+                  <div>
+                    <dt>Model height</dt>
+                    <dd>{formatDistance(readout.modelHeightM)}</dd>
+                  </div>
+                  <div>
+                    <dt>Local AGL</dt>
+                    <dd>{formatDistance(readout.aglM)}</dd>
+                  </div>
+                  <div>
+                    <dt>{frame?.field.display_name}</dt>
+                    <dd>
+                      {readout.value.toFixed(3)} {frame?.field.units}
+                    </dd>
+                  </div>
+                  <div className="mw-readout-wide">
+                    <dt>Native level</dt>
+                    <dd>{formatDistance(readout.nominalHeightM)} nominal</dd>
+                  </div>
+                </dl>
+              ) : (
+                <p>Move across the cross-section to inspect x, physical height, and local AGL.</p>
+              )}
+            </section>
+
+            <section className="mw-native-facts">
+              <h2>Native geometry</h2>
+              <dl>
+                <div>
+                  <dt>Grid</dt>
+                  <dd>
+                    {frame ? `${frame.geometry.x_center_m.length} × ${frame.values.length}` : "—"}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Active top</dt>
+                  <dd>{frame ? formatDistance(frame.geometry.active_top_m) : "—"}</dd>
+                </div>
+                <div>
+                  <dt>Placement</dt>
+                  <dd>
+                    {frame?.field.vertical_grid === "physical_full_levels"
+                      ? "Full levels"
+                      : "Scalar levels"}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Interpolation</dt>
+                  <dd>None on field values</dd>
+                </div>
+              </dl>
+            </section>
+          </aside>
+        </div>
+      )}
+
+      {frame && (
+        <footer className="mw-research-footer">
+          <div>
+            <strong>Scope</strong>
+            <p>{frame.caveats.join(" ")}</p>
+          </div>
+          <details>
+            <summary>Payload and provenance</summary>
+            <dl>
+              <div>
+                <dt>Run</dt>
+                <dd>{frame.run_id}</dd>
+              </div>
+              <div>
+                <dt>Source</dt>
+                <dd>{frame.provenance.source_history_file}</dd>
+              </div>
+              <div>
+                <dt>Display binning</dt>
+                <dd>{frame.provenance.display_binning}</dd>
+              </div>
+              <div>
+                <dt>Identity</dt>
+                <dd>
+                  {frame.identity.verified_before_and_after_extraction
+                    ? `${frame.identity.verified_file_count} pinned files verified before and after extraction`
+                    : "Synthetic or unverified payload"}
+                </dd>
+              </div>
+              <div>
+                <dt>Backend extraction</dt>
+                <dd>{frame.performance.extraction_ms.toFixed(1)} ms</dd>
+              </div>
+              <div>
+                <dt>Payload</dt>
+                <dd>{formatBytes(frame.performance.serialized_payload_bytes)}</dd>
+              </div>
+              <div>
+                <dt>Request to browser state</dt>
+                <dd>{requestMs === null ? "—" : `${requestMs.toFixed(1)} ms`}</dd>
+              </div>
+            </dl>
+          </details>
+        </footer>
+      )}
+    </main>
+  );
+}
+
+function TerrainCanvas({
+  frame,
+  onReadout,
+}: {
+  frame: MountainWaveTerrainFrame;
+  onReadout: (readout: TerrainReadout | null) => void;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const cells = useMemo(() => buildTerrainDisplayCells(frame), [frame]);
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    drawTerrainFrame(canvas, frame, cells);
+  }, [cells, frame]);
+
+  useEffect(() => {
+    draw();
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => draw());
+    observer?.observe(canvas);
+    window.addEventListener("resize", draw);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", draw);
+    };
+  }, [draw]);
+
+  function handlePointer(event: ReactMouseEvent<HTMLCanvasElement>) {
+    const canvas = event.currentTarget;
+    const bounds = canvas.getBoundingClientRect();
+    const plot = plotBounds(bounds.width || 900, bounds.height || 700);
+    const xMin = frame.geometry.x_edge_m[0] ?? 0;
+    const xMax = frame.geometry.x_edge_m.at(-1) ?? 1;
+    const zMax = frame.geometry.active_top_m;
+    const x = xMin + ((event.clientX - bounds.left - plot.left) / plot.width) * (xMax - xMin);
+    const z = zMax - ((event.clientY - bounds.top - plot.top) / plot.height) * zMax;
+    const cell = cells.find((candidate) => pointInPolygon(x, z, candidate.corners));
+    if (!cell) {
+      onReadout(null);
+      return;
+    }
+    onReadout(terrainReadoutForCell(frame, cell));
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="mw-terrain-canvas"
+      role="img"
+      aria-label={`${frame.field.display_name} over native curved terrain at ${formatModelTime(
+        frame.time_seconds,
+      )}`}
+      onMouseMove={handlePointer}
+      onMouseLeave={() => onReadout(null)}
+    />
+  );
+}
+
+function TerrainLegend({ frame }: { frame: MountainWaveTerrainFrame }) {
+  const stops = Array.from({ length: 9 }, (_unused, index) => {
+    const fraction = index / 8;
+    return frame.scale.maximum - fraction * (frame.scale.maximum - frame.scale.minimum);
+  });
+  return (
+    <aside className="mw-color-legend" aria-label={`${frame.field.display_name} color scale`}>
+      <strong>
+        {frame.field.key === "w" ? "w" : "θ′"} ({frame.field.units})
+      </strong>
+      <span>{formatValue(frame.scale.maximum)}</span>
+      <div className="mw-color-ramp" aria-hidden="true" />
+      <div className="mw-color-ticks" aria-hidden="true">
+        {stops.map((value) => (
+          <span key={value}>{formatValue(value)}</span>
+        ))}
+      </div>
+      <span>{formatValue(frame.scale.minimum)}</span>
+      <p>
+        This frame {formatValue(frame.scale.selected_time_minimum)} to{" "}
+        {formatValue(frame.scale.selected_time_maximum)}
+      </p>
+    </aside>
+  );
+}
+
+export function buildTerrainDisplayCells(frame: MountainWaveTerrainFrame): TerrainDisplayCell[] {
+  const cells: TerrainDisplayCell[] = [];
+  const full = frame.geometry.full_height_m;
+  const isFull = frame.field.vertical_grid === "physical_full_levels";
+  const verticalCount = frame.values.length;
+  for (let row = 0; row < verticalCount; row += 1) {
+    const lowerAtCenters = isFull
+      ? row === 0
+        ? frame.geometry.terrain_m
+        : averageRows(full[row - 1], full[row])
+      : full[row];
+    const upperAtCenters = isFull
+      ? row === verticalCount - 1
+        ? full[full.length - 1]
+        : averageRows(full[row], full[row + 1])
+      : full[row + 1];
+    const lowerAtEdges = centerValuesToEdges(lowerAtCenters);
+    const upperAtEdges = centerValuesToEdges(upperAtCenters);
+    for (let column = 0; column < frame.geometry.x_center_m.length; column += 1) {
+      const value = frame.values[row]?.[column];
+      if (!Number.isFinite(value)) continue;
+      const x0 = frame.geometry.x_edge_m[column];
+      const x1 = frame.geometry.x_edge_m[column + 1];
+      if (x0 === undefined || x1 === undefined) continue;
+      cells.push({
+        row,
+        column,
+        value,
+        nominalHeightM: isFull
+          ? (frame.geometry.nominal_full_height_m[row] ?? 0)
+          : (frame.geometry.nominal_scalar_height_m[row] ?? 0),
+        corners: [
+          { x: x0, z: lowerAtEdges[column] ?? 0 },
+          { x: x1, z: lowerAtEdges[column + 1] ?? 0 },
+          { x: x1, z: upperAtEdges[column + 1] ?? 0 },
+          { x: x0, z: upperAtEdges[column] ?? 0 },
+        ],
+      });
+    }
+  }
+  return cells;
+}
+
+export function terrainReadoutForCell(
+  frame: MountainWaveTerrainFrame,
+  cell: TerrainDisplayCell,
+): TerrainReadout {
+  const terrainHeightM = frame.geometry.terrain_m[cell.column] ?? 0;
+  const modelHeightM =
+    frame.field.vertical_grid === "physical_full_levels"
+      ? (frame.geometry.full_height_m[cell.row]?.[cell.column] ?? terrainHeightM)
+      : (frame.geometry.scalar_height_m[cell.row]?.[cell.column] ?? terrainHeightM);
+  return {
+    xM: frame.geometry.x_center_m[cell.column] ?? 0,
+    modelHeightM,
+    terrainHeightM,
+    aglM: Math.max(0, modelHeightM - terrainHeightM),
+    value: cell.value,
+    nominalHeightM: cell.nominalHeightM,
+  };
+}
+
+function drawTerrainFrame(
+  canvas: HTMLCanvasElement,
+  frame: MountainWaveTerrainFrame,
+  cells: TerrainDisplayCell[],
+) {
+  const cssWidth = canvas.clientWidth || 900;
+  const cssHeight = canvas.clientHeight || 700;
+  const pixelRatio = window.devicePixelRatio || 1;
+  canvas.width = Math.round(cssWidth * pixelRatio);
+  canvas.height = Math.round(cssHeight * pixelRatio);
+  const context = canvas.getContext("2d");
+  if (!context) return;
+  context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+  context.clearRect(0, 0, cssWidth, cssHeight);
+  context.fillStyle = "#f8fbfc";
+  context.fillRect(0, 0, cssWidth, cssHeight);
+
+  const bounds = plotBounds(cssWidth, cssHeight);
+  const xMin = frame.geometry.x_edge_m[0] ?? 0;
+  const xMax = frame.geometry.x_edge_m.at(-1) ?? 1;
+  const zMax = frame.geometry.active_top_m;
+  const toX = (value: number) => bounds.left + ((value - xMin) / (xMax - xMin)) * bounds.width;
+  const toY = (value: number) => bounds.top + bounds.height - (value / zMax) * bounds.height;
+
+  context.strokeStyle = "#dbe6eb";
+  context.lineWidth = 1;
+  context.font = "600 12px Inter, system-ui, sans-serif";
+  context.textAlign = "right";
+  context.textBaseline = "middle";
+  for (let zM = 0; zM <= zMax; zM += 5_000) {
+    const y = toY(zM);
+    context.beginPath();
+    context.moveTo(bounds.left, y);
+    context.lineTo(bounds.left + bounds.width, y);
+    context.stroke();
+    context.fillStyle = "#5f7180";
+    context.fillText(`${zM / 1_000}`, bounds.left - 12, y);
+  }
+
+  for (const cell of cells) {
+    context.beginPath();
+    cell.corners.forEach((corner, index) => {
+      if (index === 0) context.moveTo(toX(corner.x), toY(corner.z));
+      else context.lineTo(toX(corner.x), toY(corner.z));
+    });
+    context.closePath();
+    context.fillStyle = terrainFieldColor(cell.value, frame.scale.minimum, frame.scale.maximum);
+    context.fill();
+  }
+
+  const terrainEdges = centerValuesToEdges(frame.geometry.terrain_m);
+  context.beginPath();
+  context.moveTo(toX(xMin), toY(0));
+  context.lineTo(toX(xMin), toY(terrainEdges[0] ?? 0));
+  terrainEdges.forEach((height, index) =>
+    context.lineTo(toX(frame.geometry.x_edge_m[index] ?? xMin), toY(height)),
+  );
+  context.lineTo(toX(xMax), toY(0));
+  context.closePath();
+  context.fillStyle = "#3f474b";
+  context.fill();
+  context.beginPath();
+  terrainEdges.forEach((height, index) => {
+    const x = toX(frame.geometry.x_edge_m[index] ?? xMin);
+    const y = toY(height);
+    if (index === 0) context.moveTo(x, y);
+    else context.lineTo(x, y);
+  });
+  context.strokeStyle = "#12191d";
+  context.lineWidth = 2;
+  context.stroke();
+
+  context.strokeStyle = "#536773";
+  context.lineWidth = 1.5;
+  context.strokeRect(bounds.left, bounds.top, bounds.width, bounds.height);
+  context.fillStyle = "#172b3a";
+  context.font = "700 13px Inter, system-ui, sans-serif";
+  context.textBaseline = "top";
+  context.textAlign = "left";
+  context.fillText(`${formatDistance(xMin)}`, bounds.left, bounds.top + bounds.height + 12);
+  context.textAlign = "right";
+  context.fillText(
+    `${formatDistance(xMax)}`,
+    bounds.left + bounds.width,
+    bounds.top + bounds.height + 12,
+  );
+  context.textAlign = "center";
+  context.fillText("x (km)", bounds.left + bounds.width / 2, bounds.top + bounds.height + 38);
+  context.save();
+  context.translate(18, bounds.top + bounds.height / 2);
+  context.rotate(-Math.PI / 2);
+  context.fillText("Physical height (km)", 0, 0);
+  context.restore();
+}
+
+function plotBounds(width: number, height: number) {
+  return { left: 74, top: 22, width: Math.max(1, width - 96), height: Math.max(1, height - 86) };
+}
+
+function averageRows(first: number[] | undefined, second: number[] | undefined): number[] {
+  if (!first || !second || first.length !== second.length) return [];
+  return first.map((value, index) => (value + (second[index] ?? value)) / 2);
+}
+
+export function centerValuesToEdges(values: number[]): number[] {
+  if (values.length === 0) return [];
+  if (values.length === 1) return [values[0], values[0]];
+  const edges = [values[0]];
+  for (let index = 1; index < values.length; index += 1) {
+    edges.push(((values[index - 1] ?? 0) + (values[index] ?? 0)) / 2);
+  }
+  edges.push(values.at(-1) ?? 0);
+  return edges;
+}
+
+export function pointInPolygon(x: number, z: number, corners: Array<{ x: number; z: number }>) {
+  let inside = false;
+  for (let index = 0, previous = corners.length - 1; index < corners.length; previous = index++) {
+    const currentCorner = corners[index];
+    const previousCorner = corners[previous];
+    if (!currentCorner || !previousCorner) continue;
+    const intersects =
+      currentCorner.z > z !== previousCorner.z > z &&
+      x <
+        ((previousCorner.x - currentCorner.x) * (z - currentCorner.z)) /
+          (previousCorner.z - currentCorner.z) +
+          currentCorner.x;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+export function terrainFieldColor(value: number, minimum: number, maximum: number): string {
+  const span = Math.max(Number.EPSILON, maximum - minimum);
+  const normalized = Math.max(0, Math.min(1, (value - minimum) / span));
+  const scaled = normalized * (COLOR_STOPS.length - 1);
+  const lowerIndex = Math.min(COLOR_STOPS.length - 2, Math.floor(scaled));
+  const fraction = scaled - lowerIndex;
+  return interpolateHex(
+    COLOR_STOPS[lowerIndex] ?? "#ffffff",
+    COLOR_STOPS[lowerIndex + 1] ?? "#ffffff",
+    fraction,
+  );
+}
+
+function interpolateHex(first: string, second: string, fraction: number): string {
+  const firstValue = Number.parseInt(first.slice(1), 16);
+  const secondValue = Number.parseInt(second.slice(1), 16);
+  const channels = [16, 8, 0].map((shift) => {
+    const start = (firstValue >> shift) & 255;
+    const end = (secondValue >> shift) & 255;
+    return Math.round(start + (end - start) * fraction);
+  });
+  return `#${channels.map((channel) => channel.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function formatModelTime(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const remainder = Math.round(seconds % 60);
+  return `${minutes}:${remainder.toString().padStart(2, "0")} (${seconds.toLocaleString()} s)`;
+}
+
+function formatDistance(meters: number): string {
+  if (Math.abs(meters) < 1_000) return `${meters.toFixed(0)} m`;
+  return `${(meters / 1_000).toFixed(2)} km`;
+}
+
+function formatValue(value: number): string {
+  if (Math.abs(value) >= 10) return value.toFixed(1);
+  return value.toFixed(2);
+}
+
+function formatBytes(bytes: number): string {
+  return bytes >= 1024 ? `${(bytes / 1024).toFixed(1)} KiB` : `${bytes} B`;
+}

--- a/app/frontend/src/main.tsx
+++ b/app/frontend/src/main.tsx
@@ -2,9 +2,13 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { App } from "./App";
+import { MountainWaveTerrainResearch } from "./MountainWaveTerrainResearch";
+
+const isMountainWaveTerrainResearch =
+  window.location.pathname === "/research/mountain-wave-terrain";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    {isMountainWaveTerrainResearch ? <MountainWaveTerrainResearch /> : <App />}
   </StrictMode>,
 );

--- a/docs/contracts/output-product-specification.md
+++ b/docs/contracts/output-product-specification.md
@@ -78,6 +78,53 @@ Current backend output-product payloads include:
 - time-series arrays;
 - selected-region diagnostics for point, column, and box requests.
 
+### Bounded terrain-aware research payload
+
+`GET /api/research/mountain-wave-terrain` is an additive, research-only JSON
+payload for the hash-pinned Gate B dry mountain-wave result. It does not replace
+or alter the shared flat-grid visualization contract. The endpoint accepts
+`field=w|theta_perturbation` and an exact native `time_index` from `0` through
+`10`.
+
+The `mountain_wave_terrain_research_v1` response carries:
+
+- the exact 11 native model times and selected numbered history;
+- native `xh` centers and `xf` edges, terrain `zs`, native physical scalar
+  heights from `zhval`, and reconstructed physical full heights;
+- nominal `zh` and `zf` coordinates, all normalized to meters and explicitly
+  distinguished from physical model height;
+- native `w(zf,yh,xh)` or derived `th(t)-th(t=0)` values on their respective
+  physical full or scalar levels, with dimensions, staggering, and units;
+- final nominal `zf`, runtime `ztop`, configured `nz` and `dz`, and `nz*dz`
+  active-top evidence, which must agree at 20,000 m;
+- fixed cross-time field scale, selected-time range, terrain masking, display
+  binning, derivation, and no-field-interpolation provenance;
+- dry two-dimensional and singleton-`y` disclosure, pinned identity status,
+  extraction/serialization timing, and serialized payload bytes.
+
+The endpoint verifies every pinned manifest, generated input, stats/log, and
+numbered history before and after extraction. It fails closed on missing or
+changed identity, incomplete times, unsupported units or dimensions,
+non-singleton `y`, non-monotonic physical columns, active-top disagreement,
+physical heights below terrain, a bottom full level different from terrain, or
+a non-constant physical top.
+
+The browser uses the physical mesh as coordinate authority. Native field values
+are not interpolated or collocated. For raster display only, interior horizontal
+cell boundaries use the midpoint of neighboring physical center heights. Scalar
+samples occupy the physical full-level bounds around their native scalar level;
+full-level `w` samples occupy physical vertical midpoint bounds clamped to
+terrain and active top. Hover reports the selected native sample's `xh`,
+physical model height, nominal level, and local AGL (`physical height - zs` at
+the same x cell). Model height is not labeled MSL.
+
+The local inspection route is `/research/mountain-wave-terrain`. It is selected
+only by that unlinked development URL and is absent from Home, Trade Cumulus,
+and product navigation. It presents no three-dimensional extrusion. Supporting
+another terrain-following result would require integrating equivalent physical
+mesh metadata into result ingest and the shared visualization API; this bounded
+endpoint is not a generic terrain framework.
+
 ## Behavioral Rules And Invariants
 
 Raw NetCDF stays backend-owned. The browser receives JSON payloads produced by
@@ -142,6 +189,7 @@ Current API routes include:
 - `GET /api/results/{result_id}/output-products/time-height`;
 - `GET /api/results/{result_id}/output-products/time-series`;
 - `GET /api/results/{result_id}/diagnostics/selected-region`;
+- `GET /api/research/mountain-wave-terrain` (bounded research-only contract);
 - `GET /api/storage/inventory`;
 - `POST /api/storage/delete-run`.
 
@@ -188,10 +236,12 @@ Implementation evidence:
 - `app/backend/cloud_chamber/runtime_storage.py`;
 - `app/backend/cloud_chamber/run_manifest.py`;
 - `app/backend/cloud_chamber/app.py`.
+- `app/backend/cloud_chamber/mountain_wave_terrain_visualization.py`.
 
 Frontend consumers:
 
 - `app/frontend/src/App.tsx`;
+- `app/frontend/src/MountainWaveTerrainResearch.tsx`;
 - `app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts`.
 
 Tests:
@@ -204,7 +254,9 @@ Tests:
 - `app/backend/tests/test_result_cards.py`;
 - `app/backend/tests/test_runtime_storage.py`;
 - `app/backend/tests/test_app.py`;
+- `app/backend/tests/test_mountain_wave_terrain_visualization.py`;
 - `app/frontend/src/App.test.tsx`.
+- `app/frontend/src/MountainWaveTerrainResearch.test.tsx`.
 
 ## Known Implementation Limits
 

--- a/docs/research/mountain-waves/terrain-aware-visualization-validation.md
+++ b/docs/research/mountain-waves/terrain-aware-visualization-validation.md
@@ -1,0 +1,330 @@
+# Terrain-Aware Visualization Validation
+
+## Status and decision boundary
+
+Gate C implemented and validated the smallest browser path that can represent
+the exact preserved Gate B dry mountain-wave output using physical
+terrain-following geometry. The implementation is ready for manual
+PM/scientific/visual review in a draft pull request.
+
+The decision question was whether Cloud Chamber can represent the preserved
+native CM1 terrain, physical field heights, staggering, time evolution, and
+coordinate meaning honestly and at practical local cost. The answer for this
+bounded dry two-dimensional result is yes.
+
+This is not a Mountain Wave Clouds World. It does not approve moisture,
+condensation, a lenticular-cloud case, a Recipe, Control, Lens, Comparison,
+product navigation, three-dimensional terrain, or a generic terrain framework.
+No CM1 process ran, no package was generated, and no scientific input changed.
+
+## Preserved evidence identity
+
+| Item | Value |
+| --- | --- |
+| Run ID | `dry-mountain-wave-official-20260721T183530Z` |
+| Package/run implementation commit | `9ff73ff244c393bee2a2e93a851ad1ba2dc16287` |
+| Gate B merge commit | `0fc006f0fcd34216b107a7c579cf4b679293ce44` |
+| Histories | 11 numbered native files |
+| Exact times | 0 through 2,160 s at 216 s cadence |
+| Identity mode | pinned SHA-256 before and after every payload extraction |
+| Verified inputs | 23 manifest, input, stats/log, and history files |
+
+The endpoint calls the existing Gate B package loader and pinned identity
+verifier before opening native output. It repeats the verifier after extraction
+and rejects a changed hash set. The verifier also requires a completed,
+zero-exit run and no active CM1 or MPI process. Manual validation used only this
+preserved result; synthetic data was used only in automated tests.
+
+## Prior flat-grid assumptions
+
+The current shared visualization path cannot carry this result honestly:
+
+- result field metadata records one-dimensional coordinate names and native
+  dimensions, but not column-varying physical vertical geometry;
+- the shared slice payload carries a rectangular value array and units, but not
+  terrain, actual horizontal values, or a two-dimensional physical-height mesh;
+- profiles and time-height products use one one-dimensional vertical
+  coordinate;
+- point-cloud construction combines independent one-dimensional x, y, and z
+  coordinates;
+- the frontend slice raster assumes an axis-aligned rectangular grid;
+- Three.js placement uses independent axis extents and would turn singleton
+  `y` into a misleading volume if used as the authoritative surface.
+
+Passing this result through the shared path would flatten the atmosphere over
+terrain. Gate C therefore adds a bounded research payload and unlinked route;
+it does not modify flat-grid ingest, slices, point clouds, profiles,
+time-height products, Explore, Comparison, or the Three.js viewer.
+
+## Implemented data path
+
+The backend route is:
+
+```text
+GET /api/research/mountain-wave-terrain?field=w&time_index=<0..10>
+GET /api/research/mountain-wave-terrain?field=theta_perturbation&time_index=<0..10>
+```
+
+The response schema is `mountain_wave_terrain_research_v1`. Every response
+contains the exact time sequence, selected native history, native x centers and
+edges, terrain, physical scalar and full height meshes, nominal coordinates,
+field values, dimensions, units, vertical staggering, fixed cross-time scale,
+selected-time range, active-top evidence, vertical-reference semantics,
+identity status, and extraction/serialization measurements.
+
+The local inspection surface is:
+
+```text
+/research/mountain-wave-terrain
+```
+
+It is selected only from the exact local URL in `main.tsx`. It is not linked
+from Home or Trade Cumulus and does not appear in product navigation. The view
+opens on the final saved output so the central wave is immediately visible,
+while previous/next, playback, and the slider expose all 11 exact histories.
+
+## Geometry, height, and staggering
+
+Native geometry remains authoritative:
+
+- `xh` supplies scalar x centers and `xf` supplies cell edges;
+- `zs(yh,xh)` supplies terrain at the singleton y row;
+- `zhval(zh,yh,xh)` supplies native physical scalar-level height;
+- physical full-level height is reconstructed from `zs`, nominal `zf`, and the
+  verified active top using the CM1 r21.1 terrain transform;
+- native `w(zf,yh,xh)` remains on physical full levels;
+- native `th(zh,yh,xh)` remains on physical scalar levels.
+
+The endpoint independently requires these active-top sources to agree:
+
+| Source | Value |
+| --- | ---: |
+| Final nominal `zf` | 20,000 m |
+| Runtime NetCDF `ztop` | 20,000 m |
+| Configured `nz × dz` | `100 × 200 m = 20,000 m` |
+
+The unchanged namelist text `ztop=18,000 m` is retained as inactive stretched-
+grid configuration and is not used as the transform top. The full-level bottom
+equals local terrain to 0.01 m tolerance and the full-level top is constant at
+20,000 m across every x column. Native `zhval` must agree with independently
+reconstructed scalar heights to 0.02 m.
+
+The browser calls the vertical axis **Physical height (km)** and describes it
+as geometric height above the model datum. It never calls this height MSL.
+Hover identifies one native sample and reports its native `xh`, physical model
+height on the field's actual level, nominal coordinate, and local height AGL:
+
+```text
+height AGL = physical field height - zs at the same native x cell
+```
+
+## Derivation, binning, and masking
+
+`w` is native output in m/s. Potential-temperature perturbation is explicitly
+derived in K as native `th` at the selected time minus native `th` in the same
+scalar cell at `t=0 s`. No pressure field, contour, wind overlay, or horizontal
+velocity collocation is exposed.
+
+Native field values are never interpolated or collocated. Canvas cells are a
+display binning of the native samples:
+
+- scalar samples are painted between their surrounding physical full-level
+  bounds;
+- full-level `w` samples are painted between physical vertical midpoints, with
+  the bottom and top clamped to terrain and the active top;
+- interior horizontal display boundaries use the midpoint of neighboring
+  physical center heights at the native `xf` edge;
+- each polygon retains one unchanged native field value.
+
+The horizontal midpoint operation affects only display geometry; it does not
+resample a field. Tests exercise this edge construction directly. The terrain
+polygon uses the same display edges, fills every pixel below terrain, and draws
+an explicit dark terrain boundary. Cell construction rejects physical heights
+below terrain, a bottom full level different from terrain, or a non-constant
+top. Hover targets are the same above-terrain polygons, so no target exists
+below terrain.
+
+Each field uses a symmetric diverging scale fixed across all 11 times. The
+scale does not change while stepping or playing:
+
+| Field | Fixed scale | Final-time native range |
+| --- | ---: | ---: |
+| Vertical velocity `w` | -3.202856 to +3.202856 m/s | -3.094287 to +2.794157 m/s |
+| Potential-temperature perturbation | -1.069580 to +1.069580 K | -1.066132 to +1.010071 K |
+
+## Automated evidence
+
+Focused backend tests use an intentionally curved three-column terrain fixture;
+a flat-height implementation cannot satisfy its expected scalar/full meshes.
+They verify:
+
+- terrain, x, physical-height dimensions, and normalized units;
+- non-flat physical levels over curved terrain;
+- scalar versus full-level field dimensions and placement;
+- final nominal `zf`, runtime `ztop`, and `nz*dz` agreement;
+- failure on active-top mismatch;
+- full-level bottom equal to terrain and constant physical top;
+- exact 11-time ordering and failure on shifted times;
+- singleton-`y` handling;
+- failure when native `zhval` semantics are missing;
+- finite fields and no physical geometry below terrain;
+- local AGL and rejection of below-terrain AGL;
+- explicit theta-perturbation derivation from the same `t=0` cell.
+
+Focused frontend tests verify full-level midpoint bins, scalar full-level bounds,
+continuous horizontal display edges, no below-terrain polygons, exact native
+readout height/AGL, deterministic scale colors, exact-time requests, field
+switching, dry singleton-`y` disclosure, and absence of a research link from
+Home. Existing flat-grid tests remain in the full repository check and no
+shared flat-grid implementation changed.
+
+Focused verification passed:
+
+```text
+backend: 41 tests passed
+frontend: 8 tests passed
+frontend TypeScript/Vite build passed
+frontend lint passed
+backend Ruff and mypy passed
+```
+
+The final repository verification contract also passed:
+
+```text
+frontend: 124 tests passed
+frontend TypeScript/Vite build and lint passed
+backend: 581 tests passed
+backend Ruff, mypy, script syntax, forbidden-artifact, and docs/data sanity checks passed
+```
+
+The known backend NumPy ABI runtime warning and Vite large-chunk warning remain
+unchanged; neither is caused by this bounded path.
+
+## Manual visual validation
+
+The in-app browser loaded the live Vite frontend and FastAPI backend against the
+exact preserved run. Validation inspected initial and final `w`, final theta
+perturbation, every next-time transition from index 0 through 10, direct field
+switching, playback, the pointer readout, and the payload/provenance disclosure.
+Browser console errors and warnings were empty.
+
+Observed results:
+
+- the native domain spans -10 to +10 km at the x edges and 0 to 20 km in
+  physical model height;
+- the analytic bell ridge peaks at 400 m at native `x=100 m`, with the sampled
+  terrain tapering to about 3.96 m near the domain edges;
+- the atmospheric bottom follows that ridge and the dark below-terrain mask;
+- no field polygon or hover target appeared below terrain;
+- final `w` shows coherent alternating ascent/descent bands tilted downstream
+  from the terrain through the central and upper domain;
+- final theta perturbation shows corresponding coherent warm/cool tilted bands
+  on scalar physical levels;
+- the visible structures agree qualitatively with the Gate B native-output
+  evidence without inventing a pass threshold;
+- time and field changes preserve curved physical geometry and fixed scales;
+- the pointer distinguishes native x, physical model height, local AGL, and
+  nominal level;
+- the page states **Dry 2-D x-z cross-section · singleton y** and presents no
+  three-dimensional extrusion.
+
+PM live review found the research surface strong as a first pass and confirmed
+that the intended terrain-aware capability point was proven. Minor UI nits were
+identified but do not affect this gate's geometry, semantics, or practical-use
+decision and are not expanded into Gate C implementation work.
+
+### Browser geometry record
+
+| Item | Recorded value |
+| --- | ---: |
+| CSS viewport | 1,728 × 1,000 CSS px |
+| `devicePixelRatio` | 2 |
+| Browser zoom / visual viewport scale | 100% / 1 |
+| Screenshot pixels | 1,728 × 1,000 px |
+| Canvas CSS size | about 1,265 × 628 CSS px |
+| Canvas backing store | 2,530 × 1,256 px |
+
+The screenshot API returned CSS-sized 1,728 × 1,000 images even though the
+canvas used a 2× backing store. Screenshot pixels were therefore recorded
+separately and were not substituted for CSS viewport dimensions. Screenshots
+were inspected at runtime and were not committed.
+
+## Performance and practical cost
+
+Representative final-time responses after process startup were:
+
+| Field | Backend extraction | JSON serialization | Payload | HTTP request |
+| --- | ---: | ---: | ---: | ---: |
+| `w` | 132.7 ms | 2.2 ms | 556,371 bytes | 254.6 ms |
+| theta perturbation | 108.1 ms | 2.4 ms | 526,139 bytes | 211.0 ms |
+
+The first `w` request after a backend restart took 318.3 ms for extraction and
+457.2 ms end to end; this cold-start value is reported rather than hidden.
+Browser first meaningful render during the live pass was 484 ms. Measured field
+switch latency was 300 ms and time-step switch latency was 266 ms. Playback
+advanced on its 900 ms cadence without overlapping or skipped UI state.
+
+The warmed FastAPI process resident set was about 68,192 KiB after representative
+requests. Browser JavaScript heap telemetry was not exposed by the controlled
+browser, so no browser-memory number is invented. The canvas backing store and
+payload sizes are reported as the available browser-side memory evidence.
+
+There is no decimation or cache. Each request validates all pinned files and
+reads all 11 small histories to establish exact time order, stable geometry,
+and a fixed cross-time field scale. This conservative research implementation
+is practically usable for the preserved 100 × 100/101 result. A future shared
+terrain contract should separate identity/geometry/scale caching from frame
+values before attempting materially larger results.
+
+## Cloud Chamber implications
+
+This gate establishes only these bounded facts:
+
+- the backend can carry column-varying physical scalar and full-level geometry
+  without flattening it;
+- the browser can draw native terrain-following topology, mask terrain, and
+  provide scientifically precise native sample readout;
+- the current machine can switch the preserved fields and times at practical
+  local latency;
+- a source-backed moist-case selection study is mechanically supportable.
+
+It does not establish that the dry case forms clouds, that a moist reference
+case exists, that the eventual experience should resemble this research UI, or
+that generic terrain belongs in the product architecture.
+
+## Limitations and unresolved questions
+
+- The case is dry and cannot validate moisture, condensation, cloud water, or
+  lenticular-cloud formation.
+- `ny=1` validates only an authoritative two-dimensional cross-section, not a
+  terrain volume or a 3-D atmospheric viewer.
+- Only native `w` and derived theta perturbation are exposed. Pressure and
+  horizontally staggered `u`/`v` are not part of this inspection surface.
+- Horizontal physical cell edges are display midpoint geometry because native
+  physical heights are supplied at x centers. Native field values are not
+  interpolated.
+- The payload rescans all 11 files per request. That is acceptable here but is
+  not a scaling design for larger simulations.
+- Future moist reference-case selection must determine whether source output
+  provides enough terrain, moisture, cloud, and validation evidence. Gate C
+  makes no selection.
+
+No unresolved geometry, semantics, identity, visual, or practical-performance
+defect blocks the bounded decision. Product design, shared-contract design, and
+moist-case selection remain intentionally unresolved for later reviewed work.
+
+## Final disposition
+
+The exact preserved files remain hash-verified; terrain and both fields are
+placed on physical native geometry; model height, nominal coordinate, and local
+AGL are distinct; staggering and derivation are explicit; there is no fake
+volume; the dry-wave evolution is visually interpretable; flat-grid behavior is
+isolated; and local interaction is practical.
+
+```text
+advance_to_moist_reference_case_selection
+```
+
+This disposition authorizes only PM review and, if approved, a later research
+issue to select a source-backed moist orographic-cloud case. It does not create
+or activate Gate D.


### PR DESCRIPTION
## Summary

- adds a bounded, research-only backend payload for the exact hash-pinned Gate B dry mountain-wave result
- preserves native terrain-following scalar/full-level geometry, explicit staggering, fixed cross-time scales, and local AGL semantics
- adds an unlinked desktop inspection route at `/research/mountain-wave-terrain` with exact time controls, native `w`, derived theta perturbation, terrain masking, and native-sample readout
- leaves Home, Trade Cumulus, Explore/Compare, shared flat-grid payloads, and Three.js behavior unchanged
- records the Gate C validation evidence and final disposition `advance_to_moist_reference_case_selection`

Parent candidate study: #400

Closes #405 when PM review and merge posture are satisfied.

## Exact changed paths

- `app/backend/cloud_chamber/app.py`
- `app/backend/cloud_chamber/mountain_wave_terrain_visualization.py`
- `app/backend/tests/test_app.py`
- `app/backend/tests/test_mountain_wave_terrain_visualization.py`
- `app/frontend/src/CloudWorldsHome.test.tsx`
- `app/frontend/src/MountainWaveTerrainResearch.css`
- `app/frontend/src/MountainWaveTerrainResearch.test.tsx`
- `app/frontend/src/MountainWaveTerrainResearch.tsx`
- `app/frontend/src/main.tsx`
- `docs/contracts/output-product-specification.md`
- `docs/research/mountain-waves/terrain-aware-visualization-validation.md`

No CM1 source, binaries, NetCDF, logs, screenshots, generated run directories, machine-private paths, product navigation, moist case, or Gate D issue are included.

## Preserved evidence

- run ID: `dry-mountain-wave-official-20260721T183530Z`
- package/run implementation commit: `9ff73ff244c393bee2a2e93a851ad1ba2dc16287`
- Gate B merge commit: `0fc006f0fcd34216b107a7c579cf4b679293ce44`
- 23 pinned inputs and histories are verified before and after every extraction
- all 11 numbered histories retain exact expected ordering from 0 through 2,160 seconds
- active-top evidence agrees at 20,000 m across final nominal `zf`, runtime `ztop`, and configured `nz × dz`
- no CM1/MPI process ran and no package or scientific namelist was regenerated

## Scientific representation

- `w(zf,yh,xh)` remains on reconstructed physical full levels
- theta perturbation is derived as native `th(t) - th(t=0)` in the same scalar cell
- native field values are not interpolated or collocated
- canvas binning uses the physical native mesh; terrain and hover targets fail closed below terrain
- model geometric height, nominal coordinate, and local AGL remain distinct
- the authoritative view is a two-dimensional `x-z` cross-section with singleton `y`; no volume is invented

## Manual validation

The preserved result was inspected live at a 1,728 × 1,000 CSS viewport, DPR 2, and 100% browser zoom. Initial/final `w`, final theta perturbation, all eleven time transitions, playback, field switching, native pointer readout, terrain masking, and provenance disclosure were exercised. The final fields showed coherent tilted wave bands interacting with the 400 m bell ridge, with no below-terrain cells or targets.

PM live review found the surface strong as a first pass and confirmed that the intended capability point was proven. Minor UI nits are outside this gate and were not expanded into implementation work.

Representative warmed responses:

| Field | Extraction | Serialization | Payload | HTTP |
| --- | ---: | ---: | ---: | ---: |
| `w` | 132.7 ms | 2.2 ms | 556,371 bytes | 254.6 ms |
| theta perturbation | 108.1 ms | 2.4 ms | 526,139 bytes | 211.0 ms |

Browser first meaningful render was 484 ms; field switching was 300 ms; time switching was 266 ms. The warmed backend RSS was about 68,192 KiB. Browser heap telemetry was unavailable and is not invented.

## Final disposition

```text
advance_to_moist_reference_case_selection
```

This authorizes only PM review and, if approved, a later research issue to select a source-backed moist orographic-cloud case. It does not approve moisture, a lenticular-cloud result, a World, Recipe, Control, Lens, Comparison, product navigation, generic terrain support, or Gate D activation.

## Verification

- focused backend: 41 tests passed
- focused frontend: 8 tests passed
- `git diff --check`
- `scripts/check.sh`
  - 124 frontend tests passed
  - frontend lint and production build passed
  - backend Ruff and mypy passed
  - 581 backend tests passed
  - script syntax, forbidden-artifact, docs, JSON, and YAML checks passed
- existing NumPy ABI and Vite chunk-size warnings remain unchanged

## Review posture

- manual PM/scientific/visual review is required
- issue #405 remains open
- this PR is draft
- auto-merge is not enabled
- Gate D has not been created
