### PR TITLE
Research: select and run the moist mountain-wave feasibility case

### DIFF
--- a/app/backend/cloud_chamber/moist_mountain_wave_case.py
+++ b/app/backend/cloud_chamber/moist_mountain_wave_case.py
@@ -1005,14 +1005,18 @@ def verify_preserved_run_artifacts(
         actual[relative_path] = actual_sha256
 
     manifest = load_run_manifest(package.manifest_path)
-    expected_history_names = [f"cm1out_{index:06d}.nc" for index in range(1, 22)]
+    expected_output_names = [
+        *(f"cm1out_{index:06d}.nc" for index in range(1, 22)),
+        "cm1out_stats.nc",
+    ]
     manifest_history_paths = [Path(path).resolve() for path in manifest.outputs.netcdf_paths]
     expected_history_paths = [
-        (package.package_dir / name).resolve() for name in expected_history_names
+        (package.package_dir / name).resolve() for name in expected_output_names
     ]
     if manifest_history_paths != expected_history_paths:
         raise MoistMountainWaveCaseError(
-            "Preserved manifest no longer names the exact 21 pinned histories in order."
+            "Preserved manifest no longer names the exact 21 pinned histories and stats "
+            "file in order."
         )
     expected_stdout = (package.package_dir / "logs/stdout.log").resolve()
     expected_stderr = (package.package_dir / "logs/stderr.log").resolve()

--- a/app/backend/cloud_chamber/moist_mountain_wave_case.py
+++ b/app/backend/cloud_chamber/moist_mountain_wave_case.py
@@ -19,6 +19,7 @@ from cloud_chamber.mountain_wave_case import (
     accepted_model_output_paths,
     active_cm1_processes,
     collect_cm1_provenance,
+    lower_boundary_tangency_metrics,
     normalize_length_to_m,
     normalize_time_to_seconds,
     parse_namelist_assignments,
@@ -46,7 +47,8 @@ from cloud_chamber.settings import CloudChamberSettings
 
 CASE_ID = "cm1_r21_1_toy2011_boulder_moist_wave_4000s_v1"
 SCENARIO_ID = CASE_ID
-EVIDENCE_VERSION = "moist_mountain_wave_gate_d_e_v1"
+EVIDENCE_VERSION = "moist_mountain_wave_gate_d_e_v2"
+PRESERVED_RUN_ID = "moist-mountain-wave-toy-1972-20260721T215226Z"
 SOURCE_LOCK_RELATIVE_PATH = Path("docs/research/mountain-waves/moist-reference-case-selection.md")
 SOURCE_LOCK_SHA256 = "939c4b7c6b067c125402383e7ed966b6e09eed2f5e0c0762ca6331a6f381b20b"
 IGRA_STATION_ID = "USM00072476"
@@ -80,6 +82,38 @@ EDGE_WIDTH_M = 10_000.0
 REQUIRED_OUTPUT_FIELDS = ("zs", "zhval", "th", "prs", "qv", "ql", "u", "v", "w")
 REQUIRED_COORDINATES = ("time", "xh", "xf", "yh", "yf", "zh", "zf")
 _OUTPUT_LIKE_PATTERNS = ("cm1out*", "*.nc", "*.nc4", "*.ctl")
+PRESERVED_RUN_ARTIFACT_SHA256 = {
+    "run_manifest.json": "026a3887f4120fa3e2e6663d8a486a28f83338ff5b3be09639cd245fd8ba1845",
+    "case_manifest.json": "208d05ba72149a53f423ef13fa97cab4e298f374f20f30e6ea9c12fc6e016a78",
+    "namelist.input": "d94f54d5e60627daf9020aa9eceaecd4f3b35fa1c81590186c72c7ccf99a10be",
+    "input_sounding": "cb43243d04e328e9dd1a08ff52139f5a6096dcbe89f7b0d0e4aeb536f6a33b22",
+    "perts.dat": "10d4fd60cac78acc2a19fe4a84b5d3c12c7e8a2ab58789faecebc40bf23e1028",
+    "execution_preflight.json": "917f2f17c33f602760801c4447e014ef09e0f6031a2218b9dba4a49a2e0b9185",
+    "logs/stdout.log": "42a120685c18d29d855cdea5039f54a3530157f2d36497cd41318f1af97fc0cb",
+    "logs/stderr.log": "6e8658cbd2bf71044b960ff59b4371a98438c32a7d4cb54ab562294b8cc4f05d",
+    "cm1out_stats.nc": "46cf824b20ab0c4b00806cd9ec2b0e52833e35d1913e2fa4d9205e12a523ff7a",
+    "cm1out_000001.nc": "a62959ceaae1c108ea0d2eb3805809615faf233a0e35096eeeceac18329ae9a5",
+    "cm1out_000002.nc": "79a4d4a95534b29dbd98286d1086dbf2a168af4484862b994e30e09af3b76c0a",
+    "cm1out_000003.nc": "bbe5d4d40bcf59acb4c87d44a2aa73060d5dca9eb72572ccc58ec87a6b33ecf3",
+    "cm1out_000004.nc": "b5bcad79828812d1f81b1d1972622d492e7967e97dc35a9c6b505301033e16c1",
+    "cm1out_000005.nc": "5dd3efac88159d955e6e4e2880ca3faf06c7024c3ffc9de4c6f45ba43e5493df",
+    "cm1out_000006.nc": "cf5aeb035f784fc8f252f08a92b6bb6a78740431b6060a20bdbc30a3d6540699",
+    "cm1out_000007.nc": "48091a925b4e9a9219c6f1e07902ea1a09a8f427113b5f25589d0a2ef322019e",
+    "cm1out_000008.nc": "183ceae29cd44cc767a8987db4f218c9479d283d8f7330547d65992e02094752",
+    "cm1out_000009.nc": "294fe39221cfe6af1d48ea65093bc0698d903bc848535d349371f898cf66b6d6",
+    "cm1out_000010.nc": "316fb4c2c0bb2c93ef588eeae50516b78c2bca6087bc85cf62da7596c9a526b6",
+    "cm1out_000011.nc": "41a9a6c8fdd7a81e3ea1074fb2cb717a312a46602e814e58c57f5eb1b81fd2ce",
+    "cm1out_000012.nc": "e7ce11ae105ea035d9dc0f408647507a3ed51a7165eb75fae2fc38e3549d1572",
+    "cm1out_000013.nc": "93d0b34b075a194f5c621c7f8d5b0ca8de82f51170fad30456962fdacaf298e7",
+    "cm1out_000014.nc": "9410bcb03d2ff9f251356f01f9d19391eaa6d254f1bf6497f27901e461ff75e8",
+    "cm1out_000015.nc": "49956dcf04d32f2569e8d585e4d76af23e4765012c8111a63b1d426b93fe0d73",
+    "cm1out_000016.nc": "724a5acf714b2fa1a55e497a9a3c5343dea4608863db7a1702af5187d7b7063d",
+    "cm1out_000017.nc": "9bc9e235bacfc73424651bf547c68c56cf24d3422741f5d732660ff647db4290",
+    "cm1out_000018.nc": "82d3a544ff5026ad74ec066c90adcddf17251ef161bccb0053684b57c3f20375",
+    "cm1out_000019.nc": "9caac2cd58d33852934579dc2973c183113383f23665f2ed8b17795759e67613",
+    "cm1out_000020.nc": "c6920f6d47eb6b0fb8a2cfd7ca8ac901a49e92802d40f9f1f161937eadb76023",
+    "cm1out_000021.nc": "0f8f31f2bf91ca80d430b326025cc734f4295e1ad6c687d2bae7f02ae0fe2b43",
+}
 
 
 class MoistMountainWaveCaseError(RuntimeError):
@@ -234,6 +268,7 @@ class MoistMountainWaveEvidence(BaseModel):
     run_id: str
     implementation_commit: str
     generated_at: datetime
+    offline_reevaluation: dict[str, Any] | None = None
     source_lock: dict[str, Any]
     provenance: dict[str, Any]
     lifecycle: dict[str, Any]
@@ -904,6 +939,131 @@ def _audit_existing_terrain(path: Path) -> dict[str, Any]:
     return {"sha256": sha256_file(path), "maximum_roundtrip_error_m": max_error, "checks": checks}
 
 
+def load_preserved_moist_mountain_wave_run(
+    *, settings: CloudChamberSettings, run_id: str
+) -> MoistMountainWavePackageResult:
+    """Load only the exact completed run authorized for offline reevaluation."""
+    if run_id != PRESERVED_RUN_ID:
+        raise MoistMountainWaveCaseError(
+            f"Offline reevaluation is pinned to {PRESERVED_RUN_ID}; found {run_id}."
+        )
+    package_dir = settings.runtime_home.expanduser() / "runs" / run_id
+    required = {
+        "manifest": package_dir / "run_manifest.json",
+        "case_manifest": package_dir / "case_manifest.json",
+        "namelist_audit": package_dir / "source_namelist_diff.json",
+        "storage_estimate": package_dir / "storage_estimate.json",
+    }
+    missing = sorted(path.name for path in required.values() if not path.is_file())
+    if missing:
+        raise MoistMountainWaveCaseError(f"Preserved run is incomplete: {missing}")
+
+    manifest = load_run_manifest(required["manifest"])
+    case_manifest = json.loads(required["case_manifest"].read_text())
+    implementation_commit = case_manifest.get("implementation_commit")
+    if (
+        manifest.run_id != PRESERVED_RUN_ID
+        or manifest.scenario.id != SCENARIO_ID
+        or manifest.lifecycle_state != LifecycleState.COMPLETED
+        or manifest.execution.exit_code != 0
+        or not isinstance(implementation_commit, str)
+        or manifest.app.commit != implementation_commit
+    ):
+        raise MoistMountainWaveCaseError(
+            "Preserved run identity, lifecycle, or implementation commit changed."
+        )
+    return MoistMountainWavePackageResult(
+        run_id=run_id,
+        package_dir=package_dir,
+        manifest_path=required["manifest"],
+        case_manifest_path=required["case_manifest"],
+        namelist_audit_path=required["namelist_audit"],
+        storage_estimate_path=required["storage_estimate"],
+        implementation_commit=implementation_commit,
+        generated_files=tuple(required.values()),
+    )
+
+
+def verify_preserved_run_artifacts(
+    package: MoistMountainWavePackageResult,
+) -> dict[str, Any]:
+    """Fail closed unless every source, input, log, stat, and history hash is pinned."""
+    if package.run_id != PRESERVED_RUN_ID:
+        raise MoistMountainWaveCaseError("Preserved artifact verification received another run.")
+    source_lock = verify_source_lock()
+    actual: dict[str, str] = {}
+    for relative_path, expected_sha256 in PRESERVED_RUN_ARTIFACT_SHA256.items():
+        path = package.package_dir / relative_path
+        if not path.is_file():
+            raise MoistMountainWaveCaseError(f"Preserved run artifact is missing: {relative_path}.")
+        actual_sha256 = sha256_file(path)
+        if actual_sha256 != expected_sha256:
+            raise MoistMountainWaveCaseError(
+                f"Preserved run artifact changed: {relative_path}; expected "
+                f"{expected_sha256}, found {actual_sha256}."
+            )
+        actual[relative_path] = actual_sha256
+
+    manifest = load_run_manifest(package.manifest_path)
+    expected_history_names = [f"cm1out_{index:06d}.nc" for index in range(1, 22)]
+    manifest_history_paths = [Path(path).resolve() for path in manifest.outputs.netcdf_paths]
+    expected_history_paths = [
+        (package.package_dir / name).resolve() for name in expected_history_names
+    ]
+    if manifest_history_paths != expected_history_paths:
+        raise MoistMountainWaveCaseError(
+            "Preserved manifest no longer names the exact 21 pinned histories in order."
+        )
+    expected_stdout = (package.package_dir / "logs/stdout.log").resolve()
+    expected_stderr = (package.package_dir / "logs/stderr.log").resolve()
+    if Path(manifest.execution.stdout_log or "").resolve() != expected_stdout:
+        raise MoistMountainWaveCaseError("Preserved stdout path identity changed.")
+    if Path(manifest.execution.stderr_log or "").resolve() != expected_stderr:
+        raise MoistMountainWaveCaseError("Preserved stderr path identity changed.")
+
+    case_manifest = json.loads(package.case_manifest_path.read_text())
+    if case_manifest.get("source_lock") != source_lock:
+        raise MoistMountainWaveCaseError("Preserved case-manifest source lock changed.")
+    if case_manifest.get("implementation_commit") != package.implementation_commit:
+        raise MoistMountainWaveCaseError("Preserved implementation commit identity changed.")
+    return {
+        "run_id": package.run_id,
+        "source_lock": source_lock,
+        "artifact_sha256": actual,
+        "artifact_count": len(actual),
+    }
+
+
+def reevaluate_preserved_moist_mountain_wave_run(
+    *,
+    settings: CloudChamberSettings,
+    package: MoistMountainWavePackageResult,
+    evaluator_commit: str,
+) -> MoistMountainWaveEvidence:
+    """Reevaluate the pinned output without constructing or invoking a run manager."""
+    before = verify_preserved_run_artifacts(package)
+    evidence = evaluate_moist_mountain_wave_run(settings=settings, package=package)
+    after = verify_preserved_run_artifacts(package)
+    if before != after:
+        raise MoistMountainWaveCaseError(
+            "Preserved run hashes changed during offline reevaluation."
+        )
+    return evidence.model_copy(
+        update={
+            "offline_reevaluation": {
+                "mode": "fail_closed_preserved_native_output_only",
+                "run_id": package.run_id,
+                "original_implementation_commit": package.implementation_commit,
+                "evaluator_commit": evaluator_commit,
+                "run_manager_constructed_or_invoked": False,
+                "artifact_hashes_verified_before": before,
+                "artifact_hashes_verified_after": after,
+                "artifacts_unchanged": True,
+            }
+        }
+    )
+
+
 def evaluate_moist_mountain_wave_run(
     *, settings: CloudChamberSettings, package: MoistMountainWavePackageResult
 ) -> MoistMountainWaveEvidence:
@@ -936,6 +1096,10 @@ def evaluate_moist_mountain_wave_run(
     minimum_vertical_spacing = math.inf
     maximum_height_transform_error = 0.0
     top_values: list[float] = []
+    active_top_by_time: list[dict[str, Any]] = []
+    tangency_by_time: list[dict[str, Any]] = []
+    upstream_flow_by_time: list[dict[str, Any]] = []
+    initial_upstream_state: dict[str, Any] | None = None
     inventory: dict[str, Any] | None = None
 
     for path in model_paths:
@@ -946,6 +1110,8 @@ def evaluate_moist_mountain_wave_run(
             coords = _coordinates(dataset)
             terrain = _field(dataset, "zs", ("yh", "xh"))
             zh_physical = _field(dataset, "zhval", ("zh", "yh", "xh"))
+            active_top = _active_top_evidence(dataset, coords, time_seconds=time_seconds)
+            active_top_by_time.append(active_top)
             if first_coords is None:
                 first_coords = coords
                 first_terrain = terrain
@@ -976,7 +1142,7 @@ def evaluate_moist_mountain_wave_run(
                 maximum_height_transform_error,
                 float(np.max(np.abs(zh_physical - expected_zh))),
             )
-            top_values.append(float(coords["zf"][-1]))
+            top_values.append(float(active_top["final_nominal_zf_m"]))
 
             fields = {name: np.asarray(dataset[name].values) for name in REQUIRED_OUTPUT_FIELDS}
             for name, values in fields.items():
@@ -996,12 +1162,47 @@ def evaluate_moist_mountain_wave_run(
             qv = _field(dataset, "qv", ("zh", "yh", "xh"))[:, 0, :]
             theta = _field(dataset, "th", ("zh", "yh", "xh"))[:, 0, :]
             pressure = _field(dataset, "prs", ("zh", "yh", "xh"))[:, 0, :]
+            u = _field(dataset, "u", ("zh", "yh", "xf"))
+            v = _field(dataset, "v", ("zh", "yf", "xh"))
             w_full = _field(dataset, "w", ("zf", "yh", "xh"))[:, 0, :]
+            u_scalar = 0.5 * (u[:, 0, :-1] + u[:, 0, 1:])
+            v_scalar = 0.5 * (v[:, :-1, :] + v[:, 1:, :])[:, 0, :]
             w_scalar = 0.5 * (w_full[:-1] + w_full[1:])
             temperature = theta * (pressure / 100_000.0) ** (287.04 / 1004.0)
             qsat = _saturation_mixing_ratio_kg_kg(temperature, pressure)
             relative_humidity = np.divide(qv, qsat, out=np.zeros_like(qv), where=qsat > 0.0)
             height = zh_physical[:, 0, :]
+            tangency = lower_boundary_tangency_metrics(
+                x_m=coords["xh"],
+                y_m=coords["yh"],
+                zs_m=terrain,
+                u_bottom=u[0, :, :],
+                v_bottom=v[0, :, :],
+                w_bottom=w_full[0, :][None, :],
+            )
+            tangency["time_seconds"] = time_seconds
+            tangency_by_time.append(tangency)
+            upstream_flow_by_time.append(
+                _upstream_flow_evidence(
+                    time_seconds=time_seconds,
+                    x_m=coords["xh"],
+                    height_m=height,
+                    u=u_scalar,
+                    v=v_scalar,
+                    w=w_scalar,
+                )
+            )
+            if initial_upstream_state is None:
+                initial_upstream_state = _initial_upstream_state_evidence(
+                    x_m=coords["xh"],
+                    height_m=height,
+                    theta=theta,
+                    pressure=pressure,
+                    qv=qv,
+                    u=u_scalar,
+                    v=v_scalar,
+                    w=w_scalar,
+                )
             frame = _cloud_frame_evidence(
                 time_seconds=time_seconds,
                 x_m=coords["xh"],
@@ -1024,6 +1225,7 @@ def evaluate_moist_mountain_wave_run(
     assert first_coords is not None
     assert first_terrain is not None
     assert inventory is not None
+    assert initial_upstream_state is not None
 
     coherent_flags = [frame["largest_component_cells"] >= MIN_COHERENT_CELLS for frame in frames]
     persistent_windows = [
@@ -1036,7 +1238,10 @@ def evaluate_moist_mountain_wave_run(
     upstream_maximum = max(float(frame["upstream_maximum_ql_kg_kg"]) for frame in frames)
     edge_maximum = max(float(frame["edge_maximum_ql_kg_kg"]) for frame in frames)
     descent_evaporation_frames = [
-        frame["time_seconds"] for frame in frames if frame["descending_clear_near_cloud_cells"] > 0
+        frame["time_seconds"]
+        for frame in frames
+        if frame["downstream_descent_evaporation"]["selected_cell_count"] > 0
+        and frame["downstream_descent_evaporation"]["largest_component_cells"] > 0
     ]
     runtime_integrity = _runtime_integrity(package, manifest, model_paths)
     checks = {
@@ -1052,14 +1257,24 @@ def evaluate_moist_mountain_wave_run(
         "upstream_clear_at_interpretable_floor": upstream_maximum < CLOUD_FLOOR_KG_KG,
         "first_cloud_forms_interior_not_edge": first_cloud is not None
         and first_cloud["interior_cloud_cell_count"] > 0
-        and first_cloud["edge_cloud_cell_count"] == 0,
+        and first_cloud["edge_cloud_cell_count"] == 0
+        and first_cloud["peak_location_is_interior"],
         "coherent_cloud_persists_three_histories": bool(persistent_windows),
         "material_peak_reached": float(peak_frame["maximum_ql_kg_kg"]) >= MATERIAL_PEAK_KG_KG,
-        "cloud_colocated_with_ascent_and_saturation": any(
-            frame["cloud_in_ascent_and_saturation_cells"] > 0 for frame in frames
-        ),
+        "cloud_colocated_with_ascent_and_saturation": first_cloud is not None
+        and first_cloud["interior_cloud_in_ascent_and_saturation_cells"] > 0
+        and first_cloud["peak_location_w_m_s"] > 0.0
+        and first_cloud["peak_location_relative_humidity"] >= 0.99,
         "descent_and_evaporation_evidence_present": bool(descent_evaporation_frames),
         "edge_cloud_does_not_compromise_interpretation": edge_maximum < CLOUD_FLOOR_KG_KG,
+        "active_top_sources_agree_all_histories": all(
+            bool(item["all_active_top_sources_agree"]) for item in active_top_by_time
+        ),
+        "lower_boundary_tangency_metrics_retained": len(tangency_by_time)
+        == len(EXPECTED_OUTPUT_TIMES_SECONDS),
+        "initial_upstream_wind_and_stability_retained": bool(
+            initial_upstream_state["profile_by_level"]
+        ),
     }
     return MoistMountainWaveEvidence(
         run_id=package.run_id,
@@ -1093,12 +1308,26 @@ def evaluate_moist_mountain_wave_run(
             "physical_height_transform_maximum_abs_error_m": maximum_height_transform_error,
             "minimum_scalar_vertical_spacing_m": minimum_vertical_spacing,
             "active_top_values_m": top_values,
+            "active_top_checks_by_time": active_top_by_time,
+            "lower_boundary_tangency": {
+                "physical_condition": "w = u * dzs/dx + v * dzs/dy",
+                "per_time_metrics": tangency_by_time,
+                "maximum_abs_residual_m_s": max(
+                    max(
+                        abs(float(item["residual_min_m_s"])),
+                        abs(float(item["residual_max_m_s"])),
+                    )
+                    for item in tangency_by_time
+                ),
+            },
         },
         initial_and_upstream={
             "initial_maximum_ql_kg_kg": first_ql_max,
             "upstream_maximum_ql_kg_kg_all_times": upstream_maximum,
             "upstream_x_bounds_m": list(UPSTREAM_X_BOUNDS_M),
             "evaluation_top_m": EVALUATION_TOP_M,
+            "initial_upstream_state": initial_upstream_state,
+            "upstream_flow_by_time": upstream_flow_by_time,
         },
         cloud_and_wave={
             "cloud_floor_kg_kg": CLOUD_FLOOR_KG_KG,
@@ -1109,6 +1338,9 @@ def evaluate_moist_mountain_wave_run(
             "peak_cloud_frame": peak_frame,
             "persistent_windows_seconds": persistent_windows,
             "descent_evaporation_frames_seconds": descent_evaporation_frames,
+            "downstream_descent_evaporation_by_time": [
+                frame["downstream_descent_evaporation"] for frame in frames
+            ],
             "frames": frames,
         },
         boundaries_and_top={
@@ -1132,6 +1364,129 @@ def evaluate_moist_mountain_wave_run(
     )
 
 
+def _active_top_evidence(
+    dataset: xr.Dataset,
+    coords: dict[str, np.ndarray[Any, Any]],
+    *,
+    time_seconds: float,
+) -> dict[str, Any]:
+    if "ztop" not in dataset:
+        raise MoistMountainWaveCaseError("Native output is missing runtime ztop.")
+    runtime_values = normalize_length_to_m(
+        dataset["ztop"].values,
+        str(dataset["ztop"].attrs.get("units", "")),
+    ).reshape(-1)
+    if runtime_values.size != 1:
+        raise MoistMountainWaveCaseError("Runtime ztop must be scalar-valued.")
+    final_nominal_zf_m = float(coords["zf"][-1])
+    runtime_ztop_m = float(runtime_values[0])
+    configured_top_m = NZ * DZ_M
+    agrees = all(
+        math.isclose(value, final_nominal_zf_m, rel_tol=0.0, abs_tol=0.01)
+        for value in (runtime_ztop_m, configured_top_m, ACTIVE_TOP_M)
+    )
+    if not agrees:
+        raise MoistMountainWaveCaseError(
+            "Active-top evidence disagrees among final nominal zf, runtime ztop, "
+            "configured nz*dz, and the source lock."
+        )
+    return {
+        "time_seconds": time_seconds,
+        "final_nominal_zf_m": final_nominal_zf_m,
+        "runtime_ztop_m": runtime_ztop_m,
+        "configured_nz": NZ,
+        "configured_dz_m": DZ_M,
+        "configured_nz_times_dz_m": configured_top_m,
+        "source_locked_active_top_m": ACTIVE_TOP_M,
+        "all_active_top_sources_agree": agrees,
+    }
+
+
+def _upstream_flow_evidence(
+    *,
+    time_seconds: float,
+    x_m: np.ndarray[Any, Any],
+    height_m: np.ndarray[Any, Any],
+    u: np.ndarray[Any, Any],
+    v: np.ndarray[Any, Any],
+    w: np.ndarray[Any, Any],
+) -> dict[str, Any]:
+    upstream_x = (x_m >= UPSTREAM_X_BOUNDS_M[0]) & (x_m <= UPSTREAM_X_BOUNDS_M[1])
+    mask = upstream_x[None, :] & (height_m < EVALUATION_TOP_M)
+    return {
+        "time_seconds": time_seconds,
+        "x_bounds_m": list(UPSTREAM_X_BOUNDS_M),
+        "height_maximum_m": EVALUATION_TOP_M,
+        "selected_cell_count": int(np.count_nonzero(mask)),
+        "u_m_s": _numeric_summary(u[mask]),
+        "v_m_s": _numeric_summary(v[mask]),
+        "w_m_s": _numeric_summary(w[mask]),
+    }
+
+
+def _initial_upstream_state_evidence(
+    *,
+    x_m: np.ndarray[Any, Any],
+    height_m: np.ndarray[Any, Any],
+    theta: np.ndarray[Any, Any],
+    pressure: np.ndarray[Any, Any],
+    qv: np.ndarray[Any, Any],
+    u: np.ndarray[Any, Any],
+    v: np.ndarray[Any, Any],
+    w: np.ndarray[Any, Any],
+) -> dict[str, Any]:
+    upstream_x = (x_m >= UPSTREAM_X_BOUNDS_M[0]) & (x_m <= UPSTREAM_X_BOUNDS_M[1])
+    profile: list[dict[str, Any]] = []
+    for level_index in range(height_m.shape[0]):
+        selected_x = upstream_x & (height_m[level_index] < EVALUATION_TOP_M)
+        if not np.any(selected_x):
+            continue
+        profile.append(
+            {
+                "level_index": level_index,
+                "sample_count": int(np.count_nonzero(selected_x)),
+                "mean_height_m": float(np.mean(height_m[level_index, selected_x])),
+                "mean_theta_k": float(np.mean(theta[level_index, selected_x])),
+                "mean_pressure_pa": float(np.mean(pressure[level_index, selected_x])),
+                "mean_qv_kg_kg": float(np.mean(qv[level_index, selected_x])),
+                "mean_u_m_s": float(np.mean(u[level_index, selected_x])),
+                "mean_v_m_s": float(np.mean(v[level_index, selected_x])),
+                "mean_w_m_s": float(np.mean(w[level_index, selected_x])),
+            }
+        )
+    if len(profile) < 2:
+        raise MoistMountainWaveCaseError(
+            "Initial upstream profile does not contain enough levels for stability evidence."
+        )
+    heights = np.asarray([item["mean_height_m"] for item in profile], dtype=np.float64)
+    theta_values = np.asarray([item["mean_theta_k"] for item in profile], dtype=np.float64)
+    delta_height = np.diff(heights)
+    if np.any(delta_height <= 0.0):
+        raise MoistMountainWaveCaseError("Initial upstream physical heights are not monotonic.")
+    theta_mid = 0.5 * (theta_values[:-1] + theta_values[1:])
+    n_squared = 9.81 / theta_mid * np.diff(theta_values) / delta_height
+    return {
+        "method": (
+            "native t=0 scalar-grid means in the locked -100 to -60 km upstream sector "
+            "below 12 km; N^2=(g/theta_mid)*(delta theta/delta physical height)"
+        ),
+        "x_bounds_m": list(UPSTREAM_X_BOUNDS_M),
+        "height_maximum_m": EVALUATION_TOP_M,
+        "profile_by_level": profile,
+        "wind_summary": {
+            "u_m_s": _numeric_summary(u[:, upstream_x][height_m[:, upstream_x] < EVALUATION_TOP_M]),
+            "v_m_s": _numeric_summary(v[:, upstream_x][height_m[:, upstream_x] < EVALUATION_TOP_M]),
+            "w_m_s": _numeric_summary(w[:, upstream_x][height_m[:, upstream_x] < EVALUATION_TOP_M]),
+        },
+        "stability": {
+            "sample_count": int(n_squared.size),
+            "n_squared_s_2": _numeric_summary(n_squared),
+            "negative_n_squared_count": int(np.count_nonzero(n_squared < 0.0)),
+            "positive_n_squared_count": int(np.count_nonzero(n_squared > 0.0)),
+        },
+    }
+
+
 def _cloud_frame_evidence(
     *,
     time_seconds: float,
@@ -1145,6 +1500,21 @@ def _cloud_frame_evidence(
     cloud = (ql >= CLOUD_FLOOR_KG_KG) & below
     components = _connected_components(cloud)
     largest = max(components, key=len, default=[])
+    component_evidence = sorted(
+        (
+            _component_evidence(
+                component,
+                x_m=x_m,
+                height_m=height_m,
+                ql=ql,
+                w=w,
+                relative_humidity=relative_humidity,
+            )
+            for component in components
+        ),
+        key=lambda item: int(item["cell_count"]),
+        reverse=True,
+    )
     interior_x = (x_m >= INTERIOR_X_BOUNDS_M[0]) & (x_m <= INTERIOR_X_BOUNDS_M[1])
     upstream_x = (x_m >= UPSTREAM_X_BOUNDS_M[0]) & (x_m <= UPSTREAM_X_BOUNDS_M[1])
     edge_x = (x_m <= x_m.min() + EDGE_WIDTH_M) | (x_m >= x_m.max() - EDGE_WIDTH_M)
@@ -1153,6 +1523,20 @@ def _cloud_frame_evidence(
     edge = below & edge_x[None, :]
     near_cloud = _dilate_mask(cloud)
     descending_clear = near_cloud & below & (w < 0.0) & (relative_humidity < 1.0) & ~cloud
+    east_adjacent = np.zeros_like(cloud)
+    east_adjacent[:, 1:] = cloud[:, :-1]
+    downstream_descending_clear = (
+        east_adjacent & below & (w < 0.0) & (relative_humidity < 1.0) & (ql < CLOUD_FLOOR_KG_KG)
+    )
+    downstream_evidence = _downstream_descent_evidence(
+        time_seconds=time_seconds,
+        mask=downstream_descending_clear,
+        x_m=x_m,
+        height_m=height_m,
+        w=w,
+        relative_humidity=relative_humidity,
+        ql=ql,
+    )
     cloud_ascent_saturated = cloud & (w > 0.0) & (relative_humidity >= 0.99)
     peak_index = np.unravel_index(int(np.argmax(ql)), ql.shape)
     component_centroid_x: float | None = None
@@ -1170,21 +1554,134 @@ def _cloud_frame_evidence(
         "largest_component_cells": len(largest),
         "largest_component_centroid_x_m": component_centroid_x,
         "largest_component_centroid_height_m": component_centroid_z,
+        "cloud_components": component_evidence,
         "interior_cloud_cell_count": int(np.count_nonzero(cloud & interior)),
         "upstream_cloud_cell_count": int(np.count_nonzero(cloud & upstream)),
         "edge_cloud_cell_count": int(np.count_nonzero(cloud & edge)),
         "upstream_maximum_ql_kg_kg": _masked_maximum(ql, upstream),
         "edge_maximum_ql_kg_kg": _masked_maximum(ql, edge),
         "cloud_in_ascent_and_saturation_cells": int(np.count_nonzero(cloud_ascent_saturated)),
+        "interior_cloud_in_ascent_and_saturation_cells": int(
+            np.count_nonzero(cloud_ascent_saturated & interior)
+        ),
         "descending_clear_near_cloud_cells": int(np.count_nonzero(descending_clear)),
+        "downstream_descent_evaporation": downstream_evidence,
         "cloud_weighted_mean_w_m_s": _weighted_mean(w, ql, cloud),
         "cloud_weighted_mean_relative_humidity": _weighted_mean(relative_humidity, ql, cloud),
         "peak_location_x_m": float(x_m[peak_index[1]]),
         "peak_location_height_m": float(height_m[peak_index]),
         "peak_location_w_m_s": float(w[peak_index]),
         "peak_location_relative_humidity": float(relative_humidity[peak_index]),
+        "peak_location_is_interior": bool(interior[peak_index]),
         "top_abs_w_maximum_m_s": _masked_maximum(np.abs(w), top_mask),
         "top_ql_maximum_kg_kg": _masked_maximum(ql, top_mask),
+    }
+
+
+def _component_evidence(
+    component: list[tuple[int, int]],
+    *,
+    x_m: np.ndarray[Any, Any],
+    height_m: np.ndarray[Any, Any],
+    ql: np.ndarray[Any, Any],
+    w: np.ndarray[Any, Any],
+    relative_humidity: np.ndarray[Any, Any],
+) -> dict[str, Any]:
+    mask = np.zeros(ql.shape, dtype=bool)
+    for index in component:
+        mask[index] = True
+    z_indices, x_indices = np.nonzero(mask)
+    x_values = x_m[x_indices]
+    height_values = height_m[z_indices, x_indices]
+    return {
+        "cell_count": len(component),
+        "centroid_x_m": float(np.mean(x_values)),
+        "centroid_height_m": float(np.mean(height_values)),
+        "x_bounds_m": [float(np.min(x_values)), float(np.max(x_values))],
+        "height_bounds_m": [float(np.min(height_values)), float(np.max(height_values))],
+        "maximum_ql_kg_kg": float(np.max(ql[mask])),
+        "ql_weighted_mean_w_m_s": _weighted_mean(w, ql, mask),
+        "ql_weighted_mean_relative_humidity": _weighted_mean(relative_humidity, ql, mask),
+    }
+
+
+def _downstream_descent_evidence(
+    *,
+    time_seconds: float,
+    mask: np.ndarray[Any, Any],
+    x_m: np.ndarray[Any, Any],
+    height_m: np.ndarray[Any, Any],
+    w: np.ndarray[Any, Any],
+    relative_humidity: np.ndarray[Any, Any],
+    ql: np.ndarray[Any, Any],
+) -> dict[str, Any]:
+    components = _connected_components(mask)
+    largest = max(components, key=len, default=[])
+    selected_z, selected_x = np.nonzero(mask)
+    selected_count = int(selected_z.size)
+    bounds: dict[str, list[float] | None]
+    if selected_count:
+        selected_heights = height_m[selected_z, selected_x]
+        bounds = {
+            "x_bounds_m": [float(np.min(x_m[selected_x])), float(np.max(x_m[selected_x]))],
+            "height_bounds_m": [
+                float(np.min(selected_heights)),
+                float(np.max(selected_heights)),
+            ],
+        }
+    else:
+        bounds = {"x_bounds_m": None, "height_bounds_m": None}
+
+    largest_bounds: dict[str, list[float] | None]
+    if largest:
+        largest_z = np.asarray([index[0] for index in largest], dtype=np.int64)
+        largest_x = np.asarray([index[1] for index in largest], dtype=np.int64)
+        largest_heights = height_m[largest_z, largest_x]
+        largest_bounds = {
+            "x_bounds_m": [float(np.min(x_m[largest_x])), float(np.max(x_m[largest_x]))],
+            "height_bounds_m": [
+                float(np.min(largest_heights)),
+                float(np.max(largest_heights)),
+            ],
+        }
+    else:
+        largest_bounds = {"x_bounds_m": None, "height_bounds_m": None}
+
+    return {
+        "time_seconds": time_seconds,
+        "method": (
+            "clear scalar cells one x-grid cell immediately east of a cloud cell, with "
+            "w<0, RH<1, and ql below the locked interpretable cloud floor"
+        ),
+        "direction": "downstream_east_positive_x",
+        "selected_cell_count": selected_count,
+        "component_count": len(components),
+        "largest_component_cells": len(largest),
+        **bounds,
+        "largest_component_bounds": largest_bounds,
+        "w_m_s": _numeric_summary(w[mask]),
+        "relative_humidity_fraction": _numeric_summary(relative_humidity[mask]),
+        "ql_kg_kg": _numeric_summary(ql[mask]),
+    }
+
+
+def _numeric_summary(values: Any) -> dict[str, float | int | None]:
+    array = np.asarray(values, dtype=np.float64).reshape(-1)
+    finite = array[np.isfinite(array)]
+    if finite.size == 0:
+        return {
+            "sample_count": 0,
+            "minimum": None,
+            "median": None,
+            "mean": None,
+            "maximum": None,
+        }
+    return {
+        "sample_count": int(finite.size),
+        "minimum": float(np.min(finite)),
+        "median": float(np.median(finite)),
+        "mean": float(np.mean(finite)),
+        "maximum": float(np.max(finite)),
     }
 
 
@@ -1246,7 +1743,9 @@ def _weighted_mean(
 
 def _require_fields(dataset: xr.Dataset) -> None:
     available = set(dataset.data_vars) | set(dataset.coords)
-    missing = sorted((set(REQUIRED_OUTPUT_FIELDS) | set(REQUIRED_COORDINATES)) - available)
+    missing = sorted(
+        (set(REQUIRED_OUTPUT_FIELDS) | set(REQUIRED_COORDINATES) | {"ztop"}) - available
+    )
     if missing:
         raise MoistMountainWaveCaseError(f"Native output is missing required data: {missing}")
 

--- a/app/backend/cloud_chamber/moist_mountain_wave_case.py
+++ b/app/backend/cloud_chamber/moist_mountain_wave_case.py
@@ -1,0 +1,1365 @@
+"""Deterministic packaging and native-output evidence for issue #407's moist wave case."""
+
+from __future__ import annotations
+
+import json
+import math
+import shutil
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import xarray as xr
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber import __version__
+from cloud_chamber.mountain_wave_case import (
+    accepted_model_output_paths,
+    active_cm1_processes,
+    collect_cm1_provenance,
+    normalize_length_to_m,
+    normalize_time_to_seconds,
+    parse_namelist_assignments,
+    reconstruct_physical_heights,
+    replace_namelist_assignment,
+    sha256_file,
+    sha256_text,
+    verified_clean_git_commit,
+)
+from cloud_chamber.run_manifest import (
+    AppMetadata,
+    GeneratedInputs,
+    LifecycleState,
+    ProductState,
+    ProvenanceMetadata,
+    RunManifest,
+    RuntimePaths,
+    ScenarioReference,
+    UserMetadata,
+    ValidationStatus,
+    load_run_manifest,
+    write_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings
+
+CASE_ID = "cm1_r21_1_toy2011_boulder_moist_wave_4000s_v1"
+SCENARIO_ID = CASE_ID
+EVIDENCE_VERSION = "moist_mountain_wave_gate_d_e_v1"
+SOURCE_LOCK_RELATIVE_PATH = Path("docs/research/mountain-waves/moist-reference-case-selection.md")
+SOURCE_LOCK_SHA256 = "939c4b7c6b067c125402383e7ed966b6e09eed2f5e0c0762ca6331a6f381b20b"
+IGRA_STATION_ID = "USM00072476"
+IGRA_OBSERVATION_TIME = "1972-01-11T12:00:00Z"
+IGRA_SOURCE_RECORD_SHA256 = "33953228bc6bcdf7d65c5cf800b5f8bed9a71aedda910edb4d32a28bef37e652"
+
+NX = 220
+NY = 1
+NZ = 125
+DX_M = 1_000.0
+DY_M = 1_000.0
+DZ_M = 200.0
+ACTIVE_TOP_M = 25_000.0
+TERRAIN_HEIGHT_M = 2_000.0
+TERRAIN_HALF_WIDTH_M = 10_000.0
+TERRAIN_CENTER_M = 500.0
+EXPECTED_DURATION_SECONDS = 4_000
+EXPECTED_OUTPUT_CADENCE_SECONDS = 200
+EXPECTED_OUTPUT_TIMES_SECONDS = tuple(
+    range(0, EXPECTED_DURATION_SECONDS + 1, EXPECTED_OUTPUT_CADENCE_SECONDS)
+)
+NUMERICAL_CLEAR_FLOOR_KG_KG = 1.0e-12
+CLOUD_FLOOR_KG_KG = 1.0e-6
+MATERIAL_PEAK_KG_KG = 2.0e-4
+MIN_COHERENT_CELLS = 8
+MIN_PERSISTENT_FRAMES = 3
+INTERIOR_X_BOUNDS_M = (-40_000.0, 60_000.0)
+UPSTREAM_X_BOUNDS_M = (-100_000.0, -60_000.0)
+EVALUATION_TOP_M = 12_000.0
+EDGE_WIDTH_M = 10_000.0
+REQUIRED_OUTPUT_FIELDS = ("zs", "zhval", "th", "prs", "qv", "ql", "u", "v", "w")
+REQUIRED_COORDINATES = ("time", "xh", "xf", "yh", "yf", "zh", "zf")
+_OUTPUT_LIKE_PATTERNS = ("cm1out*", "*.nc", "*.nc4", "*.ctl")
+
+
+class MoistMountainWaveCaseError(RuntimeError):
+    """Raised when source lock, package, preflight, or evaluation must stop."""
+
+
+@dataclass(frozen=True)
+class ObservedSoundingRow:
+    pressure_pa: int
+    geopotential_height_m: int
+    temperature_tenths_c: int
+    relative_humidity_tenths_percent: int
+    wind_direction_deg: int
+    wind_speed_tenths_m_s: int
+
+
+# Pressure-level rows copied from the hash-pinned 1200 UTC Grand Junction IGRA record.
+OBSERVED_SOUNDING_ROWS = (
+    ObservedSoundingRow(85000, 1514, -6, 410, 121, 50),
+    ObservedSoundingRow(80700, 1929, 2, 360, 176, 60),
+    ObservedSoundingRow(70000, 3048, -88, 560, 258, 120),
+    ObservedSoundingRow(62400, 3927, -155, 830, 284, 160),
+    ObservedSoundingRow(59500, 4285, -180, 770, 291, 170),
+    ObservedSoundingRow(57500, 4540, -184, 750, 293, 210),
+    ObservedSoundingRow(54400, 4952, -209, 950, 292, 260),
+    ObservedSoundingRow(52800, 5173, -204, 940, 292, 290),
+    ObservedSoundingRow(50000, 5574, -229, 750, 298, 310),
+    ObservedSoundingRow(47500, 5949, -239, 680, 302, 330),
+    ObservedSoundingRow(43200, 6636, -283, 600, 306, 360),
+    ObservedSoundingRow(40000, 7182, -335, 710, 306, 380),
+    ObservedSoundingRow(35300, 8048, -399, 670, 306, 440),
+    ObservedSoundingRow(30000, 9138, -491, -9999, 316, 410),
+    ObservedSoundingRow(25000, 10309, -589, -9999, 334, 440),
+    ObservedSoundingRow(21300, 11298, -658, -9999, 333, 430),
+    ObservedSoundingRow(20000, 11680, -666, -9999, 321, 420),
+    ObservedSoundingRow(18200, 12251, -662, -9999, 310, 410),
+    ObservedSoundingRow(17600, 12457, -599, -9999, 309, 370),
+    ObservedSoundingRow(16800, 12748, -592, -9999, 308, 310),
+    ObservedSoundingRow(15000, 13457, -602, -9999, 299, 340),
+    ObservedSoundingRow(13500, 14121, -562, -9999, 292, 180),
+    ObservedSoundingRow(11600, 15071, -624, -9999, 274, 230),
+    ObservedSoundingRow(10000, 15979, -662, -9999, 287, 300),
+    ObservedSoundingRow(7600, 17669, -597, -9999, 281, 210),
+    ObservedSoundingRow(7400, 17838, -530, -9999, 282, 210),
+    ObservedSoundingRow(7000, 18196, -538, -9999, 281, 190),
+    ObservedSoundingRow(6100, 19080, -538, -9999, 291, 140),
+    ObservedSoundingRow(5400, 19857, -572, -9999, 285, 130),
+    ObservedSoundingRow(5000, 20347, -548, -9999, 274, 130),
+    ObservedSoundingRow(4800, 20608, -556, -9999, 271, 120),
+    ObservedSoundingRow(4300, 21317, -507, -9999, 281, 70),
+    ObservedSoundingRow(3800, 22116, -541, -9999, 3, 20),
+    ObservedSoundingRow(3300, 23033, -485, -9999, 359, 50),
+    ObservedSoundingRow(3000, 23659, -493, -9999, 344, 50),
+    ObservedSoundingRow(2400, 25122, -493, -9999, 3, 60),
+    ObservedSoundingRow(2000, 26309, -524, -9999, 344, 120),
+    ObservedSoundingRow(1700, 27360, -524, -9999, 320, 100),
+)
+
+LOCKED_NAMELIST_VALUES = {
+    "nx": "220",
+    "ny": "1",
+    "nz": "125",
+    "dx": "1000.0",
+    "dy": "1000.0",
+    "dz": "200.0",
+    "dtl": "2.000",
+    "timax": "4000.0",
+    "tapfrq": "200.0",
+    "cm1setup": "1",
+    "apmasscon": "0",
+    "imoist": "1",
+    "ipbl": "0",
+    "sgsmodel": "2",
+    "tconfig": "2",
+    "horizturb": "0",
+    "irdamp": "0",
+    "hrdamp": "0",
+    "psolver": "3",
+    "ptype": "6",
+    "icor": "0",
+    "lspgrad": "0",
+    "eqtset": "2",
+    "efall": "0",
+    "wbc": "1",
+    "ebc": "1",
+    "sbc": "1",
+    "nbc": "1",
+    "bbc": "1",
+    "tbc": "1",
+    "roflux": "0",
+    "nudgeobc": "0",
+    "isnd": "7",
+    "iwnd": "0",
+    "itern": "4",
+    "iinit": "0",
+    "irandp": "0",
+    "iorigin": "2",
+    "fcor": "0.00000",
+    "v_t": "0.0",
+    "stretch_x": "0",
+    "stretch_y": "0",
+    "stretch_z": "0",
+    "ztop": "25000.0",
+    "isfcflx": "0",
+    "sfcmodel": "0",
+    "output_format": "2",
+    "output_filetype": "2",
+    "output_interp": "0",
+    "output_rain": "0",
+    "output_dbz": "0",
+    "output_zs": "1",
+    "output_zh": "1",
+    "output_th": "1",
+    "output_prs": "1",
+    "output_qv": "1",
+    "output_q": "1",
+    "output_u": "1",
+    "output_uinterp": "1",
+    "output_v": "1",
+    "output_vinterp": "1",
+    "output_w": "1",
+    "output_winterp": "1",
+}
+
+
+class MoistStorageEstimate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_history_times_seconds: list[int]
+    expected_history_count: int
+    estimated_total_bytes: int
+    required_free_bytes: int
+    available_free_bytes: int
+    passed: bool
+
+
+class MoistExecutionPreflight(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    checked_at: datetime
+    implementation_commit: str
+    checks: dict[str, bool]
+    storage: MoistStorageEstimate
+    passed: bool
+
+
+class MoistMountainWaveEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evidence_version: str = EVIDENCE_VERSION
+    case_id: str = CASE_ID
+    run_id: str
+    implementation_commit: str
+    generated_at: datetime
+    source_lock: dict[str, Any]
+    provenance: dict[str, Any]
+    lifecycle: dict[str, Any]
+    output_inventory: dict[str, Any]
+    geometry: dict[str, Any]
+    initial_and_upstream: dict[str, Any]
+    cloud_and_wave: dict[str, Any]
+    boundaries_and_top: dict[str, Any]
+    runtime_integrity: dict[str, Any]
+    predeclared_checks: dict[str, bool]
+    caveats: list[str] = Field(default_factory=list)
+
+    def to_json_text(self) -> str:
+        return self.model_dump_json(indent=2) + "\n"
+
+
+@dataclass(frozen=True)
+class MoistMountainWavePackageResult:
+    run_id: str
+    package_dir: Path
+    manifest_path: Path
+    case_manifest_path: Path
+    namelist_audit_path: Path
+    storage_estimate_path: Path
+    implementation_commit: str
+    generated_files: tuple[Path, ...]
+
+
+def source_lock_path() -> Path:
+    return Path(__file__).resolve().parents[3] / SOURCE_LOCK_RELATIVE_PATH
+
+
+def verify_source_lock() -> dict[str, str]:
+    path = source_lock_path()
+    if not path.is_file():
+        raise MoistMountainWaveCaseError(f"Source-lock artifact is missing: {path}")
+    actual = sha256_file(path)
+    if actual != SOURCE_LOCK_SHA256:
+        raise MoistMountainWaveCaseError(
+            f"Source-lock SHA-256 changed: expected {SOURCE_LOCK_SHA256}, found {actual}."
+        )
+    return {"relative_path": SOURCE_LOCK_RELATIVE_PATH.as_posix(), "sha256": actual}
+
+
+def _temperature_k(row: ObservedSoundingRow) -> float:
+    return row.temperature_tenths_c / 10.0 + 273.15
+
+
+def _potential_temperature_k(row: ObservedSoundingRow) -> float:
+    pressure_ratio = 100_000.0 / float(row.pressure_pa)
+    return _temperature_k(row) * math.pow(pressure_ratio, 287.04 / 1004.0)
+
+
+def _saturation_mixing_ratio_kg_kg(temperature_k: Any, pressure_pa: Any) -> np.ndarray[Any, Any]:
+    temperature = np.asarray(temperature_k, dtype=np.float64)
+    pressure = np.asarray(pressure_pa, dtype=np.float64)
+    vapor_pressure = 611.2 * np.exp(17.67 * (temperature - 273.15) / (temperature - 29.65))
+    vapor_pressure = np.minimum(vapor_pressure, 0.5 * pressure)
+    return 0.622 * vapor_pressure / (pressure - vapor_pressure)
+
+
+def _mixing_ratio_g_kg(row: ObservedSoundingRow) -> float:
+    if row.relative_humidity_tenths_percent < 0:
+        return 0.0
+    relative_humidity = row.relative_humidity_tenths_percent / 1000.0
+    return float(
+        1000.0
+        * relative_humidity
+        * _saturation_mixing_ratio_kg_kg(_temperature_k(row), row.pressure_pa)
+    )
+
+
+def _cross_ridge_wind_m_s(row: ObservedSoundingRow) -> float:
+    speed = row.wind_speed_tenths_m_s / 10.0
+    return -speed * math.sin(math.radians(row.wind_direction_deg))
+
+
+def sounding_records() -> list[dict[str, float | int]]:
+    base_height = OBSERVED_SOUNDING_ROWS[0].geopotential_height_m
+    records: list[dict[str, float | int]] = []
+    for row in OBSERVED_SOUNDING_ROWS:
+        records.append(
+            {
+                "pressure_pa": row.pressure_pa,
+                "reported_geopotential_height_m": row.geopotential_height_m,
+                "model_height_m": row.geopotential_height_m - base_height,
+                "temperature_k": _temperature_k(row),
+                "theta_k": _potential_temperature_k(row),
+                "relative_humidity_percent": (
+                    row.relative_humidity_tenths_percent / 10.0
+                    if row.relative_humidity_tenths_percent >= 0
+                    else -999.9
+                ),
+                "qv_g_kg": _mixing_ratio_g_kg(row),
+                "u_m_s": _cross_ridge_wind_m_s(row),
+                "v_m_s": 0.0,
+            }
+        )
+    return records
+
+
+def render_input_sounding() -> str:
+    records = sounding_records()
+    surface = records[0]
+    lines = [
+        f"{surface['pressure_pa'] / 100.0:.4f} {surface['theta_k']:.6f} {surface['qv_g_kg']:.9f}"
+    ]
+    for record in records[1:]:
+        lines.append(
+            f"{record['model_height_m']:.1f} {record['theta_k']:.6f} "
+            f"{record['qv_g_kg']:.9f} {record['u_m_s']:.6f} {record['v_m_s']:.6f}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def audit_input_sounding(text: str) -> dict[str, Any]:
+    lines = text.splitlines()
+    records = sounding_records()
+    if len(lines) != len(records):
+        raise MoistMountainWaveCaseError("Generated sounding row count changed.")
+    parsed = [[float(value) for value in line.split()] for line in lines]
+    if len(parsed[0]) != 3 or any(len(row) != 5 for row in parsed[1:]):
+        raise MoistMountainWaveCaseError("Generated sounding has an invalid CM1 row shape.")
+    heights = np.asarray([row[0] for row in parsed[1:]], dtype=np.float64)
+    values = np.asarray([value for row in parsed for value in row], dtype=np.float64)
+    max_source_rh = max(
+        row.relative_humidity_tenths_percent / 10.0
+        for row in OBSERVED_SOUNDING_ROWS
+        if row.relative_humidity_tenths_percent >= 0
+    )
+    checks = {
+        "all_values_finite": bool(np.all(np.isfinite(values))),
+        "strictly_increasing_height": bool(np.all(np.diff(heights) > 0.0)),
+        "final_height_above_model_top": bool(heights[-1] > ACTIVE_TOP_M),
+        "surface_pressure_is_850_hpa": math.isclose(parsed[0][0], 850.0),
+        "maximum_source_rh_is_95_percent": math.isclose(max_source_rh, 95.0),
+        "missing_rh_rows_map_to_zero_qv": all(
+            math.isclose(_mixing_ratio_g_kg(row), 0.0)
+            for row in OBSERVED_SOUNDING_ROWS
+            if row.relative_humidity_tenths_percent < 0
+        ),
+    }
+    if not all(checks.values()):
+        raise MoistMountainWaveCaseError(f"Generated sounding audit failed: {checks}")
+    return {
+        "station_id": IGRA_STATION_ID,
+        "observation_time": IGRA_OBSERVATION_TIME,
+        "source_record_sha256": IGRA_SOURCE_RECORD_SHA256,
+        "surface_row_count": 1,
+        "profile_row_count": len(parsed) - 1,
+        "final_model_height_m": float(heights[-1]),
+        "maximum_source_relative_humidity_percent": max_source_rh,
+        "checks": checks,
+        "rows": records,
+    }
+
+
+def terrain_x_m() -> np.ndarray[Any, Any]:
+    return (np.arange(NX, dtype=np.float64) - (NX - 1) / 2.0) * DX_M
+
+
+def analytic_terrain_m(x_m: Any) -> np.ndarray[Any, Any]:
+    x = np.asarray(x_m, dtype=np.float64)
+    return TERRAIN_HEIGHT_M / (1.0 + ((x - TERRAIN_CENTER_M) / TERRAIN_HALF_WIDTH_M) ** 2)
+
+
+def write_terrain_file(path: Path) -> dict[str, Any]:
+    terrain = np.broadcast_to(analytic_terrain_m(terrain_x_m())[None, :], (NY, NX))
+    encoded = np.asarray(terrain, dtype="<f4")
+    path.write_bytes(encoded.tobytes(order="C"))
+    decoded = np.fromfile(path, dtype="<f4").reshape((NY, NX), order="C")
+    max_error = float(np.max(np.abs(decoded.astype(np.float64) - terrain)))
+    crest_index = int(np.argmax(decoded[0]))
+    checks = {
+        "byte_count_matches_one_direct_access_record": path.stat().st_size == 4 * NX * NY,
+        "shape_matches_ny_nx": decoded.shape == (NY, NX),
+        "all_values_finite": bool(np.all(np.isfinite(decoded))),
+        "crest_is_exact_grid_point": math.isclose(float(decoded[0, crest_index]), 2000.0),
+        "crest_x_is_500_m": math.isclose(float(terrain_x_m()[crest_index]), 500.0),
+        "float32_roundtrip_within_tolerance": max_error <= 5.0e-4,
+    }
+    if not all(checks.values()):
+        raise MoistMountainWaveCaseError(f"Generated terrain audit failed: {checks}")
+    return {
+        "formula": "2000 / (1 + ((x - 500) / 10000)^2) m",
+        "binary_layout": "one headerless little-endian IEEE-754 float32 direct-access record",
+        "array_shape": [NY, NX],
+        "storage_order": "x fastest",
+        "sha256": sha256_file(path),
+        "bytes": path.stat().st_size,
+        "crest_index": crest_index,
+        "crest_x_m": float(terrain_x_m()[crest_index]),
+        "crest_height_m": float(decoded[0, crest_index]),
+        "maximum_roundtrip_error_m": max_error,
+        "maximum_analytic_slope": 9.0
+        * TERRAIN_HEIGHT_M
+        / (8.0 * math.sqrt(3.0) * TERRAIN_HALF_WIDTH_M),
+        "checks": checks,
+    }
+
+
+def render_moist_namelist(official_text: str) -> str:
+    official = parse_namelist_assignments(official_text)
+    missing = sorted(set(LOCKED_NAMELIST_VALUES) - set(official))
+    if missing:
+        raise MoistMountainWaveCaseError(f"Pinned namelist lacks locked assignments: {missing}")
+    rendered = official_text
+    for name, value in LOCKED_NAMELIST_VALUES.items():
+        if official[name] != value:
+            rendered = replace_namelist_assignment(rendered, name, value)
+    audit_moist_namelist(official_text, rendered)
+    return rendered
+
+
+def audit_moist_namelist(official_text: str, generated_text: str) -> dict[str, Any]:
+    official = parse_namelist_assignments(official_text)
+    generated = parse_namelist_assignments(generated_text)
+    if official.keys() != generated.keys():
+        raise MoistMountainWaveCaseError("Generated namelist assignment set changed.")
+    for name, value in LOCKED_NAMELIST_VALUES.items():
+        if generated.get(name) != value:
+            raise MoistMountainWaveCaseError(
+                f"Locked namelist assignment {name} must be {value}; found {generated.get(name)}."
+            )
+    differences = []
+    for name, original in official.items():
+        current = generated[name]
+        if original == current:
+            continue
+        if name not in LOCKED_NAMELIST_VALUES:
+            raise MoistMountainWaveCaseError(
+                f"Undocumented namelist difference {name}: {original} -> {current}."
+            )
+        differences.append(
+            {
+                "name": name,
+                "official_dry_value": original,
+                "moist_case_value": current,
+                "classification": "source_locked_or_explicit_cm1_output_mapping",
+            }
+        )
+    return {
+        "official_sha256": sha256_text(official_text),
+        "generated_sha256": sha256_text(generated_text),
+        "assignment_count": len(generated),
+        "changed_assignment_count": len(differences),
+        "unchanged_assignment_count": len(generated) - len(differences),
+        "locked_values": dict(LOCKED_NAMELIST_VALUES),
+        "differences": differences,
+        "all_unlisted_assignments_preserved": True,
+    }
+
+
+def expected_output_times(namelist_text: str) -> tuple[int, ...]:
+    assignments = parse_namelist_assignments(namelist_text)
+    duration = float(assignments["timax"])
+    cadence = float(assignments["tapfrq"])
+    if not duration.is_integer() or not cadence.is_integer() or duration % cadence:
+        raise MoistMountainWaveCaseError("History duration and cadence must divide exactly.")
+    return tuple(range(0, int(duration) + 1, int(cadence)))
+
+
+def estimate_storage(namelist_text: str, target: Path) -> MoistStorageEstimate:
+    assignments = parse_namelist_assignments(namelist_text)
+    nx = int(float(assignments["nx"]))
+    ny = int(float(assignments["ny"]))
+    nz = int(float(assignments["nz"]))
+    times = expected_output_times(namelist_text)
+    scalar_cells = nx * ny * nz
+    # Twenty-five full scalar equivalents bound native, interpolated, moisture, and SGS output.
+    raw_history = 25 * scalar_cells * 4 * len(times)
+    estimated_total = math.ceil(raw_history * 1.5) + 100 * 1024 * 1024
+    target.mkdir(parents=True, exist_ok=True)
+    available = shutil.disk_usage(target).free
+    required = 2 * estimated_total
+    return MoistStorageEstimate(
+        expected_history_times_seconds=list(times),
+        expected_history_count=len(times),
+        estimated_total_bytes=estimated_total,
+        required_free_bytes=required,
+        available_free_bytes=available,
+        passed=available >= required,
+    )
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n")
+
+
+def _human_namelist_audit(audit: dict[str, Any]) -> str:
+    lines = [
+        "CM1 r21.1 moist mountain-wave namelist audit",
+        f"Official SHA-256: {audit['official_sha256']}",
+        f"Generated SHA-256: {audit['generated_sha256']}",
+        f"Assignments audited: {audit['assignment_count']}",
+        "All unlisted assignments preserved: true",
+        "",
+        "Locked differences:",
+    ]
+    lines.extend(
+        f"CHANGED {item['name']}: {item['official_dry_value']} -> {item['moist_case_value']}"
+        for item in audit["differences"]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def generate_moist_mountain_wave_package(
+    *, settings: CloudChamberSettings, run_id: str
+) -> MoistMountainWavePackageResult:
+    """Create the one source-locked package without starting CM1."""
+    implementation_commit = verified_clean_git_commit()
+    source_lock = verify_source_lock()
+    provenance = collect_cm1_provenance(settings)
+    active = active_cm1_processes()
+    if active:
+        raise MoistMountainWaveCaseError(f"CM1/MPI is already active: {active}")
+    prior = prior_moist_executions(settings.runtime_home.expanduser(), run_id)
+    if prior:
+        raise MoistMountainWaveCaseError(f"A prior execution forbids another process: {prior}")
+
+    package_dir = settings.runtime_home.expanduser() / "runs" / run_id
+    if package_dir.exists():
+        raise MoistMountainWaveCaseError(f"Run package already exists: {run_id}")
+    package_dir.mkdir(parents=True)
+    paths = {
+        "manifest": package_dir / "run_manifest.json",
+        "case_manifest": package_dir / "case_manifest.json",
+        "namelist": package_dir / "namelist.input",
+        "input_sounding": package_dir / "input_sounding",
+        "terrain": package_dir / "perts.dat",
+        "runtime_checklist": package_dir / "runtime_file_checklist.json",
+        "namelist_audit": package_dir / "source_namelist_diff.json",
+        "namelist_audit_text": package_dir / "source_namelist_diff.txt",
+        "storage_estimate": package_dir / "storage_estimate.json",
+        "package_report": package_dir / "moist_run_report.json",
+    }
+    try:
+        official_text = provenance.mountain_wave_namelist_path.read_text()
+        namelist_text = render_moist_namelist(official_text)
+        namelist_audit = audit_moist_namelist(official_text, namelist_text)
+        paths["namelist"].write_text(namelist_text)
+        sounding_text = render_input_sounding()
+        paths["input_sounding"].write_text(sounding_text)
+        sounding_audit = audit_input_sounding(sounding_text)
+        terrain_audit = write_terrain_file(paths["terrain"])
+        storage = estimate_storage(namelist_text, package_dir)
+        if not storage.passed:
+            raise MoistMountainWaveCaseError(
+                "Available storage is less than twice the conservative estimate."
+            )
+        runtime_checklist = {
+            "status": "exact_generated_runtime_files_present_in_package",
+            "consumed_files": ["input_sounding", "perts.dat"],
+            "required_files": [],
+            "source_candidates": {},
+            "explicitly_not_consumed": [
+                "LANDUSE.TBL",
+                "radiation_tables",
+                "microphysics_lookup_tables",
+                "input_grid_x",
+                "input_grid_y",
+                "input_grid_z",
+            ],
+        }
+        _write_json(paths["runtime_checklist"], runtime_checklist)
+        _write_json(paths["namelist_audit"], namelist_audit)
+        paths["namelist_audit_text"].write_text(_human_namelist_audit(namelist_audit))
+        _write_json(paths["storage_estimate"], storage.model_dump(mode="json"))
+
+        generated_hashes = {
+            path.name: sha256_file(path)
+            for key, path in paths.items()
+            if key not in {"manifest", "case_manifest", "package_report"}
+        }
+        case_manifest = {
+            "case_id": CASE_ID,
+            "scenario_id": SCENARIO_ID,
+            "authority_state": "issue_407_source_locked_research_case_not_product",
+            "run_id": run_id,
+            "implementation_commit": implementation_commit,
+            "source_lock": source_lock,
+            "source_observation": {
+                "station_id": IGRA_STATION_ID,
+                "observation_time": IGRA_OBSERVATION_TIME,
+                "record_sha256": IGRA_SOURCE_RECORD_SHA256,
+            },
+            "cm1_provenance": provenance.report_record(),
+            "namelist_audit": namelist_audit,
+            "sounding_audit": sounding_audit,
+            "terrain_audit": terrain_audit,
+            "runtime_file_checklist": runtime_checklist,
+            "storage_estimate": storage.model_dump(mode="json"),
+            "generated_input_sha256": generated_hashes,
+            "execution_authorization": {
+                "duration_seconds": EXPECTED_DURATION_SECONDS,
+                "process_count": 1,
+                "smoke_process_allowed": False,
+                "retry_allowed": False,
+                "tuning_process_allowed": False,
+            },
+            "run_recipe": None,
+            "recipe_id": None,
+            "cloud_world_id": None,
+        }
+        _write_json(paths["case_manifest"], case_manifest)
+
+        now = datetime.now(UTC)
+        manifest = RunManifest(
+            run_id=run_id,
+            scenario=ScenarioReference(id=SCENARIO_ID, schema_version=EVIDENCE_VERSION),
+            controls={},
+            run_configuration={
+                "case_id": CASE_ID,
+                "source_lock": source_lock,
+                "duration_seconds": EXPECTED_DURATION_SECONDS,
+                "output_cadence_seconds": EXPECTED_OUTPUT_CADENCE_SECONDS,
+                "expected_model_output_count": len(EXPECTED_OUTPUT_TIMES_SECONDS),
+                "domain": {
+                    "nx": NX,
+                    "ny": NY,
+                    "nz": NZ,
+                    "dx_m": DX_M,
+                    "dy_m": DY_M,
+                    "dz_m": DZ_M,
+                    "active_top_m": ACTIVE_TOP_M,
+                },
+                "generated_input_sha256": generated_hashes,
+                "cm1_provenance": provenance.report_record(),
+                "run_recipe": None,
+                "recipe_id": None,
+                "cloud_world_id": None,
+            },
+            physical_question=(
+                "Can an initially clear, source-backed moist mountain wave form coherent, "
+                "terrain-locked, nonprecipitating gravity-wave cloud in CM1 r21.1?"
+            ),
+            expected_diagnostics=[
+                "initial_and_upstream_clear_air",
+                "interior_cloud_formation_and_coherence",
+                "saturation_ascent_and_descent_evaporation",
+                "terrain_and_wave_locking",
+                "boundary_top_runtime_and_storage_integrity",
+            ],
+            generated_inputs=GeneratedInputs(
+                run_directory=str(package_dir),
+                manifest_path=str(paths["manifest"]),
+                namelist_input=str(paths["namelist"]),
+                input_sounding=str(paths["input_sounding"]),
+                dry_run_report=str(paths["package_report"]),
+                runtime_file_checklist=[str(paths["runtime_checklist"])],
+            ),
+            runtime_paths=RuntimePaths(runtime_home=str(settings.runtime_home.expanduser())),
+            app=AppMetadata(app_version=__version__, commit=implementation_commit),
+            lifecycle_state=LifecycleState.PACKAGED,
+            validation_status=ValidationStatus.VALID,
+            provenance=ProvenanceMetadata(product_state=ProductState.PACKAGED_DRY_RUN_OUTPUT),
+            created_at=now,
+            updated_at=now,
+            user=UserMetadata(name="Toy 1972 Boulder moist mountain-wave feasibility case"),
+            run_recipe=None,
+            recipe_id=None,
+            required_output_fields=list(REQUIRED_OUTPUT_FIELDS),
+            input_source="NOAA_IGRA_USM00072476_19720111T1200Z",
+            expected_outputs=["native_numbered_cm1_netcdf", "cm1_stats_and_logs"],
+            run_limitations=[
+                "two_dimensional_research_case_only",
+                "source_supported_25_km_top_sensitivity_configuration",
+                "not_a_world_recipe_or_product_decision",
+            ],
+            manual_validation_status="issue_407_native_output_evidence_pending",
+        )
+        write_run_manifest(paths["manifest"], manifest)
+        _write_json(
+            paths["package_report"],
+            {
+                "status": "source_locked_package_complete_not_executed",
+                "case_id": CASE_ID,
+                "run_id": run_id,
+                "implementation_commit": implementation_commit,
+                "source_lock": source_lock,
+                "generated_input_sha256": generated_hashes,
+                "run_recipe": None,
+                "recipe_id": None,
+                "cloud_world_id": None,
+            },
+        )
+    except Exception:
+        shutil.rmtree(package_dir, ignore_errors=True)
+        raise
+
+    return MoistMountainWavePackageResult(
+        run_id=run_id,
+        package_dir=package_dir,
+        manifest_path=paths["manifest"],
+        case_manifest_path=paths["case_manifest"],
+        namelist_audit_path=paths["namelist_audit"],
+        storage_estimate_path=paths["storage_estimate"],
+        implementation_commit=implementation_commit,
+        generated_files=tuple(paths.values()),
+    )
+
+
+def load_moist_mountain_wave_package(
+    *, settings: CloudChamberSettings, run_id: str
+) -> MoistMountainWavePackageResult:
+    package_dir = settings.runtime_home.expanduser() / "runs" / run_id
+    names = {
+        "manifest": "run_manifest.json",
+        "case_manifest": "case_manifest.json",
+        "namelist": "namelist.input",
+        "input_sounding": "input_sounding",
+        "terrain": "perts.dat",
+        "runtime_checklist": "runtime_file_checklist.json",
+        "namelist_audit": "source_namelist_diff.json",
+        "namelist_audit_text": "source_namelist_diff.txt",
+        "storage_estimate": "storage_estimate.json",
+        "package_report": "moist_run_report.json",
+    }
+    paths = {key: package_dir / name for key, name in names.items()}
+    missing = sorted(path.name for path in paths.values() if not path.is_file())
+    if missing:
+        raise MoistMountainWaveCaseError(f"Existing package is incomplete: {missing}")
+    manifest = load_run_manifest(paths["manifest"])
+    case_manifest = json.loads(paths["case_manifest"].read_text())
+    implementation_commit = case_manifest.get("implementation_commit")
+    if (
+        manifest.run_id != run_id
+        or manifest.scenario.id != SCENARIO_ID
+        or manifest.lifecycle_state != LifecycleState.PACKAGED
+        or not isinstance(implementation_commit, str)
+        or manifest.app.commit != implementation_commit
+    ):
+        raise MoistMountainWaveCaseError("Existing package identity or lifecycle is invalid.")
+    return MoistMountainWavePackageResult(
+        run_id=run_id,
+        package_dir=package_dir,
+        manifest_path=paths["manifest"],
+        case_manifest_path=paths["case_manifest"],
+        namelist_audit_path=paths["namelist_audit"],
+        storage_estimate_path=paths["storage_estimate"],
+        implementation_commit=implementation_commit,
+        generated_files=tuple(paths.values()),
+    )
+
+
+def prior_moist_executions(runtime_home: Path, current_run_id: str) -> list[str]:
+    prior: list[str] = []
+    for manifest_path in sorted((runtime_home / "runs").glob("*/run_manifest.json")):
+        try:
+            manifest = load_run_manifest(manifest_path)
+        except (OSError, ValueError):
+            continue
+        if manifest.run_id == current_run_id or manifest.scenario.id != SCENARIO_ID:
+            continue
+        if manifest.lifecycle_state not in {LifecycleState.CREATED, LifecycleState.PACKAGED}:
+            prior.append(manifest.run_id)
+    return prior
+
+
+def preflight_package_for_execution(
+    *, settings: CloudChamberSettings, package: MoistMountainWavePackageResult
+) -> MoistExecutionPreflight:
+    implementation_commit = verified_clean_git_commit()
+    if implementation_commit != package.implementation_commit:
+        raise MoistMountainWaveCaseError("Package and clean implementation commits differ.")
+    source_lock = verify_source_lock()
+    provenance = collect_cm1_provenance(settings)
+    manifest = load_run_manifest(package.manifest_path)
+    case_manifest = json.loads(package.case_manifest_path.read_text())
+    if manifest.app.commit != implementation_commit:
+        raise MoistMountainWaveCaseError("Run manifest implementation commit changed.")
+    if case_manifest.get("source_lock") != source_lock:
+        raise MoistMountainWaveCaseError("Package source-lock identity changed.")
+
+    namelist_path = package.package_dir / "namelist.input"
+    sounding_path = package.package_dir / "input_sounding"
+    terrain_path = package.package_dir / "perts.dat"
+    official_text = provenance.mountain_wave_namelist_path.read_text()
+    audit = audit_moist_namelist(official_text, namelist_path.read_text())
+    stored_audit = json.loads(package.namelist_audit_path.read_text())
+    if audit["generated_sha256"] != stored_audit.get("generated_sha256"):
+        raise MoistMountainWaveCaseError("Generated namelist changed after packaging.")
+    sounding_audit = audit_input_sounding(sounding_path.read_text())
+    terrain_audit = _audit_existing_terrain(terrain_path)
+    expected_hashes = case_manifest.get("generated_input_sha256", {})
+    actual_hashes = {
+        path.name: sha256_file(path)
+        for path in package.generated_files
+        if path.name in expected_hashes
+    }
+    if actual_hashes != expected_hashes:
+        raise MoistMountainWaveCaseError("Generated input hash identity changed.")
+
+    checklist = json.loads((package.package_dir / "runtime_file_checklist.json").read_text())
+    consumed = checklist.get("consumed_files")
+    if consumed != ["input_sounding", "perts.dat"] or checklist.get("required_files") != []:
+        raise MoistMountainWaveCaseError("Consumed runtime-file checklist is not exact.")
+    active = active_cm1_processes()
+    if active:
+        raise MoistMountainWaveCaseError(f"Another CM1/MPI process is active: {active}")
+    prior = prior_moist_executions(settings.runtime_home.expanduser(), package.run_id)
+    if prior:
+        raise MoistMountainWaveCaseError(f"A prior execution forbids this process: {prior}")
+    outputs = sorted(
+        path.name
+        for pattern in _OUTPUT_LIKE_PATTERNS
+        for path in package.package_dir.glob(pattern)
+        if path.name != "perts.dat"
+    )
+    if outputs:
+        raise MoistMountainWaveCaseError(f"Package already contains output-like files: {outputs}")
+
+    stored_storage = MoistStorageEstimate.model_validate(
+        json.loads(package.storage_estimate_path.read_text())
+    )
+    available = shutil.disk_usage(package.package_dir).free
+    storage = stored_storage.model_copy(
+        update={
+            "available_free_bytes": available,
+            "passed": available >= stored_storage.required_free_bytes,
+        }
+    )
+    checks = {
+        "clean_worktree_and_commit_match": True,
+        "source_lock_hash_matches": True,
+        "pinned_cm1_provenance_matches": True,
+        "netcdf_support_linked": bool(provenance.netcdf_link_evidence),
+        "complete_namelist_audit_matches": True,
+        "sounding_audit_matches": all(sounding_audit["checks"].values()),
+        "terrain_hash_and_readback_match": all(terrain_audit["checks"].values()),
+        "consumed_runtime_files_exact": True,
+        "expected_histories_exact": expected_output_times(namelist_path.read_text())
+        == EXPECTED_OUTPUT_TIMES_SECONDS,
+        "storage_has_double_estimate": storage.passed,
+        "no_active_cm1_or_mpi": True,
+        "no_prior_execution": True,
+        "target_has_no_output": True,
+    }
+    preflight = MoistExecutionPreflight(
+        checked_at=datetime.now(UTC),
+        implementation_commit=implementation_commit,
+        checks=checks,
+        storage=storage,
+        passed=all(checks.values()),
+    )
+    _write_json(
+        package.package_dir / "execution_preflight.json",
+        preflight.model_dump(mode="json"),
+    )
+    return preflight
+
+
+def _audit_existing_terrain(path: Path) -> dict[str, Any]:
+    if path.stat().st_size != 4 * NX * NY:
+        raise MoistMountainWaveCaseError("Existing terrain byte count changed.")
+    decoded = np.fromfile(path, dtype="<f4").reshape((NY, NX), order="C")
+    expected = np.broadcast_to(analytic_terrain_m(terrain_x_m())[None, :], (NY, NX))
+    max_error = float(np.max(np.abs(decoded.astype(np.float64) - expected)))
+    crest_index = int(np.argmax(decoded[0]))
+    checks = {
+        "byte_count_matches_one_direct_access_record": path.stat().st_size == 4 * NX * NY,
+        "shape_matches_ny_nx": decoded.shape == (NY, NX),
+        "all_values_finite": bool(np.all(np.isfinite(decoded))),
+        "crest_is_exact_grid_point": math.isclose(float(decoded[0, crest_index]), 2000.0),
+        "crest_x_is_500_m": math.isclose(float(terrain_x_m()[crest_index]), 500.0),
+        "float32_roundtrip_within_tolerance": max_error <= 5.0e-4,
+    }
+    return {"sha256": sha256_file(path), "maximum_roundtrip_error_m": max_error, "checks": checks}
+
+
+def evaluate_moist_mountain_wave_run(
+    *, settings: CloudChamberSettings, package: MoistMountainWavePackageResult
+) -> MoistMountainWaveEvidence:
+    """Evaluate the completed process directly from native numbered NetCDF."""
+    manifest = load_run_manifest(package.manifest_path)
+    if manifest.lifecycle_state != LifecycleState.COMPLETED or manifest.execution.exit_code != 0:
+        raise MoistMountainWaveCaseError("Evaluation requires one zero-exit completed process.")
+    if manifest.app.commit != package.implementation_commit:
+        raise MoistMountainWaveCaseError("Completed process commit identity changed.")
+    provenance = collect_cm1_provenance(settings)
+    candidates = [Path(path) for path in manifest.outputs.netcdf_paths]
+    if not candidates:
+        candidates = list(package.package_dir.glob("cm1out_*.nc*"))
+    model_paths = accepted_model_output_paths(candidates)
+    if len(model_paths) != len(EXPECTED_OUTPUT_TIMES_SECONDS):
+        raise MoistMountainWaveCaseError(
+            f"Expected {len(EXPECTED_OUTPUT_TIMES_SECONDS)} native histories; "
+            f"found {len(model_paths)}."
+        )
+
+    frames: list[dict[str, Any]] = []
+    finite_by_field: dict[str, list[dict[str, Any]]] = {
+        field: [] for field in REQUIRED_OUTPUT_FIELDS
+    }
+    actual_times: list[float] = []
+    first_terrain: np.ndarray[Any, Any] | None = None
+    first_coords: dict[str, np.ndarray[Any, Any]] | None = None
+    first_ql_max = math.inf
+    maximum_terrain_error = 0.0
+    minimum_vertical_spacing = math.inf
+    maximum_height_transform_error = 0.0
+    top_values: list[float] = []
+    inventory: dict[str, Any] | None = None
+
+    for path in model_paths:
+        with xr.open_dataset(path, decode_times=False) as dataset:
+            _require_fields(dataset)
+            time_seconds = _dataset_time_seconds(dataset)
+            actual_times.append(time_seconds)
+            coords = _coordinates(dataset)
+            terrain = _field(dataset, "zs", ("yh", "xh"))
+            zh_physical = _field(dataset, "zhval", ("zh", "yh", "xh"))
+            if first_coords is None:
+                first_coords = coords
+                first_terrain = terrain
+                inventory = _inventory(dataset)
+            else:
+                for name, values in first_coords.items():
+                    if not np.array_equal(values, coords[name]):
+                        raise MoistMountainWaveCaseError(f"Coordinate {name} changed by time.")
+            assert first_terrain is not None
+
+            expected_terrain = np.broadcast_to(
+                analytic_terrain_m(coords["xh"])[None, :], terrain.shape
+            )
+            maximum_terrain_error = max(
+                maximum_terrain_error,
+                float(np.max(np.abs(terrain - expected_terrain))),
+                float(np.max(np.abs(terrain - first_terrain))),
+            )
+            minimum_vertical_spacing = min(
+                minimum_vertical_spacing, float(np.min(np.diff(zh_physical, axis=0)))
+            )
+            expected_zh = reconstruct_physical_heights(
+                terrain,
+                coords["zh"],
+                active_top_m=ACTIVE_TOP_M,
+            )
+            maximum_height_transform_error = max(
+                maximum_height_transform_error,
+                float(np.max(np.abs(zh_physical - expected_zh))),
+            )
+            top_values.append(float(coords["zf"][-1]))
+
+            fields = {name: np.asarray(dataset[name].values) for name in REQUIRED_OUTPUT_FIELDS}
+            for name, values in fields.items():
+                finite = np.isfinite(values)
+                finite_by_field[name].append(
+                    {
+                        "time_seconds": time_seconds,
+                        "total_count": int(values.size),
+                        "finite_count": int(np.count_nonzero(finite)),
+                        "non_finite_count": int(values.size - np.count_nonzero(finite)),
+                        "minimum": float(np.nanmin(values)),
+                        "maximum": float(np.nanmax(values)),
+                    }
+                )
+
+            ql = _field(dataset, "ql", ("zh", "yh", "xh"))[:, 0, :]
+            qv = _field(dataset, "qv", ("zh", "yh", "xh"))[:, 0, :]
+            theta = _field(dataset, "th", ("zh", "yh", "xh"))[:, 0, :]
+            pressure = _field(dataset, "prs", ("zh", "yh", "xh"))[:, 0, :]
+            w_full = _field(dataset, "w", ("zf", "yh", "xh"))[:, 0, :]
+            w_scalar = 0.5 * (w_full[:-1] + w_full[1:])
+            temperature = theta * (pressure / 100_000.0) ** (287.04 / 1004.0)
+            qsat = _saturation_mixing_ratio_kg_kg(temperature, pressure)
+            relative_humidity = np.divide(qv, qsat, out=np.zeros_like(qv), where=qsat > 0.0)
+            height = zh_physical[:, 0, :]
+            frame = _cloud_frame_evidence(
+                time_seconds=time_seconds,
+                x_m=coords["xh"],
+                height_m=height,
+                ql=ql,
+                relative_humidity=relative_humidity,
+                w=w_scalar,
+            )
+            frames.append(frame)
+            if math.isinf(first_ql_max):
+                first_ql_max = float(np.max(ql))
+
+    if actual_times != [float(value) for value in EXPECTED_OUTPUT_TIMES_SECONDS]:
+        raise MoistMountainWaveCaseError(f"Native history times changed: {actual_times}")
+    non_finite = sum(
+        item["non_finite_count"] for records in finite_by_field.values() for item in records
+    )
+    if non_finite:
+        raise MoistMountainWaveCaseError(f"Required fields contain {non_finite} non-finite values.")
+    assert first_coords is not None
+    assert first_terrain is not None
+    assert inventory is not None
+
+    coherent_flags = [frame["largest_component_cells"] >= MIN_COHERENT_CELLS for frame in frames]
+    persistent_windows = [
+        [frames[index + offset]["time_seconds"] for offset in range(MIN_PERSISTENT_FRAMES)]
+        for index in range(len(frames) - MIN_PERSISTENT_FRAMES + 1)
+        if all(coherent_flags[index : index + MIN_PERSISTENT_FRAMES])
+    ]
+    first_cloud = next((frame for frame in frames if frame["cloud_cell_count"] > 0), None)
+    peak_frame = max(frames, key=lambda frame: float(frame["maximum_ql_kg_kg"]))
+    upstream_maximum = max(float(frame["upstream_maximum_ql_kg_kg"]) for frame in frames)
+    edge_maximum = max(float(frame["edge_maximum_ql_kg_kg"]) for frame in frames)
+    descent_evaporation_frames = [
+        frame["time_seconds"] for frame in frames if frame["descending_clear_near_cloud_cells"] > 0
+    ]
+    runtime_integrity = _runtime_integrity(package, manifest, model_paths)
+    checks = {
+        "normal_completion_and_exact_finite_histories": runtime_integrity[
+            "normal_termination_marker_present"
+        ]
+        and non_finite == 0,
+        "terrain_and_physical_height_integrity": maximum_terrain_error <= 1.0e-3
+        and maximum_height_transform_error <= 0.02
+        and minimum_vertical_spacing > 0.0
+        and all(math.isclose(value, ACTIVE_TOP_M, abs_tol=0.01) for value in top_values),
+        "initial_condensate_at_numerical_floor": first_ql_max <= NUMERICAL_CLEAR_FLOOR_KG_KG,
+        "upstream_clear_at_interpretable_floor": upstream_maximum < CLOUD_FLOOR_KG_KG,
+        "first_cloud_forms_interior_not_edge": first_cloud is not None
+        and first_cloud["interior_cloud_cell_count"] > 0
+        and first_cloud["edge_cloud_cell_count"] == 0,
+        "coherent_cloud_persists_three_histories": bool(persistent_windows),
+        "material_peak_reached": float(peak_frame["maximum_ql_kg_kg"]) >= MATERIAL_PEAK_KG_KG,
+        "cloud_colocated_with_ascent_and_saturation": any(
+            frame["cloud_in_ascent_and_saturation_cells"] > 0 for frame in frames
+        ),
+        "descent_and_evaporation_evidence_present": bool(descent_evaporation_frames),
+        "edge_cloud_does_not_compromise_interpretation": edge_maximum < CLOUD_FLOOR_KG_KG,
+    }
+    return MoistMountainWaveEvidence(
+        run_id=package.run_id,
+        implementation_commit=package.implementation_commit,
+        generated_at=datetime.now(UTC),
+        source_lock=verify_source_lock(),
+        provenance=provenance.report_record(),
+        lifecycle={
+            "state": manifest.lifecycle_state.value,
+            "exit_code": manifest.execution.exit_code,
+            "started_at": manifest.execution.started_at,
+            "finished_at": manifest.execution.finished_at,
+            "exactly_one_process_authorized": True,
+        },
+        output_inventory={
+            "model_output_files": [
+                {"filename": path.name, "bytes": path.stat().st_size} for path in model_paths
+            ],
+            "actual_times_seconds": actual_times,
+            "expected_times_seconds": list(EXPECTED_OUTPUT_TIMES_SECONDS),
+            "total_model_netcdf_bytes": sum(path.stat().st_size for path in model_paths),
+            "variable_inventory": inventory["variables"],
+            "coordinate_inventory": inventory["coordinates"],
+            "required_field_finite_counts_by_time": finite_by_field,
+        },
+        geometry={
+            "terrain_formula": "2000 / (1 + ((x - 500) / 10000)^2) m",
+            "terrain_maximum_abs_error_m": maximum_terrain_error,
+            "terrain_maximum_m": float(np.max(first_terrain)),
+            "terrain_crest_x_m": float(first_coords["xh"][int(np.argmax(first_terrain[0]))]),
+            "physical_height_transform_maximum_abs_error_m": maximum_height_transform_error,
+            "minimum_scalar_vertical_spacing_m": minimum_vertical_spacing,
+            "active_top_values_m": top_values,
+        },
+        initial_and_upstream={
+            "initial_maximum_ql_kg_kg": first_ql_max,
+            "upstream_maximum_ql_kg_kg_all_times": upstream_maximum,
+            "upstream_x_bounds_m": list(UPSTREAM_X_BOUNDS_M),
+            "evaluation_top_m": EVALUATION_TOP_M,
+        },
+        cloud_and_wave={
+            "cloud_floor_kg_kg": CLOUD_FLOOR_KG_KG,
+            "material_peak_kg_kg": MATERIAL_PEAK_KG_KG,
+            "minimum_coherent_cells": MIN_COHERENT_CELLS,
+            "minimum_persistent_frames": MIN_PERSISTENT_FRAMES,
+            "first_cloud_frame": first_cloud,
+            "peak_cloud_frame": peak_frame,
+            "persistent_windows_seconds": persistent_windows,
+            "descent_evaporation_frames_seconds": descent_evaporation_frames,
+            "frames": frames,
+        },
+        boundaries_and_top={
+            "edge_width_m": EDGE_WIDTH_M,
+            "edge_maximum_ql_kg_kg_all_times": edge_maximum,
+            "top_abs_w_maximum_m_s_all_times": max(
+                float(frame["top_abs_w_maximum_m_s"]) for frame in frames
+            ),
+            "top_ql_maximum_kg_kg_all_times": max(
+                float(frame["top_ql_maximum_kg_kg"]) for frame in frames
+            ),
+        },
+        runtime_integrity=runtime_integrity,
+        predeclared_checks=checks,
+        caveats=[
+            "two_dimensional_case_not_a_three_dimensional_cloud_volume",
+            "25_km_top_is_source_supported_but_has_no_absorbing_layer",
+            "cm1_smagorinsky_closure_is_not_pointwise_identical_to_source_model",
+            "runtime_visual_review_and_scientific_judgment_remain_manual",
+        ],
+    )
+
+
+def _cloud_frame_evidence(
+    *,
+    time_seconds: float,
+    x_m: np.ndarray[Any, Any],
+    height_m: np.ndarray[Any, Any],
+    ql: np.ndarray[Any, Any],
+    relative_humidity: np.ndarray[Any, Any],
+    w: np.ndarray[Any, Any],
+) -> dict[str, Any]:
+    below = height_m < EVALUATION_TOP_M
+    cloud = (ql >= CLOUD_FLOOR_KG_KG) & below
+    components = _connected_components(cloud)
+    largest = max(components, key=len, default=[])
+    interior_x = (x_m >= INTERIOR_X_BOUNDS_M[0]) & (x_m <= INTERIOR_X_BOUNDS_M[1])
+    upstream_x = (x_m >= UPSTREAM_X_BOUNDS_M[0]) & (x_m <= UPSTREAM_X_BOUNDS_M[1])
+    edge_x = (x_m <= x_m.min() + EDGE_WIDTH_M) | (x_m >= x_m.max() - EDGE_WIDTH_M)
+    interior = below & interior_x[None, :]
+    upstream = below & upstream_x[None, :]
+    edge = below & edge_x[None, :]
+    near_cloud = _dilate_mask(cloud)
+    descending_clear = near_cloud & below & (w < 0.0) & (relative_humidity < 1.0) & ~cloud
+    cloud_ascent_saturated = cloud & (w > 0.0) & (relative_humidity >= 0.99)
+    peak_index = np.unravel_index(int(np.argmax(ql)), ql.shape)
+    component_centroid_x: float | None = None
+    component_centroid_z: float | None = None
+    if largest:
+        component_centroid_x = float(np.mean([x_m[index[1]] for index in largest]))
+        component_centroid_z = float(np.mean([height_m[index] for index in largest]))
+    top_mask = height_m >= ACTIVE_TOP_M - 2_000.0
+    return {
+        "time_seconds": time_seconds,
+        "maximum_ql_kg_kg": float(np.max(ql)),
+        "mean_positive_ql_kg_kg": float(np.mean(ql[ql > 0.0])) if np.any(ql > 0.0) else 0.0,
+        "cloud_cell_count": int(np.count_nonzero(cloud)),
+        "component_count": len(components),
+        "largest_component_cells": len(largest),
+        "largest_component_centroid_x_m": component_centroid_x,
+        "largest_component_centroid_height_m": component_centroid_z,
+        "interior_cloud_cell_count": int(np.count_nonzero(cloud & interior)),
+        "upstream_cloud_cell_count": int(np.count_nonzero(cloud & upstream)),
+        "edge_cloud_cell_count": int(np.count_nonzero(cloud & edge)),
+        "upstream_maximum_ql_kg_kg": _masked_maximum(ql, upstream),
+        "edge_maximum_ql_kg_kg": _masked_maximum(ql, edge),
+        "cloud_in_ascent_and_saturation_cells": int(np.count_nonzero(cloud_ascent_saturated)),
+        "descending_clear_near_cloud_cells": int(np.count_nonzero(descending_clear)),
+        "cloud_weighted_mean_w_m_s": _weighted_mean(w, ql, cloud),
+        "cloud_weighted_mean_relative_humidity": _weighted_mean(relative_humidity, ql, cloud),
+        "peak_location_x_m": float(x_m[peak_index[1]]),
+        "peak_location_height_m": float(height_m[peak_index]),
+        "peak_location_w_m_s": float(w[peak_index]),
+        "peak_location_relative_humidity": float(relative_humidity[peak_index]),
+        "top_abs_w_maximum_m_s": _masked_maximum(np.abs(w), top_mask),
+        "top_ql_maximum_kg_kg": _masked_maximum(ql, top_mask),
+    }
+
+
+def _connected_components(mask: np.ndarray[Any, Any]) -> list[list[tuple[int, int]]]:
+    visited = np.zeros(mask.shape, dtype=bool)
+    components: list[list[tuple[int, int]]] = []
+    for z_index, x_index in zip(*np.nonzero(mask), strict=True):
+        start = (int(z_index), int(x_index))
+        if visited[start]:
+            continue
+        stack = [start]
+        visited[start] = True
+        component: list[tuple[int, int]] = []
+        while stack:
+            current = stack.pop()
+            component.append(current)
+            z_now, x_now = current
+            for candidate in (
+                (z_now - 1, x_now),
+                (z_now + 1, x_now),
+                (z_now, x_now - 1),
+                (z_now, x_now + 1),
+            ):
+                z_next, x_next = candidate
+                if (
+                    0 <= z_next < mask.shape[0]
+                    and 0 <= x_next < mask.shape[1]
+                    and mask[candidate]
+                    and not visited[candidate]
+                ):
+                    visited[candidate] = True
+                    stack.append(candidate)
+        components.append(component)
+    return components
+
+
+def _dilate_mask(mask: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+    dilated = mask.copy()
+    dilated[1:, :] |= mask[:-1, :]
+    dilated[:-1, :] |= mask[1:, :]
+    dilated[:, 1:] |= mask[:, :-1]
+    dilated[:, :-1] |= mask[:, 1:]
+    return dilated
+
+
+def _masked_maximum(values: np.ndarray[Any, Any], mask: np.ndarray[Any, Any]) -> float:
+    selected = values[mask]
+    return float(np.max(selected)) if selected.size else 0.0
+
+
+def _weighted_mean(
+    values: np.ndarray[Any, Any], weights: np.ndarray[Any, Any], mask: np.ndarray[Any, Any]
+) -> float | None:
+    selected_weights = weights[mask]
+    if selected_weights.size == 0 or float(np.sum(selected_weights)) <= 0.0:
+        return None
+    return float(np.average(values[mask], weights=selected_weights))
+
+
+def _require_fields(dataset: xr.Dataset) -> None:
+    available = set(dataset.data_vars) | set(dataset.coords)
+    missing = sorted((set(REQUIRED_OUTPUT_FIELDS) | set(REQUIRED_COORDINATES)) - available)
+    if missing:
+        raise MoistMountainWaveCaseError(f"Native output is missing required data: {missing}")
+
+
+def _field(dataset: xr.Dataset, name: str, dimensions: tuple[str, ...]) -> np.ndarray[Any, Any]:
+    data = dataset[name]
+    if "time" in data.dims:
+        if data.sizes["time"] != 1:
+            raise MoistMountainWaveCaseError(f"{name} must contain one time per native file.")
+        data = data.isel(time=0)
+    if set(data.dims) != set(dimensions):
+        raise MoistMountainWaveCaseError(
+            f"{name} dimensions must be {dimensions}; found {data.dims}."
+        )
+    return np.asarray(data.transpose(*dimensions).values, dtype=np.float64)
+
+
+def _dataset_time_seconds(dataset: xr.Dataset) -> float:
+    values = normalize_time_to_seconds(
+        dataset["time"].values, str(dataset["time"].attrs.get("units", ""))
+    ).reshape(-1)
+    if values.size != 1:
+        raise MoistMountainWaveCaseError("Each native history must contain exactly one time.")
+    return float(values[0])
+
+
+def _coordinates(dataset: xr.Dataset) -> dict[str, np.ndarray[Any, Any]]:
+    result: dict[str, np.ndarray[Any, Any]] = {}
+    for name in ("xh", "xf", "yh", "yf", "zh", "zf"):
+        result[name] = normalize_length_to_m(
+            dataset[name].values, str(dataset[name].attrs.get("units", ""))
+        ).reshape(-1)
+    return result
+
+
+def _inventory(dataset: xr.Dataset) -> dict[str, Any]:
+    variables = {
+        name: {
+            "dimensions": list(data.dims),
+            "shape": list(data.shape),
+            "units": str(data.attrs.get("units", "")),
+            "dtype": str(data.dtype),
+        }
+        for name, data in dataset.data_vars.items()
+    }
+    coordinates = {
+        name: {
+            "dimensions": list(data.dims),
+            "shape": list(data.shape),
+            "units": str(data.attrs.get("units", "")),
+            "dtype": str(data.dtype),
+        }
+        for name, data in dataset.coords.items()
+    }
+    return {"variables": variables, "coordinates": coordinates}
+
+
+def _runtime_integrity(
+    package: MoistMountainWavePackageResult,
+    manifest: RunManifest,
+    model_paths: list[Path],
+) -> dict[str, Any]:
+    stdout_path = Path(manifest.execution.stdout_log or "")
+    stderr_path = Path(manifest.execution.stderr_log or "")
+    stdout = stdout_path.read_text(errors="replace") if stdout_path.is_file() else ""
+    stderr = stderr_path.read_text(errors="replace") if stderr_path.is_file() else ""
+    flags = [
+        flag
+        for flag in (
+            "IEEE_INVALID_FLAG",
+            "IEEE_DIVIDE_BY_ZERO",
+            "IEEE_OVERFLOW_FLAG",
+            "IEEE_UNDERFLOW_FLAG",
+        )
+        if flag in stderr
+    ]
+    wall_clock_seconds: float | None = None
+    if manifest.execution.started_at is not None and manifest.execution.finished_at is not None:
+        wall_clock_seconds = (
+            manifest.execution.finished_at - manifest.execution.started_at
+        ).total_seconds()
+    stats_paths = sorted(package.package_dir.glob("cm1out_stats*.nc*"))
+    stats_inventory: dict[str, Any] = {"status": "not_found", "files": []}
+    if stats_paths:
+        stats_inventory = {"status": "inspected", "files": []}
+        for path in stats_paths:
+            with xr.open_dataset(path, decode_times=False) as dataset:
+                stats_inventory["files"].append(
+                    {
+                        "filename": path.name,
+                        "bytes": path.stat().st_size,
+                        "variables": sorted(str(name) for name in dataset.data_vars),
+                        "finite": all(
+                            bool(np.all(np.isfinite(np.asarray(value.values))))
+                            for value in dataset.data_vars.values()
+                        ),
+                    }
+                )
+    return {
+        "exit_code": manifest.execution.exit_code,
+        "normal_termination_marker_present": "Program terminated normally" in stdout,
+        "stdout_bytes": stdout_path.stat().st_size if stdout_path.is_file() else 0,
+        "stderr_bytes": stderr_path.stat().st_size if stderr_path.is_file() else 0,
+        "floating_point_flags": flags,
+        "stderr_excerpt": stderr[-4000:],
+        "wall_clock_seconds": wall_clock_seconds,
+        "stats_evidence": stats_inventory,
+        "package_total_bytes": sum(
+            path.stat().st_size for path in package.package_dir.rglob("*") if path.is_file()
+        ),
+        "model_output_bytes": sum(path.stat().st_size for path in model_paths),
+    }
+
+
+def write_moist_mountain_wave_evidence(path: Path, evidence: MoistMountainWaveEvidence) -> None:
+    path.write_text(evidence.to_json_text())

--- a/app/backend/tests/test_moist_mountain_wave_case.py
+++ b/app/backend/tests/test_moist_mountain_wave_case.py
@@ -344,6 +344,20 @@ def test_preserved_run_reevaluation_hashes_before_and_after_without_execution(
     )
     stats.to_netcdf(stats_path)
     stats.close()
+    completed_manifest = load_run_manifest(package.manifest_path)
+    write_run_manifest(
+        package.manifest_path,
+        completed_manifest.model_copy(
+            update={
+                "outputs": OutputMetadata(
+                    netcdf_paths=[
+                        *completed_manifest.outputs.netcdf_paths,
+                        str(stats_path),
+                    ]
+                )
+            }
+        ),
+    )
     relative_paths = [
         "run_manifest.json",
         "case_manifest.json",

--- a/app/backend/tests/test_moist_mountain_wave_case.py
+++ b/app/backend/tests/test_moist_mountain_wave_case.py
@@ -15,6 +15,7 @@ from cloud_chamber.moist_mountain_wave_case import (
     MATERIAL_PEAK_KG_KG,
     NX,
     NY,
+    PRESERVED_RUN_ID,
     MoistMountainWavePackageResult,
     analytic_terrain_m,
     audit_input_sounding,
@@ -22,11 +23,14 @@ from cloud_chamber.moist_mountain_wave_case import (
     evaluate_moist_mountain_wave_run,
     expected_output_times,
     generate_moist_mountain_wave_package,
+    load_preserved_moist_mountain_wave_run,
     preflight_package_for_execution,
+    reevaluate_preserved_moist_mountain_wave_run,
     render_input_sounding,
     render_moist_namelist,
     sounding_records,
     terrain_x_m,
+    verify_preserved_run_artifacts,
     write_terrain_file,
 )
 from cloud_chamber.mountain_wave_case import (
@@ -256,12 +260,143 @@ def test_evaluator_detects_clear_coherent_material_gravity_wave_cloud(
     assert evidence.cloud_and_wave["peak_cloud_frame"]["maximum_ql_kg_kg"] >= (MATERIAL_PEAK_KG_KG)
     assert evidence.cloud_and_wave["persistent_windows_seconds"]
     assert evidence.cloud_and_wave["descent_evaporation_frames_seconds"]
+    first_cloud = evidence.cloud_and_wave["first_cloud_frame"]
+    assert first_cloud["cloud_in_ascent_and_saturation_cells"] > 0
+    assert first_cloud["cloud_components"][0]["x_bounds_m"] == [-2500.0, -500.0]
+    downstream = first_cloud["downstream_descent_evaporation"]
+    assert downstream["direction"] == "downstream_east_positive_x"
+    assert downstream["selected_cell_count"] == 3
+    assert downstream["x_bounds_m"] == [500.0, 500.0]
+    assert downstream["w_m_s"]["median"] == -1.0
+    assert downstream["relative_humidity_fraction"]["maximum"] < 1.0
+    assert downstream["ql_kg_kg"]["maximum"] == 0.0
     assert evidence.geometry["physical_height_transform_maximum_abs_error_m"] == pytest.approx(0.0)
+    assert len(evidence.geometry["active_top_checks_by_time"]) == 21
+    assert evidence.geometry["lower_boundary_tangency"]["per_time_metrics"]
+    assert evidence.initial_and_upstream["initial_upstream_state"]["profile_by_level"]
+    assert len(evidence.initial_and_upstream["upstream_flow_by_time"]) == 21
     assert all(evidence.predeclared_checks.values())
     assert json.loads(evidence.to_json_text())["case_id"] == moist_mountain_wave_case.CASE_ID
 
 
-def _write_synthetic_native_outputs(package_dir: Path) -> list[Path]:
+def test_first_cloud_causality_cannot_pass_from_a_later_frame(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = fake_settings(tmp_path)
+    provenance = fake_provenance(tmp_path)
+    patch_package_preconditions(monkeypatch, provenance)
+    package = generate_moist_mountain_wave_package(
+        settings=settings, run_id="moist-wave-first-cloud-counterexample"
+    )
+    output_paths = _write_synthetic_native_outputs(
+        package.package_dir, first_cloud_has_ascent_and_saturation=False
+    )
+    _mark_package_completed(package, output_paths)
+
+    evidence = evaluate_moist_mountain_wave_run(settings=settings, package=package)
+
+    first_cloud = evidence.cloud_and_wave["first_cloud_frame"]
+    assert first_cloud["time_seconds"] == 200.0
+    assert first_cloud["cloud_cell_count"] > 0
+    assert first_cloud["cloud_in_ascent_and_saturation_cells"] == 0
+    assert any(
+        frame["cloud_in_ascent_and_saturation_cells"] > 0
+        for frame in evidence.cloud_and_wave["frames"]
+        if frame["time_seconds"] > 200.0
+    )
+    assert evidence.predeclared_checks["first_cloud_forms_interior_not_edge"] is True
+    assert evidence.predeclared_checks["cloud_colocated_with_ascent_and_saturation"] is False
+
+
+def test_evaluator_rejects_active_top_disagreement_in_any_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = fake_settings(tmp_path)
+    provenance = fake_provenance(tmp_path)
+    patch_package_preconditions(monkeypatch, provenance)
+    package = generate_moist_mountain_wave_package(
+        settings=settings, run_id="moist-wave-active-top-counterexample"
+    )
+    output_paths = _write_synthetic_native_outputs(package.package_dir, altered_active_top_frame=7)
+    _mark_package_completed(package, output_paths)
+
+    with pytest.raises(
+        moist_mountain_wave_case.MoistMountainWaveCaseError,
+        match="Active-top evidence disagrees",
+    ):
+        evaluate_moist_mountain_wave_run(settings=settings, package=package)
+
+
+def test_preserved_run_reevaluation_hashes_before_and_after_without_execution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = fake_settings(tmp_path)
+    provenance = fake_provenance(tmp_path)
+    patch_package_preconditions(monkeypatch, provenance)
+    package = generate_moist_mountain_wave_package(settings=settings, run_id=PRESERVED_RUN_ID)
+    output_paths = _write_synthetic_native_outputs(package.package_dir)
+    _mark_package_completed(package, output_paths, nested_logs=True)
+    (package.package_dir / "execution_preflight.json").write_text("{}\n")
+    stats_path = package.package_dir / "cm1out_stats.nc"
+    stats = xr.Dataset(
+        data_vars={"cflmax": (("time",), np.array([0.1]))},
+        coords={"time": (("time",), np.array([0.0]))},
+    )
+    stats.to_netcdf(stats_path)
+    stats.close()
+    relative_paths = [
+        "run_manifest.json",
+        "case_manifest.json",
+        "namelist.input",
+        "input_sounding",
+        "perts.dat",
+        "execution_preflight.json",
+        "logs/stdout.log",
+        "logs/stderr.log",
+        "cm1out_stats.nc",
+        *(f"cm1out_{index:06d}.nc" for index in range(1, 22)),
+    ]
+    expected_hashes = {
+        relative_path: sha256_file(package.package_dir / relative_path)
+        for relative_path in relative_paths
+    }
+    monkeypatch.setattr(
+        moist_mountain_wave_case,
+        "PRESERVED_RUN_ARTIFACT_SHA256",
+        expected_hashes,
+    )
+
+    preserved = load_preserved_moist_mountain_wave_run(settings=settings, run_id=PRESERVED_RUN_ID)
+    evidence = reevaluate_preserved_moist_mountain_wave_run(
+        settings=settings,
+        package=preserved,
+        evaluator_commit="offline-evaluator-commit",
+    )
+
+    assert evidence.implementation_commit == "implementation-commit"
+    assert evidence.offline_reevaluation is not None
+    assert evidence.offline_reevaluation["run_manager_constructed_or_invoked"] is False
+    assert evidence.offline_reevaluation["artifacts_unchanged"] is True
+    before = evidence.offline_reevaluation["artifact_hashes_verified_before"]
+    after = evidence.offline_reevaluation["artifact_hashes_verified_after"]
+    assert before == after
+    assert before["artifact_count"] == len(relative_paths)
+
+    sounding_path = package.package_dir / "input_sounding"
+    sounding_path.write_text(sounding_path.read_text() + "changed\n")
+    with pytest.raises(
+        moist_mountain_wave_case.MoistMountainWaveCaseError,
+        match="Preserved run artifact changed: input_sounding",
+    ):
+        verify_preserved_run_artifacts(preserved)
+
+
+def _write_synthetic_native_outputs(
+    package_dir: Path,
+    *,
+    first_cloud_has_ascent_and_saturation: bool = True,
+    altered_active_top_frame: int | None = None,
+) -> list[Path]:
     xh_m = terrain_x_m()
     xf_m = np.arange(-110_000.0, 111_000.0, 1_000.0)
     yh_m = np.array([0.0])
@@ -284,9 +419,10 @@ def _write_synthetic_native_outputs(package_dir: Path) -> list[Path]:
         if 2 <= number <= 8:
             for z_index in range(3):
                 ql[z_index, 0, cloud_x] = 3.0e-4
-                qv[z_index, 0, cloud_x] = qsat[z_index, 0, cloud_x]
-                w[z_index, 0, cloud_x] = 1.0
-                w[z_index + 1, 0, cloud_x] = 1.0
+                if number > 2 or first_cloud_has_ascent_and_saturation:
+                    qv[z_index, 0, cloud_x] = qsat[z_index, 0, cloud_x]
+                    w[z_index, 0, cloud_x] = 1.0
+                    w[z_index + 1, 0, cloud_x] = 1.0
             descent_x = cloud_x[-1] + 1
             w[0:3, 0, descent_x] = -1.0
         dataset = xr.Dataset(
@@ -332,6 +468,11 @@ def _write_synthetic_native_outputs(package_dir: Path) -> list[Path]:
                     w[None],
                     {"units": "m/s"},
                 ),
+                "ztop": (
+                    ("one",),
+                    np.array([24.0 if number == altered_active_top_frame else 25.0]),
+                    {"units": "km"},
+                ),
             },
             coords={
                 "time": ("time", [float(time_seconds)], {"units": "s"}),
@@ -351,10 +492,15 @@ def _write_synthetic_native_outputs(package_dir: Path) -> list[Path]:
 
 
 def _mark_package_completed(
-    package: MoistMountainWavePackageResult, output_paths: list[Path]
+    package: MoistMountainWavePackageResult,
+    output_paths: list[Path],
+    *,
+    nested_logs: bool = False,
 ) -> None:
-    stdout = package.package_dir / "stdout.log"
-    stderr = package.package_dir / "stderr.log"
+    log_dir = package.package_dir / "logs" if nested_logs else package.package_dir
+    log_dir.mkdir(exist_ok=True)
+    stdout = log_dir / "stdout.log"
+    stderr = log_dir / "stderr.log"
     stdout.write_text("Program terminated normally\n")
     stderr.write_text("")
     started = datetime(2026, 7, 21, 12, 0, tzinfo=UTC)

--- a/app/backend/tests/test_moist_mountain_wave_case.py
+++ b/app/backend/tests/test_moist_mountain_wave_case.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from cloud_chamber import moist_mountain_wave_case
+from cloud_chamber.moist_mountain_wave_case import (
+    ACTIVE_TOP_M,
+    EXPECTED_OUTPUT_TIMES_SECONDS,
+    MATERIAL_PEAK_KG_KG,
+    NX,
+    NY,
+    MoistMountainWavePackageResult,
+    analytic_terrain_m,
+    audit_input_sounding,
+    audit_moist_namelist,
+    evaluate_moist_mountain_wave_run,
+    expected_output_times,
+    generate_moist_mountain_wave_package,
+    preflight_package_for_execution,
+    render_input_sounding,
+    render_moist_namelist,
+    sounding_records,
+    terrain_x_m,
+    write_terrain_file,
+)
+from cloud_chamber.mountain_wave_case import (
+    CM1Provenance,
+    parse_namelist_assignments,
+    reconstruct_physical_heights,
+    sha256_file,
+)
+from cloud_chamber.run_manifest import (
+    ExecutionMetadata,
+    LifecycleState,
+    OutputMetadata,
+    ProductState,
+    ProvenanceMetadata,
+    load_run_manifest,
+    write_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings
+
+
+def reference_namelist_text() -> str:
+    values = dict(moist_mountain_wave_case.LOCKED_NAMELIST_VALUES)
+    values.update(
+        {
+            "nx": "100",
+            "nz": "100",
+            "dx": "200.0",
+            "dy": "200.0",
+            "timax": "2160.0",
+            "tapfrq": "216.0",
+            "cm1setup": "0",
+            "apmasscon": "1",
+            "imoist": "0",
+            "sgsmodel": "1",
+            "tconfig": "1",
+            "irdamp": "1",
+            "ptype": "5",
+            "icor": "1",
+            "lspgrad": "1",
+            "wbc": "2",
+            "ebc": "2",
+            "isnd": "9",
+            "iwnd": "6",
+            "itern": "1",
+            "fcor": "0.00010",
+            "v_t": "7.0",
+            "ztop": "18000.0",
+            "output_format": "1",
+            "output_filetype": "1",
+            "output_interp": "1",
+            "output_rain": "1",
+            "output_dbz": "1",
+        }
+    )
+    values["unlisted_control"] = "17"
+    return (
+        "\n &param0\n"
+        + "".join(f" {name:<20} = {value},\n" for name, value in values.items())
+        + " /\n"
+    )
+
+
+def fake_settings(tmp_path: Path) -> CloudChamberSettings:
+    runtime_home = tmp_path / "CloudChamber"
+    cm1_root = tmp_path / "cm1r21.1"
+    cm1_run_dir = cm1_root / "run"
+    cm1_run_dir.mkdir(parents=True, exist_ok=True)
+    return CloudChamberSettings(
+        runtime_home=runtime_home,
+        cm1_root=cm1_root,
+        cm1_run_dir=cm1_run_dir,
+        cache_dir=runtime_home / "cache",
+        log_dir=runtime_home / "logs",
+    )
+
+
+def fake_provenance(tmp_path: Path) -> CM1Provenance:
+    settings = fake_settings(tmp_path)
+    assert settings.cm1_root is not None
+    assert settings.cm1_run_dir is not None
+    official = settings.cm1_root / "run/config_files/nh_mountain_waves/namelist.input"
+    official.parent.mkdir(parents=True, exist_ok=True)
+    official.write_text(reference_namelist_text())
+    executable = settings.cm1_run_dir / "cm1.exe"
+    executable.write_text("fake netcdf executable")
+    return CM1Provenance(
+        release="21.1",
+        official_tag_commit="test-tag-commit",
+        official_source_tag="test-source-tag",
+        source_tree_path=settings.cm1_root,
+        run_directory_path=settings.cm1_run_dir,
+        executable_path=executable,
+        executable_sha256="executable-hash",
+        source_manifest_method="test source manifest",
+        source_manifest_sha256="source-manifest-hash",
+        readme_namelist_sha256="namelist-readme-hash",
+        readme_terrain_sha256="terrain-readme-hash",
+        mountain_wave_namelist_path=official,
+        mountain_wave_namelist_sha256=sha256_file(official),
+        critical_source_sha256={"src/init_terrain.F": "terrain-source-hash"},
+        netcdf_link_evidence=["libnetcdf"],
+    )
+
+
+def patch_package_preconditions(monkeypatch: pytest.MonkeyPatch, provenance: CM1Provenance) -> None:
+    monkeypatch.setattr(
+        moist_mountain_wave_case,
+        "collect_cm1_provenance",
+        lambda _settings: provenance,
+    )
+    monkeypatch.setattr(
+        moist_mountain_wave_case,
+        "verified_clean_git_commit",
+        lambda: "implementation-commit",
+    )
+    monkeypatch.setattr(moist_mountain_wave_case, "active_cm1_processes", lambda: [])
+    monkeypatch.setattr(
+        moist_mountain_wave_case,
+        "verify_source_lock",
+        lambda: {
+            "relative_path": moist_mountain_wave_case.SOURCE_LOCK_RELATIVE_PATH.as_posix(),
+            "sha256": moist_mountain_wave_case.SOURCE_LOCK_SHA256,
+        },
+    )
+
+
+def test_sounding_is_exactly_derived_and_initially_unsaturated() -> None:
+    text = render_input_sounding()
+    audit = audit_input_sounding(text)
+    records = sounding_records()
+
+    assert len(text.splitlines()) == len(records) == 38
+    assert audit["profile_row_count"] == 37
+    assert audit["final_model_height_m"] == 25_846.0
+    assert audit["maximum_source_relative_humidity_percent"] == 95.0
+    assert audit["checks"]["missing_rh_rows_map_to_zero_qv"] is True
+    assert records[0]["pressure_pa"] == 85_000
+    assert records[0]["theta_k"] == pytest.approx(285.5125, abs=1.0e-4)
+    assert records[0]["qv_g_kg"] == pytest.approx(1.767594, abs=1.0e-6)
+    assert records[0]["u_m_s"] == pytest.approx(-4.2858, abs=1.0e-4)
+
+
+def test_terrain_binary_is_exact_single_float32_record(tmp_path: Path) -> None:
+    path = tmp_path / "perts.dat"
+    audit = write_terrain_file(path)
+    values = np.fromfile(path, dtype="<f4").reshape((NY, NX))
+
+    assert path.stat().st_size == 4 * NX * NY
+    assert values.shape == (1, 220)
+    assert audit["crest_x_m"] == 500.0
+    assert audit["crest_height_m"] == 2_000.0
+    assert audit["maximum_analytic_slope"] == pytest.approx(0.1299038106)
+    assert all(audit["checks"].values())
+
+
+def test_namelist_preserves_unlisted_assignments_and_locks_complete_case() -> None:
+    official = reference_namelist_text()
+    generated = render_moist_namelist(official)
+    audit = audit_moist_namelist(official, generated)
+
+    assert expected_output_times(generated) == EXPECTED_OUTPUT_TIMES_SECONDS
+    assert "unlisted_control" not in {difference["name"] for difference in audit["differences"]}
+    assert parse_namelist_assignments(generated)["unlisted_control"] == "17"
+    assert audit["all_unlisted_assignments_preserved"] is True
+
+    altered = generated.replace(" unlisted_control", " changed_unlisted_control")
+    with pytest.raises(
+        moist_mountain_wave_case.MoistMountainWaveCaseError,
+        match="assignment set",
+    ):
+        audit_moist_namelist(official, altered)
+
+
+def test_package_and_repeated_hard_preflight_are_nonexecuting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = fake_settings(tmp_path)
+    provenance = fake_provenance(tmp_path)
+    patch_package_preconditions(monkeypatch, provenance)
+
+    package = generate_moist_mountain_wave_package(settings=settings, run_id="moist-wave-fixture")
+    preflight = preflight_package_for_execution(settings=settings, package=package)
+    manifest = load_run_manifest(package.manifest_path)
+    case_manifest = json.loads(package.case_manifest_path.read_text())
+    checklist = json.loads((package.package_dir / "runtime_file_checklist.json").read_text())
+
+    assert manifest.lifecycle_state == LifecycleState.PACKAGED
+    assert manifest.execution.process_id is None
+    assert manifest.run_recipe is None
+    assert manifest.recipe_id is None
+    assert case_manifest["cloud_world_id"] is None
+    assert checklist["consumed_files"] == ["input_sounding", "perts.dat"]
+    assert checklist["required_files"] == []
+    assert preflight.passed is True
+    assert all(preflight.checks.values())
+    assert {path.name for path in package.generated_files} == {
+        "run_manifest.json",
+        "case_manifest.json",
+        "namelist.input",
+        "input_sounding",
+        "perts.dat",
+        "runtime_file_checklist.json",
+        "source_namelist_diff.json",
+        "source_namelist_diff.txt",
+        "storage_estimate.json",
+        "moist_run_report.json",
+    }
+
+
+def test_evaluator_detects_clear_coherent_material_gravity_wave_cloud(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = fake_settings(tmp_path)
+    provenance = fake_provenance(tmp_path)
+    patch_package_preconditions(monkeypatch, provenance)
+    package = generate_moist_mountain_wave_package(
+        settings=settings, run_id="moist-wave-native-fixture"
+    )
+    output_paths = _write_synthetic_native_outputs(package.package_dir)
+    _mark_package_completed(package, output_paths)
+
+    evidence = evaluate_moist_mountain_wave_run(settings=settings, package=package)
+
+    assert evidence.output_inventory["actual_times_seconds"] == list(EXPECTED_OUTPUT_TIMES_SECONDS)
+    assert evidence.initial_and_upstream["initial_maximum_ql_kg_kg"] == 0.0
+    assert evidence.initial_and_upstream["upstream_maximum_ql_kg_kg_all_times"] == 0.0
+    assert evidence.cloud_and_wave["peak_cloud_frame"]["maximum_ql_kg_kg"] >= (MATERIAL_PEAK_KG_KG)
+    assert evidence.cloud_and_wave["persistent_windows_seconds"]
+    assert evidence.cloud_and_wave["descent_evaporation_frames_seconds"]
+    assert evidence.geometry["physical_height_transform_maximum_abs_error_m"] == pytest.approx(0.0)
+    assert all(evidence.predeclared_checks.values())
+    assert json.loads(evidence.to_json_text())["case_id"] == moist_mountain_wave_case.CASE_ID
+
+
+def _write_synthetic_native_outputs(package_dir: Path) -> list[Path]:
+    xh_m = terrain_x_m()
+    xf_m = np.arange(-110_000.0, 111_000.0, 1_000.0)
+    yh_m = np.array([0.0])
+    yf_m = np.array([-500.0, 500.0])
+    zh_m = np.array([1_000.0, 3_000.0, 10_000.0, 24_000.0])
+    zf_m = np.array([0.0, 2_000.0, 5_000.0, 15_000.0, 25_000.0])
+    terrain = analytic_terrain_m(xh_m)[None, :]
+    zh_physical = reconstruct_physical_heights(terrain, zh_m, active_top_m=ACTIVE_TOP_M)
+    pressure = 85_000.0 * np.exp(-zh_physical / 8_000.0)
+    temperature = np.full_like(pressure, 280.0)
+    theta = temperature / (pressure / 100_000.0) ** (287.04 / 1004.0)
+    qsat = moist_mountain_wave_case._saturation_mixing_ratio_kg_kg(temperature, pressure)
+    cloud_x = np.flatnonzero((xh_m >= -2_500.0) & (xh_m <= 1_500.0))[:3]
+    outputs: list[Path] = []
+
+    for number, time_seconds in enumerate(EXPECTED_OUTPUT_TIMES_SECONDS, start=1):
+        ql = np.zeros((4, 1, NX), dtype=np.float64)
+        qv = 0.8 * qsat
+        w = np.zeros((5, 1, NX), dtype=np.float64)
+        if 2 <= number <= 8:
+            for z_index in range(3):
+                ql[z_index, 0, cloud_x] = 3.0e-4
+                qv[z_index, 0, cloud_x] = qsat[z_index, 0, cloud_x]
+                w[z_index, 0, cloud_x] = 1.0
+                w[z_index + 1, 0, cloud_x] = 1.0
+            descent_x = cloud_x[-1] + 1
+            w[0:3, 0, descent_x] = -1.0
+        dataset = xr.Dataset(
+            data_vars={
+                "zs": (("time", "yh", "xh"), terrain[None], {"units": "m"}),
+                "zhval": (
+                    ("time", "zh", "yh", "xh"),
+                    zh_physical[None],
+                    {"units": "m"},
+                ),
+                "th": (
+                    ("time", "zh", "yh", "xh"),
+                    theta[None],
+                    {"units": "K"},
+                ),
+                "prs": (
+                    ("time", "zh", "yh", "xh"),
+                    pressure[None],
+                    {"units": "Pa"},
+                ),
+                "qv": (
+                    ("time", "zh", "yh", "xh"),
+                    qv[None],
+                    {"units": "kg/kg"},
+                ),
+                "ql": (
+                    ("time", "zh", "yh", "xh"),
+                    ql[None],
+                    {"units": "kg/kg"},
+                ),
+                "u": (
+                    ("time", "zh", "yh", "xf"),
+                    np.full((1, 4, 1, NX + 1), 10.0),
+                    {"units": "m/s"},
+                ),
+                "v": (
+                    ("time", "zh", "yf", "xh"),
+                    np.zeros((1, 4, 2, NX)),
+                    {"units": "m/s"},
+                ),
+                "w": (
+                    ("time", "zf", "yh", "xh"),
+                    w[None],
+                    {"units": "m/s"},
+                ),
+            },
+            coords={
+                "time": ("time", [float(time_seconds)], {"units": "s"}),
+                "xh": ("xh", xh_m / 1000.0, {"units": "km"}),
+                "xf": ("xf", xf_m / 1000.0, {"units": "km"}),
+                "yh": ("yh", yh_m / 1000.0, {"units": "km"}),
+                "yf": ("yf", yf_m / 1000.0, {"units": "km"}),
+                "zh": ("zh", zh_m / 1000.0, {"units": "km"}),
+                "zf": ("zf", zf_m / 1000.0, {"units": "km"}),
+            },
+        )
+        path = package_dir / f"cm1out_{number:06d}.nc"
+        dataset.to_netcdf(path)
+        dataset.close()
+        outputs.append(path)
+    return outputs
+
+
+def _mark_package_completed(
+    package: MoistMountainWavePackageResult, output_paths: list[Path]
+) -> None:
+    stdout = package.package_dir / "stdout.log"
+    stderr = package.package_dir / "stderr.log"
+    stdout.write_text("Program terminated normally\n")
+    stderr.write_text("")
+    started = datetime(2026, 7, 21, 12, 0, tzinfo=UTC)
+    finished = datetime(2026, 7, 21, 12, 2, tzinfo=UTC)
+    manifest = load_run_manifest(package.manifest_path)
+    completed = manifest.model_copy(
+        update={
+            "lifecycle_state": LifecycleState.COMPLETED,
+            "execution": ExecutionMetadata(
+                command=["cm1.exe"],
+                process_id=123,
+                started_at=started,
+                finished_at=finished,
+                exit_code=0,
+                stdout_log=str(stdout),
+                stderr_log=str(stderr),
+            ),
+            "outputs": OutputMetadata(netcdf_paths=[str(path) for path in output_paths]),
+            "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+        }
+    )
+    write_run_manifest(package.manifest_path, completed)

--- a/docs/research/mountain-waves/moist-orographic-cloud-run-report.md
+++ b/docs/research/mountain-waves/moist-orographic-cloud-run-report.md
@@ -2,6 +2,9 @@
 
 Status: one source-locked CM1 process completed and evaluated.
 
+Review correction status: the exact preserved output was reevaluated offline with the
+hash-pinned v2 evaluator. No CM1 process or run manager was started.
+
 Final disposition: `advance_as_candidate_world_evidence`
 
 ## Decision and boundary
@@ -53,6 +56,7 @@ centering offset, the pinned CM1 2 s integration step, and 200 s evidence cadenc
 case_id: cm1_r21_1_toy2011_boulder_moist_wave_4000s_v1
 run_id: moist-mountain-wave-toy-1972-20260721T215226Z
 implementation commit: ebdbb528c92c57d3d4a19080b4bddc4820b0bc6a
+offline evaluator commit: 133e4840d9bba9cf0e5199eabc8ae36146ff21d7
 CM1 release: 21.1
 CM1 tag commit: 0f734f64efa89a684963a66d2ac32db67617912b
 CM1 executable SHA-256: 5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1
@@ -76,6 +80,25 @@ radiation, aerosol, microphysics lookup, or external-grid file was consumed.
 
 Exactly one full 4,000 s CM1 process ran. No shortened smoke process, tuning process,
 retry, alternate executable, LAN worker, or second process ran.
+
+## Corrected offline reevaluation
+
+The PM/scientific review authorized one evaluator-only correction against the exact
+preserved run. The v2 path verifies the source lock and 30 pinned artifacts before and
+after reading output: both manifests, generated namelist, sounding, terrain record,
+execution preflight, stdout/stderr, stats NetCDF, and all 21 numbered histories. The
+before/after hash maps are identical. The path is pinned to the run ID above, rejects
+any other run, and does not import, construct, or invoke a run manager.
+
+```text
+evidence version: moist_mountain_wave_gate_d_e_v2
+offline evaluator commit: 133e4840d9bba9cf0e5199eabc8ae36146ff21d7
+corrected evidence SHA-256: 4d68ab004ad62ac7bb4d1668743caa67f64ed341f1e025bdbc427fe668af08ad
+original implementation commit retained: ebdbb528c92c57d3d4a19080b4bddc4820b0bc6a
+preserved artifact count: 30
+preserved artifacts unchanged: true
+run manager constructed or invoked: false
+```
 
 ## Generated configuration and audit
 
@@ -123,22 +146,28 @@ criterion rather than replacing it with a new post-run threshold.
    4,000 s at exact 200 s intervals; every required field was finite at every time.
 2. **Terrain, physical-height, and active-top integrity:** passed. Terrain error was
    `9.54e-5 m`, physical-height transform error was `0.0041 m`, minimum scalar spacing
-   was `183.996 m`, and the output top was `25,000.002 m` at every history.
+   was `183.996 m`, and final nominal `zf` and runtime `ztop` were both `25,000.002 m`
+   at every history, agreeing with configured `125 x 200 m = 25,000 m`.
 3. **Initial and upstream clear air:** passed. Initial maximum `ql` was zero. The
    maximum `ql` in the `-100..-60 km`, below-12-km upstream sector was zero at every
    history.
 4. **Interior formation with ascent and saturation:** passed. First condensate above
    `1e-6 kg/kg` appeared at 200 s in one 15-cell component at `x=-7.5..-0.5 km` and
-   `z=3.52..3.87 km`; 12 cells were simultaneously ascending and at least 99% RH.
+   `z=3.52..3.87 km`; 12 of those same first-frame interior cells were simultaneously
+   ascending and at least 99% RH. The first-frame peak itself was at `x=-2.5 km`,
+   `z=3.60 km`, with `w=0.371 m/s` and RH `100.67%`.
 5. **Coherence, persistence, and material peak:** passed. The cloud was coherent for
    every history from 200 through 4,000 s. Peak `ql` reached `6.4445e-4 kg/kg`
    (`0.6445 g/kg`), above the predeclared `0.2 g/kg` material check.
-6. **Descent and evaporation:** passed. At 1,200 s, eight east/downstream cells adjacent
-   to the dominant cloud were clear, descending, and unsaturated; median `w` was
-   `-1.63 m/s` and median RH was 97.9%. At 4,000 s there were 30 such cells, with
-   median `w=-4.18 m/s`, median RH 93.6%, and `ql=0`. Cumulative CM1 condensation was
-   `6.9582e7` mass units and evaporation was `5.9357e7`, so active evaporation was
-   substantial rather than inferred only from a color boundary.
+6. **Descent and evaporation:** passed. The corrected method selects clear cells one
+   scalar-grid cell immediately east of cloud, with `w<0`, RH below one, and `ql` below
+   the locked cloud floor. At 1,200 s it retains 18 cells in 11 connected groups across
+   `x=-5.5..18.5 km`, `z=2.62..4.73 km`; median `w` was `-2.26 m/s`, median RH was
+   96.34%, and `ql=0`. At 4,000 s it retains 30 cells in 15 groups across
+   `x=17.5..27.5 km`, `z=2.38..8.33 km`; median `w=-4.18 m/s`, median RH 93.60%, and
+   `ql=0`. Cumulative CM1 condensation was `6.9582e7` mass units and evaporation was
+   `5.9357e7`, so active evaporation was substantial rather than inferred only from a
+   color boundary.
 7. **Terrain/wave locking:** passed. The early windward component remained tied to the
    mountain. By 1,600 s the dominant component was the lee cloud at `x=14.5..19.5 km`;
    its centroid stayed between 17.2 and 19.1 km through 4,000 s while it grew. It did
@@ -188,7 +217,8 @@ Runtime evidence identities:
 | Stdout | `42a120685c18d29d855cdea5039f54a3530157f2d36497cd41318f1af97fc0cb` |
 | Stderr | `6e8658cbd2bf71044b960ff59b4371a98438c32a7d4cb54ab562294b8cc4f05d` |
 | Stats NetCDF | `46cf824b20ab0c4b00806cd9ec2b0e52833e35d1913e2fa4d9205e12a523ff7a` |
-| Native evaluator evidence | `354b99419cdae3d27374080807f92c2c078b7ec87b1d17cae86b09e017d013d0` |
+| Original v1 evaluator evidence | `354b99419cdae3d27374080807f92c2c078b7ec87b1d17cae86b09e017d013d0` |
+| Corrected v2 offline evaluator evidence | `4d68ab004ad62ac7bb4d1668743caa67f64ed341f1e025bdbc427fe668af08ad` |
 
 ## Native output inventory
 
@@ -258,6 +288,19 @@ alternating vertical-motion pattern.
 
 ## Boundary, top, and startup assessment
 
+- Every history reports final nominal `zf=25,000.002 m` and runtime
+  `ztop=25,000.002 m`; both agree with configured `nz x dz=25,000 m` and the source
+  lock. The evaluator fails closed on disagreement at any time.
+- Actual staggered `u`, `v`, and bottom `w` retain lower-boundary tangency metrics at
+  every history. The initial residual RMS was `0.0284 m/s` with predicted/observed
+  correlation `0.99984`; at 4,000 s RMS was `0.0558 m/s` with correlation `0.99985`.
+  The maximum absolute residual across all histories was `0.3323 m/s`.
+- The native initial upstream profile in the locked `-100..-60 km`, below-12-km
+  sector contains 2,400 cells. Initial `u` ranged from `-3.63` to `35.60 m/s`, with
+  median `25.89 m/s`; `v=0`, and median `w=0`. All 59 calculated layer values of
+  `N^2` were positive, with median `1.056e-4 s^-2` and range
+  `9.64e-6..1.759e-3 s^-2`. Per-time upstream wind summaries are retained through
+  4,000 s.
 - The periodic west/east seam remained clear. No cloud originated in the outer 10 km
   edge sectors or the far-upstream source sector.
 - The first native frame at 0 s had `ql=0` everywhere and maximum RH 94.93%. Cloud
@@ -282,8 +325,11 @@ Both views used red for ascent, blue for descent, and outlined cells for
 broad mountain, a shallow windward streamer, and a substantial but not artificially
 stretched lee-wave cloud. The 4,000 s dominant component spans approximately
 `x=13.5..26.5 km` and `z=2.42..8.45 km`. Browser inspection at desktop size found all
-four canvases correctly proportioned and no console errors. The HTML, JSON, and PNG
-review artifacts remain runtime-only and are not committed.
+four canvases correctly proportioned and no console errors. These temporary diagnostic
+renders were generated outside the application visualization machinery by reading the
+native NetCDF directly; they are not output from the merged Gate C route or any Cloud
+Chamber product surface. The HTML, JSON, and PNG review artifacts remain runtime-only
+and are not committed.
 
 ## Limitations and unresolved questions
 

--- a/docs/research/mountain-waves/moist-orographic-cloud-run-report.md
+++ b/docs/research/mountain-waves/moist-orographic-cloud-run-report.md
@@ -1,0 +1,314 @@
+# Moist Orographic-Cloud Run Report
+
+Status: one source-locked CM1 process completed and evaluated.
+
+Final disposition: `advance_as_candidate_world_evidence`
+
+## Decision and boundary
+
+The decision question was whether pinned CM1 r21.1 can begin from a source-backed,
+unsaturated two-dimensional atmosphere and produce coherent cloud condensate through
+terrain-forced gravity-wave ascent, with physically legible descent and evaporation.
+
+It can. The run produced a compact windward cloud by 200 s, a separate lee-wave cloud
+by 1,200 s, and a persistent, terrain-relative lee cloud through the 4,000 s endpoint.
+The run remained nonprecipitating, numerically stable, finite, clear at initialization
+and in the upstream/periodic-edge sectors, and practical on the local machine.
+
+This evidence does not define or approve a Cloud World, Recipe, Control, Lens,
+Comparison, generic terrain feature, or product surface. It supports consideration of
+a later bounded candidate product slice only.
+
+## Source lock and references
+
+The pre-execution source lock is:
+
+```text
+docs/research/mountain-waves/moist-reference-case-selection.md
+SHA-256: 939c4b7c6b067c125402383e7ed966b6e09eed2f5e0c0762ca6331a6f381b20b
+```
+
+It selected the Toy (2011) 11 January 1972 Boulder moist mountain-wave experiment.
+The exact observed profile is the NOAA IGRA record headed
+`#USM00072476 1972 01 11 12`, extracted-record SHA-256
+`33953228bc6bcdf7d65c5cf800b5f8bed9a71aedda910edb4d32a28bef37e652`.
+
+Primary references:
+
+- Michael D. Toy, 2011, [Incorporating Condensational Heating into a Nonhydrostatic Atmospheric Model Based on a Hybrid Isentropic-Sigma Vertical Coordinate](https://doi.org/10.1175/MWR-D-10-05015.1).
+- Michael D. Toy and David A. Randall, 2009, [Design of a Nonhydrostatic Atmospheric Model Based on a Generalized Vertical Coordinate](https://doi.org/10.1175/2009MWR2834.1).
+- J. D. Doyle et al., 2000, [An Intercomparison of Model-Predicted Wave Breaking for the 11 January 1972 Boulder Windstorm](https://doi.org/10.1175/1520-0493(2000)128%3C0901:AIOMPW%3E2.0.CO;2).
+- Dale R. Durran and Joseph B. Klemp, 1983, [A Compressible Model for the Simulation of Moist Mountain Waves](https://doi.org/10.1175/1520-0493(1983)111%3C2341:ACMFTS%3E2.0.CO;2).
+- NOAA NCEI, [IGRA v2.2 station USM00072476 period-of-record data](https://www.ncei.noaa.gov/data/integrated-global-radiosonde-archive/access/data-por/USM00072476-data.txt.zip) and [sounding format](https://www.ncei.noaa.gov/data/integrated-global-radiosonde-archive/doc/igra2-data-format.txt).
+
+The complete source-to-CM1 difference table remains in the hash-pinned selection
+artifact. The material differences are the source-supported 25 km sensitivity top,
+CM1 Gal-Chen coordinate, CM1 Smagorinsky closure, CM1 water-only reversible physics,
+direct deterministic processing of the archived IGRA observation, a half-grid terrain
+centering offset, the pinned CM1 2 s integration step, and 200 s evidence cadence.
+
+## Package and process identity
+
+```text
+case_id: cm1_r21_1_toy2011_boulder_moist_wave_4000s_v1
+run_id: moist-mountain-wave-toy-1972-20260721T215226Z
+implementation commit: ebdbb528c92c57d3d4a19080b4bddc4820b0bc6a
+CM1 release: 21.1
+CM1 tag commit: 0f734f64efa89a684963a66d2ac32db67617912b
+CM1 executable SHA-256: 5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1
+CM1 source-manifest SHA-256: fbe2367dfcd6d8c55cac4bd03362d8d49f13f80cebd13b36230c20d71119a84e
+```
+
+The executable exposed both NetCDF C and Fortran linkage. Critical source and CM1
+documentation hashes matched the preserved Gate B provenance.
+
+Runtime input identities:
+
+| Input | SHA-256 | Disposition |
+| --- | --- | --- |
+| `namelist.input` | `d94f54d5e60627daf9020aa9eceaecd4f3b35fa1c81590186c72c7ccf99a10be` | Consumed configuration |
+| `input_sounding` | `cb43243d04e328e9dd1a08ff52139f5a6096dcbe89f7b0d0e4aeb536f6a33b22` | Consumed, 38 exact rows |
+| `perts.dat` | `10d4fd60cac78acc2a19fe4a84b5d3c12c7e8a2ab58789faecebc40bf23e1028` | Consumed, one 880-byte float32 record |
+
+The runtime checklist contained exactly `input_sounding` and `perts.dat`. No land,
+radiation, aerosol, microphysics lookup, or external-grid file was consumed.
+`run_recipe`, `recipe_id`, and `cloud_world_id` were null.
+
+Exactly one full 4,000 s CM1 process ran. No shortened smoke process, tuning process,
+retry, alternate executable, LAN worker, or second process ran.
+
+## Generated configuration and audit
+
+The generated namelist retained all 342 assignments from the pinned official
+mountain-wave namelist and changed 28 source-locked or explicit output mappings:
+
+```text
+nx 100 -> 220                 nz 100 -> 125
+dx 200 -> 1000 m              dy 200 -> 1000 m
+timax 2160 -> 4000 s          tapfrq 216 -> 200 s
+cm1setup 0 -> 1               apmasscon 1 -> 0
+imoist 0 -> 1                 sgsmodel 1 -> 2
+tconfig 1 -> 2                irdamp 1 -> 0
+ptype 5 -> 6                  icor 1 -> 0
+lspgrad 1 -> 0                wbc/ebc 2 -> 1
+isnd 9 -> 7                   iwnd 6 -> 0
+itern 1 -> 4                  fcor 0.00010 -> 0
+v_t 7 -> 0 m/s                ztop 18000 -> 25000 m
+output_format 1 -> 2          output_filetype 1 -> 2
+output_interp 1 -> 0          output_rain 1 -> 0
+output_dbz 1 -> 0
+```
+
+Locked values that already matched the official file included `ny=1`, `dz=200 m`,
+`dtl=2 s`, `eqtset=2`, `efall=0`, periodic singleton-y boundaries, free-slip rigid
+bottom/top, no surface flux/PBL, no random or thermal initialization, and native plus
+scalar-interpolated wind output.
+
+The horizontal domain is 220 km. The active top is 25 km with 125 uniform nominal
+levels. Terrain is
+`2000 / (1 + ((x - 500 m) / 10000 m)^2)` meters. Binary readback recovered the exact
+2,000 m crest at `x=500 m`, with maximum float32 roundtrip error below 0.0005 m.
+
+The 850 hPa sounding header and 37 profile rows were finite and strictly increasing in
+height; the last row was 25,846 m above the model reference, above the active top. The
+maximum source RH was 95%, and all rows without reported RH followed the locked CM1
+0.01% RH mapping. Initial condensate categories were absent by construction.
+
+## Predeclared criteria and result
+
+The source lock required all of the following. The result is recorded beside each
+criterion rather than replacing it with a new post-run threshold.
+
+1. **Normal completion, 21 exact finite histories:** passed. Times were 0 through
+   4,000 s at exact 200 s intervals; every required field was finite at every time.
+2. **Terrain, physical-height, and active-top integrity:** passed. Terrain error was
+   `9.54e-5 m`, physical-height transform error was `0.0041 m`, minimum scalar spacing
+   was `183.996 m`, and the output top was `25,000.002 m` at every history.
+3. **Initial and upstream clear air:** passed. Initial maximum `ql` was zero. The
+   maximum `ql` in the `-100..-60 km`, below-12-km upstream sector was zero at every
+   history.
+4. **Interior formation with ascent and saturation:** passed. First condensate above
+   `1e-6 kg/kg` appeared at 200 s in one 15-cell component at `x=-7.5..-0.5 km` and
+   `z=3.52..3.87 km`; 12 cells were simultaneously ascending and at least 99% RH.
+5. **Coherence, persistence, and material peak:** passed. The cloud was coherent for
+   every history from 200 through 4,000 s. Peak `ql` reached `6.4445e-4 kg/kg`
+   (`0.6445 g/kg`), above the predeclared `0.2 g/kg` material check.
+6. **Descent and evaporation:** passed. At 1,200 s, eight east/downstream cells adjacent
+   to the dominant cloud were clear, descending, and unsaturated; median `w` was
+   `-1.63 m/s` and median RH was 97.9%. At 4,000 s there were 30 such cells, with
+   median `w=-4.18 m/s`, median RH 93.6%, and `ql=0`. Cumulative CM1 condensation was
+   `6.9582e7` mass units and evaporation was `5.9357e7`, so active evaporation was
+   substantial rather than inferred only from a color boundary.
+7. **Terrain/wave locking:** passed. The early windward component remained tied to the
+   mountain. By 1,600 s the dominant component was the lee cloud at `x=14.5..19.5 km`;
+   its centroid stayed between 17.2 and 19.1 km through 4,000 s while it grew. It did
+   not translate from a boundary.
+8. **Interpretable moist wave without contaminating edge/top/startup effects:** passed.
+   Alternating ascent/descent bands remained legible. Edge-sector maximum `ql` was
+   `7.28e-13 kg/kg`, below even the numerical clear floor. Top-layer maximum `ql` was
+   zero; maximum top-layer `|w|` was `0.569 m/s`, 4.3% of the domain maximum.
+9. **Honest native geometry and practical local cost:** passed. The run completed in
+   65.07 s, used 44 MB total, and emitted 30.34 MB of numbered model NetCDF.
+10. **Runtime-only visual review:** passed. Equal-scale and expanded-height views both
+    show the terrain, windward streamer, separate lee cloud, and alternating wave
+    ascent/descent without inventing a three-dimensional volume.
+
+## Lifecycle and runtime integrity
+
+```text
+started:  2026-07-21T21:52:59.086107Z
+finished: 2026-07-21T21:54:04.155245Z
+exit code: 0
+wall clock: 65.069138 s
+normal termination marker: present
+maximum CFL: 0.145988
+maximum w: 13.121550 m/s
+minimum w: -6.565818 m/s
+maximum RH: 1.000004
+precipitation rate: 0 at every stats time
+rain-process accumulator: 0
+```
+
+The 2,001-record stats NetCDF was finite. Total mass changed by `-3.006e-5` relative;
+total moisture changed by `-3.104e-5` relative. Vapor decreased as liquid increased,
+consistent with the selected reversible moisture treatment.
+
+Stderr contained only CM1's `IEEE_UNDERFLOW_FLAG` notice. There was no invalid,
+divide-by-zero, or overflow flag; all required histories and all stats variables were
+finite, maximum CFL remained 0.146, and CM1 terminated normally. The underflow is
+retained as a runtime caveat rather than treated as a fatal integrity failure.
+
+Runtime evidence identities:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| Final run manifest | `026a3887f4120fa3e2e6663d8a486a28f83338ff5b3be09639cd245fd8ba1845` |
+| Case manifest | `208d05ba72149a53f423ef13fa97cab4e298f374f20f30e6ea9c12fc6e016a78` |
+| Repeated execution preflight | `917f2f17c33f602760801c4447e014ef09e0f6031a2218b9dba4a49a2e0b9185` |
+| Stdout | `42a120685c18d29d855cdea5039f54a3530157f2d36497cd41318f1af97fc0cb` |
+| Stderr | `6e8658cbd2bf71044b960ff59b4371a98438c32a7d4cb54ab562294b8cc4f05d` |
+| Stats NetCDF | `46cf824b20ab0c4b00806cd9ec2b0e52833e35d1913e2fa4d9205e12a523ff7a` |
+| Native evaluator evidence | `354b99419cdae3d27374080807f92c2c078b7ec87b1d17cae86b09e017d013d0` |
+
+## Native output inventory
+
+Each numbered file contains one time. Coordinates are `xh(220)`, `xf(221)`, `yh(1)`,
+`yf(2)`, `zh(125)`, and `zf(126)`, all reported in kilometers; time is in seconds.
+
+| Group | Native shape | Units / staggering |
+| --- | --- | --- |
+| `zs` | `(1,1,220)` | m, scalar horizontal grid |
+| `zhval`, `th`, `prs`, `qv`, `ql` | `(1,125,1,220)` | physical m, K, Pa, kg/kg, kg/kg; scalar grid |
+| `uinterp`, `vinterp`, `winterp` | `(1,125,1,220)` | m/s, scalar grid |
+| `u` | `(1,125,1,221)` | m/s, x-face staggered |
+| `v` | `(1,125,2,220)` | m/s, y-face staggered |
+| `w` | `(1,126,1,220)` | m/s, full-level staggered |
+| `kmh`, `kmv`, `khh`, `khv` | `(1,126,1,220)` | m2/s, full-level SGS diagnostics |
+
+Surface wind/stress/pressure variables and scalar `ztop` were also emitted. No rain,
+ice, snow, graupel, or reflectivity field was present, as required by `ptype=6`.
+
+| File | Time (s) | Bytes | SHA-256 |
+| --- | ---: | ---: | --- |
+| `cm1out_000001.nc` | 0 | 877,496 | `a62959ceaae1c108ea0d2eb3805809615faf233a0e35096eeeceac18329ae9a5` |
+| `cm1out_000002.nc` | 200 | 1,406,783 | `79a4d4a95534b29dbd98286d1086dbf2a168af4484862b994e30e09af3b76c0a` |
+| `cm1out_000003.nc` | 400 | 1,460,096 | `bbe5d4d40bcf59acb4c87d44a2aa73060d5dca9eb72572ccc58ec87a6b33ecf3` |
+| `cm1out_000004.nc` | 600 | 1,464,637 | `b5bcad79828812d1f81b1d1972622d492e7967e97dc35a9c6b505301033e16c1` |
+| `cm1out_000005.nc` | 800 | 1,455,818 | `5dd3efac88159d955e6e4e2880ca3faf06c7024c3ffc9de4c6f45ba43e5493df` |
+| `cm1out_000006.nc` | 1000 | 1,466,280 | `cf5aeb035f784fc8f252f08a92b6bb6a78740431b6060a20bdbc30a3d6540699` |
+| `cm1out_000007.nc` | 1200 | 1,471,806 | `48091a925b4e9a9219c6f1e07902ea1a09a8f427113b5f25589d0a2ef322019e` |
+| `cm1out_000008.nc` | 1400 | 1,467,851 | `183ceae29cd44cc767a8987db4f218c9479d283d8f7330547d65992e02094752` |
+| `cm1out_000009.nc` | 1600 | 1,466,002 | `294fe39221cfe6af1d48ea65093bc0698d903bc848535d349371f898cf66b6d6` |
+| `cm1out_000010.nc` | 1800 | 1,475,479 | `316fb4c2c0bb2c93ef588eeae50516b78c2bca6087bc85cf62da7596c9a526b6` |
+| `cm1out_000011.nc` | 2000 | 1,474,791 | `41a9a6c8fdd7a81e3ea1074fb2cb717a312a46602e814e58c57f5eb1b81fd2ce` |
+| `cm1out_000012.nc` | 2200 | 1,476,258 | `e7ce11ae105ea035d9dc0f408647507a3ed51a7165eb75fae2fc38e3549d1572` |
+| `cm1out_000013.nc` | 2400 | 1,479,651 | `93d0b34b075a194f5c621c7f8d5b0ca8de82f51170fad30456962fdacaf298e7` |
+| `cm1out_000014.nc` | 2600 | 1,482,511 | `9410bcb03d2ff9f251356f01f9d19391eaa6d254f1bf6497f27901e461ff75e8` |
+| `cm1out_000015.nc` | 2800 | 1,484,687 | `49956dcf04d32f2569e8d585e4d76af23e4765012c8111a63b1d426b93fe0d73` |
+| `cm1out_000016.nc` | 3000 | 1,484,529 | `724a5acf714b2fa1a55e497a9a3c5343dea4608863db7a1702af5187d7b7063d` |
+| `cm1out_000017.nc` | 3200 | 1,485,877 | `9bc9e235bacfc73424651bf547c68c56cf24d3422741f5d732660ff647db4290` |
+| `cm1out_000018.nc` | 3400 | 1,486,332 | `82d3a544ff5026ad74ec066c90adcddf17251ef161bccb0053684b57c3f20375` |
+| `cm1out_000019.nc` | 3600 | 1,490,416 | `9caac2cd58d33852934579dc2973c183113383f23665f2ed8b17795759e67613` |
+| `cm1out_000020.nc` | 3800 | 1,490,540 | `c6920f6d47eb6b0fb8a2cfd7ca8ac901a49e92802d40f9f1f161937eadb76023` |
+| `cm1out_000021.nc` | 4000 | 1,492,797 | `0f8f31f2bf91ca80d430b326025cc734f4295e1ad6c687d2bae7f02ae0fe2b43` |
+
+## Cloud evolution and moist feedback
+
+| Time (s) | Max ql (g/kg) | Cloud cells | Largest component | Dominant centroid x / z (km) |
+| ---: | ---: | ---: | ---: | ---: |
+| 0 | 0 | 0 | 0 | none |
+| 200 | 0.0305 | 15 | 15 | -3.77 / 3.69 |
+| 600 | 0.0809 | 52 | 41 | -6.18 / 3.76 |
+| 1,200 | 0.1780 | 127 | 88 | -7.41 / 3.54 |
+| 1,600 | 0.2793 | 199 | 105 | 16.81 / 4.93 |
+| 2,400 | 0.4560 | 286 | 197 | 18.01 / 5.40 |
+| 3,200 | 0.5885 | 341 | 265 | 18.82 / 5.55 |
+| 4,000 | 0.6445 | 386 | 336 | 19.07 / 5.56 |
+
+The switch in dominant centroid at 1,600 s is not a cloud translating across the
+periodic domain. The native frames show the earlier windward layer and the separately
+formed lee-wave component; the latter becomes the largest connected component.
+
+Cloud-weighted mean `w` remained positive at every cloudy history. At 4,000 s it was
+`0.389 m/s`; 189 cloud cells were both ascending and at least 99% RH. The peak-`ql`
+cell itself can lie near the overturning/descending side of the mature cloud, but the
+weighted field and boundary profiles preserve the expected formation in ascent and
+evaporation in descent. Latent heating strengthens the wave without obscuring the
+alternating vertical-motion pattern.
+
+## Boundary, top, and startup assessment
+
+- The periodic west/east seam remained clear. No cloud originated in the outer 10 km
+  edge sectors or the far-upstream source sector.
+- The first native frame at 0 s had `ql=0` everywhere and maximum RH 94.93%. Cloud
+  first appeared at 200 s over the windward slope, so it was not initialized or
+  broadly produced by sounding adjustment.
+- There was no Rayleigh absorber, matching the selected 25 km source sensitivity
+  case. Wave motion reached the upper domain, but the top 2 km remained cloud-free and
+  its maximum `|w|` was small relative to the interior maximum. Top behavior therefore
+  does not compromise the below-9-km cloud interpretation over 4,000 s.
+- Total mass and moisture drift were about 0.003%, with no precipitation sink. This is
+  small relative to the condensate signal and does not change the disposition.
+
+## Runtime-only visual review
+
+Two runtime-only browser renders were inspected directly from the native NetCDF:
+
+1. an expanded-height four-frame view for detailed wave/cloud inspection; and
+2. an equal physical x/z scale view cropped to `x=-30..50 km`, `z=0..12 km`.
+
+Both views used red for ascent, blue for descent, and outlined cells for
+`ql >= 0.001 g/kg`. The equal-scale view is the more honest geometry check: it shows a
+broad mountain, a shallow windward streamer, and a substantial but not artificially
+stretched lee-wave cloud. The 4,000 s dominant component spans approximately
+`x=13.5..26.5 km` and `z=2.42..8.45 km`. Browser inspection at desktop size found all
+four canvases correctly proportioned and no console errors. The HTML, JSON, and PNG
+review artifacts remain runtime-only and are not committed.
+
+## Limitations and unresolved questions
+
+- This is one two-dimensional historical windstorm case, not a general validation of
+  moist orographic cloud behavior.
+- CM1's Smagorinsky closure and Gal-Chen coordinate are close mappings, not pointwise
+  reproductions of Toy's model.
+- The source-supported 25 km top removes the unspecified upper stretching but retains
+  more reflection risk than the 48 km main configuration.
+- The profile is deterministically reconstructed from the archived observation rather
+  than the authors' private processed sounding, so quantitative amplitudes should not
+  be treated as a paper reproduction.
+- The cloud grows through the 4,000 s checkpoint rather than reaching a steady mature
+  state. A future product-slice decision would need to choose what portion of this
+  evolution is experientially useful; this report does not make that decision.
+- The observed shallow low-level wind reversal is retained. Cloud-bearing flow from
+  roughly 2.5 to 8.5 km is left-to-right in the runtime review frame at about
+  16-36 m/s.
+
+## Final disposition
+
+`advance_as_candidate_world_evidence`
+
+The source lock is defensible, the only authorized process passed integrity checks,
+and the native evidence shows clear-air formation, coherent persistence, terrain/wave
+locking, active descent/evaporation, and a visually legible gravity-wave cloud system.
+This disposition records feasibility evidence only. It does not approve the candidate
+World or authorize another CM1 process.

--- a/docs/research/mountain-waves/moist-reference-case-selection.md
+++ b/docs/research/mountain-waves/moist-reference-case-selection.md
@@ -1,0 +1,234 @@
+# Moist Mountain-Wave Reference Case Selection
+
+Status: source locked for the single process conditionally authorized by issue #407.
+
+This artifact selects one bounded scientific case. It does not define or approve a
+Cloud World, Recipe, Control, Lens, Comparison, product surface, or reusable terrain
+architecture.
+
+## Decision question
+
+Can CM1 r21.1 reproduce a source-backed, initially clear, two-dimensional
+orographic-cloud response in which cloud condensate forms in terrain-forced ascent,
+persists as a coherent wave feature, and reduces or evaporates in descending flow,
+without cloudy initialization or an invented humidity profile?
+
+## Candidate comparison
+
+The search was deliberately limited to three primary-source cases.
+
+| Candidate | Recoverable setup | Initially clear / zero condensate | Native 2-D | CM1 r21.1 mapping | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| Toy (2011), 11 January 1972 Boulder windstorm moist mountain-wave experiment | Domain, grid, Agnesi terrain, boundaries, duration checkpoints, nonprecipitating moisture treatment, and the exact upstream observation are recoverable through Toy (2011), Toy and Randall (2009), Toy's 2008 dissertation, Doyle et al. (2000), and the NOAA IGRA observation. | Yes. Toy explicitly states that the horizontally uniform initial atmosphere is unsaturated; NOAA reports a maximum 95% RH in the retained moist profile, and the source experiment adds moisture but no initial cloud. | Yes, `x-z`. | External `input_sounding`, deterministic `itern=4` terrain, and CM1's reversible water-only physics require no source change. | **Selected.** It directly demonstrates layered windward, hydraulic-jump, and lee-wave cloud formation from clear air. |
+| Durran and Klemp (1983), observed-moisture Boulder windstorm | Most numerical settings and the observed-moisture result are published. The source reports model clouds similar to observations and no precipitation in the drier observed-moisture case. | Yes for the observed-moisture experiment. | Yes. | Dynamics and warm-cloud physics are representable. | Rejected as the implementation reference because the temperature and wind profiles used by Peltier and Clark are published graphically rather than as an exact numerical ledger. It remains supporting mechanism evidence. |
+| Miglietta and Rotunno (2005), moist nearly neutral ridge flow | The idealized ridge and sensitivity family are well documented. | No. The experiment begins saturated and explicitly varies initial cloud water. | Yes. | Representable only by beginning cloudy or by changing the source case. | Rejected because it cannot answer the clear-air-to-cloud decision question. |
+
+Primary references:
+
+- Michael D. Toy, 2011, [Incorporating Condensational Heating into a Nonhydrostatic Atmospheric Model Based on a Hybrid Isentropic-Sigma Vertical Coordinate](https://doi.org/10.1175/MWR-D-10-05015.1), *Monthly Weather Review*, 139, 2940-2954.
+- Michael D. Toy and David A. Randall, 2009, [Design of a Nonhydrostatic Atmospheric Model Based on a Generalized Vertical Coordinate](https://doi.org/10.1175/2009MWR2834.1), *Monthly Weather Review*, 137, 2305-2330.
+- J. D. Doyle et al., 2000, [An Intercomparison of Model-Predicted Wave Breaking for the 11 January 1972 Boulder Windstorm](https://doi.org/10.1175/1520-0493(2000)128%3C0901:AIOMPW%3E2.0.CO;2), *Monthly Weather Review*, 128, 901-914.
+- Dale R. Durran and Joseph B. Klemp, 1983, [A Compressible Model for the Simulation of Moist Mountain Waves](https://doi.org/10.1175/1520-0493(1983)111%3C2341:ACMFTS%3E2.0.CO;2), *Monthly Weather Review*, 111, 2341-2361.
+- M. M. Miglietta and R. Rotunno, 2005, [Simulations of Moist Nearly Neutral Flow over a Ridge](https://doi.org/10.1175/JAS3410.1), *Journal of the Atmospheric Sciences*, 62, 1410-1427.
+
+The exact observed profile comes from NOAA NCEI's [IGRA v2.2 period-of-record file for station USM00072476](https://www.ncei.noaa.gov/data/integrated-global-radiosonde-archive/access/data-por/USM00072476-data.txt.zip), using only the sounding headed `#USM00072476 1972 01 11 12`. The extracted 79-line source record has SHA-256:
+
+```text
+33953228bc6bcdf7d65c5cf800b5f8bed9a71aedda910edb4d32a28bef37e652
+```
+
+The field interpretation follows NOAA's [IGRA v2.2 sounding-data format](https://www.ncei.noaa.gov/data/integrated-global-radiosonde-archive/doc/igra2-data-format.txt). The downloaded format document used for this lock has SHA-256:
+
+```text
+dfd7b4d2dd18a255477455a7caefd12cb21c30549a1e70cbc3a51db9f41c1dfe
+```
+
+The period-of-record zip is updated by NOAA as new soundings arrive, so its whole-file
+hash is not the immutable identity. The extracted historical record above is.
+
+## Selected case identity
+
+```text
+case_id: cm1_r21_1_toy2011_boulder_moist_wave_4000s_v1
+scientific case: Toy (2011) 11 January 1972 Boulder moist mountain-wave experiment
+checkpoint: 4000 s
+technical purpose: one clear-upstream moist orographic-cloud feasibility run
+```
+
+Toy (2011) publishes cloud fields at 1,200, 4,000, and 8,000 s. The selected
+4,000-second checkpoint is long enough to include the initial layered windward clouds
+and developed downstream wave response while remaining inside the approximately
+three-hour window for which Toy's source-backed 25 km-top sensitivity configuration
+was reported to agree closely with the 48 km configuration below 25 km.
+
+## Numerical ledger
+
+Every material value below has one classification:
+
+- **direct source**: stated in the primary paper, dissertation, or observation;
+- **exact derivation**: calculated without a free parameter from direct-source values;
+- **CM1 mapping**: required to express the source case in pinned CM1 r21.1;
+- **operational evidence choice**: affects output or evaluation, not the physical case.
+
+### Domain and terrain
+
+| Item | Locked value | Classification and evidence |
+| --- | --- | --- |
+| Dimensionality | `nx=220`, `ny=1`, `nz=125`; one `x-z` plane | Direct source: Toy (2011) and Toy (2008) specify a two-dimensional experiment; 220 km / 1 km and 25 km / 0.2 km give the exact counts. |
+| Horizontal domain | 220 km centered on the ridge; scalar `xh` from -109.5 to +109.5 km | Direct source extent and spacing; CM1 centered-origin mapping with `iorigin=2`. |
+| Horizontal spacing | `dx=1000 m`; singleton `dy=1000 m` | Direct source `dx`; `dy` is an inactive singleton-dimension CM1 mapping. |
+| Vertical domain | Uniform `dz=200 m`, active top 25,000 m | Direct source sensitivity configuration: 125 levels in the lowest 25 km; Toy (2008) reports nearly identical sub-25-km results with the top at 25 km for the experiment period. |
+| Timestep | Fixed `dtl=2 s` | CM1 mapping: the pinned official `nh_mountain_waves` case uses 2 s with the same 200 m vertical spacing and vertically implicit acoustic solver. It is not a claim about Toy's model timestep. |
+| Duration | `timax=4000 s` | Direct source checkpoint in Toy (2011) Fig. 1a. |
+| Terrain | `z_s(x)=2000/[1+((x-500)/10000)^2]` m | Direct source height 2 km, half-width 10 km, and witch-of-Agnesi form. The +500 m center is the CM1 half-cell mapping that places the continuous ridge crest on one centered scalar point. |
+| Terrain implementation | `itern=4`, one little-endian IEEE-754 float32 direct-access record, shape `(ny,nx)` with `x` fastest | CM1 mapping from r21.1 `src/init_terrain.F`; generated `perts.dat` remains runtime-only and is hash/readback audited. |
+| Maximum analytic slope | `0.1299038106` | Exact derivation from the Agnesi curve: `9 h/(8 sqrt(3) a)`. |
+| Crest grid compression | bottom-layer thickness at the 2 km crest is 92% of the flat value, or 184 m | Exact derivation from CM1's Gal-Chen transform: `(ztop-h)/ztop`. No undocumented CM1 slope tolerance is asserted. |
+
+### Initial atmosphere
+
+The model reference surface is the observed 850 hPa level at 1,514 m MSL, mapped to
+`z=0`, following Toy's stated 850 hPa reference pressure. Pressure-level records from
+850 through 17 hPa are retained; the last row maps to 25,846 m and therefore satisfies
+CM1's requirement that the final sounding row exceed the 25 km model top.
+
+| Item | Locked construction | Classification and evidence |
+| --- | --- | --- |
+| Pressure / height | Reported IGRA pressure and geopotential height; model height is `reported_height - 1514 m` | Direct observation plus exact offset. |
+| Temperature | Reported IGRA temperature in tenths C, converted by `T_K=T_C+273.15` | Direct observation plus exact unit conversion. |
+| Potential temperature | `theta=T_K*(100000/p)^(Rd/Cp)` with CM1 constants `Rd=287.04`, `Cp=1004 J kg-1 K-1` | Exact derivation and CM1 input mapping. |
+| Water vapor where RH is reported | `qv=RH*0.622*es(T)/(p-es(T))`, using CM1 r21.1's Bolton liquid saturation formula | Direct observed RH plus exact CM1-compatible derivation. |
+| Water vapor where RH is absent | Input `qv=0`; r21.1 replaces values below `1e-12 kg/kg` with 0.01% liquid RH during `isnd=7` initialization | Required CM1 mapping, explicitly audited. It does not create condensate. |
+| Wind | Cross-ridge `u=-speed*sin(direction)` from reported meteorological direction and speed; `v=0` | Exact derivation of the observed eastward component; direct 2-D mapping. |
+| Surface state | `p=850 hPa`; `T=272.55 K`; `theta=285.5125 K`; `qv=1.767594 g/kg`; `u=-4.2858 m/s` | Direct 850 hPa observation plus exact conversions. The weak easterly first level is retained rather than tuned away. |
+| Maximum source RH | 95% at reported 544 hPa / model 3,438 m | Direct observation. The source-backed minimum unsaturated margin is 5 percentage points. |
+| Initial condensate | `ql=0` everywhere; no `qc`, `qr`, `qi`, `qs`, or `qg` category exists in the chosen two-variable scheme | Direct source intent and CM1 `isnd=7` / `ptype=6` mapping. Any positive initial `ql` blocks acceptance. |
+| Stability | Whatever follows from the retained observed `theta(z)` profile after r21.1 hydrostatic interpolation | Direct observation and exact CM1 behavior; no analytic stability is substituted. |
+
+CM1 r21.1 reads the generated external sounding as:
+
+```text
+surface pressure (mb), surface theta (K), surface qv (g/kg)
+z (m), theta (K), qv (g/kg), u (m/s), v (m/s)
+```
+
+It linearly interpolates wind to staggered physical heights. For thermodynamics, it
+constructs hydrostatic pressure, converts the supplied `qv` rows to RH, linearly
+interpolates `theta` and RH to each column's terrain-aware physical scalar heights,
+then reconstructs hydrostatic pressure and `qv`. Package audit records every emitted
+row and verifies finite values, strict height ordering, final height above the active
+top, exact source-record identity, and a maximum source RH of 95%.
+
+### Moist physics
+
+| Setting | Locked value | Classification and evidence |
+| --- | --- | --- |
+| Moist equations | `imoist=1`, `eqtset=2` | Required CM1 mapping; equation set 2 conserves moist mass and energy including hydrometeor heat capacity. |
+| Microphysics | `ptype=6`, Rotunno-Emanuel water-only with `qv` and `ql` | Required CM1 mapping to Toy's nonprecipitating vapor/cloud-water treatment. |
+| Liquid fall speed | `v_t=0 m/s`; `efall=0` | Required CM1 mapping for reversible, nonprecipitating condensate with conserved total water. |
+| Saturation adjustment | Active r21.1 `satadj` for `ptype=6` | Required CM1 behavior; latent heating accompanies conversion between `qv` and `ql`. |
+| Precipitation and ice | Absent | Direct source behavior for this experiment. No rain, ice, snow, graupel, reflectivity, or lookup table is added. |
+| Runtime files | `input_sounding` and `perts.dat` only, in addition to `namelist.input` | Exact consumed-file mapping. No `LANDUSE.TBL`, radiation table, aerosol table, or surface file is consumed. |
+
+### Boundaries, damping, and diffusion
+
+| Item | Locked value | Classification and evidence |
+| --- | --- | --- |
+| West/east | `wbc=ebc=1`, periodic | Direct source. The upstream-sector test therefore concerns the clear source region, not an open-boundary inflow. |
+| South/north | `sbc=nbc=1`, periodic singleton `y` | Required 2-D CM1 mapping. |
+| Bottom / top | `bbc=tbc=1`, free slip; terrain impermeability remains active | Direct source free-slip lower boundary and rigid lid; CM1 mapping. |
+| Inflow nudging / mass limiter | `nudgeobc=0`, `roflux=0`, `apmasscon=0` | Direct/CM1 mapping; these open-boundary mechanisms are inapplicable to the periodic domain. |
+| Rayleigh damping | `irdamp=0`, `hrdamp=0` | Direct source 25 km-top sensitivity configuration: no absorbing layer. Top evidence remains an explicit acceptance check. |
+| Rotation / large-scale pressure gradient | `icor=0`, `lspgrad=0` | Direct source: no rotation. |
+| Turbulence | `cm1setup=1`, `sgsmodel=2`, `tconfig=2`, no PBL or surface fluxes | CM1 mapping to the source's modified Smagorinsky first-order closure. CM1's closure is not numerically identical and is disclosed below. |
+| Advection / pressure solver | Pinned official mountain-wave defaults: fifth-order scalar/velocity advection and `psolver=3` | CM1 mapping. These are implementation numerics, not claimed source equivalence. |
+| Initial perturbation | `iinit=0`, `irandp=0` | Direct source mechanism: terrain interacting with the horizontally uniform sounding is the forcing. |
+
+### Output and evidence lock
+
+| Item | Locked value | Classification and rationale |
+| --- | --- | --- |
+| Native history | NetCDF, one file per time, `output_format=2`, `output_filetype=2`, no nominal-height interpolation | Operational evidence choice required for native terrain-aware evaluation. |
+| Cadence | 200 s from 0 through 4,000 s inclusive; 21 expected histories | Operational evidence choice. It resolves the published 1,200 and 4,000 s checkpoints and provides repeated formation/evaporation evidence. |
+| Required fields | `zs`, `zhval`, `th`, `prs`, `qv`, `ql`, scalar-interpolated and native `u/v/w`, plus available SGS diagnostics and CM1 stats/logs | Operational evidence choice tied to the predeclared questions. |
+| Numerical clear floor | `ql <= 1e-12 kg/kg` at initial time | CM1 mapping to the scheme's small-value scale; any larger initial value is recorded and blocks a clear initialization finding. |
+| Interpretable cloud floor | `ql >= 1e-6 kg/kg` (0.001 g/kg) | Case-specific operational evidence choice, ten million times the numerical floor and equal to Cloud Chamber's existing explicit cloud-water visibility floor. It is not a universal cloud definition. |
+| Material peak check | `max(ql) >= 2e-4 kg/kg` (0.2 g/kg) | Case-specific primary-source check: Durran and Klemp's observed-moisture Boulder figure distinguishes cloud water above 0.2 g/kg. It supplements, rather than replaces, the lower formation floor. |
+| Coherence | At least one four-neighbor-connected `x-z` component of 8 cells at or above the interpretable floor | Operational evidence choice that excludes isolated pixels at this exact 1 km by 0.2 km grid. |
+| Persistence | A coherent component at or above the floor at 3 consecutive saved times (at least 400 s from first to third frame) | Operational evidence choice. It rejects a one-frame transient without making a universal lifetime claim. |
+| Interior formation region | `-40 <= x <= 60 km`, below 12 km MSL-equivalent model height | Operational region centered on the 0.5 km crest and covering the source-described windward, jump, and lee-wave cloud response. |
+| Upstream clear sector | `-100 <= x <= -60 km`, below 12 km | Operational contamination check far upstream of the ridge and away from the periodic seam. |
+| Edge sectors | outermost 10 km on each side | Operational periodic-seam contamination check. |
+
+Relative humidity is recomputed from native `qv`, `prs`, and temperature derived from
+native `th` and `prs`, using the same Bolton liquid-saturation formula as r21.1.
+Physical heights come from native `zhval`; `zs` and the final `zf` coordinate independently
+check terrain and active-top integrity.
+
+## Predeclared criteria
+
+### Successful feasibility evidence
+
+All of the following are required:
+
+1. CM1 exits zero, reports normal completion, and emits all 21 exact times with finite required fields.
+2. Native terrain matches the generated Agnesi record, physical heights are monotonic, and the active top is 25 km.
+3. Initial `ql` is at or below `1e-12 kg/kg` everywhere; the initial and upstream source sectors are below the interpretable cloud floor.
+4. The first `ql >= 1e-6 kg/kg` occurs in the interior region, not an edge sector, and is colocated with positive terrain-forced `w` and RH approaching or reaching one.
+5. At least one 8-cell connected cloud component persists for three consecutive histories and the run reaches the 0.2 g/kg material-peak check.
+6. A cloud-bearing ascent phase is followed spatially or temporally by a contiguous descending phase in which RH falls below saturation and `ql` falls below the interpretable floor. The evaluator must retain the numeric profiles; a label alone is insufficient.
+7. The dominant cloud response remains organized relative to the ridge and wave pattern rather than appearing as a boundary-originating translated patch.
+8. Wave structure remains interpretable after latent heating; edge, periodic seam, top, and startup evidence do not compromise the central result.
+9. Native geometry and cloud fields are sufficient for honest terrain-aware inspection, and measured runtime/storage remain practical on the local machine.
+10. Runtime-only visual review shows a legible cloud response with potential experiential value.
+
+### Inconclusive evidence
+
+The result is inconclusive if required fields/times are absent, source and runtime RH
+contradict, condensate remains between numerical and interpretable floors, cadence
+cannot establish persistence or evaporation, edge/top/startup effects overlap the
+central interpretation, or evaluator and source behavior disagree.
+
+### Rejection evidence
+
+Reject or defer if the run starts cloudy, forms cloud first at a periodic edge, never
+forms a coherent interior cloud, does not reach a materially legible condensate scale,
+cannot show a descent/evaporation phase, becomes numerically unstable, loses terrain
+or coordinate integrity, or costs disproportionately more than the evidence is worth.
+
+## Source-to-CM1 differences
+
+| Source behavior | CM1 implementation | Reason | Expected consequence | Acceptable for this gate? |
+| --- | --- | --- | --- | --- |
+| Toy compares hybrid-isentropic and terrain-following sigma coordinates. | CM1 uses its Gal-Chen terrain-following coordinate. | Pinned r21.1 capability; the source explicitly includes the sigma-coordinate comparison. | Moisture transport details may differ, but clear-air formation and terrain-wave organization remain directly testable. | Yes. |
+| Main published run has a 48 km top and 205 levels, stretched above 35 km. | Source-supported sensitivity configuration uses a 25 km top and 125 uniform 200 m levels. | Exact high-level stretching is not numerically published; Toy (2008) reports nearly identical below-25-km results over the experiment period with the 25 km top. | Greater risk of top reflection, explicitly evaluated; much lower local cost. | Yes, only if top evidence remains separated from cloud interpretation. |
+| Source model uses a modified Smagorinsky closure with Richardson dependence. | CM1 `cm1setup=1`, `sgsmodel=2`, `tconfig=2`. | Closest source-faithful built-in closure without source modification. | Turbulent mixing magnitudes are not expected to match pointwise; early laminar cloud formation and gross wave locking remain assessable. | Yes for feasibility, not quantitative validation. |
+| Source uses a reversible, nonprecipitating condensation treatment. | CM1 `ptype=6`, `v_t=0`, saturation adjustment, `qv+ql`. | Simplest built-in water-only reversible treatment. | Condensation/evaporation and latent heating are represented; no rain or ice can obscure the mechanism. | Yes. |
+| Source paper inherits its processed sounding from earlier work. | Package uses the exact NOAA IGRA observation identified by station/time and deterministic conversions. | Supplies an auditable numerical profile instead of digitizing a figure. | Minor processing differences from the authors' private/intercomparison profile may alter detailed wave amplitude; the reported layers, clear RH margin, and source identity are preserved. | Yes for feasibility; disclose in result interpretation. |
+| Source ridge is centered continuously. | Ridge center is +0.5 grid cell so one scalar point samples the exact 2 km crest. | Required discrete-grid mapping. | Only a half-cell coordinate-origin shift in a periodic domain. | Yes. |
+| Toy's timestep is not published as a transferable CM1 value. | `dtl=2 s`, the pinned official CM1 mountain-wave value for 200 m vertical spacing. | Required CM1 numerical mapping. | Affects cost and numerical integration, not the specified atmospheric state. | Yes if CFL/runtime diagnostics are clean. |
+| Paper figures are sparse in time. | Native output every 200 s. | Required persistence, formation, and evaporation evidence. | More storage only; no physical tendency changes. | Yes. |
+| Source renderer/coordinate plots are not Cloud Chamber contracts. | Runtime-only terrain-aware cross sections use native `zs`, `zhval`, `ql`, `qv`, `w`, and `th`. | Required review evidence. | No model consequence and no frontend/product implication. | Yes. |
+
+No material difference is intentionally left undocumented. If implementation or CM1
+startup reveals another active difference, execution is blocked rather than silently
+accepting it.
+
+## Conditional execution gate
+
+The one process authorized by issue #407 may start only after:
+
+- this artifact and the complete package/evaluator implementation are committed;
+- focused tests and `scripts/check.sh` pass;
+- the worktree is clean at that exact implementation commit;
+- the pinned CM1 r21.1 source, executable, documentation, critical-source hashes, and NetCDF linkage match Gate B provenance;
+- generated sounding and terrain hashes/readback audits pass;
+- the complete namelist audit contains only the locked differences above;
+- the consumed runtime-file checklist contains exactly `input_sounding` and `perts.dat`;
+- expected histories, output size, and twice-required free space pass;
+- no CM1/MPI process is active;
+- the target contains no output-like file; and
+- no prior execution exists for this technical case identity.
+
+The authorization remains exactly one full 4,000-second process: no smoke, tuning,
+retry, alternate executable, LAN worker, or second process.

--- a/scripts/run_moist_mountain_wave_experiment.py
+++ b/scripts/run_moist_mountain_wave_experiment.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Package, explicitly execute, and evaluate issue #407's one authorized process."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_ROOT = REPO_ROOT / "app" / "backend"
+BACKEND_VENV_PYTHON = BACKEND_ROOT / ".venv" / "bin" / "python"
+
+if (
+    BACKEND_VENV_PYTHON.exists()
+    and Path(sys.executable).resolve() != BACKEND_VENV_PYTHON.resolve()
+):
+    os.execv(
+        str(BACKEND_VENV_PYTHON),
+        [str(BACKEND_VENV_PYTHON), str(Path(__file__).resolve()), *sys.argv[1:]],
+    )
+if sys.version_info < (3, 12):  # noqa: UP036
+    raise SystemExit(
+        "run_moist_mountain_wave_experiment.py requires Python 3.12 or newer."
+    )
+
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError  # noqa: E402
+from cloud_chamber.moist_mountain_wave_case import (  # noqa: E402
+    MoistMountainWaveCaseError,
+    evaluate_moist_mountain_wave_run,
+    generate_moist_mountain_wave_package,
+    load_moist_mountain_wave_package,
+    preflight_package_for_execution,
+    write_moist_mountain_wave_evidence,
+)
+from cloud_chamber.mountain_wave_case import MountainWaveCaseError  # noqa: E402
+from cloud_chamber.run_manifest import LifecycleState  # noqa: E402
+from cloud_chamber.settings import load_settings  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    runtime_home = Path(args.runtime_home).expanduser() if args.runtime_home else None
+    settings = load_settings(home=runtime_home)
+    run_id = args.run_id or _default_run_id()
+
+    try:
+        package_dir = settings.runtime_home.expanduser() / "runs" / run_id
+        if args.execute and package_dir.exists():
+            package = load_moist_mountain_wave_package(settings=settings, run_id=run_id)
+        else:
+            package = generate_moist_mountain_wave_package(
+                settings=settings, run_id=run_id
+            )
+        preflight = preflight_package_for_execution(settings=settings, package=package)
+        if not preflight.passed:
+            raise MoistMountainWaveCaseError(
+                "Hard execution preflight did not fully pass."
+            )
+        if not args.execute:
+            print(
+                json.dumps(
+                    {
+                        "status": "source_locked_package_and_hard_preflight_complete_not_executed",
+                        "run_id": run_id,
+                        "manifest_path": str(package.manifest_path),
+                        "case_manifest_path": str(package.case_manifest_path),
+                        "execution_preflight": str(
+                            package.package_dir / "execution_preflight.json"
+                        ),
+                        "execution_requires_explicit_flag": "--execute",
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+
+        manager = LocalRunManager(settings=settings)
+        status = manager.launch(package.manifest_path)
+        try:
+            while status.lifecycle_state in {
+                LifecycleState.QUEUED,
+                LifecycleState.RUNNING,
+            }:
+                time.sleep(args.poll_seconds)
+                status = manager.status(package.manifest_path)
+        except KeyboardInterrupt:
+            manager.cancel()
+            raise
+
+        if status.lifecycle_state != LifecycleState.COMPLETED or status.exit_code != 0:
+            print(
+                json.dumps(
+                    {
+                        "status": "single_authorized_process_failed_no_retry_permitted",
+                        "run_id": run_id,
+                        "lifecycle_state": status.lifecycle_state.value,
+                        "exit_code": status.exit_code,
+                    },
+                    indent=2,
+                ),
+                file=sys.stderr,
+            )
+            return 2
+
+        evidence = evaluate_moist_mountain_wave_run(settings=settings, package=package)
+        evidence_path = package.package_dir / "moist_mountain_wave_evidence.json"
+        write_moist_mountain_wave_evidence(evidence_path, evidence)
+        print(
+            json.dumps(
+                {
+                    "status": "single_authorized_process_completed_and_evaluated",
+                    "run_id": run_id,
+                    "manifest_path": str(package.manifest_path),
+                    "evidence_path": str(evidence_path),
+                    "wall_clock_seconds": evidence.runtime_integrity[
+                        "wall_clock_seconds"
+                    ],
+                    "peak_ql_kg_kg": evidence.cloud_and_wave["peak_cloud_frame"][
+                        "maximum_ql_kg_kg"
+                    ],
+                    "predeclared_checks": evidence.predeclared_checks,
+                    "smoke_tuning_retry_or_second_process": False,
+                },
+                indent=2,
+            )
+        )
+        return 0
+    except KeyboardInterrupt:
+        print(
+            "moist-mountain-wave: authorized process canceled; no retry is permitted",
+            file=sys.stderr,
+        )
+        return 130
+    except (
+        MoistMountainWaveCaseError,
+        MountainWaveCaseError,
+        LocalRunManagerError,
+    ) as exc:
+        print(f"moist-mountain-wave: {exc}", file=sys.stderr)
+        return 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate the exact source-locked moist mountain-wave package. Execution is "
+            "opt-in and limited to one complete 4000-second CM1 process."
+        )
+    )
+    parser.add_argument("--run-id", help="Runtime-local technical run identifier.")
+    parser.add_argument(
+        "--runtime-home",
+        help="Cloud Chamber runtime home. Defaults to configured local settings.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="After repeated hard preflight passes, start the one authorized CM1 process.",
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=float,
+        default=2.0,
+        help="Status polling interval while the authorized process is active.",
+    )
+    return parser
+
+
+def _default_run_id() -> str:
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"moist-mountain-wave-toy-1972-{timestamp}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_moist_mountain_wave_experiment.py
+++ b/scripts/run_moist_mountain_wave_experiment.py
@@ -31,16 +31,20 @@ if sys.version_info < (3, 12):  # noqa: UP036
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
-from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError  # noqa: E402
 from cloud_chamber.moist_mountain_wave_case import (  # noqa: E402
     MoistMountainWaveCaseError,
     evaluate_moist_mountain_wave_run,
     generate_moist_mountain_wave_package,
     load_moist_mountain_wave_package,
+    load_preserved_moist_mountain_wave_run,
     preflight_package_for_execution,
+    reevaluate_preserved_moist_mountain_wave_run,
     write_moist_mountain_wave_evidence,
 )
-from cloud_chamber.mountain_wave_case import MountainWaveCaseError  # noqa: E402
+from cloud_chamber.mountain_wave_case import (  # noqa: E402
+    MountainWaveCaseError,
+    verified_clean_git_commit,
+)
 from cloud_chamber.run_manifest import LifecycleState  # noqa: E402
 from cloud_chamber.settings import load_settings  # noqa: E402
 
@@ -53,6 +57,41 @@ def main(argv: list[str] | None = None) -> int:
     run_id = args.run_id or _default_run_id()
 
     try:
+        if args.reevaluate_preserved_run:
+            if args.run_id is None:
+                raise MoistMountainWaveCaseError(
+                    "Offline reevaluation requires the exact preserved --run-id."
+                )
+            package = load_preserved_moist_mountain_wave_run(
+                settings=settings, run_id=run_id
+            )
+            evidence = reevaluate_preserved_moist_mountain_wave_run(
+                settings=settings,
+                package=package,
+                evaluator_commit=verified_clean_git_commit(),
+            )
+            evidence_path = package.package_dir / "moist_mountain_wave_evidence_v2.json"
+            write_moist_mountain_wave_evidence(evidence_path, evidence)
+            assert evidence.offline_reevaluation is not None
+            print(
+                json.dumps(
+                    {
+                        "status": "preserved_run_offline_reevaluated_without_cm1",
+                        "run_id": run_id,
+                        "evidence_path": str(evidence_path),
+                        "implementation_commit": package.implementation_commit,
+                        "evaluator_commit": evidence.offline_reevaluation[
+                            "evaluator_commit"
+                        ],
+                        "preserved_artifacts_unchanged": True,
+                        "run_manager_constructed_or_invoked": False,
+                        "predeclared_checks": evidence.predeclared_checks,
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+
         package_dir = settings.runtime_home.expanduser() / "runs" / run_id
         if args.execute and package_dir.exists():
             package = load_moist_mountain_wave_package(settings=settings, run_id=run_id)
@@ -83,15 +122,26 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 0
 
+        from cloud_chamber.local_run_manager import (
+            LocalRunManager,
+            LocalRunManagerError,
+        )
+
         manager = LocalRunManager(settings=settings)
-        status = manager.launch(package.manifest_path)
+        try:
+            status = manager.launch(package.manifest_path)
+        except LocalRunManagerError as exc:
+            raise MoistMountainWaveCaseError(str(exc)) from exc
         try:
             while status.lifecycle_state in {
                 LifecycleState.QUEUED,
                 LifecycleState.RUNNING,
             }:
                 time.sleep(args.poll_seconds)
-                status = manager.status(package.manifest_path)
+                try:
+                    status = manager.status(package.manifest_path)
+                except LocalRunManagerError as exc:
+                    raise MoistMountainWaveCaseError(str(exc)) from exc
         except KeyboardInterrupt:
             manager.cancel()
             raise
@@ -140,11 +190,7 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 130
-    except (
-        MoistMountainWaveCaseError,
-        MountainWaveCaseError,
-        LocalRunManagerError,
-    ) as exc:
+    except (MoistMountainWaveCaseError, MountainWaveCaseError) as exc:
         print(f"moist-mountain-wave: {exc}", file=sys.stderr)
         return 2
 
@@ -161,10 +207,19 @@ def _build_parser() -> argparse.ArgumentParser:
         "--runtime-home",
         help="Cloud Chamber runtime home. Defaults to configured local settings.",
     )
-    parser.add_argument(
+    execution_mode = parser.add_mutually_exclusive_group()
+    execution_mode.add_argument(
         "--execute",
         action="store_true",
         help="After repeated hard preflight passes, start the one authorized CM1 process.",
+    )
+    execution_mode.add_argument(
+        "--reevaluate-preserved-run",
+        action="store_true",
+        help=(
+            "Fail closed while reevaluating the exact hash-pinned completed run; this "
+            "mode never imports, constructs, or invokes the run manager."
+        ),
     )
     parser.add_argument(
         "--poll-seconds",


### PR DESCRIPTION
Closes #407

## Summary

- source-locks the Toy (2011) 11 January 1972 Boulder moist mountain-wave experiment, using the exact NOAA IGRA Grand Junction 12Z profile and a complete source-to-CM1 mapping
- adds a deterministic CM1 r21.1 package, hard preflight, and native numbered-NetCDF evaluator with fixture-only automated tests
- records the one authorized run and its scientific/runtime evidence in the run report
- adds the PM-authorized fail-closed offline reevaluation of that exact preserved run
- changes no frontend, product document, World, Recipe, Control, Lens, Comparison, navigation, or generic terrain contract

## Process execution

The CM1 process **did run**.

- run ID: `moist-mountain-wave-toy-1972-20260721T215226Z`
- package/run implementation commit: `ebdbb528c92c57d3d4a19080b4bddc4820b0bc6a`
- source-lock SHA-256: `939c4b7c6b067c125402383e7ed966b6e09eed2f5e0c0762ca6331a6f381b20b`
- exactly one full selected-case CM1 process ran for the configured 4,000 s
- no shortened smoke process, tuning process, retry, alternate executable, LAN worker, or second process ran

The hard preflight passed immediately before launch, including source/provenance hashes, NetCDF linkage, complete namelist audit, exact sounding and terrain readback, consumed-file inventory, expected histories/storage, doubled free-space requirement, clean implementation commit, no active CM1/MPI process, no prior execution, and an output-clean target package.

## Authorized offline evaluator correction

No CM1 process, package regeneration, configuration change, or run-manager action occurred during the correction.

- corrected evidence version: `moist_mountain_wave_gate_d_e_v2`
- offline evaluator commit: `133e4840d9bba9cf0e5199eabc8ae36146ff21d7`
- corrected runtime-only evidence SHA-256: `4d68ab004ad62ac7bb4d1668743caa67f64ed341f1e025bdbc427fe668af08ad`
- original implementation commit retained: `ebdbb528c92c57d3d4a19080b4bddc4820b0bc6a`
- the source lock and 30 pinned artifacts were verified before and after evaluation with identical hash maps
- the pinned set covers both manifests, generated namelist, sounding, terrain record, execution preflight, stdout/stderr, stats NetCDF, and all 21 native histories
- the evaluator-only path rejects any other run ID and does not import, construct, or invoke the run manager

The corrected evidence now:

- requires the same first cloudy frame to be interior, edge-clear, ascending, and near-saturated; at 200 s, 12 of 15 first-frame cloud cells meet the ascent/saturation condition, and the peak cell has `w=0.371 m/s` and RH `100.67%`
- retains every cloud component's cell count, physical extent, centroid, peak `ql`, and cloud-weighted `w`/RH at every time
- retains east/downstream clear-descending evidence by time with connected-group counts, physical bounds, and numeric `w`, RH, and `ql` summaries
- verifies final nominal `zf`, runtime `ztop`, configured `nz x dz`, and the source-locked 25 km top at every history
- retains lower-boundary tangency metrics from actual staggered `u`/`v` and bottom `w`; initial/final residual RMS values are `0.0284/0.0558 m/s`, with correlations `0.99984/0.99985`
- retains the native initial upstream wind profile, per-time upstream flow, and stability; all 59 initial below-12-km upstream `N^2` layers are positive, with median `1.056e-4 s^-2`

At 1,200 s the reproducible east-adjacent method retains 18 clear descending unsaturated cells across `x=-5.5..18.5 km`, `z=2.62..4.73 km`; median `w=-2.26 m/s`, median RH `96.34%`, and `ql=0`. At 4,000 s it retains 30 cells across `x=17.5..27.5 km`, `z=2.38..8.33 km`; median `w=-4.18 m/s`, median RH `93.60%`, and `ql=0`.

## Result

- CM1 exited zero with normal termination and 21 finite native histories from 0 through 4,000 s at 200 s cadence.
- Initial and upstream maximum cloud liquid were both zero.
- The first coherent interior cloud formed at 200 s in terrain-forced saturated ascent.
- Coherent condensate persisted through the endpoint and reached `0.6445 g/kg` maximum cloud liquid.
- A separate lee-wave cloud became dominant and remained terrain/wave locked, with active descending unsaturated clear air and substantial CM1 evaporation evidence downstream.
- The periodic edge and model top remained cloud-free; edge/top/startup evidence did not compromise the central interpretation.
- Runtime was 65.07 s; the package used 44 MB, including 30.34 MB of numbered model output.
- Stderr retained CM1's `IEEE_UNDERFLOW_FLAG` notice. There was no invalid, divide-by-zero, or overflow flag; required output and stats were finite, maximum CFL was 0.146, and termination was normal.
- Runtime-only browser review included both expanded-height and equal physical x/z scale views. Those temporary diagnostic renders read native NetCDF outside the application visualization machinery; they are not output from the merged Gate C route or any Cloud Chamber product surface, and they remain outside Git.

## Final disposition

```text
advance_as_candidate_world_evidence
```

This is feasibility evidence only. It does not approve Mountain Wave Clouds as a World or make a Recipe, Control, Lens, Comparison, product-navigation, or final UX decision.

## Verification

- focused evaluator suite: 8 passed, including first-frame causality, active-top mismatch, and preserved-artifact mutation regressions
- `git diff --check main...HEAD`
- `BACKEND_PYTHON=/absolute/repo/path/app/backend/.venv/bin/python scripts/check.sh`
  - 124 frontend tests passed
  - frontend production build passed
  - formatting and lint passed
  - strict mypy passed across 73 backend source files
  - 589 backend tests passed
  - script syntax, forbidden-artifact, and docs/JSON/YAML checks passed
  - one existing NumPy ABI runtime warning was emitted by `test_results_ingest_and_lookup_api`

Manual PM and scientific-evidence review is required. This PR remains intentionally draft. Do not merge or enable auto-merge until that review is complete.
