### PR TITLE
Document current product sequence after Supercells

### DIFF
--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -217,6 +217,8 @@ After #421 merges, the immediate bounded follow-ups are:
 → #428 — shared Context and Science | Notes | Details information architecture
 ```
 
+Issue #428 may establish durable per-Simulation Notes as the first bounded durable-content contract. It must not also implement complete Explore-state persistence, resume, Saved Views, Saved Comparisons, or a generic annotation framework.
+
 The next program should then establish:
 
 ```text

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -18,6 +18,7 @@ Use this product-authority order:
 4. approved product-architecture documents:
    - [Application Semantics](product/APPLICATION_SEMANTICS.md)
    - [MVP](product/MVP.md)
+   - [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md)
 5. bounded approved product documents such as [Trade Cumulus Product Slice](product/TRADE_CUMULUS_PRODUCT_SLICE.md)
 6. current implementation documentation and code
 7. research and run evidence
@@ -26,21 +27,17 @@ The North Star and Product Vision are the highest product authority.
 
 Application Semantics is the approved semantic authority for Cloud World, Recipe, Simulation, Lens, Saved View, Comparison, Exploration, Experiment, and supporting terms.
 
-The MVP is approved controlling scope for Cloud Chamber as a single-user personal cloud laboratory and growing cloud-world atlas. PR #384 established the MVP. Issue #396 amends the homepage, Fun With Soundings, Trade Cumulus Lab, variation, and implementation-roadmap details.
+The MVP is approved controlling scope for Cloud Chamber as a single-user personal cloud laboratory and growing cloud-world atlas. PR #384 established the MVP. Issue #396 amended its homepage, Fun With Soundings, Trade Cumulus Lab, variation, and original implementation-roadmap details.
 
-The controlling initial information architecture is:
+The Current Product Sequence records later approved sequencing across the current World portfolio. It supersedes only conflicting implementation-order language in the older MVP and documentation-status roadmaps. It does not reopen the MVP thesis or Application Semantics.
+
+The current approved destination model is:
 
 ```text
 Cloud Chamber
 ├── Trade Cumulus — Cloud World
-│   ├── Overview
-│   ├── Simulations
-│   ├── Saved Views
-│   ├── Comparisons
-│   └── Lab
-│       ├── Activity
-│       ├── Create Variation
-│       └── History
+├── Mountain Waves — Cloud World
+├── Supercells — approved Cloud World; implementation governed by #423
 └── Fun With Soundings — Atmospheric workbench
     ├── Find Soundings
     ├── Candidates
@@ -50,9 +47,11 @@ Cloud Chamber
 
 Cloud Worlds are not organized for the sole user under Installed, Draft, candidate, graduated, or development-state categories. Technical content availability remains an operational state.
 
+A World should expose only surfaces it actually implements. Do not create empty Lab, Compare, Saved View, or other placeholders merely to make all Worlds look structurally identical.
+
 Fun With Soundings is a first-class workbench and is not a Cloud World.
 
-The Trade Cumulus Product Slice remains a bounded scientific/product document. It is subordinate to the North Star, Product Vision, approved PM decisions, Application Semantics, and the MVP. It does not make a Recipe, Control, Lens, Comparison, or scientific claim supported merely by being documented.
+The Trade Cumulus Product Slice remains a bounded scientific/product document. It is subordinate to the North Star, Product Vision, approved PM decisions, Application Semantics, the MVP, and the Current Product Sequence. It does not make a Recipe, Control, Lens, Comparison, or scientific claim supported merely by being documented.
 
 PM decisions and product documents do not silently rewrite higher authority. Changes require explicit PM approval.
 
@@ -73,7 +72,7 @@ These documents describe current software and operations.
 
 They may identify legacy behavior, unresolved questions, and implementation constraints. They do not establish final product design.
 
-The current transitional embedding of legacy Build and Results under Trade Cumulus does not override the approved final Lab and Fun With Soundings structure.
+Do not update Current State or Current Architecture to describe an approved future capability before its implementation merges. Update them later when the repository’s actual descriptive state changes.
 
 ## 4. Development and operational documentation
 
@@ -180,18 +179,20 @@ These labels are interpretive aids. The repository has not moved or relabeled ev
 2. [Product Vision](product/PRODUCT_VISION.md)
 3. [Application Semantics](product/APPLICATION_SEMANTICS.md)
 4. [MVP](product/MVP.md)
-5. [Trade Cumulus Product Slice](product/TRADE_CUMULUS_PRODUCT_SLICE.md)
-6. [Current State](current/CURRENT_STATE.md)
-7. [Current Architecture](current/CURRENT_ARCHITECTURE.md)
+5. [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md)
+6. relevant bounded World/product decision records
+7. [Current State](current/CURRENT_STATE.md)
+8. [Current Architecture](current/CURRENT_ARCHITECTURE.md)
 
 ### Contribute during the gated program
 
 1. [AGENTS.md](../AGENTS.md)
 2. approved PM decisions in issue #364 and the controlling bounded issue
-3. [MVP](product/MVP.md)
-4. [Application Semantics](product/APPLICATION_SEMANTICS.md)
-5. relevant current operational documentation
-6. current code and tests
+3. [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md)
+4. [MVP](product/MVP.md)
+5. [Application Semantics](product/APPLICATION_SEMANTICS.md)
+6. relevant current operational documentation
+7. current code and tests
 
 Ignore conflicting product-direction language in lower-authority documents and ask for direction when a conflict affects the task.
 
@@ -209,40 +210,51 @@ Use current source code, tests, runtime contracts, Current State, and merged PR 
 
 Do not rely on one old product specification or roadmap.
 
-## 9. Active MVP implementation roadmap
+## 9. Current implementation sequence
 
-One implementation issue is active at a time. The queued roadmap is visible:
+The controlling sequence is maintained in [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md).
+
+The currently approved order is:
 
 ```text
-#386 / PR #387 — World-scoped foundation — complete
-#388 — integrated Explore
-#389 — ordinary related-Simulation Compare
-#390 — Saved Views, Saved Comparisons, notes, and resume
-#395 — Fun With Soundings
-#394 — Trade Cumulus Lab Activity and History
-#391 — Create Variation from a Simulation and return after the run
-#392 — durable World content and repair
-#393 — hardening and personal acceptance
+#420 — higher-resolution presentation runs for the current Trade Cumulus and
+       Mountain Waves built-in Simulations
+
+→ #423 — build Supercells as the third three-dimensional Cloud World
+
+→ #421 — produce and adopt the higher-resolution, denser-cadence,
+         longer-duration Supercell presentation run
+
+→ return to shared functionality across the three-World application
 ```
 
-Issue #364 records activation, exits, and any roadmap changes.
+After #421, PM will freshly scope the next program from the implemented product. The intended areas are:
 
-Current issue bodies and latest PM comments control their bounded implementation scope. Older comments are historical when a later PM comment explicitly supersedes them.
+- durable World-aware Explore state, resume, and Saved Views;
+- ordinary related-Simulation Compare and saved Comparisons;
+- a fresh review of variations across Trade Cumulus, Mountain Waves, and Supercells;
+- later notes, content durability, cleanup, repair, Activity/History consistency, and personal acceptance.
+
+The older bodies of issues #389, #390, and #391 remain useful prior plans, but they are not current assignment authority until PM reviews and updates or replaces them for the three-World application.
+
+Issue #364 records major activation, exit, and roadmap changes. Current issue bodies and latest PM comments control each bounded implementation scope. Older comments are historical when a later PM comment explicitly supersedes them.
 
 ## Program note
 
 The documentation tree has not been comprehensively reorganized.
 
-Completed program work includes:
+Completed or approved program work includes:
 
 - operational-documentation recovery;
 - semantic architecture;
 - contract classification;
 - canonical BOMEX and Trade Cumulus evidence;
-- Updraft Lens and fixed scale;
-- the first featured Comparison;
-- approved MVP authority;
-- the World-scoped foundation.
+- the Trade Cumulus Updraft Lens, fixed scale, and first featured Comparison;
+- approved MVP authority and World-scoped foundation;
+- Mountain Waves benchmark, visualization, World, Explore, and variation work;
+- Supercell benchmark selection, exact reproduction, examination validation, and the approved Supercells World decision;
+- active presentation-quality run work for current Worlds;
+- active Supercells implementation and approved later high-resolution Supercell run.
 
 Remaining repository moves, rewrites, archives, and implementation work must occur through bounded approved issues.
 

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -6,11 +6,9 @@ The Cloud Chamber documentation tree contains current technical information, res
 
 A document’s presence under `docs/` does not make it current authority.
 
-Use the hierarchy below.
-
 ## 1. Controlling product authority
 
-Use this product-authority order:
+Use this order:
 
 1. [North Star](../NORTH_STAR.md)
 2. [Product Vision](product/PRODUCT_VISION.md)
@@ -19,62 +17,58 @@ Use this product-authority order:
    - [Application Semantics](product/APPLICATION_SEMANTICS.md)
    - [MVP](product/MVP.md)
    - [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md)
-5. bounded approved product documents such as [Trade Cumulus Product Slice](product/TRADE_CUMULUS_PRODUCT_SLICE.md)
+5. bounded approved World or product documents
 6. current implementation documentation and code
 7. research and run evidence
 
 The North Star and Product Vision are the highest product authority.
 
-Application Semantics is the approved semantic authority for Cloud World, Recipe, Simulation, Lens, Saved View, Comparison, Exploration, Experiment, and supporting terms.
+Application Semantics controls the meaning of Cloud World, Recipe, Simulation, Lens, Saved View, Comparison, Exploration, Experiment, and supporting terms.
 
-The MVP is approved controlling scope for Cloud Chamber as a single-user personal cloud laboratory and growing cloud-world atlas. PR #384 established the MVP. Issue #396 amended its homepage, Fun With Soundings, Trade Cumulus Lab, variation, and original implementation-roadmap details.
+The MVP controls Cloud Chamber’s approved scope as a single-user personal cloud laboratory and growing cloud-world atlas. The Current Product Sequence controls later implementation ordering where it conflicts with the MVP’s historical roadmap. It does not reopen the MVP thesis or Application Semantics.
 
-The Current Product Sequence records later approved sequencing across the current World portfolio. It supersedes only conflicting implementation-order language in the older MVP and documentation-status roadmaps. It does not reopen the MVP thesis or Application Semantics.
+Current issue bodies and the latest explicit PM comments control bounded implementation scope.
 
-The current approved destination model is:
+## 2. Current approved destination model
 
 ```text
 Cloud Chamber
 ├── Trade Cumulus — Cloud World
 ├── Mountain Waves — Cloud World
-├── Supercells — approved Cloud World; implementation governed by #423
-└── Fun With Soundings — Atmospheric workbench
-    ├── Find Soundings
-    ├── Candidates
-    ├── Build & Run
-    └── Past Experiments
+├── Supercells — Cloud World
+└── Fun With Soundings — atmospheric workbench
 ```
+
+The three Worlds share product vocabulary and core workspace behavior but may legitimately differ in geometry, Lenses, controls, comparison questions, and variation surfaces.
+
+A World should expose only surfaces it actually implements. Do not create empty Lab, Compare, Saved View, or other placeholders merely to make all Worlds structurally identical.
 
 Cloud Worlds are not organized for the sole user under Installed, Draft, candidate, graduated, or development-state categories. Technical content availability remains an operational state.
 
-A World should expose only surfaces it actually implements. Do not create empty Lab, Compare, Saved View, or other placeholders merely to make all Worlds look structurally identical.
-
 Fun With Soundings is a first-class workbench and is not a Cloud World.
 
-The Trade Cumulus Product Slice remains a bounded scientific/product document. It is subordinate to the North Star, Product Vision, approved PM decisions, Application Semantics, the MVP, and the Current Product Sequence. It does not make a Recipe, Control, Lens, Comparison, or scientific claim supported merely by being documented.
+The [Trade Cumulus Product Slice](product/TRADE_CUMULUS_PRODUCT_SLICE.md) remains a bounded scientific/product document subordinate to higher authority. Its presence does not by itself establish a Recipe, Control, Lens, Comparison, or scientific claim.
 
-PM decisions and product documents do not silently rewrite higher authority. Changes require explicit PM approval.
-
-## 2. Repository and agent authority
+## 3. Repository and agent authority
 
 - [AGENTS.md](../AGENTS.md)
 
-`AGENTS.md` defines how agents and contributors must operate during the gated program. It does not replace product authority.
+`AGENTS.md` defines how agents and contributors must operate. It does not replace product authority.
 
-## 3. Current descriptive documents
+## 4. Current descriptive documents
 
 - [Current State](current/CURRENT_STATE.md)
 - [Current Architecture](current/CURRENT_ARCHITECTURE.md)
 - [Ingest, Results, And Runtime Cleanup Lifecycle](current/INGEST_RESULTS_STORAGE_LIFECYCLE.md)
 - [README](../README.md)
 
-These documents describe current software and operations.
+These documents describe current software and operations. They may identify legacy behavior, unresolved questions, and implementation constraints. They do not establish final product design.
 
-They may identify legacy behavior, unresolved questions, and implementation constraints. They do not establish final product design.
+Do not update Current State or Current Architecture to describe an approved future capability before its implementation merges. Update them when the repository’s actual descriptive state changes.
 
-Do not update Current State or Current Architecture to describe an approved future capability before its implementation merges. Update them later when the repository’s actual descriptive state changes.
+Current State and Current Architecture now require a bounded factual refresh after the completed World and presentation-run work. Until that update merges, use current code, tests, merged PR history, and the Current Product Sequence together rather than treating their older Build/Results/Explore framing as complete.
 
-## 4. Development and operational documentation
+## 5. Development and operational documentation
 
 - [Development](development/DEVELOPMENT.md)
 - [Testing](development/TESTING.md)
@@ -83,21 +77,17 @@ Do not update Current State or Current Architecture to describe an approved futu
 
 Use operational instructions where they remain accurate.
 
-Stage 1 operational-documentation recovery, the disposition audit, and the highest-risk archive moves are complete.
-
-Stage 2 semantic architecture is complete.
-
-Stage 3 contract classification is complete.
+Operational-documentation recovery, the documentation disposition audit, semantic architecture, and active-contract classification are complete.
 
 For documents not handled by those programs:
 
-- prefer commands, paths, APIs, test procedures, and implemented behavior that can be verified;
+- prefer verifiable commands, paths, APIs, test procedures, and implemented behavior;
 - do not execute old product priorities, scenario sequencing, or roadmap language without a current approved issue;
 - resolve product conflicts in favor of the authority order above.
 
-## 5. Architecture and data-model documents
+## 6. Architecture and data-model documents
 
-Architecture documents may describe real implemented systems and useful constraints. They may also contain product assumptions inherited from earlier directions.
+Architecture documents may describe real implemented systems and useful constraints while also containing product assumptions inherited from earlier directions.
 
 Interpret them as:
 
@@ -109,18 +99,18 @@ Do not automatically interpret them as:
 
 Architecture changes remain subject to approved product authority and bounded implementation issues.
 
-## 6. Implemented contracts
+## 7. Implemented contracts
 
 The active `docs/contracts/` directory contains current implemented contracts verified against code and tests:
 
 - [Output Product Specification](contracts/output-product-specification.md)
 - [Sounding Candidate Screening Contract](contracts/sounding-candidate-screening.md)
 
-These contracts describe interfaces and current behavior. They do not define the final product hierarchy or make Cloud Worlds, Recipes, Simulations, Comparisons, or workbench experiments scientifically supported.
+These contracts describe interfaces and current behavior. They do not define the final product hierarchy or make a Cloud World, Recipe, Simulation, Comparison, or workbench experiment scientifically supported.
 
 Historical and proposal contracts live under `docs/archive/contracts/`.
 
-## 7. Research and experiment evidence
+## 8. Research and experiment evidence
 
 Documents under `research/` record investigations, validation attempts, run outcomes, literature findings, and design exploration.
 
@@ -131,11 +121,11 @@ Research is evidence. It is not automatically:
 - roadmap priority;
 - proof that an experimental mechanism should be a default;
 - proof that a sounding experiment belongs to a Cloud World;
-- proof that a Cloud World should be categorized by development state.
+- proof that a new Cloud World should be activated.
 
 Negative, failed, contradictory, and superseded evidence should be preserved.
 
-## 8. Historical and superseded product direction
+## 9. Historical and superseded product direction
 
 Known high-risk archived examples include:
 
@@ -180,81 +170,81 @@ These labels are interpretive aids. The repository has not moved or relabeled ev
 3. [Application Semantics](product/APPLICATION_SEMANTICS.md)
 4. [MVP](product/MVP.md)
 5. [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md)
-6. relevant bounded World/product decision records
+6. relevant bounded World and product decisions
 7. [Current State](current/CURRENT_STATE.md)
 8. [Current Architecture](current/CURRENT_ARCHITECTURE.md)
 
-### Contribute during the gated program
+### Contribute
 
 1. [AGENTS.md](../AGENTS.md)
-2. approved PM decisions in issue #364 and the controlling bounded issue
+2. explicit PM decisions and the controlling bounded issue
 3. [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md)
 4. [MVP](product/MVP.md)
 5. [Application Semantics](product/APPLICATION_SEMANTICS.md)
-6. relevant current operational documentation
+6. relevant operational documentation
 7. current code and tests
 
-Ignore conflicting product-direction language in lower-authority documents and ask for direction when a conflict affects the task.
+Ignore conflicting lower-authority roadmap language and ask for direction when a conflict affects the task.
 
 ### Understand a scientific or CM1 experiment
 
 1. Identify the relevant research and run records.
-2. Determine whether it is a canonical source, controlled adaptation, exploratory sounding experiment, technical mechanism, or hypothesis.
+2. Determine whether the work is a canonical source, controlled adaptation, exploratory sounding experiment, technical mechanism, or hypothesis.
 3. Confirm the actual configuration, output, integrity, and provenance.
 4. Do not assume that a Result belongs to a Cloud World.
 5. Do not assume that an experiment is a supported Recipe or product default.
 
 ### Understand current implementation
 
-Use current source code, tests, runtime contracts, Current State, and merged PR history together.
+Use current source code, tests, runtime contracts, Current State, Current Architecture, and merged PR history together. Do not rely on one old product specification or roadmap.
 
-Do not rely on one old product specification or roadmap.
-
-## 9. Current implementation sequence
+## 10. Current implementation sequence
 
 The controlling sequence is maintained in [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md).
 
-The currently approved order is:
+The presentation-quality and third-World foundation is:
 
 ```text
-#420 — higher-resolution presentation runs for the current Trade Cumulus and
-       Mountain Waves built-in Simulations
-
-→ #423 — build Supercells as the third three-dimensional Cloud World
-
-→ #421 — produce and adopt the higher-resolution, denser-cadence,
-         longer-duration Supercell presentation run
-
-→ return to shared functionality across the three-World application
+#420 — Trade Cumulus and Mountain Waves presentation runs — complete
+#423 — Supercells World and Explore — complete
+#421 — high-resolution Supercell presentation run — final adoption review
 ```
 
-After #421, PM will freshly scope the next program from the implemented product. The intended areas are:
+After #421 merges, the immediate bounded follow-ups are:
 
-- durable World-aware Explore state, resume, and Saved Views;
-- ordinary related-Simulation Compare and saved Comparisons;
-- a fresh review of variations across Trade Cumulus, Mountain Waves, and Supercells;
-- later notes, content durability, cleanup, repair, Activity/History consistency, and personal acceptance.
+```text
+#429 — Supercells slice-position and 3-D camera navigation
+→ #428 — shared Context and Science | Notes | Details information architecture
+```
 
-The older bodies of issues #389, #390, and #391 remain useful prior plans, but they are not current assignment authority until PM reviews and updates or replaces them for the three-World application.
+The next program should then establish:
 
-Issue #364 records major activation, exit, and roadmap changes. Current issue bodies and latest PM comments control each bounded implementation scope. Older comments are historical when a later PM comment explicitly supersedes them.
+```text
+versioned World-aware Explore state
+→ last-state resume
+→ Saved Views
+→ ordinary World-aware Compare
+→ Saved Comparisons
+→ fresh three-World variation review
+```
+
+Later work should reconcile Activity and History, Result-to-Simulation promotion, retained-asset protection, storage and dependency-aware deletion, repair, state migration, performance, and personal acceptance.
+
+Issues #389, #390, and #391 remain useful prior plans but are not current assignment authority until PM updates or replaces them for the three-World application.
+
+Squall Line issue #414 remains blocked. Completion of the Supercell program does not automatically activate a fourth World.
 
 ## Program note
 
-The documentation tree has not been comprehensively reorganized.
-
-Completed or approved program work includes:
+Completed or approved work includes:
 
 - operational-documentation recovery;
-- semantic architecture;
-- contract classification;
+- semantic architecture and contract classification;
 - canonical BOMEX and Trade Cumulus evidence;
-- the Trade Cumulus Updraft Lens, fixed scale, and first featured Comparison;
-- approved MVP authority and World-scoped foundation;
-- Mountain Waves benchmark, visualization, World, Explore, and variation work;
-- Supercell benchmark selection, exact reproduction, examination validation, and the approved Supercells World decision;
-- active presentation-quality run work for current Worlds;
-- active Supercells implementation and approved later high-resolution Supercell run.
+- Trade Cumulus World, Updraft Lens, fixed scale, featured Comparison, and presentation runs;
+- Mountain Waves benchmark, visualization, World, Explore, variation, and presentation runs;
+- Supercell benchmark selection, exact reproduction, examination validation, World, Explore, and presentation run pending final adoption corrections;
+- approved MVP authority and World-scoped foundation.
 
 Remaining repository moves, rewrites, archives, and implementation work must occur through bounded approved issues.
 

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -117,7 +117,9 @@ below the fold
 
 World-specific scientific content remains legitimate. Shared structure must not erase scientific or geometric differences.
 
-Per-Simulation Notes introduced through this work must be treated as the first bounded durable-content contract, not as disposable frontend-only state or a general annotation platform.
+Per-Simulation Notes introduced through this work must be treated as the first bounded durable-content contract, not as disposable frontend-only state or a general annotation platform. The contract should use stable World and Simulation identity, persist across reloads, fail visibly, and leave a clear extension path for later Saved Views and Saved Comparisons without implementing those features now.
+
+Issue #428 must not serialize complete Explore state, implement resume, create Saved Views, or establish a generic annotation framework. Those belong to the next program after the shared information architecture is stable.
 
 ## Next program: personal scientific memory
 

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -4,7 +4,7 @@
 
 ## Purpose and authority
 
-This document records the current implementation sequence and the product areas to address after the first three Cloud Worlds are established.
+This document records the current implementation sequence now that Cloud Chamber has established its first three Cloud Worlds.
 
 It is subordinate to:
 

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -1,0 +1,195 @@
+# Cloud Chamber Current Product Sequence
+
+**Status:** Approved PM sequencing direction.
+
+## Purpose and authority
+
+This document records the current implementation sequence and the product areas to revisit after the present Cloud World work is complete.
+
+It is subordinate to:
+
+1. `NORTH_STAR.md`;
+2. `docs/product/PRODUCT_VISION.md`;
+3. explicit later PM decisions;
+4. `docs/product/APPLICATION_SEMANTICS.md`;
+5. `docs/product/MVP.md`.
+
+Where this document conflicts with the historical implementation ordering in section 19 of `docs/product/MVP.md` or section 9 of `docs/DOCUMENTATION_STATUS.md`, this document controls the **current sequence only**. It does not reopen the MVP thesis, product semantics, or the approved meaning of Cloud Worlds, Simulations, Lenses, Explore, Compare, Saved Views, or variations.
+
+Current issue bodies and the latest explicit PM comments continue to control the bounded scope of each implementation task.
+
+## Product-drift check
+
+```text
+Stable vision:
+Cloud Chamber remains Tim's personal laboratory for creating beautiful,
+scientifically meaningful cloud worlds, seeing invisible atmospheric
+processes, changing the atmosphere, and learning from the response.
+
+Current task:
+Improve the presentation quality of the existing Worlds, build Supercells as
+the third World, replace its proof-quality output with a higher-resolution
+presentation run, and then return to shared product functionality.
+
+Non-implications:
+This does not create public users, collaboration, a marketplace, a generic
+visualization framework, a universal CM1 editor, operational forecasting, or
+an automatic roadmap for every open issue.
+
+Portfolio effect:
+The work broadens and strengthens the cloud-world atlas while preserving the
+shared personal-laboratory model.
+```
+
+## Current product portfolio
+
+Cloud Chamber now has or has explicitly approved the following first-class destinations:
+
+```text
+Cloud Chamber
+├── Trade Cumulus — Cloud World
+├── Mountain Waves — Cloud World
+├── Supercells — Cloud World approved; implementation in #423
+└── Fun With Soundings — atmospheric workbench
+```
+
+The three Worlds share product vocabulary and core workspace behavior, but they are not required to have identical geometry, Lenses, controls, comparison questions, or variation surfaces.
+
+- **Trade Cumulus** is a three-dimensional shallow-cloud World.
+- **Mountain Waves** is currently an honest terrain-aware two-dimensional World.
+- **Supercells** is an approved three-dimensional deep-convection World.
+- **Fun With Soundings** remains a non-World workbench for observed atmospheres and broader experiments.
+
+A World appears as a World. Do not expose candidate, installed, draft, graduated, or authoring-maturity taxonomy to the sole user.
+
+## Immediate implementation sequence
+
+The approved sequence is:
+
+```text
+#420 — generate higher-resolution presentation runs for the four existing
+       Trade Cumulus and Mountain Waves Simulations
+
+→ #423 — build Supercells as the third three-dimensional Cloud World using
+         the current accepted benchmark output
+
+→ #421 — generate and adopt the higher-resolution, denser-cadence,
+         longer-duration Supercell presentation run
+
+→ return to shared product functionality across the three-World application
+```
+
+### #420 — current presentation runs
+
+Issue #420 may improve and replace the backing output for the current built-in Trade Cumulus and Mountain Waves Simulations. It should preserve their stable product identities while improving spatial detail, animation cadence, and experiential quality.
+
+### #423 — Supercells World
+
+Issue #423 implements the approved `supercells` World, the stable `supercells_quarter_circle_reference` Simulation identity, the integrated three-dimensional Explore workspace, and the three accepted Lenses:
+
+- Rotating Updraft;
+- Cloud and Precipitation;
+- Low-Level Interactions.
+
+It may use the accepted Gate B benchmark as the initial backing output. It must not bind product identity or frontend routing permanently to that run ID.
+
+### #421 — Supercell presentation run
+
+Issue #421 produces the more detailed, smoother, and longer Supercell output after the production Explore contract exists. If accepted, that output should normally become the backing asset for the same stable Quarter-Circle Supercell identity rather than creating a parallel product path.
+
+This ordering intentionally lets the World implementation establish the required fields, payloads, scales, timeline semantics, and performance behavior before the expensive final run is adopted.
+
+## Direction after #421
+
+After #421 is accepted, return to functionality that makes Cloud Chamber durable and worth revisiting across Worlds.
+
+The next program should cover the areas below, but the exact issue order and scope require a fresh PM decision against the then-current three-World implementation.
+
+### Durable Explore state, resume, and Saved Views
+
+Establish one World-aware, serializable Explore-state contract that can represent the actual implemented geometries and controls, including as applicable:
+
+- World and Simulation identity;
+- model time or playback range;
+- Lens or Field state;
+- three-dimensional camera and viewport;
+- active plan or section view and physical coordinates;
+- selected point or region;
+- overlays and meaningful display settings;
+- inspector section and collapse state;
+- title and optional note.
+
+Ordinary last-active-state resume and an explicitly named Saved View are related but distinct behaviors.
+
+The contract must work for Trade Cumulus, Mountain Waves, and Supercells without pretending their view state is identical.
+
+### Ordinary Compare and saved Comparisons
+
+Revisit ordinary related-Simulation Compare as a shared World capability.
+
+The current MVP decisions remain useful:
+
+- differences appear before interpretation;
+- time links by modeled seconds rather than frame index;
+- planes link by physical coordinate rather than array index;
+- cameras link only through an honest compatible mapping;
+- Lenses and scales link only when compatible;
+- aligned, independent, and mixed states are supported;
+- no interpolation is presented as model output.
+
+The implementation must be World-aware. Trade Cumulus, Mountain Waves, and Supercells ask different comparison questions and may support different linked states.
+
+Saved Comparisons should follow the ordinary Compare state contract and reopen as live examinations, not screenshots.
+
+### Variations require a fresh review
+
+Do **not** execute the older general variation roadmap or copy the current Trade Cumulus and Mountain Waves variation surfaces into Supercells without reconsideration.
+
+The existing work is valuable implementation evidence, but the variation model should be reviewed against the actual three-World product after #421.
+
+That review must decide, World by World:
+
+- which Simulations are eligible parents;
+- which physical and numerical settings are worth exposing;
+- which settings require profiles, grouped controls, or advanced disclosure;
+- appropriate default duration, grid, and output cadence for ordinary personal experiments;
+- how expensive runs are estimated and communicated;
+- which differences are required for lineage and Compare;
+- what makes a completed Result inspectable as the named Simulation;
+- which controls are genuinely shared and which are World-specific;
+- whether a shared variation shell with World-specific contracts is better than separate implementations;
+- what Supercells variations should initially permit.
+
+The user may change several supported settings in one variation. Do not reduce the experience to one-variable wizards or imply one-factor causation when several values changed.
+
+Existing issues such as #391, #389, and #390 are prior bounded plans. They must be reviewed and updated or replaced before assignment; their older bodies are not automatic current implementation authority.
+
+### Later durability and acceptance work
+
+After Saved Views, Compare, and the refreshed variation direction are established, revisit:
+
+- Simulation notes;
+- saved Comparison notes and explanations;
+- content protection and dependency-aware cleanup;
+- repair of missing retained assets;
+- Activity and History consistency across Worlds;
+- personal acceptance and measured performance on the target machine.
+
+Do not create the entire follow-on backlog in advance. Create the next bounded issue when the preceding implementation and PM review provide the required evidence.
+
+## Sequencing rules
+
+- One major implementation issue remains active at a time unless Tim explicitly authorizes overlap.
+- Expensive CM1 execution work and application implementation may overlap only when their ownership and runtime constraints do not conflict.
+- Presentation-run upgrades preserve stable World and Simulation identities unless a later PM decision says otherwise.
+- Shared functionality must be built against the actual three-World application, not only generalized from Trade Cumulus.
+- World-specific scientific and visual differences remain legitimate; shared shells must not erase them.
+- Do not assign #389, #390, #391, or derived follow-on work without a fresh scope review after #421.
+- Do not begin Squall Line #414 under this sequence.
+- Manual PM review and disabled auto-merge remain required.
+
+## Updating this document
+
+Update this document when PM changes the active sequence or approves the next shared-functionality program.
+
+Do not use routine implementation completion to silently expand product scope. Current implementation status belongs in descriptive documentation after the relevant PRs merge.

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -4,7 +4,7 @@
 
 ## Purpose and authority
 
-This document records the current implementation sequence and the product areas to revisit after the present Cloud World work is complete.
+This document records the current implementation sequence and the product areas to address after the first three Cloud Worlds are established.
 
 It is subordinate to:
 
@@ -14,9 +14,9 @@ It is subordinate to:
 4. `docs/product/APPLICATION_SEMANTICS.md`;
 5. `docs/product/MVP.md`.
 
-Where this document conflicts with the historical implementation ordering in section 19 of `docs/product/MVP.md` or section 9 of `docs/DOCUMENTATION_STATUS.md`, this document controls the **current sequence only**. It does not reopen the MVP thesis, product semantics, or the approved meaning of Cloud Worlds, Simulations, Lenses, Explore, Compare, Saved Views, or variations.
+Where this document conflicts with historical implementation ordering in `docs/product/MVP.md` or `docs/DOCUMENTATION_STATUS.md`, this document controls the **current sequence only**. It does not reopen the MVP thesis, product semantics, or the approved meaning of Cloud Worlds, Simulations, Lenses, Explore, Compare, Saved Views, or variations.
 
-Current issue bodies and the latest explicit PM comments continue to control the bounded scope of each implementation task.
+Current issue bodies and the latest explicit PM comments control each bounded implementation task.
 
 ## Product-drift check
 
@@ -27,9 +27,9 @@ scientifically meaningful cloud worlds, seeing invisible atmospheric
 processes, changing the atmosphere, and learning from the response.
 
 Current task:
-Improve the presentation quality of the existing Worlds, build Supercells as
-the third World, replace its proof-quality output with a higher-resolution
-presentation run, and then return to shared product functionality.
+Finish the first three-World Explore foundation, make examination state
+persistent, support ordinary comparison, and then reconsider variations
+against the actual product.
 
 Non-implications:
 This does not create public users, collaboration, a marketplace, a generic
@@ -37,99 +37,133 @@ visualization framework, a universal CM1 editor, operational forecasting, or
 an automatic roadmap for every open issue.
 
 Portfolio effect:
-The work broadens and strengthens the cloud-world atlas while preserving the
-shared personal-laboratory model.
+The work deepens the existing cloud-world atlas before another World is added.
 ```
 
 ## Current product portfolio
 
-Cloud Chamber now has or has explicitly approved the following first-class destinations:
+Cloud Chamber has the following first-class destinations:
 
 ```text
 Cloud Chamber
 ├── Trade Cumulus — Cloud World
 ├── Mountain Waves — Cloud World
-├── Supercells — Cloud World approved; implementation in #423
+├── Supercells — Cloud World
 └── Fun With Soundings — atmospheric workbench
 ```
 
 The three Worlds share product vocabulary and core workspace behavior, but they are not required to have identical geometry, Lenses, controls, comparison questions, or variation surfaces.
 
 - **Trade Cumulus** is a three-dimensional shallow-cloud World.
-- **Mountain Waves** is currently an honest terrain-aware two-dimensional World.
-- **Supercells** is an approved three-dimensional deep-convection World.
+- **Mountain Waves** is currently a terrain-aware two-dimensional World.
+- **Supercells** is a three-dimensional deep-convection World.
 - **Fun With Soundings** remains a non-World workbench for observed atmospheres and broader experiments.
 
 A World appears as a World. Do not expose candidate, installed, draft, graduated, or authoring-maturity taxonomy to the sole user.
 
-## Immediate implementation sequence
+## Completed foundation and current transition
 
-The approved sequence is:
+The presentation-quality and third-World program established:
 
 ```text
-#420 — generate higher-resolution presentation runs for the four existing
-       Trade Cumulus and Mountain Waves Simulations
+#420 — higher-resolution presentation runs for the four existing
+       Trade Cumulus and Mountain Waves Simulations — complete
 
-→ #423 — build Supercells as the third three-dimensional Cloud World using
-         the current accepted benchmark output
+#423 — Supercells as the third three-dimensional Cloud World — complete
 
-→ #421 — generate and adopt the higher-resolution, denser-cadence,
-         longer-duration Supercell presentation run
-
-→ return to shared product functionality across the three-World application
+#421 — higher-resolution, denser-cadence, longer-duration Supercell
+       presentation run — final adoption review in PR #430
 ```
 
-### #420 — current presentation runs
+The completed work preserves stable World and Simulation identities while allowing backing run assets to improve.
 
-Issue #420 may improve and replace the backing output for the current built-in Trade Cumulus and Mountain Waves Simulations. It should preserve their stable product identities while improving spatial detail, animation cadence, and experiential quality.
+PR #430 must complete its bounded review corrections and merge before #421 is treated as complete. No additional CM1 run is required unless a later explicit PM decision authorizes one.
 
-### #423 — Supercells World
+## Immediate bounded follow-ups
 
-Issue #423 implements the approved `supercells` World, the stable `supercells_quarter_circle_reference` Simulation identity, the integrated three-dimensional Explore workspace, and the three accepted Lenses:
+After PR #430 merges, execute:
 
-- Rotating Updraft;
-- Cloud and Precipitation;
-- Low-Level Interactions.
+```text
+#429 — add slice-position navigation and missing 3-D camera controls to
+       Supercells Explore
 
-It may use the accepted Gate B benchmark as the initial backing output. It must not bind product identity or frontend routing permanently to that run ID.
+→ #428 — commonalize live Context and below-the-fold Science, Notes, and
+         Details across all three Worlds
+```
 
-### #421 — Supercell presentation run
+### #429 — complete Supercells spatial navigation
 
-Issue #421 produces the more detailed, smoother, and longer Supercell output after the production Explore contract exists. If accepted, that output should normally become the backing asset for the same stable Quarter-Circle Supercell identity rather than creating a parallel product path.
+Issue #429 closes a bounded usability gap in the accepted Supercells workspace:
 
-This ordering intentionally lets the World implementation establish the required fields, payloads, scales, timeline semantics, and performance behavior before the expensive final run is adopted.
+- move horizontal and vertical evidence planes by native physical coordinate;
+- keep the represented 2-D and 3-D planes synchronized;
+- preserve user-selected slice positions during playback;
+- expose zoom and vertical-pan controls already supported by the shared 3-D viewer behavior;
+- preserve per-Lens camera and slice state.
 
-## Direction after #421
+It does not reopen Supercell Lens questions, scales, scientific fields, or rendering design.
 
-After #421 is accepted, return to functionality that makes Cloud Chamber durable and worth revisiting across Worlds.
+### #428 — shared Explore information architecture
 
-The next program should cover the areas below, but the exact issue order and scope require a fresh PM decision against the then-current three-World implementation.
+Issue #428 should establish one recognizable information hierarchy across Trade Cumulus, Mountain Waves, and Supercells:
 
-### Durable Explore state, resume, and Saved Views
+```text
+above the fold
+  coordinated viewer(s) + controls + timeline + concise live Context
 
-Establish one World-aware, serializable Explore-state contract that can represent the actual implemented geometries and controls, including as applicable:
+below the fold
+  Science | Notes | Details
+```
 
-- World and Simulation identity;
+World-specific scientific content remains legitimate. Shared structure must not erase scientific or geometric differences.
+
+Per-Simulation Notes introduced through this work must be treated as the first bounded durable-content contract, not as disposable frontend-only state or a general annotation platform.
+
+## Next program: personal scientific memory
+
+After #429 and #428, establish one versioned, World-aware Explore-state contract before implementing Compare.
+
+The contract should represent, as applicable:
+
+- World and stable Simulation identity;
 - model time or playback range;
 - Lens or Field state;
 - three-dimensional camera and viewport;
-- active plan or section view and physical coordinates;
+- active plan or section orientation and physical coordinate;
 - selected point or region;
 - overlays and meaningful display settings;
-- inspector section and collapse state;
-- title and optional note.
+- Context collapse state and active secondary-information section;
+- title and optional note;
+- schema version and bounded migration or failure behavior.
 
-Ordinary last-active-state resume and an explicitly named Saved View are related but distinct behaviors.
+Implement in this order:
 
-The contract must work for Trade Cumulus, Mountain Waves, and Supercells without pretending their view state is identical.
+```text
+serializable Explore state
+→ ordinary last-active-state resume
+→ explicitly named Saved Views
+```
 
-### Ordinary Compare and saved Comparisons
+Ordinary resume and Saved Views are related but distinct. The contract must work for all three Worlds without pretending their state is identical.
 
-Revisit ordinary related-Simulation Compare as a shared World capability.
+Use this default-state precedence:
+
+```text
+explicit Saved View
+> last active state
+> curated Simulation/Lens default
+> technical fallback
+```
+
+Provide a clear return to the curated default state.
+
+## Then: ordinary Compare and Saved Comparisons
+
+Build ordinary Compare from two compatible Explore states rather than creating a parallel examination model.
 
 The current MVP decisions remain useful:
 
-- differences appear before interpretation;
+- configuration and lineage differences appear before interpretation;
 - time links by modeled seconds rather than frame index;
 - planes link by physical coordinate rather than array index;
 - cameras link only through an honest compatible mapping;
@@ -137,59 +171,71 @@ The current MVP decisions remain useful:
 - aligned, independent, and mixed states are supported;
 - no interpolation is presented as model output.
 
-The implementation must be World-aware. Trade Cumulus, Mountain Waves, and Supercells ask different comparison questions and may support different linked states.
+Implement in this order:
 
-Saved Comparisons should follow the ordinary Compare state contract and reopen as live examinations, not screenshots.
+```text
+ordinary World-aware Compare
+→ Saved Comparisons that reopen as live examinations
+```
 
-### Variations require a fresh review
+Trade Cumulus, Mountain Waves, and Supercells ask different comparison questions and may support different linked states.
 
-Do **not** execute the older general variation roadmap or copy the current Trade Cumulus and Mountain Waves variation surfaces into Supercells without reconsideration.
+## Variations require a fresh review
 
-The existing work is valuable implementation evidence, but the variation model should be reviewed against the actual three-World product after #421.
+Do **not** execute the older general variation roadmap or copy current Trade Cumulus and Mountain Waves controls into Supercells without reconsideration.
 
-That review must decide, World by World:
+Review the variation model against the actual three-World product after Saved Views and ordinary Compare establish the required state and lineage contracts.
+
+Decide, World by World:
 
 - which Simulations are eligible parents;
 - which physical and numerical settings are worth exposing;
 - which settings require profiles, grouped controls, or advanced disclosure;
-- appropriate default duration, grid, and output cadence for ordinary personal experiments;
-- how expensive runs are estimated and communicated;
+- appropriate default duration, grid, and output cadence for ordinary experiments;
+- how runtime and retained-storage cost are estimated and communicated;
 - which differences are required for lineage and Compare;
-- what makes a completed Result inspectable as the named Simulation;
+- what makes a completed Result eligible to become a named Simulation;
 - which controls are genuinely shared and which are World-specific;
-- whether a shared variation shell with World-specific contracts is better than separate implementations;
+- whether one shared variation shell with World-specific contracts is preferable;
 - what Supercells variations should initially permit.
 
 The user may change several supported settings in one variation. Do not reduce the experience to one-variable wizards or imply one-factor causation when several values changed.
 
-Existing issues such as #391, #389, and #390 are prior bounded plans. They must be reviewed and updated or replaced before assignment; their older bodies are not automatic current implementation authority.
+Existing issues #389, #390, and #391 are prior bounded plans. They must be updated or replaced before assignment; their older bodies are not current implementation authority.
 
-### Later durability and acceptance work
+## Later durability and acceptance work
 
-After Saved Views, Compare, and the refreshed variation direction are established, revisit:
+After Saved Views, Compare, and refreshed variation direction are established, revisit:
 
-- Simulation notes;
-- saved Comparison notes and explanations;
-- content protection and dependency-aware cleanup;
-- repair of missing retained assets;
+- Saved Comparison notes and explanations;
 - Activity and History consistency across Worlds;
-- personal acceptance and measured performance on the target machine.
+- the Result-to-Simulation promotion lifecycle;
+- protected built-in and user-created retained assets;
+- visible storage cost and dependency-aware deletion;
+- repair or reimport of missing retained assets;
+- version migration for durable state;
+- measured performance and personal acceptance on the target machine.
 
-Do not create the entire follow-on backlog in advance. Create the next bounded issue when the preceding implementation and PM review provide the required evidence.
+Do not create the entire follow-on backlog in advance. Create or rewrite the next bounded issue when preceding implementation and PM review provide the necessary evidence.
+
+## Deferred World expansion
+
+Do not begin Squall Line issue #414 under this sequence.
+
+A fourth World should not be activated merely because the Supercell program completed. PM must first decide that adding another scientific regime is more valuable than making the existing three Worlds durable, comparable, and experimentally useful.
 
 ## Sequencing rules
 
 - One major implementation issue remains active at a time unless Tim explicitly authorizes overlap.
-- Expensive CM1 execution work and application implementation may overlap only when their ownership and runtime constraints do not conflict.
+- Expensive CM1 execution and application implementation may overlap only when ownership and runtime constraints do not conflict.
 - Presentation-run upgrades preserve stable World and Simulation identities unless a later PM decision says otherwise.
-- Shared functionality must be built against the actual three-World application, not only generalized from Trade Cumulus.
+- Shared functionality must be built against the actual three-World application, not generalized only from Trade Cumulus.
 - World-specific scientific and visual differences remain legitimate; shared shells must not erase them.
-- Do not assign #389, #390, #391, or derived follow-on work without a fresh scope review after #421.
-- Do not begin Squall Line #414 under this sequence.
+- Do not assign #389, #390, #391, or derived work without fresh scope review.
 - Manual PM review and disabled auto-merge remain required.
 
 ## Updating this document
 
 Update this document when PM changes the active sequence or approves the next shared-functionality program.
 
-Do not use routine implementation completion to silently expand product scope. Current implementation status belongs in descriptive documentation after the relevant PRs merge.
+Routine implementation completion must not silently expand product scope. Current implementation facts belong in descriptive documentation after the relevant PRs merge.


### PR DESCRIPTION
## Purpose

Record the approved implementation sequence and the direction for returning to shared functionality after the current Cloud World work.

## Changes

- add `docs/product/CURRENT_PRODUCT_SEQUENCE.md` as the current sequencing authority subordinate to the North Star, Product Vision, Application Semantics, and MVP;
- record the approved order:
  - #420 presentation runs;
  - #423 Supercells World;
  - #421 high-resolution Supercell run;
  - fresh scoping of shared functionality;
- record the intended post-#421 areas:
  - durable Explore state, resume, and Saved Views;
  - ordinary Compare and saved Comparisons;
  - a fresh three-World review of variations;
  - later notes, durability, cleanup, repair, and personal acceptance;
- state explicitly that older #389/#390/#391 issue bodies must be reviewed and updated or replaced before assignment;
- update `docs/DOCUMENTATION_STATUS.md` to index the new authority, show the current World portfolio, and replace its stale roadmap summary.

## Boundaries

- does not change the North Star, Product Vision, Application Semantics, or core MVP thesis;
- does not create follow-on implementation issues;
- does not describe #423 or #421 as already implemented;
- does not update Current State or Current Architecture before those implementations merge;
- does not activate Squall Line work.

## Verification

- branch comparison against `main`: exactly two documentation files changed;
- `scripts/check.sh` was not run locally because this documentation-only change was made through the GitHub connector without a repository checkout; CI must pass before merge;
- manual PM review required;
- auto-merge remains disabled.