### PR TITLE
Add Supercells as the third Cloud World

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -120,9 +120,18 @@ from cloud_chamber.storm_examination import (
 from cloud_chamber.storm_examination import (
     StormExaminationError,
     preserved_storm_examination_frame,
+    supercells_explore_frame,
 )
 from cloud_chamber.storm_examination import (
     ViewportId as StormExaminationViewportId,
+)
+from cloud_chamber.supercells_world import (
+    REFERENCE_SIMULATION_ID as SUPERCELLS_REFERENCE_SIMULATION_ID,
+)
+from cloud_chamber.supercells_world import (
+    SupercellsWorldDetail,
+    SupercellsWorldSummary,
+    supercells_world_detail,
 )
 from cloud_chamber.trade_cumulus_comparison_story import (
     TradeCumulusComparisonStoryConflict,
@@ -583,8 +592,11 @@ def storage_inventory() -> dict[str, object]:
     return inventory.model_dump(mode="json")
 
 
-@app.get("/api/worlds", response_model=list[CloudWorldSummary | MountainWavesWorldSummary])
-def list_worlds() -> list[CloudWorldSummary | MountainWavesWorldSummary]:
+@app.get(
+    "/api/worlds",
+    response_model=list[CloudWorldSummary | MountainWavesWorldSummary | SupercellsWorldSummary],
+)
+def list_worlds() -> list[CloudWorldSummary | MountainWavesWorldSummary | SupercellsWorldSummary]:
     try:
         return list_cloud_world_summaries(load_settings())
     except (OSError, ValueError) as exc:
@@ -611,6 +623,11 @@ def get_mountain_waves_world() -> MountainWavesWorldDetail:
         raise HTTPException(
             status_code=500, detail="Mountain Waves World data is unavailable."
         ) from exc
+
+
+@app.get("/api/worlds/supercells", response_model=SupercellsWorldDetail)
+def get_supercells_world() -> SupercellsWorldDetail:
+    return supercells_world_detail(load_settings())
 
 
 @app.get(
@@ -905,6 +922,33 @@ def get_mountain_wave_terrain_frame(
     except MountainWaveTerrainVisualizationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return result.model_dump(mode="json")
+
+
+@app.get("/api/worlds/supercells/simulations/{simulation_id}/frame")
+def get_supercells_simulation_frame(
+    simulation_id: str,
+    lens: StormExaminationLensId = "rotating_updraft",
+    time_index: int = 5,
+    viewport: StormExaminationViewportId = "storm",
+    x_index: int | None = None,
+    y_index: int | None = None,
+    z_index: int | None = None,
+) -> dict[str, object]:
+    if simulation_id != SUPERCELLS_REFERENCE_SIMULATION_ID:
+        raise HTTPException(status_code=404, detail="Supercell Simulation not found.")
+    try:
+        frame = supercells_explore_frame(
+            load_settings(),
+            lens=lens,
+            time_index=time_index,
+            viewport=viewport,
+            x_index=x_index,
+            y_index=y_index,
+            z_index=z_index,
+        )
+    except StormExaminationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return frame.model_dump(mode="json")
 
 
 @app.get("/api/research/storm-examination")

--- a/app/backend/cloud_chamber/cloud_worlds.py
+++ b/app/backend/cloud_chamber/cloud_worlds.py
@@ -22,6 +22,7 @@ from cloud_chamber.result_ingest import (
 )
 from cloud_chamber.run_manifest import LifecycleState, RunManifestError, load_run_manifest
 from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.supercells_world import SupercellsWorldSummary, supercells_world_detail
 from cloud_chamber.trade_cumulus_comparison_story import (
     CASE_ID,
     COMPARISON_GROUP_ID,
@@ -270,11 +271,12 @@ _LINEAGE_KEYS = {
 
 def list_cloud_world_summaries(
     settings: CloudChamberSettings,
-) -> list[CloudWorldSummary | MountainWavesWorldSummary]:
+) -> list[CloudWorldSummary | MountainWavesWorldSummary | SupercellsWorldSummary]:
     """Return real Cloud Worlds without assigning one shared scientific framing."""
     return [
         trade_cumulus_world_detail(settings).summary(),
         mountain_waves_world_detail(settings).summary(),
+        supercells_world_detail(settings).summary(),
     ]
 
 

--- a/app/backend/cloud_chamber/storm_examination.py
+++ b/app/backend/cloud_chamber/storm_examination.py
@@ -22,6 +22,12 @@ HYDROMETEORS = ("qc", "qr", "qi", "qs", "qg")
 LensId = Literal["rotating_updraft", "cloud_precipitation", "low_level_interactions"]
 ViewportId = Literal["storm", "full"]
 FramePurpose = Literal["research", "product"]
+STORM_VIEW_BOUNDS_KM = {
+    "x_min": -35.5,
+    "x_max": 24.5,
+    "y_min": -33.5,
+    "y_max": 26.5,
+}
 
 W_COLORS = (
     "#4b0082",
@@ -149,6 +155,7 @@ class PlanView(BaseModel):
     y_km: list[float]
     level_index: int
     level_km: float
+    selection_z_indices: list[list[int]] | None = None
     primary: FieldLayer
     overlays: dict[str, FieldLayer]
     categories: CategoryLayer | None = None
@@ -206,6 +213,8 @@ class StormExaminationFrame(BaseModel):
     lens_id: LensId
     lens_name: str
     lens_question: str
+    what_to_notice_now: str
+    what_to_notice_by_view: dict[str, str] | None = None
     time_index: int
     time_seconds: float
     times_seconds: list[float]
@@ -340,7 +349,7 @@ def _storm_frame(
         z_km=float(z_km[primary_z]),
         w_m_s=float(fields["winterp"][primary_index]),
     )
-    bounds = _viewport_bounds(viewport, x_km, y_km, primary)
+    bounds = _viewport_bounds(viewport, x_km, y_km)
     x_indices = _coordinate_indices(x_km, bounds["x_min"], bounds["x_max"])
     y_indices = _coordinate_indices(y_km, bounds["y_min"], bounds["y_max"])
     plan = _plan_view(lens, fields, x_km, y_km, z_km, default_level, x_indices, y_indices)
@@ -380,6 +389,10 @@ def _storm_frame(
         primary,
     )
     lens_name, lens_question = _lens_identity(lens)
+    what_to_notice_by_view = _what_to_notice_by_view(
+        lens, time_seconds, plan, xz_section, yz_section
+    )
+    default_notice_view = "xz" if lens == "cloud_precipitation" else "plan"
     scene = (
         _volume_scene(
             lens,
@@ -413,6 +426,8 @@ def _storm_frame(
         lens_id=lens,
         lens_name=lens_name,
         lens_question=lens_question,
+        what_to_notice_now=what_to_notice_by_view[default_notice_view],
+        what_to_notice_by_view=what_to_notice_by_view,
         time_index=checked_time_index,
         time_seconds=time_seconds,
         times_seconds=[value for _path, value in inventory],
@@ -600,6 +615,7 @@ def _plan_view(
         ),
     }
     if lens == "rotating_updraft":
+        total = _total_condensate_g_kg(view_fields)
         primary = _layer(
             "winterp",
             "Vertical velocity",
@@ -627,13 +643,25 @@ def _plan_view(
             view_fields["uh"],
             _uh_scale(),
         )
+        overlays["total_condensate"] = _layer(
+            "total_condensate",
+            "Total condensate",
+            "g/kg",
+            "derived",
+            list(HYDROMETEORS),
+            total[level_index],
+            _condensate_scale(),
+            "1000 * (qc + qr + qi + qs + qg)",
+        )
         title = "Midlevel updraft and rotation"
         subtitle = "Signed vertical velocity with cyclonic vorticity and 2-5 km AGL UH"
         categories = None
+        selection_z_indices = None
         vectors: list[WindVector] = []
     elif lens == "cloud_precipitation":
         total = _total_condensate_g_kg(view_fields)
         column_max = np.max(total, axis=0)
+        strongest_level = np.argmax(total, axis=0)
         primary = _layer(
             "column_max_total_condensate",
             "Column-maximum total condensate",
@@ -644,18 +672,26 @@ def _plan_view(
             _condensate_scale(),
             "1000 * max_z(qc + qr + qi + qs + qg)",
         )
-        categories = _column_hydrometeor_categories(view_fields, column_max)
+        categories = _column_hydrometeor_categories(view_fields, column_max, strongest_level)
+        aligned_vertical_velocity = np.take_along_axis(
+            view_fields["winterp"], strongest_level[np.newaxis, :, :], axis=0
+        )[0]
         overlays["vertical_velocity"] = _layer(
-            "winterp",
-            "Vertical velocity",
+            "vertical_velocity_at_condensate_maximum",
+            "Vertical velocity at strongest condensate level",
             "m/s",
-            "native",
-            ["winterp"],
-            view_fields["winterp"][level_index],
+            "derived",
+            ["winterp", *HYDROMETEORS],
+            aligned_vertical_velocity,
             _midlevel_w_scale(),
+            (
+                "native winterp sampled at each x/y cell's level of maximum "
+                "1000 * (qc + qr + qi + qs + qg)"
+            ),
         )
         title = "Cloud and precipitation structure"
-        subtitle = "Dominant hydrometeor at the column's strongest condensate level"
+        subtitle = "Column-derived category and motion at each cell's strongest condensate level"
+        selection_z_indices = [[int(value) for value in row] for row in strongest_level.tolist()]
         vectors = []
     else:
         primary = _layer(
@@ -668,9 +704,28 @@ def _plan_view(
             _low_level_w_scale(),
         )
         title = "Low-level motion and rain footprint"
-        subtitle = "1.25 km vertical motion, accumulated rain, and model-relative flow"
+        subtitle = (
+            "1.25 km current motion, precipitation, model-relative flow, "
+            "and historical rain accumulation"
+        )
+        selection_z_indices = None
         categories = None
-        vectors = _wind_vectors(view_fields, view_x_km, view_y_km)
+        vectors = _wind_vectors(view_fields, view_x_km, view_y_km, level_index)
+        precipitating = 1_000.0 * (
+            view_fields["qr"][level_index]
+            + view_fields["qs"][level_index]
+            + view_fields["qg"][level_index]
+        )
+        overlays["low_level_precipitating_condensate"] = _layer(
+            "low_level_precipitating_condensate",
+            "Current precipitating condensate",
+            "g/kg",
+            "derived",
+            ["qr", "qs", "qg"],
+            precipitating,
+            _condensate_scale(),
+            "1000 * (qr + qs + qg) at the displayed 1.25 km level",
+        )
     return PlanView(
         title=title,
         subtitle=subtitle,
@@ -680,6 +735,7 @@ def _plan_view(
         y_km=_float_list(view_y_km),
         level_index=level_index,
         level_km=float(z_km[level_index]),
+        selection_z_indices=selection_z_indices,
         primary=primary,
         overlays=overlays,
         categories=categories,
@@ -708,6 +764,7 @@ def _vertical_section(
         w_section = fields["winterp"][:, y_index, horizontal_indices]
         condensate = _total_condensate_g_kg(fields)[:, y_index, horizontal_indices]
         reflectivity = fields["dbz"][:, y_index, horizontal_indices]
+        vorticity = fields["zvort"][:, y_index, horizontal_indices]
         precipitating = 1_000.0 * (
             fields["qr"][:, y_index, horizontal_indices]
             + fields["qs"][:, y_index, horizontal_indices]
@@ -722,6 +779,7 @@ def _vertical_section(
         w_section = fields["winterp"][:, horizontal_indices, x_index]
         condensate = _total_condensate_g_kg(fields)[:, horizontal_indices, x_index]
         reflectivity = fields["dbz"][:, horizontal_indices, x_index]
+        vorticity = fields["zvort"][:, horizontal_indices, x_index]
         precipitating = 1_000.0 * (
             fields["qr"][:, horizontal_indices, x_index]
             + fields["qs"][:, horizontal_indices, x_index]
@@ -765,6 +823,15 @@ def _vertical_section(
             ["winterp"],
             w_section,
             _section_w_scale(),
+        ),
+        "vertical_vorticity": _layer(
+            "zvort",
+            "Vertical vorticity",
+            "s^-1",
+            "native",
+            ["zvort"],
+            vorticity,
+            _vorticity_scale(),
         ),
     }
     if lens == "cloud_precipitation":
@@ -912,10 +979,9 @@ def _total_condensate_g_kg(
 def _column_hydrometeor_categories(
     fields: dict[str, np.ndarray[Any, np.dtype[np.float64]]],
     column_max: np.ndarray[Any, np.dtype[np.float64]],
+    strongest_level: np.ndarray[Any, np.dtype[np.int64]],
 ) -> CategoryLayer:
     masses = np.stack([fields[name] for name in HYDROMETEORS], axis=0)
-    total = np.sum(masses, axis=0)
-    strongest_level = np.argmax(total, axis=0)
     categories = np.zeros(column_max.shape, dtype=np.int64)
     for y_index in range(column_max.shape[0]):
         for x_index in range(column_max.shape[1]):
@@ -997,8 +1063,8 @@ def _wind_vectors(
     fields: dict[str, np.ndarray[Any, np.dtype[np.float64]]],
     x_km: np.ndarray[Any, np.dtype[np.float64]],
     y_km: np.ndarray[Any, np.dtype[np.float64]],
+    level_index: int,
 ) -> list[WindVector]:
-    level_index = 0
     stride = 8
     vectors: list[WindVector] = []
     for y_index in range(0, len(y_km), stride):
@@ -1040,6 +1106,8 @@ def _volume_scene(
     total = _total_condensate_g_kg(view)
     precipitating = 1_000.0 * (view["qr"] + view["qs"] + view["qg"])
     budget_scale = 1.0 if viewport == "storm" else 0.62
+    low_level_volume = z_km[:, np.newaxis, np.newaxis] <= 5.25
+    scene_z_max = 5.25 if lens == "low_level_interactions" else float(np.max(z_km))
 
     cloud = _volume_layer(
         key="storm_cloud_body",
@@ -1050,15 +1118,15 @@ def _volume_scene(
         derivation="1000 * (qc + qr + qi + qs + qg)",
         rendering="neutral_cloud",
         values=total,
-        mask=total >= 0.05,
+        mask=(total >= 0.05) & (low_level_volume if lens == "low_level_interactions" else True),
         x_km=view_x,
         y_km=view_y,
         z_km=z_km,
         point_budget=round(12_000 * budget_scale),
         threshold_label="Total condensate at or above 0.05 g/kg",
-        default_visible=lens != "cloud_precipitation",
-        default_opacity=0.34,
-        default_point_size=5.5,
+        default_visible=lens == "rotating_updraft",
+        default_opacity=0.22,
+        default_point_size=4.5,
         scale=_condensate_scale(),
     )
     layers: list[VolumeLayer] = [cloud]
@@ -1068,24 +1136,44 @@ def _volume_scene(
         layers.extend(
             [
                 _volume_layer(
-                    key="vertical_motion",
-                    display_name="Strong vertical motion",
+                    key="rising_core",
+                    display_name="Rising core",
                     units="m/s",
                     evidence_kind="native",
                     source_fields=["winterp"],
                     derivation=None,
                     rendering="signed_scalar",
                     values=view["winterp"],
-                    mask=np.abs(view["winterp"]) >= 5.0,
+                    mask=view["winterp"] >= 5.0,
                     x_km=view_x,
                     y_km=view_y,
                     z_km=z_km,
-                    point_budget=round(7_500 * budget_scale),
-                    threshold_label="Absolute vertical velocity at or above 5 m/s",
+                    point_budget=round(6_000 * budget_scale),
+                    threshold_label="Rising motion at or above 5 m/s",
                     default_visible=True,
-                    default_opacity=0.78,
-                    default_point_size=6.5,
-                    scale=_section_w_scale(),
+                    default_opacity=0.88,
+                    default_point_size=6.8,
+                    scale=_midlevel_w_scale(),
+                ),
+                _volume_layer(
+                    key="strong_descent",
+                    display_name="Strong descent",
+                    units="m/s",
+                    evidence_kind="native",
+                    source_fields=["winterp"],
+                    derivation=None,
+                    rendering="signed_scalar",
+                    values=view["winterp"],
+                    mask=view["winterp"] <= -5.0,
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=z_km,
+                    point_budget=round(3_000 * budget_scale),
+                    threshold_label="Descending motion at or below -5 m/s",
+                    default_visible=False,
+                    default_opacity=0.58,
+                    default_point_size=5.0,
+                    scale=_midlevel_w_scale(),
                 ),
                 _volume_layer(
                     key="cyclonic_rotation",
@@ -1096,15 +1184,15 @@ def _volume_scene(
                     derivation=None,
                     rendering="scalar",
                     values=view["zvort"],
-                    mask=(view["zvort"] >= 0.005) & (view["winterp"] >= 2.0),
+                    mask=(view["zvort"] >= 0.01) & (view["winterp"] >= 2.0),
                     x_km=view_x,
                     y_km=view_y,
                     z_km=z_km,
                     point_budget=round(3_500 * budget_scale),
-                    threshold_label="Cyclonic vorticity at or above 0.005 s^-1 in rising air",
+                    threshold_label="Cyclonic vorticity at or above 0.01 s^-1 in rising air",
                     default_visible=True,
-                    default_opacity=0.74,
-                    default_point_size=5.5,
+                    default_opacity=0.92,
+                    default_point_size=4.2,
                     scale=_vorticity_scale(),
                 ),
                 _surface_volume_layer(
@@ -1116,15 +1204,15 @@ def _volume_scene(
                     derivation=None,
                     rendering="scalar",
                     values=view["uh"],
-                    mask=view["uh"] >= 100.0,
+                    mask=view["uh"] >= 300.0,
                     x_km=view_x,
                     y_km=view_y,
                     z_km=float(z_km[0]),
                     point_budget=round(3_000 * budget_scale),
-                    threshold_label="Cyclonic 2-5 km AGL UH at or above 100 m^2/s^2",
+                    threshold_label="Cyclonic 2-5 km AGL UH at or above 300 m^2/s^2",
                     default_visible=True,
-                    default_opacity=0.7,
-                    default_point_size=6.0,
+                    default_opacity=0.78,
+                    default_point_size=5.2,
                     scale=_uh_scale(),
                 ),
                 _volume_layer(
@@ -1136,7 +1224,7 @@ def _volume_scene(
                     derivation=None,
                     rendering="scalar",
                     values=view["dbz"],
-                    mask=view["dbz"] >= 20.0,
+                    mask=(view["dbz"] >= 20.0) & low_level_volume,
                     x_km=view_x,
                     y_km=view_y,
                     z_km=z_km,
@@ -1152,7 +1240,10 @@ def _volume_scene(
     elif lens == "cloud_precipitation":
         masses = np.stack([view[name] for name in HYDROMETEORS], axis=0)
         categories = np.argmax(masses, axis=0).astype(np.int64) + 1
-        categories[total < 0.05] = 0
+        dominant_mass = np.max(masses, axis=0) * 1_000.0
+        category_thresholds = np.asarray([0.0, 0.10, 0.20, 0.10, 0.30, 2.00])
+        category_mask = dominant_mass >= category_thresholds[categories]
+        categories[~category_mask] = 0
         layers.extend(
             [
                 _volume_layer(
@@ -1164,17 +1255,20 @@ def _volume_scene(
                     derivation="largest native hydrometeor mass mixing ratio per cloudy cell",
                     rendering="categorical",
                     values=total,
-                    mask=total >= 0.05,
+                    mask=category_mask,
                     categories=categories,
                     category_definitions=_hydrometeor_category_definitions(),
                     x_km=view_x,
                     y_km=view_y,
                     z_km=z_km,
-                    point_budget=round(16_000 * budget_scale),
-                    threshold_label="Total condensate at or above 0.05 g/kg",
+                    point_budget=round(10_000 * budget_scale),
+                    threshold_label=(
+                        "Native dominant-species thresholds: qc/qi 0.10, qr 0.20, "
+                        "qs 0.30, qg 2.00 g/kg"
+                    ),
                     default_visible=True,
-                    default_opacity=0.72,
-                    default_point_size=6.0,
+                    default_opacity=0.42,
+                    default_point_size=4.2,
                     scale=_condensate_scale(),
                 ),
                 _volume_layer(
@@ -1264,23 +1358,26 @@ def _volume_scene(
                 ),
                 _volume_layer(
                     key="precipitating_condensate",
-                    display_name="Precipitating condensate",
+                    display_name="Low-level precipitating condensate",
                     units="g/kg",
                     evidence_kind="derived",
                     source_fields=["qr", "qs", "qg"],
                     derivation="1000 * (qr + qs + qg)",
                     rendering="scalar",
                     values=precipitating,
-                    mask=precipitating >= 0.05,
+                    mask=(precipitating >= 0.25) & (z_km[:, np.newaxis, np.newaxis] <= 3.25),
                     x_km=view_x,
                     y_km=view_y,
                     z_km=z_km,
                     point_budget=round(6_000 * budget_scale),
-                    threshold_label="Rain, snow, and hail-treated large ice at or above 0.05 g/kg",
-                    default_visible=False,
-                    default_opacity=0.58,
-                    default_point_size=5.5,
-                    scale=_condensate_scale(),
+                    threshold_label=(
+                        "Rain, snow, and hail-treated large ice at or above 0.25 g/kg "
+                        "through 3.25 km"
+                    ),
+                    default_visible=True,
+                    default_opacity=0.24,
+                    default_point_size=3.2,
+                    scale=_precipitating_condensate_scale(),
                 ),
                 _volume_layer(
                     key="reflectivity",
@@ -1291,7 +1388,7 @@ def _volume_scene(
                     derivation=None,
                     rendering="scalar",
                     values=view["dbz"],
-                    mask=view["dbz"] >= 20.0,
+                    mask=(view["dbz"] >= 20.0) & low_level_volume,
                     x_km=view_x,
                     y_km=view_y,
                     z_km=z_km,
@@ -1317,9 +1414,13 @@ def _volume_scene(
         coordinate_extents_km={
             "x": {"min": float(np.min(view_x)), "max": float(np.max(view_x))},
             "y": {"min": float(np.min(view_y)), "max": float(np.max(view_y))},
-            "z": {"min": float(np.min(z_km)), "max": float(np.max(z_km))},
+            "z": {"min": float(np.min(z_km)), "max": scene_z_max},
         },
-        coordinate_sizes={"x": len(x_km), "y": len(y_km), "z": len(z_km)},
+        coordinate_sizes={
+            "x": len(x_km),
+            "y": len(y_km),
+            "z": int(np.count_nonzero(z_km <= scene_z_max)),
+        },
         layers=layers,
         wind_vectors=wind_vectors,
         wind_reference_m_s=25.0,
@@ -1431,33 +1532,122 @@ def _viewport_bounds(
     viewport: ViewportId,
     x_km: np.ndarray[Any, np.dtype[np.float64]],
     y_km: np.ndarray[Any, np.dtype[np.float64]],
-    primary: PointMarker,
 ) -> dict[str, float]:
     x_min, x_max = float(np.min(x_km) - 0.5), float(np.max(x_km) + 0.5)
     y_min, y_max = float(np.min(y_km) - 0.5), float(np.max(y_km) + 0.5)
     if viewport == "full":
         return {"x_min": x_min, "x_max": x_max, "y_min": y_min, "y_max": y_max}
-    half_width = 30.0
-    focus_x_min = max(x_min, primary.x_km - half_width)
-    focus_x_max = min(x_max, primary.x_km + half_width)
-    focus_y_min = max(y_min, primary.y_km - half_width)
-    focus_y_max = min(y_max, primary.y_km + half_width)
-    if focus_x_max - focus_x_min < half_width * 2:
-        if focus_x_min == x_min:
-            focus_x_max = min(x_max, x_min + half_width * 2)
-        else:
-            focus_x_min = max(x_min, x_max - half_width * 2)
-    if focus_y_max - focus_y_min < half_width * 2:
-        if focus_y_min == y_min:
-            focus_y_max = min(y_max, y_min + half_width * 2)
-        else:
-            focus_y_min = max(y_min, y_max - half_width * 2)
     return {
-        "x_min": focus_x_min,
-        "x_max": focus_x_max,
-        "y_min": focus_y_min,
-        "y_max": focus_y_max,
+        "x_min": max(x_min, STORM_VIEW_BOUNDS_KM["x_min"]),
+        "x_max": min(x_max, STORM_VIEW_BOUNDS_KM["x_max"]),
+        "y_min": max(y_min, STORM_VIEW_BOUNDS_KM["y_min"]),
+        "y_max": min(y_max, STORM_VIEW_BOUNDS_KM["y_max"]),
     }
+
+
+def _what_to_notice_by_view(
+    lens: LensId,
+    time_seconds: float,
+    plan: PlanView,
+    xz_section: VerticalSection,
+    yz_section: VerticalSection,
+) -> dict[str, str]:
+    minutes = round(time_seconds / 60)
+    if lens == "rotating_updraft":
+        w = np.asarray(plan.primary.values, dtype=np.float64)
+        vorticity = np.asarray(plan.overlays["vertical_vorticity"].values, dtype=np.float64)
+        overlap = int(np.count_nonzero((w >= 5.0) & (vorticity >= 0.01)))
+        uh_max = plan.overlays["updraft_helicity"].selected_frame_maximum
+        return {
+            "plan": (
+                f"At {minutes} min, {overlap} cells on the 3.25 km slice combine "
+                f"rising motion of at least 5 m/s with cyclonic vorticity of at least "
+                f"0.01 s^-1; 2-5 km AGL UH peaks at {uh_max:.0f} m^2/s^2."
+            ),
+            "xz": _rotating_section_notice(minutes, xz_section),
+            "yz": _rotating_section_notice(minutes, yz_section),
+        }
+    if lens == "cloud_precipitation":
+        categories = plan.categories
+        if categories is None:
+            plan_notice = f"At {minutes} min, the column-derived cloud view is unavailable."
+        else:
+            common = _most_common_category(categories)
+            plan_notice = (
+                f"At {minutes} min, the column-derived x-y view most often assigns "
+                f"{common.lower()} where condensate is present; column-maximum total "
+                f"condensate reaches {plan.primary.selected_frame_maximum:.2f} g/kg. "
+                "Selecting a cell inspects the native level responsible for that category."
+            )
+        return {
+            "plan": plan_notice,
+            "xz": _cloud_section_notice(minutes, xz_section),
+            "yz": _cloud_section_notice(minutes, yz_section),
+        }
+    w_min = plan.primary.selected_frame_minimum
+    w_max = plan.primary.selected_frame_maximum
+    rain_max = plan.overlays["accumulated_surface_rain"].selected_frame_maximum
+    precip_max = plan.overlays["low_level_precipitating_condensate"].selected_frame_maximum
+    return {
+        "plan": (
+            f"At {minutes} min, current 1.25 km motion spans {w_min:+.1f} to "
+            f"{w_max:+.1f} m/s and precipitating condensate reaches "
+            f"{precip_max:.2f} g/kg; the historical rain footprint peaks at "
+            f"{rain_max:.1f} mm."
+        ),
+        "xz": _low_level_section_notice(minutes, xz_section),
+        "yz": _low_level_section_notice(minutes, yz_section),
+    }
+
+
+def _most_common_category(categories: CategoryLayer) -> str:
+    codes = np.asarray(categories.values, dtype=np.int64)
+    present = codes[codes > 0]
+    definitions = {item.code: item.label for item in categories.categories}
+    if present.size == 0:
+        return "No hydrometeor"
+    return definitions[int(np.bincount(present).argmax())]
+
+
+def _rotating_section_notice(minutes: int, section: VerticalSection) -> str:
+    w = np.asarray(section.primary.values, dtype=np.float64)
+    vorticity = np.asarray(section.overlays["vertical_vorticity"].values, dtype=np.float64)
+    overlap = int(np.count_nonzero((w >= 5.0) & (vorticity >= 0.01)))
+    return (
+        f"At {minutes} min, this {section.orientation} section intersects {overlap} cells "
+        f"with both rising motion of at least 5 m/s and cyclonic vorticity of at least "
+        f"0.01 s^-1; vertical velocity spans "
+        f"{section.primary.selected_frame_minimum:+.1f} to "
+        f"{section.primary.selected_frame_maximum:+.1f} m/s."
+    )
+
+
+def _cloud_section_notice(minutes: int, section: VerticalSection) -> str:
+    categories = section.categories
+    if categories is None:
+        return f"At {minutes} min, this {section.orientation} cloud section is unavailable."
+    common = _most_common_category(categories)
+    total_max = section.primary.selected_frame_maximum
+    precip_max = section.overlays["precipitating_condensate"].selected_frame_maximum
+    coordinate = "y" if section.orientation == "xz" else "x"
+    return (
+        f"At {minutes} min, this {section.orientation} section through {coordinate} = "
+        f"{section.cross_section_coordinate_km:.1f} km most often shows {common.lower()} "
+        f"where condensate is present; total condensate reaches {total_max:.2f} g/kg "
+        f"and precipitating condensate reaches {precip_max:.2f} g/kg."
+    )
+
+
+def _low_level_section_notice(minutes: int, section: VerticalSection) -> str:
+    precip_max = section.overlays["precipitating_condensate"].selected_frame_maximum
+    coordinate = "y" if section.orientation == "xz" else "x"
+    return (
+        f"At {minutes} min, this {section.orientation} section through {coordinate} = "
+        f"{section.cross_section_coordinate_km:.1f} km shows vertical motion from "
+        f"{section.primary.selected_frame_minimum:+.1f} to "
+        f"{section.primary.selected_frame_maximum:+.1f} m/s; current precipitating "
+        f"condensate reaches {precip_max:.2f} g/kg."
+    )
 
 
 def _lens_identity(lens: LensId) -> tuple[str, str]:
@@ -1614,16 +1804,29 @@ def _condensate_scale() -> ScaleMetadata:
     )
 
 
+def _precipitating_condensate_scale() -> ScaleMetadata:
+    return ScaleMetadata(
+        scale_id="supercell_low_level_precipitating_condensate_v1",
+        display_name="Low-level precipitating condensate",
+        units="g/kg",
+        scale_type="fixed_continuous",
+        minimum=0,
+        maximum=10,
+        breakpoints=[0.25, 1, 3, 6],
+        colors=["#f4ecdc", "#dfc18b", "#bd8446", "#8a5526", "#583516"],
+    )
+
+
 def _vorticity_scale() -> ScaleMetadata:
     return ScaleMetadata(
         scale_id="supercell_vertical_vorticity_v1",
-        display_name="Vertical vorticity",
+        display_name="Cyclonic vertical vorticity",
         units="s^-1",
         scale_type="fixed_continuous",
-        minimum=-0.035,
+        minimum=0,
         maximum=0.035,
-        breakpoints=[-0.02, -0.01, -0.005, 0.005, 0.01, 0.02],
-        colors=["#7e22ce", "#ffffff", "#111827"],
+        breakpoints=[0.01, 0.02, 0.03],
+        colors=["#d8c4e2", "#9c5bad", "#632b73", "#32113d"],
     )
 
 

--- a/app/backend/cloud_chamber/storm_examination.py
+++ b/app/backend/cloud_chamber/storm_examination.py
@@ -21,6 +21,7 @@ HISTORY_FILENAMES = tuple(f"cm1out_{index:06d}.nc" for index in range(1, 10))
 HYDROMETEORS = ("qc", "qr", "qi", "qs", "qg")
 LensId = Literal["rotating_updraft", "cloud_precipitation", "low_level_interactions"]
 ViewportId = Literal["storm", "full"]
+FramePurpose = Literal["research", "product"]
 
 W_COLORS = (
     "#4b0082",
@@ -101,6 +102,44 @@ class PointMarker(BaseModel):
     w_m_s: float
 
 
+class VolumeLayer(BaseModel):
+    key: str
+    display_name: str
+    units: str
+    evidence_kind: Literal["native", "derived"]
+    source_fields: list[str]
+    derivation: str | None = None
+    rendering: Literal["neutral_cloud", "signed_scalar", "scalar", "categorical"]
+    points: list[tuple[float, float, float, float, int]]
+    source_count: int
+    returned_count: int
+    threshold_label: str
+    default_visible: bool
+    default_opacity: float
+    default_point_size: float
+    scale: ScaleMetadata | None = None
+    categories: list[CategoryDefinition] = Field(default_factory=list)
+
+
+class VolumeWindVector(BaseModel):
+    x_km: float
+    y_km: float
+    z_km: float
+    u_m_s: float
+    v_m_s: float
+    magnitude_m_s: float
+
+
+class StormVolumeScene(BaseModel):
+    coordinate_extents_km: dict[str, dict[str, float]]
+    coordinate_sizes: dict[str, int]
+    layers: list[VolumeLayer]
+    wind_vectors: list[VolumeWindVector] = Field(default_factory=list)
+    wind_reference_m_s: float
+    point_budget: int
+    source_history_file: str
+
+
 class PlanView(BaseModel):
     title: str
     subtitle: str
@@ -153,10 +192,14 @@ class TimelineCheckpoint(BaseModel):
 
 
 class StormExaminationFrame(BaseModel):
-    schema_version: Literal["storm_examination_gate_c_v1"] = "storm_examination_gate_c_v1"
-    authority_state: Literal["issue_418_gate_c_research_not_product"] = (
-        "issue_418_gate_c_research_not_product"
+    schema_version: Literal["storm_examination_gate_c_v1", "supercells_explore_v1"] = (
+        "storm_examination_gate_c_v1"
     )
+    authority_state: Literal[
+        "issue_418_gate_c_research_not_product", "supercells_product_world"
+    ] = "issue_418_gate_c_research_not_product"
+    world_id: Literal["supercells"] | None = None
+    simulation_id: Literal["supercells_quarter_circle_reference"] | None = None
     run_id: str
     case_id: str
     simulation_label: str
@@ -175,6 +218,7 @@ class StormExaminationFrame(BaseModel):
     plan: PlanView
     xz_section: VerticalSection
     yz_section: VerticalSection
+    scene: StormVolumeScene | None = None
     caveats: list[str]
     provenance: dict[str, str]
     extraction_milliseconds: float
@@ -189,6 +233,61 @@ def preserved_storm_examination_frame(
     x_index: int | None = None,
     y_index: int | None = None,
     z_index: int | None = None,
+) -> StormExaminationFrame:
+    """Return the accepted Gate C research surface through the shared extractor."""
+    return _storm_frame(
+        settings,
+        lens=lens,
+        time_index=time_index,
+        viewport=viewport,
+        x_index=x_index,
+        y_index=y_index,
+        z_index=z_index,
+        purpose="research",
+    )
+
+
+def supercells_explore_frame(
+    settings: CloudChamberSettings,
+    *,
+    lens: LensId = "rotating_updraft",
+    time_index: int = 5,
+    viewport: ViewportId = "storm",
+    x_index: int | None = None,
+    y_index: int | None = None,
+    z_index: int | None = None,
+) -> StormExaminationFrame:
+    """Return the production Supercells frame from the accepted Gate C science path."""
+    return _storm_frame(
+        settings,
+        lens=lens,
+        time_index=time_index,
+        viewport=viewport,
+        x_index=x_index,
+        y_index=y_index,
+        z_index=z_index,
+        purpose="product",
+    )
+
+
+def storm_examination_inventory(
+    settings: CloudChamberSettings,
+) -> tuple[tuple[Path, float], ...]:
+    """Return the cached, identity-validated retained history inventory."""
+    run_dir = settings.runtime_home.expanduser() / "runs" / PRESERVED_RUN_ID
+    return _validated_inventory(run_dir)
+
+
+def _storm_frame(
+    settings: CloudChamberSettings,
+    *,
+    lens: LensId,
+    time_index: int,
+    viewport: ViewportId,
+    x_index: int | None,
+    y_index: int | None,
+    z_index: int | None,
+    purpose: FramePurpose,
 ) -> StormExaminationFrame:
     """Extract coordinated, bounded views from one retained native history."""
     started = time.perf_counter()
@@ -281,7 +380,33 @@ def preserved_storm_examination_frame(
         primary,
     )
     lens_name, lens_question = _lens_identity(lens)
+    scene = (
+        _volume_scene(
+            lens,
+            fields,
+            x_km,
+            y_km,
+            z_km,
+            x_indices,
+            y_indices,
+            default_level,
+            history_path.name,
+            viewport,
+        )
+        if purpose == "product"
+        else None
+    )
     return StormExaminationFrame(
+        schema_version=(
+            "supercells_explore_v1" if purpose == "product" else "storm_examination_gate_c_v1"
+        ),
+        authority_state=(
+            "supercells_product_world"
+            if purpose == "product"
+            else "issue_418_gate_c_research_not_product"
+        ),
+        world_id="supercells" if purpose == "product" else None,
+        simulation_id="supercells_quarter_circle_reference" if purpose == "product" else None,
         run_id=PRESERVED_RUN_ID,
         case_id=PRESERVED_CASE_ID,
         simulation_label="Official CM1 r21.1 quarter-circle benchmark",
@@ -300,6 +425,7 @@ def preserved_storm_examination_frame(
         plan=plan,
         xz_section=xz_section,
         yz_section=yz_section,
+        scene=scene,
         caveats=[
             "Saved histories are 15 minutes apart; continuity between frames is inferred, "
             "not observed continuously.",
@@ -315,11 +441,17 @@ def preserved_storm_examination_frame(
         provenance={
             "source_history_file": history_path.name,
             "source_kind": "retained_native_cm1_history",
-            "browser_payload": "selected plan and two native-grid vertical sections only",
+            "browser_payload": (
+                "bounded 3-D layers, selected plan, and two native-grid vertical sections"
+                if purpose == "product"
+                else "selected plan and two native-grid vertical sections only"
+            ),
             "interpolation": "none",
             "coordinate_frame": "translating_model_coordinates",
             "product_boundary": (
-                "bounded Gate C research; not a Cloud World or final Lens implementation"
+                "Supercells production Explore"
+                if purpose == "product"
+                else "bounded Gate C research; not a Cloud World or final Lens implementation"
             ),
         },
         extraction_milliseconds=round((time.perf_counter() - started) * 1_000, 3),
@@ -837,17 +969,21 @@ def _category_layer(
         ),
         values=[[int(value) for value in row] for row in values.tolist()],
         magnitude=magnitude,
-        categories=[
-            CategoryDefinition(
-                code=0, key="clear", label="Below condensate threshold", color="#ffffff"
-            ),
-            CategoryDefinition(code=1, key="qc", label="Cloud liquid", color="#62c6d7"),
-            CategoryDefinition(code=2, key="qr", label="Rain", color="#2a78b8"),
-            CategoryDefinition(code=3, key="qi", label="Cloud ice", color="#cab6e8"),
-            CategoryDefinition(code=4, key="qs", label="Snow", color="#8b9fd8"),
-            CategoryDefinition(code=5, key="qg", label="Hail-treated large ice", color="#e38a36"),
-        ],
+        categories=_hydrometeor_category_definitions(),
     )
+
+
+def _hydrometeor_category_definitions() -> list[CategoryDefinition]:
+    return [
+        CategoryDefinition(
+            code=0, key="clear", label="Below condensate threshold", color="#ffffff"
+        ),
+        CategoryDefinition(code=1, key="qc", label="Cloud liquid", color="#62c6d7"),
+        CategoryDefinition(code=2, key="qr", label="Rain", color="#2a78b8"),
+        CategoryDefinition(code=3, key="qi", label="Cloud ice", color="#cab6e8"),
+        CategoryDefinition(code=4, key="qs", label="Snow", color="#8b9fd8"),
+        CategoryDefinition(code=5, key="qg", label="Hail-treated large ice", color="#e38a36"),
+    ]
 
 
 def _wind_vectors(
@@ -866,6 +1002,416 @@ def _wind_vectors(
                 WindVector(
                     x_km=float(x_km[x_index]),
                     y_km=float(y_km[y_index]),
+                    u_m_s=u,
+                    v_m_s=v,
+                    magnitude_m_s=float(np.hypot(u, v)),
+                )
+            )
+    return vectors
+
+
+def _volume_scene(
+    lens: LensId,
+    fields: dict[str, np.ndarray[Any, np.dtype[np.float64]]],
+    x_km: np.ndarray[Any, np.dtype[np.float64]],
+    y_km: np.ndarray[Any, np.dtype[np.float64]],
+    z_km: np.ndarray[Any, np.dtype[np.float64]],
+    x_indices: np.ndarray[Any, np.dtype[np.int64]],
+    y_indices: np.ndarray[Any, np.dtype[np.int64]],
+    level_index: int,
+    history_filename: str,
+    viewport: ViewportId,
+) -> StormVolumeScene:
+    view = {
+        name: values[:, y_indices, :][:, :, x_indices]
+        if values.ndim == 3
+        else values[y_indices, :][:, x_indices]
+        for name, values in fields.items()
+    }
+    view_x = x_km[x_indices]
+    view_y = y_km[y_indices]
+    total = _total_condensate_g_kg(view)
+    precipitating = 1_000.0 * (view["qr"] + view["qs"] + view["qg"])
+    budget_scale = 1.0 if viewport == "storm" else 0.62
+
+    cloud = _volume_layer(
+        key="storm_cloud_body",
+        display_name="Storm cloud body",
+        units="g/kg",
+        evidence_kind="derived",
+        source_fields=list(HYDROMETEORS),
+        derivation="1000 * (qc + qr + qi + qs + qg)",
+        rendering="neutral_cloud",
+        values=total,
+        mask=total >= 0.05,
+        x_km=view_x,
+        y_km=view_y,
+        z_km=z_km,
+        point_budget=round(12_000 * budget_scale),
+        threshold_label="Total condensate at or above 0.05 g/kg",
+        default_visible=lens != "cloud_precipitation",
+        default_opacity=0.34,
+        default_point_size=5.5,
+        scale=_condensate_scale(),
+    )
+    layers: list[VolumeLayer] = [cloud]
+    wind_vectors: list[VolumeWindVector] = []
+
+    if lens == "rotating_updraft":
+        layers.extend(
+            [
+                _volume_layer(
+                    key="vertical_motion",
+                    display_name="Strong vertical motion",
+                    units="m/s",
+                    evidence_kind="native",
+                    source_fields=["winterp"],
+                    derivation=None,
+                    rendering="signed_scalar",
+                    values=view["winterp"],
+                    mask=np.abs(view["winterp"]) >= 5.0,
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=z_km,
+                    point_budget=round(7_500 * budget_scale),
+                    threshold_label="Absolute vertical velocity at or above 5 m/s",
+                    default_visible=True,
+                    default_opacity=0.78,
+                    default_point_size=6.5,
+                    scale=_section_w_scale(),
+                ),
+                _volume_layer(
+                    key="cyclonic_rotation",
+                    display_name="Cyclonic vertical vorticity",
+                    units="s^-1",
+                    evidence_kind="native",
+                    source_fields=["zvort"],
+                    derivation=None,
+                    rendering="scalar",
+                    values=view["zvort"],
+                    mask=(view["zvort"] >= 0.005) & (view["winterp"] >= 2.0),
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=z_km,
+                    point_budget=round(3_500 * budget_scale),
+                    threshold_label="Cyclonic vorticity at or above 0.005 s^-1 in rising air",
+                    default_visible=True,
+                    default_opacity=0.74,
+                    default_point_size=5.5,
+                    scale=_vorticity_scale(),
+                ),
+                _surface_volume_layer(
+                    key="updraft_helicity",
+                    display_name="2-5 km AGL updraft helicity",
+                    units="m^2/s^2",
+                    evidence_kind="native",
+                    source_fields=["uh"],
+                    derivation=None,
+                    rendering="scalar",
+                    values=view["uh"],
+                    mask=view["uh"] >= 100.0,
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=float(z_km[0]),
+                    point_budget=round(3_000 * budget_scale),
+                    threshold_label="Cyclonic 2-5 km AGL UH at or above 100 m^2/s^2",
+                    default_visible=True,
+                    default_opacity=0.7,
+                    default_point_size=6.0,
+                    scale=_uh_scale(),
+                ),
+                _volume_layer(
+                    key="reflectivity",
+                    display_name="Reflectivity",
+                    units="dBZ",
+                    evidence_kind="native",
+                    source_fields=["dbz"],
+                    derivation=None,
+                    rendering="scalar",
+                    values=view["dbz"],
+                    mask=view["dbz"] >= 20.0,
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=z_km,
+                    point_budget=round(5_000 * budget_scale),
+                    threshold_label="Reflectivity at or above 20 dBZ",
+                    default_visible=False,
+                    default_opacity=0.58,
+                    default_point_size=5.0,
+                    scale=_reflectivity_scale(),
+                ),
+            ]
+        )
+    elif lens == "cloud_precipitation":
+        masses = np.stack([view[name] for name in HYDROMETEORS], axis=0)
+        categories = np.argmax(masses, axis=0).astype(np.int64) + 1
+        categories[total < 0.05] = 0
+        layers.extend(
+            [
+                _volume_layer(
+                    key="hydrometeor_categories",
+                    display_name="Dominant hydrometeor",
+                    units="g/kg",
+                    evidence_kind="derived",
+                    source_fields=list(HYDROMETEORS),
+                    derivation="largest native hydrometeor mass mixing ratio per cloudy cell",
+                    rendering="categorical",
+                    values=total,
+                    mask=total >= 0.05,
+                    categories=categories,
+                    category_definitions=_hydrometeor_category_definitions(),
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=z_km,
+                    point_budget=round(16_000 * budget_scale),
+                    threshold_label="Total condensate at or above 0.05 g/kg",
+                    default_visible=True,
+                    default_opacity=0.72,
+                    default_point_size=6.0,
+                    scale=_condensate_scale(),
+                ),
+                _volume_layer(
+                    key="vertical_motion",
+                    display_name="Strong vertical motion",
+                    units="m/s",
+                    evidence_kind="native",
+                    source_fields=["winterp"],
+                    derivation=None,
+                    rendering="signed_scalar",
+                    values=view["winterp"],
+                    mask=np.abs(view["winterp"]) >= 8.0,
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=z_km,
+                    point_budget=round(5_000 * budget_scale),
+                    threshold_label="Absolute vertical velocity at or above 8 m/s",
+                    default_visible=False,
+                    default_opacity=0.6,
+                    default_point_size=5.5,
+                    scale=_section_w_scale(),
+                ),
+                _volume_layer(
+                    key="reflectivity",
+                    display_name="Reflectivity",
+                    units="dBZ",
+                    evidence_kind="native",
+                    source_fields=["dbz"],
+                    derivation=None,
+                    rendering="scalar",
+                    values=view["dbz"],
+                    mask=view["dbz"] >= 25.0,
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=z_km,
+                    point_budget=round(5_000 * budget_scale),
+                    threshold_label="Reflectivity at or above 25 dBZ",
+                    default_visible=False,
+                    default_opacity=0.55,
+                    default_point_size=5.0,
+                    scale=_reflectivity_scale(),
+                ),
+            ]
+        )
+    else:
+        layers.extend(
+            [
+                _surface_volume_layer(
+                    key="low_level_vertical_motion",
+                    display_name="Low-level vertical motion",
+                    units="m/s",
+                    evidence_kind="native",
+                    source_fields=["winterp"],
+                    derivation=None,
+                    rendering="signed_scalar",
+                    values=view["winterp"][level_index],
+                    mask=np.ones_like(view["winterp"][level_index], dtype=np.bool_),
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=float(z_km[level_index]),
+                    point_budget=round(8_000 * budget_scale),
+                    threshold_label=f"Native plane at z = {float(z_km[level_index]):.2f} km",
+                    default_visible=True,
+                    default_opacity=0.72,
+                    default_point_size=5.0,
+                    scale=_low_level_w_scale(),
+                ),
+                _surface_volume_layer(
+                    key="accumulated_surface_rain",
+                    display_name="Accumulated surface rain",
+                    units="mm",
+                    evidence_kind="derived",
+                    source_fields=["rain"],
+                    derivation="native accumulated rain in cm multiplied by 10",
+                    rendering="scalar",
+                    values=view["rain"] * 10.0,
+                    mask=view["rain"] >= 0.01,
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=float(z_km[0]),
+                    point_budget=round(5_000 * budget_scale),
+                    threshold_label="Accumulated rain at or above 0.1 mm",
+                    default_visible=True,
+                    default_opacity=0.72,
+                    default_point_size=5.5,
+                    scale=_rain_scale(),
+                ),
+                _volume_layer(
+                    key="precipitating_condensate",
+                    display_name="Precipitating condensate",
+                    units="g/kg",
+                    evidence_kind="derived",
+                    source_fields=["qr", "qs", "qg"],
+                    derivation="1000 * (qr + qs + qg)",
+                    rendering="scalar",
+                    values=precipitating,
+                    mask=precipitating >= 0.05,
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=z_km,
+                    point_budget=round(6_000 * budget_scale),
+                    threshold_label="Rain, snow, and hail-treated large ice at or above 0.05 g/kg",
+                    default_visible=False,
+                    default_opacity=0.58,
+                    default_point_size=5.5,
+                    scale=_condensate_scale(),
+                ),
+                _volume_layer(
+                    key="reflectivity",
+                    display_name="Reflectivity",
+                    units="dBZ",
+                    evidence_kind="native",
+                    source_fields=["dbz"],
+                    derivation=None,
+                    rendering="scalar",
+                    values=view["dbz"],
+                    mask=view["dbz"] >= 20.0,
+                    x_km=view_x,
+                    y_km=view_y,
+                    z_km=z_km,
+                    point_budget=round(5_000 * budget_scale),
+                    threshold_label="Reflectivity at or above 20 dBZ",
+                    default_visible=False,
+                    default_opacity=0.52,
+                    default_point_size=5.0,
+                    scale=_reflectivity_scale(),
+                ),
+            ]
+        )
+        wind_vectors = _volume_wind_vectors(
+            view,
+            view_x,
+            view_y,
+            float(z_km[level_index]),
+            level_index,
+            5 if viewport == "storm" else 10,
+        )
+
+    return StormVolumeScene(
+        coordinate_extents_km={
+            "x": {"min": float(np.min(view_x)), "max": float(np.max(view_x))},
+            "y": {"min": float(np.min(view_y)), "max": float(np.max(view_y))},
+            "z": {"min": float(np.min(z_km)), "max": float(np.max(z_km))},
+        },
+        coordinate_sizes={"x": len(x_km), "y": len(y_km), "z": len(z_km)},
+        layers=layers,
+        wind_vectors=wind_vectors,
+        wind_reference_m_s=25.0,
+        point_budget=sum(layer.returned_count for layer in layers),
+        source_history_file=history_filename,
+    )
+
+
+def _volume_layer(
+    *,
+    key: str,
+    display_name: str,
+    units: str,
+    evidence_kind: Literal["native", "derived"],
+    source_fields: list[str],
+    derivation: str | None,
+    rendering: Literal["neutral_cloud", "signed_scalar", "scalar", "categorical"],
+    values: np.ndarray[Any, np.dtype[np.float64]],
+    mask: np.ndarray[Any, np.dtype[np.bool_]],
+    x_km: np.ndarray[Any, np.dtype[np.float64]],
+    y_km: np.ndarray[Any, np.dtype[np.float64]],
+    z_km: np.ndarray[Any, np.dtype[np.float64]],
+    point_budget: int,
+    threshold_label: str,
+    default_visible: bool,
+    default_opacity: float,
+    default_point_size: float,
+    scale: ScaleMetadata | None,
+    categories: np.ndarray[Any, np.dtype[np.int64]] | None = None,
+    category_definitions: list[CategoryDefinition] | None = None,
+) -> VolumeLayer:
+    locations = np.argwhere(mask & np.isfinite(values))
+    source_count = len(locations)
+    if source_count > point_budget:
+        stride = max(1, int(np.ceil(source_count / point_budget)))
+        locations = locations[::stride][:point_budget]
+    points = [
+        (
+            round(float(x_km[x_index]), 5),
+            round(float(y_km[y_index]), 5),
+            round(float(z_km[z_index]), 5),
+            round(float(values[z_index, y_index, x_index]), 6),
+            int(categories[z_index, y_index, x_index]) if categories is not None else 0,
+        )
+        for z_index, y_index, x_index in locations
+    ]
+    return VolumeLayer(
+        key=key,
+        display_name=display_name,
+        units=units,
+        evidence_kind=evidence_kind,
+        source_fields=source_fields,
+        derivation=derivation,
+        rendering=rendering,
+        points=points,
+        source_count=source_count,
+        returned_count=len(points),
+        threshold_label=threshold_label,
+        default_visible=default_visible,
+        default_opacity=default_opacity,
+        default_point_size=default_point_size,
+        scale=scale,
+        categories=category_definitions or [],
+    )
+
+
+def _surface_volume_layer(
+    *,
+    values: np.ndarray[Any, np.dtype[np.float64]],
+    mask: np.ndarray[Any, np.dtype[np.bool_]],
+    z_km: float,
+    **kwargs: Any,
+) -> VolumeLayer:
+    return _volume_layer(
+        values=values[np.newaxis, :, :],
+        mask=mask[np.newaxis, :, :],
+        z_km=np.asarray([z_km], dtype=np.float64),
+        **kwargs,
+    )
+
+
+def _volume_wind_vectors(
+    fields: dict[str, np.ndarray[Any, np.dtype[np.float64]]],
+    x_km: np.ndarray[Any, np.dtype[np.float64]],
+    y_km: np.ndarray[Any, np.dtype[np.float64]],
+    z_km: float,
+    level_index: int,
+    stride: int,
+) -> list[VolumeWindVector]:
+    vectors: list[VolumeWindVector] = []
+    for y_index in range(0, len(y_km), stride):
+        for x_index in range(0, len(x_km), stride):
+            u = float(fields["uinterp"][level_index, y_index, x_index])
+            v = float(fields["vinterp"][level_index, y_index, x_index])
+            vectors.append(
+                VolumeWindVector(
+                    x_km=float(x_km[x_index]),
+                    y_km=float(y_km[y_index]),
+                    z_km=z_km,
                     u_m_s=u,
                     v_m_s=v,
                     magnitude_m_s=float(np.hypot(u, v)),

--- a/app/backend/cloud_chamber/storm_examination.py
+++ b/app/backend/cloud_chamber/storm_examination.py
@@ -645,6 +645,15 @@ def _plan_view(
             "1000 * max_z(qc + qr + qi + qs + qg)",
         )
         categories = _column_hydrometeor_categories(view_fields, column_max)
+        overlays["vertical_velocity"] = _layer(
+            "winterp",
+            "Vertical velocity",
+            "m/s",
+            "native",
+            ["winterp"],
+            view_fields["winterp"][level_index],
+            _midlevel_w_scale(),
+        )
         title = "Cloud and precipitation structure"
         subtitle = "Dominant hydrometeor at the column's strongest condensate level"
         vectors = []
@@ -659,9 +668,7 @@ def _plan_view(
             _low_level_w_scale(),
         )
         title = "Low-level motion and rain footprint"
-        subtitle = (
-            "1.25 km vertical motion, accumulated rain, reflectivity, and model-relative flow"
-        )
+        subtitle = "1.25 km vertical motion, accumulated rain, and model-relative flow"
         categories = None
         vectors = _wind_vectors(view_fields, view_x_km, view_y_km)
     return PlanView(

--- a/app/backend/cloud_chamber/supercells_world.py
+++ b/app/backend/cloud_chamber/supercells_world.py
@@ -1,0 +1,151 @@
+"""Stable product identity and retained-output state for the Supercells World."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.storm_examination import (
+    PRESERVED_CASE_ID,
+    PRESERVED_RUN_ID,
+    StormExaminationError,
+    storm_examination_inventory,
+)
+
+WORLD_ID: Literal["supercells"] = "supercells"
+WORLD_DISPLAY_NAME: Literal["Supercells"] = "Supercells"
+REFERENCE_SIMULATION_ID: Literal["supercells_quarter_circle_reference"] = (
+    "supercells_quarter_circle_reference"
+)
+REFERENCE_DISPLAY_NAME: Literal["Quarter-Circle Supercell"] = "Quarter-Circle Supercell"
+WORLD_SHORT_DESCRIPTION = (
+    "A deep rotating thunderstorm for seeing organized ascent, rotation, hydrometeors, "
+    "precipitation, and low-level flow evolve together."
+)
+
+AvailabilityState = Literal["available", "partial", "unavailable"]
+TechnicalState = Literal["available", "missing", "invalid"]
+
+
+class SupercellSimulationRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    simulation_id: Literal["supercells_quarter_circle_reference"] = REFERENCE_SIMULATION_ID
+    display_name: Literal["Quarter-Circle Supercell"] = REFERENCE_DISPLAY_NAME
+    role: Literal["reference"] = "reference"
+    world_id: Literal["supercells"] = WORLD_ID
+    run_id: str = PRESERVED_RUN_ID
+    case_id: str = PRESERVED_CASE_ID
+    technical_state: TechnicalState
+    technical_state_message: str
+    explore_available: bool
+    saved_output_count: int
+    model_start_seconds: float | None
+    model_end_seconds: float | None
+    history_cadence_seconds: float | None
+    lineage_state: Literal["known"] = "known"
+
+
+class SupercellsCapabilities(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    reference_explore: bool
+    lab: Literal[False] = False
+    compare: Literal[False] = False
+    saved_views: Literal[False] = False
+
+
+class SupercellsWorldSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    world_id: Literal["supercells"] = WORLD_ID
+    display_name: Literal["Supercells"] = WORLD_DISPLAY_NAME
+    short_description: str = WORLD_SHORT_DESCRIPTION
+    reference_simulation_id: Literal["supercells_quarter_circle_reference"] = (
+        REFERENCE_SIMULATION_ID
+    )
+    reference_available: bool
+    simulation_count: int
+    saved_view_count: Literal[0] = 0
+    saved_comparison_count: Literal[0] = 0
+    featured_comparison_count: Literal[0] = 0
+    active_run_count: Literal[0] = 0
+    completed_uninspected_run_count: Literal[0] = 0
+    availability_state: AvailabilityState
+    availability_message: str
+
+
+class SupercellsWorldDetail(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    world_id: Literal["supercells"] = WORLD_ID
+    display_name: Literal["Supercells"] = WORLD_DISPLAY_NAME
+    short_description: str = WORLD_SHORT_DESCRIPTION
+    availability_state: AvailabilityState
+    availability_message: str
+    reference_simulation: SupercellSimulationRecord
+    simulations: list[SupercellSimulationRecord]
+    capabilities: SupercellsCapabilities
+    caveats: list[str] = Field(default_factory=list)
+
+    def summary(self) -> SupercellsWorldSummary:
+        available = self.reference_simulation.technical_state == "available"
+        return SupercellsWorldSummary(
+            reference_available=available,
+            simulation_count=1 if available else 0,
+            availability_state=self.availability_state,
+            availability_message=self.availability_message,
+        )
+
+
+def supercells_world_detail(settings: CloudChamberSettings) -> SupercellsWorldDetail:
+    """Resolve the one approved built-in without exposing its machine-private path."""
+    try:
+        inventory = storm_examination_inventory(settings)
+    except StormExaminationError as exc:
+        message = str(exc)
+        state: TechnicalState = "missing" if "unavailable" in message.lower() else "invalid"
+        simulation = SupercellSimulationRecord(
+            technical_state=state,
+            technical_state_message=message,
+            explore_available=False,
+            saved_output_count=0,
+            model_start_seconds=None,
+            model_end_seconds=None,
+            history_cadence_seconds=None,
+        )
+        return SupercellsWorldDetail(
+            availability_state="unavailable",
+            availability_message=(
+                "The Quarter-Circle Supercell output is not available for Explore."
+            ),
+            reference_simulation=simulation,
+            simulations=[simulation],
+            capabilities=SupercellsCapabilities(reference_explore=False),
+            caveats=[message],
+        )
+
+    times = [item[1] for item in inventory]
+    cadence = times[1] - times[0] if len(times) > 1 else None
+    simulation = SupercellSimulationRecord(
+        technical_state="available",
+        technical_state_message="Retained native CM1 output is ready for inspection.",
+        explore_available=True,
+        saved_output_count=len(times),
+        model_start_seconds=times[0],
+        model_end_seconds=times[-1],
+        history_cadence_seconds=cadence,
+    )
+    return SupercellsWorldDetail(
+        availability_state="available",
+        availability_message="Quarter-Circle Supercell is available for Explore.",
+        reference_simulation=simulation,
+        simulations=[simulation],
+        capabilities=SupercellsCapabilities(reference_explore=True),
+        caveats=[
+            "This is an idealized stock CM1 quarter-circle benchmark, not an observed storm.",
+            "Horizontal coordinates and winds use the translating model frame.",
+        ],
+    )

--- a/app/backend/tests/test_cloud_worlds.py
+++ b/app/backend/tests/test_cloud_worlds.py
@@ -174,7 +174,7 @@ def test_world_summary_and_detail_map_exact_known_pair(
     detail = trade_cumulus_world_detail(settings)
     summaries = list_cloud_world_summaries(settings)
 
-    assert len(summaries) == 2
+    assert len(summaries) == 3
     summaries_by_id = {summary.world_id: summary for summary in summaries}
     trade_cumulus = summaries_by_id["trade_cumulus"]
     assert trade_cumulus.reference_available is True
@@ -182,6 +182,7 @@ def test_world_summary_and_detail_map_exact_known_pair(
     assert trade_cumulus.saved_view_count == 0
     assert trade_cumulus.saved_comparison_count == 1
     assert summaries_by_id["mountain_waves"].availability_state == "unavailable"
+    assert summaries_by_id["supercells"].availability_state == "unavailable"
     assert detail.reference_simulation.simulation_id == REFERENCE_SIMULATION_ID
     assert detail.reference_simulation.run_id == PRESENTATION_BASELINE_RUN_ID
     assert detail.reference_simulation.display_name == "Canonical BOMEX Baseline"

--- a/app/backend/tests/test_storm_examination.py
+++ b/app/backend/tests/test_storm_examination.py
@@ -59,8 +59,10 @@ def _write_retained_fixture(runtime_home: Path) -> Path:
         qg[0, 2, 2, 2] = 0.004
         surface = np.zeros((1, len(y), len(x)), dtype=np.float32)
         surface[0, 2, 2] = number
-        u = np.full(shape, 12.0, dtype=np.float32)
-        v = np.full(shape, -4.0, dtype=np.float32)
+        u = np.full(shape, 5.0, dtype=np.float32)
+        v = np.full(shape, -1.0, dtype=np.float32)
+        u[0, 1] = 12.0
+        v[0, 1] = -4.0
         dataset = xr.Dataset(
             data_vars={
                 "winterp": (("time", "zh", "yh", "xh"), w, {"units": "m/s"}),
@@ -103,15 +105,20 @@ def test_rotating_updraft_returns_coordinated_native_slices(tmp_path: Path) -> N
     assert frame.plan.level_km == pytest.approx(3.25)
     assert frame.plan.primary.key == "winterp"
     assert frame.plan.primary.evidence_kind == "native"
-    assert frame.plan.x_indices == [1, 2, 3]
-    assert frame.plan.y_indices == [1, 2, 3]
-    assert np.asarray(frame.plan.primary.values).shape == (3, 3)
+    assert frame.plan.x_indices == [1, 2]
+    assert frame.plan.y_indices == [1, 2]
+    assert np.asarray(frame.plan.primary.values).shape == (2, 2)
     assert frame.plan.overlays["vertical_vorticity"].units == "s^-1"
+    assert frame.plan.overlays["total_condensate"].units == "g/kg"
+    assert frame.xz_section.overlays["vertical_vorticity"].units == "s^-1"
     assert frame.xz_section.cross_section_coordinate_km == pytest.approx(0)
     assert frame.yz_section.cross_section_coordinate_km == pytest.approx(0)
-    assert frame.xz_section.horizontal_indices == [1, 2, 3]
-    assert frame.yz_section.horizontal_indices == [1, 2, 3]
+    assert frame.xz_section.horizontal_indices == [1, 2]
+    assert frame.yz_section.horizontal_indices == [1, 2]
     assert frame.primary_updraft.w_m_s == pytest.approx(46)
+    assert "combine rising motion" in frame.what_to_notice_now
+    assert frame.what_to_notice_by_view is not None
+    assert "this xz section intersects" in frame.what_to_notice_by_view["xz"]
     assert all("tmp" not in value for value in frame.provenance.values())
 
 
@@ -128,11 +135,20 @@ def test_cloud_and_precipitation_labels_derived_hydrometeor_grouping(tmp_path: P
     assert frame.plan.categories.evidence_kind == "derived"
     assert frame.plan.categories.source_fields == ["qc", "qr", "qi", "qs", "qg"]
     assert "max total-condensate level" in frame.plan.categories.derivation
+    assert frame.plan.selection_z_indices is not None
+    assert frame.plan.selection_z_indices[2][2] == 2
     assert frame.plan.primary.units == "g/kg"
+    assert frame.plan.overlays["vertical_velocity"].evidence_kind == "derived"
+    assert "sampled at each x/y cell's level" in (
+        frame.plan.overlays["vertical_velocity"].derivation or ""
+    )
     assert frame.xz_section.categories is not None
     assert frame.xz_section.overlays["reflectivity"].evidence_kind == "native"
     assert frame.selected_point.values["total_condensate"] == pytest.approx(2)
     assert frame.selected_point.evidence_kind["total_condensate"] == "derived"
+    assert frame.what_to_notice_by_view is not None
+    assert "responsible for that category" in frame.what_to_notice_by_view["plan"]
+    assert "this yz section" in frame.what_to_notice_by_view["yz"]
 
 
 def test_low_level_view_combines_motion_rain_and_model_relative_flow(tmp_path: Path) -> None:
@@ -157,6 +173,25 @@ def test_low_level_view_combines_motion_rain_and_model_relative_flow(tmp_path: P
     assert "multiplied by 10" in (frame.plan.overlays["accumulated_surface_rain"].derivation or "")
     assert frame.selected_point.states[0] == "Descending"
     assert frame.selected_point.coordinate_frame.startswith("translating model frame")
+    assert frame.what_to_notice_by_view is not None
+    assert "historical rain footprint" in frame.what_to_notice_by_view["plan"]
+    assert "current precipitating condensate" in frame.what_to_notice_by_view["xz"]
+
+
+def test_storm_viewport_is_fixed_across_saved_outputs(tmp_path: Path) -> None:
+    _write_retained_fixture(tmp_path)
+    settings = _settings(tmp_path)
+
+    first = supercells_explore_frame(settings, time_index=0, viewport="storm")
+    last = supercells_explore_frame(settings, time_index=8, viewport="storm")
+
+    assert first.viewport_bounds_km == last.viewport_bounds_km
+    assert first.viewport_bounds_km == {
+        "x_min": -35.5,
+        "x_max": 24.5,
+        "y_min": -33.5,
+        "y_max": 26.5,
+    }
 
 
 def test_retained_identity_mismatch_fails_closed(tmp_path: Path) -> None:
@@ -183,10 +218,14 @@ def test_product_frame_adds_bounded_volume_layers_without_changing_science_path(
     assert frame.scene is not None
     layers = {layer.key: layer for layer in frame.scene.layers}
     assert layers["storm_cloud_body"].threshold_label.endswith("0.05 g/kg")
-    assert layers["vertical_motion"].scale is not None
-    assert layers["vertical_motion"].scale.scale_id == "supercell_full_depth_vertical_velocity_v1"
+    assert layers["rising_core"].scale is not None
+    assert layers["rising_core"].scale.scale_id == "supercell_midlevel_vertical_velocity_v1"
+    assert layers["rising_core"].default_visible is True
+    assert layers["strong_descent"].default_visible is False
     assert layers["cyclonic_rotation"].source_fields == ["zvort"]
+    assert layers["cyclonic_rotation"].threshold_label.endswith("0.01 s^-1 in rising air")
     assert layers["updraft_helicity"].default_visible is True
+    assert "300 m^2/s^2" in layers["updraft_helicity"].threshold_label
     assert layers["reflectivity"].default_visible is False
     assert all(layer.returned_count <= layer.source_count for layer in layers.values())
 
@@ -218,5 +257,17 @@ def test_product_low_level_scene_identifies_model_relative_flow(tmp_path: Path) 
     assert frame.scene is not None
     assert frame.scene.wind_vectors
     assert frame.scene.wind_vectors[0].z_km == pytest.approx(1.25)
+    assert frame.scene.coordinate_extents_km["z"]["max"] == pytest.approx(5.25)
+    assert frame.scene.coordinate_sizes["z"] == 3
+    layers = {layer.key: layer for layer in frame.scene.layers}
+    precipitation = layers["precipitating_condensate"]
+    assert precipitation.scale is not None
+    assert precipitation.scale.scale_id == "supercell_low_level_precipitating_condensate_v1"
+    assert "through 3.25 km" in precipitation.threshold_label
+    assert max(point[2] for point in precipitation.points) <= 3.25
+    assert max(point[2] for point in layers["reflectivity"].points) <= 5.25
+    assert frame.plan.wind_vectors[0].u_m_s == pytest.approx(12)
+    assert layers["precipitating_condensate"].default_visible is True
+    assert frame.plan.overlays["low_level_precipitating_condensate"].units == "g/kg"
     assert frame.selected_point.coordinate_frame.startswith("translating model frame")
     assert "cold pool" in frame.caveats[-1]

--- a/app/backend/tests/test_storm_examination.py
+++ b/app/backend/tests/test_storm_examination.py
@@ -11,6 +11,7 @@ from cloud_chamber.storm_examination import (
     PRESERVED_RUN_ID,
     StormExaminationError,
     preserved_storm_examination_frame,
+    supercells_explore_frame,
 )
 
 
@@ -164,3 +165,58 @@ def test_retained_identity_mismatch_fails_closed(tmp_path: Path) -> None:
 
     with pytest.raises(StormExaminationError, match="case identity"):
         preserved_storm_examination_frame(_settings(tmp_path))
+
+
+def test_product_frame_adds_bounded_volume_layers_without_changing_science_path(
+    tmp_path: Path,
+) -> None:
+    _write_retained_fixture(tmp_path)
+
+    frame = supercells_explore_frame(
+        _settings(tmp_path), lens="rotating_updraft", time_index=5, viewport="storm"
+    )
+
+    assert frame.schema_version == "supercells_explore_v1"
+    assert frame.authority_state == "supercells_product_world"
+    assert frame.world_id == "supercells"
+    assert frame.simulation_id == "supercells_quarter_circle_reference"
+    assert frame.scene is not None
+    layers = {layer.key: layer for layer in frame.scene.layers}
+    assert layers["storm_cloud_body"].threshold_label.endswith("0.05 g/kg")
+    assert layers["vertical_motion"].scale is not None
+    assert layers["vertical_motion"].scale.scale_id == "supercell_full_depth_vertical_velocity_v1"
+    assert layers["cyclonic_rotation"].source_fields == ["zvort"]
+    assert layers["updraft_helicity"].default_visible is True
+    assert layers["reflectivity"].default_visible is False
+    assert all(layer.returned_count <= layer.source_count for layer in layers.values())
+
+
+def test_product_hydrometeor_scene_keeps_exact_large_ice_label(tmp_path: Path) -> None:
+    _write_retained_fixture(tmp_path)
+
+    frame = supercells_explore_frame(
+        _settings(tmp_path), lens="cloud_precipitation", time_index=5, viewport="full"
+    )
+
+    assert frame.scene is not None
+    category_layer = next(
+        layer for layer in frame.scene.layers if layer.key == "hydrometeor_categories"
+    )
+    assert category_layer.default_visible is True
+    assert category_layer.categories[-1].label == "Hail-treated large ice"
+    assert category_layer.scale is not None
+    assert category_layer.scale.scale_id == "supercell_total_condensate_v1"
+
+
+def test_product_low_level_scene_identifies_model_relative_flow(tmp_path: Path) -> None:
+    _write_retained_fixture(tmp_path)
+
+    frame = supercells_explore_frame(
+        _settings(tmp_path), lens="low_level_interactions", time_index=5, viewport="storm"
+    )
+
+    assert frame.scene is not None
+    assert frame.scene.wind_vectors
+    assert frame.scene.wind_vectors[0].z_km == pytest.approx(1.25)
+    assert frame.selected_point.coordinate_frame.startswith("translating model frame")
+    assert "cold pool" in frame.caveats[-1]

--- a/app/backend/tests/test_supercells_world.py
+++ b/app/backend/tests/test_supercells_world.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.storm_examination import StormExaminationError
+from cloud_chamber.supercells_world import supercells_world_detail
+
+
+def _settings(runtime_home: Path) -> CloudChamberSettings:
+    return CloudChamberSettings(
+        runtime_home=runtime_home,
+        cm1_root=None,
+        cm1_run_dir=None,
+        cache_dir=runtime_home / "cache",
+        log_dir=runtime_home / "logs",
+    )
+
+
+def test_world_exposes_stable_identity_and_data_driven_timeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "cloud_chamber.supercells_world.storm_examination_inventory",
+        lambda _settings: tuple(
+            (tmp_path / f"cm1out_{index + 1:06d}.nc", float(index * 900)) for index in range(9)
+        ),
+    )
+
+    detail = supercells_world_detail(_settings(tmp_path))
+
+    assert detail.world_id == "supercells"
+    assert detail.display_name == "Supercells"
+    assert len(detail.simulations) == 1
+    simulation = detail.reference_simulation
+    assert simulation.simulation_id == "supercells_quarter_circle_reference"
+    assert simulation.display_name == "Quarter-Circle Supercell"
+    assert simulation.explore_available is True
+    assert simulation.saved_output_count == 9
+    assert simulation.model_end_seconds == 7_200
+    assert simulation.history_cadence_seconds == 900
+    assert detail.capabilities.lab is False
+    assert detail.capabilities.compare is False
+    assert detail.summary().simulation_count == 1
+
+
+def test_world_remains_usable_when_retained_output_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def unavailable(_settings: CloudChamberSettings) -> None:
+        raise StormExaminationError("The accepted Gate B retained output is unavailable.")
+
+    monkeypatch.setattr("cloud_chamber.supercells_world.storm_examination_inventory", unavailable)
+
+    detail = supercells_world_detail(_settings(tmp_path))
+
+    assert detail.availability_state == "unavailable"
+    assert detail.reference_simulation.technical_state == "missing"
+    assert detail.reference_simulation.explore_available is False
+    assert detail.simulations[0].simulation_id == "supercells_quarter_circle_reference"
+    assert detail.summary().simulation_count == 0

--- a/app/frontend/e2e/mocked-smoke/supercells.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/supercells.spec.ts
@@ -72,14 +72,21 @@ test.describe("mocked smoke: Supercells product path", () => {
     const planBox = await page.getByLabel("Midlevel storm structure plan view").boundingBox();
     expect((planBox?.width ?? 0) / (planBox?.height ?? 1)).toBeCloseTo(1, 1);
 
+    await expect(page.getByLabel("Camera view")).toHaveValue("look_along_y");
+    await page.getByLabel("Camera view").selectOption("top_down_xy");
     await page.getByRole("button", { name: "Cloud and Precipitation" }).click();
     await expect(page.getByRole("button", { name: "Cloud and Precipitation" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
+    await expect(
+      page
+        .getByLabel("Slice orientation")
+        .getByRole("button", { name: "Vertical x-z" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    await expect(page.getByLabel("Camera view")).toHaveValue("look_along_y");
     await page.locator(".true3d-display-control > summary").click();
     await expect(page.getByLabel("Dominant hydrometeor")).toBeChecked();
-    await expect(page.getByLabel("Strong vertical motion")).not.toBeChecked();
     await expect(page.getByText("Hail-treated large ice").first()).toBeVisible();
 
     await page.getByRole("button", { name: "Low-Level Interactions" }).click();
@@ -87,13 +94,21 @@ test.describe("mocked smoke: Supercells product path", () => {
       "aria-pressed",
       "true",
     );
-    await expect(page.getByLabel("Model-relative flow")).toBeChecked();
-    await expect(page.getByLabel("Accumulated rain").first()).toBeChecked();
+    await expect(page.getByLabel("Flow arrows at 1.25 km")).toBeChecked();
+    await expect(page.getByLabel("Accumulated rain (history)").first()).toBeChecked();
+    await expect(page.getByLabel("Current precipitation")).toBeChecked();
+
+    await page.getByRole("button", { name: "Rotating Updraft" }).click();
+    await expect(page.getByLabel("Camera view")).toHaveValue("top_down_xy");
+    await page.getByRole("button", { name: "Low-Level Interactions" }).click();
 
     await page
       .getByLabel("Slice orientation")
       .getByRole("button", { name: "Vertical x-z" })
       .click();
+    await expect(page.getByLabel("Accumulated rain (history)")).toHaveCount(0);
+    await expect(page.getByLabel("Flow arrows at 1.25 km")).toHaveCount(0);
+    await expect(page.getByLabel("Current precipitation")).toBeChecked();
     await expect(page.getByText("Slice: xz section at y = 10.0 km")).toBeVisible();
     await expect(page.getByLabel("xz section at y = 10.0 km")).toBeVisible();
     const sectionBox = await page.getByLabel("xz section at y = 10.0 km").boundingBox();
@@ -270,6 +285,12 @@ function supercellsFrame(url: string) {
         : typedLens === "cloud_precipitation"
           ? "How are cloud and precipitation organized through the storm?"
           : "How do ascent, descent, rain, and horizontal flow meet beneath the storm?",
+    what_to_notice_now: "This saved output contains coordinated frame-specific evidence.",
+    what_to_notice_by_view: {
+      plan: "Plan evidence at this saved output.",
+      xz: "X-z evidence at this saved output.",
+      yz: "Y-z evidence at this saved output.",
+    },
     time_index: timeIndex,
     time_seconds: times[timeIndex],
     times_seconds: times,
@@ -392,6 +413,14 @@ function plan(lens: string, x: number[], y: number[]) {
     y_km: y,
     level_index: 1,
     level_km: 3,
+    selection_z_indices:
+      lens === "cloud_precipitation"
+        ? [
+            [0, 1, 2],
+            [1, 2, 1],
+            [0, 1, 2],
+          ]
+        : null,
     primary: field(),
     overlays: {
       vertical_vorticity: field("zvort", "Vertical vorticity"),
@@ -399,6 +428,11 @@ function plan(lens: string, x: number[], y: number[]) {
       vertical_velocity: field("winterp", "Vertical velocity"),
       composite_reflectivity: field("dbz", "Reflectivity"),
       accumulated_surface_rain: field("rain", "Accumulated rain"),
+      total_condensate: field("total_condensate", "Total condensate"),
+      low_level_precipitating_condensate: field(
+        "precipitating_condensate",
+        "Current precipitating condensate",
+      ),
     },
     categories: null,
     wind_vectors: [{ x_km: 0, y_km: 10, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
@@ -416,6 +450,7 @@ function section(orientation: "xz" | "yz", horizontal: "x" | "y", coordinate: nu
     cross_section_coordinate_km: coordinate,
     primary: field(),
     overlays: {
+      vertical_vorticity: field("zvort", "Vertical vorticity"),
       total_condensate: field("total_condensate", "Total condensate"),
       precipitating_condensate: field("precipitating_condensate", "Precipitating condensate"),
       reflectivity: field("dbz", "Reflectivity"),
@@ -475,17 +510,23 @@ function scene(lens: string, viewport: string) {
     lens === "cloud_precipitation"
       ? [
           layer("hydrometeor_categories", "Dominant hydrometeor", "categorical", true, null),
-          layer("vertical_motion", "Strong vertical motion", "signed_scalar", false),
         ]
       : lens === "low_level_interactions"
         ? [
-            layer("storm_cloud_body", "Storm cloud body", "neutral_cloud", true, null),
+            layer("storm_cloud_body", "Storm cloud body", "neutral_cloud", false, null),
+            layer(
+              "precipitating_condensate",
+              "Low-level precipitating condensate",
+              "scalar",
+              true,
+            ),
             layer("low_level_vertical_motion", "Low-level vertical motion", "signed_scalar", true),
             layer("accumulated_surface_rain", "Accumulated rain", "scalar", true),
           ]
         : [
             layer("storm_cloud_body", "Storm cloud body", "neutral_cloud", true, null),
-            layer("vertical_motion", "Strong vertical motion", "signed_scalar", true),
+            layer("rising_core", "Rising core", "signed_scalar", true),
+            layer("strong_descent", "Strong descent", "signed_scalar", false),
             layer("cyclonic_rotation", "Cyclonic rotation", "scalar", true),
             layer("updraft_helicity", "2-5 km updraft helicity", "scalar", true),
           ];
@@ -493,7 +534,7 @@ function scene(lens: string, viewport: string) {
     coordinate_extents_km: {
       x: { min: -extent, max: extent },
       y: { min: -extent, max: extent },
-      z: { min: 0.25, max: 19.75 },
+      z: { min: 0.25, max: lens === "low_level_interactions" ? 5.25 : 19.75 },
     },
     coordinate_sizes: { x: 120, y: 120, z: 40 },
     layers,

--- a/app/frontend/e2e/mocked-smoke/supercells.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/supercells.spec.ts
@@ -1,0 +1,486 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+import { collectConsoleProblems, gotoApp } from "../helpers";
+import { mockCloudChamberApis } from "../fixtures";
+
+const simulation = {
+  simulation_id: "supercells_quarter_circle_reference",
+  display_name: "Quarter-Circle Supercell",
+  role: "reference",
+  world_id: "supercells",
+  run_id: "quarter-circle-supercell-official-20260722T142521Z",
+  case_id: "cm1_r21_1_quarter_circle_supercell_official_v0",
+  technical_state: "available",
+  technical_state_message: "Nine retained histories are available.",
+  explore_available: true,
+  saved_output_count: 9,
+  model_start_seconds: 0,
+  model_end_seconds: 7_200,
+  history_cadence_seconds: 900,
+  lineage_state: "known",
+};
+
+const wScale = {
+  scale_id: "supercells_vertical_velocity_v1",
+  display_name: "Vertical velocity",
+  units: "m/s",
+  scale_type: "fixed_discrete",
+  minimum: -30,
+  maximum: 30,
+  breakpoints: [-24, -18, -12, -6, 6, 12, 18, 24, 27],
+  colors: [
+    "#4b0082",
+    "#0057d9",
+    "#00c9d8",
+    "#ffffff",
+    "#00d63b",
+    "#8fe000",
+    "#ffe000",
+    "#ff9800",
+    "#ff3b00",
+    "#c40000",
+  ],
+  fixed_across_time: true,
+};
+
+test.describe("mocked smoke: Supercells product path", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1728, height: 1000 });
+    await mockCloudChamberApis(page);
+    await mockSupercellsProductPath(page);
+  });
+
+  test("coordinates all three Lenses, evidence, Context, timeline, and maximize state", async ({
+    page,
+  }) => {
+    const consoleProblems = collectConsoleProblems(page);
+    await gotoSupercellsExplore(page);
+
+    await expect(page.getByRole("button", { name: "Rotating Updraft" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible();
+    await expect(page.getByLabel("Midlevel storm structure plan view")).toBeVisible();
+    await expect(page.getByText("frame 6 of 9 · Organized mature storm")).toBeVisible();
+    const sceneBox = await page.getByLabel("3-D storm scene").boundingBox();
+    const evidenceBox = await page.getByLabel("Coordinated storm evidence").boundingBox();
+    const contextBox = await page.getByLabel("Explore inspector").boundingBox();
+    expect(sceneBox?.width ?? 0).toBeLessThan((evidenceBox?.width ?? 1) * 1.7);
+    expect(evidenceBox?.width ?? 0).toBeGreaterThan(500);
+    expect(contextBox?.width ?? 0).toBeGreaterThanOrEqual(288);
+
+    await page.getByRole("button", { name: "Cloud and Precipitation" }).click();
+    await expect(page.getByRole("button", { name: "Cloud and Precipitation" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await page.locator(".true3d-display-control > summary").click();
+    await expect(page.getByLabel("Dominant hydrometeor")).toBeChecked();
+    await expect(page.getByLabel("Strong vertical motion")).not.toBeChecked();
+    await expect(page.getByText("Hail-treated large ice").first()).toBeVisible();
+
+    await page.getByRole("button", { name: "Low-Level Interactions" }).click();
+    await expect(page.getByRole("button", { name: "Low-Level Interactions" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(page.getByLabel("Model-relative flow")).toBeChecked();
+    await expect(page.getByLabel("Accumulated rain").first()).toBeChecked();
+
+    await page.getByLabel("Evidence view").getByRole("button", { name: "xz" }).click();
+    await expect(page.getByText("Slice: xz section at y = 10.0 km")).toBeVisible();
+    await expect(page.getByLabel("xz section at y = 10.0 km")).toBeVisible();
+
+    await page.getByLabel("xz section at y = 10.0 km").click({ position: { x: 180, y: 120 } });
+    await page.getByRole("tab", { name: "Science" }).click();
+    await expect(page.getByText("Selected point")).toBeVisible();
+
+    await page.getByRole("button", { name: "Next saved output" }).click();
+    await expect(page.getByText("90 min · 5,400 s")).toBeVisible();
+    await page.getByLabel("Playback speed").selectOption("2");
+    await expect(page.getByLabel("Playback speed")).toHaveValue("2");
+
+    const evidenceBefore = await page.getByLabel("Coordinated storm evidence").boundingBox();
+    await page.getByRole("button", { name: "Maximize evidence" }).click();
+    const evidenceMaximized = await page.getByLabel("Coordinated storm evidence").boundingBox();
+    expect(evidenceMaximized?.width ?? 0).toBeGreaterThan((evidenceBefore?.width ?? 0) * 2);
+    await page.getByRole("button", { name: "Restore evidence" }).click();
+
+    await page.getByRole("button", { name: "Maximize 3-D viewer" }).click();
+    await expect(page.getByRole("button", { name: "Restore 3-D viewer" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Low-Level Interactions" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await page.getByRole("button", { name: "Restore 3-D viewer" }).click();
+
+    expect(consoleProblems).toEqual([]);
+  });
+
+  test("keeps the coordinated 2-D evidence usable when WebGL is unavailable", async ({ page }) => {
+    await page.addInitScript(() => {
+      const original = HTMLCanvasElement.prototype.getContext;
+      HTMLCanvasElement.prototype.getContext = function (contextId, options) {
+        if (String(contextId).includes("webgl")) return null;
+        return original.call(this, contextId, options as CanvasRenderingContext2DSettings);
+      } as typeof HTMLCanvasElement.prototype.getContext;
+    });
+
+    await gotoSupercellsExplore(page);
+    await expect(page.getByText(/Three\.js renderer unavailable/)).toBeVisible();
+    await expect(page.getByLabel("Midlevel storm structure plan view")).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Explain" })).toBeVisible();
+    await expect(page.getByLabel("Saved output time")).toBeEnabled();
+  });
+
+  test("keeps both scientific viewers useful in a 1024px desktop half-window", async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 856 });
+    await gotoSupercellsExplore(page);
+
+    const sceneFrame = await page.locator(".supercells-scene .true3d-scene-frame").boundingBox();
+    const evidence = await page.getByLabel("Coordinated storm evidence").boundingBox();
+    const documentWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const documentHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+
+    expect(sceneFrame?.height ?? 0).toBeGreaterThanOrEqual(398);
+    expect(evidence?.height ?? 0).toBeGreaterThanOrEqual(398);
+    expect(documentWidth).toBe(1024);
+    expect(documentHeight).toBeLessThanOrEqual(856);
+    await expect(page.getByRole("button", { name: "Maximize evidence" })).toBeInViewport();
+    await expect(page.getByRole("button", { name: "Previous saved output" })).toBeInViewport();
+    await expect(page.getByRole("button", { name: "Next saved output" })).toBeInViewport();
+    await expect(page.getByRole("button", { name: "Play" })).toBeInViewport();
+  });
+});
+
+async function gotoSupercellsExplore(page: Page) {
+  await gotoApp(page);
+  await page.getByRole("button", { name: "Enter Supercells" }).click();
+  await expect(page.getByRole("heading", { name: "Supercells" })).toBeVisible();
+  await page.getByRole("button", { name: "Explore" }).click();
+  await expect(page.getByRole("heading", { name: "Quarter-Circle Supercell" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Rotating Updraft" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+}
+
+async function mockSupercellsProductPath(page: Page) {
+  await page.unroute("**/api/worlds");
+  await page.route("**/api/worlds", (route) =>
+    json(route, [
+      {
+        world_id: "supercells",
+        display_name: "Supercells",
+        short_description: "Inspect a retained idealized rotating storm.",
+        reference_simulation_id: simulation.simulation_id,
+        reference_available: true,
+        simulation_count: 1,
+        saved_view_count: 0,
+        saved_comparison_count: 0,
+        featured_comparison_count: 0,
+        active_run_count: 0,
+        completed_uninspected_run_count: 0,
+        availability_state: "available",
+        availability_message: "Available",
+      },
+    ]),
+  );
+  await page.route("**/api/worlds/supercells", (route) =>
+    json(route, {
+      world_id: "supercells",
+      display_name: "Supercells",
+      short_description: "Inspect a retained idealized rotating storm.",
+      availability_state: "available",
+      availability_message: "The Quarter-Circle Supercell is available.",
+      reference_simulation: simulation,
+      simulations: [simulation],
+      capabilities: {
+        reference_explore: true,
+        lab: false,
+        compare: false,
+        saved_views: false,
+      },
+      caveats: ["This idealized benchmark is not a forecast."],
+    }),
+  );
+  await page.route("**/api/worlds/supercells/simulations/*/frame**", (route) =>
+    json(route, supercellsFrame(route.request().url())),
+  );
+}
+
+function supercellsFrame(url: string) {
+  const search = new URL(url).searchParams;
+  const lens = search.get("lens") ?? "rotating_updraft";
+  const viewport = search.get("viewport") === "full" ? "full" : "storm";
+  const timeIndex = Number(search.get("time_index") ?? 5);
+  const times = [0, 900, 1_800, 2_700, 3_600, 4_500, 5_400, 6_300, 7_200];
+  const xIndex = Number(search.get("x_index") ?? 1);
+  const yIndex = Number(search.get("y_index") ?? 1);
+  const zIndex = Number(search.get("z_index") ?? 1);
+  const x = [-10, 0, 10];
+  const y = [-10, 10, 20];
+  const z = [0.5, 3, 8];
+  const names = {
+    rotating_updraft: "Rotating Updraft",
+    cloud_precipitation: "Cloud and Precipitation",
+    low_level_interactions: "Low-Level Interactions",
+  } as const;
+  const typedLens = lens as keyof typeof names;
+  return {
+    schema_version: "supercells_explore_v1",
+    authority_state: "supercells_product_world",
+    world_id: "supercells",
+    simulation_id: simulation.simulation_id,
+    run_id: simulation.run_id,
+    case_id: simulation.case_id,
+    simulation_label: simulation.display_name,
+    lens_id: typedLens,
+    lens_name: names[typedLens],
+    lens_question:
+      typedLens === "rotating_updraft"
+        ? "Where is the storm rising and rotating as one organized structure?"
+        : typedLens === "cloud_precipitation"
+          ? "How are cloud and precipitation organized through the storm?"
+          : "How do ascent, descent, rain, and horizontal flow meet beneath the storm?",
+    time_index: timeIndex,
+    time_seconds: times[timeIndex],
+    times_seconds: times,
+    mature_checkpoint_indices: [3, 4, 5, 6, 7, 8],
+    timeline_checkpoints: [
+      {
+        time_seconds: 4_500,
+        label: "75 min",
+        phase: "Organized mature storm",
+        phase_kind: "visible_checkpoint",
+      },
+    ],
+    viewport,
+    viewport_bounds_km:
+      viewport === "storm"
+        ? { x_min: -30, x_max: 30, y_min: -30, y_max: 30 }
+        : { x_min: -60, x_max: 60, y_min: -60, y_max: 60 },
+    primary_updraft: {
+      x_index: 1,
+      y_index: 1,
+      z_index: 1,
+      x_km: 0,
+      y_km: 10,
+      z_km: 3,
+      w_m_s: 48,
+    },
+    selected_point: selectedPoint(xIndex, yIndex, zIndex, x, y, z, times[timeIndex]),
+    plan: plan(typedLens, x, y),
+    xz_section: section("xz", "x", y[yIndex] ?? 10),
+    yz_section: section("yz", "y", x[xIndex] ?? 0),
+    scene: scene(typedLens, viewport),
+    caveats: ["Saved histories are 15 minutes apart."],
+    provenance: { source_history_file: `cm1out_${String(timeIndex + 1).padStart(6, "0")}.nc` },
+    extraction_milliseconds: 80,
+  };
+}
+
+function selectedPoint(
+  xIndex: number,
+  yIndex: number,
+  zIndex: number,
+  x: number[],
+  y: number[],
+  z: number[],
+  time: number,
+) {
+  const values = {
+    vertical_velocity: 12,
+    vertical_vorticity: 0.03,
+    updraft_helicity: 510,
+    reflectivity: 52,
+    cloud_liquid: 1.2,
+    rain_water: 2.1,
+    cloud_ice: 0.4,
+    snow: 0.8,
+    hail_treated_large_ice: 1.5,
+    total_condensate: 6,
+    accumulated_surface_rain: 22,
+    model_relative_u: 14,
+    model_relative_v: 7,
+  };
+  return {
+    x_index: xIndex,
+    y_index: yIndex,
+    z_index: zIndex,
+    x_km: x[xIndex] ?? 0,
+    y_km: y[yIndex] ?? 10,
+    z_km: z[zIndex] ?? 3,
+    model_time_seconds: time,
+    coordinate_frame: "translating model frame; native model-relative winds",
+    values,
+    units: Object.fromEntries(
+      Object.keys(values).map((key) => [
+        key,
+        key.includes("velocity") || key.startsWith("model_relative")
+          ? "m/s"
+          : key === "vertical_vorticity"
+            ? "s^-1"
+            : key === "updraft_helicity"
+              ? "m^2/s^2"
+              : key === "reflectivity"
+                ? "dBZ"
+                : key === "accumulated_surface_rain"
+                  ? "mm"
+                  : "g/kg",
+      ]),
+    ),
+    evidence_kind: Object.fromEntries(Object.keys(values).map((key) => [key, "native"])),
+    states: ["Rising", "Rotating", "Condensate present"],
+    distance_to_primary_updraft_km: 0,
+  };
+}
+
+function field(key = "winterp", displayName = "Vertical velocity") {
+  return {
+    key,
+    display_name: displayName,
+    units: key === "dbz" ? "dBZ" : "m/s",
+    evidence_kind: "native",
+    source_fields: [key],
+    derivation: null,
+    values: [
+      [-8, -3, 2],
+      [-2, 12, 18],
+      [1, 7, -5],
+    ],
+    selected_frame_minimum: -8,
+    selected_frame_maximum: 18,
+    scale: wScale,
+  };
+}
+
+function plan(lens: string, x: number[], y: number[]) {
+  return {
+    title: lens === "cloud_precipitation" ? "Hydrometeor plan" : "Midlevel storm structure",
+    subtitle: "Native-grid plan evidence",
+    x_indices: [0, 1, 2],
+    y_indices: [0, 1, 2],
+    x_km: x,
+    y_km: y,
+    level_index: 1,
+    level_km: 3,
+    primary: field(),
+    overlays: {
+      vertical_vorticity: field("zvort", "Vertical vorticity"),
+      updraft_helicity: field("uh", "Updraft helicity"),
+      composite_reflectivity: field("dbz", "Reflectivity"),
+      accumulated_surface_rain: field("rain", "Accumulated rain"),
+    },
+    categories: null,
+    wind_vectors: [{ x_km: 0, y_km: 10, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
+  };
+}
+
+function section(orientation: "xz" | "yz", horizontal: "x" | "y", coordinate: number) {
+  return {
+    orientation,
+    title: `${orientation} section at ${orientation === "xz" ? "y" : "x"} = ${coordinate.toFixed(1)} km`,
+    horizontal_dimension: horizontal,
+    horizontal_indices: [0, 1, 2],
+    horizontal_km: [-10, 0, 10],
+    z_km: [0.5, 3, 8],
+    cross_section_coordinate_km: coordinate,
+    primary: field(),
+    overlays: {
+      total_condensate: field("total_condensate", "Total condensate"),
+      precipitating_condensate: field("precipitating_condensate", "Precipitating condensate"),
+      reflectivity: field("dbz", "Reflectivity"),
+      vertical_velocity: field(),
+    },
+    categories: null,
+  };
+}
+
+function scene(lens: string, viewport: string) {
+  const extent = viewport === "storm" ? 30 : 60;
+  const points = Array.from({ length: 75 }, (_, index) => {
+    const angle = (index / 75) * Math.PI * 2;
+    const radius = 4 + (index % 8);
+    return [
+      Math.cos(angle) * radius,
+      10 + Math.sin(angle) * radius,
+      0.5 + (index % 18) * 0.6,
+      -22 + (index % 10) * 5,
+      1 + (index % 5),
+    ];
+  });
+  const layer = (
+    key: string,
+    displayName: string,
+    rendering: string,
+    visible: boolean,
+    scale: typeof wScale | null = wScale,
+  ) => ({
+    key,
+    display_name: displayName,
+    units: rendering === "categorical" ? "g/kg" : "m/s",
+    evidence_kind: "native",
+    source_fields: ["winterp"],
+    derivation: null,
+    rendering,
+    points,
+    source_count: points.length,
+    returned_count: points.length,
+    threshold_label: "Fixed retained-run threshold",
+    default_visible: visible,
+    default_opacity: 0.8,
+    default_point_size: 1,
+    scale,
+    categories:
+      rendering === "categorical"
+        ? [
+            { code: 1, key: "qc", label: "Cloud liquid", color: "#d6f0f7" },
+            { code: 2, key: "qr", label: "Rain", color: "#2f7fb5" },
+            { code: 3, key: "qi", label: "Cloud ice", color: "#c9c5ef" },
+            { code: 4, key: "qs", label: "Snow", color: "#71b7d4" },
+            { code: 5, key: "qg", label: "Hail-treated large ice", color: "#7c4d8f" },
+          ]
+        : [],
+  });
+  const layers =
+    lens === "cloud_precipitation"
+      ? [
+          layer("hydrometeor_categories", "Dominant hydrometeor", "categorical", true, null),
+          layer("vertical_motion", "Strong vertical motion", "signed_scalar", false),
+        ]
+      : lens === "low_level_interactions"
+        ? [
+            layer("storm_cloud_body", "Storm cloud body", "neutral_cloud", true, null),
+            layer("low_level_vertical_motion", "Low-level vertical motion", "signed_scalar", true),
+            layer("accumulated_surface_rain", "Accumulated rain", "scalar", true),
+          ]
+        : [
+            layer("storm_cloud_body", "Storm cloud body", "neutral_cloud", true, null),
+            layer("vertical_motion", "Strong vertical motion", "signed_scalar", true),
+            layer("cyclonic_rotation", "Cyclonic rotation", "scalar", true),
+            layer("updraft_helicity", "2-5 km updraft helicity", "scalar", true),
+          ];
+  return {
+    coordinate_extents_km: {
+      x: { min: -extent, max: extent },
+      y: { min: -extent, max: extent },
+      z: { min: 0.25, max: 19.75 },
+    },
+    coordinate_sizes: { x: 120, y: 120, z: 40 },
+    layers,
+    wind_vectors: [{ x_km: 0, y_km: 10, z_km: 1.25, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
+    wind_reference_m_s: 25,
+    point_budget: 20_000,
+    source_history_file: "cm1out_000006.nc",
+  };
+}
+
+function json(route: Route, payload: unknown, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(payload),
+  });
+}

--- a/app/frontend/e2e/mocked-smoke/supercells.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/supercells.spec.ts
@@ -69,6 +69,8 @@ test.describe("mocked smoke: Supercells product path", () => {
     expect(sceneBox?.width ?? 0).toBeLessThan((evidenceBox?.width ?? 1) * 1.7);
     expect(evidenceBox?.width ?? 0).toBeGreaterThan(500);
     expect(contextBox?.width ?? 0).toBeGreaterThanOrEqual(288);
+    const planBox = await page.getByLabel("Midlevel storm structure plan view").boundingBox();
+    expect((planBox?.width ?? 0) / (planBox?.height ?? 1)).toBeCloseTo(1, 1);
 
     await page.getByRole("button", { name: "Cloud and Precipitation" }).click();
     await expect(page.getByRole("button", { name: "Cloud and Precipitation" })).toHaveAttribute(
@@ -88,9 +90,17 @@ test.describe("mocked smoke: Supercells product path", () => {
     await expect(page.getByLabel("Model-relative flow")).toBeChecked();
     await expect(page.getByLabel("Accumulated rain").first()).toBeChecked();
 
-    await page.getByLabel("Evidence view").getByRole("button", { name: "xz" }).click();
+    await page
+      .getByLabel("Slice orientation")
+      .getByRole("button", { name: "Vertical x-z" })
+      .click();
     await expect(page.getByText("Slice: xz section at y = 10.0 km")).toBeVisible();
     await expect(page.getByLabel("xz section at y = 10.0 km")).toBeVisible();
+    const sectionBox = await page.getByLabel("xz section at y = 10.0 km").boundingBox();
+    const sectionAspect = await page.locator(".storm-section-plot").evaluate((element) =>
+      Number(getComputedStyle(element).getPropertyValue("--storm-data-aspect")),
+    );
+    expect((sectionBox?.width ?? 0) / (sectionBox?.height ?? 1)).toBeCloseTo(sectionAspect, 1);
 
     await page.getByLabel("xz section at y = 10.0 km").click({ position: { x: 180, y: 120 } });
     await page.getByRole("tab", { name: "Science" }).click();
@@ -105,7 +115,20 @@ test.describe("mocked smoke: Supercells product path", () => {
     await page.getByRole("button", { name: "Maximize evidence" }).click();
     const evidenceMaximized = await page.getByLabel("Coordinated storm evidence").boundingBox();
     expect(evidenceMaximized?.width ?? 0).toBeGreaterThan((evidenceBefore?.width ?? 0) * 2);
+    await expect(page.getByRole("button", { name: "Open Context" })).toBeVisible();
+    await expect(page.getByLabel("Explore inspector")).toHaveCount(0);
+    const maximizedSectionBox = await page.getByLabel("xz section at y = 10.0 km").boundingBox();
+    expect(
+      (maximizedSectionBox?.width ?? 0) / (maximizedSectionBox?.height ?? 1),
+    ).toBeCloseTo(sectionAspect, 1);
+    await page.getByRole("button", { name: "Open Context" }).click();
+    await expect(page.getByLabel("Explore inspector")).toBeVisible();
     await page.getByRole("button", { name: "Restore evidence" }).click();
+
+    await page.getByRole("button", { name: "Collapse Context" }).click();
+    await expect(page.getByLabel("Explore inspector")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Open Context" })).toBeVisible();
+    await page.getByRole("button", { name: "Open Context" }).click();
 
     await page.getByRole("button", { name: "Maximize 3-D viewer" }).click();
     await expect(page.getByRole("button", { name: "Restore 3-D viewer" })).toBeVisible();
@@ -147,6 +170,9 @@ test.describe("mocked smoke: Supercells product path", () => {
     expect(evidence?.height ?? 0).toBeGreaterThanOrEqual(398);
     expect(documentWidth).toBe(1024);
     expect(documentHeight).toBeLessThanOrEqual(856);
+    await expect(page.getByRole("heading", { name: "Horizontal x-y slice" })).toBeVisible();
+    const compactPlan = await page.getByLabel("Midlevel storm structure plan view").boundingBox();
+    expect((compactPlan?.width ?? 0) / (compactPlan?.height ?? 1)).toBeCloseTo(1, 1);
     await expect(page.getByRole("button", { name: "Maximize evidence" })).toBeInViewport();
     await expect(page.getByRole("button", { name: "Previous saved output" })).toBeInViewport();
     await expect(page.getByRole("button", { name: "Next saved output" })).toBeInViewport();
@@ -370,6 +396,7 @@ function plan(lens: string, x: number[], y: number[]) {
     overlays: {
       vertical_vorticity: field("zvort", "Vertical vorticity"),
       updraft_helicity: field("uh", "Updraft helicity"),
+      vertical_velocity: field("winterp", "Vertical velocity"),
       composite_reflectivity: field("dbz", "Reflectivity"),
       accumulated_surface_rain: field("rain", "Accumulated rain"),
     },

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -6,6 +6,8 @@ import { CloudWorldsHome } from "./CloudWorldsHome";
 import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
 import { MountainWavesExplore } from "./MountainWavesExplore";
 import { type MountainWavesSimulation, MountainWavesWorld } from "./MountainWavesWorld";
+import { SupercellsExplore } from "./SupercellsExplore";
+import { type SupercellSimulation, SupercellsWorld } from "./SupercellsWorld";
 import {
   TradeCumulusComparisonStory,
   type TradeCumulusComparisonStoryResponse,
@@ -1277,7 +1279,9 @@ type ProductLocation =
   | "explore"
   | "comparison"
   | "mountain-world"
-  | "mountain-explore";
+  | "mountain-explore"
+  | "supercells-world"
+  | "supercells-explore";
 type WorldExploreContext =
   | { kind: "simulation"; displayName: string }
   | { kind: "lab_result"; displayName: string };
@@ -2296,6 +2300,7 @@ async function responseError(response: Response, fallback: string): Promise<stri
 
 export function App() {
   const [productLocation, setProductLocation] = useState<ProductLocation>("worlds");
+  const [supercellSimulation, setSupercellSimulation] = useState<SupercellSimulation | null>(null);
   const [mountainWavesSimulation, setMountainWavesSimulation] =
     useState<MountainWavesSimulation | null>(null);
   const [worldSection, setWorldSection] = useState<TradeCumulusWorldSection>("overview");
@@ -4237,7 +4242,9 @@ export function App() {
   return (
     <main
       className={`app-shell${
-        productLocation === "explore" || productLocation === "mountain-explore"
+        productLocation === "explore" ||
+        productLocation === "mountain-explore" ||
+        productLocation === "supercells-explore"
           ? " app-shell-explore"
           : ""
       }`}
@@ -4266,6 +4273,10 @@ export function App() {
           onEnterMountainWaves={() => {
             setMountainWavesSimulation(null);
             setProductLocation("mountain-world");
+          }}
+          onEnterSupercells={() => {
+            setSupercellSimulation(null);
+            setProductLocation("supercells-world");
           }}
           fallback={legacyWorkspace}
         />
@@ -4304,6 +4315,28 @@ export function App() {
           <MountainWavesExplore
             simulation={mountainWavesSimulation}
             onBack={() => setProductLocation("mountain-world")}
+          />
+        </section>
+      )}
+
+      {productLocation === "supercells-world" && (
+        <SupercellsWorld
+          onBackToWorlds={() => setProductLocation("worlds")}
+          onExploreSimulation={(simulation) => {
+            setSupercellSimulation(simulation);
+            setProductLocation("supercells-explore");
+          }}
+        />
+      )}
+
+      {productLocation === "supercells-explore" && supercellSimulation && (
+        <section
+          className="world-context-workspace"
+          aria-label={`${supercellSimulation.display_name} workspace`}
+        >
+          <SupercellsExplore
+            simulation={supercellSimulation}
+            onBack={() => setProductLocation("supercells-world")}
           />
         </section>
       )}

--- a/app/frontend/src/CloudWorldsHome.test.tsx
+++ b/app/frontend/src/CloudWorldsHome.test.tsx
@@ -36,6 +36,22 @@ const mountainWavesSummary: CloudWorldSummary = {
   availability_message: "Dry Ridge and Boulder Windstorm are available.",
 };
 
+const supercellsSummary: CloudWorldSummary = {
+  world_id: "supercells",
+  display_name: "Supercells",
+  short_description: "Enter a deep rotating thunderstorm and reveal its internal structure.",
+  reference_simulation_id: "supercells_quarter_circle_reference",
+  reference_available: true,
+  simulation_count: 1,
+  saved_view_count: 0,
+  saved_comparison_count: 0,
+  featured_comparison_count: 0,
+  active_run_count: 0,
+  completed_uninspected_run_count: 0,
+  availability_state: "available",
+  availability_message: "Quarter-Circle Supercell is available for Explore.",
+};
+
 describe("CloudWorldsHome", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
@@ -45,14 +61,16 @@ describe("CloudWorldsHome", () => {
     vi.unstubAllGlobals();
   });
 
-  it("presents both Cloud Worlds as peer entrances", async () => {
-    vi.mocked(fetch).mockResolvedValue(ok([summary, mountainWavesSummary]));
+  it("presents all three Cloud Worlds as peer entrances", async () => {
+    vi.mocked(fetch).mockResolvedValue(ok([summary, mountainWavesSummary, supercellsSummary]));
     const onEnterTradeCumulus = vi.fn();
     const onEnterMountainWaves = vi.fn();
+    const onEnterSupercells = vi.fn();
     render(
       <CloudWorldsHome
         onEnterTradeCumulus={onEnterTradeCumulus}
         onEnterMountainWaves={onEnterMountainWaves}
+        onEnterSupercells={onEnterSupercells}
       />,
     );
 
@@ -62,10 +80,14 @@ describe("CloudWorldsHome", () => {
     expect(screen.getByRole("heading", { name: "Mountain Waves" })).toBeInTheDocument();
     expect(screen.getByText(mountainWavesSummary.short_description)).toBeInTheDocument();
     expect(screen.getByText("Boulder Windstorm")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Supercells" })).toBeInTheDocument();
+    expect(screen.getByText("Quarter-Circle Supercell")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Enter Trade Cumulus" }));
     fireEvent.click(screen.getByRole("button", { name: "Enter Mountain Waves" }));
+    fireEvent.click(screen.getByRole("button", { name: "Enter Supercells" }));
     expect(onEnterTradeCumulus).toHaveBeenCalledOnce();
     expect(onEnterMountainWaves).toHaveBeenCalledOnce();
+    expect(onEnterSupercells).toHaveBeenCalledOnce();
   });
 
   it("shows bounded partial availability", async () => {
@@ -79,7 +101,13 @@ describe("CloudWorldsHome", () => {
         },
       ]),
     );
-    render(<CloudWorldsHome onEnterTradeCumulus={vi.fn()} onEnterMountainWaves={vi.fn()} />);
+    render(
+      <CloudWorldsHome
+        onEnterTradeCumulus={vi.fn()}
+        onEnterMountainWaves={vi.fn()}
+        onEnterSupercells={vi.fn()}
+      />,
+    );
 
     expect(await screen.findByText("Partially available")).toBeInTheDocument();
     expect(screen.getByText("Canonical BOMEX Baseline is missing.")).toBeInTheDocument();
@@ -94,6 +122,7 @@ describe("CloudWorldsHome", () => {
       <CloudWorldsHome
         onEnterTradeCumulus={vi.fn()}
         onEnterMountainWaves={vi.fn()}
+        onEnterSupercells={vi.fn()}
         fallback={<div>Existing application remains available</div>}
       />,
     );

--- a/app/frontend/src/CloudWorldsHome.tsx
+++ b/app/frontend/src/CloudWorldsHome.tsx
@@ -33,7 +33,26 @@ export type MountainWavesWorldSummary = {
   availability_message: string;
 };
 
-export type CloudWorldSummary = TradeCumulusWorldSummary | MountainWavesWorldSummary;
+export type SupercellsWorldSummary = {
+  world_id: "supercells";
+  display_name: "Supercells";
+  short_description: string;
+  reference_simulation_id: "supercells_quarter_circle_reference";
+  reference_available: boolean;
+  simulation_count: number;
+  saved_view_count: 0;
+  saved_comparison_count: 0;
+  featured_comparison_count: 0;
+  active_run_count: 0;
+  completed_uninspected_run_count: 0;
+  availability_state: "available" | "partial" | "unavailable";
+  availability_message: string;
+};
+
+export type CloudWorldSummary =
+  | TradeCumulusWorldSummary
+  | MountainWavesWorldSummary
+  | SupercellsWorldSummary;
 
 type LoadState =
   | { status: "loading"; worlds: CloudWorldSummary[]; error: null }
@@ -43,10 +62,12 @@ type LoadState =
 export function CloudWorldsHome({
   onEnterTradeCumulus,
   onEnterMountainWaves,
+  onEnterSupercells,
   fallback,
 }: {
   onEnterTradeCumulus: () => void;
   onEnterMountainWaves: () => void;
+  onEnterSupercells: () => void;
   fallback?: ReactNode;
 }) {
   const [loadState, setLoadState] = useState<LoadState>({
@@ -115,7 +136,11 @@ export function CloudWorldsHome({
               key={world.world_id}
               world={world}
               onEnter={
-                world.world_id === "trade_cumulus" ? onEnterTradeCumulus : onEnterMountainWaves
+                world.world_id === "trade_cumulus"
+                  ? onEnterTradeCumulus
+                  : world.world_id === "mountain_waves"
+                    ? onEnterMountainWaves
+                    : onEnterSupercells
               }
             />
           ))}
@@ -208,7 +233,9 @@ function labSummary(world: CloudWorldSummary): string {
 
 function referenceLabel(world: CloudWorldSummary): string {
   if (!world.reference_available) return "Unavailable";
-  return world.world_id === "trade_cumulus" ? "Canonical BOMEX" : "Boulder Windstorm";
+  if (world.world_id === "trade_cumulus") return "Canonical BOMEX";
+  if (world.world_id === "mountain_waves") return "Boulder Windstorm";
+  return "Quarter-Circle Supercell";
 }
 
 function validateWorldSummaries(payload: unknown): CloudWorldSummary[] {
@@ -220,6 +247,22 @@ function validateWorldSummaries(payload: unknown): CloudWorldSummary[] {
 
 function isWorldSummary(value: unknown): value is CloudWorldSummary {
   if (!isRecord(value)) return false;
+  if (value.world_id === "supercells") {
+    return (
+      value.display_name === "Supercells" &&
+      typeof value.short_description === "string" &&
+      value.reference_simulation_id === "supercells_quarter_circle_reference" &&
+      typeof value.reference_available === "boolean" &&
+      isNonnegativeNumber(value.simulation_count) &&
+      value.saved_view_count === 0 &&
+      value.saved_comparison_count === 0 &&
+      value.featured_comparison_count === 0 &&
+      value.active_run_count === 0 &&
+      value.completed_uninspected_run_count === 0 &&
+      ["available", "partial", "unavailable"].includes(String(value.availability_state)) &&
+      typeof value.availability_message === "string"
+    );
+  }
   if (value.world_id === "mountain_waves") {
     return (
       value.display_name === "Mountain Waves" &&

--- a/app/frontend/src/IntegratedExploreWorkspace.test.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.test.tsx
@@ -48,4 +48,25 @@ describe("IntegratedExploreWorkspace", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open inspector" }));
     expect(screen.getByText("Authored explanation")).toBeVisible();
   });
+
+  it("uses an accessible tabbed Context inspector when Science is available", () => {
+    render(
+      <ExploreInspector
+        sections={{
+          explain: <p>Storm explanation</p>,
+          science: <p>Selected native evidence</p>,
+          notes: <p>Simulation notes</p>,
+          details: <p>Run lineage</p>,
+        }}
+      />,
+    );
+
+    const tablist = screen.getByRole("tablist", { name: "Context sections" });
+    expect(screen.getByRole("tab", { name: "Explain" })).toHaveAttribute("aria-selected", "true");
+    fireEvent.click(screen.getByRole("tab", { name: "Science" }));
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Selected native evidence");
+    expect(screen.getByRole("tab", { name: "Science" })).toHaveAttribute("aria-selected", "true");
+    expect(tablist).toBeVisible();
+    expect(screen.queryByLabelText("Simulation notebook")).not.toBeInTheDocument();
+  });
 });

--- a/app/frontend/src/IntegratedExploreWorkspace.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.tsx
@@ -53,9 +53,22 @@ export function IntegratedExploreWorkspace({
   );
 }
 
-export function ExploreInspector({ sections }: { sections: InspectorSections }) {
-  const [collapsed, setCollapsed] = useState(false);
+export function ExploreInspector({
+  id,
+  sections,
+  collapsed: controlledCollapsed,
+  onCollapsedChange,
+  showCollapseControl = true,
+}: {
+  id?: string;
+  sections: InspectorSections;
+  collapsed?: boolean;
+  onCollapsedChange?: (collapsed: boolean) => void;
+  showCollapseControl?: boolean;
+}) {
+  const [internalCollapsed, setInternalCollapsed] = useState(false);
   const [activeTab, setActiveTab] = useState<InspectorTab>("explain");
+  const collapsed = controlledCollapsed ?? internalCollapsed;
   const tabbed = sections.science !== undefined;
   const activePanel =
     activeTab === "explain"
@@ -66,25 +79,36 @@ export function ExploreInspector({ sections }: { sections: InspectorSections }) 
           ? sections.notes
           : sections.details;
 
+  function toggleCollapsed() {
+    const next = !collapsed;
+    if (controlledCollapsed === undefined) setInternalCollapsed(next);
+    onCollapsedChange?.(next);
+  }
+
+  if (collapsed && !showCollapseControl) return null;
+
   return (
     <>
       <aside
+        id={id}
         className={`explore-inspector${collapsed ? " explore-inspector-collapsed" : ""}`}
         aria-label="Explore inspector"
         data-collapsed={collapsed ? "true" : "false"}
       >
         <header className="explore-inspector-header">
           {!collapsed && <strong>Context</strong>}
-          <button
-            type="button"
-            className="explore-inspector-toggle"
-            aria-expanded={!collapsed}
-            aria-label={collapsed ? "Open inspector" : "Collapse inspector"}
-            title={collapsed ? "Open inspector" : "Collapse inspector"}
-            onClick={() => setCollapsed((current) => !current)}
-          >
-            <span aria-hidden="true">{collapsed ? "\u00ab" : "\u00bb"}</span>
-          </button>
+          {showCollapseControl && (
+            <button
+              type="button"
+              className="explore-inspector-toggle"
+              aria-expanded={!collapsed}
+              aria-label={collapsed ? "Open inspector" : "Collapse inspector"}
+              title={collapsed ? "Open inspector" : "Collapse inspector"}
+              onClick={toggleCollapsed}
+            >
+              <span aria-hidden="true">{collapsed ? "\u00ab" : "\u00bb"}</span>
+            </button>
+          )}
         </header>
         <div hidden={collapsed}>
           {tabbed && (

--- a/app/frontend/src/IntegratedExploreWorkspace.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.tsx
@@ -2,9 +2,12 @@ import { type ReactNode, useState } from "react";
 
 type InspectorSections = {
   explain: ReactNode;
+  science?: ReactNode;
   notes: ReactNode;
   details: ReactNode;
 };
+
+type InspectorTab = "explain" | "science" | "notes" | "details";
 
 export function IntegratedExploreWorkspace({
   worldName,
@@ -52,6 +55,16 @@ export function IntegratedExploreWorkspace({
 
 export function ExploreInspector({ sections }: { sections: InspectorSections }) {
   const [collapsed, setCollapsed] = useState(false);
+  const [activeTab, setActiveTab] = useState<InspectorTab>("explain");
+  const tabbed = sections.science !== undefined;
+  const activePanel =
+    activeTab === "explain"
+      ? sections.explain
+      : activeTab === "science"
+        ? sections.science
+        : activeTab === "notes"
+          ? sections.notes
+          : sections.details;
 
   return (
     <>
@@ -74,15 +87,41 @@ export function ExploreInspector({ sections }: { sections: InspectorSections }) 
           </button>
         </header>
         <div hidden={collapsed}>
-          <section className="explore-inspector-panel" aria-label="Context inspector">
-            {sections.explain}
+          {tabbed && (
+            <nav className="explore-inspector-tabs" aria-label="Context sections" role="tablist">
+              {(["explain", "science", "notes", "details"] as InspectorTab[]).map((tab) => (
+                <button
+                  key={tab}
+                  type="button"
+                  id={`explore-inspector-tab-${tab}`}
+                  role="tab"
+                  className={activeTab === tab ? "active-control" : ""}
+                  aria-selected={activeTab === tab}
+                  aria-controls="explore-inspector-active-panel"
+                  onClick={() => setActiveTab(tab)}
+                >
+                  {tab[0].toUpperCase() + tab.slice(1)}
+                </button>
+              ))}
+            </nav>
+          )}
+          <section
+            id={tabbed ? "explore-inspector-active-panel" : undefined}
+            className="explore-inspector-panel"
+            aria-label="Context inspector"
+            role={tabbed ? "tabpanel" : undefined}
+            aria-labelledby={tabbed ? `explore-inspector-tab-${activeTab}` : undefined}
+          >
+            {tabbed ? activePanel : sections.explain}
           </section>
         </div>
       </aside>
-      <section className="explore-secondary-content" aria-label="Simulation notebook and details">
-        <section aria-label="Simulation notebook">{sections.notes}</section>
-        <section aria-label="Simulation technical details">{sections.details}</section>
-      </section>
+      {!tabbed && (
+        <section className="explore-secondary-content" aria-label="Simulation notebook and details">
+          <section aria-label="Simulation notebook">{sections.notes}</section>
+          <section aria-label="Simulation technical details">{sections.details}</section>
+        </section>
+      )}
     </>
   );
 }

--- a/app/frontend/src/StormExaminationResearch.css
+++ b/app/frontend/src/StormExaminationResearch.css
@@ -181,19 +181,30 @@
   padding: 0.3rem 0 0.3rem 0.65rem;
 }
 
-.storm-legend > strong {
+.storm-legend-heading {
+  display: grid;
+  gap: 0.06rem;
+}
+
+.storm-legend-heading > strong {
   font-size: 0.7rem;
 }
 
-.storm-legend > p,
-.storm-legend > small {
+.storm-legend-heading > small,
+.storm-legend-note,
+.storm-legend-range {
   margin: 0;
   color: var(--color-text-muted);
   font-size: 0.57rem;
   line-height: 1.25;
 }
 
-.storm-legend ol {
+.storm-legend-range {
+  display: grid;
+  gap: 0.08rem;
+}
+
+.storm-legend-scale {
   display: grid;
   gap: 0.05rem;
   margin: 0.15rem 0;
@@ -201,7 +212,7 @@
   list-style: none;
 }
 
-.storm-legend li {
+.storm-legend-scale li {
   display: grid;
   grid-template-columns: 0.55rem minmax(0, 1fr);
   gap: 0.28rem;
@@ -211,11 +222,11 @@
   line-height: 1.08;
 }
 
-.storm-legend li span {
+.storm-legend-scale li span {
   border: 1px solid rgba(49, 69, 82, 0.16);
 }
 
-.storm-legend li b {
+.storm-legend-scale li b {
   align-self: center;
   font-weight: 750;
 }

--- a/app/frontend/src/StormExaminationResearch.css
+++ b/app/frontend/src/StormExaminationResearch.css
@@ -256,6 +256,10 @@
   border-color: #632b73;
 }
 
+.storm-key-teal {
+  border-color: #2f7280;
+}
+
 .storm-key-brown {
   border-color: #7b572a;
 }

--- a/app/frontend/src/StormExaminationResearch.test.tsx
+++ b/app/frontend/src/StormExaminationResearch.test.tsx
@@ -51,6 +51,8 @@ function layer(key = "winterp", displayName = "Vertical velocity") {
 const frame: StormExaminationFrame = {
   schema_version: "storm_examination_gate_c_v1",
   authority_state: "issue_418_gate_c_research_not_product",
+  world_id: null,
+  simulation_id: null,
   run_id: "quarter-circle-supercell-official-20260722T142521Z",
   case_id: "cm1_r21_1_quarter_circle_supercell_official_v0",
   simulation_label: "Official CM1 r21.1 quarter-circle benchmark",
@@ -190,6 +192,7 @@ const frame: StormExaminationFrame = {
     },
     categories: null,
   },
+  scene: null,
   caveats: [
     "Saved histories are 15 minutes apart.",
     "Coordinates are in the translating model frame.",
@@ -352,7 +355,8 @@ describe("StormExaminationResearch", () => {
   it("fails locally when retained evidence is unavailable and retries without leaving the page", async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: false,
-      json: () => Promise.resolve({ detail: "The accepted Gate B retained output is unavailable." }),
+      json: () =>
+        Promise.resolve({ detail: "The accepted Gate B retained output is unavailable." }),
     } as Response);
 
     render(<StormExaminationResearch />);

--- a/app/frontend/src/StormExaminationResearch.test.tsx
+++ b/app/frontend/src/StormExaminationResearch.test.tsx
@@ -152,6 +152,7 @@ const frame: StormExaminationFrame = {
     overlays: {
       vertical_vorticity: layer("zvort", "Vertical vorticity"),
       updraft_helicity: layer("uh", "Updraft helicity"),
+      vertical_velocity: layer("winterp", "Vertical velocity"),
       composite_reflectivity: layer("dbz", "Reflectivity"),
       accumulated_surface_rain: layer("rain", "Rain"),
     },

--- a/app/frontend/src/StormExaminationResearch.test.tsx
+++ b/app/frontend/src/StormExaminationResearch.test.tsx
@@ -59,6 +59,7 @@ const frame: StormExaminationFrame = {
   lens_id: "rotating_updraft",
   lens_name: "Rotating Updraft",
   lens_question: "Where is the storm rising and rotating as one organized structure?",
+  what_to_notice_now: "The rotating core is organized at this saved output.",
   time_index: 5,
   time_seconds: 4500,
   times_seconds: [0, 900, 1800, 2700, 3600, 4500, 5400, 6300, 7200],
@@ -148,6 +149,7 @@ const frame: StormExaminationFrame = {
     y_km: [-10, 10],
     level_index: 1,
     level_km: 3.25,
+    selection_z_indices: null,
     primary: layer(),
     overlays: {
       vertical_vorticity: layer("zvort", "Vertical vorticity"),
@@ -155,6 +157,11 @@ const frame: StormExaminationFrame = {
       vertical_velocity: layer("winterp", "Vertical velocity"),
       composite_reflectivity: layer("dbz", "Reflectivity"),
       accumulated_surface_rain: layer("rain", "Rain"),
+      total_condensate: layer("total_condensate", "Total condensate"),
+      low_level_precipitating_condensate: layer(
+        "precipitating_condensate",
+        "Current precipitating condensate",
+      ),
     },
     categories: null,
     wind_vectors: [{ x_km: 0, y_km: 0, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
@@ -169,6 +176,7 @@ const frame: StormExaminationFrame = {
     cross_section_coordinate_km: 10,
     primary: layer(),
     overlays: {
+      vertical_vorticity: layer("zvort", "Vertical vorticity"),
       total_condensate: layer("total_condensate", "Total condensate"),
       precipitating_condensate: layer("precipitating_condensate", "Precipitating condensate"),
       reflectivity: layer("dbz", "Reflectivity"),
@@ -186,6 +194,7 @@ const frame: StormExaminationFrame = {
     cross_section_coordinate_km: 10,
     primary: layer(),
     overlays: {
+      vertical_vorticity: layer("zvort", "Vertical vorticity"),
       total_condensate: layer("total_condensate", "Total condensate"),
       precipitating_condensate: layer("precipitating_condensate", "Precipitating condensate"),
       reflectivity: layer("dbz", "Reflectivity"),

--- a/app/frontend/src/StormExaminationResearch.tsx
+++ b/app/frontend/src/StormExaminationResearch.tsx
@@ -70,6 +70,7 @@ export type PlanView = {
   y_km: number[];
   level_index: number;
   level_km: number;
+  selection_z_indices: number[][] | null;
   primary: FieldLayer;
   overlays: Record<string, FieldLayer>;
   categories: CategoryLayer | null;
@@ -152,6 +153,8 @@ export type StormExaminationFrame = {
   lens_id: LensId;
   lens_name: string;
   lens_question: string;
+  what_to_notice_now: string;
+  what_to_notice_by_view?: Partial<Record<"plan" | "xz" | "yz", string>> | null;
   time_index: number;
   time_seconds: number;
   times_seconds: number[];
@@ -641,10 +644,14 @@ export function StormPlanPlot({
       (canvas ? plotGeometry(canvas, 43, 12, 12, 34, frame.viewport_bounds_km) : null);
     const model = pointerToModel(event, canvas, geometry);
     if (!model) return;
+    const localXIndex = nearestIndex(frame.plan.x_km, model.x);
+    const localYIndex = nearestIndex(frame.plan.y_km, model.y);
     onSelect({
-      xIndex: frame.plan.x_indices[nearestIndex(frame.plan.x_km, model.x)],
-      yIndex: frame.plan.y_indices[nearestIndex(frame.plan.y_km, model.y)],
-      zIndex: frame.plan.level_index,
+      xIndex: frame.plan.x_indices[localXIndex],
+      yIndex: frame.plan.y_indices[localYIndex],
+      zIndex:
+        frame.plan.selection_z_indices?.[localYIndex]?.[localXIndex] ??
+        frame.plan.level_index,
     });
   }
 
@@ -739,19 +746,31 @@ export function StormSectionPlot({
 export function StormLegend({
   frame,
   overlays,
+  evidenceView = "plan",
 }: {
   frame: StormExaminationFrame;
   overlays?: OverlayState;
+  evidenceView?: "plan" | "xz" | "yz";
 }) {
-  if (frame.plan.categories) {
+  const evidence =
+    evidenceView === "plan"
+      ? frame.plan
+      : evidenceView === "xz"
+        ? frame.xz_section
+        : frame.yz_section;
+  if (evidence.categories) {
     return (
       <aside className="storm-legend storm-category-legend" aria-label="Hydrometeor legend">
         <div className="storm-legend-heading">
           <strong>Dominant hydrometeor</strong>
-          <small>at column condensate maximum</small>
+          <small>
+            {evidenceView === "plan"
+              ? "column-derived at each cell's condensate maximum"
+              : "at each native section cell"}
+          </small>
         </div>
         <ol className="storm-legend-scale">
-          {frame.plan.categories.categories
+          {evidence.categories.categories
             .filter((category) => category.code > 0)
             .map((category) => (
               <li key={category.code}>
@@ -762,18 +781,18 @@ export function StormLegend({
         </ol>
         <div className="storm-legend-range">
           <span>
-            Mass {formatValue(frame.plan.primary.selected_frame_minimum)} to{" "}
-            {formatValue(frame.plan.primary.selected_frame_maximum)} g/kg
+            Mass {formatValue(evidence.primary.selected_frame_minimum)} to{" "}
+            {formatValue(evidence.primary.selected_frame_maximum)} g/kg
           </span>
         </div>
         <small className="storm-legend-note">
           Derived category; native species retained in Context.
         </small>
-        <OverlayKey lens={frame.lens_id} overlays={overlays} />
+        <OverlayKey lens={frame.lens_id} overlays={overlays} evidenceView={evidenceView} />
       </aside>
     );
   }
-  const scale = frame.plan.primary.scale;
+  const scale = evidence.primary.scale;
   return (
     <aside className="storm-legend" aria-label={`${scale.display_name} legend`}>
       <div className="storm-legend-heading">
@@ -792,27 +811,45 @@ export function StormLegend({
           ))}
       </ol>
       <div className="storm-legend-range">
-        <span>Frame max {formatSigned(frame.plan.primary.selected_frame_maximum)}</span>
-        <span>Frame min {formatSigned(frame.plan.primary.selected_frame_minimum)}</span>
+        <span>Frame max {formatSigned(evidence.primary.selected_frame_maximum)}</span>
+        <span>Frame min {formatSigned(evidence.primary.selected_frame_minimum)}</span>
       </div>
-      <OverlayKey lens={frame.lens_id} overlays={overlays} />
+      <OverlayKey lens={frame.lens_id} overlays={overlays} evidenceView={evidenceView} />
     </aside>
   );
 }
 
-function OverlayKey({ lens, overlays }: { lens: LensId; overlays?: OverlayState }) {
+function OverlayKey({
+  lens,
+  overlays,
+  evidenceView,
+}: {
+  lens: LensId;
+  overlays?: OverlayState;
+  evidenceView: "plan" | "xz" | "yz";
+}) {
   const items: Array<[string, string]> = [];
   if (lens === "rotating_updraft") {
+    if (overlays?.condensate) items.push(["teal", "Cloud boundary >= 0.05 g/kg"]);
     if (overlays?.rotation) items.push(["purple", "Cyclonic vorticity >= 0.01 s^-1"]);
-    if (overlays?.updraftHelicity) items.push(["black", "UH >= 300 m^2/s^2"]);
+    if (evidenceView === "plan" && overlays?.updraftHelicity) {
+      items.push(["black", "UH >= 300 m^2/s^2"]);
+    }
     if (overlays?.reflectivity) items.push(["brown", "Reflectivity >= 35 dBZ"]);
   } else if (lens === "cloud_precipitation") {
     if (overlays?.verticalMotion) items.push(["signed", "w >= +5 red / w <= -5 blue"]);
     if (overlays?.reflectivity) items.push(["black", "Reflectivity >= 35 dBZ"]);
   } else {
-    if (overlays?.rain) items.push(["navy", "Rain footprint >= 2 mm"]);
+    if (evidenceView === "plan" && overlays?.rain) {
+      items.push(["navy", "Accumulated rain (history) >= 2 mm"]);
+    }
+    if (overlays?.precipitatingCondensate) {
+      items.push(["brown", "Current precipitating condensate >= 0.1 g/kg"]);
+    }
     if (overlays?.reflectivity) items.push(["brown", "Reflectivity >= 35 dBZ"]);
-    if (overlays?.wind) items.push(["arrow", "Model-relative flow"]);
+    if (evidenceView === "plan" && overlays?.wind) {
+      items.push(["arrow", "Model-relative flow at 1.25 km"]);
+    }
   }
   if (!items.length) return null;
   return (
@@ -981,6 +1018,17 @@ function drawPlan(
     drawRaster(context, geometry, frame.plan.primary);
   }
   if (frame.lens_id === "rotating_updraft") {
+    const totalCondensate = frame.plan.overlays.total_condensate;
+    if (overlays.condensate && totalCondensate) {
+      drawThresholdOutline(
+        context,
+        geometry,
+        totalCondensate,
+        0.05,
+        "#2f7280",
+        1.15,
+      );
+    }
     if (overlays.rotation) {
       drawThresholdOutline(
         context,
@@ -1026,6 +1074,24 @@ function drawPlan(
       );
     }
   } else {
+    const currentPrecipitation = frame.plan.overlays.low_level_precipitating_condensate;
+    if (overlays.precipitatingCondensate && currentPrecipitation) {
+      drawTransparentRaster(
+        context,
+        geometry,
+        currentPrecipitation,
+        "#7b572a",
+        0.2,
+      );
+      drawThresholdOutline(
+        context,
+        geometry,
+        currentPrecipitation,
+        0.1,
+        "#7b572a",
+        1.5,
+      );
+    }
     if (overlays.rain) {
       drawTransparentRaster(
         context,
@@ -1083,14 +1149,25 @@ function drawSection(
     }
   } else {
     drawRaster(context, geometry, section.primary);
+    const verticalVorticity = section.overlays.vertical_vorticity;
+    if (overlays.rotation && frame.lens_id === "rotating_updraft" && verticalVorticity) {
+      drawThresholdOutline(
+        context,
+        geometry,
+        verticalVorticity,
+        0.01,
+        "#632b73",
+        1.8,
+      );
+    }
     if (overlays.condensate && frame.lens_id === "rotating_updraft") {
       drawThresholdOutline(
         context,
         geometry,
         section.overlays.total_condensate,
         0.05,
-        "#111820",
-        1.4,
+        "#2f7280",
+        1.3,
       );
     }
     if (overlays.precipitatingCondensate && frame.lens_id === "low_level_interactions") {
@@ -1099,7 +1176,7 @@ function drawSection(
         geometry,
         section.overlays.precipitating_condensate,
         0.1,
-        "#111820",
+        "#7b572a",
         1.4,
       );
     }

--- a/app/frontend/src/StormExaminationResearch.tsx
+++ b/app/frontend/src/StormExaminationResearch.tsx
@@ -6,11 +6,11 @@ import "./App.css";
 import "./StormExaminationResearch.css";
 import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
 
-type LensId = "rotating_updraft" | "cloud_precipitation" | "low_level_interactions";
-type ViewportId = "storm" | "full";
-type SectionOrientation = "xz" | "yz";
+export type LensId = "rotating_updraft" | "cloud_precipitation" | "low_level_interactions";
+export type ViewportId = "storm" | "full";
+export type SectionOrientation = "xz" | "yz";
 
-type ScaleMetadata = {
+export type ScaleMetadata = {
   scale_id: string;
   display_name: string;
   units: string;
@@ -22,7 +22,7 @@ type ScaleMetadata = {
   fixed_across_time: boolean;
 };
 
-type FieldLayer = {
+export type FieldLayer = {
   key: string;
   display_name: string;
   units: string;
@@ -35,14 +35,14 @@ type FieldLayer = {
   scale: ScaleMetadata;
 };
 
-type CategoryDefinition = {
+export type CategoryDefinition = {
   code: number;
   key: string;
   label: string;
   color: string;
 };
 
-type CategoryLayer = {
+export type CategoryLayer = {
   key: string;
   display_name: string;
   evidence_kind: "derived";
@@ -53,7 +53,7 @@ type CategoryLayer = {
   categories: CategoryDefinition[];
 };
 
-type WindVector = {
+export type WindVector = {
   x_km: number;
   y_km: number;
   u_m_s: number;
@@ -61,7 +61,7 @@ type WindVector = {
   magnitude_m_s: number;
 };
 
-type PlanView = {
+export type PlanView = {
   title: string;
   subtitle: string;
   x_indices: number[];
@@ -76,7 +76,7 @@ type PlanView = {
   wind_vectors: WindVector[];
 };
 
-type VerticalSection = {
+export type VerticalSection = {
   orientation: SectionOrientation;
   title: string;
   horizontal_dimension: "x" | "y";
@@ -89,7 +89,7 @@ type VerticalSection = {
   categories: CategoryLayer | null;
 };
 
-type SelectedPoint = {
+export type SelectedPoint = {
   x_index: number;
   y_index: number;
   z_index: number;
@@ -105,9 +105,47 @@ type SelectedPoint = {
   distance_to_primary_updraft_km: number;
 };
 
+export type VolumeLayer = {
+  key: string;
+  display_name: string;
+  units: string;
+  evidence_kind: "native" | "derived";
+  source_fields: string[];
+  derivation: string | null;
+  rendering: "neutral_cloud" | "signed_scalar" | "scalar" | "categorical";
+  points: Array<[number, number, number, number, number]>;
+  source_count: number;
+  returned_count: number;
+  threshold_label: string;
+  default_visible: boolean;
+  default_opacity: number;
+  default_point_size: number;
+  scale: ScaleMetadata | null;
+  categories: CategoryDefinition[];
+};
+
+export type StormVolumeScene = {
+  coordinate_extents_km: Record<"x" | "y" | "z", { min: number; max: number }>;
+  coordinate_sizes: Record<"x" | "y" | "z", number>;
+  layers: VolumeLayer[];
+  wind_vectors: Array<{
+    x_km: number;
+    y_km: number;
+    z_km: number;
+    u_m_s: number;
+    v_m_s: number;
+    magnitude_m_s: number;
+  }>;
+  wind_reference_m_s: number;
+  point_budget: number;
+  source_history_file: string;
+};
+
 export type StormExaminationFrame = {
-  schema_version: "storm_examination_gate_c_v1";
-  authority_state: "issue_418_gate_c_research_not_product";
+  schema_version: "storm_examination_gate_c_v1" | "supercells_explore_v1";
+  authority_state: "issue_418_gate_c_research_not_product" | "supercells_product_world";
+  world_id: "supercells" | null;
+  simulation_id: "supercells_quarter_circle_reference" | null;
   run_id: string;
   case_id: string;
   simulation_label: string;
@@ -139,13 +177,14 @@ export type StormExaminationFrame = {
   plan: PlanView;
   xz_section: VerticalSection;
   yz_section: VerticalSection;
+  scene: StormVolumeScene | null;
   caveats: string[];
   provenance: Record<string, string>;
   extraction_milliseconds: number;
 };
 
-type Selection = { xIndex: number; yIndex: number; zIndex: number };
-type OverlayState = {
+export type Selection = { xIndex: number; yIndex: number; zIndex: number };
+export type OverlayState = {
   rotation: boolean;
   updraftHelicity: boolean;
   reflectivity: boolean;
@@ -189,7 +228,7 @@ const HYDROMETEOR_SHORT: Record<string, string> = {
   qr: "Rain",
   qi: "Cloud ice",
   qs: "Snow",
-  qg: "Large ice",
+  qg: "Hail-treated large ice",
 };
 
 export function StormExaminationResearch() {
@@ -573,7 +612,7 @@ function StormTimeline({
   );
 }
 
-function StormPlanPlot({
+export function StormPlanPlot({
   frame,
   overlays,
   onSelect,
@@ -623,7 +662,7 @@ function StormPlanPlot({
   );
 }
 
-function StormSectionPlot({
+export function StormSectionPlot({
   section,
   frame,
   overlays,
@@ -681,7 +720,7 @@ function StormSectionPlot({
   );
 }
 
-function StormLegend({ frame }: { frame: StormExaminationFrame }) {
+export function StormLegend({ frame }: { frame: StormExaminationFrame }) {
   if (frame.plan.categories) {
     return (
       <aside className="storm-legend" aria-label="Hydrometeor legend">

--- a/app/frontend/src/StormExaminationResearch.tsx
+++ b/app/frontend/src/StormExaminationResearch.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { MouseEvent as ReactMouseEvent } from "react";
+import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
 
 import "./App.css";
 import "./StormExaminationResearch.css";
@@ -386,7 +386,7 @@ export function StormExaminationResearch() {
                     onSelect={selectPoint}
                   />
                 </div>
-                <StormLegend frame={frame} />
+                <StormLegend frame={frame} overlays={overlays} />
               </div>
             ) : (
               <div className="storm-loading" role="status">
@@ -623,6 +623,12 @@ export function StormPlanPlot({
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const geometryRef = useRef<PlotGeometry | null>(null);
+  const plotStyle = dataAspectStyle(
+    frame.viewport_bounds_km.x_min,
+    frame.viewport_bounds_km.x_max,
+    frame.viewport_bounds_km.y_min,
+    frame.viewport_bounds_km.y_max,
+  );
   useCanvasRender(canvasRef, () => {
     const canvas = canvasRef.current;
     if (canvas) geometryRef.current = drawPlan(canvas, frame, overlays);
@@ -643,7 +649,7 @@ export function StormPlanPlot({
   }
 
   return (
-    <figure className="storm-plot storm-plan-plot">
+    <figure className="storm-plot storm-plan-plot" style={plotStyle}>
       <figcaption>
         <div>
           <strong>{frame.plan.title}</strong>
@@ -675,6 +681,16 @@ export function StormSectionPlot({
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const geometryRef = useRef<PlotGeometry | null>(null);
+  const horizontalMinimum = section.horizontal_km[0];
+  const horizontalMaximum = section.horizontal_km.at(-1) ?? horizontalMinimum;
+  const verticalMinimum = section.z_km[0] - 0.25;
+  const verticalMaximum = (section.z_km.at(-1) ?? 20) + 0.25;
+  const plotStyle = dataAspectStyle(
+    horizontalMinimum,
+    horizontalMaximum,
+    verticalMinimum,
+    verticalMaximum,
+  );
   useCanvasRender(canvasRef, () => {
     const canvas = canvasRef.current;
     if (canvas) geometryRef.current = drawSection(canvas, section, frame, overlays);
@@ -706,7 +722,7 @@ export function StormSectionPlot({
   }
 
   return (
-    <figure className="storm-plot storm-section-plot">
+    <figure className="storm-plot storm-section-plot" style={plotStyle}>
       <figcaption>
         <strong>{section.title}</strong>
         <span>{section.primary.display_name}</span>
@@ -720,13 +736,21 @@ export function StormSectionPlot({
   );
 }
 
-export function StormLegend({ frame }: { frame: StormExaminationFrame }) {
+export function StormLegend({
+  frame,
+  overlays,
+}: {
+  frame: StormExaminationFrame;
+  overlays?: OverlayState;
+}) {
   if (frame.plan.categories) {
     return (
-      <aside className="storm-legend" aria-label="Hydrometeor legend">
-        <strong>Dominant hydrometeor</strong>
-        <small>at column condensate maximum</small>
-        <ol>
+      <aside className="storm-legend storm-category-legend" aria-label="Hydrometeor legend">
+        <div className="storm-legend-heading">
+          <strong>Dominant hydrometeor</strong>
+          <small>at column condensate maximum</small>
+        </div>
+        <ol className="storm-legend-scale">
           {frame.plan.categories.categories
             .filter((category) => category.code > 0)
             .map((category) => (
@@ -736,23 +760,29 @@ export function StormLegend({ frame }: { frame: StormExaminationFrame }) {
               </li>
             ))}
         </ol>
-        <p>
-          Mass: {formatValue(frame.plan.primary.selected_frame_minimum)} to{" "}
-          {formatValue(frame.plan.primary.selected_frame_maximum)} g/kg
-        </p>
-        <small>Derived category; native species retained in Context.</small>
-        <OverlayKey lens={frame.lens_id} />
+        <div className="storm-legend-range">
+          <span>
+            Mass {formatValue(frame.plan.primary.selected_frame_minimum)} to{" "}
+            {formatValue(frame.plan.primary.selected_frame_maximum)} g/kg
+          </span>
+        </div>
+        <small className="storm-legend-note">
+          Derived category; native species retained in Context.
+        </small>
+        <OverlayKey lens={frame.lens_id} overlays={overlays} />
       </aside>
     );
   }
   const scale = frame.plan.primary.scale;
   return (
     <aside className="storm-legend" aria-label={`${scale.display_name} legend`}>
-      <strong>w (m/s)</strong>
-      <p>Frame max {formatSigned(frame.plan.primary.selected_frame_maximum)}</p>
-      <ol>
+      <div className="storm-legend-heading">
+        <strong>w (m/s)</strong>
+        <small>Fixed across all retained times</small>
+      </div>
+      <ol className="storm-legend-scale">
         {scale.colors
-          .map((color, index) => ({ color, label: scaleIntervalLabel(scale, index) }))
+          .map((color, index) => ({ color, label: compactScaleIntervalLabel(scale, index) }))
           .reverse()
           .map((item) => (
             <li key={`${item.color}-${item.label}`}>
@@ -761,31 +791,30 @@ export function StormLegend({ frame }: { frame: StormExaminationFrame }) {
             </li>
           ))}
       </ol>
-      <p>Frame min {formatSigned(frame.plan.primary.selected_frame_minimum)}</p>
-      <small>Fixed across all retained times.</small>
-      <OverlayKey lens={frame.lens_id} />
+      <div className="storm-legend-range">
+        <span>Frame max {formatSigned(frame.plan.primary.selected_frame_maximum)}</span>
+        <span>Frame min {formatSigned(frame.plan.primary.selected_frame_minimum)}</span>
+      </div>
+      <OverlayKey lens={frame.lens_id} overlays={overlays} />
     </aside>
   );
 }
 
-function OverlayKey({ lens }: { lens: LensId }) {
-  const items =
-    lens === "rotating_updraft"
-      ? [
-          ["purple", "Cyclonic vorticity >= 0.01 s^-1"],
-          ["black", "UH >= 300 m^2/s^2"],
-          ["brown", "Reflectivity >= 35 dBZ"],
-        ]
-      : lens === "cloud_precipitation"
-        ? [
-            ["black", "Reflectivity >= 35 dBZ"],
-            ["signed", "w: red rising / blue descending"],
-          ]
-        : [
-            ["navy", "Rain footprint >= 2 mm"],
-            ["brown", "Reflectivity >= 35 dBZ"],
-            ["arrow", "Native model-relative flow"],
-          ];
+function OverlayKey({ lens, overlays }: { lens: LensId; overlays?: OverlayState }) {
+  const items: Array<[string, string]> = [];
+  if (lens === "rotating_updraft") {
+    if (overlays?.rotation) items.push(["purple", "Cyclonic vorticity >= 0.01 s^-1"]);
+    if (overlays?.updraftHelicity) items.push(["black", "UH >= 300 m^2/s^2"]);
+    if (overlays?.reflectivity) items.push(["brown", "Reflectivity >= 35 dBZ"]);
+  } else if (lens === "cloud_precipitation") {
+    if (overlays?.verticalMotion) items.push(["signed", "w >= +5 red / w <= -5 blue"]);
+    if (overlays?.reflectivity) items.push(["black", "Reflectivity >= 35 dBZ"]);
+  } else {
+    if (overlays?.rain) items.push(["navy", "Rain footprint >= 2 mm"]);
+    if (overlays?.reflectivity) items.push(["brown", "Reflectivity >= 35 dBZ"]);
+    if (overlays?.wind) items.push(["arrow", "Model-relative flow"]);
+  }
+  if (!items.length) return null;
   return (
     <div className="storm-overlay-key">
       {items.map(([kind, label]) => (
@@ -983,6 +1012,9 @@ function drawPlan(
       );
     }
   } else if (frame.lens_id === "cloud_precipitation") {
+    if (overlays.verticalMotion) {
+      drawSignedOutlines(context, geometry, frame.plan.overlays.vertical_velocity, 5);
+    }
     if (overlays.reflectivity) {
       drawThresholdOutline(
         context,
@@ -1108,16 +1140,43 @@ function plotGeometry(
   bounds: Record<"x_min" | "x_max" | "y_min" | "y_max", number>,
 ): PlotGeometry {
   const rect = canvas.getBoundingClientRect();
+  const availableWidth = Math.max(20, rect.width - left - right);
+  const availableHeight = Math.max(20, rect.height - top - bottom);
+  const modelWidth = Math.max(Number.EPSILON, bounds.x_max - bounds.x_min);
+  const modelHeight = Math.max(Number.EPSILON, bounds.y_max - bounds.y_min);
+  const modelAspect = modelWidth / modelHeight;
+  let width = availableWidth;
+  let height = width / modelAspect;
+  let fittedLeft = left;
+  let fittedTop = top;
+  if (height > availableHeight) {
+    height = availableHeight;
+    width = height * modelAspect;
+    fittedLeft += (availableWidth - width) / 2;
+  } else {
+    fittedTop += (availableHeight - height) / 2;
+  }
   return {
-    left,
-    top,
-    width: Math.max(20, rect.width - left - right),
-    height: Math.max(20, rect.height - top - bottom),
+    left: fittedLeft,
+    top: fittedTop,
+    width,
+    height,
     xMinimum: bounds.x_min,
     xMaximum: bounds.x_max,
     yMinimum: bounds.y_min,
     yMaximum: bounds.y_max,
   };
+}
+
+function dataAspectStyle(
+  horizontalMinimum: number,
+  horizontalMaximum: number,
+  verticalMinimum: number,
+  verticalMaximum: number,
+): CSSProperties {
+  const horizontalSpan = Math.max(Number.EPSILON, horizontalMaximum - horizontalMinimum);
+  const verticalSpan = Math.max(Number.EPSILON, verticalMaximum - verticalMinimum);
+  return { "--storm-data-aspect": horizontalSpan / verticalSpan } as CSSProperties;
 }
 
 function drawGrid(context: CanvasRenderingContext2D, geometry: PlotGeometry) {
@@ -1269,12 +1328,14 @@ function drawSignedOutlines(
   layer: FieldLayer,
   threshold: number,
 ) {
-  drawThresholdOutline(context, geometry, layer, threshold, "#b5221f", 1.25);
   const negative: FieldLayer = {
     ...layer,
     values: layer.values.map((row) => row.map((value) => (value === null ? null : -value))),
   };
-  drawThresholdOutline(context, geometry, negative, threshold, "#174f9c", 1.25);
+  drawThresholdOutline(context, geometry, layer, threshold, "rgba(255,255,255,0.94)", 4.2);
+  drawThresholdOutline(context, geometry, negative, threshold, "rgba(255,255,255,0.94)", 4.2);
+  drawThresholdOutline(context, geometry, layer, threshold, "#c72b22", 2.2);
+  drawThresholdOutline(context, geometry, negative, threshold, "#1559b0", 2.2);
 }
 
 function drawWindVectors(
@@ -1404,12 +1465,24 @@ function scaleColor(value: number, scale: ScaleMetadata): string {
   return scale.colors[Math.round(normalized * (scale.colors.length - 1))] ?? scale.colors[0];
 }
 
+function compactScaleIntervalLabel(scale: ScaleMetadata, index: number): string {
+  const lower = index === 0 ? null : scale.breakpoints[index - 1];
+  const upper = scale.breakpoints[index] ?? null;
+  if (lower === null) return `<${formatCompactLegendValue(upper ?? scale.minimum)}`;
+  if (upper === null) return `>=${formatCompactLegendValue(lower)}`;
+  return `${formatCompactLegendValue(lower)}–${formatCompactLegendValue(upper)}`;
+}
+
 function scaleIntervalLabel(scale: ScaleMetadata, index: number): string {
   const lower = index === 0 ? null : scale.breakpoints[index - 1];
   const upper = scale.breakpoints[index] ?? null;
   if (lower === null) return `< ${formatValue(upper ?? scale.minimum)}`;
   if (upper === null) return `>= ${formatValue(lower)}`;
   return `${formatValue(lower)} to < ${formatValue(upper)}`;
+}
+
+function formatCompactLegendValue(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(0) : formatValue(value);
 }
 
 function withAlpha(hex: string, alpha: number): string {

--- a/app/frontend/src/SupercellsExplore.css
+++ b/app/frontend/src/SupercellsExplore.css
@@ -147,6 +147,14 @@
   font-size: 0.62rem;
 }
 
+.supercells-loading-surface {
+  display: grid;
+  min-height: 16rem;
+  place-items: center;
+  color: var(--color-text-muted);
+  font-weight: 700;
+}
+
 .supercells-evidence {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
@@ -204,7 +212,8 @@
   grid-template-areas:
     "heading range"
     "scale scale"
-    "note overlays";
+    "note note"
+    "overlays overlays";
   grid-template-columns: minmax(0, 1fr) max-content;
   gap: 0.28rem 0.65rem;
   align-items: center;
@@ -281,7 +290,8 @@
 }
 
 .supercells-evidence .storm-overlay-key > div {
-  grid-template-columns: 1.1rem auto;
+  grid-template-columns: 1.1rem minmax(0, 1fr);
+  min-width: 0;
 }
 
 .supercells-workbench > .explore-inspector {
@@ -341,6 +351,27 @@
 .context-callout {
   border-left: 3px solid var(--color-accent-primary);
   padding-left: 0.5rem;
+}
+
+.supercells-notice-now {
+  display: grid;
+  gap: 0.18rem;
+  margin: 0.6rem 0;
+  border-left: 3px solid #4d7890;
+  padding: 0.45rem 0.55rem;
+  background: #eef6f9;
+}
+
+.supercells-notice-now strong {
+  color: var(--color-text-primary);
+  font-size: 0.72rem;
+}
+
+.supercells-notice-now p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.72rem;
+  line-height: 1.35;
 }
 
 .context-coordinate-frame {
@@ -484,6 +515,11 @@
 .supercells-display-controls {
   display: grid;
   gap: 0.65rem;
+}
+
+.supercells-display-heading {
+  color: var(--color-text-primary);
+  font-size: 0.72rem;
 }
 
 .supercells-layer-list,

--- a/app/frontend/src/SupercellsExplore.css
+++ b/app/frontend/src/SupercellsExplore.css
@@ -1,0 +1,809 @@
+.supercells-explore-shell {
+  display: grid;
+  grid-template-rows: minmax(32rem, calc(100vh - 21rem)) auto auto;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px 0 18px;
+}
+
+.supercells-workbench {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(24rem, 1fr) minmax(18rem, 20rem);
+  grid-template-rows: minmax(0, 1fr);
+  gap: 8px;
+  min-width: 0;
+  min-height: 0;
+}
+
+.supercells-scene {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--color-visualization-background);
+}
+
+.supercells-scene > .true3d-viewer,
+.supercells-scene .true3d-scene-frame {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.supercells-scene .true3d-viewer {
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+}
+
+.supercells-lens-switcher {
+  position: absolute;
+  z-index: 7;
+  top: 0.65rem;
+  right: 0.65rem;
+  display: flex;
+  gap: 0.16rem;
+  max-width: calc(100% - 1.3rem);
+  border: 1px solid rgba(91, 125, 145, 0.45);
+  border-radius: 4px;
+  padding: 0.18rem;
+  background: rgba(250, 253, 254, 0.92);
+  box-shadow: 0 4px 14px rgba(36, 63, 82, 0.12);
+}
+
+.supercells-lens-switcher button {
+  min-height: 1.8rem;
+  border: 0;
+  border-radius: 2px;
+  padding: 0.28rem 0.45rem;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 0.68rem;
+  box-shadow: none;
+  white-space: nowrap;
+}
+
+.supercells-lens-switcher .active-control {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+}
+
+.supercells-lens-switcher button:hover,
+.supercells-lens-switcher button:focus-visible,
+.supercells-lens-switcher .active-control:hover,
+.supercells-lens-switcher .active-control:focus-visible {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+}
+
+.supercells-evidence .instrument-view-toggle button:hover,
+.supercells-evidence .instrument-view-toggle button:focus-visible,
+.supercells-evidence .instrument-view-toggle .active-control:hover,
+.supercells-evidence .instrument-view-toggle .active-control:focus-visible {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+}
+
+.supercells-frame-loading {
+  position: absolute;
+  z-index: 6;
+  top: 3.45rem;
+  right: 0.65rem;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  padding: 0.25rem 0.38rem;
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--color-text-muted);
+  font-size: 0.62rem;
+}
+
+.supercells-evidence {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 0.4rem;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--color-border);
+  padding-left: 8px;
+}
+
+.supercells-evidence-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 8.2rem;
+  gap: 0.42rem;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.supercells-active-plot,
+.supercells-active-plot > .storm-plot {
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+}
+
+.supercells-evidence .storm-legend {
+  max-height: 100%;
+  overflow: auto;
+  padding-left: 0.42rem;
+}
+
+.supercells-workbench > .explore-inspector {
+  grid-column: auto;
+  grid-row: auto;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.supercells-workbench > .explore-inspector > div {
+  min-height: 0;
+  overflow: auto;
+}
+
+.supercells-workbench > .explore-inspector-collapsed {
+  max-width: 3.2rem;
+}
+
+.supercells-workbench > .explore-secondary-content {
+  display: none;
+}
+
+.supercells-scene .true3d-context-stack {
+  max-width: calc(100% - 25rem);
+}
+
+.supercells-explore-shell:has(.explore-inspector-collapsed) .supercells-workbench {
+  grid-template-columns: minmax(0, 1.45fr) minmax(24rem, 1fr) 3.2rem;
+}
+
+.supercells-context-panel h3 {
+  font-size: 0.98rem;
+  line-height: 1.22;
+}
+
+.supercells-context-panel .metric-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.supercells-state-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 0.55rem;
+}
+
+.supercells-state-row span {
+  border-radius: 3px;
+  padding: 0.2rem 0.36rem;
+  background: var(--color-accent-soft);
+  color: var(--color-text-primary);
+  font-size: 0.66rem;
+  font-weight: 750;
+}
+
+.context-callout {
+  border-left: 3px solid var(--color-accent-primary);
+  padding-left: 0.5rem;
+}
+
+.context-coordinate-frame {
+  color: var(--color-text-muted);
+  font-size: 0.68rem;
+}
+
+.supercells-detail-list {
+  display: grid;
+  gap: 0.4rem;
+  padding-left: 1rem;
+}
+
+.supercells-detail-list li {
+  display: grid;
+  gap: 0.08rem;
+}
+
+.supercells-detail-list span,
+.supercells-detail-list code {
+  overflow-wrap: anywhere;
+  font-size: 0.66rem;
+}
+
+.supercells-control-deck {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  gap: 0.7rem;
+  align-items: center;
+  min-width: 0;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0.42rem 0.55rem;
+}
+
+.supercells-control-deck fieldset {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  min-width: 0;
+  margin: 0;
+  border: 0;
+  padding: 0;
+}
+
+.supercells-control-deck legend {
+  padding: 0;
+  color: var(--color-text-muted);
+  font-size: 0.62rem;
+  font-weight: 800;
+}
+
+.supercells-control-deck button,
+.supercells-control-deck label {
+  font-size: 0.66rem;
+}
+
+.supercells-control-deck button {
+  min-height: 1.9rem;
+  padding: 0.28rem 0.46rem;
+  white-space: nowrap;
+}
+
+.supercells-overlay-controls {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.supercells-overlay-controls label {
+  display: flex;
+  gap: 0.22rem;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.supercells-timeline {
+  display: grid;
+  grid-template-columns: auto auto minmax(18rem, 1fr) auto auto;
+  gap: 0.5rem;
+  align-items: center;
+  min-width: 0;
+  min-height: 3.7rem;
+  margin: 0;
+  border: 0;
+  padding: 0.2rem 0.55rem;
+}
+
+.supercells-timeline legend {
+  padding: 0;
+  color: var(--color-text-muted);
+  font-size: 0.62rem;
+  font-weight: 800;
+}
+
+.supercells-play-button {
+  display: grid;
+  width: 2.2rem;
+  min-width: 2.2rem;
+  height: 2.2rem;
+  place-items: center;
+  padding: 0;
+}
+
+.supercells-time-scrubber {
+  display: grid;
+  grid-template-columns: auto minmax(12rem, 1fr) minmax(10rem, auto);
+  gap: 0.55rem;
+  align-items: center;
+  min-width: 0;
+  font-size: 0.66rem;
+  font-weight: 750;
+}
+
+.supercells-time-scrubber input {
+  width: 100%;
+}
+
+.supercells-time-readout {
+  display: grid;
+  min-width: 0;
+}
+
+.supercells-time-readout strong {
+  font-size: 0.7rem;
+}
+
+.supercells-time-readout small,
+.supercells-timeline-status {
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-size: 0.58rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.supercells-speed-control select {
+  width: auto;
+  min-width: 4rem;
+}
+
+.supercells-display-controls {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.supercells-layer-list,
+.supercells-category-filters {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.3rem 0.65rem;
+}
+
+.supercells-layer-list label,
+.supercells-category-filters label {
+  display: flex;
+  gap: 0.28rem;
+  align-items: start;
+  font-size: 0.68rem;
+}
+
+.supercells-category-filters {
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  padding: 0.55rem 0 0;
+}
+
+.supercells-category-filters legend {
+  padding: 0 0.25rem;
+  color: var(--color-text-muted);
+  font-size: 0.64rem;
+  font-weight: 800;
+}
+
+.supercells-render-sliders {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.55rem;
+}
+
+.supercells-render-sliders label {
+  display: grid;
+  grid-template-columns: auto minmax(4rem, 1fr) auto;
+  gap: 0.35rem;
+  align-items: center;
+  font-size: 0.66rem;
+  font-weight: 750;
+}
+
+.supercells-explore-focused-scene .supercells-scene,
+.supercells-explore-focused-evidence .supercells-evidence {
+  grid-column: 1 / -1;
+}
+
+.supercells-explore-focused-scene .supercells-evidence,
+.supercells-explore-focused-scene .explore-inspector,
+.supercells-explore-focused-evidence .supercells-scene,
+.supercells-explore-focused-evidence .explore-inspector {
+  display: none;
+}
+
+.supercells-explore-focused-evidence .supercells-evidence-body {
+  grid-template-columns: minmax(0, 1fr) 10rem;
+}
+
+.supercells-local-error {
+  align-self: center;
+  justify-self: center;
+  max-width: 30rem;
+}
+
+.supercells-simulation-grid {
+  grid-template-columns: minmax(24rem, 42rem);
+}
+
+.simulation-card-facts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.simulation-card-facts div {
+  display: grid;
+}
+
+.simulation-card-facts dt {
+  color: var(--color-text-muted);
+  font-size: 0.7rem;
+  font-weight: 750;
+}
+
+.simulation-card-facts dd {
+  margin: 0;
+  font-weight: 800;
+}
+
+@media (max-width: 1199px) {
+  .app-shell-explore:has(.supercells-explore-shell) {
+    gap: 0;
+    min-height: 100vh;
+    padding: 0 12px;
+  }
+
+  .app-shell-explore:has(.supercells-explore-shell) .topbar {
+    height: 48px;
+    box-sizing: border-box;
+    padding: 0;
+  }
+
+  .app-shell-explore:has(.supercells-explore-shell) .topbar h1 {
+    font-size: 1.1rem;
+  }
+
+  .app-shell-explore:has(.supercells-explore-shell) .topbar .secondary-button {
+    border: 0;
+    padding: 0.3rem 0.45rem;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .app-shell-explore:has(.supercells-explore-shell) > .world-context-workspace,
+  .app-shell-explore:has(.supercells-explore-shell) .integrated-explore-workspace {
+    min-height: calc(100vh - 48px);
+    gap: 0;
+  }
+
+  .app-shell-explore:has(.supercells-explore-shell) .integrated-explore-workspace {
+    grid-template-rows: 56px auto;
+  }
+
+  .app-shell-explore:has(.supercells-explore-shell) .integrated-explore-header {
+    display: flex;
+    height: 56px;
+    box-sizing: border-box;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.8rem;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0;
+  }
+
+  .app-shell-explore:has(.supercells-explore-shell) .integrated-explore-identity {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.8rem;
+  }
+
+  .app-shell-explore:has(.supercells-explore-shell) .integrated-explore-identity h2 {
+    overflow: hidden;
+    margin: 0;
+    font-size: 1.05rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .app-shell-explore:has(.supercells-explore-shell) .integrated-explore-back {
+    display: inline-flex;
+    min-height: 0;
+    align-items: center;
+    gap: 0.32rem;
+    border: 0;
+    padding: 0.3rem 0.2rem;
+    background: transparent;
+    color: var(--color-accent-primary);
+    box-shadow: none;
+    white-space: nowrap;
+  }
+
+  .supercells-explore-shell {
+    grid-template-rows: minmax(31rem, calc(100vh - 19rem)) auto auto;
+    padding-bottom: 8px;
+  }
+
+  .supercells-workbench,
+  .supercells-explore-shell:has(.explore-inspector-collapsed) .supercells-workbench {
+    grid-template-columns: minmax(0, 1.45fr) minmax(19rem, 0.78fr);
+    grid-template-rows: minmax(25rem, 1fr) auto;
+  }
+
+  .supercells-workbench > .explore-inspector {
+    grid-column: 1 / -1;
+    grid-row: auto;
+    max-height: 17rem;
+    border-top: 1px solid var(--color-border);
+    border-left: 0;
+  }
+
+  .supercells-scene .true3d-viewer {
+    position: relative;
+    display: block;
+  }
+
+  .supercells-scene .true3d-scene-frame,
+  .supercells-scene .true3d-scene-frame-tall {
+    height: 100%;
+    min-height: 0;
+    border-radius: 4px;
+  }
+
+  .supercells-scene .true3d-controls-compact {
+    position: absolute;
+    z-index: 8;
+    bottom: 0.65rem;
+    left: 0.65rem;
+    display: flex;
+    width: auto;
+    max-width: calc(100% - 1.3rem);
+    gap: 0;
+    align-items: center;
+    border: 1px solid rgba(91, 125, 145, 0.56);
+    border-radius: 4px;
+    padding: 0.2rem;
+    background: rgba(250, 253, 254, 0.94);
+    box-shadow: 0 5px 16px rgba(36, 63, 82, 0.14);
+  }
+
+  .supercells-scene .true3d-controls-compact:has(.true3d-display-control[open]) {
+    width: min(24rem, calc(100% - 1.3rem));
+    box-sizing: border-box;
+    border-radius: 0 0 4px 4px;
+  }
+
+  .supercells-scene .true3d-controls-compact > label {
+    display: flex;
+    align-items: center;
+    border-left: 1px solid var(--color-border);
+    padding-left: 0.2rem;
+  }
+
+  .supercells-scene .true3d-controls-compact > label select,
+  .supercells-scene .true3d-controls-compact > button {
+    width: auto;
+    height: 2rem;
+    min-height: 2rem;
+    border: 0;
+    border-radius: 2px;
+    padding: 0.2rem 0.45rem;
+    background: transparent;
+    color: var(--color-text-primary);
+    font-size: 0.72rem;
+    box-shadow: none;
+  }
+
+  .supercells-scene .true3d-controls-compact > button {
+    width: 2rem;
+    border-left: 1px solid var(--color-border);
+    font-size: 1rem;
+  }
+
+  .supercells-scene .true3d-display-control {
+    position: static;
+    display: flex;
+    height: 2rem;
+    align-items: center;
+  }
+
+  .supercells-scene .true3d-display-control > summary {
+    display: flex;
+    height: 2rem;
+    min-height: 2rem;
+    align-items: center;
+    margin: 0;
+    border: 0;
+    padding: 0 0.5rem;
+    background: transparent;
+    color: var(--color-text-primary);
+    font-size: 0.72rem;
+    font-weight: 800;
+    list-style: none;
+  }
+
+  .supercells-scene .true3d-display-panel {
+    position: absolute;
+    bottom: 100%;
+    left: -1px;
+    width: calc(100% + 2px);
+    box-sizing: border-box;
+    border: 1px solid var(--color-border-strong);
+    border-bottom: 0;
+    border-radius: 4px 4px 0 0;
+    padding: 0.7rem;
+    background: rgba(255, 255, 255, 0.97);
+    box-shadow: 0 -7px 20px rgba(36, 63, 82, 0.14);
+  }
+
+  .supercells-evidence .instrument-header {
+    display: grid;
+    width: 100%;
+    min-height: 42px;
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.45rem;
+    box-sizing: border-box;
+    overflow: hidden;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 0.35rem;
+  }
+
+  .supercells-evidence .instrument-header h2,
+  .supercells-evidence .instrument-header p {
+    overflow: hidden;
+    margin: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .supercells-evidence .instrument-header > div:first-child {
+    min-width: 0;
+  }
+
+  .supercells-evidence .instrument-header h2 {
+    font-size: 0.98rem;
+  }
+
+  .supercells-evidence .instrument-header p {
+    font-size: 0.72rem;
+  }
+
+  .supercells-evidence .instrument-actions,
+  .supercells-evidence .instrument-view-toggle {
+    display: flex;
+    flex: 0 0 auto;
+    gap: 0.18rem;
+    align-items: center;
+  }
+
+  .supercells-evidence .instrument-view-toggle button {
+    min-height: 1.75rem;
+    border: 0;
+    padding: 0.27rem 0.38rem;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 0.7rem;
+    box-shadow: none;
+  }
+
+  .supercells-evidence .viewer-maximize-button {
+    width: 1.75rem;
+    min-width: 1.75rem;
+    height: 1.75rem;
+    min-height: 1.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    padding: 0;
+    background: transparent;
+    color: var(--color-text-primary);
+    font-size: 1rem;
+    box-shadow: none;
+  }
+
+  .supercells-workbench > .explore-inspector .explore-inspector-header {
+    display: grid;
+    min-height: 2rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    border-bottom: 1px solid var(--color-border);
+    padding-left: 8px;
+  }
+
+  .supercells-workbench > .explore-inspector .explore-inspector-tabs {
+    position: sticky;
+    z-index: 3;
+    top: 0;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0;
+    background: var(--color-surface);
+  }
+
+  .supercells-workbench > .explore-inspector .explore-inspector-tabs button {
+    min-height: 1.9rem;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    padding: 0.35rem 0.18rem;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 0.68rem;
+    box-shadow: none;
+  }
+
+  .supercells-workbench > .explore-inspector .explore-inspector-tabs .active-control {
+    border-bottom-color: var(--color-accent-primary);
+    color: var(--color-accent-primary);
+  }
+
+  .supercells-workbench > .explore-inspector .explore-inspector-toggle {
+    width: 1.85rem;
+    height: 1.85rem;
+    min-height: 1.85rem;
+    border: 1px solid var(--color-border);
+    padding: 0;
+    background: transparent;
+    color: var(--color-accent-primary);
+    box-shadow: none;
+  }
+
+  .supercells-workbench > .explore-inspector > div {
+    min-height: 0;
+    overflow: auto;
+  }
+
+  .supercells-workbench > .explore-inspector .explore-inspector-panel {
+    display: grid;
+    gap: 0.45rem;
+    padding: 0.5rem 8px;
+  }
+
+  .supercells-control-deck {
+    grid-template-columns: repeat(2, auto);
+  }
+
+  .supercells-overlay-controls {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+  }
+
+  .supercells-time-scrubber {
+    grid-template-columns: minmax(10rem, 1fr) 9rem;
+  }
+
+  .supercells-time-scrubber > span:first-child {
+    display: none;
+  }
+
+  .supercells-timeline button {
+    min-height: 2.2rem;
+    padding: 0;
+  }
+
+  .supercells-timeline .frame-step-controls {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+  }
+
+  .supercells-timeline .frame-step-controls button {
+    width: 2.2rem;
+    min-width: 2.2rem;
+  }
+
+  .supercells-timeline .timelapse-icon {
+    display: inline-flex;
+    width: 0.8rem;
+    height: 0.8rem;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .supercells-timeline .timelapse-icon-play > span {
+    width: 0;
+    height: 0;
+    border-top: 0.36rem solid transparent;
+    border-bottom: 0.36rem solid transparent;
+    border-left: 0.58rem solid currentColor;
+    transform: translateX(0.05rem);
+  }
+
+  .supercells-timeline .timelapse-icon-pause {
+    gap: 0.18rem;
+  }
+
+  .supercells-timeline .timelapse-icon-pause > span {
+    width: 0.18rem;
+    height: 0.72rem;
+    border-radius: 1px;
+    background: currentColor;
+  }
+}

--- a/app/frontend/src/SupercellsExplore.css
+++ b/app/frontend/src/SupercellsExplore.css
@@ -8,7 +8,7 @@
 
 .supercells-workbench {
   display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(24rem, 1fr) minmax(18rem, 20rem);
+  grid-template-columns: minmax(0, 1.1fr) minmax(31rem, 1fr) minmax(18rem, 20rem);
   grid-template-rows: minmax(0, 1fr);
   gap: 8px;
   min-width: 0;
@@ -84,6 +84,56 @@
   color: var(--color-accent-primary);
 }
 
+.supercells-context-toggle {
+  width: 1.75rem;
+  min-width: 1.75rem;
+  height: 1.75rem;
+  min-height: 1.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  padding: 0;
+  background: transparent;
+  color: var(--color-accent-primary);
+  box-shadow: none;
+}
+
+.supercells-context-toggle:hover,
+.supercells-context-toggle:focus-visible {
+  border-color: var(--color-accent-primary);
+  background: var(--color-accent-soft);
+}
+
+.supercells-context-toggle-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.supercells-context-toggle-frame {
+  position: relative;
+  display: block;
+  width: 0.94rem;
+  height: 0.68rem;
+  border: 1px solid currentColor;
+  border-radius: 2px;
+}
+
+.supercells-context-toggle-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  width: 0.36rem;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  border-left: 1px solid currentColor;
+  background: var(--color-accent-soft);
+  font-size: 0.62rem;
+  font-weight: 800;
+}
+
 .supercells-frame-loading {
   position: absolute;
   z-index: 6;
@@ -110,24 +160,128 @@
 
 .supercells-evidence-body {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 8.2rem;
+  grid-template-rows: minmax(0, 1fr) auto;
   gap: 0.42rem;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
 }
 
-.supercells-active-plot,
-.supercells-active-plot > .storm-plot {
+.supercells-active-plot {
+  display: flex;
   min-width: 0;
   min-height: 0;
-  height: 100%;
+  align-items: flex-start;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.supercells-active-plot:has(.storm-section-plot) {
+  align-items: center;
+}
+
+.supercells-active-plot > .storm-plot {
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  height: auto;
+}
+
+.supercells-active-plot > .storm-plan-plot {
+  max-width: min(100%, max(14rem, calc(100vh - 27rem)));
+}
+
+.supercells-active-plot > .storm-plot canvas {
+  width: 100%;
+  height: auto;
+  aspect-ratio: var(--storm-data-aspect);
 }
 
 .supercells-evidence .storm-legend {
-  max-height: 100%;
-  overflow: auto;
-  padding-left: 0.42rem;
+  align-self: stretch;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "heading range"
+    "scale scale"
+    "note overlays";
+  grid-template-columns: minmax(0, 1fr) max-content;
+  gap: 0.28rem 0.65rem;
+  align-items: center;
+  max-height: none;
+  overflow: visible;
+  border-top: 1px solid var(--color-border);
+  border-left: 0;
+  padding: 0.42rem 0.2rem 0;
+}
+
+.supercells-evidence .storm-legend-heading {
+  grid-area: heading;
+}
+
+.supercells-evidence .storm-legend-scale {
+  grid-area: scale;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.12rem 0.5rem;
+  width: 100%;
+  min-width: 0;
+  max-width: 52rem;
+  margin: 0;
+  justify-self: center;
+}
+
+.supercells-evidence .storm-legend-range {
+  grid-area: range;
+  min-width: 5.8rem;
+  justify-self: end;
+  white-space: nowrap;
+}
+
+.supercells-evidence .storm-legend-scale li {
+  grid-template-columns: 0.62rem minmax(0, 1fr);
+  min-width: 0;
+  font-size: 0.56rem;
+  white-space: nowrap;
+}
+
+.supercells-evidence .storm-legend-scale li b {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.supercells-evidence .storm-category-legend .storm-legend-scale li {
+  align-items: start;
+  white-space: normal;
+}
+
+.supercells-evidence .storm-category-legend .storm-legend-scale li b {
+  line-height: 1.05;
+}
+
+.supercells-evidence .storm-category-legend .storm-legend-scale li span {
+  width: 0.62rem;
+  height: 0.72rem;
+}
+
+.supercells-evidence .storm-legend-note {
+  grid-area: note;
+}
+
+.supercells-evidence .storm-overlay-key {
+  grid-area: overlays;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 0.85rem;
+  justify-content: flex-end;
+  border-top: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.supercells-evidence .storm-overlay-key > div {
+  grid-template-columns: 1.1rem auto;
 }
 
 .supercells-workbench > .explore-inspector {
@@ -147,10 +301,6 @@
   overflow: auto;
 }
 
-.supercells-workbench > .explore-inspector-collapsed {
-  max-width: 3.2rem;
-}
-
 .supercells-workbench > .explore-secondary-content {
   display: none;
 }
@@ -159,8 +309,8 @@
   max-width: calc(100% - 25rem);
 }
 
-.supercells-explore-shell:has(.explore-inspector-collapsed) .supercells-workbench {
-  grid-template-columns: minmax(0, 1.45fr) minmax(24rem, 1fr) 3.2rem;
+.supercells-workbench.supercells-context-collapsed {
+  grid-template-columns: minmax(0, 1.05fr) minmax(31rem, 1fr);
 }
 
 .supercells-context-panel h3 {
@@ -387,15 +537,42 @@
   grid-column: 1 / -1;
 }
 
+.supercells-explore-focused-evidence {
+  grid-template-rows: minmax(40rem, calc(100vh - 12rem)) auto auto;
+}
+
 .supercells-explore-focused-scene .supercells-evidence,
 .supercells-explore-focused-scene .explore-inspector,
-.supercells-explore-focused-evidence .supercells-scene,
-.supercells-explore-focused-evidence .explore-inspector {
+.supercells-explore-focused-evidence .supercells-scene {
   display: none;
 }
 
+.supercells-explore-focused-evidence .supercells-workbench {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.supercells-explore-focused-evidence
+  .supercells-workbench:not(.supercells-context-collapsed) {
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 20rem);
+}
+
+.supercells-explore-focused-evidence
+  .supercells-workbench:not(.supercells-context-collapsed)
+  .supercells-evidence {
+  grid-column: 1;
+}
+
+.supercells-explore-focused-evidence .supercells-workbench > .explore-inspector {
+  grid-column: 2;
+  grid-row: 1;
+}
+
 .supercells-explore-focused-evidence .supercells-evidence-body {
-  grid-template-columns: minmax(0, 1fr) 10rem;
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.supercells-explore-focused-evidence .supercells-active-plot > .storm-plan-plot {
+  max-width: min(100%, max(28rem, calc(100vh - 23rem)));
 }
 
 .supercells-local-error {
@@ -509,7 +686,7 @@
   }
 
   .supercells-workbench,
-  .supercells-explore-shell:has(.explore-inspector-collapsed) .supercells-workbench {
+  .supercells-workbench.supercells-context-collapsed {
     grid-template-columns: minmax(0, 1.45fr) minmax(19rem, 0.78fr);
     grid-template-rows: minmax(25rem, 1fr) auto;
   }
@@ -626,8 +803,9 @@
     min-height: 42px;
     min-width: 0;
     grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-rows: auto auto;
     align-items: center;
-    gap: 0.45rem;
+    gap: 0.25rem;
     box-sizing: border-box;
     overflow: hidden;
     border-bottom: 1px solid var(--color-border);
@@ -658,18 +836,44 @@
   .supercells-evidence .instrument-view-toggle {
     display: flex;
     flex: 0 0 auto;
-    gap: 0.18rem;
+    gap: 0.12rem;
     align-items: center;
+  }
+
+  .supercells-evidence .instrument-actions {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-content: flex-end;
   }
 
   .supercells-evidence .instrument-view-toggle button {
     min-height: 1.75rem;
     border: 0;
-    padding: 0.27rem 0.38rem;
+    padding: 0.27rem 0.3rem;
     background: transparent;
     color: var(--color-text-muted);
-    font-size: 0.7rem;
+    font-size: 0.66rem;
     box-shadow: none;
+  }
+
+  .supercells-evidence .storm-legend {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "heading"
+      "range"
+      "scale"
+      "overlays"
+      "note";
+  }
+
+  .supercells-evidence .storm-legend-range {
+    display: flex;
+    gap: 0.75rem;
+    justify-self: start;
+  }
+
+  .supercells-evidence .storm-overlay-key {
+    justify-content: flex-start;
   }
 
   .supercells-evidence .viewer-maximize-button {

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -1,0 +1,562 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SupercellsExplore } from "./SupercellsExplore";
+import type {
+  FieldLayer,
+  LensId,
+  StormExaminationFrame,
+  VolumeLayer,
+} from "./StormExaminationResearch";
+import type { SupercellSimulation } from "./SupercellsWorld";
+
+vi.mock("./True3DViewer", () => ({
+  True3DViewer: ({
+    fieldLabel,
+    activeSliceLabel,
+    maximized,
+    onToggleMaximize,
+    onSelectStormPoint,
+    compactDisplayControls,
+  }: {
+    fieldLabel: string;
+    activeSliceLabel: string;
+    maximized: boolean;
+    onToggleMaximize: () => void;
+    onSelectStormPoint: (point: [number, number, number, number, number]) => void;
+    compactDisplayControls: ReactNode;
+  }) => (
+    <section aria-label="Mock 3-D storm scene">
+      <h2>{fieldLabel}</h2>
+      <p>{activeSliceLabel}</p>
+      <button type="button" onClick={() => onSelectStormPoint([9.1, 19.1, 3.1, 12, 0])}>
+        Select 3-D point
+      </button>
+      <button type="button" onClick={onToggleMaximize}>
+        {maximized ? "Restore scene" : "Maximize scene"}
+      </button>
+      {compactDisplayControls}
+    </section>
+  ),
+}));
+
+const simulation: SupercellSimulation = {
+  simulation_id: "supercells_quarter_circle_reference",
+  display_name: "Quarter-Circle Supercell",
+  role: "reference",
+  world_id: "supercells",
+  run_id: "quarter-circle-supercell-official-20260722T142521Z",
+  case_id: "cm1_r21_1_quarter_circle_supercell_official_v0",
+  technical_state: "available",
+  technical_state_message: "Available",
+  explore_available: true,
+  saved_output_count: 9,
+  model_start_seconds: 0,
+  model_end_seconds: 7_200,
+  history_cadence_seconds: 900,
+  lineage_state: "known",
+};
+
+const wScale = {
+  scale_id: "supercells_vertical_velocity_v1",
+  display_name: "Vertical velocity",
+  units: "m/s",
+  scale_type: "fixed_discrete" as const,
+  minimum: -30,
+  maximum: 30,
+  breakpoints: [-24, -18, -12, -6, 6, 12, 18, 24, 27],
+  colors: [
+    "#4b0082",
+    "#0057d9",
+    "#00c9d8",
+    "#ffffff",
+    "#00d63b",
+    "#8fe000",
+    "#ffe000",
+    "#ff9800",
+    "#ff3b00",
+    "#c40000",
+  ],
+  fixed_across_time: true,
+};
+
+function field(key = "winterp", displayName = "Vertical velocity"): FieldLayer {
+  return {
+    key,
+    display_name: displayName,
+    units: key === "dbz" ? "dBZ" : "m/s",
+    evidence_kind: "native",
+    source_fields: [key],
+    derivation: null,
+    values: [
+      [-5, 3, 8],
+      [0, 12, -2],
+      [2, 7, -8],
+    ],
+    selected_frame_minimum: -8,
+    selected_frame_maximum: 12,
+    scale: wScale,
+  };
+}
+
+function sceneLayers(lens: LensId): VolumeLayer[] {
+  const base = {
+    units: "m/s",
+    evidence_kind: "native" as const,
+    source_fields: ["winterp"],
+    derivation: null,
+    points: [
+      [-10, -10, 1, -8, 0],
+      [0, 0, 4, 18, 0],
+      [10, 20, 8, 8, 0],
+    ] as Array<[number, number, number, number, number]>,
+    source_count: 3,
+    returned_count: 3,
+    threshold_label: "Fixed retained-run scale",
+    default_opacity: 0.8,
+    default_point_size: 1,
+    scale: wScale,
+    categories: [],
+  };
+  if (lens === "cloud_precipitation") {
+    return [
+      {
+        ...base,
+        key: "hydrometeor_categories",
+        display_name: "Dominant hydrometeor",
+        units: "g/kg",
+        source_fields: ["qc", "qr", "qi", "qs", "qg"],
+        rendering: "categorical",
+        points: [
+          [-10, -10, 1, 0.4, 1],
+          [0, 0, 4, 1.2, 2],
+          [10, 20, 8, 2.1, 5],
+        ],
+        default_visible: true,
+        scale: null,
+        categories: [
+          { code: 1, key: "qc", label: "Cloud liquid", color: "#d6f0f7" },
+          { code: 2, key: "qr", label: "Rain", color: "#2f7fb5" },
+          { code: 5, key: "qg", label: "Hail-treated large ice", color: "#7c4d8f" },
+        ],
+      },
+      {
+        ...base,
+        key: "vertical_motion",
+        display_name: "Strong vertical motion",
+        rendering: "signed_scalar",
+        default_visible: false,
+      },
+    ];
+  }
+  if (lens === "low_level_interactions") {
+    return [
+      {
+        ...base,
+        key: "storm_cloud_body",
+        display_name: "Storm cloud body",
+        rendering: "neutral_cloud",
+        default_visible: true,
+        scale: null,
+      },
+      {
+        ...base,
+        key: "low_level_vertical_motion",
+        display_name: "Low-level vertical motion",
+        rendering: "signed_scalar",
+        default_visible: true,
+      },
+      {
+        ...base,
+        key: "accumulated_surface_rain",
+        display_name: "Accumulated rain",
+        units: "mm",
+        rendering: "scalar",
+        default_visible: true,
+      },
+    ];
+  }
+  return [
+    {
+      ...base,
+      key: "storm_cloud_body",
+      display_name: "Storm cloud body",
+      rendering: "neutral_cloud",
+      default_visible: true,
+      scale: null,
+    },
+    {
+      ...base,
+      key: "vertical_motion",
+      display_name: "Strong vertical motion",
+      rendering: "signed_scalar",
+      default_visible: true,
+    },
+    {
+      ...base,
+      key: "cyclonic_rotation",
+      display_name: "Cyclonic rotation",
+      rendering: "scalar",
+      default_visible: true,
+    },
+    {
+      ...base,
+      key: "updraft_helicity",
+      display_name: "2-5 km updraft helicity",
+      rendering: "scalar",
+      default_visible: true,
+    },
+  ];
+}
+
+function frameFor(url: string): StormExaminationFrame {
+  const search = new URL(url, "http://localhost").searchParams;
+  const lens = (search.get("lens") ?? "rotating_updraft") as LensId;
+  const viewport = search.get("viewport") === "full" ? "full" : "storm";
+  const timeIndex = Number(search.get("time_index") ?? 5);
+  const times = [0, 900, 1_800, 2_700, 3_600, 4_500, 5_400, 6_300, 7_200];
+  const xIndex = Number(search.get("x_index") ?? 1);
+  const yIndex = Number(search.get("y_index") ?? 1);
+  const zIndex = Number(search.get("z_index") ?? 1);
+  const xCoordinates = [-10, 0, 10];
+  const yCoordinates = [-10, 10, 20];
+  const zCoordinates = [0.5, 3, 8];
+  const names = {
+    rotating_updraft: "Rotating Updraft",
+    cloud_precipitation: "Cloud and Precipitation",
+    low_level_interactions: "Low-Level Interactions",
+  };
+  return {
+    schema_version: "supercells_explore_v1",
+    authority_state: "supercells_product_world",
+    world_id: "supercells",
+    simulation_id: "supercells_quarter_circle_reference",
+    run_id: simulation.run_id,
+    case_id: simulation.case_id,
+    simulation_label: simulation.display_name,
+    lens_id: lens,
+    lens_name: names[lens],
+    lens_question:
+      lens === "rotating_updraft"
+        ? "Where is the storm rising and rotating as one organized structure?"
+        : lens === "cloud_precipitation"
+          ? "How are cloud and precipitation organized through the storm?"
+          : "How do ascent, descent, rain, and horizontal flow meet beneath the storm?",
+    time_index: timeIndex,
+    time_seconds: times[timeIndex],
+    times_seconds: times,
+    mature_checkpoint_indices: [3, 4, 5, 6, 7, 8],
+    timeline_checkpoints: [
+      {
+        time_seconds: 4_500,
+        label: "75 min",
+        phase: "Organized mature storm",
+        phase_kind: "visible_checkpoint",
+      },
+    ],
+    viewport,
+    viewport_bounds_km:
+      viewport === "storm"
+        ? { x_min: -30, x_max: 30, y_min: -30, y_max: 30 }
+        : { x_min: -60, x_max: 60, y_min: -60, y_max: 60 },
+    primary_updraft: {
+      x_index: 1,
+      y_index: 1,
+      z_index: 1,
+      x_km: 0,
+      y_km: 10,
+      z_km: 3,
+      w_m_s: 48,
+    },
+    selected_point: {
+      x_index: xIndex,
+      y_index: yIndex,
+      z_index: zIndex,
+      x_km: xCoordinates[xIndex] ?? 0,
+      y_km: yCoordinates[yIndex] ?? 10,
+      z_km: zCoordinates[zIndex] ?? 3,
+      model_time_seconds: times[timeIndex],
+      coordinate_frame: "translating model frame; native model-relative winds",
+      values: {
+        vertical_velocity: 12,
+        vertical_vorticity: 0.03,
+        updraft_helicity: 510,
+        reflectivity: 52,
+        cloud_liquid: 1.2,
+        rain_water: 2.1,
+        cloud_ice: 0.4,
+        snow: 0.8,
+        hail_treated_large_ice: 1.5,
+        total_condensate: 6,
+        accumulated_surface_rain: 22,
+        model_relative_u: 14,
+        model_relative_v: 7,
+      },
+      units: {
+        vertical_velocity: "m/s",
+        vertical_vorticity: "s^-1",
+        updraft_helicity: "m^2/s^2",
+        reflectivity: "dBZ",
+        cloud_liquid: "g/kg",
+        rain_water: "g/kg",
+        cloud_ice: "g/kg",
+        snow: "g/kg",
+        hail_treated_large_ice: "g/kg",
+        total_condensate: "g/kg",
+        accumulated_surface_rain: "mm",
+        model_relative_u: "m/s",
+        model_relative_v: "m/s",
+      },
+      evidence_kind: {
+        vertical_velocity: "native",
+        vertical_vorticity: "native",
+        updraft_helicity: "native",
+        reflectivity: "native",
+        cloud_liquid: "native",
+        rain_water: "native",
+        cloud_ice: "native",
+        snow: "native",
+        hail_treated_large_ice: "native",
+        total_condensate: "derived",
+        accumulated_surface_rain: "derived",
+        model_relative_u: "native",
+        model_relative_v: "native",
+      },
+      states: ["Rising", "Rotating", "Condensate present"],
+      distance_to_primary_updraft_km: 0,
+    },
+    plan: {
+      title: lens === "cloud_precipitation" ? "Hydrometeor plan" : "Midlevel storm structure",
+      subtitle: "Native-grid plan evidence",
+      x_indices: [0, 1, 2],
+      y_indices: [0, 1, 2],
+      x_km: xCoordinates,
+      y_km: yCoordinates,
+      level_index: 1,
+      level_km: 3,
+      primary: field(),
+      overlays: {
+        vertical_vorticity: field("zvort", "Vertical vorticity"),
+        updraft_helicity: field("uh", "Updraft helicity"),
+        composite_reflectivity: field("dbz", "Reflectivity"),
+        accumulated_surface_rain: field("rain", "Accumulated rain"),
+      },
+      categories: null,
+      wind_vectors: [{ x_km: 0, y_km: 10, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
+    },
+    xz_section: section("xz", "x", yCoordinates[yIndex] ?? 10),
+    yz_section: section("yz", "y", xCoordinates[xIndex] ?? 0),
+    scene: {
+      coordinate_extents_km: {
+        x: { min: viewport === "storm" ? -30 : -60, max: viewport === "storm" ? 30 : 60 },
+        y: { min: viewport === "storm" ? -30 : -60, max: viewport === "storm" ? 30 : 60 },
+        z: { min: 0.25, max: 19.75 },
+      },
+      coordinate_sizes: { x: 120, y: 120, z: 40 },
+      layers: sceneLayers(lens),
+      wind_vectors: [{ x_km: 0, y_km: 10, z_km: 1.25, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
+      wind_reference_m_s: 25,
+      point_budget: 20_000,
+      source_history_file: `cm1out_${String(timeIndex + 1).padStart(6, "0")}.nc`,
+    },
+    caveats: ["Saved histories are 15 minutes apart."],
+    provenance: { source_history_file: `cm1out_${String(timeIndex + 1).padStart(6, "0")}.nc` },
+    extraction_milliseconds: 120,
+  };
+}
+
+function section(orientation: "xz" | "yz", horizontal: "x" | "y", coordinate: number) {
+  return {
+    orientation,
+    title: `${orientation} section at ${orientation === "xz" ? "y" : "x"} = ${coordinate.toFixed(1)} km`,
+    horizontal_dimension: horizontal,
+    horizontal_indices: [0, 1, 2],
+    horizontal_km: [-10, 0, 10],
+    z_km: [0.5, 3, 8],
+    cross_section_coordinate_km: coordinate,
+    primary: field(),
+    overlays: {
+      total_condensate: field("total_condensate", "Total condensate"),
+      precipitating_condensate: field("precipitating_condensate", "Precipitating condensate"),
+      reflectivity: field("dbz", "Reflectivity"),
+      vertical_velocity: field(),
+    },
+    categories: null,
+  };
+}
+
+describe("SupercellsExplore", () => {
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  const originalBounds = HTMLCanvasElement.prototype.getBoundingClientRect;
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => Promise.resolve(ok(frameFor(String(input))))),
+    );
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    Object.defineProperty(HTMLCanvasElement.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ width: 500, height: 300, left: 0, top: 0, right: 500, bottom: 300 }),
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: () => canvasContext(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: originalGetContext,
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: originalBounds,
+    });
+  });
+
+  it("opens at the mature Rotating Updraft frame with the complete retained timeline", async () => {
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+
+    expect(await screen.findByRole("heading", { name: "Rotating Updraft" })).toBeVisible();
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("lens=rotating_updraft&viewport=storm&time_index=5"),
+      expect.anything(),
+    );
+    expect(screen.getByLabelText("Saved output time")).toHaveAttribute("max", "8");
+    expect(screen.getByText("frame 6 of 9 · Organized mature storm")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Rotating Updraft" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("keeps lens defaults, viewport, evidence orientation, and native selection synchronized", async () => {
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    await screen.findByRole("heading", { name: "Rotating Updraft" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cloud and Precipitation" }));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("lens=cloud_precipitation&viewport=storm&time_index=5"),
+        expect.anything(),
+      ),
+    );
+    expect(await screen.findByRole("heading", { name: "Cloud and Precipitation" })).toBeVisible();
+    await waitFor(() =>
+      expect(
+        screen.getAllByLabelText("Hydrometeors").some((control) => control.matches(":checked")),
+      ).toBe(true),
+    );
+    expect(
+      screen.getAllByLabelText("Vertical motion").every((control) => !control.matches(":checked")),
+    ).toBe(true);
+
+    fireEvent.click(
+      within(screen.getByLabelText("Evidence view")).getByRole("button", { name: "xz" }),
+    );
+    expect((await screen.findAllByText("xz section at y = 10.0 km")).length).toBeGreaterThan(1);
+    expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent(
+      "xz section at y = 10.0 km",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Full domain" }));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("lens=cloud_precipitation&viewport=full&time_index=5"),
+        expect.anything(),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select 3-D point" }));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/x_index=2&y_index=2&z_index=1/),
+        expect.anything(),
+      ),
+    );
+    fireEvent.click(screen.getByRole("tab", { name: "Science" }));
+    expect(await screen.findByText("Selected point")).toBeVisible();
+    expect(screen.getByRole("heading", { name: "x 10.0, y 20.0, z 3.00 km" })).toBeVisible();
+  });
+
+  it("preserves the lens and time while maximizing and restoring either scientific view", async () => {
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    await screen.findByRole("heading", { name: "Rotating Updraft" });
+
+    fireEvent.change(screen.getByLabelText("Saved output time"), { target: { value: "8" } });
+    expect(await screen.findByText("120 min · 7,200 s")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Maximize scene" }));
+    expect(screen.getByLabelText("Supercells integrated Explore workspace")).toHaveClass(
+      "supercells-explore-focused-scene",
+    );
+    expect(screen.getByRole("button", { name: "Restore scene" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Restore scene" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Maximize evidence" }));
+    expect(screen.getByLabelText("Supercells integrated Explore workspace")).toHaveClass(
+      "supercells-explore-focused-evidence",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Restore evidence" }));
+
+    expect(screen.getByRole("button", { name: "Rotating Updraft" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByLabelText("Saved output time")).toHaveValue("8");
+  });
+
+  it("offers the shared Explain, Science, Notes, and Details inspector grammar", async () => {
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    await screen.findByRole("heading", { name: "Rotating Updraft" });
+
+    const inspector = screen.getByLabelText("Explore inspector");
+    for (const name of ["Explain", "Science", "Notes", "Details"]) {
+      expect(within(inspector).getByRole("tab", { name })).toBeVisible();
+    }
+    fireEvent.click(within(inspector).getByRole("tab", { name: "Notes" }));
+    expect(screen.getByRole("heading", { name: "Simulation notes" })).toBeVisible();
+    fireEvent.click(within(inspector).getByRole("tab", { name: "Details" }));
+    expect(screen.getByRole("heading", { name: "Simulation details" })).toBeVisible();
+  });
+});
+
+function canvasContext() {
+  return {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+    measureText: () => ({ width: 20 }),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    closePath: vi.fn(),
+    arc: vi.fn(),
+    setLineDash: vi.fn(),
+  };
+}
+
+function ok(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -19,6 +19,7 @@ vi.mock("./True3DViewer", () => ({
     onToggleMaximize,
     onSelectStormPoint,
     compactDisplayControls,
+    cameraPreset,
   }: {
     fieldLabel: string;
     activeSliceLabel: string;
@@ -26,10 +27,12 @@ vi.mock("./True3DViewer", () => ({
     onToggleMaximize: () => void;
     onSelectStormPoint: (point: [number, number, number, number, number]) => void;
     compactDisplayControls: ReactNode;
+    cameraPreset: string;
   }) => (
     <section aria-label="Mock 3-D storm scene">
       <h2>{fieldLabel}</h2>
       <p>{activeSliceLabel}</p>
+      <p>Camera: {cameraPreset}</p>
       <button type="button" onClick={() => onSelectStormPoint([9.1, 19.1, 3.1, 12, 0])}>
         Select 3-D point
       </button>
@@ -141,13 +144,6 @@ function sceneLayers(lens: LensId): VolumeLayer[] {
           { code: 5, key: "qg", label: "Hail-treated large ice", color: "#7c4d8f" },
         ],
       },
-      {
-        ...base,
-        key: "vertical_motion",
-        display_name: "Strong vertical motion",
-        rendering: "signed_scalar",
-        default_visible: false,
-      },
     ];
   }
   if (lens === "low_level_interactions") {
@@ -157,7 +153,7 @@ function sceneLayers(lens: LensId): VolumeLayer[] {
         key: "storm_cloud_body",
         display_name: "Storm cloud body",
         rendering: "neutral_cloud",
-        default_visible: true,
+        default_visible: false,
         scale: null,
       },
       {
@@ -175,6 +171,14 @@ function sceneLayers(lens: LensId): VolumeLayer[] {
         rendering: "scalar",
         default_visible: true,
       },
+      {
+        ...base,
+        key: "precipitating_condensate",
+        display_name: "Low-level precipitating condensate",
+        units: "g/kg",
+        rendering: "scalar",
+        default_visible: true,
+      },
     ];
   }
   return [
@@ -188,10 +192,17 @@ function sceneLayers(lens: LensId): VolumeLayer[] {
     },
     {
       ...base,
-      key: "vertical_motion",
-      display_name: "Strong vertical motion",
+      key: "rising_core",
+      display_name: "Rising core",
       rendering: "signed_scalar",
       default_visible: true,
+    },
+    {
+      ...base,
+      key: "strong_descent",
+      display_name: "Strong descent",
+      rendering: "signed_scalar",
+      default_visible: false,
     },
     {
       ...base,
@@ -243,6 +254,12 @@ function frameFor(url: string): StormExaminationFrame {
         : lens === "cloud_precipitation"
           ? "How are cloud and precipitation organized through the storm?"
           : "How do ascent, descent, rain, and horizontal flow meet beneath the storm?",
+    what_to_notice_now: "This saved output contains coordinated frame-specific evidence.",
+    what_to_notice_by_view: {
+      plan: "Plan evidence at this saved output.",
+      xz: "X-z evidence at this saved output.",
+      yz: "Y-z evidence at this saved output.",
+    },
     time_index: timeIndex,
     time_seconds: times[timeIndex],
     times_seconds: times,
@@ -335,13 +352,26 @@ function frameFor(url: string): StormExaminationFrame {
       y_km: yCoordinates,
       level_index: 1,
       level_km: 3,
+      selection_z_indices:
+        lens === "cloud_precipitation"
+          ? [
+              [0, 2, 2],
+              [1, 2, 1],
+              [0, 1, 2],
+            ]
+          : null,
       primary: field(),
       overlays: {
         vertical_vorticity: field("zvort", "Vertical vorticity"),
         updraft_helicity: field("uh", "Updraft helicity"),
-        vertical_velocity: field("winterp", "Vertical velocity"),
-        composite_reflectivity: field("dbz", "Reflectivity"),
-        accumulated_surface_rain: field("rain", "Accumulated rain"),
+      vertical_velocity: field("winterp", "Vertical velocity"),
+      composite_reflectivity: field("dbz", "Reflectivity"),
+      accumulated_surface_rain: field("rain", "Accumulated rain"),
+      total_condensate: field("total_condensate", "Total condensate"),
+      low_level_precipitating_condensate: field(
+          "precipitating_condensate",
+          "Current precipitating condensate",
+        ),
       },
       categories: null,
       wind_vectors: [{ x_km: 0, y_km: 10, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
@@ -352,11 +382,14 @@ function frameFor(url: string): StormExaminationFrame {
       coordinate_extents_km: {
         x: { min: viewport === "storm" ? -30 : -60, max: viewport === "storm" ? 30 : 60 },
         y: { min: viewport === "storm" ? -30 : -60, max: viewport === "storm" ? 30 : 60 },
-        z: { min: 0.25, max: 19.75 },
+        z: { min: 0.25, max: lens === "low_level_interactions" ? 5.25 : 19.75 },
       },
       coordinate_sizes: { x: 120, y: 120, z: 40 },
       layers: sceneLayers(lens),
-      wind_vectors: [{ x_km: 0, y_km: 10, z_km: 1.25, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
+      wind_vectors:
+        lens === "low_level_interactions"
+          ? [{ x_km: 0, y_km: 10, z_km: 1.25, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }]
+          : [],
       wind_reference_m_s: 25,
       point_budget: 20_000,
       source_history_file: `cm1out_${String(timeIndex + 1).padStart(6, "0")}.nc`,
@@ -382,6 +415,7 @@ function section(orientation: "xz" | "yz", horizontal: "x" | "y", coordinate: nu
       precipitating_condensate: field("precipitating_condensate", "Precipitating condensate"),
       reflectivity: field("dbz", "Reflectivity"),
       vertical_velocity: field(),
+      vertical_vorticity: field("zvort", "Vertical vorticity"),
     },
     categories: null,
   };
@@ -441,6 +475,7 @@ describe("SupercellsExplore", () => {
       "aria-pressed",
       "true",
     );
+    expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent("Camera: look_along_y");
   });
 
   it("keeps lens defaults, viewport, evidence orientation, and native selection synchronized", async () => {
@@ -456,21 +491,47 @@ describe("SupercellsExplore", () => {
     );
     expect(await screen.findByRole("heading", { name: "Cloud and Precipitation" })).toBeVisible();
     await waitFor(() =>
-      expect(
-        screen.getAllByLabelText("Hydrometeors").some((control) => control.matches(":checked")),
-      ).toBe(true),
+      expect(screen.getByLabelText("Dominant hydrometeor")).toBeChecked(),
     );
-    expect(screen.getByLabelText("Vertical motion")).toBeChecked();
+    expect(screen.getByLabelText("Vertical-motion contours")).toBeChecked();
+    expect(screen.getByText("X-z evidence at this saved output.")).toBeVisible();
+    expect(
+      screen.getByText(/This storm-core native section shows the dominant hydrometeor/),
+    ).toBeVisible();
 
-    fireEvent.click(
-      within(screen.getByLabelText("Slice orientation")).getByRole("button", {
-        name: "Vertical x-z",
-      }),
+    const orientation = within(screen.getByLabelText("Slice orientation"));
+    expect(orientation.getByRole("button", { name: "Vertical x-z" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
     );
     expect((await screen.findAllByText("xz section at y = 10.0 km")).length).toBeGreaterThan(1);
     expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent(
       "xz section at y = 10.0 km",
     );
+    fireEvent.click(orientation.getByRole("button", { name: "Horizontal x-y" }));
+    fireEvent.click(screen.getByLabelText("Hydrometeor plan plan view"), {
+      clientX: 250,
+      clientY: 150,
+    });
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/x_index=1&y_index=0&z_index=2/),
+        expect.anything(),
+      ),
+    );
+    fireEvent.click(orientation.getByRole("button", { name: "Vertical y-z" }));
+    expect((await screen.findAllByText("yz section at x = 0.0 km")).length).toBeGreaterThan(1);
+    expect(screen.getByText("Y-z evidence at this saved output.")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Rotating Updraft" }));
+    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    fireEvent.click(screen.getByRole("button", { name: "Cloud and Precipitation" }));
+    await screen.findByRole("heading", { name: "Cloud and Precipitation" });
+    expect(
+      within(screen.getByLabelText("Slice orientation")).getByRole("button", {
+        name: "Vertical y-z",
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
 
     fireEvent.click(screen.getByRole("button", { name: "Full domain" }));
     await waitFor(() =>

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -339,6 +339,7 @@ function frameFor(url: string): StormExaminationFrame {
       overlays: {
         vertical_vorticity: field("zvort", "Vertical vorticity"),
         updraft_helicity: field("uh", "Updraft helicity"),
+        vertical_velocity: field("winterp", "Vertical velocity"),
         composite_reflectivity: field("dbz", "Reflectivity"),
         accumulated_surface_rain: field("rain", "Accumulated rain"),
       },
@@ -459,12 +460,12 @@ describe("SupercellsExplore", () => {
         screen.getAllByLabelText("Hydrometeors").some((control) => control.matches(":checked")),
       ).toBe(true),
     );
-    expect(
-      screen.getAllByLabelText("Vertical motion").every((control) => !control.matches(":checked")),
-    ).toBe(true);
+    expect(screen.getByLabelText("Vertical motion")).toBeChecked();
 
     fireEvent.click(
-      within(screen.getByLabelText("Evidence view")).getByRole("button", { name: "xz" }),
+      within(screen.getByLabelText("Slice orientation")).getByRole("button", {
+        name: "Vertical x-z",
+      }),
     );
     expect((await screen.findAllByText("xz section at y = 10.0 km")).length).toBeGreaterThan(1);
     expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent(
@@ -509,6 +510,10 @@ describe("SupercellsExplore", () => {
     expect(screen.getByLabelText("Supercells integrated Explore workspace")).toHaveClass(
       "supercells-explore-focused-evidence",
     );
+    expect(screen.getByRole("button", { name: "Open Context" })).toBeVisible();
+    expect(screen.queryByLabelText("Explore inspector")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open Context" }));
+    expect(screen.getByLabelText("Explore inspector")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Restore evidence" }));
 
     expect(screen.getByRole("button", { name: "Rotating Updraft" })).toHaveAttribute(

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -1,0 +1,1085 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
+import type { SupercellSimulation } from "./SupercellsWorld";
+import {
+  type LensId,
+  type OverlayState,
+  type Selection,
+  type StormExaminationFrame,
+  StormLegend,
+  StormPlanPlot,
+  StormSectionPlot,
+  type ViewportId,
+} from "./StormExaminationResearch";
+import { type StormScenePayload, type StormScenePoint, True3DViewer } from "./True3DViewer";
+
+import "./StormExaminationResearch.css";
+import "./SupercellsExplore.css";
+
+type EvidenceView = "plan" | "xz" | "yz";
+type FocusedViewer = "scene" | "evidence" | null;
+
+const LENSES: Array<{ id: LensId; label: string }> = [
+  { id: "rotating_updraft", label: "Rotating Updraft" },
+  { id: "cloud_precipitation", label: "Cloud and Precipitation" },
+  { id: "low_level_interactions", label: "Low-Level Interactions" },
+];
+
+const HYDROMETEOR_CODES = [
+  { code: 1, label: "Cloud liquid" },
+  { code: 2, label: "Rain" },
+  { code: 3, label: "Cloud ice" },
+  { code: 4, label: "Snow" },
+  { code: 5, label: "Hail-treated large ice" },
+];
+
+export function SupercellsExplore({
+  simulation,
+  onBack,
+}: {
+  simulation: SupercellSimulation;
+  onBack: () => void;
+}) {
+  const [lens, setLens] = useState<LensId>("rotating_updraft");
+  const [viewport, setViewport] = useState<ViewportId>("storm");
+  const [timeIndex, setTimeIndex] = useState(5);
+  const [frame, setFrame] = useState<StormExaminationFrame | null>(null);
+  const [selection, setSelection] = useState<Selection | null>(null);
+  const [evidenceView, setEvidenceView] = useState<EvidenceView>("plan");
+  const [focusedViewer, setFocusedViewer] = useState<FocusedViewer>(null);
+  const [overlays, setOverlays] = useState<OverlayState>(() => overlayDefaults("rotating_updraft"));
+  const [visibleLayerKeys, setVisibleLayerKeys] = useState<string[]>([]);
+  const [categoryCodes, setCategoryCodes] = useState<number[]>(
+    HYDROMETEOR_CODES.map((item) => item.code),
+  );
+  const [sceneOpacity, setSceneOpacity] = useState(1);
+  const [scenePointSize, setScenePointSize] = useState(1);
+  const [playing, setPlaying] = useState(false);
+  const [playbackSpeed, setPlaybackSpeed] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
+  const frameCache = useRef(new Map<string, StormExaminationFrame>());
+  const defaultsLens = useRef<LensId | null>(null);
+
+  const requestKey = frameRequestKey(lens, viewport, timeIndex, selection);
+  const loadFrame = useCallback(
+    async (signal: AbortSignal) => {
+      const cached = frameCache.current.get(requestKey);
+      if (cached) {
+        setFrame(cached);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const payload = await fetchSupercellFrame(
+          simulation.simulation_id,
+          lens,
+          viewport,
+          timeIndex,
+          selection,
+          signal,
+        );
+        frameCache.current.set(requestKey, payload);
+        trimCache(frameCache.current, 8);
+        setFrame(payload);
+        void prefetchAdjacentFrames(
+          frameCache.current,
+          simulation.simulation_id,
+          payload,
+          lens,
+          viewport,
+        );
+      } catch (caught) {
+        if (!signal.aborted) {
+          setError(caught instanceof Error ? caught.message : "Supercell frame unavailable.");
+        }
+      } finally {
+        if (!signal.aborted) setLoading(false);
+      }
+    },
+    [lens, requestKey, selection, simulation.simulation_id, timeIndex, viewport],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadFrame(controller.signal);
+    return () => controller.abort();
+  }, [loadFrame, retryNonce]);
+
+  useEffect(() => {
+    if (!frame?.scene || frame.lens_id !== lens || defaultsLens.current === lens) return;
+    defaultsLens.current = lens;
+    setVisibleLayerKeys(
+      frame.scene.layers.filter((layer) => layer.default_visible).map((layer) => layer.key),
+    );
+    setOverlays(overlayDefaults(lens));
+    setCategoryCodes(HYDROMETEOR_CODES.map((item) => item.code));
+  }, [frame, lens]);
+
+  useEffect(() => {
+    if (!playing || loading || !frame) return;
+    const timer = window.setTimeout(() => {
+      setTimeIndex((current) => (current >= frame.times_seconds.length - 1 ? 0 : current + 1));
+    }, 1_350 / playbackSpeed);
+    return () => window.clearTimeout(timer);
+  }, [frame, loading, playbackSpeed, playing]);
+
+  const scene = useMemo(
+    () => filterHydrometeorCategories(frame?.scene ?? null, categoryCodes),
+    [categoryCodes, frame?.scene],
+  );
+  const activeSlice = useMemo(
+    () => (frame ? evidenceSlice(frame, evidenceView) : null),
+    [evidenceView, frame],
+  );
+  const activeSliceLabel = frame ? evidenceLabel(frame, evidenceView) : "Evidence unavailable";
+  const checkpoint = frame?.timeline_checkpoints.find(
+    (item) => item.time_seconds === frame.time_seconds,
+  );
+  const windVectors = frame?.scene?.wind_vectors ?? [];
+
+  function chooseLens(next: LensId) {
+    setPlaying(false);
+    setLens(next);
+    defaultsLens.current = null;
+  }
+
+  function selectPoint(next: Selection) {
+    setPlaying(false);
+    setSelection(next);
+  }
+
+  function selectScenePoint(point: StormScenePoint) {
+    if (!frame) return;
+    selectPoint({
+      xIndex: nearestCoordinateIndex(point[0], frame.plan.x_km, frame.plan.x_indices),
+      yIndex: nearestCoordinateIndex(point[1], frame.plan.y_km, frame.plan.y_indices),
+      zIndex: nearestCoordinateIndex(point[2], frame.xz_section.z_km),
+    });
+  }
+
+  function toggleLayer(key: string, visible: boolean) {
+    setVisibleLayerKeys((current) =>
+      visible ? [...new Set([...current, key])] : current.filter((item) => item !== key),
+    );
+  }
+
+  return (
+    <IntegratedExploreWorkspace
+      worldName="Supercells"
+      simulationName={simulation.display_name}
+      backLabel="Back to Supercells"
+      onBack={onBack}
+    >
+      <section
+        className={`supercells-explore-shell${
+          focusedViewer ? ` supercells-explore-focused-${focusedViewer}` : ""
+        }`}
+        aria-label="Supercells integrated Explore workspace"
+      >
+        <div className="supercells-workbench">
+          <section className="supercells-scene" aria-label="3-D storm scene">
+            <div className="supercells-lens-switcher" aria-label="Supercell Lens">
+              {LENSES.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  className={lens === item.id ? "active-control" : ""}
+                  aria-pressed={lens === item.id}
+                  onClick={() => chooseLens(item.id)}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+            {frame?.scene ? (
+              <True3DViewer
+                resultName={simulation.display_name}
+                pointCloud={null}
+                fieldLabel={frame.lens_name}
+                valueChannelLabel="Native and explicitly derived Supercell layers."
+                activeSlice={activeSlice}
+                activeSliceLabel={activeSliceLabel}
+                showSlicePlane={evidenceView !== "plan"}
+                selectedRegion={
+                  frame && selection
+                    ? {
+                        xIndex: frame.selected_point.x_index,
+                        yIndex: frame.selected_point.y_index,
+                        zIndex: frame.selected_point.z_index,
+                      }
+                    : null
+                }
+                coordinateSizes={frame.scene.coordinate_sizes}
+                selectedTimeLabel={formatTime(frame.time_seconds)}
+                sceneTimeLabel={formatTime(frame.time_seconds)}
+                thresholdLabel="Lens-owned fixed thresholds"
+                opacity={1}
+                pointSize={1}
+                status={loading ? "Loading frame" : "Scene synchronized"}
+                provenanceLabel="Retained native CM1 history; deterministic bounded selection."
+                noCloudMessage="No visible storm layers at this saved output."
+                windVectors={windVectors}
+                showWindVectors={lens === "low_level_interactions" && overlays.wind}
+                windMode="total"
+                windReferenceMps={frame.scene.wind_reference_m_s}
+                windArrowDomainFraction={0.055}
+                compactWorkspace
+                maximized={focusedViewer === "scene"}
+                onToggleMaximize={() =>
+                  setFocusedViewer((current) => (current === "scene" ? null : "scene"))
+                }
+                stormScene={scene}
+                visibleStormLayerKeys={visibleLayerKeys}
+                stormOpacity={sceneOpacity}
+                stormPointSize={scenePointSize}
+                compactAxisLabels
+                selectedPointCoordinates={
+                  selection && frame
+                    ? {
+                        x: frame.selected_point.x_km,
+                        y: frame.selected_point.y_km,
+                        z: frame.selected_point.z_km,
+                      }
+                    : null
+                }
+                onSelectStormPoint={selectScenePoint}
+                compactDisplayControls={
+                  <StormDisplayControls
+                    frame={frame}
+                    visibleLayerKeys={visibleLayerKeys}
+                    opacity={sceneOpacity}
+                    pointSize={scenePointSize}
+                    categoryCodes={categoryCodes}
+                    onLayer={toggleLayer}
+                    onOpacity={setSceneOpacity}
+                    onPointSize={setScenePointSize}
+                    onCategoryCodes={setCategoryCodes}
+                  />
+                }
+              />
+            ) : (
+              <LocalFailure
+                title="3-D storm scene unavailable"
+                message={error ?? "The selected frame did not provide a bounded 3-D scene."}
+                onRetry={() => setRetryNonce((current) => current + 1)}
+              />
+            )}
+            {loading && frame && <div className="supercells-frame-loading">Loading frame...</div>}
+          </section>
+
+          <section className="supercells-evidence" aria-label="Coordinated storm evidence">
+            <header className="instrument-header">
+              <div>
+                <h2>{evidenceTitle(evidenceView)}</h2>
+                <p>{activeSliceLabel}</p>
+              </div>
+              <div className="instrument-actions">
+                <div className="instrument-view-toggle" aria-label="Evidence view">
+                  {(["plan", "xz", "yz"] as EvidenceView[]).map((view) => (
+                    <button
+                      key={view}
+                      type="button"
+                      className={evidenceView === view ? "active-control" : ""}
+                      aria-pressed={evidenceView === view}
+                      onClick={() => setEvidenceView(view)}
+                    >
+                      {view === "plan" ? "Plan" : view}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  className="viewer-maximize-button"
+                  aria-label={
+                    focusedViewer === "evidence" ? "Restore evidence" : "Maximize evidence"
+                  }
+                  title={focusedViewer === "evidence" ? "Restore evidence" : "Maximize evidence"}
+                  onClick={() =>
+                    setFocusedViewer((current) => (current === "evidence" ? null : "evidence"))
+                  }
+                >
+                  <span aria-hidden="true">⛶</span>
+                </button>
+              </div>
+            </header>
+            {frame ? (
+              <div className="supercells-evidence-body">
+                <div className="supercells-active-plot">
+                  {evidenceView === "plan" ? (
+                    <StormPlanPlot frame={frame} overlays={overlays} onSelect={selectPoint} />
+                  ) : (
+                    <StormSectionPlot
+                      section={evidenceView === "xz" ? frame.xz_section : frame.yz_section}
+                      frame={frame}
+                      overlays={overlays}
+                      onSelect={selectPoint}
+                    />
+                  )}
+                </div>
+                <StormLegend frame={frame} />
+              </div>
+            ) : (
+              <LocalFailure
+                title="Storm evidence unavailable"
+                message={error ?? "The selected plan or section could not be loaded."}
+                onRetry={() => setRetryNonce((current) => current + 1)}
+              />
+            )}
+          </section>
+
+          <ExploreInspector
+            sections={{
+              explain: <SupercellExplanation frame={frame} lens={lens} viewport={viewport} />,
+              science: <SupercellScience frame={frame} selected={selection !== null} />,
+              notes: <SupercellNotes />,
+              details: <SupercellDetails frame={frame} simulation={simulation} />,
+            }}
+          />
+        </div>
+
+        <StormExploreControls
+          lens={lens}
+          viewport={viewport}
+          evidenceView={evidenceView}
+          overlays={overlays}
+          visibleLayerKeys={visibleLayerKeys}
+          onViewport={(next) => {
+            setPlaying(false);
+            setViewport(next);
+          }}
+          onEvidenceView={setEvidenceView}
+          onOverlays={setOverlays}
+          onLayer={toggleLayer}
+        />
+
+        <SupercellTimeline
+          frame={frame}
+          timeIndex={timeIndex}
+          playing={playing}
+          playbackSpeed={playbackSpeed}
+          loading={loading}
+          checkpoint={checkpoint?.phase ?? null}
+          onTimeIndex={(next) => {
+            setPlaying(false);
+            setTimeIndex(next);
+          }}
+          onPlaying={setPlaying}
+          onPlaybackSpeed={setPlaybackSpeed}
+        />
+      </section>
+    </IntegratedExploreWorkspace>
+  );
+}
+
+function StormDisplayControls({
+  frame,
+  visibleLayerKeys,
+  opacity,
+  pointSize,
+  categoryCodes,
+  onLayer,
+  onOpacity,
+  onPointSize,
+  onCategoryCodes,
+}: {
+  frame: StormExaminationFrame;
+  visibleLayerKeys: string[];
+  opacity: number;
+  pointSize: number;
+  categoryCodes: number[];
+  onLayer: (key: string, visible: boolean) => void;
+  onOpacity: (value: number) => void;
+  onPointSize: (value: number) => void;
+  onCategoryCodes: (values: number[]) => void;
+}) {
+  return (
+    <section className="supercells-display-controls" aria-label="3-D storm display controls">
+      <div className="supercells-layer-list">
+        {frame.scene?.layers.map((layer) => (
+          <label key={layer.key}>
+            <input
+              type="checkbox"
+              checked={visibleLayerKeys.includes(layer.key)}
+              onChange={(event) => onLayer(layer.key, event.currentTarget.checked)}
+            />
+            {layer.display_name}
+          </label>
+        ))}
+      </div>
+      {frame.lens_id === "cloud_precipitation" && (
+        <fieldset className="supercells-category-filters">
+          <legend>Hydrometeors</legend>
+          {HYDROMETEOR_CODES.map((category) => (
+            <label key={category.code}>
+              <input
+                type="checkbox"
+                checked={categoryCodes.includes(category.code)}
+                onChange={(event) =>
+                  onCategoryCodes(
+                    event.currentTarget.checked
+                      ? [...categoryCodes, category.code]
+                      : categoryCodes.filter((code) => code !== category.code),
+                  )
+                }
+              />
+              {category.label}
+            </label>
+          ))}
+        </fieldset>
+      )}
+      <div className="supercells-render-sliders">
+        <label>
+          Opacity
+          <input
+            type="range"
+            min={0.25}
+            max={1.25}
+            step={0.05}
+            value={opacity}
+            onChange={(event) => onOpacity(Number(event.currentTarget.value))}
+          />
+          <span>{opacity.toFixed(2)}x</span>
+        </label>
+        <label>
+          Point size
+          <input
+            type="range"
+            min={0.5}
+            max={1.8}
+            step={0.1}
+            value={pointSize}
+            onChange={(event) => onPointSize(Number(event.currentTarget.value))}
+          />
+          <span>{pointSize.toFixed(1)}x</span>
+        </label>
+      </div>
+    </section>
+  );
+}
+
+function StormExploreControls({
+  lens,
+  viewport,
+  evidenceView,
+  overlays,
+  visibleLayerKeys,
+  onViewport,
+  onEvidenceView,
+  onOverlays,
+  onLayer,
+}: {
+  lens: LensId;
+  viewport: ViewportId;
+  evidenceView: EvidenceView;
+  overlays: OverlayState;
+  visibleLayerKeys: string[];
+  onViewport: (value: ViewportId) => void;
+  onEvidenceView: (value: EvidenceView) => void;
+  onOverlays: (value: OverlayState) => void;
+  onLayer: (key: string, visible: boolean) => void;
+}) {
+  const controls = overlayControls(lens);
+  function update(control: OverlayControl, checked: boolean) {
+    onOverlays({ ...overlays, [control.overlayKey]: checked });
+    if (control.layerKey) onLayer(control.layerKey, checked);
+  }
+  return (
+    <section className="supercells-control-deck" aria-label="Supercell visualization controls">
+      <fieldset>
+        <legend>Viewport</legend>
+        <div className="segmented-buttons">
+          <button
+            type="button"
+            className={viewport === "storm" ? "active-control" : ""}
+            aria-pressed={viewport === "storm"}
+            onClick={() => onViewport("storm")}
+          >
+            Storm region
+          </button>
+          <button
+            type="button"
+            className={viewport === "full" ? "active-control" : ""}
+            aria-pressed={viewport === "full"}
+            onClick={() => onViewport("full")}
+          >
+            Full domain
+          </button>
+        </div>
+      </fieldset>
+      <fieldset>
+        <legend>Evidence</legend>
+        <div className="segmented-buttons">
+          {(["plan", "xz", "yz"] as EvidenceView[]).map((view) => (
+            <button
+              key={view}
+              type="button"
+              className={evidenceView === view ? "active-control" : ""}
+              aria-pressed={evidenceView === view}
+              onClick={() => onEvidenceView(view)}
+            >
+              {view === "plan" ? "Plan" : view}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+      <fieldset className="supercells-overlay-controls">
+        <legend>Overlays</legend>
+        {controls.map((control) => (
+          <label key={control.label}>
+            <input
+              type="checkbox"
+              checked={
+                control.layerKey
+                  ? visibleLayerKeys.includes(control.layerKey)
+                  : overlays[control.overlayKey]
+              }
+              onChange={(event) => update(control, event.currentTarget.checked)}
+            />
+            {control.label}
+          </label>
+        ))}
+      </fieldset>
+    </section>
+  );
+}
+
+type OverlayControl = {
+  label: string;
+  overlayKey: keyof OverlayState;
+  layerKey?: string;
+};
+
+function overlayControls(lens: LensId): OverlayControl[] {
+  if (lens === "rotating_updraft") {
+    return [
+      { label: "Cloud body", overlayKey: "condensate", layerKey: "storm_cloud_body" },
+      { label: "Vertical motion", overlayKey: "verticalMotion", layerKey: "vertical_motion" },
+      { label: "Rotation", overlayKey: "rotation", layerKey: "cyclonic_rotation" },
+      { label: "2-5 km UH", overlayKey: "updraftHelicity", layerKey: "updraft_helicity" },
+      { label: "Reflectivity", overlayKey: "reflectivity", layerKey: "reflectivity" },
+    ];
+  }
+  if (lens === "cloud_precipitation") {
+    return [
+      { label: "Hydrometeors", overlayKey: "condensate", layerKey: "hydrometeor_categories" },
+      { label: "Reflectivity", overlayKey: "reflectivity", layerKey: "reflectivity" },
+      { label: "Vertical motion", overlayKey: "verticalMotion", layerKey: "vertical_motion" },
+    ];
+  }
+  return [
+    { label: "Cloud body", overlayKey: "condensate", layerKey: "storm_cloud_body" },
+    {
+      label: "Low-level motion",
+      overlayKey: "verticalMotion",
+      layerKey: "low_level_vertical_motion",
+    },
+    { label: "Accumulated rain", overlayKey: "rain", layerKey: "accumulated_surface_rain" },
+    { label: "Model-relative flow", overlayKey: "wind" },
+    { label: "Reflectivity", overlayKey: "reflectivity", layerKey: "reflectivity" },
+    {
+      label: "Precipitating condensate",
+      overlayKey: "precipitatingCondensate",
+      layerKey: "precipitating_condensate",
+    },
+  ];
+}
+
+function SupercellTimeline({
+  frame,
+  timeIndex,
+  playing,
+  playbackSpeed,
+  loading,
+  checkpoint,
+  onTimeIndex,
+  onPlaying,
+  onPlaybackSpeed,
+}: {
+  frame: StormExaminationFrame | null;
+  timeIndex: number;
+  playing: boolean;
+  playbackSpeed: number;
+  loading: boolean;
+  checkpoint: string | null;
+  onTimeIndex: (value: number) => void;
+  onPlaying: (value: boolean) => void;
+  onPlaybackSpeed: (value: number) => void;
+}) {
+  const times = frame?.times_seconds ?? [];
+  const disabled = times.length === 0;
+  return (
+    <fieldset className="supercells-timeline" aria-label="Saved-output timeline">
+      <legend>Time</legend>
+      <div className="frame-step-controls">
+        <button
+          type="button"
+          aria-label="Previous saved output"
+          title="Previous saved output"
+          disabled={disabled || timeIndex === 0}
+          onClick={() => onTimeIndex(Math.max(0, timeIndex - 1))}
+        >
+          <span aria-hidden="true">‹</span>
+        </button>
+        <button
+          type="button"
+          aria-label="Next saved output"
+          title="Next saved output"
+          disabled={disabled || timeIndex >= times.length - 1}
+          onClick={() => onTimeIndex(Math.min(times.length - 1, timeIndex + 1))}
+        >
+          <span aria-hidden="true">›</span>
+        </button>
+      </div>
+      <button
+        type="button"
+        className="supercells-play-button"
+        aria-label={playing ? "Pause" : "Play"}
+        title={playing ? "Pause" : "Play"}
+        disabled={disabled}
+        onClick={() => onPlaying(!playing)}
+      >
+        <span
+          className={`timelapse-icon timelapse-icon-${playing ? "pause" : "play"}`}
+          aria-hidden="true"
+        >
+          {playing ? (
+            <>
+              <span />
+              <span />
+            </>
+          ) : (
+            <span />
+          )}
+        </span>
+      </button>
+      <label className="supercells-time-scrubber">
+        <span>Saved output</span>
+        <input
+          aria-label="Saved output time"
+          type="range"
+          min={0}
+          max={Math.max(0, times.length - 1)}
+          value={timeIndex}
+          disabled={disabled}
+          onChange={(event) => onTimeIndex(Number(event.currentTarget.value))}
+        />
+        <span className="supercells-time-readout">
+          <strong>{formatTime(times[timeIndex] ?? 0)}</strong>
+          <small>
+            frame {Math.min(timeIndex + 1, Math.max(1, times.length))} of{" "}
+            {Math.max(1, times.length)}
+            {checkpoint ? ` · ${checkpoint}` : ""}
+          </small>
+        </span>
+      </label>
+      <label className="supercells-speed-control">
+        <span className="sr-only">Playback speed</span>
+        <select
+          aria-label="Playback speed"
+          value={playbackSpeed}
+          onChange={(event) => onPlaybackSpeed(Number(event.currentTarget.value))}
+        >
+          <option value={0.5}>0.5x</option>
+          <option value={1}>1x</option>
+          <option value={2}>2x</option>
+        </select>
+      </label>
+      {loading && <span className="supercells-timeline-status">Loading saved output...</span>}
+    </fieldset>
+  );
+}
+
+function SupercellExplanation({
+  frame,
+  lens,
+  viewport,
+}: {
+  frame: StormExaminationFrame | null;
+  lens: LensId;
+  viewport: ViewportId;
+}) {
+  const question =
+    frame?.lens_question ?? LENSES.find((item) => item.id === lens)?.label ?? "Storm evidence";
+  return (
+    <section className="supercells-context-panel">
+      <p className="eyebrow">{frame?.lens_name ?? "Supercell Lens"}</p>
+      <h3>{question}</h3>
+      <p>{lensExplanation(lens)}</p>
+      <dl className="metric-grid">
+        <Metric label="Simulation" value="Quarter-Circle Supercell" />
+        <Metric label="Viewport" value={viewport === "storm" ? "Storm region" : "Full domain"} />
+        <Metric label="Model time" value={formatTime(frame?.time_seconds ?? 0)} />
+        <Metric
+          label="Frame"
+          value={frame ? `${frame.time_index + 1} of ${frame.times_seconds.length}` : "Loading"}
+        />
+      </dl>
+      <p className="context-callout">
+        Select a cell in the plan or section to inspect native-grid evidence.
+      </p>
+    </section>
+  );
+}
+
+function SupercellScience({
+  frame,
+  selected,
+}: {
+  frame: StormExaminationFrame | null;
+  selected: boolean;
+}) {
+  if (!frame) return <p>Scientific evidence is loading.</p>;
+  const point = frame.selected_point;
+  return (
+    <section className="supercells-context-panel">
+      <p className="eyebrow">{selected ? "Selected point" : "Strongest-updraft reference"}</p>
+      <h3>
+        x {point.x_km.toFixed(1)}, y {point.y_km.toFixed(1)}, z {point.z_km.toFixed(2)} km
+      </h3>
+      <div className="supercells-state-row">
+        {point.states.map((state) => (
+          <span key={state}>{state}</span>
+        ))}
+      </div>
+      <dl className="metric-grid">
+        {scienceKeys(frame.lens_id).map((key) => (
+          <Metric
+            key={key}
+            label={scienceLabel(key)}
+            value={`${formatScientific(point.values[key])} ${point.units[key] ?? ""}`.trim()}
+          />
+        ))}
+        <Metric
+          label="Distance to strongest updraft"
+          value={`${point.distance_to_primary_updraft_km.toFixed(1)} km`}
+        />
+      </dl>
+      <p className="context-coordinate-frame">{point.coordinate_frame}</p>
+    </section>
+  );
+}
+
+function SupercellNotes() {
+  return (
+    <section className="supercells-context-panel">
+      <h3>Simulation notes</h3>
+      <p>No note is recorded for this built-in Simulation.</p>
+    </section>
+  );
+}
+
+function SupercellDetails({
+  frame,
+  simulation,
+}: {
+  frame: StormExaminationFrame | null;
+  simulation: SupercellSimulation;
+}) {
+  return (
+    <section className="supercells-context-panel">
+      <h3>Simulation details</h3>
+      <dl className="metric-grid">
+        <Metric label="World ID" value="supercells" />
+        <Metric label="Simulation ID" value={simulation.simulation_id} />
+        <Metric label="Run ID" value={simulation.run_id} />
+        <Metric label="Case ID" value={simulation.case_id} />
+        <Metric label="History" value={frame?.provenance.source_history_file ?? "Loading"} />
+        <Metric label="Coordinates" value="Translating model frame" />
+      </dl>
+      {frame && (
+        <details>
+          <summary>Fields, scales, and thresholds</summary>
+          <ul className="supercells-detail-list">
+            {frame.scene?.layers.map((layer) => (
+              <li key={layer.key}>
+                <strong>{layer.display_name}</strong>
+                <span>
+                  {layer.evidence_kind} · {layer.source_fields.join(", ")} · {layer.threshold_label}
+                </span>
+                {layer.scale && <code>{layer.scale.scale_id}</code>}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+      <details>
+        <summary>Relevant limitations</summary>
+        <ul>
+          {frame?.caveats.map((caveat) => <li key={caveat}>{caveat}</li>) ?? <li>Loading.</li>}
+        </ul>
+      </details>
+    </section>
+  );
+}
+
+function LocalFailure({
+  title,
+  message,
+  onRetry,
+}: {
+  title: string;
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <section className="layer-local-error supercells-local-error">
+      <h3>{title}</h3>
+      <p role="alert">{message}</p>
+      <button type="button" onClick={onRetry}>
+        Retry
+      </button>
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+function overlayDefaults(lens: LensId): OverlayState {
+  return {
+    rotation: lens === "rotating_updraft",
+    updraftHelicity: lens === "rotating_updraft",
+    reflectivity: lens === "cloud_precipitation",
+    condensate: true,
+    rain: lens === "low_level_interactions",
+    wind: lens === "low_level_interactions",
+    precipitatingCondensate: false,
+    verticalMotion: true,
+  };
+}
+
+function filterHydrometeorCategories(
+  scene: StormExaminationFrame["scene"],
+  categoryCodes: number[],
+): StormScenePayload | null {
+  if (!scene) return null;
+  return {
+    coordinate_extents_km: scene.coordinate_extents_km,
+    layers: scene.layers.map((layer) =>
+      layer.key === "hydrometeor_categories"
+        ? { ...layer, points: layer.points.filter((point) => categoryCodes.includes(point[4])) }
+        : layer,
+    ),
+  };
+}
+
+function nearestCoordinateIndex(
+  value: number,
+  coordinates: number[],
+  sourceIndices?: number[],
+): number {
+  let nearest = 0;
+  let distance = Number.POSITIVE_INFINITY;
+  coordinates.forEach((coordinate, index) => {
+    const nextDistance = Math.abs(coordinate - value);
+    if (nextDistance < distance) {
+      distance = nextDistance;
+      nearest = index;
+    }
+  });
+  return sourceIndices?.[nearest] ?? nearest;
+}
+
+function evidenceSlice(frame: StormExaminationFrame, view: EvidenceView) {
+  const field = {
+    raw_field_name: frame.plan.primary.key,
+    display_name: frame.plan.primary.display_name,
+    units: frame.plan.primary.units,
+  };
+  if (view === "plan") {
+    return {
+      field,
+      selection: {
+        orientation: "horizontal" as const,
+        selected_dimension: "zh",
+        selected_index: frame.plan.level_index,
+        selected_coordinate_value: frame.plan.level_km,
+        level_coordinate_value: frame.plan.level_km,
+        level_units: "km",
+        level_meters: frame.plan.level_km * 1_000,
+      },
+    };
+  }
+  const section = view === "xz" ? frame.xz_section : frame.yz_section;
+  return {
+    field,
+    selection: {
+      orientation: view === "xz" ? ("vertical_x" as const) : ("vertical_y" as const),
+      selected_dimension: view === "xz" ? "yh" : "xh",
+      selected_index: view === "xz" ? frame.selected_point.y_index : frame.selected_point.x_index,
+      selected_coordinate_value: section.cross_section_coordinate_km,
+      level_coordinate_value: null,
+      level_units: "km",
+      level_meters: null,
+    },
+  };
+}
+
+function evidenceLabel(frame: StormExaminationFrame, view: EvidenceView): string {
+  if (view === "plan") {
+    return `${frame.plan.title} · z = ${frame.plan.level_km.toFixed(2)} km`;
+  }
+  return view === "xz" ? frame.xz_section.title : frame.yz_section.title;
+}
+
+function evidenceTitle(view: EvidenceView): string {
+  return view === "plan" ? "Plan evidence" : `${view} evidence`;
+}
+
+function lensExplanation(lens: LensId): string {
+  if (lens === "rotating_updraft") {
+    return "Signed vertical motion reveals ascent and descent; cyclonic vorticity and 2–5 km updraft helicity show where rising and rotating structure overlap.";
+  }
+  if (lens === "cloud_precipitation") {
+    return "Native cloud liquid, rain, cloud ice, snow, and hail-treated large ice are grouped by the dominant mass species while the inspector retains every value.";
+  }
+  return "Low-level vertical motion, accumulated rain, and model-relative horizontal flow show how ascent, descent, and precipitation meet beneath the storm without diagnosing a cold pool.";
+}
+
+function scienceKeys(lens: LensId): string[] {
+  if (lens === "rotating_updraft") {
+    return [
+      "vertical_velocity",
+      "vertical_vorticity",
+      "updraft_helicity",
+      "reflectivity",
+      "total_condensate",
+    ];
+  }
+  if (lens === "cloud_precipitation") {
+    return [
+      "cloud_liquid",
+      "rain_water",
+      "cloud_ice",
+      "snow",
+      "hail_treated_large_ice",
+      "total_condensate",
+      "reflectivity",
+    ];
+  }
+  return [
+    "vertical_velocity",
+    "accumulated_surface_rain",
+    "model_relative_u",
+    "model_relative_v",
+    "reflectivity",
+    "total_condensate",
+  ];
+}
+
+function scienceLabel(key: string): string {
+  return (
+    {
+      vertical_velocity: "Vertical velocity",
+      vertical_vorticity: "Vertical vorticity",
+      updraft_helicity: "2–5 km AGL UH",
+      reflectivity: "Reflectivity",
+      cloud_liquid: "Cloud liquid",
+      rain_water: "Rain water",
+      cloud_ice: "Cloud ice",
+      snow: "Snow",
+      hail_treated_large_ice: "Hail-treated large ice",
+      total_condensate: "Total condensate",
+      accumulated_surface_rain: "Accumulated surface rain",
+      model_relative_u: "Model-relative u",
+      model_relative_v: "Model-relative v",
+    }[key] ?? key
+  );
+}
+
+function formatScientific(value: number | undefined): string {
+  if (value === undefined || !Number.isFinite(value)) return "Unavailable";
+  if (Math.abs(value) >= 100) return value.toFixed(0);
+  if (Math.abs(value) >= 10) return value.toFixed(1);
+  if (Math.abs(value) >= 0.1) return value.toFixed(2);
+  return value.toExponential(2);
+}
+
+function formatTime(seconds: number): string {
+  const minutes = Math.round(seconds / 60);
+  return `${minutes} min · ${seconds.toLocaleString()} s`;
+}
+
+function frameRequestKey(
+  lens: LensId,
+  viewport: ViewportId,
+  timeIndex: number,
+  selection: Selection | null,
+): string {
+  return `${lens}:${viewport}:${timeIndex}:${selection ? `${selection.xIndex},${selection.yIndex},${selection.zIndex}` : "primary"}`;
+}
+
+async function fetchSupercellFrame(
+  simulationId: string,
+  lens: LensId,
+  viewport: ViewportId,
+  timeIndex: number,
+  selection: Selection | null,
+  signal?: AbortSignal,
+): Promise<StormExaminationFrame> {
+  const search = new URLSearchParams({ lens, viewport, time_index: String(timeIndex) });
+  if (selection) {
+    search.set("x_index", String(selection.xIndex));
+    search.set("y_index", String(selection.yIndex));
+    search.set("z_index", String(selection.zIndex));
+  }
+  const response = await fetch(
+    `/api/worlds/supercells/simulations/${simulationId}/frame?${search}`,
+    { signal },
+  );
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(payload?.detail ?? `Supercell frame failed (${response.status}).`);
+  }
+  const payload = (await response.json()) as StormExaminationFrame;
+  if (
+    payload.schema_version !== "supercells_explore_v1" ||
+    payload.world_id !== "supercells" ||
+    payload.simulation_id !== "supercells_quarter_circle_reference"
+  ) {
+    throw new Error("Supercell frame response does not match the production World contract.");
+  }
+  return payload;
+}
+
+async function prefetchAdjacentFrames(
+  cache: Map<string, StormExaminationFrame>,
+  simulationId: string,
+  frame: StormExaminationFrame,
+  lens: LensId,
+  viewport: ViewportId,
+) {
+  const candidates = [frame.time_index - 1, frame.time_index + 1].filter(
+    (index) => index >= 0 && index < frame.times_seconds.length,
+  );
+  for (const index of candidates) {
+    const key = frameRequestKey(lens, viewport, index, null);
+    if (cache.has(key)) continue;
+    try {
+      cache.set(key, await fetchSupercellFrame(simulationId, lens, viewport, index, null));
+      trimCache(cache, 8);
+    } catch {
+      // Adjacent prefetch is optional; the requested frame remains authoritative.
+    }
+  }
+}
+
+function trimCache(cache: Map<string, StormExaminationFrame>, maximum: number) {
+  while (cache.size > maximum) {
+    const first = cache.keys().next().value as string | undefined;
+    if (first === undefined) return;
+    cache.delete(first);
+  }
+}

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -12,13 +12,29 @@ import {
   StormSectionPlot,
   type ViewportId,
 } from "./StormExaminationResearch";
-import { type StormScenePayload, type StormScenePoint, True3DViewer } from "./True3DViewer";
+import {
+  type CameraPreset,
+  type StormScenePayload,
+  type StormScenePoint,
+  True3DViewer,
+} from "./True3DViewer";
 
 import "./StormExaminationResearch.css";
 import "./SupercellsExplore.css";
 
 type EvidenceView = "plan" | "xz" | "yz";
 type FocusedViewer = "scene" | "evidence" | null;
+type LensPresentation = {
+  viewport: ViewportId;
+  evidenceView: EvidenceView;
+  overlays: OverlayState;
+  visibleLayerKeys: string[] | null;
+  categoryCodes: number[];
+  cameraPreset: CameraPreset;
+  sceneOpacity: number;
+  scenePointSize: number;
+  selection: Selection | null;
+};
 
 const LENSES: Array<{ id: LensId; label: string }> = [
   { id: "rotating_updraft", label: "Rotating Updraft" },
@@ -42,27 +58,31 @@ export function SupercellsExplore({
   onBack: () => void;
 }) {
   const [lens, setLens] = useState<LensId>("rotating_updraft");
-  const [viewport, setViewport] = useState<ViewportId>("storm");
   const [timeIndex, setTimeIndex] = useState(5);
   const [frame, setFrame] = useState<StormExaminationFrame | null>(null);
-  const [selection, setSelection] = useState<Selection | null>(null);
-  const [evidenceView, setEvidenceView] = useState<EvidenceView>("plan");
+  const [presentations, setPresentations] = useState<Record<LensId, LensPresentation>>(
+    lensPresentationDefaults,
+  );
+  const presentation = presentations[lens];
+  const {
+    viewport,
+    evidenceView,
+    overlays,
+    categoryCodes,
+    cameraPreset,
+    sceneOpacity,
+    scenePointSize,
+    selection,
+  } = presentation;
+  const visibleLayerKeys = presentation.visibleLayerKeys ?? [];
   const [focusedViewer, setFocusedViewer] = useState<FocusedViewer>(null);
   const [contextCollapsed, setContextCollapsed] = useState(false);
-  const [overlays, setOverlays] = useState<OverlayState>(() => overlayDefaults("rotating_updraft"));
-  const [visibleLayerKeys, setVisibleLayerKeys] = useState<string[]>([]);
-  const [categoryCodes, setCategoryCodes] = useState<number[]>(
-    HYDROMETEOR_CODES.map((item) => item.code),
-  );
-  const [sceneOpacity, setSceneOpacity] = useState(1);
-  const [scenePointSize, setScenePointSize] = useState(1);
   const [playing, setPlaying] = useState(false);
   const [playbackSpeed, setPlaybackSpeed] = useState(1);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [retryNonce, setRetryNonce] = useState(0);
   const frameCache = useRef(new Map<string, StormExaminationFrame>());
-  const defaultsLens = useRef<LensId | null>(null);
   const contextBeforeEvidenceFocus = useRef(false);
 
   const requestKey = frameRequestKey(lens, viewport, timeIndex, selection);
@@ -114,14 +134,21 @@ export function SupercellsExplore({
   }, [loadFrame, retryNonce]);
 
   useEffect(() => {
-    if (!frame?.scene || frame.lens_id !== lens || defaultsLens.current === lens) return;
-    defaultsLens.current = lens;
-    setVisibleLayerKeys(
-      frame.scene.layers.filter((layer) => layer.default_visible).map((layer) => layer.key),
-    );
-    setOverlays(overlayDefaults(lens));
-    setCategoryCodes(HYDROMETEOR_CODES.map((item) => item.code));
-  }, [frame, lens]);
+    if (
+      !frame?.scene ||
+      frame.lens_id !== lens ||
+      presentations[lens].visibleLayerKeys !== null
+    )
+      return;
+    const layerKeys = frame.scene.layers
+      .filter((layer) => layer.default_visible)
+      .map((layer) => layer.key);
+    if (lens === "low_level_interactions") layerKeys.push("model_relative_wind");
+    setPresentations((current) => ({
+      ...current,
+      [lens]: { ...current[lens], visibleLayerKeys: layerKeys },
+    }));
+  }, [frame, lens, presentations]);
 
   useEffect(() => {
     if (!playing || loading || !frame) return;
@@ -147,13 +174,20 @@ export function SupercellsExplore({
 
   function chooseLens(next: LensId) {
     setPlaying(false);
+    setFrame(null);
     setLens(next);
-    defaultsLens.current = null;
   }
 
   function selectPoint(next: Selection) {
     setPlaying(false);
-    setSelection(next);
+    updatePresentation({ selection: next });
+  }
+
+  function updatePresentation(patch: Partial<LensPresentation>) {
+    setPresentations((current) => ({
+      ...current,
+      [lens]: { ...current[lens], ...patch },
+    }));
   }
 
   function selectScenePoint(point: StormScenePoint) {
@@ -166,9 +200,11 @@ export function SupercellsExplore({
   }
 
   function toggleLayer(key: string, visible: boolean) {
-    setVisibleLayerKeys((current) =>
-      visible ? [...new Set([...current, key])] : current.filter((item) => item !== key),
-    );
+    updatePresentation({
+      visibleLayerKeys: visible
+        ? [...new Set([...visibleLayerKeys, key])]
+        : visibleLayerKeys.filter((item) => item !== key),
+    });
   }
 
   function toggleEvidenceFocus() {
@@ -242,11 +278,12 @@ export function SupercellsExplore({
                 provenanceLabel="Retained native CM1 history; deterministic bounded selection."
                 noCloudMessage="No visible storm layers at this saved output."
                 windVectors={windVectors}
-                showWindVectors={lens === "low_level_interactions" && overlays.wind}
+                showWindVectors={visibleLayerKeys.includes("model_relative_wind")}
                 windMode="total"
                 windReferenceMps={frame.scene.wind_reference_m_s}
                 windArrowDomainFraction={0.055}
                 compactWorkspace
+                compactDisplayLabel="3-D layers"
                 maximized={focusedViewer === "scene"}
                 onToggleMaximize={() =>
                   setFocusedViewer((current) => (current === "scene" ? null : "scene"))
@@ -266,6 +303,8 @@ export function SupercellsExplore({
                     : null
                 }
                 onSelectStormPoint={selectScenePoint}
+                cameraPreset={cameraPreset}
+                onCameraPresetChange={(next) => updatePresentation({ cameraPreset: next })}
                 compactDisplayControls={
                   <StormDisplayControls
                     frame={frame}
@@ -274,12 +313,16 @@ export function SupercellsExplore({
                     pointSize={scenePointSize}
                     categoryCodes={categoryCodes}
                     onLayer={toggleLayer}
-                    onOpacity={setSceneOpacity}
-                    onPointSize={setScenePointSize}
-                    onCategoryCodes={setCategoryCodes}
+                    onOpacity={(next) => updatePresentation({ sceneOpacity: next })}
+                    onPointSize={(next) => updatePresentation({ scenePointSize: next })}
+                    onCategoryCodes={(next) => updatePresentation({ categoryCodes: next })}
                   />
                 }
               />
+            ) : loading ? (
+              <div className="supercells-loading-surface" role="status">
+                Loading 3-D Lens...
+              </div>
             ) : (
               <LocalFailure
                 title="3-D storm scene unavailable"
@@ -293,7 +336,7 @@ export function SupercellsExplore({
           <section className="supercells-evidence" aria-label="Coordinated storm evidence">
             <header className="instrument-header">
               <div>
-                <h2>{evidenceTitle(evidenceView)}</h2>
+                <h2>{evidenceTitle(frame, evidenceView)}</h2>
                 <p>{activeSliceLabel}</p>
               </div>
               <div className="instrument-actions">
@@ -304,7 +347,7 @@ export function SupercellsExplore({
                       type="button"
                       className={evidenceView === view ? "active-control" : ""}
                       aria-pressed={evidenceView === view}
-                      onClick={() => setEvidenceView(view)}
+                      onClick={() => updatePresentation({ evidenceView: view })}
                     >
                       {sliceControlLabel(view)}
                     </button>
@@ -354,7 +397,11 @@ export function SupercellsExplore({
                     />
                   )}
                 </div>
-                <StormLegend frame={frame} overlays={overlays} />
+                <StormLegend frame={frame} overlays={overlays} evidenceView={evidenceView} />
+              </div>
+            ) : loading ? (
+              <div className="supercells-loading-surface" role="status">
+                Loading coordinated evidence...
               </div>
             ) : (
               <LocalFailure
@@ -371,7 +418,14 @@ export function SupercellsExplore({
             onCollapsedChange={setContextCollapsed}
             showCollapseControl={false}
             sections={{
-              explain: <SupercellExplanation frame={frame} lens={lens} viewport={viewport} />,
+              explain: (
+                <SupercellExplanation
+                  frame={frame}
+                  lens={lens}
+                  viewport={viewport}
+                  evidenceView={evidenceView}
+                />
+              ),
               science: <SupercellScience frame={frame} selected={selection !== null} />,
               notes: <SupercellNotes />,
               details: <SupercellDetails frame={frame} simulation={simulation} />,
@@ -384,14 +438,12 @@ export function SupercellsExplore({
           viewport={viewport}
           evidenceView={evidenceView}
           overlays={overlays}
-          visibleLayerKeys={visibleLayerKeys}
           onViewport={(next) => {
             setPlaying(false);
-            setViewport(next);
+            updatePresentation({ viewport: next });
           }}
-          onEvidenceView={setEvidenceView}
-          onOverlays={setOverlays}
-          onLayer={toggleLayer}
+          onEvidenceView={(next) => updatePresentation({ evidenceView: next })}
+          onOverlays={(next) => updatePresentation({ overlays: next })}
         />
 
         <SupercellTimeline
@@ -436,6 +488,7 @@ function StormDisplayControls({
 }) {
   return (
     <section className="supercells-display-controls" aria-label="3-D storm display controls">
+      <strong className="supercells-display-heading">3-D layers</strong>
       <div className="supercells-layer-list">
         {frame.scene?.layers.map((layer) => (
           <label key={layer.key}>
@@ -447,6 +500,18 @@ function StormDisplayControls({
             {layer.display_name}
           </label>
         ))}
+        {Boolean(frame.scene?.wind_vectors.length) && (
+          <label>
+            <input
+              type="checkbox"
+              checked={visibleLayerKeys.includes("model_relative_wind")}
+              onChange={(event) =>
+                onLayer("model_relative_wind", event.currentTarget.checked)
+              }
+            />
+            Model-relative wind at 1.25 km
+          </label>
+        )}
       </div>
       {frame.lens_id === "cloud_precipitation" && (
         <fieldset className="supercells-category-filters">
@@ -504,26 +569,21 @@ function StormExploreControls({
   viewport,
   evidenceView,
   overlays,
-  visibleLayerKeys,
   onViewport,
   onEvidenceView,
   onOverlays,
-  onLayer,
 }: {
   lens: LensId;
   viewport: ViewportId;
   evidenceView: EvidenceView;
   overlays: OverlayState;
-  visibleLayerKeys: string[];
   onViewport: (value: ViewportId) => void;
   onEvidenceView: (value: EvidenceView) => void;
   onOverlays: (value: OverlayState) => void;
-  onLayer: (key: string, visible: boolean) => void;
 }) {
-  const controls = overlayControls(lens);
+  const controls = overlayControls(lens, evidenceView);
   function update(control: OverlayControl, checked: boolean) {
     onOverlays({ ...overlays, [control.overlayKey]: checked });
-    if (control.layerKey) onLayer(control.layerKey, checked);
   }
   return (
     <section className="supercells-control-deck" aria-label="Supercell visualization controls">
@@ -565,16 +625,12 @@ function StormExploreControls({
         </div>
       </fieldset>
       <fieldset className="supercells-overlay-controls">
-        <legend>Overlays</legend>
+        <legend>2-D evidence</legend>
         {controls.map((control) => (
           <label key={control.label}>
             <input
               type="checkbox"
-              checked={
-                control.layerKey
-                  ? visibleLayerKeys.includes(control.layerKey)
-                  : overlays[control.overlayKey]
-              }
+              checked={overlays[control.overlayKey]}
               onChange={(event) => update(control, event.currentTarget.checked)}
             />
             {control.label}
@@ -588,42 +644,37 @@ function StormExploreControls({
 type OverlayControl = {
   label: string;
   overlayKey: keyof OverlayState;
-  layerKey?: string;
 };
 
-function overlayControls(lens: LensId): OverlayControl[] {
+function overlayControls(lens: LensId, evidenceView: EvidenceView): OverlayControl[] {
   if (lens === "rotating_updraft") {
-    return [
-      { label: "Cloud body", overlayKey: "condensate", layerKey: "storm_cloud_body" },
-      { label: "Vertical motion", overlayKey: "verticalMotion", layerKey: "vertical_motion" },
-      { label: "Rotation", overlayKey: "rotation", layerKey: "cyclonic_rotation" },
-      { label: "2-5 km UH", overlayKey: "updraftHelicity", layerKey: "updraft_helicity" },
-      { label: "Reflectivity", overlayKey: "reflectivity", layerKey: "reflectivity" },
+    const controls: OverlayControl[] = [
+      { label: "Cloud boundary", overlayKey: "condensate" },
+      { label: "Rotation contour", overlayKey: "rotation" },
+      { label: "Reflectivity contour", overlayKey: "reflectivity" },
     ];
+    if (evidenceView === "plan") {
+      controls.splice(2, 0, { label: "2-5 km UH footprint", overlayKey: "updraftHelicity" });
+    }
+    return controls;
   }
   if (lens === "cloud_precipitation") {
     return [
-      { label: "Hydrometeors", overlayKey: "condensate", layerKey: "hydrometeor_categories" },
-      { label: "Reflectivity", overlayKey: "reflectivity", layerKey: "reflectivity" },
-      { label: "Vertical motion", overlayKey: "verticalMotion" },
+      { label: "Vertical-motion contours", overlayKey: "verticalMotion" },
+      { label: "Reflectivity contour", overlayKey: "reflectivity" },
     ];
   }
-  return [
-    { label: "Cloud body", overlayKey: "condensate", layerKey: "storm_cloud_body" },
-    {
-      label: "Low-level motion",
-      overlayKey: "verticalMotion",
-      layerKey: "low_level_vertical_motion",
-    },
-    { label: "Accumulated rain", overlayKey: "rain", layerKey: "accumulated_surface_rain" },
-    { label: "Model-relative flow", overlayKey: "wind" },
-    { label: "Reflectivity", overlayKey: "reflectivity", layerKey: "reflectivity" },
-    {
-      label: "Precipitating condensate",
-      overlayKey: "precipitatingCondensate",
-      layerKey: "precipitating_condensate",
-    },
+  const controls: OverlayControl[] = [
+    { label: "Current precipitation", overlayKey: "precipitatingCondensate" },
+    { label: "Reflectivity contour", overlayKey: "reflectivity" },
   ];
+  if (evidenceView === "plan") {
+    controls.unshift(
+      { label: "Accumulated rain (history)", overlayKey: "rain" },
+      { label: "Flow arrows at 1.25 km", overlayKey: "wind" },
+    );
+  }
+  return controls;
 }
 
 function SupercellTimeline({
@@ -735,10 +786,12 @@ function SupercellExplanation({
   frame,
   lens,
   viewport,
+  evidenceView,
 }: {
   frame: StormExaminationFrame | null;
   lens: LensId;
   viewport: ViewportId;
+  evidenceView: EvidenceView;
 }) {
   const question =
     frame?.lens_question ?? LENSES.find((item) => item.id === lens)?.label ?? "Storm evidence";
@@ -746,7 +799,13 @@ function SupercellExplanation({
     <section className="supercells-context-panel">
       <p className="eyebrow">{frame?.lens_name ?? "Supercell Lens"}</p>
       <h3>{question}</h3>
-      <p>{lensExplanation(lens)}</p>
+      <p>{lensExplanation(lens, evidenceView)}</p>
+      {frame && (
+        <div className="supercells-notice-now">
+          <strong>What to notice now</strong>
+          <p>{frame.what_to_notice_by_view?.[evidenceView] ?? frame.what_to_notice_now}</p>
+        </div>
+      )}
       <dl className="metric-grid">
         <Metric label="Simulation" value="Quarter-Circle Supercell" />
         <Metric label="Viewport" value={viewport === "storm" ? "Storm region" : "Full domain"} />
@@ -888,11 +947,50 @@ function overlayDefaults(lens: LensId): OverlayState {
     rotation: lens === "rotating_updraft",
     updraftHelicity: lens === "rotating_updraft",
     reflectivity: false,
-    condensate: true,
+    condensate: lens === "rotating_updraft",
     rain: lens === "low_level_interactions",
     wind: lens === "low_level_interactions",
-    precipitatingCondensate: false,
+    precipitatingCondensate: lens === "low_level_interactions",
     verticalMotion: true,
+  };
+}
+
+function lensPresentationDefaults(): Record<LensId, LensPresentation> {
+  const categoryCodes = HYDROMETEOR_CODES.map((item) => item.code);
+  return {
+    rotating_updraft: {
+      viewport: "storm",
+      evidenceView: "plan",
+      overlays: overlayDefaults("rotating_updraft"),
+      visibleLayerKeys: null,
+      categoryCodes,
+      cameraPreset: "look_along_y",
+      sceneOpacity: 1,
+      scenePointSize: 1,
+      selection: null,
+    },
+    cloud_precipitation: {
+      viewport: "storm",
+      evidenceView: "xz",
+      overlays: overlayDefaults("cloud_precipitation"),
+      visibleLayerKeys: null,
+      categoryCodes,
+      cameraPreset: "look_along_y",
+      sceneOpacity: 0.9,
+      scenePointSize: 0.9,
+      selection: null,
+    },
+    low_level_interactions: {
+      viewport: "storm",
+      evidenceView: "plan",
+      overlays: overlayDefaults("low_level_interactions"),
+      visibleLayerKeys: null,
+      categoryCodes,
+      cameraPreset: "low_level",
+      sceneOpacity: 1,
+      scenePointSize: 1,
+      selection: null,
+    },
   };
 }
 
@@ -929,12 +1027,12 @@ function nearestCoordinateIndex(
 }
 
 function evidenceSlice(frame: StormExaminationFrame, view: EvidenceView) {
-  const field = {
-    raw_field_name: frame.plan.primary.key,
-    display_name: frame.plan.primary.display_name,
-    units: frame.plan.primary.units,
-  };
   if (view === "plan") {
+    const field = {
+      raw_field_name: frame.plan.primary.key,
+      display_name: frame.plan.primary.display_name,
+      units: frame.plan.primary.units,
+    };
     return {
       field,
       selection: {
@@ -950,7 +1048,11 @@ function evidenceSlice(frame: StormExaminationFrame, view: EvidenceView) {
   }
   const section = view === "xz" ? frame.xz_section : frame.yz_section;
   return {
-    field,
+    field: {
+      raw_field_name: section.primary.key,
+      display_name: section.primary.display_name,
+      units: section.primary.units,
+    },
     selection: {
       orientation: view === "xz" ? ("vertical_x" as const) : ("vertical_y" as const),
       selected_dimension: view === "xz" ? "yh" : "xh",
@@ -965,12 +1067,21 @@ function evidenceSlice(frame: StormExaminationFrame, view: EvidenceView) {
 
 function evidenceLabel(frame: StormExaminationFrame, view: EvidenceView): string {
   if (view === "plan") {
+    if (frame.plan.selection_z_indices) {
+      return `${frame.plan.title} · column-derived at each cell's condensate maximum`;
+    }
     return `${frame.plan.title} · z = ${frame.plan.level_km.toFixed(2)} km`;
   }
   return view === "xz" ? frame.xz_section.title : frame.yz_section.title;
 }
 
-function evidenceTitle(view: EvidenceView): string {
+function evidenceTitle(
+  frame: StormExaminationFrame | null,
+  view: EvidenceView,
+): string {
+  if (view === "plan" && frame?.plan.selection_z_indices) {
+    return "Column-derived x-y view";
+  }
   return `${sliceControlLabel(view)} slice`;
 }
 
@@ -979,14 +1090,20 @@ function sliceControlLabel(view: EvidenceView): string {
   return view === "xz" ? "Vertical x-z" : "Vertical y-z";
 }
 
-function lensExplanation(lens: LensId): string {
+function lensExplanation(lens: LensId, evidenceView: EvidenceView): string {
   if (lens === "rotating_updraft") {
-    return "Signed vertical motion reveals ascent and descent; cyclonic vorticity and 2–5 km updraft helicity show where rising and rotating structure overlap.";
+    return evidenceView === "plan"
+      ? "The 3.25 km x-y slice pairs signed vertical motion with cyclonic vorticity and the 2–5 km updraft-helicity footprint, showing where ascent and rotation organize together."
+      : "This native vertical section pairs signed vertical motion with cyclonic-vorticity contours, showing whether the rotating rising core remains vertically connected.";
   }
   if (lens === "cloud_precipitation") {
-    return "Native cloud liquid, rain, cloud ice, snow, and hail-treated large ice are grouped by the dominant mass species while the inspector retains every value.";
+    return evidenceView === "plan"
+      ? "This column-derived x-y view assigns each cell the hydrometeor that dominates at its strongest-condensate level and samples vertical motion at that same level. Selecting a cell inspects the responsible native level in Context."
+      : "This storm-core native section shows the dominant hydrometeor at each cell. Vertical-motion contours remain subordinate, and every native species value remains available in Context.";
   }
-  return "Low-level vertical motion, accumulated rain, and model-relative horizontal flow show how ascent, descent, and precipitation meet beneath the storm without diagnosing a cold pool.";
+  return evidenceView === "plan"
+    ? "The fixed 3-D lower-troposphere view and 1.25 km x-y slice coordinate current motion, precipitating condensate, and model-relative flow with the historical accumulated-rain footprint without diagnosing a cold pool."
+    : "The 3-D view remains fixed on the lowest 5.25 km, while this native vertical section shows full-depth current ascent, descent, and precipitating condensate; accumulated surface rain remains a separate historical plan-view quantity.";
 }
 
 function scienceKeys(lens: LensId): string[] {

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -48,6 +48,7 @@ export function SupercellsExplore({
   const [selection, setSelection] = useState<Selection | null>(null);
   const [evidenceView, setEvidenceView] = useState<EvidenceView>("plan");
   const [focusedViewer, setFocusedViewer] = useState<FocusedViewer>(null);
+  const [contextCollapsed, setContextCollapsed] = useState(false);
   const [overlays, setOverlays] = useState<OverlayState>(() => overlayDefaults("rotating_updraft"));
   const [visibleLayerKeys, setVisibleLayerKeys] = useState<string[]>([]);
   const [categoryCodes, setCategoryCodes] = useState<number[]>(
@@ -62,6 +63,7 @@ export function SupercellsExplore({
   const [retryNonce, setRetryNonce] = useState(0);
   const frameCache = useRef(new Map<string, StormExaminationFrame>());
   const defaultsLens = useRef<LensId | null>(null);
+  const contextBeforeEvidenceFocus = useRef(false);
 
   const requestKey = frameRequestKey(lens, viewport, timeIndex, selection);
   const loadFrame = useCallback(
@@ -169,6 +171,17 @@ export function SupercellsExplore({
     );
   }
 
+  function toggleEvidenceFocus() {
+    if (focusedViewer === "evidence") {
+      setFocusedViewer(null);
+      setContextCollapsed(contextBeforeEvidenceFocus.current);
+      return;
+    }
+    contextBeforeEvidenceFocus.current = contextCollapsed;
+    setContextCollapsed(true);
+    setFocusedViewer("evidence");
+  }
+
   return (
     <IntegratedExploreWorkspace
       worldName="Supercells"
@@ -182,7 +195,11 @@ export function SupercellsExplore({
         }`}
         aria-label="Supercells integrated Explore workspace"
       >
-        <div className="supercells-workbench">
+        <div
+          className={`supercells-workbench${
+            contextCollapsed ? " supercells-context-collapsed" : ""
+          }`}
+        >
           <section className="supercells-scene" aria-label="3-D storm scene">
             <div className="supercells-lens-switcher" aria-label="Supercell Lens">
               {LENSES.map((item) => (
@@ -280,7 +297,7 @@ export function SupercellsExplore({
                 <p>{activeSliceLabel}</p>
               </div>
               <div className="instrument-actions">
-                <div className="instrument-view-toggle" aria-label="Evidence view">
+                <div className="instrument-view-toggle" aria-label="Slice orientation">
                   {(["plan", "xz", "yz"] as EvidenceView[]).map((view) => (
                     <button
                       key={view}
@@ -289,7 +306,7 @@ export function SupercellsExplore({
                       aria-pressed={evidenceView === view}
                       onClick={() => setEvidenceView(view)}
                     >
-                      {view === "plan" ? "Plan" : view}
+                      {sliceControlLabel(view)}
                     </button>
                   ))}
                 </div>
@@ -300,11 +317,26 @@ export function SupercellsExplore({
                     focusedViewer === "evidence" ? "Restore evidence" : "Maximize evidence"
                   }
                   title={focusedViewer === "evidence" ? "Restore evidence" : "Maximize evidence"}
-                  onClick={() =>
-                    setFocusedViewer((current) => (current === "evidence" ? null : "evidence"))
-                  }
+                  onClick={toggleEvidenceFocus}
                 >
                   <span aria-hidden="true">⛶</span>
+                </button>
+                <button
+                  type="button"
+                  className="supercells-context-toggle"
+                  aria-expanded={!contextCollapsed}
+                  aria-controls={contextCollapsed ? undefined : "supercells-context-inspector"}
+                  aria-label={contextCollapsed ? "Open Context" : "Collapse Context"}
+                  title={contextCollapsed ? "Open Context" : "Collapse Context"}
+                  onClick={() => setContextCollapsed((current) => !current)}
+                >
+                  <span className="supercells-context-toggle-icon" aria-hidden="true">
+                    <span className="supercells-context-toggle-frame">
+                      <span className="supercells-context-toggle-panel">
+                        {contextCollapsed ? "\u2039" : "\u203a"}
+                      </span>
+                    </span>
+                  </span>
                 </button>
               </div>
             </header>
@@ -322,7 +354,7 @@ export function SupercellsExplore({
                     />
                   )}
                 </div>
-                <StormLegend frame={frame} />
+                <StormLegend frame={frame} overlays={overlays} />
               </div>
             ) : (
               <LocalFailure
@@ -334,6 +366,10 @@ export function SupercellsExplore({
           </section>
 
           <ExploreInspector
+            id="supercells-context-inspector"
+            collapsed={contextCollapsed}
+            onCollapsedChange={setContextCollapsed}
+            showCollapseControl={false}
             sections={{
               explain: <SupercellExplanation frame={frame} lens={lens} viewport={viewport} />,
               science: <SupercellScience frame={frame} selected={selection !== null} />,
@@ -513,7 +549,7 @@ function StormExploreControls({
         </div>
       </fieldset>
       <fieldset>
-        <legend>Evidence</legend>
+        <legend>Slice</legend>
         <div className="segmented-buttons">
           {(["plan", "xz", "yz"] as EvidenceView[]).map((view) => (
             <button
@@ -523,7 +559,7 @@ function StormExploreControls({
               aria-pressed={evidenceView === view}
               onClick={() => onEvidenceView(view)}
             >
-              {view === "plan" ? "Plan" : view}
+              {sliceControlLabel(view)}
             </button>
           ))}
         </div>
@@ -569,7 +605,7 @@ function overlayControls(lens: LensId): OverlayControl[] {
     return [
       { label: "Hydrometeors", overlayKey: "condensate", layerKey: "hydrometeor_categories" },
       { label: "Reflectivity", overlayKey: "reflectivity", layerKey: "reflectivity" },
-      { label: "Vertical motion", overlayKey: "verticalMotion", layerKey: "vertical_motion" },
+      { label: "Vertical motion", overlayKey: "verticalMotion" },
     ];
   }
   return [
@@ -851,7 +887,7 @@ function overlayDefaults(lens: LensId): OverlayState {
   return {
     rotation: lens === "rotating_updraft",
     updraftHelicity: lens === "rotating_updraft",
-    reflectivity: lens === "cloud_precipitation",
+    reflectivity: false,
     condensate: true,
     rain: lens === "low_level_interactions",
     wind: lens === "low_level_interactions",
@@ -935,7 +971,12 @@ function evidenceLabel(frame: StormExaminationFrame, view: EvidenceView): string
 }
 
 function evidenceTitle(view: EvidenceView): string {
-  return view === "plan" ? "Plan evidence" : `${view} evidence`;
+  return `${sliceControlLabel(view)} slice`;
+}
+
+function sliceControlLabel(view: EvidenceView): string {
+  if (view === "plan") return "Horizontal x-y";
+  return view === "xz" ? "Vertical x-z" : "Vertical y-z";
 }
 
 function lensExplanation(lens: LensId): string {

--- a/app/frontend/src/SupercellsWorld.test.tsx
+++ b/app/frontend/src/SupercellsWorld.test.tsx
@@ -1,0 +1,117 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type SupercellsWorldDetail, SupercellsWorld } from "./SupercellsWorld";
+
+const world: SupercellsWorldDetail = {
+  world_id: "supercells",
+  display_name: "Supercells",
+  short_description: "Inspect an evolving idealized rotating storm.",
+  availability_state: "available",
+  availability_message: "The Quarter-Circle Supercell is available.",
+  reference_simulation: {
+    simulation_id: "supercells_quarter_circle_reference",
+    display_name: "Quarter-Circle Supercell",
+    role: "reference",
+    world_id: "supercells",
+    run_id: "quarter-circle-supercell-official-20260722T142521Z",
+    case_id: "cm1_r21_1_quarter_circle_supercell_official_v0",
+    technical_state: "available",
+    technical_state_message: "Nine retained histories are available.",
+    explore_available: true,
+    saved_output_count: 9,
+    model_start_seconds: 0,
+    model_end_seconds: 7_200,
+    history_cadence_seconds: 900,
+    lineage_state: "known",
+  },
+  simulations: [],
+  capabilities: {
+    reference_explore: true,
+    lab: false,
+    compare: false,
+    saved_views: false,
+  },
+  caveats: ["This idealized benchmark is not a forecast or a reconstruction of a real storm."],
+};
+world.simulations = [world.reference_simulation];
+
+describe("SupercellsWorld", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("exposes only the approved Overview, Simulations, and Explore path", async () => {
+    vi.mocked(fetch).mockResolvedValue(ok(world));
+    const onExplore = vi.fn();
+    const onBack = vi.fn();
+    render(<SupercellsWorld onBackToWorlds={onBack} onExploreSimulation={onExplore} />);
+
+    expect(await screen.findByRole("heading", { name: "Supercells" })).toBeInTheDocument();
+    const navigation = screen.getByRole("navigation", { name: "Supercells sections" });
+    expect(within(navigation).getByRole("button", { name: "Overview" })).toBeVisible();
+    expect(within(navigation).getByRole("button", { name: "Simulations" })).toBeVisible();
+    expect(within(navigation).queryByRole("button", { name: /Lab|Compare|Saved/ })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Explore" }));
+    expect(onExplore).toHaveBeenCalledWith(world.reference_simulation);
+
+    fireEvent.click(
+      within(screen.getByRole("navigation", { name: "Breadcrumb" })).getByRole("button"),
+    );
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when the retained reference output is unavailable", async () => {
+    const unavailable: SupercellsWorldDetail = {
+      ...world,
+      availability_state: "unavailable",
+      availability_message: "The retained Supercell output is missing.",
+      reference_simulation: {
+        ...world.reference_simulation,
+        technical_state: "missing",
+        technical_state_message: "The retained run directory could not be found.",
+        explore_available: false,
+        saved_output_count: 0,
+        model_start_seconds: null,
+        model_end_seconds: null,
+        history_cadence_seconds: null,
+      },
+      simulations: [],
+    };
+    unavailable.simulations = [unavailable.reference_simulation];
+    vi.mocked(fetch).mockResolvedValue(ok(unavailable));
+    render(<SupercellsWorld onBackToWorlds={vi.fn()} onExploreSimulation={vi.fn()} />);
+
+    expect(await screen.findByText("The retained run directory could not be found.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Explore" })).toBeDisabled();
+    expect(screen.getByText("The retained Supercell output is missing.")).toBeVisible();
+  });
+
+  it("keeps an endpoint failure local and retryable", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "Output inventory failed." }), { status: 503 }),
+      )
+      .mockResolvedValueOnce(ok(world));
+    render(<SupercellsWorld onBackToWorlds={vi.fn()} onExploreSimulation={vi.fn()} />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Output inventory failed.");
+    fireEvent.click(screen.getByRole("button", { name: "Retry Supercells" }));
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Quarter-Circle Supercell" })).toBeVisible(),
+    );
+  });
+});
+
+function ok(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/app/frontend/src/SupercellsWorld.tsx
+++ b/app/frontend/src/SupercellsWorld.tsx
@@ -1,0 +1,255 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type SupercellSimulation = {
+  simulation_id: "supercells_quarter_circle_reference";
+  display_name: "Quarter-Circle Supercell";
+  role: "reference";
+  world_id: "supercells";
+  run_id: string;
+  case_id: string;
+  technical_state: "available" | "missing" | "invalid";
+  technical_state_message: string;
+  explore_available: boolean;
+  saved_output_count: number;
+  model_start_seconds: number | null;
+  model_end_seconds: number | null;
+  history_cadence_seconds: number | null;
+  lineage_state: "known";
+};
+
+export type SupercellsWorldDetail = {
+  world_id: "supercells";
+  display_name: "Supercells";
+  short_description: string;
+  availability_state: "available" | "partial" | "unavailable";
+  availability_message: string;
+  reference_simulation: SupercellSimulation;
+  simulations: SupercellSimulation[];
+  capabilities: {
+    reference_explore: boolean;
+    lab: false;
+    compare: false;
+    saved_views: false;
+  };
+  caveats: string[];
+};
+
+type WorldSection = "overview" | "simulations";
+
+export function SupercellsWorld({
+  onBackToWorlds,
+  onExploreSimulation,
+}: {
+  onBackToWorlds: () => void;
+  onExploreSimulation: (simulation: SupercellSimulation) => void;
+}) {
+  const [section, setSection] = useState<WorldSection>("overview");
+  const [world, setWorld] = useState<SupercellsWorldDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadWorld = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/worlds/supercells");
+      if (!response.ok) {
+        throw new Error(await responseMessage(response, "Supercells is unavailable."));
+      }
+      setWorld(validateSupercellsWorld(await response.json()));
+    } catch (caught) {
+      setWorld(null);
+      setError(caught instanceof Error ? caught.message : "Supercells is unavailable.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadWorld();
+  }, [loadWorld]);
+
+  if (loading) {
+    return (
+      <section className="world-shell" aria-label="Supercells World">
+        <WorldBreadcrumb onBackToWorlds={onBackToWorlds} />
+        <section className="status-panel" role="status">
+          Loading Supercells...
+        </section>
+      </section>
+    );
+  }
+
+  if (!world) {
+    return (
+      <section className="world-shell" aria-label="Supercells World">
+        <WorldBreadcrumb onBackToWorlds={onBackToWorlds} />
+        <section className="world-load-failure" aria-label="Supercells unavailable">
+          <div>
+            <h2>Supercells could not be loaded</h2>
+            <p role="alert">{error}</p>
+            <p>Other Cloud Worlds remain available.</p>
+          </div>
+          <button type="button" onClick={() => void loadWorld()}>
+            Retry Supercells
+          </button>
+        </section>
+      </section>
+    );
+  }
+
+  const simulation = world.reference_simulation;
+  return (
+    <section className="world-shell" aria-label="Supercells World">
+      <WorldBreadcrumb onBackToWorlds={onBackToWorlds} />
+      <header className="world-header">
+        <div>
+          <h2>{world.display_name}</h2>
+          <p>{world.short_description}</p>
+        </div>
+      </header>
+
+      <nav className="world-section-nav" aria-label="Supercells sections">
+        {(["overview", "simulations"] as WorldSection[]).map((item) => (
+          <button
+            key={item}
+            type="button"
+            className={section === item ? "active-control" : ""}
+            onClick={() => setSection(item)}
+          >
+            {item === "overview" ? "Overview" : "Simulations"}
+          </button>
+        ))}
+      </nav>
+
+      <section className="world-section" aria-labelledby={`supercells-${section}-title`}>
+        <div className="world-section-heading">
+          <div>
+            <p className="eyebrow">{section === "overview" ? "Overview" : "Simulations"}</p>
+            <h3 id={`supercells-${section}-title`}>
+              {section === "overview"
+                ? "Enter the rotating storm"
+                : "Retained Supercell Simulations"}
+            </h3>
+          </div>
+          {section === "simulations" && (
+            <p>{simulation.explore_available ? "1 inspectable" : "0 inspectable"}</p>
+          )}
+        </div>
+        {world.availability_state !== "available" && (
+          <p className="world-availability-message">{world.availability_message}</p>
+        )}
+        <div className="simulation-card-grid supercells-simulation-grid">
+          <SupercellSimulationCard simulation={simulation} onExplore={onExploreSimulation} />
+        </div>
+        {section === "overview" && <p className="world-science-note">{world.caveats[0]}</p>}
+      </section>
+    </section>
+  );
+}
+
+function SupercellSimulationCard({
+  simulation,
+  onExplore,
+}: {
+  simulation: SupercellSimulation;
+  onExplore: (simulation: SupercellSimulation) => void;
+}) {
+  return (
+    <article className="simulation-card supercell-simulation-card">
+      <div className="simulation-card-heading">
+        <div>
+          <p className="eyebrow">Reference Simulation</p>
+          <h3>{simulation.display_name}</h3>
+        </div>
+        {simulation.technical_state !== "available" && (
+          <span className={`world-availability ${simulation.technical_state}`}>
+            {simulation.technical_state === "missing" ? "Output unavailable" : "Output invalid"}
+          </span>
+        )}
+      </div>
+      <p>
+        Follow organized ascent and rotation, liquid and ice, precipitation, and low-level flow
+        through an idealized CM1 supercell.
+      </p>
+      {simulation.explore_available ? (
+        <dl className="simulation-card-facts">
+          <div>
+            <dt>Saved outputs</dt>
+            <dd>{simulation.saved_output_count}</dd>
+          </div>
+          <div>
+            <dt>Model time</dt>
+            <dd>{formatDuration(simulation.model_end_seconds)}</dd>
+          </div>
+          <div>
+            <dt>Cadence</dt>
+            <dd>{formatDuration(simulation.history_cadence_seconds)}</dd>
+          </div>
+        </dl>
+      ) : (
+        <p className="world-availability-message">{simulation.technical_state_message}</p>
+      )}
+      <div className="button-row">
+        <button
+          type="button"
+          disabled={!simulation.explore_available}
+          onClick={() => onExplore(simulation)}
+        >
+          Explore
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function WorldBreadcrumb({ onBackToWorlds }: { onBackToWorlds: () => void }) {
+  return (
+    <nav className="world-breadcrumb" aria-label="Breadcrumb">
+      <button type="button" onClick={onBackToWorlds}>
+        Cloud Worlds
+      </button>
+      <span aria-hidden="true">/</span>
+      <span>Supercells</span>
+    </nav>
+  );
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds === null) return "Unavailable";
+  if (seconds >= 3_600 && seconds % 3_600 === 0) return `${seconds / 3_600} hr`;
+  if (seconds >= 60 && seconds % 60 === 0) return `${seconds / 60} min`;
+  return `${seconds.toLocaleString()} s`;
+}
+
+function validateSupercellsWorld(payload: unknown): SupercellsWorldDetail {
+  if (
+    !isRecord(payload) ||
+    payload.world_id !== "supercells" ||
+    !Array.isArray(payload.simulations)
+  ) {
+    throw new Error("Supercells response does not match the required World contract.");
+  }
+  const reference = payload.reference_simulation;
+  if (
+    !isRecord(reference) ||
+    reference.simulation_id !== "supercells_quarter_circle_reference" ||
+    reference.display_name !== "Quarter-Circle Supercell"
+  ) {
+    throw new Error("Supercells reference Simulation identity is invalid.");
+  }
+  return payload as SupercellsWorldDetail;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function responseMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await response.json()) as { detail?: unknown };
+    return typeof payload.detail === "string" ? payload.detail : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -58,6 +58,30 @@ type PointCloudResponse = {
   caveats: string[];
 };
 
+export type StormSceneLayer = {
+  key: string;
+  display_name: string;
+  units: string;
+  rendering: "neutral_cloud" | "signed_scalar" | "scalar" | "categorical";
+  points: Array<[number, number, number, number, number]>;
+  default_opacity: number;
+  default_point_size: number;
+  scale: {
+    minimum: number;
+    maximum: number;
+    breakpoints: number[];
+    colors: string[];
+  } | null;
+  categories: Array<{ code: number; color: string }>;
+};
+
+export type StormScenePayload = {
+  coordinate_extents_km: Record<"x" | "y" | "z", { min: number; max: number }>;
+  layers: StormSceneLayer[];
+};
+
+export type StormScenePoint = [number, number, number, number, number];
+
 type SliceResponse = {
   field: VisualizableField;
   selection: {
@@ -108,6 +132,13 @@ type True3DViewerProps = {
   compactDisplayControls?: ReactNode;
   maximized?: boolean;
   onToggleMaximize?: () => void;
+  stormScene?: StormScenePayload | null;
+  visibleStormLayerKeys?: string[];
+  stormOpacity?: number;
+  stormPointSize?: number;
+  compactAxisLabels?: boolean;
+  selectedPointCoordinates?: { x: number; y: number; z: number } | null;
+  onSelectStormPoint?: (point: StormScenePoint) => void;
 };
 
 type SceneRefs = {
@@ -178,22 +209,34 @@ export function True3DViewer({
   compactDisplayControls,
   maximized = false,
   onToggleMaximize,
+  stormScene = null,
+  visibleStormLayerKeys = [],
+  stormOpacity = 1,
+  stormPointSize = 1,
+  compactAxisLabels = false,
+  selectedPointCoordinates = null,
+  onSelectStormPoint,
 }: True3DViewerProps) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const axisLabelLayerRef = useRef<HTMLDivElement | null>(null);
   const refs = useRef<SceneRefs | null>(null);
   const axisOcclusionRef = useRef({ frame: updraftLensFrame, opacity: updraftLensOpacity });
+  const stormSelectionRef = useRef(onSelectStormPoint);
   axisOcclusionRef.current = { frame: updraftLensFrame, opacity: updraftLensOpacity };
+  stormSelectionRef.current = onSelectStormPoint;
   const [renderError, setRenderError] = useState<string | null>(null);
   const [cameraStatus, setCameraStatus] = useState("Camera ready");
   const [tallViewport, setTallViewport] = useState(false);
 
-  const boundsKey = boundsSignature(pointCloud);
+  const boundsKey = boundsSignature(pointCloud, stormScene);
   const bounds = useMemo(() => sceneBoundsFromSignature(boundsKey), [boundsKey]);
-  const axisLabels = useMemo(() => axisLabelDefinitions(bounds), [bounds]);
+  const axisLabels = useMemo(
+    () => axisLabelDefinitions(bounds, compactAxisLabels),
+    [bounds, compactAxisLabels],
+  );
   const selectedPoint = useMemo(
-    () => selectedRegionPoint(selectedRegion, coordinateSizes, bounds),
-    [bounds, coordinateSizes, selectedRegion],
+    () => selectedPointCoordinates ?? selectedRegionPoint(selectedRegion, coordinateSizes, bounds),
+    [bounds, coordinateSizes, selectedPointCoordinates, selectedRegion],
   );
 
   const resetCamera = useCallback(() => {
@@ -273,6 +316,21 @@ export function True3DViewer({
       };
       applyCameraPreset("overview", { camera, controls }, bounds);
 
+      let pointerDown: { x: number; y: number } | null = null;
+      const handlePointerDown = (event: PointerEvent) => {
+        pointerDown = { x: event.clientX, y: event.clientY };
+      };
+      const handlePointerUp = (event: PointerEvent) => {
+        if (!pointerDown || !stormSelectionRef.current) return;
+        const movement = Math.hypot(event.clientX - pointerDown.x, event.clientY - pointerDown.y);
+        pointerDown = null;
+        if (movement > 4) return;
+        const point = selectedStormScenePoint(event, renderer.domElement, camera, scene, bounds);
+        if (point) stormSelectionRef.current(point);
+      };
+      renderer.domElement.addEventListener("pointerdown", handlePointerDown);
+      renderer.domElement.addEventListener("pointerup", handlePointerUp);
+
       const resize = () => {
         if (!mounted) return;
         const width = Math.max(1, mount.clientWidth);
@@ -322,6 +380,8 @@ export function True3DViewer({
         window.cancelAnimationFrame(current.animationFrame);
         current.resizeObserver?.disconnect();
         current.controls.dispose();
+        current.renderer.domElement.removeEventListener("pointerdown", handlePointerDown);
+        current.renderer.domElement.removeEventListener("pointerup", handlePointerUp);
         disposeScene(current.scene);
         current.renderer.dispose();
         current.renderer.domElement.remove();
@@ -353,6 +413,10 @@ export function True3DViewer({
       updraftLensFrame,
       updraftLensOpacity,
       showUpdraftLensBoundary,
+      stormScene,
+      visibleStormLayerKeys,
+      stormOpacity,
+      stormPointSize,
     });
   }, [
     activeSlice,
@@ -370,6 +434,10 @@ export function True3DViewer({
     updraftLensFrame,
     updraftLensOpacity,
     showUpdraftLensBoundary,
+    stormScene,
+    visibleStormLayerKeys,
+    stormOpacity,
+    stormPointSize,
   ]);
 
   return (
@@ -495,13 +563,14 @@ export function True3DViewer({
             Three.js renderer unavailable: {renderError}
           </p>
         )}
-        {(!pointCloud || pointCloud.points.length === 0) && (
-          <div className="true3d-empty-state">
-            <p className="eyebrow">3-D scalar layer</p>
-            <h4>{noCloudMessage}</h4>
-            <p>The domain and slice plane remain visible so the result does not look broken.</p>
-          </div>
-        )}
+        {(!pointCloud || pointCloud.points.length === 0) &&
+          (!stormScene || visibleStormLayerKeys.length === 0) && (
+            <div className="true3d-empty-state">
+              <p className="eyebrow">3-D scalar layer</p>
+              <h4>{noCloudMessage}</h4>
+              <p>The domain and slice plane remain visible so the result does not look broken.</p>
+            </div>
+          )}
       </div>
 
       {compactWorkspace ? (
@@ -625,6 +694,10 @@ function rebuildScene(
     updraftLensFrame,
     updraftLensOpacity,
     showUpdraftLensBoundary,
+    stormScene,
+    visibleStormLayerKeys,
+    stormOpacity,
+    stormPointSize,
   }: {
     bounds: SceneBounds;
     pointCloud: PointCloudResponse | null;
@@ -641,6 +714,10 @@ function rebuildScene(
     updraftLensFrame: UpdraftLensFrame | null;
     updraftLensOpacity: number;
     showUpdraftLensBoundary: boolean;
+    stormScene: StormScenePayload | null;
+    visibleStormLayerKeys: string[];
+    stormOpacity: number;
+    stormPointSize: number;
   },
 ) {
   disposeScene(scene);
@@ -656,6 +733,14 @@ function rebuildScene(
 
   if (pointCloud?.points.length) {
     scene.add(cloudPointLayer(pointCloud, bounds, opacity, pointSize, Boolean(updraftLensFrame)));
+  }
+
+  if (stormScene) {
+    for (const layer of stormScene.layers) {
+      if (visibleStormLayerKeys.includes(layer.key) && layer.points.length > 0) {
+        scene.add(stormPointLayer(layer, bounds, stormOpacity, stormPointSize));
+      }
+    }
   }
 
   if (showWindVectors && windVectors.length) {
@@ -791,11 +876,15 @@ function horizontalWindLayer(
   return group;
 }
 
-function boundsSignature(pointCloud: PointCloudResponse | null): string {
+function boundsSignature(
+  pointCloud: PointCloudResponse | null,
+  stormScene: StormScenePayload | null,
+): string {
   const extents = pointCloud?.coordinate_extents;
-  const x = extents?.xh ?? extents?.x ?? DEFAULT_BOUNDS.x;
-  const y = extents?.yh ?? extents?.y ?? DEFAULT_BOUNDS.y;
-  const z = extents?.zh ?? extents?.z ?? DEFAULT_BOUNDS.z;
+  const stormExtents = stormScene?.coordinate_extents_km;
+  const x = extents?.xh ?? extents?.x ?? extentWithUnits(stormExtents?.x) ?? DEFAULT_BOUNDS.x;
+  const y = extents?.yh ?? extents?.y ?? extentWithUnits(stormExtents?.y) ?? DEFAULT_BOUNDS.y;
+  const z = extents?.zh ?? extents?.z ?? extentWithUnits(stormExtents?.z) ?? DEFAULT_BOUNDS.z;
   return [
     x.min,
     x.max,
@@ -807,6 +896,12 @@ function boundsSignature(pointCloud: PointCloudResponse | null): string {
     z.max,
     z.units ?? "",
   ].join("|");
+}
+
+function extentWithUnits(
+  extent: { min: number; max: number } | undefined,
+): CoordinateExtent | null {
+  return extent ? { ...extent, units: "km" } : null;
 }
 
 function sceneBoundsFromSignature(signature: string): SceneBounds {
@@ -937,7 +1032,7 @@ function axisTickMarks(bounds: SceneBounds): THREE.Group {
   return group;
 }
 
-function axisLabelDefinitions(bounds: SceneBounds): AxisLabel[] {
+function axisLabelDefinitions(bounds: SceneBounds, compact: boolean): AxisLabel[] {
   const labelOffset = Math.max(0.18, bounds.maxRange * 0.035);
   const floor = -bounds.zRange / 2;
   const xMin = -bounds.xRange / 2;
@@ -958,7 +1053,7 @@ function axisLabelDefinitions(bounds: SceneBounds): AxisLabel[] {
       position: new THREE.Vector3(xMin - labelOffset, floor, centeredCoordinate(value, bounds.y)),
     });
   }
-  for (const value of majorTickValues(bounds.z)) {
+  for (const value of compact ? representativeTickValues(bounds.z) : majorTickValues(bounds.z)) {
     labels.push({
       axis: "z",
       text: `z ${formatSignedCoordinate(value, bounds.z.units)}`,
@@ -966,6 +1061,33 @@ function axisLabelDefinitions(bounds: SceneBounds): AxisLabel[] {
     });
   }
   return labels;
+}
+
+function representativeTickValues(extent: CoordinateExtent): number[] {
+  const midpoint = (extent.min + extent.max) / 2;
+  return [...new Set([extent.min, midpoint, extent.max].map(roundTick))];
+}
+
+function selectedStormScenePoint(
+  event: PointerEvent,
+  canvas: HTMLCanvasElement,
+  camera: THREE.Camera,
+  scene: THREE.Scene,
+  bounds: SceneBounds,
+): StormScenePoint | null {
+  const rect = canvas.getBoundingClientRect();
+  const pointer = new THREE.Vector2(
+    ((event.clientX - rect.left) / rect.width) * 2 - 1,
+    -((event.clientY - rect.top) / rect.height) * 2 + 1,
+  );
+  const raycaster = new THREE.Raycaster();
+  raycaster.params.Points = { threshold: bounds.maxRange * 0.018 };
+  raycaster.setFromCamera(pointer, camera);
+  for (const intersection of raycaster.intersectObjects(scene.children, true)) {
+    const points = intersection.object.userData.stormPoints as StormScenePoint[] | undefined;
+    if (points && intersection.index !== undefined) return points[intersection.index] ?? null;
+  }
+  return null;
 }
 
 function positionAxisLabels(
@@ -1086,6 +1208,73 @@ function cloudPointLayer(
   layer.name = "CM1 scalar point cloud";
   layer.renderOrder = 20;
   return layer;
+}
+
+function stormPointLayer(
+  layer: StormSceneLayer,
+  bounds: SceneBounds,
+  opacityMultiplier: number,
+  pointSizeMultiplier: number,
+): THREE.Points {
+  const positions = new Float32Array(layer.points.length * 3);
+  const colors = new Float32Array(layer.points.length * 3);
+  layer.points.forEach((point, index) => {
+    const mapped = mapCoordinate(point[0], point[1], point[2], bounds);
+    positions[index * 3] = mapped.x;
+    positions[index * 3 + 1] = mapped.y;
+    positions[index * 3 + 2] = mapped.z;
+    const color = stormPointColor(layer, point[3], point[4]);
+    colors[index * 3] = color.r;
+    colors[index * 3 + 1] = color.g;
+    colors[index * 3 + 2] = color.b;
+  });
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+  const material = new THREE.PointsMaterial({
+    size: scalarPointPixelSize(layer.default_point_size * pointSizeMultiplier),
+    vertexColors: true,
+    transparent: true,
+    opacity: Math.min(1, Math.max(0.05, layer.default_opacity * opacityMultiplier)),
+    depthWrite: layer.rendering !== "neutral_cloud",
+    sizeAttenuation: false,
+  });
+  const points = new THREE.Points(geometry, material);
+  points.name = `Supercells ${layer.display_name}`;
+  points.userData.stormPoints = layer.points;
+  points.renderOrder = layer.rendering === "neutral_cloud" ? 12 : 22;
+  return points;
+}
+
+function stormPointColor(layer: StormSceneLayer, value: number, categoryCode: number): THREE.Color {
+  if (layer.rendering === "neutral_cloud") {
+    const intensity = normalize(value, layer.scale?.minimum ?? 0, layer.scale?.maximum ?? 16);
+    return new THREE.Color().setRGB(
+      0.72 + intensity * 0.2,
+      0.84 + intensity * 0.13,
+      0.88 + intensity * 0.11,
+    );
+  }
+  if (layer.rendering === "categorical") {
+    const category = layer.categories.find((item) => item.code === categoryCode);
+    return new THREE.Color(category?.color ?? "#ffffff");
+  }
+  const scale = layer.scale;
+  if (!scale || scale.colors.length === 0) return new THREE.Color("#5d7f91");
+  if (layer.rendering === "signed_scalar" || scale.breakpoints.length === scale.colors.length - 1) {
+    const interval = scale.breakpoints.findIndex((breakpoint) => value < breakpoint);
+    const colorIndex = interval === -1 ? scale.colors.length - 1 : interval;
+    return new THREE.Color(scale.colors[Math.min(colorIndex, scale.colors.length - 1)]);
+  }
+  const normalized = normalize(value, scale.minimum, scale.maximum);
+  const scaled = normalized * Math.max(1, scale.colors.length - 1);
+  const lowerIndex = Math.min(scale.colors.length - 1, Math.floor(scaled));
+  const upperIndex = Math.min(scale.colors.length - 1, lowerIndex + 1);
+  return new THREE.Color(scale.colors[lowerIndex]).lerp(
+    new THREE.Color(scale.colors[upperIndex]),
+    scaled - lowerIndex,
+  );
 }
 
 function scalarPointColor(

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -130,6 +130,7 @@ type True3DViewerProps = {
   showUpdraftLensLegend?: boolean;
   compactWorkspace?: boolean;
   compactDisplayControls?: ReactNode;
+  compactDisplayLabel?: string;
   maximized?: boolean;
   onToggleMaximize?: () => void;
   stormScene?: StormScenePayload | null;
@@ -139,6 +140,8 @@ type True3DViewerProps = {
   compactAxisLabels?: boolean;
   selectedPointCoordinates?: { x: number; y: number; z: number } | null;
   onSelectStormPoint?: (point: StormScenePoint) => void;
+  cameraPreset?: CameraPreset;
+  onCameraPresetChange?: (preset: CameraPreset) => void;
 };
 
 type SceneRefs = {
@@ -160,7 +163,12 @@ type SceneBounds = {
   maxRange: number;
 };
 
-type CameraPreset = "overview" | "top_down_xy" | "look_along_x" | "look_along_y";
+export type CameraPreset =
+  | "overview"
+  | "top_down_xy"
+  | "look_along_x"
+  | "look_along_y"
+  | "low_level";
 
 type AxisLabel = {
   axis: "x" | "y" | "z";
@@ -207,6 +215,7 @@ export function True3DViewer({
   showUpdraftLensLegend = true,
   compactWorkspace = false,
   compactDisplayControls,
+  compactDisplayLabel = "Display",
   maximized = false,
   onToggleMaximize,
   stormScene = null,
@@ -216,16 +225,22 @@ export function True3DViewer({
   compactAxisLabels = false,
   selectedPointCoordinates = null,
   onSelectStormPoint,
+  cameraPreset = "overview",
+  onCameraPresetChange,
 }: True3DViewerProps) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const axisLabelLayerRef = useRef<HTMLDivElement | null>(null);
   const refs = useRef<SceneRefs | null>(null);
   const axisOcclusionRef = useRef({ frame: updraftLensFrame, opacity: updraftLensOpacity });
   const stormSelectionRef = useRef(onSelectStormPoint);
+  const cameraPresetRef = useRef(cameraPreset);
   axisOcclusionRef.current = { frame: updraftLensFrame, opacity: updraftLensOpacity };
   stormSelectionRef.current = onSelectStormPoint;
+  cameraPresetRef.current = cameraPreset;
   const [renderError, setRenderError] = useState<string | null>(null);
   const [cameraStatus, setCameraStatus] = useState("Camera ready");
+  const [selectedCameraPreset, setSelectedCameraPreset] =
+    useState<CameraPreset>(cameraPreset);
   const [tallViewport, setTallViewport] = useState(false);
 
   const boundsKey = boundsSignature(pointCloud, stormScene);
@@ -240,16 +255,28 @@ export function True3DViewer({
   );
 
   const resetCamera = useCallback(() => {
-    applyCameraPreset("overview", refs.current, bounds);
-    setCameraStatus("Camera reset to overview");
-  }, [bounds]);
+    applyCameraPreset(
+      selectedCameraPreset,
+      refs.current,
+      bounds,
+      cameraDistanceScale(selectedCameraPreset, maximized),
+    );
+    setCameraStatus(`${cameraPresetStatus(selectedCameraPreset)} (reset)`);
+  }, [bounds, maximized, selectedCameraPreset]);
 
   const setCameraPreset = useCallback(
     (preset: CameraPreset) => {
-      applyCameraPreset(preset, refs.current, bounds);
+      setSelectedCameraPreset(preset);
+      applyCameraPreset(
+        preset,
+        refs.current,
+        bounds,
+        cameraDistanceScale(preset, maximized),
+      );
       setCameraStatus(cameraPresetStatus(preset));
+      onCameraPresetChange?.(preset);
     },
-    [bounds],
+    [bounds, maximized, onCameraPresetChange],
   );
 
   const zoomCamera = useCallback((direction: "in" | "out") => {
@@ -314,7 +341,7 @@ export function True3DViewer({
         MIDDLE: THREE.MOUSE.DOLLY,
         RIGHT: THREE.MOUSE.PAN,
       };
-      applyCameraPreset("overview", { camera, controls }, bounds);
+      applyCameraPreset(cameraPresetRef.current, { camera, controls }, bounds);
 
       let pointerDown: { x: number; y: number } | null = null;
       const handlePointerDown = (event: PointerEvent) => {
@@ -393,6 +420,17 @@ export function True3DViewer({
       return undefined;
     }
   }, [axisLabels, bounds]);
+
+  useEffect(() => {
+    setSelectedCameraPreset(cameraPreset);
+    applyCameraPreset(
+      cameraPreset,
+      refs.current,
+      bounds,
+      cameraDistanceScale(cameraPreset, maximized),
+    );
+    setCameraStatus(cameraPresetStatus(cameraPreset));
+  }, [bounds, cameraPreset, maximized]);
 
   useEffect(() => {
     const current = refs.current;
@@ -578,7 +616,7 @@ export function True3DViewer({
           {compactDisplayControls && (
             <details className="true3d-display-control">
               <summary>
-                <span>Display</span>
+                <span>{compactDisplayLabel}</span>
               </summary>
               <div className="true3d-display-panel">{compactDisplayControls}</div>
             </details>
@@ -587,13 +625,14 @@ export function True3DViewer({
             <span className="sr-only">Camera view</span>
             <select
               aria-label="Camera view"
-              defaultValue="overview"
+              value={selectedCameraPreset}
               onChange={(event) => setCameraPreset(event.target.value as CameraPreset)}
             >
               <option value="overview">Overview</option>
               <option value="top_down_xy">Top-down x-y</option>
               <option value="look_along_x">Look along x</option>
               <option value="look_along_y">Look along y</option>
+              <option value="low_level">Low-level</option>
             </select>
           </label>
           <button
@@ -1441,9 +1480,11 @@ function applyCameraPreset(
   preset: CameraPreset,
   refs: Pick<SceneRefs, "camera" | "controls"> | null,
   bounds: SceneBounds,
+  distanceScale = 1,
 ) {
   if (!refs) return;
-  const distance = Math.max(bounds.xRange, bounds.yRange, bounds.zRange) * 1.65;
+  const distance =
+    Math.max(bounds.xRange, bounds.yRange, bounds.zRange) * 1.65 * distanceScale;
   if (preset === "top_down_xy") {
     refs.camera.position.set(0, distance, 0.001);
     refs.camera.up.set(0, 0, -1);
@@ -1453,6 +1494,22 @@ function applyCameraPreset(
   } else if (preset === "look_along_y") {
     refs.camera.position.set(0, bounds.zRange * 0.22, distance);
     refs.camera.up.set(0, 1, 0);
+  } else if (preset === "low_level") {
+    const lowTarget = centeredCoordinate(
+      Math.min(bounds.z.max, bounds.z.min + 1.0),
+      bounds.z,
+    );
+    const xTarget = 0;
+    const yTarget = bounds.yRange * 0.18;
+    refs.camera.position.set(
+      xTarget + bounds.xRange * 0.18,
+      lowTarget + bounds.maxRange * 0.72,
+      yTarget + bounds.yRange * 0.42,
+    );
+    refs.camera.up.set(0, 1, 0);
+    refs.controls.target.set(xTarget, lowTarget, yTarget);
+    refs.controls.update();
+    return;
   } else {
     refs.camera.position.set(bounds.xRange * 0.85, bounds.zRange * 0.8, bounds.yRange * 1.18);
     refs.camera.up.set(0, 1, 0);
@@ -1461,12 +1518,19 @@ function applyCameraPreset(
   refs.controls.update();
 }
 
+function cameraDistanceScale(preset: CameraPreset, maximized: boolean): number {
+  if (!maximized || preset === "low_level") return 1;
+  if (preset === "top_down_xy") return 0.78;
+  return 0.62;
+}
+
 function cameraPresetStatus(preset: CameraPreset): string {
   const labels: Record<CameraPreset, string> = {
     overview: "Camera set to overview",
     top_down_xy: "Camera set to top-down x-y view",
     look_along_x: "Camera looking along the x axis",
     look_along_y: "Camera looking along the y axis",
+    low_level: "Camera focused on the low-level storm",
   };
   return labels[preset];
 }


### PR DESCRIPTION
Closes #423

## Outcome

Adds **Supercells** as Cloud Chamber's third Cloud World with stable identities:

- World: `supercells`
- Reference Simulation: `supercells_quarter_circle_reference`
- Display name: **Quarter-Circle Supercell**
- Backing artifact: Gate B retained run `quarter-circle-supercell-official-20260722T142521Z` (`cm1_r21_1_quarter_circle_supercell_official_v0`)

The accepted #421 presentation run is not yet the accepted backing artifact, so the stable Simulation identity resolves through one backend update point rather than a frontend run ID.

## Integrated Explore contract

- A bounded multi-layer Three.js scene remains coordinated with one active Horizontal x-y, Vertical x-z, or Vertical y-z slice.
- Lens, viewport, saved output, native-grid selection, fixed scales, overlays, and selected vertical plane stay synchronized.
- Storm region and Full domain derive physical bounds from retained coordinates and use server-side crop/downsample/point budgets.
- Timeline exposes all nine retained outputs from 0-120 minutes with stepping, playback, scrubbing, speed, bounded caching, and adjacent-frame prefetch.
- 3-D and 2-D failures are local and retryable; neither destroys the remaining workspace.
- All three Lenses use a large scientific plot with a compact horizontal legend below it.
- Horizontal x-y plots retain a 1:1 native domain; the retained vertical sections preserve their approximately 2.95:1 native horizontal/vertical domain in side-by-side and expanded views.
- Context uses an attached right-sidebar control beside maximize. Maximizing closes Context, the control can reopen it, and collapsing Context removes the column rather than leaving a white strip.
- Desktop review covered 1024x856, 1440x900, and 1920x1080. At 1440 with Context open, space is apportioned approximately 40% scene / 36% slice / 23% Context.

## Lens defaults

- **Rotating Updraft** (default): neutral condensate cloud body, signed vertical motion, cyclonic vertical vorticity in rising air, and the 2-5 km updraft-helicity footprint; reflectivity is optional and off by default.
- **Cloud and Precipitation**: dominant native-cell qc/qr/qi/qs/qg category with condensate-mass intensity and visible red-rising / blue-descending vertical-motion contours; reflectivity is optional and off by default. Species filters preserve the exact **hail-treated large ice** label.
- **Low-Level Interactions**: neutral cloud body, 1.25 km signed-motion plane, accumulated surface rain, and thinned native model-relative flow; reflectivity and precipitating condensate are optional and off by default.

The Context inspector uses Explain, Science, Notes, and Details tabs. Native selection reports exact species values and coordinates rather than treating category markers as literal particles or threshold contours as storm-object boundaries.

## Fixed Supercell scales

- `supercell_midlevel_vertical_velocity_v1`: -30 to +30 m/s
- `supercell_low_level_vertical_velocity_v1`: -15 to +15 m/s
- `supercell_full_depth_vertical_velocity_v1`: -65 to +65 m/s
- `supercell_reflectivity_v1`: -10 to 70 dBZ
- `supercell_accumulated_rain_v1`: 0 to 90 mm
- `supercell_total_condensate_v1`: 0 to 16 g/kg
- `supercell_vertical_vorticity_v1`: -0.035 to +0.035 s^-1
- `supercell_updraft_helicity_v1`: -800 to +800 m^2/s^2

## Performance

Representative Rotating Updraft frame 6, measured through the production endpoint:

| Viewport | HTTP | Serialized payload | Endpoint time |
|---|---:|---:|---:|
| Storm region | 200 | 972,773 bytes | 0.222 s |
| Full domain | 200 | 1,428,787 bytes | 0.340 s |

The payload contains bounded display primitives, not complete native 3-D volumes. Ordinary frame access opens only the selected retained history while stable inventory metadata remains cached by artifact fingerprint.

## Visual review inventory

- `/Users/timpeterson/CloudChamber/review/issue-423/19-rotating-side-by-side-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/20-rotating-expanded-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/21-cloud-precip-side-by-side-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/22-cloud-precip-expanded-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/23-low-level-side-by-side-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/24-low-level-expanded-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/25-vertical-xz-side-by-side-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/26-vertical-xz-expanded-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/27-expanded-context-open-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/28-context-collapsed-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/29-1024x856-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/30-1920x1080-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/31-vertical-yz-wide-final.png`
- `/Users/timpeterson/CloudChamber/review/issue-423/32-3d-pixel-check-final.png`

Live review covered all three Lenses in side-by-side and expanded views, both viewports, all three slice orientations, native selection in 2-D and 3-D, playback, camera/reset, maximize/restore, Context collapse/reopen, and local WebGL/evidence failures. The final browser console had no warnings or errors. The 3-D pixel sample contained 54,789 distinct colors with substantial channel variance, confirming a nonblank render.

## Verification

- `git diff --check`
- Focused backend: 23 passed
- Focused frontend: 9 passed after the final interaction changes
- Targeted mocked Playwright: 3 passed, including native-aspect assertions, Context state, 1024x856, and forced WebGL failure
- `scripts/check.sh` at final head `729663ee`:
  - frontend lint passed
  - 150 frontend tests passed
  - production build passed
  - backend formatting, Ruff, and mypy passed
  - 644 backend tests passed
  - script syntax, forbidden-artifact, and docs/JSON/YAML checks passed

Known existing warnings: Vite's bundle-size advisory and one NumPy ABI warning in the ingest test.

## Changed files

- `app/backend/cloud_chamber/app.py`
- `app/backend/cloud_chamber/cloud_worlds.py`
- `app/backend/cloud_chamber/storm_examination.py`
- `app/backend/cloud_chamber/supercells_world.py`
- `app/backend/tests/test_cloud_worlds.py`
- `app/backend/tests/test_storm_examination.py`
- `app/backend/tests/test_supercells_world.py`
- `app/frontend/e2e/mocked-smoke/supercells.spec.ts`
- `app/frontend/src/App.tsx`
- `app/frontend/src/CloudWorldsHome.test.tsx`
- `app/frontend/src/CloudWorldsHome.tsx`
- `app/frontend/src/IntegratedExploreWorkspace.test.tsx`
- `app/frontend/src/IntegratedExploreWorkspace.tsx`
- `app/frontend/src/StormExaminationResearch.css`
- `app/frontend/src/StormExaminationResearch.test.tsx`
- `app/frontend/src/StormExaminationResearch.tsx`
- `app/frontend/src/SupercellsExplore.css`
- `app/frontend/src/SupercellsExplore.test.tsx`
- `app/frontend/src/SupercellsExplore.tsx`
- `app/frontend/src/SupercellsWorld.test.tsx`
- `app/frontend/src/SupercellsWorld.tsx`
- `app/frontend/src/True3DViewer.tsx`

## Scope and review posture

No CM1 process was started. This contains no Lab, Recipe, variation, Compare, Saved Views, Fort Worth, cold-pool diagnosis, tornado/hazard workflow, Squall Line work, or generic visualization framework. Auto-merge remains disabled; this draft requires manual PM review.
