### PR TITLE
Add Supercells slice and camera navigation

### DIFF
--- a/app/backend/cloud_chamber/storm_examination.py
+++ b/app/backend/cloud_chamber/storm_examination.py
@@ -208,6 +208,8 @@ class VolumeWindVector(BaseModel):
 class StormVolumeScene(BaseModel):
     coordinate_extents_km: dict[str, dict[str, float]]
     coordinate_sizes: dict[str, int]
+    coordinate_indices: dict[str, list[int]]
+    coordinate_values_km: dict[str, list[float]]
     layers: list[VolumeLayer]
     wind_vectors: list[VolumeWindVector] = Field(default_factory=list)
     wind_reference_m_s: float
@@ -441,7 +443,7 @@ def _storm_frame(
     if purpose == "product" and viewport == "full":
         x_indices = x_indices[::2]
         y_indices = y_indices[::2]
-    plan = _plan_view(lens, fields, x_km, y_km, z_km, default_level, x_indices, y_indices)
+    plan = _plan_view(lens, fields, x_km, y_km, z_km, selected_z, x_indices, y_indices)
     xz_section = _vertical_section(
         lens,
         "xz",
@@ -491,6 +493,8 @@ def _storm_frame(
             z_km,
             x_indices,
             y_indices,
+            native_x_indices,
+            native_y_indices,
             default_level,
             history_path.name,
             viewport,
@@ -1307,6 +1311,8 @@ def _volume_scene(
     z_km: np.ndarray[Any, np.dtype[np.float64]],
     x_indices: np.ndarray[Any, np.dtype[np.int64]],
     y_indices: np.ndarray[Any, np.dtype[np.int64]],
+    navigation_x_indices: np.ndarray[Any, np.dtype[np.int64]],
+    navigation_y_indices: np.ndarray[Any, np.dtype[np.int64]],
     level_index: int,
     history_filename: str,
     viewport: ViewportId,
@@ -1324,6 +1330,7 @@ def _volume_scene(
     budget_scale = 1.0 if viewport == "storm" else 0.62
     low_level_volume = z_km[:, np.newaxis, np.newaxis] <= 5.25
     scene_z_max = 5.25 if lens == "low_level_interactions" else float(np.max(z_km))
+    scene_z_indices = np.flatnonzero(z_km <= scene_z_max)
 
     cloud = _volume_layer(
         key="storm_cloud_body",
@@ -1635,7 +1642,17 @@ def _volume_scene(
         coordinate_sizes={
             "x": len(x_km),
             "y": len(y_km),
-            "z": int(np.count_nonzero(z_km <= scene_z_max)),
+            "z": len(scene_z_indices),
+        },
+        coordinate_indices={
+            "x": [int(value) for value in navigation_x_indices],
+            "y": [int(value) for value in navigation_y_indices],
+            "z": [int(value) for value in scene_z_indices],
+        },
+        coordinate_values_km={
+            "x": _float_list(x_km[navigation_x_indices]),
+            "y": _float_list(y_km[navigation_y_indices]),
+            "z": _float_list(z_km[scene_z_indices]),
         },
         layers=layers,
         wind_vectors=wind_vectors,

--- a/app/backend/cloud_chamber/storm_examination.py
+++ b/app/backend/cloud_chamber/storm_examination.py
@@ -495,7 +495,7 @@ def _storm_frame(
             y_indices,
             native_x_indices,
             native_y_indices,
-            default_level,
+            selected_z,
             history_path.name,
             viewport,
         )
@@ -873,7 +873,7 @@ def _plan_view(
             _condensate_scale(),
             "1000 * (qc + qr + qi + qs + qg)",
         )
-        title = "Midlevel updraft and rotation"
+        title = "Updraft and rotation"
         subtitle = "Signed vertical velocity with cyclonic vorticity and 2-5 km AGL UH"
         categories = None
         selection_z_indices = None
@@ -924,8 +924,9 @@ def _plan_view(
             _low_level_w_scale(),
         )
         title = "Low-level motion and rain footprint"
+        level_km = float(z_km[level_index])
         subtitle = (
-            "1.25 km current motion, precipitation, model-relative flow, "
+            f"{level_km:.2f} km current motion, precipitation, model-relative flow, "
             "and historical rain accumulation"
         )
         selection_z_indices = None
@@ -944,7 +945,7 @@ def _plan_view(
             ["qr", "qs", "qg"],
             precipitating,
             _condensate_scale(),
-            "1000 * (qr + qs + qg) at the displayed 1.25 km level",
+            f"1000 * (qr + qs + qg) at the displayed {level_km:.2f} km level",
         )
     return PlanView(
         title=title,
@@ -1795,7 +1796,7 @@ def _what_to_notice_by_view(
         uh_max = plan.overlays["updraft_helicity"].selected_frame_maximum
         return {
             "plan": (
-                f"At {minutes} min, {overlap} cells on the 3.25 km slice combine "
+                f"At {minutes} min, {overlap} cells on the {plan.level_km:.2f} km slice combine "
                 f"rising motion of at least 5 m/s with cyclonic vorticity of at least "
                 f"0.01 s^-1; 2-5 km AGL UH peaks at {uh_max:.0f} m^2/s^2."
             ),
@@ -1825,7 +1826,8 @@ def _what_to_notice_by_view(
     precip_max = plan.overlays["low_level_precipitating_condensate"].selected_frame_maximum
     return {
         "plan": (
-            f"At {minutes} min, current 1.25 km motion spans {w_min:+.1f} to "
+            f"At {minutes} min, current {plan.level_km:.2f} km motion spans "
+            f"{w_min:+.1f} to "
             f"{w_max:+.1f} m/s and precipitating condensate reaches "
             f"{precip_max:.2f} g/kg; the historical rain footprint peaks at "
             f"{rain_max:.1f} mm."

--- a/app/backend/tests/test_storm_examination.py
+++ b/app/backend/tests/test_storm_examination.py
@@ -373,6 +373,9 @@ def test_product_frame_exposes_native_plane_inventory_and_honors_selected_height
 
     assert frame.plan.level_index == 4
     assert frame.plan.level_km == pytest.approx(15.25)
+    assert frame.plan.title == "Updraft and rotation"
+    assert frame.what_to_notice_by_view is not None
+    assert "15.25 km slice" in frame.what_to_notice_by_view["plan"]
     assert frame.scene is not None
     assert frame.scene.coordinate_indices == {
         "x": [1, 2, 3],
@@ -411,17 +414,23 @@ def test_product_low_level_scene_identifies_model_relative_flow(tmp_path: Path) 
     _write_retained_fixture(tmp_path, presentation=True)
 
     frame = supercells_explore_frame(
-        _settings(tmp_path), lens="low_level_interactions", time_index=5, viewport="storm"
+        _settings(tmp_path),
+        lens="low_level_interactions",
+        time_index=5,
+        viewport="storm",
+        z_index=2,
     )
 
     assert frame.scene is not None
     assert frame.scene.wind_vectors
-    assert frame.scene.wind_vectors[0].z_km == pytest.approx(1.25)
+    assert frame.plan.level_km == pytest.approx(3.25)
+    assert frame.scene.wind_vectors[0].z_km == pytest.approx(frame.plan.level_km)
     assert frame.scene.coordinate_extents_km["z"]["max"] == pytest.approx(5.25)
     assert frame.scene.coordinate_sizes["z"] == 3
     assert frame.scene.coordinate_indices["z"] == [0, 1, 2]
     assert frame.scene.coordinate_values_km["z"] == pytest.approx([0.25, 1.25, 3.25])
     layers = {layer.key: layer for layer in frame.scene.layers}
+    motion = layers["low_level_vertical_motion"]
     precipitation = layers["precipitating_condensate"]
     accumulated_rain = layers["accumulated_surface_rain"]
     assert precipitation.scale is not None
@@ -431,9 +440,17 @@ def test_product_low_level_scene_identifies_model_relative_flow(tmp_path: Path) 
     assert accumulated_rain.scale.maximum == 120
     assert "through 3.25 km" in precipitation.threshold_label
     assert max(point[2] for point in precipitation.points) <= 3.25
+    assert motion.points
+    assert all(point[2] == pytest.approx(frame.plan.level_km) for point in motion.points)
     assert max(point[2] for point in layers["reflectivity"].points) <= 5.25
-    assert frame.plan.wind_vectors[0].u_m_s == pytest.approx(12)
+    assert frame.plan.wind_vectors[0].u_m_s == pytest.approx(frame.scene.wind_vectors[0].u_m_s)
+    assert frame.plan.wind_vectors[0].v_m_s == pytest.approx(frame.scene.wind_vectors[0].v_m_s)
     assert layers["precipitating_condensate"].default_visible is True
     assert frame.plan.overlays["low_level_precipitating_condensate"].units == "g/kg"
+    assert "displayed 3.25 km level" in (
+        frame.plan.overlays["low_level_precipitating_condensate"].derivation or ""
+    )
+    assert frame.what_to_notice_by_view is not None
+    assert "current 3.25 km motion" in frame.what_to_notice_by_view["plan"]
     assert frame.selected_point.coordinate_frame.startswith("translating model frame")
     assert "cold pool" in frame.caveats[-1]

--- a/app/backend/tests/test_storm_examination.py
+++ b/app/backend/tests/test_storm_examination.py
@@ -356,6 +356,34 @@ def test_product_frame_adds_bounded_volume_layers_without_changing_science_path(
     assert all(layer.returned_count <= layer.source_count for layer in layers.values())
 
 
+def test_product_frame_exposes_native_plane_inventory_and_honors_selected_height(
+    tmp_path: Path,
+) -> None:
+    _write_retained_fixture(tmp_path, presentation=True)
+
+    frame = supercells_explore_frame(
+        _settings(tmp_path),
+        lens="rotating_updraft",
+        time_index=5,
+        viewport="storm",
+        x_index=2,
+        y_index=1,
+        z_index=4,
+    )
+
+    assert frame.plan.level_index == 4
+    assert frame.plan.level_km == pytest.approx(15.25)
+    assert frame.scene is not None
+    assert frame.scene.coordinate_indices == {
+        "x": [1, 2, 3],
+        "y": [1, 2, 3],
+        "z": [0, 1, 2, 3, 4],
+    }
+    assert frame.scene.coordinate_values_km["x"] == pytest.approx([-30, 0, 30])
+    assert frame.scene.coordinate_values_km["y"] == pytest.approx([-30, 0, 30])
+    assert frame.scene.coordinate_values_km["z"] == pytest.approx([0.25, 1.25, 3.25, 10.25, 15.25])
+
+
 def test_product_hydrometeor_scene_keeps_exact_large_ice_label(tmp_path: Path) -> None:
     _write_retained_fixture(tmp_path, presentation=True)
 
@@ -366,6 +394,8 @@ def test_product_hydrometeor_scene_keeps_exact_large_ice_label(tmp_path: Path) -
     assert frame.scene is not None
     assert frame.plan.x_indices == [0, 2, 4]
     assert frame.plan.y_indices == [0, 2, 4]
+    assert frame.scene.coordinate_indices["x"] == [0, 1, 2, 3, 4]
+    assert frame.scene.coordinate_indices["y"] == [0, 1, 2, 3, 4]
     assert frame.provenance["full_domain_level_of_detail"] == "every_other_native_x_y_cell"
     category_layer = next(
         layer for layer in frame.scene.layers if layer.key == "hydrometeor_categories"
@@ -389,6 +419,8 @@ def test_product_low_level_scene_identifies_model_relative_flow(tmp_path: Path) 
     assert frame.scene.wind_vectors[0].z_km == pytest.approx(1.25)
     assert frame.scene.coordinate_extents_km["z"]["max"] == pytest.approx(5.25)
     assert frame.scene.coordinate_sizes["z"] == 3
+    assert frame.scene.coordinate_indices["z"] == [0, 1, 2]
+    assert frame.scene.coordinate_values_km["z"] == pytest.approx([0.25, 1.25, 3.25])
     layers = {layer.key: layer for layer in frame.scene.layers}
     precipitation = layers["precipitating_condensate"]
     accumulated_rain = layers["accumulated_surface_rain"]

--- a/app/frontend/e2e/mocked-smoke/supercells.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/supercells.spec.ts
@@ -17,6 +17,7 @@ const simulation = {
   model_start_seconds: 0,
   model_end_seconds: 7_200,
   history_cadence_seconds: 900,
+  default_explore_time_index: 5,
   lineage_state: "known",
 };
 
@@ -72,17 +73,35 @@ test.describe("mocked smoke: Supercells product path", () => {
     const planBox = await page.getByLabel("Midlevel storm structure plan view").boundingBox();
     expect((planBox?.width ?? 0) / (planBox?.height ?? 1)).toBeCloseTo(1, 1);
 
+    await expect(page.getByLabel("Horizontal x-y z position")).toHaveValue("1");
+    await expect(page.getByText("z 3.00 km")).toBeVisible();
+    await expect(page.getByText("native index 1")).toBeVisible();
+    await page.getByLabel("Horizontal x-y z position").fill("0");
+    await expect(page.getByLabel("Horizontal x-y z position")).toHaveValue("0");
+    await expect(page.getByText("z 0.50 km")).toBeVisible();
+    await expect(page.getByText("native index 0")).toBeVisible();
+    await expect(page.getByText(/Slice: Midlevel storm structure · z = 0.50 km/)).toBeVisible();
+
+    for (const command of ["Zoom in", "Zoom out", "Pan view up", "Pan view down"]) {
+      await expect(page.getByRole("button", { name: command })).toBeVisible();
+    }
+    await page.getByRole("button", { name: "Zoom in" }).click();
+    await expect(page.locator('.true3d-controls-compact [aria-live="polite"]')).toHaveText(
+      "Camera zoomed in",
+    );
     await expect(page.getByLabel("Camera view")).toHaveValue("look_along_y");
     await page.getByLabel("Camera view").selectOption("top_down_xy");
+    const rotatingCameraPosition = await page
+      .getByLabel("True 3-D scalar field viewer")
+      .getAttribute("data-camera-position");
+    expect(rotatingCameraPosition).toBeTruthy();
     await page.getByRole("button", { name: "Cloud and Precipitation" }).click();
     await expect(page.getByRole("button", { name: "Cloud and Precipitation" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
     await expect(
-      page
-        .getByLabel("Slice orientation")
-        .getByRole("button", { name: "Vertical x-z" }),
+      page.getByLabel("Slice orientation").getByRole("button", { name: "Vertical x-z" }),
     ).toHaveAttribute("aria-pressed", "true");
     await expect(page.getByLabel("Camera view")).toHaveValue("look_along_y");
     await page.locator(".true3d-display-control > summary").click();
@@ -100,6 +119,10 @@ test.describe("mocked smoke: Supercells product path", () => {
 
     await page.getByRole("button", { name: "Rotating Updraft" }).click();
     await expect(page.getByLabel("Camera view")).toHaveValue("top_down_xy");
+    await expect(page.getByLabel("True 3-D scalar field viewer")).toHaveAttribute(
+      "data-camera-position",
+      rotatingCameraPosition ?? "",
+    );
     await page.getByRole("button", { name: "Low-Level Interactions" }).click();
 
     await page
@@ -112,9 +135,11 @@ test.describe("mocked smoke: Supercells product path", () => {
     await expect(page.getByText("Slice: xz section at y = 10.0 km")).toBeVisible();
     await expect(page.getByLabel("xz section at y = 10.0 km")).toBeVisible();
     const sectionBox = await page.getByLabel("xz section at y = 10.0 km").boundingBox();
-    const sectionAspect = await page.locator(".storm-section-plot").evaluate((element) =>
-      Number(getComputedStyle(element).getPropertyValue("--storm-data-aspect")),
-    );
+    const sectionAspect = await page
+      .locator(".storm-section-plot")
+      .evaluate((element) =>
+        Number(getComputedStyle(element).getPropertyValue("--storm-data-aspect")),
+      );
     expect((sectionBox?.width ?? 0) / (sectionBox?.height ?? 1)).toBeCloseTo(sectionAspect, 1);
 
     await page.getByLabel("xz section at y = 10.0 km").click({ position: { x: 180, y: 120 } });
@@ -133,9 +158,10 @@ test.describe("mocked smoke: Supercells product path", () => {
     await expect(page.getByRole("button", { name: "Open Context" })).toBeVisible();
     await expect(page.getByLabel("Explore inspector")).toHaveCount(0);
     const maximizedSectionBox = await page.getByLabel("xz section at y = 10.0 km").boundingBox();
-    expect(
-      (maximizedSectionBox?.width ?? 0) / (maximizedSectionBox?.height ?? 1),
-    ).toBeCloseTo(sectionAspect, 1);
+    expect((maximizedSectionBox?.width ?? 0) / (maximizedSectionBox?.height ?? 1)).toBeCloseTo(
+      sectionAspect,
+      1,
+    );
     await page.getByRole("button", { name: "Open Context" }).click();
     await expect(page.getByLabel("Explore inspector")).toBeVisible();
     await page.getByRole("button", { name: "Restore evidence" }).click();
@@ -147,6 +173,8 @@ test.describe("mocked smoke: Supercells product path", () => {
 
     await page.getByRole("button", { name: "Maximize 3-D viewer" }).click();
     await expect(page.getByRole("button", { name: "Restore 3-D viewer" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Zoom in" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Pan view down" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Low-Level Interactions" })).toHaveAttribute(
       "aria-pressed",
       "true",
@@ -318,7 +346,7 @@ function supercellsFrame(url: string) {
       w_m_s: 48,
     },
     selected_point: selectedPoint(xIndex, yIndex, zIndex, x, y, z, times[timeIndex]),
-    plan: plan(typedLens, x, y),
+    plan: plan(typedLens, x, y, zIndex, z),
     xz_section: section("xz", "x", y[yIndex] ?? 10),
     yz_section: section("yz", "y", x[xIndex] ?? 0),
     scene: scene(typedLens, viewport),
@@ -403,7 +431,7 @@ function field(key = "winterp", displayName = "Vertical velocity") {
   };
 }
 
-function plan(lens: string, x: number[], y: number[]) {
+function plan(lens: string, x: number[], y: number[], zIndex: number, z: number[]) {
   return {
     title: lens === "cloud_precipitation" ? "Hydrometeor plan" : "Midlevel storm structure",
     subtitle: "Native-grid plan evidence",
@@ -411,8 +439,8 @@ function plan(lens: string, x: number[], y: number[]) {
     y_indices: [0, 1, 2],
     x_km: x,
     y_km: y,
-    level_index: 1,
-    level_km: 3,
+    level_index: zIndex,
+    level_km: z[zIndex] ?? 3,
     selection_z_indices:
       lens === "cloud_precipitation"
         ? [
@@ -508,18 +536,11 @@ function scene(lens: string, viewport: string) {
   });
   const layers =
     lens === "cloud_precipitation"
-      ? [
-          layer("hydrometeor_categories", "Dominant hydrometeor", "categorical", true, null),
-        ]
+      ? [layer("hydrometeor_categories", "Dominant hydrometeor", "categorical", true, null)]
       : lens === "low_level_interactions"
         ? [
             layer("storm_cloud_body", "Storm cloud body", "neutral_cloud", false, null),
-            layer(
-              "precipitating_condensate",
-              "Low-level precipitating condensate",
-              "scalar",
-              true,
-            ),
+            layer("precipitating_condensate", "Low-level precipitating condensate", "scalar", true),
             layer("low_level_vertical_motion", "Low-level vertical motion", "signed_scalar", true),
             layer("accumulated_surface_rain", "Accumulated rain", "scalar", true),
           ]
@@ -537,6 +558,8 @@ function scene(lens: string, viewport: string) {
       z: { min: 0.25, max: lens === "low_level_interactions" ? 5.25 : 19.75 },
     },
     coordinate_sizes: { x: 120, y: 120, z: 40 },
+    coordinate_indices: { x: [0, 1, 2], y: [0, 1, 2], z: [0, 1, 2] },
+    coordinate_values_km: { x: [-10, 0, 10], y: [-10, 10, 20], z: [0.5, 3, 8] },
     layers,
     wind_vectors: [{ x_km: 0, y_km: 10, z_km: 1.25, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
     wind_reference_m_s: 25,

--- a/app/frontend/e2e/mocked-smoke/supercells.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/supercells.spec.ts
@@ -62,7 +62,7 @@ test.describe("mocked smoke: Supercells product path", () => {
       "true",
     );
     await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible();
-    await expect(page.getByLabel("Midlevel storm structure plan view")).toBeVisible();
+    await expect(page.getByLabel("Updraft and rotation plan view")).toBeVisible();
     await expect(page.getByText("frame 6 of 9 · Organized mature storm")).toBeVisible();
     const sceneBox = await page.getByLabel("3-D storm scene").boundingBox();
     const evidenceBox = await page.getByLabel("Coordinated storm evidence").boundingBox();
@@ -70,7 +70,7 @@ test.describe("mocked smoke: Supercells product path", () => {
     expect(sceneBox?.width ?? 0).toBeLessThan((evidenceBox?.width ?? 1) * 1.7);
     expect(evidenceBox?.width ?? 0).toBeGreaterThan(500);
     expect(contextBox?.width ?? 0).toBeGreaterThanOrEqual(288);
-    const planBox = await page.getByLabel("Midlevel storm structure plan view").boundingBox();
+    const planBox = await page.getByLabel("Updraft and rotation plan view").boundingBox();
     expect((planBox?.width ?? 0) / (planBox?.height ?? 1)).toBeCloseTo(1, 1);
 
     await expect(page.getByLabel("Horizontal x-y z position")).toHaveValue("1");
@@ -80,7 +80,7 @@ test.describe("mocked smoke: Supercells product path", () => {
     await expect(page.getByLabel("Horizontal x-y z position")).toHaveValue("0");
     await expect(page.getByText("z 0.50 km")).toBeVisible();
     await expect(page.getByText("native index 0")).toBeVisible();
-    await expect(page.getByText(/Slice: Midlevel storm structure · z = 0.50 km/)).toBeVisible();
+    await expect(page.getByText(/Slice: Updraft and rotation · z = 0.50 km/)).toBeVisible();
 
     for (const command of ["Zoom in", "Zoom out", "Pan view up", "Pan view down"]) {
       await expect(page.getByRole("button", { name: command })).toBeVisible();
@@ -113,9 +113,13 @@ test.describe("mocked smoke: Supercells product path", () => {
       "aria-pressed",
       "true",
     );
-    await expect(page.getByLabel("Flow arrows at 1.25 km")).toBeChecked();
+    await expect(page.getByLabel("Flow arrows at z = 3.00 km")).toBeChecked();
+    await expect(page.getByText("Model-relative wind at z = 3.00 km").first()).toBeVisible();
     await expect(page.getByLabel("Accumulated rain (history)").first()).toBeChecked();
     await expect(page.getByLabel("Current precipitation")).toBeChecked();
+    await page.getByLabel("Horizontal x-y z position").fill("0");
+    await expect(page.getByLabel("Flow arrows at z = 0.50 km")).toBeChecked();
+    await expect(page.getByText("Model-relative wind at z = 0.50 km").first()).toBeVisible();
 
     await page.getByRole("button", { name: "Rotating Updraft" }).click();
     await expect(page.getByLabel("Camera view")).toHaveValue("top_down_xy");
@@ -130,7 +134,7 @@ test.describe("mocked smoke: Supercells product path", () => {
       .getByRole("button", { name: "Vertical x-z" })
       .click();
     await expect(page.getByLabel("Accumulated rain (history)")).toHaveCount(0);
-    await expect(page.getByLabel("Flow arrows at 1.25 km")).toHaveCount(0);
+    await expect(page.getByLabel(/Flow arrows at z =/)).toHaveCount(0);
     await expect(page.getByLabel("Current precipitation")).toBeChecked();
     await expect(page.getByText("Slice: xz section at y = 10.0 km")).toBeVisible();
     await expect(page.getByLabel("xz section at y = 10.0 km")).toBeVisible();
@@ -195,7 +199,7 @@ test.describe("mocked smoke: Supercells product path", () => {
 
     await gotoSupercellsExplore(page);
     await expect(page.getByText(/Three\.js renderer unavailable/)).toBeVisible();
-    await expect(page.getByLabel("Midlevel storm structure plan view")).toBeVisible();
+    await expect(page.getByLabel("Updraft and rotation plan view")).toBeVisible();
     await expect(page.getByRole("tab", { name: "Explain" })).toBeVisible();
     await expect(page.getByLabel("Saved output time")).toBeEnabled();
   });
@@ -214,7 +218,7 @@ test.describe("mocked smoke: Supercells product path", () => {
     expect(documentWidth).toBe(1024);
     expect(documentHeight).toBeLessThanOrEqual(856);
     await expect(page.getByRole("heading", { name: "Horizontal x-y slice" })).toBeVisible();
-    const compactPlan = await page.getByLabel("Midlevel storm structure plan view").boundingBox();
+    const compactPlan = await page.getByLabel("Updraft and rotation plan view").boundingBox();
     expect((compactPlan?.width ?? 0) / (compactPlan?.height ?? 1)).toBeCloseTo(1, 1);
     await expect(page.getByRole("button", { name: "Maximize evidence" })).toBeInViewport();
     await expect(page.getByRole("button", { name: "Previous saved output" })).toBeInViewport();
@@ -349,7 +353,7 @@ function supercellsFrame(url: string) {
     plan: plan(typedLens, x, y, zIndex, z),
     xz_section: section("xz", "x", y[yIndex] ?? 10),
     yz_section: section("yz", "y", x[xIndex] ?? 0),
-    scene: scene(typedLens, viewport),
+    scene: scene(typedLens, viewport, z[zIndex] ?? 3),
     caveats: ["Saved histories are 15 minutes apart."],
     provenance: { source_history_file: `cm1out_${String(timeIndex + 1).padStart(6, "0")}.nc` },
     extraction_milliseconds: 80,
@@ -433,7 +437,12 @@ function field(key = "winterp", displayName = "Vertical velocity") {
 
 function plan(lens: string, x: number[], y: number[], zIndex: number, z: number[]) {
   return {
-    title: lens === "cloud_precipitation" ? "Hydrometeor plan" : "Midlevel storm structure",
+    title:
+      lens === "cloud_precipitation"
+        ? "Hydrometeor plan"
+        : lens === "low_level_interactions"
+          ? "Low-level motion and rain footprint"
+          : "Updraft and rotation",
     subtitle: "Native-grid plan evidence",
     x_indices: [0, 1, 2],
     y_indices: [0, 1, 2],
@@ -488,7 +497,7 @@ function section(orientation: "xz" | "yz", horizontal: "x" | "y", coordinate: nu
   };
 }
 
-function scene(lens: string, viewport: string) {
+function scene(lens: string, viewport: string, selectedLevelKm: number) {
   const extent = viewport === "storm" ? 30 : 60;
   const points = Array.from({ length: 75 }, (_, index) => {
     const angle = (index / 75) * Math.PI * 2;
@@ -561,7 +570,16 @@ function scene(lens: string, viewport: string) {
     coordinate_indices: { x: [0, 1, 2], y: [0, 1, 2], z: [0, 1, 2] },
     coordinate_values_km: { x: [-10, 0, 10], y: [-10, 10, 20], z: [0.5, 3, 8] },
     layers,
-    wind_vectors: [{ x_km: 0, y_km: 10, z_km: 1.25, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
+    wind_vectors: [
+      {
+        x_km: 0,
+        y_km: 10,
+        z_km: selectedLevelKm,
+        u_m_s: 12,
+        v_m_s: 5,
+        magnitude_m_s: 13,
+      },
+    ],
     wind_reference_m_s: 25,
     point_budget: 20_000,
     source_history_file: "cm1out_000006.nc",

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { CloudWorldsHome } from "./CloudWorldsHome";
 import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
 import { MountainWavesExplore } from "./MountainWavesExplore";
 import { type MountainWavesSimulation, MountainWavesWorld } from "./MountainWavesWorld";
+import { NativeSlicePositionControl } from "./NativeSlicePositionControl";
 import { SupercellsExplore } from "./SupercellsExplore";
 import { type SupercellSimulation, SupercellsWorld } from "./SupercellsWorld";
 import {
@@ -10937,64 +10938,23 @@ export function VisualizerSceneShell({
                       </button>
                     </div>
 
-                    <label htmlFor="updraft-lens-plane-position">
-                      Position
-                      <input
-                        id="updraft-lens-plane-position"
-                        aria-label="Updraft Lens slice position"
-                        type="range"
-                        min={0}
-                        max={Math.max(0, activeSliceMax - 1)}
-                        value={activeSliceIndex}
-                        onChange={(event) => {
-                          const nextIndex = Number(event.target.value);
-                          if (activeSlicePlane === "horizontal") {
-                            setHorizontalSliceLevel(nextIndex);
-                          } else {
-                            setVerticalSliceIndex(nextIndex);
-                          }
-                          setSelectedRegion(null);
-                        }}
-                      />
-                      <span className="slice-position-label">
-                        <span>{updraftLensPlaneLabel}</span>
-                        <small>index {activeSliceIndex}</small>
-                      </span>
-                    </label>
-
-                    <div className="button-row slice-move-buttons">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const nextIndex = Math.max(0, activeSliceIndex - 1);
-                          if (activeSlicePlane === "horizontal") {
-                            setHorizontalSliceLevel(nextIndex);
-                          } else {
-                            setVerticalSliceIndex(nextIndex);
-                          }
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const nextIndex = Math.min(
-                            Math.max(0, activeSliceMax - 1),
-                            activeSliceIndex + 1,
-                          );
-                          if (activeSlicePlane === "horizontal") {
-                            setHorizontalSliceLevel(nextIndex);
-                          } else {
-                            setVerticalSliceIndex(nextIndex);
-                          }
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
-                      </button>
-                    </div>
+                    <NativeSlicePositionControl
+                      id="updraft-lens-plane-position"
+                      ariaLabel="Updraft Lens slice position"
+                      plane={activeSlicePlane}
+                      positionIndex={activeSliceIndex}
+                      positionCount={activeSliceMax}
+                      positionLabel={updraftLensPlaneLabel}
+                      indexLabel={`index ${activeSliceIndex}`}
+                      onPositionChange={(nextIndex) => {
+                        if (activeSlicePlane === "horizontal") {
+                          setHorizontalSliceLevel(nextIndex);
+                        } else {
+                          setVerticalSliceIndex(nextIndex);
+                        }
+                        setSelectedRegion(null);
+                      }}
+                    />
 
                     <label className="checkbox-label" htmlFor="updraft-lens-cloud-boundary">
                       <input
@@ -11114,64 +11074,23 @@ export function VisualizerSceneShell({
                       </button>
                     </div>
 
-                    <label htmlFor="explore-slice-position">
-                      Position
-                      <input
-                        id="explore-slice-position"
-                        aria-label="Slice position"
-                        type="range"
-                        min={0}
-                        max={Math.max(0, activeSliceMax - 1)}
-                        value={activeSliceIndex}
-                        onChange={(event) => {
-                          const nextIndex = Number(event.target.value);
-                          if (activeSlicePlane === "horizontal") {
-                            setHorizontalSliceLevel(nextIndex);
-                          } else {
-                            setVerticalSliceIndex(nextIndex);
-                          }
-                          setSelectedRegion(null);
-                        }}
-                      />
-                      <span className="slice-position-label">
-                        {activeSlicePositionLabel || `index ${activeSliceIndex}`}{" "}
-                        <small>index {activeSliceIndex}</small>
-                      </span>
-                    </label>
-
-                    <div className="button-row slice-move-buttons">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const nextIndex = Math.max(0, activeSliceIndex - 1);
-                          if (activeSlicePlane === "horizontal") {
-                            setHorizontalSliceLevel(nextIndex);
-                          } else {
-                            setVerticalSliceIndex(nextIndex);
-                          }
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        {activeSlicePlane === "horizontal" ? "Move down" : "Move back"}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const nextIndex = Math.min(
-                            Math.max(0, activeSliceMax - 1),
-                            activeSliceIndex + 1,
-                          );
-                          if (activeSlicePlane === "horizontal") {
-                            setHorizontalSliceLevel(nextIndex);
-                          } else {
-                            setVerticalSliceIndex(nextIndex);
-                          }
-                          setSelectedRegion(null);
-                        }}
-                      >
-                        {activeSlicePlane === "horizontal" ? "Move up" : "Move forward"}
-                      </button>
-                    </div>
+                    <NativeSlicePositionControl
+                      id="explore-slice-position"
+                      ariaLabel="Slice position"
+                      plane={activeSlicePlane}
+                      positionIndex={activeSliceIndex}
+                      positionCount={activeSliceMax}
+                      positionLabel={activeSlicePositionLabel || `index ${activeSliceIndex}`}
+                      indexLabel={`index ${activeSliceIndex}`}
+                      onPositionChange={(nextIndex) => {
+                        if (activeSlicePlane === "horizontal") {
+                          setHorizontalSliceLevel(nextIndex);
+                        } else {
+                          setVerticalSliceIndex(nextIndex);
+                        }
+                        setSelectedRegion(null);
+                      }}
+                    />
 
                     <label className="checkbox-label" htmlFor="show-slice-plane">
                       <input

--- a/app/frontend/src/NativeSlicePositionControl.tsx
+++ b/app/frontend/src/NativeSlicePositionControl.tsx
@@ -1,0 +1,83 @@
+export type NativeSlicePlane = "horizontal" | "vertical_x" | "vertical_y";
+
+export function NativeSlicePositionControl({
+  id,
+  ariaLabel,
+  plane,
+  positionIndex,
+  positionCount,
+  positionLabel,
+  indexLabel,
+  onPositionChange,
+  onReset,
+  resetLabel = "Reset position",
+  compact = false,
+}: {
+  id: string;
+  ariaLabel: string;
+  plane: NativeSlicePlane;
+  positionIndex: number;
+  positionCount: number;
+  positionLabel: string;
+  indexLabel: string;
+  onPositionChange: (positionIndex: number) => void;
+  onReset?: () => void;
+  resetLabel?: string;
+  compact?: boolean;
+}) {
+  const lastPosition = Math.max(0, positionCount - 1);
+  const clampedPosition = Math.min(lastPosition, Math.max(0, positionIndex));
+  const [previousLabel, nextLabel] =
+    plane === "horizontal" ? ["Move down", "Move up"] : ["Move back", "Move forward"];
+
+  function move(offset: number) {
+    onPositionChange(Math.min(lastPosition, Math.max(0, clampedPosition + offset)));
+  }
+
+  return (
+    <>
+      <label
+        className={`native-slice-position-range${
+          compact ? " native-slice-position-range-compact" : ""
+        }`}
+        htmlFor={id}
+      >
+        <span className={compact ? "sr-only" : ""}>Position</span>
+        <input
+          id={id}
+          aria-label={ariaLabel}
+          type="range"
+          min={0}
+          max={lastPosition}
+          step={1}
+          value={clampedPosition}
+          disabled={positionCount <= 1}
+          onChange={(event) => onPositionChange(Number(event.currentTarget.value))}
+        />
+        <span className="slice-position-label">
+          <span>{positionLabel}</span>
+          <small>{indexLabel}</small>
+        </span>
+      </label>
+      <div className="button-row slice-move-buttons">
+        <button type="button" disabled={clampedPosition === 0} onClick={() => move(-1)}>
+          {previousLabel}
+        </button>
+        <button type="button" disabled={clampedPosition === lastPosition} onClick={() => move(1)}>
+          {nextLabel}
+        </button>
+        {onReset && (
+          <button
+            type="button"
+            className={compact ? "native-slice-position-reset" : ""}
+            aria-label={resetLabel}
+            title={resetLabel}
+            onClick={onReset}
+          >
+            {compact ? <span aria-hidden="true">{"\u21ba"}</span> : resetLabel}
+          </button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/frontend/src/StormExaminationResearch.test.tsx
+++ b/app/frontend/src/StormExaminationResearch.test.tsx
@@ -141,7 +141,7 @@ const frame: StormExaminationFrame = {
     distance_to_primary_updraft_km: 0,
   },
   plan: {
-    title: "Midlevel updraft and rotation",
+    title: "Updraft and rotation",
     subtitle: "Signed vertical velocity with rotation",
     x_indices: [0, 1],
     y_indices: [0, 1],
@@ -342,7 +342,7 @@ describe("StormExaminationResearch", () => {
     render(<StormExaminationResearch />);
     await screen.findByRole("heading", { name: "Rotating Updraft" });
 
-    fireEvent.click(screen.getByLabelText("Midlevel updraft and rotation plan view"), {
+    fireEvent.click(screen.getByLabelText("Updraft and rotation plan view"), {
       clientX: 250,
       clientY: 150,
       offsetX: 250,

--- a/app/frontend/src/StormExaminationResearch.tsx
+++ b/app/frontend/src/StormExaminationResearch.tsx
@@ -128,6 +128,8 @@ export type VolumeLayer = {
 export type StormVolumeScene = {
   coordinate_extents_km: Record<"x" | "y" | "z", { min: number; max: number }>;
   coordinate_sizes: Record<"x" | "y" | "z", number>;
+  coordinate_indices: Record<"x" | "y" | "z", number[]>;
+  coordinate_values_km: Record<"x" | "y" | "z", number[]>;
   layers: VolumeLayer[];
   wind_vectors: Array<{
     x_km: number;
@@ -650,8 +652,7 @@ export function StormPlanPlot({
       xIndex: frame.plan.x_indices[localXIndex],
       yIndex: frame.plan.y_indices[localYIndex],
       zIndex:
-        frame.plan.selection_z_indices?.[localYIndex]?.[localXIndex] ??
-        frame.plan.level_index,
+        frame.plan.selection_z_indices?.[localYIndex]?.[localXIndex] ?? frame.plan.level_index,
     });
   }
 
@@ -1020,14 +1021,7 @@ function drawPlan(
   if (frame.lens_id === "rotating_updraft") {
     const totalCondensate = frame.plan.overlays.total_condensate;
     if (overlays.condensate && totalCondensate) {
-      drawThresholdOutline(
-        context,
-        geometry,
-        totalCondensate,
-        0.05,
-        "#2f7280",
-        1.15,
-      );
+      drawThresholdOutline(context, geometry, totalCondensate, 0.05, "#2f7280", 1.15);
     }
     if (overlays.rotation) {
       drawThresholdOutline(
@@ -1076,21 +1070,8 @@ function drawPlan(
   } else {
     const currentPrecipitation = frame.plan.overlays.low_level_precipitating_condensate;
     if (overlays.precipitatingCondensate && currentPrecipitation) {
-      drawTransparentRaster(
-        context,
-        geometry,
-        currentPrecipitation,
-        "#7b572a",
-        0.2,
-      );
-      drawThresholdOutline(
-        context,
-        geometry,
-        currentPrecipitation,
-        0.1,
-        "#7b572a",
-        1.5,
-      );
+      drawTransparentRaster(context, geometry, currentPrecipitation, "#7b572a", 0.2);
+      drawThresholdOutline(context, geometry, currentPrecipitation, 0.1, "#7b572a", 1.5);
     }
     if (overlays.rain) {
       drawTransparentRaster(
@@ -1151,14 +1132,7 @@ function drawSection(
     drawRaster(context, geometry, section.primary);
     const verticalVorticity = section.overlays.vertical_vorticity;
     if (overlays.rotation && frame.lens_id === "rotating_updraft" && verticalVorticity) {
-      drawThresholdOutline(
-        context,
-        geometry,
-        verticalVorticity,
-        0.01,
-        "#632b73",
-        1.8,
-      );
+      drawThresholdOutline(context, geometry, verticalVorticity, 0.01, "#632b73", 1.8);
     }
     if (overlays.condensate && frame.lens_id === "rotating_updraft") {
       drawThresholdOutline(

--- a/app/frontend/src/StormExaminationResearch.tsx
+++ b/app/frontend/src/StormExaminationResearch.tsx
@@ -789,7 +789,12 @@ export function StormLegend({
         <small className="storm-legend-note">
           Derived category; native species retained in Context.
         </small>
-        <OverlayKey lens={frame.lens_id} overlays={overlays} evidenceView={evidenceView} />
+        <OverlayKey
+          lens={frame.lens_id}
+          overlays={overlays}
+          evidenceView={evidenceView}
+          planLevelKm={frame.plan.level_km}
+        />
       </aside>
     );
   }
@@ -815,7 +820,12 @@ export function StormLegend({
         <span>Frame max {formatSigned(evidence.primary.selected_frame_maximum)}</span>
         <span>Frame min {formatSigned(evidence.primary.selected_frame_minimum)}</span>
       </div>
-      <OverlayKey lens={frame.lens_id} overlays={overlays} evidenceView={evidenceView} />
+      <OverlayKey
+        lens={frame.lens_id}
+        overlays={overlays}
+        evidenceView={evidenceView}
+        planLevelKm={frame.plan.level_km}
+      />
     </aside>
   );
 }
@@ -824,10 +834,12 @@ function OverlayKey({
   lens,
   overlays,
   evidenceView,
+  planLevelKm,
 }: {
   lens: LensId;
   overlays?: OverlayState;
   evidenceView: "plan" | "xz" | "yz";
+  planLevelKm: number;
 }) {
   const items: Array<[string, string]> = [];
   if (lens === "rotating_updraft") {
@@ -849,7 +861,7 @@ function OverlayKey({
     }
     if (overlays?.reflectivity) items.push(["brown", "Reflectivity >= 35 dBZ"]);
     if (evidenceView === "plan" && overlays?.wind) {
-      items.push(["arrow", "Model-relative flow at 1.25 km"]);
+      items.push(["arrow", `Model-relative flow at z = ${planLevelKm.toFixed(2)} km`]);
     }
   }
   if (!items.length) return null;

--- a/app/frontend/src/SupercellsExplore.css
+++ b/app/frontend/src/SupercellsExplore.css
@@ -398,7 +398,7 @@
 
 .supercells-control-deck {
   display: grid;
-  grid-template-columns: auto auto minmax(0, 1fr);
+  grid-template-columns: auto auto minmax(20rem, 0.9fr) minmax(0, 1fr);
   gap: 0.7rem;
   align-items: center;
   min-width: 0;
@@ -438,6 +438,61 @@
 .supercells-overlay-controls {
   flex-wrap: wrap;
   justify-content: flex-end;
+}
+
+.supercells-control-deck .supercells-slice-position {
+  display: grid;
+  grid-template-columns: minmax(17rem, 1fr) auto;
+  gap: 0.42rem;
+}
+
+.supercells-slice-position p {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.64rem;
+  line-height: 1.25;
+}
+
+.supercells-slice-position .native-slice-position-range {
+  display: grid;
+  grid-template-columns: auto minmax(7rem, 1fr) auto;
+  gap: 0.42rem;
+  align-items: center;
+  min-width: 0;
+  color: var(--color-text-primary);
+  font-weight: 750;
+}
+
+.supercells-slice-position .native-slice-position-range-compact {
+  grid-template-columns: minmax(7rem, 1fr) auto;
+}
+
+.supercells-slice-position .native-slice-position-range input {
+  width: 100%;
+  min-width: 0;
+}
+
+.supercells-slice-position .slice-position-label {
+  white-space: nowrap;
+}
+
+.supercells-slice-position .slice-move-buttons {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.2rem;
+  align-items: center;
+}
+
+.supercells-control-deck .native-slice-position-reset {
+  display: grid;
+  width: 1.9rem;
+  min-width: 1.9rem;
+  height: 1.9rem;
+  min-height: 1.9rem;
+  place-items: center;
+  padding: 0;
+  font-size: 1rem;
 }
 
 .supercells-overlay-controls label {
@@ -587,8 +642,7 @@
   grid-template-columns: minmax(0, 1fr);
 }
 
-.supercells-explore-focused-evidence
-  .supercells-workbench:not(.supercells-context-collapsed) {
+.supercells-explore-focused-evidence .supercells-workbench:not(.supercells-context-collapsed) {
   grid-template-columns: minmax(0, 1fr) minmax(18rem, 20rem);
 }
 
@@ -718,7 +772,8 @@
 
   .supercells-explore-shell {
     grid-template-rows: minmax(31rem, calc(100vh - 19rem)) auto auto;
-    padding-bottom: 8px;
+    gap: 4px;
+    padding-bottom: 0;
   }
 
   .supercells-workbench,
@@ -987,7 +1042,7 @@
   }
 
   .supercells-control-deck {
-    grid-template-columns: repeat(2, auto);
+    grid-template-columns: repeat(2, auto) minmax(17rem, 1fr);
   }
 
   .supercells-overlay-controls {

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -22,6 +22,7 @@ vi.mock("./True3DViewer", () => ({
     cameraPreset,
     cameraTransform,
     onCameraTransformChange,
+    windOverlayLabel,
   }: {
     fieldLabel: string;
     activeSliceLabel: string;
@@ -40,12 +41,14 @@ vi.mock("./True3DViewer", () => ({
       target: [number, number, number];
       up: [number, number, number];
     }) => void;
+    windOverlayLabel?: string;
   }) => (
     <section aria-label="Mock 3-D storm scene">
       <h2>{fieldLabel}</h2>
       <p>{activeSliceLabel}</p>
       <p>Camera: {cameraPreset}</p>
       <p>Camera position: {cameraTransform?.position.join(",") ?? "default"}</p>
+      {windOverlayLabel && <p>{windOverlayLabel}</p>}
       <button
         type="button"
         onClick={() =>
@@ -370,7 +373,7 @@ function frameFor(url: string): StormExaminationFrame {
       distance_to_primary_updraft_km: 0,
     },
     plan: {
-      title: lens === "cloud_precipitation" ? "Hydrometeor plan" : "Midlevel storm structure",
+      title: lens === "cloud_precipitation" ? "Hydrometeor plan" : "Updraft and rotation",
       subtitle: "Native-grid plan evidence",
       x_indices: [0, 1, 2],
       y_indices: [0, 1, 2],
@@ -420,7 +423,16 @@ function frameFor(url: string): StormExaminationFrame {
       layers: sceneLayers(lens),
       wind_vectors:
         lens === "low_level_interactions"
-          ? [{ x_km: 0, y_km: 10, z_km: 1.25, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }]
+          ? [
+              {
+                x_km: 0,
+                y_km: 10,
+                z_km: zCoordinates[zIndex] ?? 3,
+                u_m_s: 12,
+                v_m_s: 5,
+                magnitude_m_s: 13,
+              },
+            ]
           : [],
       wind_reference_m_s: 25,
       point_budget: 20_000,
@@ -586,6 +598,61 @@ describe("SupercellsExplore", () => {
         expect.anything(),
       ),
     );
+  });
+
+  it("keeps rapid cross-axis slice changes in one local native selection", async () => {
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    await screen.findByRole("heading", { name: "Rotating Updraft" });
+
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (/x_index=1&y_index=1&z_index=2/.test(url)) {
+        return new Promise<Response>(() => {});
+      }
+      return Promise.resolve(ok(frameFor(url)));
+    });
+
+    fireEvent.change(screen.getByLabelText("Horizontal x-y z position"), {
+      target: { value: "2" },
+    });
+    fireEvent.click(
+      within(screen.getByLabelText("Slice orientation")).getByRole("button", {
+        name: "Vertical x-z",
+      }),
+    );
+    fireEvent.change(screen.getByLabelText("Vertical x-z y position"), {
+      target: { value: "0" },
+    });
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/x_index=1&y_index=0&z_index=2/),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("uses the selected Low-Level altitude in 2-D and 3-D labels", async () => {
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    await screen.findByRole("heading", { name: "Rotating Updraft" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Low-Level Interactions" }));
+    await screen.findByRole("heading", { name: "Low-Level Interactions" });
+    fireEvent.change(screen.getByLabelText("Horizontal x-y z position"), {
+      target: { value: "2" },
+    });
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/lens=low_level_interactions.*z_index=2/),
+        expect.anything(),
+      ),
+    );
+    expect(
+      await screen.findAllByText("Model-relative wind at z = 8.00 km"),
+    ).not.toHaveLength(0);
+    expect(screen.getByText(/x-y slice at z = 8.00 km coordinate current motion/)).toBeVisible();
+    expect(screen.getByText("Model-relative flow at z = 8.00 km")).toBeVisible();
   });
 
   it("keeps a user-framed camera transform per Lens across ordinary workspace changes", async () => {

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -20,6 +20,8 @@ vi.mock("./True3DViewer", () => ({
     onSelectStormPoint,
     compactDisplayControls,
     cameraPreset,
+    cameraTransform,
+    onCameraTransformChange,
   }: {
     fieldLabel: string;
     activeSliceLabel: string;
@@ -28,11 +30,34 @@ vi.mock("./True3DViewer", () => ({
     onSelectStormPoint: (point: [number, number, number, number, number]) => void;
     compactDisplayControls: ReactNode;
     cameraPreset: string;
+    cameraTransform: {
+      position: [number, number, number];
+      target: [number, number, number];
+      up: [number, number, number];
+    } | null;
+    onCameraTransformChange: (transform: {
+      position: [number, number, number];
+      target: [number, number, number];
+      up: [number, number, number];
+    }) => void;
   }) => (
     <section aria-label="Mock 3-D storm scene">
       <h2>{fieldLabel}</h2>
       <p>{activeSliceLabel}</p>
       <p>Camera: {cameraPreset}</p>
+      <p>Camera position: {cameraTransform?.position.join(",") ?? "default"}</p>
+      <button
+        type="button"
+        onClick={() =>
+          onCameraTransformChange({
+            position: [4, 5, 6],
+            target: [1, 2, 3],
+            up: [0, 1, 0],
+          })
+        }
+      >
+        Move mock camera
+      </button>
       <button type="button" onClick={() => onSelectStormPoint([9.1, 19.1, 3.1, 12, 0])}>
         Select 3-D point
       </button>
@@ -351,8 +376,8 @@ function frameFor(url: string): StormExaminationFrame {
       y_indices: [0, 1, 2],
       x_km: xCoordinates,
       y_km: yCoordinates,
-      level_index: 1,
-      level_km: 3,
+      level_index: zIndex,
+      level_km: zCoordinates[zIndex] ?? 3,
       selection_z_indices:
         lens === "cloud_precipitation"
           ? [
@@ -365,11 +390,11 @@ function frameFor(url: string): StormExaminationFrame {
       overlays: {
         vertical_vorticity: field("zvort", "Vertical vorticity"),
         updraft_helicity: field("uh", "Updraft helicity"),
-      vertical_velocity: field("winterp", "Vertical velocity"),
-      composite_reflectivity: field("dbz", "Reflectivity"),
-      accumulated_surface_rain: field("rain", "Accumulated rain"),
-      total_condensate: field("total_condensate", "Total condensate"),
-      low_level_precipitating_condensate: field(
+        vertical_velocity: field("winterp", "Vertical velocity"),
+        composite_reflectivity: field("dbz", "Reflectivity"),
+        accumulated_surface_rain: field("rain", "Accumulated rain"),
+        total_condensate: field("total_condensate", "Total condensate"),
+        low_level_precipitating_condensate: field(
           "precipitating_condensate",
           "Current precipitating condensate",
         ),
@@ -386,6 +411,12 @@ function frameFor(url: string): StormExaminationFrame {
         z: { min: 0.25, max: lens === "low_level_interactions" ? 5.25 : 19.75 },
       },
       coordinate_sizes: { x: 120, y: 120, z: 40 },
+      coordinate_indices: { x: [0, 1, 2], y: [0, 1, 2], z: [0, 1, 2] },
+      coordinate_values_km: {
+        x: xCoordinates,
+        y: yCoordinates,
+        z: zCoordinates,
+      },
       layers: sceneLayers(lens),
       wind_vectors:
         lens === "low_level_interactions"
@@ -479,6 +510,107 @@ describe("SupercellsExplore", () => {
     expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent("Camera: look_along_y");
   });
 
+  it("moves each evidence orientation through native planes and keeps a user plane across time", async () => {
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    await screen.findByRole("heading", { name: "Rotating Updraft" });
+
+    const horizontalPosition = screen.getByLabelText("Horizontal x-y z position");
+    expect(horizontalPosition).toHaveValue("1");
+    expect(screen.getByText("z 3.00 km")).toBeVisible();
+    expect(screen.getByText("native index 1")).toBeVisible();
+
+    fireEvent.change(horizontalPosition, { target: { value: "0" } });
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/x_index=1&y_index=1&z_index=0/),
+        expect.anything(),
+      ),
+    );
+    expect(screen.getByLabelText("Horizontal x-y z position")).toHaveValue("0");
+    expect(await screen.findByText("z 0.50 km")).toBeVisible();
+    expect(screen.getByText("native index 0")).toBeVisible();
+
+    fireEvent.change(screen.getByLabelText("Horizontal x-y z position"), {
+      target: { value: "2" },
+    });
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/x_index=1&y_index=1&z_index=2/),
+        expect.anything(),
+      ),
+    );
+    expect(await screen.findByText("z 8.00 km")).toBeVisible();
+    expect(screen.getByText("native index 2")).toBeVisible();
+
+    const orientation = within(screen.getByLabelText("Slice orientation"));
+    fireEvent.click(orientation.getByRole("button", { name: "Vertical x-z" }));
+    expect(screen.getByLabelText("Vertical x-z y position")).toHaveValue("1");
+    fireEvent.change(screen.getByLabelText("Vertical x-z y position"), {
+      target: { value: "0" },
+    });
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/x_index=1&y_index=0&z_index=2/),
+        expect.anything(),
+      ),
+    );
+    expect(await screen.findByText("y -10.0 km")).toBeVisible();
+    expect(screen.getByText("native index 0")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next saved output" }));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/time_index=38&x_index=1&y_index=0&z_index=2/),
+        expect.anything(),
+      ),
+    );
+    expect(screen.getByLabelText("Vertical x-z y position")).toHaveValue("0");
+
+    fireEvent.click(orientation.getByRole("button", { name: "Vertical y-z" }));
+    fireEvent.change(screen.getByLabelText("Vertical y-z x position"), {
+      target: { value: "2" },
+    });
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/x_index=2&y_index=0&z_index=2/),
+        expect.anything(),
+      ),
+    );
+    expect(await screen.findByText("x 10.0 km")).toBeVisible();
+    expect(screen.getByText("native index 2")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Return slice to curated position" }));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/lens=rotating_updraft&viewport=storm&time_index=38$/),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("keeps a user-framed camera transform per Lens across ordinary workspace changes", async () => {
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    await screen.findByRole("heading", { name: "Rotating Updraft" });
+
+    expect(screen.getByText("Camera position: default")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Move mock camera" }));
+    expect(screen.getByText("Camera position: 4,5,6")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Maximize scene" }));
+    expect(screen.getByText("Camera position: 4,5,6")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Restore scene" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next saved output" }));
+    expect(screen.getByText("Camera position: 4,5,6")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cloud and Precipitation" }));
+    await screen.findByRole("heading", { name: "Cloud and Precipitation" });
+    expect(screen.getByText("Camera position: default")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Rotating Updraft" }));
+    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    expect(screen.getByText("Camera position: 4,5,6")).toBeVisible();
+  });
+
   it("keeps lens defaults, viewport, evidence orientation, and native selection synchronized", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
     await screen.findByRole("heading", { name: "Rotating Updraft" });
@@ -491,9 +623,7 @@ describe("SupercellsExplore", () => {
       ),
     );
     expect(await screen.findByRole("heading", { name: "Cloud and Precipitation" })).toBeVisible();
-    await waitFor(() =>
-      expect(screen.getByLabelText("Dominant hydrometeor")).toBeChecked(),
-    );
+    await waitFor(() => expect(screen.getByLabelText("Dominant hydrometeor")).toBeChecked());
     expect(screen.getByLabelText("Vertical-motion contours")).toBeChecked();
     expect(screen.getByText("X-z evidence at this saved output.")).toBeVisible();
     expect(
@@ -549,9 +679,24 @@ describe("SupercellsExplore", () => {
         expect.anything(),
       ),
     );
+    expect(screen.getByLabelText("Vertical y-z x position")).toHaveValue("2");
+    fireEvent.click(orientation.getByRole("button", { name: "Vertical x-z" }));
+    expect(screen.getByLabelText("Vertical x-z y position")).toHaveValue("2");
+    fireEvent.change(screen.getByLabelText("Vertical x-z y position"), {
+      target: { value: "1" },
+    });
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/x_index=2&y_index=1&z_index=1/),
+        expect.anything(),
+      ),
+    );
+    expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent(
+      "xz section at y = 10.0 km",
+    );
     fireEvent.click(screen.getByRole("tab", { name: "Science" }));
     expect(await screen.findByText("Selected point")).toBeVisible();
-    expect(screen.getByRole("heading", { name: "x 10.0, y 20.0, z 3.00 km" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "x 10.0, y 10.0, z 3.00 km" })).toBeVisible();
   });
 
   it("preserves the lens and time while maximizing and restoring either scientific view", async () => {

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
+import { NativeSlicePositionControl } from "./NativeSlicePositionControl";
 import type { SupercellSimulation } from "./SupercellsWorld";
 import {
   type LensId,
@@ -13,6 +14,7 @@ import {
   type ViewportId,
 } from "./StormExaminationResearch";
 import {
+  type CameraTransform,
   type CameraPreset,
   type StormScenePayload,
   type StormScenePoint,
@@ -24,6 +26,13 @@ import "./SupercellsExplore.css";
 
 type EvidenceView = "plan" | "xz" | "yz";
 type FocusedViewer = "scene" | "evidence" | null;
+type SliceAxis = "x" | "y" | "z";
+type SlicePositionState = {
+  axis: SliceAxis;
+  coordinatesKm: number[];
+  nativeIndices: number[];
+  positionIndex: number;
+};
 type LensPresentation = {
   viewport: ViewportId;
   evidenceView: EvidenceView;
@@ -31,6 +40,7 @@ type LensPresentation = {
   visibleLayerKeys: string[] | null;
   categoryCodes: number[];
   cameraPreset: CameraPreset;
+  cameraTransform: CameraTransform | null;
   sceneOpacity: number;
   scenePointSize: number;
   selection: Selection | null;
@@ -60,9 +70,8 @@ export function SupercellsExplore({
   const [lens, setLens] = useState<LensId>("rotating_updraft");
   const [timeIndex, setTimeIndex] = useState(simulation.default_explore_time_index);
   const [frame, setFrame] = useState<StormExaminationFrame | null>(null);
-  const [presentations, setPresentations] = useState<Record<LensId, LensPresentation>>(
-    lensPresentationDefaults,
-  );
+  const [presentations, setPresentations] =
+    useState<Record<LensId, LensPresentation>>(lensPresentationDefaults);
   const presentation = presentations[lens];
   const {
     viewport,
@@ -70,6 +79,7 @@ export function SupercellsExplore({
     overlays,
     categoryCodes,
     cameraPreset,
+    cameraTransform,
     sceneOpacity,
     scenePointSize,
     selection,
@@ -115,6 +125,7 @@ export function SupercellsExplore({
           payload,
           lens,
           viewport,
+          selection,
         );
       } catch (caught) {
         if (!signal.aborted) {
@@ -134,11 +145,7 @@ export function SupercellsExplore({
   }, [loadFrame, retryNonce]);
 
   useEffect(() => {
-    if (
-      !frame?.scene ||
-      frame.lens_id !== lens ||
-      presentations[lens].visibleLayerKeys !== null
-    )
+    if (!frame?.scene || frame.lens_id !== lens || presentations[lens].visibleLayerKeys !== null)
       return;
     const layerKeys = frame.scene.layers
       .filter((layer) => layer.default_visible)
@@ -167,6 +174,10 @@ export function SupercellsExplore({
     [evidenceView, frame],
   );
   const activeSliceLabel = frame ? evidenceLabel(frame, evidenceView) : "Evidence unavailable";
+  const slicePosition = useMemo(
+    () => (frame ? slicePositionState(frame, evidenceView, selection) : null),
+    [evidenceView, frame, selection],
+  );
   const checkpoint = frame?.timeline_checkpoints.find(
     (item) => item.time_seconds === frame.time_seconds,
   );
@@ -197,6 +208,26 @@ export function SupercellsExplore({
       yIndex: nearestCoordinateIndex(point[1], frame.plan.y_km, frame.plan.y_indices),
       zIndex: nearestCoordinateIndex(point[2], frame.xz_section.z_km),
     });
+  }
+
+  function setSlicePosition(positionIndex: number) {
+    if (!frame || !slicePosition) return;
+    const nativeIndex = slicePosition.nativeIndices[positionIndex];
+    if (nativeIndex === undefined) return;
+    const next = {
+      xIndex: frame.selected_point.x_index,
+      yIndex: frame.selected_point.y_index,
+      zIndex: frame.selected_point.z_index,
+    };
+    if (slicePosition.axis === "x") next.xIndex = nativeIndex;
+    if (slicePosition.axis === "y") next.yIndex = nativeIndex;
+    if (slicePosition.axis === "z") next.zIndex = nativeIndex;
+    selectPoint(next);
+  }
+
+  function resetSlicePosition() {
+    setPlaying(false);
+    updatePresentation({ selection: null });
   }
 
   function toggleLayer(key: string, visible: boolean) {
@@ -258,7 +289,7 @@ export function SupercellsExplore({
                 valueChannelLabel="Native and explicitly derived Supercell layers."
                 activeSlice={activeSlice}
                 activeSliceLabel={activeSliceLabel}
-                showSlicePlane={evidenceView !== "plan"}
+                showSlicePlane={evidenceView !== "plan" || frame.plan.selection_z_indices === null}
                 selectedRegion={
                   frame && selection
                     ? {
@@ -305,6 +336,8 @@ export function SupercellsExplore({
                 onSelectStormPoint={selectScenePoint}
                 cameraPreset={cameraPreset}
                 onCameraPresetChange={(next) => updatePresentation({ cameraPreset: next })}
+                cameraTransform={cameraTransform}
+                onCameraTransformChange={(next) => updatePresentation({ cameraTransform: next })}
                 compactDisplayControls={
                   <StormDisplayControls
                     frame={frame}
@@ -443,6 +476,9 @@ export function SupercellsExplore({
             updatePresentation({ viewport: next });
           }}
           onEvidenceView={(next) => updatePresentation({ evidenceView: next })}
+          slicePosition={slicePosition}
+          onSlicePosition={setSlicePosition}
+          onResetSlicePosition={resetSlicePosition}
           onOverlays={(next) => updatePresentation({ overlays: next })}
         />
 
@@ -505,9 +541,7 @@ function StormDisplayControls({
             <input
               type="checkbox"
               checked={visibleLayerKeys.includes("model_relative_wind")}
-              onChange={(event) =>
-                onLayer("model_relative_wind", event.currentTarget.checked)
-              }
+              onChange={(event) => onLayer("model_relative_wind", event.currentTarget.checked)}
             />
             Model-relative wind at 1.25 km
           </label>
@@ -569,16 +603,22 @@ function StormExploreControls({
   viewport,
   evidenceView,
   overlays,
+  slicePosition,
   onViewport,
   onEvidenceView,
+  onSlicePosition,
+  onResetSlicePosition,
   onOverlays,
 }: {
   lens: LensId;
   viewport: ViewportId;
   evidenceView: EvidenceView;
   overlays: OverlayState;
+  slicePosition: SlicePositionState | null;
   onViewport: (value: ViewportId) => void;
   onEvidenceView: (value: EvidenceView) => void;
+  onSlicePosition: (positionIndex: number) => void;
+  onResetSlicePosition: () => void;
   onOverlays: (value: OverlayState) => void;
 }) {
   const controls = overlayControls(lens, evidenceView);
@@ -624,6 +664,12 @@ function StormExploreControls({
           ))}
         </div>
       </fieldset>
+      <SupercellSlicePositionControl
+        view={evidenceView}
+        position={slicePosition}
+        onPosition={onSlicePosition}
+        onReset={onResetSlicePosition}
+      />
       <fieldset className="supercells-overlay-controls">
         <legend>2-D evidence</legend>
         {controls.map((control) => (
@@ -638,6 +684,54 @@ function StormExploreControls({
         ))}
       </fieldset>
     </section>
+  );
+}
+
+function SupercellSlicePositionControl({
+  view,
+  position,
+  onPosition,
+  onReset,
+}: {
+  view: EvidenceView;
+  position: SlicePositionState | null;
+  onPosition: (positionIndex: number) => void;
+  onReset: () => void;
+}) {
+  if (!position) {
+    return (
+      <fieldset className="supercells-slice-position">
+        <legend>Position</legend>
+        <p>Column-derived across z; choose a vertical slice to position a native plane.</p>
+      </fieldset>
+    );
+  }
+  const coordinate = position.coordinatesKm[position.positionIndex] ?? 0;
+  const nativeIndex = position.nativeIndices[position.positionIndex] ?? 0;
+  const label = `${sliceControlLabel(view)} ${position.axis} position`;
+  const plane =
+    view === "plan"
+      ? ("horizontal" as const)
+      : view === "xz"
+        ? ("vertical_x" as const)
+        : ("vertical_y" as const);
+  return (
+    <fieldset className="supercells-slice-position">
+      <legend>Position</legend>
+      <NativeSlicePositionControl
+        id={`supercells-${view}-position`}
+        ariaLabel={label}
+        plane={plane}
+        positionIndex={position.positionIndex}
+        positionCount={position.coordinatesKm.length}
+        positionLabel={`${position.axis} ${formatCoordinateKm(coordinate)}`}
+        indexLabel={`native index ${nativeIndex}`}
+        onPositionChange={onPosition}
+        onReset={onReset}
+        resetLabel="Return slice to curated position"
+        compact
+      />
+    </fieldset>
   );
 }
 
@@ -967,6 +1061,7 @@ function lensPresentationDefaults(): Record<LensId, LensPresentation> {
       visibleLayerKeys: null,
       categoryCodes,
       cameraPreset: "look_along_y",
+      cameraTransform: null,
       sceneOpacity: 1,
       scenePointSize: 1,
       selection: null,
@@ -978,6 +1073,7 @@ function lensPresentationDefaults(): Record<LensId, LensPresentation> {
       visibleLayerKeys: null,
       categoryCodes,
       cameraPreset: "look_along_y",
+      cameraTransform: null,
       sceneOpacity: 0.9,
       scenePointSize: 0.9,
       selection: null,
@@ -989,6 +1085,7 @@ function lensPresentationDefaults(): Record<LensId, LensPresentation> {
       visibleLayerKeys: null,
       categoryCodes,
       cameraPreset: "low_level",
+      cameraTransform: null,
       sceneOpacity: 1,
       scenePointSize: 1,
       selection: null,
@@ -1026,6 +1123,37 @@ function nearestCoordinateIndex(
     }
   });
   return sourceIndices?.[nearest] ?? nearest;
+}
+
+function slicePositionState(
+  frame: StormExaminationFrame,
+  view: EvidenceView,
+  selection: Selection | null,
+): SlicePositionState | null {
+  if (view === "plan" && frame.plan.selection_z_indices) return null;
+  const axis: SliceAxis = view === "plan" ? "z" : view === "xz" ? "y" : "x";
+  const coordinatesKm = frame.scene?.coordinate_values_km[axis] ?? [];
+  const nativeIndices = frame.scene?.coordinate_indices[axis] ?? [];
+  if (coordinatesKm.length === 0 || coordinatesKm.length !== nativeIndices.length) return null;
+  const selectedNativeIndex =
+    axis === "x"
+      ? (selection?.xIndex ?? frame.selected_point.x_index)
+      : axis === "y"
+        ? (selection?.yIndex ?? frame.selected_point.y_index)
+        : (selection?.zIndex ?? frame.plan.level_index);
+  const exactPosition = nativeIndices.indexOf(selectedNativeIndex);
+  const positionIndex =
+    exactPosition >= 0
+      ? exactPosition
+      : nativeIndices.reduce(
+          (nearest, candidate, index) =>
+            Math.abs(candidate - selectedNativeIndex) <
+            Math.abs(nativeIndices[nearest] - selectedNativeIndex)
+              ? index
+              : nearest,
+          0,
+        );
+  return { axis, coordinatesKm, nativeIndices, positionIndex };
 }
 
 function evidenceSlice(frame: StormExaminationFrame, view: EvidenceView) {
@@ -1077,10 +1205,7 @@ function evidenceLabel(frame: StormExaminationFrame, view: EvidenceView): string
   return view === "xz" ? frame.xz_section.title : frame.yz_section.title;
 }
 
-function evidenceTitle(
-  frame: StormExaminationFrame | null,
-  view: EvidenceView,
-): string {
+function evidenceTitle(frame: StormExaminationFrame | null, view: EvidenceView): string {
   if (view === "plan" && frame?.plan.selection_z_indices) {
     return "Column-derived x-y view";
   }
@@ -1172,6 +1297,11 @@ function formatTime(seconds: number): string {
   return `${minutes} min · ${seconds.toLocaleString()} s`;
 }
 
+function formatCoordinateKm(value: number): string {
+  const precision = Math.abs(value) >= 10 ? 1 : 2;
+  return `${value.toFixed(precision)} km`;
+}
+
 function frameRequestKey(
   lens: LensId,
   viewport: ViewportId,
@@ -1220,15 +1350,16 @@ async function prefetchAdjacentFrames(
   frame: StormExaminationFrame,
   lens: LensId,
   viewport: ViewportId,
+  selection: Selection | null,
 ) {
   const candidates = [frame.time_index + 1, frame.time_index - 1].filter(
     (index) => index >= 0 && index < frame.times_seconds.length,
   );
   for (const index of candidates) {
-    const key = frameRequestKey(lens, viewport, index, null);
+    const key = frameRequestKey(lens, viewport, index, selection);
     if (cache.has(key)) continue;
     try {
-      cache.set(key, await fetchSupercellFrame(simulationId, lens, viewport, index, null));
+      cache.set(key, await fetchSupercellFrame(simulationId, lens, viewport, index, selection));
       trimCache(cache, 8);
     } catch {
       // Adjacent prefetch is optional; the requested frame remains authoritative.

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -214,11 +214,13 @@ export function SupercellsExplore({
     if (!frame || !slicePosition) return;
     const nativeIndex = slicePosition.nativeIndices[positionIndex];
     if (nativeIndex === undefined) return;
-    const next = {
-      xIndex: frame.selected_point.x_index,
-      yIndex: frame.selected_point.y_index,
-      zIndex: frame.selected_point.z_index,
-    };
+    const next = selection
+      ? { ...selection }
+      : {
+          xIndex: frame.selected_point.x_index,
+          yIndex: frame.selected_point.y_index,
+          zIndex: frame.selected_point.z_index,
+        };
     if (slicePosition.axis === "x") next.xIndex = nativeIndex;
     if (slicePosition.axis === "y") next.yIndex = nativeIndex;
     if (slicePosition.axis === "z") next.zIndex = nativeIndex;
@@ -312,6 +314,7 @@ export function SupercellsExplore({
                 showWindVectors={visibleLayerKeys.includes("model_relative_wind")}
                 windMode="total"
                 windReferenceMps={frame.scene.wind_reference_m_s}
+                windOverlayLabel={`Model-relative wind at z = ${frame.plan.level_km.toFixed(2)} km`}
                 windArrowDomainFraction={0.055}
                 compactWorkspace
                 compactDisplayLabel="3-D layers"
@@ -470,6 +473,7 @@ export function SupercellsExplore({
           lens={lens}
           viewport={viewport}
           evidenceView={evidenceView}
+          planLevelKm={frame?.plan.level_km ?? null}
           overlays={overlays}
           onViewport={(next) => {
             setPlaying(false);
@@ -543,7 +547,7 @@ function StormDisplayControls({
               checked={visibleLayerKeys.includes("model_relative_wind")}
               onChange={(event) => onLayer("model_relative_wind", event.currentTarget.checked)}
             />
-            Model-relative wind at 1.25 km
+            Model-relative wind at z = {frame.plan.level_km.toFixed(2)} km
           </label>
         )}
       </div>
@@ -602,6 +606,7 @@ function StormExploreControls({
   lens,
   viewport,
   evidenceView,
+  planLevelKm,
   overlays,
   slicePosition,
   onViewport,
@@ -613,6 +618,7 @@ function StormExploreControls({
   lens: LensId;
   viewport: ViewportId;
   evidenceView: EvidenceView;
+  planLevelKm: number | null;
   overlays: OverlayState;
   slicePosition: SlicePositionState | null;
   onViewport: (value: ViewportId) => void;
@@ -621,7 +627,7 @@ function StormExploreControls({
   onResetSlicePosition: () => void;
   onOverlays: (value: OverlayState) => void;
 }) {
-  const controls = overlayControls(lens, evidenceView);
+  const controls = overlayControls(lens, evidenceView, planLevelKm);
   function update(control: OverlayControl, checked: boolean) {
     onOverlays({ ...overlays, [control.overlayKey]: checked });
   }
@@ -740,7 +746,11 @@ type OverlayControl = {
   overlayKey: keyof OverlayState;
 };
 
-function overlayControls(lens: LensId, evidenceView: EvidenceView): OverlayControl[] {
+function overlayControls(
+  lens: LensId,
+  evidenceView: EvidenceView,
+  planLevelKm: number | null,
+): OverlayControl[] {
   if (lens === "rotating_updraft") {
     const controls: OverlayControl[] = [
       { label: "Cloud boundary", overlayKey: "condensate" },
@@ -763,9 +773,13 @@ function overlayControls(lens: LensId, evidenceView: EvidenceView): OverlayContr
     { label: "Reflectivity contour", overlayKey: "reflectivity" },
   ];
   if (evidenceView === "plan") {
+    const flowLevel =
+      typeof planLevelKm === "number" && Number.isFinite(planLevelKm)
+        ? ` at z = ${planLevelKm.toFixed(2)} km`
+        : "";
     controls.unshift(
       { label: "Accumulated rain (history)", overlayKey: "rain" },
-      { label: "Flow arrows at 1.25 km", overlayKey: "wind" },
+      { label: `Flow arrows${flowLevel}`, overlayKey: "wind" },
     );
   }
   return controls;
@@ -893,7 +907,7 @@ function SupercellExplanation({
     <section className="supercells-context-panel">
       <p className="eyebrow">{frame?.lens_name ?? "Supercell Lens"}</p>
       <h3>{question}</h3>
-      <p>{lensExplanation(lens, evidenceView)}</p>
+      <p>{lensExplanation(lens, evidenceView, frame?.plan.level_km)}</p>
       {frame && (
         <div className="supercells-notice-now">
           <strong>What to notice now</strong>
@@ -1217,10 +1231,17 @@ function sliceControlLabel(view: EvidenceView): string {
   return view === "xz" ? "Vertical x-z" : "Vertical y-z";
 }
 
-function lensExplanation(lens: LensId, evidenceView: EvidenceView): string {
+function lensExplanation(
+  lens: LensId,
+  evidenceView: EvidenceView,
+  planLevelKm?: number,
+): string {
+  const level = typeof planLevelKm === "number" && Number.isFinite(planLevelKm)
+    ? `z = ${planLevelKm.toFixed(2)} km`
+    : "the selected native altitude";
   if (lens === "rotating_updraft") {
     return evidenceView === "plan"
-      ? "The 3.25 km x-y slice pairs signed vertical motion with cyclonic vorticity and the 2–5 km updraft-helicity footprint, showing where ascent and rotation organize together."
+      ? `The x-y slice at ${level} pairs signed vertical motion with cyclonic vorticity and the 2–5 km updraft-helicity footprint, showing where ascent and rotation organize together.`
       : "This native vertical section pairs signed vertical motion with cyclonic-vorticity contours, showing whether the rotating rising core remains vertically connected.";
   }
   if (lens === "cloud_precipitation") {
@@ -1229,7 +1250,7 @@ function lensExplanation(lens: LensId, evidenceView: EvidenceView): string {
       : "This storm-core native section shows the dominant hydrometeor at each cell. Vertical-motion contours remain subordinate, and every native species value remains available in Context.";
   }
   return evidenceView === "plan"
-    ? "The fixed 3-D lower-troposphere view and 1.25 km x-y slice coordinate current motion, precipitating condensate, and model-relative flow with the historical accumulated-rain footprint without diagnosing a cold pool."
+    ? `The fixed 3-D lower-troposphere view and x-y slice at ${level} coordinate current motion, precipitating condensate, and model-relative flow with the historical accumulated-rain footprint without diagnosing a cold pool.`
     : "The 3-D view remains fixed on the lowest 5.25 km, while this native vertical section shows full-depth current ascent, descent, and precipitating condensate; accumulated surface rain remains a separate historical plan-view quantity.";
 }
 

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -129,6 +129,7 @@ type True3DViewerProps = {
   showWindVectors?: boolean;
   windMode?: UpdraftLensWindMode;
   windReferenceMps?: number;
+  windOverlayLabel?: string;
   windArrowDomainFraction?: number;
   updraftLensFrame?: UpdraftLensFrame | null;
   updraftLensOpacity?: number;
@@ -216,6 +217,7 @@ export function True3DViewer({
   showWindVectors = false,
   windMode = "perturbation",
   windReferenceMps = 0,
+  windOverlayLabel,
   windArrowDomainFraction = 0.08,
   updraftLensFrame = null,
   updraftLensOpacity = 0.9,
@@ -566,7 +568,10 @@ export function True3DViewer({
         )}
         {!compactWorkspace && showWindVectors && windVectors.length > 0 && (
           <div className="true3d-wind-legend" aria-label="Horizontal wind overlay legend">
-            <strong>{windMode === "perturbation" ? "Local departures" : "Total wind"}</strong>
+            <strong>
+              {windOverlayLabel ??
+                (windMode === "perturbation" ? "Local departures" : "Total wind")}
+            </strong>
             <span>{windReferenceMps.toFixed(1)} m/s reference = 8% domain width</span>
           </div>
         )}
@@ -607,7 +612,10 @@ export function True3DViewer({
             )}
             {showWindVectors && windVectors.length > 0 && (
               <div className="true3d-wind-legend" aria-label="Horizontal wind overlay legend">
-                <strong>{windMode === "perturbation" ? "Local departures" : "Total wind"}</strong>
+                <strong>
+                  {windOverlayLabel ??
+                    (windMode === "perturbation" ? "Local departures" : "Total wind")}
+                </strong>
                 <span>{windReferenceMps.toFixed(1)} m/s reference</span>
               </div>
             )}

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -82,6 +82,12 @@ export type StormScenePayload = {
 
 export type StormScenePoint = [number, number, number, number, number];
 
+export type CameraTransform = {
+  position: [number, number, number];
+  target: [number, number, number];
+  up: [number, number, number];
+};
+
 type SliceResponse = {
   field: VisualizableField;
   selection: {
@@ -142,6 +148,8 @@ type True3DViewerProps = {
   onSelectStormPoint?: (point: StormScenePoint) => void;
   cameraPreset?: CameraPreset;
   onCameraPresetChange?: (preset: CameraPreset) => void;
+  cameraTransform?: CameraTransform | null;
+  onCameraTransformChange?: (transform: CameraTransform) => void;
 };
 
 type SceneRefs = {
@@ -227,6 +235,8 @@ export function True3DViewer({
   onSelectStormPoint,
   cameraPreset = "overview",
   onCameraPresetChange,
+  cameraTransform = null,
+  onCameraTransformChange,
 }: True3DViewerProps) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const axisLabelLayerRef = useRef<HTMLDivElement | null>(null);
@@ -234,13 +244,17 @@ export function True3DViewer({
   const axisOcclusionRef = useRef({ frame: updraftLensFrame, opacity: updraftLensOpacity });
   const stormSelectionRef = useRef(onSelectStormPoint);
   const cameraPresetRef = useRef(cameraPreset);
+  const cameraTransformRef = useRef(cameraTransform);
+  const cameraTransformChangeRef = useRef(onCameraTransformChange);
+  const appliedCameraPresetRef = useRef(cameraPreset);
   axisOcclusionRef.current = { frame: updraftLensFrame, opacity: updraftLensOpacity };
   stormSelectionRef.current = onSelectStormPoint;
   cameraPresetRef.current = cameraPreset;
+  cameraTransformRef.current = cameraTransform;
+  cameraTransformChangeRef.current = onCameraTransformChange;
   const [renderError, setRenderError] = useState<string | null>(null);
   const [cameraStatus, setCameraStatus] = useState("Camera ready");
-  const [selectedCameraPreset, setSelectedCameraPreset] =
-    useState<CameraPreset>(cameraPreset);
+  const [selectedCameraPreset, setSelectedCameraPreset] = useState<CameraPreset>(cameraPreset);
   const [tallViewport, setTallViewport] = useState(false);
 
   const boundsKey = boundsSignature(pointCloud, stormScene);
@@ -254,6 +268,12 @@ export function True3DViewer({
     [bounds, coordinateSizes, selectedPointCoordinates, selectedRegion],
   );
 
+  const reportCameraTransform = useCallback(() => {
+    const current = refs.current;
+    if (!current) return;
+    cameraTransformChangeRef.current?.(cameraTransformFromRefs(current));
+  }, []);
+
   const resetCamera = useCallback(() => {
     applyCameraPreset(
       selectedCameraPreset,
@@ -262,31 +282,32 @@ export function True3DViewer({
       cameraDistanceScale(selectedCameraPreset, maximized),
     );
     setCameraStatus(`${cameraPresetStatus(selectedCameraPreset)} (reset)`);
-  }, [bounds, maximized, selectedCameraPreset]);
+    reportCameraTransform();
+  }, [bounds, maximized, reportCameraTransform, selectedCameraPreset]);
 
   const setCameraPreset = useCallback(
     (preset: CameraPreset) => {
       setSelectedCameraPreset(preset);
-      applyCameraPreset(
-        preset,
-        refs.current,
-        bounds,
-        cameraDistanceScale(preset, maximized),
-      );
+      applyCameraPreset(preset, refs.current, bounds, cameraDistanceScale(preset, maximized));
       setCameraStatus(cameraPresetStatus(preset));
+      reportCameraTransform();
       onCameraPresetChange?.(preset);
     },
-    [bounds, maximized, onCameraPresetChange],
+    [bounds, maximized, onCameraPresetChange, reportCameraTransform],
   );
 
-  const zoomCamera = useCallback((direction: "in" | "out") => {
-    setCameraStatus(direction === "in" ? "Camera zoomed in" : "Camera zoomed out");
-    const current = refs.current;
-    if (!current) return;
-    const scale = direction === "in" ? 0.82 : 1.18;
-    current.camera.position.multiplyScalar(scale);
-    current.controls.update();
-  }, []);
+  const zoomCamera = useCallback(
+    (direction: "in" | "out") => {
+      setCameraStatus(direction === "in" ? "Camera zoomed in" : "Camera zoomed out");
+      const current = refs.current;
+      if (!current) return;
+      const scale = direction === "in" ? 0.82 : 1.18;
+      current.camera.position.multiplyScalar(scale);
+      current.controls.update();
+      reportCameraTransform();
+    },
+    [reportCameraTransform],
+  );
 
   const moveCameraVertical = useCallback(
     (direction: "up" | "down") => {
@@ -298,8 +319,9 @@ export function True3DViewer({
       current.camera.position.y += delta;
       current.controls.target.y += delta;
       current.controls.update();
+      reportCameraTransform();
     },
-    [bounds.zRange],
+    [bounds.zRange, reportCameraTransform],
   );
 
   const toggleViewportHeight = useCallback(() => {
@@ -342,6 +364,14 @@ export function True3DViewer({
         RIGHT: THREE.MOUSE.PAN,
       };
       applyCameraPreset(cameraPresetRef.current, { camera, controls }, bounds);
+      if (cameraTransformRef.current) {
+        applyCameraTransform(cameraTransformRef.current, { camera, controls });
+      }
+      const handleCameraEnd = () => {
+        const current = refs.current;
+        if (current) cameraTransformChangeRef.current?.(cameraTransformFromRefs(current));
+      };
+      controls.addEventListener("end", handleCameraEnd);
 
       let pointerDown: { x: number; y: number } | null = null;
       const handlePointerDown = (event: PointerEvent) => {
@@ -406,6 +436,7 @@ export function True3DViewer({
         if (!current) return;
         window.cancelAnimationFrame(current.animationFrame);
         current.resizeObserver?.disconnect();
+        current.controls.removeEventListener("end", handleCameraEnd);
         current.controls.dispose();
         current.renderer.domElement.removeEventListener("pointerdown", handlePointerDown);
         current.renderer.domElement.removeEventListener("pointerup", handlePointerUp);
@@ -422,15 +453,18 @@ export function True3DViewer({
   }, [axisLabels, bounds]);
 
   useEffect(() => {
+    const presetChanged = appliedCameraPresetRef.current !== cameraPreset;
+    appliedCameraPresetRef.current = cameraPreset;
     setSelectedCameraPreset(cameraPreset);
-    applyCameraPreset(
-      cameraPreset,
-      refs.current,
-      bounds,
-      cameraDistanceScale(cameraPreset, maximized),
-    );
-    setCameraStatus(cameraPresetStatus(cameraPreset));
-  }, [bounds, cameraPreset, maximized]);
+    if (cameraTransform) {
+      applyCameraTransform(cameraTransform, refs.current);
+    } else {
+      applyCameraPreset(cameraPreset, refs.current, bounds);
+    }
+    if (!cameraTransform || presetChanged) {
+      setCameraStatus(cameraPresetStatus(cameraPreset));
+    }
+  }, [bounds, cameraPreset, cameraTransform]);
 
   useEffect(() => {
     const current = refs.current;
@@ -485,6 +519,7 @@ export function True3DViewer({
       data-result-name={resultName}
       data-updraft-lens-opacity={updraftLensFrame ? updraftLensOpacity : undefined}
       data-updraft-lens-cloud-boundary={updraftLensFrame ? showUpdraftLensBoundary : undefined}
+      data-camera-position={cameraTransform?.position.join(",")}
     >
       {!compactWorkspace && (
         <div className="true3d-scene-header">
@@ -638,6 +673,42 @@ export function True3DViewer({
           <button
             type="button"
             className="true3d-icon-command"
+            aria-label="Zoom in"
+            title="Zoom in"
+            onClick={() => zoomCamera("in")}
+          >
+            <span aria-hidden="true">+</span>
+          </button>
+          <button
+            type="button"
+            className="true3d-icon-command"
+            aria-label="Zoom out"
+            title="Zoom out"
+            onClick={() => zoomCamera("out")}
+          >
+            <span aria-hidden="true">-</span>
+          </button>
+          <button
+            type="button"
+            className="true3d-icon-command"
+            aria-label="Pan view up"
+            title="Pan view up"
+            onClick={() => moveCameraVertical("up")}
+          >
+            <span aria-hidden="true">{"\u2191"}</span>
+          </button>
+          <button
+            type="button"
+            className="true3d-icon-command"
+            aria-label="Pan view down"
+            title="Pan view down"
+            onClick={() => moveCameraVertical("down")}
+          >
+            <span aria-hidden="true">{"\u2193"}</span>
+          </button>
+          <button
+            type="button"
+            className="true3d-icon-command"
             aria-label="Reset camera"
             title="Reset camera"
             onClick={resetCamera}
@@ -655,6 +726,9 @@ export function True3DViewer({
               <span aria-hidden="true">{"\u26f6"}</span>
             </button>
           )}
+          <span className="sr-only" role="status" aria-live="polite">
+            {cameraStatus}
+          </span>
         </div>
       ) : (
         <>
@@ -1483,8 +1557,7 @@ function applyCameraPreset(
   distanceScale = 1,
 ) {
   if (!refs) return;
-  const distance =
-    Math.max(bounds.xRange, bounds.yRange, bounds.zRange) * 1.65 * distanceScale;
+  const distance = Math.max(bounds.xRange, bounds.yRange, bounds.zRange) * 1.65 * distanceScale;
   if (preset === "top_down_xy") {
     refs.camera.position.set(0, distance, 0.001);
     refs.camera.up.set(0, 0, -1);
@@ -1495,10 +1568,7 @@ function applyCameraPreset(
     refs.camera.position.set(0, bounds.zRange * 0.22, distance);
     refs.camera.up.set(0, 1, 0);
   } else if (preset === "low_level") {
-    const lowTarget = centeredCoordinate(
-      Math.min(bounds.z.max, bounds.z.min + 1.0),
-      bounds.z,
-    );
+    const lowTarget = centeredCoordinate(Math.min(bounds.z.max, bounds.z.min + 1.0), bounds.z);
     const xTarget = 0;
     const yTarget = bounds.yRange * 0.18;
     refs.camera.position.set(
@@ -1515,6 +1585,25 @@ function applyCameraPreset(
     refs.camera.up.set(0, 1, 0);
   }
   refs.controls.target.set(0, 0, 0);
+  refs.controls.update();
+}
+
+function cameraTransformFromRefs(refs: Pick<SceneRefs, "camera" | "controls">): CameraTransform {
+  return {
+    position: [refs.camera.position.x, refs.camera.position.y, refs.camera.position.z],
+    target: [refs.controls.target.x, refs.controls.target.y, refs.controls.target.z],
+    up: [refs.camera.up.x, refs.camera.up.y, refs.camera.up.z],
+  };
+}
+
+function applyCameraTransform(
+  transform: CameraTransform,
+  refs: Pick<SceneRefs, "camera" | "controls"> | null,
+) {
+  if (!refs) return;
+  refs.camera.position.fromArray(transform.position);
+  refs.camera.up.fromArray(transform.up);
+  refs.controls.target.fromArray(transform.target);
   refs.controls.update();
 }
 


### PR DESCRIPTION
## Summary

- expose exact native x/y/z coordinate and index inventories for Supercells Explore and honor a user-selected horizontal level
- reuse a shared Trade Cumulus position-control component for native plane scrubbing, stepping, coordinate/index readout, and curated-position reset
- keep point selection, 2-D evidence, and the represented 3-D plane synchronized while preserving user-directed position across playback
- expose existing `True3DViewer` zoom and vertical-pan commands in compact and maximized Supercells views
- preserve controlled camera transforms per Lens across time, evidence orientation, overlays, maximize, and Context changes

## Verification

- `scripts/check.sh`
  - 152 frontend tests passed
  - production frontend build passed
  - 655 backend tests passed
  - script, artifact, and docs/data sanity checks passed
- `npm run test:e2e -- e2e/mocked-smoke/supercells.spec.ts`
  - 3 mocked Playwright journeys passed, including WebGL failure isolation and the 1024 desktop contract
- live browser inspection at 1024 x 856 and 1440 x 900
  - no document overflow at either size
  - horizontal and vertical native-plane movement updated both 2-D and 3-D representations
  - point-derived position remained synchronized when changing orientation
  - per-Lens camera position survived Lens changes
  - compact and maximized camera controls remained available
  - no browser console warnings or errors

Manual PM review is required. Auto-merge is not enabled.

Closes #429