### PR TITLE
Update current documentation for the three-World application

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,131 +2,122 @@
 
 ## See clouds from the inside
 
-Cloud Chamber exists because clouds are beautiful, dynamic, and mostly hidden from us.
+Cloud Chamber is a local, single-user atmospheric laboratory for exploring
+scientifically meaningful cloud simulations. The current application opens into
+three Cloud Worlds:
 
-> **Cloud Chamber is intended to become a place where people can create beautiful, scientifically meaningful cloud worlds, see the invisible processes inside them, change the atmosphere, and learn by watching the clouds respond.**
+| Cloud World | Current experience |
+| --- | --- |
+| **Trade Cumulus** | A three-dimensional shallow-cloud field with two retained Simulations, an Updraft Lens, direct field inspection, and one featured moisture Comparison. |
+| **Mountain Waves** | A terrain-aware native two-dimensional x-z World with dry and moist Simulations, Field views, Wave Structure and Wave Cloud Lenses, and a working variation Lab. |
+| **Supercells** | A coordinated three-dimensional storm view plus native x-y, x-z, and y-z evidence for a retained quarter-circle Supercell Simulation and three storm Lenses. |
 
-That is the product vision, not a description of the software as it exists today.
+The approved product direction also includes **Fun With Soundings**, a
+non-World atmospheric workbench. It is not currently accessible from the
+application. Sounding search, screening, package generation, run management,
+Results, and general Explore capabilities remain available through transitional
+paths, including the existing Trade Cumulus Lab.
 
-Today, Cloud Chamber is a working but uneven collection of CM1 run-building, run-management, sounding, diagnostics, and visualization capabilities shaped by several earlier product directions. Some of those capabilities are strong foundations. Others are incomplete, misframed, or may not belong in the eventual product.
+Cloud Chamber is not a forecasting product. It uses idealized and source-backed
+CM1 experiments to make cloud structure and normally invisible atmospheric
+processes visible.
 
-The long-term vision is a scientific cloud laboratory: a collection of explorable cloud worlds where users can watch clouds form and evolve, reveal the normally invisible processes inside them, change meaningful atmospheric conditions, and understand how the clouds respond.
+## Current boundaries
 
-Read the controlling product documents:
+The implemented application does not yet provide:
 
-- [North Star](NORTH_STAR.md)
-- [Product Vision](docs/product/PRODUCT_VISION.md)
-- [Application Semantics](docs/product/APPLICATION_SEMANTICS.md)
+- durable Saved Views;
+- ordinary World-aware Compare beyond the featured Trade Cumulus Comparison;
+- one shared variation workflow across all three Worlds;
+- a first-class Fun With Soundings destination;
+- durable persistence for complete Explore or comparison workspaces.
 
-## Repository status
+These are current limitations, not decisions to remove the corresponding
+approved product concepts.
 
-Cloud Chamber is currently in a **gated product-architecture program** after
-the initial repository-recovery and semantic-architecture stages.
+## Product authority
 
-The repository contains substantial working simulation, run-management, data, and visualization infrastructure. It also contains scenarios, workflows, terminology, and planning documents inherited from several earlier product directions.
+Read these documents before nontrivial product work:
 
-The current application is therefore **evidence and capability, not the final product design**.
+1. [North Star](NORTH_STAR.md)
+2. [Product Vision](docs/product/PRODUCT_VISION.md)
+3. [Application Semantics](docs/product/APPLICATION_SEMANTICS.md)
+4. [MVP](docs/product/MVP.md)
+5. [Documentation Status and Authority](docs/DOCUMENTATION_STATUS.md)
 
-Do not infer the long-term product from:
+Current software is described in:
 
-- the current default scenario;
-- the current Build, Results, or Explore workflow;
-- existing sounding scores or recommendation language;
-- a particular trigger or forcing mechanism;
-- an old roadmap, product specification, or issue;
-- one successful or unsuccessful CM1 run.
-
-See [Current State](docs/current/CURRENT_STATE.md) for a candid description of what exists today and what remains under review.
-
-## What works today
-
-Cloud Chamber currently provides useful foundations for future product development:
-
-- local CM1 package generation and execution;
-- serial run queueing, progress reporting, cancellation, and automatic ingest;
-- optional trusted-LAN execution support;
-- persistent result records with names, tags, notes, provenance, and cleanup controls;
-- backend-owned NetCDF ingest and bounded visualization-ready data products;
-- saved-output playback and time-based result inspection;
-- 2-D slices and 3-D inspection of CM1-derived fields;
-- separate treatment of cloud water, ice and other hydrometeors, rain water aloft, surface rain, and reflectivity;
-- observed-sounding ingest, caching, diagnostics, and run configuration;
-- runtime-integrity and field-quality checks that distinguish a completed process from trustworthy scientific output.
-
-These capabilities are not all guaranteed to appear in the eventual product in their current form. They should be preserved while their future roles are evaluated.
-
-## What is not settled
-
-The following remain open product and scientific questions:
-
-- the first cloud world or cloud worlds to support;
-- what constitutes a validated Cloud Chamber recipe;
-- how observed atmospheres should enter regime-specific experiments;
-- which controls belong to each cloud regime;
-- practical and high-fidelity compute tiers;
-- how beautiful cloud appearance and scientific field inspection should work together;
-- the role of Build, Results, and Explore in the eventual experience;
-- the experimentation path;
-- the MVP.
-
-Existing scenarios and implementation choices do not answer those questions by themselves.
-
-## Documentation
-
-Start here:
-
-- [Documentation status and authority](docs/DOCUMENTATION_STATUS.md)
 - [Current State](docs/current/CURRENT_STATE.md)
 - [Current Architecture](docs/current/CURRENT_ARCHITECTURE.md)
-- [Development](docs/development/DEVELOPMENT.md)
-- [Testing](docs/development/TESTING.md)
-- [CI and Branch Protection](docs/development/CI_AND_BRANCH_PROTECTION.md)
 
-The read-only documentation disposition audit is complete and approved. The
-highest-risk superseded product-direction documents are preserved under
-`docs/archive/`, current operational docs are maintained under `docs/current/`
-and `docs/development/`, Application Semantics is the approved semantic
-authority, and the repository intentionally has no controlling roadmap during
-the gated product-architecture program. The
-[documentation status and authority guide](docs/DOCUMENTATION_STATUS.md)
-explains how to interpret remaining documents.
+## Run locally
 
-## Development
+Prerequisites:
 
-From the repository root, start the local frontend and backend:
+- Git and Bash;
+- Node.js with npm; CI currently uses Node 22;
+- Python 3.12 or newer;
+- `lsof`.
+
+Install frontend dependencies:
+
+```sh
+cd app/frontend
+npm install
+```
+
+Install backend dependencies:
+
+```sh
+cd app/backend
+python3.12 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev]"
+```
+
+From the repository root, start both servers:
 
 ```sh
 scripts/dev.sh start
 ```
 
-Other server controls:
+The default addresses are:
+
+- frontend: `http://localhost:5173`
+- backend: `http://127.0.0.1:8000`
+
+Other server commands:
 
 ```sh
 scripts/dev.sh status
 scripts/dev.sh restart
-scripts/dev.sh stop
 scripts/dev.sh logs
+scripts/dev.sh stop
 ```
 
-Run the canonical local validation gate before opening a pull request:
+Run the repository verification gate before opening a pull request:
 
 ```sh
 scripts/check.sh
 ```
 
-For mocked browser workflow checks:
+Run mocked browser checks separately:
 
 ```sh
 scripts/check-e2e.sh
 ```
 
-The frontend normally runs at `http://localhost:5173` and the backend at `http://127.0.0.1:8000`.
+See [Development](docs/development/DEVELOPMENT.md) and
+[Testing](docs/development/TESTING.md) for the complete operational contract.
 
-Real CM1 execution requires an external local CM1 installation and local Cloud Chamber settings. See [Development](docs/development/DEVELOPMENT.md) for setup details.
+## CM1 and runtime assets
 
-## Runtime data
+CM1 is external to this repository. Real execution requires a compatible local
+CM1 installation, a configured `cm1.exe`, and the required runtime files.
+Automated tests use tiny fixtures and fake processes; CI does not run CM1.
 
-Runtime data belongs outside the repository by default:
+Cloud Chamber stores local runtime state outside Git by default:
 
 ```text
 ~/CloudChamber/
@@ -136,28 +127,28 @@ Runtime data belongs outside the repository by default:
   logs/
 ```
 
-`./local-data/` may be used as a gitignored development override.
+The retained NetCDF histories that back built-in Simulations are large local
+assets under the runtime home. Stable World and Simulation identities resolve
+to those run assets; the assets themselves are not stored in Git.
 
 Do not commit:
 
 - CM1 source or binaries;
-- NetCDF output;
-- generated run directories;
+- NetCDF output or generated run directories;
 - `LANDUSE.TBL`;
 - downloaded sounding caches;
 - local settings or machine-private paths;
-- screenshots, videos, traces, logs, or large processed visualization artifacts.
+- logs, screenshots, videos, traces, or large processed visualization
+  artifacts.
 
-## Contributing during the gated product-architecture program
+## Repository guides
 
-Read [AGENTS.md](AGENTS.md) before nontrivial work.
+- [Development](docs/development/DEVELOPMENT.md)
+- [Testing](docs/development/TESTING.md)
+- [CI and Branch Protection](docs/development/CI_AND_BRANCH_PROTECTION.md)
+- [Ingest, Results, and Runtime Cleanup Lifecycle](docs/current/INGEST_RESULTS_STORAGE_LIFECYCLE.md)
 
-Use the [controlled-work issue template](.github/ISSUE_TEMPLATE/controlled-work.md) to define bounded work before implementation, and the [Codex task prompt template](docs/templates/codex-task-prompt.md) to translate an approved issue into execution instructions.
-
-During the gated product-architecture program:
-
-- all pull requests require manual review;
-- auto-merge is disabled;
-- agents do not create follow-up issues autonomously;
-- product, scientific, recipe, scenario, roadmap, and major UX decisions require explicit direction;
-- existing issues and documents are not presumed to be current product authority.
+Read [AGENTS.md](AGENTS.md) before agent-assisted work. Cloud Chamber is in a
+gated product-architecture program after the completed repository-recovery and
+semantic-architecture stages. Work remains bounded, pull requests require
+manual review, and auto-merge remains disabled.

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -1,14 +1,17 @@
 # Cloud Chamber Documentation Status and Authority
 
-## Authority and status
+## Authority and Status
 
-The Cloud Chamber documentation tree contains current technical information, research evidence, historical decisions, proposals, and superseded product direction.
+The Cloud Chamber documentation tree contains current technical information,
+research evidence, historical decisions, proposals, and superseded product
+direction. A document's presence under `docs/` does not make it current
+authority.
 
-A document’s presence under `docs/` does not make it current authority.
+Use the hierarchy below.
 
-## 1. Controlling product authority
+## 1. Controlling Product Authority
 
-Use this order:
+Use this product-authority order:
 
 1. [North Star](../NORTH_STAR.md)
 2. [Product Vision](product/PRODUCT_VISION.md)
@@ -17,115 +20,162 @@ Use this order:
    - [Application Semantics](product/APPLICATION_SEMANTICS.md)
    - [MVP](product/MVP.md)
    - [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md)
-5. bounded approved World or product documents
+5. bounded approved World or product documents such as
+   [Trade Cumulus Product Slice](product/TRADE_CUMULUS_PRODUCT_SLICE.md)
 6. current implementation documentation and code
 7. research and run evidence
 
 The North Star and Product Vision are the highest product authority.
 
-Application Semantics controls the meaning of Cloud World, Recipe, Simulation, Lens, Saved View, Comparison, Exploration, Experiment, and supporting terms.
+Application Semantics defines Cloud World, Recipe, Simulation, Lens, Saved
+View, Comparison, Exploration, Experiment, and supporting terms.
 
-The MVP controls Cloud Chamber’s approved scope as a single-user personal cloud laboratory and growing cloud-world atlas. The Current Product Sequence controls later implementation ordering where it conflicts with the MVP’s historical roadmap. It does not reopen the MVP thesis or Application Semantics.
+The MVP defines Cloud Chamber as a local, single-user personal cloud laboratory
+and growing cloud-world atlas. The Current Product Sequence controls later
+implementation ordering where it conflicts with the MVP's historical roadmap.
+It does not reopen the MVP thesis or Application Semantics.
 
-Current issue bodies and the latest explicit PM comments control bounded implementation scope.
+Current issue bodies and the latest explicit PM comments control each bounded
+implementation task.
 
-## 2. Current approved destination model
+## 2. Approved Direction Versus Implemented State
 
-```text
-Cloud Chamber
-├── Trade Cumulus — Cloud World
-├── Mountain Waves — Cloud World
-├── Supercells — Cloud World
-└── Fun With Soundings — atmospheric workbench
-```
+Keep product approval separate from software availability:
 
-The three Worlds share product vocabulary and core workspace behavior but may legitimately differ in geometry, Lenses, controls, comparison questions, and variation surfaces.
+| Subject | Approved direction | Current implemented state |
+| --- | --- | --- |
+| Cloud Worlds | A growing collection of explorable cloud regimes | Trade Cumulus, Mountain Waves, and Supercells are accessible |
+| Fun With Soundings | A separate first-class atmospheric workbench | Not accessible; sounding and run capabilities remain in transitional paths |
+| Saved Views | Durable user-curated views | Placeholder only; no durable Saved Views |
+| Compare | Related Simulations can be compared | One featured Trade Cumulus Comparison; no ordinary World-aware Compare |
+| Variation | Create a related Simulation from a World Simulation | Working Mountain Waves Lab path; no shared three-World workflow |
+| Explore | World-specific science in a shared application vocabulary | Implemented separately for all three accessible Worlds |
 
-A World should expose only surfaces it actually implements. Do not create empty Lab, Compare, Saved View, or other placeholders merely to make all Worlds structurally identical.
+The three Worlds share product vocabulary and core workspace behavior but may
+legitimately differ in geometry, Lenses, controls, comparison questions, and
+variation surfaces.
 
-Cloud Worlds are not organized for the sole user under Installed, Draft, candidate, graduated, or development-state categories. Technical content availability remains an operational state.
+A World should expose only surfaces it implements. Do not create empty Lab,
+Compare, or Saved View placeholders merely to make all Worlds structurally
+identical.
 
-Fun With Soundings is a first-class workbench and is not a Cloud World.
+Fun With Soundings is an approved first-class workbench, not a Cloud World.
+Issue #395 remains queued; approval does not make the workbench accessible in
+the current application.
 
-The [Trade Cumulus Product Slice](product/TRADE_CUMULUS_PRODUCT_SLICE.md) remains a bounded scientific/product document subordinate to higher authority. Its presence does not by itself establish a Recipe, Control, Lens, Comparison, or scientific claim.
+The Trade Cumulus Product Slice remains subordinate to the North Star, Product
+Vision, approved PM decisions, Application Semantics, and the MVP. Being
+documented does not by itself make a Recipe, Lens, Comparison, or scientific
+claim supported.
 
-## 3. Repository and agent authority
+Do not rewrite approved concepts merely because their implementation is
+incomplete. Do not describe approved but inaccessible work as shipped.
+
+## 3. Current Product Sequence
+
+[Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md) is the
+repository authority for current implementation ordering. The latest approved
+PM comment and issue body still control the exact scope of each bounded task.
+
+The presentation-quality and three-World foundation is complete through #420,
+#423, #421, and #429. Issue #428 remains the immediate shared Explore
+information-architecture follow-up.
+
+Rewritten issues #394 and #395 and issues #432 through #438 record bounded
+follow-on product work for Activity and History, Fun With Soundings, durable
+Explore state and Saved Views, Compare and Saved Comparisons, variation
+contracts, retained assets, and curated defaults. Their presence does not
+activate them or replace the sequencing authority. Issues #389, #390, and #391
+were closed as superseded and are not current assignment authority.
+
+Keep detailed ordering in Current Product Sequence and explicit later PM
+decisions rather than duplicating a second roadmap here.
+
+## 4. Repository and Agent Authority
 
 - [AGENTS.md](../AGENTS.md)
 
-`AGENTS.md` defines how agents and contributors must operate. It does not replace product authority.
+`AGENTS.md` controls how agents and contributors operate during the current
+gated product-architecture program. Repository recovery and semantic
+architecture are completed earlier stages; their completion did not end the
+requirements for bounded work, manual pull-request review, or disabled
+auto-merge.
 
-## 4. Current descriptive documents
+`AGENTS.md` does not replace product authority.
 
+## 5. Current Descriptive Documents
+
+- [README](../README.md)
 - [Current State](current/CURRENT_STATE.md)
 - [Current Architecture](current/CURRENT_ARCHITECTURE.md)
-- [Ingest, Results, And Runtime Cleanup Lifecycle](current/INGEST_RESULTS_STORAGE_LIFECYCLE.md)
-- [README](../README.md)
+- [Ingest, Results, and Runtime Cleanup Lifecycle](current/INGEST_RESULTS_STORAGE_LIFECYCLE.md)
 
-These documents describe current software and operations. They may identify legacy behavior, unresolved questions, and implementation constraints. They do not establish final product design.
+These documents describe current software and operations. They may identify
+transitional behavior and implementation limits; they do not establish product
+direction.
 
-Do not update Current State or Current Architecture to describe an approved future capability before its implementation merges. Update them when the repository’s actual descriptive state changes.
+The current embedding of legacy Build and Results under Trade Cumulus does not
+override the approved World Lab or Fun With Soundings concepts.
 
-Current State and Current Architecture now require a bounded factual refresh after the completed World and presentation-run work. Until that update merges, use current code, tests, merged PR history, and the Current Product Sequence together rather than treating their older Build/Results/Explore framing as complete.
+Do not update Current State or Current Architecture to describe an approved
+future capability before its implementation merges. Update them when the
+repository's actual descriptive state changes.
 
-## 5. Development and operational documentation
+## 6. Development and Operational Documentation
 
 - [Development](development/DEVELOPMENT.md)
 - [Testing](development/TESTING.md)
 - [CI and Branch Protection](development/CI_AND_BRANCH_PROTECTION.md)
 - [Trusted LAN Worker](development/LAN_WORKER.md)
 
-Use operational instructions where they remain accurate.
+Use operational instructions where they remain accurate. Prefer commands,
+paths, APIs, and test procedures that can be verified against current code.
 
-Operational-documentation recovery, the documentation disposition audit, semantic architecture, and active-contract classification are complete.
+Completed earlier-stage programs include:
+
+- repository and operational-documentation recovery;
+- documentation disposition audit;
+- semantic architecture;
+- active contract classification;
+- archive moves for the highest-risk superseded product direction.
 
 For documents not handled by those programs:
 
-- prefer verifiable commands, paths, APIs, test procedures, and implemented behavior;
-- do not execute old product priorities, scenario sequencing, or roadmap language without a current approved issue;
-- resolve product conflicts in favor of the authority order above.
+- do not execute old scenario sequencing or roadmap language;
+- resolve product conflicts using the authority order above;
+- preserve useful implementation and research evidence;
+- request PM direction when a conflict affects bounded work.
 
-## 6. Architecture and data-model documents
+## 7. Implemented Contracts
 
-Architecture documents may describe real implemented systems and useful constraints while also containing product assumptions inherited from earlier directions.
-
-Interpret them as:
-
-> This is what the current software does or was designed to do.
-
-Do not automatically interpret them as:
-
-> This is what the eventual product must be.
-
-Architecture changes remain subject to approved product authority and bounded implementation issues.
-
-## 7. Implemented contracts
-
-The active `docs/contracts/` directory contains current implemented contracts verified against code and tests:
+The active `docs/contracts/` directory contains verified current contracts:
 
 - [Output Product Specification](contracts/output-product-specification.md)
 - [Sounding Candidate Screening Contract](contracts/sounding-candidate-screening.md)
 
-These contracts describe interfaces and current behavior. They do not define the final product hierarchy or make a Cloud World, Recipe, Simulation, Comparison, or workbench experiment scientifically supported.
+Implemented contracts describe current interfaces and behavior. They do not
+define final product hierarchy or make a World, Recipe, Simulation,
+Comparison, or Experiment scientifically supported.
 
 Historical and proposal contracts live under `docs/archive/contracts/`.
 
-## 8. Research and experiment evidence
+## 8. Research and Experiment Evidence
 
-Documents under `research/` record investigations, validation attempts, run outcomes, literature findings, and design exploration.
+Documents under `research/` record investigations, validation attempts, run
+outcomes, literature findings, and design exploration.
 
 Research is evidence. It is not automatically:
 
 - product direction;
 - a supported Recipe;
 - roadmap priority;
-- proof that an experimental mechanism should be a default;
-- proof that a sounding experiment belongs to a Cloud World;
-- proof that a new Cloud World should be activated.
+- a default forcing or initiation mechanism;
+- proof that a Result belongs to a Cloud World;
+- proof that a research route is a product route.
 
 Negative, failed, contradictory, and superseded evidence should be preserved.
 
-## 9. Historical and superseded product direction
+## 9. Historical and Superseded Direction
 
 Known high-risk archived examples include:
 
@@ -135,21 +185,21 @@ Known high-risk archived examples include:
 - [Configurable observed-sounding roadmap](archive/roadmaps/configurable-observed-sounding-roadmap-legacy.md);
 - [Thermal Fate process diagnostics](archive/product-direction/thermal-fate-diagnostics-legacy.md);
 - [Guided experiment notebook UX reset](archive/ux/guided-experiment-notebook-reset-legacy.md);
-- [Codex project setup notes](archive/setup/codex-project-setup-legacy.md);
 - [legacy roadmap and startup issues](archive/roadmaps/roadmap-and-issues-legacy.md);
 - [deep-convection package design proposal](archive/proposals/deep-convection-package-design-legacy.md).
 
-Active-path documents may still contain superseded framing. Until bounded work changes them:
+Active-path documents may still contain superseded framing. Until bounded work
+changes them:
 
 - do not use them as controlling product authority;
-- do not update them merely for cosmetic consistency;
 - do not execute their roadmap language;
-- do not delete them without approved disposition.
+- do not delete them without approved disposition;
+- do not update them merely for cosmetic consistency.
 
-## Document status vocabulary
+## Document Status Vocabulary
 
 | Status | Meaning |
-|---|---|
+| --- | --- |
 | **Authoritative** | Controls product or repository behavior |
 | **Current descriptive** | Accurately describes present software or operations |
 | **Implemented contract** | Describes a verified current interface |
@@ -159,11 +209,12 @@ Active-path documents may still contain superseded framing. Until bounded work c
 | **Superseded** | Conflicts with or has been replaced by current authority |
 | **Unresolved** | Requires product, scientific, or implementation review |
 
-These labels are interpretive aids. The repository has not moved or relabeled every file.
+These labels are interpretive aids. The repository has not moved or relabeled
+every file.
 
-## Recommended reading paths
+## Recommended Reading Paths
 
-### Understand the product
+### Understand the Product
 
 1. [North Star](../NORTH_STAR.md)
 2. [Product Vision](product/PRODUCT_VISION.md)
@@ -174,80 +225,40 @@ These labels are interpretive aids. The repository has not moved or relabeled ev
 7. [Current State](current/CURRENT_STATE.md)
 8. [Current Architecture](current/CURRENT_ARCHITECTURE.md)
 
-### Contribute
+### Contribute During the Gated Program
 
 1. [AGENTS.md](../AGENTS.md)
 2. explicit PM decisions and the controlling bounded issue
 3. [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md)
-4. [MVP](product/MVP.md)
-5. [Application Semantics](product/APPLICATION_SEMANTICS.md)
-6. relevant operational documentation
-7. current code and tests
+4. relevant product authority
+5. current operational documentation
+6. current code and tests
 
-Ignore conflicting lower-authority roadmap language and ask for direction when a conflict affects the task.
+Ignore conflicting lower-authority product language and ask for direction when
+a conflict affects the task.
 
-### Understand a scientific or CM1 experiment
+### Understand a Scientific or CM1 Experiment
 
 1. Identify the relevant research and run records.
-2. Determine whether the work is a canonical source, controlled adaptation, exploratory sounding experiment, technical mechanism, or hypothesis.
-3. Confirm the actual configuration, output, integrity, and provenance.
+2. Determine whether the work is canonical, adapted, exploratory, technical, or
+   hypothetical.
+3. Confirm the actual configuration, output, runtime integrity, and provenance.
 4. Do not assume that a Result belongs to a Cloud World.
 5. Do not assume that an experiment is a supported Recipe or product default.
 
-### Understand current implementation
+### Understand Current Implementation
 
-Use current source code, tests, runtime contracts, Current State, Current Architecture, and merged PR history together. Do not rely on one old product specification or roadmap.
+Use source code, tests, runtime contracts, [Current State](current/CURRENT_STATE.md),
+[Current Architecture](current/CURRENT_ARCHITECTURE.md), and merged pull-request
+history together.
 
-## 10. Current implementation sequence
+Do not rely on one old product specification, roadmap, or research page.
 
-The controlling sequence is maintained in [Current Product Sequence](product/CURRENT_PRODUCT_SEQUENCE.md).
+## Program Note
 
-The presentation-quality and third-World foundation is:
+The documentation tree has not been comprehensively reorganized. Remaining
+moves, rewrites, archives, and implementation work require bounded approved
+issues.
 
-```text
-#420 — Trade Cumulus and Mountain Waves presentation runs — complete
-#423 — Supercells World and Explore — complete
-#421 — high-resolution Supercell presentation run — final adoption review
-```
-
-After #421 merges, the immediate bounded follow-ups are:
-
-```text
-#429 — Supercells slice-position and 3-D camera navigation
-→ #428 — shared Context and Science | Notes | Details information architecture
-```
-
-Issue #428 may establish durable per-Simulation Notes as the first bounded durable-content contract. It must not also implement complete Explore-state persistence, resume, Saved Views, Saved Comparisons, or a generic annotation framework.
-
-The next program should then establish:
-
-```text
-versioned World-aware Explore state
-→ last-state resume
-→ Saved Views
-→ ordinary World-aware Compare
-→ Saved Comparisons
-→ fresh three-World variation review
-```
-
-Later work should reconcile Activity and History, Result-to-Simulation promotion, retained-asset protection, storage and dependency-aware deletion, repair, state migration, performance, and personal acceptance.
-
-Issues #389, #390, and #391 remain useful prior plans but are not current assignment authority until PM updates or replaces them for the three-World application.
-
-Squall Line issue #414 remains blocked. Completion of the Supercell program does not automatically activate a fourth World.
-
-## Program note
-
-Completed or approved work includes:
-
-- operational-documentation recovery;
-- semantic architecture and contract classification;
-- canonical BOMEX and Trade Cumulus evidence;
-- Trade Cumulus World, Updraft Lens, fixed scale, featured Comparison, and presentation runs;
-- Mountain Waves benchmark, visualization, World, Explore, variation, and presentation runs;
-- Supercell benchmark selection, exact reproduction, examination validation, World, Explore, and presentation run pending final adoption corrections;
-- approved MVP authority and World-scoped foundation.
-
-Remaining repository moves, rewrites, archives, and implementation work must occur through bounded approved issues.
-
-No bulk documentation or product rewrite is authorized by this status document.
+This status document records authority and current disposition. It does not
+authorize bulk documentation changes or redefine product scope.

--- a/docs/current/CURRENT_ARCHITECTURE.md
+++ b/docs/current/CURRENT_ARCHITECTURE.md
@@ -1,180 +1,277 @@
 # Cloud Chamber Current Architecture
 
-**Status:** Descriptive implementation snapshot
+**Status:** Current descriptive implementation snapshot
 
-This document describes the repository and application architecture that exist today. It is not
-a final product architecture, product specification, recipe policy, or roadmap.
+This document describes the repository and application architecture that exist
+today. It is not a final product architecture, scientific specification, or
+roadmap.
 
-The controlling product documents remain:
+The controlling documents remain:
 
 1. [North Star](../../NORTH_STAR.md)
 2. [Product Vision](../product/PRODUCT_VISION.md)
 3. [Application Semantics](../product/APPLICATION_SEMANTICS.md)
-4. [Current State](CURRENT_STATE.md)
+4. [MVP](../product/MVP.md)
+5. [Current State](CURRENT_STATE.md)
 
-## Current Implementation Flow
+## System Shape
 
-The current technical flow is:
+Cloud Chamber is a local-first React/Vite application backed by FastAPI and an
+external CM1 installation:
 
 ```text
-React / TypeScript / Vite frontend
--> FastAPI backend
--> package generation and manifests
--> external CM1 execution
--> local or trusted-LAN run handling
--> runtime output and NetCDF ingest
--> result metadata and optional notebook state
--> backend diagnostics and bounded visualization payloads
--> browser inspection
+React / TypeScript / Vite
+          |
+          v
+FastAPI World, run, result, and visualization APIs
+          |
+          +--> local runtime metadata and retained presentation inventory
+          |
+          +--> backend NetCDF readers and derived scientific payloads
+          |
+          +--> generated packages, queue, and external cm1.exe
 ```
 
-This is the present implementation. It does not establish that the same surfaces, boundaries,
-or persistence choices belong in the eventual product.
+The browser does not parse raw NetCDF. The backend owns native-file access,
+validation, cropping, slicing, point selection, derived values, and payload
+bounds.
+
+## Product Routes
+
+The frontend is a state-driven React application under `app/frontend`. Its
+primary product routes resolve these locations:
+
+```text
+Cloud Worlds home
+World overview and section
+Trade Cumulus Explore and featured Comparison
+Mountain Waves World and Explore
+Supercells World and Explore
+```
+
+The Cloud Worlds home obtains inventory from `GET /api/worlds`. World-specific
+inventory endpoints provide stable content identity and availability:
+
+```text
+GET /api/worlds/trade-cumulus
+GET /api/worlds/mountain-waves
+GET /api/worlds/supercells
+```
+
+Fun With Soundings does not yet have a first-class product route.
+
+Legacy Build, Results, generic Explore, scenario, sounding, run, and result
+paths remain in the application. The current World home can fall back to those
+legacy surfaces when World inventory cannot load, and Trade Cumulus Lab embeds
+some of them. This is transitional compatibility, not the intended final
+navigation model.
+
+## World and Simulation Identity
+
+World and Simulation identity is owned by backend inventory code, separate from
+runtime artifacts:
+
+```text
+stable World ID
+  -> stable Simulation ID
+     -> current retained run/result identity
+        -> local run directory and NetCDF histories
+```
+
+Trade Cumulus, Mountain Waves, and Supercells each have explicit inventory and
+availability logic. A built-in Simulation is available only when its expected
+artifacts, lineage, geometry, fields, and time inventory satisfy that World's
+contract. Invalid or conflicting content is reported rather than replaced with
+an arbitrary compatible-looking run.
+
+World responses are kept lightweight. Deep validation is performed at
+promotion or discovery boundaries and cached against artifact fingerprints
+where implemented, rather than reopening every history during ordinary World
+polling.
+
+## Explore Architecture
+
+The Explore implementations reuse common application vocabulary but adapt to
+different native data geometry.
+
+### Trade Cumulus
+
+Trade Cumulus coordinates a direct Three.js cloud-point view with native scalar
+slices, an Updraft Lens, Context, controls, and a timeline. Its visualization
+APIs provide:
+
+- field catalogs and defaults;
+- bounded three-dimensional point clouds;
+- native horizontal and vertical slices;
+- Updraft Lens frames and fixed defaults;
+- wind vectors and selected-point evidence.
+
+Point budgets and rendering levels of detail keep large retained runs usable.
+Playback waits for coordinated payloads and rejects stale responses so rapid
+time changes do not build an unbounded request backlog.
+
+### Mountain Waves
+
+Mountain Waves output is native x-z with singleton y. Its Explore path returns
+terrain-aware two-dimensional frames rather than extruding the data into a fake
+three-dimensional field:
+
+```text
+GET /api/worlds/mountain-waves/simulations/{simulation_id}/frame
+```
+
+The backend owns native geometry, terrain, field extraction, overlay evidence,
+fixed Simulation scales, and point evidence. Expanded-height and
+true-physical-scale display modes are frontend geometry choices over the same
+physical coordinates.
+
+Run metadata, times, geometry, and fixed scales are cached by artifact
+fingerprint. After validation, a frame request reads the selected history
+rather than traversing the complete time series.
+
+### Supercells
+
+Supercells Explore coordinates:
+
+- a bounded three-dimensional storm payload;
+- native x-y, x-z, and y-z sections;
+- World-specific Lens payloads and overlays;
+- one shared time, camera, orientation, and slice-position state;
+- selected-point evidence and Context.
+
+Frames are served through:
+
+```text
+GET /api/worlds/supercells/simulations/{simulation_id}/frame
+```
+
+The backend caches validated run inventory using artifact fingerprints. A
+selected frame opens its corresponding history only. The frontend keeps a
+small frame cache and prefetches adjacent frames for playback.
+
+## Scientific Payload Rules
+
+Explore payloads preserve several implementation boundaries:
+
+- native coordinates remain authoritative;
+- user-visible units are explicit and may be converted only at the display
+  boundary;
+- fixed scale identities and ranges belong to the World or Simulation and do
+  not autoscale independently at each frame;
+- slices are extracted on native planes;
+- crops reduce the domain without inventing coordinates;
+- three-dimensional payloads use declared point budgets and levels of detail;
+- cloud points represent cloudy native cells, not droplets or synthetic
+  particles;
+- derived contours, boundaries, vectors, and state labels identify their
+  source fields and thresholds;
+- selected-point values come from native or explicitly derived data.
+
+Browser views are therefore bounded interpretations of CM1-derived output, not
+raw model files.
+
+## Timeline and Frame Loading
+
+All three product Explore paths expose saved model outputs on a persistent
+timeline with previous, play or pause, next, slider, and speed controls.
+
+Fixed scales and static geometry are computed once per validated retained run
+or cached against its fingerprint. Frame-specific APIs then return only the
+requested time's bounded scientific payloads. Frontend request coordination
+prevents stale frames from replacing newer selections. Supercells additionally
+keeps a bounded client frame cache and adjacent-frame prefetch.
+
+The implementations are not yet one shared playback engine, but the product
+behavior and visual grammar are aligned.
 
 ## State Distinctions
 
 The current code keeps these states distinct:
 
-| State | Current meaning | Primary implementation |
-| --- | --- | --- |
-| Configured/generated package | CM1-facing files have been written under the runtime home, but CM1 has not produced output. | `generate_dry_run_package` and `RunManifest` |
-| Queued or running CM1 process | A packaged run is queued or an external CM1 executable is active. | `LocalRunQueueManager`, `LocalRunManager`, LAN worker wrapper |
-| Completed process | CM1 exited or a stale running manifest was reconciled. | `LocalRunManager._refresh_active`, `reconcile_completed_run_manifest` |
-| Completed process with output | The completed manifest lists NetCDF or raw CM1 artifacts. | `OutputMetadata`, runtime inventory |
-| Runtime-integrity assessment | Backend-derived trust state based on runtime warnings and field-quality evidence. | `runtime_integrity.py`, ingest diagnostics |
-| Ingested result metadata | Backend-created `result_metadata.json` beside the run output. | `result_ingest.py` |
-| Editable notebook state | Optional local sidecar state for name, tags, and notes. | `result_cards.py` |
-| Backend-derived diagnostic | Summary or science metadata computed by backend code from CM1-derived data. | `result_diagnostics.py`, `output_products.py` |
-| Visualization interpretation | Browser-ready field catalogs, slices, point clouds, defaults, and selected-region summaries. | `visualization_data.py`, `selected_region_diagnostics.py` |
+| State | Current meaning |
+| --- | --- |
+| Stable World or Simulation identity | Product-owned identity independent of a current run |
+| Configured package | CM1-facing inputs exist, but no CM1 output is implied |
+| Queued or running process | An external CM1 execution is waiting or active |
+| Completed process | CM1 exited; scientific output may still be missing or invalid |
+| Completed output | Expected output artifacts exist |
+| Runtime-integrity assessment | Backend trust state based on runtime and field evidence |
+| Promoted retained Simulation | Validated output is bound to a stable Simulation identity |
+| Ingested result metadata | Backend-created metadata exists beside a run |
+| Editable result sidecar | Optional local name, tag, or note state exists |
+| Backend-derived diagnostic | A quantity was calculated from CM1-derived data |
+| Visualization interpretation | A bounded browser payload or Lens represents available evidence |
 
-The application currently treats process success, output existence, ingest success, runtime
-integrity, notebook edits, and browser visualization as separate facts.
+Process success, output existence, promotion, ingest, integrity, and browser
+visibility are separate facts.
 
-## Frontend
+## Run and Result Runtime
 
-The frontend is a React and TypeScript application built with Vite under `app/frontend`.
-It currently exposes Build, Results, and Explore surfaces. Those are present UI surfaces,
-not a final decision about product navigation.
-
-The browser calls backend APIs for package generation, local queueing, LAN-worker actions,
-storage inventory, result cards, diagnostics, and visualization-ready payloads.
-
-Browser code currently does not parse raw NetCDF. Raw CM1 output is handled by the backend.
-Any browser view of CM1 fields is an interpretation of backend-derived data, with source,
-field, time, and rendering caveats carried by the payload when available.
-
-## Backend
-
-The backend is a FastAPI app under `app/backend/cloud_chamber`. It currently owns:
-
-- scenario and observed-sounding API surfaces;
-- dry-run package generation;
-- run manifests and lifecycle states;
-- local CM1 launch/status/cancel handling;
-- serial local queueing and automatic ingest;
-- trusted-LAN worker command wrapping;
-- result ingest and result-card sidecar state;
-- runtime storage inventory and safe cleanup;
-- backend diagnostics and visualization-ready field payloads.
-
-This backend ownership is a present constraint, not a final product decision.
-
-## Package Generation
-
-`generate_dry_run_package` writes a run directory under:
+CM1 remains external to the repository. Package generation writes reviewable
+inputs and manifests under:
 
 ```text
 <runtime-home>/runs/<run-id>/
 ```
 
-The current generated package includes:
+The local run manager launches the configured `cm1.exe`, records process and
+log state, and inventories output. The serial queue runs one local process at a
+time and can ingest successful output-producing runs. A bounded trusted-LAN
+path can execute a copied package while the primary Cloud Chamber host remains
+the system of record.
 
-- `run_manifest.json`
-- `case_manifest.json`
-- `namelist.input`
-- `input_sounding`
-- `dry_run_report.json`
-- `runtime_file_checklist.json`
-- optional source-customization or surface-forcing sidecar files for supported paths
+Result ingest writes `result_metadata.json` inside the original run directory.
+Editable name, tags, and notes may be stored in a sibling `result_card.json`.
+Deleting that run directory can remove the package, logs, NetCDF output, result
+metadata, and notebook state together.
 
-Package generation writes reviewable inputs and metadata. It does not launch CM1, create
-NetCDF output, or make a scientific outcome trustworthy by itself.
+See [Ingest, Results, and Runtime Cleanup Lifecycle](INGEST_RESULTS_STORAGE_LIFECYCLE.md).
 
-## CM1 Execution
+## Persistence and Asset Boundaries
 
-CM1 remains external to the repository. The current local launch path discovers configured
-CM1 settings from the runtime home, environment variables, or local probes, stages required
-runtime files from the configured CM1 run directory, and executes `cm1.exe` from the generated
-package directory.
+The runtime home defaults to `~/CloudChamber` and stores:
 
-The local run manager tracks one active local CM1 process at a time. It records command,
-process ID, timestamps, stdout/stderr log paths, exit code, output artifacts, and runtime
-warnings on the run manifest.
+- settings and CM1 discovery;
+- generated packages and manifests;
+- local NetCDF histories;
+- queue and process state;
+- logs;
+- sounding caches;
+- retained presentation-run assets;
+- result metadata and editable result sidecars;
+- validation and derived caches.
 
-The serial queue persists queue state in the runtime home, launches packaged runs one at a
-time, refreshes the active run, and auto-ingests successful output-producing completed runs.
-When ingest fails, the queue records the failure and leaves manual retry possible.
+Large CM1 histories and generated visualization artifacts are not stored in
+Git. Built-in World content therefore depends on local retained assets being
+present and valid.
 
-The trusted-LAN path is optional and bounded. The primary Cloud Chamber host generates the
-package and remains the system of record. The worker receives a copied package, runs CM1,
-returns output and logs to the primary host runtime home, and then local ingest handles the
-result.
+Saved Views and complete Explore workspace state are not durably persisted.
+The only product Comparison currently exposed is the featured Trade Cumulus
+pair. World-aware variation exists for Mountain Waves but is not yet one shared
+cross-World system.
 
-## Ingest, Results, And Storage
+## Product and Research Boundaries
 
-The current ingest path reads completed CM1 NetCDF model-output files with backend Python
-code. Raw `.dat` and `.ctl` artifacts may be cataloged on the manifest, but NetCDF model-field
-files are required for current ingest.
+Product World APIs live under `/api/worlds/...`. Research endpoints such as
+`/api/research/mountain-wave-terrain` and
+`/api/research/storm-examination` remain separate evidence and validation
+surfaces.
 
-`result_metadata.json` is written inside the original run directory. Optional notebook state
-is written to sibling `result_card.json`.
+Research pages may prove geometry, fields, or scientific encodings that later
+support product work. Their routes, temporary controls, and one-off narrative
+do not become product architecture merely because the underlying science is
+reused.
 
-Results currently list cards by scanning:
+## Current Architectural Limits
 
-```text
-<runtime-home>/runs/*/result_metadata.json
-```
+- World shells and Explore implementations share vocabulary but still contain
+  World-specific state and rendering code.
+- Context and below-the-fold information architecture is not yet common.
+- Durable Saved Views and general World-aware Compare are absent.
+- Variation is implemented only for Mountain Waves.
+- Legacy run, result, and sounding surfaces remain interleaved with the newer
+  World application.
+- Filesystem-backed runtime metadata is local and not a durable multi-device
+  store.
 
-Explore and visualization endpoints also rely on the original run directory and the NetCDF
-paths referenced by result metadata. Deleting a run directory currently removes the package,
-logs, CM1 output, result metadata, and notebook sidecar state for that result.
-
-See [Ingest, Results, And Runtime Cleanup Lifecycle](INGEST_RESULTS_STORAGE_LIFECYCLE.md)
-for the current lifecycle audit.
-
-## Diagnostics And Visualization Payloads
-
-Backend diagnostics currently derive cloud, vertical velocity, rain, reflectivity,
-runtime-integrity, field-quality, selected-region, and output-product summaries where
-the required fields exist.
-
-Visualization endpoints return bounded backend-derived payloads for field catalogs,
-view defaults, slices, point clouds, output-product options, profiles, time-height data,
-time series, and selected-region summaries.
-
-These payloads are not raw model output. They are current interpretations of CM1-derived
-data intended for browser inspection.
-
-## Runtime Boundaries
-
-The runtime home defaults to `~/CloudChamber` unless overridden. Runtime-local data includes
-settings, generated run packages, CM1 output, logs, cached sounding source data, queue state,
-LAN-worker configuration, and local result metadata.
-
-The repository must not track runtime-local data, CM1 source trees, CM1 executables, NetCDF
-output, generated packages, `LANDUSE.TBL`, local settings, logs, screenshots, videos, traces,
-or large processed visualization artifacts.
-
-## Open Product Questions
-
-The current architecture leaves several decisions unresolved:
-
-- whether Build, Results, and Explore remain the long-term interface structure;
-- whether filesystem-backed result metadata remains sufficient;
-- whether observed soundings, candidate screening, local queueing, LAN execution, or specific
-  initiation and forcing mechanisms remain product priorities;
-- which current scenarios or run paths provide implementation evidence or
-  ingredients for future Recipes within a Cloud World;
-- how visualization and process explanation are combined in the final experience.
-
-Those decisions are outside this descriptive architecture snapshot.
+These are implementation facts, not decisions to narrow the approved product.

--- a/docs/current/CURRENT_STATE.md
+++ b/docs/current/CURRENT_STATE.md
@@ -1,269 +1,205 @@
 # Cloud Chamber Current State
 
-**Status:** Descriptive repository snapshot
+**Status:** Current descriptive implementation snapshot
 
 ## Purpose
 
-This document describes the software and repository as they exist today.
+This document describes the software and repository as they exist today. It is
+not a roadmap or a substitute for product authority.
 
-It is not:
-
-- a product vision;
-- a roadmap;
-- an MVP definition;
-- a decision about which current capabilities should remain;
-- a decision about which scenarios or experiments should become supported recipes;
-- a decision about the final application structure.
-
-The controlling product documents are:
+Read higher-authority documents first:
 
 1. [North Star](../../NORTH_STAR.md)
 2. [Product Vision](../product/PRODUCT_VISION.md)
 3. [Application Semantics](../product/APPLICATION_SEMANTICS.md)
+4. [MVP](../product/MVP.md)
 
-Where this document describes current implementation that does not match the Product Vision, the mismatch is intentional and should remain visible.
+Where current implementation is incomplete, this document records the gap
+without changing the approved product direction.
 
-## Current repository condition
+## Current Application
 
-Cloud Chamber has been developed through several different product framings.
-
-The repository currently contains language, workflows, scenarios, contracts, issues, and implementation choices associated with ideas including:
-
-- Baseline Shallow Cumulus as a Golden Path;
-- Thermal Fate as an organizing concept;
-- configurable observed-sounding runs;
-- sounding screening and recommendation;
-- surface-forcing experiments;
-- explicit thermal and deep-convection initiation;
-- cloud-opportunity and scout-to-full-run workflows.
-
-These framings overlap and sometimes conflict.
-
-Their presence in the repository records project history and implementation context. It does not establish current product direction.
-
-## Current application structure
-
-The application is local-first and uses an external CM1 installation.
-
-The current technical flow is broadly:
+Cloud Chamber is a local, single-user atmospheric laboratory. Its primary
+entrance is a Cloud Worlds home with three accessible Worlds:
 
 ```text
-React / TypeScript frontend
-→ Python / FastAPI backend
-→ configured run and package generation
-→ external CM1 execution
-→ runtime and NetCDF ingest
-→ persistent result metadata
-→ backend-derived diagnostics and visualization data
-→ browser-based inspection
+Cloud Chamber
+├── Trade Cumulus
+├── Mountain Waves
+└── Supercells
 ```
 
-The current interface is organized around three top-level areas:
+Each World owns stable World and Simulation identities. Those product
+identities resolve to local retained run and result assets; they are not the
+same thing as CM1 run IDs, result IDs, or filesystem paths.
 
-- **Build**
-- **Results**
-- **Explore**
+**Fun With Soundings** is approved as a separate atmospheric workbench, not a
+Cloud World. It is not currently accessible as a first-class application
+destination. Issue #395 remains open for that work.
 
-This is the present interface structure. No decision has been made that it is the final product structure.
+## Accessible Cloud Worlds
 
-## Implemented capabilities
+| World | Current content | Current surfaces | Current limitation |
+| --- | --- | --- | --- |
+| **Trade Cumulus** | Canonical BOMEX Baseline and More Moisture retained Simulations | Overview, Simulations, Saved Views placeholder, featured Comparison, Lab, and Explore | Saved Views are not durable; ordinary World-aware Compare is not implemented; Lab still embeds transitional Build and Results |
+| **Mountain Waves** | Dry Ridge and Boulder Windstorm retained Simulations | Overview, Simulations, variation Lab, and Explore | Variation is World-specific rather than shared; no ordinary Compare or Saved Views |
+| **Supercells** | Quarter-Circle Supercell retained Simulation | Overview, Simulations, and Explore | No variation Lab, ordinary Compare, or Saved Views |
 
-### Run configuration and packaging
+The World Overview and Simulations surfaces use stable content identities and
+explicit availability states. Missing, invalid, or conflicting retained
+content fails closed instead of silently substituting a different run.
 
-The repository currently supports combinations of:
+## Explore Experiences
 
-- committed scenario templates;
-- observed IGRA sounding input;
-- CM1-facing package and manifest generation;
-- run duration, domain, grid, cadence, and output selection;
-- surface heat and moisture forcing;
-- supported idealized initiation modes;
-- provenance and configuration review before execution.
+The three Explore implementations share Cloud Chamber's interaction and visual
+vocabulary while preserving the geometry and evidence native to each regime.
 
-The exact options available depend on the selected workflow and current implementation path.
+### Trade Cumulus
 
-### CM1 execution and run management
+Trade Cumulus Explore combines:
 
-The application currently includes:
+- a true three-dimensional shallow-cloud point field;
+- native horizontal and vertical scalar slices;
+- direct Field inspection and an Updraft Lens;
+- a cloud boundary and horizontal-wind evidence;
+- fixed World-owned scientific scales;
+- synchronized time, slice position, selected-point evidence, and Context.
 
-- local CM1 launch;
-- serial local run queueing;
-- progress and estimated completion reporting;
-- cancellation where technically practical;
-- automatic ingest for completed output-producing runs;
-- optional trusted-LAN execution for supported paths;
-- runtime logs and lifecycle state;
-- checks that distinguish process completion from trustworthy scientific output.
+### Mountain Waves
 
-### Results and storage
+Mountain Waves output is native two-dimensional x-z data. Explore therefore
+uses:
 
-The application currently includes:
+- one large terrain-aware x-z scientific view;
+- direct Field inspection;
+- Wave Structure and Wave Cloud Lenses;
+- expanded-height and true-physical-scale geometry;
+- terrain, wind, cloud-point, boundary, saturation, and potential-temperature
+  evidence where applicable;
+- fixed World-owned scales, timeline, selected-point evidence, and Context.
 
-- persistent result records;
-- editable result names, tags, and notes;
-- run, scenario, sounding, configuration, and source provenance;
-- explicit result and runtime cleanup controls;
-- field-quality and runtime-integrity metadata;
-- result summaries derived by the backend.
+There is no fake singleton-y three-dimensional extrusion.
 
-### Scientific fields and diagnostics
+### Supercells
 
-Current ingest and diagnostic code handles a range of CM1-derived information, including where available:
+Supercells Explore coordinates:
 
-- cloud water;
-- vertical velocity;
-- water vapor and thermodynamic fields;
-- rain water aloft;
-- surface rain;
-- reflectivity;
-- ice and other hydrometeor species;
-- surface heat and moisture fluxes;
-- cloud-top and hydrometeor-envelope distinctions;
-- selected-region or selected-point summaries;
-- sounding-derived diagnostics and screening fields.
+- a three-dimensional storm view;
+- native horizontal x-y and vertical x-z and y-z sections;
+- Rotating Updraft, Cloud and Precipitation, and Low-Level Interactions Lenses;
+- storm-region and full-domain inspection;
+- fixed World-owned scales and World-specific overlays;
+- synchronized camera, slice position, timeline, selected-point evidence, and
+  Context.
 
-Availability and trust vary by run configuration, output fields, and data quality.
+The sections use native model coordinates. Moving between a Lens and a direct
+slice preserves the selected orientation and position where the underlying
+data permits.
 
-### Visualization
+## Shared Scientific Presentation
 
-The current application includes:
+Current Explore surfaces use:
 
-- 2-D field slices;
-- initial 3-D field inspection;
-- cloud-water visualization;
-- output-time selection;
-- saved-output timelapse playback;
-- camera and field controls;
-- selected-region and selected-point inspection.
+- fixed-across-time, World-owned scales rather than per-frame autoscaling;
+- concise legends with explicit units and displayed frame extrema;
+- backend-derived, bounded payloads rather than browser-side NetCDF parsing;
+- native coordinates and declared derived quantities;
+- selected-point evidence tied to actual payload values;
+- persistent playback and saved-output controls;
+- explicit loading, missing-content, and failure states.
 
-The current visualizer does not yet provide the complete experience described in the Product Vision.
+World-specific Lenses combine fields and overlays to answer a bounded
+scientific question. A Lens is an interpretation layer, not a new model field
+or a claim of unsupported process evidence.
 
-### Observed-sounding support
+## Retained Presentation Simulations
 
-The repository currently includes:
+The built-in World content currently resolves to retained presentation-quality
+CM1 output:
 
-- IGRA sounding parsing and normalization;
-- observed thermodynamic and wind-profile handling;
-- local sounding cache workflows;
-- sounding-derived diagnostics;
-- candidate screening, sorting, saving, tagging, and notes;
-- package configuration from selected observed soundings.
+| World | Stable Simulation | Current retained run |
+| --- | --- | --- |
+| Trade Cumulus | Canonical BOMEX Baseline | `trade-cumulus-presentation-v1-baseline-20260722` |
+| Trade Cumulus | More Moisture | `trade-cumulus-presentation-v1-more-moisture-20260722` |
+| Mountain Waves | Dry Ridge | `dry-mountain-wave-presentation-v1-20260722` |
+| Mountain Waves | Boulder Windstorm | `moist-mountain-wave-presentation-v1-20260722` |
+| Supercells | Quarter-Circle Supercell | `quarter-circle-supercell-presentation-v1-20260723` |
 
-The existence of these capabilities does not decide how important observed soundings will be in the eventual product.
+These run IDs identify current local artifacts, not permanent product identity.
+The large NetCDF histories remain outside Git under the runtime home.
 
-### Run, research, and scenario content
+## Transitional Capabilities
 
-The repository currently contains:
+Working infrastructure remains available even where its product placement is
+not final:
 
-- a lower-atmosphere scenario catalog;
-- shallow-cumulus contrast scenarios;
-- low-cloud and warm-rain placeholders;
-- uniform and differential surface-forcing work;
-- observed-sounding evolution paths;
-- explicit thermal-initiation work;
-- deep-convection benchmark work;
-- research notes and run records from successful, unsuccessful, and inconclusive experiments.
+- observed-sounding search, screening, caching, and package configuration;
+- CM1 package generation and provenance review;
+- local CM1 launch, serial queueing, progress, cancellation, and ingest;
+- Results records with local notes, tags, diagnostics, and cleanup;
+- generic field and result inspection;
+- trusted-LAN execution for supported paths;
+- runtime-integrity and field-quality handling.
 
-The scientific and product status of these items has not yet been reviewed under the new Product Vision.
+Some of this infrastructure appears inside the current Trade Cumulus Lab.
+That transitional placement does not make Build or Results the final World Lab
+information architecture, and it does not make Fun With Soundings accessible.
 
-## Current documentation condition
+## Current Gaps
 
-The documentation tree contains a mixture of:
+The implemented application does not yet provide:
 
-- current operational instructions;
-- implemented technical contracts;
-- research evidence;
-- design proposals;
-- historical roadmaps;
-- superseded product direction;
-- documents that combine several of those roles.
+- durable Saved Views;
+- ordinary World-aware Compare beyond the featured Trade Cumulus Comparison;
+- one shared World-aware variation workflow across all accessible Worlds;
+- a first-class Fun With Soundings entrance;
+- one common Context and below-the-fold information architecture across all
+  Explore implementations;
+- durable persistence for complete Explore or comparison workspaces.
 
-Batch 1 established the North Star, Product Vision, and repository-recovery `AGENTS.md`.
+Issue #428 tracks the approved cleanup of Explore Context and below-the-fold
+content. Older issues #389, #390, and #391 are closed as superseded by the
+current three-World implementation sequence; they should not be read as active
+roadmap authority.
 
-A full file-by-file read-only documentation disposition audit has been
-completed and approved. Stage 1 operational-documentation recovery and Stage 2
-semantic architecture are complete. The active contract directory has been
-classified so implemented contracts remain active while proposal and historical
-mixed contracts are archived under `docs/archive/contracts/`.
+## Local-First Runtime
 
-Remaining repository moves, rewrites, archives, splits, deletions, and deferrals
-outside those completed stages may still exist.
+The current technical flow is:
 
-Until a document is handled by an approved bounded stage:
+```text
+React / TypeScript / Vite frontend
+-> Python / FastAPI backend
+-> generated CM1 package and manifest
+-> external CM1 process
+-> local NetCDF histories and runtime evidence
+-> backend validation, ingest, diagnostics, and visualization payloads
+-> browser inspection
+```
 
-- lower-authority documents may contain useful facts;
-- their product framing may be stale;
-- their roadmap language should not be executed without new approval;
-- their presence should not be interpreted as a decision to keep or remove the described capability.
+Runtime assets default to `~/CloudChamber`. The application depends on those
+local assets for retained Simulations and generated Experiments. Deleting a run
+can remove the corresponding output and result sidecars; the repository is not
+a durable store for those artifacts.
 
-See [Documentation Status and Authority](../DOCUMENTATION_STATUS.md).
+## Interpretation Rules
 
-## Current gated product-architecture status
+- **Accessible** means the user can reach the World or surface in the current
+  application.
+- **Implemented** means a capability exists in the current software; it does
+  not elevate that capability above product authority.
+- **Retained Simulation** means validated output is available locally for a
+  stable Simulation identity.
+- **Presentation run** describes the current backing artifact, not the stable
+  Simulation identity.
+- **Lens** means a World-owned scientific interpretation of available evidence,
+  not a new prognostic field.
+- **Transitional** does not mean disposable; it means the eventual product
+  placement remains incomplete.
+- Research pages and one-off validation artifacts are evidence, not product
+  routes.
 
-Completed:
+## Updating This Document
 
-- approved North Star;
-- approved Product Vision;
-- gated-program `AGENTS.md`;
-- closure of selected superseded product-direction issues and pull requests;
-- replacement README;
-- this descriptive Current State document;
-- documentation status and authority guide;
-- operational-documentation recovery;
-- approved Application Semantics;
-- active contract classification for implemented contracts;
-- concise pull-request template update;
-- controlled-work issue template;
-- reusable Codex task prompt template.
-
-Not yet completed:
-
-- scenario dependency and status review;
-- CM1 experimentation strategy;
-- MVP definition;
-- final application architecture or workflow decisions.
-
-## Questions that remain open
-
-No final decision has yet been made about:
-
-- which cloud regime or regimes should be developed first;
-- which current scenarios have scientific or product value;
-- what a supported Cloud Chamber recipe requires;
-- how observed soundings should be used;
-- which current forcing and initiation mechanisms should remain available;
-- which diagnostics should be central to the user experience;
-- which current capabilities should be retained, changed, or removed;
-- whether Build, Results, and Explore should remain the top-level structure;
-- what compute and fidelity tiers the product should support;
-- what belongs in the MVP;
-- how comparison should work;
-- how cloud appearance and invisible-process visualization should be combined.
-
-Those questions should be answered through explicit product decisions and the forthcoming experimentation strategy, not inferred from current code or repository history.
-
-## Interpretation rules
-
-When using this document:
-
-- **Implemented** means the capability exists in some current form. It does not mean the capability is approved for the eventual product.
-- **Current** means present in the repository or application now. It does not mean preferred.
-- **Historical** does not mean useless.
-- **Under review** does not mean targeted for removal.
-- A successful experiment does not establish a general recipe.
-- An unsuccessful experiment does not establish that the underlying cloud regime or mechanism lacks value.
-- Existing architecture creates constraints and opportunities, but does not by itself decide the product.
-
-## Updating this document
-
-Update this document only to reflect material changes in the descriptive state of the repository or application.
-
-Do not use an update to this document to make product decisions.
-
-Any proposed edit should make clear whether it is:
-
-- correcting a factual description;
-- recording an implemented capability;
-- recording removal of an implemented capability;
-- recording repository-recovery progress;
-- or attempting to make a product decision that belongs elsewhere.
+Update this file when the material descriptive state changes. Do not use it to
+approve a new World, Recipe, scientific interpretation, or implementation
+sequence.


### PR DESCRIPTION
## Summary

- replace the stale Build / Results / Explore-era snapshot with the current three-World application
- document stable product identity, native World geometry, World-specific Explore payloads, retained presentation assets, and runtime boundaries
- separate approved direction from implemented availability and keep Saved Views, ordinary World-aware Compare, shared variation, and Fun With Soundings visible as current gaps
- link the merged Current Product Sequence authority and use the current gated product-architecture framing

Closes #431

## Factual audit

| Material claim | Implementation source |
| --- | --- |
| Trade Cumulus, Mountain Waves, and Supercells are accessible peer Worlds | `app/frontend/src/App.tsx`, `CloudWorldsHome.tsx`, the three `*World.tsx` components, `GET /api/worlds`, and live navigation |
| Stable World and Simulation identities resolve separately to retained run assets | `app/backend/cloud_chamber/cloud_worlds.py`, `mountain_waves_world.py`, and `supercells_world.py` |
| Trade Cumulus combines a 3-D cloud field, native slices, and Updraft Lens | `IntegratedExploreWorkspace.tsx`, `True3DViewer.tsx`, `UpdraftLensSlice.tsx`, and visualization APIs |
| Mountain Waves is native terrain-aware x-z, with Field, Wave Structure, and Wave Cloud views | `MountainWavesExplore.tsx`, `mountain_waves_world.py`, and the live Boulder Windstorm Explore surface |
| Supercells coordinates 3-D with native x-y, x-z, and y-z evidence and three Lenses | `SupercellsExplore.tsx`, `supercells_world.py`, and the live Quarter-Circle Supercell Explore surface |
| Fixed scales, bounded crops/slices/point budgets, native selection, and frame-aware loading are implemented | the three World backends, `visualization_data.py`, Explore components, and their tests |
| Built-ins use retained presentation-quality local outputs outside Git | `presentation_runs.py`, `supercell_presentation.py`, World inventory modules, PRs #425 and #430 |
| Saved Views, ordinary World-aware Compare, and shared three-World variation are not implemented | current World components, capability payloads, and live World section audit |
| Fun With Soundings is approved but not accessible | current app routing/home inventory and queued issue #395 |
| Current sequence and gated-program governance | `docs/product/CURRENT_PRODUCT_SEQUENCE.md`, current `AGENTS.md`, and latest PM issue decisions |

## Review corrections

- rebased onto merged PR #424 and linked `docs/product/CURRENT_PRODUCT_SEQUENCE.md` from authority and reading paths
- removed the obsolete claim that PR #424 lacked review and removed the duplicate roadmap/self-referential #431 row
- retained only a concise current transition summary, including the completed foundation, #428, and bounded records #394/#395 and #432-#438
- replaced repository-recovery-only governance wording with the current gated product-architecture program and described repository recovery as a completed earlier stage

## Verification

- live desktop navigation audit of the Cloud Worlds home and all three World and Explore surfaces
- local Markdown-link check for all four changed documents
- `git diff --check`
- `scripts/check.sh`
  - 154 frontend tests passed
  - production frontend build passed
  - 655 backend tests passed
  - script and documentation sanity checks passed

## Review posture

Manual PM review is required. Auto-merge is not enabled.
