### PR TITLE
Unify Explore Context and durable Simulation notes

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -15,6 +15,7 @@ from cloud_chamber.cloud_worlds import (
     CloudWorldSummary,
     TradeCumulusWorldDetail,
     list_cloud_world_summaries,
+    trade_cumulus_simulation_exists,
     trade_cumulus_world_detail,
 )
 from cloud_chamber.dry_run_package import (
@@ -60,6 +61,7 @@ from cloud_chamber.mountain_waves_world import (
     MountainWavesWorldDetail,
     MountainWavesWorldSummary,
     mountain_waves_run_manifest,
+    mountain_waves_simulation,
     mountain_waves_world_detail,
 )
 from cloud_chamber.observed_sounding import ObservedSoundingError, parse_igra_station_text
@@ -94,7 +96,14 @@ from cloud_chamber.selected_region_diagnostics import (
     SelectedRegionRequest,
     selected_region_diagnostics,
 )
-from cloud_chamber.settings import load_settings
+from cloud_chamber.settings import CloudChamberSettings, load_settings
+from cloud_chamber.simulation_notes import (
+    SimulationNoteError,
+    SimulationNoteResponse,
+    SimulationNoteUpdate,
+    load_simulation_note,
+    save_simulation_note,
+)
 from cloud_chamber.sounding_candidates import (
     CandidateHistoryScope,
     CandidateReadinessFilter,
@@ -632,6 +641,59 @@ def get_supercells_world() -> SupercellsWorldDetail:
 
 
 @app.get(
+    "/api/worlds/{world_id}/simulations/{simulation_id}/note",
+    response_model=SimulationNoteResponse,
+)
+def get_simulation_note(world_id: str, simulation_id: str) -> SimulationNoteResponse:
+    settings = load_settings()
+    canonical_world_id = _canonical_note_world_id(world_id)
+    if not _simulation_note_target_exists(
+        canonical_world_id,
+        simulation_id,
+        settings=settings,
+    ):
+        raise HTTPException(status_code=404, detail="Cloud World Simulation not found.")
+    try:
+        note = load_simulation_note(
+            settings,
+            world_id=canonical_world_id,
+            simulation_id=simulation_id,
+        )
+    except SimulationNoteError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return SimulationNoteResponse(note=note)
+
+
+@app.put(
+    "/api/worlds/{world_id}/simulations/{simulation_id}/note",
+    response_model=SimulationNoteResponse,
+)
+def put_simulation_note(
+    world_id: str,
+    simulation_id: str,
+    request: SimulationNoteUpdate,
+) -> SimulationNoteResponse:
+    settings = load_settings()
+    canonical_world_id = _canonical_note_world_id(world_id)
+    if not _simulation_note_target_exists(
+        canonical_world_id,
+        simulation_id,
+        settings=settings,
+    ):
+        raise HTTPException(status_code=404, detail="Cloud World Simulation not found.")
+    try:
+        note = save_simulation_note(
+            settings,
+            world_id=canonical_world_id,
+            simulation_id=simulation_id,
+            text=request.text,
+        )
+    except SimulationNoteError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return SimulationNoteResponse(note=note)
+
+
+@app.get(
     "/api/worlds/mountain-waves/variation-template",
     response_model=MountainWavesVariationTemplate,
 )
@@ -974,6 +1036,35 @@ def get_storm_examination_frame(
     except StormExaminationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return result.model_dump(mode="json")
+
+
+def _canonical_note_world_id(world_id: str) -> str:
+    aliases = {
+        "trade-cumulus": "trade_cumulus",
+        "trade_cumulus": "trade_cumulus",
+        "mountain-waves": "mountain_waves",
+        "mountain_waves": "mountain_waves",
+        "supercells": "supercells",
+    }
+    canonical = aliases.get(world_id)
+    if canonical is None:
+        raise HTTPException(status_code=404, detail="Cloud World not found.")
+    return canonical
+
+
+def _simulation_note_target_exists(
+    world_id: str,
+    simulation_id: str,
+    *,
+    settings: CloudChamberSettings,
+) -> bool:
+    if world_id == "trade_cumulus":
+        return trade_cumulus_simulation_exists(settings, simulation_id)
+    if world_id == "mountain_waves":
+        return mountain_waves_simulation(settings, simulation_id) is not None
+    if world_id == "supercells":
+        return simulation_id == SUPERCELLS_REFERENCE_SIMULATION_ID
+    return False
 
 
 @app.get("/api/results/{result_id}/visualization/trade-cumulus-updraft-lens/frame")

--- a/app/backend/cloud_chamber/cloud_worlds.py
+++ b/app/backend/cloud_chamber/cloud_worlds.py
@@ -371,6 +371,39 @@ def trade_cumulus_world_detail(settings: CloudChamberSettings) -> TradeCumulusWo
     )
 
 
+def trade_cumulus_simulation_exists(
+    settings: CloudChamberSettings,
+    simulation_id: str,
+) -> bool:
+    """Resolve one stable Simulation identity without building the complete World."""
+    known = {
+        spec.simulation_id: _load_known_simulation(settings, spec)
+        for spec in (_REFERENCE_SPEC, _MORE_MOISTURE_SPEC)
+    }
+    if simulation_id in known:
+        return known[simulation_id].metadata is not None
+
+    other_metadata = [
+        metadata
+        for metadata in list_result_metadata(settings)
+        if metadata.result_id
+        not in {
+            PRESENTATION_BASELINE_RESULT_ID,
+            PRESENTATION_MORE_MOISTURE_RESULT_ID,
+        }
+        and _is_trade_cumulus_result(metadata)
+    ]
+    retained, _ = _ordinary_simulations(
+        other_metadata,
+        known_metadata={
+            record.record.simulation_id: record.metadata
+            for record in known.values()
+            if record.record.simulation_id is not None and record.metadata is not None
+        },
+    )
+    return any(record.simulation_id == simulation_id for record in retained)
+
+
 def configuration_differences(
     left: ResultMetadata, right: ResultMetadata
 ) -> list[ConfigurationDifference]:

--- a/app/backend/cloud_chamber/selected_region_diagnostics.py
+++ b/app/backend/cloud_chamber/selected_region_diagnostics.py
@@ -25,6 +25,7 @@ from cloud_chamber.visualization_data import (
     _coordinate_units,
     _coordinate_values,
     _field_dimensions,
+    _open_dataset_for_time,
     _open_dataset_sequence,
     _provenance,
     _time_value_seconds,
@@ -151,52 +152,173 @@ def selected_region_diagnostics(
         raise SelectedRegionError("neighborhood must be greater than or equal to 0.")
 
     metadata = get_result_metadata(settings, result_id)
+    if _has_one_file_per_time(metadata):
+        try:
+            return _selected_region_diagnostics_from_files(metadata, request)
+        except VisualizationDataError as exc:
+            raise SelectedRegionError(str(exc)) from exc
+
     dataset, close_datasets = _open_dataset_sequence(metadata)
     try:
         caveats = list(metadata.warnings)
-        if "qc" not in dataset.data_vars:
+        cloud_liquid_field = _cloud_liquid_field(dataset)
+        if cloud_liquid_field is None:
             caveats.append("missing_qc_field")
         if "w" not in dataset.data_vars:
             caveats.append("missing_w_field")
 
-        reference_field = (
-            "qc" if "qc" in dataset.data_vars else "w" if "w" in dataset.data_vars else None
-        )
+        reference_field = cloud_liquid_field or ("w" if "w" in dataset.data_vars else None)
         if reference_field is None:
             raise SelectedRegionError("Selected-region diagnostics require qc or w fields.")
         region = _region_metadata(dataset, request, reference_field)
         diagnostics = _local_diagnostics(dataset, request, caveats)
         comparison = _comparison_to_domain(metadata, diagnostics)
         interpretation = _interpret_region(diagnostics, caveats)
-        return SelectedRegionDiagnosticsResponse(
-            result_id=metadata.result_id,
-            run_id=metadata.run_id,
-            scenario_id=metadata.scenario_id,
-            region=region,
-            diagnostics=diagnostics,
-            comparison_to_domain=comparison,
-            interpretation=interpretation,
-            provenance=_provenance(
-                metadata,
-                processing_method="backend_xarray_selected_region_diagnostics",
-                rendering_method="thermal_fate_inspector_summary",
-                provenance_label=(
-                    "CM1-derived selected-region diagnostics; native-grid summary; "
-                    "browser receives bounded payload only"
-                ),
-            ),
-            caveats=_dedupe(
-                [
-                    *caveats,
-                    "native_grid_region_summary_no_interpolation",
-                    "selected_region_is_not_cloud_object_tracking",
-                ]
-            ),
+        return _selected_region_response(
+            metadata,
+            region,
+            diagnostics,
+            comparison,
+            interpretation,
+            caveats,
         )
     except VisualizationDataError as exc:
         raise SelectedRegionError(str(exc)) from exc
     finally:
         _close_all(close_datasets)
+
+
+def _has_one_file_per_time(metadata: Any) -> bool:
+    return (
+        metadata.time_steps is not None
+        and metadata.time_steps > 1
+        and len(metadata.model_output_paths) == metadata.time_steps
+    )
+
+
+def _selected_region_diagnostics_from_files(
+    metadata: Any,
+    request: SelectedRegionRequest,
+) -> SelectedRegionDiagnosticsResponse:
+    caveats = list(metadata.warnings)
+    diagnostics = LocalDiagnosticSummary()
+    region: RegionMetadata | None = None
+
+    for time_index in range(int(metadata.time_steps or 0)):
+        dataset, close_datasets, _ = _open_dataset_for_time(metadata, time_index)
+        try:
+            if region is None:
+                cloud_liquid_field = _cloud_liquid_field(dataset)
+                reference_field = cloud_liquid_field or ("w" if "w" in dataset.data_vars else None)
+                if reference_field is None:
+                    raise SelectedRegionError("Selected-region diagnostics require qc or w fields.")
+                region = _region_metadata(dataset, request, reference_field)
+                if cloud_liquid_field is None:
+                    caveats.append("missing_qc_field")
+                if "w" not in dataset.data_vars:
+                    caveats.append("missing_w_field")
+            _merge_local_diagnostics(
+                diagnostics,
+                _local_diagnostics(dataset, request, caveats),
+            )
+        finally:
+            _close_all(close_datasets)
+
+    if region is None:
+        raise SelectedRegionError("Selected-region diagnostics found no retained model output.")
+    comparison = _comparison_to_domain(metadata, diagnostics)
+    interpretation = _interpret_region(diagnostics, caveats)
+    return _selected_region_response(
+        metadata,
+        region,
+        diagnostics,
+        comparison,
+        interpretation,
+        caveats,
+    )
+
+
+def _merge_local_diagnostics(
+    target: LocalDiagnosticSummary,
+    source: LocalDiagnosticSummary,
+) -> None:
+    target.available = target.available and source.available
+    target.local_w_max_time_series.extend(source.local_w_max_time_series)
+    target.local_w_min_time_series.extend(source.local_w_min_time_series)
+    target.local_qc_max_time_series.extend(source.local_qc_max_time_series)
+    target.local_cloud_fraction_time_series.extend(source.local_cloud_fraction_time_series)
+    target.local_cloud_base_time_series.extend(source.local_cloud_base_time_series)
+    target.local_cloud_top_time_series.extend(source.local_cloud_top_time_series)
+    target.local_max_qc_height_time_series.extend(source.local_max_qc_height_time_series)
+    target.local_max_w_height_time_series.extend(source.local_max_w_height_time_series)
+    target.local_qr_max_time_series.extend(source.local_qr_max_time_series)
+
+    if source.local_max_w_m_s is not None and (
+        target.local_max_w_m_s is None or source.local_max_w_m_s > target.local_max_w_m_s
+    ):
+        target.local_max_w_m_s = source.local_max_w_m_s
+        target.time_of_local_max_w_seconds = source.time_of_local_max_w_seconds
+    if source.local_min_w_m_s is not None and (
+        target.local_min_w_m_s is None or source.local_min_w_m_s < target.local_min_w_m_s
+    ):
+        target.local_min_w_m_s = source.local_min_w_m_s
+        target.time_of_local_min_w_seconds = source.time_of_local_min_w_seconds
+    if source.local_max_qc_kg_kg is not None and (
+        target.local_max_qc_kg_kg is None or source.local_max_qc_kg_kg > target.local_max_qc_kg_kg
+    ):
+        target.local_max_qc_kg_kg = source.local_max_qc_kg_kg
+        target.time_of_local_max_qc_seconds = source.time_of_local_max_qc_seconds
+    if (
+        target.first_local_cloud_time_seconds is None
+        and source.first_local_cloud_time_seconds is not None
+    ):
+        target.first_local_cloud_time_seconds = source.first_local_cloud_time_seconds
+    if source.local_max_qr_kg_kg is not None and (
+        target.local_max_qr_kg_kg is None or source.local_max_qr_kg_kg > target.local_max_qr_kg_kg
+    ):
+        target.local_max_qr_kg_kg = source.local_max_qr_kg_kg
+        target.time_of_local_max_qr_seconds = source.time_of_local_max_qr_seconds
+    target.local_rain_present = target.local_rain_present or source.local_rain_present
+    if (
+        target.first_local_rain_time_seconds is None
+        and source.first_local_rain_time_seconds is not None
+    ):
+        target.first_local_rain_time_seconds = source.first_local_rain_time_seconds
+
+
+def _selected_region_response(
+    metadata: Any,
+    region: RegionMetadata,
+    diagnostics: LocalDiagnosticSummary,
+    comparison: DomainComparison,
+    interpretation: SelectedRegionInterpretation,
+    caveats: list[str],
+) -> SelectedRegionDiagnosticsResponse:
+    return SelectedRegionDiagnosticsResponse(
+        result_id=metadata.result_id,
+        run_id=metadata.run_id,
+        scenario_id=metadata.scenario_id,
+        region=region,
+        diagnostics=diagnostics,
+        comparison_to_domain=comparison,
+        interpretation=interpretation,
+        provenance=_provenance(
+            metadata,
+            processing_method="backend_xarray_selected_region_diagnostics",
+            rendering_method="thermal_fate_inspector_summary",
+            provenance_label=(
+                "CM1-derived selected-region diagnostics; native-grid summary; "
+                "browser receives bounded payload only"
+            ),
+        ),
+        caveats=_dedupe(
+            [
+                *caveats,
+                "native_grid_region_summary_no_interpolation",
+                "selected_region_is_not_cloud_object_tracking",
+            ]
+        ),
+    )
 
 
 def _local_diagnostics(
@@ -205,8 +327,9 @@ def _local_diagnostics(
     caveats: list[str],
 ) -> LocalDiagnosticSummary:
     summary = LocalDiagnosticSummary()
-    if "qc" in dataset.data_vars:
-        _add_qc_summary(dataset, request, summary, caveats)
+    cloud_liquid_field = _cloud_liquid_field(dataset)
+    if cloud_liquid_field is not None:
+        _add_qc_summary(dataset, cloud_liquid_field, request, summary, caveats)
     else:
         summary.available = False
     if "w" in dataset.data_vars:
@@ -220,11 +343,12 @@ def _local_diagnostics(
 
 def _add_qc_summary(
     dataset: Any,
+    field_name: str,
     request: SelectedRegionRequest,
     summary: LocalDiagnosticSummary,
     caveats: list[str],
 ) -> None:
-    data_array = dataset["qc"]
+    data_array = dataset[field_name]
     dims = _field_dimensions(data_array)
     if not dims.time or not dims.vertical or not dims.y or not dims.x:
         summary.available = False
@@ -266,6 +390,13 @@ def _add_qc_summary(
             max_time = time_seconds
     summary.local_max_qc_kg_kg = max_value
     summary.time_of_local_max_qc_seconds = max_time
+
+
+def _cloud_liquid_field(dataset: Any) -> str | None:
+    for field_name in ("qc", "ql"):
+        if field_name in dataset.data_vars:
+            return field_name
+    return None
 
 
 def _add_w_summary(

--- a/app/backend/cloud_chamber/simulation_notes.py
+++ b/app/backend/cloud_chamber/simulation_notes.py
@@ -1,0 +1,128 @@
+"""Durable notes keyed to stable Cloud World and Simulation identities."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from cloud_chamber.settings import CloudChamberSettings
+
+NOTE_SCHEMA_VERSION: Literal[1] = 1
+MAX_NOTE_CHARACTERS = 20_000
+_IDENTITY_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+
+
+class SimulationNoteError(ValueError):
+    """Raised when a Simulation note cannot be read or persisted safely."""
+
+
+class SimulationNoteRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = NOTE_SCHEMA_VERSION
+    world_id: str
+    simulation_id: str
+    text: str = Field(max_length=MAX_NOTE_CHARACTERS)
+    created_at: datetime
+    updated_at: datetime
+
+
+class SimulationNoteResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    note: SimulationNoteRecord | None
+
+
+class SimulationNoteUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    text: str = Field(max_length=MAX_NOTE_CHARACTERS)
+
+
+def load_simulation_note(
+    settings: CloudChamberSettings,
+    *,
+    world_id: str,
+    simulation_id: str,
+) -> SimulationNoteRecord | None:
+    """Load one note without coupling it to a replaceable run artifact."""
+    path = _note_path(settings, world_id=world_id, simulation_id=simulation_id)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+        record = SimulationNoteRecord.model_validate(payload)
+    except (OSError, json.JSONDecodeError, ValidationError) as exc:
+        raise SimulationNoteError("The saved Simulation note is invalid or unreadable.") from exc
+    if record.world_id != world_id or record.simulation_id != simulation_id:
+        raise SimulationNoteError("The saved Simulation note identity does not match its path.")
+    return record
+
+
+def save_simulation_note(
+    settings: CloudChamberSettings,
+    *,
+    world_id: str,
+    simulation_id: str,
+    text: str,
+) -> SimulationNoteRecord | None:
+    """Atomically save one note, or clear it when the submitted text is empty."""
+    path = _note_path(settings, world_id=world_id, simulation_id=simulation_id)
+    normalized_text = text.strip()
+    if not normalized_text:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise SimulationNoteError("The Simulation note could not be cleared.") from exc
+        return None
+
+    existing = load_simulation_note(
+        settings,
+        world_id=world_id,
+        simulation_id=simulation_id,
+    )
+    now = datetime.now(UTC)
+    record = SimulationNoteRecord(
+        world_id=world_id,
+        simulation_id=simulation_id,
+        text=normalized_text,
+        created_at=existing.created_at if existing else now,
+        updated_at=now,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        with temporary_path.open("x") as handle:
+            handle.write(record.model_dump_json(indent=2) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    except OSError as exc:
+        temporary_path.unlink(missing_ok=True)
+        raise SimulationNoteError("The Simulation note could not be saved.") from exc
+    return record
+
+
+def _note_path(
+    settings: CloudChamberSettings,
+    *,
+    world_id: str,
+    simulation_id: str,
+) -> Path:
+    _validate_identity("World", world_id)
+    _validate_identity("Simulation", simulation_id)
+    return (
+        settings.runtime_home.expanduser() / "simulation-notes" / world_id / f"{simulation_id}.json"
+    )
+
+
+def _validate_identity(label: str, value: str) -> None:
+    if not _IDENTITY_PATTERN.fullmatch(value):
+        raise SimulationNoteError(f"{label} identity is invalid.")

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -38,6 +38,78 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
 
 
+@pytest.mark.parametrize(
+    ("world_slug", "world_id", "simulation_id"),
+    [
+        (
+            "trade-cumulus",
+            "trade_cumulus",
+            "trade_cumulus_canonical_bomex",
+        ),
+        (
+            "mountain-waves",
+            "mountain_waves",
+            "mountain_waves_boulder_moist_reference",
+        ),
+        (
+            "supercells",
+            "supercells",
+            "supercells_quarter_circle_reference",
+        ),
+    ],
+)
+def test_simulation_note_api_saves_reloads_and_clears_for_each_world(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    world_slug: str,
+    world_id: str,
+    simulation_id: str,
+) -> None:
+    settings = SimpleNamespace(runtime_home=tmp_path)
+    monkeypatch.setattr("cloud_chamber.app.load_settings", lambda: settings)
+    monkeypatch.setattr(
+        "cloud_chamber.app._simulation_note_target_exists",
+        lambda *_args, **_kwargs: True,
+    )
+    client = TestClient(app)
+    path = f"/api/worlds/{world_slug}/simulations/{simulation_id}/note"
+
+    empty = client.get(path)
+    saved = client.put(path, json={"text": f"Observation for {world_id}."})
+    reloaded = client.get(path)
+    cleared = client.put(path, json={"text": ""})
+
+    assert empty.status_code == 200
+    assert empty.json() == {"note": None}
+    assert saved.status_code == 200
+    assert saved.json()["note"]["world_id"] == world_id
+    assert saved.json()["note"]["simulation_id"] == simulation_id
+    assert saved.json()["note"]["text"] == f"Observation for {world_id}."
+    assert reloaded.json() == saved.json()
+    assert cleared.status_code == 200
+    assert cleared.json() == {"note": None}
+    assert client.get(path).json() == {"note": None}
+
+
+def test_simulation_note_api_fails_closed_for_unknown_simulation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "cloud_chamber.app.load_settings",
+        lambda: SimpleNamespace(runtime_home=tmp_path),
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.app._simulation_note_target_exists",
+        lambda *_args, **_kwargs: False,
+    )
+
+    response = TestClient(app).get("/api/worlds/supercells/simulations/not-a-simulation/note")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Cloud World Simulation not found."
+
+
 def _world_summary_payload() -> dict[str, object]:
     return {
         "world_id": "trade_cumulus",

--- a/app/backend/tests/test_cloud_worlds.py
+++ b/app/backend/tests/test_cloud_worlds.py
@@ -17,6 +17,7 @@ from cloud_chamber.cloud_worlds import (
     REFERENCE_SIMULATION_ID,
     configuration_differences,
     list_cloud_world_summaries,
+    trade_cumulus_simulation_exists,
     trade_cumulus_world_detail,
 )
 from cloud_chamber.result_ingest import ResultMetadata
@@ -190,6 +191,21 @@ def test_world_summary_and_detail_map_exact_known_pair(
     assert detail.simulations[1].parent_simulation_id == REFERENCE_SIMULATION_ID
     assert len(detail.simulations) == 2
     assert detail.featured_comparison.open_available is True
+
+
+def test_simulation_identity_lookup_skips_complete_world_construction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = _settings(tmp_path)
+    _install_pair(settings, monkeypatch)
+    monkeypatch.setattr(
+        "cloud_chamber.cloud_worlds.trade_cumulus_moisture_comparison_story",
+        lambda _settings: pytest.fail("The identity lookup must not build the featured story."),
+    )
+
+    assert trade_cumulus_simulation_exists(settings, REFERENCE_SIMULATION_ID)
+    assert trade_cumulus_simulation_exists(settings, MORE_MOISTURE_SIMULATION_ID)
+    assert not trade_cumulus_simulation_exists(settings, "not-a-simulation")
 
 
 def test_missing_baseline_is_bounded_and_keeps_lab_available(tmp_path: Path) -> None:

--- a/app/backend/tests/test_selected_region_diagnostics.py
+++ b/app/backend/tests/test_selected_region_diagnostics.py
@@ -46,6 +46,8 @@ def create_region_result(
     include_w: bool = True,
     include_qr: bool = True,
     run_id: str = "run-region",
+    separate_files: bool = False,
+    cloud_field_name: str = "qc",
 ) -> tuple[CloudChamberSettings, str]:
     settings = fake_settings(tmp_path)
     package = generate_dry_run_package(
@@ -53,13 +55,19 @@ def create_region_result(
         runtime_home=settings.runtime_home,
         run_id=run_id,
     )
-    netcdf_path = package.package_dir / "cm1out_000001.nc"
-    write_region_netcdf(
-        netcdf_path,
-        include_qc=include_qc,
-        include_w=include_w,
-        include_qr=include_qr,
-    )
+    netcdf_paths = [
+        package.package_dir / f"cm1out_{index + 1:06d}.nc"
+        for index in range(3 if separate_files else 1)
+    ]
+    for index, netcdf_path in enumerate(netcdf_paths):
+        write_region_netcdf(
+            netcdf_path,
+            include_qc=include_qc,
+            include_w=include_w,
+            include_qr=include_qr,
+            time_indices=[index] if separate_files else None,
+            cloud_field_name=cloud_field_name,
+        )
     manifest = load_run_manifest(package.manifest_path)
     write_run_manifest(
         package.manifest_path,
@@ -67,7 +75,7 @@ def create_region_result(
             update={
                 "lifecycle_state": LifecycleState.COMPLETED,
                 "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
-                "outputs": OutputMetadata(netcdf_paths=[str(netcdf_path)]),
+                "outputs": OutputMetadata(netcdf_paths=[str(path) for path in netcdf_paths]),
             }
         ),
     )
@@ -81,29 +89,44 @@ def write_region_netcdf(
     include_qc: bool,
     include_w: bool,
     include_qr: bool,
+    time_indices: list[int] | None = None,
+    cloud_field_name: str = "qc",
 ) -> None:
+    selected_times = time_indices or [0, 1, 2]
     data_vars = {}
     if include_qc:
         qc = np.zeros((3, 3, 3, 4), dtype=float)
         qc[1, 1, 1, 2] = 2e-6
         qc[2, 2, 1, 2] = 5e-6
         qc[2, 1, 0, 0] = np.inf
-        data_vars["qc"] = (("time", "zh", "yh", "xh"), qc, {"units": "kg/kg"})
+        data_vars[cloud_field_name] = (
+            ("time", "zh", "yh", "xh"),
+            qc[selected_times],
+            {"units": "kg/kg"},
+        )
     if include_w:
         w = np.zeros((3, 3, 3, 4), dtype=float)
         w[0, 1, 1, 2] = 0.4
         w[1, 1, 1, 2] = 1.8
         w[2, 2, 1, 2] = 2.4
         w[2, 0, 0, 0] = -0.7
-        data_vars["w"] = (("time", "zf", "yh", "xh"), w, {"units": "m/s"})
+        data_vars["w"] = (("time", "zf", "yh", "xh"), w[selected_times], {"units": "m/s"})
     if include_qr:
         qr = np.zeros((3, 3, 3, 4), dtype=float)
         qr[2, 1, 1, 2] = 2e-7
-        data_vars["qr"] = (("time", "zh", "yh", "xh"), qr, {"units": "kg/kg"})
+        data_vars["qr"] = (
+            ("time", "zh", "yh", "xh"),
+            qr[selected_times],
+            {"units": "kg/kg"},
+        )
     xr.Dataset(
         data_vars=data_vars,
         coords={
-            "time": ("time", [0.0, 900.0, 1800.0], {"units": "s"}),
+            "time": (
+                "time",
+                [[0.0, 900.0, 1800.0][index] for index in selected_times],
+                {"units": "s"},
+            ),
             "zh": ("zh", [0.4, 0.8, 1.2], {"units": "km"}),
             "zf": ("zf", [0.0, 0.8, 1.6], {"units": "km"}),
             "yh": ("yh", [0.0, 1.0, 2.0], {"units": "km"}),
@@ -158,6 +181,52 @@ def test_column_region_uses_vertical_extent_and_detects_growth(tmp_path: Path) -
     assert payload.diagnostics.local_cloud_top_time_series[-1].value == 1200.0
     assert payload.diagnostics.local_max_w_height_time_series[-1].value == 1600.0
     assert payload.interpretation.thermal_fate_label == "Growing cumulus"
+
+
+def test_separate_history_files_are_processed_with_bounded_memory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings, result_id = create_region_result(tmp_path, separate_files=True)
+
+    def reject_combined_sequence(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("one-file-per-time histories must not be concatenated")
+
+    monkeypatch.setattr(
+        "cloud_chamber.selected_region_diagnostics._open_dataset_sequence",
+        reject_combined_sequence,
+    )
+    payload = selected_region_diagnostics(
+        settings,
+        result_id,
+        SelectedRegionRequest(region_type="column", x_index=2, y_index=1),
+    )
+
+    assert len(payload.diagnostics.local_w_max_time_series) == 3
+    assert payload.diagnostics.local_max_w_m_s == 2.4
+    assert payload.diagnostics.time_of_local_max_w_seconds == 1800.0
+    assert payload.diagnostics.local_max_qc_kg_kg == 5e-6
+    assert payload.diagnostics.local_cloud_top_time_series[-1].value == 1200.0
+    assert payload.diagnostics.first_local_rain_time_seconds == 1800.0
+
+
+def test_native_ql_is_used_as_cloud_liquid_history(tmp_path: Path) -> None:
+    settings, result_id = create_region_result(
+        tmp_path,
+        separate_files=True,
+        cloud_field_name="ql",
+    )
+
+    payload = selected_region_diagnostics(
+        settings,
+        result_id,
+        SelectedRegionRequest(region_type="column", x_index=2, y_index=1),
+    )
+
+    assert payload.diagnostics.available is True
+    assert payload.diagnostics.local_max_qc_kg_kg == 5e-6
+    assert payload.diagnostics.first_local_cloud_time_seconds == 900.0
+    assert "missing_qc_field" not in payload.caveats
 
 
 def test_box_region_summarizes_bounded_area(tmp_path: Path) -> None:

--- a/app/backend/tests/test_simulation_notes.py
+++ b/app/backend/tests/test_simulation_notes.py
@@ -1,0 +1,133 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from cloud_chamber.settings import load_settings
+from cloud_chamber.simulation_notes import (
+    MAX_NOTE_CHARACTERS,
+    SimulationNoteError,
+    load_simulation_note,
+    save_simulation_note,
+)
+
+
+def test_simulation_note_persists_by_stable_world_and_simulation_identity(
+    tmp_path: Path,
+) -> None:
+    settings = load_settings(home=tmp_path)
+
+    created = save_simulation_note(
+        settings,
+        world_id="trade_cumulus",
+        simulation_id="trade_cumulus_canonical_bomex",
+        text="  Cloud deepens after the third hour.  ",
+    )
+
+    assert created is not None
+    assert created.text == "Cloud deepens after the third hour."
+    assert created.created_at == created.updated_at
+    loaded = load_simulation_note(
+        settings,
+        world_id="trade_cumulus",
+        simulation_id="trade_cumulus_canonical_bomex",
+    )
+    assert loaded == created
+    assert (
+        tmp_path / "simulation-notes" / "trade_cumulus" / "trade_cumulus_canonical_bomex.json"
+    ).exists()
+
+
+def test_simulation_note_update_preserves_created_at_and_clear_removes_record(
+    tmp_path: Path,
+) -> None:
+    settings = load_settings(home=tmp_path)
+    first = save_simulation_note(
+        settings,
+        world_id="mountain_waves",
+        simulation_id="mountain_waves_boulder_moist_reference",
+        text="First observation",
+    )
+    updated = save_simulation_note(
+        settings,
+        world_id="mountain_waves",
+        simulation_id="mountain_waves_boulder_moist_reference",
+        text="Updated observation",
+    )
+
+    assert first is not None
+    assert updated is not None
+    assert updated.created_at == first.created_at
+    assert updated.updated_at >= first.updated_at
+
+    cleared = save_simulation_note(
+        settings,
+        world_id="mountain_waves",
+        simulation_id="mountain_waves_boulder_moist_reference",
+        text="   ",
+    )
+
+    assert cleared is None
+    assert (
+        load_simulation_note(
+            settings,
+            world_id="mountain_waves",
+            simulation_id="mountain_waves_boulder_moist_reference",
+        )
+        is None
+    )
+
+
+def test_simulation_note_rejects_invalid_identity_and_corrupt_saved_data(
+    tmp_path: Path,
+) -> None:
+    settings = load_settings(home=tmp_path)
+    with pytest.raises(SimulationNoteError, match="World identity is invalid"):
+        save_simulation_note(
+            settings,
+            world_id="../supercells",
+            simulation_id="supercells_quarter_circle_reference",
+            text="unsafe",
+        )
+
+    path = tmp_path / "simulation-notes" / "supercells" / "supercells_quarter_circle_reference.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"schema_version": 1, "text": "incomplete"}))
+
+    with pytest.raises(SimulationNoteError, match="invalid or unreadable"):
+        load_simulation_note(
+            settings,
+            world_id="supercells",
+            simulation_id="supercells_quarter_circle_reference",
+        )
+
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "world_id": "supercells",
+                "simulation_id": "supercells_quarter_circle_reference",
+                "text": "future schema",
+                "created_at": "2026-07-23T12:00:00Z",
+                "updated_at": "2026-07-23T12:00:00Z",
+            },
+        ),
+    )
+    with pytest.raises(SimulationNoteError, match="invalid or unreadable"):
+        load_simulation_note(
+            settings,
+            world_id="supercells",
+            simulation_id="supercells_quarter_circle_reference",
+        )
+
+
+def test_simulation_note_text_is_bounded(tmp_path: Path) -> None:
+    settings = load_settings(home=tmp_path)
+
+    with pytest.raises(ValueError):
+        save_simulation_note(
+            settings,
+            world_id="supercells",
+            simulation_id="supercells_quarter_circle_reference",
+            text="x" * (MAX_NOTE_CHARACTERS + 1),
+        )

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -1709,8 +1709,14 @@ export async function mockCloudChamberApis(page: Page) {
         first_local_cloud_time_seconds: 1800,
         local_cloud_fraction_time_series: [{ time_seconds: 1800, value: 0.5 }],
         local_qc_max_time_series: [{ time_seconds: 1800, value: 0.002 }],
-        local_cloud_base_time_series: [],
-        local_cloud_top_time_series: [],
+        local_cloud_base_time_series: [
+          { time_seconds: 1800, value: 500 },
+          { time_seconds: 2700, value: 650 },
+        ],
+        local_cloud_top_time_series: [
+          { time_seconds: 1800, value: 1100 },
+          { time_seconds: 2700, value: 1600 },
+        ],
         local_max_qc_height_time_series: [],
         local_max_w_height_time_series: [],
         local_rain_present: true,

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -1224,6 +1224,17 @@ function mockPointCloudPoints(fieldName: string, dryFailed: boolean, threshold: 
 }
 
 export async function mockCloudChamberApis(page: Page) {
+  const simulationNotes = new Map<
+    string,
+    {
+      schema_version: number;
+      world_id: string;
+      simulation_id: string;
+      text: string;
+      created_at: string;
+      updated_at: string;
+    }
+  >();
   let savedSoundingCandidates: Array<{
     saved_candidate_id: string;
     candidate: typeof shallowSoundingCandidate;
@@ -1246,6 +1257,33 @@ export async function mockCloudChamberApis(page: Page) {
     queued_count: 0,
     updated_at: "2026-05-22T15:15:00Z",
   };
+
+  await page.route("**/api/worlds/*/simulations/*/note", (route) => {
+    const url = new URL(route.request().url());
+    const segments = url.pathname.split("/");
+    const worldId = (segments[3] ?? "").replaceAll("-", "_");
+    const simulationId = decodeURIComponent(segments[5] ?? "");
+    const key = `${worldId}/${simulationId}`;
+    if (route.request().method() === "PUT") {
+      const body = (route.request().postDataJSON() ?? {}) as { text?: string };
+      const text = body.text?.trim() ?? "";
+      if (text) {
+        const existing = simulationNotes.get(key);
+        const updatedAt = "2026-07-23T18:30:00Z";
+        simulationNotes.set(key, {
+          schema_version: 1,
+          world_id: worldId,
+          simulation_id: simulationId,
+          text,
+          created_at: existing?.created_at ?? updatedAt,
+          updated_at: updatedAt,
+        });
+      } else {
+        simulationNotes.delete(key);
+      }
+    }
+    return json(route, { note: simulationNotes.get(key) ?? null });
+  });
 
   await page.route("**/api/worlds", (route) => json(route, []));
 

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -479,7 +479,48 @@ function comparisonLensFrame(member: ComparisonMember) {
   };
 }
 
+function comparisonLensDefaults(member: ComparisonMember) {
+  return {
+    result_id: member.result_id,
+    case_id: "bomex_trade_cumulus_baseline_v0",
+    eligible: true,
+    primary_field: "w",
+    cloud_field: "ql",
+    orientation: "vertical_x",
+    default_time_index: member.curated_view.time_index,
+    default_time_seconds: member.curated_view.time_seconds,
+    default_time_method: "curated_comparison_view",
+    default_plane_dimension: "y",
+    default_plane_index: member.curated_view.plane_index,
+    default_plane_coordinate: member.curated_view.plane_coordinate,
+    default_plane_units: "km",
+    default_plane_method: "curated_comparison_view",
+    cloud_threshold_kg_kg: 1e-6,
+    ...comparisonUpdraftScale,
+    wind_target_level_m: 600,
+    wind_actual_level_m: 580,
+    wind_level_index: 14,
+    wind_default_mode: "perturbation",
+    wind_stride: 8,
+    wind_shown_by_default: true,
+    perturbation_wind_reference_m_s: 0.9,
+    total_wind_reference_m_s: 8.8,
+    wind_arrow_domain_fraction: 0.08,
+    provenance: comparisonLensFrame(member).provenance,
+    caveats: [],
+  };
+}
+
 async function mockTradeCumulusComparison(page: Parameters<typeof mockCloudChamberApis>[0]) {
+  for (const result of [comparisonBaselineResult, comparisonMoreMoistureResult]) {
+    await page.route(`**/api/results/${result.result_id}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(result),
+      }),
+    );
+  }
   await page.route("**/api/results", (route) =>
     route.fulfill({
       status: 200,
@@ -507,6 +548,19 @@ async function mockTradeCumulusComparison(page: Parameters<typeof mockCloudChamb
       body: JSON.stringify(comparisonPointCloud(member)),
     });
   });
+  await page.route(
+    "**/api/results/*/visualization/trade-cumulus-updraft-lens/defaults",
+    (route) => {
+      const member = route.request().url().includes(comparisonMoreMoistureId)
+        ? comparisonStory.more_moisture
+        : comparisonStory.baseline;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(comparisonLensDefaults(member)),
+      });
+    },
+  );
   await page.route("**/api/results/*/visualization/trade-cumulus-updraft-lens/frame**", (route) => {
     const member = route.request().url().includes(comparisonMoreMoistureId)
       ? comparisonStory.more_moisture
@@ -584,7 +638,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByLabel("Canonical BOMEX Baseline workspace")).toBeVisible();
     await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible();
     await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
-    await expect(page.getByRole("complementary", { name: "Explore inspector" })).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Context" })).toBeVisible();
     await expect(page.getByText("Cloud formed")).toBeVisible();
     await expect(page.getByText("Deep convection not detected")).toHaveCount(0);
     await expect(page.getByRole("heading", { name: "Updraft Lens" })).toBeVisible({
@@ -597,12 +651,16 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await page.getByRole("button", { name: "Previous" }).click();
     await page.getByLabel("Updraft Lens slice position").fill("3");
     await expect(page.getByLabel("Updraft Lens slice position")).toHaveValue("3");
-    await expect(page.getByRole("heading", { name: "What am I seeing?" })).toBeVisible();
+    await expect(page.getByLabel("Current scientific context")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Where is air rising and sinking through cloud?" }),
+    ).toBeVisible();
+    await page.getByRole("tab", { name: "Details" }).click();
     await expect(page.getByRole("heading", { name: "Simulation details" })).toBeVisible();
-    await page.getByRole("button", { name: "Collapse inspector" }).click();
-    await expect(page.getByRole("button", { name: "Open inspector" })).toBeVisible();
-    await page.getByRole("button", { name: "Open inspector" }).click();
-    await expect(page.getByRole("heading", { name: "What am I seeing?" })).toBeVisible();
+    await page.getByRole("button", { name: "Hide Context" }).click();
+    await expect(page.getByRole("button", { name: "Show Context" })).toBeVisible();
+    await page.getByRole("button", { name: "Show Context" }).click();
+    await expect(page.getByLabel("Current scientific context")).toBeVisible();
     await expect(page.getByRole("button", { name: "Compare" })).toHaveCount(0);
     await page.getByRole("button", { name: "Back to Trade Cumulus" }).click();
 
@@ -937,7 +995,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     const moreMoistureControls = simulations.nth(1).getByLabel("3-D camera controls");
     await baselineControls.getByRole("button", { name: "Look along x" }).click();
     await expect(baselineControls).toContainText("Camera looking along the x axis");
-    await expect(moreMoistureControls).toContainText("Camera ready");
+    await expect(moreMoistureControls).toContainText("Camera set to overview");
 
     await page.setViewportSize({ width: 1440, height: 1000 });
     await simulations.nth(1).getByRole("button", { name: "Open More Moisture in Explore" }).click();
@@ -1117,10 +1175,14 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       .getByRole("button", { name: /inspect .*row 2, column 2/i })
       .first()
       .click();
-    await expect(page.getByText(/what happened here/i).first()).toBeVisible();
-    await expect(page.getByText("Point ready")).toBeVisible();
-    await expect(page.getByText(/cloud water appeared locally/i)).toBeVisible();
-    await expect(page.getByText(/local max w/i)).toBeVisible();
+    const selectedEvidence = page.getByLabel("Selected native-grid evidence");
+    await expect(selectedEvidence).toBeVisible();
+    await expect(
+      selectedEvidence.getByRole("heading", { name: "Native-grid evidence" }),
+    ).toBeVisible();
+    await expect(selectedEvidence.getByText("Cloud water", { exact: true })).toBeVisible();
+    await expect(selectedEvidence.getByText("Native cell", { exact: true })).toBeVisible();
+    await page.getByRole("tab", { name: "Details" }).click();
     await page.getByText("Technical slice details").first().click();
     await expect(page.getByText(/finite values/i).first()).toBeVisible();
     await expect(page.getByText(/\[\[[\d.,\s]+\]\]/)).not.toBeVisible();
@@ -1591,25 +1653,34 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
   test("Explore keeps current context primary and persists notes below the viewers", async ({
     page,
   }) => {
-    await gotoResults(page);
-    await page.getByRole("button", { name: "Open in Explore" }).first().click();
+    await mockTradeCumulusWorld(page);
+    await gotoApp(page);
+    await page.getByRole("button", { name: "Enter Trade Cumulus" }).click();
+    await page
+      .getByLabel("Canonical BOMEX Baseline Simulation")
+      .getByRole("button", { name: "Explore" })
+      .click();
 
     await expect(page.getByLabel("Integrated Explore workspace")).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByRole("heading", { name: "What am I seeing?" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Science" })).toHaveCount(0);
+    await expect(page.getByLabel("Current scientific context")).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Science" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Notes" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Details" })).toBeVisible();
     await expect(page.getByText("Process evidence")).toHaveCount(0);
 
-    const notebook = page.getByLabel("Simulation notebook", { exact: true });
-    await notebook.scrollIntoViewIfNeeded();
-    const notes = notebook.getByRole("textbox", { name: "Simulation notes" });
+    const support = page.getByLabel("Simulation support", { exact: true });
+    await support.scrollIntoViewIfNeeded();
+    await support.getByRole("tab", { name: "Notes" }).click();
+    const notes = support.getByRole("textbox", { name: /Notes for/ });
     await notes.fill("Watch the western cloud turret.");
-    await notebook.getByRole("button", { name: "Save note" }).click();
-    await expect(notebook.getByText("Note saved")).toBeVisible();
+    await support.getByRole("button", { name: "Save note" }).click();
+    await expect(support.getByRole("status")).toHaveText("Saved");
     await expect(notes).toHaveValue("Watch the western cloud turret.");
+    await support.getByRole("tab", { name: "Details" }).click();
     await expect(page.getByRole("heading", { name: "Simulation details" })).toBeVisible();
-    await expect(page.getByText("Visualization details")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Field quality" })).toBeVisible();
   });
 
   test("Results to Explore loads cloud-forming qc and w fields", async ({ page }) => {
@@ -1695,7 +1766,9 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(
       page.getByText(/No cloud water formed in this result; vertical velocity is available/i),
     ).toBeVisible();
-    await expect(page.getByText(/For this no-cloud result, use vertical velocity/)).toBeVisible();
+    await expect(page.getByLabel("Current scientific context")).toContainText(
+      "Use vertical velocity slices to inspect thermals that did not produce cloud.",
+    );
     await expect(page.getByText("No cloud formed here")).toHaveCount(0);
 
     await expect(page.getByText(/slice synced/i).first()).toBeVisible({ timeout: 10_000 });
@@ -1744,7 +1817,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("button", { name: "Retry 3-D layer" })).toBeVisible();
     await expect(page.getByText("Slice synced")).toBeVisible();
     await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
-    await expect(page.getByRole("complementary", { name: "Explore inspector" })).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Context" })).toBeVisible();
   });
 
   test("Explore isolates a failed slice from the 3-D scene timeline and inspector", async ({
@@ -1765,7 +1838,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("button", { name: "Retry Field Slice" })).toBeVisible();
     await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible();
     await expect(page.getByRole("slider", { name: "Saved output time" })).toBeVisible();
-    await expect(page.getByRole("complementary", { name: "Explore inspector" })).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Context" })).toBeVisible();
   });
 
   test("Explore desktop cockpit prioritizes viewers and supports either maximized view", async ({
@@ -1784,8 +1857,11 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
 
     const scene = page.getByLabel("True 3-D scalar field viewer");
     const slice = page.getByLabel("Field Slice");
-    const context = page.getByRole("complementary", { name: "Explore inspector" });
-    const notebook = page.getByLabel("Simulation notebook and details");
+    const context = page.getByRole("complementary", { name: "Context" });
+    const notebook = page.getByRole("region", {
+      name: "Simulation support",
+      exact: true,
+    });
     await expect(scene).toBeVisible({ timeout: 12_000 });
     await expect(slice).toBeVisible();
     await expect(context).toBeVisible();

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -1182,6 +1182,16 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     ).toBeVisible();
     await expect(selectedEvidence.getByText("Cloud water", { exact: true })).toBeVisible();
     await expect(selectedEvidence.getByText("Native cell", { exact: true })).toBeVisible();
+    await page.getByRole("tab", { name: "Science" }).click();
+    await expect(page.getByRole("button", { name: "Load selected-column history" })).toBeVisible();
+    await expect(page.getByText("Thermal Fate")).toHaveCount(0);
+    await expect(page.getByText("What happened here?")).toHaveCount(0);
+    await page.getByRole("button", { name: "Load selected-column history" }).click();
+    const localHistory = page.getByLabel("Selected-column history");
+    await expect(localHistory.getByText("Vertical-motion envelope")).toBeVisible();
+    await expect(localHistory.getByText("First local cloud")).toBeVisible();
+    await localHistory.getByText("Cloud-depth evolution").click();
+    await expect(localHistory.getByText(/1,800 s: base 500 m, top 1,100 m/)).toBeVisible();
     await page.getByRole("tab", { name: "Details" }).click();
     await page.getByText("Technical slice details").first().click();
     await expect(page.getByText(/finite values/i).first()).toBeVisible();

--- a/app/frontend/e2e/mocked-smoke/navigation.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/navigation.spec.ts
@@ -11,7 +11,11 @@ import {
 import { mockCloudChamberApis } from "../fixtures";
 
 function rgbChannels(value: string) {
-  const channels = value.match(/\d+(\.\d+)?/g)?.slice(0, 3).map(Number) ?? [];
+  const channels =
+    value
+      .match(/\d+(\.\d+)?/g)
+      ?.slice(0, 3)
+      .map(Number) ?? [];
   return {
     red: channels[0] ?? 0,
     green: channels[1] ?? 0,
@@ -22,9 +26,7 @@ function rgbChannels(value: string) {
 function relativeLuminance({ red, green, blue }: ReturnType<typeof rgbChannels>) {
   const values = [red, green, blue].map((channel) => {
     const normalized = channel / 255;
-    return normalized <= 0.03928
-      ? normalized / 12.92
-      : ((normalized + 0.055) / 1.055) ** 2.4;
+    return normalized <= 0.03928 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
   });
   return values[0] * 0.2126 + values[1] * 0.7152 + values[2] * 0.0722;
 }
@@ -82,7 +84,9 @@ test.describe("mocked smoke: app shell", () => {
     await gotoApp(page);
 
     const shellBackground = rgbChannels(
-      await page.locator(".app-shell").evaluate((element) => getComputedStyle(element).backgroundColor),
+      await page
+        .locator(".app-shell")
+        .evaluate((element) => getComputedStyle(element).backgroundColor),
     );
     const activeWorkspace = page.getByRole("button", { name: /^Results$/ });
     const activeBackground = rgbChannels(
@@ -125,8 +129,7 @@ test.describe("mocked smoke: app shell", () => {
       await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
       await gotoExplore(page);
       await expect(page.getByLabel("Explore this result")).toBeVisible();
-      await expect(page.getByRole("heading", { name: "What am I seeing?" }))
-        .toBeVisible();
+      await expect(page.getByLabel("Current scientific context")).toBeVisible();
     });
   }
 });

--- a/app/frontend/e2e/mocked-smoke/supercells.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/supercells.spec.ts
@@ -66,7 +66,7 @@ test.describe("mocked smoke: Supercells product path", () => {
     await expect(page.getByText("frame 6 of 9 · Organized mature storm")).toBeVisible();
     const sceneBox = await page.getByLabel("3-D storm scene").boundingBox();
     const evidenceBox = await page.getByLabel("Coordinated storm evidence").boundingBox();
-    const contextBox = await page.getByLabel("Explore inspector").boundingBox();
+    const contextBox = await page.getByRole("complementary", { name: "Context" }).boundingBox();
     expect(sceneBox?.width ?? 0).toBeLessThan((evidenceBox?.width ?? 1) * 1.7);
     expect(evidenceBox?.width ?? 0).toBeGreaterThan(500);
     expect(contextBox?.width ?? 0).toBeGreaterThanOrEqual(288);
@@ -147,11 +147,14 @@ test.describe("mocked smoke: Supercells product path", () => {
     expect((sectionBox?.width ?? 0) / (sectionBox?.height ?? 1)).toBeCloseTo(sectionAspect, 1);
 
     await page.getByLabel("xz section at y = 10.0 km").click({ position: { x: 180, y: 120 } });
-    await page.getByRole("tab", { name: "Science" }).click();
-    await expect(page.getByText("Selected point")).toBeVisible();
+    const selectedEvidence = page.getByLabel("Selected native-grid evidence");
+    await expect(selectedEvidence).toBeVisible();
+    await expect(
+      selectedEvidence.getByRole("heading", { name: "Native-grid evidence" }),
+    ).toBeVisible();
 
     await page.getByRole("button", { name: "Next saved output" }).click();
-    await expect(page.getByText("90 min · 5,400 s")).toBeVisible();
+    await expect(page.getByLabel("Saved-output timeline")).toContainText("90 min · 5,400 s");
     await page.getByLabel("Playback speed").selectOption("2");
     await expect(page.getByLabel("Playback speed")).toHaveValue("2");
 
@@ -160,18 +163,18 @@ test.describe("mocked smoke: Supercells product path", () => {
     const evidenceMaximized = await page.getByLabel("Coordinated storm evidence").boundingBox();
     expect(evidenceMaximized?.width ?? 0).toBeGreaterThan((evidenceBefore?.width ?? 0) * 2);
     await expect(page.getByRole("button", { name: "Open Context" })).toBeVisible();
-    await expect(page.getByLabel("Explore inspector")).toHaveCount(0);
+    await expect(page.getByRole("complementary", { name: "Context" })).toHaveCount(0);
     const maximizedSectionBox = await page.getByLabel("xz section at y = 10.0 km").boundingBox();
     expect((maximizedSectionBox?.width ?? 0) / (maximizedSectionBox?.height ?? 1)).toBeCloseTo(
       sectionAspect,
       1,
     );
     await page.getByRole("button", { name: "Open Context" }).click();
-    await expect(page.getByLabel("Explore inspector")).toBeVisible();
+    await expect(page.getByRole("complementary", { name: "Context" })).toBeVisible();
     await page.getByRole("button", { name: "Restore evidence" }).click();
 
     await page.getByRole("button", { name: "Collapse Context" }).click();
-    await expect(page.getByLabel("Explore inspector")).toHaveCount(0);
+    await expect(page.getByRole("complementary", { name: "Context" })).toHaveCount(0);
     await expect(page.getByRole("button", { name: "Open Context" })).toBeVisible();
     await page.getByRole("button", { name: "Open Context" }).click();
 
@@ -200,7 +203,8 @@ test.describe("mocked smoke: Supercells product path", () => {
     await gotoSupercellsExplore(page);
     await expect(page.getByText(/Three\.js renderer unavailable/)).toBeVisible();
     await expect(page.getByLabel("Updraft and rotation plan view")).toBeVisible();
-    await expect(page.getByRole("tab", { name: "Explain" })).toBeVisible();
+    await expect(page.getByLabel("Current scientific context")).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Science" })).toBeVisible();
     await expect(page.getByLabel("Saved output time")).toBeEnabled();
   });
 
@@ -211,12 +215,10 @@ test.describe("mocked smoke: Supercells product path", () => {
     const sceneFrame = await page.locator(".supercells-scene .true3d-scene-frame").boundingBox();
     const evidence = await page.getByLabel("Coordinated storm evidence").boundingBox();
     const documentWidth = await page.evaluate(() => document.documentElement.scrollWidth);
-    const documentHeight = await page.evaluate(() => document.documentElement.scrollHeight);
 
     expect(sceneFrame?.height ?? 0).toBeGreaterThanOrEqual(398);
     expect(evidence?.height ?? 0).toBeGreaterThanOrEqual(398);
     expect(documentWidth).toBe(1024);
-    expect(documentHeight).toBeLessThanOrEqual(856);
     await expect(page.getByRole("heading", { name: "Horizontal x-y slice" })).toBeVisible();
     const compactPlan = await page.getByLabel("Updraft and rotation plan view").boundingBox();
     expect((compactPlan?.width ?? 0) / (compactPlan?.height ?? 1)).toBeCloseTo(1, 1);

--- a/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
@@ -61,7 +61,7 @@ test.describe("mocked smoke: visualizer occlusion regression", () => {
   });
 
   test("3-D scene does not cover its primary controls", async ({ page }) => {
-    await expect(page.getByText(/what am i seeing/i).first()).toBeVisible({
+    await expect(page.getByLabel("Current scientific context")).toBeVisible({
       timeout: 12_000,
     });
     await expect(page.getByLabel("True 3-D scalar field viewer")).toBeVisible({

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -731,7 +731,7 @@
   flex: 0 0 auto;
 }
 
-.mountain-waves-state-row {
+.explore-context-state-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;
@@ -4784,31 +4784,6 @@ details[open] > summary {
     overflow: auto;
   }
 
-  .integrated-explore-workspace .explore-inspector-tabs {
-    position: sticky;
-    z-index: 3;
-    top: 0;
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0.2rem;
-    border-bottom: 1px solid var(--color-border);
-    padding: 0.35rem;
-    background: var(--color-surface);
-  }
-
-  .integrated-explore-workspace .explore-inspector-tabs button {
-    padding: 0.34rem 0.2rem;
-    background: transparent;
-    color: var(--color-text-muted);
-    font-size: 0.74rem;
-    box-shadow: none;
-  }
-
-  .integrated-explore-workspace .explore-inspector-tabs .active-control {
-    background: var(--color-accent-soft);
-    color: var(--color-accent-primary);
-  }
-
   .integrated-explore-workspace .explore-inspector-panel {
     display: grid;
     gap: 0.65rem;
@@ -5748,33 +5723,6 @@ details[open] > summary {
     font-size: 0.78rem;
   }
 
-  .integrated-explore-workspace .explore-inspector-tabs {
-    position: static;
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0;
-    border: 0;
-    padding: 0;
-    background: transparent;
-  }
-
-  .integrated-explore-workspace .explore-inspector-tabs button {
-    border: 0;
-    border-bottom: 2px solid transparent;
-    border-radius: 0;
-    padding: 0.58rem 0.18rem 0.48rem;
-    background: transparent;
-    color: var(--color-text-muted);
-    font-size: 0.7rem;
-    box-shadow: none;
-  }
-
-  .integrated-explore-workspace .explore-inspector-tabs .active-control {
-    border-bottom-color: var(--color-accent-primary);
-    background: transparent;
-    color: var(--color-accent-primary);
-  }
-
   .integrated-explore-workspace .explore-inspector-toggle {
     align-self: center;
     width: 1.85rem;
@@ -5817,8 +5765,9 @@ details[open] > summary {
 
   .integrated-explore-workspace .selected-region-inspector .section-heading {
     display: grid;
-    grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.3rem;
+    align-items: start;
   }
 
   .integrated-explore-workspace .selected-region-inspector .state-chip {
@@ -5929,11 +5878,13 @@ details[open] > summary {
 
   .simulation-notes-actions {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.6rem;
     align-items: center;
   }
 
-  .simulation-notes-actions p {
+  .simulation-notes-actions p,
+  .simulation-notes-actions small {
     margin: 0;
     color: var(--color-text-muted);
     font-size: 0.72rem;
@@ -5943,23 +5894,46 @@ details[open] > summary {
     grid-column: 1 / -1;
     grid-row: 4;
     display: grid;
-    grid-template-columns: minmax(18rem, 0.8fr) minmax(0, 1.2fr);
-    gap: 1.5rem;
+    grid-template-rows: auto minmax(15rem, auto);
+    gap: 0;
     border-top: 1px solid var(--color-border-strong);
-    padding: 1.15rem 0 2rem;
+    padding: 0 0 2rem;
   }
 
-  .explore-secondary-content > section {
+  .explore-secondary-tabs {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0.5rem 0 0;
+  }
+
+  .explore-secondary-tabs button {
+    min-width: 7rem;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    padding: 0.65rem 1rem 0.55rem;
+    background: transparent;
+    color: var(--color-text-muted);
+    box-shadow: none;
+  }
+
+  .explore-secondary-tabs button:hover,
+  .explore-secondary-tabs button:focus-visible,
+  .explore-secondary-tabs .active-control {
+    border-bottom-color: var(--color-accent-primary);
+    background: transparent;
+    color: var(--color-accent-primary);
+  }
+
+  .explore-secondary-panel {
     min-width: 0;
-  }
-
-  .explore-secondary-content > section + section {
-    border-left: 1px solid var(--color-border);
-    padding-left: 1.5rem;
+    max-width: 76rem;
+    padding: 1.1rem 0;
   }
 
   .explore-secondary-content .metric-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .explore-secondary-content dd,
@@ -5967,6 +5941,90 @@ details[open] > summary {
   .explore-secondary-content pre {
     overflow-wrap: anywhere;
     word-break: break-word;
+  }
+
+  .explore-science-section,
+  .simulation-notes,
+  .explore-secondary-panel > section {
+    display: grid;
+    gap: 0.65rem;
+  }
+
+  .explore-science-section > *,
+  .simulation-notes > * {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  .explore-science-callout,
+  .explore-context-notice {
+    border-left: 3px solid var(--color-accent-primary);
+    padding: 0.45rem 0.65rem;
+    background: rgba(232, 243, 249, 0.62);
+  }
+
+  .explore-science-callout p,
+  .explore-context-notice p {
+    margin: 0.2rem 0 0;
+  }
+
+  .explore-context-content {
+    display: grid;
+    gap: 0.55rem;
+  }
+
+  .explore-context-content > * {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  .explore-context-content > h3 {
+    font-size: 1rem;
+    line-height: 1.25;
+  }
+
+  .explore-context-explanation p {
+    margin: 0;
+  }
+
+  .selected-region-inspector {
+    border-top: 1px solid var(--color-border-strong);
+    border-bottom: 1px solid var(--color-border);
+    padding: 0.65rem 0;
+  }
+
+  .selected-region-inspector h4 {
+    margin: 0;
+    font-size: 0.8rem;
+  }
+
+  .simulation-notes-description {
+    color: var(--color-text-muted);
+  }
+
+  .simulation-note-state {
+    align-self: center;
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+    font-weight: 750;
+  }
+
+  .simulation-note-state-unsaved {
+    color: #8a5b12;
+  }
+
+  .simulation-note-state-failed,
+  .simulation-note-failure {
+    color: var(--color-danger);
+  }
+
+  .simulation-note-failure {
+    display: grid;
+    justify-items: start;
+    gap: 0.55rem;
+    border-left: 3px solid var(--color-danger);
+    padding: 0.65rem;
+    background: #fff4f2;
   }
 
   .integrated-explore-workspace .visualizer-shell-focused-scene .true3d-viewer {
@@ -6330,7 +6388,8 @@ details[open] > summary {
 
   .integrated-explore-workspace
     .visualizer-shell.mountain-waves-explore-shell
-    .mountain-waves-control-strip fieldset {
+    .mountain-waves-control-strip
+    fieldset {
     border: 0;
     padding: 0;
   }
@@ -6422,5 +6481,4 @@ details[open] > summary {
     .mountain-waves-overlay-controls {
     grid-template-columns: repeat(5, auto);
   }
-
 }

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3645,8 +3645,14 @@ function selectedRegionResponse() {
         { time_seconds: 900, value: 0.000006 },
         { time_seconds: 1800, value: 0.00002 },
       ],
-      local_cloud_base_time_series: [],
-      local_cloud_top_time_series: [],
+      local_cloud_base_time_series: [
+        { time_seconds: 900, value: 500 },
+        { time_seconds: 1800, value: 600 },
+      ],
+      local_cloud_top_time_series: [
+        { time_seconds: 900, value: 900 },
+        { time_seconds: 1800, value: 1400 },
+      ],
       local_max_qc_height_time_series: [],
       local_max_w_height_time_series: [],
       local_rain_present: true,
@@ -7832,6 +7838,47 @@ describe("App", () => {
 
     expect(screen.queryByLabelText("Selected native-grid evidence")).not.toBeInTheDocument();
     expect(screen.getByText("Slice synced")).toBeInTheDocument();
+  });
+
+  it("loads quantitative selected-column history on demand under Science", async () => {
+    render(<App />);
+
+    await openSelectedResultInExplore();
+    await screen.findByText("Slice synced");
+    const heatmap = screen.getAllByRole("img", { name: /heatmap/i })[0];
+    fireEvent.click(within(heatmap).getByRole("button", { name: /row 1, column 2/i }));
+
+    const loadHistory = await screen.findByRole("button", {
+      name: "Load selected-column history",
+    });
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(([url]) => String(url).includes("/diagnostics/selected-region")),
+    ).toBe(false);
+    expect(screen.queryByText("Thermal Fate")).not.toBeInTheDocument();
+    expect(screen.queryByText("What happened here?")).not.toBeInTheDocument();
+
+    fireEvent.click(loadHistory);
+
+    const localHistory = await screen.findByLabelText("Selected-column history");
+    expect(within(localHistory).getByText("Vertical-motion envelope")).toBeInTheDocument();
+    expect(within(localHistory).getByText("-1.2 m/s to 4.5 m/s")).toBeInTheDocument();
+    expect(within(localHistory).getByText("First local cloud")).toBeInTheDocument();
+    expect(within(localHistory).getByText("0.02 g/kg at 1,800 s")).toBeInTheDocument();
+    fireEvent.click(within(localHistory).getByText("Cloud-depth evolution"));
+    expect(
+      within(localHistory).getByText(/900 s: base 500 m, top 900 m, depth 400 m/),
+    ).toBeVisible();
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(([url]) => String(url).includes("/diagnostics/selected-region")),
+    ).toBe(true);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/diagnostics\/selected-region\?region_type=column.*x_index=.*y_index=/),
+    );
+    expect(within(localHistory).queryByText("Growing cumulus")).not.toBeInTheDocument();
   });
 
   it("selects the source grid point represented by a downsampled cloud-water block", async () => {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -6777,7 +6777,9 @@ describe("App", () => {
     expect(await screen.findByLabelText("Explore viewer controls")).toBeInTheDocument();
     expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     expect(screen.getByLabelText("Time")).toHaveValue("2");
-    expect(screen.getByRole("heading", { name: "What am I seeing?" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "What does this saved cloud field show now?" }),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText("Process mode")).not.toBeInTheDocument();
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
@@ -7515,7 +7517,7 @@ describe("App", () => {
     expect(await screen.findByLabelText("Explore viewer controls")).toBeInTheDocument();
     await screen.findByText("Slice synced");
     expect(screen.getByLabelText("Slice field")).toHaveValue("qc");
-    expect(screen.getAllByText("qc (Cloud water)").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/g\/kg/).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Horizontal layer" })).toHaveClass("active-control");
     expect(screen.getByRole("heading", { name: "Field Slice" })).toBeInTheDocument();
@@ -7643,7 +7645,9 @@ describe("App", () => {
 
     const heatmap = screen.getAllByRole("img", { name: /heatmap/i })[0];
     fireEvent.click(within(heatmap).getByRole("button", { name: /row 1, column 2/i }));
-    expect(await screen.findByText("Point ready")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Native-grid evidence" }),
+    ).toBeInTheDocument();
 
     vi.useFakeTimers();
     fireEvent.click(screen.getByRole("button", { name: "Play" }));
@@ -7793,7 +7797,7 @@ describe("App", () => {
     vi.useRealTimers();
   });
 
-  it("selects a slice region and renders backend Thermal Fate Inspector diagnostics", async () => {
+  it("selects a slice cell and renders immediate current-frame native evidence", async () => {
     render(<App />);
 
     await openSelectedResultInExplore();
@@ -7802,30 +7806,32 @@ describe("App", () => {
     const heatmap = screen.getAllByRole("img", { name: /heatmap/i })[0];
     fireEvent.click(within(heatmap).getByRole("button", { name: /row 1, column 2/i }));
 
-    expect(await screen.findByText("Point ready")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "What happened here?" })).toBeInTheDocument();
-    expect(screen.getAllByText("Growing cumulus").length).toBeGreaterThan(0);
+    const selectedEvidence = await screen.findByLabelText("Selected native-grid evidence");
     expect(
-      screen.getByText(/Cloud water appeared locally after upward motion strengthened/),
+      within(selectedEvidence).getByRole("heading", { name: "Native-grid evidence" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("First local cloud time")).toBeInTheDocument();
-    expect(screen.getByText("Local max qc")).toBeInTheDocument();
-    expect(screen.getAllByText("2.000e-2 g/kg").length).toBeGreaterThan(0);
-    expect(screen.getByText("Local max w")).toBeInTheDocument();
-    expect(screen.getByText("4.5 m/s")).toBeInTheDocument();
-    expect(screen.getByText("Local rain")).toBeInTheDocument();
-    expect(screen.getAllByText("Rain water aloft detected").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("xh[32]; 0.05 km").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("yh[16]; -1.55 km").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("zh[15]; 0.62 km").length).toBeGreaterThan(0);
-    expect(screen.queryByText(/0\.05000000074505806/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/-1\.5500000715255737/)).not.toBeInTheDocument();
-    expect(screen.getByText("Selected-point details")).toBeInTheDocument();
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "/api/results/result-dry-run-quicklook/diagnostics/selected-region?region_type=point",
-      ),
-    );
+    expect(within(selectedEvidence).getByText("Cloud water")).toBeInTheDocument();
+    expect(within(selectedEvidence).getByText("Native cell")).toBeInTheDocument();
+    expect(within(selectedEvidence).getByRole("button", { name: "Clear" })).toBeInTheDocument();
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(([url]) => String(url).includes("/diagnostics/selected-region")),
+    ).toBe(false);
+  });
+
+  it("clears selected native evidence without disturbing the current view", async () => {
+    render(<App />);
+
+    await openSelectedResultInExplore();
+    await screen.findByText("Slice synced");
+    const heatmap = screen.getAllByRole("img", { name: /heatmap/i })[0];
+    fireEvent.click(within(heatmap).getByRole("button", { name: /row 1, column 2/i }));
+    const selectedEvidence = await screen.findByLabelText("Selected native-grid evidence");
+    fireEvent.click(within(selectedEvidence).getByRole("button", { name: "Clear" }));
+
+    expect(screen.queryByLabelText("Selected native-grid evidence")).not.toBeInTheDocument();
+    expect(screen.getByText("Slice synced")).toBeInTheDocument();
   });
 
   it("selects the source grid point represented by a downsampled cloud-water block", async () => {
@@ -7854,95 +7860,14 @@ describe("App", () => {
       }),
     );
 
-    expect(await screen.findByText("Point ready")).toBeInTheDocument();
-    const selectedPoint = screen.getByLabelText("Selected point context");
+    const selectedPoint = await screen.findByLabelText("Selected native-grid evidence");
     expect(within(selectedPoint).getByText("0.005 g/kg")).toBeInTheDocument();
     expect(within(selectedPoint).queryByText("0 kg/kg")).not.toBeInTheDocument();
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("x_index=1&y_index=0&z_index=1"));
-  });
-
-  it("shows selected-region backend failures as actionable inspector errors", async () => {
-    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === "/api/scenarios") {
-        return Promise.resolve(new Response(JSON.stringify(scenarioResponse), { status: 200 }));
-      }
-      if (url === "/api/results") {
-        return Promise.resolve(new Response(JSON.stringify(resultsResponse), { status: 200 }));
-      }
-      if (url === "/api/storage/inventory") {
-        return Promise.resolve(
-          new Response(JSON.stringify(storageInventoryResponse), { status: 200 }),
-        );
-      }
-      if (url.includes("/visualization/fields")) {
-        return Promise.resolve(new Response(JSON.stringify(fieldCatalogResponse), { status: 200 }));
-      }
-      if (url.includes("/visualization/defaults")) {
-        return Promise.resolve(
-          new Response(JSON.stringify(selectedTimeDefaultsResponse(url)), { status: 200 }),
-        );
-      }
-      if (url.includes("/visualization/point-cloud")) {
-        const parsed = new URL(url, "http://localhost");
-        const requestedField = mockPointFieldFromParam(parsed.searchParams.get("field"));
-        return Promise.resolve(
-          new Response(
-            JSON.stringify(
-              pointCloudResponse({
-                field: requestedField,
-                threshold: Number(parsed.searchParams.get("threshold") ?? 0.000001),
-                timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
-              }),
-            ),
-            { status: 200 },
-          ),
-        );
-      }
-      if (url.includes("/visualization/slice")) {
-        const parsed = new URL(url, "http://localhost");
-        return Promise.resolve(
-          new Response(
-            JSON.stringify(
-              sliceResponse({
-                field: mockFieldFromParam(parsed.searchParams.get("field")),
-                orientation:
-                  parsed.searchParams.get("orientation") === "vertical_y"
-                    ? "vertical_y"
-                    : parsed.searchParams.get("orientation") === "vertical_x"
-                      ? "vertical_x"
-                      : "horizontal",
-                timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
-                levelIndex: Number(parsed.searchParams.get("level_index") ?? 0),
-              }),
-            ),
-            { status: 200 },
-          ),
-        );
-      }
-      if (url.includes("/diagnostics/selected-region")) {
-        return Promise.resolve(
-          new Response(JSON.stringify({ detail: "Unsupported selected region." }), {
-            status: 400,
-          }),
-        );
-      }
-      return Promise.resolve(new Response("not found", { status: 404 }));
-    });
-
-    render(<App />);
-
-    const resultDetail = await screen.findByLabelText("Result detail");
-    fireEvent.click(within(resultDetail).getByRole("button", { name: "Open in Explore" }));
-    await screen.findByText("Slice synced");
-    fireEvent.click(
-      within(screen.getAllByRole("img", { name: /heatmap/i })[0]).getByRole("button", {
-        name: /row 1, column 1/i,
-      }),
-    );
-
-    expect(await screen.findByRole("alert")).toHaveTextContent("Unsupported selected region.");
-    expect(screen.getByText("Point unavailable")).toBeInTheDocument();
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(([url]) => String(url).includes("/diagnostics/selected-region")),
+    ).toBe(false);
   });
 
   it("supports field and time selection through visualization-ready APIs", async () => {
@@ -7953,9 +7878,7 @@ describe("App", () => {
     fireEvent.change(await screen.findByLabelText("Slice field"), { target: { value: "w" } });
     fireEvent.change(screen.getByLabelText("Time"), { target: { value: "1" } });
 
-    await waitFor(() => {
-      expect(screen.getByText("w (Vertical velocity)")).toBeInTheDocument();
-    });
+    await waitFor(() => expect(screen.getByLabelText("Slice field")).toHaveValue("w"));
     expect(screen.getAllByText("900 s").length).toBeGreaterThan(0);
     expect(screen.getAllByText("6.5 m/s").length).toBeGreaterThan(0);
     expect(fetch).toHaveBeenCalledWith(
@@ -7971,10 +7894,12 @@ describe("App", () => {
 
     expect(await screen.findByLabelText("Integrated Explore workspace")).toBeInTheDocument();
     await screen.findAllByText("Cloud-water point layer loaded");
-    expect(screen.getByRole("heading", { name: "What am I seeing?" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Current context")).toBeInTheDocument();
-    expect(screen.getByLabelText("Simulation notebook and details")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Science" })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "What does this saved cloud field show now?" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Context")).toBeInTheDocument();
+    expect(screen.getByLabelText("Simulation support")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Science" })).toBeInTheDocument();
     expect(screen.queryByText("Process evidence")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Process mode")).not.toBeInTheDocument();
     expect(screen.queryByText(/Thermal Fate/)).not.toBeInTheDocument();
@@ -8194,7 +8119,7 @@ describe("App", () => {
     expect(screen.getByText("No cloud formed")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "For this no-cloud result, use vertical velocity (w) slices to inspect the thermals.",
+        "Use vertical velocity slices to inspect thermals that did not produce cloud.",
       ),
     ).toBeInTheDocument();
     await screen.findByText("Slice synced");
@@ -8321,7 +8246,7 @@ describe("App", () => {
     expect(await screen.findByText("3-D cloud layer unavailable")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Field Slice" })).toBeInTheDocument();
     expect(screen.getByRole("slider", { name: "Saved output time" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Explore inspector")).toBeInTheDocument();
+    expect(screen.getByLabelText("Context")).toBeInTheDocument();
     expect(await screen.findByText("Slice synced")).toBeInTheDocument();
 
     allowPointCloud = true;
@@ -8353,7 +8278,7 @@ describe("App", () => {
     expect(await screen.findByText("Field Slice unavailable")).toBeInTheDocument();
     expect(screen.getByLabelText("True 3-D scalar field viewer")).toBeInTheDocument();
     expect(screen.getByRole("slider", { name: "Saved output time" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Explore inspector")).toBeInTheDocument();
+    expect(screen.getByLabelText("Context")).toBeInTheDocument();
     await screen.findAllByText("Cloud-water point layer loaded");
 
     allowSlice = true;
@@ -8380,7 +8305,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Scientific visualization workbench")).toBeInTheDocument();
     expect(screen.getByLabelText("Fixed visualization viewport region")).toBeInTheDocument();
-    expect(screen.getByLabelText("Explore inspector")).toBeInTheDocument();
+    expect(screen.getByLabelText("Context")).toBeInTheDocument();
     expect(screen.getByLabelText("Explore viewer controls")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Field Slice" })).toBeInTheDocument();
     expect(within(viewer).queryByText("True 3-D scene")).not.toBeInTheDocument();
@@ -8410,28 +8335,67 @@ describe("App", () => {
       screen.getAllByText("Current field max: 0.008 g/kg. Visible points above 0.001 g/kg: 3.")
         .length,
     ).toBeGreaterThan(0);
-    expect(screen.getByText("0 to 3 km")).toBeInTheDocument();
-    expect(screen.getByText("0.8 km to 1.2 km")).toBeInTheDocument();
-    expect(screen.getByText("x 2, y 1, z 1.2 km, value 0.008 g/kg")).toBeInTheDocument();
-    expect(screen.getByText("3 of 3")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "What does this saved cloud field show now?" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Simulation support")).toBeInTheDocument();
     expect(screen.getAllByText("2,700 s").length).toBeGreaterThan(0);
-    expect(screen.getByText("0.002 g/kg to 0.008 g/kg")).toBeInTheDocument();
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining("time_index=3"));
     expect(fetch).toHaveBeenCalledWith(
       "/api/results/result-dry-run-quicklook/visualization/defaults?time_index=3",
     );
   });
 
-  it("saves Simulation notes from Explore through the result API", async () => {
+  it("saves stable Simulation notes from Trade Cumulus Explore", async () => {
+    mockWorldScopedApp();
     const defaultFetch = vi.mocked(fetch).getMockImplementation();
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/api/results/result-dry-run-quicklook" && init?.method === "PATCH") {
-        const body = JSON.parse(String(init.body ?? "{}")) as { notes?: string | null };
+      const noteUrl = "/api/worlds/trade-cumulus/simulations/trade_cumulus_canonical_bomex/note";
+      if (url === noteUrl && !init?.method) {
+        return Promise.resolve(new Response(JSON.stringify({ note: null }), { status: 200 }));
+      }
+      if (url === noteUrl && init?.method === "PUT") {
+        const body = JSON.parse(String(init.body ?? "{}")) as { text?: string };
         return Promise.resolve(
-          new Response(JSON.stringify({ ...resultCard, notes: body.notes ?? null }), {
-            status: 200,
-          }),
+          new Response(
+            JSON.stringify({
+              note: {
+                schema_version: 1,
+                world_id: "trade_cumulus",
+                simulation_id: "trade_cumulus_canonical_bomex",
+                text: body.text ?? "",
+                created_at: "2026-07-23T12:00:00Z",
+                updated_at: "2026-07-23T12:00:00Z",
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.includes(comparisonBaselineResultCard.result_id)) {
+        if (url.endsWith("/visualization/fields")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(tradeCumulusFieldCatalog), { status: 200 }),
+          );
+        }
+        if (url.includes("/visualization/defaults")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(tradeCumulusViewDefaults), { status: 200 }),
+          );
+        }
+        if (url.endsWith("/trade-cumulus-updraft-lens/defaults")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(tradeCumulusUpdraftLensDefaults), { status: 200 }),
+          );
+        }
+        if (url.includes("/visualization/slice")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(tradeCumulusSliceResponse(url)), { status: 200 }),
+          );
+        }
+        return (
+          defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
         );
       }
       return (
@@ -8440,21 +8404,31 @@ describe("App", () => {
     });
 
     render(<App />);
-    await openSelectedResultInExplore();
+    fireEvent.click(await screen.findByRole("button", { name: "Enter Trade Cumulus" }));
+    fireEvent.click(
+      within(await screen.findByLabelText("Canonical BOMEX Baseline Simulation")).getByRole(
+        "button",
+        { name: "Explore" },
+      ),
+    );
+    const support = await screen.findByLabelText("Simulation support");
+    fireEvent.click(within(support).getByRole("tab", { name: "Notes" }));
 
-    const notes = await screen.findByRole("textbox", { name: "Simulation notes" });
-    expect(notes).toHaveValue("Reference-derived quick-look result.");
+    const notes = await screen.findByRole("textbox", {
+      name: "Notes for Canonical BOMEX Baseline",
+    });
+    expect(notes).toHaveValue("");
     fireEvent.change(notes, { target: { value: "Watch the western cloud turret." } });
     fireEvent.click(screen.getByRole("button", { name: "Save note" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Note saved")).toBeInTheDocument();
+      expect(screen.getByText("Saved")).toBeInTheDocument();
     });
     expect(fetch).toHaveBeenCalledWith(
-      "/api/results/result-dry-run-quicklook",
+      "/api/worlds/trade-cumulus/simulations/trade_cumulus_canonical_bomex/note",
       expect.objectContaining({
-        method: "PATCH",
-        body: JSON.stringify({ notes: "Watch the western cloud turret." }),
+        method: "PUT",
+        body: JSON.stringify({ text: "Watch the western cloud turret." }),
       }),
     );
     expect(notes).toHaveValue("Watch the western cloud turret.");
@@ -8486,7 +8460,7 @@ describe("App", () => {
     const viewer = screen.getByLabelText("True 3-D scalar field viewer");
     expect(within(viewer).getByText(/Slice: Horizontal layer at z = /)).toBeInTheDocument();
     expect(within(viewer).queryByText(/Slice: Vertical x-z slice at y = /)).not.toBeInTheDocument();
-    expect(screen.getAllByText("qc (Cloud water)").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("option", { name: "qc - Cloud water" }).length).toBeGreaterThan(0);
     expect(screen.getAllByText("native_grid_view_no_interpolation").length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: "Move down" }));
     expect(screen.getByLabelText("Slice position")).toHaveValue("0");
@@ -8522,7 +8496,7 @@ describe("App", () => {
     fireEvent.change(screen.getByLabelText("Time"), { target: { value: "1" } });
 
     await waitFor(() => {
-      expect(screen.getAllByText("w (Vertical velocity)").length).toBeGreaterThan(0);
+      expect(screen.getByLabelText("Slice field")).toHaveValue("w");
     });
     expect(screen.getAllByText("900 s").length).toBeGreaterThan(0);
     expect(screen.getAllByText("6.5 m/s").length).toBeGreaterThan(0);
@@ -8575,9 +8549,6 @@ describe("App", () => {
     expect(cameraView).toHaveValue("look_along_x");
     fireEvent.change(cameraView, { target: { value: "look_along_y" } });
     expect(cameraView).toHaveValue("look_along_y");
-    fireEvent.click(screen.getByText("Visualization details"));
-    expect(screen.getByText("Direct Three.js point cloud")).toBeInTheDocument();
-
     fireEvent.click(within(cameraControls).getByRole("button", { name: "Reset camera" }));
   });
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,12 +1,19 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import type { CSSProperties, FormEvent } from "react";
+import type { CSSProperties, FormEvent, ReactNode } from "react";
 
 import "./App.css";
 import { CloudWorldsHome } from "./CloudWorldsHome";
-import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
+import {
+  ExploreContextContent,
+  ExploreInspector,
+  ExploreSelectedEvidence,
+  ExploreSecondarySections,
+  IntegratedExploreWorkspace,
+} from "./IntegratedExploreWorkspace";
 import { MountainWavesExplore } from "./MountainWavesExplore";
 import { type MountainWavesSimulation, MountainWavesWorld } from "./MountainWavesWorld";
 import { NativeSlicePositionControl } from "./NativeSlicePositionControl";
+import { SimulationNotes } from "./SimulationNotes";
 import { SupercellsExplore } from "./SupercellsExplore";
 import { type SupercellSimulation, SupercellsWorld } from "./SupercellsWorld";
 import {
@@ -1425,75 +1432,6 @@ type SelectedRegionRequest = {
   neighborhood?: number;
 };
 
-type AxisSelection = {
-  dimension: string;
-  start_index: number;
-  end_index: number;
-  start_coordinate: number | string | null;
-  end_coordinate: number | string | null;
-  units: string | null;
-};
-
-type TimeValue = {
-  time_seconds: number | null;
-  value: number | null;
-};
-
-type SelectedRegionDiagnosticsResponse = {
-  result_id: string;
-  run_id: string;
-  scenario_id: string;
-  region: {
-    region_type: RegionType;
-    requested: Record<string, unknown>;
-    x: AxisSelection | null;
-    y: AxisSelection | null;
-    vertical: AxisSelection | null;
-    native_grid: string | null;
-    cell_count: number | null;
-  };
-  diagnostics: {
-    available: boolean;
-    local_max_w_m_s: number | null;
-    time_of_local_max_w_seconds: number | null;
-    local_min_w_m_s: number | null;
-    time_of_local_min_w_seconds: number | null;
-    local_w_max_time_series: TimeValue[];
-    local_w_min_time_series: TimeValue[];
-    local_max_qc_kg_kg: number | null;
-    time_of_local_max_qc_seconds: number | null;
-    first_local_cloud_time_seconds: number | null;
-    local_cloud_fraction_time_series: TimeValue[];
-    local_qc_max_time_series: TimeValue[];
-    local_cloud_base_time_series: TimeValue[];
-    local_cloud_top_time_series: TimeValue[];
-    local_max_qc_height_time_series: TimeValue[];
-    local_max_w_height_time_series: TimeValue[];
-    local_rain_present: boolean;
-    first_local_rain_time_seconds: number | null;
-    local_max_qr_kg_kg: number | null;
-    time_of_local_max_qr_seconds: number | null;
-    local_qr_max_time_series: TimeValue[];
-  };
-  comparison_to_domain: {
-    local_max_w_fraction_of_domain: number | null;
-    local_max_qc_fraction_of_domain: number | null;
-    local_first_cloud_time_delta_seconds: number | null;
-    local_cloud_top_fraction_of_domain: number | null;
-    local_first_rain_time_delta_seconds: number | null;
-    caveats: string[];
-  };
-  interpretation: {
-    thermal_fate_label: string;
-    confidence: ProcessSupport;
-    main_limiting_factor: string;
-    summary: string;
-    caveats: string[];
-  };
-  provenance: ProvenancePayload;
-  caveats: string[];
-};
-
 type FieldViewDefaults = {
   field: string;
   time_index: number;
@@ -2260,34 +2198,6 @@ async function fetchVisualizationPointCloud(
     throw new Error(await responseError(response, "Unable to load 3-D scalar point layer."));
   }
   return response.json() as Promise<PointCloudResponse>;
-}
-
-async function fetchSelectedRegionDiagnostics(
-  resultId: string,
-  request: SelectedRegionRequest,
-): Promise<SelectedRegionDiagnosticsResponse> {
-  const search = new URLSearchParams({
-    region_type: request.regionType,
-    neighborhood: String(request.neighborhood ?? 0),
-  });
-  addOptionalIndex(search, "x_index", request.xIndex);
-  addOptionalIndex(search, "y_index", request.yIndex);
-  addOptionalIndex(search, "z_index", request.zIndex);
-  addOptionalIndex(search, "x_start", request.xStart);
-  addOptionalIndex(search, "x_end", request.xEnd);
-  addOptionalIndex(search, "y_start", request.yStart);
-  addOptionalIndex(search, "y_end", request.yEnd);
-  addOptionalIndex(search, "z_start", request.zStart);
-  addOptionalIndex(search, "z_end", request.zEnd);
-  const response = await fetch(`/api/results/${resultId}/diagnostics/selected-region?${search}`);
-  if (!response.ok) {
-    throw new Error(await responseError(response, "Unable to inspect the selected region."));
-  }
-  return response.json() as Promise<SelectedRegionDiagnosticsResponse>;
-}
-
-function addOptionalIndex(search: URLSearchParams, key: string, value: number | undefined) {
-  if (value !== undefined) search.set(key, String(value));
 }
 
 async function responseError(response: Response, fallback: string): Promise<string> {
@@ -4191,7 +4101,6 @@ export function App() {
     <ExploreWorkspace
       selectedResult={selectedResult}
       comparisonStory={comparisonStoryActive ? comparisonStory : null}
-      onResultUpdated={updateResultInList}
       onBackToResults={() => {
         setComparisonStoryActive(false);
         setActiveSection("results");
@@ -4373,7 +4282,6 @@ export function App() {
             <ExploreWorkspace
               selectedResult={selectedResult}
               comparisonStory={productLocation === "comparison" ? comparisonStory : null}
-              onResultUpdated={updateResultInList}
               onBackToResults={returnToTradeCumulus}
               onOpenResult={(resultId) => {
                 selectOrdinaryResult(resultId);
@@ -7541,7 +7449,6 @@ function NotebookWorkspace({
 function ExploreWorkspace({
   selectedResult,
   comparisonStory,
-  onResultUpdated,
   onOpenResult,
   onBackToResults,
   worldName,
@@ -7554,7 +7461,6 @@ function ExploreWorkspace({
 }: {
   selectedResult: ResultCard | undefined;
   comparisonStory: TradeCumulusComparisonStoryResponse | null;
-  onResultUpdated: (result: ResultCard) => void;
   onOpenResult: (resultId: string) => void;
   onBackToResults: () => void;
   worldName?: string;
@@ -7592,7 +7498,6 @@ function ExploreWorkspace({
             backLabel={backLabel}
             onBack={onBack}
             onCompare={onCompare}
-            onResultUpdated={onResultUpdated}
           />
         </section>
       )}
@@ -9835,7 +9740,6 @@ export function VisualizerSceneShell({
   backLabel,
   onBack,
   onCompare,
-  onResultUpdated,
 }: {
   result: ResultCard;
   worldName?: string;
@@ -9845,7 +9749,6 @@ export function VisualizerSceneShell({
   backLabel?: string;
   onBack?: () => void;
   onCompare?: () => void;
-  onResultUpdated?: (result: ResultCard) => void;
 }) {
   const resultId = result.result_id;
   const updraftLensEligible = tradeCumulusUpdraftLensEligible(result);
@@ -9894,10 +9797,6 @@ export function VisualizerSceneShell({
   const [sliceLoadAttempt, setSliceLoadAttempt] = useState(0);
   const [updraftLensLoadAttempt, setUpdraftLensLoadAttempt] = useState(0);
   const [selectedRegion, setSelectedRegion] = useState<SelectedRegionRequest | null>(null);
-  const [regionDiagnostics, setRegionDiagnostics] =
-    useState<SelectedRegionDiagnosticsResponse | null>(null);
-  const [regionStatus, setRegionStatus] = useState("Click a slice cell to inspect that point.");
-  const [regionError, setRegionError] = useState<string | null>(null);
   const [updraftLensDefaults, setUpdraftLensDefaults] = useState<UpdraftLensDefaults | null>(null);
   const [updraftLensActive, setUpdraftLensActive] = useState(false);
   const [updraftLensFrame, setUpdraftLensFrame] = useState<UpdraftLensFrame | null>(null);
@@ -9944,9 +9843,6 @@ export function VisualizerSceneShell({
     setSliceLoadAttempt(0);
     setUpdraftLensLoadAttempt(0);
     setSelectedRegion(null);
-    setRegionDiagnostics(null);
-    setRegionError(null);
-    setRegionStatus("Click a slice cell to inspect that point.");
     setUpdraftLensDefaults(null);
     setUpdraftLensActive(false);
     setUpdraftLensFrame(null);
@@ -10112,9 +10008,6 @@ export function VisualizerSceneShell({
     selectedField?.provenance.provenance_label ??
     catalog?.provenance.provenance_label ??
     "CM1-derived visualization-ready data; rendering not implemented";
-  const selectedDefaults = defaultsForField(viewDefaults, selectedFieldName);
-  const selectedTimeFieldDefaults = defaultsForField(selectedTimeDefaults, selectedFieldName);
-  const selectedTimeSliceDefaults = defaultsForField(selectedTimeDefaults, sliceFieldName);
   const selectedTimeValue = timeOptions[displayTimeIndex] ?? null;
   const selectedTimeLabel = formatTimeValue(selectedTimeValue);
   const displayTimeValue = timeOptions[displayTimeIndex] ?? null;
@@ -10167,15 +10060,9 @@ export function VisualizerSceneShell({
       : null,
   ].filter((preset): preset is { label: string; seconds: number } => preset !== null);
 
-  const clearSelectedRegionForTimeChange = useCallback(
-    (nextStatus = "Click a slice cell to inspect that point.") => {
-      setSelectedRegion(null);
-      setRegionDiagnostics(null);
-      setRegionError(null);
-      setRegionStatus(nextStatus);
-    },
-    [],
-  );
+  const clearSelectedRegionForTimeChange = useCallback(() => {
+    setSelectedRegion(null);
+  }, []);
 
   const handleTimeIndexChange = useCallback(
     (nextIndex: number) => {
@@ -10199,7 +10086,7 @@ export function VisualizerSceneShell({
     }
     setPlaybackTimeIndex(resolvedTimeIndex);
     setIsPlaybackRunning(true);
-    clearSelectedRegionForTimeChange("Pause playback to select a cell and explain this time step.");
+    clearSelectedRegionForTimeChange();
   }, [
     clearSelectedRegionForTimeChange,
     isPlaybackRunning,
@@ -10312,11 +10199,9 @@ export function VisualizerSceneShell({
 
   useEffect(() => {
     if (!isPlaybackRunning || !canPlayTimelapse || !playbackFrameReady) return undefined;
-    clearSelectedRegionForTimeChange("Pause playback to select a cell and explain this time step.");
+    clearSelectedRegionForTimeChange();
     const timeoutId = window.setTimeout(() => {
-      clearSelectedRegionForTimeChange(
-        "Pause playback to select a cell and explain this time step.",
-      );
+      clearSelectedRegionForTimeChange();
       setPlaybackTimeIndex((current) => {
         if (current >= timeMax) {
           setIsPlaybackRunning(false);
@@ -10552,41 +10437,9 @@ export function VisualizerSceneShell({
     updraftLensWindMode,
   ]);
 
-  useEffect(() => {
-    if (!selectedRegion) {
-      setRegionDiagnostics(null);
-      setRegionError(null);
-      setRegionStatus("Click a slice cell to inspect that point.");
-      return;
-    }
-    let active = true;
-    setRegionDiagnostics(null);
-    setRegionError(null);
-    setRegionStatus("Loading selected-point diagnostics...");
-    fetchSelectedRegionDiagnostics(result.result_id, selectedRegion)
-      .then((payload) => {
-        if (!active) return;
-        setRegionDiagnostics(payload);
-        setRegionStatus("Point ready");
-      })
-      .catch((caught: unknown) => {
-        if (!active) return;
-        setRegionDiagnostics(null);
-        setRegionError(
-          caught instanceof Error ? caught.message : "Unable to inspect the selected point.",
-        );
-        setRegionStatus("Point unavailable");
-      });
-    return () => {
-      active = false;
-    };
-  }, [result.result_id, selectedRegion]);
-
   function selectPointFromSlice(slice: SliceResponse, rowIndex: number, columnIndex: number) {
     if (isPlaybackRunning) {
-      clearSelectedRegionForTimeChange(
-        "Pause playback to select a cell and explain this time step.",
-      );
+      clearSelectedRegionForTimeChange();
       return;
     }
     setSelectedRegion(selectionFromSlice(slice, rowIndex, columnIndex, "point"));
@@ -10594,9 +10447,7 @@ export function VisualizerSceneShell({
 
   function selectPointFromUpdraftLens(selection: UpdraftLensPointSelection) {
     if (isPlaybackRunning) {
-      clearSelectedRegionForTimeChange(
-        "Pause playback to select a cell and explain this time step.",
-      );
+      clearSelectedRegionForTimeChange();
       return;
     }
     setSelectedRegion({
@@ -11107,160 +10958,30 @@ export function VisualizerSceneShell({
             )}
           </div>
 
-          <ExploreInspector
-            sections={{
-              explain:
-                selectedRegion || regionError || isPlaybackRunning ? (
+          <ExploreInspector>
+            <ResultExplanationPanel
+              result={result}
+              simulationName={productSimulationName}
+              tradeCumulus={updraftLensEligible}
+              isNoCloudWithUpdraft={isNoCloudWithUpdraft}
+              updraftLensActive={updraftLensActive}
+              updraftLensFrame={updraftLensFrame}
+              selectedTimeLabel={selectedTimeLabel}
+              activeSliceLabel={activeSliceLabel}
+              selectedEvidence={
+                selectedRegion || isPlaybackRunning ? (
                   <SelectedRegionInspector
                     selectedRegion={selectedRegion}
                     slice={updraftLensActive ? null : activeSlice}
                     selectedValue={selectedSliceValue}
-                    diagnostics={regionDiagnostics}
-                    status={regionStatus}
-                    error={regionError}
+                    updraftLensFrame={updraftLensActive ? updraftLensFrame : null}
                     playbackRunning={isPlaybackRunning}
+                    onClear={() => setSelectedRegion(null)}
                   />
-                ) : (
-                  <ResultExplanationPanel
-                    result={result}
-                    tradeCumulus={updraftLensEligible}
-                    isNoCloudWithUpdraft={isNoCloudWithUpdraft}
-                    updraftLensActive={updraftLensActive}
-                    updraftLensFrame={updraftLensFrame}
-                    selectedTimeLabel={selectedTimeLabel}
-                    activeSliceLabel={activeSliceLabel}
-                  />
-                ),
-              notes: <SimulationNotesPanel result={result} onResultUpdated={onResultUpdated} />,
-              details: (
-                <>
-                  <SimulationDetailsPanel
-                    result={result}
-                    simulationRecord={simulationRecord}
-                    assetPath={assetPath}
-                    selectedField={selectedField}
-                    sliceField={sliceField}
-                    selectedTimeLabel={selectedTimeLabel}
-                    activeSliceLabel={activeSliceLabel}
-                  />
-                  <details className="technical-details">
-                    <summary>Visualization details</summary>
-                    <dl className="metric-grid">
-                      <Metric label="Run ID" value={result.run_id} />
-                      <Metric label="Renderer" value="Direct Three.js point cloud" />
-                      <Metric
-                        label="3-D field"
-                        value={
-                          selectedField
-                            ? `${selectedField.raw_field_name} (${selectedField.display_name})`
-                            : "Unavailable"
-                        }
-                      />
-                      <Metric label="3-D scene time" value={sceneTimeLabel} />
-                      <Metric label="Slice time" value={selectedTimeLabel} />
-                      <Metric label="Slice plane" value={activeSliceLabel} />
-                      <Metric label="Slice plane visible" value={showSlicePlanes ? "Yes" : "No"} />
-                      <Metric
-                        label={selectedEncoding?.thresholdLabel ?? "Visible threshold"}
-                        value={formatScientific(
-                          threshold * scalarDisplayScale(selectedField),
-                          scalarDisplayUnits(selectedField),
-                        )}
-                      />
-                      <Metric label="Opacity" value={String(opacity)} />
-                      <Metric label="Point size" value={`${pointSize}px`} />
-                      <Metric
-                        label="Point count"
-                        value={
-                          pointCloud
-                            ? `${pointCloud.stats.returned_count.toLocaleString()} of ${pointCloud.stats.source_count.toLocaleString()}`
-                            : "Unavailable"
-                        }
-                      />
-                      <Metric
-                        label={selectedEncoding?.rangeLabel ?? "3-D field range"}
-                        value={
-                          pointCloud
-                            ? `${formatFieldMaybeNumber(pointCloud.stats.min_value, selectedField)} to ${formatFieldMaybeNumber(
-                                pointCloud.stats.max_value,
-                                selectedField,
-                              )}`
-                            : "Unavailable"
-                        }
-                      />
-                      <Metric
-                        label="Selected-field range"
-                        value={
-                          pointCloud
-                            ? `${formatFieldMaybeNumber(pointCloud.stats.field_min_value, selectedField)} to ${formatFieldMaybeNumber(
-                                pointCloud.stats.field_max_value,
-                                selectedField,
-                              )}`
-                            : "Unavailable"
-                        }
-                      />
-                      <Metric
-                        label="Downsampling"
-                        value={
-                          pointCloud?.stats.downsampled
-                            ? `Deterministic stride ${pointCloud.stats.downsample_stride}`
-                            : "Not applied"
-                        }
-                      />
-                      <Metric
-                        label="Default source"
-                        value={
-                          selectedTimeFieldDefaults?.source ??
-                          selectedDefaults?.source ??
-                          "domain center fallback"
-                        }
-                      />
-                      <Metric
-                        label="Slice source"
-                        value={
-                          sliceField
-                            ? `${sliceField.raw_field_name} (${sliceField.display_name})`
-                            : "Unavailable"
-                        }
-                      />
-                      <Metric
-                        label="Slice orientation"
-                        value={
-                          activeSlicePlane === "horizontal" && sceneHorizontalSlice
-                            ? `${sceneHorizontalSlice.selection.orientation} at ${sceneHorizontalSlice.selection.selected_dimension}[${sceneHorizontalSlice.selection.selected_index}]`
-                            : sceneVerticalSlice
-                              ? `${sceneVerticalSlice.selection.orientation} at ${sceneVerticalSlice.selection.selected_dimension}[${sceneVerticalSlice.selection.selected_index}]`
-                              : "Unavailable"
-                        }
-                      />
-                      <Metric label="Domain x extent" value={extentLabel(pointCloud, "xh")} />
-                      <Metric label="Domain y extent" value={extentLabel(pointCloud, "yh")} />
-                      <Metric label="Domain z extent" value={verticalExtentLabel(pointCloud)} />
-                      <Metric
-                        label="Active cloud z range"
-                        value={
-                          pointCloud
-                            ? `${formatMaybeNumber(pointCloud.stats.active_z_min, verticalCoordinateUnit(pointCloud))} to ${formatMaybeNumber(
-                                pointCloud.stats.active_z_max,
-                                verticalCoordinateUnit(pointCloud),
-                              )}`
-                            : "Unavailable"
-                        }
-                      />
-                      <Metric
-                        label="Max 3-D field location"
-                        value={maxPointLocationLabel(pointCloud)}
-                      />
-                      <Metric
-                        label="Selected-time slice default"
-                        value={selectedTimeSliceDefaults?.source ?? "Unavailable"}
-                      />
-                    </dl>
-                  </details>
-                </>
-              ),
-            }}
-          />
+                ) : undefined
+              }
+            />
+          </ExploreInspector>
         </div>
 
         {catalog && sliceField && (
@@ -11397,6 +11118,37 @@ export function VisualizerSceneShell({
             )}
           </section>
         )}
+
+        <ExploreSecondarySections
+          sections={{
+            science: <TradeCumulusScience result={result} />,
+            notes: simulationRecord?.simulation_id ? (
+              <SimulationNotes
+                worldId={simulationRecord.world_id}
+                simulationId={simulationRecord.simulation_id}
+                simulationName={productSimulationName}
+              />
+            ) : (
+              <section className="simulation-note-failure">
+                <h3>Simulation notes</h3>
+                <p role="alert">
+                  Notes are unavailable because this result has no stable Simulation identity.
+                </p>
+              </section>
+            ),
+            details: (
+              <SimulationDetailsPanel
+                result={result}
+                simulationRecord={simulationRecord}
+                assetPath={assetPath}
+                selectedField={selectedField}
+                sliceField={sliceField}
+                selectedTimeLabel={selectedTimeLabel}
+                activeSliceLabel={activeSliceLabel}
+              />
+            ),
+          }}
+        />
       </section>
     </IntegratedExploreWorkspace>
   );
@@ -11539,20 +11291,24 @@ function ExploreRenderingControls({
 
 function ResultExplanationPanel({
   result,
+  simulationName,
   tradeCumulus,
   isNoCloudWithUpdraft,
   updraftLensActive,
   updraftLensFrame,
   selectedTimeLabel,
   activeSliceLabel,
+  selectedEvidence,
 }: {
   result: ResultCard;
+  simulationName: string;
   tradeCumulus: boolean;
   isNoCloudWithUpdraft: boolean;
   updraftLensActive: boolean;
   updraftLensFrame: UpdraftLensFrame | null;
   selectedTimeLabel: string;
   activeSliceLabel: string;
+  selectedEvidence?: ReactNode;
 }) {
   const cloudLabel = tradeCumulus
     ? fieldQualityBlocksEvidence(result, "qc")
@@ -11571,108 +11327,84 @@ function ResultExplanationPanel({
           "m/s",
         )}. Warm colors mark rising air, cool colors mark sinking air, and the black outline marks cloud water.`
       : `At model time ${selectedTimeLabel}, the 3-D cloud field and ${activeSliceLabel} show the same saved model state. The plane in the scene locates the Field Slice in the cloud domain.`;
+  const identity = updraftLensActive ? "Updraft Lens" : "Field";
+  const question = updraftLensActive
+    ? "Where is air rising and sinking through cloud?"
+    : "What does this saved cloud field show now?";
   return (
-    <section className="selected-region-inspector" aria-label="Result-level explanation panel">
-      <div className="section-heading compact-heading">
-        <div>
-          <h3>What am I seeing?</h3>
-        </div>
-        <StatusBadge
-          label={
-            cloudLabel === "Cloud formed"
-              ? "Cloud formed"
-              : cloudLabel === "No cloud formed"
-                ? "No cloud formed"
-                : cloudLabel
-          }
-          tone={cloudLabel === "Cloud formed" ? "good" : "warning"}
-        />
-      </div>
-      <p>{currentViewExplanation}</p>
-      <section aria-label="Current context">
-        <dl className="context-metrics">
-          <Metric label="Model time" value={selectedTimeLabel} />
-          <Metric label="First cloud" value={formatSeconds(resultFirstCloudTime(result))} />
-          <Metric label="Cloud water max" value={formatMixingRatio(resultMaxQc(result))} />
-          <Metric
-            label="Vertical velocity"
-            value={`${formatNumber(resultMinDowndraft(result), "m/s")} to ${formatNumber(
-              resultMaxUpdraft(result),
-              "m/s",
-            )}`}
+    <ExploreContextContent
+      identity={identity}
+      question={question}
+      explanation={<p>{currentViewExplanation}</p>}
+      selectedEvidence={selectedEvidence}
+      whatToNotice={
+        <div className="explore-context-status">
+          <StatusBadge
+            label={cloudLabel}
+            tone={cloudLabel === "Cloud formed" ? "good" : "warning"}
           />
-        </dl>
-      </section>
-      {isNoCloudWithUpdraft && (
-        <p>For this no-cloud result, use vertical velocity (w) slices to inspect the thermals.</p>
-      )}
-    </section>
+          {isNoCloudWithUpdraft && (
+            <p>Use vertical velocity slices to inspect thermals that did not produce cloud.</p>
+          )}
+        </div>
+      }
+      orientation={[
+        { label: "Simulation", value: simulationName },
+        { label: "View", value: identity },
+        { label: "Model time", value: selectedTimeLabel },
+        { label: "Slice", value: activeSliceLabel },
+        {
+          label: "Relevant caveat",
+          value:
+            result.runtime_integrity?.state === "caveated"
+              ? "This Simulation carries runtime-integrity caveats; see Details."
+              : "The view describes retained saved output, not continuous model evolution.",
+        },
+      ]}
+      selectionPrompt={
+        selectedEvidence ? undefined : "Select a slice cell for coordinated native-grid evidence."
+      }
+    />
   );
 }
 
-function SimulationNotesPanel({
-  result,
-  onResultUpdated,
-}: {
-  result: ResultCard;
-  onResultUpdated?: (result: ResultCard) => void;
-}) {
-  const [draft, setDraft] = useState(result.notes ?? "");
-  const [status, setStatus] = useState("");
-  const [saving, setSaving] = useState(false);
-  const statusResultIdRef = useRef(result.result_id);
-
-  useEffect(() => {
-    const resultChanged = statusResultIdRef.current !== result.result_id;
-    statusResultIdRef.current = result.result_id;
-    setDraft(result.notes ?? "");
-    if (resultChanged) setStatus("");
-  }, [result.result_id, result.notes]);
-
-  async function saveNote(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setSaving(true);
-    setStatus("Saving note...");
-    try {
-      const updated = await patchResultCard(result.result_id, {
-        notes: draft.trim() || null,
-      });
-      setDraft(updated.notes ?? "");
-      onResultUpdated?.(updated);
-      setStatus("Note saved");
-    } catch (caught) {
-      setStatus(caught instanceof Error ? caught.message : "Unable to save note.");
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  const savedNote = result.notes ?? "";
+function TradeCumulusScience({ result }: { result: ResultCard }) {
   return (
-    <section aria-labelledby="simulation-notes-title">
-      <h3 id="simulation-notes-title">Simulation notes</h3>
-      <form className="simulation-notes-form" onSubmit={(event) => void saveNote(event)}>
-        <label htmlFor={`simulation-notes-${result.result_id}`}>
-          <span className="sr-only">Notes for {result.name}</span>
-          <textarea
-            id={`simulation-notes-${result.result_id}`}
-            aria-label="Simulation notes"
-            rows={9}
-            placeholder="Record observations, questions, or follow-up ideas."
-            value={draft}
-            onChange={(event) => {
-              setDraft(event.target.value);
-              setStatus("");
-            }}
-          />
-        </label>
-        <div className="simulation-notes-actions">
-          <button type="submit" disabled={saving || draft === savedNote}>
-            {saving ? "Saving..." : "Save note"}
-          </button>
-          {status && <p role="status">{status}</p>}
-        </div>
-      </form>
+    <section className="explore-science-section">
+      <p className="eyebrow">Science</p>
+      <h3>Cloud-field evolution</h3>
+      <p>
+        Follow the timing and magnitude of cloud water together with the vertical-motion envelope.
+        The Updraft Lens shows their spatial relationship at one saved time; these Simulation-wide
+        extrema summarize the retained history.
+      </p>
+      <dl className="metric-grid compact-metric-grid">
+        <Metric label="First cloud" value={formatSeconds(resultFirstCloudTime(result))} />
+        <Metric label="Maximum cloud water" value={formatMixingRatio(resultMaxQc(result))} />
+        <Metric
+          label="Vertical-motion envelope"
+          value={`${formatNumber(resultMinDowndraft(result), "m/s")} to ${formatNumber(
+            resultMaxUpdraft(result),
+            "m/s",
+          )}`}
+        />
+        <Metric
+          label="Coherent cloud top"
+          value={formatNumber(resultCloudTopMeters(result), "m")}
+        />
+        <Metric
+          label="Latest retained output"
+          value={formatSeconds(resultLatestOutputTime(result))}
+        />
+        <Metric label="Surface rain" value={surfaceRainOutcome(result)} />
+      </dl>
+      <details>
+        <summary>Interpretation boundaries</summary>
+        <p>
+          Lens colors and boundaries are visualization interpretations of retained CM1 fields.
+          Extrema describe saved outputs and do not identify a causal cloud process by themselves.
+        </p>
+      </details>
     </section>
   );
 }
@@ -11899,6 +11631,48 @@ function selectedUpdraftLensValue(
   return frame.w_values_m_s[indices[rowDimension]]?.[indices[columnDimension]] ?? null;
 }
 
+function selectedUpdraftLensEvidence(
+  frame: UpdraftLensFrame,
+  selectedRegion: SelectedRegionRequest,
+): {
+  x: string;
+  y: string;
+  z: string;
+  verticalVelocity: number | null;
+  cloudy: boolean;
+} | null {
+  const xIndex = selectedRegion.xIndex;
+  const yIndex = selectedRegion.yIndex;
+  const zIndex = selectedRegion.zIndex;
+  if (xIndex === undefined || yIndex === undefined || zIndex === undefined) return null;
+  const indices = { x: xIndex, y: yIndex, z: zIndex };
+  if (indices[frame.plane_dimension] !== frame.plane_index) return null;
+  const rowDimension = frame.dimension_order[0];
+  const columnDimension = frame.dimension_order[1];
+  if (!rowDimension || !columnDimension) return null;
+  const rowIndex = indices[rowDimension];
+  const columnIndex = indices[columnDimension];
+  return {
+    x: updraftLensCoordinateLabel(frame.x_values_km, xIndex),
+    y: updraftLensCoordinateLabel(frame.y_values_km, yIndex),
+    z: updraftLensCoordinateLabel(frame.z_values_km, zIndex),
+    verticalVelocity: frame.w_values_m_s[rowIndex]?.[columnIndex] ?? null,
+    cloudy: frame.cloud_mask[rowIndex]?.[columnIndex] ?? false,
+  };
+}
+
+function updraftLensCoordinateLabel(valuesKm: number[], index: number): string {
+  const coordinate = valuesKm[index];
+  return coordinate === undefined ? `index ${index}` : `${formatCompactNumber(coordinate)} km`;
+}
+
+function motionStateLabel(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "Motion unavailable";
+  if (value > 0.1) return "Rising";
+  if (value < -0.1) return "Descending";
+  return "Near neutral";
+}
+
 function updraftLensSliceLabel(
   frame: UpdraftLensFrame | null,
   orientation: SceneSlicePlane,
@@ -12087,200 +11861,82 @@ function SelectedRegionInspector({
   selectedRegion,
   slice,
   selectedValue,
-  diagnostics,
-  status,
-  error,
+  updraftLensFrame,
   playbackRunning,
+  onClear,
 }: {
   selectedRegion: SelectedRegionRequest | null;
   slice: SliceResponse | null;
   selectedValue: number | null;
-  diagnostics: SelectedRegionDiagnosticsResponse | null;
-  status: string;
-  error: string | null;
+  updraftLensFrame: UpdraftLensFrame | null;
   playbackRunning?: boolean;
+  onClear: () => void;
 }) {
-  if (!selectedRegion && !error && !playbackRunning) {
-    return null;
-  }
-
-  return (
-    <section className="selected-region-inspector" aria-label="What happened here panel">
-      <div className="section-heading compact-heading">
-        <div>
-          <p className="eyebrow">Explanation</p>
-          <h3>What happened here?</h3>
-        </div>
-        <p className="state-chip">
-          {playbackRunning && !selectedRegion && !error ? "Playback running" : status}
-        </p>
-      </div>
-
-      {error && <p role="alert">{error}</p>}
-
-      {playbackRunning && !selectedRegion && !error && (
+  if (!selectedRegion && !playbackRunning) return null;
+  if (playbackRunning && !selectedRegion) {
+    return (
+      <section className="selected-region-inspector">
+        <p className="eyebrow">Selection paused</p>
+        <h4>Playback is running</h4>
         <p>Pause playback to select a cell and explain this time step.</p>
-      )}
+      </section>
+    );
+  }
+  if (!selectedRegion) return null;
 
-      {selectedRegion && (
-        <SelectedPointContext
-          selectedRegion={selectedRegion}
-          slice={slice}
-          selectedValue={selectedValue}
-          diagnostics={diagnostics}
-        />
-      )}
+  const lensEvidence = updraftLensFrame
+    ? selectedUpdraftLensEvidence(updraftLensFrame, selectedRegion)
+    : null;
+  const states = lensEvidence
+    ? [motionStateLabel(lensEvidence.verticalVelocity), lensEvidence.cloudy ? "Cloudy" : "Clear"]
+    : slice?.field.raw_field_name === "w" && selectedValue !== null
+      ? [motionStateLabel(selectedValue)]
+      : [];
+  const metrics = lensEvidence
+    ? [
+        { label: "x", value: lensEvidence.x },
+        { label: "y", value: lensEvidence.y },
+        { label: "z", value: lensEvidence.z },
+        { label: "Model time", value: formatSeconds(updraftLensFrame?.time_seconds ?? null) },
+        {
+          label: "Vertical velocity",
+          value: formatNumber(lensEvidence.verticalVelocity, "m/s"),
+        },
+        {
+          label: "Cloud liquid water",
+          value: `${lensEvidence.cloudy ? "At or above" : "Below"} ${formatCompactNumber(
+            updraftLensFrame!.cloud_threshold_kg_kg * 1_000,
+          )} g/kg`,
+        },
+      ]
+    : [
+        {
+          label: "Slice",
+          value: slice
+            ? slicePlainLabel(slice, slice.selection.orientation, slice.selection.selected_index)
+            : "Unavailable",
+        },
+        { label: "Model time", value: formatSeconds(slice?.selection.time_seconds ?? null) },
+        {
+          label: slice?.field.display_name ?? "Selected field",
+          value: formatFieldMaybeNumber(selectedValue, slice?.field),
+        },
+        {
+          label: "Native cell",
+          value: `x ${indexOrUnavailable(selectedRegion.xIndex)} · y ${indexOrUnavailable(
+            selectedRegion.yIndex,
+          )} · z ${indexOrUnavailable(selectedRegion.zIndex)}`,
+        },
+      ];
 
-      {diagnostics && (
-        <>
-          <div className="inspector-summary">
-            <StatusBadge
-              label={diagnostics.interpretation.thermal_fate_label}
-              tone={
-                diagnostics.interpretation.confidence === "supported"
-                  ? "good"
-                  : diagnostics.interpretation.confidence === "candidate"
-                    ? "neutral"
-                    : "warning"
-              }
-            />
-            <p>{diagnostics.interpretation.summary}</p>
-          </div>
-
-          <dl className="metric-grid">
-            <Metric
-              label="Confidence"
-              value={processSupportLabel(diagnostics.interpretation.confidence)}
-            />
-            <Metric
-              label="Main limiting factor"
-              value={humanize(diagnostics.interpretation.main_limiting_factor)}
-            />
-            <Metric
-              label="First local cloud time"
-              value={formatSeconds(diagnostics.diagnostics.first_local_cloud_time_seconds)}
-            />
-            <Metric
-              label="Local max qc"
-              value={formatMixingRatio(diagnostics.diagnostics.local_max_qc_kg_kg)}
-            />
-            <Metric
-              label="Local max w"
-              value={formatNumber(diagnostics.diagnostics.local_max_w_m_s, "m/s")}
-            />
-            <Metric
-              label="Local min w"
-              value={formatNumber(diagnostics.diagnostics.local_min_w_m_s, "m/s")}
-            />
-            <Metric
-              label="Local rain"
-              value={
-                diagnostics.diagnostics.local_rain_present
-                  ? "Rain water aloft detected"
-                  : "No rain water aloft detected"
-              }
-            />
-          </dl>
-
-          <details>
-            <summary>Selected-point details</summary>
-            <dl className="metric-grid">
-              <Metric label="Region type" value={humanize(diagnostics.region.region_type)} />
-              <Metric label="Native grid" value={diagnostics.region.native_grid ?? "Unavailable"} />
-              <Metric
-                label="Cell count"
-                value={String(diagnostics.region.cell_count ?? "unknown")}
-              />
-              <Metric label="x" value={axisSelectionLabel(diagnostics.region.x)} />
-              <Metric label="y" value={axisSelectionLabel(diagnostics.region.y)} />
-              <Metric label="vertical" value={axisSelectionLabel(diagnostics.region.vertical)} />
-              <Metric
-                label="Max w fraction"
-                value={formatRatio(diagnostics.comparison_to_domain.local_max_w_fraction_of_domain)}
-              />
-              <Metric
-                label="Max qc fraction"
-                value={formatRatio(
-                  diagnostics.comparison_to_domain.local_max_qc_fraction_of_domain,
-                )}
-              />
-              <Metric
-                label="First cloud delta"
-                value={formatSignedSeconds(
-                  diagnostics.comparison_to_domain.local_first_cloud_time_delta_seconds,
-                )}
-              />
-              <Metric
-                label="Cloud-top fraction"
-                value={formatRatio(
-                  diagnostics.comparison_to_domain.local_cloud_top_fraction_of_domain,
-                )}
-              />
-            </dl>
-            <ul className="compact-list">
-              {_dedupeStrings([
-                ...diagnostics.caveats,
-                ...diagnostics.interpretation.caveats,
-                ...diagnostics.comparison_to_domain.caveats,
-              ]).map((caveat) => (
-                <li key={caveat}>{caveat}</li>
-              ))}
-            </ul>
-          </details>
-        </>
-      )}
-    </section>
-  );
-}
-
-function SelectedPointContext({
-  selectedRegion,
-  slice,
-  selectedValue,
-  diagnostics,
-}: {
-  selectedRegion: SelectedRegionRequest;
-  slice: SliceResponse | null;
-  selectedValue: number | null;
-  diagnostics: SelectedRegionDiagnosticsResponse | null;
-}) {
-  const x = diagnostics?.region.x
-    ? axisSelectionLabel(diagnostics.region.x)
-    : indexOrUnavailable(selectedRegion.xIndex);
-  const y = diagnostics?.region.y
-    ? axisSelectionLabel(diagnostics.region.y)
-    : indexOrUnavailable(selectedRegion.yIndex);
-  const z = diagnostics?.region.vertical
-    ? axisSelectionLabel(diagnostics.region.vertical)
-    : indexOrUnavailable(selectedRegion.zIndex);
   return (
-    <section className="selected-point-context" aria-label="Selected point context">
-      <h4>Selected point</h4>
-      <dl className="metric-grid">
-        <Metric
-          label="Slice"
-          value={
-            slice
-              ? slicePlainLabel(slice, slice.selection.orientation, slice.selection.selected_index)
-              : "Unavailable"
-          }
-        />
-        <Metric label="Time" value={formatSeconds(slice?.selection.time_seconds ?? null)} />
-        <Metric
-          label="Field"
-          value={
-            slice ? `${slice.field.raw_field_name} (${slice.field.display_name})` : "Unavailable"
-          }
-        />
-        <Metric
-          label="Selected field value"
-          value={formatFieldMaybeNumber(selectedValue, slice?.field)}
-        />
-        <Metric label="x" value={x} />
-        <Metric label="y" value={y} />
-        <Metric label="z" value={z} />
-      </dl>
-    </section>
+    <ExploreSelectedEvidence
+      eyebrow="Selected cell"
+      title="Native-grid evidence"
+      states={states}
+      metrics={metrics}
+      onClear={onClear}
+    />
   );
 }
 
@@ -13745,24 +13401,6 @@ function Metric({ label, value }: { label: string; value: string }) {
   );
 }
 
-type ProcessSupport =
-  | "supported"
-  | "candidate"
-  | "insufficient_evidence"
-  | "unsupported_missing_fields"
-  | "future";
-
-function processSupportLabel(value: ProcessSupport): string {
-  const labels: Record<ProcessSupport, string> = {
-    supported: "Supported",
-    candidate: "Candidate",
-    insufficient_evidence: "Insufficient evidence",
-    unsupported_missing_fields: "Unavailable",
-    future: "Future",
-  };
-  return labels[value];
-}
-
 function selectionFromSlice(
   slice: SliceResponse,
   rowIndex: number,
@@ -13839,38 +13477,8 @@ function isSelectedSliceDisplayCell(
   return false;
 }
 
-function axisSelectionLabel(axis: AxisSelection | null): string {
-  if (!axis) return "Unavailable";
-  const coordinate =
-    axis.start_coordinate === axis.end_coordinate
-      ? formatAxisCoordinate(axis.start_coordinate)
-      : `${formatAxisCoordinate(axis.start_coordinate)} to ${formatAxisCoordinate(axis.end_coordinate)}`;
-  const index =
-    axis.start_index === axis.end_index
-      ? `${axis.dimension}[${axis.start_index}]`
-      : `${axis.dimension}[${axis.start_index}..${axis.end_index}]`;
-  return `${index}; ${coordinate}${axis.units ? ` ${axis.units}` : ""}`;
-}
-
-function formatAxisCoordinate(value: number | string | null | undefined): string {
-  if (value === null || value === undefined) return "unknown";
-  const numericValue = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(numericValue) ? formatCompactNumber(numericValue) : String(value);
-}
-
 function indexOrUnavailable(index: number | undefined): string {
   return index === undefined ? "Unavailable" : `index ${index}`;
-}
-
-function formatRatio(value: number | null): string {
-  if (value === null || !Number.isFinite(value)) return "Unavailable";
-  return `${formatCompactNumber(value * 100)}%`;
-}
-
-function formatSignedSeconds(value: number | null): string {
-  if (value === null || !Number.isFinite(value)) return "Unavailable";
-  const prefix = value > 0 ? "+" : "";
-  return `${prefix}${formatSeconds(value)}`;
 }
 
 function _dedupeStrings(values: string[]): string[] {
@@ -14468,32 +14076,6 @@ function normalize(value: number, min: number, max: number): number {
   return (value - min) / (max - min);
 }
 
-function extentLabel(pointCloud: PointCloudResponse | null, coordinate: string): string {
-  const extent = pointCloud?.coordinate_extents[coordinate];
-  if (!extent) return "Unavailable";
-  const suffix = extent.units ? ` ${extent.units}` : "";
-  return `${formatCompactNumber(extent.min)} to ${formatCompactNumber(extent.max)}${suffix}`;
-}
-
-function verticalExtentLabel(pointCloud: PointCloudResponse | null): string {
-  const extent =
-    pointCloud?.coordinate_extents.zh ??
-    pointCloud?.coordinate_extents.zf ??
-    pointCloud?.coordinate_extents.z;
-  if (!extent) return "Unavailable";
-  const suffix = extent.units ? ` ${extent.units}` : "";
-  return `${formatCompactNumber(extent.min)} to ${formatCompactNumber(extent.max)}${suffix}`;
-}
-
-function verticalCoordinateUnit(pointCloud: PointCloudResponse | null): string | null {
-  return (
-    pointCloud?.coordinate_units.zh ??
-    pointCloud?.coordinate_units.zf ??
-    pointCloud?.coordinate_units.z ??
-    null
-  );
-}
-
 function pointCloudFieldSummary(pointCloud: PointCloudResponse): string {
   const maxValue = formatFieldMaybeNumber(pointCloud.stats.field_max_value, pointCloud.field);
   const threshold = formatFieldMaybeNumber(pointCloud.selection.threshold, pointCloud.field);
@@ -14507,15 +14089,6 @@ function emptyPointCloudStatus(
   const maxValue = formatFieldMaybeNumber(pointCloud.stats.field_max_value, selectedEncoding.field);
   const threshold = formatFieldMaybeNumber(pointCloud.selection.threshold, selectedEncoding.field);
   return `${selectedEncoding.field.display_name} max is ${maxValue}; no points are above ${threshold}`;
-}
-
-function maxPointLocationLabel(pointCloud: PointCloudResponse | null): string {
-  const location = pointCloud?.stats.max_value_location;
-  if (!location) return "Unavailable";
-  const units = verticalCoordinateUnit(pointCloud) ?? "";
-  return `x ${formatCompactNumber(location.x)}, y ${formatCompactNumber(location.y)}, z ${formatCompactNumber(
-    location.z,
-  )}${units ? ` ${units}` : ""}, value ${formatFieldMaybeNumber(location.value, pointCloud?.field)}`;
 }
 
 function heatmapScaleClass(field: VisualizableField): string {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1432,6 +1432,31 @@ type SelectedRegionRequest = {
   neighborhood?: number;
 };
 
+type SelectedRegionTimeValue = {
+  time_seconds: number | null;
+  value: number | null;
+};
+
+type SelectedRegionHistoryResponse = {
+  diagnostics: {
+    available: boolean;
+    local_max_w_m_s: number | null;
+    time_of_local_max_w_seconds: number | null;
+    local_min_w_m_s: number | null;
+    time_of_local_min_w_seconds: number | null;
+    local_max_qc_kg_kg: number | null;
+    time_of_local_max_qc_seconds: number | null;
+    first_local_cloud_time_seconds: number | null;
+    local_cloud_base_time_series: SelectedRegionTimeValue[];
+    local_cloud_top_time_series: SelectedRegionTimeValue[];
+    local_rain_present: boolean;
+    first_local_rain_time_seconds: number | null;
+    local_max_qr_kg_kg: number | null;
+    time_of_local_max_qr_seconds: number | null;
+  };
+  caveats: string[];
+};
+
 type FieldViewDefaults = {
   field: string;
   time_index: number;
@@ -2198,6 +2223,35 @@ async function fetchVisualizationPointCloud(
     throw new Error(await responseError(response, "Unable to load 3-D scalar point layer."));
   }
   return response.json() as Promise<PointCloudResponse>;
+}
+
+async function fetchSelectedRegionHistory(
+  resultId: string,
+  request: SelectedRegionRequest,
+): Promise<SelectedRegionHistoryResponse> {
+  const search = new URLSearchParams({
+    region_type: request.regionType,
+    neighborhood: String(request.neighborhood ?? 0),
+  });
+  const indices: Array<[string, number | undefined]> = [
+    ["x_index", request.xIndex],
+    ["y_index", request.yIndex],
+    ["z_index", request.zIndex],
+    ["x_start", request.xStart],
+    ["x_end", request.xEnd],
+    ["y_start", request.yStart],
+    ["y_end", request.yEnd],
+    ["z_start", request.zStart],
+    ["z_end", request.zEnd],
+  ];
+  indices.forEach(([key, value]) => {
+    if (value !== undefined) search.set(key, String(value));
+  });
+  const response = await fetch(`/api/results/${resultId}/diagnostics/selected-region?${search}`);
+  if (!response.ok) {
+    throw new Error(await responseError(response, "Unable to load selected-column history."));
+  }
+  return response.json() as Promise<SelectedRegionHistoryResponse>;
 }
 
 async function responseError(response: Response, fallback: string): Promise<string> {
@@ -11121,7 +11175,7 @@ export function VisualizerSceneShell({
 
         <ExploreSecondarySections
           sections={{
-            science: <TradeCumulusScience result={result} />,
+            science: <TradeCumulusScience result={result} selectedRegion={selectedRegion} />,
             notes: simulationRecord?.simulation_id ? (
               <SimulationNotes
                 worldId={simulationRecord.world_id}
@@ -11368,7 +11422,65 @@ function ResultExplanationPanel({
   );
 }
 
-function TradeCumulusScience({ result }: { result: ResultCard }) {
+function TradeCumulusScience({
+  result,
+  selectedRegion,
+}: {
+  result: ResultCard;
+  selectedRegion: SelectedRegionRequest | null;
+}) {
+  const [localHistory, setLocalHistory] = useState<SelectedRegionHistoryResponse | null>(null);
+  const [localHistoryLoading, setLocalHistoryLoading] = useState(false);
+  const [localHistoryError, setLocalHistoryError] = useState<string | null>(null);
+  const requestRef = useRef(0);
+  const selectionKey = selectedRegion
+    ? [
+        selectedRegion.regionType,
+        selectedRegion.xIndex,
+        selectedRegion.yIndex,
+        selectedRegion.zIndex,
+        selectedRegion.xStart,
+        selectedRegion.xEnd,
+        selectedRegion.yStart,
+        selectedRegion.yEnd,
+        selectedRegion.zStart,
+        selectedRegion.zEnd,
+        selectedRegion.neighborhood,
+      ].join(":")
+    : "";
+
+  useEffect(() => {
+    requestRef.current += 1;
+    setLocalHistory(null);
+    setLocalHistoryLoading(false);
+    setLocalHistoryError(null);
+  }, [result.result_id, selectionKey]);
+
+  async function loadLocalHistory() {
+    if (!selectedRegion) return;
+    const requestId = requestRef.current + 1;
+    requestRef.current = requestId;
+    setLocalHistoryLoading(true);
+    setLocalHistoryError(null);
+    try {
+      const payload = await fetchSelectedRegionHistory(result.result_id, {
+        regionType: "column",
+        xIndex: selectedRegion.xIndex,
+        yIndex: selectedRegion.yIndex,
+        neighborhood: selectedRegion.neighborhood ?? 0,
+      });
+      if (requestRef.current !== requestId) return;
+      setLocalHistory(payload);
+    } catch (caught) {
+      if (requestRef.current !== requestId) return;
+      setLocalHistoryError(
+        caught instanceof Error ? caught.message : "Unable to load selected-column history.",
+      );
+    } finally {
+      if (requestRef.current === requestId) setLocalHistoryLoading(false);
+    }
+  }
+
   return (
     <section className="explore-science-section">
       <p className="eyebrow">Science</p>
@@ -11405,8 +11517,179 @@ function TradeCumulusScience({ result }: { result: ResultCard }) {
           Extrema describe saved outputs and do not identify a causal cloud process by themselves.
         </p>
       </details>
+      <section className="selected-column-history" aria-label="Selected-column history">
+        <p className="eyebrow">Selected column</p>
+        <h3>Local history at the selected column</h3>
+        {selectedRegion ? (
+          <>
+            <p>
+              Load retained quantitative history for the column containing the cell selected in
+              Context. This can take longer than reading the current frame.
+            </p>
+            {!localHistory && (
+              <button
+                type="button"
+                className="secondary-button"
+                disabled={localHistoryLoading}
+                onClick={() => void loadLocalHistory()}
+              >
+                {localHistoryLoading ? "Loading local history..." : "Load selected-column history"}
+              </button>
+            )}
+            {localHistoryError && (
+              <div className="layer-local-error" role="alert">
+                <span>{localHistoryError}</span>
+                <button type="button" onClick={() => void loadLocalHistory()}>
+                  Retry local history
+                </button>
+              </div>
+            )}
+            {localHistory && (
+              <SelectedColumnHistory
+                history={localHistory}
+                loading={localHistoryLoading}
+                onReload={loadLocalHistory}
+              />
+            )}
+          </>
+        ) : (
+          <p>Select a slice cell to make its column history available here.</p>
+        )}
+      </section>
     </section>
   );
+}
+
+function SelectedColumnHistory({
+  history,
+  loading,
+  onReload,
+}: {
+  history: SelectedRegionHistoryResponse;
+  loading: boolean;
+  onReload: () => Promise<void>;
+}) {
+  const diagnostics = history.diagnostics;
+  const cloudDepth = pairCloudDepthHistory(
+    diagnostics.local_cloud_base_time_series,
+    diagnostics.local_cloud_top_time_series,
+  );
+  return (
+    <section className="explore-science-callout">
+      <div className="section-heading compact-heading">
+        <div>
+          <p className="eyebrow">Retained column history</p>
+          <h4>Quantitative local evidence</h4>
+        </div>
+        <button
+          type="button"
+          className="secondary-button"
+          disabled={loading}
+          onClick={() => void onReload()}
+        >
+          {loading ? "Reloading..." : "Reload"}
+        </button>
+      </div>
+      {diagnostics.available ? (
+        <>
+          <dl className="metric-grid compact-metric-grid">
+            <Metric
+              label="Vertical-motion envelope"
+              value={`${formatNumber(diagnostics.local_min_w_m_s, "m/s")} to ${formatNumber(
+                diagnostics.local_max_w_m_s,
+                "m/s",
+              )}`}
+            />
+            <Metric
+              label="Strongest ascent"
+              value={formatSeconds(diagnostics.time_of_local_max_w_seconds)}
+            />
+            <Metric
+              label="Strongest descent"
+              value={formatSeconds(diagnostics.time_of_local_min_w_seconds)}
+            />
+            <Metric
+              label="First local cloud"
+              value={formatSeconds(diagnostics.first_local_cloud_time_seconds)}
+            />
+            <Metric
+              label="Maximum local cloud water"
+              value={`${formatNumber(
+                diagnostics.local_max_qc_kg_kg === null
+                  ? null
+                  : diagnostics.local_max_qc_kg_kg * 1_000,
+                "g/kg",
+              )} at ${formatSeconds(diagnostics.time_of_local_max_qc_seconds)}`}
+            />
+            <Metric
+              label="First local rain water"
+              value={formatSeconds(diagnostics.first_local_rain_time_seconds)}
+            />
+            <Metric
+              label="Maximum local rain water"
+              value={
+                diagnostics.local_rain_present
+                  ? `${formatNumber(
+                      diagnostics.local_max_qr_kg_kg === null
+                        ? null
+                        : diagnostics.local_max_qr_kg_kg * 1_000,
+                      "g/kg",
+                    )} at ${formatSeconds(diagnostics.time_of_local_max_qr_seconds)}`
+                  : "Not detected"
+              }
+            />
+          </dl>
+          <details>
+            <summary>Cloud-depth evolution</summary>
+            {cloudDepth.length > 0 ? (
+              <ul className="compact-list">
+                {cloudDepth.map((frame) => (
+                  <li key={`${frame.timeSeconds}-${frame.baseMeters}-${frame.topMeters}`}>
+                    {formatSeconds(frame.timeSeconds)}: base {formatNumber(frame.baseMeters, "m")},
+                    top {formatNumber(frame.topMeters, "m")}, depth{" "}
+                    {formatNumber(
+                      frame.baseMeters !== null && frame.topMeters !== null
+                        ? Math.max(0, frame.topMeters - frame.baseMeters)
+                        : null,
+                      "m",
+                    )}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>No local cloud-depth series is available for this selected column.</p>
+            )}
+          </details>
+        </>
+      ) : (
+        <p>Local history is unavailable for this selected column.</p>
+      )}
+      {history.caveats.length > 0 && (
+        <details>
+          <summary>Data caveats</summary>
+          <ul className="compact-list">
+            {_dedupeStrings(history.caveats).map((caveat) => (
+              <li key={caveat}>{humanize(caveat)}</li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </section>
+  );
+}
+
+function pairCloudDepthHistory(
+  bases: SelectedRegionTimeValue[],
+  tops: SelectedRegionTimeValue[],
+): Array<{ timeSeconds: number | null; baseMeters: number | null; topMeters: number | null }> {
+  const topsByTime = new Map(tops.map((item) => [item.time_seconds, item.value]));
+  return bases
+    .map((base) => ({
+      timeSeconds: base.time_seconds,
+      baseMeters: base.value,
+      topMeters: topsByTime.get(base.time_seconds) ?? null,
+    }))
+    .filter((item) => item.baseMeters !== null || item.topMeters !== null);
 }
 
 function SimulationDetailsPanel({

--- a/app/frontend/src/IntegratedExploreWorkspace.test.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.test.tsx
@@ -1,7 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
+import {
+  ExploreContextContent,
+  ExploreInspector,
+  ExploreSecondarySections,
+  IntegratedExploreWorkspace,
+} from "./IntegratedExploreWorkspace";
 
 describe("IntegratedExploreWorkspace", () => {
   it("leads with stable product identity and bounded actions", () => {
@@ -26,34 +31,34 @@ describe("IntegratedExploreWorkspace", () => {
     expect(onCompare).toHaveBeenCalledOnce();
   });
 
-  it("keeps current context primary and places notes and details in secondary content", () => {
+  it("keeps one context-sensitive sidebar that collapses independently", () => {
     render(
       <ExploreInspector
-        sections={{
-          explain: <p>Authored explanation</p>,
-          notes: <p>No note recorded</p>,
-          details: <p>Technical provenance</p>,
-        }}
+        children={
+          <ExploreContextContent
+            identity="Updraft Lens"
+            question="Where is air rising through cloud?"
+            explanation={<p>Warm colors show rising air.</p>}
+            selectedEvidence={<p>Selected cell evidence</p>}
+            orientation={[{ label: "Model time", value: "1,200 s" }]}
+          />
+        }
       />,
     );
 
-    expect(screen.getByText("Authored explanation")).toBeVisible();
-    expect(screen.getByLabelText("Simulation notebook")).toHaveTextContent("No note recorded");
-    expect(screen.getByLabelText("Simulation technical details")).toHaveTextContent(
-      "Technical provenance",
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Collapse inspector" }));
-    expect(screen.getByLabelText("Explore inspector")).toHaveAttribute("data-collapsed", "true");
-    expect(screen.getByLabelText("Simulation notebook")).toBeVisible();
-    fireEvent.click(screen.getByRole("button", { name: "Open inspector" }));
-    expect(screen.getByText("Authored explanation")).toBeVisible();
+    expect(screen.getByText("Selected cell evidence")).toBeVisible();
+    expect(screen.getByLabelText("Context")).toHaveAttribute("data-collapsed", "false");
+    expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Hide Context" }));
+    expect(screen.getByLabelText("Context")).toHaveAttribute("data-collapsed", "true");
+    fireEvent.click(screen.getByRole("button", { name: "Show Context" }));
+    expect(screen.getByText("Warm colors show rising air.")).toBeVisible();
   });
 
-  it("uses an accessible tabbed Context inspector when Science is available", () => {
+  it("places Science, Notes, and Details in one accessible below-workspace navigator", () => {
     render(
-      <ExploreInspector
+      <ExploreSecondarySections
         sections={{
-          explain: <p>Storm explanation</p>,
           science: <p>Selected native evidence</p>,
           notes: <p>Simulation notes</p>,
           details: <p>Run lineage</p>,
@@ -61,12 +66,15 @@ describe("IntegratedExploreWorkspace", () => {
       />,
     );
 
-    const tablist = screen.getByRole("tablist", { name: "Context sections" });
-    expect(screen.getByRole("tab", { name: "Explain" })).toHaveAttribute("aria-selected", "true");
-    fireEvent.click(screen.getByRole("tab", { name: "Science" }));
+    const tablist = screen.getByRole("tablist", { name: "Simulation support sections" });
+    expect(screen.getByRole("tab", { name: "Science" })).toHaveAttribute("aria-selected", "true");
+    fireEvent.click(screen.getByRole("tab", { name: "Notes" }));
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Simulation notes");
+    fireEvent.keyDown(screen.getByRole("tab", { name: "Notes" }), { key: "ArrowRight" });
+    expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute("aria-selected", "true");
+    fireEvent.keyDown(screen.getByRole("tab", { name: "Details" }), { key: "Home" });
     expect(screen.getByRole("tabpanel")).toHaveTextContent("Selected native evidence");
     expect(screen.getByRole("tab", { name: "Science" })).toHaveAttribute("aria-selected", "true");
     expect(tablist).toBeVisible();
-    expect(screen.queryByLabelText("Simulation notebook")).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/IntegratedExploreWorkspace.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.tsx
@@ -1,13 +1,13 @@
-import { type ReactNode, useState } from "react";
+import { type KeyboardEvent, type ReactNode, useId, useRef, useState } from "react";
 
-type InspectorSections = {
-  explain: ReactNode;
-  science?: ReactNode;
-  notes: ReactNode;
-  details: ReactNode;
+export type ExploreSecondarySection = "science" | "notes" | "details";
+
+export type ExploreSecondaryContent = Record<ExploreSecondarySection, ReactNode>;
+
+export type ExploreContextMetric = {
+  label: string;
+  value: ReactNode;
 };
-
-type InspectorTab = "explain" | "science" | "notes" | "details";
 
 export function IntegratedExploreWorkspace({
   worldName,
@@ -55,29 +55,19 @@ export function IntegratedExploreWorkspace({
 
 export function ExploreInspector({
   id,
-  sections,
+  children,
   collapsed: controlledCollapsed,
   onCollapsedChange,
   showCollapseControl = true,
 }: {
   id?: string;
-  sections: InspectorSections;
+  children: ReactNode;
   collapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
   showCollapseControl?: boolean;
 }) {
   const [internalCollapsed, setInternalCollapsed] = useState(false);
-  const [activeTab, setActiveTab] = useState<InspectorTab>("explain");
   const collapsed = controlledCollapsed ?? internalCollapsed;
-  const tabbed = sections.science !== undefined;
-  const activePanel =
-    activeTab === "explain"
-      ? sections.explain
-      : activeTab === "science"
-        ? sections.science
-        : activeTab === "notes"
-          ? sections.notes
-          : sections.details;
 
   function toggleCollapsed() {
     const next = !collapsed;
@@ -88,64 +78,202 @@ export function ExploreInspector({
   if (collapsed && !showCollapseControl) return null;
 
   return (
-    <>
-      <aside
-        id={id}
-        className={`explore-inspector${collapsed ? " explore-inspector-collapsed" : ""}`}
-        aria-label="Explore inspector"
-        data-collapsed={collapsed ? "true" : "false"}
-      >
-        <header className="explore-inspector-header">
-          {!collapsed && <strong>Context</strong>}
-          {showCollapseControl && (
-            <button
-              type="button"
-              className="explore-inspector-toggle"
-              aria-expanded={!collapsed}
-              aria-label={collapsed ? "Open inspector" : "Collapse inspector"}
-              title={collapsed ? "Open inspector" : "Collapse inspector"}
-              onClick={toggleCollapsed}
-            >
-              <span aria-hidden="true">{collapsed ? "\u00ab" : "\u00bb"}</span>
-            </button>
-          )}
-        </header>
-        <div hidden={collapsed}>
-          {tabbed && (
-            <nav className="explore-inspector-tabs" aria-label="Context sections" role="tablist">
-              {(["explain", "science", "notes", "details"] as InspectorTab[]).map((tab) => (
-                <button
-                  key={tab}
-                  type="button"
-                  id={`explore-inspector-tab-${tab}`}
-                  role="tab"
-                  className={activeTab === tab ? "active-control" : ""}
-                  aria-selected={activeTab === tab}
-                  aria-controls="explore-inspector-active-panel"
-                  onClick={() => setActiveTab(tab)}
-                >
-                  {tab[0].toUpperCase() + tab.slice(1)}
-                </button>
-              ))}
-            </nav>
-          )}
-          <section
-            id={tabbed ? "explore-inspector-active-panel" : undefined}
-            className="explore-inspector-panel"
-            aria-label="Context inspector"
-            role={tabbed ? "tabpanel" : undefined}
-            aria-labelledby={tabbed ? `explore-inspector-tab-${activeTab}` : undefined}
+    <aside
+      id={id}
+      className={`explore-inspector${collapsed ? " explore-inspector-collapsed" : ""}`}
+      aria-label="Context"
+      data-collapsed={collapsed ? "true" : "false"}
+    >
+      <header className="explore-inspector-header">
+        {!collapsed && <strong>Context</strong>}
+        {showCollapseControl && (
+          <button
+            type="button"
+            className="explore-inspector-toggle"
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? "Show Context" : "Hide Context"}
+            title={collapsed ? "Show Context" : "Hide Context"}
+            onClick={toggleCollapsed}
           >
-            {tabbed ? activePanel : sections.explain}
-          </section>
-        </div>
-      </aside>
-      {!tabbed && (
-        <section className="explore-secondary-content" aria-label="Simulation notebook and details">
-          <section aria-label="Simulation notebook">{sections.notes}</section>
-          <section aria-label="Simulation technical details">{sections.details}</section>
+            <span aria-hidden="true">{collapsed ? "\u00ab" : "\u00bb"}</span>
+          </button>
+        )}
+      </header>
+      <div hidden={collapsed}>
+        <section className="explore-inspector-panel" aria-label="Current scientific context">
+          {children}
+        </section>
+      </div>
+    </aside>
+  );
+}
+
+export function ExploreContextContent({
+  identity,
+  question,
+  explanation,
+  selectedEvidence,
+  whatToNotice,
+  orientation,
+  selectionPrompt,
+}: {
+  identity: string;
+  question: string;
+  explanation: ReactNode;
+  selectedEvidence?: ReactNode;
+  whatToNotice?: ReactNode;
+  orientation: ExploreContextMetric[];
+  selectionPrompt?: ReactNode;
+}) {
+  return (
+    <section className="explore-context-content">
+      <p className="eyebrow">{identity}</p>
+      <h3>{question}</h3>
+      {selectedEvidence}
+      <div className="explore-context-explanation">{explanation}</div>
+      {whatToNotice && (
+        <section className="explore-context-notice" aria-label="What to notice now">
+          <strong>What to notice now</strong>
+          <div>{whatToNotice}</div>
         </section>
       )}
-    </>
+      <dl className="context-metrics">
+        {orientation.map((metric) => (
+          <div key={metric.label}>
+            <dt>{metric.label}</dt>
+            <dd>{metric.value}</dd>
+          </div>
+        ))}
+      </dl>
+      {selectionPrompt && <p className="context-selection-prompt">{selectionPrompt}</p>}
+    </section>
+  );
+}
+
+export function ExploreSelectedEvidence({
+  eyebrow,
+  title,
+  states,
+  metrics,
+  onClear,
+  className,
+}: {
+  eyebrow: string;
+  title: string;
+  states?: string[];
+  metrics: ExploreContextMetric[];
+  onClear: () => void;
+  className?: string;
+}) {
+  return (
+    <section
+      className={`selected-region-inspector explore-selected-evidence${
+        className ? ` ${className}` : ""
+      }`}
+      aria-label="Selected native-grid evidence"
+    >
+      <div className="section-heading">
+        <div>
+          <p className="eyebrow">{eyebrow}</p>
+          <h4>{title}</h4>
+        </div>
+        <button type="button" className="secondary-button" onClick={onClear}>
+          Clear
+        </button>
+      </div>
+      {states && states.length > 0 && (
+        <div className="explore-context-state-row">
+          {states.map((state) => (
+            <span key={state} className="state-chip">
+              {state}
+            </span>
+          ))}
+        </div>
+      )}
+      <dl className="context-metrics">
+        {metrics.map((metric) => (
+          <div key={metric.label}>
+            <dt>{metric.label}</dt>
+            <dd>{metric.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+export function ExploreSecondarySections({
+  sections,
+  label = "Simulation support",
+}: {
+  sections: ExploreSecondaryContent;
+  label?: string;
+}) {
+  const [activeSection, setActiveSection] = useState<ExploreSecondarySection>("science");
+  const baseId = useId();
+  const tabRefs = useRef<Partial<Record<ExploreSecondarySection, HTMLButtonElement | null>>>({});
+  const orderedSections: ExploreSecondarySection[] = ["science", "notes", "details"];
+
+  function selectSection(section: ExploreSecondarySection, focus = false) {
+    setActiveSection(section);
+    if (focus) tabRefs.current[section]?.focus();
+  }
+
+  function handleKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    section: ExploreSecondarySection,
+  ) {
+    const index = orderedSections.indexOf(section);
+    let next: ExploreSecondarySection | undefined;
+    if (event.key === "ArrowRight") {
+      next = orderedSections[(index + 1) % orderedSections.length];
+    } else if (event.key === "ArrowLeft") {
+      next = orderedSections[(index - 1 + orderedSections.length) % orderedSections.length];
+    } else if (event.key === "Home") {
+      next = orderedSections[0];
+    } else if (event.key === "End") {
+      next = orderedSections[orderedSections.length - 1];
+    }
+    if (!next) return;
+    event.preventDefault();
+    selectSection(next, true);
+  }
+
+  return (
+    <section className="explore-secondary-content" aria-label={label}>
+      <nav className="explore-secondary-tabs" aria-label={`${label} sections`} role="tablist">
+        {orderedSections.map((section) => (
+          <button
+            key={section}
+            ref={(node) => {
+              tabRefs.current[section] = node;
+            }}
+            type="button"
+            id={`${baseId}-${section}-tab`}
+            role="tab"
+            className={activeSection === section ? "active-control" : ""}
+            aria-selected={activeSection === section}
+            aria-controls={`${baseId}-${section}-panel`}
+            tabIndex={activeSection === section ? 0 : -1}
+            onClick={() => selectSection(section)}
+            onKeyDown={(event) => handleKeyDown(event, section)}
+          >
+            {section[0].toUpperCase() + section.slice(1)}
+          </button>
+        ))}
+      </nav>
+      {orderedSections.map((section) => (
+        <section
+          key={section}
+          id={`${baseId}-${section}-panel`}
+          className="explore-secondary-panel"
+          role="tabpanel"
+          aria-labelledby={`${baseId}-${section}-tab`}
+          hidden={activeSection !== section}
+        >
+          {sections[section]}
+        </section>
+      ))}
+    </section>
   );
 }

--- a/app/frontend/src/MountainWavesExplore.test.tsx
+++ b/app/frontend/src/MountainWavesExplore.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MountainWavesExplore, mountainWavesCloudPointRendering } from "./MountainWavesExplore";
@@ -238,6 +238,28 @@ describe("MountainWavesExplore", () => {
     expect(screen.getAllByRole("button", { name: "Wave Cloud Lens" })).toHaveLength(1);
   });
 
+  it("uses the shared live Context and below-workspace support sections", async () => {
+    render(<MountainWavesExplore simulation={simulation} onBack={vi.fn()} />);
+    await screen.findByRole("heading", { name: "Wave Cloud Lens" });
+
+    const context = screen.getByLabelText("Context");
+    expect(
+      within(context).getByRole("heading", {
+        name: "Where does cloud sit within rising and descending wave motion?",
+      }),
+    ).toBeVisible();
+    expect(within(context).queryByRole("tab")).not.toBeInTheDocument();
+
+    const support = screen.getByLabelText("Simulation support");
+    for (const name of ["Science", "Notes", "Details"]) {
+      expect(within(support).getByRole("tab", { name })).toBeVisible();
+    }
+    fireEvent.click(within(support).getByRole("tab", { name: "Notes" }));
+    expect(
+      await screen.findByRole("textbox", { name: "Notes for Boulder Windstorm" }),
+    ).toBeVisible();
+  });
+
   it("waits for the displayed frame before advancing playback again", async () => {
     const playbackFrame = { ...frame, times_seconds: [0, 180, 360] };
     vi.mocked(fetch).mockResolvedValue(ok(playbackFrame));
@@ -293,7 +315,7 @@ describe("MountainWavesExplore", () => {
     await waitFor(() =>
       expect(fetch).toHaveBeenCalledWith(expect.stringContaining("field=w&time_index=-1")),
     );
-    expect(screen.getAllByRole("heading", { name: "Vertical velocity" })).toHaveLength(2);
+    expect(screen.getByRole("heading", { name: "Vertical velocity" })).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "True physical scale" }));
     expect(screen.getByText(/equal x\/z physical scale/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Full domain" }));
@@ -408,7 +430,7 @@ describe("MountainWavesExplore", () => {
 
     resolveW?.(ok({ ...frame, field: { ...frame.field, key: "w" }, overlay: null }));
     await new Promise((resolve) => window.setTimeout(resolve, 0));
-    expect(screen.getAllByRole("heading", { name: "Cloud liquid water" })).toHaveLength(2);
+    expect(screen.getByRole("heading", { name: "Cloud liquid water" })).toBeVisible();
   });
 });
 

--- a/app/frontend/src/MountainWavesExplore.tsx
+++ b/app/frontend/src/MountainWavesExplore.tsx
@@ -1,8 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent } from "react";
 
-import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
+import {
+  ExploreContextContent,
+  ExploreInspector,
+  ExploreSelectedEvidence,
+  ExploreSecondarySections,
+  IntegratedExploreWorkspace,
+} from "./IntegratedExploreWorkspace";
 import type { MountainWavesSimulation } from "./MountainWavesWorld";
+import { SimulationNotes } from "./SimulationNotes";
 import { scalarPointPixelSize } from "./True3DViewer.utils";
 
 type MountainWaveField =
@@ -596,27 +603,29 @@ export function MountainWavesExplore({
           onPlaybackSpeed={setPlaybackSpeed}
         />
 
-        <ExploreInspector
+        <ExploreInspector>
+          <MountainWavesContext
+            simulation={simulation}
+            frame={frame}
+            viewMode={viewMode}
+            geometryMode={geometryMode}
+            viewportMode={viewportMode ?? frame?.viewport.default_mode ?? "full"}
+            selectedEvidence={selectedEvidence}
+            onClearSelection={() => setSelectedPoint(null)}
+          />
+        </ExploreInspector>
+
+        <ExploreSecondarySections
           sections={{
-            explain: (
-              <MountainWavesContext
-                simulation={simulation}
-                frame={frame}
-                viewMode={viewMode}
-                geometryMode={geometryMode}
-                viewportMode={viewportMode ?? frame?.viewport.default_mode ?? "full"}
-                selectedEvidence={selectedEvidence}
-                onClearSelection={() => setSelectedPoint(null)}
-              />
+            science: (
+              <MountainWavesScience simulation={simulation} frame={frame} viewMode={viewMode} />
             ),
             notes: (
-              <section className="mountain-waves-notebook">
-                <h3>Experiment question</h3>
-                <p>
-                  {simulation.user_question ||
-                    "No question was recorded for this Simulation. New questions can be attached when creating a Variation in the Lab."}
-                </p>
-              </section>
+              <SimulationNotes
+                worldId="mountain_waves"
+                simulationId={simulation.simulation_id}
+                simulationName={simulation.display_name}
+              />
             ),
             details: <MountainWavesDetails simulation={simulation} frame={frame} />,
           }}
@@ -931,109 +940,187 @@ function MountainWavesContext({
   selectedEvidence: ReturnType<typeof pointEvidence> | null;
   onClearSelection: () => void;
 }) {
-  if (selectedEvidence) {
-    return (
-      <section className="selected-region-inspector mountain-waves-point-context">
-        <div className="section-heading">
-          <div>
-            <p className="eyebrow">Selected point</p>
-            <h3>Native cell evidence</h3>
-          </div>
-          <button type="button" className="secondary-button" onClick={onClearSelection}>
-            Clear selection
-          </button>
-        </div>
-        <div className="mountain-waves-state-row">
-          <span className="state-chip">{selectedEvidence.motionState}</span>
-          {selectedEvidence.cloudState && (
-            <span className="state-chip">{selectedEvidence.cloudState}</span>
-          )}
-          {selectedEvidence.saturationState && (
-            <span className="state-chip">{selectedEvidence.saturationState}</span>
-          )}
-        </div>
-        <dl className="context-metrics">
-          <Metric label="x" value={`${formatNumber(selectedEvidence.xM / 1_000)} km`} />
-          <Metric label="Model height" value={`${formatNumber(selectedEvidence.modelHeightM)} m`} />
-          <Metric label="Local AGL" value={`${formatNumber(selectedEvidence.aglM)} m`} />
-          <Metric label="Model time" value={formatTime(selectedEvidence.timeSeconds)} />
-          <Metric label="Horizontal wind" value={`${formatSigned(selectedEvidence.u)} m/s`} />
-          <Metric label="Vertical velocity" value={`${formatSigned(selectedEvidence.w)} m/s`} />
-          {selectedEvidence.ql !== null && (
-            <Metric
-              label="Cloud liquid water"
-              value={`${formatNumber(selectedEvidence.ql, 4)} g/kg`}
-            />
-          )}
-          {selectedEvidence.rh !== null && (
-            <Metric label="Relative humidity" value={`${formatNumber(selectedEvidence.rh, 1)}%`} />
-          )}
-          <Metric
-            label="Potential temperature"
-            value={`${formatNumber(selectedEvidence.theta, 1)} K`}
-          />
-          <Metric
-            label="Potential-temperature perturbation"
-            value={`${formatSigned(selectedEvidence.thetaPerturbation)} K`}
-          />
-        </dl>
-      </section>
-    );
-  }
+  const identity =
+    viewMode === "cloud"
+      ? "Wave Cloud Lens"
+      : viewMode === "structure"
+        ? "Wave Structure Lens"
+        : "Field";
+  const question =
+    viewMode === "cloud"
+      ? "Where does cloud sit within rising and descending wave motion?"
+      : viewMode === "structure"
+        ? "How is terrain displacing the atmosphere into a gravity wave?"
+        : `What does ${frame?.field.display_name ?? "this field"} show directly?`;
+  const explanation =
+    viewMode === "cloud"
+      ? "Vertical velocity remains primary. Native cloudy-cell markers and the black boundary locate cloud liquid water; the saturation contour and horizontal wind place that cloud in the wave."
+      : viewMode === "structure"
+        ? "Vertical velocity remains primary while horizontal wind and potential-temperature contours reveal the terrain-forced displacement."
+        : `The selected Field is shown directly on one fixed Simulation scale${frame ? ` in ${frame.field.units}` : ""}.`;
+  const relevantCaveat =
+    geometryMode === "expanded"
+      ? "Displayed terrain angles are vertically exaggerated for inspection."
+      : viewMode === "cloud"
+        ? "Cloud state is instantaneous; no formation or erosion process is inferred at a point."
+        : simulation.moist
+          ? "Point labels describe the saved instant; they do not infer process direction."
+          : simulation.moist_fields_available
+            ? "The configured atmosphere is dry; retained moisture fields remain available for inspection."
+            : "This dry Simulation contains no water-vapor or cloud fields.";
+  const selectedPoint = selectedEvidence ? (
+    <ExploreSelectedEvidence
+      eyebrow="Selected point"
+      title="Native cell evidence"
+      states={[
+        selectedEvidence.motionState,
+        selectedEvidence.cloudState,
+        selectedEvidence.saturationState,
+      ].filter((state): state is string => Boolean(state))}
+      metrics={[
+        { label: "x", value: `${formatNumber(selectedEvidence.xM / 1_000)} km` },
+        {
+          label: "Model height",
+          value: `${formatNumber(selectedEvidence.modelHeightM)} m`,
+        },
+        { label: "Local AGL", value: `${formatNumber(selectedEvidence.aglM)} m` },
+        { label: "Model time", value: formatTime(selectedEvidence.timeSeconds) },
+        {
+          label: "Horizontal wind",
+          value: `${formatSigned(selectedEvidence.u)} m/s`,
+        },
+        {
+          label: "Vertical velocity",
+          value: `${formatSigned(selectedEvidence.w)} m/s`,
+        },
+        ...(selectedEvidence.ql !== null
+          ? [
+              {
+                label: "Cloud liquid water",
+                value: `${formatNumber(selectedEvidence.ql, 4)} g/kg`,
+              },
+            ]
+          : []),
+        ...(selectedEvidence.rh !== null
+          ? [
+              {
+                label: "Relative humidity",
+                value: `${formatNumber(selectedEvidence.rh, 1)}%`,
+              },
+            ]
+          : []),
+        {
+          label: "Potential-temperature perturbation",
+          value: `${formatSigned(selectedEvidence.thetaPerturbation)} K`,
+        },
+      ]}
+      onClear={onClearSelection}
+      className="mountain-waves-point-context"
+    />
+  ) : undefined;
 
   return (
-    <section className="mountain-waves-context-summary">
-      <p className="eyebrow">
-        {viewMode === "cloud"
-          ? "Wave Cloud Lens"
-          : viewMode === "structure"
-            ? "Wave Structure Lens"
-            : "Field"}
-      </p>
-      <h3>
-        {viewMode === "cloud"
-          ? "Where does cloud sit within rising and descending wave motion?"
-          : viewMode === "structure"
-            ? "How is terrain displacing the atmosphere into a gravity wave?"
-            : frame?.field.display_name}
-      </h3>
+    <ExploreContextContent
+      identity={identity}
+      question={question}
+      explanation={<p>{explanation}</p>}
+      selectedEvidence={selectedPoint}
+      whatToNotice={
+        frame ? (
+          <p>
+            This frame spans {formatSigned(frame.scale.selected_time_minimum)} to{" "}
+            {formatSigned(frame.scale.selected_time_maximum)} {frame.scale.units} on the fixed
+            Simulation scale.
+          </p>
+        ) : undefined
+      }
+      orientation={[
+        { label: "Simulation", value: simulation.display_name },
+        { label: "Atmosphere", value: simulation.moist ? "Moist" : "Dry" },
+        {
+          label: "Geometry",
+          value: geometryMode === "expanded" ? "Expanded height" : "True physical scale",
+        },
+        {
+          label: "Viewport",
+          value: viewportMode === "focus" ? "Focus region" : "Full domain",
+        },
+        { label: "Model time", value: formatTime(frame?.time_seconds ?? 0) },
+        { label: "Relevant caveat", value: relevantCaveat },
+      ]}
+      selectionPrompt={
+        selectedEvidence ? undefined : "Select a point in the cross-section for native values."
+      }
+    />
+  );
+}
+
+function MountainWavesScience({
+  simulation,
+  frame,
+  viewMode,
+}: {
+  simulation: MountainWavesSimulation;
+  frame: MountainWaveFrame | null;
+  viewMode: ViewMode;
+}) {
+  return (
+    <section className="explore-science-section">
+      <p className="eyebrow">Science</p>
+      <h3>Terrain-forced wave structure</h3>
       <p>
         {viewMode === "cloud"
-          ? "Vertical velocity remains primary. Native-cell cloud points and the black boundary locate cloud liquid water; the RH = 100% contour and horizontal wind show the moist wave environment. Potential-temperature contours can be added for wave structure."
+          ? "Use the signed vertical-motion field to locate wave ascent and descent, then test whether native cloudy cells, their boundary, and saturation occupy the expected phase of that wave."
           : viewMode === "structure"
-            ? "Vertical velocity remains primary while horizontal wind and total potential-temperature contours reveal the terrain-forced wave."
-            : `The selected Field is shown directly on its fixed Simulation scale${frame ? ` in ${frame.field.units}` : ""}.`}
+            ? "Alternating ascent and descent, wind deflection, and displaced potential-temperature surfaces show the resolved wave without requiring cloud."
+            : "Field mode preserves one quantitative model variable so its magnitude and location can be inspected without interpretive overlays."}
       </p>
-      <dl className="context-metrics">
-        <Metric label="Simulation" value={simulation.display_name} />
-        <Metric label="Atmosphere" value={simulation.moist ? "Moist" : "Dry"} />
+      {simulation.user_question && (
+        <section className="explore-science-callout">
+          <strong>Experiment question</strong>
+          <p>{simulation.user_question}</p>
+        </section>
+      )}
+      <dl className="metric-grid compact-metric-grid">
         <Metric
-          label="Geometry"
-          value={geometryMode === "expanded" ? "Expanded height" : "True physical scale"}
-        />
-        <Metric
-          label="Viewport"
-          value={viewportMode === "focus" ? "Focus region" : "Full domain"}
-        />
-        <Metric label="Model time" value={formatTime(frame?.time_seconds ?? 0)} />
-        <Metric
-          label="Relevant caveat"
+          label="Fixed field scale"
           value={
-            geometryMode === "expanded"
-              ? "Displayed terrain angles are vertically exaggerated for inspection."
-              : viewMode === "cloud"
-                ? "Cloud state is instantaneous; no formation or erosion process is inferred at a point."
-                : simulation.moist
-                  ? "Point labels describe the saved instant; they do not infer process direction."
-                  : simulation.moist_fields_available
-                    ? "The configured atmosphere is dry; retained moisture fields remain available for inspection."
-                    : "This dry Simulation contains no water-vapor or cloud fields."
+            frame
+              ? `${formatSigned(frame.scale.minimum)} to ${formatSigned(frame.scale.maximum)} ${frame.scale.units}`
+              : "Loading"
+          }
+        />
+        <Metric
+          label="Current frame range"
+          value={
+            frame
+              ? `${formatSigned(frame.scale.selected_time_minimum)} to ${formatSigned(
+                  frame.scale.selected_time_maximum,
+                )} ${frame.scale.units}`
+              : "Loading"
+          }
+        />
+        <Metric
+          label="Native geometry"
+          value={frame?.provenance.topology ?? "Native 2-D x-z output"}
+        />
+        <Metric
+          label="Cloud threshold"
+          value={
+            frame?.overlay ? `${formatNumber(frame.overlay.threshold, 4)} g/kg` : "Not available"
           }
         />
       </dl>
-      <p className="context-selection-prompt">
-        Select a point in the cross-section for native values.
-      </p>
+      {frame && frame.caveats.length > 0 && (
+        <details>
+          <summary>Scientific limitations</summary>
+          <ul>
+            {frame.caveats.map((caveat) => (
+              <li key={caveat}>{caveat}</li>
+            ))}
+          </ul>
+        </details>
+      )}
     </section>
   );
 }

--- a/app/frontend/src/SimulationNotes.test.tsx
+++ b/app/frontend/src/SimulationNotes.test.tsx
@@ -1,0 +1,189 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SimulationNotes } from "./SimulationNotes";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("SimulationNotes", () => {
+  it("loads, reports unsaved changes, saves, reloads, and clears a stable Simulation note", async () => {
+    let savedText = "Existing observation.";
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        const body = JSON.parse(String(init.body)) as { text: string };
+        savedText = body.text.trim();
+      }
+      return new Response(
+        JSON.stringify({
+          note: savedText
+            ? {
+                schema_version: 1,
+                world_id: "supercells",
+                simulation_id: "supercells_quarter_circle_reference",
+                text: savedText,
+                created_at: "2026-07-23T00:00:00Z",
+                updated_at: "2026-07-23T00:00:00Z",
+              }
+            : null,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const view = render(
+      <SimulationNotes
+        worldId="supercells"
+        simulationId="supercells_quarter_circle_reference"
+        simulationName="Quarter-Circle Supercell"
+      />,
+    );
+
+    const editor = await screen.findByRole("textbox", {
+      name: "Notes for Quarter-Circle Supercell",
+    });
+    expect(editor).toHaveValue("Existing observation.");
+    fireEvent.change(editor, { target: { value: "Updated observation." } });
+    expect(screen.getByRole("status")).toHaveTextContent("Unsaved changes");
+    fireEvent.click(screen.getByRole("button", { name: "Save note" }));
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Saved"));
+
+    view.unmount();
+    render(
+      <SimulationNotes
+        worldId="supercells"
+        simulationId="supercells_quarter_circle_reference"
+        simulationName="Quarter-Circle Supercell"
+      />,
+    );
+    expect(
+      await screen.findByRole("textbox", { name: "Notes for Quarter-Circle Supercell" }),
+    ).toHaveValue("Updated observation.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear note" }));
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Note cleared"));
+    expect(screen.getByRole("textbox")).toHaveValue("");
+  });
+
+  it("contains a note-specific load failure without hiding other Explore content", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ detail: "The saved Simulation note is unreadable." }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+
+    render(
+      <div>
+        <p>Science remains available.</p>
+        <SimulationNotes
+          worldId="mountain_waves"
+          simulationId="mountain_waves_boulder_moist_reference"
+          simulationName="Boulder Windstorm"
+        />
+      </div>,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "The saved Simulation note is unreadable.",
+    );
+    expect(screen.getByText("Science remains available.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
+  });
+
+  it("keeps an unsaved note editable when saving fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ note: null }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "The Simulation note could not be saved." }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SimulationNotes
+        worldId="trade_cumulus"
+        simulationId="trade_cumulus_canonical_bomex"
+        simulationName="Canonical BOMEX Baseline"
+      />,
+    );
+
+    const editor = await screen.findByRole("textbox", {
+      name: "Notes for Canonical BOMEX Baseline",
+    });
+    fireEvent.change(editor, { target: { value: "Keep this draft." } });
+    fireEvent.click(screen.getByRole("button", { name: "Save note" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "The Simulation note could not be saved.",
+      ),
+    );
+    expect(editor).toHaveValue("Keep this draft.");
+    expect(editor).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Save note" })).toBeEnabled();
+  });
+
+  it("does not retain another Simulation's note when identity changes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            note: {
+              schema_version: 1,
+              world_id: "mountain_waves",
+              simulation_id: "mountain_waves_boulder_moist_reference",
+              text: "Boulder note.",
+              created_at: "2026-07-23T00:00:00Z",
+              updated_at: "2026-07-23T00:00:00Z",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "Simulation unavailable." }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const view = render(
+      <SimulationNotes
+        worldId="mountain_waves"
+        simulationId="mountain_waves_boulder_moist_reference"
+        simulationName="Boulder Windstorm"
+      />,
+    );
+    expect(await screen.findByRole("textbox", { name: "Notes for Boulder Windstorm" })).toHaveValue(
+      "Boulder note.",
+    );
+
+    view.rerender(
+      <SimulationNotes
+        worldId="mountain_waves"
+        simulationId="mountain_waves_dry_ridge"
+        simulationName="Dry Ridge"
+      />,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Simulation unavailable.");
+    expect(screen.queryByText("Boulder note.")).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/SimulationNotes.tsx
+++ b/app/frontend/src/SimulationNotes.tsx
@@ -1,0 +1,202 @@
+import { type FormEvent, useEffect, useId, useState } from "react";
+
+const MAX_SIMULATION_NOTE_CHARACTERS = 20_000;
+
+type SimulationNoteRecord = {
+  schema_version: number;
+  world_id: string;
+  simulation_id: string;
+  text: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type SimulationNoteResponse = {
+  note: SimulationNoteRecord | null;
+};
+
+type NoteState = "loading" | "saved" | "unsaved" | "saving" | "failed";
+
+export function SimulationNotes({
+  worldId,
+  simulationId,
+  simulationName,
+}: {
+  worldId: string;
+  simulationId: string;
+  simulationName: string;
+}) {
+  const editorId = useId();
+  const [draft, setDraft] = useState("");
+  const [savedText, setSavedText] = useState("");
+  const [state, setState] = useState<NoteState>("loading");
+  const [message, setMessage] = useState("Loading note...");
+  const [reloadNonce, setReloadNonce] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setDraft("");
+    setSavedText("");
+    setState("loading");
+    setMessage("Loading note...");
+    void loadSimulationNote(worldId, simulationId, controller.signal)
+      .then((response) => {
+        const text = response.note?.text ?? "";
+        setDraft(text);
+        setSavedText(text);
+        setState("saved");
+        setMessage(text ? "Saved" : "No note saved yet");
+      })
+      .catch((caught: unknown) => {
+        if (caught instanceof DOMException && caught.name === "AbortError") return;
+        setState("failed");
+        setMessage(noteErrorMessage(caught, "Unable to load this Simulation note."));
+      });
+    return () => controller.abort();
+  }, [reloadNonce, simulationId, worldId]);
+
+  async function saveNote(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setState("saving");
+    setMessage("Saving...");
+    try {
+      const response = await putSimulationNote(worldId, simulationId, draft);
+      const text = response.note?.text ?? "";
+      setDraft(text);
+      setSavedText(text);
+      setState("saved");
+      setMessage(text ? "Saved" : "Note cleared");
+    } catch (caught) {
+      setState("failed");
+      setMessage(noteErrorMessage(caught, "Unable to save this Simulation note."));
+    }
+  }
+
+  async function clearNote() {
+    setState("saving");
+    setMessage("Clearing...");
+    try {
+      await putSimulationNote(worldId, simulationId, "");
+      setDraft("");
+      setSavedText("");
+      setState("saved");
+      setMessage("Note cleared");
+    } catch (caught) {
+      setState("failed");
+      setMessage(noteErrorMessage(caught, "Unable to clear this Simulation note."));
+    }
+  }
+
+  const loadFailed = state === "failed" && savedText === "" && draft === "";
+  const saving = state === "saving";
+  const dirty = draft !== savedText;
+
+  return (
+    <section className="simulation-notes" aria-labelledby={`${editorId}-title`}>
+      <div className="section-heading compact-heading">
+        <div>
+          <p className="eyebrow">Notebook</p>
+          <h3 id={`${editorId}-title`}>Simulation notes</h3>
+        </div>
+        <span className={`simulation-note-state simulation-note-state-${state}`} role="status">
+          {message}
+        </span>
+      </div>
+      <p className="simulation-notes-description">
+        Observations and questions for {simulationName}. This note stays with the Simulation.
+      </p>
+      {loadFailed ? (
+        <div className="simulation-note-failure">
+          <p role="alert">{message}</p>
+          <button type="button" onClick={() => setReloadNonce((current) => current + 1)}>
+            Retry
+          </button>
+        </div>
+      ) : (
+        <form className="simulation-notes-form" onSubmit={(event) => void saveNote(event)}>
+          <label htmlFor={`${editorId}-editor`}>
+            <span className="sr-only">Notes for {simulationName}</span>
+            <textarea
+              id={`${editorId}-editor`}
+              aria-label={`Notes for ${simulationName}`}
+              rows={10}
+              maxLength={MAX_SIMULATION_NOTE_CHARACTERS}
+              placeholder="Record observations, questions, or follow-up ideas."
+              value={draft}
+              disabled={state === "loading" || saving}
+              onChange={(event) => {
+                setDraft(event.target.value);
+                setState("unsaved");
+                setMessage("Unsaved changes");
+              }}
+            />
+          </label>
+          <div className="simulation-notes-actions">
+            <button type="submit" disabled={!dirty || saving || state === "loading"}>
+              {saving ? "Saving..." : "Save note"}
+            </button>
+            <button
+              type="button"
+              className="secondary-button"
+              disabled={(!draft && !savedText) || saving || state === "loading"}
+              onClick={() => void clearNote()}
+            >
+              Clear note
+            </button>
+            <small>
+              {draft.length.toLocaleString()} / {MAX_SIMULATION_NOTE_CHARACTERS.toLocaleString()}
+            </small>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}
+
+async function loadSimulationNote(
+  worldId: string,
+  simulationId: string,
+  signal?: AbortSignal,
+): Promise<SimulationNoteResponse> {
+  const response = await fetch(noteUrl(worldId, simulationId), { signal });
+  if (!response.ok) {
+    throw new Error(await responseMessage(response, "Unable to load this Simulation note."));
+  }
+  return (await response.json()) as SimulationNoteResponse;
+}
+
+async function putSimulationNote(
+  worldId: string,
+  simulationId: string,
+  text: string,
+): Promise<SimulationNoteResponse> {
+  const response = await fetch(noteUrl(worldId, simulationId), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  if (!response.ok) {
+    throw new Error(await responseMessage(response, "Unable to save this Simulation note."));
+  }
+  return (await response.json()) as SimulationNoteResponse;
+}
+
+function noteUrl(worldId: string, simulationId: string): string {
+  const worldSlug = worldId.replaceAll("_", "-");
+  return `/api/worlds/${encodeURIComponent(worldSlug)}/simulations/${encodeURIComponent(
+    simulationId,
+  )}/note`;
+}
+
+async function responseMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await response.json()) as { detail?: string };
+    return payload.detail || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function noteErrorMessage(caught: unknown, fallback: string): string {
+  return caught instanceof Error ? caught.message : fallback;
+}

--- a/app/frontend/src/StormExaminationResearch.tsx
+++ b/app/frontend/src/StormExaminationResearch.tsx
@@ -634,10 +634,12 @@ export function StormPlanPlot({
   frame,
   overlays,
   onSelect,
+  showSelection = true,
 }: {
   frame: StormExaminationFrame;
   overlays: OverlayState;
   onSelect: (value: Selection) => void;
+  showSelection?: boolean;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const geometryRef = useRef<PlotGeometry | null>(null);
@@ -649,8 +651,8 @@ export function StormPlanPlot({
   );
   useCanvasRender(canvasRef, () => {
     const canvas = canvasRef.current;
-    if (canvas) geometryRef.current = drawPlan(canvas, frame, overlays);
-  }, [frame, overlays]);
+    if (canvas) geometryRef.current = drawPlan(canvas, frame, overlays, showSelection);
+  }, [frame, overlays, showSelection]);
 
   function select(event: ReactMouseEvent<HTMLCanvasElement>) {
     const canvas = canvasRef.current;
@@ -694,11 +696,13 @@ export function StormSectionPlot({
   frame,
   overlays,
   onSelect,
+  showSelection = true,
 }: {
   section: VerticalSection;
   frame: StormExaminationFrame;
   overlays: OverlayState;
   onSelect: (value: Selection) => void;
+  showSelection?: boolean;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const geometryRef = useRef<PlotGeometry | null>(null);
@@ -714,8 +718,10 @@ export function StormSectionPlot({
   );
   useCanvasRender(canvasRef, () => {
     const canvas = canvasRef.current;
-    if (canvas) geometryRef.current = drawSection(canvas, section, frame, overlays);
-  }, [frame, overlays, section]);
+    if (canvas) {
+      geometryRef.current = drawSection(canvas, section, frame, overlays, showSelection);
+    }
+  }, [frame, overlays, section, showSelection]);
 
   function select(event: ReactMouseEvent<HTMLCanvasElement>) {
     const canvas = canvasRef.current;
@@ -1034,6 +1040,7 @@ function drawPlan(
   canvas: HTMLCanvasElement,
   frame: StormExaminationFrame,
   overlays: OverlayState,
+  showSelection = true,
 ): PlotGeometry {
   const context = prepareCanvas(canvas);
   const geometry = plotGeometry(canvas, 43, 12, 12, 34, frame.viewport_bounds_km);
@@ -1127,8 +1134,10 @@ function drawPlan(
     }
     if (overlays.wind) drawWindVectors(context, geometry, frame.plan.wind_vectors);
   }
-  drawPlanCrosshairs(context, geometry, frame.selected_point);
-  drawSelectedMarker(context, geometry, frame.selected_point.x_km, frame.selected_point.y_km);
+  if (showSelection) {
+    drawPlanCrosshairs(context, geometry, frame.selected_point);
+    drawSelectedMarker(context, geometry, frame.selected_point.x_km, frame.selected_point.y_km);
+  }
   return geometry;
 }
 
@@ -1137,6 +1146,7 @@ function drawSection(
   section: VerticalSection,
   frame: StormExaminationFrame,
   overlays: OverlayState,
+  showSelection = true,
 ): PlotGeometry {
   const context = prepareCanvas(canvas);
   const xMinimum = section.horizontal_km[0];
@@ -1183,9 +1193,11 @@ function drawSection(
       drawThresholdOutline(context, geometry, section.overlays.reflectivity, 35, "#7b572a", 1.05);
     }
   }
-  const horizontal =
-    section.orientation === "xz" ? frame.selected_point.x_km : frame.selected_point.y_km;
-  drawSelectedMarker(context, geometry, horizontal, frame.selected_point.z_km);
+  if (showSelection) {
+    const horizontal =
+      section.orientation === "xz" ? frame.selected_point.x_km : frame.selected_point.y_km;
+    drawSelectedMarker(context, geometry, horizontal, frame.selected_point.z_km);
+  }
   return geometry;
 }
 

--- a/app/frontend/src/StormExaminationResearch.tsx
+++ b/app/frontend/src/StormExaminationResearch.tsx
@@ -4,7 +4,11 @@ import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
 
 import "./App.css";
 import "./StormExaminationResearch.css";
-import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
+import {
+  ExploreInspector,
+  ExploreSecondarySections,
+  IntegratedExploreWorkspace,
+} from "./IntegratedExploreWorkspace";
 
 export type LensId = "rotating_updraft" | "cloud_precipitation" | "low_level_interactions";
 export type ViewportId = "storm" | "full";
@@ -429,16 +433,25 @@ export function StormExaminationResearch() {
             onPlaybackSpeed={setPlaybackSpeed}
           />
 
-          <ExploreInspector
+          <ExploreInspector>
+            <StormContext frame={frame} lens={lens} viewport={viewport} />
+          </ExploreInspector>
+          <ExploreSecondarySections
+            label="Research support"
             sections={{
-              explain: <StormContext frame={frame} lens={lens} viewport={viewport} />,
-              notes: (
+              science: (
                 <section>
                   <h3>Gate C examination</h3>
                   <p>
                     This bounded surface evaluates whether one retained storm result supports a
                     legible Storms World. It is not a product route or a final Lens contract.
                   </p>
+                </section>
+              ),
+              notes: (
+                <section>
+                  <h3>Simulation notes</h3>
+                  <p>Durable notes are available from the Supercells World Explore route.</p>
                 </section>
               ),
               details: <StormDetails frame={frame} />,

--- a/app/frontend/src/SupercellsExplore.css
+++ b/app/frontend/src/SupercellsExplore.css
@@ -1,6 +1,6 @@
 .supercells-explore-shell {
   display: grid;
-  grid-template-rows: minmax(32rem, calc(100vh - 21rem)) auto auto;
+  grid-template-rows: minmax(32rem, calc(100vh - 21rem)) auto auto auto;
   gap: 8px;
   min-width: 0;
   padding: 10px 0 18px;
@@ -311,10 +311,6 @@
   overflow: auto;
 }
 
-.supercells-workbench > .explore-secondary-content {
-  display: none;
-}
-
 .supercells-scene .true3d-context-stack {
   max-width: calc(100% - 25rem);
 }
@@ -330,22 +326,6 @@
 
 .supercells-context-panel .metric-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.supercells-state-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  margin-bottom: 0.55rem;
-}
-
-.supercells-state-row span {
-  border-radius: 3px;
-  padding: 0.2rem 0.36rem;
-  background: var(--color-accent-soft);
-  color: var(--color-text-primary);
-  font-size: 0.66rem;
-  font-weight: 750;
 }
 
 .context-callout {
@@ -988,35 +968,6 @@
     align-items: center;
     border-bottom: 1px solid var(--color-border);
     padding-left: 8px;
-  }
-
-  .supercells-workbench > .explore-inspector .explore-inspector-tabs {
-    position: sticky;
-    z-index: 3;
-    top: 0;
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0;
-    border-bottom: 1px solid var(--color-border);
-    padding: 0;
-    background: var(--color-surface);
-  }
-
-  .supercells-workbench > .explore-inspector .explore-inspector-tabs button {
-    min-height: 1.9rem;
-    border: 0;
-    border-bottom: 2px solid transparent;
-    border-radius: 0;
-    padding: 0.35rem 0.18rem;
-    background: transparent;
-    color: var(--color-text-muted);
-    font-size: 0.68rem;
-    box-shadow: none;
-  }
-
-  .supercells-workbench > .explore-inspector .explore-inspector-tabs .active-control {
-    border-bottom-color: var(--color-accent-primary);
-    color: var(--color-accent-primary);
   }
 
   .supercells-workbench > .explore-inspector .explore-inspector-toggle {

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -465,6 +465,17 @@ function section(orientation: "xz" | "yz", horizontal: "x" | "y", coordinate: nu
   };
 }
 
+const LENS_QUESTIONS = {
+  rotating_updraft: "Where is the storm rising and rotating as one organized structure?",
+  cloud_precipitation: "How are cloud and precipitation organized through the storm?",
+  low_level_interactions:
+    "How do ascent, descent, rain, and horizontal flow meet beneath the storm?",
+} as const;
+
+function waitForLensContext(lens: LensId) {
+  return screen.findByRole("heading", { name: LENS_QUESTIONS[lens] });
+}
+
 describe("SupercellsExplore", () => {
   const originalGetContext = HTMLCanvasElement.prototype.getContext;
   const originalBounds = HTMLCanvasElement.prototype.getBoundingClientRect;
@@ -508,7 +519,7 @@ describe("SupercellsExplore", () => {
   it("opens at the mature Rotating Updraft frame with the complete retained timeline", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
 
-    expect(await screen.findByRole("heading", { name: "Rotating Updraft" })).toBeVisible();
+    expect(await waitForLensContext("rotating_updraft")).toBeVisible();
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining("lens=rotating_updraft&viewport=storm&time_index=37"),
       expect.anything(),
@@ -524,7 +535,7 @@ describe("SupercellsExplore", () => {
 
   it("moves each evidence orientation through native planes and keeps a user plane across time", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
-    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    await waitForLensContext("rotating_updraft");
 
     const horizontalPosition = screen.getByLabelText("Horizontal x-y z position");
     expect(horizontalPosition).toHaveValue("1");
@@ -602,7 +613,7 @@ describe("SupercellsExplore", () => {
 
   it("keeps rapid cross-axis slice changes in one local native selection", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
-    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    await waitForLensContext("rotating_updraft");
 
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
@@ -634,10 +645,10 @@ describe("SupercellsExplore", () => {
 
   it("uses the selected Low-Level altitude in 2-D and 3-D labels", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
-    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    await waitForLensContext("rotating_updraft");
 
     fireEvent.click(screen.getByRole("button", { name: "Low-Level Interactions" }));
-    await screen.findByRole("heading", { name: "Low-Level Interactions" });
+    await waitForLensContext("low_level_interactions");
     fireEvent.change(screen.getByLabelText("Horizontal x-y z position"), {
       target: { value: "2" },
     });
@@ -648,16 +659,14 @@ describe("SupercellsExplore", () => {
         expect.anything(),
       ),
     );
-    expect(
-      await screen.findAllByText("Model-relative wind at z = 8.00 km"),
-    ).not.toHaveLength(0);
+    expect(await screen.findAllByText("Model-relative wind at z = 8.00 km")).not.toHaveLength(0);
     expect(screen.getByText(/x-y slice at z = 8.00 km coordinate current motion/)).toBeVisible();
     expect(screen.getByText("Model-relative flow at z = 8.00 km")).toBeVisible();
   });
 
   it("keeps a user-framed camera transform per Lens across ordinary workspace changes", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
-    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    await waitForLensContext("rotating_updraft");
 
     expect(screen.getByText("Camera position: default")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Move mock camera" }));
@@ -670,17 +679,17 @@ describe("SupercellsExplore", () => {
     expect(screen.getByText("Camera position: 4,5,6")).toBeVisible();
 
     fireEvent.click(screen.getByRole("button", { name: "Cloud and Precipitation" }));
-    await screen.findByRole("heading", { name: "Cloud and Precipitation" });
+    await waitForLensContext("cloud_precipitation");
     expect(screen.getByText("Camera position: default")).toBeVisible();
 
     fireEvent.click(screen.getByRole("button", { name: "Rotating Updraft" }));
-    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    await waitForLensContext("rotating_updraft");
     expect(screen.getByText("Camera position: 4,5,6")).toBeVisible();
   });
 
   it("keeps lens defaults, viewport, evidence orientation, and native selection synchronized", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
-    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    await waitForLensContext("rotating_updraft");
 
     fireEvent.click(screen.getByRole("button", { name: "Cloud and Precipitation" }));
     await waitFor(() =>
@@ -689,7 +698,7 @@ describe("SupercellsExplore", () => {
         expect.anything(),
       ),
     );
-    expect(await screen.findByRole("heading", { name: "Cloud and Precipitation" })).toBeVisible();
+    expect(await waitForLensContext("cloud_precipitation")).toBeVisible();
     await waitFor(() => expect(screen.getByLabelText("Dominant hydrometeor")).toBeChecked());
     expect(screen.getByLabelText("Vertical-motion contours")).toBeChecked();
     expect(screen.getByText("X-z evidence at this saved output.")).toBeVisible();
@@ -722,9 +731,9 @@ describe("SupercellsExplore", () => {
     expect(screen.getByText("Y-z evidence at this saved output.")).toBeVisible();
 
     fireEvent.click(screen.getByRole("button", { name: "Rotating Updraft" }));
-    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    await waitForLensContext("rotating_updraft");
     fireEvent.click(screen.getByRole("button", { name: "Cloud and Precipitation" }));
-    await screen.findByRole("heading", { name: "Cloud and Precipitation" });
+    await waitForLensContext("cloud_precipitation");
     expect(
       within(screen.getByLabelText("Slice orientation")).getByRole("button", {
         name: "Vertical y-z",
@@ -761,14 +770,14 @@ describe("SupercellsExplore", () => {
     expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent(
       "xz section at y = 10.0 km",
     );
-    fireEvent.click(screen.getByRole("tab", { name: "Science" }));
-    expect(await screen.findByText("Selected point")).toBeVisible();
-    expect(screen.getByRole("heading", { name: "x 10.0, y 10.0, z 3.00 km" })).toBeVisible();
+    const context = screen.getByLabelText("Context");
+    expect(await within(context).findByText("Selected cell")).toBeVisible();
+    expect(within(context).getByRole("heading", { name: "Native-grid evidence" })).toBeVisible();
   });
 
   it("preserves the lens and time while maximizing and restoring either scientific view", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
-    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    await waitForLensContext("rotating_updraft");
 
     fireEvent.change(screen.getByLabelText("Saved output time"), { target: { value: "90" } });
     expect(await screen.findByText("180 min · 10,800 s")).toBeVisible();
@@ -785,9 +794,9 @@ describe("SupercellsExplore", () => {
       "supercells-explore-focused-evidence",
     );
     expect(screen.getByRole("button", { name: "Open Context" })).toBeVisible();
-    expect(screen.queryByLabelText("Explore inspector")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Context")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open Context" }));
-    expect(screen.getByLabelText("Explore inspector")).toBeVisible();
+    expect(screen.getByLabelText("Context")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Restore evidence" }));
 
     expect(screen.getByRole("button", { name: "Rotating Updraft" })).toHaveAttribute(
@@ -797,17 +806,21 @@ describe("SupercellsExplore", () => {
     expect(screen.getByLabelText("Saved output time")).toHaveValue("90");
   });
 
-  it("offers the shared Explain, Science, Notes, and Details inspector grammar", async () => {
+  it("uses one live Context sidebar with shared below-workspace support sections", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
-    await screen.findByRole("heading", { name: "Rotating Updraft" });
+    await waitForLensContext("rotating_updraft");
 
-    const inspector = screen.getByLabelText("Explore inspector");
-    for (const name of ["Explain", "Science", "Notes", "Details"]) {
-      expect(within(inspector).getByRole("tab", { name })).toBeVisible();
+    const context = screen.getByLabelText("Context");
+    expect(within(context).getByText("What to notice now")).toBeVisible();
+    expect(within(context).queryByRole("tab")).not.toBeInTheDocument();
+
+    const support = screen.getByLabelText("Simulation support");
+    for (const name of ["Science", "Notes", "Details"]) {
+      expect(within(support).getByRole("tab", { name })).toBeVisible();
     }
-    fireEvent.click(within(inspector).getByRole("tab", { name: "Notes" }));
+    fireEvent.click(within(support).getByRole("tab", { name: "Notes" }));
     expect(screen.getByRole("heading", { name: "Simulation notes" })).toBeVisible();
-    fireEvent.click(within(inspector).getByRole("tab", { name: "Details" }));
+    fireEvent.click(within(support).getByRole("tab", { name: "Details" }));
     expect(screen.getByRole("heading", { name: "Simulation details" })).toBeVisible();
   });
 });

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -643,6 +643,33 @@ describe("SupercellsExplore", () => {
     );
   });
 
+  it("clears selected evidence without moving a non-default vertical plane", async () => {
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    await waitForLensContext("rotating_updraft");
+
+    fireEvent.click(
+      within(screen.getByLabelText("Slice orientation")).getByRole("button", {
+        name: "Vertical x-z",
+      }),
+    );
+    const position = screen.getByLabelText("Vertical x-z y position");
+    fireEvent.change(position, { target: { value: "0" } });
+
+    const selectedEvidence = await screen.findByLabelText("Selected native-grid evidence");
+    expect(position).toHaveValue("0");
+    expect(screen.getAllByText("y -10.0 km").length).toBeGreaterThan(0);
+
+    fireEvent.click(within(selectedEvidence).getByRole("button", { name: "Clear" }));
+
+    expect(screen.queryByLabelText("Selected native-grid evidence")).not.toBeInTheDocument();
+    expect(position).toHaveValue("0");
+    expect(screen.getAllByText("y -10.0 km").length).toBeGreaterThan(0);
+    expect(fetch).toHaveBeenLastCalledWith(
+      expect.stringMatching(/x_index=1&y_index=0&z_index=1/),
+      expect.anything(),
+    );
+  });
+
   it("uses the selected Low-Level altitude in 2-D and 3-D labels", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
     await waitForLensContext("rotating_updraft");

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -51,6 +51,7 @@ type LensPresentation = {
   sceneOpacity: number;
   scenePointSize: number;
   selection: Selection | null;
+  selectedEvidenceVisible: boolean;
 };
 
 const LENSES: Array<{ id: LensId; label: string }> = [
@@ -90,6 +91,7 @@ export function SupercellsExplore({
     sceneOpacity,
     scenePointSize,
     selection,
+    selectedEvidenceVisible,
   } = presentation;
   const visibleLayerKeys = presentation.visibleLayerKeys ?? [];
   const [focusedViewer, setFocusedViewer] = useState<FocusedViewer>(null);
@@ -198,7 +200,7 @@ export function SupercellsExplore({
 
   function selectPoint(next: Selection) {
     setPlaying(false);
-    updatePresentation({ selection: next });
+    updatePresentation({ selection: next, selectedEvidenceVisible: true });
   }
 
   function updatePresentation(patch: Partial<LensPresentation>) {
@@ -236,7 +238,12 @@ export function SupercellsExplore({
 
   function resetSlicePosition() {
     setPlaying(false);
-    updatePresentation({ selection: null });
+    updatePresentation({ selection: null, selectedEvidenceVisible: false });
+  }
+
+  function clearSelectedEvidence() {
+    setPlaying(false);
+    updatePresentation({ selectedEvidenceVisible: false });
   }
 
   function toggleLayer(key: string, visible: boolean) {
@@ -300,7 +307,7 @@ export function SupercellsExplore({
                 activeSliceLabel={activeSliceLabel}
                 showSlicePlane={evidenceView !== "plan" || frame.plan.selection_z_indices === null}
                 selectedRegion={
-                  frame && selection
+                  frame && selection && selectedEvidenceVisible
                     ? {
                         xIndex: frame.selected_point.x_index,
                         yIndex: frame.selected_point.y_index,
@@ -335,7 +342,7 @@ export function SupercellsExplore({
                 stormPointSize={scenePointSize}
                 compactAxisLabels
                 selectedPointCoordinates={
-                  selection && frame
+                  selection && selectedEvidenceVisible && frame
                     ? {
                         x: frame.selected_point.x_km,
                         y: frame.selected_point.y_km,
@@ -430,13 +437,19 @@ export function SupercellsExplore({
               <div className="supercells-evidence-body">
                 <div className="supercells-active-plot">
                   {evidenceView === "plan" ? (
-                    <StormPlanPlot frame={frame} overlays={overlays} onSelect={selectPoint} />
+                    <StormPlanPlot
+                      frame={frame}
+                      overlays={overlays}
+                      onSelect={selectPoint}
+                      showSelection={selection === null || selectedEvidenceVisible}
+                    />
                   ) : (
                     <StormSectionPlot
                       section={evidenceView === "xz" ? frame.xz_section : frame.yz_section}
                       frame={frame}
                       overlays={overlays}
                       onSelect={selectPoint}
+                      showSelection={selection === null || selectedEvidenceVisible}
                     />
                   )}
                 </div>
@@ -466,8 +479,8 @@ export function SupercellsExplore({
               lens={lens}
               viewport={viewport}
               evidenceView={evidenceView}
-              selected={selection !== null}
-              onClearSelection={resetSlicePosition}
+              selected={selection !== null && selectedEvidenceVisible}
+              onClearSelection={clearSelectedEvidence}
             />
           </ExploreInspector>
         </div>
@@ -1136,6 +1149,7 @@ function lensPresentationDefaults(): Record<LensId, LensPresentation> {
       sceneOpacity: 1,
       scenePointSize: 1,
       selection: null,
+      selectedEvidenceVisible: false,
     },
     cloud_precipitation: {
       viewport: "storm",
@@ -1148,6 +1162,7 @@ function lensPresentationDefaults(): Record<LensId, LensPresentation> {
       sceneOpacity: 0.9,
       scenePointSize: 0.9,
       selection: null,
+      selectedEvidenceVisible: false,
     },
     low_level_interactions: {
       viewport: "storm",
@@ -1160,6 +1175,7 @@ function lensPresentationDefaults(): Record<LensId, LensPresentation> {
       sceneOpacity: 1,
       scenePointSize: 1,
       selection: null,
+      selectedEvidenceVisible: false,
     },
   };
 }

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { ExploreInspector, IntegratedExploreWorkspace } from "./IntegratedExploreWorkspace";
+import {
+  ExploreContextContent,
+  ExploreInspector,
+  ExploreSelectedEvidence,
+  ExploreSecondarySections,
+  IntegratedExploreWorkspace,
+} from "./IntegratedExploreWorkspace";
 import { NativeSlicePositionControl } from "./NativeSlicePositionControl";
+import { SimulationNotes } from "./SimulationNotes";
 import type { SupercellSimulation } from "./SupercellsWorld";
 import {
   type LensId,
@@ -453,20 +460,16 @@ export function SupercellsExplore({
             collapsed={contextCollapsed}
             onCollapsedChange={setContextCollapsed}
             showCollapseControl={false}
-            sections={{
-              explain: (
-                <SupercellExplanation
-                  frame={frame}
-                  lens={lens}
-                  viewport={viewport}
-                  evidenceView={evidenceView}
-                />
-              ),
-              science: <SupercellScience frame={frame} selected={selection !== null} />,
-              notes: <SupercellNotes />,
-              details: <SupercellDetails frame={frame} simulation={simulation} />,
-            }}
-          />
+          >
+            <SupercellExplanation
+              frame={frame}
+              lens={lens}
+              viewport={viewport}
+              evidenceView={evidenceView}
+              selected={selection !== null}
+              onClearSelection={resetSlicePosition}
+            />
+          </ExploreInspector>
         </div>
 
         <StormExploreControls
@@ -499,6 +502,20 @@ export function SupercellsExplore({
           }}
           onPlaying={setPlaying}
           onPlaybackSpeed={setPlaybackSpeed}
+        />
+
+        <ExploreSecondarySections
+          sections={{
+            science: <SupercellScience frame={frame} lens={lens} />,
+            notes: (
+              <SimulationNotes
+                worldId="supercells"
+                simulationId={simulation.simulation_id}
+                simulationName={simulation.display_name}
+              />
+            ),
+            details: <SupercellDetails frame={frame} simulation={simulation} />,
+          }}
         />
       </section>
     </IntegratedExploreWorkspace>
@@ -895,88 +912,128 @@ function SupercellExplanation({
   lens,
   viewport,
   evidenceView,
+  selected,
+  onClearSelection,
 }: {
   frame: StormExaminationFrame | null;
   lens: LensId;
   viewport: ViewportId;
   evidenceView: EvidenceView;
+  selected: boolean;
+  onClearSelection: () => void;
 }) {
   const question =
     frame?.lens_question ?? LENSES.find((item) => item.id === lens)?.label ?? "Storm evidence";
+  const point = frame?.selected_point;
+  const selectedEvidence =
+    selected && point ? (
+      <ExploreSelectedEvidence
+        eyebrow="Selected cell"
+        title="Native-grid evidence"
+        states={point.states}
+        metrics={[
+          { label: "x", value: `${point.x_km.toFixed(1)} km` },
+          { label: "y", value: `${point.y_km.toFixed(1)} km` },
+          { label: "z", value: `${point.z_km.toFixed(2)} km` },
+          { label: "Model time", value: formatTime(point.model_time_seconds) },
+          ...scienceKeys(frame.lens_id).map((key) => ({
+            label: scienceLabel(key),
+            value: `${formatScientific(point.values[key])} ${point.units[key] ?? ""}`.trim(),
+          })),
+        ]}
+        onClear={onClearSelection}
+        className="supercells-selected-context"
+      />
+    ) : undefined;
   return (
-    <section className="supercells-context-panel">
-      <p className="eyebrow">{frame?.lens_name ?? "Supercell Lens"}</p>
-      <h3>{question}</h3>
-      <p>{lensExplanation(lens, evidenceView, frame?.plan.level_km)}</p>
-      {frame && (
-        <div className="supercells-notice-now">
-          <strong>What to notice now</strong>
+    <ExploreContextContent
+      identity={frame?.lens_name ?? "Supercell Lens"}
+      question={question}
+      explanation={<p>{lensExplanation(lens, evidenceView, frame?.plan.level_km)}</p>}
+      selectedEvidence={selectedEvidence}
+      whatToNotice={
+        frame ? (
           <p>{frame.what_to_notice_by_view?.[evidenceView] ?? frame.what_to_notice_now}</p>
-        </div>
+        ) : undefined
+      }
+      orientation={[
+        { label: "Simulation", value: "Quarter-Circle Supercell" },
+        { label: "View", value: sliceControlLabel(evidenceView) },
+        { label: "Viewport", value: viewport === "storm" ? "Storm region" : "Full domain" },
+        { label: "Model time", value: formatTime(frame?.time_seconds ?? 0) },
+        {
+          label: "Relevant caveat",
+          value:
+            frame?.caveats[lens === "low_level_interactions" ? 4 : 0] ??
+            "Retained storm evidence is loading.",
+        },
+      ]}
+      selectionPrompt={
+        selected ? undefined : "Select a cell in the plan or section for native-grid evidence."
+      }
+    />
+  );
+}
+
+function SupercellScience({ frame, lens }: { frame: StormExaminationFrame | null; lens: LensId }) {
+  const primary = frame?.plan.primary;
+  return (
+    <section className="explore-science-section">
+      <p className="eyebrow">Science</p>
+      <h3>{frame?.lens_name ?? LENSES.find((item) => item.id === lens)?.label}</h3>
+      <p>{supercellScienceExplanation(lens)}</p>
+      <dl className="metric-grid compact-metric-grid">
+        <Metric
+          label="Fixed primary scale"
+          value={
+            primary
+              ? `${formatScientific(primary.scale.minimum)} to ${formatScientific(
+                  primary.scale.maximum,
+                )} ${primary.scale.units}`
+              : "Loading"
+          }
+        />
+        <Metric
+          label="Current plan range"
+          value={
+            primary
+              ? `${formatScientific(primary.selected_frame_minimum)} to ${formatScientific(
+                  primary.selected_frame_maximum,
+                )} ${primary.units}`
+              : "Loading"
+          }
+        />
+        <Metric
+          label="Coordinate frame"
+          value={frame?.selected_point.coordinate_frame ?? "Translating model frame"}
+        />
+        <Metric
+          label="Sampling"
+          value="Retained native cells; overlays identify explicitly derived quantities"
+        />
+      </dl>
+      {frame && (
+        <details>
+          <summary>Scientific limitations</summary>
+          <ul>
+            {frame.caveats.map((caveat) => (
+              <li key={caveat}>{caveat}</li>
+            ))}
+          </ul>
+        </details>
       )}
-      <dl className="metric-grid">
-        <Metric label="Simulation" value="Quarter-Circle Supercell" />
-        <Metric label="Viewport" value={viewport === "storm" ? "Storm region" : "Full domain"} />
-        <Metric label="Model time" value={formatTime(frame?.time_seconds ?? 0)} />
-        <Metric
-          label="Frame"
-          value={frame ? `${frame.time_index + 1} of ${frame.times_seconds.length}` : "Loading"}
-        />
-      </dl>
-      <p className="context-callout">
-        Select a cell in the plan or section to inspect native-grid evidence.
-      </p>
     </section>
   );
 }
 
-function SupercellScience({
-  frame,
-  selected,
-}: {
-  frame: StormExaminationFrame | null;
-  selected: boolean;
-}) {
-  if (!frame) return <p>Scientific evidence is loading.</p>;
-  const point = frame.selected_point;
-  return (
-    <section className="supercells-context-panel">
-      <p className="eyebrow">
-        {selected ? "Selected point" : "Strongest-updraft column at slice level"}
-      </p>
-      <h3>
-        x {point.x_km.toFixed(1)}, y {point.y_km.toFixed(1)}, z {point.z_km.toFixed(2)} km
-      </h3>
-      <div className="supercells-state-row">
-        {point.states.map((state) => (
-          <span key={state}>{state}</span>
-        ))}
-      </div>
-      <dl className="metric-grid">
-        {scienceKeys(frame.lens_id).map((key) => (
-          <Metric
-            key={key}
-            label={scienceLabel(key)}
-            value={`${formatScientific(point.values[key])} ${point.units[key] ?? ""}`.trim()}
-          />
-        ))}
-        <Metric
-          label="Horizontal distance to strongest-updraft column"
-          value={`${point.distance_to_primary_updraft_km.toFixed(1)} km`}
-        />
-      </dl>
-      <p className="context-coordinate-frame">{point.coordinate_frame}</p>
-    </section>
-  );
-}
-
-function SupercellNotes() {
-  return (
-    <section className="supercells-context-panel">
-      <h3>Simulation notes</h3>
-      <p>No note is recorded for this built-in Simulation.</p>
-    </section>
-  );
+function supercellScienceExplanation(lens: LensId): string {
+  if (lens === "rotating_updraft") {
+    return "Compare the signed updraft with cyclonic vorticity and the 2-5 km updraft-helicity footprint. Their overlap shows where sustained ascent and rotation are organized together; no single overlay is treated as the storm by itself.";
+  }
+  if (lens === "cloud_precipitation") {
+    return "Dominant hydrometeor identity shows which retained condensate species has the largest local mass. Use it with the vertical-motion field and precipitation evidence to distinguish cloud structure from falling or accumulated water.";
+  }
+  return "Read low-level ascent and descent together with the rain footprint and model-relative flow. The view tests how outflow, inflow, precipitation, and near-surface vertical motion occupy the same storm-relative region without inferring a process from one cell.";
 }
 
 function SupercellDetails({
@@ -1231,14 +1288,11 @@ function sliceControlLabel(view: EvidenceView): string {
   return view === "xz" ? "Vertical x-z" : "Vertical y-z";
 }
 
-function lensExplanation(
-  lens: LensId,
-  evidenceView: EvidenceView,
-  planLevelKm?: number,
-): string {
-  const level = typeof planLevelKm === "number" && Number.isFinite(planLevelKm)
-    ? `z = ${planLevelKm.toFixed(2)} km`
-    : "the selected native altitude";
+function lensExplanation(lens: LensId, evidenceView: EvidenceView, planLevelKm?: number): string {
+  const level =
+    typeof planLevelKm === "number" && Number.isFinite(planLevelKm)
+      ? `z = ${planLevelKm.toFixed(2)} km`
+      : "the selected native altitude";
   if (lens === "rotating_updraft") {
     return evidenceView === "plan"
       ? `The x-y slice at ${level} pairs signed vertical motion with cyclonic vorticity and the 2–5 km updraft-helicity footprint, showing where ascent and rotation organize together.`

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -78,8 +78,14 @@ repository authority for current implementation ordering. The latest approved
 PM comment and issue body still control the exact scope of each bounded task.
 
 The presentation-quality and three-World foundation is complete through #420,
-#423, #421, and #429. Issue #428 remains the immediate shared Explore
-information-architecture follow-up.
+#423, #421, #429, and #428. All three Explore implementations now use one
+collapsible Context and shared below-the-fold Science, Notes, and Details
+structure. Per-Simulation Notes are the first durable content contract; complete
+Explore state and Saved Views remain unimplemented.
+
+The next approved program is personal scientific memory: define one versioned,
+World-aware serializable Explore-state contract before ordinary resume, named
+Saved Views, or Compare work.
 
 Rewritten issues #394 and #395 and issues #432 through #438 record bounded
 follow-on product work for Activity and History, Fun With Soundings, durable

--- a/docs/current/CURRENT_ARCHITECTURE.md
+++ b/docs/current/CURRENT_ARCHITECTURE.md
@@ -149,6 +149,26 @@ The backend caches validated run inventory using artifact fingerprints. A
 selected frame opens its corresponding history only. The frontend keeps a
 small frame cache and prefetches adjacent frames for playback.
 
+### Shared information architecture
+
+All three Explore implementations compose the shared
+`IntegratedExploreWorkspace`, `ExploreInspector`, `ExploreContextContent`,
+`ExploreSelectedEvidence`, and `ExploreSecondarySections` contracts.
+
+The shared structure is:
+
+```text
+coordinated scientific viewer(s) + controls + timeline + collapsible Context
+
+Science | Notes | Details
+```
+
+Context owns concise current-view explanation and immediate selected-point
+evidence. Science owns World-specific retained-history evidence, Notes owns
+user-authored per-Simulation content, and Details owns technical and provenance
+information. World-specific geometry and science remain in their World
+components rather than being forced through one generic renderer.
+
 ## Scientific Payload Rules
 
 Explore payloads preserve several implementation boundaries:
@@ -239,11 +259,27 @@ The runtime home defaults to `~/CloudChamber` and stores:
 - sounding caches;
 - retained presentation-run assets;
 - result metadata and editable result sidecars;
+- per-Simulation notes keyed by stable World and Simulation identity;
 - validation and derived caches.
 
 Large CM1 histories and generated visualization artifacts are not stored in
 Git. Built-in World content therefore depends on local retained assets being
 present and valid.
+
+Per-Simulation Notes are the first bounded durable product-content contract:
+
+```text
+GET /api/worlds/{world_id}/simulations/{simulation_id}/note
+PUT /api/worlds/{world_id}/simulations/{simulation_id}/note
+
+<runtime-home>/simulation-notes/<world_id>/<simulation_id>.json
+```
+
+The backend validates stable identities and bounded text, and writes updates
+atomically through a temporary file, filesystem synchronization, and replace.
+Blank content clears the note. Read and write failures stay local to Notes and
+are reported in the interface. Notes do not become run identity, result
+metadata, or a general annotation model.
 
 Saved Views and complete Explore workspace state are not durably persisted.
 The only product Comparison currently exposed is the featured Trade Cumulus
@@ -266,7 +302,6 @@ reused.
 
 - World shells and Explore implementations share vocabulary but still contain
   World-specific state and rendering code.
-- Context and below-the-fold information architecture is not yet common.
 - Durable Saved Views and general World-aware Compare are absent.
 - Variation is implemented only for Mountain Waves.
 - Legacy run, result, and sounding surfaces remain interleaved with the newer

--- a/docs/current/CURRENT_STATE.md
+++ b/docs/current/CURRENT_STATE.md
@@ -108,6 +108,12 @@ Current Explore surfaces use:
 - persistent playback and saved-output controls;
 - explicit loading, missing-content, and failure states.
 
+Each Explore now places concise, context-sensitive explanation and current
+selected-point evidence in one collapsible **Context** inspector. Supporting
+content follows the shared below-the-fold **Science | Notes | Details**
+structure. Science remains World-specific, Notes persist by stable World and
+Simulation identity, and Details contain technical and provenance evidence.
+
 World-specific Lenses combine fields and overlays to answer a bounded
 scientific question. A Lens is an interpretation layer, not a new model field
 or a claim of unsupported process evidence.
@@ -153,14 +159,13 @@ The implemented application does not yet provide:
 - ordinary World-aware Compare beyond the featured Trade Cumulus Comparison;
 - one shared World-aware variation workflow across all accessible Worlds;
 - a first-class Fun With Soundings entrance;
-- one common Context and below-the-fold information architecture across all
-  Explore implementations;
 - durable persistence for complete Explore or comparison workspaces.
 
-Issue #428 tracks the approved cleanup of Explore Context and below-the-fold
-content. Older issues #389, #390, and #391 are closed as superseded by the
-current three-World implementation sequence; they should not be read as active
-roadmap authority.
+Per-Simulation Notes are durable content, but camera, time, Lens, overlay,
+selection, and other complete Explore workspace state are not yet persisted.
+Older issues #389, #390, and #391 are closed as superseded by the current
+three-World implementation sequence; they should not be read as active roadmap
+authority.
 
 ## Local-First Runtime
 

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -72,40 +72,18 @@ The presentation-quality and third-World program established:
 #423 — Supercells as the third three-dimensional Cloud World — complete
 
 #421 — higher-resolution, denser-cadence, longer-duration Supercell
-       presentation run — final adoption review in PR #430
+       presentation run — complete
+
+#429 — Supercells slice-position navigation and missing camera controls
+       — complete
+
+#428 — shared live Context, below-the-fold Science | Notes | Details, and
+       durable per-Simulation Notes across all three Worlds — complete
 ```
 
 The completed work preserves stable World and Simulation identities while allowing backing run assets to improve.
 
-PR #430 must complete its bounded review corrections and merge before #421 is treated as complete. No additional CM1 run is required unless a later explicit PM decision authorizes one.
-
-## Immediate bounded follow-ups
-
-After PR #430 merges, execute:
-
-```text
-#429 — add slice-position navigation and missing 3-D camera controls to
-       Supercells Explore
-
-→ #428 — commonalize live Context and below-the-fold Science, Notes, and
-         Details across all three Worlds
-```
-
-### #429 — complete Supercells spatial navigation
-
-Issue #429 closes a bounded usability gap in the accepted Supercells workspace:
-
-- move horizontal and vertical evidence planes by native physical coordinate;
-- keep the represented 2-D and 3-D planes synchronized;
-- preserve user-selected slice positions during playback;
-- expose zoom and vertical-pan controls already supported by the shared 3-D viewer behavior;
-- preserve per-Lens camera and slice state.
-
-It does not reopen Supercell Lens questions, scales, scientific fields, or rendering design.
-
-### #428 — shared Explore information architecture
-
-Issue #428 should establish one recognizable information hierarchy across Trade Cumulus, Mountain Waves, and Supercells:
+The shared Explore information architecture is:
 
 ```text
 above the fold
@@ -117,13 +95,11 @@ below the fold
 
 World-specific scientific content remains legitimate. Shared structure must not erase scientific or geometric differences.
 
-Per-Simulation Notes introduced through this work must be treated as the first bounded durable-content contract, not as disposable frontend-only state or a general annotation platform. The contract should use stable World and Simulation identity, persist across reloads, fail visibly, and leave a clear extension path for later Saved Views and Saved Comparisons without implementing those features now.
-
-Issue #428 must not serialize complete Explore state, implement resume, create Saved Views, or establish a generic annotation framework. Those belong to the next program after the shared information architecture is stable.
+Per-Simulation Notes are the first bounded durable-content contract. They use stable World and Simulation identity, persist across reloads, and fail visibly. They do not serialize complete Explore state, implement resume, create Saved Views, or establish a generic annotation framework.
 
 ## Next program: personal scientific memory
 
-After #429 and #428, establish one versioned, World-aware Explore-state contract before implementing Compare.
+Establish one versioned, World-aware Explore-state contract before implementing Compare.
 
 The contract should represent, as applicable:
 


### PR DESCRIPTION
Closes #428

## Product-drift check

- **Stable vision:** Cloud Chamber remains a personal scientific laboratory of distinct Cloud Worlds.
- **Current task:** all three Explore experiences now share one information hierarchy and one real per-Simulation Notes contract.
- **Non-implications:** no Lens, field, scale, overlay, rendering, timeline, slice/camera navigation, Simulation data, Compare, Lab, or World-navigation behavior was redefined.
- **Portfolio effect:** Trade Cumulus, Mountain Waves, and Supercells retain their own science and geometry while reading as one application.

## Summary

- Replaced the sidebar tab mishmash with one concise, context-sensitive `Context` surface in all three Worlds. Selected native-grid evidence is promoted in that same sidebar, and collapsing it returns the width to the scientific viewers.
- Added one shared accessible below-the-fold `Science | Notes | Details` area with fixed ordering, keyboard navigation, shared spacing/focus treatment, and World-specific content.
- Added backend-owned, atomic, bounded per-Simulation notes keyed by stable `world_id + simulation_id`, with load/save/edit/reload/clear and object-specific failure handling.
- Removed the history-wide Trade Cumulus selection diagnostic request. Selected evidence now comes immediately from the loaded native slice or Lens frame, matching the other World implementations.
- Added focused component, API, persistence, World, failure, keyboard, selection, collapse, and mocked browser coverage.

## Changed files

Backend and tests:

```text
app/backend/cloud_chamber/app.py
app/backend/cloud_chamber/cloud_worlds.py
app/backend/cloud_chamber/simulation_notes.py
app/backend/tests/test_app.py
app/backend/tests/test_cloud_worlds.py
app/backend/tests/test_simulation_notes.py
```

Frontend implementation and tests:

```text
app/frontend/src/App.css
app/frontend/src/App.test.tsx
app/frontend/src/App.tsx
app/frontend/src/IntegratedExploreWorkspace.test.tsx
app/frontend/src/IntegratedExploreWorkspace.tsx
app/frontend/src/MountainWavesExplore.test.tsx
app/frontend/src/MountainWavesExplore.tsx
app/frontend/src/SimulationNotes.test.tsx
app/frontend/src/SimulationNotes.tsx
app/frontend/src/StormExaminationResearch.tsx
app/frontend/src/SupercellsExplore.css
app/frontend/src/SupercellsExplore.test.tsx
app/frontend/src/SupercellsExplore.tsx
```

Mocked browser contract:

```text
app/frontend/e2e/fixtures.ts
app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
app/frontend/e2e/mocked-smoke/navigation.spec.ts
app/frontend/e2e/mocked-smoke/supercells.spec.ts
app/frontend/e2e/mocked-smoke/visualizer-occlusion.spec.ts
```

## Verification

- `git diff --check`
- `BACKEND_PYTHON=/Users/timpeterson/Documents/Codex/cloud-chamber/app/backend/.venv/bin/python scripts/check.sh`
  - 159 frontend tests
  - production build
  - 664 backend tests
  - script, artifact, and docs checks
- `scripts/check-e2e.sh`
  - 30 mocked desktop Playwright journeys
- Live retained-Simulation review at 1920-wide and 1440 x 900 desktop sizes across all three Worlds
- Notes save/reload/clear exercised in each World; temporary review notes cleared

Known non-blocking output remains unchanged: the Vite chunk-size warning and one existing NumPy ABI warning.

## Visual review

Review archive:

```text
/Users/timpeterson/Documents/Codex/cloud-chamber-issue-428-review.zip
```

The archive contains, for each World:

- default Context;
- selected native-grid evidence in Context;
- collapsed Context with reclaimed viewer width;
- below-the-fold Science, reloaded Notes, and Details;
- a narrower desktop check.

The live pass evaluated scientific hierarchy and readability, not only successful rendering. Context remains concise and view-specific; deeper content is discoverable without crowding the viewers; selected evidence uses native or explicitly derived values.

No CM1 process was started. No retained NetCDF or model output was modified. This PR is intentionally draft and must remain manual-review only.
