### PR TITLE
MVP workspace: create Fun With Soundings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## See clouds from the inside
 
 Cloud Chamber is a local, single-user atmospheric laboratory for exploring
-scientifically meaningful cloud simulations. The current application opens into
+scientifically meaningful cloud simulations. The current application provides
 three Cloud Worlds:
 
 | Cloud World | Current experience |
@@ -12,11 +12,17 @@ three Cloud Worlds:
 | **Mountain Waves** | A terrain-aware native two-dimensional x-z World with dry and moist Simulations, Field views, Wave Structure and Wave Cloud Lenses, and a working variation Lab. |
 | **Supercells** | A coordinated three-dimensional storm view plus native x-y, x-z, and y-z evidence for a retained quarter-circle Supercell Simulation and three storm Lenses. |
 
-The approved product direction also includes **Fun With Soundings**, a
-non-World atmospheric workbench. It is not currently accessible from the
-application. Sounding search, screening, package generation, run management,
-Results, and general Explore capabilities remain available through transitional
-paths, including the existing Trade Cumulus Lab.
+The home also provides **Fun With Soundings**, a first-class non-World
+atmospheric workbench. Its stable `/fun-with-soundings` route organizes work as
+**Find Soundings**, **Candidates**, **Build & Run**, **Runs**, and **Explore**.
+Direct non-World Explore routes use
+`/fun-with-soundings/explore/{result_id}`. The selected atmosphere remains
+visible as the user moves from source evidence through experiment setup.
+
+The workbench reuses the existing package, queue, worker, ingest, storage, and
+visualization services. **Runs** means technical execution; completed retained
+work is an **Experiment** unless a current Cloud World inventory verifies its
+stable **Simulation** identity and exact run/result linkage.
 
 Cloud Chamber is not a forecasting product. It uses idealized and source-backed
 CM1 experiments to make cloud structure and normally invisible atmospheric
@@ -29,7 +35,6 @@ The implemented application does not yet provide:
 - durable Saved Views;
 - ordinary World-aware Compare beyond the featured Trade Cumulus Comparison;
 - one shared variation workflow across all three Worlds;
-- a first-class Fun With Soundings destination;
 - durable persistence for complete Explore or comparison workspaces.
 
 These are current limitations, not decisions to remove the corresponding

--- a/app/backend/cloud_chamber/igra_catalog.py
+++ b/app/backend/cloud_chamber/igra_catalog.py
@@ -532,30 +532,48 @@ def _fetch_url_text(url: str, *, max_bytes: int) -> str:
 
 def _fetch_url_bytes(url: str, *, max_bytes: int) -> bytes:
     try:
-        transport = httpx.HTTPTransport(local_address="0.0.0.0", retries=1)
-        with (
-            httpx.Client(
-                transport=transport,
-                follow_redirects=True,
-                timeout=httpx.Timeout(30),
-            ) as client,
-            client.stream("GET", url) as response,
-        ):
-            response.raise_for_status()
-            content_length = response.headers.get("content-length")
-            if content_length is not None and int(content_length) > max_bytes:
-                raise IGRACatalogError(f"IGRA source URL exceeded maximum size: {url}")
-            chunks: list[bytes] = []
-            payload_size = 0
-            for chunk in response.iter_bytes():
-                payload_size += len(chunk)
-                if payload_size > max_bytes:
-                    raise IGRACatalogError(f"IGRA source URL exceeded maximum size: {url}")
-                chunks.append(chunk)
-            payload = b"".join(chunks)
+        return _stream_url_bytes(url, max_bytes=max_bytes)
+    except (httpx.ConnectError, httpx.ConnectTimeout):
+        try:
+            transport = httpx.HTTPTransport(local_address="0.0.0.0", retries=1)
+            return _stream_url_bytes(url, max_bytes=max_bytes, transport=transport)
+        except (httpx.HTTPError, ValueError) as exc:
+            raise IGRACatalogError(f"Unable to fetch IGRA source URL: {url}") from exc
     except (httpx.HTTPError, ValueError) as exc:
         raise IGRACatalogError(f"Unable to fetch IGRA source URL: {url}") from exc
-    return payload
+
+
+def _stream_url_bytes(
+    url: str,
+    *,
+    max_bytes: int,
+    transport: httpx.BaseTransport | None = None,
+) -> bytes:
+    client = (
+        httpx.Client(follow_redirects=True, timeout=httpx.Timeout(30))
+        if transport is None
+        else httpx.Client(
+            transport=transport,
+            follow_redirects=True,
+            timeout=httpx.Timeout(30),
+        )
+    )
+    with (
+        client,
+        client.stream("GET", url) as response,
+    ):
+        response.raise_for_status()
+        content_length = response.headers.get("content-length")
+        if content_length is not None and int(content_length) > max_bytes:
+            raise IGRACatalogError(f"IGRA source URL exceeded maximum size: {url}")
+        chunks: list[bytes] = []
+        payload_size = 0
+        for chunk in response.iter_bytes():
+            payload_size += len(chunk)
+            if payload_size > max_bytes:
+                raise IGRACatalogError(f"IGRA source URL exceeded maximum size: {url}")
+            chunks.append(chunk)
+        return b"".join(chunks)
 
 
 def _parse_optional_text(text: str) -> str | None:

--- a/app/backend/cloud_chamber/igra_catalog.py
+++ b/app/backend/cloud_chamber/igra_catalog.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 import io
 import json
 import re
-import urllib.error
 import urllib.parse
-import urllib.request
 import zipfile
 from datetime import UTC, datetime
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 
+import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
 from cloud_chamber.settings import CloudChamberSettings
@@ -533,12 +532,29 @@ def _fetch_url_text(url: str, *, max_bytes: int) -> str:
 
 def _fetch_url_bytes(url: str, *, max_bytes: int) -> bytes:
     try:
-        with urllib.request.urlopen(url, timeout=30) as response:
-            payload = cast(bytes, response.read(max_bytes + 1))
-    except (urllib.error.URLError, TimeoutError) as exc:
+        transport = httpx.HTTPTransport(local_address="0.0.0.0", retries=1)
+        with (
+            httpx.Client(
+                transport=transport,
+                follow_redirects=True,
+                timeout=httpx.Timeout(30),
+            ) as client,
+            client.stream("GET", url) as response,
+        ):
+            response.raise_for_status()
+            content_length = response.headers.get("content-length")
+            if content_length is not None and int(content_length) > max_bytes:
+                raise IGRACatalogError(f"IGRA source URL exceeded maximum size: {url}")
+            chunks: list[bytes] = []
+            payload_size = 0
+            for chunk in response.iter_bytes():
+                payload_size += len(chunk)
+                if payload_size > max_bytes:
+                    raise IGRACatalogError(f"IGRA source URL exceeded maximum size: {url}")
+                chunks.append(chunk)
+            payload = b"".join(chunks)
+    except (httpx.HTTPError, ValueError) as exc:
         raise IGRACatalogError(f"Unable to fetch IGRA source URL: {url}") from exc
-    if len(payload) > max_bytes:
-        raise IGRACatalogError(f"IGRA source URL exceeded maximum size: {url}")
     return payload
 
 

--- a/app/backend/cloud_chamber/runtime_storage.py
+++ b/app/backend/cloud_chamber/runtime_storage.py
@@ -40,6 +40,8 @@ class RunStorageEntry(BaseModel):
     lifecycle_state: str | None = None
     validation_status: str | None = None
     product_state: str | None = None
+    input_source: str | None = None
+    has_observed_sounding: bool = False
     run_configuration: dict[str, object] | None = None
     pre_run_validation_report: dict[str, object] | None = None
     created_at: str | None = None
@@ -309,6 +311,8 @@ def _entry_from_manifest(
         lifecycle_state=manifest.lifecycle_state.value,
         validation_status=manifest.validation_status.value,
         product_state=manifest.provenance.product_state.value,
+        input_source=manifest.input_source,
+        has_observed_sounding=manifest.observed_sounding is not None,
         run_configuration=manifest.run_configuration,
         pre_run_validation_report=manifest.pre_run_validation_report,
         created_at=manifest.created_at.isoformat(),

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -9,6 +9,7 @@ description = "Local backend tooling for Cloud Chamber CM1 experiments."
 requires-python = ">=3.12"
 dependencies = [
   "fastapi>=0.115",
+  "httpx>=0.27",
   "pyyaml>=6.0",
   "scipy>=1.14",
   "xarray>=2024.7",
@@ -16,7 +17,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "httpx>=0.27",
   "mypy>=1.10",
   "pytest>=8.2",
   "ruff>=0.5",

--- a/app/backend/tests/test_igra_catalog.py
+++ b/app/backend/tests/test_igra_catalog.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
+import httpx
 import pytest
 
 import cloud_chamber.igra_catalog as igra_catalog
@@ -79,7 +80,7 @@ def station_zip(filename: str = "USM00072558-data-beg2025.txt") -> bytes:
     return payload.getvalue()
 
 
-def test_fetch_url_bytes_uses_ipv4_transport_and_streaming_size_limit(
+def test_fetch_url_bytes_uses_ordinary_streaming_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: dict[str, object] = {}
@@ -114,21 +115,162 @@ def test_fetch_url_bytes_uses_ipv4_transport_and_streaming_size_limit(
             calls["request"] = (method, url)
             return FakeResponse()
 
-    def fake_transport(**kwargs: object) -> object:
-        calls["transport"] = kwargs
-        return object()
-
-    monkeypatch.setattr("cloud_chamber.igra_catalog.httpx.HTTPTransport", fake_transport)
     monkeypatch.setattr("cloud_chamber.igra_catalog.httpx.Client", FakeClient)
 
     payload = igra_catalog._fetch_url_bytes("https://example.test/sounding.zip", max_bytes=4)
 
     assert payload == b"abcd"
-    assert calls["transport"] == {"local_address": "0.0.0.0", "retries": 1}
     assert calls["request"] == ("GET", "https://example.test/sounding.zip")
     client_options = calls["client"]
     assert isinstance(client_options, dict)
     assert client_options["follow_redirects"] is True
+    assert "transport" not in client_options
+
+
+def test_fetch_url_bytes_retries_connection_failure_with_ipv4_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+    fallback_transport = object()
+
+    class FakeResponse:
+        headers = {"content-length": "4"}
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self) -> Iterator[bytes]:
+            yield b"fallback"
+
+    class FakeClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.options = kwargs
+            calls.append(kwargs)
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def stream(self, _method: str, url: str) -> FakeResponse:
+            if "transport" not in self.options:
+                raise httpx.ConnectError(
+                    "ordinary connection failed",
+                    request=httpx.Request("GET", url),
+                )
+            return FakeResponse()
+
+    transport_calls: list[dict[str, object]] = []
+
+    def fake_transport(**kwargs: object) -> object:
+        transport_calls.append(kwargs)
+        return fallback_transport
+
+    monkeypatch.setattr("cloud_chamber.igra_catalog.httpx.HTTPTransport", fake_transport)
+    monkeypatch.setattr("cloud_chamber.igra_catalog.httpx.Client", FakeClient)
+
+    payload = igra_catalog._fetch_url_bytes("https://example.test/sounding.zip", max_bytes=20)
+
+    assert payload == b"fallback"
+    assert transport_calls == [{"local_address": "0.0.0.0", "retries": 1}]
+    assert len(calls) == 2
+    assert "transport" not in calls[0]
+    assert calls[1]["transport"] is fallback_transport
+
+
+def test_fetch_url_bytes_does_not_retry_http_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport_called = False
+
+    class FakeResponse:
+        headers: dict[str, str] = {}
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def raise_for_status(self) -> None:
+            request = httpx.Request("GET", "https://example.test/failure")
+            response = httpx.Response(503, request=request)
+            raise httpx.HTTPStatusError(
+                "service unavailable",
+                request=request,
+                response=response,
+            )
+
+        def iter_bytes(self) -> Iterator[bytes]:
+            return iter(())
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def stream(self, _method: str, _url: str) -> FakeResponse:
+            return FakeResponse()
+
+    def fake_transport(**_kwargs: object) -> object:
+        nonlocal transport_called
+        transport_called = True
+        return object()
+
+    monkeypatch.setattr("cloud_chamber.igra_catalog.httpx.HTTPTransport", fake_transport)
+    monkeypatch.setattr("cloud_chamber.igra_catalog.httpx.Client", FakeClient)
+
+    with pytest.raises(IGRACatalogError, match="Unable to fetch IGRA source URL"):
+        igra_catalog._fetch_url_bytes("https://example.test/failure", max_bytes=20)
+
+    assert transport_called is False
+
+
+def test_fetch_url_bytes_enforces_streaming_size_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        headers: dict[str, str] = {}
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self) -> Iterator[bytes]:
+            yield b"ab"
+            yield b"cd"
+
+    class FakeClient:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def stream(self, _method: str, _url: str) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr("cloud_chamber.igra_catalog.httpx.Client", FakeClient)
 
     with pytest.raises(IGRACatalogError, match="exceeded maximum size"):
         igra_catalog._fetch_url_bytes("https://example.test/sounding.zip", max_bytes=3)

--- a/app/backend/tests/test_igra_catalog.py
+++ b/app/backend/tests/test_igra_catalog.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import io
 import zipfile
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
+import cloud_chamber.igra_catalog as igra_catalog
 from cloud_chamber.igra_catalog import (
     IGRACacheManifest,
     IGRACatalogError,
@@ -75,6 +77,61 @@ def station_zip(filename: str = "USM00072558-data-beg2025.txt") -> bytes:
     with zipfile.ZipFile(payload, "w") as archive:
         archive.writestr(filename, "#USM00072558 2025 01 01 00\n")
     return payload.getvalue()
+
+
+def test_fetch_url_bytes_uses_ipv4_transport_and_streaming_size_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    class FakeResponse:
+        headers = {"content-length": "4"}
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self) -> Iterator[bytes]:
+            yield b"ab"
+            yield b"cd"
+
+    class FakeClient:
+        def __init__(self, **kwargs: object) -> None:
+            calls["client"] = kwargs
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def stream(self, method: str, url: str) -> FakeResponse:
+            calls["request"] = (method, url)
+            return FakeResponse()
+
+    def fake_transport(**kwargs: object) -> object:
+        calls["transport"] = kwargs
+        return object()
+
+    monkeypatch.setattr("cloud_chamber.igra_catalog.httpx.HTTPTransport", fake_transport)
+    monkeypatch.setattr("cloud_chamber.igra_catalog.httpx.Client", FakeClient)
+
+    payload = igra_catalog._fetch_url_bytes("https://example.test/sounding.zip", max_bytes=4)
+
+    assert payload == b"abcd"
+    assert calls["transport"] == {"local_address": "0.0.0.0", "retries": 1}
+    assert calls["request"] == ("GET", "https://example.test/sounding.zip")
+    client_options = calls["client"]
+    assert isinstance(client_options, dict)
+    assert client_options["follow_redirects"] is True
+
+    with pytest.raises(IGRACatalogError, match="exceeded maximum size"):
+        igra_catalog._fetch_url_bytes("https://example.test/sounding.zip", max_bytes=3)
 
 
 def test_recent_directory_parser_finds_station_period_zip_links() -> None:

--- a/app/backend/tests/test_runtime_storage.py
+++ b/app/backend/tests/test_runtime_storage.py
@@ -202,6 +202,8 @@ def test_inventory_classifies_valid_manifest_with_output_artifacts(tmp_path: Pat
     assert entry.lifecycle_state == "completed"
     assert entry.validation_status == "valid"
     assert entry.product_state == "completed_cm1_result"
+    assert entry.input_source == "generated_reference"
+    assert entry.has_observed_sounding is False
     assert entry.run_configuration is not None
     assert entry.run_configuration["duration"] == "short_6h"
     assert entry.pre_run_validation_report is not None

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -746,24 +746,23 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await page.getByRole("button", { name: "Create packages and queue selected runs" }).click();
     await expect(page.getByText("1 queued locally")).toBeVisible();
     await page.getByRole("button", { name: "Open Runs" }).click();
-    await expect(page.getByRole("heading", { name: "Past runs" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Past Experiments" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Refresh current work" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Refresh archive" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Refresh Experiments" })).toBeVisible();
 
     await jobs.getByRole("button", { name: "5 Explore" }).click();
     await expect(page).toHaveURL(/\/fun-with-soundings\/explore\/result-observed-sounding$/);
-    await expect(page.getByRole("combobox", { name: "Soundings run" })).toHaveValue(
+    await expect(page.getByRole("combobox", { name: "Soundings Experiment" })).toHaveValue(
       "result-observed-sounding",
     );
-    await expect(page.getByText("Experiment", { exact: true })).toBeVisible();
-    await page.getByRole("button", { name: "Back to Runs" }).click();
+    await page.getByRole("button", { name: "Back to Past Experiments" }).click();
 
-    const pastRuns = page.getByRole("region", { name: "Past runs" });
+    const pastRuns = page.getByRole("region", { name: "Past Experiments" });
     await expect(
       pastRuns.getByRole("button", { name: "Uploaded Sounding — Valley, Nebraska" }),
     ).toBeVisible();
     await pastRuns.getByRole("combobox", { name: "Ownership" }).selectOption("world");
-    const runsList = pastRuns.getByRole("region", { name: "Runs list" });
+    const runsList = pastRuns.getByRole("region", { name: "Experiments list" });
     await expect(runsList.getByRole("button", { name: "Open Trade Cumulus" })).toHaveCount(2);
     await runsList.getByRole("button", { name: "Open Trade Cumulus" }).first().click();
     await expect(page.getByRole("navigation", { name: "Trade Cumulus sections" })).toBeVisible();

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -689,6 +689,87 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     expect(browserErrors).toEqual([]);
   });
 
+  test("Fun With Soundings carries a selected atmosphere through runs and World ownership", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.unroute("**/api/worlds");
+    await page.unroute("**/api/comparisons/trade-cumulus-moisture-v1");
+    await mockTradeCumulusWorld(page);
+    await page.route("**/api/worlds/mountain-waves", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ simulations: [] }),
+      }),
+    );
+    await page.route("**/api/worlds/supercells", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ simulations: [] }),
+      }),
+    );
+    await page.route("**/api/results", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          results: [comparisonBaselineResult, comparisonMoreMoistureResult, ...results],
+        }),
+      }),
+    );
+    await gotoApp(page);
+
+    await page.getByRole("button", { name: "Open Fun With Soundings" }).click();
+    await expect(page).toHaveURL(/\/fun-with-soundings$/);
+    await expect(page.getByRole("heading", { name: "Fun With Soundings" })).toBeVisible();
+    await expect(page.getByText("Atmospheric workbench", { exact: true })).toBeVisible();
+    await expect(page.getByText("Not a Cloud World", { exact: true })).toBeVisible();
+
+    const jobs = page.getByRole("navigation", { name: "Fun With Soundings sections" });
+    await expect(jobs.getByRole("button")).toHaveCount(5);
+    await jobs.getByRole("button", { name: "2 Candidates" }).click();
+    await page.getByText("Advanced filters", { exact: true }).click();
+    await page.getByRole("button", { name: "Apply advanced filters" }).click();
+
+    const valleyCard = page.getByLabel("Sounding candidate Valley, Nebraska (USM00072558)");
+    await expect(valleyCard).toBeVisible();
+    await valleyCard.getByRole("button", { name: "Configure run" }).click();
+    await expect(page.getByLabel("Selected sounding run setup")).toBeVisible();
+    await expect(page.getByLabel("Selected atmosphere")).toContainText(
+      "Valley, Nebraska (USM00072558)",
+    );
+
+    await page.getByRole("button", { name: "Add to run plan" }).click();
+    await expect(page.getByRole("region", { name: "Run plan" })).toBeVisible();
+    await page.getByRole("button", { name: "Create packages and queue selected runs" }).click();
+    await expect(page.getByText("1 queued locally")).toBeVisible();
+    await page.getByRole("button", { name: "Open Runs" }).click();
+    await expect(page.getByRole("heading", { name: "Past runs" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Refresh current work" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Refresh archive" })).toBeVisible();
+
+    await jobs.getByRole("button", { name: "5 Explore" }).click();
+    await expect(page).toHaveURL(/\/fun-with-soundings\/explore\/result-observed-sounding$/);
+    await expect(page.getByRole("combobox", { name: "Soundings run" })).toHaveValue(
+      "result-observed-sounding",
+    );
+    await expect(page.getByText("Experiment", { exact: true })).toBeVisible();
+    await page.getByRole("button", { name: "Back to Runs" }).click();
+
+    const pastRuns = page.getByRole("region", { name: "Past runs" });
+    await expect(
+      pastRuns.getByRole("button", { name: "Uploaded Sounding — Valley, Nebraska" }),
+    ).toBeVisible();
+    await pastRuns.getByRole("combobox", { name: "Ownership" }).selectOption("world");
+    const runsList = pastRuns.getByRole("region", { name: "Runs list" });
+    await expect(runsList.getByRole("button", { name: "Open Trade Cumulus" })).toHaveCount(2);
+    await runsList.getByRole("button", { name: "Open Trade Cumulus" }).first().click();
+    await expect(page.getByRole("navigation", { name: "Trade Cumulus sections" })).toBeVisible();
+    await expect(page).toHaveURL(/\/$/);
+  });
+
   test("Build exposes the Golden Path scenario and creates a safe dry-run package", async ({
     page,
   }) => {
@@ -748,12 +829,12 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
       .selectOption("__observed_sounding_upload__");
     await expect(page.getByRole("heading", { name: "Observed Soundings" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Find interesting soundings" })).toBeVisible();
-    await expect(page.getByRole("tab", { name: "Cached recommendations" })).toHaveAttribute(
+    await expect(page.getByRole("tab", { name: "Station catalog" })).toHaveAttribute(
       "aria-selected",
       "true",
     );
     await expect(page.getByLabel("IGRA station sounding-data file")).not.toBeVisible();
-    await page.getByRole("tab", { name: "Upload IGRA station text" }).click();
+    await page.getByRole("tab", { name: "Upload IGRA file" }).click();
     await expect(page.getByLabel("IGRA station sounding-data file")).toBeVisible();
     await expect(page.getByLabel("Low-level humidity")).not.toBeVisible();
     await expect(page.getByLabel("Use uploaded sounding")).not.toBeVisible();

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -1108,12 +1108,26 @@ small {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(247, 251, 253, 0.86));
 }
 
-.atmosphere-source-panel,
 .candidate-search-controls,
 .upload-source-stack,
 .run-plan-panel {
   display: grid;
   gap: 0.85rem;
+}
+
+.atmosphere-source-switcher {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-block: 1px solid var(--color-border);
+  padding: 0.45rem 0.1rem;
+}
+
+.atmosphere-source-switcher > strong {
+  flex: 0 0 auto;
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
 }
 
 .selected-sounding-setup {
@@ -1218,11 +1232,15 @@ small {
 }
 
 .source-path-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
   align-items: stretch;
 }
 
 .source-path-tabs button {
-  min-height: 2.55rem;
+  min-height: 2.15rem;
+  padding: 0.38rem 0.65rem;
 }
 
 .candidate-search-controls label {
@@ -1310,6 +1328,121 @@ small {
   border-radius: 8px;
   padding: 0.75rem;
   background: rgba(255, 255, 255, 0.68);
+}
+
+.sounding-discovery-flow {
+  display: grid;
+  border-top: 1px solid var(--color-border);
+}
+
+.sounding-discovery-step {
+  display: grid;
+  grid-template-columns: 2.15rem minmax(0, 1fr);
+  gap: 0.75rem;
+  padding: 0.95rem 0.15rem;
+}
+
+.sounding-discovery-step + .sounding-discovery-step {
+  border-top: 1px solid var(--color-border);
+}
+
+.sounding-discovery-step-number {
+  display: grid;
+  width: 1.8rem;
+  height: 1.8rem;
+  place-items: center;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 50%;
+  background: var(--color-surface-muted);
+  color: var(--color-accent-strong);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.sounding-discovery-step-content {
+  display: grid;
+  min-width: 0;
+  gap: 0.65rem;
+}
+
+.sounding-discovery-step-content h4,
+.sounding-discovery-step-content p {
+  margin: 0;
+}
+
+.station-coverage-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(8rem, 1fr));
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.station-coverage-summary > div {
+  display: grid;
+  gap: 0.1rem;
+  border-left: 2px solid var(--color-border-strong);
+  padding: 0.35rem 0.65rem;
+}
+
+.station-coverage-summary dt {
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.station-coverage-summary dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-weight: 850;
+}
+
+.specific-station-picker {
+  display: grid;
+  gap: 0.65rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.7rem;
+}
+
+.station-catalog-toolbar {
+  display: grid;
+  grid-template-columns: minmax(14rem, 1fr) auto auto;
+  gap: 0.7rem;
+  align-items: end;
+}
+
+.sounding-initial-search-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 0.7rem;
+  align-items: start;
+}
+
+.sounding-initial-search-controls label {
+  display: grid;
+  gap: 0.3rem;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.sounding-initial-search-controls small {
+  color: var(--color-text-muted);
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.station-catalog-toolbar label {
+  display: grid;
+  gap: 0.3rem;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.station-catalog-toolbar p {
+  align-self: center;
+  color: var(--color-text-muted);
+  font-size: 0.88rem;
+  font-weight: 700;
 }
 
 .station-picklist {
@@ -4219,7 +4352,8 @@ details[open] > summary {
 .worlds-home,
 .world-shell,
 .world-context-workspace,
-.legacy-workspace-fallback {
+.legacy-workspace-fallback,
+.soundings-workbench {
   display: grid;
   align-content: start;
   gap: 1rem;
@@ -4268,6 +4402,393 @@ details[open] > summary {
   padding: clamp(1rem, 2vw, 1.5rem);
   background: var(--color-surface);
   box-shadow: var(--shadow-subtle);
+}
+
+.workbench-card {
+  border-left: 4px solid var(--color-accent-primary);
+  background:
+    linear-gradient(90deg, rgba(232, 243, 249, 0.72), transparent 24rem), var(--color-surface);
+}
+
+.soundings-workbench-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.95rem;
+}
+
+.soundings-workbench-header h2,
+.soundings-workbench-header p,
+.soundings-job-heading h3,
+.soundings-job-heading p,
+.selected-atmosphere-strip h3,
+.selected-atmosphere-strip p {
+  margin-bottom: 0;
+}
+
+.soundings-workbench-header > div:first-child {
+  max-width: 60rem;
+}
+
+.soundings-workbench-identity {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 0.18rem;
+  border-left: 3px solid var(--color-accent-primary);
+  padding: 0.25rem 0 0.25rem 0.8rem;
+  color: var(--color-text-muted);
+  text-align: right;
+}
+
+.soundings-workbench-identity strong {
+  color: var(--color-text-primary);
+}
+
+.soundings-job-nav {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0;
+  border-block: 1px solid var(--color-border);
+}
+
+.soundings-job-nav button {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.55rem;
+  align-items: center;
+  border: 0;
+  border-right: 1px solid var(--color-border);
+  border-radius: 0;
+  padding: 0.72rem 0.85rem;
+  background: transparent;
+  color: var(--color-text-muted);
+  box-shadow: none;
+  text-align: left;
+}
+
+.soundings-job-nav button:last-child {
+  border-right: 0;
+}
+
+.soundings-job-nav button > span {
+  display: grid;
+  width: 1.55rem;
+  height: 1.55rem;
+  place-items: center;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 50%;
+  font-size: 0.78rem;
+}
+
+.soundings-job-nav button.active-control {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+  box-shadow: inset 0 -3px 0 var(--color-accent-primary);
+}
+
+.soundings-job-nav button.active-control > span {
+  border-color: var(--color-accent-primary);
+  background: var(--color-surface);
+}
+
+.selected-atmosphere-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  min-height: 4.5rem;
+  border: 1px dashed var(--color-border-strong);
+  border-radius: 8px;
+  padding: 0.75rem 0.9rem;
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.selected-atmosphere-strip.has-selected-atmosphere {
+  border-style: solid;
+  border-left: 4px solid var(--color-success);
+  background: var(--color-surface);
+}
+
+.selected-atmosphere-strip dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(8rem, 1fr));
+  gap: 1.5rem;
+  margin: 0;
+}
+
+.selected-atmosphere-strip dl div {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.selected-atmosphere-strip dt {
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.selected-atmosphere-strip dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.soundings-job-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.2rem;
+}
+
+.soundings-job-content,
+.soundings-job-panel,
+.soundings-activity-layout {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.soundings-job-content > .soundings-job-panel {
+  max-width: 96rem;
+}
+
+.soundings-next-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--color-border);
+  padding: 0.85rem 0.2rem 0;
+}
+
+.soundings-next-action > div:first-child {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.soundings-next-action span {
+  color: var(--color-text-muted);
+}
+
+.soundings-activity-layout > .results-library {
+  border-top: 1px solid var(--color-border-strong);
+  padding-top: 1.25rem;
+}
+
+.soundings-runs-overview {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.soundings-explore-landing {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.soundings-explore-landing h3,
+.soundings-explore-landing p,
+.soundings-explore-empty h4,
+.soundings-explore-empty p {
+  margin-bottom: 0;
+}
+
+.soundings-explore-empty {
+  display: grid;
+  gap: 0.45rem;
+  border-left: 4px solid var(--color-border-strong);
+  padding: 0.8rem 1rem;
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.soundings-explore-empty button {
+  margin-top: 0.35rem;
+}
+
+.soundings-explore-ready-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+  gap: 0.75rem;
+}
+
+.soundings-explore-ready-list button {
+  display: grid;
+  gap: 0.2rem;
+  border: 1px solid var(--color-border);
+  padding: 0.85rem;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-subtle);
+  text-align: left;
+}
+
+.soundings-explore-ready-list button span {
+  color: var(--color-text-muted);
+  font-weight: 650;
+}
+
+.soundings-runs-heading {
+  align-items: end;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.75rem;
+}
+
+.soundings-runs-heading h3,
+.soundings-runs-heading p {
+  margin-bottom: 0;
+}
+
+.soundings-run-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+  border-block: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.soundings-run-summary > div {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+  padding: 0.75rem 1rem;
+  border-right: 1px solid var(--color-border);
+}
+
+.soundings-run-summary > div:last-child {
+  border-right: 0;
+}
+
+.soundings-run-summary dt,
+.soundings-current-queue dt {
+  color: var(--color-text-muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.soundings-run-summary dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: 1.3rem;
+  font-weight: 850;
+  font-variant-numeric: tabular-nums;
+}
+
+.soundings-current-queue {
+  display: grid;
+  grid-template-columns: minmax(18rem, 1fr) minmax(32rem, 1.5fr);
+  gap: 1.5rem;
+  align-items: center;
+  border-left: 4px solid var(--color-accent-primary);
+  padding: 0.7rem 0.9rem;
+  background: var(--color-accent-soft);
+}
+
+.soundings-current-queue h4,
+.soundings-current-queue p {
+  margin-bottom: 0;
+}
+
+.soundings-current-queue > dl {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1.5fr) repeat(2, minmax(7rem, 0.7fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.soundings-current-queue dl > div {
+  min-width: 0;
+}
+
+.soundings-current-queue dd {
+  margin: 0.15rem 0 0;
+  overflow-wrap: anywhere;
+  color: var(--color-text-primary);
+  font-weight: 800;
+}
+
+.soundings-runs-overview > .pipeline-panel {
+  border: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.soundings-runs-overview > .pipeline-panel > .state-note {
+  max-width: 58rem;
+}
+
+.soundings-runs-overview > .pipeline-panel > .pipeline-run-list {
+  grid-template-columns: repeat(auto-fit, minmax(25rem, 1fr));
+}
+
+.soundings-runs-overview > .pipeline-panel > .pipeline-run-list .pipeline-run-card {
+  background: var(--color-surface);
+}
+
+.soundings-run-details,
+.soundings-archive-more-filters {
+  border-block: 1px solid var(--color-border);
+  padding: 0.75rem 0;
+}
+
+.soundings-run-details > summary,
+.soundings-archive-more-filters > summary {
+  width: fit-content;
+  cursor: pointer;
+  color: var(--color-accent-primary);
+  font-weight: 850;
+}
+
+.soundings-run-details > p {
+  max-width: 60rem;
+  margin: 0.55rem 0 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.soundings-run-details > .local-run-panel {
+  margin-top: 0.75rem;
+}
+
+.soundings-archive-primary-filters {
+  grid-template-columns: minmax(16rem, 1.5fr) repeat(2, minmax(10rem, 0.8fr));
+}
+
+.soundings-archive-more-filters[open] > summary {
+  margin-bottom: 0.65rem;
+}
+
+.soundings-ownership-status {
+  width: fit-content;
+  margin: -0.35rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.86rem;
+}
+
+.soundings-archive-filter-grid {
+  grid-template-columns: repeat(4, minmax(9rem, 1fr));
+}
+
+.soundings-explore-run-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.soundings-explore-run-selector > span {
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.soundings-explore-run-selector select {
+  width: clamp(14rem, 24vw, 24rem);
+  padding: 0.42rem 2rem 0.42rem 0.65rem;
 }
 
 .world-card-main,

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3716,6 +3716,7 @@ function downsampledCloudSliceResponse() {
 }
 
 beforeEach(() => {
+  window.history.replaceState({}, "", "/");
   let runStatusRefreshCount = 0;
   vi.stubGlobal(
     "fetch",
@@ -4086,6 +4087,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  window.history.replaceState({}, "", "/");
   vi.useRealTimers();
   vi.unstubAllGlobals();
 });
@@ -4404,6 +4406,197 @@ describe("App", () => {
     expect(screen.getByRole("heading", { name: "Return to the cloud field" })).toBeInTheDocument();
   });
 
+  it("opens the Soundings workbench as a stable runs workspace and returns World-owned runs", async () => {
+    mockWorldScopedApp();
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Open Fun With Soundings" }));
+    expect(window.location.pathname).toBe("/fun-with-soundings");
+    expect(await screen.findByRole("heading", { name: "Fun With Soundings" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "4 Runs" }));
+    const pastRuns = (
+      await screen.findByRole("heading", {
+        name: "Past runs",
+      })
+    ).closest("section");
+    expect(pastRuns).not.toBeNull();
+    expect(within(pastRuns!).getByRole("button", { name: "Refresh archive" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Refresh current work" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Refresh results" })).not.toBeInTheDocument();
+
+    await screen.findByText(/retained Simulation identifiers linked/);
+    fireEvent.change(within(pastRuns!).getByRole("combobox", { name: "Ownership" }), {
+      target: { value: "world" },
+    });
+    const worldButtons = await screen.findAllByRole("button", { name: "Open Trade Cumulus" });
+    expect(worldButtons.length).toBeGreaterThan(0);
+
+    fireEvent.click(worldButtons[0]);
+    expect(
+      await screen.findByRole("navigation", { name: "Trade Cumulus sections" }),
+    ).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/");
+  });
+
+  it("opens Soundings Explore directly and switches among ingested sounding runs", async () => {
+    mockWorldScopedApp();
+    const secondObservedResult = {
+      ...observedSoundingResultCard,
+      result_id: "result-observed-sounding-denver",
+      run_id: "dry-run-observed-sounding-denver",
+      name: "Uploaded Sounding — Denver, Colorado",
+      observed_sounding: {
+        ...observedSoundingResultCard.observed_sounding,
+        station_id: "USM00072469",
+        station_name: "Denver, Colorado",
+      },
+    };
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/results") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              results: [observedSoundingResultCard, secondObservedResult],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Open Fun With Soundings" }));
+    fireEvent.click(await screen.findByRole("button", { name: "5 Explore" }));
+
+    const runSelector = await screen.findByRole("combobox", { name: "Soundings run" });
+    expect(window.location.pathname).toBe(
+      `/fun-with-soundings/explore/${observedSoundingResultCard.result_id}`,
+    );
+    expect(runSelector).toHaveValue(observedSoundingResultCard.result_id);
+
+    fireEvent.change(runSelector, { target: { value: secondObservedResult.result_id } });
+    await waitFor(() => {
+      expect(window.location.pathname).toBe(
+        `/fun-with-soundings/explore/${secondObservedResult.result_id}`,
+      );
+    });
+    expect(screen.getByRole("heading", { name: secondObservedResult.name })).toBeInTheDocument();
+  });
+
+  it("guides an empty cache through station download and sounding search", async () => {
+    mockWorldScopedApp();
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let stationDownloaded = false;
+    let cacheRequest = "";
+    let analyzeRequest = "";
+    const availableReference = {
+      ...igraCatalogResponse.catalog.zip_references[0],
+      cached_status: "not_cached",
+    };
+    const downloadedReference = {
+      ...availableReference,
+      cached_status: "cached_extracted",
+    };
+
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/igra/recent/catalog") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              catalog: {
+                ...igraCatalogResponse.catalog,
+                zip_references: [stationDownloaded ? downloadedReference : availableReference],
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/igra/recent/cache") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              entries: stationDownloaded ? [igraCacheResponse.entries[0]] : [],
+              updated_at: "2026-07-01T12:00:00Z",
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/sounding-candidates/screening-inputs") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              inputs: stationDownloaded ? [screeningInputsResponse.inputs[0]] : [],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/igra/recent/cache-batch" && init?.method === "POST") {
+        cacheRequest = String(init.body ?? "");
+        stationDownloaded = true;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              requested_limit: 10,
+              requested_station_ids: ["USM00072558"],
+              selected_count: 1,
+              cached_entries: [igraCacheResponse.entries[0]],
+              failed: [],
+              remaining_uncached_count: 0,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/sounding-candidates/analyze") {
+        analyzeRequest = String(init?.body ?? "");
+        return Promise.resolve(
+          new Response(JSON.stringify(screeningResponseForRequest(init)), { status: 200 }),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Open Fun With Soundings" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Find and download soundings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/normal search uses all 1 stations/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Choose specific stations" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Search focus" })).toHaveValue("best_overall");
+    expect(screen.getByRole("combobox", { name: "Station history" })).toHaveValue("all_cached");
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose specific stations" }));
+    expect(screen.getByRole("checkbox", { name: /Valley, Nebraska/ })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Use entire catalog" }));
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download 1 remaining station history" }));
+
+    expect(await screen.findByText("Downloaded")).toBeInTheDocument();
+    expect(cacheRequest).toContain('"station_ids":["USM00072558"]');
+    fireEvent.click(screen.getByRole("button", { name: "Search all 1 stations" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Screen interesting soundings" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Recommendation run complete")).toBeInTheDocument();
+    expect(analyzeRequest).toContain('"station_ids":[]');
+  });
+
   it("returns from stable Simulation Explore and the featured Comparison to the World", async () => {
     mockWorldScopedApp();
     render(<App />);
@@ -4623,12 +4816,12 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Build" }));
 
     expect(await screen.findByRole("heading", { name: "Observed Soundings" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Cached recommendations" })).toHaveAttribute(
+    expect(screen.getByRole("tab", { name: "Station catalog" })).toHaveAttribute(
       "aria-selected",
       "true",
     );
     expect(screen.queryByLabelText("IGRA station sounding-data file")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("tab", { name: "Upload IGRA station text" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Upload IGRA file" }));
     expect(screen.getByLabelText("IGRA station sounding-data file")).toBeInTheDocument();
     expect(screen.queryByLabelText("Low-level humidity")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Use uploaded sounding")).not.toBeInTheDocument();
@@ -5089,7 +5282,7 @@ describe("App", () => {
       screen.queryByLabelText("Saved sounding candidate Valley, Nebraska (USM00072558)"),
     ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("tab", { name: "Cached recommendations" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Station catalog" }));
     fireEvent.change(screen.getByLabelText("Story"), {
       target: { value: "needs_review" },
     });
@@ -5148,7 +5341,7 @@ describe("App", () => {
       target: { value: "__observed_sounding_upload__" },
     });
 
-    expect(await screen.findByRole("tab", { name: "Cached recommendations" })).toHaveAttribute(
+    expect(await screen.findByRole("tab", { name: "Station catalog" })).toHaveAttribute(
       "aria-selected",
       "true",
     );

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -2268,6 +2268,8 @@ const storageRuns = [
     lifecycle_state: "packaged",
     validation_status: "valid",
     product_state: "packaged_dry_run_output",
+    input_source: "observed_sounding",
+    has_observed_sounding: true,
     run_configuration: defaultRunConfiguration,
     created_at: "2026-05-22T15:55:36Z",
     updated_at: "2026-05-22T16:05:36Z",
@@ -4406,7 +4408,7 @@ describe("App", () => {
     expect(screen.getByRole("heading", { name: "Return to the cloud field" })).toBeInTheDocument();
   });
 
-  it("opens the Soundings workbench as a stable runs workspace and returns World-owned runs", async () => {
+  it("opens the Soundings workbench with Experiments separate from verified Simulations", async () => {
     mockWorldScopedApp();
     render(<App />);
 
@@ -4415,18 +4417,24 @@ describe("App", () => {
     expect(await screen.findByRole("heading", { name: "Fun With Soundings" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "4 Runs" }));
-    const pastRuns = (
+    const pastExperiments = (
       await screen.findByRole("heading", {
-        name: "Past runs",
+        name: "Past Experiments",
       })
     ).closest("section");
-    expect(pastRuns).not.toBeNull();
-    expect(within(pastRuns!).getByRole("button", { name: "Refresh archive" })).toBeInTheDocument();
+    expect(pastExperiments).not.toBeNull();
+    expect(
+      within(pastExperiments!).getByRole("button", { name: "Refresh Experiments" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Refresh current work" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Refresh results" })).not.toBeInTheDocument();
 
-    await screen.findByText(/retained Simulation identifiers linked/);
-    fireEvent.change(within(pastRuns!).getByRole("combobox", { name: "Ownership" }), {
+    expect(
+      await screen.findByText(
+        /retained Simulations verified\. Could not check Mountain Waves, Supercells; affected Experiments remain unassigned\./,
+      ),
+    ).toBeInTheDocument();
+    fireEvent.change(within(pastExperiments!).getByRole("combobox", { name: "Ownership" }), {
       target: { value: "world" },
     });
     const worldButtons = await screen.findAllByRole("button", { name: "Open Trade Cumulus" });
@@ -4437,6 +4445,59 @@ describe("App", () => {
       await screen.findByRole("navigation", { name: "Trade Cumulus sections" }),
     ).toBeInTheDocument();
     expect(window.location.pathname).toBe("/");
+  });
+
+  it("keeps unmatched World-associated metadata as an unassigned Experiment", async () => {
+    mockWorldScopedApp();
+    const unmatchedAssociatedResult = {
+      ...resultCard,
+      result_id: "result-unmatched-world-associated",
+      run_id: "run-unmatched-world-associated",
+      name: "Unmatched World-associated output",
+      run_configuration: {
+        ...defaultRunConfiguration,
+        cloud_world_id: "trade_cumulus",
+        simulation_id: "trade_cumulus_missing_simulation",
+      },
+    };
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/results") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ results: [unmatchedAssociatedResult] }), { status: 200 }),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Open Fun With Soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "4 Runs" }));
+
+    const pastExperiments = (
+      await screen.findByRole("heading", { name: "Past Experiments" })
+    ).closest("section");
+    expect(pastExperiments).not.toBeNull();
+    fireEvent.change(within(pastExperiments!).getByRole("combobox", { name: "Ownership" }), {
+      target: { value: "legacy" },
+    });
+    expect(await screen.findByText("Legacy / unassigned")).toBeInTheDocument();
+    const unmatchedCard = screen
+      .getByRole("article", { name: "Unmatched World-associated output Experiment" })
+      .closest("article");
+    expect(unmatchedCard).not.toBeNull();
+    fireEvent.click(within(unmatchedCard!).getByRole("button", { name: "Open in Explore" }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe(
+        "/fun-with-soundings/explore/result-unmatched-world-associated",
+      );
+    });
+    expect(
+      await screen.findByRole("heading", { name: "Unmatched World-associated output" }),
+    ).toBeInTheDocument();
   });
 
   it("opens Soundings Explore directly and switches among ingested sounding runs", async () => {
@@ -4473,7 +4534,7 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Open Fun With Soundings" }));
     fireEvent.click(await screen.findByRole("button", { name: "5 Explore" }));
 
-    const runSelector = await screen.findByRole("combobox", { name: "Soundings run" });
+    const runSelector = await screen.findByRole("combobox", { name: "Soundings Experiment" });
     expect(window.location.pathname).toBe(
       `/fun-with-soundings/explore/${observedSoundingResultCard.result_id}`,
     );
@@ -4486,6 +4547,68 @@ describe("App", () => {
       );
     });
     expect(screen.getByRole("heading", { name: secondObservedResult.name })).toBeInTheDocument();
+  });
+
+  it("reports a non-Soundings global runner without claiming it as Soundings work", async () => {
+    mockWorldScopedApp();
+    const worldRun = {
+      ...storageRuns[0],
+      run_id: "mountain-waves-active-run",
+      input_source: "cm1_built_in",
+      has_observed_sounding: false,
+      run_configuration: {
+        ...defaultRunConfiguration,
+        cloud_world_id: "mountain_waves",
+        simulation_id: "mountain_waves_active_variation",
+      },
+      category: "running",
+      lifecycle_state: "running",
+    };
+    const occupiedQueue = {
+      ...emptyRunQueue,
+      active_run_id: worldRun.run_id,
+      entries: [
+        {
+          run_id: worldRun.run_id,
+          manifest_path: worldRun.manifest_path,
+          state: "running",
+          queued_at: "2026-07-24T12:00:00Z",
+          updated_at: "2026-07-24T12:01:00Z",
+        },
+      ],
+    };
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/storage/inventory") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ...storageInventoryResponse,
+              runs: [worldRun],
+              largest_runs: [worldRun],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url === "/api/runs/queue") {
+        return Promise.resolve(new Response(JSON.stringify(occupiedQueue), { status: 200 }));
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Open Fun With Soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "4 Runs" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Other Cloud Chamber work is running" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("World-associated work")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "CM1 is running" })).not.toBeInTheDocument();
   });
 
   it("guides an empty cache through station download and sounding search", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -4,6 +4,11 @@ import type { CSSProperties, FormEvent, ReactNode } from "react";
 import "./App.css";
 import { CloudWorldsHome } from "./CloudWorldsHome";
 import {
+  FunWithSoundings,
+  type FunWithSoundingsSection,
+  type SelectedAtmosphereSummary,
+} from "./FunWithSoundings";
+import {
   ExploreContextContent,
   ExploreInspector,
   ExploreSelectedEvidence,
@@ -1103,6 +1108,8 @@ type PersistedRunConfiguration = {
   configuration_id?: string | null;
   case_id?: string | null;
   mapping_version?: string | null;
+  cloud_world_id?: string | null;
+  simulation_id?: string | null;
   cm1_values?: RunConfigurationCM1Values | null;
   expected_model_output_count?: number | null;
 };
@@ -1179,10 +1186,24 @@ type ResultCard = {
   completed_at: string | null;
   ingested_at: string;
   updated_at: string;
+  workbench_world_id?: "trade_cumulus" | "mountain_waves" | "supercells" | null;
+  workbench_simulation_id?: string | null;
+  workbench_simulation_name?: string | null;
 };
 
 type ResultsResponse = {
   results: ResultCard[];
+};
+
+type WorldResultOwnership = {
+  worldId: "trade_cumulus" | "mountain_waves" | "supercells";
+  simulationId: string;
+  simulationName: string;
+};
+
+type WorldResultOwnershipIndex = {
+  byResultId: Record<string, WorldResultOwnership>;
+  byRunId: Record<string, WorldResultOwnership>;
 };
 
 type ResultsBooleanFilter = "all" | "yes" | "no" | "unknown";
@@ -1202,6 +1223,16 @@ type ResultsFilterState = {
   scenario: string;
   cloud: ResultsBooleanFilter;
   rain: ResultsBooleanFilter;
+  sort: ResultsSortKey;
+};
+
+type SoundingsArchiveFilterState = {
+  search: string;
+  ownership: "sounding" | "legacy" | "world" | "all";
+  tag: string;
+  lifecycle: "all" | "saved" | "completed" | "needs_attention";
+  trust: "all" | "trusted" | "caveated" | "unassessed";
+  date: "all" | "7d" | "30d" | "365d";
   sort: ResultsSortKey;
 };
 
@@ -1289,7 +1320,28 @@ type ProductLocation =
   | "mountain-world"
   | "mountain-explore"
   | "supercells-world"
-  | "supercells-explore";
+  | "supercells-explore"
+  | "soundings"
+  | "soundings-explore";
+
+function productLocationFromPath(pathname: string): ProductLocation {
+  if (pathname.startsWith("/fun-with-soundings/explore/")) return "soundings-explore";
+  if (pathname.startsWith("/fun-with-soundings")) return "soundings";
+  return "worlds";
+}
+
+function soundingsExploreResultIdFromPath(pathname: string): string | null {
+  const prefix = "/fun-with-soundings/explore/";
+  if (!pathname.startsWith(prefix)) return null;
+  const encodedResultId = pathname.slice(prefix.length).split("/")[0];
+  if (!encodedResultId) return null;
+  try {
+    return decodeURIComponent(encodedResultId);
+  } catch {
+    return null;
+  }
+}
+
 type WorldExploreContext =
   | { kind: "simulation"; displayName: string }
   | { kind: "lab_result"; displayName: string };
@@ -2032,6 +2084,102 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+const EMPTY_WORLD_RESULT_OWNERSHIP: WorldResultOwnershipIndex = {
+  byResultId: {},
+  byRunId: {},
+};
+
+async function fetchWorldResultOwnership(): Promise<{
+  index: WorldResultOwnershipIndex;
+  unavailableWorldNames: string[];
+}> {
+  const worlds: Array<{
+    worldId: WorldResultOwnership["worldId"];
+    displayName: string;
+    endpoint: string;
+  }> = [
+    {
+      worldId: "trade_cumulus",
+      displayName: "Trade Cumulus",
+      endpoint: "/api/worlds/trade-cumulus",
+    },
+    {
+      worldId: "mountain_waves",
+      displayName: "Mountain Waves",
+      endpoint: "/api/worlds/mountain-waves",
+    },
+    {
+      worldId: "supercells",
+      displayName: "Supercells",
+      endpoint: "/api/worlds/supercells",
+    },
+  ];
+  const settled = await Promise.allSettled(
+    worlds.map(async (world) => {
+      const response = await fetch(world.endpoint);
+      if (!response.ok) {
+        throw new Error(world.displayName);
+      }
+      const payload = await response.json();
+      if (!isObject(payload) || !Array.isArray(payload.simulations)) {
+        throw new Error(world.displayName);
+      }
+      return {
+        world,
+        simulations: payload.simulations.filter(isObject),
+      };
+    }),
+  );
+  const index: WorldResultOwnershipIndex = {
+    byResultId: {},
+    byRunId: {},
+  };
+  const unavailableWorldNames: string[] = [];
+
+  settled.forEach((result, indexPosition) => {
+    const world = worlds[indexPosition];
+    if (result.status === "rejected") {
+      unavailableWorldNames.push(world.displayName);
+      return;
+    }
+    result.value.simulations.forEach((simulation) => {
+      const simulationId = simulation.simulation_id;
+      const simulationName = simulation.display_name;
+      if (typeof simulationId !== "string" || typeof simulationName !== "string") return;
+      const ownership: WorldResultOwnership = {
+        worldId: world.worldId,
+        simulationId,
+        simulationName,
+      };
+      if (typeof simulation.result_id === "string" && simulation.result_id) {
+        index.byResultId[simulation.result_id] = ownership;
+      }
+      if (typeof simulation.run_id === "string" && simulation.run_id) {
+        index.byRunId[simulation.run_id] = ownership;
+      }
+    });
+  });
+
+  return { index, unavailableWorldNames };
+}
+
+function decorateResultsWithWorldOwnership(
+  results: ResultCard[],
+  index: WorldResultOwnershipIndex,
+): ResultCard[] {
+  return results.map((result) => {
+    if (result.run_configuration?.cloud_world_id) return result;
+    const ownership = index.byResultId[result.result_id] ?? index.byRunId[result.run_id];
+    if (!ownership) return result;
+    return {
+      ...result,
+      workbench_world_id: ownership.worldId,
+      workbench_simulation_id: ownership.simulationId,
+      workbench_simulation_name: ownership.simulationName,
+    };
+  });
+}
+
 async function patchResultCard(
   resultId: string,
   update: Partial<Pick<ResultCard, "name" | "tags" | "notes">>,
@@ -2264,7 +2412,10 @@ async function responseError(response: Response, fallback: string): Promise<stri
 }
 
 export function App() {
-  const [productLocation, setProductLocation] = useState<ProductLocation>("worlds");
+  const [productLocation, setProductLocation] = useState<ProductLocation>(() =>
+    productLocationFromPath(window.location.pathname),
+  );
+  const [soundingsSection, setSoundingsSection] = useState<FunWithSoundingsSection>("find");
   const [supercellSimulation, setSupercellSimulation] = useState<SupercellSimulation | null>(null);
   const [mountainWavesSimulation, setMountainWavesSimulation] =
     useState<MountainWavesSimulation | null>(null);
@@ -2336,10 +2487,26 @@ export function App() {
   const [failedAutoFinalizingWorkerRunIds, setFailedAutoFinalizingWorkerRunIds] = useState<
     string[]
   >([]);
+
+  useEffect(() => {
+    const handleHistoryNavigation = () => {
+      const nextLocation = productLocationFromPath(window.location.pathname);
+      setProductLocation(nextLocation);
+      const routeResultId = soundingsExploreResultIdFromPath(window.location.pathname);
+      if (routeResultId) setSelectedResultId(routeResultId);
+    };
+    window.addEventListener("popstate", handleHistoryNavigation);
+    return () => window.removeEventListener("popstate", handleHistoryNavigation);
+  }, []);
   const [ingestedResultId, setIngestedResultId] = useState<string | null>(null);
   const [results, setResults] = useState<ResultCard[]>([]);
   const [selectedResultId, setSelectedResultId] = useState<string | null>(null);
   const selectedResultIdRef = useRef<string | null>(null);
+  const worldResultOwnershipRef = useRef<WorldResultOwnershipIndex>(EMPTY_WORLD_RESULT_OWNERSHIP);
+  const worldOwnershipLoadStartedRef = useRef(false);
+  const [worldOwnershipStatus, setWorldOwnershipStatus] = useState(
+    "World ownership is checked when Past Experiments opens.",
+  );
   const [comparisonStory, setComparisonStory] =
     useState<TradeCumulusComparisonStoryResponse | null>(null);
   const [comparisonStoryStatus, setComparisonStoryStatus] = useState<string | null>(null);
@@ -2411,9 +2578,17 @@ export function App() {
     fetchResults()
       .then((payload) => {
         if (!active) return;
-        const prioritized = prioritizeResults(payload.results);
+        const prioritized = prioritizeResults(
+          decorateResultsWithWorldOwnership(payload.results, worldResultOwnershipRef.current),
+        );
         setResults(prioritized);
-        setSelectedResultId((current) => current ?? prioritized[0]?.result_id ?? null);
+        setSelectedResultId((current) => {
+          const routeResultId = soundingsExploreResultIdFromPath(window.location.pathname);
+          if (routeResultId && prioritized.some((result) => result.result_id === routeResultId)) {
+            return routeResultId;
+          }
+          return current ?? prioritized[0]?.result_id ?? null;
+        });
         setResultsStatus(payload.results.length > 0 ? "Results loaded" : "No ingested results");
       })
       .catch((caught: unknown) => {
@@ -2445,6 +2620,33 @@ export function App() {
       active = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (
+      (productLocation !== "soundings" && productLocation !== "soundings-explore") ||
+      worldOwnershipLoadStartedRef.current
+    )
+      return;
+    worldOwnershipLoadStartedRef.current = true;
+    setWorldOwnershipStatus("Checking retained Simulation ownership...");
+    void fetchWorldResultOwnership()
+      .then(({ index, unavailableWorldNames }) => {
+        worldResultOwnershipRef.current = index;
+        setResults((current) => decorateResultsWithWorldOwnership(current, index));
+        const linkedCount =
+          Object.keys(index.byResultId).length + Object.keys(index.byRunId).length;
+        setWorldOwnershipStatus(
+          unavailableWorldNames.length > 0
+            ? `${linkedCount} retained Simulation identifiers linked. Could not check ${unavailableWorldNames.join(", ")}.`
+            : `${linkedCount} retained Simulation identifiers linked across all Cloud Worlds.`,
+        );
+      })
+      .catch(() => {
+        setWorldOwnershipStatus(
+          "Cloud World ownership is temporarily unavailable; records remain unassigned rather than being silently reclassified.",
+        );
+      });
+  }, [productLocation]);
 
   useEffect(() => {
     let active = true;
@@ -2509,6 +2711,13 @@ export function App() {
         ? results.find((result) => result.result_id === selectedResultId)
         : results[0],
     [results, selectedResultId],
+  );
+  const soundingsExploreResults = useMemo(
+    () => results.filter((result) => resultArchiveOwnership(result) === "sounding"),
+    [results],
+  );
+  const selectedSoundingsExploreResult = soundingsExploreResults.find(
+    (result) => result.result_id === selectedResultId,
   );
 
   useEffect(() => {
@@ -2719,11 +2928,11 @@ export function App() {
       handleSelectScenario(OBSERVED_SOUNDING_EXPERIMENT_ID);
     }
     if (sourcePath === "cached_recommendations") {
-      setCandidateStatus("Cached recommendations selected");
+      setCandidateStatus("Station catalog selected");
     } else if (sourcePath === "saved_candidates") {
       setCandidateStatus("Saved candidates selected");
     } else {
-      setObservedSoundingStatus((current) => current ?? "Upload an IGRA station text file");
+      setObservedSoundingStatus((current) => current ?? "Upload an IGRA station file");
     }
   }
 
@@ -2764,7 +2973,7 @@ export function App() {
   function handleSelectAllCachedStations() {
     setSelectedStationIds([]);
     setStationSelectionMode("all_cached");
-    markCandidateSearchSettingsChanged("All cached stations selected; search selected soundings");
+    markCandidateSearchSettingsChanged("Default station set restored; search soundings");
   }
 
   function handleClearSelectedStations() {
@@ -2884,12 +3093,12 @@ export function App() {
     }
   }
 
-  async function handlePrepareAndSearchLocalSoundings() {
+  async function handlePrepareAndSearchLocalSoundings(): Promise<boolean> {
     const stationIds = selectedStationIdsForCandidateRequest();
     if (stationSelectionMode === "selected" && stationIds.length === 0) {
       setCandidateError("Select at least one station, or switch to all cached stations.");
       setCandidateStatus("Station selection required");
-      return;
+      return false;
     }
     const resultLimit = boundedInteger(candidateResultLimit, 1, 500, 100);
     setCandidateError(null);
@@ -2927,11 +3136,13 @@ export function App() {
           ? "Recommendation run complete"
           : "Recommendation run found no matching candidates",
       );
+      return true;
     } catch (caught) {
       setCandidateError(
         caught instanceof Error ? caught.message : "Unable to search selected soundings.",
       );
       setCandidateStatus("Selected sounding search failed");
+      return false;
     }
   }
 
@@ -2950,17 +3161,15 @@ export function App() {
     }
   }
 
-  async function handleCacheIGRAStationFiles() {
-    const stationIds = selectedStationIdsForCandidateRequest();
+  async function handleCacheIGRAStationFiles(stationIdsOverride?: string[]) {
+    const stationIds = stationIdsOverride ?? selectedStationIdsForCandidateRequest();
     if (stationIds.length === 0) {
-      setCandidateError("Select one or more catalog stations to cache.");
-      setCandidateStatus("Station selection required");
+      setCandidateError("No station histories are available to download.");
+      setCandidateStatus("No station downloads needed");
       return;
     }
     setCandidateError(null);
-    setCandidateStatus(
-      `Caching ${stationIds.length} selected station${stationIds.length === 1 ? "" : "s"}`,
-    );
+    setCandidateStatus(`Caching ${stationIds.length} station${stationIds.length === 1 ? "" : "s"}`);
     try {
       const result = await cacheIGRARecentBatch({ stationIds });
       await refreshSoundingCandidateState(
@@ -3589,7 +3798,9 @@ export function App() {
   async function refreshResults(selectResultId?: string) {
     const comparisonRequest = fetchTradeCumulusComparisonStory();
     const payload = await fetchResults();
-    const prioritized = prioritizeResults(payload.results);
+    const prioritized = prioritizeResults(
+      decorateResultsWithWorldOwnership(payload.results, worldResultOwnershipRef.current),
+    );
     setResults(prioritized);
     setSelectedResultId((current) => {
       if (selectResultId) return selectResultId;
@@ -3613,9 +3824,81 @@ export function App() {
     return prioritized;
   }
 
+  function navigateProduct(location: ProductLocation, path: string) {
+    setProductLocation(location);
+    if (window.location.pathname !== path) {
+      window.history.pushState({ productLocation: location }, "", path);
+    }
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
+  }
+
+  function returnHome() {
+    navigateProduct("worlds", "/");
+  }
+
+  function enterFunWithSoundings(section: FunWithSoundingsSection = soundingsSection) {
+    if (selectedScenarioId !== OBSERVED_SOUNDING_EXPERIMENT_ID) {
+      handleSelectScenario(OBSERVED_SOUNDING_EXPERIMENT_ID);
+    }
+    setSoundingsSection(section);
+    navigateProduct("soundings", "/fun-with-soundings");
+  }
+
   function selectOrdinaryResult(resultId: string) {
     setComparisonStoryActive(false);
     setSelectedResultId(resultId);
+  }
+
+  function openSoundingsResult(resultId: string, mode: "details" | "explore") {
+    const result = results.find((candidate) => candidate.result_id === resultId);
+    const worldId = resultCloudWorldId(result);
+    selectOrdinaryResult(resultId);
+    if (worldId === "trade_cumulus") {
+      setWorldSection("simulations");
+      navigateProduct("world", "/");
+      return;
+    }
+    if (worldId === "mountain_waves") {
+      setMountainWavesSimulation(null);
+      navigateProduct("mountain-world", "/");
+      return;
+    }
+    if (worldId === "supercells") {
+      setSupercellSimulation(null);
+      navigateProduct("supercells-world", "/");
+      return;
+    }
+    if (mode === "explore") {
+      navigateProduct(
+        "soundings-explore",
+        `/fun-with-soundings/explore/${encodeURIComponent(resultId)}`,
+      );
+      return;
+    }
+    setSoundingsSection("activity");
+    navigateProduct("soundings", "/fun-with-soundings");
+  }
+
+  function openSoundingsExploreSection() {
+    setSoundingsSection("explore");
+    const selectedSoundingsResult = soundingsExploreResults.find(
+      (result) => result.result_id === selectedResultId,
+    );
+    const resultToOpen = selectedSoundingsResult ?? soundingsExploreResults[0];
+    if (resultToOpen) {
+      openSoundingsResult(resultToOpen.result_id, "explore");
+      return;
+    }
+    navigateProduct("soundings", "/fun-with-soundings");
+  }
+
+  function handleSoundingsSectionChange(section: FunWithSoundingsSection) {
+    if (section === "explore") {
+      openSoundingsExploreSection();
+      return;
+    }
+    enterFunWithSoundings(section);
   }
 
   function enterWorldExplore(resultId: string, simulation?: SimulationRecord) {
@@ -3972,6 +4255,7 @@ export function App() {
 
   const buildWorkspace = (
     <BuildWorkspace
+      soundingsSection={productLocation === "soundings" ? soundingsSection : undefined}
       scenarioLoadState={scenarioLoadState}
       scenarioError={scenarioError}
       packageError={error}
@@ -4028,6 +4312,7 @@ export function App() {
       results={results}
       autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIdSet}
       failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIdSet}
+      onNavigateSoundingsSection={setSoundingsSection}
       onSelectScenario={handleSelectScenario}
       onControlChange={(id, value) =>
         setControls((current) => ({
@@ -4061,7 +4346,10 @@ export function App() {
       onScreenSoundingCandidates={handleScreenSoundingCandidates}
       onSaveSoundingCandidate={handleSaveSoundingCandidate}
       onRemoveSavedSoundingCandidate={handleRemoveSavedSoundingCandidate}
-      onSelectCandidateForRunSetup={handleSelectCandidateForRunSetup}
+      onSelectCandidateForRunSetup={(candidate, savedCandidate, activeStory) => {
+        handleSelectCandidateForRunSetup(candidate, savedCandidate, activeStory);
+        if (productLocation === "soundings") setSoundingsSection("build");
+      }}
       onAddSelectedSoundingToRunPlan={handleAddSelectedSoundingToRunPlan}
       onDuplicateRunPlanItem={handleDuplicateRunPlanItem}
       onRemoveRunPlanItem={handleRemoveRunPlanItem}
@@ -4093,10 +4381,18 @@ export function App() {
         else handleWorkspaceNavigation("explore");
       }}
       onOpenStoredResult={(resultId) => {
-        openOrdinaryResult(resultId, "results");
+        if (productLocation === "soundings") {
+          openSoundingsResult(resultId, "details");
+        } else {
+          openOrdinaryResult(resultId, "results");
+        }
       }}
       onExploreStoredResult={(resultId) => {
-        openOrdinaryResult(resultId, "explore");
+        if (productLocation === "soundings") {
+          openSoundingsResult(resultId, "explore");
+        } else {
+          openOrdinaryResult(resultId, "explore");
+        }
       }}
       onRefreshStorage={handleRefreshStorage}
       onPreviewRunDelete={handlePreviewRunDelete}
@@ -4109,10 +4405,12 @@ export function App() {
 
   const resultsWorkspace = (
     <ResultsWorkspace
+      context={productLocation === "soundings" ? "soundings" : "legacy"}
       results={results}
       selectedResult={selectedResult}
       selectedResultId={selectedResultId}
       resultsStatus={resultsStatus}
+      worldOwnershipStatus={productLocation === "soundings" ? worldOwnershipStatus : undefined}
       resultsError={resultsError}
       resultDeletePreview={resultDeletePreview}
       draft={resultDraft}
@@ -4127,6 +4425,10 @@ export function App() {
       onSubmit={handleResultUpdate}
       onRefreshResults={handleRefreshResults}
       onInspect={() => {
+        if (productLocation === "soundings" && selectedResultId) {
+          openSoundingsResult(selectedResultId, "explore");
+          return;
+        }
         setComparisonStoryActive(false);
         if (productLocation === "world" && selectedResultId) {
           enterWorldExplore(selectedResultId);
@@ -4142,6 +4444,11 @@ export function App() {
           setActiveSection("explore");
         }
       }}
+      onOpenResultInExplore={
+        productLocation === "soundings"
+          ? (resultId) => openSoundingsResult(resultId, "explore")
+          : undefined
+      }
       onPreviewResultDelete={handlePreviewResultDelete}
       onConfirmResultDelete={handleConfirmResultDelete}
       onCancelResultDelete={() => {
@@ -4202,13 +4509,24 @@ export function App() {
     activeWorldSimulation?.compare_suggestions.length &&
     worldDetail?.featured_comparison.open_available,
   );
+  const selectedAtmosphere = selectedAtmosphereSummary(
+    observedSoundingParse?.selected_sounding ?? null,
+    selectedCandidateScreening,
+    atmosphereSourcePath,
+  );
+  const soundingsAvailability = soundingWorkbenchAvailability(
+    scenarioLoadState,
+    scenarioError,
+    scenarios,
+  );
 
   return (
     <main
       className={`app-shell${
         productLocation === "explore" ||
         productLocation === "mountain-explore" ||
-        productLocation === "supercells-explore"
+        productLocation === "supercells-explore" ||
+        productLocation === "soundings-explore"
           ? " app-shell-explore"
           : ""
       }`}
@@ -4218,11 +4536,7 @@ export function App() {
           <h1>Cloud Chamber</h1>
         </div>
         {productLocation !== "worlds" && (
-          <button
-            type="button"
-            className="secondary-button"
-            onClick={() => setProductLocation("worlds")}
-          >
+          <button type="button" className="secondary-button" onClick={returnHome}>
             Home
           </button>
         )}
@@ -4242,8 +4556,28 @@ export function App() {
             setSupercellSimulation(null);
             setProductLocation("supercells-world");
           }}
+          onEnterFunWithSoundings={() => enterFunWithSoundings("find")}
+          soundingsAvailability={soundingsAvailability}
           fallback={legacyWorkspace}
         />
+      )}
+
+      {productLocation === "soundings" && (
+        <FunWithSoundings
+          activeSection={soundingsSection}
+          selectedAtmosphere={selectedAtmosphere}
+          onSectionChange={handleSoundingsSectionChange}
+          onBackHome={returnHome}
+        >
+          {soundingsSection === "activity" ? (
+            <div className="soundings-activity-layout">
+              {buildWorkspace}
+              {resultsWorkspace}
+            </div>
+          ) : (
+            buildWorkspace
+          )}
+        </FunWithSoundings>
       )}
 
       {productLocation === "world" && (
@@ -4305,6 +4639,37 @@ export function App() {
         </section>
       )}
 
+      {productLocation === "soundings-explore" && (
+        <section
+          className="world-context-workspace"
+          aria-label={`${
+            selectedSoundingsExploreResult?.name ?? "Soundings Explore"
+          } atmospheric experiment workspace`}
+        >
+          {selectedSoundingsExploreResult ? (
+            <ExploreWorkspace
+              selectedResult={selectedSoundingsExploreResult}
+              comparisonStory={null}
+              onBackToResults={() => enterFunWithSoundings("activity")}
+              onOpenResult={(resultId) => openSoundingsResult(resultId, "explore")}
+              worldName="Fun With Soundings"
+              simulationName={selectedSoundingsExploreResult.name}
+              resultOptions={soundingsExploreResults}
+              onSelectResult={(resultId) => openSoundingsResult(resultId, "explore")}
+              backLabel="Back to Runs"
+              onBack={() => enterFunWithSoundings("activity")}
+            />
+          ) : (
+            <ScenarioStatePanel
+              title="This Soundings run is not available in Explore"
+              body="Choose an ingested Soundings experiment. World-owned Simulations remain available from their Cloud World."
+              actionLabel="Back to Runs"
+              onAction={() => enterFunWithSoundings("activity")}
+            />
+          )}
+        </section>
+      )}
+
       {(productLocation === "explore" || productLocation === "comparison") && (
         <section
           className="world-context-workspace"
@@ -4357,6 +4722,7 @@ export function App() {
 }
 
 function BuildWorkspace({
+  soundingsSection,
   scenarioLoadState,
   scenarioError,
   packageError,
@@ -4413,6 +4779,7 @@ function BuildWorkspace({
   results,
   autoFinalizingWorkerRunIds,
   failedAutoFinalizingWorkerRunIds,
+  onNavigateSoundingsSection,
   onSelectScenario,
   onControlChange,
   onRunConfigurationChange,
@@ -4473,6 +4840,7 @@ function BuildWorkspace({
   onConfirmRunDelete,
   onRetryScenarios,
 }: {
+  soundingsSection?: FunWithSoundingsSection;
   scenarioLoadState: ScenarioLoadState;
   scenarioError: string | null;
   packageError: string | null;
@@ -4527,8 +4895,10 @@ function BuildWorkspace({
   runDeletePreview: DeleteRunResponse | null;
   runDeleteMessage: string | null;
   results: ResultCard[];
+  soundingsLanguage?: boolean;
   autoFinalizingWorkerRunIds: Set<string>;
   failedAutoFinalizingWorkerRunIds: Set<string>;
+  onNavigateSoundingsSection: (section: FunWithSoundingsSection) => void;
   onSelectScenario: (scenarioId: string) => void;
   onControlChange: (controlId: string, value: string) => void;
   onRunConfigurationChange: (configuration: RunConfigurationInput) => void;
@@ -4552,8 +4922,8 @@ function BuildWorkspace({
   onCandidateResultLimitChange: (value: string) => void;
   onCandidateDetailChange: (candidateId: string) => void;
   onRefreshIGRAData: () => void;
-  onCacheIGRAStationFiles: () => void;
-  onPrepareAndSearchLocalSoundings: () => void;
+  onCacheIGRAStationFiles: (stationIds?: string[]) => void;
+  onPrepareAndSearchLocalSoundings: () => Promise<boolean>;
   onScreenSoundingCandidates: () => void;
   onSaveSoundingCandidate: (candidate: SoundingCandidate) => void;
   onRemoveSavedSoundingCandidate: (savedCandidateId: string) => void;
@@ -4613,6 +4983,266 @@ function BuildWorkspace({
       onCreateAndQueue={onCreateAndQueueRunPlan}
     />
   );
+  const atmosphereSourcePicker = (
+    <AtmosphereSourcePicker
+      sourcePath={atmosphereSourcePath}
+      savedCandidateCount={savedCandidates.length}
+      onChange={onAtmosphereSourcePathChange}
+    />
+  );
+  const candidatePanel = (mode: "find" | "candidates") => (
+    <ObservedAtmosphereCandidatesPanel
+      mode={mode}
+      catalog={igraCatalog}
+      cache={igraCache}
+      screeningInputs={screeningInputs}
+      searchIntent={searchIntent}
+      stationSelectionMode={stationSelectionMode}
+      selectedStationIds={selectedStationIds}
+      historyScope={candidateHistoryScope}
+      storyFilter={candidateStoryFilter}
+      storyFamilyFilter={candidateStoryFamilyFilter}
+      supportFilter={candidateSupportFilter}
+      sort={candidateSort}
+      stationSearch={candidateStationSearch}
+      readinessFilter={candidateReadinessFilter}
+      latestPerStation={candidateLatestPerStation}
+      resultLimit={candidateResultLimit}
+      status={candidateStatus}
+      error={candidateError}
+      screening={candidateScreening}
+      savedCandidates={savedCandidates}
+      selectedCandidateId={candidateDetailId}
+      onSearchIntentChange={onSearchIntentChange}
+      onStationSelectionModeChange={onStationSelectionModeChange}
+      onSelectedStationToggle={onSelectedStationToggle}
+      onSelectAllCachedStations={onSelectAllCachedStations}
+      onClearSelectedStations={onClearSelectedStations}
+      onHistoryScopeChange={onCandidateHistoryScopeChange}
+      onStoryFilterChange={onCandidateStoryFilterChange}
+      onStoryFamilyFilterChange={onCandidateStoryFamilyFilterChange}
+      onSupportFilterChange={onCandidateSupportFilterChange}
+      onSortChange={onCandidateSortChange}
+      onStationSearchChange={onCandidateStationSearchChange}
+      onReadinessFilterChange={onCandidateReadinessFilterChange}
+      onClearFilters={onClearCandidateAnalysisFilters}
+      onLatestPerStationChange={onCandidateLatestPerStationChange}
+      onResultLimitChange={onCandidateResultLimitChange}
+      onCandidateDetailChange={onCandidateDetailChange}
+      onRefreshIGRAData={onRefreshIGRAData}
+      onCacheStationFiles={onCacheIGRAStationFiles}
+      onPrepareAndSearch={async () => {
+        const searchCompleted = await onPrepareAndSearchLocalSoundings();
+        if (mode === "find" && searchCompleted) {
+          onNavigateSoundingsSection("candidates");
+        }
+        return searchCompleted;
+      }}
+      onScreen={onScreenSoundingCandidates}
+      onSave={onSaveSoundingCandidate}
+      onSelectForRunSetup={onSelectCandidateForRunSetup}
+    />
+  );
+  const savedCandidatesPanel = (
+    <SavedCandidatesSourcePanel
+      savedCandidates={savedCandidates}
+      status={candidateStatus}
+      error={candidateError}
+      onSave={onSaveSoundingCandidate}
+      onRemoveSaved={onRemoveSavedSoundingCandidate}
+      onSelectForRunSetup={onSelectCandidateForRunSetup}
+    />
+  );
+  const runWorkflowProps: LocalRunWorkflowPanelProps = {
+    dryRun,
+    runStatus,
+    runQueue,
+    runQueueStatus,
+    error: runWorkflowError,
+    lanWorkerConfig,
+    lanWorkerStatus,
+    lanWorkerError,
+    lanWorkerActionStatus,
+    ingestedResultId,
+    onRefreshRunStatus,
+    onLaunchLanWorkerRun,
+    onRefreshLanWorkerStatus,
+    onCollectLanWorkerRun,
+    onCleanupLanWorkerRun,
+    onIngestRun,
+    storageInventory,
+    storageStatus,
+    storageError,
+    runDeletePreview,
+    runDeleteMessage,
+    results,
+    soundingsLanguage: Boolean(soundingsSection),
+    autoFinalizingWorkerRunIds,
+    failedAutoFinalizingWorkerRunIds,
+    onLaunchStoredRun,
+    onLaunchStoredLanWorkerRun,
+    onRefreshStoredLanWorkerStatus,
+    onFinalizeStoredLanWorkerRun,
+    onIngestStoredRun,
+    onOpenInResults,
+    onInspectIngested,
+    onOpenStoredResult,
+    onExploreStoredResult,
+    onRefreshStorage,
+    onPreviewRunDelete,
+    onConfirmRunDelete,
+  };
+  const soundingsRunsPanel = <SoundingsRunsPanel {...runWorkflowProps} />;
+
+  if (soundingsSection) {
+    if (scenarioLoadState !== "loaded" || !selectedScenario) {
+      return (
+        <section className="soundings-job-panel">
+          <ScenarioStatePanel
+            title={
+              scenarioLoadState === "loading"
+                ? "Loading sounding infrastructure"
+                : scenarioLoadState === "empty"
+                  ? "No experiment templates available"
+                  : "Sounding infrastructure unavailable"
+            }
+            body={
+              scenarioLoadState === "loading"
+                ? "Cloud Chamber is checking the local scenario, package, and execution services."
+                : (scenarioError ??
+                  "The local backend did not provide the experiment template required by this workbench.")
+            }
+            actionLabel={scenarioLoadState === "loading" ? undefined : "Retry"}
+            onAction={scenarioLoadState === "loading" ? undefined : onRetryScenarios}
+          />
+        </section>
+      );
+    }
+
+    if (soundingsSection === "find") {
+      return (
+        <section className="soundings-job-panel" aria-label="Find Soundings">
+          {atmosphereSourcePicker}
+          {atmosphereSourcePath === "cached_recommendations" && candidatePanel("find")}
+          {atmosphereSourcePath === "saved_candidates" && savedCandidatesPanel}
+          {atmosphereSourcePath === "upload_igra_text" && (
+            <UploadSoundingSourcePanel
+              observedSoundingParse={observedSoundingParse}
+              observedSoundingStatus={observedSoundingStatus}
+              observedSoundingError={observedSoundingError}
+              selectedCandidateScreening={selectedCandidateScreening}
+              onObservedSoundingFile={onObservedSoundingFile}
+              onObservedSoundingTimeChange={onObservedSoundingTimeChange}
+            />
+          )}
+          {observedSoundingParse?.selected_sounding && (
+            <div className="soundings-next-action">
+              <div>
+                <strong>Atmosphere ready</strong>
+                <span>Continue to experiment setup or review candidate context first.</span>
+              </div>
+              <div className="button-row">
+                <button type="button" onClick={() => onNavigateSoundingsSection("build")}>
+                  Build an experiment
+                </button>
+                <button
+                  type="button"
+                  className="secondary-button"
+                  onClick={() => onNavigateSoundingsSection("candidates")}
+                >
+                  Review candidates
+                </button>
+              </div>
+            </div>
+          )}
+        </section>
+      );
+    }
+
+    if (soundingsSection === "candidates") {
+      return (
+        <section className="soundings-job-panel" aria-label="Sounding candidates">
+          {atmosphereSourcePicker}
+          {atmosphereSourcePath === "cached_recommendations" && candidatePanel("candidates")}
+          {atmosphereSourcePath === "saved_candidates" && savedCandidatesPanel}
+          {atmosphereSourcePath === "upload_igra_text" && (
+            <ScenarioStatePanel
+              title="Candidate screening uses cached profiles"
+              body="The uploaded atmosphere remains selected. Return to Find Soundings to choose another source, or continue directly to Build & Run."
+              actionLabel="Continue to Build & Run"
+              onAction={() => onNavigateSoundingsSection("build")}
+            />
+          )}
+        </section>
+      );
+    }
+
+    if (soundingsSection === "build") {
+      return (
+        <section className="soundings-job-panel" aria-label="Build and run sounding experiment">
+          {observedSoundingParse?.selected_sounding ? (
+            <SelectedSoundingRunSetupPanel
+              observedSounding={observedSoundingParse.selected_sounding}
+              selectedCandidateScreening={selectedCandidateScreening}
+              runConfiguration={runConfiguration}
+              runConfigurationPreview={runConfigurationPreview}
+              soundingsLanguage
+              onRunConfigurationChange={onRunConfigurationChange}
+              onAddSelectedSoundingToRunPlan={onAddSelectedSoundingToRunPlan}
+            />
+          ) : (
+            <ScenarioStatePanel
+              title="Select an atmosphere before configuring an experiment"
+              body="Choose a cached candidate or load an IGRA station file. Its source, time, and validation state will remain visible here."
+              actionLabel="Find an atmosphere"
+              onAction={() => onNavigateSoundingsSection("find")}
+            />
+          )}
+          {runPlanPanel}
+          {validationMessages.length > 0 && (
+            <div className="validation" role="alert">
+              {validationMessages.map((message) => (
+                <p key={message}>{message}</p>
+              ))}
+            </div>
+          )}
+          {packageError && (
+            <div className="validation" role="alert">
+              <p>{packageError}</p>
+            </div>
+          )}
+          {blockedPreRunValidationReport && (
+            <PreRunValidationReportPanel report={blockedPreRunValidationReport} />
+          )}
+          {(runPlanItems.length > 0 || dryRun || runStatus) && (
+            <div className="soundings-next-action">
+              <div>
+                <strong>Execution activity is preserved</strong>
+                <span>
+                  Leave this setup and return to queue, worker, ingest, and storage status.
+                </span>
+              </div>
+              <button type="button" onClick={() => onNavigateSoundingsSection("activity")}>
+                Open Runs
+              </button>
+            </div>
+          )}
+        </section>
+      );
+    }
+
+    if (soundingsSection === "explore") {
+      return (
+        <SoundingsExploreLanding
+          results={results.filter((result) => resultArchiveOwnership(result) === "sounding")}
+          onOpen={onExploreStoredResult}
+          onViewRuns={() => onNavigateSoundingsSection("activity")}
+        />
+      );
+    }
+
+    return soundingsRunsPanel;
+  }
 
   return (
     <section className="workspace-section" aria-labelledby="build-title">
@@ -4892,6 +5522,7 @@ function BuildWorkspace({
             runDeletePreview={runDeletePreview}
             runDeleteMessage={runDeleteMessage}
             results={results}
+            soundingsLanguage={false}
             autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIds}
             failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIds}
             onLaunchStoredRun={onLaunchStoredRun}
@@ -5135,6 +5766,7 @@ function RunConfigurationPanel({
   onAddToRunPlan,
   onChange,
   embedded = false,
+  soundingsLanguage = false,
 }: {
   configuration: RunConfigurationInput;
   preview: RunConfiguration;
@@ -5142,6 +5774,7 @@ function RunConfigurationPanel({
   onAddToRunPlan?: () => void;
   onChange: (configuration: RunConfigurationInput) => void;
   embedded?: boolean;
+  soundingsLanguage?: boolean;
 }) {
   const recipeMismatchWarning = selectedCandidateScreening
     ? candidateRecipeMismatchWarning(selectedCandidateScreening)
@@ -5278,7 +5911,7 @@ function RunConfigurationPanel({
         <RunConfigurationSelect
           id="run-cadence"
           label="Output cadence"
-          description="Saved-output interval for Results and Explore."
+          description={`Saved-output interval for ${soundingsLanguage ? "Runs" : "Results"} and Explore.`}
           value={configuration.output_cadence}
           options={OUTPUT_CADENCE_OPTIONS}
           onChange={(value) => update("output_cadence", value)}
@@ -5485,35 +6118,24 @@ function AtmosphereSourcePicker({
   savedCandidateCount: number;
   onChange: (sourcePath: AtmosphereSourcePath) => void;
 }) {
-  const options: Array<{ value: AtmosphereSourcePath; label: string; description: string }> = [
+  const options: Array<{ value: AtmosphereSourcePath; label: string }> = [
     {
       value: "cached_recommendations",
-      label: "Cached recommendations",
-      description: "Search local cached soundings and review recommendation evidence.",
+      label: "Station catalog",
     },
     {
       value: "saved_candidates",
       label: `Saved candidates${savedCandidateCount > 0 ? ` (${savedCandidateCount})` : ""}`,
-      description: "Use your saved shortlist as the atmosphere source.",
     },
     {
       value: "upload_igra_text",
-      label: "Upload IGRA station text",
-      description: "Manually upload and validate a station text file.",
+      label: "Upload IGRA file",
     },
   ];
-  const selected = options.find((option) => option.value === sourcePath) ?? options[0];
   return (
-    <section className="experiment-summary atmosphere-source-panel" aria-label="Atmosphere source">
-      <div className="panel-heading-row">
-        <div>
-          <p className="eyebrow">Atmosphere source</p>
-          <h3>Choose one source path</h3>
-          <p className="field-help">{selected.description}</p>
-        </div>
-        <StatusBadge label={selected.label} tone="neutral" />
-      </div>
-      <div className="button-row source-path-tabs" role="tablist" aria-label="Atmosphere sources">
+    <section className="atmosphere-source-switcher" aria-label="Atmosphere source">
+      <strong>Source</strong>
+      <div className="source-path-tabs" role="tablist" aria-label="Atmosphere sources">
         {options.map((option) => (
           <button
             key={option.value}
@@ -5532,6 +6154,7 @@ function AtmosphereSourcePicker({
 }
 
 function ObservedAtmosphereCandidatesPanel({
+  mode = "combined",
   catalog,
   cache,
   screeningInputs,
@@ -5575,6 +6198,7 @@ function ObservedAtmosphereCandidatesPanel({
   onSave,
   onSelectForRunSetup,
 }: {
+  mode?: "combined" | "find" | "candidates";
   catalog: IGRACatalogResponse["catalog"] | null;
   cache: IGRACacheResponse | null;
   screeningInputs: ScreeningInput[];
@@ -5612,8 +6236,8 @@ function ObservedAtmosphereCandidatesPanel({
   onResultLimitChange: (value: string) => void;
   onCandidateDetailChange: (candidateId: string) => void;
   onRefreshIGRAData: () => void;
-  onCacheStationFiles: () => void;
-  onPrepareAndSearch: () => void;
+  onCacheStationFiles: (stationIds?: string[]) => void;
+  onPrepareAndSearch: () => void | Promise<boolean>;
   onScreen: () => void;
   onSave: (candidate: SoundingCandidate, tags?: string[], notes?: string | null) => void;
   onSelectForRunSetup: (
@@ -5622,6 +6246,10 @@ function ObservedAtmosphereCandidatesPanel({
     activeStory?: CandidateStoryId,
   ) => void;
 }) {
+  const [stationCatalogSearch, setStationCatalogSearch] = useState("");
+  const [showSpecificStations, setShowSpecificStations] = useState(
+    stationSelectionMode === "selected",
+  );
   const visibleCandidates = screening?.candidates ?? [];
   const selectedCandidate =
     visibleCandidates.find((candidate) => candidate.candidate_id === selectedCandidateId) ??
@@ -5683,13 +6311,31 @@ function ObservedAtmosphereCandidatesPanel({
     );
   }, [catalog?.zip_references, screeningInputs]);
   const selectedStationIdSet = useMemo(() => new Set(selectedStationIds), [selectedStationIds]);
+  const normalizedStationCatalogSearch = stationCatalogSearch.trim().toLowerCase();
+  const visibleStationOptions = stationOptions.filter((station) => {
+    if (!normalizedStationCatalogSearch) return true;
+    return [station.station_name, station.station_id]
+      .filter((value): value is string => Boolean(value))
+      .some((value) => value.toLowerCase().includes(normalizedStationCatalogSearch));
+  });
   const cachedStationOptions = stationOptions.filter((option) => option.cached);
+  const explicitlySelectedStationOptions = stationOptions.filter((option) =>
+    selectedStationIdSet.has(option.station_id),
+  );
   const activeStationOptions =
-    stationSelectionMode === "selected"
-      ? stationOptions.filter((option) => selectedStationIdSet.has(option.station_id))
-      : cachedStationOptions;
+    mode === "find" && stationSelectionMode === "all_cached"
+      ? stationOptions
+      : stationSelectionMode === "selected"
+        ? explicitlySelectedStationOptions
+        : cachedStationOptions;
   const selectedCachedStationOptions = activeStationOptions.filter((option) => option.cached);
   const selectedUncachedStationOptions = activeStationOptions.filter((option) => !option.cached);
+  const selectedStationsReadyToSearch =
+    selectedCachedStationOptions.length > 0 && selectedUncachedStationOptions.length === 0;
+  const catalogIsLoading = status.startsWith("Refreshing IGRA station catalog");
+  const stationFilesAreDownloading = status.startsWith("Caching ");
+  const candidateSearchIsRunning =
+    status.startsWith("Preparing selected soundings") || status.startsWith("Searching ");
   const selectedCachedSoundingCount = selectedCachedStationOptions.reduce(
     (total, option) => total + option.sounding_count,
     0,
@@ -5716,7 +6362,9 @@ function ObservedAtmosphereCandidatesPanel({
       : "No cached stations selected";
   const stationSelectionSummary =
     stationSelectionMode === "all_cached"
-      ? `All ${cachedStationOptions.length.toLocaleString()} cached station${cachedStationOptions.length === 1 ? "" : "s"}`
+      ? mode === "find"
+        ? `Entire ${stationOptions.length.toLocaleString()}-station catalog`
+        : `All ${cachedStationOptions.length.toLocaleString()} cached station${cachedStationOptions.length === 1 ? "" : "s"}`
       : `${selectedStationIds.length.toLocaleString()} selected station${selectedStationIds.length === 1 ? "" : "s"}`;
   const lastAnalysisSummary = screening
     ? `${visibleCandidates.length.toLocaleString()} shown from ${(
@@ -5746,198 +6394,510 @@ function ObservedAtmosphereCandidatesPanel({
       <div className="panel-heading-row">
         <div>
           <p className="eyebrow">Observed atmosphere</p>
-          <h3 id="sounding-candidates-title">Find interesting soundings</h3>
+          <h3 id="sounding-candidates-title">
+            {mode === "find"
+              ? "Find and download soundings"
+              : mode === "candidates"
+                ? "Screen interesting soundings"
+                : "Find interesting soundings"}
+          </h3>
           <p className="field-help">
-            Choose the stations and history to search, then review the matching candidate evidence.
+            {mode === "find"
+              ? "Download the regional station catalog, set the first-search criteria, and find an atmosphere to use."
+              : mode === "candidates"
+                ? "Choose the history to analyze, then review the matching candidate evidence."
+                : "Choose the stations and history to analyze, then review the matching candidate evidence."}
           </p>
         </div>
-        <p className="state-chip" role="status">
-          {status}
-        </p>
-      </div>
-
-      <section
-        className="candidate-search-controls"
-        aria-label="Prepare and search local soundings"
-      >
-        <div className="run-configuration-grid">
-          <label>
-            <span>Source region</span>
-            <select aria-label="Source region" value="great_plains_midwest" disabled>
-              <option value="great_plains_midwest">Great Plains / Midwest</option>
-            </select>
-            <small>Current local station catalog scope.</small>
-          </label>
-          <label>
-            <span>Search intent</span>
-            <select
-              aria-label="Search intent"
-              value={searchIntent}
-              onChange={(event) => onSearchIntentChange(event.target.value as SearchIntent)}
-            >
-              {SEARCH_INTENT_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-              <option value="winter_disabled" disabled>
-                Cold season / winter (not supported yet)
-              </option>
-            </select>
-            <small>Sets the recommendation category and explanation focus.</small>
-          </label>
-          <label>
-            <span>History scope</span>
-            <select
-              aria-label="History scope"
-              value={historyScope}
-              onChange={(event) =>
-                onHistoryScopeChange(event.target.value as CandidateHistoryScope)
-              }
-            >
-              {HISTORY_SCOPE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-            <small>
-              {HISTORY_SCOPE_OPTIONS.find((option) => option.value === historyScope)?.description}
-            </small>
-          </label>
-          {historyScope === "latest_per_station" && (
-            <label>
-              <span>Latest soundings per station</span>
-              <input
-                aria-label="Latest soundings per station"
-                type="number"
-                min="1"
-                max="2000"
-                value={latestPerStation}
-                onChange={(event) => onLatestPerStationChange(event.target.value)}
-              />
-              <small>Applied to each selected cached station.</small>
-            </label>
-          )}
-          <label>
-            <span>Returned candidate limit</span>
-            <input
-              aria-label="Returned candidate limit"
-              type="number"
-              min="1"
-              max="500"
-              value={resultLimit}
-              onChange={(event) => onResultLimitChange(event.target.value)}
-            />
-            <small>Limit is applied after the selected soundings are analyzed.</small>
-          </label>
-        </div>
-        <div className="candidate-search-set-summary" aria-label="Selected soundings">
-          <Metric label="Selected soundings" value={plannedAnalysisSummary} />
-          <Metric label="Station set" value={stationSelectionSummary} />
-          <Metric label="Cached inventory" value={cachedInventorySummary} />
-          <Metric
-            label="Uncached selected"
-            value={`${selectedUncachedStationOptions.length.toLocaleString()} station${selectedUncachedStationOptions.length === 1 ? "" : "s"}`}
-          />
-        </div>
-        <div className="candidate-discovery-actions" aria-label="Sounding search action">
-          <button type="button" onClick={onPrepareAndSearch}>
-            Search selected soundings
-          </button>
-        </div>
-      </section>
-
-      <section className="candidate-station-picker" aria-label="Station picker">
-        <div className="panel-heading-row">
-          <div>
-            <h4>Station set</h4>
-            <p className="field-help">
-              Search all cached stations, or choose specific stations to cache or analyze.
-            </p>
-          </div>
-          <div className="button-row">
-            <button
-              type="button"
-              className={
-                stationSelectionMode === "all_cached"
-                  ? "active-secondary-button"
-                  : "secondary-button"
-              }
-              onClick={onSelectAllCachedStations}
-            >
-              All cached stations
-            </button>
-            <button
-              type="button"
-              className={
-                stationSelectionMode === "selected" ? "active-secondary-button" : "secondary-button"
-              }
-              onClick={() => onStationSelectionModeChange("selected")}
-            >
-              Choose stations
-            </button>
-            <button type="button" className="secondary-button" onClick={onClearSelectedStations}>
-              Clear selected
-            </button>
-          </div>
-        </div>
-        {stationSelectionMode === "selected" ? (
-          <div className="station-picklist">
-            {stationOptions.length === 0 ? (
-              <p className="field-help">Refresh the IGRA catalog to load station choices.</p>
-            ) : (
-              stationOptions.map((station) => (
-                <label key={station.station_id} className="station-picklist-row">
-                  <input
-                    type="checkbox"
-                    checked={selectedStationIdSet.has(station.station_id)}
-                    onChange={() => onSelectedStationToggle(station.station_id)}
-                  />
-                  <span>
-                    <strong>{station.station_name ?? station.station_id}</strong>
-                    <small>
-                      {station.station_id} ·{" "}
-                      {station.cached
-                        ? `${station.sounding_count.toLocaleString()} cached sounding${station.sounding_count === 1 ? "" : "s"}`
-                        : "not cached"}
-                    </small>
-                  </span>
-                  <StatusBadge
-                    label={station.cached ? "Cached" : "Available to cache"}
-                    tone={station.cached ? "good" : "neutral"}
-                  />
-                </label>
-              ))
-            )}
-          </div>
-        ) : (
-          <p className="field-help">
-            Using all cached stations. Click Choose stations to pick specific stations or cache
-            uncached catalog stations.
+        {mode !== "find" && (
+          <p className="state-chip" role="status">
+            {status}
           </p>
         )}
-      </section>
+      </div>
 
-      <details className="candidate-cache-summary" aria-label="Local sounding data">
-        <summary>
-          {screeningInputs.length > 0
-            ? `Local data ready · ${cachedStationFiles.toLocaleString()} station file${cachedStationFiles === 1 ? "" : "s"} · ${cachedInventorySummary} · refreshed ${
-                catalog?.refreshed_at ? formatDate(catalog.refreshed_at) : "not refreshed here"
-              }`
-            : "No cached soundings ready"}
-        </summary>
-        <dl className="compact-metrics candidate-cache-metrics">
-          <Metric label="Region" value={catalog?.region.label ?? "Great Plains / Midwest"} />
-          <Metric
-            label="Catalog"
-            value={catalog?.refreshed_at ? formatDate(catalog.refreshed_at) : "Not refreshed here"}
-          />
-          <Metric label="Station files" value={cachedStationFiles.toLocaleString()} />
-          <Metric label="Parsed soundings" value={cachedInventorySummary} />
-          <Metric label="Last search" value={lastAnalysisSummary} />
-        </dl>
-      </details>
+      {mode !== "find" && (
+        <section
+          className="candidate-search-controls"
+          aria-label="Prepare and search local soundings"
+        >
+          <div className="run-configuration-grid">
+            <label>
+              <span>Source region</span>
+              <select aria-label="Source region" value="great_plains_midwest" disabled>
+                <option value="great_plains_midwest">Great Plains / Midwest</option>
+              </select>
+              <small>Current local station catalog scope.</small>
+            </label>
+            <label>
+              <span>Search intent</span>
+              <select
+                aria-label="Search intent"
+                value={searchIntent}
+                onChange={(event) => onSearchIntentChange(event.target.value as SearchIntent)}
+              >
+                {SEARCH_INTENT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+                <option value="winter_disabled" disabled>
+                  Cold season / winter (not supported yet)
+                </option>
+              </select>
+              <small>Sets the recommendation category and explanation focus.</small>
+            </label>
+            <label>
+              <span>History scope</span>
+              <select
+                aria-label="History scope"
+                value={historyScope}
+                onChange={(event) =>
+                  onHistoryScopeChange(event.target.value as CandidateHistoryScope)
+                }
+              >
+                {HISTORY_SCOPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <small>
+                {HISTORY_SCOPE_OPTIONS.find((option) => option.value === historyScope)?.description}
+              </small>
+            </label>
+            {historyScope === "latest_per_station" && (
+              <label>
+                <span>Latest soundings per station</span>
+                <input
+                  aria-label="Latest soundings per station"
+                  type="number"
+                  min="1"
+                  max="2000"
+                  value={latestPerStation}
+                  onChange={(event) => onLatestPerStationChange(event.target.value)}
+                />
+                <small>Applied to each selected cached station.</small>
+              </label>
+            )}
+            <label>
+              <span>Returned candidate limit</span>
+              <input
+                aria-label="Returned candidate limit"
+                type="number"
+                min="1"
+                max="500"
+                value={resultLimit}
+                onChange={(event) => onResultLimitChange(event.target.value)}
+              />
+              <small>Limit is applied after the selected soundings are analyzed.</small>
+            </label>
+          </div>
+          <div className="candidate-search-set-summary" aria-label="Selected soundings">
+            <Metric label="Selected soundings" value={plannedAnalysisSummary} />
+            <Metric label="Station set" value={stationSelectionSummary} />
+            <Metric label="Cached inventory" value={cachedInventorySummary} />
+            <Metric
+              label="Uncached selected"
+              value={`${selectedUncachedStationOptions.length.toLocaleString()} station${selectedUncachedStationOptions.length === 1 ? "" : "s"}`}
+            />
+          </div>
+          <div className="candidate-discovery-actions" aria-label="Sounding search action">
+            <button type="button" onClick={onPrepareAndSearch}>
+              Search selected soundings
+            </button>
+          </div>
+        </section>
+      )}
+
+      {mode === "find" && (
+        <section className="sounding-discovery-flow" aria-label="Find downloadable soundings">
+          <section className="sounding-discovery-step">
+            <div className="sounding-discovery-step-number" aria-hidden="true">
+              1
+            </div>
+            <div className="sounding-discovery-step-content">
+              <div className="panel-heading-row">
+                <div>
+                  <h4>Weather station coverage</h4>
+                  <p className="field-help">
+                    {stationOptions.length > 0
+                      ? `The normal search uses all ${stationOptions.length.toLocaleString()} stations in ${catalog?.region.label ?? "the current region"}.`
+                      : "Load the regional station catalog to see profiles available for download."}
+                  </p>
+                </div>
+                <div className="button-row">
+                  <button
+                    type="button"
+                    className="secondary-button"
+                    disabled={catalogIsLoading}
+                    onClick={onRefreshIGRAData}
+                  >
+                    {catalogIsLoading
+                      ? "Loading station catalog..."
+                      : stationOptions.length > 0
+                        ? "Update catalog"
+                        : "Load catalog"}
+                  </button>
+                  {stationOptions.length > 0 && (
+                    <button
+                      type="button"
+                      className="secondary-button"
+                      onClick={() => {
+                        if (showSpecificStations) {
+                          onSelectAllCachedStations();
+                          setShowSpecificStations(false);
+                        } else {
+                          onStationSelectionModeChange("selected");
+                          setShowSpecificStations(true);
+                        }
+                      }}
+                    >
+                      {showSpecificStations ? "Use entire catalog" : "Choose specific stations"}
+                    </button>
+                  )}
+                </div>
+              </div>
+              {stationOptions.length > 0 && (
+                <>
+                  <dl className="station-coverage-summary" aria-label="Station coverage">
+                    <Metric label="Catalog" value={`${stationOptions.length} stations`} />
+                    <Metric label="Downloaded" value={`${cachedStationOptions.length} stations`} />
+                    <Metric
+                      label="Remaining"
+                      value={`${(stationOptions.length - cachedStationOptions.length).toLocaleString()} stations`}
+                    />
+                  </dl>
+                  {showSpecificStations && (
+                    <section
+                      className="specific-station-picker"
+                      aria-label="Choose specific stations"
+                    >
+                      <div className="station-catalog-toolbar">
+                        <label>
+                          <span>Find a station</span>
+                          <input
+                            type="search"
+                            value={stationCatalogSearch}
+                            placeholder="City or station ID"
+                            onChange={(event) => setStationCatalogSearch(event.target.value)}
+                          />
+                        </label>
+                        <p>
+                          {selectedStationIds.length > 0
+                            ? `${selectedStationIds.length.toLocaleString()} station${selectedStationIds.length === 1 ? "" : "s"} selected`
+                            : "Select the exceptions you want to search"}
+                        </p>
+                        {selectedStationIds.length > 0 && (
+                          <button
+                            type="button"
+                            className="secondary-button"
+                            onClick={onClearSelectedStations}
+                          >
+                            Clear
+                          </button>
+                        )}
+                      </div>
+                      <div className="station-picklist">
+                        {visibleStationOptions.length > 0 ? (
+                          visibleStationOptions.map((station) => (
+                            <label key={station.station_id} className="station-picklist-row">
+                              <input
+                                type="checkbox"
+                                checked={selectedStationIdSet.has(station.station_id)}
+                                onChange={() => onSelectedStationToggle(station.station_id)}
+                              />
+                              <span>
+                                <strong>{station.station_name ?? station.station_id}</strong>
+                                <small>
+                                  {station.station_id}
+                                  {station.latest_valid_time_utc
+                                    ? ` · latest ${formatDate(station.latest_valid_time_utc)}`
+                                    : ""}
+                                </small>
+                              </span>
+                              <StatusBadge
+                                label={station.cached ? "Downloaded" : "Available"}
+                                tone={station.cached ? "good" : "neutral"}
+                              />
+                            </label>
+                          ))
+                        ) : (
+                          <p className="field-help">
+                            No stations match “{stationCatalogSearch.trim()}”.
+                          </p>
+                        )}
+                      </div>
+                    </section>
+                  )}
+                </>
+              )}
+            </div>
+          </section>
+
+          <section className="sounding-discovery-step">
+            <div className="sounding-discovery-step-number" aria-hidden="true">
+              2
+            </div>
+            <div className="sounding-discovery-step-content">
+              <h4>Download station histories</h4>
+              <p className="field-help">
+                Histories stay on this computer. The normal path downloads every station in the
+                regional catalog before searching.
+              </p>
+              <div className="candidate-discovery-actions">
+                {selectedCachedStationOptions.length > 0 &&
+                selectedUncachedStationOptions.length === 0 ? (
+                  <StatusBadge
+                    label={`Ready · ${selectedCachedStationOptions.length.toLocaleString()} station${selectedCachedStationOptions.length === 1 ? "" : "s"} downloaded`}
+                    tone="good"
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    disabled={
+                      selectedUncachedStationOptions.length === 0 || stationFilesAreDownloading
+                    }
+                    onClick={() =>
+                      onCacheStationFiles(
+                        selectedUncachedStationOptions.map((option) => option.station_id),
+                      )
+                    }
+                  >
+                    {stationFilesAreDownloading
+                      ? "Downloading sounding histories..."
+                      : selectedUncachedStationOptions.length > 0
+                        ? stationSelectionMode === "all_cached"
+                          ? `Download ${selectedUncachedStationOptions.length.toLocaleString()} remaining station histor${selectedUncachedStationOptions.length === 1 ? "y" : "ies"}`
+                          : `Download ${selectedUncachedStationOptions.length.toLocaleString()} selected station histor${selectedUncachedStationOptions.length === 1 ? "y" : "ies"}`
+                        : "Choose stations to download"}
+                  </button>
+                )}
+                {activeStationOptions.length > 0 && (
+                  <span className="field-help">
+                    {selectedCachedStationOptions.length.toLocaleString()} downloaded ·{" "}
+                    {selectedUncachedStationOptions.length.toLocaleString()} remaining
+                  </span>
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section className="sounding-discovery-step">
+            <div className="sounding-discovery-step-number" aria-hidden="true">
+              3
+            </div>
+            <div className="sounding-discovery-step-content">
+              <div>
+                <h4>Search downloaded soundings</h4>
+                <p className="field-help">
+                  Choose what you want to find and how much station history to analyze. You can
+                  refine the same search later in Candidates.
+                </p>
+              </div>
+              <div
+                className="sounding-initial-search-controls"
+                aria-label="Initial sounding search options"
+              >
+                <label>
+                  <span>Search focus</span>
+                  <select
+                    aria-label="Search focus"
+                    value={searchIntent}
+                    onChange={(event) => onSearchIntentChange(event.target.value as SearchIntent)}
+                  >
+                    {SEARCH_INTENT_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <small>Sets the candidate question and initial evidence filters.</small>
+                </label>
+                <label>
+                  <span>Station history</span>
+                  <select
+                    aria-label="Station history"
+                    value={historyScope}
+                    onChange={(event) =>
+                      onHistoryScopeChange(event.target.value as CandidateHistoryScope)
+                    }
+                  >
+                    {HISTORY_SCOPE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <small>
+                    {
+                      HISTORY_SCOPE_OPTIONS.find((option) => option.value === historyScope)
+                        ?.description
+                    }
+                  </small>
+                </label>
+                {historyScope === "latest_per_station" && (
+                  <label>
+                    <span>Latest per station</span>
+                    <input
+                      aria-label="Latest soundings per station"
+                      type="number"
+                      min="1"
+                      max="2000"
+                      value={latestPerStation}
+                      onChange={(event) => onLatestPerStationChange(event.target.value)}
+                    />
+                    <small>Most recent profiles to analyze from each selected station.</small>
+                  </label>
+                )}
+                <label>
+                  <span>Candidates to show</span>
+                  <input
+                    aria-label="Candidates to show"
+                    type="number"
+                    min="1"
+                    max="500"
+                    value={resultLimit}
+                    onChange={(event) => onResultLimitChange(event.target.value)}
+                  />
+                  <small>Applied after the selected profiles are analyzed.</small>
+                </label>
+              </div>
+              <div className="candidate-discovery-actions">
+                <button
+                  type="button"
+                  disabled={!selectedStationsReadyToSearch || candidateSearchIsRunning}
+                  onClick={onPrepareAndSearch}
+                >
+                  {candidateSearchIsRunning
+                    ? `Searching ${plannedAnalysisCount.toLocaleString()} soundings...`
+                    : selectedStationsReadyToSearch
+                      ? stationSelectionMode === "all_cached"
+                        ? `Search all ${selectedCachedStationOptions.length.toLocaleString()} stations`
+                        : `Search ${selectedCachedStationOptions.length.toLocaleString()} selected station${selectedCachedStationOptions.length === 1 ? "" : "s"}`
+                      : selectedUncachedStationOptions.length > 0
+                        ? "Download remaining station histories first"
+                        : "Choose stations to search"}
+                </button>
+                <span className="field-help" role="status">
+                  {candidateSearchIsRunning ? status : plannedAnalysisSummary}
+                </span>
+              </div>
+            </div>
+          </section>
+        </section>
+      )}
+
+      {mode === "combined" && (
+        <section className="candidate-station-picker" aria-label="Station picker">
+          <div className="panel-heading-row">
+            <div>
+              <h4>Station set</h4>
+              <p className="field-help">
+                Search all cached stations, or choose specific stations to cache or analyze.
+              </p>
+            </div>
+            <div className="button-row">
+              <button
+                type="button"
+                className={
+                  stationSelectionMode === "all_cached"
+                    ? "active-secondary-button"
+                    : "secondary-button"
+                }
+                onClick={onSelectAllCachedStations}
+              >
+                All cached stations
+              </button>
+              <button
+                type="button"
+                className={
+                  stationSelectionMode === "selected"
+                    ? "active-secondary-button"
+                    : "secondary-button"
+                }
+                onClick={() => onStationSelectionModeChange("selected")}
+              >
+                Choose stations
+              </button>
+              <button type="button" className="secondary-button" onClick={onClearSelectedStations}>
+                Clear selected
+              </button>
+            </div>
+          </div>
+          {stationSelectionMode === "selected" ? (
+            <div className="station-picklist">
+              {stationOptions.length === 0 ? (
+                <p className="field-help">Refresh the IGRA catalog to load station choices.</p>
+              ) : (
+                stationOptions.map((station) => (
+                  <label key={station.station_id} className="station-picklist-row">
+                    <input
+                      type="checkbox"
+                      checked={selectedStationIdSet.has(station.station_id)}
+                      onChange={() => onSelectedStationToggle(station.station_id)}
+                    />
+                    <span>
+                      <strong>{station.station_name ?? station.station_id}</strong>
+                      <small>
+                        {station.station_id} ·{" "}
+                        {station.cached
+                          ? `${station.sounding_count.toLocaleString()} cached sounding${station.sounding_count === 1 ? "" : "s"}`
+                          : "not cached"}
+                      </small>
+                    </span>
+                    <StatusBadge
+                      label={station.cached ? "Cached" : "Available to cache"}
+                      tone={station.cached ? "good" : "neutral"}
+                    />
+                  </label>
+                ))
+              )}
+            </div>
+          ) : (
+            <p className="field-help">
+              Using all cached stations. Click Choose stations to pick specific stations or cache
+              uncached catalog stations.
+            </p>
+          )}
+          <div className="candidate-discovery-actions">
+            <button type="button" className="secondary-button" onClick={onRefreshIGRAData}>
+              Refresh station catalog
+            </button>
+            <button
+              type="button"
+              disabled={selectedUncachedStationOptions.length === 0}
+              onClick={() => onCacheStationFiles()}
+            >
+              Cache selected stations
+            </button>
+          </div>
+        </section>
+      )}
+
+      {mode !== "candidates" && (
+        <details className="candidate-cache-summary" aria-label="Local sounding data">
+          <summary>
+            {screeningInputs.length > 0
+              ? `Local data ready · ${cachedStationFiles.toLocaleString()} station file${cachedStationFiles === 1 ? "" : "s"} · ${cachedInventorySummary} · refreshed ${
+                  catalog?.refreshed_at ? formatDate(catalog.refreshed_at) : "not refreshed here"
+                }`
+              : "No cached soundings ready"}
+          </summary>
+          <dl className="compact-metrics candidate-cache-metrics">
+            <Metric label="Region" value={catalog?.region.label ?? "Great Plains / Midwest"} />
+            <Metric
+              label="Catalog"
+              value={
+                catalog?.refreshed_at ? formatDate(catalog.refreshed_at) : "Not refreshed here"
+              }
+            />
+            <Metric label="Station files" value={cachedStationFiles.toLocaleString()} />
+            <Metric label="Parsed soundings" value={cachedInventorySummary} />
+            <Metric label="Last search" value={lastAnalysisSummary} />
+          </dl>
+        </details>
+      )}
 
       {error && (
         <div className="validation" role="alert">
@@ -5945,7 +6905,7 @@ function ObservedAtmosphereCandidatesPanel({
         </div>
       )}
 
-      {activeRefinements.length > 0 && (
+      {mode !== "find" && activeRefinements.length > 0 && (
         <div className="screening-guidance-note">
           <strong>Search filters applied</strong>
           <span>{activeRefinements.join(" · ")}</span>
@@ -5955,207 +6915,219 @@ function ObservedAtmosphereCandidatesPanel({
         </div>
       )}
 
-      <details className="candidate-advanced-filters">
-        <summary>Advanced filters</summary>
-        <div className="candidate-toolbar" aria-label="Advanced sounding candidate controls">
-          <label>
-            Story
-            <select
-              value={storyFilter}
-              onChange={(event) => onStoryFilterChange(event.target.value as CandidateStoryFilter)}
-            >
-              <option value="all">All screening stories</option>
-              <option value="deep_convection_trial">Deep-convection stories</option>
-              <option value="shallow_cumulus_candidate">Cloud-forming shallow cumulus</option>
-              <option value="dry_failed_candidate">Dry failed cumulus</option>
-              <option value="capped_suppressed_candidate">Capped / suppressed</option>
-              <option value="humid_rainy_candidate">Humid / rainy</option>
-              <option value="severe_thunderstorm_environment">
-                Severe thunderstorm environment
-              </option>
-              <option value="supercell_environment">Supercell-like environment</option>
-              <option value="high_cape_pulse_storm">High-CAPE pulse storm</option>
-              <option value="dry_microburst_inverted_v">Dry microburst / inverted-V</option>
-              <option value="squall_line_cold_pool_candidate">
-                Squall-line / cold-pool candidate
-              </option>
-              <option value="elevated_convection">Elevated convection</option>
-              <option value="needs_review">Needs review</option>
-              <option value="poor_or_incomplete_candidate">Poor or incomplete</option>
-            </select>
-          </label>
-          <label>
-            Story family
-            <select
-              value={storyFamilyFilter}
-              onChange={(event) =>
-                onStoryFamilyFilterChange(event.target.value as CandidateStoryFamilyFilter)
-              }
-            >
-              <option value="all">All families</option>
-              <option value="lower_atmosphere">Lower-atmosphere stories</option>
-              <option value="deep_convection">Deep-convection stories</option>
-              <option value="review">Needs review / incomplete</option>
-            </select>
-          </label>
-          <label>
-            Evidence tier
-            <select
-              value={supportFilter}
-              onChange={(event) =>
-                onSupportFilterChange(event.target.value as CandidateSupportFilter)
-              }
-            >
-              <option value="all">All evidence tiers</option>
-              <option value="supported">Supported</option>
-              <option value="weak">Plausible / caveated</option>
-              <option value="unavailable">Little or no signal</option>
-            </select>
-          </label>
-          <label>
-            Sort
-            <select
-              value={sort}
-              onChange={(event) => onSortChange(event.target.value as CandidateSort)}
-            >
-              <option value="best_match">Best match</option>
-              <option value="valid_time">Valid time</option>
-              <option value="station_id">Station ID</option>
-              <option value="station_name">Station name</option>
-              <option value="primary_story">Primary story</option>
-              <option value="story_family">Story family</option>
-              <option value="rank_score">Rank score</option>
-              <option value="deep_tower_opportunity">Experimental Deep-Tower evidence</option>
-              <option value="confidence">Confidence</option>
-              <option value="support">Evidence tier</option>
-              <option value="package_readiness">Package readiness</option>
-              <option value="observed_wind_available">Observed wind availability</option>
-              <option value="profile_top_m_agl">Profile top</option>
-              <option value="lowest_level_m_agl">Lowest usable level</option>
-              <option value="data_completeness_score">Data completeness</option>
-              <option value="low_level_qv_g_kg">Low-level qv</option>
-              <option value="mean_qv_0_500m_g_kg">Mean qv 0-500 m</option>
-              <option value="mean_qv_0_1000m_g_kg">Mean qv 0-1 km</option>
-              <option value="surface_t_td_spread_c">Surface T-Td spread</option>
-              <option value="estimated_lcl_height_m_agl">Estimated LCL</option>
-              <option value="lapse_rate_0_1000m_c_per_km">Low-level lapse rate</option>
-              <option value="midlevel_lapse_rate_700_500_hpa_c_per_km">Midlevel lapse rate</option>
-              <option value="cap_strength_proxy">Cap/inversion strength</option>
-              <option value="cap_height_m_agl">Cap/inversion height</option>
-              <option value="bulk_shear_0_1km_m_s">Bulk shear 0-1 km</option>
-              <option value="bulk_shear_0_3km_m_s">Bulk shear 0-3 km</option>
-              <option value="bulk_shear_0_6km_m_s">Bulk shear 0-6 km</option>
-              <option value="midlevel_dry_layer_proxy">Dry-layer proxy</option>
-              <option value="dry_microburst_inverted_v_proxy">Inverted-V proxy</option>
-              <option value="freezing_level_m_agl">Freezing level</option>
-            </select>
-          </label>
-          <label>
-            Result text search
-            <input
-              type="search"
-              value={stationSearch}
-              placeholder="Station name, ID, or story"
-              onChange={(event) => onStationSearchChange(event.target.value)}
-            />
-          </label>
-          <label>
-            Readiness
-            <select
-              value={readinessFilter}
-              onChange={(event) =>
-                onReadinessFilterChange(event.target.value as CandidateReadinessFilter)
-              }
-            >
-              <option value="all">All readiness states</option>
-              <option value="package_ready">Package-ready only</option>
-              <option value="blocked">Blocked / needs review</option>
-            </select>
-          </label>
-          <div className="candidate-toolbar-actions">
-            <button type="button" className="secondary-button" onClick={onScreen}>
-              Apply advanced filters
-            </button>
-            <button type="button" className="secondary-button" onClick={onRefreshIGRAData}>
-              Refresh catalog
-            </button>
-            <button
-              type="button"
-              className="secondary-button"
-              disabled={selectedUncachedStationOptions.length === 0}
-              onClick={onCacheStationFiles}
-            >
-              Cache selected stations
-            </button>
-          </div>
-        </div>
-        <dl className="compact-metrics">
-          <Metric label="Cached stations" value={cachedStations.toString()} />
-          <Metric label="Cached station files" value={cachedStationFiles.toString()} />
-          <Metric label="Selected soundings" value={plannedAnalysisSummary} />
-          <Metric label="Returned candidate limit" value={resultLimit} />
-        </dl>
-      </details>
-
-      <div className="candidate-workspace">
-        <section aria-label="Screened sounding candidates">
-          {screening && (
-            <div className="candidate-list-heading">
-              <h4>
-                {activeRefinements.length > 0 ? "Refined candidates" : "Screened cached soundings"}
-              </h4>
-              <p className="field-help">{filterTraceSummary.summary}</p>
-              {filterTraceSummary.detail && (
-                <p className="field-help candidate-filter-detail">{filterTraceSummary.detail}</p>
+      {mode !== "find" && (
+        <details className="candidate-advanced-filters">
+          <summary>Advanced filters</summary>
+          <div className="candidate-toolbar" aria-label="Advanced sounding candidate controls">
+            <label>
+              Story
+              <select
+                value={storyFilter}
+                onChange={(event) =>
+                  onStoryFilterChange(event.target.value as CandidateStoryFilter)
+                }
+              >
+                <option value="all">All screening stories</option>
+                <option value="deep_convection_trial">Deep-convection stories</option>
+                <option value="shallow_cumulus_candidate">Cloud-forming shallow cumulus</option>
+                <option value="dry_failed_candidate">Dry failed cumulus</option>
+                <option value="capped_suppressed_candidate">Capped / suppressed</option>
+                <option value="humid_rainy_candidate">Humid / rainy</option>
+                <option value="severe_thunderstorm_environment">
+                  Severe thunderstorm environment
+                </option>
+                <option value="supercell_environment">Supercell-like environment</option>
+                <option value="high_cape_pulse_storm">High-CAPE pulse storm</option>
+                <option value="dry_microburst_inverted_v">Dry microburst / inverted-V</option>
+                <option value="squall_line_cold_pool_candidate">
+                  Squall-line / cold-pool candidate
+                </option>
+                <option value="elevated_convection">Elevated convection</option>
+                <option value="needs_review">Needs review</option>
+                <option value="poor_or_incomplete_candidate">Poor or incomplete</option>
+              </select>
+            </label>
+            <label>
+              Story family
+              <select
+                value={storyFamilyFilter}
+                onChange={(event) =>
+                  onStoryFamilyFilterChange(event.target.value as CandidateStoryFamilyFilter)
+                }
+              >
+                <option value="all">All families</option>
+                <option value="lower_atmosphere">Lower-atmosphere stories</option>
+                <option value="deep_convection">Deep-convection stories</option>
+                <option value="review">Needs review / incomplete</option>
+              </select>
+            </label>
+            <label>
+              Evidence tier
+              <select
+                value={supportFilter}
+                onChange={(event) =>
+                  onSupportFilterChange(event.target.value as CandidateSupportFilter)
+                }
+              >
+                <option value="all">All evidence tiers</option>
+                <option value="supported">Supported</option>
+                <option value="weak">Plausible / caveated</option>
+                <option value="unavailable">Little or no signal</option>
+              </select>
+            </label>
+            <label>
+              Sort
+              <select
+                value={sort}
+                onChange={(event) => onSortChange(event.target.value as CandidateSort)}
+              >
+                <option value="best_match">Best match</option>
+                <option value="valid_time">Valid time</option>
+                <option value="station_id">Station ID</option>
+                <option value="station_name">Station name</option>
+                <option value="primary_story">Primary story</option>
+                <option value="story_family">Story family</option>
+                <option value="rank_score">Rank score</option>
+                <option value="deep_tower_opportunity">Experimental Deep-Tower evidence</option>
+                <option value="confidence">Confidence</option>
+                <option value="support">Evidence tier</option>
+                <option value="package_readiness">Package readiness</option>
+                <option value="observed_wind_available">Observed wind availability</option>
+                <option value="profile_top_m_agl">Profile top</option>
+                <option value="lowest_level_m_agl">Lowest usable level</option>
+                <option value="data_completeness_score">Data completeness</option>
+                <option value="low_level_qv_g_kg">Low-level qv</option>
+                <option value="mean_qv_0_500m_g_kg">Mean qv 0-500 m</option>
+                <option value="mean_qv_0_1000m_g_kg">Mean qv 0-1 km</option>
+                <option value="surface_t_td_spread_c">Surface T-Td spread</option>
+                <option value="estimated_lcl_height_m_agl">Estimated LCL</option>
+                <option value="lapse_rate_0_1000m_c_per_km">Low-level lapse rate</option>
+                <option value="midlevel_lapse_rate_700_500_hpa_c_per_km">
+                  Midlevel lapse rate
+                </option>
+                <option value="cap_strength_proxy">Cap/inversion strength</option>
+                <option value="cap_height_m_agl">Cap/inversion height</option>
+                <option value="bulk_shear_0_1km_m_s">Bulk shear 0-1 km</option>
+                <option value="bulk_shear_0_3km_m_s">Bulk shear 0-3 km</option>
+                <option value="bulk_shear_0_6km_m_s">Bulk shear 0-6 km</option>
+                <option value="midlevel_dry_layer_proxy">Dry-layer proxy</option>
+                <option value="dry_microburst_inverted_v_proxy">Inverted-V proxy</option>
+                <option value="freezing_level_m_agl">Freezing level</option>
+              </select>
+            </label>
+            <label>
+              Result text search
+              <input
+                type="search"
+                value={stationSearch}
+                placeholder="Station name, ID, or story"
+                onChange={(event) => onStationSearchChange(event.target.value)}
+              />
+            </label>
+            <label>
+              Readiness
+              <select
+                value={readinessFilter}
+                onChange={(event) =>
+                  onReadinessFilterChange(event.target.value as CandidateReadinessFilter)
+                }
+              >
+                <option value="all">All readiness states</option>
+                <option value="package_ready">Package-ready only</option>
+                <option value="blocked">Blocked / needs review</option>
+              </select>
+            </label>
+            <div className="candidate-toolbar-actions">
+              <button type="button" className="secondary-button" onClick={onScreen}>
+                Apply advanced filters
+              </button>
+              <button type="button" className="secondary-button" onClick={onRefreshIGRAData}>
+                Refresh catalog
+              </button>
+              {mode === "candidates" && (
+                <button
+                  type="button"
+                  className="secondary-button"
+                  disabled={selectedUncachedStationOptions.length === 0}
+                  onClick={() => onCacheStationFiles()}
+                >
+                  Cache selected stations
+                </button>
               )}
             </div>
-          )}
-          {visibleCandidates.length === 0 ? (
-            <div className="scenario-state-panel">
-              <h4>No screened candidates loaded</h4>
-              <p>
-                Refresh the IGRA catalog if needed, cache station files, then analyze
-                recommendations from the soundings already cached locally.
-              </p>
-            </div>
-          ) : (
-            <div className="candidate-list">
-              {visibleCandidates.map((candidate) => (
-                <SoundingCandidateCard
-                  key={candidate.candidate_id}
-                  candidate={candidate}
-                  storyFilter={storyFilter}
-                  storyFamilyFilter={storyFamilyFilter}
-                  selected={selectedCandidate?.candidate_id === candidate.candidate_id}
-                  saved={savedCandidateIds.has(candidate.candidate_id)}
-                  onSelect={() => onCandidateDetailChange(candidate.candidate_id)}
-                  onSave={() => onSave(candidate)}
-                  onSelectForRunSetup={(activeStory) =>
-                    onSelectForRunSetup(
-                      candidate,
-                      savedCandidates.find(
-                        (saved) => saved.candidate.candidate_id === candidate.candidate_id,
-                      ),
-                      activeStory,
-                    )
-                  }
-                />
-              ))}
-            </div>
-          )}
-        </section>
+          </div>
+          <dl className="compact-metrics">
+            <Metric label="Cached stations" value={cachedStations.toString()} />
+            <Metric label="Cached station files" value={cachedStationFiles.toString()} />
+            <Metric label="Selected soundings" value={plannedAnalysisSummary} />
+            <Metric label="Returned candidate limit" value={resultLimit} />
+          </dl>
+        </details>
+      )}
 
-        <SoundingCandidateDetail
-          candidate={selectedCandidate}
-          storyFilter={storyFilter}
-          storyFamilyFilter={storyFamilyFilter}
-          savedCandidate={selectedSavedCandidate}
-          onSave={onSave}
-          onSelectForRunSetup={(candidate, activeStory) =>
-            onSelectForRunSetup(candidate, selectedSavedCandidate ?? undefined, activeStory)
-          }
-        />
-      </div>
+      {mode !== "find" && (
+        <div className="candidate-workspace">
+          <section aria-label="Screened sounding candidates">
+            {screening && (
+              <div className="candidate-list-heading">
+                <h4>
+                  {activeRefinements.length > 0
+                    ? "Refined candidates"
+                    : "Screened cached soundings"}
+                </h4>
+                <p className="field-help">{filterTraceSummary.summary}</p>
+                {filterTraceSummary.detail && (
+                  <p className="field-help candidate-filter-detail">{filterTraceSummary.detail}</p>
+                )}
+              </div>
+            )}
+            {visibleCandidates.length === 0 ? (
+              <div className="scenario-state-panel">
+                <h4>No screened candidates loaded</h4>
+                <p>
+                  Refresh the IGRA catalog if needed, cache station files, then analyze
+                  recommendations from the soundings already cached locally.
+                </p>
+              </div>
+            ) : (
+              <div className="candidate-list">
+                {visibleCandidates.map((candidate) => (
+                  <SoundingCandidateCard
+                    key={candidate.candidate_id}
+                    candidate={candidate}
+                    storyFilter={storyFilter}
+                    storyFamilyFilter={storyFamilyFilter}
+                    selected={selectedCandidate?.candidate_id === candidate.candidate_id}
+                    saved={savedCandidateIds.has(candidate.candidate_id)}
+                    onSelect={() => onCandidateDetailChange(candidate.candidate_id)}
+                    onSave={() => onSave(candidate)}
+                    onSelectForRunSetup={(activeStory) =>
+                      onSelectForRunSetup(
+                        candidate,
+                        savedCandidates.find(
+                          (saved) => saved.candidate.candidate_id === candidate.candidate_id,
+                        ),
+                        activeStory,
+                      )
+                    }
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+
+          <SoundingCandidateDetail
+            candidate={selectedCandidate}
+            storyFilter={storyFilter}
+            storyFamilyFilter={storyFamilyFilter}
+            savedCandidate={selectedSavedCandidate}
+            onSave={onSave}
+            onSelectForRunSetup={(candidate, activeStory) =>
+              onSelectForRunSetup(candidate, selectedSavedCandidate ?? undefined, activeStory)
+            }
+          />
+        </div>
+      )}
     </section>
   );
 }
@@ -6708,6 +7680,7 @@ function SelectedSoundingRunSetupPanel({
   selectedCandidateScreening,
   runConfiguration,
   runConfigurationPreview,
+  soundingsLanguage = false,
   onRunConfigurationChange,
   onAddSelectedSoundingToRunPlan,
 }: {
@@ -6715,6 +7688,7 @@ function SelectedSoundingRunSetupPanel({
   selectedCandidateScreening: Record<string, unknown> | null;
   runConfiguration: RunConfigurationInput;
   runConfigurationPreview: RunConfiguration;
+  soundingsLanguage?: boolean;
   onRunConfigurationChange: (configuration: RunConfigurationInput) => void;
   onAddSelectedSoundingToRunPlan: () => void;
 }) {
@@ -6775,6 +7749,7 @@ function SelectedSoundingRunSetupPanel({
         selectedCandidateScreening={selectedCandidateScreening}
         onAddToRunPlan={onAddSelectedSoundingToRunPlan}
         onChange={onRunConfigurationChange}
+        soundingsLanguage={soundingsLanguage}
         embedded
       />
     </section>
@@ -7337,10 +8312,12 @@ function RunPlanConfigurationFields({
 }
 
 function ResultsWorkspace({
+  context = "legacy",
   results,
   selectedResult,
   selectedResultId,
   resultsStatus,
+  worldOwnershipStatus,
   resultsError,
   resultDeletePreview,
   draft,
@@ -7352,14 +8329,17 @@ function ResultsWorkspace({
   onRefreshResults,
   onInspect,
   onCompare,
+  onOpenResultInExplore,
   onPreviewResultDelete,
   onConfirmResultDelete,
   onCancelResultDelete,
 }: {
+  context?: "legacy" | "soundings";
   results: ResultCard[];
   selectedResult: ResultCard | undefined;
   selectedResultId: string | null;
   resultsStatus: string;
+  worldOwnershipStatus?: string;
   resultsError: string | null;
   resultDeletePreview: DeleteResultResponse | null;
   draft: { name: string; tags: string; notes: string };
@@ -7371,6 +8351,7 @@ function ResultsWorkspace({
   onRefreshResults: () => void;
   onInspect: () => void;
   onCompare: () => void;
+  onOpenResultInExplore?: (resultId: string) => void;
   onPreviewResultDelete: (resultId: string) => void;
   onConfirmResultDelete: (resultId: string) => void;
   onCancelResultDelete: () => void;
@@ -7379,24 +8360,39 @@ function ResultsWorkspace({
     <section className="results-library" aria-labelledby="results-title">
       <div className="section-heading">
         <div>
-          <h2 id="results-title">Experiment Notebook</h2>
+          <p className="eyebrow">{context === "soundings" ? "Archive" : "Results"}</p>
+          <h2 id="results-title">
+            {context === "soundings" ? "Past runs" : "Experiment Notebook"}
+          </h2>
           <p>
-            Review ingested cloud experiments, scan result cards, and open results for explanation.
+            {context === "soundings"
+              ? "Reopen ingested Soundings runs. Use Ownership when you need legacy records or World-owned Simulations."
+              : "Review ingested cloud experiments, scan result cards, and open results for explanation."}
           </p>
         </div>
         <button type="button" onClick={onRefreshResults}>
-          Refresh results
+          {context === "soundings" ? "Refresh archive" : "Refresh results"}
         </button>
       </div>
       {resultsStatus !== "Results loaded" && resultsStatus !== "Loading results..." && (
         <p className="inline-status" role="status">
-          {resultsStatus}
+          {context === "soundings" ? soundingsRunLanguage(resultsStatus) : resultsStatus}
+        </p>
+      )}
+      {context === "soundings" && worldOwnershipStatus && (
+        <p className="soundings-ownership-status" role="status">
+          {worldOwnershipStatus}
         </p>
       )}
 
-      {resultsError && <p role="alert">{resultsError}</p>}
+      {resultsError && (
+        <p role="alert">
+          {context === "soundings" ? soundingsRunLanguage(resultsError) : resultsError}
+        </p>
+      )}
 
       <NotebookWorkspace
+        context={context}
         results={results}
         selectedResult={selectedResult}
         selectedResultId={selectedResultId}
@@ -7408,10 +8404,13 @@ function ResultsWorkspace({
         onSubmit={onSubmit}
         onInspect={onInspect}
         onCompare={onCompare}
-        onOpenResultInExplore={(resultId) => {
-          onSelectResult(resultId);
-          onInspect();
-        }}
+        onOpenResultInExplore={
+          onOpenResultInExplore ??
+          ((resultId) => {
+            onSelectResult(resultId);
+            onInspect();
+          })
+        }
         deletePreview={resultDeletePreview}
         onPreviewDelete={onPreviewResultDelete}
         onConfirmDelete={onConfirmResultDelete}
@@ -7422,6 +8421,7 @@ function ResultsWorkspace({
 }
 
 function NotebookWorkspace({
+  context = "legacy",
   results,
   selectedResult,
   selectedResultId,
@@ -7439,6 +8439,7 @@ function NotebookWorkspace({
   onConfirmDelete,
   onCancelDelete,
 }: {
+  context?: "legacy" | "soundings";
   results: ResultCard[];
   selectedResult: ResultCard | undefined;
   selectedResultId: string | null;
@@ -7457,32 +8458,83 @@ function NotebookWorkspace({
   onCancelDelete: () => void;
 }) {
   const [filters, setFilters] = useState<ResultsFilterState>(DEFAULT_RESULTS_FILTERS);
+  const [soundingsFilters, setSoundingsFilters] = useState<SoundingsArchiveFilterState>(
+    DEFAULT_SOUNDINGS_ARCHIVE_FILTERS,
+  );
   const scenarioOptions = useMemo(() => resultScenarioOptions(results), [results]);
-  const filteredResults = useMemo(() => filterAndSortResults(results, filters), [results, filters]);
-  const filtersActive = resultsFiltersActive(filters);
+  const filteredResults = useMemo(
+    () =>
+      context === "soundings"
+        ? filterSoundingsArchiveResults(results, soundingsFilters)
+        : filterAndSortResults(results, filters),
+    [context, filters, results, soundingsFilters],
+  );
+  const filtersActive =
+    context === "soundings"
+      ? soundingsArchiveFiltersActive(soundingsFilters)
+      : resultsFiltersActive(filters);
+  const visibleSelectedResult =
+    filteredResults.find((result) => result.result_id === selectedResultId) ??
+    filteredResults[0] ??
+    undefined;
+
+  useEffect(() => {
+    if (
+      context === "soundings" &&
+      visibleSelectedResult &&
+      visibleSelectedResult.result_id !== selectedResultId
+    ) {
+      onSelectResult(visibleSelectedResult.result_id);
+    }
+  }, [context, onSelectResult, selectedResultId, visibleSelectedResult]);
 
   return (
-    <section className="workspace-section" aria-label="Notebook entries">
-      <ResultsFilterBar
-        filters={filters}
-        scenarioOptions={scenarioOptions}
-        totalCount={results.length}
-        visibleCount={filteredResults.length}
-        onChange={setFilters}
-        onReset={() => setFilters(DEFAULT_RESULTS_FILTERS)}
-      />
+    <section
+      className="workspace-section"
+      aria-label={context === "soundings" ? "Past runs" : "Notebook entries"}
+    >
+      {context === "soundings" ? (
+        <SoundingsArchiveFilterBar
+          filters={soundingsFilters}
+          totalCount={results.length}
+          visibleCount={filteredResults.length}
+          onChange={setSoundingsFilters}
+          onReset={() => setSoundingsFilters(DEFAULT_SOUNDINGS_ARCHIVE_FILTERS)}
+        />
+      ) : (
+        <ResultsFilterBar
+          filters={filters}
+          scenarioOptions={scenarioOptions}
+          totalCount={results.length}
+          visibleCount={filteredResults.length}
+          onChange={setFilters}
+          onReset={() => setFilters(DEFAULT_RESULTS_FILTERS)}
+        />
+      )}
       <div className="results-layout">
         <ExperimentNotebookList
+          context={context}
           results={filteredResults}
           totalResults={results.length}
           filtersActive={filtersActive}
           selectedResultId={selectedResultId}
           onSelect={onSelectResult}
           onOpenExplore={onOpenResultInExplore}
-          onResetFilters={() => setFilters(DEFAULT_RESULTS_FILTERS)}
+          onResetFilters={() =>
+            context === "soundings"
+              ? setSoundingsFilters(DEFAULT_SOUNDINGS_ARCHIVE_FILTERS)
+              : setFilters(DEFAULT_RESULTS_FILTERS)
+          }
         />
         <ResultNotebookCard
-          result={selectedResult}
+          context={context}
+          result={
+            context === "soundings"
+              ? visibleSelectedResult?.result_id === selectedResult?.result_id
+                ? selectedResult
+                : undefined
+              : selectedResult
+          }
           draft={draft}
           comparisonStory={comparisonStory}
           comparisonStoryStatus={comparisonStoryStatus}
@@ -7512,6 +8564,8 @@ function ExploreWorkspace({
   backLabel,
   onBack,
   onCompare,
+  resultOptions,
+  onSelectResult,
 }: {
   selectedResult: ResultCard | undefined;
   comparisonStory: TradeCumulusComparisonStoryResponse | null;
@@ -7524,6 +8578,8 @@ function ExploreWorkspace({
   backLabel?: string;
   onBack?: () => void;
   onCompare?: () => void;
+  resultOptions?: ResultCard[];
+  onSelectResult?: (resultId: string) => void;
 }) {
   return (
     <section className="workspace-section explore-workspace" aria-label="Explore this result">
@@ -7552,6 +8608,8 @@ function ExploreWorkspace({
             backLabel={backLabel}
             onBack={onBack}
             onCompare={onCompare}
+            resultOptions={resultOptions}
+            onSelectResult={onSelectResult}
           />
         </section>
       )}
@@ -7576,6 +8634,8 @@ type LocalRunWorkflowPanelProps = {
   runDeletePreview: DeleteRunResponse | null;
   runDeleteMessage: string | null;
   results: ResultCard[];
+  soundingsLanguage?: boolean;
+  includePipeline?: boolean;
   autoFinalizingWorkerRunIds: Set<string>;
   failedAutoFinalizingWorkerRunIds: Set<string>;
   onRefreshRunStatus: () => void;
@@ -7598,7 +8658,7 @@ type LocalRunWorkflowPanelProps = {
   onConfirmRunDelete: (runId: string) => void;
 };
 
-function RunMonitorPanel(props: LocalRunWorkflowPanelProps) {
+function runActivityCounts(props: LocalRunWorkflowPanelProps) {
   const activeRunIds = new Set<string>();
   if (props.runQueue?.active_run_id) activeRunIds.add(props.runQueue.active_run_id);
   if (
@@ -7616,6 +8676,56 @@ function RunMonitorPanel(props: LocalRunWorkflowPanelProps) {
   const queuedCount = props.runQueue?.queued_count ?? 0;
   const completedCount =
     props.storageInventory?.runs.filter((run) => run.lifecycle_state === "completed").length ?? 0;
+  return { activeCount, queuedCount, completedCount };
+}
+
+function SoundingsExploreLanding({
+  results,
+  onOpen,
+  onViewRuns,
+}: {
+  results: ResultCard[];
+  onOpen: (resultId: string) => void;
+  onViewRuns: () => void;
+}) {
+  return (
+    <section className="soundings-explore-landing" aria-labelledby="soundings-explore-title">
+      <div className="section-heading">
+        <div>
+          <p className="eyebrow">Explore</p>
+          <h3 id="soundings-explore-title">Explore sounding runs</h3>
+          <p>Inspect completed, ingested Soundings experiments.</p>
+        </div>
+      </div>
+      {results.length === 0 ? (
+        <section className="soundings-explore-empty">
+          <h4>No Soundings run is ready to explore yet</h4>
+          <p>
+            Explore becomes available after a Soundings experiment completes and its output is
+            ingested.
+          </p>
+          <button type="button" onClick={onViewRuns}>
+            View current runs
+          </button>
+        </section>
+      ) : (
+        <div className="soundings-explore-ready-list" aria-label="Runs ready to explore">
+          {results.map((result) => (
+            <button key={result.result_id} type="button" onClick={() => onOpen(result.result_id)}>
+              <strong>{result.name}</strong>
+              <span>
+                {result.observed_sounding?.station_name ?? result.input_source_label ?? "Sounding"}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function RunMonitorPanel(props: LocalRunWorkflowPanelProps) {
+  const { activeCount, queuedCount, completedCount } = runActivityCounts(props);
   return (
     <details className="run-monitor-panel" open={activeCount > 0 || queuedCount > 0}>
       <summary>
@@ -7629,6 +8739,109 @@ function RunMonitorPanel(props: LocalRunWorkflowPanelProps) {
       </summary>
       <LocalRunWorkflowPanel {...props} />
     </details>
+  );
+}
+
+function SoundingsRunsPanel(props: LocalRunWorkflowPanelProps) {
+  const { activeCount, queuedCount, completedCount } = runActivityCounts(props);
+  const currentRunId = props.dryRun ? runIdFromPackage(props.dryRun) : null;
+  const activeRunId = props.runQueue?.active_run_id ?? null;
+  const activeRun = props.storageInventory?.runs.find((run) => run.run_id === activeRunId);
+  const activeRunLabel =
+    activeRun?.scenario_name ?? activeRun?.scenario_id ?? activeRunId ?? "None";
+  const actionableRuns = selectPipelineRuns(
+    props.storageInventory?.runs ?? [],
+    props.results,
+    currentRunId,
+    props.runQueue,
+  );
+  const hasTechnicalDetails = Boolean(
+    props.dryRun ||
+    props.runStatus ||
+    props.runQueue ||
+    props.lanWorkerConfig ||
+    props.lanWorkerStatus ||
+    props.storageInventory ||
+    props.error,
+  );
+
+  return (
+    <section className="soundings-runs-overview" aria-labelledby="soundings-runs-title">
+      <div className="section-heading soundings-runs-heading">
+        <div>
+          <p className="eyebrow">Runs</p>
+          <h3 id="soundings-runs-title">Run status</h3>
+          <p>Track CM1 work in progress. Completed, ingested experiments appear in Past runs.</p>
+        </div>
+        <button type="button" onClick={props.onRefreshStorage}>
+          Refresh current work
+        </button>
+      </div>
+
+      <dl className="soundings-run-summary" aria-label="Run summary">
+        <Metric label="Active" value={activeCount.toLocaleString()} />
+        <Metric label="Waiting" value={queuedCount.toLocaleString()} />
+        <Metric label="Current work" value={actionableRuns.length.toLocaleString()} />
+        <Metric label="Completed locally" value={completedCount.toLocaleString()} />
+      </dl>
+
+      {(props.runQueue?.active_run_id || queuedCount > 0) && (
+        <section className="soundings-current-queue" aria-label="Current local queue">
+          <div>
+            <p className="eyebrow">Local queue</p>
+            <h4>{props.runQueue?.active_run_id ? "CM1 is running" : "Runs are waiting"}</h4>
+            <p>{props.runQueueStatus}</p>
+          </div>
+          <dl>
+            <Metric label="Active run" value={activeRunLabel} />
+            <Metric label="Waiting" value={queuedCount.toLocaleString()} />
+            <Metric
+              label="Last refresh"
+              value={
+                props.runQueue?.updated_at ? formatShortTime(props.runQueue.updated_at) : "Not yet"
+              }
+            />
+          </dl>
+        </section>
+      )}
+
+      <LocalPipelinePanel
+        inventory={props.storageInventory}
+        status={props.storageStatus}
+        error={props.storageError}
+        deletePreview={props.runDeletePreview}
+        deleteMessage={props.runDeleteMessage}
+        results={props.results}
+        soundingsLanguage
+        currentRunId={currentRunId}
+        runQueue={props.runQueue}
+        lanWorkerConfigured={props.lanWorkerConfig?.configured ?? false}
+        autoFinalizingWorkerRunIds={props.autoFinalizingWorkerRunIds}
+        failedAutoFinalizingWorkerRunIds={props.failedAutoFinalizingWorkerRunIds}
+        showRefreshButton={false}
+        onLaunchStoredRun={props.onLaunchStoredRun}
+        onLaunchStoredLanWorkerRun={props.onLaunchStoredLanWorkerRun}
+        onRefreshStoredLanWorkerStatus={props.onRefreshStoredLanWorkerStatus}
+        onFinalizeStoredLanWorkerRun={props.onFinalizeStoredLanWorkerRun}
+        onIngestStoredRun={props.onIngestStoredRun}
+        onOpenStoredResult={props.onOpenStoredResult}
+        onExploreStoredResult={props.onExploreStoredResult}
+        onRefreshStorage={props.onRefreshStorage}
+        onPreviewDelete={props.onPreviewRunDelete}
+        onConfirmDelete={props.onConfirmRunDelete}
+      />
+
+      {hasTechnicalDetails && (
+        <details className="soundings-run-details">
+          <summary>Package, worker, queue, and runtime details</summary>
+          <p>
+            Open this only when you need package provenance, worker state, logs, or technical
+            troubleshooting.
+          </p>
+          <LocalRunWorkflowPanel {...props} includePipeline={false} />
+        </details>
+      )}
+    </section>
   );
 }
 
@@ -7649,6 +8862,8 @@ function LocalRunWorkflowPanel({
   runDeletePreview,
   runDeleteMessage,
   results,
+  soundingsLanguage = false,
+  includePipeline = true,
   autoFinalizingWorkerRunIds,
   failedAutoFinalizingWorkerRunIds,
   onRefreshRunStatus,
@@ -7785,7 +9000,7 @@ function LocalRunWorkflowPanel({
             )}
             <p className="state-note">
               A generated package is not a completed CM1 result. Launch, output detection, ingest,
-              and saved result review are separate states.
+              and saved {soundingsLanguage ? "run review" : "result review"} are separate states.
             </p>
             {dryRun.report.run_configuration_summary && (
               <p className="state-note">
@@ -7831,6 +9046,7 @@ function LocalRunWorkflowPanel({
             error={lanWorkerError}
             ingestedResultId={ingestedResultId}
             canStart={false}
+            soundingsLanguage={soundingsLanguage}
             onLaunch={onLaunchLanWorkerRun}
             onRefresh={onRefreshLanWorkerStatus}
             onCollect={onCollectLanWorkerRun}
@@ -7838,7 +9054,11 @@ function LocalRunWorkflowPanel({
           />
         )}
 
-        <LocalRunQueuePanel queue={runQueue} status={runQueueStatus} />
+        <LocalRunQueuePanel
+          queue={runQueue}
+          status={runQueueStatus}
+          soundingsLanguage={soundingsLanguage}
+        />
 
         {runStatus ? (
           <div className="run-status-panel" aria-label="Local run status">
@@ -7978,11 +9198,16 @@ function LocalRunWorkflowPanel({
         )}
 
         {ingestedResultId && (
-          <div className="post-ingest-actions" aria-label="Ingested result actions">
-            <p>Result metadata created: {ingestedResultId}</p>
+          <div
+            className="post-ingest-actions"
+            aria-label={soundingsLanguage ? "Ingested run actions" : "Ingested result actions"}
+          >
+            <p>
+              {soundingsLanguage ? "Run record" : "Result metadata"} created: {ingestedResultId}
+            </p>
             <div className="button-row">
               <button type="button" onClick={onOpenInResults}>
-                Open in Results
+                {soundingsLanguage ? "Open run" : "Open in Results"}
               </button>
               <button type="button" onClick={onInspectIngested}>
                 Open in Explore
@@ -7992,34 +9217,45 @@ function LocalRunWorkflowPanel({
         )}
       </div>
 
-      <LocalPipelinePanel
-        inventory={storageInventory}
-        status={storageStatus}
-        error={storageError}
-        deletePreview={runDeletePreview}
-        deleteMessage={runDeleteMessage}
-        results={results}
-        currentRunId={currentRunId}
-        runQueue={runQueue}
-        lanWorkerConfigured={lanWorkerConfig?.configured ?? false}
-        autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIds}
-        failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIds}
-        onLaunchStoredRun={onLaunchStoredRun}
-        onLaunchStoredLanWorkerRun={onLaunchStoredLanWorkerRun}
-        onRefreshStoredLanWorkerStatus={onRefreshStoredLanWorkerStatus}
-        onFinalizeStoredLanWorkerRun={onFinalizeStoredLanWorkerRun}
-        onIngestStoredRun={onIngestStoredRun}
-        onOpenStoredResult={onOpenStoredResult}
-        onExploreStoredResult={onExploreStoredResult}
-        onRefreshStorage={onRefreshStorage}
-        onPreviewDelete={onPreviewRunDelete}
-        onConfirmDelete={onConfirmRunDelete}
-      />
+      {includePipeline && (
+        <LocalPipelinePanel
+          inventory={storageInventory}
+          status={storageStatus}
+          error={storageError}
+          deletePreview={runDeletePreview}
+          deleteMessage={runDeleteMessage}
+          results={results}
+          soundingsLanguage={soundingsLanguage}
+          currentRunId={currentRunId}
+          runQueue={runQueue}
+          lanWorkerConfigured={lanWorkerConfig?.configured ?? false}
+          autoFinalizingWorkerRunIds={autoFinalizingWorkerRunIds}
+          failedAutoFinalizingWorkerRunIds={failedAutoFinalizingWorkerRunIds}
+          onLaunchStoredRun={onLaunchStoredRun}
+          onLaunchStoredLanWorkerRun={onLaunchStoredLanWorkerRun}
+          onRefreshStoredLanWorkerStatus={onRefreshStoredLanWorkerStatus}
+          onFinalizeStoredLanWorkerRun={onFinalizeStoredLanWorkerRun}
+          onIngestStoredRun={onIngestStoredRun}
+          onOpenStoredResult={onOpenStoredResult}
+          onExploreStoredResult={onExploreStoredResult}
+          onRefreshStorage={onRefreshStorage}
+          onPreviewDelete={onPreviewRunDelete}
+          onConfirmDelete={onConfirmRunDelete}
+        />
+      )}
     </section>
   );
 }
 
-function LocalRunQueuePanel({ queue, status }: { queue: RunQueueResponse | null; status: string }) {
+function LocalRunQueuePanel({
+  queue,
+  status,
+  soundingsLanguage = false,
+}: {
+  queue: RunQueueResponse | null;
+  status: string;
+  soundingsLanguage?: boolean;
+}) {
   const visibleEntries = visibleRunQueueEntries(queue);
   return (
     <section className="run-status-panel" aria-label="Local serial run queue">
@@ -8047,9 +9283,17 @@ function LocalRunQueuePanel({ queue, status }: { queue: RunQueueResponse | null;
             <li key={`${entry.run_id}-${entry.queued_at}`}>
               <strong>{entry.run_id}</strong>{" "}
               <span className="muted-inline">{runQueueEntryLabel(entry)}</span>
-              {entry.result_id && <span className="muted-inline"> result {entry.result_id}</span>}
+              {entry.result_id && (
+                <span className="muted-inline">
+                  {" "}
+                  {soundingsLanguage ? "run record" : "result"} {entry.result_id}
+                </span>
+              )}
               {entry.cleanup_status && (
-                <span className="muted-inline"> package retained for Results/Explore</span>
+                <span className="muted-inline">
+                  {" "}
+                  package retained for {soundingsLanguage ? "Runs" : "Results"}/Explore
+                </span>
               )}
             </li>
           ))}
@@ -8092,6 +9336,7 @@ function LanWorkerRunPanel({
   error,
   ingestedResultId,
   canStart,
+  soundingsLanguage = false,
   onLaunch,
   onRefresh,
   onCollect,
@@ -8106,6 +9351,7 @@ function LanWorkerRunPanel({
   error: string | null;
   ingestedResultId: string | null;
   canStart: boolean;
+  soundingsLanguage?: boolean;
   onLaunch: () => void;
   onRefresh: () => void;
   onCollect: () => void;
@@ -8214,7 +9460,8 @@ function LanWorkerRunPanel({
           )}
           {cleanupComplete && (
             <p className="state-note">
-              LAN worker cleanup complete. Results and Explore use the MacBook-local copy.
+              LAN worker cleanup complete. {soundingsLanguage ? "Runs" : "Results"} and Explore use
+              the MacBook-local copy.
             </p>
           )}
         </>
@@ -8230,11 +9477,13 @@ function LocalPipelinePanel({
   deletePreview,
   deleteMessage,
   results,
+  soundingsLanguage = false,
   currentRunId,
   runQueue,
   lanWorkerConfigured,
   autoFinalizingWorkerRunIds,
   failedAutoFinalizingWorkerRunIds,
+  showRefreshButton = true,
   onLaunchStoredRun,
   onLaunchStoredLanWorkerRun,
   onRefreshStoredLanWorkerStatus,
@@ -8252,11 +9501,13 @@ function LocalPipelinePanel({
   deletePreview: DeleteRunResponse | null;
   deleteMessage: string | null;
   results: ResultCard[];
+  soundingsLanguage?: boolean;
   currentRunId: string | null;
   runQueue: RunQueueResponse | null;
   lanWorkerConfigured: boolean;
   autoFinalizingWorkerRunIds: Set<string>;
   failedAutoFinalizingWorkerRunIds: Set<string>;
+  showRefreshButton?: boolean;
   onLaunchStoredRun: (manifestPath: string) => void;
   onLaunchStoredLanWorkerRun: (manifestPath: string) => void;
   onRefreshStoredLanWorkerStatus: (manifestPath: string) => void;
@@ -8275,31 +9526,39 @@ function LocalPipelinePanel({
     <section className="pipeline-panel" aria-labelledby="pipeline-title">
       <div className="panel-heading-row">
         <div>
-          <p className="eyebrow">Build pipeline</p>
-          <h4 id="pipeline-title">Packages and runs needing action</h4>
+          <p className="eyebrow">{soundingsLanguage ? "Queue and ingest" : "Build pipeline"}</p>
+          <h4 id="pipeline-title">
+            {soundingsLanguage ? "Runs in progress" : "Packages and runs needing action"}
+          </h4>
         </div>
         <StatusBadge label={panelStatus} tone={error ? "warning" : "neutral"} />
       </div>
       <p className="state-note">
-        Active packages and runs that still need launch, status review, troubleshooting, or ingest.
-        Ingested results live in Results; non-ingested package and run cleanup stays here.
+        {soundingsLanguage
+          ? "Only active, queued, blocked, or not-yet-ingested runs appear here."
+          : "Active packages and runs that still need launch, status review, troubleshooting, or ingest."}
+        {soundingsLanguage
+          ? " Completed records move to Past runs after ingest."
+          : " Ingested results live in Results; non-ingested package and run cleanup stays here."}
       </p>
       {error && <p role="alert">{error}</p>}
       {deleteMessage && <p role="status">{deleteMessage}</p>}
-      <div className="button-row">
-        <button type="button" className="secondary-button" onClick={onRefreshStorage}>
-          Refresh runs
-        </button>
-      </div>
+      {showRefreshButton && (
+        <div className="button-row">
+          <button type="button" className="secondary-button" onClick={onRefreshStorage}>
+            Refresh runs
+          </button>
+        </div>
+      )}
 
       {deletePreview && (
         <section className="delete-preview" aria-label="Local run delete preview">
           <h5>Delete local package/run data preview</h5>
           <p>
             Cleanup removes local generated package files, copied runtime files, CM1 output/logs if
-            present, and local sidecars stored under this run directory. It does not touch Results
-            entries, the source repo, the runtime home itself, or the external CM1 install. No files
-            have been deleted yet.
+            present, and local sidecars stored under this run directory. It does not touch{" "}
+            {soundingsLanguage ? "retained run records" : "Results entries"}, the source repo, the
+            runtime home itself, or the external CM1 install. No files have been deleted yet.
           </p>
           <dl className="metric-grid">
             <Metric label="Run ID" value={deletePreview.run_id} />
@@ -8319,8 +9578,9 @@ function LocalPipelinePanel({
 
       {runs.length === 0 ? (
         <p>
-          No active or incomplete packages/runs need Build action. Ingested experiments are managed
-          in Results.
+          {soundingsLanguage
+            ? "No runs need attention."
+            : "No active or incomplete packages/runs need Build action. Ingested experiments are managed in Results."}
         </p>
       ) : (
         <div className="pipeline-run-list" aria-label="Local packages and runs">
@@ -8329,6 +9589,7 @@ function LocalPipelinePanel({
               key={`${run.run_id}-${run.path ?? run.manifest_path ?? index}`}
               run={run}
               result={resultForRun(results, run.run_id)}
+              soundingsLanguage={soundingsLanguage}
               current={run.run_id === currentRunId}
               queueEntry={queueEntryForRun(runQueue, run.run_id)}
               lanWorkerConfigured={lanWorkerConfigured}
@@ -8353,6 +9614,7 @@ function LocalPipelinePanel({
 function PipelineRunCard({
   run,
   result,
+  soundingsLanguage = false,
   current,
   queueEntry,
   lanWorkerConfigured,
@@ -8369,6 +9631,7 @@ function PipelineRunCard({
 }: {
   run: RunStorageEntry;
   result: ResultCard | undefined;
+  soundingsLanguage?: boolean;
   current: boolean;
   queueEntry: RunQueueEntry | undefined;
   lanWorkerConfigured: boolean;
@@ -8409,8 +9672,10 @@ function PipelineRunCard({
   const stateTone = resultBacked ? "good" : pipelineRunTone(run, result);
   const nextStep =
     queueAutoIngested && !result
-      ? "Result auto-ingested. The run directory is retained because it backs Results and Explore."
-      : pipelineRunNextStep(run, result);
+      ? soundingsLanguage
+        ? "Run auto-ingested. The run directory is retained because it backs the run record and Explore."
+        : "Result auto-ingested. The run directory is retained because it backs Results and Explore."
+      : pipelineRunNextStep(run, result, soundingsLanguage);
   const showWorkerMessage = Boolean(run.worker_message && !run.worker_state);
   const runProgress = pipelineRunProgressSummary(run);
   const workerProgress = workerProgressSummary(run);
@@ -8827,8 +10092,16 @@ function pipelineRunTone(
   return "neutral";
 }
 
-function pipelineRunNextStep(run: RunStorageEntry, result: ResultCard | undefined): string {
-  if (result) return "Review and local result cleanup are available in Results.";
+function pipelineRunNextStep(
+  run: RunStorageEntry,
+  result: ResultCard | undefined,
+  soundingsLanguage = false,
+): string {
+  if (result) {
+    return soundingsLanguage
+      ? "Review and local run cleanup are available in Past runs."
+      : "Review and local result cleanup are available in Results.";
+  }
   if (run.worker_state === "running")
     return "CM1 is running on the LAN worker; refresh runs for status.";
   if (run.worker_state === "completed") {
@@ -9107,7 +10380,143 @@ function ResultsFilterBar({
   );
 }
 
+function SoundingsArchiveFilterBar({
+  filters,
+  totalCount,
+  visibleCount,
+  onChange,
+  onReset,
+}: {
+  filters: SoundingsArchiveFilterState;
+  totalCount: number;
+  visibleCount: number;
+  onChange: (filters: SoundingsArchiveFilterState) => void;
+  onReset: () => void;
+}) {
+  const update = (patch: Partial<SoundingsArchiveFilterState>) =>
+    onChange({ ...filters, ...patch });
+
+  return (
+    <section
+      className="results-filter-bar soundings-archive-filters"
+      aria-label="Past runs filters"
+    >
+      <div className="results-filter-summary">
+        <p>
+          Showing <strong>{visibleCount}</strong> of <strong>{totalCount}</strong> retained runs
+        </p>
+        <button
+          type="button"
+          className="secondary-button"
+          onClick={onReset}
+          disabled={!soundingsArchiveFiltersActive(filters)}
+        >
+          Reset archive
+        </button>
+      </div>
+      <div className="results-filter-grid soundings-archive-primary-filters">
+        <label>
+          Search
+          <input
+            type="search"
+            value={filters.search}
+            onChange={(event) => update({ search: event.target.value })}
+            placeholder="name, station, run, or note"
+          />
+        </label>
+        <label>
+          Ownership
+          <select
+            value={filters.ownership}
+            onChange={(event) =>
+              update({ ownership: event.target.value as SoundingsArchiveFilterState["ownership"] })
+            }
+          >
+            <option value="sounding">Sounding runs</option>
+            <option value="legacy">Legacy / unassigned</option>
+            <option value="world">World-owned Simulations</option>
+            <option value="all">All retained runs</option>
+          </select>
+        </label>
+        <label>
+          Sort
+          <select
+            value={filters.sort}
+            onChange={(event) => update({ sort: event.target.value as ResultsSortKey })}
+          >
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="name">Name A-Z</option>
+            <option value="scenario">Experiment type</option>
+            <option value="first_cloud">First cloud time</option>
+            <option value="max_qc">Maximum cloud water</option>
+            <option value="max_updraft">Maximum updraft</option>
+          </select>
+        </label>
+      </div>
+      <details className="soundings-archive-more-filters">
+        <summary>More filters</summary>
+        <div className="results-filter-grid soundings-archive-filter-grid">
+          <label>
+            Tag
+            <input
+              value={filters.tag}
+              onChange={(event) => update({ tag: event.target.value })}
+              placeholder="tag contains..."
+            />
+          </label>
+          <label>
+            Lifecycle
+            <select
+              value={filters.lifecycle}
+              onChange={(event) =>
+                update({
+                  lifecycle: event.target.value as SoundingsArchiveFilterState["lifecycle"],
+                })
+              }
+            >
+              <option value="all">All lifecycle states</option>
+              <option value="saved">Saved or protected</option>
+              <option value="completed">Completed output</option>
+              <option value="needs_attention">Needs attention</option>
+            </select>
+          </label>
+          <label>
+            Trust
+            <select
+              value={filters.trust}
+              onChange={(event) =>
+                update({ trust: event.target.value as SoundingsArchiveFilterState["trust"] })
+              }
+            >
+              <option value="all">All trust states</option>
+              <option value="trusted">Trusted</option>
+              <option value="caveated">Caveated or failed</option>
+              <option value="unassessed">Not assessed</option>
+            </select>
+          </label>
+          <label>
+            Date
+            <select
+              value={filters.date}
+              onChange={(event) =>
+                update({ date: event.target.value as SoundingsArchiveFilterState["date"] })
+              }
+            >
+              <option value="all">Any date</option>
+              <option value="7d">Last 7 days</option>
+              <option value="30d">Last 30 days</option>
+              <option value="365d">Last year</option>
+            </select>
+          </label>
+        </div>
+      </details>
+    </section>
+  );
+}
+
 function ExperimentNotebookList({
+  context = "legacy",
   results,
   totalResults,
   filtersActive,
@@ -9116,6 +10525,7 @@ function ExperimentNotebookList({
   onOpenExplore,
   onResetFilters,
 }: {
+  context?: "legacy" | "soundings";
   results: ResultCard[];
   totalResults: number;
   filtersActive: boolean;
@@ -9125,12 +10535,30 @@ function ExperimentNotebookList({
   onResetFilters: () => void;
 }) {
   if (results.length === 0) {
+    if (context === "soundings" && totalResults > 0 && !filtersActive) {
+      return (
+        <section className="notebook-list-panel empty-results" aria-label="Runs list">
+          <p className="eyebrow">Sounding run archive</p>
+          <h3>No ingested Soundings runs yet.</h3>
+          <p>
+            {totalResults.toLocaleString()} other retained run
+            {totalResults === 1 ? " is" : "s are"} available under Ownership.
+          </p>
+        </section>
+      );
+    }
     if (filtersActive && totalResults > 0) {
       return (
-        <section className="notebook-list-panel empty-results" aria-label="Results list">
+        <section
+          className="notebook-list-panel empty-results"
+          aria-label={context === "soundings" ? "Runs list" : "Results list"}
+        >
           <p className="eyebrow">No matches</p>
-          <h3>No results match the current filters.</h3>
-          <p>Try clearing filters or widening the search to see the full experiment notebook.</p>
+          <h3>No {context === "soundings" ? "runs" : "results"} match the current filters.</h3>
+          <p>
+            Try clearing filters or widening the search to see the full{" "}
+            {context === "soundings" ? "run archive" : "experiment notebook"}.
+          </p>
           <button type="button" onClick={onResetFilters}>
             Clear filters
           </button>
@@ -9138,25 +10566,37 @@ function ExperimentNotebookList({
       );
     }
     return (
-      <section className="notebook-list-panel empty-results" aria-label="Results list">
-        <p className="eyebrow">Notebook empty</p>
-        <h3>No ingested CM1 results yet.</h3>
-        <p>Completed and ingested CM1 runs will appear here as experiment notebook entries.</p>
+      <section
+        className="notebook-list-panel empty-results"
+        aria-label={context === "soundings" ? "Runs list" : "Results list"}
+      >
+        <p className="eyebrow">
+          {context === "soundings" ? "Run archive empty" : "Notebook empty"}
+        </p>
+        <h3>No ingested CM1 {context === "soundings" ? "runs" : "results"} yet.</h3>
+        <p>
+          Completed and ingested CM1 runs will appear here as{" "}
+          {context === "soundings" ? "retained runs" : "experiment notebook entries"}.
+        </p>
       </section>
     );
   }
 
   return (
-    <section className="notebook-list-panel" aria-label="Results list">
-      <p className="eyebrow">Experiment list</p>
+    <section
+      className="notebook-list-panel"
+      aria-label={context === "soundings" ? "Runs list" : "Results list"}
+    >
+      <p className="eyebrow">{context === "soundings" ? "Run list" : "Experiment list"}</p>
       <div className="experiment-card-list">
         {results.map((result) => {
           const selected = result.result_id === selectedResultId;
+          const owner = resultCloudWorldId(result);
           return (
             <article
               key={result.result_id}
               className={`experiment-card${selected ? " selected-experiment-card" : ""}`}
-              aria-label={`${result.name} experiment`}
+              aria-label={`${result.name} ${context === "soundings" ? "run" : "experiment"}`}
             >
               <div className="experiment-card-main">
                 <button
@@ -9176,13 +10616,25 @@ function ExperimentNotebookList({
                   <OutcomeBadge result={result} />
                   <StatusBadge label={rainWaterOutcome(result)} tone="neutral" />
                   <StatusBadge label={resultInputSourceLabel(result)} tone="neutral" />
+                  {context === "soundings" && (
+                    <StatusBadge
+                      label={
+                        owner
+                          ? `${cloudWorldDisplayName(owner)} Simulation`
+                          : result.input_source === "observed_sounding"
+                            ? "Sounding experiment"
+                            : "Legacy / unassigned"
+                      }
+                      tone={owner ? "good" : "neutral"}
+                    />
+                  )}
                 </div>
                 <p className="science-card-summary">{compactScienceSummary(result)}</p>
                 <p className="result-story">{resultStory(result)}</p>
               </div>
               <div className="experiment-card-actions">
                 <button type="button" onClick={() => onOpenExplore(result.result_id)}>
-                  Open in Explore
+                  {owner ? `Open ${cloudWorldDisplayName(owner)}` : "Open in Explore"}
                 </button>
               </div>
               <details className="technical-details">
@@ -9203,6 +10655,7 @@ function ExperimentNotebookList({
 }
 
 function ResultNotebookCard({
+  context = "legacy",
   result,
   draft,
   comparisonStory,
@@ -9216,6 +10669,7 @@ function ResultNotebookCard({
   onConfirmDelete,
   onCancelDelete,
 }: {
+  context?: "legacy" | "soundings";
   result: ResultCard | undefined;
   draft: { name: string; tags: string; notes: string };
   comparisonStory: TradeCumulusComparisonStoryResponse | null;
@@ -9231,8 +10685,14 @@ function ResultNotebookCard({
 }) {
   if (!result) {
     return (
-      <section className="status-panel" aria-label="Result detail">
-        <p>Select an ingested CM1 result to review its notebook card.</p>
+      <section
+        className="status-panel"
+        aria-label={context === "soundings" ? "Run detail" : "Result detail"}
+      >
+        <p>
+          Select an ingested CM1 {context === "soundings" ? "run" : "result"} to review its{" "}
+          {context === "soundings" ? "record" : "notebook card"}.
+        </p>
       </section>
     );
   }
@@ -9245,10 +10705,13 @@ function ResultNotebookCard({
   );
 
   return (
-    <section className="notebook-card" aria-label="Result detail">
+    <section
+      className="notebook-card"
+      aria-label={context === "soundings" ? "Run detail" : "Result detail"}
+    >
       <div className="notebook-title">
         <div>
-          <p className="eyebrow">Notebook entry</p>
+          <p className="eyebrow">{context === "soundings" ? "Run record" : "Notebook entry"}</p>
           <h3>{result.name}</h3>
           <p>
             {result.scenario_name ?? humanize(result.scenario_id)} ·{" "}
@@ -9309,7 +10772,11 @@ function ResultNotebookCard({
         <Metric label="Latest output" value={formatSeconds(resultLatestOutputTime(result))} />
         <Metric
           label="Local data"
-          value="Run-directory backed; delete removes the result and local run files"
+          value={
+            context === "soundings"
+              ? "Run-directory backed; delete removes the run record and local files"
+              : "Run-directory backed; delete removes the result and local run files"
+          }
         />
       </dl>
 
@@ -9319,13 +10786,19 @@ function ResultNotebookCard({
           className="delete-preview result-delete-preview"
           aria-label="Result delete preview"
         >
-          <h4>Delete result and local run data preview</h4>
+          <h4>
+            Delete{" "}
+            {context === "soundings"
+              ? "run and local data preview"
+              : "result and local run data preview"}
+          </h4>
           <p>
-            This removes the ingested result, notebook edits, diagnostics, derived products, CM1
-            output, logs, and local run files stored under this run directory. The result will
-            disappear from Results, Explore, and local inventory after confirmation. It does not
-            touch the source repo, runtime home itself, or external CM1 install. No files have been
-            deleted yet.
+            This removes the ingested {context === "soundings" ? "run record" : "result"}, notebook
+            edits, diagnostics, derived products, CM1 output, logs, and local run files stored under
+            this run directory. The {context === "soundings" ? "run" : "result"} will disappear from{" "}
+            {context === "soundings" ? "Past runs" : "Results"}, Explore, and local inventory after
+            confirmation. It does not touch the source repo, runtime home itself, or external CM1
+            install. No files have been deleted yet.
           </p>
           <dl className="metric-grid">
             <Metric label="Run ID" value={visibleDeletePreview.run_id} />
@@ -9353,7 +10826,7 @@ function ResultNotebookCard({
               className="danger-button"
               onClick={() => onConfirmDelete(visibleDeletePreview.result_id)}
             >
-              Delete result and local run data
+              Delete {context === "soundings" ? "run and local data" : "result and local run data"}
             </button>
           </div>
         </section>
@@ -9366,7 +10839,10 @@ function ResultNotebookCard({
           <Metric label="Scenario ID" value={result.scenario_id} />
           <Metric label="Lifecycle" value={result.source_lifecycle_state} />
           <Metric label="Product state" value={result.source_product_state} />
-          <Metric label="Result state" value={result.status} />
+          <Metric
+            label={context === "soundings" ? "Run state" : "Result state"}
+            value={result.status}
+          />
           <Metric label="Source model" value={result.source_model} />
           <Metric
             label="Input source"
@@ -9455,14 +10931,17 @@ function ResultNotebookCard({
             </button>
           )}
           <button type="button" onClick={onInspect}>
-            Open in Explore
+            {context === "soundings" && resultCloudWorldId(result)
+              ? `Open ${cloudWorldDisplayName(resultCloudWorldId(result)!)}`
+              : "Open in Explore"}
           </button>
           <button
             type="button"
             className="danger-button"
             onClick={() => onPreviewDelete(result.result_id)}
           >
-            Preview delete result and local run data
+            Preview delete{" "}
+            {context === "soundings" ? "run and local data" : "result and local run data"}
           </button>
           <button type="submit" className="secondary-button">
             Save changes
@@ -9794,6 +11273,8 @@ export function VisualizerSceneShell({
   backLabel,
   onBack,
   onCompare,
+  resultOptions,
+  onSelectResult,
 }: {
   result: ResultCard;
   worldName?: string;
@@ -9803,12 +11284,16 @@ export function VisualizerSceneShell({
   backLabel?: string;
   onBack?: () => void;
   onCompare?: () => void;
+  resultOptions?: ResultCard[];
+  onSelectResult?: (resultId: string) => void;
 }) {
   const resultId = result.result_id;
   const updraftLensEligible = tradeCumulusUpdraftLensEligible(result);
   const productWorldName = worldName ?? (updraftLensEligible ? "Trade Cumulus" : "Cloud Chamber");
   const productSimulationName =
     simulationName ?? worldSimulationDisplayName(result.result_id, result.name);
+  const productEntityLabel =
+    productWorldName === "Fun With Soundings" ? "Experiment" : "Simulation";
   const initialResultRef = useRef(result);
   if (initialResultRef.current.result_id !== resultId) {
     initialResultRef.current = result;
@@ -9910,10 +11395,16 @@ export function VisualizerSceneShell({
     autoActivatedUpdraftLensResultRef.current = null;
     updraftLensRequestRef.current += 1;
     setSceneStatus("Loading scene data...");
+    const defaultsRequest = fetchVisualizationDefaults(resultId).catch(() => null);
+    void defaultsRequest.then((defaults) => {
+      if (active && defaults) setViewDefaults(defaults);
+    });
     withTimeout(
       Promise.all([
         fetchVisualizationFields(resultId),
-        fetchVisualizationDefaults(resultId).catch(() => null),
+        withTimeout(defaultsRequest, "Visualization defaults are still loading.", 2_000).catch(
+          () => null,
+        ),
       ]),
       "Timed out loading visualization fields. Check the backend and retry.",
     )
@@ -10543,6 +12034,24 @@ export function VisualizerSceneShell({
       backLabel={backLabel}
       onBack={onBack}
       onCompare={onCompare}
+      headerActions={
+        resultOptions && resultOptions.length > 0 && onSelectResult ? (
+          <label className="soundings-explore-run-selector">
+            <span>Run</span>
+            <select
+              aria-label="Soundings run"
+              value={resultId}
+              onChange={(event) => onSelectResult(event.target.value)}
+            >
+              {resultOptions.map((option) => (
+                <option key={option.result_id} value={option.result_id}>
+                  {soundingsExploreOptionLabel(option)}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : undefined
+      }
     >
       <section
         className={`visualizer-shell${focusedViewer ? ` visualizer-shell-focused-${focusedViewer}` : ""}`}
@@ -11016,6 +12525,7 @@ export function VisualizerSceneShell({
             <ResultExplanationPanel
               result={result}
               simulationName={productSimulationName}
+              entityLabel={productEntityLabel}
               tradeCumulus={updraftLensEligible}
               isNoCloudWithUpdraft={isNoCloudWithUpdraft}
               updraftLensActive={updraftLensActive}
@@ -11175,7 +12685,13 @@ export function VisualizerSceneShell({
 
         <ExploreSecondarySections
           sections={{
-            science: <TradeCumulusScience result={result} selectedRegion={selectedRegion} />,
+            science: (
+              <TradeCumulusScience
+                result={result}
+                selectedRegion={selectedRegion}
+                entityLabel={productEntityLabel}
+              />
+            ),
             notes: simulationRecord?.simulation_id ? (
               <SimulationNotes
                 worldId={simulationRecord.world_id}
@@ -11184,9 +12700,10 @@ export function VisualizerSceneShell({
               />
             ) : (
               <section className="simulation-note-failure">
-                <h3>Simulation notes</h3>
+                <h3>{productEntityLabel} notes</h3>
                 <p role="alert">
-                  Notes are unavailable because this result has no stable Simulation identity.
+                  Notes are unavailable because this result has no stable{" "}
+                  {productEntityLabel.toLowerCase()} identity.
                 </p>
               </section>
             ),
@@ -11346,6 +12863,7 @@ function ExploreRenderingControls({
 function ResultExplanationPanel({
   result,
   simulationName,
+  entityLabel,
   tradeCumulus,
   isNoCloudWithUpdraft,
   updraftLensActive,
@@ -11356,6 +12874,7 @@ function ResultExplanationPanel({
 }: {
   result: ResultCard;
   simulationName: string;
+  entityLabel: "Simulation" | "Experiment";
   tradeCumulus: boolean;
   isNoCloudWithUpdraft: boolean;
   updraftLensActive: boolean;
@@ -11403,7 +12922,7 @@ function ResultExplanationPanel({
         </div>
       }
       orientation={[
-        { label: "Simulation", value: simulationName },
+        { label: entityLabel, value: simulationName },
         { label: "View", value: identity },
         { label: "Model time", value: selectedTimeLabel },
         { label: "Slice", value: activeSliceLabel },
@@ -11411,7 +12930,7 @@ function ResultExplanationPanel({
           label: "Relevant caveat",
           value:
             result.runtime_integrity?.state === "caveated"
-              ? "This Simulation carries runtime-integrity caveats; see Details."
+              ? `This ${entityLabel} carries runtime-integrity caveats; see Details.`
               : "The view describes retained saved output, not continuous model evolution.",
         },
       ]}
@@ -11425,9 +12944,11 @@ function ResultExplanationPanel({
 function TradeCumulusScience({
   result,
   selectedRegion,
+  entityLabel,
 }: {
   result: ResultCard;
   selectedRegion: SelectedRegionRequest | null;
+  entityLabel: "Simulation" | "Experiment";
 }) {
   const [localHistory, setLocalHistory] = useState<SelectedRegionHistoryResponse | null>(null);
   const [localHistoryLoading, setLocalHistoryLoading] = useState(false);
@@ -11487,8 +13008,8 @@ function TradeCumulusScience({
       <h3>Cloud-field evolution</h3>
       <p>
         Follow the timing and magnitude of cloud water together with the vertical-motion envelope.
-        The Updraft Lens shows their spatial relationship at one saved time; these Simulation-wide
-        extrema summarize the retained history.
+        The Updraft Lens shows their spatial relationship at one saved time; these{" "}
+        {entityLabel.toLowerCase()}-wide extrema summarize the retained history.
       </p>
       <dl className="metric-grid compact-metric-grid">
         <Metric label="First cloud" value={formatSeconds(resultFirstCloudTime(result))} />
@@ -14556,6 +16077,16 @@ const DEFAULT_RESULTS_FILTERS: ResultsFilterState = {
   sort: "newest",
 };
 
+const DEFAULT_SOUNDINGS_ARCHIVE_FILTERS: SoundingsArchiveFilterState = {
+  search: "",
+  ownership: "sounding",
+  tag: "",
+  lifecycle: "all",
+  trust: "all",
+  date: "all",
+  sort: "newest",
+};
+
 function prioritizeResults(results: ResultCard[]): ResultCard[] {
   return [...results].sort((left, right) => resultPriority(right) - resultPriority(left));
 }
@@ -14582,8 +16113,103 @@ function filterAndSortResults(results: ResultCard[], filters: ResultsFilterState
     .sort((left, right) => compareResults(left, right, filters.sort));
 }
 
+function filterSoundingsArchiveResults(
+  results: ResultCard[],
+  filters: SoundingsArchiveFilterState,
+): ResultCard[] {
+  const query = filters.search.trim().toLowerCase();
+  const tag = filters.tag.trim().toLowerCase();
+  const minimumDate =
+    filters.date === "all"
+      ? null
+      : Date.now() -
+        {
+          "7d": 7,
+          "30d": 30,
+          "365d": 365,
+        }[filters.date] *
+          24 *
+          60 *
+          60 *
+          1000;
+  return [...results]
+    .filter((result) => resultMatchesSearch(result, query))
+    .filter((result) => {
+      const ownership = resultArchiveOwnership(result);
+      return filters.ownership === "all" || ownership === filters.ownership;
+    })
+    .filter(
+      (result) => !tag || result.tags.some((resultTag) => resultTag.toLowerCase().includes(tag)),
+    )
+    .filter((result) => {
+      if (filters.lifecycle === "all") return true;
+      if (filters.lifecycle === "saved") return result.saved || result.protected;
+      if (filters.lifecycle === "completed") {
+        return result.completed_at !== null && result.status !== "failed";
+      }
+      return (
+        result.status.includes("fail") ||
+        result.source_lifecycle_state.includes("fail") ||
+        (result.missing_required_output_fields?.length ?? 0) > 0
+      );
+    })
+    .filter((result) => {
+      if (filters.trust === "all") return true;
+      const state = result.runtime_integrity?.state ?? "not_assessed";
+      if (filters.trust === "trusted") return state === "trusted";
+      if (filters.trust === "unassessed") return state === "not_assessed";
+      return state === "caveated" || state === "failed";
+    })
+    .filter((result) => {
+      if (minimumDate === null) return true;
+      const timestamp = new Date(result.completed_at ?? result.created_at).getTime();
+      return Number.isFinite(timestamp) && timestamp >= minimumDate;
+    })
+    .sort((left, right) => compareResults(left, right, filters.sort));
+}
+
 function resultsFiltersActive(filters: ResultsFilterState): boolean {
   return JSON.stringify(filters) !== JSON.stringify(DEFAULT_RESULTS_FILTERS);
+}
+
+function soundingsArchiveFiltersActive(filters: SoundingsArchiveFilterState): boolean {
+  return JSON.stringify(filters) !== JSON.stringify(DEFAULT_SOUNDINGS_ARCHIVE_FILTERS);
+}
+
+function resultArchiveOwnership(result: ResultCard): "sounding" | "legacy" | "world" {
+  if (resultCloudWorldId(result)) return "world";
+  if (result.input_source === "observed_sounding" || result.observed_sounding) return "sounding";
+  return "legacy";
+}
+
+function soundingsExploreOptionLabel(result: ResultCard): string {
+  const station =
+    result.observed_sounding?.station_name ?? result.input_source_label ?? result.name;
+  const validTime = result.observed_sounding?.valid_time_utc;
+  return validTime ? `${station} · ${formatDate(validTime)}` : station;
+}
+
+function resultCloudWorldId(
+  result: ResultCard | undefined,
+): "trade_cumulus" | "mountain_waves" | "supercells" | null {
+  const value = result?.run_configuration?.cloud_world_id ?? result?.workbench_world_id;
+  return value === "trade_cumulus" || value === "mountain_waves" || value === "supercells"
+    ? value
+    : null;
+}
+
+function cloudWorldDisplayName(worldId: "trade_cumulus" | "mountain_waves" | "supercells"): string {
+  if (worldId === "trade_cumulus") return "Trade Cumulus";
+  if (worldId === "mountain_waves") return "Mountain Waves";
+  return "Supercells";
+}
+
+function soundingsRunLanguage(value: string): string {
+  return value
+    .replaceAll("Results", "Runs")
+    .replaceAll("results", "runs")
+    .replaceAll("Result", "Run")
+    .replaceAll("result", "run");
 }
 
 function resultScenarioOptions(results: ResultCard[]): Array<{ value: string; label: string }> {
@@ -14626,6 +16252,63 @@ function resultSearchText(result: ResultCard): string {
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
+}
+
+function selectedAtmosphereSummary(
+  sounding: ObservedSoundingRecord | null,
+  candidateScreening: Record<string, unknown> | null,
+  sourcePath: AtmosphereSourcePath,
+): SelectedAtmosphereSummary | null {
+  if (!sounding) return null;
+  const source =
+    sourcePath === "cached_recommendations"
+      ? "Cached recommendation"
+      : sourcePath === "saved_candidates"
+        ? "Saved candidate"
+        : "Uploaded IGRA station text";
+  return {
+    station: selectedObservedSoundingStationLabel(sounding, candidateScreening),
+    validTime: formatDate(sounding.valid_time_utc),
+    source,
+    quality: humanize(sounding.validation.status),
+    usableLevels: sounding.levels.length,
+  };
+}
+
+function soundingWorkbenchAvailability(
+  loadState: ScenarioLoadState,
+  error: string | null,
+  scenarios: Scenario[],
+): {
+  state: "loading" | "available" | "partial" | "unavailable";
+  message: string;
+} {
+  if (loadState === "loading") {
+    return { state: "loading", message: "Checking local sounding infrastructure." };
+  }
+  if (loadState === "failed") {
+    return {
+      state: "unavailable",
+      message: error ?? "The local scenario and package service is unavailable.",
+    };
+  }
+  if (loadState === "empty") {
+    return {
+      state: "unavailable",
+      message: "The local backend returned no experiment templates.",
+    };
+  }
+  if (!scenarios.some((scenario) => scenario.id === OBSERVED_SOUNDING_BASE_SCENARIO_ID)) {
+    return {
+      state: "partial",
+      message:
+        "Sounding discovery is visible, but the observed-atmosphere package template is missing.",
+    };
+  }
+  return {
+    state: "available",
+    message: "Sounding discovery, package, execution, and archive services are available.",
+  };
 }
 
 function matchesBooleanFilter(

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1202,8 +1202,8 @@ type WorldResultOwnership = {
 };
 
 type WorldResultOwnershipIndex = {
-  byResultId: Record<string, WorldResultOwnership>;
-  byRunId: Record<string, WorldResultOwnership>;
+  byResultId: Record<string, WorldResultOwnership | null>;
+  byRunId: Record<string, WorldResultOwnership | null>;
 };
 
 type ResultsBooleanFilter = "all" | "yes" | "no" | "unknown";
@@ -1243,6 +1243,8 @@ type RunStorageEntry = {
   lifecycle_state: string | null;
   validation_status: string | null;
   product_state: string | null;
+  input_source?: string | null;
+  has_observed_sounding?: boolean;
   run_configuration: PersistedRunConfiguration | null;
   pre_run_validation_report?: PreRunValidationReport | null;
   created_at: string | null;
@@ -2151,12 +2153,8 @@ async function fetchWorldResultOwnership(): Promise<{
         simulationId,
         simulationName,
       };
-      if (typeof simulation.result_id === "string" && simulation.result_id) {
-        index.byResultId[simulation.result_id] = ownership;
-      }
-      if (typeof simulation.run_id === "string" && simulation.run_id) {
-        index.byRunId[simulation.run_id] = ownership;
-      }
+      registerWorldOwnership(index.byResultId, simulation.result_id, ownership);
+      registerWorldOwnership(index.byRunId, simulation.run_id, ownership);
     });
   });
 
@@ -2168,16 +2166,52 @@ function decorateResultsWithWorldOwnership(
   index: WorldResultOwnershipIndex,
 ): ResultCard[] {
   return results.map((result) => {
-    if (result.run_configuration?.cloud_world_id) return result;
-    const ownership = index.byResultId[result.result_id] ?? index.byRunId[result.run_id];
-    if (!ownership) return result;
+    const resultOwnership = index.byResultId[result.result_id];
+    const runOwnership = index.byRunId[result.run_id];
+    const ownership =
+      resultOwnership &&
+      runOwnership &&
+      sameWorldOwnership(resultOwnership, runOwnership) &&
+      declaredWorldOwnershipMatches(result, resultOwnership)
+        ? resultOwnership
+        : null;
     return {
       ...result,
-      workbench_world_id: ownership.worldId,
-      workbench_simulation_id: ownership.simulationId,
-      workbench_simulation_name: ownership.simulationName,
+      workbench_world_id: ownership?.worldId ?? null,
+      workbench_simulation_id: ownership?.simulationId ?? null,
+      workbench_simulation_name: ownership?.simulationName ?? null,
     };
   });
+}
+
+function registerWorldOwnership(
+  index: Record<string, WorldResultOwnership | null>,
+  identifier: unknown,
+  ownership: WorldResultOwnership,
+) {
+  if (typeof identifier !== "string" || !identifier) return;
+  if (!(identifier in index)) {
+    index[identifier] = ownership;
+    return;
+  }
+  const existing = index[identifier];
+  if (!existing || !sameWorldOwnership(existing, ownership)) {
+    index[identifier] = null;
+  }
+}
+
+function sameWorldOwnership(left: WorldResultOwnership, right: WorldResultOwnership): boolean {
+  return left.worldId === right.worldId && left.simulationId === right.simulationId;
+}
+
+function declaredWorldOwnershipMatches(
+  result: ResultCard,
+  ownership: WorldResultOwnership,
+): boolean {
+  const declaredWorldId = result.run_configuration?.cloud_world_id;
+  if (declaredWorldId && declaredWorldId !== ownership.worldId) return false;
+  const declaredSimulationId = result.run_configuration?.simulation_id;
+  return !declaredSimulationId || declaredSimulationId === ownership.simulationId;
 }
 
 async function patchResultCard(
@@ -2633,12 +2667,15 @@ export function App() {
       .then(({ index, unavailableWorldNames }) => {
         worldResultOwnershipRef.current = index;
         setResults((current) => decorateResultsWithWorldOwnership(current, index));
-        const linkedCount =
-          Object.keys(index.byResultId).length + Object.keys(index.byRunId).length;
+        const linkedCount = new Set(
+          Object.values(index.byResultId)
+            .filter((ownership): ownership is WorldResultOwnership => ownership !== null)
+            .map((ownership) => `${ownership.worldId}:${ownership.simulationId}`),
+        ).size;
         setWorldOwnershipStatus(
           unavailableWorldNames.length > 0
-            ? `${linkedCount} retained Simulation identifiers linked. Could not check ${unavailableWorldNames.join(", ")}.`
-            : `${linkedCount} retained Simulation identifiers linked across all Cloud Worlds.`,
+            ? `${linkedCount} retained Simulations verified. Could not check ${unavailableWorldNames.join(", ")}; affected Experiments remain unassigned.`
+            : `${linkedCount} retained Simulations verified across all Cloud Worlds.`,
         );
       })
       .catch(() => {
@@ -2713,7 +2750,7 @@ export function App() {
     [results, selectedResultId],
   );
   const soundingsExploreResults = useMemo(
-    () => results.filter((result) => resultArchiveOwnership(result) === "sounding"),
+    () => results.filter((result) => resultArchiveOwnership(result) !== "world"),
     [results],
   );
   const selectedSoundingsExploreResult = soundingsExploreResults.find(
@@ -4656,14 +4693,14 @@ export function App() {
               simulationName={selectedSoundingsExploreResult.name}
               resultOptions={soundingsExploreResults}
               onSelectResult={(resultId) => openSoundingsResult(resultId, "explore")}
-              backLabel="Back to Runs"
+              backLabel="Back to Past Experiments"
               onBack={() => enterFunWithSoundings("activity")}
             />
           ) : (
             <ScenarioStatePanel
-              title="This Soundings run is not available in Explore"
+              title="This Soundings Experiment is not available in Explore"
               body="Choose an ingested Soundings experiment. World-owned Simulations remain available from their Cloud World."
-              actionLabel="Back to Runs"
+              actionLabel="Back to Past Experiments"
               onAction={() => enterFunWithSoundings("activity")}
             />
           )}
@@ -5234,7 +5271,7 @@ function BuildWorkspace({
     if (soundingsSection === "explore") {
       return (
         <SoundingsExploreLanding
-          results={results.filter((result) => resultArchiveOwnership(result) === "sounding")}
+          results={results.filter((result) => resultArchiveOwnership(result) !== "world")}
           onOpen={onExploreStoredResult}
           onViewRuns={() => onNavigateSoundingsSection("activity")}
         />
@@ -8360,23 +8397,23 @@ function ResultsWorkspace({
     <section className="results-library" aria-labelledby="results-title">
       <div className="section-heading">
         <div>
-          <p className="eyebrow">{context === "soundings" ? "Archive" : "Results"}</p>
+          <p className="eyebrow">{context === "soundings" ? "Experiments" : "Results"}</p>
           <h2 id="results-title">
-            {context === "soundings" ? "Past runs" : "Experiment Notebook"}
+            {context === "soundings" ? "Past Experiments" : "Experiment Notebook"}
           </h2>
           <p>
             {context === "soundings"
-              ? "Reopen ingested Soundings runs. Use Ownership when you need legacy records or World-owned Simulations."
+              ? "Reopen completed, ingested Soundings Experiments. Use Ownership to inspect legacy records or verified World Simulations."
               : "Review ingested cloud experiments, scan result cards, and open results for explanation."}
           </p>
         </div>
         <button type="button" onClick={onRefreshResults}>
-          {context === "soundings" ? "Refresh archive" : "Refresh results"}
+          {context === "soundings" ? "Refresh Experiments" : "Refresh results"}
         </button>
       </div>
       {resultsStatus !== "Results loaded" && resultsStatus !== "Loading results..." && (
         <p className="inline-status" role="status">
-          {context === "soundings" ? soundingsRunLanguage(resultsStatus) : resultsStatus}
+          {context === "soundings" ? soundingsExperimentStatus(resultsStatus) : resultsStatus}
         </p>
       )}
       {context === "soundings" && worldOwnershipStatus && (
@@ -8387,7 +8424,7 @@ function ResultsWorkspace({
 
       {resultsError && (
         <p role="alert">
-          {context === "soundings" ? soundingsRunLanguage(resultsError) : resultsError}
+          {context === "soundings" ? soundingsExperimentStatus(resultsError) : resultsError}
         </p>
       )}
 
@@ -8491,7 +8528,7 @@ function NotebookWorkspace({
   return (
     <section
       className="workspace-section"
-      aria-label={context === "soundings" ? "Past runs" : "Notebook entries"}
+      aria-label={context === "soundings" ? "Past Experiments" : "Notebook entries"}
     >
       {context === "soundings" ? (
         <SoundingsArchiveFilterBar
@@ -8693,13 +8730,13 @@ function SoundingsExploreLanding({
       <div className="section-heading">
         <div>
           <p className="eyebrow">Explore</p>
-          <h3 id="soundings-explore-title">Explore sounding runs</h3>
+          <h3 id="soundings-explore-title">Explore Soundings Experiments</h3>
           <p>Inspect completed, ingested Soundings experiments.</p>
         </div>
       </div>
       {results.length === 0 ? (
         <section className="soundings-explore-empty">
-          <h4>No Soundings run is ready to explore yet</h4>
+          <h4>No Soundings Experiment is ready to explore yet</h4>
           <p>
             Explore becomes available after a Soundings experiment completes and its output is
             ingested.
@@ -8709,7 +8746,7 @@ function SoundingsExploreLanding({
           </button>
         </section>
       ) : (
-        <div className="soundings-explore-ready-list" aria-label="Runs ready to explore">
+        <div className="soundings-explore-ready-list" aria-label="Experiments ready to explore">
           {results.map((result) => (
             <button key={result.result_id} type="button" onClick={() => onOpen(result.result_id)}>
               <strong>{result.name}</strong>
@@ -8743,17 +8780,64 @@ function RunMonitorPanel(props: LocalRunWorkflowPanelProps) {
 }
 
 function SoundingsRunsPanel(props: LocalRunWorkflowPanelProps) {
-  const { activeCount, queuedCount, completedCount } = runActivityCounts(props);
   const currentRunId = props.dryRun ? runIdFromPackage(props.dryRun) : null;
-  const activeRunId = props.runQueue?.active_run_id ?? null;
-  const activeRun = props.storageInventory?.runs.find((run) => run.run_id === activeRunId);
+  const inventoryRuns = props.storageInventory?.runs ?? [];
+  const isSoundingsRun = (runId: string) => {
+    if (runId === currentRunId) return true;
+    const run = inventoryRuns.find((candidate) => candidate.run_id === runId);
+    return run ? runWorkCategory(run, resultForRun(props.results, runId)) === "sounding" : false;
+  };
+  const soundingsInventory = props.storageInventory
+    ? {
+        ...props.storageInventory,
+        runs: inventoryRuns.filter((run) => isSoundingsRun(run.run_id)),
+        largest_runs: props.storageInventory.largest_runs.filter((run) =>
+          isSoundingsRun(run.run_id),
+        ),
+      }
+    : null;
+  const soundingsQueue = props.runQueue
+    ? {
+        ...props.runQueue,
+        entries: props.runQueue.entries.filter((entry) => isSoundingsRun(entry.run_id)),
+        active_run_id:
+          props.runQueue.active_run_id && isSoundingsRun(props.runQueue.active_run_id)
+            ? props.runQueue.active_run_id
+            : null,
+        queued_count: props.runQueue.entries.filter(
+          (entry) => entry.state === "queued" && isSoundingsRun(entry.run_id),
+        ).length,
+      }
+    : null;
+  const soundingsProps: LocalRunWorkflowPanelProps = {
+    ...props,
+    storageInventory: soundingsInventory,
+    runQueue: soundingsQueue,
+  };
+  const { activeCount, queuedCount, completedCount } = runActivityCounts(soundingsProps);
+  const activeRunId = soundingsQueue?.active_run_id ?? null;
+  const activeRun = soundingsInventory?.runs.find((run) => run.run_id === activeRunId);
   const activeRunLabel =
     activeRun?.scenario_name ?? activeRun?.scenario_id ?? activeRunId ?? "None";
+  const globalActiveRunId = props.runQueue?.active_run_id ?? null;
+  const globalActiveRun = inventoryRuns.find((run) => run.run_id === globalActiveRunId);
+  const externalActiveRunId =
+    globalActiveRunId && !isSoundingsRun(globalActiveRunId) ? globalActiveRunId : null;
+  const otherActionableRuns = selectPipelineRuns(
+    inventoryRuns.filter((run) => !isSoundingsRun(run.run_id)),
+    props.results,
+    null,
+    props.runQueue,
+  );
+  const worldWorkCount = otherActionableRuns.filter(
+    (run) => runWorkCategory(run, resultForRun(props.results, run.run_id)) === "world",
+  ).length;
+  const legacyWorkCount = otherActionableRuns.length - worldWorkCount;
   const actionableRuns = selectPipelineRuns(
-    props.storageInventory?.runs ?? [],
+    soundingsInventory?.runs ?? [],
     props.results,
     currentRunId,
-    props.runQueue,
+    soundingsQueue,
   );
   const hasTechnicalDetails = Boolean(
     props.dryRun ||
@@ -8771,7 +8855,10 @@ function SoundingsRunsPanel(props: LocalRunWorkflowPanelProps) {
         <div>
           <p className="eyebrow">Runs</p>
           <h3 id="soundings-runs-title">Run status</h3>
-          <p>Track CM1 work in progress. Completed, ingested experiments appear in Past runs.</p>
+          <p>
+            Track technical CM1 execution. Completed, ingested Experiments appear in Past
+            Experiments.
+          </p>
         </div>
         <button type="button" onClick={props.onRefreshStorage}>
           Refresh current work
@@ -8785,7 +8872,38 @@ function SoundingsRunsPanel(props: LocalRunWorkflowPanelProps) {
         <Metric label="Completed locally" value={completedCount.toLocaleString()} />
       </dl>
 
-      {(props.runQueue?.active_run_id || queuedCount > 0) && (
+      {externalActiveRunId && (
+        <section
+          className="soundings-current-queue"
+          aria-label="Global runner occupied by other work"
+        >
+          <div>
+            <p className="eyebrow">Global CM1 runner</p>
+            <h4>Other Cloud Chamber work is running</h4>
+            <p>
+              Soundings execution is waiting for the shared runner. This is not a Soundings Run.
+            </p>
+          </div>
+          <dl>
+            <Metric
+              label="Work type"
+              value={
+                globalActiveRun
+                  ? runWorkCategoryLabel(
+                      runWorkCategory(
+                        globalActiveRun,
+                        resultForRun(props.results, globalActiveRun.run_id),
+                      ),
+                    )
+                  : "Legacy / unassigned work"
+              }
+            />
+            <Metric label="Active Run ID" value={externalActiveRunId} />
+          </dl>
+        </section>
+      )}
+
+      {(activeRunId || queuedCount > 0) && (
         <section className="soundings-current-queue" aria-label="Current local queue">
           <div>
             <p className="eyebrow">Local queue</p>
@@ -8805,8 +8923,15 @@ function SoundingsRunsPanel(props: LocalRunWorkflowPanelProps) {
         </section>
       )}
 
+      {otherActionableRuns.length > 0 && (
+        <p className="soundings-ownership-status">
+          Other technical work is tracked outside this Soundings queue: {worldWorkCount}{" "}
+          World-associated · {legacyWorkCount} legacy / unassigned.
+        </p>
+      )}
+
       <LocalPipelinePanel
-        inventory={props.storageInventory}
+        inventory={soundingsInventory}
         status={props.storageStatus}
         error={props.storageError}
         deletePreview={props.runDeletePreview}
@@ -8814,7 +8939,7 @@ function SoundingsRunsPanel(props: LocalRunWorkflowPanelProps) {
         results={props.results}
         soundingsLanguage
         currentRunId={currentRunId}
-        runQueue={props.runQueue}
+        runQueue={soundingsQueue}
         lanWorkerConfigured={props.lanWorkerConfig?.configured ?? false}
         autoFinalizingWorkerRunIds={props.autoFinalizingWorkerRunIds}
         failedAutoFinalizingWorkerRunIds={props.failedAutoFinalizingWorkerRunIds}
@@ -8838,7 +8963,7 @@ function SoundingsRunsPanel(props: LocalRunWorkflowPanelProps) {
             Open this only when you need package provenance, worker state, logs, or technical
             troubleshooting.
           </p>
-          <LocalRunWorkflowPanel {...props} includePipeline={false} />
+          <LocalRunWorkflowPanel {...soundingsProps} includePipeline={false} />
         </details>
       )}
     </section>
@@ -9203,7 +9328,8 @@ function LocalRunWorkflowPanel({
             aria-label={soundingsLanguage ? "Ingested run actions" : "Ingested result actions"}
           >
             <p>
-              {soundingsLanguage ? "Run record" : "Result metadata"} created: {ingestedResultId}
+              {soundingsLanguage ? "Experiment record" : "Result metadata"} created:{" "}
+              {ingestedResultId}
             </p>
             <div className="button-row">
               <button type="button" onClick={onOpenInResults}>
@@ -9538,7 +9664,7 @@ function LocalPipelinePanel({
           ? "Only active, queued, blocked, or not-yet-ingested runs appear here."
           : "Active packages and runs that still need launch, status review, troubleshooting, or ingest."}
         {soundingsLanguage
-          ? " Completed records move to Past runs after ingest."
+          ? " Completed records move to Past Experiments after ingest."
           : " Ingested results live in Results; non-ingested package and run cleanup stays here."}
       </p>
       {error && <p role="alert">{error}</p>}
@@ -10099,7 +10225,7 @@ function pipelineRunNextStep(
 ): string {
   if (result) {
     return soundingsLanguage
-      ? "Review and local run cleanup are available in Past runs."
+      ? "Experiment review and local Run cleanup are available in Past Experiments."
       : "Review and local result cleanup are available in Results.";
   }
   if (run.worker_state === "running")
@@ -10399,11 +10525,11 @@ function SoundingsArchiveFilterBar({
   return (
     <section
       className="results-filter-bar soundings-archive-filters"
-      aria-label="Past runs filters"
+      aria-label="Past Experiments filters"
     >
       <div className="results-filter-summary">
         <p>
-          Showing <strong>{visibleCount}</strong> of <strong>{totalCount}</strong> retained runs
+          Showing <strong>{visibleCount}</strong> of <strong>{totalCount}</strong> retained records
         </p>
         <button
           type="button"
@@ -10432,10 +10558,10 @@ function SoundingsArchiveFilterBar({
               update({ ownership: event.target.value as SoundingsArchiveFilterState["ownership"] })
             }
           >
-            <option value="sounding">Sounding runs</option>
-            <option value="legacy">Legacy / unassigned</option>
+            <option value="sounding">Soundings Experiments</option>
+            <option value="legacy">Legacy / unassigned Experiments</option>
             <option value="world">World-owned Simulations</option>
-            <option value="all">All retained runs</option>
+            <option value="all">All retained work</option>
           </select>
         </label>
         <label>
@@ -10537,11 +10663,11 @@ function ExperimentNotebookList({
   if (results.length === 0) {
     if (context === "soundings" && totalResults > 0 && !filtersActive) {
       return (
-        <section className="notebook-list-panel empty-results" aria-label="Runs list">
-          <p className="eyebrow">Sounding run archive</p>
-          <h3>No ingested Soundings runs yet.</h3>
+        <section className="notebook-list-panel empty-results" aria-label="Experiments list">
+          <p className="eyebrow">Soundings Experiments</p>
+          <h3>No ingested Soundings Experiments yet.</h3>
           <p>
-            {totalResults.toLocaleString()} other retained run
+            {totalResults.toLocaleString()} other retained record
             {totalResults === 1 ? " is" : "s are"} available under Ownership.
           </p>
         </section>
@@ -10551,13 +10677,15 @@ function ExperimentNotebookList({
       return (
         <section
           className="notebook-list-panel empty-results"
-          aria-label={context === "soundings" ? "Runs list" : "Results list"}
+          aria-label={context === "soundings" ? "Experiments list" : "Results list"}
         >
           <p className="eyebrow">No matches</p>
-          <h3>No {context === "soundings" ? "runs" : "results"} match the current filters.</h3>
+          <h3>
+            No {context === "soundings" ? "Experiments" : "results"} match the current filters.
+          </h3>
           <p>
             Try clearing filters or widening the search to see the full{" "}
-            {context === "soundings" ? "run archive" : "experiment notebook"}.
+            {context === "soundings" ? "Experiment archive" : "experiment notebook"}.
           </p>
           <button type="button" onClick={onResetFilters}>
             Clear filters
@@ -10568,15 +10696,15 @@ function ExperimentNotebookList({
     return (
       <section
         className="notebook-list-panel empty-results"
-        aria-label={context === "soundings" ? "Runs list" : "Results list"}
+        aria-label={context === "soundings" ? "Experiments list" : "Results list"}
       >
         <p className="eyebrow">
-          {context === "soundings" ? "Run archive empty" : "Notebook empty"}
+          {context === "soundings" ? "Experiment archive empty" : "Notebook empty"}
         </p>
-        <h3>No ingested CM1 {context === "soundings" ? "runs" : "results"} yet.</h3>
+        <h3>No ingested CM1 {context === "soundings" ? "Experiments" : "results"} yet.</h3>
         <p>
           Completed and ingested CM1 runs will appear here as{" "}
-          {context === "soundings" ? "retained runs" : "experiment notebook entries"}.
+          {context === "soundings" ? "Experiments" : "experiment notebook entries"}.
         </p>
       </section>
     );
@@ -10585,9 +10713,9 @@ function ExperimentNotebookList({
   return (
     <section
       className="notebook-list-panel"
-      aria-label={context === "soundings" ? "Runs list" : "Results list"}
+      aria-label={context === "soundings" ? "Experiments list" : "Results list"}
     >
-      <p className="eyebrow">{context === "soundings" ? "Run list" : "Experiment list"}</p>
+      <p className="eyebrow">Experiment list</p>
       <div className="experiment-card-list">
         {results.map((result) => {
           const selected = result.result_id === selectedResultId;
@@ -10596,7 +10724,7 @@ function ExperimentNotebookList({
             <article
               key={result.result_id}
               className={`experiment-card${selected ? " selected-experiment-card" : ""}`}
-              aria-label={`${result.name} ${context === "soundings" ? "run" : "experiment"}`}
+              aria-label={`${result.name} Experiment`}
             >
               <div className="experiment-card-main">
                 <button
@@ -10687,10 +10815,10 @@ function ResultNotebookCard({
     return (
       <section
         className="status-panel"
-        aria-label={context === "soundings" ? "Run detail" : "Result detail"}
+        aria-label={context === "soundings" ? "Experiment detail" : "Result detail"}
       >
         <p>
-          Select an ingested CM1 {context === "soundings" ? "run" : "result"} to review its{" "}
+          Select an ingested CM1 {context === "soundings" ? "Experiment" : "result"} to review its{" "}
           {context === "soundings" ? "record" : "notebook card"}.
         </p>
       </section>
@@ -10707,11 +10835,13 @@ function ResultNotebookCard({
   return (
     <section
       className="notebook-card"
-      aria-label={context === "soundings" ? "Run detail" : "Result detail"}
+      aria-label={context === "soundings" ? "Experiment detail" : "Result detail"}
     >
       <div className="notebook-title">
         <div>
-          <p className="eyebrow">{context === "soundings" ? "Run record" : "Notebook entry"}</p>
+          <p className="eyebrow">
+            {context === "soundings" ? "Experiment record" : "Notebook entry"}
+          </p>
           <h3>{result.name}</h3>
           <p>
             {result.scenario_name ?? humanize(result.scenario_id)} ·{" "}
@@ -10774,7 +10904,7 @@ function ResultNotebookCard({
           label="Local data"
           value={
             context === "soundings"
-              ? "Run-directory backed; delete removes the run record and local files"
+              ? "Experiment record backed by a local Run directory"
               : "Run-directory backed; delete removes the result and local run files"
           }
         />
@@ -10789,16 +10919,16 @@ function ResultNotebookCard({
           <h4>
             Delete{" "}
             {context === "soundings"
-              ? "run and local data preview"
+              ? "Experiment and backing Run data preview"
               : "result and local run data preview"}
           </h4>
           <p>
-            This removes the ingested {context === "soundings" ? "run record" : "result"}, notebook
-            edits, diagnostics, derived products, CM1 output, logs, and local run files stored under
-            this run directory. The {context === "soundings" ? "run" : "result"} will disappear from{" "}
-            {context === "soundings" ? "Past runs" : "Results"}, Explore, and local inventory after
-            confirmation. It does not touch the source repo, runtime home itself, or external CM1
-            install. No files have been deleted yet.
+            This removes the ingested {context === "soundings" ? "Experiment record" : "result"},
+            notebook edits, diagnostics, derived products, CM1 output, logs, and local files stored
+            under its backing Run directory. The {context === "soundings" ? "Experiment" : "result"}{" "}
+            will disappear from {context === "soundings" ? "Past Experiments" : "Results"}, Explore,
+            and local inventory after confirmation. It does not touch the source repo, runtime home
+            itself, or external CM1 install. No files have been deleted yet.
           </p>
           <dl className="metric-grid">
             <Metric label="Run ID" value={visibleDeletePreview.run_id} />
@@ -10826,7 +10956,10 @@ function ResultNotebookCard({
               className="danger-button"
               onClick={() => onConfirmDelete(visibleDeletePreview.result_id)}
             >
-              Delete {context === "soundings" ? "run and local data" : "result and local run data"}
+              Delete{" "}
+              {context === "soundings"
+                ? "Experiment and backing Run data"
+                : "result and local run data"}
             </button>
           </div>
         </section>
@@ -10840,7 +10973,7 @@ function ResultNotebookCard({
           <Metric label="Lifecycle" value={result.source_lifecycle_state} />
           <Metric label="Product state" value={result.source_product_state} />
           <Metric
-            label={context === "soundings" ? "Run state" : "Result state"}
+            label={context === "soundings" ? "Experiment state" : "Result state"}
             value={result.status}
           />
           <Metric label="Source model" value={result.source_model} />
@@ -10941,7 +11074,9 @@ function ResultNotebookCard({
             onClick={() => onPreviewDelete(result.result_id)}
           >
             Preview delete{" "}
-            {context === "soundings" ? "run and local data" : "result and local run data"}
+            {context === "soundings"
+              ? "Experiment and backing Run data"
+              : "result and local run data"}
           </button>
           <button type="submit" className="secondary-button">
             Save changes
@@ -12037,9 +12172,9 @@ export function VisualizerSceneShell({
       headerActions={
         resultOptions && resultOptions.length > 0 && onSelectResult ? (
           <label className="soundings-explore-run-selector">
-            <span>Run</span>
+            <span>Experiment</span>
             <select
-              aria-label="Soundings run"
+              aria-label="Soundings Experiment"
               value={resultId}
               onChange={(event) => onSelectResult(event.target.value)}
             >
@@ -16182,6 +16317,29 @@ function resultArchiveOwnership(result: ResultCard): "sounding" | "legacy" | "wo
   return "legacy";
 }
 
+function runWorkCategory(
+  run: RunStorageEntry,
+  result: ResultCard | undefined,
+): "sounding" | "legacy" | "world" {
+  if (result && resultArchiveOwnership(result) === "world") return "world";
+  if (run.run_configuration?.cloud_world_id) return "world";
+  if (
+    result?.input_source === "observed_sounding" ||
+    result?.observed_sounding ||
+    run.input_source === "observed_sounding" ||
+    run.has_observed_sounding
+  ) {
+    return "sounding";
+  }
+  return "legacy";
+}
+
+function runWorkCategoryLabel(category: "sounding" | "legacy" | "world"): string {
+  if (category === "sounding") return "Soundings work";
+  if (category === "world") return "World-associated work";
+  return "Legacy / unassigned work";
+}
+
 function soundingsExploreOptionLabel(result: ResultCard): string {
   const station =
     result.observed_sounding?.station_name ?? result.input_source_label ?? result.name;
@@ -16192,7 +16350,7 @@ function soundingsExploreOptionLabel(result: ResultCard): string {
 function resultCloudWorldId(
   result: ResultCard | undefined,
 ): "trade_cumulus" | "mountain_waves" | "supercells" | null {
-  const value = result?.run_configuration?.cloud_world_id ?? result?.workbench_world_id;
+  const value = result?.workbench_world_id;
   return value === "trade_cumulus" || value === "mountain_waves" || value === "supercells"
     ? value
     : null;
@@ -16204,12 +16362,13 @@ function cloudWorldDisplayName(worldId: "trade_cumulus" | "mountain_waves" | "su
   return "Supercells";
 }
 
-function soundingsRunLanguage(value: string): string {
-  return value
-    .replaceAll("Results", "Runs")
-    .replaceAll("results", "runs")
-    .replaceAll("Result", "Run")
-    .replaceAll("result", "run");
+function soundingsExperimentStatus(value: string): string {
+  const messages: Record<string, string> = {
+    "No ingested results": "No ingested Experiments",
+    "Results unavailable": "Experiments unavailable",
+    "Could not load results.": "Could not load Experiments.",
+  };
+  return messages[value] ?? value;
 }
 
 function resultScenarioOptions(results: ResultCard[]): Array<{ value: string; label: string }> {

--- a/app/frontend/src/CloudWorldsHome.test.tsx
+++ b/app/frontend/src/CloudWorldsHome.test.tsx
@@ -66,11 +66,17 @@ describe("CloudWorldsHome", () => {
     const onEnterTradeCumulus = vi.fn();
     const onEnterMountainWaves = vi.fn();
     const onEnterSupercells = vi.fn();
+    const onEnterFunWithSoundings = vi.fn();
     render(
       <CloudWorldsHome
         onEnterTradeCumulus={onEnterTradeCumulus}
         onEnterMountainWaves={onEnterMountainWaves}
         onEnterSupercells={onEnterSupercells}
+        onEnterFunWithSoundings={onEnterFunWithSoundings}
+        soundingsAvailability={{
+          state: "available",
+          message: "Sounding infrastructure is available.",
+        }}
       />,
     );
 
@@ -82,12 +88,18 @@ describe("CloudWorldsHome", () => {
     expect(screen.getByText("Boulder Windstorm")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Supercells" })).toBeInTheDocument();
     expect(screen.getByText("Quarter-Circle Supercell")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Fun With Soundings" })).toBeInTheDocument();
+    expect(screen.getByText("Atmospheric workbench")).toBeInTheDocument();
+    expect(screen.queryByText(/Installed Worlds/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Draft Worlds/i)).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Enter Trade Cumulus" }));
     fireEvent.click(screen.getByRole("button", { name: "Enter Mountain Waves" }));
     fireEvent.click(screen.getByRole("button", { name: "Enter Supercells" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Fun With Soundings" }));
     expect(onEnterTradeCumulus).toHaveBeenCalledOnce();
     expect(onEnterMountainWaves).toHaveBeenCalledOnce();
     expect(onEnterSupercells).toHaveBeenCalledOnce();
+    expect(onEnterFunWithSoundings).toHaveBeenCalledOnce();
   });
 
   it("shows bounded partial availability", async () => {
@@ -106,6 +118,7 @@ describe("CloudWorldsHome", () => {
         onEnterTradeCumulus={vi.fn()}
         onEnterMountainWaves={vi.fn()}
         onEnterSupercells={vi.fn()}
+        onEnterFunWithSoundings={vi.fn()}
       />,
     );
 
@@ -123,11 +136,13 @@ describe("CloudWorldsHome", () => {
         onEnterTradeCumulus={vi.fn()}
         onEnterMountainWaves={vi.fn()}
         onEnterSupercells={vi.fn()}
+        onEnterFunWithSoundings={vi.fn()}
         fallback={<div>Existing application remains available</div>}
       />,
     );
 
     expect(await screen.findByText("World inventory unavailable.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Fun With Soundings" })).toBeInTheDocument();
     expect(screen.getByText("Existing application remains available")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Retry Worlds" }));
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));

--- a/app/frontend/src/CloudWorldsHome.tsx
+++ b/app/frontend/src/CloudWorldsHome.tsx
@@ -63,11 +63,21 @@ export function CloudWorldsHome({
   onEnterTradeCumulus,
   onEnterMountainWaves,
   onEnterSupercells,
+  onEnterFunWithSoundings,
+  soundingsAvailability = {
+    state: "loading",
+    message: "Checking local sounding infrastructure.",
+  },
   fallback,
 }: {
   onEnterTradeCumulus: () => void;
   onEnterMountainWaves: () => void;
   onEnterSupercells: () => void;
+  onEnterFunWithSoundings: () => void;
+  soundingsAvailability?: {
+    state: "loading" | "available" | "partial" | "unavailable";
+    message: string;
+  };
   fallback?: ReactNode;
 }) {
   const [loadState, setLoadState] = useState<LoadState>({
@@ -104,6 +114,7 @@ export function CloudWorldsHome({
         <section className="status-panel" role="status">
           Loading Cloud Worlds...
         </section>
+        <WorkbenchCard availability={soundingsAvailability} onEnter={onEnterFunWithSoundings} />
       </section>
     );
   }
@@ -121,6 +132,7 @@ export function CloudWorldsHome({
             Retry Worlds
           </button>
         </section>
+        <WorkbenchCard availability={soundingsAvailability} onEnter={onEnterFunWithSoundings} />
         {fallback}
       </section>
     );
@@ -150,6 +162,7 @@ export function CloudWorldsHome({
           <p>No Cloud Worlds are installed.</p>
         </section>
       )}
+      <WorkbenchCard availability={soundingsAvailability} onEnter={onEnterFunWithSoundings} />
     </section>
   );
 }
@@ -198,6 +211,71 @@ function WorldCard({ world, onEnter }: { world: CloudWorldSummary; onEnter: () =
       <div className="world-card-action">
         <button type="button" onClick={onEnter}>
           Enter {world.display_name}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function WorkbenchCard({
+  availability,
+  onEnter,
+}: {
+  availability: {
+    state: "loading" | "available" | "partial" | "unavailable";
+    message: string;
+  };
+  onEnter: () => void;
+}) {
+  return (
+    <article className="world-card workbench-card" aria-labelledby="soundings-workbench-card-title">
+      <div className="world-card-main">
+        <div className="world-card-heading">
+          <div>
+            <p className="eyebrow">Atmospheric workbench</p>
+            <h2 id="soundings-workbench-card-title">Fun With Soundings</h2>
+          </div>
+          {availability.state !== "available" && (
+            <span className={`world-availability ${availability.state}`}>
+              {availability.state === "loading"
+                ? "Checking availability"
+                : availability.state === "partial"
+                  ? "Partially available"
+                  : "Unavailable"}
+            </span>
+          )}
+        </div>
+        <p className="world-description">
+          Find an observed atmosphere, screen its possibilities, and carry a bounded experiment
+          through package, run, ingest, and inspection.
+        </p>
+        {availability.state !== "available" && (
+          <p className="world-availability-message">{availability.message}</p>
+        )}
+      </div>
+
+      <dl className="world-card-metrics">
+        <div>
+          <dt>Sources</dt>
+          <dd>Cached or uploaded</dd>
+        </div>
+        <div>
+          <dt>Selection</dt>
+          <dd>Candidate screening</dd>
+        </div>
+        <div>
+          <dt>Execution</dt>
+          <dd>Local or LAN worker</dd>
+        </div>
+        <div>
+          <dt>History</dt>
+          <dd>Experiments and activity</dd>
+        </div>
+      </dl>
+
+      <div className="world-card-action">
+        <button type="button" onClick={onEnter}>
+          Open Fun With Soundings
         </button>
       </div>
     </article>

--- a/app/frontend/src/CloudWorldsHome.tsx
+++ b/app/frontend/src/CloudWorldsHome.tsx
@@ -159,7 +159,7 @@ export function CloudWorldsHome({
         </div>
       ) : (
         <section className="status-panel">
-          <p>No Cloud Worlds are installed.</p>
+          <p>No Cloud Worlds are currently available.</p>
         </section>
       )}
       <WorkbenchCard availability={soundingsAvailability} onEnter={onEnterFunWithSoundings} />

--- a/app/frontend/src/FunWithSoundings.test.tsx
+++ b/app/frontend/src/FunWithSoundings.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FunWithSoundings } from "./FunWithSoundings";
+
+describe("FunWithSoundings", () => {
+  it("keeps the selected atmosphere visible while moving among the five jobs", () => {
+    const onSectionChange = vi.fn();
+    render(
+      <FunWithSoundings
+        activeSection="candidates"
+        selectedAtmosphere={{
+          station: "Denver / Stapleton",
+          validTime: "Jul 22, 2026, 6:00 PM",
+          source: "Cached recommendation",
+          quality: "Valid",
+          usableLevels: 84,
+        }}
+        onSectionChange={onSectionChange}
+        onBackHome={vi.fn()}
+      >
+        <p>Candidate workspace</p>
+      </FunWithSoundings>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Fun With Soundings" })).toBeInTheDocument();
+    expect(screen.getByText("Atmospheric workbench")).toBeInTheDocument();
+    expect(screen.getByText("Not a Cloud World")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Denver / Stapleton" })).toBeInTheDocument();
+    expect(screen.getByText("84")).toBeInTheDocument();
+    expect(screen.getByText("Candidate workspace")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Build & Run/ }));
+    expect(onSectionChange).toHaveBeenCalledWith("build");
+
+    fireEvent.click(screen.getByRole("button", { name: /Explore/ }));
+    expect(onSectionChange).toHaveBeenCalledWith("explore");
+  });
+
+  it("offers a direct recovery path when no atmosphere is selected", () => {
+    const onSectionChange = vi.fn();
+    render(
+      <FunWithSoundings
+        activeSection="build"
+        selectedAtmosphere={null}
+        onSectionChange={onSectionChange}
+        onBackHome={vi.fn()}
+      >
+        <p>Build workspace</p>
+      </FunWithSoundings>,
+    );
+
+    expect(screen.getByRole("heading", { name: "No atmosphere selected" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Find an atmosphere" }));
+    expect(onSectionChange).toHaveBeenCalledWith("find");
+  });
+});

--- a/app/frontend/src/FunWithSoundings.tsx
+++ b/app/frontend/src/FunWithSoundings.tsx
@@ -1,0 +1,149 @@
+import type { ReactNode } from "react";
+
+export type FunWithSoundingsSection = "find" | "candidates" | "build" | "activity" | "explore";
+
+export type SelectedAtmosphereSummary = {
+  station: string;
+  validTime: string;
+  source: string;
+  quality: string;
+  usableLevels: number;
+};
+
+const SECTIONS: Array<{
+  id: FunWithSoundingsSection;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "find",
+    label: "Find Soundings",
+    description: "Find a cached atmosphere or load an IGRA station file.",
+  },
+  {
+    id: "candidates",
+    label: "Candidates",
+    description: "Screen, compare, and keep atmospheric candidates.",
+  },
+  {
+    id: "build",
+    label: "Build & Run",
+    description: "Configure a bounded experiment and create its package.",
+  },
+  {
+    id: "activity",
+    label: "Runs",
+    description: "Track active work and reopen retained runs.",
+  },
+  {
+    id: "explore",
+    label: "Explore",
+    description: "Inspect completed, ingested sounding experiments.",
+  },
+];
+
+export function FunWithSoundings({
+  activeSection,
+  selectedAtmosphere,
+  children,
+  onSectionChange,
+  onBackHome,
+}: {
+  activeSection: FunWithSoundingsSection;
+  selectedAtmosphere: SelectedAtmosphereSummary | null;
+  children: ReactNode;
+  onSectionChange: (section: FunWithSoundingsSection) => void;
+  onBackHome: () => void;
+}) {
+  return (
+    <section className="soundings-workbench" aria-labelledby="soundings-workbench-title">
+      <nav className="world-breadcrumb" aria-label="Breadcrumb">
+        <button type="button" onClick={onBackHome}>
+          Cloud Chamber
+        </button>
+        <span aria-hidden="true">/</span>
+        <span>Fun With Soundings</span>
+      </nav>
+
+      <header className="soundings-workbench-header">
+        <div>
+          <p className="eyebrow">Atmospheric workbench</p>
+          <h2 id="soundings-workbench-title">Fun With Soundings</h2>
+          <p>
+            Begin with an observed atmosphere, ask a bounded question, and follow the experiment
+            from source evidence through retained output.
+          </p>
+        </div>
+        <div className="soundings-workbench-identity" aria-label="Workbench identity">
+          <span>Observed or user-supplied atmosphere</span>
+          <strong>Not a Cloud World</strong>
+        </div>
+      </header>
+
+      <nav className="soundings-job-nav" aria-label="Fun With Soundings sections">
+        {SECTIONS.map((section, index) => (
+          <button
+            key={section.id}
+            type="button"
+            className={section.id === activeSection ? "active-control" : ""}
+            aria-current={section.id === activeSection ? "page" : undefined}
+            onClick={() => onSectionChange(section.id)}
+          >
+            <span>{index + 1}</span>
+            <strong>{section.label}</strong>
+          </button>
+        ))}
+      </nav>
+
+      {activeSection !== "activity" &&
+        activeSection !== "explore" &&
+        (selectedAtmosphere || activeSection !== "find") && (
+          <section
+            className={`selected-atmosphere-strip${
+              selectedAtmosphere ? " has-selected-atmosphere" : ""
+            }`}
+            aria-label="Selected atmosphere"
+          >
+            <div>
+              <p className="eyebrow">Selected atmosphere</p>
+              {selectedAtmosphere ? (
+                <>
+                  <h3>{selectedAtmosphere.station}</h3>
+                  <p>
+                    {selectedAtmosphere.validTime} · {selectedAtmosphere.source}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <h3>No atmosphere selected</h3>
+                  <p>Choose a sounding in Find Soundings to continue.</p>
+                </>
+              )}
+            </div>
+            {selectedAtmosphere ? (
+              <dl>
+                <div>
+                  <dt>Quality</dt>
+                  <dd>{selectedAtmosphere.quality}</dd>
+                </div>
+                <div>
+                  <dt>Usable levels</dt>
+                  <dd>{selectedAtmosphere.usableLevels.toLocaleString()}</dd>
+                </div>
+              </dl>
+            ) : (
+              <button
+                type="button"
+                className="secondary-button"
+                onClick={() => onSectionChange("find")}
+              >
+                Find an atmosphere
+              </button>
+            )}
+          </section>
+        )}
+
+      <div className="soundings-job-content">{children}</div>
+    </section>
+  );
+}

--- a/app/frontend/src/IntegratedExploreWorkspace.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.tsx
@@ -15,6 +15,7 @@ export function IntegratedExploreWorkspace({
   backLabel,
   onBack,
   onCompare,
+  headerActions,
   children,
 }: {
   worldName: string;
@@ -22,6 +23,7 @@ export function IntegratedExploreWorkspace({
   backLabel?: string;
   onBack?: () => void;
   onCompare?: () => void;
+  headerActions?: ReactNode;
   children: ReactNode;
 }) {
   return (
@@ -40,11 +42,14 @@ export function IntegratedExploreWorkspace({
           )}
           <h2>{simulationName}</h2>
         </div>
-        {onCompare && (
+        {(headerActions || onCompare) && (
           <div className="integrated-explore-actions">
-            <button type="button" onClick={onCompare}>
-              Compare
-            </button>
+            {headerActions}
+            {onCompare && (
+              <button type="button" onClick={onCompare}>
+                Compare
+              </button>
+            )}
           </div>
         )}
       </header>

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -45,7 +45,7 @@ Keep product approval separate from software availability:
 | Subject | Approved direction | Current implemented state |
 | --- | --- | --- |
 | Cloud Worlds | A growing collection of explorable cloud regimes | Trade Cumulus, Mountain Waves, and Supercells are accessible |
-| Fun With Soundings | A separate first-class atmospheric workbench | Not accessible; sounding and run capabilities remain in transitional paths |
+| Fun With Soundings | A separate first-class atmospheric workbench | Accessible with five jobs, direct non-World Explore, and conservative World ownership |
 | Saved Views | Durable user-curated views | Placeholder only; no durable Saved Views |
 | Compare | Related Simulations can be compared | One featured Trade Cumulus Comparison; no ordinary World-aware Compare |
 | Variation | Create a related Simulation from a World Simulation | Working Mountain Waves Lab path; no shared three-World workflow |
@@ -60,8 +60,10 @@ Compare, or Saved View placeholders merely to make all Worlds structurally
 identical.
 
 Fun With Soundings is an approved first-class workbench, not a Cloud World.
-Issue #395 remains queued; approval does not make the workbench accessible in
-the current application.
+Issue #395 implemented its stable entrance, Find Soundings, Candidates, Build &
+Run, Runs, Explore, atmosphere continuity, and Past Experiments ownership
+boundary. Runs remain technical execution; retained non-World work remains an
+Experiment; only current inventory-verified World objects are Simulations.
 
 The Trade Cumulus Product Slice remains subordinate to the North Star, Product
 Vision, approved PM decisions, Application Semantics, and the MVP. Being
@@ -78,7 +80,8 @@ repository authority for current implementation ordering. The latest approved
 PM comment and issue body still control the exact scope of each bounded task.
 
 The presentation-quality and three-World foundation is complete through #420,
-#423, #421, #429, and #428. All three Explore implementations now use one
+#423, #421, #429, and #428. The first-class Fun With Soundings workbench is
+complete through #395. All three Explore implementations now use one
 collapsible Context and shared below-the-fold Science, Notes, and Details
 structure. Per-Simulation Notes are the first durable content contract; complete
 Explore state and Saved Views remain unimplemented.
@@ -87,12 +90,15 @@ The next approved program is personal scientific memory: define one versioned,
 World-aware serializable Explore-state contract before ordinary resume, named
 Saved Views, or Compare work.
 
-Rewritten issues #394 and #395 and issues #432 through #438 record bounded
-follow-on product work for Activity and History, Fun With Soundings, durable
-Explore state and Saved Views, Compare and Saved Comparisons, variation
+Rewritten issue #394 and issues #432 through #438 record bounded
+follow-on product work for Activity and History, durable Explore state and
+Saved Views, Compare and Saved Comparisons, variation
 contracts, retained assets, and curated defaults. Their presence does not
 activate them or replace the sequencing authority. Issues #389, #390, and #391
 were closed as superseded and are not current assignment authority.
+
+Issue #394 remains queued and incomplete; its dependencies and explicit PM
+activation still govern any Activity and History reconciliation.
 
 Keep detailed ordering in Current Product Sequence and explicit later PM
 decisions rather than duplicating a second roadmap here.

--- a/docs/current/CURRENT_ARCHITECTURE.md
+++ b/docs/current/CURRENT_ARCHITECTURE.md
@@ -47,6 +47,7 @@ World overview and section
 Trade Cumulus Explore and featured Comparison
 Mountain Waves World and Explore
 Supercells World and Explore
+Fun With Soundings workbench and direct Explore
 ```
 
 The Cloud Worlds home obtains inventory from `GET /api/worlds`. World-specific
@@ -58,12 +59,17 @@ GET /api/worlds/mountain-waves
 GET /api/worlds/supercells
 ```
 
-Fun With Soundings does not yet have a first-class product route.
+Fun With Soundings uses stable frontend routes:
 
-Legacy Build, Results, generic Explore, scenario, sounding, run, and result
-paths remain in the application. The current World home can fall back to those
-legacy surfaces when World inventory cannot load, and Trade Cumulus Lab embeds
-some of them. This is transitional compatibility, not the intended final
+```text
+/fun-with-soundings
+/fun-with-soundings/explore/{result_id}
+```
+
+Its five jobs compose existing sounding catalog, candidate screening, package,
+run, worker, ingest, storage, and visualization APIs rather than duplicating
+those execution paths. Trade Cumulus Lab still embeds some transitional Build
+and Results surfaces; that compatibility is not the intended final World Lab
 navigation model.
 
 ## World and Simulation Identity
@@ -83,6 +89,14 @@ availability logic. A built-in Simulation is available only when its expected
 artifacts, lineage, geometry, fields, and time inventory satisfy that World's
 contract. Invalid or conflicting content is reported rather than replaced with
 an arbitrary compatible-looking run.
+
+Fun With Soundings checks current World inventories before presenting a
+retained record as a Simulation. Promotion in the workbench requires one
+inventory entry with stable Simulation identity and matching current result and
+run links. `cloud_world_id` metadata alone, a one-sided identifier match,
+conflicting inventory entries, or an unavailable inventory does not establish
+ownership. Those records remain Experiments and are labeled legacy or
+unassigned.
 
 World responses are kept lightweight. Deep validation is performed at
 promotion or discovery boundaries and cached against artifact fingerprints
@@ -217,6 +231,7 @@ The current code keeps these states distinct:
 | Completed output | Expected output artifacts exist |
 | Runtime-integrity assessment | Backend trust state based on runtime and field evidence |
 | Promoted retained Simulation | Validated output is bound to a stable Simulation identity |
+| Experiment | Configured or retained non-World work, including unassigned output |
 | Ingested result metadata | Backend-created metadata exists beside a run |
 | Editable result sidecar | Optional local name, tag, or note state exists |
 | Backend-derived diagnostic | A quantity was calculated from CM1-derived data |
@@ -244,6 +259,13 @@ Result ingest writes `result_metadata.json` inside the original run directory.
 Editable name, tags, and notes may be stored in a sibling `result_card.json`.
 Deleting that run directory can remove the package, logs, NetCDF output, result
 metadata, and notebook state together.
+
+The product language follows the same state boundary: **Run** refers to
+technical execution, **Experiment** refers to non-World scientific work, and
+**Simulation** refers to a stable World-owned object verified by current World
+inventory. The storage inventory exposes bounded manifest input-source evidence
+so the Soundings Runs job can separate workbench execution from
+World-associated or legacy/unassigned technical work after reload.
 
 See [Ingest, Results, and Runtime Cleanup Lifecycle](INGEST_RESULTS_STORAGE_LIFECYCLE.md).
 

--- a/docs/current/CURRENT_STATE.md
+++ b/docs/current/CURRENT_STATE.md
@@ -26,16 +26,44 @@ entrance is a Cloud Worlds home with three accessible Worlds:
 Cloud Chamber
 ├── Trade Cumulus
 ├── Mountain Waves
-└── Supercells
+├── Supercells
+└── Fun With Soundings — atmospheric workbench
 ```
 
 Each World owns stable World and Simulation identities. Those product
 identities resolve to local retained run and result assets; they are not the
 same thing as CM1 run IDs, result IDs, or filesystem paths.
 
-**Fun With Soundings** is approved as a separate atmospheric workbench, not a
-Cloud World. It is not currently accessible as a first-class application
-destination. Issue #395 remains open for that work.
+**Fun With Soundings** is accessible as a separate atmospheric workbench, not
+a Cloud World. Its stable route is `/fun-with-soundings`, with a direct
+non-World Explore route at `/fun-with-soundings/explore/{result_id}`.
+
+## Fun With Soundings
+
+The workbench organizes the existing observed-atmosphere path into five jobs:
+
+```text
+Find Soundings → Candidates → Build & Run → Runs → Explore
+```
+
+Atmosphere selection remains visible across Find, Candidates, and Build & Run.
+The implementation reuses the existing package, local and LAN-worker execution,
+serial queue, ingest, storage, cleanup, and visualization paths.
+
+The workbench preserves explicit lifecycle language:
+
+- a **Run** is technical CM1 execution;
+- an ingested non-World record is an **Experiment**;
+- a World-owned **Simulation** is shown only when current World inventory
+  verifies stable Simulation identity and matching run and result links;
+- ambiguous, stale, or unavailable ownership evidence remains visibly legacy
+  or unassigned.
+
+The Runs job shows Soundings execution without claiming other use of the shared
+CM1 runner as workbench-owned. Past Experiments supports Soundings,
+legacy/unassigned, and verified World ownership views. A verified Simulation
+opens in its World; other retained Experiments open directly in non-World
+Explore.
 
 ## Accessible Cloud Worlds
 
@@ -139,7 +167,8 @@ The large NetCDF histories remain outside Git under the runtime home.
 Working infrastructure remains available even where its product placement is
 not final:
 
-- observed-sounding search, screening, caching, and package configuration;
+- observed-sounding search, screening, caching, and package configuration,
+  now organized in Fun With Soundings;
 - CM1 package generation and provenance review;
 - local CM1 launch, serial queueing, progress, cancellation, and ingest;
 - Results records with local notes, tags, diagnostics, and cleanup;
@@ -149,7 +178,7 @@ not final:
 
 Some of this infrastructure appears inside the current Trade Cumulus Lab.
 That transitional placement does not make Build or Results the final World Lab
-information architecture, and it does not make Fun With Soundings accessible.
+information architecture.
 
 ## Current Gaps
 
@@ -158,7 +187,6 @@ The implemented application does not yet provide:
 - durable Saved Views;
 - ordinary World-aware Compare beyond the featured Trade Cumulus Comparison;
 - one shared World-aware variation workflow across all accessible Worlds;
-- a first-class Fun With Soundings entrance;
 - durable persistence for complete Explore or comparison workspaces.
 
 Per-Simulation Notes are durable content, but camera, time, Lens, overlay,

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -79,6 +79,9 @@ The presentation-quality and third-World program established:
 
 #428 — shared live Context, below-the-fold Science | Notes | Details, and
        durable per-Simulation Notes across all three Worlds — complete
+
+#395 — first-class Fun With Soundings workbench with five jobs, atmosphere
+       continuity, Past Experiments, and direct non-World Explore — complete
 ```
 
 The completed work preserves stable World and Simulation identities while allowing backing run assets to improve.
@@ -98,6 +101,11 @@ World-specific scientific content remains legitimate. Shared structure must not 
 Per-Simulation Notes are the first bounded durable-content contract. They use stable World and Simulation identity, persist across reloads, and fail visibly. They do not serialize complete Explore state, implement resume, create Saved Views, or establish a generic annotation framework.
 
 ## Next program: personal scientific memory
+
+Issue #432 is the next approved program in this sequence. Issue #394 remains
+queued and incomplete; it still depends on #435 and explicit PM activation.
+Completing #395 satisfies only the Fun With Soundings dependency named by
+#394.
 
 Establish one versioned, World-aware Explore-state contract before implementing Compare.
 


### PR DESCRIPTION
Closes #395 when merged.

## Outcome

Creates **Fun With Soundings** as a first-class atmospheric workbench beside the three Cloud Worlds.

The workbench has five direct jobs:

1. Find Soundings
2. Candidates
3. Build & Run
4. Runs
5. Explore

An ingested non-World Experiment opens directly from the workbench, and Explore can switch among other eligible Soundings Experiments without returning to the archive. Verified World-owned Simulations open in their owning World.

## PM rereview corrections

- Declared `httpx` as a backend runtime dependency.
- Uses the ordinary streamed client first and retries with the bounded IPv4 transport only after a connection failure.
- Tests the ordinary path, IPv4 fallback, HTTP failure, and streamed-size limit.
- Restored the product distinction among technical **Runs**, non-World **Experiments**, and verified World-owned **Simulations**.
- Removed blanket Result-to-Run string replacement and authored explicit workbench messages.
- Renamed the retained archive to **Past Experiments** and made deletion wording identify both the Experiment record and backing Run data.
- Changed the Cloud Worlds empty state to availability language.
- Made World ownership fail closed: promotion requires matching current World inventory identity plus exact run and result linkage.
- Keeps unmatched, ambiguous, and unavailable ownership legacy/unassigned and routes eligible records to non-World Explore.
- Separates Soundings work from World-associated and legacy/unassigned technical work in Runs, including a shared-runner banner.
- Updated README, Current State, Current Architecture, Documentation Status, and Current Product Sequence without implying #394 is complete.

## Verification

- `git diff --check`
- `scripts/check.sh`
  - 168 frontend tests passed
  - production build passed
  - backend formatting and typing passed
  - 670 backend tests passed
  - script, artifact, and documentation checks passed
- `scripts/check-e2e.sh`
  - 31 of 31 mocked desktop Playwright tests passed at the repository's normal 30-second configuration after the unrelated external CM1 process completed
- Live in-app browser review plus controlled Playwright review at 1440 x 900 and 1180 x 820.
- No CM1 process was started, stopped, paused, or reprioritized by this rework.

## Review packet

`/Users/timpeterson/Documents/Codex/fun-with-soundings-pr-441-rereview.zip`

The packet contains:

- narrow-desktop Find Soundings;
- technical Runs and Past Experiments;
- a verified Simulation opening in its World;
- unmatched World-associated metadata remaining an Experiment;
- the shared runner occupied by non-Soundings work;
- partial World inventory failure remaining explicit and fail closed;
- four additional captures from the live in-app browser.

## Review posture

- Manual review preserved
- Auto-merge disabled
