### PR TITLE
Define curated Explore defaults and complete reset behavior

### DIFF
--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -351,7 +351,33 @@ const comparisonUpdraftScale = {
 
 type ComparisonMember = typeof comparisonStory.baseline;
 
-function comparisonPointCloud(member: ComparisonMember) {
+function authoredExplorePresentation(member: ComparisonMember) {
+  return member.control_state === "baseline"
+    ? {
+        time_index: 100,
+        time_seconds: 12_060,
+        plane_index: 1,
+        plane_coordinate: 2.366666555404663,
+      }
+    : {
+        time_index: 116,
+        time_seconds: 13_920,
+        plane_index: 1,
+        plane_coordinate: 1.6333333253860474,
+      };
+}
+
+function frameTimeSeconds(member: ComparisonMember, timeIndex: number) {
+  if (timeIndex === member.curated_view.time_index) return member.curated_view.time_seconds;
+  const authored = authoredExplorePresentation(member);
+  if (timeIndex === authored.time_index) return authored.time_seconds;
+  return timeIndex * 120;
+}
+
+function comparisonPointCloud(
+  member: ComparisonMember,
+  timeIndex = member.curated_view.time_index,
+) {
   const offset = member.control_state === "baseline" ? 0 : 0.45;
   const points: Array<[number, number, number, number]> = [
     [-1.8 + offset, -0.8, 0.5, 0.00035],
@@ -367,8 +393,8 @@ function comparisonPointCloud(member: ComparisonMember) {
     field: { raw_field_name: "ql", display_name: "Cloud water", units: "kg/kg" },
     selection: {
       field: "ql",
-      time_index: member.curated_view.time_index,
-      time_seconds: member.curated_view.time_seconds,
+      time_index: timeIndex,
+      time_seconds: frameTimeSeconds(member, timeIndex),
       threshold: 1e-6,
       max_points: 50_000,
     },
@@ -407,7 +433,14 @@ function comparisonPointCloud(member: ComparisonMember) {
   };
 }
 
-function comparisonLensFrame(member: ComparisonMember) {
+function comparisonLensFrame(
+  member: ComparisonMember,
+  {
+    timeIndex = member.curated_view.time_index,
+    planeIndex = member.curated_view.plane_index,
+  }: { timeIndex?: number; planeIndex?: number } = {},
+) {
+  const authored = authoredExplorePresentation(member);
   const values =
     member.control_state === "baseline"
       ? [
@@ -424,12 +457,17 @@ function comparisonLensFrame(member: ComparisonMember) {
         ];
   return {
     result_id: member.result_id,
-    time_index: member.curated_view.time_index,
-    time_seconds: member.curated_view.time_seconds,
+    time_index: timeIndex,
+    time_seconds: frameTimeSeconds(member, timeIndex),
     orientation: "vertical_x",
     plane_dimension: "y",
-    plane_index: member.curated_view.plane_index,
-    plane_coordinate: member.curated_view.plane_coordinate,
+    plane_index: planeIndex,
+    plane_coordinate:
+      planeIndex === authored.plane_index
+        ? authored.plane_coordinate
+        : planeIndex === member.curated_view.plane_index
+          ? member.curated_view.plane_coordinate
+          : -3.2 + planeIndex * 0.1,
     plane_units: "km",
     dimension_order: ["z", "x"],
     x_indices: [0, 1, 2, 3],
@@ -480,6 +518,7 @@ function comparisonLensFrame(member: ComparisonMember) {
 }
 
 function comparisonLensDefaults(member: ComparisonMember) {
+  const authored = authoredExplorePresentation(member);
   return {
     result_id: member.result_id,
     case_id: "bomex_trade_cumulus_baseline_v0",
@@ -487,14 +526,14 @@ function comparisonLensDefaults(member: ComparisonMember) {
     primary_field: "w",
     cloud_field: "ql",
     orientation: "vertical_x",
-    default_time_index: member.curated_view.time_index,
-    default_time_seconds: member.curated_view.time_seconds,
-    default_time_method: "curated_comparison_view",
+    default_time_index: authored.time_index,
+    default_time_seconds: authored.time_seconds,
+    default_time_method: "authored_simulation_presentation",
     default_plane_dimension: "y",
-    default_plane_index: member.curated_view.plane_index,
-    default_plane_coordinate: member.curated_view.plane_coordinate,
+    default_plane_index: authored.plane_index,
+    default_plane_coordinate: authored.plane_coordinate,
     default_plane_units: "km",
-    default_plane_method: "curated_comparison_view",
+    default_plane_method: "authored_simulation_presentation",
     cloud_threshold_kg_kg: 1e-6,
     ...comparisonUpdraftScale,
     wind_target_level_m: 600,
@@ -507,6 +546,76 @@ function comparisonLensDefaults(member: ComparisonMember) {
     total_wind_reference_m_s: 8.8,
     wind_arrow_domain_fraction: 0.08,
     provenance: comparisonLensFrame(member).provenance,
+    caveats: [],
+  };
+}
+
+function comparisonFieldCatalog(member: ComparisonMember) {
+  const times = Array.from(
+    { length: Math.max(member.curated_view.time_index + 1, 181) },
+    (_, index) => index * 120,
+  );
+  const authored = authoredExplorePresentation(member);
+  times[authored.time_index] = authored.time_seconds;
+  const provenance = {
+    source_model: "CM1",
+    result_id: member.result_id,
+    run_id: member.run_id,
+    scenario_id: "bomex_trade_cumulus_baseline_v0",
+    source_product_state: "completed_cm1_result",
+    result_state: "ingested",
+    processing_method: "native-grid field catalog",
+    rendering_method: "visualization-ready metadata",
+    provenance_label: "CM1-derived Trade Cumulus visualization fields",
+  };
+  const fields = [
+    {
+      raw_field_name: "ql",
+      canonical_field_name: "cloud_water",
+      display_name: "Cloud liquid",
+      units: "kg/kg",
+      dimensions: ["time", "zh", "yh", "xh"],
+      native_grid: "zh/yh/xh",
+      vertical: "zh",
+    },
+    {
+      raw_field_name: "qv",
+      canonical_field_name: "water_vapor",
+      display_name: "Water vapor",
+      units: "kg/kg",
+      dimensions: ["time", "zh", "yh", "xh"],
+      native_grid: "zh/yh/xh",
+      vertical: "zh",
+    },
+    {
+      raw_field_name: "w",
+      canonical_field_name: "vertical_velocity",
+      display_name: "Vertical velocity",
+      units: "m/s",
+      dimensions: ["time", "zf", "yh", "xh"],
+      native_grid: "zf/yh/xh",
+      vertical: "zf",
+    },
+  ];
+  return {
+    result_id: member.result_id,
+    run_id: member.run_id,
+    scenario_id: "bomex_trade_cumulus_baseline_v0",
+    source_model: "CM1",
+    available_fields: fields.map((field) => ({
+      ...field,
+      shape: [times.length, 64, 128, 128],
+      coordinate_names: {
+        time: "time",
+        vertical: field.vertical,
+        y: "yh",
+        x: "xh",
+      },
+      time_coordinate_values: times,
+      provenance,
+      caveats: ["native_grid_no_interpolation"],
+    })),
+    provenance,
     caveats: [],
   };
 }
@@ -539,13 +648,26 @@ async function mockTradeCumulusComparison(page: Parameters<typeof mockCloudChamb
   );
   await page.route("**/api/results/*/visualization/point-cloud**", (route) => {
     const url = route.request().url();
+    const parsed = new URL(url);
     const member = url.includes(comparisonMoreMoistureId)
       ? comparisonStory.more_moisture
       : comparisonStory.baseline;
     return route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify(comparisonPointCloud(member)),
+      body: JSON.stringify(
+        comparisonPointCloud(member, Number(parsed.searchParams.get("time_index") ?? 0)),
+      ),
+    });
+  });
+  await page.route("**/api/results/*/visualization/fields", (route) => {
+    const member = route.request().url().includes(comparisonMoreMoistureId)
+      ? comparisonStory.more_moisture
+      : comparisonStory.baseline;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(comparisonFieldCatalog(member)),
     });
   });
   await page.route(
@@ -562,13 +684,20 @@ async function mockTradeCumulusComparison(page: Parameters<typeof mockCloudChamb
     },
   );
   await page.route("**/api/results/*/visualization/trade-cumulus-updraft-lens/frame**", (route) => {
-    const member = route.request().url().includes(comparisonMoreMoistureId)
+    const url = route.request().url();
+    const parsed = new URL(url);
+    const member = url.includes(comparisonMoreMoistureId)
       ? comparisonStory.more_moisture
       : comparisonStory.baseline;
     return route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify(comparisonLensFrame(member)),
+      body: JSON.stringify(
+        comparisonLensFrame(member, {
+          timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
+          planeIndex: Number(parsed.searchParams.get("plane_index") ?? 0),
+        }),
+      ),
     });
   });
 }

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -5383,6 +5383,29 @@ details[open] > summary {
   white-space: nowrap;
 }
 
+.explore-curated-default-notice {
+  position: absolute;
+  z-index: 14;
+  top: 0.45rem;
+  right: 0.45rem;
+  max-width: min(34rem, 72%);
+  margin: 0;
+  border-left: 3px solid var(--color-accent-primary);
+  padding: 0.42rem 0.65rem;
+  pointer-events: none;
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  font-size: 0.82rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.explore-curated-default-notice-partially_incompatible,
+.explore-curated-default-notice-technical_fallback {
+  border-left-color: var(--color-warning);
+  background: var(--color-warning-soft);
+  color: var(--color-text-primary);
+}
+
 /* Integrated Explore uses a fixed desktop cockpit instead of the legacy stacked workbench. */
 @media (min-width: 1100px) {
   .app-shell-explore {
@@ -5470,6 +5493,24 @@ details[open] > summary {
 
   .integrated-explore-actions button {
     padding: 0.42rem 0.75rem;
+  }
+
+  .integrated-explore-actions .return-to-curated-view {
+    border-color: var(--color-border-strong);
+    background: var(--color-surface);
+    color: var(--color-accent-primary);
+    box-shadow: none;
+  }
+
+  .integrated-explore-workspace
+    .visualizer-shell:has(> .explore-curated-default-notice-partially_incompatible),
+  .integrated-explore-workspace
+    .visualizer-shell:has(> .explore-curated-default-notice-technical_fallback),
+  .integrated-explore-workspace
+    .supercells-explore-shell:has(> .explore-curated-default-notice-partially_incompatible),
+  .integrated-explore-workspace
+    .supercells-explore-shell:has(> .explore-curated-default-notice-technical_fallback) {
+    padding-top: 3.4rem;
   }
 
   .integrated-explore-workspace .visualizer-shell {

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -5388,7 +5388,8 @@ details[open] > summary {
   z-index: 14;
   top: 0.45rem;
   right: 0.45rem;
-  max-width: min(34rem, 72%);
+  left: 0.45rem;
+  max-width: none;
   margin: 0;
   border-left: 3px solid var(--color-accent-primary);
   padding: 0.42rem 0.65rem;
@@ -5397,6 +5398,10 @@ details[open] > summary {
   color: var(--color-text-secondary);
   font-size: 0.82rem;
   box-shadow: var(--shadow-soft);
+}
+
+.explore-curated-default-notice-applying {
+  border-left-color: var(--color-text-secondary);
 }
 
 .explore-curated-default-notice-partially_incompatible,
@@ -5502,14 +5507,8 @@ details[open] > summary {
     box-shadow: none;
   }
 
-  .integrated-explore-workspace
-    .visualizer-shell:has(> .explore-curated-default-notice-partially_incompatible),
-  .integrated-explore-workspace
-    .visualizer-shell:has(> .explore-curated-default-notice-technical_fallback),
-  .integrated-explore-workspace
-    .supercells-explore-shell:has(> .explore-curated-default-notice-partially_incompatible),
-  .integrated-explore-workspace
-    .supercells-explore-shell:has(> .explore-curated-default-notice-technical_fallback) {
+  .integrated-explore-workspace .visualizer-shell:has(> .explore-curated-default-notice),
+  .integrated-explore-workspace .supercells-explore-shell:has(> .explore-curated-default-notice) {
     padding-top: 3.4rem;
   }
 
@@ -5863,6 +5862,14 @@ details[open] > summary {
   .integrated-explore-workspace .updraft-lens-slice-without-legend {
     width: 100%;
     max-width: none;
+  }
+
+  .integrated-explore-workspace .layer-local-error-slice {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+    padding: 0.8rem;
   }
 
   .updraft-lens-instrument-body {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { App, VisualizerSceneShell } from "./App";
+import type { SimulationRecord } from "./TradeCumulusWorld";
 
 const defaultRunConfiguration = {
   configuration_id: "short_6h__cells_64__local_6km__standard_15min__full",
@@ -3331,7 +3332,10 @@ const tradeCumulusFieldCatalog = {
     },
     fieldCatalogResponse.available_fields[5],
     fieldCatalogResponse.available_fields[1],
-  ],
+  ].map((field) => ({
+    ...field,
+    time_coordinate_values: [0, 900, 1800, 12_060],
+  })),
 };
 
 const tradeCumulusViewDefaults = {
@@ -3385,7 +3389,7 @@ const tradeCumulusUpdraftLensDefaults = {
   default_time_method: "max_finite_domain_mean_cwp_at_or_after_10800_seconds",
   default_plane_dimension: "y",
   default_plane_index: 1,
-  default_plane_coordinate: 0.05,
+  default_plane_coordinate: 2.366666555404663,
   default_plane_units: "km",
   default_plane_method: "greatest_coherent_positive_w_times_ql_score",
   cloud_threshold_kg_kg: 1e-6,
@@ -3495,21 +3499,38 @@ function tradeCumulusUpdraftLensFrame({
   };
 }
 
-function tradeCumulusPointCloudResponse() {
-  const response = pointCloudResponse({ field: "qc", timeIndex: 2 });
+function tradeCumulusPointCloudResponse({
+  field = "ql",
+  timeIndex = 2,
+}: {
+  field?: "ql" | "qv";
+  timeIndex?: number;
+} = {}) {
+  const sourceField = field === "ql" ? "qc" : field;
+  const response = pointCloudResponse({ field: sourceField, timeIndex });
+  const fieldMetadata =
+    tradeCumulusFieldCatalog.available_fields.find(
+      (candidate) => candidate.raw_field_name === field,
+    ) ?? tradeCumulusFieldCatalog.available_fields[0];
   return {
     ...response,
     result_id: "result-trade-cumulus",
     run_id: "trade-cumulus",
     scenario_id: "bomex_trade_cumulus_baseline_v0",
-    field: tradeCumulusFieldCatalog.available_fields[0],
-    selection: { ...response.selection, field: "ql" },
+    field: fieldMetadata,
+    selection: { ...response.selection, field },
   };
 }
 
 function tradeCumulusSliceResponse(url: string) {
   const parsed = new URL(url, "http://localhost");
-  const field = parsed.searchParams.get("field") === "w" ? "w" : "qc";
+  const requestedField = parsed.searchParams.get("field") ?? "ql";
+  const sourceField = requestedField === "ql" ? "qc" : requestedField;
+  const field = (
+    ["qc", "w", "qr", "theta", "temperature", "qv", "dbz", "rain"].includes(sourceField)
+      ? sourceField
+      : "qc"
+  ) as MockVisualFieldName;
   const response = sliceResponse({
     field,
     orientation:
@@ -3527,9 +3548,9 @@ function tradeCumulusSliceResponse(url: string) {
     run_id: "trade-cumulus",
     scenario_id: "bomex_trade_cumulus_baseline_v0",
     field:
-      field === "w"
-        ? tradeCumulusFieldCatalog.available_fields[1]
-        : tradeCumulusFieldCatalog.available_fields[0],
+      tradeCumulusFieldCatalog.available_fields.find(
+        (candidate) => candidate.raw_field_name === requestedField,
+      ) ?? tradeCumulusFieldCatalog.available_fields[0],
   };
 }
 
@@ -4149,8 +4170,17 @@ function mockTradeCumulusVisualizer(
       );
     }
     if (url.includes("/api/results/result-trade-cumulus/visualization/point-cloud")) {
+      const parsed = new URL(url, "http://localhost");
       return Promise.resolve(
-        new Response(JSON.stringify(tradeCumulusPointCloudResponse()), { status: 200 }),
+        new Response(
+          JSON.stringify(
+            tradeCumulusPointCloudResponse({
+              field: parsed.searchParams.get("field") === "qv" ? "qv" : "ql",
+              timeIndex: Number(parsed.searchParams.get("time_index") ?? 2),
+            }),
+          ),
+          { status: 200 },
+        ),
       );
     }
     if (url.includes("/api/results/result-trade-cumulus/visualization/slice")) {
@@ -4274,7 +4304,7 @@ const cloudWorldSummary = {
   availability_message: "Reference, variation, and featured comparison are available.",
 };
 
-const worldBaselineSimulation = {
+const worldBaselineSimulation: SimulationRecord = {
   simulation_id: "trade_cumulus_canonical_bomex",
   display_name: "Canonical BOMEX Baseline",
   role: "reference",
@@ -4297,7 +4327,7 @@ const worldBaselineSimulation = {
   completed_at: null,
 };
 
-const worldMoreMoistureSimulation = {
+const worldMoreMoistureSimulation: SimulationRecord = {
   ...worldBaselineSimulation,
   simulation_id: "trade_cumulus_more_moisture",
   display_name: "More Moisture",
@@ -7802,6 +7832,34 @@ describe("App", () => {
             new Response(JSON.stringify(tradeCumulusViewDefaults), { status: 200 }),
           );
         }
+        if (url.includes("/visualization/point-cloud")) {
+          const parsed = new URL(url, "http://localhost");
+          return Promise.resolve(
+            new Response(
+              JSON.stringify(
+                tradeCumulusPointCloudResponse({
+                  field: parsed.searchParams.get("field") === "qv" ? "qv" : "ql",
+                  timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
+                }),
+              ),
+              { status: 200 },
+            ),
+          );
+        }
+        if (url.includes("/trade-cumulus-updraft-lens/frame")) {
+          const parsed = new URL(url, "http://localhost");
+          return Promise.resolve(
+            new Response(
+              JSON.stringify(
+                tradeCumulusUpdraftLensFrame({
+                  timeIndex: Number(parsed.searchParams.get("time_index") ?? 0),
+                  planeIndex: Number(parsed.searchParams.get("plane_index") ?? 1),
+                }),
+              ),
+              { status: 200 },
+            ),
+          );
+        }
         if (url.includes("/visualization/slice")) {
           return Promise.resolve(
             new Response(JSON.stringify(tradeCumulusSliceResponse(url)), { status: 200 }),
@@ -7880,14 +7938,204 @@ describe("App", () => {
     await waitFor(() => expect(screen.getByLabelText("Time")).toHaveValue("3"));
 
     expect(fieldToggle).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByLabelText("3-D scalar field")).toHaveValue("ql");
-    expect(screen.getByLabelText("Slice field")).toHaveValue("ql");
+    expect(screen.getByLabelText("3-D scalar field")).toHaveValue("qv");
+    expect(screen.getByLabelText("Slice field")).toHaveValue("qv");
     expect(screen.getByRole("button", { name: "Vertical x-z slice" })).toHaveClass(
       "active-control",
     );
     expect(screen.getByLabelText("Slice position")).toHaveValue("1");
     expect(screen.getByLabelText("Layer opacity")).toHaveValue("0.68");
     expect(screen.getByLabelText("Point size")).toHaveValue("11");
+  });
+
+  it("announces a Trade restoration only after target evidence loads and clears success on edit", async () => {
+    let targetRequestCount = 0;
+    let resolveRestore: ((response: Response) => void) | undefined;
+    mockTradeCumulusVisualizer((url) => {
+      const parsed = new URL(url, "http://localhost");
+      const timeIndex = Number(parsed.searchParams.get("time_index") ?? 0);
+      if (timeIndex !== 3) {
+        return Promise.resolve(
+          new Response(JSON.stringify(tradeCumulusUpdraftLensFrame({ timeIndex })), {
+            status: 200,
+          }),
+        );
+      }
+      targetRequestCount += 1;
+      if (targetRequestCount === 1) {
+        return Promise.resolve(
+          new Response(JSON.stringify(tradeCumulusUpdraftLensFrame({ timeIndex })), {
+            status: 200,
+          }),
+        );
+      }
+      return new Promise((resolve) => {
+        resolveRestore = resolve;
+      });
+    });
+    render(
+      <VisualizerSceneShell
+        result={
+          tradeCumulusResultCard as unknown as Parameters<typeof VisualizerSceneShell>[0]["result"]
+        }
+        worldName="Trade Cumulus"
+        simulationName="Canonical BOMEX Baseline"
+        simulationRecord={worldBaselineSimulation}
+      />,
+    );
+
+    const lensToggle = await screen.findByRole("button", { name: "Updraft Lens" });
+    await waitFor(() => expect(lensToggle).toHaveAttribute("aria-pressed", "true"));
+    await screen.findByText("Lens synced");
+    fireEvent.change(screen.getByLabelText("Time"), { target: { value: "0" } });
+    await waitFor(() => expect(screen.getByLabelText("Time")).toHaveValue("0"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to curated view" }));
+    expect(
+      await screen.findByText(/Restoring the curated Updraft Lens view and loading/),
+    ).toBeVisible();
+    expect(screen.queryByText("Curated Updraft Lens view restored.")).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveRestore?.(
+        new Response(JSON.stringify(tradeCumulusUpdraftLensFrame({ timeIndex: 3 })), {
+          status: 200,
+        }),
+      );
+    });
+    expect(await screen.findByText("Curated Updraft Lens view restored.")).toBeVisible();
+
+    fireEvent.change(screen.getByLabelText("Time"), { target: { value: "0" } });
+    await waitFor(() =>
+      expect(screen.queryByText("Curated Updraft Lens view restored.")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("keeps Trade restoration errors and retry access visible when target evidence fails", async () => {
+    let targetRequestCount = 0;
+    mockTradeCumulusVisualizer((url) => {
+      const parsed = new URL(url, "http://localhost");
+      const timeIndex = Number(parsed.searchParams.get("time_index") ?? 0);
+      if (timeIndex === 3) {
+        targetRequestCount += 1;
+        if (targetRequestCount > 1) {
+          return Promise.resolve(new Response("Target Lens frame failed.", { status: 500 }));
+        }
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(tradeCumulusUpdraftLensFrame({ timeIndex })), {
+          status: 200,
+        }),
+      );
+    });
+    render(
+      <VisualizerSceneShell
+        result={
+          tradeCumulusResultCard as unknown as Parameters<typeof VisualizerSceneShell>[0]["result"]
+        }
+        worldName="Trade Cumulus"
+        simulationName="Canonical BOMEX Baseline"
+        simulationRecord={worldBaselineSimulation}
+      />,
+    );
+
+    await screen.findByText("Lens synced");
+    fireEvent.change(screen.getByLabelText("Time"), { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: "Return to curated view" }));
+
+    expect(await screen.findByText("Updraft Lens slice unavailable")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Retry Lens slice" })).toBeVisible();
+    expect(
+      await screen.findByText(/curated Updraft Lens view could not be restored/),
+    ).toBeVisible();
+    expect(screen.queryByText("Curated Updraft Lens view restored.")).not.toBeInTheDocument();
+  });
+
+  it("applies the authored More Moisture coordinates through the integrated Trade surface", async () => {
+    mockTradeCumulusVisualizer();
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/visualization/fields")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ...tradeCumulusFieldCatalog,
+              available_fields: tradeCumulusFieldCatalog.available_fields.map((field) => ({
+                ...field,
+                time_coordinate_values: [0, 4_800, 9_600, 13_920],
+              })),
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.endsWith("/trade-cumulus-updraft-lens/defaults")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ...tradeCumulusUpdraftLensDefaults,
+              default_time_index: 3,
+              default_time_seconds: 13_920,
+              default_plane_coordinate: 1.6333333253860474,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+    render(
+      <VisualizerSceneShell
+        result={
+          tradeCumulusResultCard as unknown as Parameters<typeof VisualizerSceneShell>[0]["result"]
+        }
+        worldName="Trade Cumulus"
+        simulationName="More Moisture"
+        simulationRecord={worldMoreMoistureSimulation}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Updraft Lens" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      ),
+    );
+    expect(screen.getByLabelText("Time")).toHaveValue("3");
+    expect(screen.getByLabelText("Updraft Lens slice position")).toHaveValue("1");
+  });
+
+  it("exposes a technical fallback without changing an ordinary retained Trade Simulation", async () => {
+    mockTradeCumulusVisualizer();
+    render(
+      <VisualizerSceneShell
+        result={
+          tradeCumulusResultCard as unknown as Parameters<typeof VisualizerSceneShell>[0]["result"]
+        }
+        worldName="Trade Cumulus"
+        simulationName="Retained Trade Trial"
+        simulationRecord={{
+          ...worldBaselineSimulation,
+          simulation_id: "trade_cumulus_retained_trial",
+          display_name: "Retained Trade Trial",
+        }}
+      />,
+    );
+
+    await screen.findByText("Lens synced");
+    const field = await screen.findByLabelText("3-D scalar field");
+    fireEvent.change(field, { target: { value: "qv" } });
+    await waitFor(() => expect(field).toHaveValue("qv"));
+    fireEvent.click(screen.getByRole("button", { name: "Return to curated view" }));
+
+    expect(
+      await screen.findByText(/No authored curated view is available for this Simulation/),
+    ).toBeVisible();
+    expect(field).toHaveValue("qv");
+    expect(screen.getByRole("tab", { name: "Details" })).toBeVisible();
   });
 
   it("ignores stale Updraft Lens frame responses", async () => {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -4539,6 +4539,9 @@ describe("App", () => {
       `/fun-with-soundings/explore/${observedSoundingResultCard.result_id}`,
     );
     expect(runSelector).toHaveValue(observedSoundingResultCard.result_id);
+    expect(
+      screen.queryByRole("button", { name: "Return to curated view" }),
+    ).not.toBeInTheDocument();
 
     fireEvent.change(runSelector, { target: { value: secondObservedResult.result_id } });
     await waitFor(() => {
@@ -7776,6 +7779,115 @@ describe("App", () => {
       "aria-pressed",
       "true",
     );
+  });
+
+  it("returns the current Trade Cumulus Field or Lens to its authored presentation", async () => {
+    mockWorldScopedApp();
+    const worldFetch = vi.mocked(fetch).getMockImplementation();
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes(comparisonBaselineResultCard.result_id)) {
+        if (url.endsWith("/visualization/fields")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(tradeCumulusFieldCatalog), { status: 200 }),
+          );
+        }
+        if (url.endsWith("/trade-cumulus-updraft-lens/defaults")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(tradeCumulusUpdraftLensDefaults), { status: 200 }),
+          );
+        }
+        if (url.includes("/visualization/defaults")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(tradeCumulusViewDefaults), { status: 200 }),
+          );
+        }
+        if (url.includes("/visualization/slice")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(tradeCumulusSliceResponse(url)), { status: 200 }),
+          );
+        }
+      }
+      return (
+        worldFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Enter Trade Cumulus" }));
+    fireEvent.click(
+      within(await screen.findByLabelText("Canonical BOMEX Baseline Simulation")).getByRole(
+        "button",
+        { name: "Explore" },
+      ),
+    );
+
+    const viewMode = await screen.findByLabelText("Explore view mode");
+    const lensToggle = within(viewMode).getByRole("button", { name: "Updraft Lens" });
+    await waitFor(() => expect(lensToggle).toHaveAttribute("aria-pressed", "true"));
+    const displayDetails = screen
+      .getByText("Display", { selector: "summary span" })
+      .closest("details");
+    expect(displayDetails).not.toBeNull();
+    fireEvent.click(screen.getByText("Display", { selector: "summary span" }));
+    fireEvent(displayDetails!, new Event("toggle"));
+    expect(displayDetails).toHaveAttribute("open");
+
+    fireEvent.change(screen.getByLabelText("Time"), { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: "Horizontal x-y" }));
+    fireEvent.click(screen.getByLabelText("Cloud boundary"));
+    fireEvent.click(screen.getByLabelText("Horizontal wind"));
+    fireEvent.click(screen.getByRole("button", { name: "Total wind" }));
+    fireEvent.change(screen.getByLabelText("3-D scalar field"), { target: { value: "qv" } });
+    fireEvent.change(screen.getByLabelText("Layer opacity"), { target: { value: "0.45" } });
+    fireEvent.change(screen.getByLabelText("Point size"), { target: { value: "14" } });
+    fireEvent.change(screen.getByLabelText("Lens opacity"), { target: { value: "0.75" } });
+    fireEvent.change(screen.getByLabelText("Camera view"), {
+      target: { value: "look_along_x" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to curated view" }));
+    await waitFor(() => expect(screen.getByLabelText("Time")).toHaveValue("3"));
+
+    expect(lensToggle).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Vertical x-z" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByLabelText("Updraft Lens slice position")).toHaveValue("1");
+    expect(screen.getByLabelText("Cloud boundary")).toBeChecked();
+    expect(screen.getByLabelText("Horizontal wind")).toBeChecked();
+    expect(screen.getByRole("button", { name: "Local departures" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByLabelText("3-D scalar field")).toHaveValue("ql");
+    expect(screen.getByLabelText("Layer opacity")).toHaveValue("0.68");
+    expect(screen.getByLabelText("Point size")).toHaveValue("11");
+    expect(screen.getByLabelText("Lens opacity")).toHaveValue("0.9");
+    expect(screen.getByLabelText("Camera view")).toHaveValue("overview");
+    await waitFor(() => expect(displayDetails).not.toHaveAttribute("open"));
+
+    const fieldToggle = within(viewMode).getByRole("button", { name: "Field" });
+    fireEvent.click(fieldToggle);
+    await screen.findByLabelText("Slice field");
+    fireEvent.change(screen.getByLabelText("Time"), { target: { value: "0" } });
+    fireEvent.change(screen.getByLabelText("3-D scalar field"), { target: { value: "qv" } });
+    fireEvent.click(screen.getByRole("button", { name: "Horizontal layer" }));
+    fireEvent.change(screen.getByLabelText("Layer opacity"), { target: { value: "0.4" } });
+    fireEvent.change(screen.getByLabelText("Point size"), { target: { value: "15" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to curated view" }));
+    await waitFor(() => expect(screen.getByLabelText("Time")).toHaveValue("3"));
+
+    expect(fieldToggle).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("3-D scalar field")).toHaveValue("ql");
+    expect(screen.getByLabelText("Slice field")).toHaveValue("ql");
+    expect(screen.getByRole("button", { name: "Vertical x-z slice" })).toHaveClass(
+      "active-control",
+    );
+    expect(screen.getByLabelText("Slice position")).toHaveValue("1");
+    expect(screen.getByLabelText("Layer opacity")).toHaveValue("0.68");
+    expect(screen.getByLabelText("Point size")).toHaveValue("11");
   });
 
   it("ignores stale Updraft Lens frame responses", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -24,6 +24,8 @@ import {
   resolveCuratedView,
   TRADE_CUMULUS_INITIAL_VIEW,
   tradeCumulusCuratedView,
+  type CuratedDefaultResolution,
+  type ResolvedCuratedView,
   type TradeCumulusCuratedView,
 } from "./exploreCuratedDefaults";
 import { MountainWavesExplore } from "./MountainWavesExplore";
@@ -11410,6 +11412,12 @@ function tradeCumulusUpdraftLensEligible(result: ResultCard): boolean {
   );
 }
 
+type PendingTradeCuratedRestore = {
+  resolution: CuratedDefaultResolution<ResolvedCuratedView<TradeCumulusCuratedView>>;
+  target: ResolvedCuratedView<TradeCumulusCuratedView>;
+  source: "initial" | "return";
+};
+
 export function VisualizerSceneShell({
   result,
   worldName,
@@ -11438,6 +11446,8 @@ export function VisualizerSceneShell({
   const productWorldName = worldName ?? (updraftLensEligible ? "Trade Cumulus" : "Cloud Chamber");
   const productSimulationName =
     simulationName ?? worldSimulationDisplayName(result.result_id, result.name);
+  const isTradeCumulusWorldExplore =
+    simulationRecord?.world_id === "trade_cumulus" || productWorldName === "Trade Cumulus";
   const productEntityLabel =
     productWorldName === "Fun With Soundings" ? "Experiment" : "Simulation";
   const initialResultRef = useRef(result);
@@ -11464,6 +11474,8 @@ export function VisualizerSceneShell({
   const [contextCollapsed, setContextCollapsed] = useState(false);
   const [secondarySection, setSecondarySection] = useState<ExploreSecondarySection>("science");
   const [curatedNotice, setCuratedNotice] = useState<ExploreCuratedNotice | null>(null);
+  const [pendingCuratedRestore, setPendingCuratedRestore] =
+    useState<PendingTradeCuratedRestore | null>(null);
   const [pointCloud, setPointCloud] = useState<PointCloudResponse | null>(null);
   const [showSlicePlanes, setShowSlicePlanes] = useState(true);
   const [sliceFieldName, setSliceFieldName] = useState("qc");
@@ -11502,6 +11514,7 @@ export function VisualizerSceneShell({
   const updraftLensRequestRef = useRef(0);
   const autoActivatedUpdraftLensResultRef = useRef<string | null>(null);
   const initialCuratedResultRef = useRef<string | null>(null);
+  const curatedNoticeSignatureRef = useRef<string | null>(null);
   const maxPoints = 50_000;
 
   useEffect(() => {
@@ -11526,6 +11539,7 @@ export function VisualizerSceneShell({
     setContextCollapsed(false);
     setSecondarySection("science");
     setCuratedNotice(null);
+    setPendingCuratedRestore(null);
     setPointCloud(null);
     setShowSlicePlanes(true);
     setSliceFieldName("qc");
@@ -11554,6 +11568,7 @@ export function VisualizerSceneShell({
     ordinaryExploreStateRef.current = null;
     autoActivatedUpdraftLensResultRef.current = null;
     initialCuratedResultRef.current = null;
+    curatedNoticeSignatureRef.current = null;
     updraftLensRequestRef.current += 1;
     setSceneStatus("Loading scene data...");
     const defaultsRequest = fetchVisualizationDefaults(resultId).catch(() => null);
@@ -11765,6 +11780,65 @@ export function VisualizerSceneShell({
       ? { label: "Rain-water onset", seconds: result.first_rain_time_seconds }
       : null,
   ].filter((preset): preset is { label: string; seconds: number } => preset !== null);
+  const curatedStateSignature = useMemo(
+    () =>
+      JSON.stringify({
+        timeIndex,
+        playbackTimeIndex,
+        isPlaybackRunning,
+        playbackSpeed,
+        focusedViewer,
+        cameraPreset,
+        cameraTransform,
+        displayControlsOpen,
+        contextCollapsed,
+        secondarySection,
+        selectedRegion,
+        selectedFieldName,
+        sliceFieldName,
+        activeSlicePlane,
+        sliceOrientation,
+        horizontalSliceLevel,
+        verticalSliceIndex,
+        threshold,
+        opacity,
+        pointSize,
+        updraftLensActive,
+        updraftLensOpacity,
+        showSlicePlanes,
+        showUpdraftLensBoundary,
+        showUpdraftLensWind,
+        updraftLensWindMode,
+      }),
+    [
+      activeSlicePlane,
+      cameraPreset,
+      cameraTransform,
+      contextCollapsed,
+      displayControlsOpen,
+      focusedViewer,
+      horizontalSliceLevel,
+      isPlaybackRunning,
+      opacity,
+      playbackSpeed,
+      playbackTimeIndex,
+      pointSize,
+      secondarySection,
+      selectedFieldName,
+      selectedRegion,
+      showSlicePlanes,
+      showUpdraftLensBoundary,
+      showUpdraftLensWind,
+      sliceFieldName,
+      sliceOrientation,
+      threshold,
+      timeIndex,
+      updraftLensActive,
+      updraftLensOpacity,
+      updraftLensWindMode,
+      verticalSliceIndex,
+    ],
+  );
 
   const clearSelectedRegionForTimeChange = useCallback(() => {
     setSelectedRegion(null);
@@ -11877,8 +11951,13 @@ export function VisualizerSceneShell({
 
   const applyTradeCumulusCuratedView = useCallback(
     (viewId: TradeCumulusCuratedView["viewId"], source: "initial" | "return") => {
-      const definition = tradeCumulusCuratedView(simulationRecord?.simulation_id, viewId);
-      const targetFieldId = definition?.fieldId ?? sliceFieldName;
+      const definition = tradeCumulusCuratedView(
+        simulationRecord?.simulation_id,
+        viewId,
+        selectedFieldName || sliceFieldName,
+        sliceFieldName || selectedFieldName,
+      );
+      const targetFieldId = definition?.sliceFieldId ?? sliceFieldName;
       const targetField = catalog?.available_fields.find(
         (field) => field.raw_field_name === targetFieldId,
       );
@@ -11886,6 +11965,9 @@ export function VisualizerSceneShell({
         availableViewIds: updraftLensDefaults ? ["field", "updraft_lens"] : ["field"],
         availableFieldIds: catalog?.available_fields.map((field) => field.raw_field_name),
         availableScaleIds: updraftLensDefaults ? [updraftLensDefaults.w_scale_id] : undefined,
+        availableOverlayIds: updraftLensDefaults
+          ? ["cloud_boundary", "horizontal_wind", "vertical_velocity"]
+          : [],
         timesSeconds: (targetField?.time_coordinate_values ?? []).filter(
           (value): value is number => typeof value === "number" && Number.isFinite(value),
         ),
@@ -11897,69 +11979,91 @@ export function VisualizerSceneShell({
         planeNativeIndices: updraftLensDefaults ? [updraftLensDefaults.default_plane_index] : [],
       });
 
-      setIsPlaybackRunning(false);
-      if (source === "return") {
-        setFocusedViewer(null);
-        setContextCollapsed(false);
-        setSecondarySection("science");
-        setSelectedRegion(null);
-      }
-      setSceneError(null);
-      setSliceError(null);
-      setPointCloudError(null);
-      setCameraTransform(null);
-      ordinaryExploreStateRef.current = null;
-      if (resolution.value) {
-        const curated = resolution.value.definition;
-        const planeIndex = resolution.value.planeNativeIndex ?? 0;
-        setTimeIndex(resolution.value.timeIndex);
-        setPlaybackTimeIndex(resolution.value.timeIndex);
-        setPlaybackSpeed(curated.playbackSpeed);
-        setActiveSlicePlane(curated.plane.orientation);
-        setSliceOrientation(
-          curated.plane.orientation === "vertical_y" ? "vertical_y" : "vertical_x",
-        );
-        setVerticalSliceIndex(planeIndex);
-        setSelectedFieldName(curated.cloudFieldId);
-        setSliceFieldName(
-          curated.viewId === "updraft_lens" ? curated.fieldId : curated.cloudFieldId,
-        );
-        setThreshold(curated.cloudThresholdKgKg);
-        setOpacity(curated.cloudOpacity);
-        setPointSize(curated.cloudPointSizePx);
-        setUpdraftLensOpacity(curated.lensOpacity);
-        setShowSlicePlanes(curated.showSlicePlane);
-        setShowUpdraftLensBoundary(curated.showCloudBoundary);
-        setShowUpdraftLensWind(curated.showHorizontalWind);
-        setUpdraftLensWindMode(curated.windMode);
-        setCameraPreset(curated.cameraPreset);
-        setCameraTransform(curated.cameraTransform);
-        if (source === "return") {
-          setDisplayControlsOpen(curated.displayControlsOpen);
-        }
-        setUpdraftLensError(null);
-        setUpdraftLensFrame(null);
-        setUpdraftLensActive(curated.viewId === "updraft_lens");
-        ordinaryExploreStateRef.current =
-          curated.viewId === "updraft_lens"
-            ? {
-                selectedFieldName: curated.cloudFieldId,
-                sliceFieldName: curated.cloudFieldId,
-                showSlicePlanes: curated.showSlicePlane,
-                threshold: curated.cloudThresholdKgKg,
-              }
-            : null;
-      }
-      if (source === "return" || resolution.status !== "applied") {
+      if (!resolution.value) {
+        setPendingCuratedRestore(null);
+        curatedNoticeSignatureRef.current = curatedStateSignature;
         setCuratedNotice({
           status: resolution.status,
           message: curatedResolutionExplanation(resolution),
+        });
+        return;
+      }
+      const curated = resolution.value.definition;
+      const planeIndex = resolution.value.planeNativeIndex ?? 0;
+      setIsPlaybackRunning(false);
+      if (source === "return") {
+        setFocusedViewer(null);
+        setContextCollapsed(curated.contextCollapsed);
+        setSecondarySection(curated.secondarySection);
+        setSelectedRegion(curated.selection);
+        setDisplayControlsOpen(curated.displayControlsOpen);
+      }
+      setTimeIndex(resolution.value.timeIndex);
+      setPlaybackTimeIndex(resolution.value.timeIndex);
+      setPlaybackSpeed(curated.playbackSpeed);
+      setActiveSlicePlane(curated.plane.orientation);
+      setSliceOrientation(curated.plane.orientation === "vertical_y" ? "vertical_y" : "vertical_x");
+      setVerticalSliceIndex(planeIndex);
+      setSelectedFieldName(curated.sceneFieldId);
+      setSliceFieldName(curated.sliceFieldId);
+      setThreshold(curated.cloudThresholdKgKg);
+      setOpacity(curated.cloudOpacity);
+      setPointSize(curated.cloudPointSizePx);
+      setUpdraftLensOpacity(curated.lensOpacity);
+      setShowSlicePlanes(curated.showSlicePlane);
+      setShowUpdraftLensBoundary(curated.showCloudBoundary);
+      setShowUpdraftLensWind(curated.showHorizontalWind);
+      setUpdraftLensWindMode(curated.windMode);
+      setCameraPreset(curated.cameraPreset);
+      setCameraTransform(curated.cameraTransform);
+      ordinaryExploreStateRef.current = null;
+      setUpdraftLensFrame(null);
+      setUpdraftLensActive(curated.viewId === "updraft_lens");
+      ordinaryExploreStateRef.current =
+        curated.viewId === "updraft_lens"
+          ? {
+              selectedFieldName: curated.sceneFieldId,
+              sliceFieldName: curated.sceneFieldId,
+              showSlicePlanes: curated.showSlicePlane,
+              threshold: curated.cloudThresholdKgKg,
+            }
+          : null;
+      setPendingCuratedRestore({
+        resolution,
+        target: resolution.value,
+        source,
+      });
+      if (source === "return") {
+        setPointCloudError(null);
+        setPointCloud(null);
+        setPointCloudLoadAttempt((current) => current + 1);
+        if (curated.viewId === "updraft_lens") {
+          setUpdraftLensError(null);
+          setUpdraftLensLoadAttempt((current) => current + 1);
+        } else {
+          setSliceError(null);
+          setSceneHorizontalSlice(null);
+          setSceneVerticalSlice(null);
+          setSliceLoadAttempt((current) => current + 1);
+        }
+        setCuratedNotice({
+          status: "applying",
+          message: `Restoring the curated ${
+            curated.viewId === "updraft_lens" ? "Updraft Lens" : "Field"
+          } view and loading its scientific evidence...`,
         });
       } else {
         setCuratedNotice(null);
       }
     },
-    [catalog, simulationRecord?.simulation_id, sliceFieldName, updraftLensDefaults],
+    [
+      catalog,
+      curatedStateSignature,
+      selectedFieldName,
+      simulationRecord?.simulation_id,
+      sliceFieldName,
+      updraftLensDefaults,
+    ],
   );
 
   useEffect(() => {
@@ -12237,6 +12341,105 @@ export function VisualizerSceneShell({
     updraftLensWindMode,
   ]);
 
+  useEffect(() => {
+    if (!pendingCuratedRestore) return;
+    const { resolution, source, target } = pendingCuratedRestore;
+    const curated = target.definition;
+    const planeIndex = target.planeNativeIndex ?? 0;
+    const controlsMatch =
+      !isPlaybackRunning &&
+      timeIndex === target.timeIndex &&
+      playbackTimeIndex === target.timeIndex &&
+      selectedFieldName === curated.sceneFieldId &&
+      sliceFieldName === curated.sliceFieldId &&
+      activeSlicePlane === curated.plane.orientation &&
+      verticalSliceIndex === planeIndex &&
+      updraftLensActive === (curated.viewId === "updraft_lens");
+    if (!controlsMatch) {
+      setPendingCuratedRestore(null);
+      setCuratedNotice(null);
+      curatedNoticeSignatureRef.current = null;
+      return;
+    }
+
+    const relevantError =
+      sceneError ??
+      pointCloudError ??
+      (curated.viewId === "updraft_lens" ? updraftLensError : sliceError);
+    if (relevantError) {
+      setPendingCuratedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({
+        status: "technical_fallback",
+        message: `The curated ${
+          curated.viewId === "updraft_lens" ? "Updraft Lens" : "Field"
+        } view could not be restored: ${relevantError} Use the visible retry action to try again.`,
+      });
+      return;
+    }
+
+    const sceneReady =
+      pointCloud?.selection.field === curated.sceneFieldId &&
+      pointCloud.selection.time_index === target.timeIndex;
+    const lensReady =
+      curated.viewId === "updraft_lens" &&
+      !updraftLensLoading &&
+      updraftLensFrame?.time_index === target.timeIndex &&
+      updraftLensFrame.orientation === curated.plane.orientation &&
+      updraftLensFrame.plane_index === planeIndex;
+    const fieldSlicesReady =
+      curated.viewId === "field" &&
+      !sliceLoading &&
+      sceneHorizontalSlice?.field.raw_field_name === curated.sliceFieldId &&
+      sceneHorizontalSlice.selection.time_index === target.timeIndex &&
+      (!sliceSupportsVertical ||
+        (sceneVerticalSlice?.field.raw_field_name === curated.sliceFieldId &&
+          sceneVerticalSlice.selection.time_index === target.timeIndex &&
+          sceneVerticalSlice.selection.orientation === curated.plane.orientation &&
+          sceneVerticalSlice.selection.selected_index === planeIndex));
+    if (!sceneReady || (!lensReady && !fieldSlicesReady)) return;
+
+    setPendingCuratedRestore(null);
+    curatedNoticeSignatureRef.current = curatedStateSignature;
+    if (source === "return" || resolution.status !== "applied") {
+      setCuratedNotice({
+        status: resolution.status,
+        message: curatedResolutionExplanation(resolution),
+      });
+    } else {
+      setCuratedNotice(null);
+    }
+  }, [
+    activeSlicePlane,
+    curatedStateSignature,
+    isPlaybackRunning,
+    pendingCuratedRestore,
+    playbackTimeIndex,
+    pointCloud,
+    pointCloudError,
+    sceneError,
+    sceneHorizontalSlice,
+    sceneVerticalSlice,
+    selectedFieldName,
+    sliceError,
+    sliceFieldName,
+    sliceLoading,
+    sliceSupportsVertical,
+    timeIndex,
+    updraftLensActive,
+    updraftLensError,
+    updraftLensFrame,
+    updraftLensLoading,
+    verticalSliceIndex,
+  ]);
+
+  useEffect(() => {
+    if (!curatedNotice || pendingCuratedRestore || !curatedNoticeSignatureRef.current) return;
+    if (curatedNoticeSignatureRef.current === curatedStateSignature) return;
+    curatedNoticeSignatureRef.current = null;
+    setCuratedNotice(null);
+  }, [curatedNotice, curatedStateSignature, pendingCuratedRestore]);
+
   function selectPointFromSlice(slice: SliceResponse, rowIndex: number, columnIndex: number) {
     if (isPlaybackRunning) {
       clearSelectedRegionForTimeChange();
@@ -12290,16 +12493,10 @@ export function VisualizerSceneShell({
       onBack={onBack}
       onCompare={onCompare}
       headerActions={
-        tradeCumulusCuratedView(
-          simulationRecord?.simulation_id,
-          updraftLensActive ? "updraft_lens" : "field",
-        ) ||
+        isTradeCumulusWorldExplore ||
         (resultOptions && resultOptions.length > 0 && onSelectResult) ? (
           <>
-            {tradeCumulusCuratedView(
-              simulationRecord?.simulation_id,
-              updraftLensActive ? "updraft_lens" : "field",
-            ) && (
+            {isTradeCumulusWorldExplore && (
               <ReturnToCuratedViewControl
                 onReturn={() =>
                   applyTradeCumulusCuratedView(
@@ -12337,7 +12534,14 @@ export function VisualizerSceneShell({
         {sceneError && (
           <div className="workspace-catalog-error" role="alert">
             <p>{sceneError}</p>
-            <button type="button" onClick={() => setFieldLoadAttempt((current) => current + 1)}>
+            <button
+              type="button"
+              onClick={() => {
+                curatedNoticeSignatureRef.current = null;
+                setCuratedNotice(null);
+                setFieldLoadAttempt((current) => current + 1);
+              }}
+            >
               Retry loading fields
             </button>
           </div>
@@ -12359,7 +12563,11 @@ export function VisualizerSceneShell({
                 <span>{pointCloudError}</span>
                 <button
                   type="button"
-                  onClick={() => setPointCloudLoadAttempt((current) => current + 1)}
+                  onClick={() => {
+                    curatedNoticeSignatureRef.current = null;
+                    setCuratedNotice(null);
+                    setPointCloudLoadAttempt((current) => current + 1);
+                  }}
                 >
                   Retry 3-D layer
                 </button>
@@ -12908,6 +13116,8 @@ export function VisualizerSceneShell({
                 <button
                   type="button"
                   onClick={() => {
+                    curatedNoticeSignatureRef.current = null;
+                    setCuratedNotice(null);
                     if (updraftLensActive) {
                       setUpdraftLensLoadAttempt((current) => current + 1);
                     } else {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -9,12 +9,23 @@ import {
   type SelectedAtmosphereSummary,
 } from "./FunWithSoundings";
 import {
+  ExploreCuratedDefaultNotice,
   ExploreContextContent,
   ExploreInspector,
   ExploreSelectedEvidence,
   ExploreSecondarySections,
   IntegratedExploreWorkspace,
+  ReturnToCuratedViewControl,
+  type ExploreCuratedNotice,
+  type ExploreSecondarySection,
 } from "./IntegratedExploreWorkspace";
+import {
+  curatedResolutionExplanation,
+  resolveCuratedView,
+  TRADE_CUMULUS_INITIAL_VIEW,
+  tradeCumulusCuratedView,
+  type TradeCumulusCuratedView,
+} from "./exploreCuratedDefaults";
 import { MountainWavesExplore } from "./MountainWavesExplore";
 import { type MountainWavesSimulation, MountainWavesWorld } from "./MountainWavesWorld";
 import { NativeSlicePositionControl } from "./NativeSlicePositionControl";
@@ -32,7 +43,7 @@ import {
   type TradeCumulusWorldDetail,
   type TradeCumulusWorldSection,
 } from "./TradeCumulusWorld";
-import { True3DViewer } from "./True3DViewer";
+import { type CameraPreset, type CameraTransform, True3DViewer } from "./True3DViewer";
 import {
   type UpdraftLensDefaults,
   type UpdraftLensFrame,
@@ -11447,6 +11458,12 @@ export function VisualizerSceneShell({
   const [opacity, setOpacity] = useState(0.68);
   const [pointSize, setPointSize] = useState(11);
   const [focusedViewer, setFocusedViewer] = useState<"scene" | "slice" | null>(null);
+  const [cameraPreset, setCameraPreset] = useState<CameraPreset>("overview");
+  const [cameraTransform, setCameraTransform] = useState<CameraTransform | null>(null);
+  const [displayControlsOpen, setDisplayControlsOpen] = useState(false);
+  const [contextCollapsed, setContextCollapsed] = useState(false);
+  const [secondarySection, setSecondarySection] = useState<ExploreSecondarySection>("science");
+  const [curatedNotice, setCuratedNotice] = useState<ExploreCuratedNotice | null>(null);
   const [pointCloud, setPointCloud] = useState<PointCloudResponse | null>(null);
   const [showSlicePlanes, setShowSlicePlanes] = useState(true);
   const [sliceFieldName, setSliceFieldName] = useState("qc");
@@ -11484,6 +11501,7 @@ export function VisualizerSceneShell({
   const ordinaryExploreStateRef = useRef<OrdinaryExploreState | null>(null);
   const updraftLensRequestRef = useRef(0);
   const autoActivatedUpdraftLensResultRef = useRef<string | null>(null);
+  const initialCuratedResultRef = useRef<string | null>(null);
   const maxPoints = 50_000;
 
   useEffect(() => {
@@ -11501,6 +11519,13 @@ export function VisualizerSceneShell({
     setThreshold(1e-6);
     setOpacity(0.68);
     setPointSize(11);
+    setFocusedViewer(null);
+    setCameraPreset("overview");
+    setCameraTransform(null);
+    setDisplayControlsOpen(false);
+    setContextCollapsed(false);
+    setSecondarySection("science");
+    setCuratedNotice(null);
     setPointCloud(null);
     setShowSlicePlanes(true);
     setSliceFieldName("qc");
@@ -11528,6 +11553,7 @@ export function VisualizerSceneShell({
     setUpdraftLensWindMode("perturbation");
     ordinaryExploreStateRef.current = null;
     autoActivatedUpdraftLensResultRef.current = null;
+    initialCuratedResultRef.current = null;
     updraftLensRequestRef.current += 1;
     setSceneStatus("Loading scene data...");
     const defaultsRequest = fetchVisualizationDefaults(resultId).catch(() => null);
@@ -11849,22 +11875,116 @@ export function VisualizerSceneShell({
     ],
   );
 
+  const applyTradeCumulusCuratedView = useCallback(
+    (viewId: TradeCumulusCuratedView["viewId"], source: "initial" | "return") => {
+      const definition = tradeCumulusCuratedView(simulationRecord?.simulation_id, viewId);
+      const targetFieldId = definition?.fieldId ?? sliceFieldName;
+      const targetField = catalog?.available_fields.find(
+        (field) => field.raw_field_name === targetFieldId,
+      );
+      const resolution = resolveCuratedView(definition, {
+        availableViewIds: updraftLensDefaults ? ["field", "updraft_lens"] : ["field"],
+        availableFieldIds: catalog?.available_fields.map((field) => field.raw_field_name),
+        availableScaleIds: updraftLensDefaults ? [updraftLensDefaults.w_scale_id] : undefined,
+        timesSeconds: (targetField?.time_coordinate_values ?? []).filter(
+          (value): value is number => typeof value === "number" && Number.isFinite(value),
+        ),
+        planeCoordinatesKm:
+          updraftLensDefaults?.default_plane_coordinate !== null &&
+          updraftLensDefaults?.default_plane_coordinate !== undefined
+            ? [updraftLensDefaults.default_plane_coordinate]
+            : [],
+        planeNativeIndices: updraftLensDefaults ? [updraftLensDefaults.default_plane_index] : [],
+      });
+
+      setIsPlaybackRunning(false);
+      if (source === "return") {
+        setFocusedViewer(null);
+        setContextCollapsed(false);
+        setSecondarySection("science");
+        setSelectedRegion(null);
+      }
+      setSceneError(null);
+      setSliceError(null);
+      setPointCloudError(null);
+      setCameraTransform(null);
+      ordinaryExploreStateRef.current = null;
+      if (resolution.value) {
+        const curated = resolution.value.definition;
+        const planeIndex = resolution.value.planeNativeIndex ?? 0;
+        setTimeIndex(resolution.value.timeIndex);
+        setPlaybackTimeIndex(resolution.value.timeIndex);
+        setPlaybackSpeed(curated.playbackSpeed);
+        setActiveSlicePlane(curated.plane.orientation);
+        setSliceOrientation(
+          curated.plane.orientation === "vertical_y" ? "vertical_y" : "vertical_x",
+        );
+        setVerticalSliceIndex(planeIndex);
+        setSelectedFieldName(curated.cloudFieldId);
+        setSliceFieldName(
+          curated.viewId === "updraft_lens" ? curated.fieldId : curated.cloudFieldId,
+        );
+        setThreshold(curated.cloudThresholdKgKg);
+        setOpacity(curated.cloudOpacity);
+        setPointSize(curated.cloudPointSizePx);
+        setUpdraftLensOpacity(curated.lensOpacity);
+        setShowSlicePlanes(curated.showSlicePlane);
+        setShowUpdraftLensBoundary(curated.showCloudBoundary);
+        setShowUpdraftLensWind(curated.showHorizontalWind);
+        setUpdraftLensWindMode(curated.windMode);
+        setCameraPreset(curated.cameraPreset);
+        setCameraTransform(curated.cameraTransform);
+        if (source === "return") {
+          setDisplayControlsOpen(curated.displayControlsOpen);
+        }
+        setUpdraftLensError(null);
+        setUpdraftLensFrame(null);
+        setUpdraftLensActive(curated.viewId === "updraft_lens");
+        ordinaryExploreStateRef.current =
+          curated.viewId === "updraft_lens"
+            ? {
+                selectedFieldName: curated.cloudFieldId,
+                sliceFieldName: curated.cloudFieldId,
+                showSlicePlanes: curated.showSlicePlane,
+                threshold: curated.cloudThresholdKgKg,
+              }
+            : null;
+      }
+      if (source === "return" || resolution.status !== "applied") {
+        setCuratedNotice({
+          status: resolution.status,
+          message: curatedResolutionExplanation(resolution),
+        });
+      } else {
+        setCuratedNotice(null);
+      }
+    },
+    [catalog, simulationRecord?.simulation_id, sliceFieldName, updraftLensDefaults],
+  );
+
   useEffect(() => {
     if (
       !updraftLensEligible ||
       updraftLensActive ||
       !updraftLensDefaults ||
       !catalog ||
-      autoActivatedUpdraftLensResultRef.current === resultId
+      initialCuratedResultRef.current === resultId
     ) {
+      return;
+    }
+    initialCuratedResultRef.current = resultId;
+    if (tradeCumulusCuratedView(simulationRecord?.simulation_id, TRADE_CUMULUS_INITIAL_VIEW)) {
+      applyTradeCumulusCuratedView(TRADE_CUMULUS_INITIAL_VIEW, "initial");
       return;
     }
     autoActivatedUpdraftLensResultRef.current = resultId;
     handleUpdraftLensToggle(true);
   }, [
+    applyTradeCumulusCuratedView,
     catalog,
     handleUpdraftLensToggle,
     resultId,
+    simulationRecord?.simulation_id,
     updraftLensActive,
     updraftLensDefaults,
     updraftLensEligible,
@@ -12170,21 +12290,42 @@ export function VisualizerSceneShell({
       onBack={onBack}
       onCompare={onCompare}
       headerActions={
-        resultOptions && resultOptions.length > 0 && onSelectResult ? (
-          <label className="soundings-explore-run-selector">
-            <span>Experiment</span>
-            <select
-              aria-label="Soundings Experiment"
-              value={resultId}
-              onChange={(event) => onSelectResult(event.target.value)}
-            >
-              {resultOptions.map((option) => (
-                <option key={option.result_id} value={option.result_id}>
-                  {soundingsExploreOptionLabel(option)}
-                </option>
-              ))}
-            </select>
-          </label>
+        tradeCumulusCuratedView(
+          simulationRecord?.simulation_id,
+          updraftLensActive ? "updraft_lens" : "field",
+        ) ||
+        (resultOptions && resultOptions.length > 0 && onSelectResult) ? (
+          <>
+            {tradeCumulusCuratedView(
+              simulationRecord?.simulation_id,
+              updraftLensActive ? "updraft_lens" : "field",
+            ) && (
+              <ReturnToCuratedViewControl
+                onReturn={() =>
+                  applyTradeCumulusCuratedView(
+                    updraftLensActive ? "updraft_lens" : "field",
+                    "return",
+                  )
+                }
+              />
+            )}
+            {resultOptions && resultOptions.length > 0 && onSelectResult && (
+              <label className="soundings-explore-run-selector">
+                <span>Experiment</span>
+                <select
+                  aria-label="Soundings Experiment"
+                  value={resultId}
+                  onChange={(event) => onSelectResult(event.target.value)}
+                >
+                  {resultOptions.map((option) => (
+                    <option key={option.result_id} value={option.result_id}>
+                      {soundingsExploreOptionLabel(option)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+          </>
         ) : undefined
       }
     >
@@ -12192,6 +12333,7 @@ export function VisualizerSceneShell({
         className={`visualizer-shell${focusedViewer ? ` visualizer-shell-focused-${focusedViewer}` : ""}`}
         aria-label="Integrated Explore workspace"
       >
+        <ExploreCuratedDefaultNotice notice={curatedNotice} />
         {sceneError && (
           <div className="workspace-catalog-error" role="alert">
             <p>{sceneError}</p>
@@ -12274,6 +12416,12 @@ export function VisualizerSceneShell({
               showUpdraftLensBoundary={updraftLensActive && showUpdraftLensBoundary}
               showUpdraftLensLegend={false}
               compactWorkspace
+              compactDisplayControlsOpen={displayControlsOpen}
+              onCompactDisplayControlsOpenChange={setDisplayControlsOpen}
+              cameraPreset={cameraPreset}
+              onCameraPresetChange={setCameraPreset}
+              cameraTransform={cameraTransform}
+              onCameraTransformChange={setCameraTransform}
               maximized={focusedViewer === "scene"}
               onToggleMaximize={() =>
                 setFocusedViewer((current) => (current === "scene" ? null : "scene"))
@@ -12656,7 +12804,7 @@ export function VisualizerSceneShell({
             )}
           </div>
 
-          <ExploreInspector>
+          <ExploreInspector collapsed={contextCollapsed} onCollapsedChange={setContextCollapsed}>
             <ResultExplanationPanel
               result={result}
               simulationName={productSimulationName}
@@ -12819,6 +12967,8 @@ export function VisualizerSceneShell({
         )}
 
         <ExploreSecondarySections
+          activeSection={secondarySection}
+          onActiveSectionChange={setSecondarySection}
           sections={{
             science: (
               <TradeCumulusScience

--- a/app/frontend/src/IntegratedExploreWorkspace.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.tsx
@@ -10,7 +10,7 @@ export type ExploreContextMetric = {
 };
 
 export type ExploreCuratedNotice = {
-  status: "applied" | "partially_incompatible" | "technical_fallback";
+  status: "applying" | "applied" | "partially_incompatible" | "technical_fallback";
   message: string;
 };
 

--- a/app/frontend/src/IntegratedExploreWorkspace.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, type ReactNode, useId, useRef, useState } from "react";
+import { type KeyboardEvent, type ReactNode, useEffect, useId, useRef, useState } from "react";
 
 export type ExploreSecondarySection = "science" | "notes" | "details";
 
@@ -7,6 +7,11 @@ export type ExploreSecondaryContent = Record<ExploreSecondarySection, ReactNode>
 export type ExploreContextMetric = {
   label: string;
   value: ReactNode;
+};
+
+export type ExploreCuratedNotice = {
+  status: "applied" | "partially_incompatible" | "technical_fallback";
+  message: string;
 };
 
 export function IntegratedExploreWorkspace({
@@ -210,17 +215,24 @@ export function ExploreSelectedEvidence({
 export function ExploreSecondarySections({
   sections,
   label = "Simulation support",
+  activeSection: controlledActiveSection,
+  onActiveSectionChange,
 }: {
   sections: ExploreSecondaryContent;
   label?: string;
+  activeSection?: ExploreSecondarySection;
+  onActiveSectionChange?: (section: ExploreSecondarySection) => void;
 }) {
-  const [activeSection, setActiveSection] = useState<ExploreSecondarySection>("science");
+  const [internalActiveSection, setInternalActiveSection] =
+    useState<ExploreSecondarySection>("science");
+  const activeSection = controlledActiveSection ?? internalActiveSection;
   const baseId = useId();
   const tabRefs = useRef<Partial<Record<ExploreSecondarySection, HTMLButtonElement | null>>>({});
   const orderedSections: ExploreSecondarySection[] = ["science", "notes", "details"];
 
   function selectSection(section: ExploreSecondarySection, focus = false) {
-    setActiveSection(section);
+    if (controlledActiveSection === undefined) setInternalActiveSection(section);
+    onActiveSectionChange?.(section);
     if (focus) tabRefs.current[section]?.focus();
   }
 
@@ -280,5 +292,40 @@ export function ExploreSecondarySections({
         </section>
       ))}
     </section>
+  );
+}
+
+export function ReturnToCuratedViewControl({ onReturn }: { onReturn: () => void }) {
+  return (
+    <button
+      type="button"
+      className="return-to-curated-view"
+      title="Restore the authored presentation for the current Field or Lens"
+      onClick={onReturn}
+    >
+      Return to curated view
+    </button>
+  );
+}
+
+export function ExploreCuratedDefaultNotice({ notice }: { notice: ExploreCuratedNotice | null }) {
+  const [visible, setVisible] = useState(Boolean(notice));
+
+  useEffect(() => {
+    setVisible(Boolean(notice));
+    if (!notice || notice.status !== "applied") return;
+    const timer = window.setTimeout(() => setVisible(false), 1_800);
+    return () => window.clearTimeout(timer);
+  }, [notice]);
+
+  if (!notice || !visible) return null;
+  return (
+    <p
+      className={`explore-curated-default-notice explore-curated-default-notice-${notice.status}`}
+      role="status"
+      aria-live="polite"
+    >
+      {notice.message}
+    </p>
   );
 }

--- a/app/frontend/src/MountainWavesExplore.test.tsx
+++ b/app/frontend/src/MountainWavesExplore.test.tsx
@@ -53,7 +53,7 @@ const frame = {
   case_label: "Boulder Windstorm",
   time_index: 0,
   time_seconds: 0,
-  times_seconds: [0, 180],
+  times_seconds: [0, 7_200],
   dry_case: false,
   field: {
     key: "cloud_over_wave",
@@ -192,7 +192,24 @@ describe("MountainWavesExplore", () => {
   const originalGetContext = HTMLCanvasElement.prototype.getContext;
 
   beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(ok(frame)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (!url.includes("/frame?")) return Promise.resolve(ok(frame));
+        const requestedIndex = Number(
+          new URL(url, "http://localhost").searchParams.get("time_index"),
+        );
+        const resolvedIndex = requestedIndex < 0 ? frame.time_index : requestedIndex;
+        return Promise.resolve(
+          ok({
+            ...frame,
+            time_index: resolvedIndex,
+            time_seconds: frame.times_seconds[resolvedIndex] ?? frame.time_seconds,
+          }),
+        );
+      }),
+    );
     vi.stubGlobal(
       "ResizeObserver",
       class {

--- a/app/frontend/src/MountainWavesExplore.test.tsx
+++ b/app/frontend/src/MountainWavesExplore.test.tsx
@@ -263,7 +263,12 @@ describe("MountainWavesExplore", () => {
   it("waits for the displayed frame before advancing playback again", async () => {
     const playbackFrame = { ...frame, times_seconds: [0, 180, 360] };
     vi.mocked(fetch).mockResolvedValue(ok(playbackFrame));
-    render(<MountainWavesExplore simulation={simulation} onBack={vi.fn()} />);
+    render(
+      <MountainWavesExplore
+        simulation={{ ...simulation, simulation_id: "mountain_waves_test_variation" }}
+        onBack={vi.fn()}
+      />,
+    );
     await screen.findByRole("heading", { name: "Wave Cloud Lens" });
 
     let resolveSecondFrame: ((response: Response) => void) | undefined;
@@ -313,7 +318,7 @@ describe("MountainWavesExplore", () => {
     await screen.findByRole("heading", { name: "Wave Cloud Lens" });
     fireEvent.click(screen.getByRole("button", { name: "Field" }));
     await waitFor(() =>
-      expect(fetch).toHaveBeenCalledWith(expect.stringContaining("field=w&time_index=-1")),
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining("field=w&time_index=1")),
     );
     expect(screen.getByRole("heading", { name: "Vertical velocity" })).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "True physical scale" }));
@@ -353,12 +358,62 @@ describe("MountainWavesExplore", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Wave Structure Lens" }));
     await waitFor(() =>
-      expect(fetch).toHaveBeenCalledWith(expect.stringContaining("field=w&time_index=-1")),
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining("field=w&time_index=1")),
     );
     expect(screen.queryByRole("checkbox", { name: "Cloud points" })).not.toBeInTheDocument();
     expect(screen.queryByRole("checkbox", { name: "RH = 100%" })).not.toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Potential temperature" })).toBeChecked();
     expect(screen.getByRole("heading", { name: "Wave Structure Lens" })).toBeInTheDocument();
+  });
+
+  it("returns the current Mountain Waves Lens to its complete authored view without deleting notes", async () => {
+    render(<MountainWavesExplore simulation={simulation} onBack={vi.fn()} />);
+    await screen.findByRole("heading", { name: "Wave Cloud Lens" });
+
+    const support = screen.getByLabelText("Simulation support");
+    fireEvent.click(within(support).getByRole("tab", { name: "Notes" }));
+    const notes = await screen.findByRole("textbox", { name: "Notes for Boulder Windstorm" });
+    fireEvent.change(notes, { target: { value: "Keep this observation." } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Full domain" }));
+    fireEvent.click(screen.getByRole("button", { name: "True physical scale" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Horizontal wind" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Cloud boundary" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "RH = 100%" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Potential temperature" }));
+    fireEvent.change(screen.getByRole("slider", { name: "Cloud opacity" }), {
+      target: { value: "0.35" },
+    });
+    fireEvent.change(screen.getByRole("slider", { name: "Cloud point size" }), {
+      target: { value: "7" },
+    });
+    fireEvent.change(screen.getByRole("slider", { name: /Saved output/ }), {
+      target: { value: "0" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to curated view" }));
+    await waitFor(() => expect(screen.queryByText("Loading frame...")).not.toBeInTheDocument());
+
+    expect(screen.getByRole("button", { name: "Wave Cloud Lens" })).toHaveClass("active-control");
+    expect(screen.getByRole("button", { name: "Focus region" })).toHaveClass("active-control");
+    expect(screen.getByRole("button", { name: "Expanded height" })).toHaveClass("active-control");
+    expect(screen.getByRole("checkbox", { name: "Horizontal wind" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Cloud points" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Cloud boundary" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "RH = 100%" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Potential temperature" })).not.toBeChecked();
+    expect(screen.getByRole("slider", { name: "Cloud opacity" })).toHaveValue("0.68");
+    expect(screen.getByRole("slider", { name: "Cloud point size" })).toHaveValue("11");
+    expect(screen.getByRole("slider", { name: /Saved output/ })).toHaveValue("1");
+    expect(within(support).getByRole("tab", { name: "Science" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    fireEvent.click(within(support).getByRole("tab", { name: "Notes" }));
+    expect(screen.getByRole("textbox", { name: "Notes for Boulder Windstorm" })).toHaveValue(
+      "Keep this observation.",
+    );
   });
 
   it("opens a dry Simulation in the Wave Structure Lens without moist-only controls", async () => {

--- a/app/frontend/src/MountainWavesExplore.tsx
+++ b/app/frontend/src/MountainWavesExplore.tsx
@@ -17,8 +17,10 @@ import {
   mountainWavesCuratedView,
   mountainWavesInitialView,
   resolveCuratedView,
+  type CuratedDefaultResolution,
   type MountainWavesCuratedView,
   type MountainWavesFieldId,
+  type ResolvedCuratedView,
 } from "./exploreCuratedDefaults";
 import type { MountainWavesSimulation } from "./MountainWavesWorld";
 import { SimulationNotes } from "./SimulationNotes";
@@ -237,6 +239,24 @@ function mountainCuratedViewId(viewMode: ViewMode): MountainWavesCuratedView["vi
   return "field";
 }
 
+type PendingMountainCuratedRestore = {
+  resolution: CuratedDefaultResolution<ResolvedCuratedView<MountainWavesCuratedView>>;
+  target: ResolvedCuratedView<MountainWavesCuratedView>;
+  source: "initial" | "return";
+};
+
+function mountainWaveAvailableOverlayIds(frame: MountainWaveFrame | null): string[] {
+  if (!frame) return [];
+  const available: string[] = [];
+  if (frame.pointer_context.horizontal_wind_m_s.length > 0) available.push("horizontal_wind");
+  if (frame.pointer_context.potential_temperature_k.length > 0) {
+    available.push("potential_temperature_contours");
+  }
+  if (frame.overlay) available.push("cloud_points", "cloud_boundary");
+  if (frame.pointer_context.relative_humidity_percent) available.push("saturation_contour");
+  return available;
+}
+
 export function MountainWavesExplore({
   simulation,
   onBack,
@@ -300,8 +320,12 @@ export function MountainWavesExplore({
   const [contextCollapsed, setContextCollapsed] = useState(false);
   const [secondarySection, setSecondarySection] = useState<ExploreSecondarySection>("science");
   const [curatedNotice, setCuratedNotice] = useState<ExploreCuratedNotice | null>(null);
+  const [pendingCuratedRestore, setPendingCuratedRestore] =
+    useState<PendingMountainCuratedRestore | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
   const requestSequence = useRef(0);
   const initialCuratedSimulationRef = useRef<string | null>(null);
+  const curatedNoticeSignatureRef = useRef<string | null>(null);
 
   const requestedField: MountainWaveField =
     viewMode === "cloud" ? "cloud_over_wave" : viewMode === "structure" ? "w" : field;
@@ -348,7 +372,7 @@ export function MountainWavesExplore({
     return () => {
       requestSequence.current += 1;
     };
-  }, [loadFrame]);
+  }, [loadFrame, retryNonce]);
 
   useEffect(() => {
     const requestedTimeIndex = timeIndex ?? frame?.time_index ?? null;
@@ -407,6 +431,8 @@ export function MountainWavesExplore({
     setContextCollapsed(false);
     setSecondarySection("science");
     setCuratedNotice(null);
+    setPendingCuratedRestore(null);
+    curatedNoticeSignatureRef.current = null;
   }, [simulation.moist_fields_available, simulation.simulation_id]);
 
   const fieldOptions = useMemo(
@@ -418,6 +444,51 @@ export function MountainWavesExplore({
     [frame?.field_options],
   );
   const selectedEvidence = selectedPoint && frame ? pointEvidence(frame, selectedPoint) : null;
+  const curatedStateSignature = useMemo(
+    () =>
+      JSON.stringify({
+        viewMode,
+        field,
+        geometryMode,
+        viewportMode,
+        timeIndex,
+        playing,
+        playbackSpeed,
+        selectedPoint,
+        cloudPoints,
+        cloudBoundary,
+        saturationContour,
+        horizontalWind,
+        structurePotentialTemperatureContours,
+        cloudPotentialTemperatureContours,
+        cloudOpacity,
+        cloudPointSize,
+        maximized,
+        contextCollapsed,
+        secondarySection,
+      }),
+    [
+      cloudBoundary,
+      cloudOpacity,
+      cloudPointSize,
+      cloudPoints,
+      cloudPotentialTemperatureContours,
+      contextCollapsed,
+      field,
+      geometryMode,
+      horizontalWind,
+      maximized,
+      playbackSpeed,
+      playing,
+      saturationContour,
+      secondarySection,
+      selectedPoint,
+      structurePotentialTemperatureContours,
+      timeIndex,
+      viewMode,
+      viewportMode,
+    ],
+  );
 
   const applyCuratedView = useCallback(
     (viewId: MountainWavesCuratedView["viewId"], source: "initial" | "return") => {
@@ -429,46 +500,70 @@ export function MountainWavesExplore({
           : ["field", "wave_structure"],
         availableFieldIds: frame?.field_options ?? [],
         availableScaleIds: frame ? [frame.scale.scale_id] : undefined,
+        availableOverlayIds: mountainWaveAvailableOverlayIds(frame),
         timesSeconds: frame?.times_seconds ?? [],
       });
 
-      if (source === "return") {
-        setPlaying(false);
-        setSelectedPoint(null);
-        setMaximized(false);
-        setContextCollapsed(false);
-        setSecondarySection("science");
-      }
-      if (resolution.value) {
-        const curated = resolution.value.definition;
-        setTimeIndex(resolution.value.timeIndex);
-        if (source === "return") {
-          setPlaybackSpeed(curated.playbackSpeed);
-          setGeometryMode(curated.geometry);
-          setViewportMode(curated.viewport);
-          setHorizontalWind(curated.overlays.horizontalWind);
-          setCloudPoints(curated.overlays.cloudPoints);
-          setCloudBoundary(curated.overlays.cloudBoundary);
-          setSaturationContour(curated.overlays.saturationContour);
-          if (viewId === "wave_cloud") {
-            setCloudPotentialTemperatureContours(curated.overlays.potentialTemperatureContours);
-          } else if (viewId === "wave_structure") {
-            setStructurePotentialTemperatureContours(curated.overlays.potentialTemperatureContours);
-          }
-          setCloudOpacity(curated.cloudOpacity);
-          setCloudPointSize(curated.cloudPointSizePx);
-        }
-      }
-      if (source === "return" || resolution.status !== "applied") {
+      if (!resolution.value) {
+        setPendingCuratedRestore(null);
+        curatedNoticeSignatureRef.current = curatedStateSignature;
         setCuratedNotice({
           status: resolution.status,
           message: curatedResolutionExplanation(resolution),
         });
+        return;
+      }
+      const curated = resolution.value.definition;
+      setTimeIndex(resolution.value.timeIndex);
+      setPlaying(false);
+      if (source === "return") {
+        setSelectedPoint(curated.selection);
+        setMaximized(false);
+        setContextCollapsed(curated.contextCollapsed);
+        setSecondarySection(curated.secondarySection);
+        setPlaybackSpeed(curated.playbackSpeed);
+        setGeometryMode(curated.geometry);
+        setViewportMode(curated.viewport);
+        setHorizontalWind(curated.overlays.horizontalWind);
+        setCloudPoints(curated.overlays.cloudPoints);
+        setCloudBoundary(curated.overlays.cloudBoundary);
+        setSaturationContour(curated.overlays.saturationContour);
+        if (viewId === "wave_cloud") {
+          setCloudPotentialTemperatureContours(curated.overlays.potentialTemperatureContours);
+        } else if (viewId === "wave_structure") {
+          setStructurePotentialTemperatureContours(curated.overlays.potentialTemperatureContours);
+        }
+        setCloudOpacity(curated.cloudOpacity);
+        setCloudPointSize(curated.cloudPointSizePx);
+        setError(null);
+        setFrame(null);
+        setRetryNonce((current) => current + 1);
+        setCuratedNotice({
+          status: "applying",
+          message: `Restoring the curated ${
+            viewId === "field"
+              ? "Field"
+              : viewId === "wave_cloud"
+                ? "Wave Cloud Lens"
+                : "Wave Structure Lens"
+          } view and loading its scientific evidence...`,
+        });
       } else {
         setCuratedNotice(null);
       }
+      setPendingCuratedRestore({
+        resolution,
+        target: resolution.value,
+        source,
+      });
     },
-    [field, frame, simulation.moist_fields_available, simulation.simulation_id],
+    [
+      curatedStateSignature,
+      field,
+      frame,
+      simulation.moist_fields_available,
+      simulation.simulation_id,
+    ],
   );
 
   useEffect(() => {
@@ -476,6 +571,103 @@ export function MountainWavesExplore({
     initialCuratedSimulationRef.current = simulation.simulation_id;
     applyCuratedView(initialViewId, "initial");
   }, [applyCuratedView, frame, initialViewId, simulation.simulation_id]);
+
+  useEffect(() => {
+    if (!pendingCuratedRestore) return;
+    const { resolution, source, target } = pendingCuratedRestore;
+    const curated = target.definition;
+    const targetViewMode = mountainViewMode(curated.viewId);
+    const controlsMatch =
+      viewMode === targetViewMode &&
+      (curated.viewId !== "field" || field === curated.fieldId) &&
+      timeIndex === target.timeIndex &&
+      !playing &&
+      geometryMode === curated.geometry &&
+      viewportMode === curated.viewport;
+    if (!controlsMatch) {
+      setPendingCuratedRestore(null);
+      setCuratedNotice(null);
+      curatedNoticeSignatureRef.current = null;
+      return;
+    }
+    if (error) {
+      setPendingCuratedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({
+        status: "technical_fallback",
+        message: `The curated ${
+          curated.viewId === "field"
+            ? "Field"
+            : curated.viewId === "wave_cloud"
+              ? "Wave Cloud Lens"
+              : "Wave Structure Lens"
+        } view could not be restored: ${error} Use Retry frame to try again.`,
+      });
+      return;
+    }
+    const expectedFrameField =
+      curated.viewId === "wave_cloud"
+        ? "cloud_over_wave"
+        : curated.viewId === "wave_structure"
+          ? "w"
+          : curated.fieldId;
+    if (
+      loading ||
+      !frame ||
+      frame.time_index !== target.timeIndex ||
+      frame.field.key !== expectedFrameField
+    ) {
+      return;
+    }
+    const confirmedResolution = resolveCuratedView(curated, {
+      availableViewIds: simulation.moist_fields_available
+        ? ["field", "wave_structure", "wave_cloud"]
+        : ["field", "wave_structure"],
+      availableFieldIds: frame.field_options,
+      availableScaleIds: [frame.scale.scale_id],
+      availableOverlayIds: mountainWaveAvailableOverlayIds(frame),
+      timesSeconds: frame.times_seconds,
+    });
+    if (!confirmedResolution.value) {
+      setPendingCuratedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({
+        status: "technical_fallback",
+        message: curatedResolutionExplanation(confirmedResolution),
+      });
+      return;
+    }
+    setPendingCuratedRestore(null);
+    curatedNoticeSignatureRef.current = curatedStateSignature;
+    if (source === "return" || resolution.status !== "applied") {
+      setCuratedNotice({
+        status: resolution.status,
+        message: curatedResolutionExplanation(resolution),
+      });
+    } else {
+      setCuratedNotice(null);
+    }
+  }, [
+    curatedStateSignature,
+    error,
+    field,
+    frame,
+    geometryMode,
+    loading,
+    pendingCuratedRestore,
+    playing,
+    simulation.moist_fields_available,
+    timeIndex,
+    viewMode,
+    viewportMode,
+  ]);
+
+  useEffect(() => {
+    if (!curatedNotice || pendingCuratedRestore || !curatedNoticeSignatureRef.current) return;
+    if (curatedNoticeSignatureRef.current === curatedStateSignature) return;
+    curatedNoticeSignatureRef.current = null;
+    setCuratedNotice(null);
+  }, [curatedNotice, curatedStateSignature, pendingCuratedRestore]);
 
   return (
     <IntegratedExploreWorkspace
@@ -555,7 +747,14 @@ export function MountainWavesExplore({
               <section className="layer-local-error mountain-waves-local-error">
                 <h3>Saved output unavailable</h3>
                 <p role="alert">{error}</p>
-                <button type="button" onClick={() => void loadFrame()}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    curatedNoticeSignatureRef.current = null;
+                    setCuratedNotice(null);
+                    setRetryNonce((current) => current + 1);
+                  }}
+                >
                   Retry frame
                 </button>
               </section>

--- a/app/frontend/src/MountainWavesExplore.tsx
+++ b/app/frontend/src/MountainWavesExplore.tsx
@@ -2,12 +2,24 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent } from "react";
 
 import {
+  ExploreCuratedDefaultNotice,
   ExploreContextContent,
   ExploreInspector,
   ExploreSelectedEvidence,
   ExploreSecondarySections,
   IntegratedExploreWorkspace,
+  ReturnToCuratedViewControl,
+  type ExploreCuratedNotice,
+  type ExploreSecondarySection,
 } from "./IntegratedExploreWorkspace";
+import {
+  curatedResolutionExplanation,
+  mountainWavesCuratedView,
+  mountainWavesInitialView,
+  resolveCuratedView,
+  type MountainWavesCuratedView,
+  type MountainWavesFieldId,
+} from "./exploreCuratedDefaults";
 import type { MountainWavesSimulation } from "./MountainWavesWorld";
 import { SimulationNotes } from "./SimulationNotes";
 import { scalarPointPixelSize } from "./True3DViewer.utils";
@@ -213,6 +225,18 @@ const FIELD_LABELS: Record<Exclude<MountainWaveField, "cloud_over_wave">, string
   theta_perturbation: "Potential-temperature perturbation",
 };
 
+function mountainViewMode(viewId: MountainWavesCuratedView["viewId"]): ViewMode {
+  if (viewId === "wave_cloud") return "cloud";
+  if (viewId === "wave_structure") return "structure";
+  return "field";
+}
+
+function mountainCuratedViewId(viewMode: ViewMode): MountainWavesCuratedView["viewId"] {
+  if (viewMode === "cloud") return "wave_cloud";
+  if (viewMode === "structure") return "wave_structure";
+  return "field";
+}
+
 export function MountainWavesExplore({
   simulation,
   onBack,
@@ -220,30 +244,64 @@ export function MountainWavesExplore({
   simulation: MountainWavesSimulation;
   onBack: () => void;
 }) {
-  const [viewMode, setViewMode] = useState<ViewMode>(
-    simulation.moist_fields_available ? "cloud" : "structure",
+  const initialViewId =
+    mountainWavesInitialView(simulation.simulation_id) ??
+    (simulation.moist_fields_available ? "wave_cloud" : "wave_structure");
+  const initialCuratedDefinition = mountainWavesCuratedView(
+    simulation.simulation_id,
+    initialViewId,
+    "w",
   );
-  const [field, setField] = useState<Exclude<MountainWaveField, "cloud_over_wave">>("w");
-  const [geometryMode, setGeometryMode] = useState<GeometryMode>("expanded");
-  const [viewportMode, setViewportMode] = useState<ViewportMode | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>(mountainViewMode(initialViewId));
+  const [field, setField] = useState<Exclude<MountainWaveField, "cloud_over_wave">>(
+    initialCuratedDefinition?.fieldId ?? "w",
+  );
+  const [geometryMode, setGeometryMode] = useState<GeometryMode>(
+    initialCuratedDefinition?.geometry ?? "expanded",
+  );
+  const [viewportMode, setViewportMode] = useState<ViewportMode | null>(
+    initialCuratedDefinition?.viewport ?? null,
+  );
   const [timeIndex, setTimeIndex] = useState<number | null>(null);
   const [frame, setFrame] = useState<MountainWaveFrame | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [playing, setPlaying] = useState(false);
-  const [playbackSpeed, setPlaybackSpeed] = useState(1);
+  const [playbackSpeed, setPlaybackSpeed] = useState(initialCuratedDefinition?.playbackSpeed ?? 1);
   const [selectedPoint, setSelectedPoint] = useState<PointSelection | null>(null);
-  const [cloudPoints, setCloudPoints] = useState(true);
-  const [cloudBoundary, setCloudBoundary] = useState(true);
-  const [saturationContour, setSaturationContour] = useState(true);
-  const [horizontalWind, setHorizontalWind] = useState(true);
+  const [cloudPoints, setCloudPoints] = useState(
+    initialCuratedDefinition?.overlays.cloudPoints ?? true,
+  );
+  const [cloudBoundary, setCloudBoundary] = useState(
+    initialCuratedDefinition?.overlays.cloudBoundary ?? true,
+  );
+  const [saturationContour, setSaturationContour] = useState(
+    initialCuratedDefinition?.overlays.saturationContour ?? true,
+  );
+  const [horizontalWind, setHorizontalWind] = useState(
+    initialCuratedDefinition?.overlays.horizontalWind ?? true,
+  );
   const [structurePotentialTemperatureContours, setStructurePotentialTemperatureContours] =
-    useState(true);
-  const [cloudPotentialTemperatureContours, setCloudPotentialTemperatureContours] = useState(false);
-  const [cloudOpacity, setCloudOpacity] = useState(0.68);
-  const [cloudPointSize, setCloudPointSize] = useState(11);
+    useState(
+      initialViewId === "wave_structure"
+        ? (initialCuratedDefinition?.overlays.potentialTemperatureContours ?? true)
+        : true,
+    );
+  const [cloudPotentialTemperatureContours, setCloudPotentialTemperatureContours] = useState(
+    initialViewId === "wave_cloud"
+      ? (initialCuratedDefinition?.overlays.potentialTemperatureContours ?? false)
+      : false,
+  );
+  const [cloudOpacity, setCloudOpacity] = useState(initialCuratedDefinition?.cloudOpacity ?? 0.68);
+  const [cloudPointSize, setCloudPointSize] = useState(
+    initialCuratedDefinition?.cloudPointSizePx ?? 11,
+  );
   const [maximized, setMaximized] = useState(false);
+  const [contextCollapsed, setContextCollapsed] = useState(false);
+  const [secondarySection, setSecondarySection] = useState<ExploreSecondarySection>("science");
+  const [curatedNotice, setCuratedNotice] = useState<ExploreCuratedNotice | null>(null);
   const requestSequence = useRef(0);
+  const initialCuratedSimulationRef = useRef<string | null>(null);
 
   const requestedField: MountainWaveField =
     viewMode === "cloud" ? "cloud_over_wave" : viewMode === "structure" ? "w" : field;
@@ -316,8 +374,40 @@ export function MountainWavesExplore({
   }, [simulation.moist_fields_available, viewMode]);
 
   useEffect(() => {
-    setViewportMode(null);
-  }, [simulation.simulation_id]);
+    const nextInitialView =
+      mountainWavesInitialView(simulation.simulation_id) ??
+      (simulation.moist_fields_available ? "wave_cloud" : "wave_structure");
+    const nextDefinition = mountainWavesCuratedView(simulation.simulation_id, nextInitialView, "w");
+    initialCuratedSimulationRef.current = null;
+    setViewMode(mountainViewMode(nextInitialView));
+    setField(nextDefinition?.fieldId ?? "w");
+    setGeometryMode(nextDefinition?.geometry ?? "expanded");
+    setViewportMode(nextDefinition?.viewport ?? null);
+    setTimeIndex(null);
+    setPlaying(false);
+    setPlaybackSpeed(nextDefinition?.playbackSpeed ?? 1);
+    setSelectedPoint(null);
+    setCloudPoints(nextDefinition?.overlays.cloudPoints ?? true);
+    setCloudBoundary(nextDefinition?.overlays.cloudBoundary ?? true);
+    setSaturationContour(nextDefinition?.overlays.saturationContour ?? true);
+    setHorizontalWind(nextDefinition?.overlays.horizontalWind ?? true);
+    if (nextInitialView === "wave_structure") {
+      setStructurePotentialTemperatureContours(
+        nextDefinition?.overlays.potentialTemperatureContours ?? true,
+      );
+    }
+    if (nextInitialView === "wave_cloud") {
+      setCloudPotentialTemperatureContours(
+        nextDefinition?.overlays.potentialTemperatureContours ?? false,
+      );
+    }
+    setCloudOpacity(nextDefinition?.cloudOpacity ?? 0.68);
+    setCloudPointSize(nextDefinition?.cloudPointSizePx ?? 11);
+    setMaximized(false);
+    setContextCollapsed(false);
+    setSecondarySection("science");
+    setCuratedNotice(null);
+  }, [simulation.moist_fields_available, simulation.simulation_id]);
 
   const fieldOptions = useMemo(
     () =>
@@ -329,17 +419,81 @@ export function MountainWavesExplore({
   );
   const selectedEvidence = selectedPoint && frame ? pointEvidence(frame, selectedPoint) : null;
 
+  const applyCuratedView = useCallback(
+    (viewId: MountainWavesCuratedView["viewId"], source: "initial" | "return") => {
+      const activeField = field as MountainWavesFieldId;
+      const definition = mountainWavesCuratedView(simulation.simulation_id, viewId, activeField);
+      const resolution = resolveCuratedView(definition, {
+        availableViewIds: simulation.moist_fields_available
+          ? ["field", "wave_structure", "wave_cloud"]
+          : ["field", "wave_structure"],
+        availableFieldIds: frame?.field_options ?? [],
+        availableScaleIds: frame ? [frame.scale.scale_id] : undefined,
+        timesSeconds: frame?.times_seconds ?? [],
+      });
+
+      if (source === "return") {
+        setPlaying(false);
+        setSelectedPoint(null);
+        setMaximized(false);
+        setContextCollapsed(false);
+        setSecondarySection("science");
+      }
+      if (resolution.value) {
+        const curated = resolution.value.definition;
+        setTimeIndex(resolution.value.timeIndex);
+        if (source === "return") {
+          setPlaybackSpeed(curated.playbackSpeed);
+          setGeometryMode(curated.geometry);
+          setViewportMode(curated.viewport);
+          setHorizontalWind(curated.overlays.horizontalWind);
+          setCloudPoints(curated.overlays.cloudPoints);
+          setCloudBoundary(curated.overlays.cloudBoundary);
+          setSaturationContour(curated.overlays.saturationContour);
+          if (viewId === "wave_cloud") {
+            setCloudPotentialTemperatureContours(curated.overlays.potentialTemperatureContours);
+          } else if (viewId === "wave_structure") {
+            setStructurePotentialTemperatureContours(curated.overlays.potentialTemperatureContours);
+          }
+          setCloudOpacity(curated.cloudOpacity);
+          setCloudPointSize(curated.cloudPointSizePx);
+        }
+      }
+      if (source === "return" || resolution.status !== "applied") {
+        setCuratedNotice({
+          status: resolution.status,
+          message: curatedResolutionExplanation(resolution),
+        });
+      } else {
+        setCuratedNotice(null);
+      }
+    },
+    [field, frame, simulation.moist_fields_available, simulation.simulation_id],
+  );
+
+  useEffect(() => {
+    if (!frame || initialCuratedSimulationRef.current === simulation.simulation_id) return;
+    initialCuratedSimulationRef.current = simulation.simulation_id;
+    applyCuratedView(initialViewId, "initial");
+  }, [applyCuratedView, frame, initialViewId, simulation.simulation_id]);
+
   return (
     <IntegratedExploreWorkspace
       worldName="Mountain Waves"
       simulationName={simulation.display_name}
       onBack={onBack}
+      headerActions={
+        <ReturnToCuratedViewControl
+          onReturn={() => applyCuratedView(mountainCuratedViewId(viewMode), "return")}
+        />
+      }
     >
       <section
         className={`visualizer-shell mountain-waves-explore-shell${
           maximized ? " mountain-waves-explore-shell-maximized" : ""
         }`}
       >
+        <ExploreCuratedDefaultNotice notice={curatedNotice} />
         <section className="mountain-waves-scientific-view" aria-label="Mountain Waves x-z view">
           <header className="instrument-header mountain-waves-instrument-header">
             <div>
@@ -603,7 +757,7 @@ export function MountainWavesExplore({
           onPlaybackSpeed={setPlaybackSpeed}
         />
 
-        <ExploreInspector>
+        <ExploreInspector collapsed={contextCollapsed} onCollapsedChange={setContextCollapsed}>
           <MountainWavesContext
             simulation={simulation}
             frame={frame}
@@ -616,6 +770,8 @@ export function MountainWavesExplore({
         </ExploreInspector>
 
         <ExploreSecondarySections
+          activeSection={secondarySection}
+          onActiveSectionChange={setSecondarySection}
           sections={{
             science: (
               <MountainWavesScience simulation={simulation} frame={frame} viewMode={viewMode} />

--- a/app/frontend/src/SupercellsExplore.css
+++ b/app/frontend/src/SupercellsExplore.css
@@ -1,4 +1,5 @@
 .supercells-explore-shell {
+  position: relative;
   display: grid;
   grid-template-rows: minmax(32rem, calc(100vh - 21rem)) auto auto auto;
   gap: 8px;

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -23,6 +23,8 @@ vi.mock("./True3DViewer", () => ({
     cameraTransform,
     onCameraTransformChange,
     windOverlayLabel,
+    compactDisplayControlsOpen,
+    onCompactDisplayControlsOpenChange,
   }: {
     fieldLabel: string;
     activeSliceLabel: string;
@@ -42,12 +44,15 @@ vi.mock("./True3DViewer", () => ({
       up: [number, number, number];
     }) => void;
     windOverlayLabel?: string;
+    compactDisplayControlsOpen?: boolean;
+    onCompactDisplayControlsOpenChange?: (open: boolean) => void;
   }) => (
     <section aria-label="Mock 3-D storm scene">
       <h2>{fieldLabel}</h2>
       <p>{activeSliceLabel}</p>
       <p>Camera: {cameraPreset}</p>
       <p>Camera position: {cameraTransform?.position.join(",") ?? "default"}</p>
+      <p>Display controls: {compactDisplayControlsOpen ? "open" : "closed"}</p>
       {windOverlayLabel && <p>{windOverlayLabel}</p>}
       <button
         type="button"
@@ -66,6 +71,12 @@ vi.mock("./True3DViewer", () => ({
       </button>
       <button type="button" onClick={onToggleMaximize}>
         {maximized ? "Restore scene" : "Maximize scene"}
+      </button>
+      <button
+        type="button"
+        onClick={() => onCompactDisplayControlsOpenChange?.(!compactDisplayControlsOpen)}
+      >
+        Toggle mock display controls
       </button>
       {compactDisplayControls}
     </section>
@@ -113,7 +124,17 @@ const wScale = {
   fixed_across_time: true,
 };
 
-function field(key = "winterp", displayName = "Vertical velocity"): FieldLayer {
+const supercellScaleIds = {
+  rotating_updraft: "supercell_midlevel_vertical_velocity_v1",
+  cloud_precipitation: "supercell_total_condensate_v2",
+  low_level_interactions: "supercell_low_level_vertical_velocity_v1",
+} as const;
+
+function field(
+  key = "winterp",
+  displayName = "Vertical velocity",
+  scaleId = wScale.scale_id,
+): FieldLayer {
   return {
     key,
     display_name: displayName,
@@ -128,11 +149,12 @@ function field(key = "winterp", displayName = "Vertical velocity"): FieldLayer {
     ],
     selected_frame_minimum: -8,
     selected_frame_maximum: 12,
-    scale: wScale,
+    scale: { ...wScale, scale_id: scaleId },
   };
 }
 
 function sceneLayers(lens: LensId): VolumeLayer[] {
+  const lensScaleId = supercellScaleIds[lens];
   const base = {
     units: "m/s",
     evidence_kind: "native" as const,
@@ -148,7 +170,7 @@ function sceneLayers(lens: LensId): VolumeLayer[] {
     threshold_label: "Fixed retained-run scale",
     default_opacity: 0.8,
     default_point_size: 1,
-    scale: wScale,
+    scale: { ...wScale, scale_id: lensScaleId },
     categories: [],
   };
   if (lens === "cloud_precipitation") {
@@ -389,7 +411,10 @@ function frameFor(url: string): StormExaminationFrame {
               [0, 1, 2],
             ]
           : null,
-      primary: field(),
+      primary:
+        lens === "cloud_precipitation"
+          ? field("total_condensate", "Total condensate", supercellScaleIds.cloud_precipitation)
+          : field("winterp", "Vertical velocity", supercellScaleIds[lens]),
       overlays: {
         vertical_vorticity: field("zvort", "Vertical vorticity"),
         updraft_helicity: field("uh", "Updraft helicity"),
@@ -405,8 +430,8 @@ function frameFor(url: string): StormExaminationFrame {
       categories: null,
       wind_vectors: [{ x_km: 0, y_km: 10, u_m_s: 12, v_m_s: 5, magnitude_m_s: 13 }],
     },
-    xz_section: section("xz", "x", yCoordinates[yIndex] ?? 10),
-    yz_section: section("yz", "y", xCoordinates[xIndex] ?? 0),
+    xz_section: section(lens, "xz", "x", yCoordinates[yIndex] ?? 10),
+    yz_section: section(lens, "yz", "y", xCoordinates[xIndex] ?? 0),
     scene: {
       coordinate_extents_km: {
         x: { min: viewport === "storm" ? -30 : -60, max: viewport === "storm" ? 30 : 60 },
@@ -444,7 +469,12 @@ function frameFor(url: string): StormExaminationFrame {
   };
 }
 
-function section(orientation: "xz" | "yz", horizontal: "x" | "y", coordinate: number) {
+function section(
+  lens: LensId,
+  orientation: "xz" | "yz",
+  horizontal: "x" | "y",
+  coordinate: number,
+) {
   return {
     orientation,
     title: `${orientation} section at ${orientation === "xz" ? "y" : "x"} = ${coordinate.toFixed(1)} km`,
@@ -453,7 +483,10 @@ function section(orientation: "xz" | "yz", horizontal: "x" | "y", coordinate: nu
     horizontal_km: [-10, 0, 10],
     z_km: [0.5, 3, 8],
     cross_section_coordinate_km: coordinate,
-    primary: field(),
+    primary:
+      lens === "cloud_precipitation"
+        ? field("total_condensate", "Total condensate", supercellScaleIds.cloud_precipitation)
+        : field("winterp", "Vertical velocity", supercellScaleIds[lens]),
     overlays: {
       total_condensate: field("total_condensate", "Total condensate"),
       precipitating_condensate: field("precipitating_condensate", "Precipitating condensate"),
@@ -801,6 +834,105 @@ describe("SupercellsExplore", () => {
     expect(await within(context).findByText("Selected cell")).toBeVisible();
     expect(within(context).getByRole("heading", { name: "Native-grid evidence" })).toBeVisible();
   });
+
+  it.each([
+    {
+      lens: "rotating_updraft" as const,
+      button: "Rotating Updraft",
+      orientation: "Horizontal x-y",
+      layer: "Storm cloud body",
+      opacity: "1",
+      pointSize: "1",
+      camera: "look_along_y",
+      positionLabel: "Horizontal x-y z position",
+      positionValue: "1",
+    },
+    {
+      lens: "cloud_precipitation" as const,
+      button: "Cloud and Precipitation",
+      orientation: "Vertical x-z",
+      layer: "Dominant hydrometeor",
+      opacity: "0.9",
+      pointSize: "0.9",
+      camera: "look_along_y",
+      positionLabel: "Vertical x-z y position",
+      positionValue: "1",
+    },
+    {
+      lens: "low_level_interactions" as const,
+      button: "Low-Level Interactions",
+      orientation: "Horizontal x-y",
+      layer: "Low-level vertical motion",
+      opacity: "1",
+      pointSize: "1",
+      camera: "low_level",
+      positionLabel: "Horizontal x-y z position",
+      positionValue: "0",
+    },
+  ])(
+    "returns $button to its complete authored presentation without switching lenses",
+    async ({
+      lens,
+      button,
+      orientation,
+      layer,
+      opacity,
+      pointSize,
+      camera,
+      positionLabel,
+      positionValue,
+    }) => {
+      render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+      await waitForLensContext("rotating_updraft");
+      if (lens !== "rotating_updraft") {
+        fireEvent.click(screen.getByRole("button", { name: button }));
+        await waitForLensContext(lens);
+      }
+      await waitFor(() => expect(screen.getByLabelText(layer)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole("button", { name: "Full domain" }));
+      const orientationControls = within(screen.getByLabelText("Slice orientation"));
+      fireEvent.click(
+        orientationControls.getByRole("button", {
+          name: orientation === "Vertical x-z" ? "Horizontal x-y" : "Vertical y-z",
+        }),
+      );
+      fireEvent.change(screen.getByLabelText("Saved output time"), {
+        target: { value: "10" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Move mock camera" }));
+      fireEvent.click(screen.getByRole("button", { name: "Toggle mock display controls" }));
+      expect(screen.getByText("Display controls: open")).toBeVisible();
+      fireEvent.click(screen.getByLabelText(layer));
+      fireEvent.change(screen.getByRole("slider", { name: /Opacity/ }), {
+        target: { value: "0.35" },
+      });
+      fireEvent.change(screen.getByRole("slider", { name: /Point size/ }), {
+        target: { value: "1.7" },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Return to curated view" }));
+      await waitFor(() => expect(screen.getByLabelText("Saved output time")).toHaveValue("37"));
+
+      expect(screen.getByRole("button", { name: button })).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: "Storm region" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(
+        within(screen.getByLabelText("Slice orientation")).getByRole("button", {
+          name: orientation,
+        }),
+      ).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByLabelText(positionLabel)).toHaveValue(positionValue);
+      expect(screen.getByLabelText(layer)).toBeChecked();
+      expect(screen.getByRole("slider", { name: /Opacity/ })).toHaveValue(opacity);
+      expect(screen.getByRole("slider", { name: /Point size/ })).toHaveValue(pointSize);
+      expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent(`Camera: ${camera}`);
+      expect(screen.getByText("Camera position: default")).toBeVisible();
+      expect(screen.getByText("Display controls: closed")).toBeVisible();
+    },
+  );
 
   it("preserves the lens and time while maximizing and restoring either scientific view", async () => {
     render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -282,8 +282,8 @@ function frameFor(url: string): StormExaminationFrame {
   const yIndex = Number(search.get("y_index") ?? 1);
   const zIndex = Number(search.get("z_index") ?? 1);
   const xCoordinates = [-10, 0, 10];
-  const yCoordinates = [-10, 10, 20];
-  const zCoordinates = [0.5, 3, 8];
+  const yCoordinates = lens === "cloud_precipitation" ? [-10, 0.75, 20] : [-10, 10, 20];
+  const zCoordinates = lens === "low_level_interactions" ? [1.1666667461395264, 3, 8] : [0.5, 3, 8];
   const names = {
     rotating_updraft: "Rotating Updraft",
     cloud_precipitation: "Cloud and Precipitation",
@@ -670,7 +670,7 @@ describe("SupercellsExplore", () => {
 
     await waitFor(() =>
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringMatching(/x_index=1&y_index=0&z_index=2/),
+        expect.stringMatching(/x_index=1&y_index=1&z_index=2/),
         expect.anything(),
       ),
     );
@@ -771,9 +771,9 @@ describe("SupercellsExplore", () => {
       "aria-pressed",
       "true",
     );
-    expect((await screen.findAllByText("xz section at y = 10.0 km")).length).toBeGreaterThan(1);
+    expect((await screen.findAllByText("xz section at y = 0.8 km")).length).toBeGreaterThan(1);
     expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent(
-      "xz section at y = 10.0 km",
+      "xz section at y = 0.8 km",
     );
     fireEvent.click(orientation.getByRole("button", { name: "Horizontal x-y" }));
     fireEvent.click(screen.getByLabelText("Hydrometeor plan plan view"), {
@@ -782,7 +782,7 @@ describe("SupercellsExplore", () => {
     });
     await waitFor(() =>
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringMatching(/x_index=1&y_index=0&z_index=2/),
+        expect.stringMatching(/x_index=1&y_index=1&z_index=2/),
         expect.anything(),
       ),
     );
@@ -828,7 +828,7 @@ describe("SupercellsExplore", () => {
       ),
     );
     expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent(
-      "xz section at y = 10.0 km",
+      "xz section at y = 0.8 km",
     );
     const context = screen.getByLabelText("Context");
     expect(await within(context).findByText("Selected cell")).toBeVisible();

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -1,12 +1,23 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  ExploreCuratedDefaultNotice,
   ExploreContextContent,
   ExploreInspector,
   ExploreSelectedEvidence,
   ExploreSecondarySections,
   IntegratedExploreWorkspace,
+  ReturnToCuratedViewControl,
+  type ExploreCuratedNotice,
+  type ExploreSecondarySection,
 } from "./IntegratedExploreWorkspace";
+import {
+  curatedResolutionExplanation,
+  resolveCuratedView,
+  SUPERCELLS_CURATED_VIEWS,
+  SUPERCELLS_INITIAL_LENS,
+  supercellsCuratedView,
+} from "./exploreCuratedDefaults";
 import { NativeSlicePositionControl } from "./NativeSlicePositionControl";
 import { SimulationNotes } from "./SimulationNotes";
 import type { SupercellSimulation } from "./SupercellsWorld";
@@ -48,6 +59,7 @@ type LensPresentation = {
   categoryCodes: number[];
   cameraPreset: CameraPreset;
   cameraTransform: CameraTransform | null;
+  displayControlsOpen: boolean;
   sceneOpacity: number;
   scenePointSize: number;
   selection: Selection | null;
@@ -75,7 +87,7 @@ export function SupercellsExplore({
   simulation: SupercellSimulation;
   onBack: () => void;
 }) {
-  const [lens, setLens] = useState<LensId>("rotating_updraft");
+  const [lens, setLens] = useState<LensId>(SUPERCELLS_INITIAL_LENS);
   const [timeIndex, setTimeIndex] = useState(simulation.default_explore_time_index);
   const [frame, setFrame] = useState<StormExaminationFrame | null>(null);
   const [presentations, setPresentations] =
@@ -88,6 +100,7 @@ export function SupercellsExplore({
     categoryCodes,
     cameraPreset,
     cameraTransform,
+    displayControlsOpen,
     sceneOpacity,
     scenePointSize,
     selection,
@@ -96,6 +109,8 @@ export function SupercellsExplore({
   const visibleLayerKeys = presentation.visibleLayerKeys ?? [];
   const [focusedViewer, setFocusedViewer] = useState<FocusedViewer>(null);
   const [contextCollapsed, setContextCollapsed] = useState(false);
+  const [secondarySection, setSecondarySection] = useState<ExploreSecondarySection>("science");
+  const [curatedNotice, setCuratedNotice] = useState<ExploreCuratedNotice | null>(null);
   const [playing, setPlaying] = useState(false);
   const [playbackSpeed, setPlaybackSpeed] = useState(1);
   const [loading, setLoading] = useState(true);
@@ -103,6 +118,7 @@ export function SupercellsExplore({
   const [retryNonce, setRetryNonce] = useState(0);
   const frameCache = useRef(new Map<string, StormExaminationFrame>());
   const contextBeforeEvidenceFocus = useRef(false);
+  const initialCuratedSimulationRef = useRef<string | null>(null);
 
   const requestKey = frameRequestKey(lens, viewport, timeIndex, selection);
   const loadFrame = useCallback(
@@ -152,19 +168,6 @@ export function SupercellsExplore({
     void loadFrame(controller.signal);
     return () => controller.abort();
   }, [loadFrame, retryNonce]);
-
-  useEffect(() => {
-    if (!frame?.scene || frame.lens_id !== lens || presentations[lens].visibleLayerKeys !== null)
-      return;
-    const layerKeys = frame.scene.layers
-      .filter((layer) => layer.default_visible)
-      .map((layer) => layer.key);
-    if (lens === "low_level_interactions") layerKeys.push("model_relative_wind");
-    setPresentations((current) => ({
-      ...current,
-      [lens]: { ...current[lens], visibleLayerKeys: layerKeys },
-    }));
-  }, [frame, lens, presentations]);
 
   useEffect(() => {
     if (!playing || loading || !frame) return;
@@ -265,12 +268,98 @@ export function SupercellsExplore({
     setFocusedViewer("evidence");
   }
 
+  const applyCuratedView = useCallback(
+    (source: "initial" | "return") => {
+      const definition = supercellsCuratedView(simulation.simulation_id, lens);
+      const authoredEvidenceView = definition?.evidenceOrientation ?? evidenceView;
+      const authoredSlice = frame ? slicePositionState(frame, authoredEvidenceView, null) : null;
+      const availableScaleIds = frame
+        ? [
+            frame.plan.primary.scale?.scale_id,
+            frame.xz_section.primary.scale?.scale_id,
+            frame.yz_section.primary.scale?.scale_id,
+            ...(frame.scene?.layers.map((layer) => layer.scale?.scale_id) ?? []),
+          ].filter((scaleId): scaleId is string => Boolean(scaleId))
+        : undefined;
+      const availableLayerIds = frame
+        ? [...(frame.scene?.layers.map((layer) => layer.key) ?? []), "model_relative_wind"]
+        : undefined;
+      const resolution = resolveCuratedView(definition, {
+        availableViewIds: LENSES.map((item) => item.id),
+        availableScaleIds,
+        availableLayerIds,
+        timesSeconds: frame?.times_seconds ?? [],
+        planeCoordinatesKm: authoredSlice?.coordinatesKm,
+        planeNativeIndices: authoredSlice?.nativeIndices,
+      });
+
+      if (source === "return") {
+        setPlaying(false);
+        setFocusedViewer(null);
+        setContextCollapsed(false);
+        setSecondarySection("science");
+        setError(null);
+      }
+      if (resolution.value && frame) {
+        const curated = resolution.value.definition;
+        const nextSelection = {
+          xIndex: frame.selected_point.x_index,
+          yIndex: frame.selected_point.y_index,
+          zIndex: frame.selected_point.z_index,
+        };
+        const planeIndex = resolution.value.planeNativeIndex;
+        if (planeIndex !== null) {
+          if (curated.plane.orientation === "horizontal") nextSelection.zIndex = planeIndex;
+          if (curated.plane.orientation === "vertical_x") nextSelection.yIndex = planeIndex;
+          if (curated.plane.orientation === "vertical_y") nextSelection.xIndex = planeIndex;
+        }
+        setTimeIndex(resolution.value.timeIndex);
+        if (source === "return") {
+          setPlaybackSpeed(curated.playbackSpeed);
+          setPresentations((current) => ({
+            ...current,
+            [lens]: {
+              viewport: curated.viewport,
+              evidenceView: curated.evidenceOrientation,
+              overlays: { ...curated.overlays },
+              visibleLayerKeys: [...curated.visibleLayerIds],
+              categoryCodes: [...curated.hydrometeorCategoryCodes],
+              cameraPreset: curated.cameraPreset,
+              cameraTransform: curated.cameraTransform,
+              displayControlsOpen: curated.displayControlsOpen,
+              sceneOpacity: curated.sceneOpacity,
+              scenePointSize: curated.scenePointSize,
+              selection: nextSelection,
+              selectedEvidenceVisible: curated.selectedEvidenceVisible,
+            },
+          }));
+        }
+      }
+      if (source === "return" || resolution.status !== "applied") {
+        setCuratedNotice({
+          status: resolution.status,
+          message: curatedResolutionExplanation(resolution),
+        });
+      } else {
+        setCuratedNotice(null);
+      }
+    },
+    [evidenceView, frame, lens, simulation.simulation_id],
+  );
+
+  useEffect(() => {
+    if (!frame || initialCuratedSimulationRef.current === simulation.simulation_id) return;
+    initialCuratedSimulationRef.current = simulation.simulation_id;
+    applyCuratedView("initial");
+  }, [applyCuratedView, frame, simulation.simulation_id]);
+
   return (
     <IntegratedExploreWorkspace
       worldName="Supercells"
       simulationName={simulation.display_name}
       backLabel="Back to Supercells"
       onBack={onBack}
+      headerActions={<ReturnToCuratedViewControl onReturn={() => applyCuratedView("return")} />}
     >
       <section
         className={`supercells-explore-shell${
@@ -278,6 +367,7 @@ export function SupercellsExplore({
         }`}
         aria-label="Supercells integrated Explore workspace"
       >
+        <ExploreCuratedDefaultNotice notice={curatedNotice} />
         <div
           className={`supercells-workbench${
             contextCollapsed ? " supercells-context-collapsed" : ""
@@ -332,6 +422,10 @@ export function SupercellsExplore({
                 windArrowDomainFraction={0.055}
                 compactWorkspace
                 compactDisplayLabel="3-D layers"
+                compactDisplayControlsOpen={displayControlsOpen}
+                onCompactDisplayControlsOpenChange={(next) =>
+                  updatePresentation({ displayControlsOpen: next })
+                }
                 maximized={focusedViewer === "scene"}
                 onToggleMaximize={() =>
                   setFocusedViewer((current) => (current === "scene" ? null : "scene"))
@@ -518,6 +612,8 @@ export function SupercellsExplore({
         />
 
         <ExploreSecondarySections
+          activeSection={secondarySection}
+          onActiveSectionChange={setSecondarySection}
           sections={{
             science: <SupercellScience frame={frame} lens={lens} />,
             notes: (
@@ -1122,62 +1218,26 @@ function Metric({ label, value }: { label: string; value: string }) {
   );
 }
 
-function overlayDefaults(lens: LensId): OverlayState {
-  return {
-    rotation: lens === "rotating_updraft",
-    updraftHelicity: lens === "rotating_updraft",
-    reflectivity: false,
-    condensate: lens === "rotating_updraft",
-    rain: lens === "low_level_interactions",
-    wind: lens === "low_level_interactions",
-    precipitatingCondensate: lens === "low_level_interactions",
-    verticalMotion: true,
-  };
-}
-
 function lensPresentationDefaults(): Record<LensId, LensPresentation> {
-  const categoryCodes = HYDROMETEOR_CODES.map((item) => item.code);
-  return {
-    rotating_updraft: {
-      viewport: "storm",
-      evidenceView: "plan",
-      overlays: overlayDefaults("rotating_updraft"),
-      visibleLayerKeys: null,
-      categoryCodes,
-      cameraPreset: "look_along_y",
-      cameraTransform: null,
-      sceneOpacity: 1,
-      scenePointSize: 1,
-      selection: null,
-      selectedEvidenceVisible: false,
-    },
-    cloud_precipitation: {
-      viewport: "storm",
-      evidenceView: "xz",
-      overlays: overlayDefaults("cloud_precipitation"),
-      visibleLayerKeys: null,
-      categoryCodes,
-      cameraPreset: "look_along_y",
-      cameraTransform: null,
-      sceneOpacity: 0.9,
-      scenePointSize: 0.9,
-      selection: null,
-      selectedEvidenceVisible: false,
-    },
-    low_level_interactions: {
-      viewport: "storm",
-      evidenceView: "plan",
-      overlays: overlayDefaults("low_level_interactions"),
-      visibleLayerKeys: null,
-      categoryCodes,
-      cameraPreset: "low_level",
-      cameraTransform: null,
-      sceneOpacity: 1,
-      scenePointSize: 1,
-      selection: null,
-      selectedEvidenceVisible: false,
-    },
-  };
+  return Object.fromEntries(
+    Object.entries(SUPERCELLS_CURATED_VIEWS).map(([lensId, curated]) => [
+      lensId,
+      {
+        viewport: curated.viewport,
+        evidenceView: curated.evidenceOrientation,
+        overlays: { ...curated.overlays },
+        visibleLayerKeys: [...curated.visibleLayerIds],
+        categoryCodes: [...curated.hydrometeorCategoryCodes],
+        cameraPreset: curated.cameraPreset,
+        cameraTransform: curated.cameraTransform,
+        displayControlsOpen: curated.displayControlsOpen,
+        sceneOpacity: curated.sceneOpacity,
+        scenePointSize: curated.scenePointSize,
+        selection: null,
+        selectedEvidenceVisible: curated.selectedEvidenceVisible,
+      },
+    ]),
+  ) as Record<LensId, LensPresentation>;
 }
 
 function filterHydrometeorCategories(

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -17,6 +17,9 @@ import {
   SUPERCELLS_CURATED_VIEWS,
   SUPERCELLS_INITIAL_LENS,
   supercellsCuratedView,
+  type CuratedDefaultResolution,
+  type ResolvedCuratedView,
+  type SupercellsCuratedView,
 } from "./exploreCuratedDefaults";
 import { NativeSlicePositionControl } from "./NativeSlicePositionControl";
 import { SimulationNotes } from "./SimulationNotes";
@@ -66,6 +69,12 @@ type LensPresentation = {
   selectedEvidenceVisible: boolean;
 };
 
+type PendingSupercellsCuratedRestore = {
+  resolution: CuratedDefaultResolution<ResolvedCuratedView<SupercellsCuratedView>>;
+  target: ResolvedCuratedView<SupercellsCuratedView>;
+  source: "initial" | "return";
+};
+
 const LENSES: Array<{ id: LensId; label: string }> = [
   { id: "rotating_updraft", label: "Rotating Updraft" },
   { id: "cloud_precipitation", label: "Cloud and Precipitation" },
@@ -79,6 +88,45 @@ const HYDROMETEOR_CODES = [
   { code: 4, label: "Snow" },
   { code: 5, label: "Hail-treated large ice" },
 ];
+
+function supercellsCuratedCapabilities(frame: StormExaminationFrame | null) {
+  if (!frame) {
+    return {
+      availableFieldIds: [] as string[],
+      availableScaleIds: [] as string[],
+      availableLayerIds: [] as string[],
+      availableOverlayIds: [] as string[],
+    };
+  }
+  const views = [frame.plan, frame.xz_section, frame.yz_section];
+  const fieldIds = new Set<string>();
+  const scaleIds = new Set<string>();
+  const overlayIds = new Set<string>();
+  views.forEach((view) => {
+    fieldIds.add(view.primary.key);
+    scaleIds.add(view.primary.scale.scale_id);
+    Object.entries(view.overlays).forEach(([overlayId, overlay]) => {
+      overlayIds.add(overlayId);
+      fieldIds.add(overlay.key);
+      scaleIds.add(overlay.scale.scale_id);
+    });
+  });
+  const layerIds = new Set(frame.scene?.layers.map((layer) => layer.key) ?? []);
+  frame.scene?.layers.forEach((layer) => {
+    layer.source_fields.forEach((fieldId) => fieldIds.add(fieldId));
+    if (layer.scale) scaleIds.add(layer.scale.scale_id);
+  });
+  if ((frame.scene?.wind_vectors.length ?? 0) > 0 || frame.plan.wind_vectors.length > 0) {
+    layerIds.add("model_relative_wind");
+    overlayIds.add("model_relative_wind");
+  }
+  return {
+    availableFieldIds: [...fieldIds],
+    availableScaleIds: [...scaleIds],
+    availableLayerIds: [...layerIds],
+    availableOverlayIds: [...overlayIds],
+  };
+}
 
 export function SupercellsExplore({
   simulation,
@@ -106,11 +154,16 @@ export function SupercellsExplore({
     selection,
     selectedEvidenceVisible,
   } = presentation;
-  const visibleLayerKeys = presentation.visibleLayerKeys ?? [];
+  const visibleLayerKeys = useMemo(
+    () => presentation.visibleLayerKeys ?? [],
+    [presentation.visibleLayerKeys],
+  );
   const [focusedViewer, setFocusedViewer] = useState<FocusedViewer>(null);
   const [contextCollapsed, setContextCollapsed] = useState(false);
   const [secondarySection, setSecondarySection] = useState<ExploreSecondarySection>("science");
   const [curatedNotice, setCuratedNotice] = useState<ExploreCuratedNotice | null>(null);
+  const [pendingCuratedRestore, setPendingCuratedRestore] =
+    useState<PendingSupercellsCuratedRestore | null>(null);
   const [playing, setPlaying] = useState(false);
   const [playbackSpeed, setPlaybackSpeed] = useState(1);
   const [loading, setLoading] = useState(true);
@@ -119,6 +172,7 @@ export function SupercellsExplore({
   const frameCache = useRef(new Map<string, StormExaminationFrame>());
   const contextBeforeEvidenceFocus = useRef(false);
   const initialCuratedSimulationRef = useRef<string | null>(null);
+  const curatedNoticeSignatureRef = useRef<string | null>(null);
 
   const requestKey = frameRequestKey(lens, viewport, timeIndex, selection);
   const loadFrame = useCallback(
@@ -194,6 +248,29 @@ export function SupercellsExplore({
     (item) => item.time_seconds === frame.time_seconds,
   );
   const windVectors = frame?.scene?.wind_vectors ?? [];
+  const curatedStateSignature = useMemo(
+    () =>
+      JSON.stringify({
+        lens,
+        timeIndex,
+        presentations,
+        focusedViewer,
+        contextCollapsed,
+        secondarySection,
+        playing,
+        playbackSpeed,
+      }),
+    [
+      contextCollapsed,
+      focusedViewer,
+      lens,
+      playbackSpeed,
+      playing,
+      presentations,
+      secondarySection,
+      timeIndex,
+    ],
+  );
 
   function chooseLens(next: LensId) {
     setPlaying(false);
@@ -268,83 +345,88 @@ export function SupercellsExplore({
     setFocusedViewer("evidence");
   }
 
+  function retryFrame() {
+    curatedNoticeSignatureRef.current = null;
+    setCuratedNotice(null);
+    setRetryNonce((current) => current + 1);
+  }
+
   const applyCuratedView = useCallback(
     (source: "initial" | "return") => {
       const definition = supercellsCuratedView(simulation.simulation_id, lens);
       const authoredEvidenceView = definition?.evidenceOrientation ?? evidenceView;
       const authoredSlice = frame ? slicePositionState(frame, authoredEvidenceView, null) : null;
-      const availableScaleIds = frame
-        ? [
-            frame.plan.primary.scale?.scale_id,
-            frame.xz_section.primary.scale?.scale_id,
-            frame.yz_section.primary.scale?.scale_id,
-            ...(frame.scene?.layers.map((layer) => layer.scale?.scale_id) ?? []),
-          ].filter((scaleId): scaleId is string => Boolean(scaleId))
-        : undefined;
-      const availableLayerIds = frame
-        ? [...(frame.scene?.layers.map((layer) => layer.key) ?? []), "model_relative_wind"]
-        : undefined;
+      const capabilities = supercellsCuratedCapabilities(frame);
       const resolution = resolveCuratedView(definition, {
         availableViewIds: LENSES.map((item) => item.id),
-        availableScaleIds,
-        availableLayerIds,
+        ...capabilities,
         timesSeconds: frame?.times_seconds ?? [],
         planeCoordinatesKm: authoredSlice?.coordinatesKm,
         planeNativeIndices: authoredSlice?.nativeIndices,
       });
 
-      if (source === "return") {
-        setPlaying(false);
-        setFocusedViewer(null);
-        setContextCollapsed(false);
-        setSecondarySection("science");
-        setError(null);
-      }
-      if (resolution.value && frame) {
-        const curated = resolution.value.definition;
-        const nextSelection = {
-          xIndex: frame.selected_point.x_index,
-          yIndex: frame.selected_point.y_index,
-          zIndex: frame.selected_point.z_index,
-        };
-        const planeIndex = resolution.value.planeNativeIndex;
-        if (planeIndex !== null) {
-          if (curated.plane.orientation === "horizontal") nextSelection.zIndex = planeIndex;
-          if (curated.plane.orientation === "vertical_x") nextSelection.yIndex = planeIndex;
-          if (curated.plane.orientation === "vertical_y") nextSelection.xIndex = planeIndex;
-        }
-        setTimeIndex(resolution.value.timeIndex);
-        if (source === "return") {
-          setPlaybackSpeed(curated.playbackSpeed);
-          setPresentations((current) => ({
-            ...current,
-            [lens]: {
-              viewport: curated.viewport,
-              evidenceView: curated.evidenceOrientation,
-              overlays: { ...curated.overlays },
-              visibleLayerKeys: [...curated.visibleLayerIds],
-              categoryCodes: [...curated.hydrometeorCategoryCodes],
-              cameraPreset: curated.cameraPreset,
-              cameraTransform: curated.cameraTransform,
-              displayControlsOpen: curated.displayControlsOpen,
-              sceneOpacity: curated.sceneOpacity,
-              scenePointSize: curated.scenePointSize,
-              selection: nextSelection,
-              selectedEvidenceVisible: curated.selectedEvidenceVisible,
-            },
-          }));
-        }
-      }
-      if (source === "return" || resolution.status !== "applied") {
+      if (!resolution.value || !frame) {
+        setPendingCuratedRestore(null);
+        curatedNoticeSignatureRef.current = curatedStateSignature;
         setCuratedNotice({
           status: resolution.status,
           message: curatedResolutionExplanation(resolution),
         });
+        return;
+      }
+      const curated = resolution.value.definition;
+      const nextSelection = {
+        xIndex: frame.selected_point.x_index,
+        yIndex: frame.selected_point.y_index,
+        zIndex: frame.selected_point.z_index,
+      };
+      const planeIndex = resolution.value.planeNativeIndex;
+      if (planeIndex !== null) {
+        if (curated.plane.orientation === "horizontal") nextSelection.zIndex = planeIndex;
+        if (curated.plane.orientation === "vertical_x") nextSelection.yIndex = planeIndex;
+        if (curated.plane.orientation === "vertical_y") nextSelection.xIndex = planeIndex;
+      }
+      setTimeIndex(resolution.value.timeIndex);
+      setPlaying(false);
+      if (source === "return") {
+        setFocusedViewer(null);
+        setContextCollapsed(curated.contextCollapsed);
+        setSecondarySection(curated.secondarySection);
+        setPlaybackSpeed(curated.playbackSpeed);
+        setPresentations((current) => ({
+          ...current,
+          [lens]: {
+            viewport: curated.viewport,
+            evidenceView: curated.evidenceOrientation,
+            overlays: { ...curated.overlays },
+            visibleLayerKeys: [...curated.visibleLayerIds],
+            categoryCodes: [...curated.hydrometeorCategoryCodes],
+            cameraPreset: curated.cameraPreset,
+            cameraTransform: curated.cameraTransform,
+            displayControlsOpen: curated.displayControlsOpen,
+            sceneOpacity: curated.sceneOpacity,
+            scenePointSize: curated.scenePointSize,
+            selection: nextSelection,
+            selectedEvidenceVisible: curated.selectedEvidenceVisible,
+          },
+        }));
+        setError(null);
+        setFrame(null);
+        setRetryNonce((current) => current + 1);
+        setCuratedNotice({
+          status: "applying",
+          message: `Restoring the curated ${LENSES.find((item) => item.id === lens)?.label ?? "Lens"} view and loading its scientific evidence...`,
+        });
       } else {
         setCuratedNotice(null);
       }
+      setPendingCuratedRestore({
+        resolution,
+        target: resolution.value,
+        source,
+      });
     },
-    [evidenceView, frame, lens, simulation.simulation_id],
+    [curatedStateSignature, evidenceView, frame, lens, simulation.simulation_id],
   );
 
   useEffect(() => {
@@ -352,6 +434,130 @@ export function SupercellsExplore({
     initialCuratedSimulationRef.current = simulation.simulation_id;
     applyCuratedView("initial");
   }, [applyCuratedView, frame, simulation.simulation_id]);
+
+  useEffect(() => {
+    if (!pendingCuratedRestore) return;
+    const { resolution, source, target } = pendingCuratedRestore;
+    const curated = target.definition;
+    const planeIndex = target.planeNativeIndex;
+    const selectionMatches =
+      source === "initial" ||
+      (selection !== null &&
+        (curated.plane.orientation !== "horizontal" || selection.zIndex === planeIndex) &&
+        (curated.plane.orientation !== "vertical_x" || selection.yIndex === planeIndex) &&
+        (curated.plane.orientation !== "vertical_y" || selection.xIndex === planeIndex));
+    const controlsMatch =
+      lens === curated.viewId &&
+      timeIndex === target.timeIndex &&
+      !playing &&
+      viewport === curated.viewport &&
+      evidenceView === curated.evidenceOrientation &&
+      JSON.stringify(overlays) === JSON.stringify(curated.overlays) &&
+      JSON.stringify(visibleLayerKeys) === JSON.stringify(curated.visibleLayerIds) &&
+      JSON.stringify(categoryCodes) === JSON.stringify(curated.hydrometeorCategoryCodes) &&
+      cameraPreset === curated.cameraPreset &&
+      JSON.stringify(cameraTransform) === JSON.stringify(curated.cameraTransform) &&
+      displayControlsOpen === curated.displayControlsOpen &&
+      sceneOpacity === curated.sceneOpacity &&
+      scenePointSize === curated.scenePointSize &&
+      selectedEvidenceVisible === curated.selectedEvidenceVisible &&
+      selectionMatches;
+    if (!controlsMatch) {
+      setPendingCuratedRestore(null);
+      setCuratedNotice(null);
+      curatedNoticeSignatureRef.current = null;
+      return;
+    }
+    if (error) {
+      setPendingCuratedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({
+        status: "technical_fallback",
+        message: `The curated ${LENSES.find((item) => item.id === lens)?.label ?? "Lens"} view could not be restored: ${error} Use Retry frame to try again.`,
+      });
+      return;
+    }
+    const loadedPlaneMatches =
+      planeIndex === null ||
+      (curated.plane.orientation === "horizontal" && frame?.plan.level_index === planeIndex) ||
+      (curated.plane.orientation === "vertical_x" &&
+        frame?.selected_point.y_index === planeIndex) ||
+      (curated.plane.orientation === "vertical_y" && frame?.selected_point.x_index === planeIndex);
+    if (
+      loading ||
+      !frame ||
+      frame.lens_id !== curated.viewId ||
+      frame.viewport !== curated.viewport ||
+      frame.time_index !== target.timeIndex ||
+      !loadedPlaneMatches
+    ) {
+      return;
+    }
+    const loadedSlice = slicePositionState(frame, curated.evidenceOrientation, null);
+    if (!loadedSlice) {
+      setPendingCuratedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({
+        status: "technical_fallback",
+        message: `The curated ${LENSES.find((item) => item.id === lens)?.label ?? "Lens"} view could not be restored because its authored slice orientation is unavailable.`,
+      });
+      return;
+    }
+    const confirmedResolution = resolveCuratedView(curated, {
+      availableViewIds: LENSES.map((item) => item.id),
+      ...supercellsCuratedCapabilities(frame),
+      timesSeconds: frame.times_seconds,
+      planeCoordinatesKm: loadedSlice.coordinatesKm,
+      planeNativeIndices: loadedSlice.nativeIndices,
+    });
+    if (!confirmedResolution.value) {
+      setPendingCuratedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({
+        status: "technical_fallback",
+        message: curatedResolutionExplanation(confirmedResolution),
+      });
+      return;
+    }
+    setPendingCuratedRestore(null);
+    curatedNoticeSignatureRef.current = curatedStateSignature;
+    if (source === "return" || resolution.status !== "applied") {
+      setCuratedNotice({
+        status: resolution.status,
+        message: curatedResolutionExplanation(resolution),
+      });
+    } else {
+      setCuratedNotice(null);
+    }
+  }, [
+    cameraPreset,
+    cameraTransform,
+    categoryCodes,
+    curatedStateSignature,
+    displayControlsOpen,
+    error,
+    evidenceView,
+    frame,
+    lens,
+    loading,
+    overlays,
+    pendingCuratedRestore,
+    playing,
+    sceneOpacity,
+    scenePointSize,
+    selectedEvidenceVisible,
+    selection,
+    timeIndex,
+    viewport,
+    visibleLayerKeys,
+  ]);
+
+  useEffect(() => {
+    if (!curatedNotice || pendingCuratedRestore || !curatedNoticeSignatureRef.current) return;
+    if (curatedNoticeSignatureRef.current === curatedStateSignature) return;
+    curatedNoticeSignatureRef.current = null;
+    setCuratedNotice(null);
+  }, [curatedNotice, curatedStateSignature, pendingCuratedRestore]);
 
   return (
     <IntegratedExploreWorkspace
@@ -471,7 +677,7 @@ export function SupercellsExplore({
               <LocalFailure
                 title="3-D storm scene unavailable"
                 message={error ?? "The selected frame did not provide a bounded 3-D scene."}
-                onRetry={() => setRetryNonce((current) => current + 1)}
+                onRetry={retryFrame}
               />
             )}
             {loading && frame && <div className="supercells-frame-loading">Loading frame...</div>}
@@ -557,7 +763,7 @@ export function SupercellsExplore({
               <LocalFailure
                 title="Storm evidence unavailable"
                 message={error ?? "The selected plan or section could not be loaded."}
-                onRetry={() => setRetryNonce((current) => current + 1)}
+                onRetry={retryFrame}
               />
             )}
           </section>

--- a/app/frontend/src/True3DViewer.tsx
+++ b/app/frontend/src/True3DViewer.tsx
@@ -138,6 +138,8 @@ type True3DViewerProps = {
   compactWorkspace?: boolean;
   compactDisplayControls?: ReactNode;
   compactDisplayLabel?: string;
+  compactDisplayControlsOpen?: boolean;
+  onCompactDisplayControlsOpenChange?: (open: boolean) => void;
   maximized?: boolean;
   onToggleMaximize?: () => void;
   stormScene?: StormScenePayload | null;
@@ -226,6 +228,8 @@ export function True3DViewer({
   compactWorkspace = false,
   compactDisplayControls,
   compactDisplayLabel = "Display",
+  compactDisplayControlsOpen,
+  onCompactDisplayControlsOpenChange,
   maximized = false,
   onToggleMaximize,
   stormScene = null,
@@ -249,6 +253,7 @@ export function True3DViewer({
   const cameraTransformRef = useRef(cameraTransform);
   const cameraTransformChangeRef = useRef(onCameraTransformChange);
   const appliedCameraPresetRef = useRef(cameraPreset);
+  const compactDisplayDetailsRef = useRef<HTMLDetailsElement | null>(null);
   axisOcclusionRef.current = { frame: updraftLensFrame, opacity: updraftLensOpacity };
   stormSelectionRef.current = onSelectStormPoint;
   cameraPresetRef.current = cameraPreset;
@@ -258,6 +263,16 @@ export function True3DViewer({
   const [cameraStatus, setCameraStatus] = useState("Camera ready");
   const [selectedCameraPreset, setSelectedCameraPreset] = useState<CameraPreset>(cameraPreset);
   const [tallViewport, setTallViewport] = useState(false);
+
+  useEffect(() => {
+    if (
+      typeof compactDisplayControlsOpen === "boolean" &&
+      compactDisplayDetailsRef.current &&
+      compactDisplayDetailsRef.current.open !== compactDisplayControlsOpen
+    ) {
+      compactDisplayDetailsRef.current.open = compactDisplayControlsOpen;
+    }
+  }, [compactDisplayControlsOpen]);
 
   const boundsKey = boundsSignature(pointCloud, stormScene);
   const bounds = useMemo(() => sceneBoundsFromSignature(boundsKey), [boundsKey]);
@@ -657,7 +672,19 @@ export function True3DViewer({
       {compactWorkspace ? (
         <div className="true3d-controls true3d-controls-compact" aria-label="3-D camera controls">
           {compactDisplayControls && (
-            <details className="true3d-display-control">
+            <details
+              ref={compactDisplayDetailsRef}
+              className="true3d-display-control"
+              open={compactDisplayControlsOpen}
+              onToggle={(event) => {
+                if (
+                  typeof compactDisplayControlsOpen !== "boolean" ||
+                  event.currentTarget.open !== compactDisplayControlsOpen
+                ) {
+                  onCompactDisplayControlsOpenChange?.(event.currentTarget.open);
+                }
+              }}
+            >
               <summary>
                 <span>{compactDisplayLabel}</span>
               </summary>

--- a/app/frontend/src/exploreCuratedDefaults.test.ts
+++ b/app/frontend/src/exploreCuratedDefaults.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mountainWavesCuratedView,
+  mountainWavesInitialView,
+  resolveCuratedView,
+  supercellsCuratedView,
+  tradeCumulusCuratedView,
+} from "./exploreCuratedDefaults";
+
+describe("authored Explore defaults", () => {
+  it("uses stable product identities and modeled coordinates without backing run IDs", () => {
+    const trade = tradeCumulusCuratedView("trade_cumulus_canonical_bomex", "updraft_lens");
+    const mountain = mountainWavesCuratedView(
+      "mountain_waves_boulder_moist_reference",
+      "wave_cloud",
+    );
+    const supercell = supercellsCuratedView(
+      "supercells_quarter_circle_reference",
+      "rotating_updraft",
+    );
+
+    expect(trade).toMatchObject({
+      worldId: "trade_cumulus",
+      simulationId: "trade_cumulus_canonical_bomex",
+      modeledTimeSeconds: 12_060,
+      plane: { orientation: "vertical_x", coordinateKm: 2.366666555404663 },
+    });
+    expect(mountain).toMatchObject({
+      worldId: "mountain_waves",
+      simulationId: "mountain_waves_boulder_moist_reference",
+      modeledTimeSeconds: 7_200,
+      geometry: "expanded",
+      viewport: "focus",
+    });
+    expect(supercell).toMatchObject({
+      worldId: "supercells",
+      simulationId: "supercells_quarter_circle_reference",
+      modeledTimeSeconds: 4_440,
+      plane: { orientation: "horizontal", coordinateKm: 3.1666669845581055 },
+    });
+    expect(JSON.stringify({ trade, mountain, supercell })).not.toMatch(
+      /resultId|runId|result_id|run_id/,
+    );
+  });
+
+  it("keeps distinct authored defaults for every implemented Mountain Waves view", () => {
+    expect(mountainWavesInitialView("mountain_waves_dry_ridge")).toBe("wave_structure");
+    expect(mountainWavesInitialView("mountain_waves_boulder_moist_reference")).toBe("wave_cloud");
+    expect(
+      mountainWavesCuratedView(
+        "mountain_waves_boulder_moist_reference",
+        "field",
+        "relative_humidity",
+      ),
+    ).toMatchObject({
+      viewId: "field",
+      fieldId: "relative_humidity",
+      fixedScaleId: "mountain_waves_relative_humidity_v1",
+      overlays: {
+        horizontalWind: false,
+        cloudPoints: false,
+        cloudBoundary: false,
+        saturationContour: false,
+        potentialTemperatureContours: false,
+      },
+    });
+    expect(
+      mountainWavesCuratedView("mountain_waves_boulder_moist_reference", "wave_structure"),
+    ).toMatchObject({
+      overlays: {
+        horizontalWind: true,
+        potentialTemperatureContours: true,
+      },
+    });
+    expect(
+      mountainWavesCuratedView("mountain_waves_boulder_moist_reference", "wave_cloud"),
+    ).toMatchObject({
+      overlays: {
+        horizontalWind: true,
+        cloudPoints: true,
+        cloudBoundary: true,
+        saturationContour: true,
+        potentialTemperatureContours: false,
+      },
+      cloudOpacity: 0.68,
+      cloudPointSizePx: 11,
+    });
+  });
+
+  it("keeps independent accepted presentations for all three Supercells Lenses", () => {
+    const rotating = supercellsCuratedView(
+      "supercells_quarter_circle_reference",
+      "rotating_updraft",
+    );
+    const cloud = supercellsCuratedView(
+      "supercells_quarter_circle_reference",
+      "cloud_precipitation",
+    );
+    const lowLevel = supercellsCuratedView(
+      "supercells_quarter_circle_reference",
+      "low_level_interactions",
+    );
+
+    expect(rotating).toMatchObject({
+      evidenceOrientation: "plan",
+      cameraPreset: "look_along_y",
+      visibleLayerIds: ["storm_cloud_body", "rising_core", "cyclonic_rotation", "updraft_helicity"],
+    });
+    expect(cloud).toMatchObject({
+      evidenceOrientation: "xz",
+      plane: { orientation: "vertical_x", coordinateKm: 0.75 },
+      visibleLayerIds: ["hydrometeor_categories"],
+      sceneOpacity: 0.9,
+      scenePointSize: 0.9,
+    });
+    expect(lowLevel).toMatchObject({
+      evidenceOrientation: "plan",
+      cameraPreset: "low_level",
+      visibleLayerIds: [
+        "low_level_vertical_motion",
+        "accumulated_surface_rain",
+        "precipitating_condensate",
+        "model_relative_wind",
+      ],
+    });
+  });
+});
+
+describe("curated-default resolver", () => {
+  it("resolves modeled time and a non-default physical plane exactly", () => {
+    const definition = supercellsCuratedView(
+      "supercells_quarter_circle_reference",
+      "cloud_precipitation",
+    );
+    const result = resolveCuratedView(definition, {
+      availableViewIds: ["cloud_precipitation"],
+      availableScaleIds: ["supercell_total_condensate_v2"],
+      availableLayerIds: ["hydrometeor_categories"],
+      timesSeconds: [4_320, 4_440, 4_560],
+      planeCoordinatesKm: [-0.75, 0, 0.75, 1.5],
+      planeNativeIndices: [21, 22, 23, 24],
+    });
+
+    expect(result).toMatchObject({
+      status: "applied",
+      value: {
+        timeIndex: 1,
+        planePositionIndex: 2,
+        planeNativeIndex: 23,
+      },
+    });
+  });
+
+  it("reports a bounded partial resolution when only nearest saved coordinates exist", () => {
+    const definition = tradeCumulusCuratedView("trade_cumulus_more_moisture", "updraft_lens");
+    const result = resolveCuratedView(definition, {
+      availableViewIds: ["updraft_lens"],
+      availableFieldIds: ["ql", "w"],
+      availableScaleIds: ["trade_cumulus_updraft_velocity_v1"],
+      timesSeconds: [13_800, 14_040],
+      planeCoordinatesKm: [1.5, 1.7],
+      planeNativeIndices: [70, 73],
+    });
+
+    expect(result.status).toBe("partially_incompatible");
+    expect(result.value).toMatchObject({ timeIndex: 0, planeNativeIndex: 73 });
+    expect(result.incompatibilities).toHaveLength(2);
+  });
+
+  it("fails visibly without silently substituting a missing scale or view", () => {
+    const definition = mountainWavesCuratedView(
+      "mountain_waves_boulder_moist_reference",
+      "wave_cloud",
+    );
+    const result = resolveCuratedView(definition, {
+      availableViewIds: ["field"],
+      availableFieldIds: ["w"],
+      availableScaleIds: ["unexpected_dynamic_scale"],
+      timesSeconds: [7_200],
+    });
+
+    expect(result).toMatchObject({
+      status: "technical_fallback",
+      value: null,
+    });
+    expect(result.incompatibilities).toEqual([
+      "view wave_cloud is unavailable",
+      "scale mountain_waves_vertical_velocity_v1 is unavailable",
+    ]);
+  });
+
+  it("makes an unauthored Simulation a visible technical fallback", () => {
+    const result = resolveCuratedView(null, { timesSeconds: [0, 60] });
+
+    expect(result.status).toBe("technical_fallback");
+    expect(result.message).toContain("No authored curated view");
+  });
+});

--- a/app/frontend/src/exploreCuratedDefaults.test.ts
+++ b/app/frontend/src/exploreCuratedDefaults.test.ts
@@ -135,8 +135,10 @@ describe("curated-default resolver", () => {
     );
     const result = resolveCuratedView(definition, {
       availableViewIds: ["cloud_precipitation"],
+      availableFieldIds: ["total_condensate"],
       availableScaleIds: ["supercell_total_condensate_v2"],
       availableLayerIds: ["hydrometeor_categories"],
+      availableOverlayIds: ["vertical_velocity"],
       timesSeconds: [4_320, 4_440, 4_560],
       planeCoordinatesKm: [-0.75, 0, 0.75, 1.5],
       planeNativeIndices: [21, 22, 23, 24],
@@ -158,6 +160,7 @@ describe("curated-default resolver", () => {
       availableViewIds: ["updraft_lens"],
       availableFieldIds: ["ql", "w"],
       availableScaleIds: ["trade_cumulus_updraft_velocity_v1"],
+      availableOverlayIds: ["cloud_boundary", "horizontal_wind", "vertical_velocity"],
       timesSeconds: [13_800, 14_040],
       planeCoordinatesKm: [1.5, 1.7],
       planeNativeIndices: [70, 73],
@@ -175,8 +178,14 @@ describe("curated-default resolver", () => {
     );
     const result = resolveCuratedView(definition, {
       availableViewIds: ["field"],
-      availableFieldIds: ["w"],
+      availableFieldIds: ["w", "cloud_liquid", "relative_humidity"],
       availableScaleIds: ["unexpected_dynamic_scale"],
+      availableOverlayIds: [
+        "horizontal_wind",
+        "cloud_points",
+        "cloud_boundary",
+        "saturation_contour",
+      ],
       timesSeconds: [7_200],
     });
 
@@ -195,5 +204,94 @@ describe("curated-default resolver", () => {
 
     expect(result.status).toBe("technical_fallback");
     expect(result.message).toContain("No authored curated view");
+  });
+
+  it("uses technical fallback for coordinates beyond the authored compatibility bounds", () => {
+    const definition = tradeCumulusCuratedView("trade_cumulus_more_moisture", "updraft_lens");
+    const capabilities = {
+      availableViewIds: ["updraft_lens"],
+      availableFieldIds: ["ql", "w"],
+      availableScaleIds: ["trade_cumulus_updraft_velocity_v1"],
+      availableOverlayIds: ["cloud_boundary", "horizontal_wind", "vertical_velocity"],
+    };
+
+    const farTime = resolveCuratedView(definition, {
+      ...capabilities,
+      timesSeconds: [0, 120],
+      planeCoordinatesKm: [1.6333333253860474],
+    });
+    const farPlane = resolveCuratedView(definition, {
+      ...capabilities,
+      timesSeconds: [13_920],
+      planeCoordinatesKm: [-3.2, -3],
+    });
+
+    expect(farTime).toMatchObject({ status: "technical_fallback", value: null });
+    expect(farTime.message).toContain("time is outside");
+    expect(farPlane).toMatchObject({ status: "technical_fallback", value: null });
+    expect(farPlane.message).toContain("plane is outside");
+  });
+
+  it("fails closed when Trade cloud evidence or required Lens overlays are absent", () => {
+    const trade = tradeCumulusCuratedView("trade_cumulus_canonical_bomex", "updraft_lens");
+    const missingCloud = resolveCuratedView(trade, {
+      availableViewIds: ["updraft_lens"],
+      availableFieldIds: ["w"],
+      availableScaleIds: ["trade_cumulus_updraft_velocity_v1"],
+      availableOverlayIds: ["cloud_boundary", "horizontal_wind", "vertical_velocity"],
+      timesSeconds: [12_060],
+      planeCoordinatesKm: [2.366666555404663],
+    });
+    const mountain = mountainWavesCuratedView(
+      "mountain_waves_boulder_moist_reference",
+      "wave_cloud",
+    );
+    const missingMountainOverlay = resolveCuratedView(mountain, {
+      availableViewIds: ["wave_cloud"],
+      availableFieldIds: ["w", "cloud_liquid", "relative_humidity"],
+      availableScaleIds: ["mountain_waves_vertical_velocity_v1"],
+      availableOverlayIds: ["horizontal_wind", "cloud_points", "cloud_boundary"],
+      timesSeconds: [7_200],
+    });
+    const supercell = supercellsCuratedView(
+      "supercells_quarter_circle_reference",
+      "low_level_interactions",
+    );
+    const missingSupercellOverlay = resolveCuratedView(supercell, {
+      availableViewIds: ["low_level_interactions"],
+      availableFieldIds: ["winterp"],
+      availableScaleIds: ["supercell_low_level_vertical_velocity_v1"],
+      availableLayerIds: [
+        "low_level_vertical_motion",
+        "accumulated_surface_rain",
+        "precipitating_condensate",
+        "model_relative_wind",
+      ],
+      availableOverlayIds: ["vertical_velocity", "accumulated_surface_rain", "model_relative_wind"],
+      timesSeconds: [4_440],
+      planeCoordinatesKm: [1.1666667461395264],
+    });
+
+    expect(missingCloud.incompatibilities).toContain("field ql is unavailable");
+    expect(missingMountainOverlay.incompatibilities).toContain(
+      "overlay saturation_contour is unavailable",
+    );
+    expect(missingSupercellOverlay.incompatibilities).toContain(
+      "overlay low_level_precipitating_condensate is unavailable",
+    );
+  });
+
+  it("authors Trade direct Field around the active supported scene and slice fields", () => {
+    const definition = tradeCumulusCuratedView("trade_cumulus_more_moisture", "field", "qv", "th");
+
+    expect(definition).toMatchObject({
+      viewId: "field",
+      sceneFieldId: "qv",
+      sliceFieldId: "th",
+      cloudFieldId: null,
+      requirements: {
+        requiredFieldIds: ["qv", "th"],
+      },
+    });
   });
 });

--- a/app/frontend/src/exploreCuratedDefaults.ts
+++ b/app/frontend/src/exploreCuratedDefaults.ts
@@ -26,13 +26,30 @@ export type CuratedPhysicalPlane = {
   coordinateKm: number;
 };
 
+export type CuratedPresentationRequirements = {
+  requiredFieldIds: string[];
+  requiredScaleIds: string[];
+  requiredLayerIds: string[];
+  requiredOverlayIds: string[];
+  optionalOverlayIds: string[];
+};
+
+export type CuratedCoordinateCompatibility = {
+  maximumTimeOffsetSeconds: number;
+  maximumPlaneOffsetKm: number | null;
+};
+
 export type TradeCumulusCuratedView = CuratedCommonState & {
   worldId: "trade_cumulus";
   simulationId: "trade_cumulus_canonical_bomex" | "trade_cumulus_more_moisture";
   viewId: "field" | "updraft_lens";
-  fieldId: "ql" | "w";
-  cloudFieldId: "ql";
+  fieldId: string;
+  sceneFieldId: string;
+  sliceFieldId: string;
+  cloudFieldId: "ql" | null;
   fixedScaleId: "trade_cumulus_updraft_velocity_v1" | null;
+  requirements: CuratedPresentationRequirements;
+  compatibility: CuratedCoordinateCompatibility;
   plane: CuratedPhysicalPlane;
   cameraPreset: CameraPreset;
   cameraTransform: CameraTransform | null;
@@ -63,6 +80,8 @@ export type MountainWavesCuratedView = CuratedCommonState & {
     | "mountain_waves_cloud_liquid_v1"
     | "mountain_waves_relative_humidity_v1"
     | "mountain_waves_theta_perturbation_v1";
+  requirements: CuratedPresentationRequirements;
+  compatibility: CuratedCoordinateCompatibility;
   geometry: "expanded";
   viewport: "focus" | "full";
   plotFraming: "fit_viewport";
@@ -105,6 +124,8 @@ export type SupercellsCuratedView = CuratedCommonState & {
   displayControlsOpen: false;
   visibleLayerIds: string[];
   fixedScaleIds: string[];
+  requirements: CuratedPresentationRequirements;
+  compatibility: CuratedCoordinateCompatibility;
   overlays: SupercellsOverlayState;
   hydrometeorCategoryCodes: readonly number[];
   sceneOpacity: number;
@@ -122,6 +143,7 @@ export type CuratedDefaultCapabilities = {
   availableFieldIds?: string[];
   availableScaleIds?: string[];
   availableLayerIds?: string[];
+  availableOverlayIds?: string[];
   timesSeconds: number[];
   planeCoordinatesKm?: number[];
   planeNativeIndices?: number[];
@@ -157,6 +179,8 @@ export const TRADE_CUMULUS_INITIAL_VIEW = "updraft_lens" as const;
 export function tradeCumulusCuratedView(
   simulationId: string | null | undefined,
   viewId: TradeCumulusCuratedView["viewId"],
+  sceneFieldId = "ql",
+  sliceFieldId = sceneFieldId,
 ): TradeCumulusCuratedView | null {
   if (
     simulationId !== "trade_cumulus_canonical_bomex" &&
@@ -165,14 +189,30 @@ export function tradeCumulusCuratedView(
     return null;
   }
   const presentation = TRADE_CUMULUS_PRESENTATIONS[simulationId];
+  const isLens = viewId === "updraft_lens";
+  const resolvedSceneFieldId = isLens ? "ql" : sceneFieldId;
+  const resolvedSliceFieldId = isLens ? "w" : sliceFieldId;
   return {
     ...COMMON_STATE,
     worldId: "trade_cumulus",
     simulationId,
     viewId,
-    fieldId: viewId === "field" ? "ql" : "w",
-    cloudFieldId: "ql",
-    fixedScaleId: viewId === "updraft_lens" ? "trade_cumulus_updraft_velocity_v1" : null,
+    fieldId: resolvedSliceFieldId,
+    sceneFieldId: resolvedSceneFieldId,
+    sliceFieldId: resolvedSliceFieldId,
+    cloudFieldId: isLens ? "ql" : null,
+    fixedScaleId: isLens ? "trade_cumulus_updraft_velocity_v1" : null,
+    requirements: {
+      requiredFieldIds: [...new Set([resolvedSceneFieldId, resolvedSliceFieldId])],
+      requiredScaleIds: isLens ? ["trade_cumulus_updraft_velocity_v1"] : [],
+      requiredLayerIds: [],
+      requiredOverlayIds: isLens ? ["cloud_boundary", "horizontal_wind", "vertical_velocity"] : [],
+      optionalOverlayIds: [],
+    },
+    compatibility: {
+      maximumTimeOffsetSeconds: 180,
+      maximumPlaneOffsetKm: 0.2,
+    },
     modeledTimeSeconds: presentation.modeledTimeSeconds,
     plane: {
       orientation: "vertical_x",
@@ -228,6 +268,14 @@ export function mountainWavesCuratedView(
   }
   if (simulationId === "mountain_waves_dry_ridge" && viewId === "wave_cloud") return null;
   const activeField = viewId === "field" ? fieldId : "w";
+  const requiredFieldIds =
+    viewId === "wave_cloud" ? ["w", "cloud_liquid", "relative_humidity"] : [activeField];
+  const requiredOverlayIds =
+    viewId === "wave_cloud"
+      ? ["horizontal_wind", "cloud_points", "cloud_boundary", "saturation_contour"]
+      : viewId === "wave_structure"
+        ? ["horizontal_wind", "potential_temperature_contours"]
+        : [];
   return {
     ...COMMON_STATE,
     worldId: "mountain_waves",
@@ -235,6 +283,17 @@ export function mountainWavesCuratedView(
     viewId,
     fieldId: activeField,
     fixedScaleId: MOUNTAIN_WAVES_SCALE_IDS[activeField],
+    requirements: {
+      requiredFieldIds,
+      requiredScaleIds: [MOUNTAIN_WAVES_SCALE_IDS[activeField]],
+      requiredLayerIds: [],
+      requiredOverlayIds,
+      optionalOverlayIds: [],
+    },
+    compatibility: {
+      maximumTimeOffsetSeconds: 180,
+      maximumPlaneOffsetKm: null,
+    },
     modeledTimeSeconds: MOUNTAIN_WAVES_TIME_SECONDS[simulationId],
     geometry: "expanded",
     viewport: simulationId === "mountain_waves_dry_ridge" ? "full" : "focus",
@@ -274,6 +333,27 @@ export const SUPERCELLS_CURATED_VIEWS: Record<SupercellsLensId, SupercellsCurate
     cameraPreset: "look_along_y",
     visibleLayerIds: ["storm_cloud_body", "rising_core", "cyclonic_rotation", "updraft_helicity"],
     fixedScaleIds: ["supercell_midlevel_vertical_velocity_v1"],
+    requirements: {
+      requiredFieldIds: ["winterp"],
+      requiredScaleIds: ["supercell_midlevel_vertical_velocity_v1"],
+      requiredLayerIds: [
+        "storm_cloud_body",
+        "rising_core",
+        "cyclonic_rotation",
+        "updraft_helicity",
+      ],
+      requiredOverlayIds: [
+        "vertical_velocity",
+        "vertical_vorticity",
+        "updraft_helicity",
+        "total_condensate",
+      ],
+      optionalOverlayIds: [],
+    },
+    compatibility: {
+      maximumTimeOffsetSeconds: 180,
+      maximumPlaneOffsetKm: 0.2,
+    },
     overlays: {
       rotation: true,
       updraftHelicity: true,
@@ -295,6 +375,17 @@ export const SUPERCELLS_CURATED_VIEWS: Record<SupercellsLensId, SupercellsCurate
     cameraPreset: "look_along_y",
     visibleLayerIds: ["hydrometeor_categories"],
     fixedScaleIds: ["supercell_total_condensate_v2"],
+    requirements: {
+      requiredFieldIds: ["total_condensate"],
+      requiredScaleIds: ["supercell_total_condensate_v2"],
+      requiredLayerIds: ["hydrometeor_categories"],
+      requiredOverlayIds: ["vertical_velocity"],
+      optionalOverlayIds: [],
+    },
+    compatibility: {
+      maximumTimeOffsetSeconds: 180,
+      maximumPlaneOffsetKm: 0.2,
+    },
     overlays: {
       rotation: false,
       updraftHelicity: false,
@@ -321,6 +412,27 @@ export const SUPERCELLS_CURATED_VIEWS: Record<SupercellsLensId, SupercellsCurate
       "model_relative_wind",
     ],
     fixedScaleIds: ["supercell_low_level_vertical_velocity_v1"],
+    requirements: {
+      requiredFieldIds: ["winterp"],
+      requiredScaleIds: ["supercell_low_level_vertical_velocity_v1"],
+      requiredLayerIds: [
+        "low_level_vertical_motion",
+        "accumulated_surface_rain",
+        "precipitating_condensate",
+        "model_relative_wind",
+      ],
+      requiredOverlayIds: [
+        "vertical_velocity",
+        "accumulated_surface_rain",
+        "low_level_precipitating_condensate",
+        "model_relative_wind",
+      ],
+      optionalOverlayIds: [],
+    },
+    compatibility: {
+      maximumTimeOffsetSeconds: 180,
+      maximumPlaneOffsetKm: 0.2,
+    },
     overlays: {
       rotation: false,
       updraftHelicity: false,
@@ -359,23 +471,23 @@ export function resolveCuratedView<T extends WorldCuratedView>(
   const partial: string[] = [];
   const viewId = curatedViewId(definition);
   validateAvailable(capabilities.availableViewIds, viewId, "view", blockers);
-  if ("fieldId" in definition) {
-    validateAvailable(capabilities.availableFieldIds, definition.fieldId, "field", blockers);
-  }
-  const scaleIds =
-    "fixedScaleIds" in definition
-      ? definition.fixedScaleIds
-      : definition.fixedScaleId
-        ? [definition.fixedScaleId]
-        : [];
-  scaleIds.forEach((scaleId) =>
+  definition.requirements.requiredFieldIds.forEach((fieldId) =>
+    validateAvailable(capabilities.availableFieldIds, fieldId, "field", blockers),
+  );
+  definition.requirements.requiredScaleIds.forEach((scaleId) =>
     validateAvailable(capabilities.availableScaleIds, scaleId, "scale", blockers),
   );
-  if ("visibleLayerIds" in definition) {
-    definition.visibleLayerIds.forEach((layerId) =>
-      validateAvailable(capabilities.availableLayerIds, layerId, "layer", blockers),
-    );
-  }
+  definition.requirements.requiredLayerIds.forEach((layerId) =>
+    validateAvailable(capabilities.availableLayerIds, layerId, "layer", blockers),
+  );
+  definition.requirements.requiredOverlayIds.forEach((overlayId) =>
+    validateAvailable(capabilities.availableOverlayIds, overlayId, "overlay", blockers),
+  );
+  definition.requirements.optionalOverlayIds.forEach((overlayId) => {
+    if (!capabilities.availableOverlayIds?.includes(overlayId)) {
+      partial.push(`optional overlay ${overlayId} is unavailable`);
+    }
+  });
   if (blockers.length > 0) {
     return technicalFallback(
       `The authored ${curatedViewLabel(definition)} view is incompatible with the available output. Current compatible controls remain in use.`,
@@ -391,6 +503,17 @@ export function resolveCuratedView<T extends WorldCuratedView>(
     );
   }
   if (!nearlyEqual(resolvedTime.value, definition.modeledTimeSeconds)) {
+    if (
+      resolvedTime.distance >
+      definition.compatibility.maximumTimeOffsetSeconds + Number.EPSILON
+    ) {
+      return technicalFallback(
+        `The authored ${curatedViewLabel(definition)} time is outside the supported coordinate-mapping range. Current compatible controls remain in use.`,
+        [
+          `nearest saved output is ${formatNumber(resolvedTime.distance)} s from the authored time; maximum compatible offset is ${formatNumber(definition.compatibility.maximumTimeOffsetSeconds)} s`,
+        ],
+      );
+    }
     partial.push(
       `authored time ${formatNumber(definition.modeledTimeSeconds)} s resolved to nearest saved output ${formatNumber(resolvedTime.value)} s`,
     );
@@ -413,6 +536,22 @@ export function resolveCuratedView<T extends WorldCuratedView>(
     planeNativeIndex =
       capabilities.planeNativeIndices?.[resolvedPlane.index] ?? resolvedPlane.index;
     if (!nearlyEqual(resolvedPlane.value, definition.plane.coordinateKm)) {
+      const maximumPlaneOffsetKm = definition.compatibility.maximumPlaneOffsetKm;
+      if (
+        maximumPlaneOffsetKm === null ||
+        resolvedPlane.distance > maximumPlaneOffsetKm + Number.EPSILON
+      ) {
+        return technicalFallback(
+          `The authored ${curatedViewLabel(definition)} plane is outside the supported coordinate-mapping range. Current compatible controls remain in use.`,
+          [
+            `nearest native plane is ${formatNumber(resolvedPlane.distance)} km from the authored plane${
+              maximumPlaneOffsetKm === null
+                ? ""
+                : `; maximum compatible offset is ${formatNumber(maximumPlaneOffsetKm)} km`
+            }`,
+          ],
+        );
+      }
       partial.push(
         `authored plane ${formatNumber(definition.plane.coordinateKm)} km resolved to nearest native plane ${formatNumber(resolvedPlane.value)} km`,
       );
@@ -487,8 +626,7 @@ function validateAvailable(
   label: string,
   blockers: string[],
 ) {
-  if (available && !available.includes(expected))
-    blockers.push(`${label} ${expected} is unavailable`);
+  if (!available?.includes(expected)) blockers.push(`${label} ${expected} is unavailable`);
 }
 
 function nearestIndex(values: number[], target: number) {
@@ -502,7 +640,7 @@ function nearestIndex(values: number[], target: number) {
       distance = candidateDistance;
     }
   }
-  return { index, value: values[index] };
+  return { index, value: values[index], distance };
 }
 
 function nearlyEqual(left: number, right: number): boolean {

--- a/app/frontend/src/exploreCuratedDefaults.ts
+++ b/app/frontend/src/exploreCuratedDefaults.ts
@@ -1,0 +1,516 @@
+import type { ExploreSecondarySection } from "./IntegratedExploreWorkspace";
+import type { CameraPreset, CameraTransform } from "./True3DViewer";
+
+export type CuratedDefaultResolutionStatus =
+  | "applied"
+  | "partially_incompatible"
+  | "technical_fallback";
+
+export type CuratedDefaultResolution<T> = {
+  status: CuratedDefaultResolutionStatus;
+  value: T | null;
+  message: string;
+  incompatibilities: string[];
+};
+
+export type CuratedCommonState = {
+  modeledTimeSeconds: number;
+  playbackSpeed: number;
+  contextCollapsed: boolean;
+  secondarySection: ExploreSecondarySection;
+  selection: null;
+};
+
+export type CuratedPhysicalPlane = {
+  orientation: "horizontal" | "vertical_x" | "vertical_y";
+  coordinateKm: number;
+};
+
+export type TradeCumulusCuratedView = CuratedCommonState & {
+  worldId: "trade_cumulus";
+  simulationId: "trade_cumulus_canonical_bomex" | "trade_cumulus_more_moisture";
+  viewId: "field" | "updraft_lens";
+  fieldId: "ql" | "w";
+  cloudFieldId: "ql";
+  fixedScaleId: "trade_cumulus_updraft_velocity_v1" | null;
+  plane: CuratedPhysicalPlane;
+  cameraPreset: CameraPreset;
+  cameraTransform: CameraTransform | null;
+  displayControlsOpen: false;
+  cloudThresholdKgKg: number;
+  cloudOpacity: number;
+  cloudPointSizePx: number;
+  lensOpacity: number;
+  showSlicePlane: boolean;
+  showCloudBoundary: boolean;
+  showHorizontalWind: boolean;
+  windMode: "perturbation";
+};
+
+export type MountainWavesFieldId =
+  | "w"
+  | "cloud_liquid"
+  | "relative_humidity"
+  | "theta_perturbation";
+
+export type MountainWavesCuratedView = CuratedCommonState & {
+  worldId: "mountain_waves";
+  simulationId: "mountain_waves_dry_ridge" | "mountain_waves_boulder_moist_reference";
+  viewId: "field" | "wave_structure" | "wave_cloud";
+  fieldId: MountainWavesFieldId;
+  fixedScaleId:
+    | "mountain_waves_vertical_velocity_v1"
+    | "mountain_waves_cloud_liquid_v1"
+    | "mountain_waves_relative_humidity_v1"
+    | "mountain_waves_theta_perturbation_v1";
+  geometry: "expanded";
+  viewport: "focus" | "full";
+  plotFraming: "fit_viewport";
+  overlays: {
+    horizontalWind: boolean;
+    cloudPoints: boolean;
+    cloudBoundary: boolean;
+    saturationContour: boolean;
+    potentialTemperatureContours: boolean;
+  };
+  cloudOpacity: number;
+  cloudPointSizePx: number;
+};
+
+export type SupercellsLensId =
+  | "rotating_updraft"
+  | "cloud_precipitation"
+  | "low_level_interactions";
+
+export type SupercellsOverlayState = {
+  rotation: boolean;
+  updraftHelicity: boolean;
+  reflectivity: boolean;
+  condensate: boolean;
+  rain: boolean;
+  wind: boolean;
+  precipitatingCondensate: boolean;
+  verticalMotion: boolean;
+};
+
+export type SupercellsCuratedView = CuratedCommonState & {
+  worldId: "supercells";
+  simulationId: "supercells_quarter_circle_reference";
+  viewId: SupercellsLensId;
+  viewport: "storm";
+  evidenceOrientation: "plan" | "xz" | "yz";
+  plane: CuratedPhysicalPlane;
+  cameraPreset: CameraPreset;
+  cameraTransform: CameraTransform | null;
+  displayControlsOpen: false;
+  visibleLayerIds: string[];
+  fixedScaleIds: string[];
+  overlays: SupercellsOverlayState;
+  hydrometeorCategoryCodes: readonly number[];
+  sceneOpacity: number;
+  scenePointSize: number;
+  selectedEvidenceVisible: false;
+};
+
+export type WorldCuratedView =
+  | TradeCumulusCuratedView
+  | MountainWavesCuratedView
+  | SupercellsCuratedView;
+
+export type CuratedDefaultCapabilities = {
+  availableViewIds?: string[];
+  availableFieldIds?: string[];
+  availableScaleIds?: string[];
+  availableLayerIds?: string[];
+  timesSeconds: number[];
+  planeCoordinatesKm?: number[];
+  planeNativeIndices?: number[];
+};
+
+export type ResolvedCuratedView<T extends WorldCuratedView> = {
+  definition: T;
+  timeIndex: number;
+  planePositionIndex: number | null;
+  planeNativeIndex: number | null;
+};
+
+const COMMON_STATE = {
+  playbackSpeed: 1,
+  contextCollapsed: false,
+  secondarySection: "science",
+  selection: null,
+} as const;
+
+const TRADE_CUMULUS_PRESENTATIONS = {
+  trade_cumulus_canonical_bomex: {
+    modeledTimeSeconds: 12_060,
+    planeCoordinateKm: 2.366666555404663,
+  },
+  trade_cumulus_more_moisture: {
+    modeledTimeSeconds: 13_920,
+    planeCoordinateKm: 1.6333333253860474,
+  },
+} as const;
+
+export const TRADE_CUMULUS_INITIAL_VIEW = "updraft_lens" as const;
+
+export function tradeCumulusCuratedView(
+  simulationId: string | null | undefined,
+  viewId: TradeCumulusCuratedView["viewId"],
+): TradeCumulusCuratedView | null {
+  if (
+    simulationId !== "trade_cumulus_canonical_bomex" &&
+    simulationId !== "trade_cumulus_more_moisture"
+  ) {
+    return null;
+  }
+  const presentation = TRADE_CUMULUS_PRESENTATIONS[simulationId];
+  return {
+    ...COMMON_STATE,
+    worldId: "trade_cumulus",
+    simulationId,
+    viewId,
+    fieldId: viewId === "field" ? "ql" : "w",
+    cloudFieldId: "ql",
+    fixedScaleId: viewId === "updraft_lens" ? "trade_cumulus_updraft_velocity_v1" : null,
+    modeledTimeSeconds: presentation.modeledTimeSeconds,
+    plane: {
+      orientation: "vertical_x",
+      coordinateKm: presentation.planeCoordinateKm,
+    },
+    cameraPreset: "overview",
+    cameraTransform: null,
+    displayControlsOpen: false,
+    cloudThresholdKgKg: 1e-6,
+    cloudOpacity: 0.68,
+    cloudPointSizePx: 11,
+    lensOpacity: 0.9,
+    showSlicePlane: true,
+    showCloudBoundary: true,
+    showHorizontalWind: true,
+    windMode: "perturbation",
+  };
+}
+
+const MOUNTAIN_WAVES_TIME_SECONDS = {
+  mountain_waves_dry_ridge: 2_160,
+  mountain_waves_boulder_moist_reference: 7_200,
+} as const;
+
+const MOUNTAIN_WAVES_SCALE_IDS: Record<
+  MountainWavesFieldId,
+  MountainWavesCuratedView["fixedScaleId"]
+> = {
+  w: "mountain_waves_vertical_velocity_v1",
+  cloud_liquid: "mountain_waves_cloud_liquid_v1",
+  relative_humidity: "mountain_waves_relative_humidity_v1",
+  theta_perturbation: "mountain_waves_theta_perturbation_v1",
+};
+
+export function mountainWavesInitialView(
+  simulationId: string,
+): MountainWavesCuratedView["viewId"] | null {
+  if (simulationId === "mountain_waves_dry_ridge") return "wave_structure";
+  if (simulationId === "mountain_waves_boulder_moist_reference") return "wave_cloud";
+  return null;
+}
+
+export function mountainWavesCuratedView(
+  simulationId: string,
+  viewId: MountainWavesCuratedView["viewId"],
+  fieldId: MountainWavesFieldId = "w",
+): MountainWavesCuratedView | null {
+  if (
+    simulationId !== "mountain_waves_dry_ridge" &&
+    simulationId !== "mountain_waves_boulder_moist_reference"
+  ) {
+    return null;
+  }
+  if (simulationId === "mountain_waves_dry_ridge" && viewId === "wave_cloud") return null;
+  const activeField = viewId === "field" ? fieldId : "w";
+  return {
+    ...COMMON_STATE,
+    worldId: "mountain_waves",
+    simulationId,
+    viewId,
+    fieldId: activeField,
+    fixedScaleId: MOUNTAIN_WAVES_SCALE_IDS[activeField],
+    modeledTimeSeconds: MOUNTAIN_WAVES_TIME_SECONDS[simulationId],
+    geometry: "expanded",
+    viewport: simulationId === "mountain_waves_dry_ridge" ? "full" : "focus",
+    plotFraming: "fit_viewport",
+    overlays: {
+      horizontalWind: viewId !== "field",
+      cloudPoints: viewId === "wave_cloud",
+      cloudBoundary: viewId === "wave_cloud",
+      saturationContour: viewId === "wave_cloud",
+      potentialTemperatureContours: viewId === "wave_structure",
+    },
+    cloudOpacity: 0.68,
+    cloudPointSizePx: 11,
+  };
+}
+
+export const SUPERCELLS_INITIAL_LENS = "rotating_updraft" as const;
+
+const SUPERCELLS_COMMON = {
+  ...COMMON_STATE,
+  worldId: "supercells",
+  simulationId: "supercells_quarter_circle_reference",
+  modeledTimeSeconds: 4_440,
+  viewport: "storm",
+  cameraTransform: null,
+  displayControlsOpen: false,
+  hydrometeorCategoryCodes: [1, 2, 3, 4, 5],
+  selectedEvidenceVisible: false,
+} as const;
+
+export const SUPERCELLS_CURATED_VIEWS: Record<SupercellsLensId, SupercellsCuratedView> = {
+  rotating_updraft: {
+    ...SUPERCELLS_COMMON,
+    viewId: "rotating_updraft",
+    evidenceOrientation: "plan",
+    plane: { orientation: "horizontal", coordinateKm: 3.1666669845581055 },
+    cameraPreset: "look_along_y",
+    visibleLayerIds: ["storm_cloud_body", "rising_core", "cyclonic_rotation", "updraft_helicity"],
+    fixedScaleIds: ["supercell_midlevel_vertical_velocity_v1"],
+    overlays: {
+      rotation: true,
+      updraftHelicity: true,
+      reflectivity: false,
+      condensate: true,
+      rain: false,
+      wind: false,
+      precipitatingCondensate: false,
+      verticalMotion: true,
+    },
+    sceneOpacity: 1,
+    scenePointSize: 1,
+  },
+  cloud_precipitation: {
+    ...SUPERCELLS_COMMON,
+    viewId: "cloud_precipitation",
+    evidenceOrientation: "xz",
+    plane: { orientation: "vertical_x", coordinateKm: 0.75 },
+    cameraPreset: "look_along_y",
+    visibleLayerIds: ["hydrometeor_categories"],
+    fixedScaleIds: ["supercell_total_condensate_v2"],
+    overlays: {
+      rotation: false,
+      updraftHelicity: false,
+      reflectivity: false,
+      condensate: false,
+      rain: false,
+      wind: false,
+      precipitatingCondensate: false,
+      verticalMotion: true,
+    },
+    sceneOpacity: 0.9,
+    scenePointSize: 0.9,
+  },
+  low_level_interactions: {
+    ...SUPERCELLS_COMMON,
+    viewId: "low_level_interactions",
+    evidenceOrientation: "plan",
+    plane: { orientation: "horizontal", coordinateKm: 1.1666667461395264 },
+    cameraPreset: "low_level",
+    visibleLayerIds: [
+      "low_level_vertical_motion",
+      "accumulated_surface_rain",
+      "precipitating_condensate",
+      "model_relative_wind",
+    ],
+    fixedScaleIds: ["supercell_low_level_vertical_velocity_v1"],
+    overlays: {
+      rotation: false,
+      updraftHelicity: false,
+      reflectivity: false,
+      condensate: false,
+      rain: true,
+      wind: true,
+      precipitatingCondensate: true,
+      verticalMotion: true,
+    },
+    sceneOpacity: 1,
+    scenePointSize: 1,
+  },
+};
+
+export function supercellsCuratedView(
+  simulationId: string,
+  lensId: SupercellsLensId,
+): SupercellsCuratedView | null {
+  if (simulationId !== "supercells_quarter_circle_reference") return null;
+  return SUPERCELLS_CURATED_VIEWS[lensId];
+}
+
+export function resolveCuratedView<T extends WorldCuratedView>(
+  definition: T | null,
+  capabilities: CuratedDefaultCapabilities,
+): CuratedDefaultResolution<ResolvedCuratedView<T>> {
+  if (!definition) {
+    return technicalFallback(
+      "No authored curated view is available for this Simulation. Current compatible controls remain in use.",
+      ["stable Simulation identity has no authored default"],
+    );
+  }
+
+  const blockers: string[] = [];
+  const partial: string[] = [];
+  const viewId = curatedViewId(definition);
+  validateAvailable(capabilities.availableViewIds, viewId, "view", blockers);
+  if ("fieldId" in definition) {
+    validateAvailable(capabilities.availableFieldIds, definition.fieldId, "field", blockers);
+  }
+  const scaleIds =
+    "fixedScaleIds" in definition
+      ? definition.fixedScaleIds
+      : definition.fixedScaleId
+        ? [definition.fixedScaleId]
+        : [];
+  scaleIds.forEach((scaleId) =>
+    validateAvailable(capabilities.availableScaleIds, scaleId, "scale", blockers),
+  );
+  if ("visibleLayerIds" in definition) {
+    definition.visibleLayerIds.forEach((layerId) =>
+      validateAvailable(capabilities.availableLayerIds, layerId, "layer", blockers),
+    );
+  }
+  if (blockers.length > 0) {
+    return technicalFallback(
+      `The authored ${curatedViewLabel(definition)} view is incompatible with the available output. Current compatible controls remain in use.`,
+      blockers,
+    );
+  }
+
+  const resolvedTime = nearestIndex(capabilities.timesSeconds, definition.modeledTimeSeconds);
+  if (resolvedTime === null) {
+    return technicalFallback(
+      `The authored ${curatedViewLabel(definition)} time cannot be resolved because this output has no saved times.`,
+      ["saved output time coordinates are unavailable"],
+    );
+  }
+  if (!nearlyEqual(resolvedTime.value, definition.modeledTimeSeconds)) {
+    partial.push(
+      `authored time ${formatNumber(definition.modeledTimeSeconds)} s resolved to nearest saved output ${formatNumber(resolvedTime.value)} s`,
+    );
+  }
+
+  let planePositionIndex: number | null = null;
+  let planeNativeIndex: number | null = null;
+  if ("plane" in definition) {
+    const resolvedPlane = nearestIndex(
+      capabilities.planeCoordinatesKm ?? [],
+      definition.plane.coordinateKm,
+    );
+    if (resolvedPlane === null) {
+      return technicalFallback(
+        `The authored ${curatedViewLabel(definition)} plane cannot be resolved from this output.`,
+        ["native plane coordinates are unavailable"],
+      );
+    }
+    planePositionIndex = resolvedPlane.index;
+    planeNativeIndex =
+      capabilities.planeNativeIndices?.[resolvedPlane.index] ?? resolvedPlane.index;
+    if (!nearlyEqual(resolvedPlane.value, definition.plane.coordinateKm)) {
+      partial.push(
+        `authored plane ${formatNumber(definition.plane.coordinateKm)} km resolved to nearest native plane ${formatNumber(resolvedPlane.value)} km`,
+      );
+    }
+  }
+
+  const value = {
+    definition,
+    timeIndex: resolvedTime.index,
+    planePositionIndex,
+    planeNativeIndex,
+  };
+  if (partial.length > 0) {
+    return {
+      status: "partially_incompatible",
+      value,
+      message: `Curated ${curatedViewLabel(definition)} view restored with the nearest compatible saved coordinates.`,
+      incompatibilities: partial,
+    };
+  }
+  return {
+    status: "applied",
+    value,
+    message: `Curated ${curatedViewLabel(definition)} view restored.`,
+    incompatibilities: [],
+  };
+}
+
+export function curatedResolutionExplanation(result: CuratedDefaultResolution<unknown>): string {
+  if (result.incompatibilities.length === 0) return result.message;
+  return `${result.message} ${result.incompatibilities.join("; ")}.`;
+}
+
+function technicalFallback<T>(
+  message: string,
+  incompatibilities: string[],
+): CuratedDefaultResolution<T> {
+  return {
+    status: "technical_fallback",
+    value: null,
+    message,
+    incompatibilities,
+  };
+}
+
+function curatedViewId(definition: WorldCuratedView): string {
+  return definition.viewId;
+}
+
+function curatedViewLabel(definition: WorldCuratedView): string {
+  switch (definition.viewId) {
+    case "updraft_lens":
+      return "Updraft Lens";
+    case "wave_structure":
+      return "Wave Structure Lens";
+    case "wave_cloud":
+      return "Wave Cloud Lens";
+    case "rotating_updraft":
+      return "Rotating Updraft";
+    case "cloud_precipitation":
+      return "Cloud and Precipitation";
+    case "low_level_interactions":
+      return "Low-Level Interactions";
+    default:
+      return "Field";
+  }
+}
+
+function validateAvailable(
+  available: string[] | undefined,
+  expected: string,
+  label: string,
+  blockers: string[],
+) {
+  if (available && !available.includes(expected))
+    blockers.push(`${label} ${expected} is unavailable`);
+}
+
+function nearestIndex(values: number[], target: number) {
+  if (values.length === 0) return null;
+  let index = 0;
+  let distance = Math.abs(values[0] - target);
+  for (let candidate = 1; candidate < values.length; candidate += 1) {
+    const candidateDistance = Math.abs(values[candidate] - target);
+    if (candidateDistance < distance) {
+      index = candidate;
+      distance = candidateDistance;
+    }
+  }
+  return { index, value: values[index] };
+}
+
+function nearlyEqual(left: number, right: number): boolean {
+  return Math.abs(left - right) <= Math.max(1e-6, Math.abs(right) * 1e-6);
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value)
+    ? String(value)
+    : value.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+}

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -50,6 +50,7 @@ Keep product approval separate from software availability:
 | Compare | Related Simulations can be compared | One featured Trade Cumulus Comparison; no ordinary World-aware Compare |
 | Variation | Create a related Simulation from a World Simulation | Working Mountain Waves Lab path; no shared three-World workflow |
 | Explore | World-specific science in a shared application vocabulary | Implemented separately for all three accessible Worlds |
+| Curated Explore defaults | Authored Simulation and Field/Lens starting states with complete reset and visible fallback | Implemented across all three accessible Worlds; not durable user state |
 
 The three Worlds share product vocabulary and core workspace behavior but may
 legitimately differ in geometry, Lenses, controls, comparison questions, and
@@ -86,14 +87,15 @@ collapsible Context and shared below-the-fold Science, Notes, and Details
 structure. Per-Simulation Notes are the first durable content contract; complete
 Explore state and Saved Views remain unimplemented.
 
-The next approved program is personal scientific memory: define one versioned,
-World-aware serializable Explore-state contract before ordinary resume, named
-Saved Views, or Compare work.
+The authored curated-default and complete reset contract is complete through
+#438. The next approved program is #432, personal scientific memory: define one
+versioned, World-aware serializable Explore-state contract and make durable
+resume and named Saved Views consume the authored fallback before Compare work.
 
-Rewritten issue #394 and issues #432 through #438 record bounded
+Rewritten issue #394 and issues #432 through #437 record bounded
 follow-on product work for Activity and History, durable Explore state and
 Saved Views, Compare and Saved Comparisons, variation
-contracts, retained assets, and curated defaults. Their presence does not
+contracts, and retained assets. Their presence does not
 activate them or replace the sequencing authority. Issues #389, #390, and #391
 were closed as superseded and are not current assignment authority.
 

--- a/docs/current/CURRENT_ARCHITECTURE.md
+++ b/docs/current/CURRENT_ARCHITECTURE.md
@@ -183,6 +183,48 @@ user-authored per-Simulation content, and Details owns technical and provenance
 information. World-specific geometry and science remain in their World
 components rather than being forced through one generic renderer.
 
+### Authored default-state contract
+
+`app/frontend/src/exploreCuratedDefaults.ts` defines the current authored
+Explore presentations. The contract has a small common identity and interaction
+vocabulary plus explicit Trade Cumulus, Mountain Waves, and Supercells payloads.
+It deliberately does not flatten the Worlds into one arbitrary React-state
+object.
+
+Stable definitions use:
+
+- World and stable Simulation identity rather than backing run ID;
+- modeled seconds rather than frame index;
+- physical section coordinates rather than native array index;
+- stable Field, Lens, scale, layer, and overlay IDs;
+- explicit camera, viewport, geometry, Context, and secondary-section state.
+
+At runtime, the resolver maps modeled time and physical plane to available
+native coordinates. Its bounded result is one of:
+
+```text
+applied
+partially_incompatible
+technical_fallback
+```
+
+Partial and fallback results carry visible incompatibility explanations.
+Missing data does not mutate the authored definition or silently promote a
+different Field, Lens, scale, time, or plane. Initial open and complete reset
+both consume the same definition.
+
+Future durable state from #432 must use this precedence:
+
+```text
+explicit Saved View
+> last active state
+> curated Simulation / active Field-or-Lens default
+> technical fallback
+```
+
+This contract does not persist state, create Saved Views, or serialize
+arbitrary component internals.
+
 ## Scientific Payload Rules
 
 Explore payloads preserve several implementation boundaries:
@@ -225,6 +267,8 @@ The current code keeps these states distinct:
 | State | Current meaning |
 | --- | --- |
 | Stable World or Simulation identity | Product-owned identity independent of a current run |
+| Authored curated Explore state | Product-owned initial and reset presentation for a stable Simulation and Field or Lens |
+| Curated-default resolution | Compatibility result mapping authored modeled time and physical coordinates to available retained data |
 | Configured package | CM1-facing inputs exist, but no CM1 output is implied |
 | Queued or running process | An external CM1 execution is waiting or active |
 | Completed process | CM1 exited; scientific output may still be missing or invalid |
@@ -304,6 +348,8 @@ are reported in the interface. Notes do not become run identity, result
 metadata, or a general annotation model.
 
 Saved Views and complete Explore workspace state are not durably persisted.
+Authored curated defaults are source-controlled product definitions, not user
+state or persistence records.
 The only product Comparison currently exposed is the featured Trade Cumulus
 pair. World-aware variation exists for Mountain Waves but is not yet one shared
 cross-World system.
@@ -324,7 +370,7 @@ reused.
 
 - World shells and Explore implementations share vocabulary but still contain
   World-specific state and rendering code.
-- Durable Saved Views and general World-aware Compare are absent.
+- Durable resume, Saved Views, and general World-aware Compare are absent.
 - Variation is implemented only for Mountain Waves.
 - Legacy run, result, and sounding surfaces remain interleaved with the newer
   World application.

--- a/docs/current/CURRENT_STATE.md
+++ b/docs/current/CURRENT_STATE.md
@@ -124,6 +124,33 @@ The sections use native model coordinates. Moving between a Lens and a direct
 slice preserves the selected orientation and position where the underlying
 data permits.
 
+## Curated Explore Defaults
+
+Each Cloud World now owns typed authored Explore presentations. Initial open
+and **Return to curated view** consume the same definitions; component
+initialization is not a second source of scientific defaults.
+
+| World and view | Authored presentation |
+| --- | --- |
+| Trade Cumulus Field | Simulation-specific modeled time and vertical x-z plane, cloud-liquid field, overview camera, accepted cloud opacity and point size |
+| Trade Cumulus Updraft Lens | The same Simulation-specific time and plane, `trade_cumulus_updraft_velocity_v1`, overview camera, cloud boundary, perturbation wind, and accepted Lens opacity |
+| Dry Ridge Field or Wave Structure Lens | 2,160 s, full domain, expanded height; Field retains its selected supported field, while Wave Structure uses vertical velocity, horizontal wind, and potential-temperature contours |
+| Boulder Windstorm Field, Wave Structure, or Wave Cloud Lens | 7,200 s, focus region, expanded height; Field retains its selected supported field, while each Lens restores its accepted overlays and fixed scale |
+| Supercells Rotating Updraft | 4,440 s, storm region, horizontal x-y at z = 3.167 km, look-along-y camera, and the accepted rotation and updraft-helicity evidence |
+| Supercells Cloud and Precipitation | 4,440 s, storm region, vertical x-z at y = 0.75 km, look-along-y camera, and the accepted hydrometeor-category presentation |
+| Supercells Low-Level Interactions | 4,440 s, storm region, horizontal x-y at z = 1.167 km, low-level camera, and the accepted rain, precipitating-condensate, wind, and vertical-motion evidence |
+
+Return restores the authored state for the currently active Field or Lens. It
+does not switch views unexpectedly, change Simulation, erase Notes, or start
+playback. It also restores modeled time, physical plane, viewport, geometry,
+camera, layers, overlays, display settings, selection, Context, and the
+secondary Science section where those dimensions apply.
+
+The resolver reports authored-default application, partial incompatibility, or
+a technical fallback. Missing times, planes, fields, scales, or layers are
+explained visibly; fallback does not rewrite the authored definition or claim
+that a substituted scientific presentation is equivalent.
+
 ## Shared Scientific Presentation
 
 Current Explore surfaces use:
@@ -185,12 +212,15 @@ information architecture.
 The implemented application does not yet provide:
 
 - durable Saved Views;
+- ordinary last-active Explore-state resume;
 - ordinary World-aware Compare beyond the featured Trade Cumulus Comparison;
 - one shared World-aware variation workflow across all accessible Worlds;
 - durable persistence for complete Explore or comparison workspaces.
 
 Per-Simulation Notes are durable content, but camera, time, Lens, overlay,
 selection, and other complete Explore workspace state are not yet persisted.
+The authored curated-default contract is implemented and is the fallback that
+future resume and Saved Views must consume.
 Older issues #389, #390, and #391 are closed as superseded by the current
 three-World implementation sequence; they should not be read as active roadmap
 authority.

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -82,6 +82,9 @@ The presentation-quality and third-World program established:
 
 #395 — first-class Fun With Soundings workbench with five jobs, atmosphere
        continuity, Past Experiments, and direct non-World Explore — complete
+
+#438 — typed World-aware curated Explore defaults, complete current-view
+       Return to curated view, and visible bounded fallback — complete
 ```
 
 The completed work preserves stable World and Simulation identities while allowing backing run assets to improve.
@@ -99,6 +102,13 @@ below the fold
 World-specific scientific content remains legitimate. Shared structure must not erase scientific or geometric differences.
 
 Per-Simulation Notes are the first bounded durable-content contract. They use stable World and Simulation identity, persist across reloads, and fail visibly. They do not serialize complete Explore state, implement resume, create Saved Views, or establish a generic annotation framework.
+
+Curated Explore defaults now define the intentional source-controlled
+presentation for each supported Simulation and Field or Lens. Initial open and
+Return to curated view consume the same definitions. Return restores the
+current Field or Lens without changing Simulation, erasing Notes, or starting
+playback. A visible technical fallback remains distinct from an authored
+scientific presentation.
 
 ## Next program: personal scientific memory
 
@@ -142,6 +152,10 @@ explicit Saved View
 ```
 
 Provide a clear return to the curated default state.
+
+The curated-default tier and complete return behavior are implemented through
+#438. Issue #432 owns the durable state above that tier; it must consume rather
+than recreate these defaults.
 
 ## Then: ordinary Compare and Saved Comparisons
 


### PR DESCRIPTION
Closes #438.

## Summary

- adds one typed, World-aware authored-default contract shared by initial open and complete reset;
- adds a consistent **Return to curated view** action to Trade Cumulus, Mountain Waves, and Supercells;
- preserves the current Field or Lens while restoring its authored modeled time, physical plane, camera, viewport/geometry, layers, overlays, display settings, selection, Context, and Science section;
- distinguishes applied, partially incompatible, and technical-fallback resolution with visible bounded explanations;
- keeps Fun With Soundings outside the World-authored-default contract.

## Default matrix

| World / authored view | Modeled time | Physical presentation | Primary authored evidence |
| --- | --- | --- | --- |
| Trade Cumulus Field | Baseline 12,060 s; More Moisture 13,920 s | Simulation-owned vertical x-z plane; overview camera | Cloud liquid, accepted cloud opacity and point size |
| Trade Cumulus Updraft Lens | Same Simulation time and plane | Overview camera | `trade_cumulus_updraft_velocity_v1`, cloud boundary, perturbation wind |
| Dry Ridge Field / Wave Structure | 2,160 s | Full domain; expanded height | Selected Field, or w with horizontal wind and potential-temperature contours |
| Boulder Field / Wave Structure / Wave Cloud | 7,200 s | Focus region; expanded height | Selected Field, or accepted per-Lens overlays and fixed scale |
| Rotating Updraft | 4,440 s | Horizontal x-y at z = 3.167 km; look along y | Rotation and 2–5 km updraft-helicity evidence |
| Cloud and Precipitation | 4,440 s | Vertical x-z at y = 0.75 km; look along y | Hydrometeor categories and vertical-motion evidence |
| Low-Level Interactions | 4,440 s | Horizontal x-y at z = 1.167 km; low-level camera | Rain, precipitating condensate, model-relative wind, and vertical motion |

## Existing defaults codified

- Trade Cumulus keeps the accepted presentation-run moments, physical x-z planes, overview camera, cloud controls, boundary, perturbation wind, and fixed Updraft Lens scale.
- Mountain Waves keeps Dry Ridge in Wave Structure / full-domain / expanded-height presentation and Boulder in Wave Cloud / focus-region / expanded-height presentation. Field reset retains the selected supported Field.
- Each Supercells Lens keeps its reviewed presentation time, camera, physical section, 3-D layers, 2-D overlays, scale identity, opacity, and point size.

No scientific Lens, field, fixed scale, threshold, interpretation, or retained backing run changed.

## Intentional behavior changes

- Initial open and reset now consume the same authored definition instead of duplicated component literals.
- Reset is complete and current-view-specific; it does not unexpectedly switch Field/Lens or Simulation.
- Reset stops playback, clears transient selection/focus/errors, closes the rendering popover, opens Context, and returns the below-the-fold section to Science.
- Successful reset confirmation is brief and nonmodal. Partial/fallback explanations remain visible in a reserved row and do not intercept input.
- Per-Simulation Notes are neither cleared nor rewritten.

## Stable representation and fallback

`app/frontend/src/exploreCuratedDefaults.ts` uses stable World and Simulation IDs, modeled seconds, physical coordinates, stable Field/Lens/scale/layer/overlay IDs, and explicit World-specific camera/viewport/geometry payloads. It contains no backing run IDs and is not a flattened React-state serialization.

The resolver returns:

```text
applied
partially_incompatible
technical_fallback
```

Missing or incompatible times, planes, fields, scales, views, or layers are explained visibly. Current compatible controls remain usable, Details remains accessible, and the authored definition is not rewritten or silently replaced.

Future precedence remains:

```text
explicit Saved View
> last active state
> curated Simulation / active Field-or-Lens default
> technical fallback
```

## Files and tests

Implementation:

- `app/frontend/src/exploreCuratedDefaults.ts`
- `app/frontend/src/IntegratedExploreWorkspace.tsx`
- `app/frontend/src/App.tsx`
- `app/frontend/src/MountainWavesExplore.tsx`
- `app/frontend/src/SupercellsExplore.tsx`
- `app/frontend/src/True3DViewer.tsx`
- corresponding CSS

Coverage:

- `app/frontend/src/exploreCuratedDefaults.test.ts`
- `app/frontend/src/App.test.tsx`
- `app/frontend/src/MountainWavesExplore.test.tsx`
- `app/frontend/src/SupercellsExplore.test.tsx`

Documentation:

- `docs/current/CURRENT_STATE.md`
- `docs/current/CURRENT_ARCHITECTURE.md`
- `docs/DOCUMENTATION_STATUS.md`
- `docs/product/CURRENT_PRODUCT_SEQUENCE.md`

## Verification

- `git diff --name-only main...HEAD` — exact 16-path implementation/test/doc set listed above
- `git diff --check` — passed
- `scripts/check.sh` — passed: 180 frontend tests, production build, 670 backend tests, script/artifact/doc checks
- `scripts/check-e2e.sh` — passed: 31 Playwright mocked smoke tests
- live retained-Simulation Playwright review at 1440 x 900 and 1180 x 820 across all three Worlds
- Fun With Soundings shared-UI regression checked; no curated reset action appears there
- no browser console errors in the live review

The known Vite chunk-size warning and backend numpy ABI warning remain unchanged.

## Visual review packet

- directory: `/Users/timpeterson/Documents/Codex/issue-438-curated-defaults-review`
- zip: `/Users/timpeterson/Documents/Codex/issue-438-curated-defaults-review.zip`
- contents: 28 screenshots plus `README.md`, covering initial/altered/reset states, all three Supercells Lenses, Mountain geometry/Field/overlay changes, Trade Field and Lens, retained Notes, bounded technical fallback, narrower desktop, and Soundings regression.

## Boundaries

No persistence, resume storage, Saved Views, Compare, variation, Activity, CM1 execution, retained-output modification, or Fun With Soundings authored-default work was added. Auto-merge remains disabled. This draft requires manual PM, UX, scientific, and visual review.
