### PR TITLE
Implement durable Explore state and Saved Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,18 @@ processes visible.
 
 The implemented application does not yet provide:
 
-- durable Saved Views;
 - ordinary World-aware Compare beyond the featured Trade Cumulus Comparison;
 - one shared variation workflow across all three Worlds;
-- durable persistence for complete Explore or comparison workspaces.
+- Saved Comparisons or durable comparison workspaces.
 
 These are current limitations, not decisions to remove the corresponding
 approved product concepts.
+
+All three Cloud Worlds now persist the last coherent Explore state and named
+Saved Views by stable World and Simulation identity. Saved Views reopen as live
+examinations, support rename and delete, and report bounded incompatibility when
+retained output changes or is unavailable. Per-Simulation Notes remain a
+separate durable-content contract.
 
 ## Product authority
 
@@ -129,8 +134,15 @@ Cloud Chamber stores local runtime state outside Git by default:
   settings.json
   runs/
   cache/
+  explore-state/
   logs/
 ```
+
+Explore state is stored under
+`<runtime-home>/explore-state/<world_id>/<simulation_id>.json`. Each file
+contains one versioned, World-specific last-active state plus that Simulation's
+named Saved Views; writes are atomic and failures remain local to the state
+controls.
 
 The retained NetCDF histories that back built-in Simulations are large local
 assets under the runtime home. Stable World and Simulation identities resolve

--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -23,6 +23,20 @@ from cloud_chamber.dry_run_package import (
     generate_dry_run_package,
     read_dry_run_report,
 )
+from cloud_chamber.explore_state import (
+    ExploreResumeUpdate,
+    ExploreStateError,
+    ExploreStateLibrary,
+    ExploreStateLibraryResponse,
+    SavedViewCreate,
+    SavedViewUpdate,
+    create_saved_view,
+    delete_saved_view,
+    explore_state_library_exists,
+    load_explore_state_library,
+    save_last_active_explore_state,
+    update_saved_view,
+)
 from cloud_chamber.igra_catalog import (
     IGRACatalogError,
     cache_station_zip_from_catalog,
@@ -646,8 +660,8 @@ def get_supercells_world() -> SupercellsWorldDetail:
 )
 def get_simulation_note(world_id: str, simulation_id: str) -> SimulationNoteResponse:
     settings = load_settings()
-    canonical_world_id = _canonical_note_world_id(world_id)
-    if not _simulation_note_target_exists(
+    canonical_world_id = _canonical_world_id(world_id)
+    if not _simulation_target_exists(
         canonical_world_id,
         simulation_id,
         settings=settings,
@@ -674,8 +688,8 @@ def put_simulation_note(
     request: SimulationNoteUpdate,
 ) -> SimulationNoteResponse:
     settings = load_settings()
-    canonical_world_id = _canonical_note_world_id(world_id)
-    if not _simulation_note_target_exists(
+    canonical_world_id = _canonical_world_id(world_id)
+    if not _simulation_target_exists(
         canonical_world_id,
         simulation_id,
         settings=settings,
@@ -691,6 +705,186 @@ def put_simulation_note(
     except SimulationNoteError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     return SimulationNoteResponse(note=note)
+
+
+def _explore_state_response(
+    library: ExploreStateLibrary,
+    *,
+    backing_simulation_available: bool,
+) -> ExploreStateLibraryResponse:
+    if not backing_simulation_available:
+        library = library.model_copy(
+            update={
+                "saved_views": [
+                    record.model_copy(
+                        update={
+                            "restoration_status": "unavailable",
+                            "restoration_message": "The backing retained output is unavailable.",
+                        }
+                    )
+                    for record in library.saved_views
+                ]
+            }
+        )
+    return ExploreStateLibraryResponse(
+        library=library,
+        backing_simulation_available=backing_simulation_available,
+    )
+
+
+@app.get(
+    "/api/worlds/{world_id}/simulations/{simulation_id}/explore-state",
+    response_model=ExploreStateLibraryResponse,
+)
+def get_simulation_explore_state(
+    world_id: str,
+    simulation_id: str,
+) -> ExploreStateLibraryResponse:
+    settings = load_settings()
+    canonical_world_id = _canonical_world_id(world_id)
+    backing_available = _simulation_target_exists(
+        canonical_world_id,
+        simulation_id,
+        settings=settings,
+    )
+    try:
+        library_exists = explore_state_library_exists(
+            settings,
+            world_id=canonical_world_id,
+            simulation_id=simulation_id,
+        )
+        if not backing_available and not library_exists:
+            raise HTTPException(status_code=404, detail="Cloud World Simulation not found.")
+        library = load_explore_state_library(
+            settings,
+            world_id=canonical_world_id,
+            simulation_id=simulation_id,
+        )
+    except ExploreStateError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return _explore_state_response(
+        library,
+        backing_simulation_available=backing_available,
+    )
+
+
+@app.put(
+    "/api/worlds/{world_id}/simulations/{simulation_id}/explore-state/resume",
+    response_model=ExploreStateLibraryResponse,
+)
+def put_simulation_explore_resume(
+    world_id: str,
+    simulation_id: str,
+    request: ExploreResumeUpdate,
+) -> ExploreStateLibraryResponse:
+    settings = load_settings()
+    canonical_world_id = _canonical_world_id(world_id)
+    if not _simulation_target_exists(
+        canonical_world_id,
+        simulation_id,
+        settings=settings,
+    ):
+        raise HTTPException(status_code=404, detail="Cloud World Simulation not found.")
+    try:
+        library = save_last_active_explore_state(
+            settings,
+            world_id=canonical_world_id,
+            simulation_id=simulation_id,
+            state=request.state,
+        )
+    except ExploreStateError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _explore_state_response(library, backing_simulation_available=True)
+
+
+@app.post(
+    "/api/worlds/{world_id}/simulations/{simulation_id}/saved-views",
+    response_model=ExploreStateLibraryResponse,
+    status_code=201,
+)
+def post_simulation_saved_view(
+    world_id: str,
+    simulation_id: str,
+    request: SavedViewCreate,
+) -> ExploreStateLibraryResponse:
+    settings = load_settings()
+    canonical_world_id = _canonical_world_id(world_id)
+    if not _simulation_target_exists(
+        canonical_world_id,
+        simulation_id,
+        settings=settings,
+    ):
+        raise HTTPException(status_code=404, detail="Cloud World Simulation not found.")
+    try:
+        library = create_saved_view(
+            settings,
+            world_id=canonical_world_id,
+            simulation_id=simulation_id,
+            request=request,
+        )
+    except ExploreStateError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _explore_state_response(library, backing_simulation_available=True)
+
+
+@app.patch(
+    "/api/worlds/{world_id}/simulations/{simulation_id}/saved-views/{saved_view_id}",
+    response_model=ExploreStateLibraryResponse,
+)
+def patch_simulation_saved_view(
+    world_id: str,
+    simulation_id: str,
+    saved_view_id: str,
+    request: SavedViewUpdate,
+) -> ExploreStateLibraryResponse:
+    settings = load_settings()
+    canonical_world_id = _canonical_world_id(world_id)
+    try:
+        library = update_saved_view(
+            settings,
+            world_id=canonical_world_id,
+            simulation_id=simulation_id,
+            saved_view_id=saved_view_id,
+            request=request,
+        )
+    except ExploreStateError as exc:
+        status_code = 404 if str(exc) == "Saved View not found." else 400
+        raise HTTPException(status_code=status_code, detail=str(exc)) from exc
+    return _explore_state_response(
+        library,
+        backing_simulation_available=_simulation_target_exists(
+            canonical_world_id, simulation_id, settings=settings
+        ),
+    )
+
+
+@app.delete(
+    "/api/worlds/{world_id}/simulations/{simulation_id}/saved-views/{saved_view_id}",
+    response_model=ExploreStateLibraryResponse,
+)
+def delete_simulation_saved_view(
+    world_id: str,
+    simulation_id: str,
+    saved_view_id: str,
+) -> ExploreStateLibraryResponse:
+    settings = load_settings()
+    canonical_world_id = _canonical_world_id(world_id)
+    try:
+        library = delete_saved_view(
+            settings,
+            world_id=canonical_world_id,
+            simulation_id=simulation_id,
+            saved_view_id=saved_view_id,
+        )
+    except ExploreStateError as exc:
+        status_code = 404 if str(exc) == "Saved View not found." else 400
+        raise HTTPException(status_code=status_code, detail=str(exc)) from exc
+    return _explore_state_response(
+        library,
+        backing_simulation_available=_simulation_target_exists(
+            canonical_world_id, simulation_id, settings=settings
+        ),
+    )
 
 
 @app.get(
@@ -1038,7 +1232,7 @@ def get_storm_examination_frame(
     return result.model_dump(mode="json")
 
 
-def _canonical_note_world_id(world_id: str) -> str:
+def _canonical_world_id(world_id: str) -> str:
     aliases = {
         "trade-cumulus": "trade_cumulus",
         "trade_cumulus": "trade_cumulus",
@@ -1052,7 +1246,7 @@ def _canonical_note_world_id(world_id: str) -> str:
     return canonical
 
 
-def _simulation_note_target_exists(
+def _simulation_target_exists(
     world_id: str,
     simulation_id: str,
     *,

--- a/app/backend/cloud_chamber/explore_state.py
+++ b/app/backend/cloud_chamber/explore_state.py
@@ -1,0 +1,512 @@
+"""Durable Explore resume state and Saved Views keyed to stable Simulation identity."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import RLock
+from typing import Annotated, Literal, cast
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from cloud_chamber.settings import CloudChamberSettings
+
+EXPLORE_STATE_SCHEMA_VERSION: Literal[1] = 1
+WORLD_STATE_VERSION: Literal[1] = 1
+MAX_SAVED_VIEW_TITLE_CHARACTERS = 120
+MAX_SAVED_VIEW_DESCRIPTION_CHARACTERS = 1_000
+_IDENTITY_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+_SAVED_VIEW_ID_PATTERN = re.compile(r"^[a-f0-9]{32}$")
+_LOCK = RLock()
+
+
+class ExploreStateError(ValueError):
+    """Raised when durable Explore state cannot be read or persisted safely."""
+
+
+class ExplorePoint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    x_km: float
+    y_km: float | None = None
+    z_km: float
+
+
+class CameraTransform(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    position: tuple[float, float, float]
+    target: tuple[float, float, float]
+    up: tuple[float, float, float]
+
+
+class ExploreWorldStateBase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state_version: Literal[1] = WORLD_STATE_VERSION
+    model_time_seconds: float
+    context_collapsed: bool = False
+    secondary_section: Literal["science", "notes", "details"] = "science"
+    selected_point: ExplorePoint | None = None
+
+
+class TradeCumulusExploreState(ExploreWorldStateBase):
+    world_id: Literal["trade_cumulus"]
+    view_id: Literal["field", "updraft_lens"]
+    scene_field_id: str
+    slice_field_id: str
+    fixed_scale_id: str | None = None
+    active_slice_plane: Literal["horizontal", "vertical_x", "vertical_y"]
+    slice_coordinate_km: float
+    slice_native_index: int = Field(ge=0)
+    horizontal_slice_coordinate_km: float | None = None
+    threshold_native: float
+    layer_opacity: float = Field(ge=0, le=1)
+    point_size_px: float = Field(gt=0, le=100)
+    lens_opacity: float = Field(ge=0, le=1)
+    show_slice_plane: bool
+    show_cloud_boundary: bool
+    show_horizontal_wind: bool
+    wind_mode: Literal["perturbation", "total"]
+    camera_preset: Literal[
+        "overview",
+        "top_down_xy",
+        "look_along_x",
+        "look_along_y",
+        "low_level",
+    ]
+    camera_transform: CameraTransform | None = None
+    playback_speed: float = Field(gt=0, le=16)
+    display_controls_open: bool = False
+
+
+class MountainWavesOverlayState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    cloud_points: bool
+    cloud_boundary: bool
+    saturation_contour: bool
+    horizontal_wind: bool
+    potential_temperature_contours: bool
+
+
+class MountainWavesExploreState(ExploreWorldStateBase):
+    world_id: Literal["mountain_waves"]
+    view_id: Literal["field", "wave_structure", "wave_cloud"]
+    field_id: Literal[
+        "w",
+        "theta_perturbation",
+        "cloud_liquid",
+        "relative_humidity",
+    ]
+    fixed_scale_id: str
+    viewport_id: Literal["focus", "full"]
+    geometry_id: Literal["expanded", "physical"]
+    overlays: MountainWavesOverlayState
+    cloud_opacity: float = Field(ge=0, le=1)
+    cloud_point_size_px: float = Field(gt=0, le=100)
+    playback_speed: float = Field(gt=0, le=16)
+
+
+class SupercellsOverlayState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rotation: bool
+    updraft_helicity: bool
+    reflectivity: bool
+    condensate: bool
+    rain: bool
+    wind: bool
+    precipitating_condensate: bool
+    vertical_motion: bool
+
+
+class SupercellsExploreState(ExploreWorldStateBase):
+    world_id: Literal["supercells"]
+    lens_id: Literal[
+        "rotating_updraft",
+        "cloud_precipitation",
+        "low_level_interactions",
+    ]
+    viewport_id: Literal["storm", "full"]
+    evidence_view: Literal["plan", "xz", "yz"]
+    plane_coordinate_km: float
+    visible_layer_ids: list[str]
+    fixed_scale_ids: list[str]
+    overlays: SupercellsOverlayState
+    hydrometeor_category_codes: list[int]
+    camera_preset: Literal[
+        "overview",
+        "top_down_xy",
+        "look_along_x",
+        "look_along_y",
+        "low_level",
+    ]
+    camera_transform: CameraTransform | None = None
+    scene_opacity: float = Field(ge=0, le=1)
+    scene_point_size: float = Field(gt=0, le=100)
+    selected_evidence_visible: bool
+    playback_speed: float = Field(gt=0, le=16)
+    display_controls_open: bool = False
+
+
+ExploreWorldState = Annotated[
+    TradeCumulusExploreState | MountainWavesExploreState | SupercellsExploreState,
+    Field(discriminator="world_id"),
+]
+
+
+class ExploreStateSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = EXPLORE_STATE_SCHEMA_VERSION
+    world_id: str
+    simulation_id: str
+    captured_at: datetime
+    state: ExploreWorldState
+
+
+class SavedViewRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    saved_view_id: str
+    title: str = Field(min_length=1, max_length=MAX_SAVED_VIEW_TITLE_CHARACTERS)
+    description: str | None = Field(
+        default=None,
+        max_length=MAX_SAVED_VIEW_DESCRIPTION_CHARACTERS,
+    )
+    created_at: datetime
+    updated_at: datetime
+    restoration_status: Literal["healthy", "partially_restorable", "unavailable"] = "healthy"
+    restoration_message: str | None = Field(default=None, max_length=1_000)
+    snapshot: ExploreStateSnapshot
+
+
+class ExploreStateLibrary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = EXPLORE_STATE_SCHEMA_VERSION
+    world_id: str
+    simulation_id: str
+    last_active: ExploreStateSnapshot | None = None
+    saved_views: list[SavedViewRecord] = Field(default_factory=list)
+
+
+class ExploreStateLibraryResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    library: ExploreStateLibrary
+    backing_simulation_available: bool
+
+
+class ExploreResumeUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: ExploreWorldState
+
+
+class SavedViewCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(min_length=1, max_length=MAX_SAVED_VIEW_TITLE_CHARACTERS)
+    description: str | None = Field(
+        default=None,
+        max_length=MAX_SAVED_VIEW_DESCRIPTION_CHARACTERS,
+    )
+    state: ExploreWorldState
+
+
+class SavedViewUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=MAX_SAVED_VIEW_TITLE_CHARACTERS,
+    )
+    description: str | None = Field(
+        default=None,
+        max_length=MAX_SAVED_VIEW_DESCRIPTION_CHARACTERS,
+    )
+    restoration_status: Literal["healthy", "partially_restorable", "unavailable"] | None = None
+    restoration_message: str | None = Field(default=None, max_length=1_000)
+
+
+def load_explore_state_library(
+    settings: CloudChamberSettings,
+    *,
+    world_id: str,
+    simulation_id: str,
+) -> ExploreStateLibrary:
+    """Load one Simulation-owned Explore library."""
+    with _LOCK:
+        path = _library_path(settings, world_id=world_id, simulation_id=simulation_id)
+        if not path.exists():
+            return ExploreStateLibrary(world_id=world_id, simulation_id=simulation_id)
+        try:
+            raw_payload = json.loads(path.read_text())
+            migration_required = (
+                isinstance(raw_payload, dict) and raw_payload.get("schema_version") == 0
+            )
+            library = ExploreStateLibrary.model_validate(_migrate_library_payload(raw_payload))
+        except (OSError, json.JSONDecodeError, ValidationError) as exc:
+            raise ExploreStateError(
+                "The saved Explore state uses an unsupported schema or is unreadable."
+            ) from exc
+        if library.world_id != world_id or library.simulation_id != simulation_id:
+            raise ExploreStateError("The saved Explore-state identity does not match its path.")
+        _validate_library_state_identity(library)
+        if migration_required:
+            _write_library(settings, library)
+        return library
+
+
+def explore_state_library_exists(
+    settings: CloudChamberSettings,
+    *,
+    world_id: str,
+    simulation_id: str,
+) -> bool:
+    return _library_path(settings, world_id=world_id, simulation_id=simulation_id).exists()
+
+
+def save_last_active_explore_state(
+    settings: CloudChamberSettings,
+    *,
+    world_id: str,
+    simulation_id: str,
+    state: ExploreWorldState,
+) -> ExploreStateLibrary:
+    with _LOCK:
+        library = load_explore_state_library(
+            settings,
+            world_id=world_id,
+            simulation_id=simulation_id,
+        )
+        _validate_state_identity(world_id, state)
+        library.last_active = _snapshot(
+            world_id=world_id,
+            simulation_id=simulation_id,
+            state=state,
+        )
+        _write_library(settings, library)
+        return library
+
+
+def create_saved_view(
+    settings: CloudChamberSettings,
+    *,
+    world_id: str,
+    simulation_id: str,
+    request: SavedViewCreate,
+) -> ExploreStateLibrary:
+    with _LOCK:
+        library = load_explore_state_library(
+            settings,
+            world_id=world_id,
+            simulation_id=simulation_id,
+        )
+        _validate_state_identity(world_id, request.state)
+        now = datetime.now(UTC)
+        title = request.title.strip()
+        if not title:
+            raise ExploreStateError("Saved View title is required.")
+        description = request.description.strip() if request.description else None
+        library.saved_views.append(
+            SavedViewRecord(
+                saved_view_id=uuid4().hex,
+                title=title,
+                description=description or None,
+                created_at=now,
+                updated_at=now,
+                snapshot=_snapshot(
+                    world_id=world_id,
+                    simulation_id=simulation_id,
+                    state=request.state,
+                    captured_at=now,
+                ),
+            )
+        )
+        _write_library(settings, library)
+        return library
+
+
+def update_saved_view(
+    settings: CloudChamberSettings,
+    *,
+    world_id: str,
+    simulation_id: str,
+    saved_view_id: str,
+    request: SavedViewUpdate,
+) -> ExploreStateLibrary:
+    _validate_saved_view_id(saved_view_id)
+    with _LOCK:
+        library = load_explore_state_library(
+            settings,
+            world_id=world_id,
+            simulation_id=simulation_id,
+        )
+        record = next(
+            (item for item in library.saved_views if item.saved_view_id == saved_view_id),
+            None,
+        )
+        if record is None:
+            raise ExploreStateError("Saved View not found.")
+        updates = request.model_dump(exclude_unset=True)
+        if "title" in updates:
+            updates["title"] = updates["title"].strip()
+            if not updates["title"]:
+                raise ExploreStateError("Saved View title is required.")
+        if "description" in updates and updates["description"] is not None:
+            updates["description"] = updates["description"].strip() or None
+        updates["updated_at"] = datetime.now(UTC)
+        updated = record.model_copy(update=updates)
+        library.saved_views = [
+            updated if item.saved_view_id == saved_view_id else item for item in library.saved_views
+        ]
+        _write_library(settings, library)
+        return library
+
+
+def delete_saved_view(
+    settings: CloudChamberSettings,
+    *,
+    world_id: str,
+    simulation_id: str,
+    saved_view_id: str,
+) -> ExploreStateLibrary:
+    _validate_saved_view_id(saved_view_id)
+    with _LOCK:
+        library = load_explore_state_library(
+            settings,
+            world_id=world_id,
+            simulation_id=simulation_id,
+        )
+        retained = [item for item in library.saved_views if item.saved_view_id != saved_view_id]
+        if len(retained) == len(library.saved_views):
+            raise ExploreStateError("Saved View not found.")
+        library.saved_views = retained
+        _write_library(settings, library)
+        return library
+
+
+def _snapshot(
+    *,
+    world_id: str,
+    simulation_id: str,
+    state: ExploreWorldState,
+    captured_at: datetime | None = None,
+) -> ExploreStateSnapshot:
+    return ExploreStateSnapshot(
+        world_id=world_id,
+        simulation_id=simulation_id,
+        captured_at=captured_at or datetime.now(UTC),
+        state=state,
+    )
+
+
+def _write_library(settings: CloudChamberSettings, library: ExploreStateLibrary) -> None:
+    path = _library_path(
+        settings,
+        world_id=library.world_id,
+        simulation_id=library.simulation_id,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        with temporary_path.open("x") as handle:
+            handle.write(library.model_dump_json(indent=2) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    except OSError as exc:
+        temporary_path.unlink(missing_ok=True)
+        raise ExploreStateError("The Explore state could not be saved.") from exc
+
+
+def _migrate_library_payload(payload: object) -> object:
+    """Migrate the one compatible development-era shape stored before v1."""
+    if not isinstance(payload, dict) or payload.get("schema_version") != 0:
+        return payload
+    migrated = cast(dict[str, object], payload)
+    migrated["schema_version"] = EXPLORE_STATE_SCHEMA_VERSION
+    snapshots = []
+    last_active = migrated.get("last_active")
+    if last_active is not None:
+        snapshots.append(last_active)
+    saved_views = migrated.get("saved_views")
+    if isinstance(saved_views, list):
+        for record in saved_views:
+            if isinstance(record, dict):
+                snapshots.append(record.get("snapshot"))
+    for snapshot in snapshots:
+        if not isinstance(snapshot, dict) or snapshot.get("schema_version") != 0:
+            raise ExploreStateError("The saved Explore state uses an unsupported legacy schema.")
+        snapshot["schema_version"] = EXPLORE_STATE_SCHEMA_VERSION
+        state = snapshot.get("state")
+        if not isinstance(state, dict) or state.get("state_version") != 0:
+            raise ExploreStateError("The saved Explore state uses an unsupported legacy schema.")
+        state["state_version"] = WORLD_STATE_VERSION
+        state.setdefault("context_collapsed", False)
+        state.setdefault("secondary_section", "science")
+        state.setdefault("selected_point", None)
+        world_id = state.get("world_id")
+        if world_id == "trade_cumulus":
+            if "slice_native_index" not in state and "slice_index" in state:
+                state["slice_native_index"] = state.pop("slice_index")
+            state.setdefault("horizontal_slice_coordinate_km", None)
+            state.setdefault("camera_transform", None)
+            state.setdefault("display_controls_open", False)
+        elif world_id == "supercells":
+            state.setdefault("camera_transform", None)
+            state.setdefault("display_controls_open", False)
+        elif world_id != "mountain_waves":
+            raise ExploreStateError("The saved Explore state uses an unsupported legacy World.")
+    return migrated
+
+
+def _library_path(
+    settings: CloudChamberSettings,
+    *,
+    world_id: str,
+    simulation_id: str,
+) -> Path:
+    _validate_identity("World", world_id)
+    _validate_identity("Simulation", simulation_id)
+    return settings.runtime_home.expanduser() / "explore-state" / world_id / f"{simulation_id}.json"
+
+
+def _validate_library_state_identity(library: ExploreStateLibrary) -> None:
+    if library.last_active:
+        _validate_snapshot_identity(library, library.last_active)
+    for record in library.saved_views:
+        _validate_saved_view_id(record.saved_view_id)
+        _validate_snapshot_identity(library, record.snapshot)
+
+
+def _validate_snapshot_identity(
+    library: ExploreStateLibrary,
+    snapshot: ExploreStateSnapshot,
+) -> None:
+    if snapshot.world_id != library.world_id or snapshot.simulation_id != library.simulation_id:
+        raise ExploreStateError("A saved Explore snapshot has mismatched identity.")
+    _validate_state_identity(library.world_id, snapshot.state)
+
+
+def _validate_state_identity(world_id: str, state: ExploreWorldState) -> None:
+    if state.world_id != world_id:
+        raise ExploreStateError("The Explore payload does not match the owning World.")
+
+
+def _validate_identity(label: str, value: str) -> None:
+    if not _IDENTITY_PATTERN.fullmatch(value):
+        raise ExploreStateError(f"{label} identity is invalid.")
+
+
+def _validate_saved_view_id(value: str) -> None:
+    if not _SAVED_VIEW_ID_PATTERN.fullmatch(value):
+        raise ExploreStateError("Saved View identity is invalid.")

--- a/app/backend/cloud_chamber/explore_state.py
+++ b/app/backend/cloud_chamber/explore_state.py
@@ -19,9 +19,26 @@ EXPLORE_STATE_SCHEMA_VERSION: Literal[1] = 1
 WORLD_STATE_VERSION: Literal[1] = 1
 MAX_SAVED_VIEW_TITLE_CHARACTERS = 120
 MAX_SAVED_VIEW_DESCRIPTION_CHARACTERS = 1_000
+MAX_SAVED_VIEWS_PER_SIMULATION = 100
+MAX_EXPLORE_STATE_FILE_BYTES = 2_000_000
+MAX_STATE_IDENTIFIER_CHARACTERS = 128
+MAX_VISIBLE_LAYER_IDS = 32
+MAX_FIXED_SCALE_IDS = 16
+MAX_HYDROMETEOR_CATEGORY_CODES = 16
 _IDENTITY_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
 _SAVED_VIEW_ID_PATTERN = re.compile(r"^[a-f0-9]{32}$")
 _LOCK = RLock()
+
+FiniteFloat = Annotated[float, Field(allow_inf_nan=False)]
+UnitIntervalFloat = Annotated[float, Field(ge=0, le=1, allow_inf_nan=False)]
+PositiveDisplayFloat = Annotated[float, Field(gt=0, le=100, allow_inf_nan=False)]
+PlaybackSpeedFloat = Annotated[float, Field(gt=0, le=16, allow_inf_nan=False)]
+StateIdentifier = Annotated[
+    str,
+    Field(min_length=1, max_length=MAX_STATE_IDENTIFIER_CHARACTERS),
+]
+NativeIndex = Annotated[int, Field(ge=0, le=10_000_000)]
+HydrometeorCategoryCode = Annotated[int, Field(ge=0, le=255)]
 
 
 class ExploreStateError(ValueError):
@@ -31,24 +48,24 @@ class ExploreStateError(ValueError):
 class ExplorePoint(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    x_km: float
-    y_km: float | None = None
-    z_km: float
+    x_km: FiniteFloat
+    y_km: FiniteFloat | None = None
+    z_km: FiniteFloat
 
 
 class CameraTransform(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    position: tuple[float, float, float]
-    target: tuple[float, float, float]
-    up: tuple[float, float, float]
+    position: tuple[FiniteFloat, FiniteFloat, FiniteFloat]
+    target: tuple[FiniteFloat, FiniteFloat, FiniteFloat]
+    up: tuple[FiniteFloat, FiniteFloat, FiniteFloat]
 
 
 class ExploreWorldStateBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     state_version: Literal[1] = WORLD_STATE_VERSION
-    model_time_seconds: float
+    model_time_seconds: FiniteFloat
     context_collapsed: bool = False
     secondary_section: Literal["science", "notes", "details"] = "science"
     selected_point: ExplorePoint | None = None
@@ -57,17 +74,17 @@ class ExploreWorldStateBase(BaseModel):
 class TradeCumulusExploreState(ExploreWorldStateBase):
     world_id: Literal["trade_cumulus"]
     view_id: Literal["field", "updraft_lens"]
-    scene_field_id: str
-    slice_field_id: str
-    fixed_scale_id: str | None = None
+    scene_field_id: StateIdentifier
+    slice_field_id: StateIdentifier
+    fixed_scale_id: StateIdentifier | None = None
     active_slice_plane: Literal["horizontal", "vertical_x", "vertical_y"]
-    slice_coordinate_km: float
-    slice_native_index: int = Field(ge=0)
-    horizontal_slice_coordinate_km: float | None = None
-    threshold_native: float
-    layer_opacity: float = Field(ge=0, le=1)
-    point_size_px: float = Field(gt=0, le=100)
-    lens_opacity: float = Field(ge=0, le=1)
+    slice_coordinate_km: FiniteFloat
+    slice_native_index: NativeIndex
+    horizontal_slice_coordinate_km: FiniteFloat | None = None
+    threshold_native: FiniteFloat
+    layer_opacity: UnitIntervalFloat
+    point_size_px: PositiveDisplayFloat
+    lens_opacity: UnitIntervalFloat
     show_slice_plane: bool
     show_cloud_boundary: bool
     show_horizontal_wind: bool
@@ -80,7 +97,7 @@ class TradeCumulusExploreState(ExploreWorldStateBase):
         "low_level",
     ]
     camera_transform: CameraTransform | None = None
-    playback_speed: float = Field(gt=0, le=16)
+    playback_speed: PlaybackSpeedFloat
     display_controls_open: bool = False
 
 
@@ -103,13 +120,13 @@ class MountainWavesExploreState(ExploreWorldStateBase):
         "cloud_liquid",
         "relative_humidity",
     ]
-    fixed_scale_id: str
+    fixed_scale_id: StateIdentifier
     viewport_id: Literal["focus", "full"]
     geometry_id: Literal["expanded", "physical"]
     overlays: MountainWavesOverlayState
-    cloud_opacity: float = Field(ge=0, le=1)
-    cloud_point_size_px: float = Field(gt=0, le=100)
-    playback_speed: float = Field(gt=0, le=16)
+    cloud_opacity: UnitIntervalFloat
+    cloud_point_size_px: PositiveDisplayFloat
+    playback_speed: PlaybackSpeedFloat
 
 
 class SupercellsOverlayState(BaseModel):
@@ -134,11 +151,13 @@ class SupercellsExploreState(ExploreWorldStateBase):
     ]
     viewport_id: Literal["storm", "full"]
     evidence_view: Literal["plan", "xz", "yz"]
-    plane_coordinate_km: float
-    visible_layer_ids: list[str]
-    fixed_scale_ids: list[str]
+    plane_coordinate_km: FiniteFloat
+    visible_layer_ids: list[StateIdentifier] = Field(max_length=MAX_VISIBLE_LAYER_IDS)
+    fixed_scale_ids: list[StateIdentifier] = Field(max_length=MAX_FIXED_SCALE_IDS)
     overlays: SupercellsOverlayState
-    hydrometeor_category_codes: list[int]
+    hydrometeor_category_codes: list[HydrometeorCategoryCode] = Field(
+        max_length=MAX_HYDROMETEOR_CATEGORY_CODES
+    )
     camera_preset: Literal[
         "overview",
         "top_down_xy",
@@ -147,10 +166,10 @@ class SupercellsExploreState(ExploreWorldStateBase):
         "low_level",
     ]
     camera_transform: CameraTransform | None = None
-    scene_opacity: float = Field(ge=0, le=1)
-    scene_point_size: float = Field(gt=0, le=100)
+    scene_opacity: UnitIntervalFloat
+    scene_point_size: PositiveDisplayFloat
     selected_evidence_visible: bool
-    playback_speed: float = Field(gt=0, le=16)
+    playback_speed: PlaybackSpeedFloat
     display_controls_open: bool = False
 
 
@@ -164,8 +183,8 @@ class ExploreStateSnapshot(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: Literal[1] = EXPLORE_STATE_SCHEMA_VERSION
-    world_id: str
-    simulation_id: str
+    world_id: StateIdentifier
+    simulation_id: StateIdentifier
     captured_at: datetime
     state: ExploreWorldState
 
@@ -190,10 +209,13 @@ class ExploreStateLibrary(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: Literal[1] = EXPLORE_STATE_SCHEMA_VERSION
-    world_id: str
-    simulation_id: str
+    world_id: StateIdentifier
+    simulation_id: StateIdentifier
     last_active: ExploreStateSnapshot | None = None
-    saved_views: list[SavedViewRecord] = Field(default_factory=list)
+    saved_views: list[SavedViewRecord] = Field(
+        default_factory=list,
+        max_length=MAX_SAVED_VIEWS_PER_SIMULATION,
+    )
 
 
 class ExploreStateLibraryResponse(BaseModel):
@@ -248,6 +270,10 @@ def load_explore_state_library(
         if not path.exists():
             return ExploreStateLibrary(world_id=world_id, simulation_id=simulation_id)
         try:
+            if path.stat().st_size > MAX_EXPLORE_STATE_FILE_BYTES:
+                raise ExploreStateError(
+                    "The saved Explore-state file exceeds the supported local size limit."
+                )
             raw_payload = json.loads(path.read_text())
             migration_required = (
                 isinstance(raw_payload, dict) and raw_payload.get("schema_version") == 0
@@ -311,6 +337,10 @@ def create_saved_view(
             simulation_id=simulation_id,
         )
         _validate_state_identity(world_id, request.state)
+        if len(library.saved_views) >= MAX_SAVED_VIEWS_PER_SIMULATION:
+            raise ExploreStateError(
+                f"A Simulation can retain at most {MAX_SAVED_VIEWS_PER_SIMULATION} Saved Views."
+            )
         now = datetime.now(UTC)
         title = request.title.strip()
         if not title:
@@ -415,11 +445,14 @@ def _write_library(settings: CloudChamberSettings, library: ExploreStateLibrary)
         world_id=library.world_id,
         simulation_id=library.simulation_id,
     )
+    serialized = library.model_dump_json(indent=2) + "\n"
+    if len(serialized.encode("utf-8")) > MAX_EXPLORE_STATE_FILE_BYTES:
+        raise ExploreStateError("The Explore state exceeds the supported local size limit.")
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
     try:
         with temporary_path.open("x") as handle:
-            handle.write(library.model_dump_json(indent=2) + "\n")
+            handle.write(serialized)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary_path, path)

--- a/app/backend/cloud_chamber/visualization_data.py
+++ b/app/backend/cloud_chamber/visualization_data.py
@@ -654,6 +654,7 @@ class SliceResponse(BaseModel):
     field: VisualizableField
     selection: SliceSelectionMetadata
     coordinate_units: dict[str, str | None] = Field(default_factory=dict)
+    coordinate_values: dict[str, list[float | str | None]] = Field(default_factory=dict)
     shape: list[int]
     dimension_order: list[str]
     data_encoding: VisualizationEncoding
@@ -1901,6 +1902,9 @@ def field_slice(
                 coordinate_units={
                     dimension: _coordinate_units(dataset, dimension) for dimension in sliced.dims
                 },
+                coordinate_values={
+                    dimension: _coordinate_values(dataset, dimension) for dimension in spatial_dims
+                },
                 shape=[int(size) for size in sliced.shape],
                 dimension_order=[str(dimension) for dimension in sliced.dims],
                 data_encoding=encoding,
@@ -1956,6 +1960,9 @@ def field_slice(
         coordinate_units = {
             dimension: _coordinate_units(dataset, dimension) for dimension in sliced.dims
         }
+        coordinate_values = {
+            dimension: _coordinate_values(dataset, dimension) for dimension in spatial_dims
+        }
         if vertical_dim and vertical_units and vertical_dim not in coordinate_units:
             coordinate_units[vertical_dim] = vertical_units
         return SliceResponse(
@@ -1965,6 +1972,7 @@ def field_slice(
             field=visual_field,
             selection=selection,
             coordinate_units=coordinate_units,
+            coordinate_values=coordinate_values,
             shape=[int(size) for size in sliced.shape],
             dimension_order=[str(dimension) for dimension in sliced.dims],
             data_encoding=encoding,

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -68,7 +68,7 @@ def test_simulation_note_api_saves_reloads_and_clears_for_each_world(
     settings = SimpleNamespace(runtime_home=tmp_path)
     monkeypatch.setattr("cloud_chamber.app.load_settings", lambda: settings)
     monkeypatch.setattr(
-        "cloud_chamber.app._simulation_note_target_exists",
+        "cloud_chamber.app._simulation_target_exists",
         lambda *_args, **_kwargs: True,
     )
     client = TestClient(app)
@@ -100,7 +100,7 @@ def test_simulation_note_api_fails_closed_for_unknown_simulation(
         lambda: SimpleNamespace(runtime_home=tmp_path),
     )
     monkeypatch.setattr(
-        "cloud_chamber.app._simulation_note_target_exists",
+        "cloud_chamber.app._simulation_target_exists",
         lambda *_args, **_kwargs: False,
     )
 
@@ -108,6 +108,130 @@ def test_simulation_note_api_fails_closed_for_unknown_simulation(
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Cloud World Simulation not found."
+
+
+def _trade_explore_state_payload() -> dict[str, object]:
+    return {
+        "state_version": 1,
+        "world_id": "trade_cumulus",
+        "model_time_seconds": 12_060,
+        "context_collapsed": False,
+        "secondary_section": "science",
+        "selected_point": None,
+        "view_id": "updraft_lens",
+        "scene_field_id": "ql",
+        "slice_field_id": "w",
+        "fixed_scale_id": "trade_cumulus_updraft_velocity_v1",
+        "active_slice_plane": "vertical_x",
+        "slice_coordinate_km": 2.3666666,
+        "slice_native_index": 5,
+        "horizontal_slice_coordinate_km": None,
+        "threshold_native": 1e-6,
+        "layer_opacity": 0.68,
+        "point_size_px": 11,
+        "lens_opacity": 0.9,
+        "show_slice_plane": True,
+        "show_cloud_boundary": True,
+        "show_horizontal_wind": True,
+        "wind_mode": "perturbation",
+        "camera_preset": "overview",
+        "camera_transform": None,
+        "playback_speed": 1,
+        "display_controls_open": False,
+    }
+
+
+def test_explore_state_api_supports_resume_and_saved_view_crud(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "cloud_chamber.app.load_settings",
+        lambda: SimpleNamespace(runtime_home=tmp_path),
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.app._simulation_target_exists",
+        lambda *_args, **_kwargs: True,
+    )
+    client = TestClient(app)
+    root = "/api/worlds/trade-cumulus/simulations/trade_cumulus_canonical_bomex"
+    state = _trade_explore_state_payload()
+
+    empty = client.get(f"{root}/explore-state")
+    resumed = client.put(f"{root}/explore-state/resume", json={"state": state})
+    created = client.post(
+        f"{root}/saved-views",
+        json={
+            "title": "Western turret",
+            "description": "Before weakening.",
+            "state": state,
+        },
+    )
+    saved_view_id = created.json()["library"]["saved_views"][0]["saved_view_id"]
+    renamed = client.patch(
+        f"{root}/saved-views/{saved_view_id}",
+        json={
+            "title": "Turret weakening",
+            "restoration_status": "partially_restorable",
+            "restoration_message": "Mapped to a nearby retained output.",
+        },
+    )
+    deleted = client.delete(f"{root}/saved-views/{saved_view_id}")
+
+    assert empty.status_code == 200
+    assert empty.json()["library"]["last_active"] is None
+    assert resumed.status_code == 200
+    assert resumed.json()["library"]["last_active"]["state"]["view_id"] == ("updraft_lens")
+    assert created.status_code == 201
+    assert renamed.status_code == 200
+    assert renamed.json()["library"]["saved_views"][0]["title"] == "Turret weakening"
+    assert renamed.json()["library"]["saved_views"][0]["restoration_status"] == (
+        "partially_restorable"
+    )
+    assert deleted.status_code == 200
+    assert deleted.json()["library"]["saved_views"] == []
+
+
+def test_explore_state_api_lists_saved_views_when_backing_output_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    available = True
+    monkeypatch.setattr(
+        "cloud_chamber.app.load_settings",
+        lambda: SimpleNamespace(runtime_home=tmp_path),
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.app._simulation_target_exists",
+        lambda *_args, **_kwargs: available,
+    )
+    client = TestClient(app)
+    root = "/api/worlds/trade-cumulus/simulations/trade_cumulus_canonical_bomex"
+    created = client.post(
+        f"{root}/saved-views",
+        json={"title": "Retained examination", "state": _trade_explore_state_payload()},
+    )
+    assert created.status_code == 201
+
+    available = False
+    missing = client.get(f"{root}/explore-state")
+    saved_view_id = created.json()["library"]["saved_views"][0]["saved_view_id"]
+    renamed = client.patch(
+        f"{root}/saved-views/{saved_view_id}",
+        json={"title": "Retained examination renamed"},
+    )
+
+    assert missing.status_code == 200
+    assert missing.json()["backing_simulation_available"] is False
+    assert missing.json()["library"]["saved_views"][0]["restoration_status"] == ("unavailable")
+    assert (
+        "backing retained output"
+        in (missing.json()["library"]["saved_views"][0]["restoration_message"])
+    )
+    assert renamed.status_code == 200
+    assert renamed.json()["backing_simulation_available"] is False
+    assert renamed.json()["library"]["saved_views"][0]["title"] == ("Retained examination renamed")
+    assert renamed.json()["library"]["saved_views"][0]["restoration_status"] == ("unavailable")
 
 
 def _world_summary_payload() -> dict[str, object]:

--- a/app/backend/tests/test_explore_state.py
+++ b/app/backend/tests/test_explore_state.py
@@ -1,9 +1,18 @@
 import json
+import math
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
+import cloud_chamber.explore_state as explore_state_module
 from cloud_chamber.explore_state import (
+    MAX_EXPLORE_STATE_FILE_BYTES,
+    MAX_FIXED_SCALE_IDS,
+    MAX_HYDROMETEOR_CATEGORY_CODES,
+    MAX_SAVED_VIEWS_PER_SIMULATION,
+    MAX_STATE_IDENTIFIER_CHARACTERS,
+    MAX_VISIBLE_LAYER_IDS,
     ExploreStateError,
     MountainWavesExploreState,
     MountainWavesOverlayState,
@@ -294,4 +303,142 @@ def test_explore_state_rejects_unsafe_identity(tmp_path: Path) -> None:
             settings,
             world_id="supercells",
             simulation_id="../outside",
+        )
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (
+            TradeCumulusExploreState,
+            {**trade_state().model_dump(), "model_time_seconds": math.inf},
+        ),
+        (
+            TradeCumulusExploreState,
+            {**trade_state().model_dump(), "slice_coordinate_km": math.nan},
+        ),
+        (
+            TradeCumulusExploreState,
+            {**trade_state().model_dump(), "threshold_native": math.inf},
+        ),
+        (
+            TradeCumulusExploreState,
+            {**trade_state().model_dump(), "point_size_px": math.inf},
+        ),
+        (
+            MountainWavesExploreState,
+            {**mountain_state().model_dump(), "cloud_opacity": math.nan},
+        ),
+        (
+            SupercellsExploreState,
+            {**supercells_state().model_dump(), "plane_coordinate_km": math.inf},
+        ),
+        (
+            SupercellsExploreState,
+            {
+                **supercells_state().model_dump(),
+                "camera_transform": {
+                    "position": [0, math.nan, 1],
+                    "target": [0, 0, 0],
+                    "up": [0, 0, 1],
+                },
+            },
+        ),
+        (
+            SupercellsExploreState,
+            {
+                **supercells_state().model_dump(),
+                "selected_point": {"x_km": 0, "y_km": math.inf, "z_km": 1},
+            },
+        ),
+    ],
+)
+def test_explore_state_rejects_non_finite_numeric_state(
+    model: type[TradeCumulusExploreState | MountainWavesExploreState | SupercellsExploreState],
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            **trade_state().model_dump(),
+            "scene_field_id": "x" * (MAX_STATE_IDENTIFIER_CHARACTERS + 1),
+        },
+        {
+            **supercells_state().model_dump(),
+            "visible_layer_ids": ["layer"] * (MAX_VISIBLE_LAYER_IDS + 1),
+        },
+        {
+            **supercells_state().model_dump(),
+            "fixed_scale_ids": ["scale"] * (MAX_FIXED_SCALE_IDS + 1),
+        },
+        {
+            **supercells_state().model_dump(),
+            "hydrometeor_category_codes": list(range(MAX_HYDROMETEOR_CATEGORY_CODES + 1)),
+        },
+        {
+            **supercells_state().model_dump(),
+            "hydrometeor_category_codes": [256],
+        },
+    ],
+)
+def test_explore_state_rejects_oversized_world_collections_and_codes(
+    payload: dict[str, object],
+) -> None:
+    model = (
+        TradeCumulusExploreState
+        if payload["world_id"] == "trade_cumulus"
+        else SupercellsExploreState
+    )
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+def test_saved_view_count_is_bounded(tmp_path: Path) -> None:
+    settings = load_settings(home=tmp_path)
+    for index in range(MAX_SAVED_VIEWS_PER_SIMULATION):
+        create_saved_view(
+            settings,
+            world_id="trade_cumulus",
+            simulation_id="trade_cumulus_canonical_bomex",
+            request=SavedViewCreate(title=f"View {index}", state=trade_state()),
+        )
+
+    with pytest.raises(ExploreStateError, match="at most 100 Saved Views"):
+        create_saved_view(
+            settings,
+            world_id="trade_cumulus",
+            simulation_id="trade_cumulus_canonical_bomex",
+            request=SavedViewCreate(title="One too many", state=trade_state()),
+        )
+
+
+def test_explore_state_file_size_is_bounded_on_read_and_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = load_settings(home=tmp_path)
+    path = tmp_path / "explore-state" / "trade_cumulus" / "trade_cumulus_canonical_bomex.json"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"x" * (MAX_EXPLORE_STATE_FILE_BYTES + 1))
+
+    with pytest.raises(ExploreStateError, match="size limit"):
+        load_explore_state_library(
+            settings,
+            world_id="trade_cumulus",
+            simulation_id="trade_cumulus_canonical_bomex",
+        )
+
+    path.unlink()
+    monkeypatch.setattr(explore_state_module, "MAX_EXPLORE_STATE_FILE_BYTES", 100)
+    with pytest.raises(ExploreStateError, match="size limit"):
+        save_last_active_explore_state(
+            settings,
+            world_id="trade_cumulus",
+            simulation_id="trade_cumulus_canonical_bomex",
+            state=trade_state(),
         )

--- a/app/backend/tests/test_explore_state.py
+++ b/app/backend/tests/test_explore_state.py
@@ -1,0 +1,297 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from cloud_chamber.explore_state import (
+    ExploreStateError,
+    MountainWavesExploreState,
+    MountainWavesOverlayState,
+    SavedViewCreate,
+    SavedViewUpdate,
+    SupercellsExploreState,
+    SupercellsOverlayState,
+    TradeCumulusExploreState,
+    create_saved_view,
+    delete_saved_view,
+    load_explore_state_library,
+    save_last_active_explore_state,
+    update_saved_view,
+)
+from cloud_chamber.settings import load_settings
+
+
+def trade_state() -> TradeCumulusExploreState:
+    return TradeCumulusExploreState(
+        world_id="trade_cumulus",
+        model_time_seconds=12_060,
+        view_id="updraft_lens",
+        scene_field_id="ql",
+        slice_field_id="w",
+        fixed_scale_id="trade_cumulus_updraft_velocity_v1",
+        active_slice_plane="vertical_x",
+        slice_coordinate_km=2.3666666,
+        slice_native_index=5,
+        threshold_native=1e-6,
+        layer_opacity=0.68,
+        point_size_px=11,
+        lens_opacity=0.9,
+        show_slice_plane=True,
+        show_cloud_boundary=True,
+        show_horizontal_wind=True,
+        wind_mode="perturbation",
+        camera_preset="overview",
+        playback_speed=1,
+    )
+
+
+def mountain_state() -> MountainWavesExploreState:
+    return MountainWavesExploreState(
+        world_id="mountain_waves",
+        model_time_seconds=7_200,
+        view_id="wave_cloud",
+        field_id="w",
+        fixed_scale_id="mountain_waves_vertical_velocity_v1",
+        viewport_id="focus",
+        geometry_id="expanded",
+        overlays=MountainWavesOverlayState(
+            cloud_points=True,
+            cloud_boundary=True,
+            saturation_contour=True,
+            horizontal_wind=True,
+            potential_temperature_contours=False,
+        ),
+        cloud_opacity=0.68,
+        cloud_point_size_px=11,
+        playback_speed=1,
+    )
+
+
+def supercells_state() -> SupercellsExploreState:
+    return SupercellsExploreState(
+        world_id="supercells",
+        model_time_seconds=4_440,
+        lens_id="rotating_updraft",
+        viewport_id="storm",
+        evidence_view="plan",
+        plane_coordinate_km=3.166667,
+        visible_layer_ids=[
+            "storm_cloud_body",
+            "rising_core",
+            "cyclonic_rotation",
+            "updraft_helicity",
+        ],
+        fixed_scale_ids=["supercell_midlevel_vertical_velocity_v1"],
+        overlays=SupercellsOverlayState(
+            rotation=True,
+            updraft_helicity=True,
+            reflectivity=False,
+            condensate=False,
+            rain=False,
+            wind=False,
+            precipitating_condensate=False,
+            vertical_motion=True,
+        ),
+        hydrometeor_category_codes=[1, 2, 3, 4, 5],
+        camera_preset="look_along_y",
+        scene_opacity=0.74,
+        scene_point_size=1,
+        selected_evidence_visible=True,
+        playback_speed=1,
+    )
+
+
+@pytest.mark.parametrize(
+    ("world_id", "simulation_id", "state"),
+    [
+        ("trade_cumulus", "trade_cumulus_canonical_bomex", trade_state()),
+        (
+            "mountain_waves",
+            "mountain_waves_boulder_moist_reference",
+            mountain_state(),
+        ),
+        ("supercells", "supercells_quarter_circle_reference", supercells_state()),
+    ],
+)
+def test_last_active_state_persists_explicit_world_payloads(
+    tmp_path: Path,
+    world_id: str,
+    simulation_id: str,
+    state: object,
+) -> None:
+    settings = load_settings(home=tmp_path)
+
+    saved = save_last_active_explore_state(
+        settings,
+        world_id=world_id,
+        simulation_id=simulation_id,
+        state=state,  # type: ignore[arg-type]
+    )
+    loaded = load_explore_state_library(
+        settings,
+        world_id=world_id,
+        simulation_id=simulation_id,
+    )
+
+    assert saved.last_active is not None
+    assert loaded == saved
+    assert loaded.last_active is not None
+    assert loaded.last_active.state.world_id == world_id
+    assert (tmp_path / "explore-state" / world_id / f"{simulation_id}.json").exists()
+
+
+def test_saved_view_create_rename_status_and_delete_are_atomic(tmp_path: Path) -> None:
+    settings = load_settings(home=tmp_path)
+    created = create_saved_view(
+        settings,
+        world_id="trade_cumulus",
+        simulation_id="trade_cumulus_canonical_bomex",
+        request=SavedViewCreate(
+            title="  Western turret  ",
+            description="  Before the pulse weakens.  ",
+            state=trade_state(),
+        ),
+    )
+
+    assert len(created.saved_views) == 1
+    saved_view_id = created.saved_views[0].saved_view_id
+    assert created.saved_views[0].title == "Western turret"
+    assert created.saved_views[0].description == "Before the pulse weakens."
+
+    updated = update_saved_view(
+        settings,
+        world_id="trade_cumulus",
+        simulation_id="trade_cumulus_canonical_bomex",
+        saved_view_id=saved_view_id,
+        request=SavedViewUpdate(
+            title="Turret weakening",
+            restoration_status="partially_restorable",
+            restoration_message="Mapped to the nearest retained plane.",
+        ),
+    )
+    assert updated.saved_views[0].title == "Turret weakening"
+    assert updated.saved_views[0].restoration_status == "partially_restorable"
+
+    deleted = delete_saved_view(
+        settings,
+        world_id="trade_cumulus",
+        simulation_id="trade_cumulus_canonical_bomex",
+        saved_view_id=saved_view_id,
+    )
+    assert deleted.saved_views == []
+    assert list((tmp_path / "explore-state").rglob("*.tmp")) == []
+
+
+def test_saved_view_rejects_whitespace_only_title(tmp_path: Path) -> None:
+    settings = load_settings(home=tmp_path)
+
+    with pytest.raises(ExploreStateError, match="title is required"):
+        create_saved_view(
+            settings,
+            world_id="trade_cumulus",
+            simulation_id="trade_cumulus_canonical_bomex",
+            request=SavedViewCreate(title="   ", state=trade_state()),
+        )
+
+
+def test_saved_view_record_survives_without_backing_output(tmp_path: Path) -> None:
+    settings = load_settings(home=tmp_path)
+    created = create_saved_view(
+        settings,
+        world_id="supercells",
+        simulation_id="supercells_quarter_circle_reference",
+        request=SavedViewCreate(title="Mature rotation", state=supercells_state()),
+    )
+
+    loaded = load_explore_state_library(
+        settings,
+        world_id="supercells",
+        simulation_id="supercells_quarter_circle_reference",
+    )
+
+    assert loaded.saved_views == created.saved_views
+    assert loaded.saved_views[0].snapshot.simulation_id == ("supercells_quarter_circle_reference")
+
+
+def test_known_legacy_state_migrates_to_version_one(tmp_path: Path) -> None:
+    settings = load_settings(home=tmp_path)
+    saved = save_last_active_explore_state(
+        settings,
+        world_id="trade_cumulus",
+        simulation_id="trade_cumulus_canonical_bomex",
+        state=trade_state(),
+    )
+    path = tmp_path / "explore-state" / "trade_cumulus" / "trade_cumulus_canonical_bomex.json"
+    payload = json.loads(path.read_text())
+    payload["schema_version"] = 0
+    payload["last_active"]["schema_version"] = 0
+    payload["last_active"]["state"]["state_version"] = 0
+    payload["last_active"]["state"]["slice_index"] = payload["last_active"]["state"].pop(
+        "slice_native_index"
+    )
+    payload["last_active"]["state"].pop("display_controls_open")
+    path.write_text(json.dumps(payload))
+
+    migrated = load_explore_state_library(
+        settings,
+        world_id="trade_cumulus",
+        simulation_id="trade_cumulus_canonical_bomex",
+    )
+
+    assert saved.last_active is not None
+    assert migrated.schema_version == 1
+    assert migrated.last_active is not None
+    assert migrated.last_active.state.state_version == 1
+    assert isinstance(migrated.last_active.state, TradeCumulusExploreState)
+    assert migrated.last_active.state.slice_native_index == 5
+    assert migrated.last_active.state.display_controls_open is False
+    rewritten = json.loads(path.read_text())
+    assert rewritten["schema_version"] == 1
+    assert rewritten["last_active"]["schema_version"] == 1
+    assert rewritten["last_active"]["state"]["state_version"] == 1
+    assert "slice_index" not in rewritten["last_active"]["state"]
+
+
+def test_explore_state_rejects_mismatched_identity_and_future_schema(
+    tmp_path: Path,
+) -> None:
+    settings = load_settings(home=tmp_path)
+    with pytest.raises(ExploreStateError, match="does not match the owning World"):
+        save_last_active_explore_state(
+            settings,
+            world_id="trade_cumulus",
+            simulation_id="trade_cumulus_canonical_bomex",
+            state=mountain_state(),
+        )
+
+    path = tmp_path / "explore-state" / "trade_cumulus" / "trade_cumulus_canonical_bomex.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "world_id": "trade_cumulus",
+                "simulation_id": "trade_cumulus_canonical_bomex",
+                "last_active": None,
+                "saved_views": [],
+            }
+        )
+    )
+
+    with pytest.raises(ExploreStateError, match="unsupported schema"):
+        load_explore_state_library(
+            settings,
+            world_id="trade_cumulus",
+            simulation_id="trade_cumulus_canonical_bomex",
+        )
+
+
+def test_explore_state_rejects_unsafe_identity(tmp_path: Path) -> None:
+    settings = load_settings(home=tmp_path)
+
+    with pytest.raises(ExploreStateError, match="Simulation identity is invalid"):
+        load_explore_state_library(
+            settings,
+            world_id="supercells",
+            simulation_id="../outside",
+        )

--- a/app/backend/tests/test_visualization_data.py
+++ b/app/backend/tests/test_visualization_data.py
@@ -1008,6 +1008,11 @@ def test_horizontal_qc_slice_uses_json_values_and_counts_non_finite(
     assert sliced.selection.level_meters == 400.0
     assert sliced.shape == [3, 4]
     assert sliced.dimension_order == ["yh", "xh"]
+    assert sliced.coordinate_values == {
+        "zh": [0.4, 0.8],
+        "yh": [0.0, 1.0, 2.0],
+        "xh": [0.0, 1.0, 2.0, 3.0],
+    }
     assert sliced.data_encoding == "json"
     assert sliced.values[0][0] is None
     assert sliced.stats.non_finite_count == 1
@@ -1039,9 +1044,15 @@ def test_vertical_qc_slices_have_stable_shape_and_order(tmp_path: Path) -> None:
     assert vertical_x.selection.selected_dimension == "yh"
     assert vertical_x.shape == [2, 4]
     assert vertical_x.dimension_order == ["zh", "xh"]
+    assert vertical_x.coordinate_values == {
+        "zh": [0.4, 0.8],
+        "yh": [0.0, 1.0, 2.0],
+        "xh": [0.0, 1.0, 2.0, 3.0],
+    }
     assert vertical_y.selection.selected_dimension == "xh"
     assert vertical_y.shape == [2, 3]
     assert vertical_y.dimension_order == ["zh", "yh"]
+    assert vertical_y.coordinate_values == vertical_x.coordinate_values
 
 
 def test_temperature_slice_is_available_when_direct_temperature_exists(tmp_path: Path) -> None:
@@ -1120,6 +1131,7 @@ def test_w_slice_uses_native_zf_grid(tmp_path: Path) -> None:
     assert sliced.selection.time_seconds == 900.0
     assert sliced.selection.level_coordinate_value == 0.8
     assert sliced.selection.level_meters == 800.0
+    assert sliced.coordinate_values["zf"] == [0.0, 0.4, 0.8]
     assert sliced.shape == [3, 4]
     assert sliced.stats.min == 60.0
     assert sliced.stats.max == 71.0

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -1235,6 +1235,37 @@ export async function mockCloudChamberApis(page: Page) {
       updated_at: string;
     }
   >();
+  type MockExploreLibrary = {
+    schema_version: 1;
+    world_id: string;
+    simulation_id: string;
+    last_active: Record<string, unknown> | null;
+    saved_views: Array<Record<string, unknown>>;
+  };
+  const exploreLibraries = new Map<string, MockExploreLibrary>();
+  let savedViewSequence = 0;
+  const exploreIdentity = (requestUrl: string) => {
+    const segments = new URL(requestUrl).pathname.split("/");
+    const worldId = (segments[3] ?? "").replaceAll("-", "_");
+    const simulationId = decodeURIComponent(segments[5] ?? "");
+    return { worldId, simulationId, key: `${worldId}/${simulationId}` };
+  };
+  const exploreLibrary = (requestUrl: string) => {
+    const { worldId, simulationId, key } = exploreIdentity(requestUrl);
+    const existing = exploreLibraries.get(key);
+    if (existing) return existing;
+    const created: MockExploreLibrary = {
+      schema_version: 1,
+      world_id: worldId,
+      simulation_id: simulationId,
+      last_active: null,
+      saved_views: [],
+    };
+    exploreLibraries.set(key, created);
+    return created;
+  };
+  const exploreResponse = (route: Parameters<typeof json>[0], library: MockExploreLibrary) =>
+    json(route, { library, backing_simulation_available: true });
   let savedSoundingCandidates: Array<{
     saved_candidate_id: string;
     candidate: typeof shallowSoundingCandidate;
@@ -1283,6 +1314,76 @@ export async function mockCloudChamberApis(page: Page) {
       }
     }
     return json(route, { note: simulationNotes.get(key) ?? null });
+  });
+
+  await page.route("**/api/worlds/*/simulations/*/explore-state", (route) =>
+    exploreResponse(route, exploreLibrary(route.request().url())),
+  );
+
+  await page.route("**/api/worlds/*/simulations/*/explore-state/resume", (route) => {
+    const library = exploreLibrary(route.request().url());
+    const { worldId, simulationId } = exploreIdentity(route.request().url());
+    const request = route.request().postDataJSON() as { state: Record<string, unknown> };
+    library.last_active = {
+      schema_version: 1,
+      world_id: worldId,
+      simulation_id: simulationId,
+      captured_at: "2026-07-26T18:00:00Z",
+      state: request.state,
+    };
+    return exploreResponse(route, library);
+  });
+
+  await page.route("**/api/worlds/*/simulations/*/saved-views**", (route) => {
+    const library = exploreLibrary(route.request().url());
+    const { worldId, simulationId } = exploreIdentity(route.request().url());
+    const segments = new URL(route.request().url()).pathname.split("/");
+    const savedViewId = decodeURIComponent(segments[7] ?? "");
+    const method = route.request().method();
+    if (method === "POST") {
+      const request = route.request().postDataJSON() as {
+        title: string;
+        description?: string | null;
+        state: Record<string, unknown>;
+      };
+      savedViewSequence += 1;
+      const now = "2026-07-26T18:00:00Z";
+      library.saved_views.push({
+        saved_view_id: savedViewSequence.toString(16).padStart(32, "0"),
+        title: request.title,
+        description: request.description ?? null,
+        created_at: now,
+        updated_at: now,
+        restoration_status: "healthy",
+        restoration_message: null,
+        snapshot: {
+          schema_version: 1,
+          world_id: worldId,
+          simulation_id: simulationId,
+          captured_at: now,
+          state: request.state,
+        },
+      });
+      return exploreResponse(route, library);
+    }
+    const savedViewIndex = library.saved_views.findIndex(
+      (candidate) => candidate.saved_view_id === savedViewId,
+    );
+    if (savedViewIndex < 0) return json(route, { detail: "Saved View not found." }, 404);
+    if (method === "DELETE") {
+      library.saved_views.splice(savedViewIndex, 1);
+      return exploreResponse(route, library);
+    }
+    if (method === "PATCH") {
+      const request = route.request().postDataJSON() as Record<string, unknown>;
+      library.saved_views[savedViewIndex] = {
+        ...library.saved_views[savedViewIndex],
+        ...request,
+        updated_at: "2026-07-26T18:01:00Z",
+      };
+      return exploreResponse(route, library);
+    }
+    return exploreResponse(route, library);
   });
 
   await page.route("**/api/worlds", (route) => json(route, []));

--- a/app/frontend/e2e/mocked-smoke/supercells.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/supercells.spec.ts
@@ -226,6 +226,17 @@ test.describe("mocked smoke: Supercells product path", () => {
     await expect(page.getByRole("button", { name: "Previous saved output" })).toBeInViewport();
     await expect(page.getByRole("button", { name: "Next saved output" })).toBeInViewport();
     await expect(page.getByRole("button", { name: "Play" })).toBeInViewport();
+
+    await page.locator("summary", { hasText: "Saved Views" }).click();
+    const savedViews = page.getByRole("region", { name: "Saved Views" });
+    await savedViews.getByLabel("Title", { exact: true }).fill("Narrow desktop examination");
+    await savedViews
+      .getByLabel("Description optional", { exact: true })
+      .fill("Verifies that the 3-D canvas cannot cover Saved View actions.");
+    await savedViews.getByRole("button", { name: "Save current view" }).click();
+    await expect(
+      savedViews.getByRole("heading", { name: "Narrow desktop examination" }),
+    ).toBeVisible();
   });
 });
 

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -5087,6 +5087,7 @@ details[open] > summary {
 
   .integrated-explore-actions {
     display: flex;
+    align-items: center;
     gap: 0.4rem;
   }
 
@@ -5505,6 +5506,178 @@ details[open] > summary {
     background: var(--color-surface);
     color: var(--color-accent-primary);
     box-shadow: none;
+  }
+
+  .saved-views-control {
+    position: relative;
+  }
+
+  .saved-views-control > summary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    min-height: 2.15rem;
+    box-sizing: border-box;
+    border: 1px solid var(--color-border-strong);
+    border-radius: 6px;
+    padding: 0.42rem 0.75rem;
+    background: var(--color-surface);
+    color: var(--color-accent-primary);
+    font-weight: 750;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .saved-views-summary-error {
+    color: var(--color-danger);
+    font-size: 0.72rem;
+  }
+
+  .saved-views-control > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .saved-views-control[open] > summary {
+    border-color: var(--color-accent-primary);
+    background: var(--color-accent-soft);
+  }
+
+  .saved-views-popover {
+    position: absolute;
+    z-index: 30;
+    top: calc(100% + 0.45rem);
+    right: 0;
+    display: grid;
+    width: min(28rem, calc(100vw - 2rem));
+    max-height: min(42rem, calc(100vh - 5rem));
+    gap: 0.8rem;
+    overflow: auto;
+    box-sizing: border-box;
+    border: 1px solid var(--color-border-strong);
+    border-radius: 6px;
+    padding: 1rem;
+    background: var(--color-surface);
+    box-shadow: 0 12px 28px rgb(31 52 68 / 18%);
+    color: var(--color-text-primary);
+  }
+
+  .saved-views-popover > header,
+  .saved-view-item-heading,
+  .saved-view-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.65rem;
+  }
+
+  .saved-views-popover h3,
+  .saved-views-popover h4,
+  .saved-views-popover p {
+    margin: 0;
+  }
+
+  .saved-views-popover h3 {
+    font-size: 1rem;
+  }
+
+  .saved-views-popover h4 {
+    font-size: 0.9rem;
+  }
+
+  .saved-views-resume-state,
+  .saved-view-status {
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+    font-weight: 750;
+    white-space: nowrap;
+  }
+
+  .saved-view-status-partially_restorable {
+    color: var(--color-warning);
+  }
+
+  .saved-view-status-unavailable,
+  .saved-views-action-message-error {
+    color: var(--color-danger);
+  }
+
+  .saved-view-create-form,
+  .saved-view-edit-form,
+  .saved-view-create-form label,
+  .saved-view-edit-form label {
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .saved-view-create-form,
+  .saved-view-edit-form {
+    gap: 0.65rem;
+  }
+
+  .saved-view-create-form label,
+  .saved-view-edit-form label {
+    color: var(--color-text-muted);
+    font-size: 0.76rem;
+    font-weight: 700;
+  }
+
+  .saved-view-create-form label span {
+    font-weight: 500;
+  }
+
+  .saved-view-create-form input,
+  .saved-view-create-form textarea,
+  .saved-view-edit-form input,
+  .saved-view-edit-form textarea {
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .saved-view-list {
+    border-top: 1px solid var(--color-border);
+  }
+
+  .saved-view-item {
+    display: grid;
+    gap: 0.45rem;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0.75rem 0;
+  }
+
+  .saved-view-item-heading {
+    align-items: flex-start;
+  }
+
+  .saved-view-item-heading > div {
+    min-width: 0;
+  }
+
+  .saved-view-item-heading p,
+  .saved-view-item > p,
+  .saved-view-item > small,
+  .saved-view-empty,
+  .saved-views-action-message {
+    color: var(--color-text-muted);
+    font-size: 0.78rem;
+  }
+
+  .saved-view-actions {
+    justify-content: flex-start;
+  }
+
+  .saved-view-actions button {
+    padding: 0.35rem 0.58rem;
+    font-size: 0.75rem;
+  }
+
+  .saved-view-actions .danger-button {
+    margin-left: auto;
+    color: #ffffff;
+  }
+
+  .saved-views-error {
+    display: grid;
+    gap: 0.5rem;
   }
 
   .integrated-explore-workspace .visualizer-shell:has(> .explore-curated-default-notice),

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -5412,6 +5412,179 @@ details[open] > summary {
   color: var(--color-text-primary);
 }
 
+.saved-views-control {
+  position: relative;
+  z-index: 40;
+}
+
+.saved-views-control > summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 2.15rem;
+  box-sizing: border-box;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 6px;
+  padding: 0.42rem 0.75rem;
+  background: var(--color-surface);
+  color: var(--color-accent-primary);
+  font-weight: 750;
+  cursor: pointer;
+  list-style: none;
+}
+
+.saved-views-summary-error {
+  color: var(--color-danger);
+  font-size: 0.72rem;
+}
+
+.saved-views-control > summary::-webkit-details-marker {
+  display: none;
+}
+
+.saved-views-control[open] > summary {
+  border-color: var(--color-accent-primary);
+  background: var(--color-accent-soft);
+}
+
+.saved-views-popover {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 0.45rem);
+  right: 0;
+  display: grid;
+  width: min(28rem, calc(100vw - 2rem));
+  max-height: min(42rem, calc(100vh - 5rem));
+  gap: 0.8rem;
+  overflow: auto;
+  box-sizing: border-box;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 6px;
+  padding: 1rem;
+  background: var(--color-surface);
+  box-shadow: 0 12px 28px rgb(31 52 68 / 18%);
+  color: var(--color-text-primary);
+}
+
+.saved-views-popover > header,
+.saved-view-item-heading,
+.saved-view-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+}
+
+.saved-views-popover h3,
+.saved-views-popover h4,
+.saved-views-popover p {
+  margin: 0;
+}
+
+.saved-views-popover h3 {
+  font-size: 1rem;
+}
+
+.saved-views-popover h4 {
+  font-size: 0.9rem;
+}
+
+.saved-views-resume-state,
+.saved-view-status {
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.saved-view-status-partially_restorable {
+  color: var(--color-warning);
+}
+
+.saved-view-status-unavailable,
+.saved-views-action-message-error {
+  color: var(--color-danger);
+}
+
+.saved-view-create-form,
+.saved-view-edit-form,
+.saved-view-create-form label,
+.saved-view-edit-form label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.saved-view-create-form,
+.saved-view-edit-form {
+  gap: 0.65rem;
+}
+
+.saved-view-create-form label,
+.saved-view-edit-form label {
+  color: var(--color-text-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.saved-view-create-form label span {
+  font-weight: 500;
+}
+
+.saved-view-create-form input,
+.saved-view-create-form textarea,
+.saved-view-edit-form input,
+.saved-view-edit-form textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.saved-view-list {
+  border-top: 1px solid var(--color-border);
+}
+
+.saved-view-item {
+  display: grid;
+  gap: 0.45rem;
+  border-bottom: 1px solid var(--color-border);
+  padding: 0.75rem 0;
+}
+
+.saved-view-item-heading {
+  align-items: flex-start;
+}
+
+.saved-view-item-heading > div {
+  min-width: 0;
+}
+
+.saved-view-item-heading p,
+.saved-view-item > p,
+.saved-view-item > small,
+.saved-view-empty,
+.saved-views-action-message {
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+}
+
+.saved-view-actions {
+  justify-content: flex-start;
+}
+
+.saved-view-actions button {
+  padding: 0.35rem 0.58rem;
+  font-size: 0.75rem;
+}
+
+.saved-view-actions .danger-button {
+  margin-left: auto;
+  color: #ffffff;
+}
+
+.saved-views-error {
+  display: grid;
+  gap: 0.5rem;
+}
+
 /* Integrated Explore uses a fixed desktop cockpit instead of the legacy stacked workbench. */
 @media (min-width: 1100px) {
   .app-shell-explore {
@@ -5506,178 +5679,6 @@ details[open] > summary {
     background: var(--color-surface);
     color: var(--color-accent-primary);
     box-shadow: none;
-  }
-
-  .saved-views-control {
-    position: relative;
-  }
-
-  .saved-views-control > summary {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    min-height: 2.15rem;
-    box-sizing: border-box;
-    border: 1px solid var(--color-border-strong);
-    border-radius: 6px;
-    padding: 0.42rem 0.75rem;
-    background: var(--color-surface);
-    color: var(--color-accent-primary);
-    font-weight: 750;
-    cursor: pointer;
-    list-style: none;
-  }
-
-  .saved-views-summary-error {
-    color: var(--color-danger);
-    font-size: 0.72rem;
-  }
-
-  .saved-views-control > summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .saved-views-control[open] > summary {
-    border-color: var(--color-accent-primary);
-    background: var(--color-accent-soft);
-  }
-
-  .saved-views-popover {
-    position: absolute;
-    z-index: 30;
-    top: calc(100% + 0.45rem);
-    right: 0;
-    display: grid;
-    width: min(28rem, calc(100vw - 2rem));
-    max-height: min(42rem, calc(100vh - 5rem));
-    gap: 0.8rem;
-    overflow: auto;
-    box-sizing: border-box;
-    border: 1px solid var(--color-border-strong);
-    border-radius: 6px;
-    padding: 1rem;
-    background: var(--color-surface);
-    box-shadow: 0 12px 28px rgb(31 52 68 / 18%);
-    color: var(--color-text-primary);
-  }
-
-  .saved-views-popover > header,
-  .saved-view-item-heading,
-  .saved-view-actions {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.65rem;
-  }
-
-  .saved-views-popover h3,
-  .saved-views-popover h4,
-  .saved-views-popover p {
-    margin: 0;
-  }
-
-  .saved-views-popover h3 {
-    font-size: 1rem;
-  }
-
-  .saved-views-popover h4 {
-    font-size: 0.9rem;
-  }
-
-  .saved-views-resume-state,
-  .saved-view-status {
-    color: var(--color-text-muted);
-    font-size: 0.72rem;
-    font-weight: 750;
-    white-space: nowrap;
-  }
-
-  .saved-view-status-partially_restorable {
-    color: var(--color-warning);
-  }
-
-  .saved-view-status-unavailable,
-  .saved-views-action-message-error {
-    color: var(--color-danger);
-  }
-
-  .saved-view-create-form,
-  .saved-view-edit-form,
-  .saved-view-create-form label,
-  .saved-view-edit-form label {
-    display: grid;
-    gap: 0.35rem;
-  }
-
-  .saved-view-create-form,
-  .saved-view-edit-form {
-    gap: 0.65rem;
-  }
-
-  .saved-view-create-form label,
-  .saved-view-edit-form label {
-    color: var(--color-text-muted);
-    font-size: 0.76rem;
-    font-weight: 700;
-  }
-
-  .saved-view-create-form label span {
-    font-weight: 500;
-  }
-
-  .saved-view-create-form input,
-  .saved-view-create-form textarea,
-  .saved-view-edit-form input,
-  .saved-view-edit-form textarea {
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .saved-view-list {
-    border-top: 1px solid var(--color-border);
-  }
-
-  .saved-view-item {
-    display: grid;
-    gap: 0.45rem;
-    border-bottom: 1px solid var(--color-border);
-    padding: 0.75rem 0;
-  }
-
-  .saved-view-item-heading {
-    align-items: flex-start;
-  }
-
-  .saved-view-item-heading > div {
-    min-width: 0;
-  }
-
-  .saved-view-item-heading p,
-  .saved-view-item > p,
-  .saved-view-item > small,
-  .saved-view-empty,
-  .saved-views-action-message {
-    color: var(--color-text-muted);
-    font-size: 0.78rem;
-  }
-
-  .saved-view-actions {
-    justify-content: flex-start;
-  }
-
-  .saved-view-actions button {
-    padding: 0.35rem 0.58rem;
-    font-size: 0.75rem;
-  }
-
-  .saved-view-actions .danger-button {
-    margin-left: auto;
-    color: #ffffff;
-  }
-
-  .saved-views-error {
-    display: grid;
-    gap: 0.5rem;
   }
 
   .integrated-explore-workspace .visualizer-shell:has(> .explore-curated-default-notice),

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -2985,7 +2985,12 @@ function sliceResponse({
             : ([0.4, 0.8, 1.2][levelIndex] ?? 0.8) * 1000
           : null,
     },
-    coordinate_units: isVertical ? { zh: "km", xh: "km" } : { yh: "km", xh: "km" },
+    coordinate_units: isSurface ? { yh: "km", xh: "km" } : { zh: "km", yh: "km", xh: "km" },
+    coordinate_values: {
+      zh: [0.4, 0.8, 1.2],
+      yh: [-3.2, 0, 3.2],
+      xh: [-3.2, 0, 3.2],
+    },
     shape: [2, 3],
     dimension_order: isVertical ? ["zh", "xh"] : ["yh", "xh"],
     data_encoding: "json",
@@ -7965,7 +7970,7 @@ describe("App", () => {
       active_slice_plane: "vertical_x",
       slice_coordinate_km: 0.05,
       slice_native_index: 1,
-      horizontal_slice_coordinate_km: 0.8,
+      horizontal_slice_coordinate_km: 0.3,
       threshold_native: 0.000001,
       layer_opacity: 0.5,
       point_size_px: 9,
@@ -8029,6 +8034,357 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "Show Context" })).toBeVisible();
     expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute("aria-selected", "true");
   });
+
+  it("keeps a user edit made before delayed Trade Cumulus startup state arrives", async () => {
+    mockTradeCumulusVisualizer();
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let resolveStartupState!: (response: Response) => void;
+    const startupState = new Promise<Response>((resolve) => {
+      resolveStartupState = resolve;
+    });
+    const resumeState = {
+      state_version: 1,
+      world_id: "trade_cumulus",
+      model_time_seconds: 900,
+      context_collapsed: true,
+      secondary_section: "details",
+      selected_point: null,
+      view_id: "updraft_lens",
+      scene_field_id: "ql",
+      slice_field_id: "ql",
+      fixed_scale_id: "trade_cumulus_updraft_velocity_v1",
+      active_slice_plane: "vertical_x",
+      slice_coordinate_km: 0.05,
+      slice_native_index: 1,
+      horizontal_slice_coordinate_km: 0.3,
+      threshold_native: 0.000001,
+      layer_opacity: 0.5,
+      point_size_px: 9,
+      lens_opacity: 0.7,
+      show_slice_plane: true,
+      show_cloud_boundary: true,
+      show_horizontal_wind: false,
+      wind_mode: "total",
+      camera_preset: "look_along_x",
+      camera_transform: null,
+      playback_speed: 2,
+      display_controls_open: false,
+    };
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url ===
+          "/api/worlds/trade-cumulus/simulations/trade_cumulus_canonical_bomex/explore-state" &&
+        !init?.method
+      ) {
+        return startupState;
+      }
+      if (url.includes("/explore-state") || url.includes("/saved-views")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              library: {
+                schema_version: 1,
+                world_id: "trade_cumulus",
+                simulation_id: "trade_cumulus_canonical_bomex",
+                last_active: null,
+                saved_views: [],
+              },
+              backing_simulation_available: true,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(
+      <VisualizerSceneShell
+        result={
+          tradeCumulusResultCard as unknown as Parameters<typeof VisualizerSceneShell>[0]["result"]
+        }
+        worldName="Trade Cumulus"
+        simulationName="Canonical BOMEX Baseline"
+        simulationRecord={worldBaselineSimulation}
+      />,
+    );
+
+    const fieldButton = await screen.findByRole("button", { name: "Field" });
+    fireEvent.click(fieldButton);
+    expect(fieldButton).toHaveAttribute("aria-pressed", "true");
+
+    act(() =>
+      resolveStartupState(
+        new Response(
+          JSON.stringify({
+            library: {
+              schema_version: 1,
+              world_id: "trade_cumulus",
+              simulation_id: "trade_cumulus_canonical_bomex",
+              last_active: {
+                schema_version: 1,
+                world_id: "trade_cumulus",
+                simulation_id: "trade_cumulus_canonical_bomex",
+                captured_at: "2026-07-26T12:00:00Z",
+                state: resumeState,
+              },
+              saved_views: [],
+            },
+            backing_simulation_available: true,
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("Loading Saved Views...")).not.toBeInTheDocument(),
+    );
+
+    expect(fieldButton).toHaveAttribute("aria-pressed", "true");
+    expect(screen.queryByText("Last active view restored.")).not.toBeInTheDocument();
+  });
+
+  it("captures a selected direct Field cell in physical native-grid coordinates", async () => {
+    mockTradeCumulusVisualizer();
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    let postedState: Record<string, unknown> | null = null;
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/explore-state")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              library: {
+                schema_version: 1,
+                world_id: "trade_cumulus",
+                simulation_id: "trade_cumulus_canonical_bomex",
+                last_active: null,
+                saved_views: [],
+              },
+              backing_simulation_available: true,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (url.includes("/saved-views") && init?.method === "POST") {
+        postedState = JSON.parse(String(init.body)).state as Record<string, unknown>;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              library: {
+                schema_version: 1,
+                world_id: "trade_cumulus",
+                simulation_id: "trade_cumulus_canonical_bomex",
+                last_active: null,
+                saved_views: [],
+              },
+              backing_simulation_available: true,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(
+      <VisualizerSceneShell
+        result={
+          tradeCumulusResultCard as unknown as Parameters<typeof VisualizerSceneShell>[0]["result"]
+        }
+        worldName="Trade Cumulus"
+        simulationName="Canonical BOMEX Baseline"
+        simulationRecord={worldBaselineSimulation}
+      />,
+    );
+
+    const viewMode = await screen.findByLabelText("Explore view mode");
+    await waitFor(() =>
+      expect(within(viewMode).getByRole("button", { name: "Updraft Lens" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      ),
+    );
+    fireEvent.click(within(viewMode).getByRole("button", { name: "Field" }));
+    await waitFor(() =>
+      expect(within(viewMode).getByRole("button", { name: "Field" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Vertical x-z slice" }));
+    const heatmap = await screen.findByRole("img", { name: /Vertical x-z slice at y = .* heatmap/ });
+    fireEvent.click(within(heatmap).getByRole("button", { name: /row 1, column 2/i }));
+    expect(await screen.findByRole("heading", { name: "Native-grid evidence" })).toBeVisible();
+
+    fireEvent.click(screen.getByText(/^Saved Views/, { selector: "summary" }));
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Direct Field cell" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save current view" }));
+    await waitFor(() => expect(postedState).not.toBeNull());
+
+    expect(postedState).toMatchObject({
+      view_id: "field",
+      active_slice_plane: "vertical_x",
+      selected_point: {
+        x_km: 0,
+        y_km: 0,
+        z_km: 0.4,
+      },
+    });
+  });
+
+  it.each([
+    {
+      label: "horizontal",
+      activePlane: "horizontal" as const,
+      savedPlaneCoordinateKm: 0.8,
+      savedNativeIndex: 0,
+      expectedIndex: "1",
+    },
+    {
+      label: "vertical",
+      activePlane: "vertical_x" as const,
+      savedPlaneCoordinateKm: 0.1,
+      savedNativeIndex: 0,
+      expectedIndex: "1",
+    },
+  ])(
+    "restores a selected direct Field cell by physical coordinates after the $label inventory changes",
+    async ({
+      activePlane,
+      savedPlaneCoordinateKm,
+      savedNativeIndex,
+      expectedIndex,
+    }) => {
+      mockTradeCumulusVisualizer();
+      const defaultFetch = vi.mocked(fetch).getMockImplementation();
+      const resumeState = {
+        state_version: 1,
+        world_id: "trade_cumulus",
+        model_time_seconds: 900,
+        context_collapsed: false,
+        secondary_section: "explain",
+        selected_point: { x_km: 0.1, y_km: 0.1, z_km: 0.8 },
+        view_id: "field",
+        scene_field_id: "ql",
+        slice_field_id: "ql",
+        fixed_scale_id: null,
+        active_slice_plane: activePlane,
+        slice_coordinate_km: savedPlaneCoordinateKm,
+        slice_native_index: savedNativeIndex,
+        horizontal_slice_coordinate_km: 0.8,
+        threshold_native: 0.000001,
+        layer_opacity: 0.68,
+        point_size_px: 11,
+        lens_opacity: 1,
+        show_slice_plane: true,
+        show_cloud_boundary: true,
+        show_horizontal_wind: true,
+        wind_mode: "perturbation",
+        camera_preset: "overview",
+        camera_transform: null,
+        playback_speed: 1,
+        display_controls_open: false,
+      };
+      vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (
+          url ===
+            "/api/worlds/trade-cumulus/simulations/trade_cumulus_canonical_bomex/explore-state" &&
+          !init?.method
+        ) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                library: {
+                  schema_version: 1,
+                  world_id: "trade_cumulus",
+                  simulation_id: "trade_cumulus_canonical_bomex",
+                  last_active: {
+                    schema_version: 1,
+                    world_id: "trade_cumulus",
+                    simulation_id: "trade_cumulus_canonical_bomex",
+                    captured_at: "2026-07-26T12:00:00Z",
+                    state: resumeState,
+                  },
+                  saved_views: [],
+                },
+                backing_simulation_available: true,
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        if (url.includes("/api/results/result-trade-cumulus/visualization/slice")) {
+          const parsed = new URL(url, "http://localhost");
+          const orientation = parsed.searchParams.get("orientation");
+          const selectedIndex = Number(parsed.searchParams.get("level_index") ?? 0);
+          const response = tradeCumulusSliceResponse(url);
+          const coordinateValues =
+            orientation === "horizontal"
+              ? {
+                  zh: [0.2, 0.8, 1.4],
+                  yh: [0, 0.1],
+                  xh: [-3.1, 0.1, 3.3],
+                }
+              : {
+                  zh: [0.2, 0.8],
+                  yh: [-0.4, 0.1],
+                  xh: [-3.1, 0.1, 3.3],
+                };
+          const selectedDimension = orientation === "horizontal" ? "zh" : "yh";
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                ...response,
+                selection: {
+                  ...response.selection,
+                  selected_dimension: selectedDimension,
+                  selected_index: selectedIndex,
+                  selected_coordinate_value:
+                    coordinateValues[selectedDimension][selectedIndex] ?? null,
+                  level_units: "km",
+                  level_coordinate_value:
+                    orientation === "horizontal"
+                      ? (coordinateValues.zh[selectedIndex] ?? null)
+                      : null,
+                },
+                coordinate_units: { zh: "km", yh: "km", xh: "km" },
+                coordinate_values: coordinateValues,
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        return (
+          defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+        );
+      });
+
+      render(
+        <VisualizerSceneShell
+          result={
+            tradeCumulusResultCard as unknown as Parameters<typeof VisualizerSceneShell>[0]["result"]
+          }
+          worldName="Trade Cumulus"
+          simulationName="Canonical BOMEX Baseline"
+          simulationRecord={worldBaselineSimulation}
+        />,
+      );
+
+      expect(await screen.findByText(/Last active view restored with adjustments/)).toBeVisible();
+      expect(screen.getByLabelText("Slice position")).toHaveValue(expectedIndex);
+      const selectedEvidence = await screen.findByRole("heading", { name: "Native-grid evidence" });
+      expect(selectedEvidence).toBeVisible();
+      expect(screen.getByText("x index 1 · y index 1 · z index 1")).toBeVisible();
+    },
+  );
 
   it("announces a Trade restoration only after target evidence loads and clears success on edit", async () => {
     let targetRequestCount = 0;

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -7948,6 +7948,88 @@ describe("App", () => {
     expect(screen.getByLabelText("Point size")).toHaveValue("11");
   });
 
+  it("resumes the last coherent Trade Cumulus examination after reload", async () => {
+    mockTradeCumulusVisualizer();
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    const resumeState = {
+      state_version: 1,
+      world_id: "trade_cumulus",
+      model_time_seconds: 900,
+      context_collapsed: true,
+      secondary_section: "details",
+      selected_point: null,
+      view_id: "updraft_lens",
+      scene_field_id: "ql",
+      slice_field_id: "ql",
+      fixed_scale_id: "trade_cumulus_updraft_velocity_v1",
+      active_slice_plane: "vertical_x",
+      slice_coordinate_km: 0.05,
+      slice_native_index: 1,
+      horizontal_slice_coordinate_km: 0.8,
+      threshold_native: 0.000001,
+      layer_opacity: 0.5,
+      point_size_px: 9,
+      lens_opacity: 0.7,
+      show_slice_plane: true,
+      show_cloud_boundary: true,
+      show_horizontal_wind: false,
+      wind_mode: "total",
+      camera_preset: "look_along_x",
+      camera_transform: null,
+      playback_speed: 2,
+      display_controls_open: false,
+    };
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/api/worlds/trade-cumulus/simulations/trade_cumulus_canonical_bomex/explore-state"
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              library: {
+                schema_version: 1,
+                world_id: "trade_cumulus",
+                simulation_id: "trade_cumulus_canonical_bomex",
+                last_active: {
+                  schema_version: 1,
+                  world_id: "trade_cumulus",
+                  simulation_id: "trade_cumulus_canonical_bomex",
+                  captured_at: "2026-07-26T12:00:00Z",
+                  state: resumeState,
+                },
+                saved_views: [],
+              },
+              backing_simulation_available: true,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(
+      <VisualizerSceneShell
+        result={
+          tradeCumulusResultCard as unknown as Parameters<typeof VisualizerSceneShell>[0]["result"]
+        }
+        worldName="Trade Cumulus"
+        simulationName="Canonical BOMEX Baseline"
+        simulationRecord={worldBaselineSimulation}
+      />,
+    );
+
+    expect(await screen.findByText("Last active view restored.")).toBeVisible();
+    expect(screen.getByLabelText("Time")).toHaveValue("1");
+    expect(screen.getByLabelText("Updraft Lens slice position")).toHaveValue("1");
+    expect(screen.getByLabelText("Horizontal wind")).not.toBeChecked();
+    expect(screen.getByRole("button", { name: "Show Context" })).toBeVisible();
+    expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute("aria-selected", "true");
+  });
+
   it("announces a Trade restoration only after target evidence loads and clears success on edit", async () => {
     let targetRequestCount = 0;
     let resolveRestore: ((response: Response) => void) | undefined;

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -20,6 +20,15 @@ import {
   type ExploreSecondarySection,
 } from "./IntegratedExploreWorkspace";
 import {
+  nearestSavedCoordinate,
+  SavedViewsControl,
+  useExploreStateLibrary,
+  type ExploreRestorationResult,
+  type ExploreWorldState,
+  type SavedViewRecord,
+  type TradeCumulusExploreState,
+} from "./ExploreStatePersistence";
+import {
   curatedResolutionExplanation,
   resolveCuratedView,
   TRADE_CUMULUS_INITIAL_VIEW,
@@ -11418,6 +11427,14 @@ type PendingTradeCuratedRestore = {
   source: "initial" | "return";
 };
 
+type PendingTradeSavedRestore = {
+  state: TradeCumulusExploreState;
+  result: ExploreRestorationResult;
+  savedViewId: string | null;
+  timeIndex: number;
+  planeIndex: number;
+};
+
 export function VisualizerSceneShell({
   result,
   worldName,
@@ -11476,6 +11493,9 @@ export function VisualizerSceneShell({
   const [curatedNotice, setCuratedNotice] = useState<ExploreCuratedNotice | null>(null);
   const [pendingCuratedRestore, setPendingCuratedRestore] =
     useState<PendingTradeCuratedRestore | null>(null);
+  const [pendingSavedRestore, setPendingSavedRestore] = useState<PendingTradeSavedRestore | null>(
+    null,
+  );
   const [pointCloud, setPointCloud] = useState<PointCloudResponse | null>(null);
   const [showSlicePlanes, setShowSlicePlanes] = useState(true);
   const [sliceFieldName, setSliceFieldName] = useState("qc");
@@ -11515,6 +11535,12 @@ export function VisualizerSceneShell({
   const autoActivatedUpdraftLensResultRef = useRef<string | null>(null);
   const initialCuratedResultRef = useRef<string | null>(null);
   const curatedNoticeSignatureRef = useRef<string | null>(null);
+  const exploreState = useExploreStateLibrary(
+    isTradeCumulusWorldExplore ? "trade_cumulus" : null,
+    isTradeCumulusWorldExplore ? (simulationRecord?.simulation_id ?? null) : null,
+  );
+  const saveExploreResume = exploreState.saveResume;
+  const updateExploreSavedView = exploreState.updateSavedView;
   const maxPoints = 50_000;
 
   useEffect(() => {
@@ -11540,6 +11566,7 @@ export function VisualizerSceneShell({
     setSecondarySection("science");
     setCuratedNotice(null);
     setPendingCuratedRestore(null);
+    setPendingSavedRestore(null);
     setPointCloud(null);
     setShowSlicePlanes(true);
     setSliceFieldName("qc");
@@ -11780,6 +11807,120 @@ export function VisualizerSceneShell({
       ? { label: "Rain-water onset", seconds: result.first_rain_time_seconds }
       : null,
   ].filter((preset): preset is { label: string; seconds: number } => preset !== null);
+  const capturedExploreState = useMemo<TradeCumulusExploreState | null>(() => {
+    if (!isTradeCumulusWorldExplore || !simulationRecord?.simulation_id) return null;
+    const modelTimeSeconds = Number(displayTimeValue);
+    const planeCoordinateKm = updraftLensActive
+      ? coordinateKilometers(
+          updraftLensFrame?.plane_coordinate ?? null,
+          updraftLensFrame?.plane_units ?? null,
+        )
+      : coordinateKilometers(
+          activeSlice?.selection.selected_coordinate_value ??
+            activeSlice?.selection.level_coordinate_value ??
+            null,
+          activeSlice?.selection.level_units ?? null,
+        );
+    if (
+      !Number.isFinite(modelTimeSeconds) ||
+      planeCoordinateKm === null ||
+      !selectedFieldName ||
+      !sliceFieldName
+    ) {
+      return null;
+    }
+    let selectedPoint: TradeCumulusExploreState["selected_point"] = null;
+    if (
+      updraftLensFrame &&
+      selectedRegion?.xIndex !== undefined &&
+      selectedRegion.yIndex !== undefined &&
+      selectedRegion.zIndex !== undefined
+    ) {
+      const xPosition = updraftLensFrame.x_indices.indexOf(selectedRegion.xIndex);
+      const yPosition = updraftLensFrame.y_indices.indexOf(selectedRegion.yIndex);
+      const zPosition = updraftLensFrame.z_indices.indexOf(selectedRegion.zIndex);
+      const xKm = updraftLensFrame.x_values_km[xPosition];
+      const yKm = updraftLensFrame.y_values_km[yPosition];
+      const zKm = updraftLensFrame.z_values_km[zPosition];
+      if (Number.isFinite(xKm) && Number.isFinite(yKm) && Number.isFinite(zKm)) {
+        selectedPoint = { x_km: xKm, y_km: yKm, z_km: zKm };
+      }
+    }
+    return {
+      state_version: 1,
+      world_id: "trade_cumulus",
+      model_time_seconds: modelTimeSeconds,
+      context_collapsed: contextCollapsed,
+      secondary_section: secondarySection,
+      selected_point: selectedPoint,
+      view_id: updraftLensActive ? "updraft_lens" : "field",
+      scene_field_id: selectedFieldName,
+      slice_field_id: sliceFieldName,
+      fixed_scale_id: updraftLensActive
+        ? (updraftLensFrame?.w_scale_id ?? updraftLensDefaults?.w_scale_id ?? null)
+        : null,
+      active_slice_plane: activeSlicePlane,
+      slice_coordinate_km: planeCoordinateKm,
+      slice_native_index: activeSliceIndex,
+      horizontal_slice_coordinate_km: coordinateKilometers(
+        sceneHorizontalSlice?.selection.level_coordinate_value ?? null,
+        sceneHorizontalSlice?.selection.level_units ?? null,
+      ),
+      threshold_native: threshold,
+      layer_opacity: opacity,
+      point_size_px: pointSize,
+      lens_opacity: updraftLensOpacity,
+      show_slice_plane: showSlicePlanes,
+      show_cloud_boundary: showUpdraftLensBoundary,
+      show_horizontal_wind: showUpdraftLensWind,
+      wind_mode: updraftLensWindMode,
+      camera_preset: cameraPreset,
+      camera_transform: cameraTransform,
+      playback_speed: playbackSpeed,
+      display_controls_open: displayControlsOpen,
+    };
+  }, [
+    activeSlice,
+    activeSliceIndex,
+    activeSlicePlane,
+    cameraPreset,
+    cameraTransform,
+    contextCollapsed,
+    displayControlsOpen,
+    displayTimeValue,
+    isTradeCumulusWorldExplore,
+    opacity,
+    playbackSpeed,
+    pointSize,
+    sceneHorizontalSlice,
+    secondarySection,
+    selectedFieldName,
+    selectedRegion,
+    showSlicePlanes,
+    showUpdraftLensBoundary,
+    showUpdraftLensWind,
+    simulationRecord?.simulation_id,
+    sliceFieldName,
+    threshold,
+    updraftLensActive,
+    updraftLensDefaults?.w_scale_id,
+    updraftLensFrame,
+    updraftLensOpacity,
+    updraftLensWindMode,
+  ]);
+  const exploreStateCoherent =
+    capturedExploreState !== null &&
+    !isPlaybackRunning &&
+    !focusedViewer &&
+    !sceneError &&
+    !pointCloudError &&
+    !sliceError &&
+    !updraftLensError &&
+    pointCloudFrameReady &&
+    sliceFrameReady &&
+    updraftLensFrameReady &&
+    !sliceLoading &&
+    !updraftLensLoading;
   const curatedStateSignature = useMemo(
     () =>
       JSON.stringify({
@@ -12066,17 +12207,236 @@ export function VisualizerSceneShell({
     ],
   );
 
+  const applySavedExploreState = useCallback(
+    (
+      savedState: ExploreWorldState,
+      savedView: SavedViewRecord | null,
+    ): ExploreRestorationResult => {
+      if (savedState.world_id !== "trade_cumulus") {
+        const result = {
+          status: "unavailable" as const,
+          message: "This Saved View belongs to another Cloud World.",
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+      const savedSceneField = catalog?.available_fields.find(
+        (field) => field.raw_field_name === savedState.scene_field_id,
+      );
+      const savedSliceField = catalog?.available_fields.find(
+        (field) => field.raw_field_name === savedState.slice_field_id,
+      );
+      if (
+        !savedSceneField ||
+        !savedSliceField ||
+        (savedState.view_id === "updraft_lens" && !updraftLensDefaults)
+      ) {
+        const result = {
+          status: "unavailable" as const,
+          message: "A saved Field or Lens is unavailable in the retained output.",
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+      if (
+        savedState.fixed_scale_id &&
+        updraftLensDefaults?.w_scale_id !== savedState.fixed_scale_id
+      ) {
+        const result = {
+          status: "unavailable" as const,
+          message: `The saved scale ${savedState.fixed_scale_id} is unavailable.`,
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+      const timesSeconds = savedSliceField.time_coordinate_values
+        .map((value) => Number(value))
+        .filter((value) => Number.isFinite(value));
+      const mappedTime = nearestSavedCoordinate(timesSeconds, savedState.model_time_seconds, 180);
+      if (!mappedTime) {
+        const result = {
+          status: "unavailable" as const,
+          message: "The saved model time is outside the retained output's compatible range.",
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+
+      const partialMessages: string[] = [];
+      if (!mappedTime.exact) {
+        partialMessages.push(
+          `time ${Math.round(savedState.model_time_seconds).toLocaleString()} s mapped to ${Math.round(mappedTime.value).toLocaleString()} s`,
+        );
+      }
+      let planeIndex = savedState.slice_native_index;
+      const planeCoordinates =
+        savedState.view_id === "updraft_lens" && updraftLensFrame
+          ? savedState.active_slice_plane === "horizontal"
+            ? updraftLensFrame.z_values_km
+            : savedState.active_slice_plane === "vertical_x"
+              ? updraftLensFrame.y_values_km
+              : updraftLensFrame.x_values_km
+          : [];
+      if (planeCoordinates.length > 0) {
+        const mappedPlane = nearestSavedCoordinate(
+          planeCoordinates,
+          savedState.slice_coordinate_km,
+          0.2,
+        );
+        if (!mappedPlane) {
+          const result = {
+            status: "unavailable" as const,
+            message: "The saved physical slice is outside the compatible native-grid range.",
+          };
+          setCuratedNotice({ status: "technical_fallback", message: result.message });
+          return result;
+        }
+        planeIndex = mappedPlane.index;
+        if (!mappedPlane.exact) {
+          partialMessages.push(
+            `slice ${savedState.slice_coordinate_km.toFixed(2)} km mapped to ${mappedPlane.value.toFixed(2)} km`,
+          );
+        }
+      } else if (
+        savedState.slice_native_index < 0 ||
+        savedState.slice_native_index >= Math.max(activeSliceMax, 1)
+      ) {
+        const result = {
+          status: "unavailable" as const,
+          message: "The saved native slice index is unavailable in this retained output.",
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+
+      let nextSelectedRegion: SelectedRegionRequest | null = null;
+      if (savedState.selected_point && updraftLensFrame) {
+        const mappedX = nearestSavedCoordinate(
+          updraftLensFrame.x_values_km,
+          savedState.selected_point.x_km,
+          0.2,
+        );
+        const mappedY = nearestSavedCoordinate(
+          updraftLensFrame.y_values_km,
+          savedState.selected_point.y_km ?? 0,
+          0.2,
+        );
+        const mappedZ = nearestSavedCoordinate(
+          updraftLensFrame.z_values_km,
+          savedState.selected_point.z_km,
+          0.2,
+        );
+        if (mappedX && mappedY && mappedZ) {
+          nextSelectedRegion = {
+            regionType: "point",
+            xIndex: updraftLensFrame.x_indices[mappedX.index],
+            yIndex: updraftLensFrame.y_indices[mappedY.index],
+            zIndex: updraftLensFrame.z_indices[mappedZ.index],
+          };
+          if (!mappedX.exact || !mappedY.exact || !mappedZ.exact) {
+            partialMessages.push("selected point mapped to the nearest native cell");
+          }
+        } else {
+          partialMessages.push("selected point could not be restored");
+        }
+      } else if (savedState.selected_point) {
+        partialMessages.push("selected point could not be restored");
+      }
+
+      const result: ExploreRestorationResult = {
+        status: partialMessages.length > 0 ? "partially_restorable" : "healthy",
+        message:
+          partialMessages.length > 0
+            ? `Saved View restored with adjustments: ${partialMessages.join("; ")}.`
+            : "Saved View restored.",
+      };
+      setPendingCuratedRestore(null);
+      setIsPlaybackRunning(false);
+      setFocusedViewer(null);
+      setSelectedFieldName(savedState.scene_field_id);
+      setSliceFieldName(savedState.slice_field_id);
+      setTimeIndex(mappedTime.index);
+      setPlaybackTimeIndex(mappedTime.index);
+      setPlaybackSpeed(savedState.playback_speed);
+      setThreshold(savedState.threshold_native);
+      setOpacity(savedState.layer_opacity);
+      setPointSize(savedState.point_size_px);
+      setCameraPreset(savedState.camera_preset);
+      setCameraTransform(savedState.camera_transform);
+      setDisplayControlsOpen(savedState.display_controls_open);
+      setContextCollapsed(savedState.context_collapsed);
+      setSecondarySection(savedState.secondary_section);
+      setSelectedRegion(nextSelectedRegion);
+      setShowSlicePlanes(savedState.show_slice_plane);
+      setActiveSlicePlane(savedState.active_slice_plane);
+      setSliceOrientation(
+        savedState.active_slice_plane === "vertical_y" ? "vertical_y" : "vertical_x",
+      );
+      if (savedState.active_slice_plane === "horizontal") {
+        setHorizontalSliceLevel(planeIndex);
+      } else {
+        setVerticalSliceIndex(planeIndex);
+      }
+      setUpdraftLensOpacity(savedState.lens_opacity);
+      setShowUpdraftLensBoundary(savedState.show_cloud_boundary);
+      setShowUpdraftLensWind(savedState.show_horizontal_wind);
+      setUpdraftLensWindMode(savedState.wind_mode);
+      setUpdraftLensActive(savedState.view_id === "updraft_lens");
+      ordinaryExploreStateRef.current =
+        savedState.view_id === "updraft_lens"
+          ? {
+              selectedFieldName: savedState.scene_field_id,
+              sliceFieldName: savedState.scene_field_id,
+              showSlicePlanes: savedState.show_slice_plane,
+              threshold: savedState.threshold_native,
+            }
+          : null;
+      setPointCloudError(null);
+      setSliceError(null);
+      setUpdraftLensError(null);
+      setPointCloud(null);
+      setUpdraftLensFrame(null);
+      setSceneHorizontalSlice(null);
+      setSceneVerticalSlice(null);
+      setPointCloudLoadAttempt((current) => current + 1);
+      if (savedState.view_id === "updraft_lens") {
+        setUpdraftLensLoadAttempt((current) => current + 1);
+      } else {
+        setSliceLoadAttempt((current) => current + 1);
+      }
+      setCuratedNotice({
+        status: "applying",
+        message: "Restoring the saved Trade Cumulus examination and loading its evidence...",
+      });
+      setPendingSavedRestore({
+        state: savedState,
+        result,
+        savedViewId: savedView?.saved_view_id ?? null,
+        timeIndex: mappedTime.index,
+        planeIndex,
+      });
+      return result;
+    },
+    [activeSliceMax, catalog?.available_fields, updraftLensDefaults, updraftLensFrame],
+  );
+
   useEffect(() => {
     if (
       !updraftLensEligible ||
       updraftLensActive ||
       !updraftLensDefaults ||
       !catalog ||
+      exploreState.loading ||
       initialCuratedResultRef.current === resultId
     ) {
       return;
     }
     initialCuratedResultRef.current = resultId;
+    const resumeState = exploreState.library?.last_active?.state;
+    if (resumeState?.world_id === "trade_cumulus") {
+      applySavedExploreState(resumeState, null);
+      return;
+    }
     if (tradeCumulusCuratedView(simulationRecord?.simulation_id, TRADE_CUMULUS_INITIAL_VIEW)) {
       applyTradeCumulusCuratedView(TRADE_CUMULUS_INITIAL_VIEW, "initial");
       return;
@@ -12085,7 +12445,10 @@ export function VisualizerSceneShell({
     handleUpdraftLensToggle(true);
   }, [
     applyTradeCumulusCuratedView,
+    applySavedExploreState,
     catalog,
+    exploreState.library?.last_active?.state,
+    exploreState.loading,
     handleUpdraftLensToggle,
     resultId,
     simulationRecord?.simulation_id,
@@ -12434,11 +12797,206 @@ export function VisualizerSceneShell({
   ]);
 
   useEffect(() => {
-    if (!curatedNotice || pendingCuratedRestore || !curatedNoticeSignatureRef.current) return;
+    if (!pendingSavedRestore) return;
+    const savedState = pendingSavedRestore.state;
+    const controlsMatch =
+      !isPlaybackRunning &&
+      timeIndex === pendingSavedRestore.timeIndex &&
+      playbackTimeIndex === pendingSavedRestore.timeIndex &&
+      selectedFieldName === savedState.scene_field_id &&
+      sliceFieldName === savedState.slice_field_id &&
+      activeSlicePlane === savedState.active_slice_plane &&
+      activeSliceIndex === pendingSavedRestore.planeIndex &&
+      updraftLensActive === (savedState.view_id === "updraft_lens");
+    if (!controlsMatch) {
+      setPendingSavedRestore(null);
+      setCuratedNotice(null);
+      curatedNoticeSignatureRef.current = null;
+      return;
+    }
+
+    const relevantError =
+      sceneError ??
+      pointCloudError ??
+      (savedState.view_id === "updraft_lens" ? updraftLensError : sliceError);
+    if (relevantError) {
+      const message = `The saved Trade Cumulus examination could not be restored: ${relevantError}`;
+      setPendingSavedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
+      if (pendingSavedRestore.savedViewId) {
+        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
+          restoration_status: "unavailable",
+          restoration_message: message,
+        });
+      }
+      return;
+    }
+
+    const sceneReady =
+      !selectedEncoding ||
+      (pointCloud?.selection.field === savedState.scene_field_id &&
+        pointCloud.selection.time_index === pendingSavedRestore.timeIndex);
+    const lensReady =
+      savedState.view_id === "updraft_lens" &&
+      !updraftLensLoading &&
+      updraftLensFrame?.time_index === pendingSavedRestore.timeIndex &&
+      updraftLensFrame.orientation === savedState.active_slice_plane &&
+      updraftLensFrame.plane_index === pendingSavedRestore.planeIndex;
+    const fieldSlice =
+      savedState.active_slice_plane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice;
+    const fieldSlicesReady =
+      savedState.view_id === "field" &&
+      !sliceLoading &&
+      fieldSlice?.field.raw_field_name === savedState.slice_field_id &&
+      fieldSlice.selection.time_index === pendingSavedRestore.timeIndex &&
+      fieldSlice.selection.orientation === savedState.active_slice_plane &&
+      fieldSlice.selection.selected_index === pendingSavedRestore.planeIndex;
+    if (!sceneReady || (!lensReady && !fieldSlicesReady)) return;
+
+    if (savedState.fixed_scale_id && updraftLensFrame?.w_scale_id !== savedState.fixed_scale_id) {
+      const message = `The saved scale ${savedState.fixed_scale_id} is unavailable for this output.`;
+      setPendingSavedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
+      if (pendingSavedRestore.savedViewId) {
+        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
+          restoration_status: "unavailable",
+          restoration_message: message,
+        });
+      }
+      return;
+    }
+
+    const loadedCoordinateKm =
+      savedState.view_id === "updraft_lens"
+        ? coordinateKilometers(
+            updraftLensFrame?.plane_coordinate ?? null,
+            updraftLensFrame?.plane_units ?? null,
+          )
+        : coordinateKilometers(
+            fieldSlice?.selection.selected_coordinate_value ??
+              fieldSlice?.selection.level_coordinate_value ??
+              null,
+            fieldSlice?.selection.level_units ?? null,
+          );
+    if (
+      loadedCoordinateKm === null ||
+      Math.abs(loadedCoordinateKm - savedState.slice_coordinate_km) > 0.2 + Number.EPSILON
+    ) {
+      const coordinateInventory =
+        savedState.view_id === "updraft_lens"
+          ? savedState.active_slice_plane === "horizontal"
+            ? (updraftLensFrame?.z_values_km ?? [])
+            : savedState.active_slice_plane === "vertical_x"
+              ? (updraftLensFrame?.y_values_km ?? [])
+              : (updraftLensFrame?.x_values_km ?? [])
+          : [];
+      const remappedPlane = nearestSavedCoordinate(
+        coordinateInventory,
+        savedState.slice_coordinate_km,
+        0.2,
+      );
+      if (remappedPlane && remappedPlane.index !== pendingSavedRestore.planeIndex) {
+        if (savedState.active_slice_plane === "horizontal") {
+          setHorizontalSliceLevel(remappedPlane.index);
+        } else {
+          setVerticalSliceIndex(remappedPlane.index);
+        }
+        setPendingSavedRestore({
+          ...pendingSavedRestore,
+          planeIndex: remappedPlane.index,
+          result: {
+            status: "partially_restorable",
+            message: `Saved View restored with adjustments: slice ${savedState.slice_coordinate_km.toFixed(2)} km mapped to ${remappedPlane.value.toFixed(2)} km.`,
+          },
+        });
+        return;
+      }
+      const message = "The saved physical slice could not be matched to retained output.";
+      setPendingSavedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
+      if (pendingSavedRestore.savedViewId) {
+        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
+          restoration_status: "unavailable",
+          restoration_message: message,
+        });
+      }
+      return;
+    }
+
+    setPendingSavedRestore(null);
+    curatedNoticeSignatureRef.current = curatedStateSignature;
+    setCuratedNotice({
+      status:
+        pendingSavedRestore.result.status === "healthy" ? "applied" : "partially_incompatible",
+      message:
+        pendingSavedRestore.savedViewId === null
+          ? pendingSavedRestore.result.message.replace("Saved View", "Last active view")
+          : pendingSavedRestore.result.message,
+    });
+  }, [
+    activeSliceIndex,
+    activeSlicePlane,
+    curatedStateSignature,
+    isPlaybackRunning,
+    pendingSavedRestore,
+    playbackTimeIndex,
+    pointCloud,
+    pointCloudError,
+    sceneError,
+    sceneHorizontalSlice,
+    sceneVerticalSlice,
+    selectedEncoding,
+    selectedFieldName,
+    sliceError,
+    sliceFieldName,
+    sliceLoading,
+    timeIndex,
+    updraftLensActive,
+    updraftLensError,
+    updraftLensFrame,
+    updraftLensLoading,
+    updateExploreSavedView,
+  ]);
+
+  useEffect(() => {
+    if (
+      initialCuratedResultRef.current !== resultId ||
+      !exploreStateCoherent ||
+      !capturedExploreState ||
+      pendingCuratedRestore ||
+      pendingSavedRestore
+    ) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      void saveExploreResume(capturedExploreState);
+    }, 800);
+    return () => window.clearTimeout(timer);
+  }, [
+    capturedExploreState,
+    exploreStateCoherent,
+    pendingCuratedRestore,
+    pendingSavedRestore,
+    resultId,
+    saveExploreResume,
+  ]);
+
+  useEffect(() => {
+    if (
+      !curatedNotice ||
+      pendingCuratedRestore ||
+      pendingSavedRestore ||
+      !curatedNoticeSignatureRef.current
+    ) {
+      return;
+    }
     if (curatedNoticeSignatureRef.current === curatedStateSignature) return;
     curatedNoticeSignatureRef.current = null;
     setCuratedNotice(null);
-  }, [curatedNotice, curatedStateSignature, pendingCuratedRestore]);
+  }, [curatedNotice, curatedStateSignature, pendingCuratedRestore, pendingSavedRestore]);
 
   function selectPointFromSlice(slice: SliceResponse, rowIndex: number, columnIndex: number) {
     if (isPlaybackRunning) {
@@ -12497,14 +13055,22 @@ export function VisualizerSceneShell({
         (resultOptions && resultOptions.length > 0 && onSelectResult) ? (
           <>
             {isTradeCumulusWorldExplore && (
-              <ReturnToCuratedViewControl
-                onReturn={() =>
-                  applyTradeCumulusCuratedView(
-                    updraftLensActive ? "updraft_lens" : "field",
-                    "return",
-                  )
-                }
-              />
+              <>
+                <SavedViewsControl
+                  controller={exploreState}
+                  currentState={capturedExploreState}
+                  coherent={exploreStateCoherent}
+                  onOpen={(state, savedView) => applySavedExploreState(state, savedView)}
+                />
+                <ReturnToCuratedViewControl
+                  onReturn={() =>
+                    applyTradeCumulusCuratedView(
+                      updraftLensActive ? "updraft_lens" : "field",
+                      "return",
+                    )
+                  }
+                />
+              </>
             )}
             {resultOptions && resultOptions.length > 0 && onSelectResult && (
               <label className="soundings-explore-run-selector">
@@ -13892,6 +14458,19 @@ function coordinateTextWithUnits(
     ? formatCompactNumber(numericCoordinate)
     : String(coordinate);
   return `${value}${units ? ` ${units}` : ""}`;
+}
+
+function coordinateKilometers(
+  coordinate: number | string | null | undefined,
+  units: string | null | undefined,
+): number | null {
+  const value = typeof coordinate === "number" ? coordinate : Number(coordinate);
+  if (!Number.isFinite(value)) return null;
+  const normalizedUnits = units?.trim().toLowerCase();
+  if (normalizedUnits === "m" || normalizedUnits === "meter" || normalizedUnits === "meters") {
+    return value / 1_000;
+  }
+  return value;
 }
 
 function selectedSliceCellValue(

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1429,6 +1429,7 @@ type SliceResponse = {
     level_meters: number | null;
   };
   coordinate_units: Record<string, string | null>;
+  coordinate_values?: Record<string, Array<number | string | null>>;
   shape: number[];
   dimension_order: string[];
   data_encoding: "json";
@@ -11430,9 +11431,11 @@ type PendingTradeCuratedRestore = {
 type PendingTradeSavedRestore = {
   state: TradeCumulusExploreState;
   result: ExploreRestorationResult;
-  savedViewId: string | null;
+  source: "saved_view" | "last_active";
+  resolve: (result: ExploreRestorationResult) => void;
   timeIndex: number;
   planeIndex: number;
+  horizontalPlaneIndex: number;
 };
 
 export function VisualizerSceneShell({
@@ -11534,13 +11537,13 @@ export function VisualizerSceneShell({
   const updraftLensRequestRef = useRef(0);
   const autoActivatedUpdraftLensResultRef = useRef<string | null>(null);
   const initialCuratedResultRef = useRef<string | null>(null);
+  const startupUserEditedRef = useRef(false);
   const curatedNoticeSignatureRef = useRef<string | null>(null);
   const exploreState = useExploreStateLibrary(
     isTradeCumulusWorldExplore ? "trade_cumulus" : null,
     isTradeCumulusWorldExplore ? (simulationRecord?.simulation_id ?? null) : null,
   );
   const saveExploreResume = exploreState.saveResume;
-  const updateExploreSavedView = exploreState.updateSavedView;
   const maxPoints = 50_000;
 
   useEffect(() => {
@@ -11595,6 +11598,7 @@ export function VisualizerSceneShell({
     ordinaryExploreStateRef.current = null;
     autoActivatedUpdraftLensResultRef.current = null;
     initialCuratedResultRef.current = null;
+    startupUserEditedRef.current = false;
     curatedNoticeSignatureRef.current = null;
     updraftLensRequestRef.current += 1;
     setSceneStatus("Loading scene data...");
@@ -11845,6 +11849,8 @@ export function VisualizerSceneShell({
       if (Number.isFinite(xKm) && Number.isFinite(yKm) && Number.isFinite(zKm)) {
         selectedPoint = { x_km: xKm, y_km: yKm, z_km: zKm };
       }
+    } else if (!updraftLensActive) {
+      selectedPoint = physicalPointFromFieldSlice(activeSlice, selectedRegion);
     }
     return {
       state_version: 1,
@@ -12211,14 +12217,14 @@ export function VisualizerSceneShell({
     (
       savedState: ExploreWorldState,
       savedView: SavedViewRecord | null,
-    ): ExploreRestorationResult => {
+    ): Promise<ExploreRestorationResult> => {
       if (savedState.world_id !== "trade_cumulus") {
         const result = {
           status: "unavailable" as const,
           message: "This Saved View belongs to another Cloud World.",
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
       const savedSceneField = catalog?.available_fields.find(
         (field) => field.raw_field_name === savedState.scene_field_id,
@@ -12236,7 +12242,7 @@ export function VisualizerSceneShell({
           message: "A saved Field or Lens is unavailable in the retained output.",
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
       if (
         savedState.fixed_scale_id &&
@@ -12247,7 +12253,7 @@ export function VisualizerSceneShell({
           message: `The saved scale ${savedState.fixed_scale_id} is unavailable.`,
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
       const timesSeconds = savedSliceField.time_coordinate_values
         .map((value) => Number(value))
@@ -12259,7 +12265,7 @@ export function VisualizerSceneShell({
           message: "The saved model time is outside the retained output's compatible range.",
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
 
       const partialMessages: string[] = [];
@@ -12268,49 +12274,83 @@ export function VisualizerSceneShell({
           `time ${Math.round(savedState.model_time_seconds).toLocaleString()} s mapped to ${Math.round(mappedTime.value).toLocaleString()} s`,
         );
       }
-      let planeIndex = savedState.slice_native_index;
-      const planeCoordinates =
+      const activeFieldSlice =
+        savedState.active_slice_plane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice;
+      const mappedPlane =
         savedState.view_id === "updraft_lens" && updraftLensFrame
-          ? savedState.active_slice_plane === "horizontal"
-            ? updraftLensFrame.z_values_km
-            : savedState.active_slice_plane === "vertical_x"
-              ? updraftLensFrame.y_values_km
-              : updraftLensFrame.x_values_km
-          : [];
-      if (planeCoordinates.length > 0) {
-        const mappedPlane = nearestSavedCoordinate(
-          planeCoordinates,
-          savedState.slice_coordinate_km,
-          0.2,
-        );
-        if (!mappedPlane) {
-          const result = {
-            status: "unavailable" as const,
-            message: "The saved physical slice is outside the compatible native-grid range.",
-          };
-          setCuratedNotice({ status: "technical_fallback", message: result.message });
-          return result;
-        }
-        planeIndex = mappedPlane.index;
-        if (!mappedPlane.exact) {
-          partialMessages.push(
-            `slice ${savedState.slice_coordinate_km.toFixed(2)} km mapped to ${mappedPlane.value.toFixed(2)} km`,
-          );
-        }
-      } else if (
-        savedState.slice_native_index < 0 ||
-        savedState.slice_native_index >= Math.max(activeSliceMax, 1)
+          ? nearestSavedCoordinate(
+              savedState.active_slice_plane === "horizontal"
+                ? updraftLensFrame.z_values_km
+                : savedState.active_slice_plane === "vertical_x"
+                  ? updraftLensFrame.y_values_km
+                  : updraftLensFrame.x_values_km,
+              savedState.slice_coordinate_km,
+              0.2,
+            )
+          : mapSavedFieldPlane(activeFieldSlice, savedState.slice_coordinate_km, 0.2);
+      const planeEvidencePending =
+        savedState.view_id === "updraft_lens"
+          ? updraftLensFrame === null
+          : activeFieldSlice === null;
+      if (
+        !mappedPlane &&
+        planeEvidencePending &&
+        savedState.slice_native_index >= 0 &&
+        savedState.slice_native_index < Math.max(activeSliceMax, 1)
       ) {
+        // The native index is provisional until the requested Lens frame supplies coordinates.
+      } else if (!mappedPlane) {
         const result = {
           status: "unavailable" as const,
-          message: "The saved native slice index is unavailable in this retained output.",
+          message: "The saved physical slice is outside the compatible native-grid range.",
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
+      }
+      const planeIndex = mappedPlane?.index ?? savedState.slice_native_index;
+      if (mappedPlane && !mappedPlane.exact) {
+        partialMessages.push(
+          `slice ${savedState.slice_coordinate_km.toFixed(2)} km mapped to ${mappedPlane.value.toFixed(2)} km`,
+        );
+      }
+
+      let horizontalPlaneIndex =
+        savedState.active_slice_plane === "horizontal" ? planeIndex : horizontalSliceLevel;
+      if (savedState.horizontal_slice_coordinate_km !== null) {
+        const mappedHorizontal =
+          savedState.view_id === "updraft_lens" && updraftLensFrame
+            ? nearestSavedCoordinate(
+                updraftLensFrame.z_values_km,
+                savedState.horizontal_slice_coordinate_km,
+                0.2,
+              )
+            : mapSavedFieldPlane(
+                sceneHorizontalSlice,
+                savedState.horizontal_slice_coordinate_km,
+                0.2,
+              );
+        const horizontalEvidencePending =
+          savedState.view_id === "updraft_lens"
+            ? updraftLensFrame === null
+            : sceneHorizontalSlice === null;
+        if (!mappedHorizontal && !horizontalEvidencePending) {
+          const result = {
+            status: "unavailable" as const,
+            message: "The saved horizontal 3-D slice is outside the compatible native-grid range.",
+          };
+          setCuratedNotice({ status: "technical_fallback", message: result.message });
+          return Promise.resolve(result);
+        }
+        if (mappedHorizontal) horizontalPlaneIndex = mappedHorizontal.index;
+        if (mappedHorizontal && !mappedHorizontal.exact) {
+          partialMessages.push(
+            `horizontal slice ${savedState.horizontal_slice_coordinate_km.toFixed(2)} km mapped to ${mappedHorizontal.value.toFixed(2)} km`,
+          );
+        }
       }
 
       let nextSelectedRegion: SelectedRegionRequest | null = null;
-      if (savedState.selected_point && updraftLensFrame) {
+      if (savedState.selected_point && savedState.view_id === "updraft_lens" && updraftLensFrame) {
         const mappedX = nearestSavedCoordinate(
           updraftLensFrame.x_values_km,
           savedState.selected_point.x_km,
@@ -12340,7 +12380,21 @@ export function VisualizerSceneShell({
           partialMessages.push("selected point could not be restored");
         }
       } else if (savedState.selected_point) {
-        partialMessages.push("selected point could not be restored");
+        const mappedPoint = mapPhysicalPointToFieldSlice(
+          savedState.active_slice_plane === "horizontal"
+            ? sceneHorizontalSlice
+            : sceneVerticalSlice,
+          savedState.selected_point,
+          0.2,
+        );
+        if (mappedPoint) {
+          nextSelectedRegion = mappedPoint.selection;
+          if (!mappedPoint.exact) {
+            partialMessages.push("selected point mapped to the nearest native cell");
+          }
+        } else {
+          partialMessages.push("selected point could not be restored");
+        }
       }
 
       const result: ExploreRestorationResult = {
@@ -12372,9 +12426,10 @@ export function VisualizerSceneShell({
       setSliceOrientation(
         savedState.active_slice_plane === "vertical_y" ? "vertical_y" : "vertical_x",
       );
-      if (savedState.active_slice_plane === "horizontal") {
-        setHorizontalSliceLevel(planeIndex);
-      } else {
+      setHorizontalSliceLevel(
+        savedState.active_slice_plane === "horizontal" ? planeIndex : horizontalPlaneIndex,
+      );
+      if (savedState.active_slice_plane !== "horizontal") {
         setVerticalSliceIndex(planeIndex);
       }
       setUpdraftLensOpacity(savedState.lens_opacity);
@@ -12408,16 +12463,28 @@ export function VisualizerSceneShell({
         status: "applying",
         message: "Restoring the saved Trade Cumulus examination and loading its evidence...",
       });
-      setPendingSavedRestore({
-        state: savedState,
-        result,
-        savedViewId: savedView?.saved_view_id ?? null,
-        timeIndex: mappedTime.index,
-        planeIndex,
+      return new Promise((resolve) => {
+        setPendingSavedRestore({
+          state: savedState,
+          result,
+          source: savedView ? "saved_view" : "last_active",
+          resolve,
+          timeIndex: mappedTime.index,
+          planeIndex,
+          horizontalPlaneIndex:
+            savedState.active_slice_plane === "horizontal" ? planeIndex : horizontalPlaneIndex,
+        });
       });
-      return result;
     },
-    [activeSliceMax, catalog?.available_fields, updraftLensDefaults, updraftLensFrame],
+    [
+      activeSliceMax,
+      catalog?.available_fields,
+      horizontalSliceLevel,
+      sceneHorizontalSlice,
+      sceneVerticalSlice,
+      updraftLensDefaults,
+      updraftLensFrame,
+    ],
   );
 
   useEffect(() => {
@@ -12432,9 +12499,12 @@ export function VisualizerSceneShell({
       return;
     }
     initialCuratedResultRef.current = resultId;
+    if (startupUserEditedRef.current) {
+      return;
+    }
     const resumeState = exploreState.library?.last_active?.state;
     if (resumeState?.world_id === "trade_cumulus") {
-      applySavedExploreState(resumeState, null);
+      void applySavedExploreState(resumeState, null);
       return;
     }
     if (tradeCumulusCuratedView(simulationRecord?.simulation_id, TRADE_CUMULUS_INITIAL_VIEW)) {
@@ -12807,11 +12877,14 @@ export function VisualizerSceneShell({
       sliceFieldName === savedState.slice_field_id &&
       activeSlicePlane === savedState.active_slice_plane &&
       activeSliceIndex === pendingSavedRestore.planeIndex &&
+      horizontalSliceLevel === pendingSavedRestore.horizontalPlaneIndex &&
       updraftLensActive === (savedState.view_id === "updraft_lens");
     if (!controlsMatch) {
+      const message = "The saved Trade Cumulus examination was interrupted before it loaded.";
+      pendingSavedRestore.resolve({ status: "unavailable", message });
       setPendingSavedRestore(null);
-      setCuratedNotice(null);
-      curatedNoticeSignatureRef.current = null;
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
       return;
     }
 
@@ -12821,15 +12894,10 @@ export function VisualizerSceneShell({
       (savedState.view_id === "updraft_lens" ? updraftLensError : sliceError);
     if (relevantError) {
       const message = `The saved Trade Cumulus examination could not be restored: ${relevantError}`;
+      pendingSavedRestore.resolve({ status: "unavailable", message });
       setPendingSavedRestore(null);
       curatedNoticeSignatureRef.current = curatedStateSignature;
       setCuratedNotice({ status: "technical_fallback", message });
-      if (pendingSavedRestore.savedViewId) {
-        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
-          restoration_status: "unavailable",
-          restoration_message: message,
-        });
-      }
       return;
     }
 
@@ -12845,26 +12913,30 @@ export function VisualizerSceneShell({
       updraftLensFrame.plane_index === pendingSavedRestore.planeIndex;
     const fieldSlice =
       savedState.active_slice_plane === "horizontal" ? sceneHorizontalSlice : sceneVerticalSlice;
+    const horizontalFieldSliceReady =
+      sceneHorizontalSlice?.field.raw_field_name === savedState.slice_field_id &&
+      sceneHorizontalSlice.selection.time_index === pendingSavedRestore.timeIndex &&
+      sceneHorizontalSlice.selection.orientation === "horizontal" &&
+      sceneHorizontalSlice.selection.selected_index === pendingSavedRestore.horizontalPlaneIndex;
+    const verticalFieldSliceReady =
+      !sliceSupportsVertical ||
+      (sceneVerticalSlice?.field.raw_field_name === savedState.slice_field_id &&
+        sceneVerticalSlice.selection.time_index === pendingSavedRestore.timeIndex &&
+        sceneVerticalSlice.selection.orientation === savedState.active_slice_plane &&
+        sceneVerticalSlice.selection.selected_index === pendingSavedRestore.planeIndex);
     const fieldSlicesReady =
       savedState.view_id === "field" &&
       !sliceLoading &&
-      fieldSlice?.field.raw_field_name === savedState.slice_field_id &&
-      fieldSlice.selection.time_index === pendingSavedRestore.timeIndex &&
-      fieldSlice.selection.orientation === savedState.active_slice_plane &&
-      fieldSlice.selection.selected_index === pendingSavedRestore.planeIndex;
+      horizontalFieldSliceReady &&
+      (savedState.active_slice_plane === "horizontal" || verticalFieldSliceReady);
     if (!sceneReady || (!lensReady && !fieldSlicesReady)) return;
 
     if (savedState.fixed_scale_id && updraftLensFrame?.w_scale_id !== savedState.fixed_scale_id) {
       const message = `The saved scale ${savedState.fixed_scale_id} is unavailable for this output.`;
+      pendingSavedRestore.resolve({ status: "unavailable", message });
       setPendingSavedRestore(null);
       curatedNoticeSignatureRef.current = curatedStateSignature;
       setCuratedNotice({ status: "technical_fallback", message });
-      if (pendingSavedRestore.savedViewId) {
-        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
-          restoration_status: "unavailable",
-          restoration_message: message,
-        });
-      }
       return;
     }
 
@@ -12891,7 +12963,7 @@ export function VisualizerSceneShell({
             : savedState.active_slice_plane === "vertical_x"
               ? (updraftLensFrame?.y_values_km ?? [])
               : (updraftLensFrame?.x_values_km ?? [])
-          : [];
+          : slicePlaneCoordinateValuesKm(fieldSlice);
       const remappedPlane = nearestSavedCoordinate(
         coordinateInventory,
         savedState.slice_coordinate_km,
@@ -12906,6 +12978,10 @@ export function VisualizerSceneShell({
         setPendingSavedRestore({
           ...pendingSavedRestore,
           planeIndex: remappedPlane.index,
+          horizontalPlaneIndex:
+            savedState.active_slice_plane === "horizontal"
+              ? remappedPlane.index
+              : pendingSavedRestore.horizontalPlaneIndex,
           result: {
             status: "partially_restorable",
             message: `Saved View restored with adjustments: slice ${savedState.slice_coordinate_km.toFixed(2)} km mapped to ${remappedPlane.value.toFixed(2)} km.`,
@@ -12914,25 +12990,90 @@ export function VisualizerSceneShell({
         return;
       }
       const message = "The saved physical slice could not be matched to retained output.";
+      pendingSavedRestore.resolve({ status: "unavailable", message });
       setPendingSavedRestore(null);
       curatedNoticeSignatureRef.current = curatedStateSignature;
       setCuratedNotice({ status: "technical_fallback", message });
-      if (pendingSavedRestore.savedViewId) {
-        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
-          restoration_status: "unavailable",
-          restoration_message: message,
-        });
-      }
       return;
     }
 
+    if (savedState.horizontal_slice_coordinate_km !== null) {
+      const loadedHorizontalCoordinateKm =
+        savedState.view_id === "updraft_lens"
+          ? (updraftLensFrame?.z_values_km[pendingSavedRestore.horizontalPlaneIndex] ?? null)
+          : coordinateKilometers(
+              sceneHorizontalSlice?.selection.selected_coordinate_value ??
+                sceneHorizontalSlice?.selection.level_coordinate_value ??
+                null,
+              sceneHorizontalSlice?.selection.level_units ?? null,
+            );
+      if (
+        loadedHorizontalCoordinateKm === null ||
+        Math.abs(
+          loadedHorizontalCoordinateKm - savedState.horizontal_slice_coordinate_km,
+        ) >
+          0.2 + Number.EPSILON
+      ) {
+        const remappedHorizontal = nearestSavedCoordinate(
+          savedState.view_id === "updraft_lens"
+            ? (updraftLensFrame?.z_values_km ?? [])
+            : slicePlaneCoordinateValuesKm(sceneHorizontalSlice),
+          savedState.horizontal_slice_coordinate_km,
+          0.2,
+        );
+        if (
+          remappedHorizontal &&
+          remappedHorizontal.index !== pendingSavedRestore.horizontalPlaneIndex
+        ) {
+          setHorizontalSliceLevel(remappedHorizontal.index);
+          setPendingSavedRestore({
+            ...pendingSavedRestore,
+            horizontalPlaneIndex: remappedHorizontal.index,
+            result: {
+              status: "partially_restorable",
+              message: `Saved View restored with adjustments: horizontal slice ${savedState.horizontal_slice_coordinate_km.toFixed(2)} km mapped to ${remappedHorizontal.value.toFixed(2)} km.`,
+            },
+          });
+          return;
+        }
+        const message = "The saved horizontal 3-D slice could not be matched to retained output.";
+        pendingSavedRestore.resolve({ status: "unavailable", message });
+        setPendingSavedRestore(null);
+        curatedNoticeSignatureRef.current = curatedStateSignature;
+        setCuratedNotice({ status: "technical_fallback", message });
+        return;
+      }
+    }
+
+    if (savedState.selected_point && !selectedRegion && savedState.view_id === "field") {
+      const remappedPoint = mapPhysicalPointToFieldSlice(
+        fieldSlice,
+        savedState.selected_point,
+        0.2,
+      );
+      if (remappedPoint) {
+        setSelectedRegion(remappedPoint.selection);
+        if (!remappedPoint.exact) {
+          setPendingSavedRestore({
+            ...pendingSavedRestore,
+            result: {
+              status: "partially_restorable",
+              message: "Saved View restored with adjustments: selected point mapped to the nearest native cell.",
+            },
+          });
+        }
+        return;
+      }
+    }
+
+    pendingSavedRestore.resolve(pendingSavedRestore.result);
     setPendingSavedRestore(null);
     curatedNoticeSignatureRef.current = curatedStateSignature;
     setCuratedNotice({
       status:
         pendingSavedRestore.result.status === "healthy" ? "applied" : "partially_incompatible",
       message:
-        pendingSavedRestore.savedViewId === null
+        pendingSavedRestore.source === "last_active"
           ? pendingSavedRestore.result.message.replace("Saved View", "Last active view")
           : pendingSavedRestore.result.message,
     });
@@ -12940,6 +13081,7 @@ export function VisualizerSceneShell({
     activeSliceIndex,
     activeSlicePlane,
     curatedStateSignature,
+    horizontalSliceLevel,
     isPlaybackRunning,
     pendingSavedRestore,
     playbackTimeIndex,
@@ -12950,15 +13092,16 @@ export function VisualizerSceneShell({
     sceneVerticalSlice,
     selectedEncoding,
     selectedFieldName,
+    selectedRegion,
     sliceError,
     sliceFieldName,
     sliceLoading,
+    sliceSupportsVertical,
     timeIndex,
     updraftLensActive,
     updraftLensError,
     updraftLensFrame,
     updraftLensLoading,
-    updateExploreSavedView,
   ]);
 
   useEffect(() => {
@@ -13050,6 +13193,9 @@ export function VisualizerSceneShell({
       backLabel={backLabel}
       onBack={onBack}
       onCompare={onCompare}
+      onUserInteractionCapture={() => {
+        if (exploreState.loading) startupUserEditedRef.current = true;
+      }}
       headerActions={
         isTradeCumulusWorldExplore ||
         (resultOptions && resultOptions.length > 0 && onSelectResult) ? (
@@ -14471,6 +14617,105 @@ function coordinateKilometers(
     return value / 1_000;
   }
   return value;
+}
+
+function sliceCoordinateValuesKm(slice: SliceResponse | null, dimension: string | null): number[] {
+  if (!slice || !dimension) return [];
+  const units = slice.coordinate_units[dimension];
+  return (slice.coordinate_values?.[dimension] ?? []).map(
+    (value) => coordinateKilometers(value, units) ?? Number.NaN,
+  );
+}
+
+function slicePlaneCoordinateValuesKm(slice: SliceResponse | null): number[] {
+  return sliceCoordinateValuesKm(slice, slice?.selection.selected_dimension ?? null);
+}
+
+function mapSavedFieldPlane(
+  slice: SliceResponse | null,
+  targetKm: number,
+  maximumDistanceKm: number,
+): { index: number; value: number; exact: boolean } | null {
+  const fromInventory = nearestSavedCoordinate(
+    slicePlaneCoordinateValuesKm(slice),
+    targetKm,
+    maximumDistanceKm,
+  );
+  if (fromInventory) return fromInventory;
+  if (!slice) return null;
+  const selectedCoordinateKm = coordinateKilometers(
+    slice.selection.selected_coordinate_value ?? slice.selection.level_coordinate_value,
+    slice.selection.level_units,
+  );
+  if (
+    selectedCoordinateKm === null ||
+    Math.abs(selectedCoordinateKm - targetKm) > maximumDistanceKm + Number.EPSILON
+  ) {
+    return null;
+  }
+  return {
+    index: slice.selection.selected_index,
+    value: selectedCoordinateKm,
+    exact: Math.abs(selectedCoordinateKm - targetKm) <= Number.EPSILON,
+  };
+}
+
+function physicalPointFromFieldSlice(
+  slice: SliceResponse | null,
+  selectedRegion: SelectedRegionRequest | null,
+): TradeCumulusExploreState["selected_point"] {
+  if (
+    !slice ||
+    !selectedRegion ||
+    selectedRegion.xIndex === undefined ||
+    selectedRegion.yIndex === undefined ||
+    selectedRegion.zIndex === undefined
+  ) {
+    return null;
+  }
+  const xName = slice.field.coordinate_names.x;
+  const yName = slice.field.coordinate_names.y;
+  const zName = slice.field.coordinate_names.vertical;
+  const xKm = sliceCoordinateValuesKm(slice, xName)[selectedRegion.xIndex];
+  const yKm = sliceCoordinateValuesKm(slice, yName)[selectedRegion.yIndex];
+  const zKm = sliceCoordinateValuesKm(slice, zName)[selectedRegion.zIndex];
+  return Number.isFinite(xKm) && Number.isFinite(yKm) && Number.isFinite(zKm)
+    ? { x_km: xKm, y_km: yKm, z_km: zKm }
+    : null;
+}
+
+function mapPhysicalPointToFieldSlice(
+  slice: SliceResponse | null,
+  point: TradeCumulusExploreState["selected_point"],
+  maximumDistanceKm: number,
+): { selection: SelectedRegionRequest; exact: boolean } | null {
+  if (!slice || !point || point.y_km === null) return null;
+  const x = nearestSavedCoordinate(
+    sliceCoordinateValuesKm(slice, slice.field.coordinate_names.x),
+    point.x_km,
+    maximumDistanceKm,
+  );
+  const y = nearestSavedCoordinate(
+    sliceCoordinateValuesKm(slice, slice.field.coordinate_names.y),
+    point.y_km,
+    maximumDistanceKm,
+  );
+  const z = nearestSavedCoordinate(
+    sliceCoordinateValuesKm(slice, slice.field.coordinate_names.vertical),
+    point.z_km,
+    maximumDistanceKm,
+  );
+  if (!x || !y || !z) return null;
+  return {
+    selection: {
+      regionType: "point",
+      xIndex: x.index,
+      yIndex: y.index,
+      zIndex: z.index,
+      neighborhood: 0,
+    },
+    exact: x.exact && y.exact && z.exact,
+  };
 }
 
 function selectedSliceCellValue(

--- a/app/frontend/src/ExploreStatePersistence.test.tsx
+++ b/app/frontend/src/ExploreStatePersistence.test.tsx
@@ -401,4 +401,120 @@ describe("useExploreStateLibrary", () => {
     expect(result.current.library?.last_active?.state.model_time_seconds).toBe(1_800);
     expect(persistedState.model_time_seconds).toBe(1_800);
   });
+
+  it("clears a different queued state when the newest state matches the active write", async () => {
+    const activeWrite = deferred<Response>();
+    const requestedStates: TradeCumulusExploreState[] = [];
+    const persisted = { state: null as TradeCumulusExploreState | null };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method !== "PUT") {
+          return Promise.resolve(
+            new Response(JSON.stringify(libraryResponse(null)), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
+        }
+        const state = JSON.parse(String(init.body)).state as TradeCumulusExploreState;
+        requestedStates.push(state);
+        return activeWrite.promise.then((response) => {
+          persisted.state = state;
+          return response;
+        });
+      }),
+    );
+    const { result } = renderHook(() =>
+      useExploreStateLibrary("trade_cumulus", "trade_cumulus_canonical_bomex"),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const activeState = { ...tradeState, model_time_seconds: 900 };
+    const supersededState = { ...tradeState, model_time_seconds: 1_800 };
+    let drain!: Promise<void>;
+    act(() => {
+      drain = result.current.saveResume(activeState);
+      void result.current.saveResume(supersededState);
+      void result.current.saveResume(activeState);
+    });
+
+    expect(requestedStates).toEqual([activeState]);
+    expect(result.current.savingResume).toBe(true);
+    activeWrite.resolve(
+      new Response(JSON.stringify(libraryResponse(activeState)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await act(async () => drain);
+
+    expect(requestedStates).toEqual([activeState]);
+    expect(result.current.savingResume).toBe(false);
+    expect(result.current.library?.last_active?.state.model_time_seconds).toBe(900);
+    expect(persisted.state?.model_time_seconds).toBe(900);
+  });
+
+  it("rewrites the persisted state when a different active write could overwrite it", async () => {
+    const activeWrite = deferred<Response>();
+    const latestWrite = deferred<Response>();
+    const persistedState = { ...tradeState, model_time_seconds: 900 };
+    let simulatedPersistedState = persistedState;
+    const requestedStates: TradeCumulusExploreState[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method !== "PUT") {
+          return Promise.resolve(
+            new Response(JSON.stringify(libraryResponse(persistedState)), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
+        }
+        const state = JSON.parse(String(init.body)).state as TradeCumulusExploreState;
+        requestedStates.push(state);
+        const write = requestedStates.length === 1 ? activeWrite.promise : latestWrite.promise;
+        return write.then((response) => {
+          simulatedPersistedState = state;
+          return response;
+        });
+      }),
+    );
+    const { result } = renderHook(() =>
+      useExploreStateLibrary("trade_cumulus", "trade_cumulus_canonical_bomex"),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const interveningState = { ...tradeState, model_time_seconds: 1_800 };
+    let drain!: Promise<void>;
+    act(() => {
+      drain = result.current.saveResume(interveningState);
+      void result.current.saveResume(persistedState);
+    });
+
+    expect(requestedStates).toEqual([interveningState]);
+    expect(result.current.savingResume).toBe(true);
+    activeWrite.resolve(
+      new Response(JSON.stringify(libraryResponse(interveningState)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await waitFor(() => expect(requestedStates).toEqual([interveningState, persistedState]));
+    expect(result.current.library?.last_active?.state.model_time_seconds).toBe(900);
+    expect(result.current.savingResume).toBe(true);
+
+    latestWrite.resolve(
+      new Response(JSON.stringify(libraryResponse(persistedState)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await act(async () => drain);
+
+    expect(result.current.savingResume).toBe(false);
+    expect(result.current.library?.last_active?.state.model_time_seconds).toBe(900);
+    expect(simulatedPersistedState.model_time_seconds).toBe(900);
+  });
 });

--- a/app/frontend/src/ExploreStatePersistence.test.tsx
+++ b/app/frontend/src/ExploreStatePersistence.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -7,6 +7,7 @@ import {
   SavedViewsControl,
   type TradeCumulusExploreState,
   nearestSavedCoordinate,
+  useExploreStateLibrary,
 } from "./ExploreStatePersistence";
 
 const tradeState: TradeCumulusExploreState = {
@@ -55,8 +56,40 @@ const savedView: SavedViewRecord = {
   },
 };
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function libraryResponse(state: TradeCumulusExploreState | null) {
+  return {
+    library: {
+      schema_version: 1 as const,
+      world_id: "trade_cumulus",
+      simulation_id: "trade_cumulus_canonical_bomex",
+      last_active: state
+        ? {
+            schema_version: 1 as const,
+            world_id: "trade_cumulus",
+            simulation_id: "trade_cumulus_canonical_bomex",
+            captured_at: "2026-07-26T12:00:00Z",
+            state,
+          }
+        : null,
+      saved_views: [],
+    },
+    backing_simulation_available: true,
+  };
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("nearestSavedCoordinate", () => {
@@ -106,7 +139,7 @@ describe("SavedViewsControl", () => {
     const createSavedView = vi.fn().mockResolvedValue(undefined);
     const updateSavedView = vi.fn().mockResolvedValue(undefined);
     const deleteSavedView = vi.fn().mockResolvedValue(undefined);
-    const onOpen = vi.fn().mockReturnValue({
+    const onOpen = vi.fn().mockResolvedValue({
       status: "healthy",
       message: "Saved View restored.",
     });
@@ -173,5 +206,199 @@ describe("SavedViewsControl", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
     await waitFor(() => expect(deleteSavedView).toHaveBeenCalledWith(savedView.saved_view_id));
+  });
+
+  it("keeps a Saved View opening until its target evidence is coherent", async () => {
+    const restoration = deferred<{
+      status: "healthy";
+      message: string;
+    }>();
+    const updateSavedView = vi.fn().mockResolvedValue(undefined);
+    const controller: ExploreStateLibraryController = {
+      library: {
+        ...libraryResponse(null).library,
+        saved_views: [savedView],
+      },
+      loading: false,
+      error: null,
+      savingResume: false,
+      backingSimulationAvailable: true,
+      saveResume: vi.fn(),
+      createSavedView: vi.fn(),
+      updateSavedView,
+      deleteSavedView: vi.fn(),
+      retry: vi.fn(),
+    };
+
+    render(
+      <SavedViewsControl
+        controller={controller}
+        currentState={tradeState}
+        coherent
+        onOpen={() => restoration.promise}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Saved Views (1)"));
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(screen.getByText("Opening Cloud turret...")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Open" })).toBeDisabled();
+    expect(updateSavedView).not.toHaveBeenCalled();
+
+    restoration.resolve({ status: "healthy", message: "Saved View restored." });
+    await waitFor(() =>
+      expect(updateSavedView).toHaveBeenCalledWith(savedView.saved_view_id, {
+        restoration_status: "healthy",
+        restoration_message: "Saved View restored.",
+      }),
+    );
+    expect(screen.getByText("Saved View restored.")).toBeVisible();
+  });
+
+  it("records failed evidence loading only after restoration reaches a final state", async () => {
+    const updateSavedView = vi.fn().mockResolvedValue(undefined);
+    const controller: ExploreStateLibraryController = {
+      library: {
+        ...libraryResponse(null).library,
+        saved_views: [savedView],
+      },
+      loading: false,
+      error: null,
+      savingResume: false,
+      backingSimulationAvailable: true,
+      saveResume: vi.fn(),
+      createSavedView: vi.fn(),
+      updateSavedView,
+      deleteSavedView: vi.fn(),
+      retry: vi.fn(),
+    };
+
+    render(
+      <SavedViewsControl
+        controller={controller}
+        currentState={tradeState}
+        coherent
+        onOpen={vi.fn().mockResolvedValue({
+          status: "unavailable",
+          message: "The saved output evidence is unavailable.",
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Saved Views (1)"));
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+
+    expect(await screen.findByText("The saved output evidence is unavailable.")).toBeVisible();
+    expect(updateSavedView).toHaveBeenCalledTimes(1);
+    expect(updateSavedView).toHaveBeenCalledWith(savedView.saved_view_id, {
+      restoration_status: "unavailable",
+      restoration_message: "The saved output evidence is unavailable.",
+    });
+  });
+
+  it("keeps a successful live restoration usable when status persistence fails", async () => {
+    const updateSavedView = vi.fn().mockRejectedValue(new Error("Local state is read-only."));
+    const controller: ExploreStateLibraryController = {
+      library: {
+        ...libraryResponse(null).library,
+        saved_views: [savedView],
+      },
+      loading: false,
+      error: null,
+      savingResume: false,
+      backingSimulationAvailable: true,
+      saveResume: vi.fn(),
+      createSavedView: vi.fn(),
+      updateSavedView,
+      deleteSavedView: vi.fn(),
+      retry: vi.fn(),
+    };
+
+    render(
+      <SavedViewsControl
+        controller={controller}
+        currentState={tradeState}
+        coherent
+        onOpen={vi.fn().mockResolvedValue({
+          status: "healthy",
+          message: "Saved View restored.",
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Saved Views (1)"));
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+
+    expect(
+      await screen.findByText(
+        "Saved View restored. Its restoration status could not be recorded: Local state is read-only.",
+      ),
+    ).toBeVisible();
+    expect(updateSavedView).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useExploreStateLibrary", () => {
+  it("serializes overlapping resume writes and leaves the newest state in client and storage", async () => {
+    const firstWrite = deferred<Response>();
+    const secondWrite = deferred<Response>();
+    const requestedStates: TradeCumulusExploreState[] = [];
+    let persistedState: TradeCumulusExploreState | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method !== "PUT") {
+          return Promise.resolve(
+            new Response(JSON.stringify(libraryResponse(null)), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
+        }
+        expect(url).toContain("/explore-state/resume");
+        const state = JSON.parse(String(init.body)).state as TradeCumulusExploreState;
+        requestedStates.push(state);
+        return requestedStates.length === 1 ? firstWrite.promise : secondWrite.promise;
+      }),
+    );
+    const { result } = renderHook(() =>
+      useExploreStateLibrary("trade_cumulus", "trade_cumulus_canonical_bomex"),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const olderState = { ...tradeState, model_time_seconds: 900 };
+    const newestState = { ...tradeState, model_time_seconds: 1_800 };
+    let drain!: Promise<void>;
+    act(() => {
+      drain = result.current.saveResume(olderState);
+      void result.current.saveResume(newestState);
+    });
+    await waitFor(() => expect(result.current.savingResume).toBe(true));
+    expect(requestedStates).toEqual([olderState]);
+
+    persistedState = olderState;
+    firstWrite.resolve(
+      new Response(JSON.stringify(libraryResponse(olderState)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await waitFor(() => expect(requestedStates).toEqual([olderState, newestState]));
+    expect(result.current.library?.last_active).toBeNull();
+    expect(result.current.savingResume).toBe(true);
+
+    persistedState = newestState;
+    secondWrite.resolve(
+      new Response(JSON.stringify(libraryResponse(newestState)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await act(async () => drain);
+
+    expect(result.current.savingResume).toBe(false);
+    expect(result.current.library?.last_active?.state.model_time_seconds).toBe(1_800);
+    expect(persistedState.model_time_seconds).toBe(1_800);
   });
 });

--- a/app/frontend/src/ExploreStatePersistence.test.tsx
+++ b/app/frontend/src/ExploreStatePersistence.test.tsx
@@ -1,0 +1,177 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type ExploreStateLibraryController,
+  type SavedViewRecord,
+  SavedViewsControl,
+  type TradeCumulusExploreState,
+  nearestSavedCoordinate,
+} from "./ExploreStatePersistence";
+
+const tradeState: TradeCumulusExploreState = {
+  state_version: 1,
+  world_id: "trade_cumulus",
+  model_time_seconds: 12_060,
+  context_collapsed: false,
+  secondary_section: "science",
+  selected_point: null,
+  view_id: "updraft_lens",
+  scene_field_id: "ql",
+  slice_field_id: "ql",
+  fixed_scale_id: "trade_cumulus_updraft_velocity_v1",
+  active_slice_plane: "vertical_x",
+  slice_coordinate_km: 0.05,
+  slice_native_index: 1,
+  horizontal_slice_coordinate_km: 0.8,
+  threshold_native: 0.000001,
+  layer_opacity: 0.68,
+  point_size_px: 11,
+  lens_opacity: 0.9,
+  show_slice_plane: true,
+  show_cloud_boundary: true,
+  show_horizontal_wind: true,
+  wind_mode: "perturbation",
+  camera_preset: "overview",
+  camera_transform: null,
+  playback_speed: 1,
+  display_controls_open: false,
+};
+
+const savedView: SavedViewRecord = {
+  saved_view_id: "0123456789abcdef0123456789abcdef",
+  title: "Cloud turret",
+  description: "Before the pulse weakens.",
+  created_at: "2026-07-26T12:00:00Z",
+  updated_at: "2026-07-26T12:00:00Z",
+  restoration_status: "healthy",
+  restoration_message: null,
+  snapshot: {
+    schema_version: 1,
+    world_id: "trade_cumulus",
+    simulation_id: "trade_cumulus_canonical_bomex",
+    captured_at: "2026-07-26T12:00:00Z",
+    state: tradeState,
+  },
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("nearestSavedCoordinate", () => {
+  it("maps exact and bounded physical coordinates without accepting distant output", () => {
+    expect(nearestSavedCoordinate([-1, 0, 1], 0, 0.2)).toEqual({
+      index: 1,
+      value: 0,
+      exact: true,
+    });
+    expect(nearestSavedCoordinate([-1, 0, 1], 0.08, 0.2)).toEqual({
+      index: 1,
+      value: 0,
+      exact: false,
+    });
+    expect(nearestSavedCoordinate([-1, 0, 1], 0.4, 0.2)).toBeNull();
+  });
+});
+
+describe("SavedViewsControl", () => {
+  it("surfaces persistence errors before the control is opened", () => {
+    const controller: ExploreStateLibraryController = {
+      library: null,
+      loading: false,
+      error: "Unable to load Saved Views and resume state.",
+      savingResume: false,
+      backingSimulationAvailable: false,
+      saveResume: vi.fn(),
+      createSavedView: vi.fn(),
+      updateSavedView: vi.fn(),
+      deleteSavedView: vi.fn(),
+      retry: vi.fn(),
+    };
+
+    render(
+      <SavedViewsControl
+        controller={controller}
+        currentState={null}
+        coherent={false}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("State error")).toBeVisible();
+  });
+
+  it("creates, opens, renames, and deletes live examinations", async () => {
+    const createSavedView = vi.fn().mockResolvedValue(undefined);
+    const updateSavedView = vi.fn().mockResolvedValue(undefined);
+    const deleteSavedView = vi.fn().mockResolvedValue(undefined);
+    const onOpen = vi.fn().mockReturnValue({
+      status: "healthy",
+      message: "Saved View restored.",
+    });
+    const controller: ExploreStateLibraryController = {
+      library: {
+        schema_version: 1,
+        world_id: "trade_cumulus",
+        simulation_id: "trade_cumulus_canonical_bomex",
+        last_active: null,
+        saved_views: [savedView],
+      },
+      loading: false,
+      error: null,
+      savingResume: false,
+      backingSimulationAvailable: true,
+      saveResume: vi.fn(),
+      createSavedView,
+      updateSavedView,
+      deleteSavedView,
+      retry: vi.fn(),
+    };
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(
+      <SavedViewsControl
+        controller={controller}
+        currentState={tradeState}
+        coherent
+        onOpen={onOpen}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Saved Views (1)"));
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Later pulse" } });
+    fireEvent.change(screen.getByLabelText(/Description/), {
+      target: { value: "Compare after the next retained output." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save current view" }));
+    await waitFor(() =>
+      expect(createSavedView).toHaveBeenCalledWith(
+        "Later pulse",
+        "Compare after the next retained output.",
+        tradeState,
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    await waitFor(() => expect(onOpen).toHaveBeenCalledWith(tradeState, savedView));
+    expect(updateSavedView).toHaveBeenCalledWith(savedView.saved_view_id, {
+      restoration_status: "healthy",
+      restoration_message: "Saved View restored.",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+    const titleInputs = screen.getAllByLabelText("Title");
+    fireEvent.change(titleInputs.at(-1)!, { target: { value: "Renamed turret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(updateSavedView).toHaveBeenCalledWith(savedView.saved_view_id, {
+        title: "Renamed turret",
+        description: "Before the pulse weakens.",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => expect(deleteSavedView).toHaveBeenCalledWith(savedView.saved_view_id));
+  });
+});

--- a/app/frontend/src/ExploreStatePersistence.tsx
+++ b/app/frontend/src/ExploreStatePersistence.tsx
@@ -196,22 +196,38 @@ export function useExploreStateLibrary(
   const [backingSimulationAvailable, setBackingSimulationAvailable] = useState(true);
   const [retryNonce, setRetryNonce] = useState(0);
   const lastResumeSignature = useRef<string | null>(null);
+  const activeResumeSignature = useRef<string | null>(null);
+  const queuedResume = useRef<{ state: ExploreWorldState; signature: string } | null>(null);
+  const resumeDrain = useRef<Promise<void> | null>(null);
+  const activeIdentity = useRef<string | null>(null);
 
   useEffect(() => {
     if (!worldId || !simulationId) {
+      activeIdentity.current = null;
+      queuedResume.current = null;
+      activeResumeSignature.current = null;
+      resumeDrain.current = null;
       setLibrary(null);
       setLoading(false);
       setError(null);
+      setSavingResume(false);
       setBackingSimulationAvailable(false);
       return;
     }
+    const identity = `${worldId}/${simulationId}`;
+    activeIdentity.current = identity;
+    queuedResume.current = null;
+    activeResumeSignature.current = null;
+    resumeDrain.current = null;
     const controller = new AbortController();
     setLoading(true);
     setError(null);
+    setSavingResume(false);
     setLibrary(null);
     lastResumeSignature.current = null;
     void exploreRequest(exploreStateUrl(worldId, simulationId), { signal: controller.signal })
       .then((response) => {
+        if (activeIdentity.current !== identity) return;
         setLibrary(response.library);
         setBackingSimulationAvailable(response.backing_simulation_available);
         lastResumeSignature.current = response.library.last_active
@@ -220,35 +236,67 @@ export function useExploreStateLibrary(
       })
       .catch((caught: unknown) => {
         if (caught instanceof DOMException && caught.name === "AbortError") return;
+        if (activeIdentity.current !== identity) return;
         setError(exploreErrorMessage(caught, "Unable to load Saved Views and resume state."));
       })
       .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
+        if (!controller.signal.aborted && activeIdentity.current === identity) setLoading(false);
       });
     return () => controller.abort();
   }, [retryNonce, simulationId, worldId]);
 
   const saveResume = useCallback(
-    async (state: ExploreWorldState) => {
+    (state: ExploreWorldState): Promise<void> => {
       if (!worldId || !simulationId) throw new Error("Stable Simulation identity is unavailable.");
+      const identity = `${worldId}/${simulationId}`;
       const signature = JSON.stringify(state);
-      if (signature === lastResumeSignature.current) return;
-      setSavingResume(true);
-      try {
-        const response = await exploreRequest(`${exploreStateUrl(worldId, simulationId)}/resume`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ state }),
-        });
-        lastResumeSignature.current = signature;
-        setLibrary(response.library);
-        setBackingSimulationAvailable(response.backing_simulation_available);
-        setError(null);
-      } catch (caught) {
-        setError(exploreErrorMessage(caught, "Unable to save Explore resume state."));
-      } finally {
-        setSavingResume(false);
+      if (
+        signature === lastResumeSignature.current ||
+        signature === activeResumeSignature.current ||
+        signature === queuedResume.current?.signature
+      ) {
+        return resumeDrain.current ?? Promise.resolve();
       }
+      queuedResume.current = { state, signature };
+      if (resumeDrain.current) return resumeDrain.current;
+
+      const drain = async () => {
+        setSavingResume(true);
+        while (queuedResume.current && activeIdentity.current === identity) {
+          const pending = queuedResume.current;
+          queuedResume.current = null;
+          activeResumeSignature.current = pending.signature;
+          try {
+            const response = await exploreRequest(
+              `${exploreStateUrl(worldId, simulationId)}/resume`,
+              {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ state: pending.state }),
+              },
+            );
+            if (activeIdentity.current !== identity) return;
+            if (queuedResume.current) continue;
+            lastResumeSignature.current = pending.signature;
+            setLibrary(response.library);
+            setBackingSimulationAvailable(response.backing_simulation_available);
+            setError(null);
+          } catch (caught) {
+            if (activeIdentity.current !== identity) return;
+            if (!queuedResume.current) {
+              setError(exploreErrorMessage(caught, "Unable to save Explore resume state."));
+            }
+          } finally {
+            activeResumeSignature.current = null;
+          }
+        }
+      };
+      const currentDrain = drain().finally(() => {
+        if (activeIdentity.current === identity) setSavingResume(false);
+        if (resumeDrain.current === currentDrain) resumeDrain.current = null;
+      });
+      resumeDrain.current = currentDrain;
+      return currentDrain;
     },
     [simulationId, worldId],
   );
@@ -256,18 +304,23 @@ export function useExploreStateLibrary(
   const createSavedView = useCallback(
     async (title: string, description: string, state: ExploreWorldState) => {
       if (!worldId || !simulationId) throw new Error("Stable Simulation identity is unavailable.");
-      const response = await exploreRequest(savedViewsUrl(worldId, simulationId), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: title.trim(),
-          description: description.trim() || null,
-          state,
-        }),
-      });
-      setLibrary(response.library);
-      setBackingSimulationAvailable(response.backing_simulation_available);
-      setError(null);
+      try {
+        const response = await exploreRequest(savedViewsUrl(worldId, simulationId), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: title.trim(),
+            description: description.trim() || null,
+            state,
+          }),
+        });
+        setLibrary(response.library);
+        setBackingSimulationAvailable(response.backing_simulation_available);
+        setError(null);
+      } catch (caught) {
+        setError(exploreErrorMessage(caught, "Unable to save this view."));
+        throw caught;
+      }
     },
     [simulationId, worldId],
   );
@@ -283,17 +336,22 @@ export function useExploreStateLibrary(
       },
     ) => {
       if (!worldId || !simulationId) throw new Error("Stable Simulation identity is unavailable.");
-      const response = await exploreRequest(
-        `${savedViewsUrl(worldId, simulationId)}/${encodeURIComponent(savedViewId)}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(update),
-        },
-      );
-      setLibrary(response.library);
-      setBackingSimulationAvailable(response.backing_simulation_available);
-      setError(null);
+      try {
+        const response = await exploreRequest(
+          `${savedViewsUrl(worldId, simulationId)}/${encodeURIComponent(savedViewId)}`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(update),
+          },
+        );
+        setLibrary(response.library);
+        setBackingSimulationAvailable(response.backing_simulation_available);
+        setError(null);
+      } catch (caught) {
+        setError(exploreErrorMessage(caught, "Unable to update this Saved View."));
+        throw caught;
+      }
     },
     [simulationId, worldId],
   );
@@ -301,13 +359,18 @@ export function useExploreStateLibrary(
   const deleteSavedView = useCallback(
     async (savedViewId: string) => {
       if (!worldId || !simulationId) throw new Error("Stable Simulation identity is unavailable.");
-      const response = await exploreRequest(
-        `${savedViewsUrl(worldId, simulationId)}/${encodeURIComponent(savedViewId)}`,
-        { method: "DELETE" },
-      );
-      setLibrary(response.library);
-      setBackingSimulationAvailable(response.backing_simulation_available);
-      setError(null);
+      try {
+        const response = await exploreRequest(
+          `${savedViewsUrl(worldId, simulationId)}/${encodeURIComponent(savedViewId)}`,
+          { method: "DELETE" },
+        );
+        setLibrary(response.library);
+        setBackingSimulationAvailable(response.backing_simulation_available);
+        setError(null);
+      } catch (caught) {
+        setError(exploreErrorMessage(caught, "Unable to delete this Saved View."));
+        throw caught;
+      }
     },
     [simulationId, worldId],
   );
@@ -338,7 +401,7 @@ export function SavedViewsControl({
   onOpen: (
     state: ExploreWorldState,
     savedView: SavedViewRecord,
-  ) => Promise<ExploreRestorationResult> | ExploreRestorationResult;
+  ) => Promise<ExploreRestorationResult>;
 }) {
   const panelId = useId();
   const [title, setTitle] = useState("");
@@ -370,8 +433,15 @@ export function SavedViewsControl({
   async function openSavedView(savedView: SavedViewRecord) {
     setActionState("saving");
     setActionMessage(`Opening ${savedView.title}...`);
+    let result: ExploreRestorationResult;
     try {
-      const result = await onOpen(savedView.snapshot.state, savedView);
+      result = await onOpen(savedView.snapshot.state, savedView);
+    } catch (caught) {
+      setActionState("failed");
+      setActionMessage(exploreErrorMessage(caught, "Unable to open this Saved View."));
+      return;
+    }
+    try {
       await controller.updateSavedView(savedView.saved_view_id, {
         restoration_status: result.status,
         restoration_message: result.message,
@@ -379,13 +449,13 @@ export function SavedViewsControl({
       setActionState(result.status === "unavailable" ? "failed" : "idle");
       setActionMessage(result.message);
     } catch (caught) {
-      const message = exploreErrorMessage(caught, "Unable to open this Saved View.");
       setActionState("failed");
-      setActionMessage(message);
-      await controller.updateSavedView(savedView.saved_view_id, {
-        restoration_status: "unavailable",
-        restoration_message: message,
-      });
+      setActionMessage(
+        `${result.message} Its restoration status could not be recorded: ${exploreErrorMessage(
+          caught,
+          "local persistence failed.",
+        )}`,
+      );
     }
   }
 

--- a/app/frontend/src/ExploreStatePersistence.tsx
+++ b/app/frontend/src/ExploreStatePersistence.tsx
@@ -250,15 +250,16 @@ export function useExploreStateLibrary(
       if (!worldId || !simulationId) throw new Error("Stable Simulation identity is unavailable.");
       const identity = `${worldId}/${simulationId}`;
       const signature = JSON.stringify(state);
-      if (
-        signature === lastResumeSignature.current ||
-        signature === activeResumeSignature.current ||
-        signature === queuedResume.current?.signature
-      ) {
-        return resumeDrain.current ?? Promise.resolve();
+      if (resumeDrain.current) {
+        if (signature === activeResumeSignature.current) {
+          queuedResume.current = null;
+        } else {
+          queuedResume.current = { state, signature };
+        }
+        return resumeDrain.current;
       }
+      if (signature === lastResumeSignature.current) return Promise.resolve();
       queuedResume.current = { state, signature };
-      if (resumeDrain.current) return resumeDrain.current;
 
       const drain = async () => {
         setSavingResume(true);

--- a/app/frontend/src/ExploreStatePersistence.tsx
+++ b/app/frontend/src/ExploreStatePersistence.tsx
@@ -1,0 +1,676 @@
+import {
+  type FormEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+
+import type { ExploreSecondarySection } from "./IntegratedExploreWorkspace";
+import type { CameraPreset, CameraTransform } from "./True3DViewer";
+
+export type ExplorePoint = {
+  x_km: number;
+  y_km: number | null;
+  z_km: number;
+};
+
+type ExploreStateCommon = {
+  state_version: 1;
+  model_time_seconds: number;
+  context_collapsed: boolean;
+  secondary_section: ExploreSecondarySection;
+  selected_point: ExplorePoint | null;
+};
+
+export type TradeCumulusExploreState = ExploreStateCommon & {
+  world_id: "trade_cumulus";
+  view_id: "field" | "updraft_lens";
+  scene_field_id: string;
+  slice_field_id: string;
+  fixed_scale_id: string | null;
+  active_slice_plane: "horizontal" | "vertical_x" | "vertical_y";
+  slice_coordinate_km: number;
+  slice_native_index: number;
+  horizontal_slice_coordinate_km: number | null;
+  threshold_native: number;
+  layer_opacity: number;
+  point_size_px: number;
+  lens_opacity: number;
+  show_slice_plane: boolean;
+  show_cloud_boundary: boolean;
+  show_horizontal_wind: boolean;
+  wind_mode: "perturbation" | "total";
+  camera_preset: CameraPreset;
+  camera_transform: CameraTransform | null;
+  playback_speed: number;
+  display_controls_open: boolean;
+};
+
+export type MountainWavesExploreState = ExploreStateCommon & {
+  world_id: "mountain_waves";
+  view_id: "field" | "wave_structure" | "wave_cloud";
+  field_id: "w" | "theta_perturbation" | "cloud_liquid" | "relative_humidity";
+  fixed_scale_id: string;
+  viewport_id: "focus" | "full";
+  geometry_id: "expanded" | "physical";
+  overlays: {
+    cloud_points: boolean;
+    cloud_boundary: boolean;
+    saturation_contour: boolean;
+    horizontal_wind: boolean;
+    potential_temperature_contours: boolean;
+  };
+  cloud_opacity: number;
+  cloud_point_size_px: number;
+  playback_speed: number;
+};
+
+export type SupercellsExploreState = ExploreStateCommon & {
+  world_id: "supercells";
+  lens_id: "rotating_updraft" | "cloud_precipitation" | "low_level_interactions";
+  viewport_id: "storm" | "full";
+  evidence_view: "plan" | "xz" | "yz";
+  plane_coordinate_km: number;
+  visible_layer_ids: string[];
+  fixed_scale_ids: string[];
+  overlays: {
+    rotation: boolean;
+    updraft_helicity: boolean;
+    reflectivity: boolean;
+    condensate: boolean;
+    rain: boolean;
+    wind: boolean;
+    precipitating_condensate: boolean;
+    vertical_motion: boolean;
+  };
+  hydrometeor_category_codes: number[];
+  camera_preset: CameraPreset;
+  camera_transform: CameraTransform | null;
+  scene_opacity: number;
+  scene_point_size: number;
+  selected_evidence_visible: boolean;
+  playback_speed: number;
+  display_controls_open: boolean;
+};
+
+export type ExploreWorldState =
+  | TradeCumulusExploreState
+  | MountainWavesExploreState
+  | SupercellsExploreState;
+
+export type ExploreStateSnapshot = {
+  schema_version: 1;
+  world_id: string;
+  simulation_id: string;
+  captured_at: string;
+  state: ExploreWorldState;
+};
+
+export type SavedViewRecord = {
+  saved_view_id: string;
+  title: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  restoration_status: "healthy" | "partially_restorable" | "unavailable";
+  restoration_message: string | null;
+  snapshot: ExploreStateSnapshot;
+};
+
+export type ExploreStateLibrary = {
+  schema_version: 1;
+  world_id: string;
+  simulation_id: string;
+  last_active: ExploreStateSnapshot | null;
+  saved_views: SavedViewRecord[];
+};
+
+type ExploreStateLibraryResponse = {
+  library: ExploreStateLibrary;
+  backing_simulation_available: boolean;
+};
+
+export type ExploreRestorationResult = {
+  status: "healthy" | "partially_restorable" | "unavailable";
+  message: string;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function nearestSavedCoordinate(
+  values: number[],
+  target: number,
+  maximumDistance: number,
+): { index: number; value: number; exact: boolean } | null {
+  if (!Number.isFinite(target) || values.length === 0) return null;
+  let index = -1;
+  let distance = Number.POSITIVE_INFINITY;
+  values.forEach((value, candidateIndex) => {
+    if (!Number.isFinite(value)) return;
+    const candidateDistance = Math.abs(value - target);
+    if (candidateDistance < distance) {
+      index = candidateIndex;
+      distance = candidateDistance;
+    }
+  });
+  if (index < 0 || distance > maximumDistance + Number.EPSILON) return null;
+  return {
+    index,
+    value: values[index],
+    exact: distance <= Number.EPSILON,
+  };
+}
+
+export type ExploreStateLibraryController = {
+  library: ExploreStateLibrary | null;
+  loading: boolean;
+  error: string | null;
+  savingResume: boolean;
+  backingSimulationAvailable: boolean;
+  saveResume: (state: ExploreWorldState) => Promise<void>;
+  createSavedView: (title: string, description: string, state: ExploreWorldState) => Promise<void>;
+  updateSavedView: (
+    savedViewId: string,
+    update: {
+      title?: string;
+      description?: string | null;
+      restoration_status?: ExploreRestorationResult["status"];
+      restoration_message?: string | null;
+    },
+  ) => Promise<void>;
+  deleteSavedView: (savedViewId: string) => Promise<void>;
+  retry: () => void;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useExploreStateLibrary(
+  worldId: ExploreWorldState["world_id"] | null,
+  simulationId: string | null,
+): ExploreStateLibraryController {
+  const [library, setLibrary] = useState<ExploreStateLibrary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [savingResume, setSavingResume] = useState(false);
+  const [backingSimulationAvailable, setBackingSimulationAvailable] = useState(true);
+  const [retryNonce, setRetryNonce] = useState(0);
+  const lastResumeSignature = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!worldId || !simulationId) {
+      setLibrary(null);
+      setLoading(false);
+      setError(null);
+      setBackingSimulationAvailable(false);
+      return;
+    }
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    setLibrary(null);
+    lastResumeSignature.current = null;
+    void exploreRequest(exploreStateUrl(worldId, simulationId), { signal: controller.signal })
+      .then((response) => {
+        setLibrary(response.library);
+        setBackingSimulationAvailable(response.backing_simulation_available);
+        lastResumeSignature.current = response.library.last_active
+          ? JSON.stringify(response.library.last_active.state)
+          : null;
+      })
+      .catch((caught: unknown) => {
+        if (caught instanceof DOMException && caught.name === "AbortError") return;
+        setError(exploreErrorMessage(caught, "Unable to load Saved Views and resume state."));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [retryNonce, simulationId, worldId]);
+
+  const saveResume = useCallback(
+    async (state: ExploreWorldState) => {
+      if (!worldId || !simulationId) throw new Error("Stable Simulation identity is unavailable.");
+      const signature = JSON.stringify(state);
+      if (signature === lastResumeSignature.current) return;
+      setSavingResume(true);
+      try {
+        const response = await exploreRequest(`${exploreStateUrl(worldId, simulationId)}/resume`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ state }),
+        });
+        lastResumeSignature.current = signature;
+        setLibrary(response.library);
+        setBackingSimulationAvailable(response.backing_simulation_available);
+        setError(null);
+      } catch (caught) {
+        setError(exploreErrorMessage(caught, "Unable to save Explore resume state."));
+      } finally {
+        setSavingResume(false);
+      }
+    },
+    [simulationId, worldId],
+  );
+
+  const createSavedView = useCallback(
+    async (title: string, description: string, state: ExploreWorldState) => {
+      if (!worldId || !simulationId) throw new Error("Stable Simulation identity is unavailable.");
+      const response = await exploreRequest(savedViewsUrl(worldId, simulationId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim() || null,
+          state,
+        }),
+      });
+      setLibrary(response.library);
+      setBackingSimulationAvailable(response.backing_simulation_available);
+      setError(null);
+    },
+    [simulationId, worldId],
+  );
+
+  const updateSavedView = useCallback(
+    async (
+      savedViewId: string,
+      update: {
+        title?: string;
+        description?: string | null;
+        restoration_status?: ExploreRestorationResult["status"];
+        restoration_message?: string | null;
+      },
+    ) => {
+      if (!worldId || !simulationId) throw new Error("Stable Simulation identity is unavailable.");
+      const response = await exploreRequest(
+        `${savedViewsUrl(worldId, simulationId)}/${encodeURIComponent(savedViewId)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(update),
+        },
+      );
+      setLibrary(response.library);
+      setBackingSimulationAvailable(response.backing_simulation_available);
+      setError(null);
+    },
+    [simulationId, worldId],
+  );
+
+  const deleteSavedView = useCallback(
+    async (savedViewId: string) => {
+      if (!worldId || !simulationId) throw new Error("Stable Simulation identity is unavailable.");
+      const response = await exploreRequest(
+        `${savedViewsUrl(worldId, simulationId)}/${encodeURIComponent(savedViewId)}`,
+        { method: "DELETE" },
+      );
+      setLibrary(response.library);
+      setBackingSimulationAvailable(response.backing_simulation_available);
+      setError(null);
+    },
+    [simulationId, worldId],
+  );
+
+  return {
+    library,
+    loading,
+    error,
+    savingResume,
+    backingSimulationAvailable,
+    saveResume,
+    createSavedView,
+    updateSavedView,
+    deleteSavedView,
+    retry: () => setRetryNonce((current) => current + 1),
+  };
+}
+
+export function SavedViewsControl({
+  controller,
+  currentState,
+  coherent,
+  onOpen,
+}: {
+  controller: ExploreStateLibraryController;
+  currentState: ExploreWorldState | null;
+  coherent: boolean;
+  onOpen: (
+    state: ExploreWorldState,
+    savedView: SavedViewRecord,
+  ) => Promise<ExploreRestorationResult> | ExploreRestorationResult;
+}) {
+  const panelId = useId();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [actionState, setActionState] = useState<"idle" | "saving" | "failed">("idle");
+  const [actionMessage, setActionMessage] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const savedViews = controller.library?.saved_views ?? [];
+
+  async function saveCurrentView(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!currentState || !coherent || !title.trim()) return;
+    setActionState("saving");
+    setActionMessage("Saving view...");
+    try {
+      await controller.createSavedView(title, description, currentState);
+      setTitle("");
+      setDescription("");
+      setActionState("idle");
+      setActionMessage("Saved");
+    } catch (caught) {
+      setActionState("failed");
+      setActionMessage(exploreErrorMessage(caught, "Unable to save this view."));
+    }
+  }
+
+  async function openSavedView(savedView: SavedViewRecord) {
+    setActionState("saving");
+    setActionMessage(`Opening ${savedView.title}...`);
+    try {
+      const result = await onOpen(savedView.snapshot.state, savedView);
+      await controller.updateSavedView(savedView.saved_view_id, {
+        restoration_status: result.status,
+        restoration_message: result.message,
+      });
+      setActionState(result.status === "unavailable" ? "failed" : "idle");
+      setActionMessage(result.message);
+    } catch (caught) {
+      const message = exploreErrorMessage(caught, "Unable to open this Saved View.");
+      setActionState("failed");
+      setActionMessage(message);
+      await controller.updateSavedView(savedView.saved_view_id, {
+        restoration_status: "unavailable",
+        restoration_message: message,
+      });
+    }
+  }
+
+  async function renameSavedView(event: FormEvent<HTMLFormElement>, savedViewId: string) {
+    event.preventDefault();
+    if (!editTitle.trim()) return;
+    setActionState("saving");
+    try {
+      await controller.updateSavedView(savedViewId, {
+        title: editTitle.trim(),
+        description: editDescription.trim() || null,
+      });
+      setEditingId(null);
+      setActionState("idle");
+      setActionMessage("Saved View updated");
+    } catch (caught) {
+      setActionState("failed");
+      setActionMessage(exploreErrorMessage(caught, "Unable to update this Saved View."));
+    }
+  }
+
+  async function removeSavedView(savedView: SavedViewRecord) {
+    if (!window.confirm(`Delete the Saved View "${savedView.title}"?`)) return;
+    setActionState("saving");
+    try {
+      await controller.deleteSavedView(savedView.saved_view_id);
+      setActionState("idle");
+      setActionMessage("Saved View deleted");
+    } catch (caught) {
+      setActionState("failed");
+      setActionMessage(exploreErrorMessage(caught, "Unable to delete this Saved View."));
+    }
+  }
+
+  return (
+    <details className="saved-views-control">
+      <summary aria-controls={panelId}>
+        Saved Views{savedViews.length > 0 ? ` (${savedViews.length})` : ""}
+        {controller.error && (
+          <span className="saved-views-summary-error" title={controller.error}>
+            State error
+          </span>
+        )}
+      </summary>
+      <section id={panelId} className="saved-views-popover" aria-label="Saved Views">
+        <header>
+          <div>
+            <p className="eyebrow">Live examinations</p>
+            <h3>Saved Views</h3>
+          </div>
+          {controller.savingResume && (
+            <span className="saved-views-resume-state">Saving state...</span>
+          )}
+        </header>
+
+        {controller.loading ? (
+          <p role="status">Loading Saved Views...</p>
+        ) : controller.error && !controller.library ? (
+          <div className="saved-views-error">
+            <p role="alert">{controller.error}</p>
+            <button type="button" onClick={controller.retry}>
+              Retry
+            </button>
+          </div>
+        ) : (
+          <>
+            <form
+              className="saved-view-create-form"
+              onSubmit={(event) => void saveCurrentView(event)}
+            >
+              <label>
+                Title
+                <input
+                  type="text"
+                  maxLength={120}
+                  required
+                  value={title}
+                  placeholder="Name this examination"
+                  onChange={(event) => setTitle(event.target.value)}
+                />
+              </label>
+              <label>
+                Description <span>optional</span>
+                <textarea
+                  rows={2}
+                  maxLength={1_000}
+                  value={description}
+                  placeholder="What is worth returning to?"
+                  onChange={(event) => setDescription(event.target.value)}
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={!coherent || !currentState || !title.trim() || actionState === "saving"}
+              >
+                Save current view
+              </button>
+              {!coherent && <small>Wait for the current scientific view to finish loading.</small>}
+            </form>
+
+            <div className="saved-view-list">
+              {savedViews.length === 0 ? (
+                <p className="saved-view-empty">No Saved Views yet.</p>
+              ) : (
+                savedViews.map((savedView) => (
+                  <article key={savedView.saved_view_id} className="saved-view-item">
+                    {editingId === savedView.saved_view_id ? (
+                      <form
+                        className="saved-view-edit-form"
+                        onSubmit={(event) => void renameSavedView(event, savedView.saved_view_id)}
+                      >
+                        <label>
+                          Title
+                          <input
+                            type="text"
+                            maxLength={120}
+                            required
+                            value={editTitle}
+                            onChange={(event) => setEditTitle(event.target.value)}
+                          />
+                        </label>
+                        <label>
+                          Description
+                          <textarea
+                            rows={2}
+                            maxLength={1_000}
+                            value={editDescription}
+                            onChange={(event) => setEditDescription(event.target.value)}
+                          />
+                        </label>
+                        <div className="saved-view-actions">
+                          <button type="submit">Save</button>
+                          <button
+                            type="button"
+                            className="secondary-button"
+                            onClick={() => setEditingId(null)}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </form>
+                    ) : (
+                      <>
+                        <div className="saved-view-item-heading">
+                          <div>
+                            <h4>{savedView.title}</h4>
+                            <p>{savedViewSummary(savedView.snapshot.state)}</p>
+                          </div>
+                          <SavedViewStatus record={savedView} />
+                        </div>
+                        {savedView.description && <p>{savedView.description}</p>}
+                        {savedView.restoration_message && (
+                          <small>{savedView.restoration_message}</small>
+                        )}
+                        <div className="saved-view-actions">
+                          <button
+                            type="button"
+                            disabled={
+                              !controller.backingSimulationAvailable || actionState === "saving"
+                            }
+                            onClick={() => void openSavedView(savedView)}
+                          >
+                            Open
+                          </button>
+                          <button
+                            type="button"
+                            className="secondary-button"
+                            onClick={() => {
+                              setEditingId(savedView.saved_view_id);
+                              setEditTitle(savedView.title);
+                              setEditDescription(savedView.description ?? "");
+                            }}
+                          >
+                            Rename
+                          </button>
+                          <button
+                            type="button"
+                            className="secondary-button danger-button"
+                            onClick={() => void removeSavedView(savedView)}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </>
+                    )}
+                  </article>
+                ))
+              )}
+            </div>
+          </>
+        )}
+
+        {(actionMessage || controller.error) && (
+          <p
+            className={`saved-views-action-message${
+              actionState === "failed" || controller.error
+                ? " saved-views-action-message-error"
+                : ""
+            }`}
+            role={actionState === "failed" || controller.error ? "alert" : "status"}
+          >
+            {actionMessage || controller.error}
+          </p>
+        )}
+      </section>
+    </details>
+  );
+}
+
+function SavedViewStatus({ record }: { record: SavedViewRecord }) {
+  const labels: Record<SavedViewRecord["restoration_status"], string> = {
+    healthy: "Ready",
+    partially_restorable: "Adjusted",
+    unavailable: "Unavailable",
+  };
+  return (
+    <span className={`saved-view-status saved-view-status-${record.restoration_status}`}>
+      {labels[record.restoration_status]}
+    </span>
+  );
+}
+
+function savedViewSummary(state: ExploreWorldState): ReactNode {
+  const time = formatSavedTime(state.model_time_seconds);
+  if (state.world_id === "trade_cumulus") {
+    return `${state.view_id === "updraft_lens" ? "Updraft Lens" : "Field"} · ${time} · ${sliceOrientationLabel(state.active_slice_plane)}`;
+  }
+  if (state.world_id === "mountain_waves") {
+    const view =
+      state.view_id === "wave_cloud"
+        ? "Wave Cloud Lens"
+        : state.view_id === "wave_structure"
+          ? "Wave Structure Lens"
+          : "Field";
+    return `${view} · ${time} · ${state.geometry_id === "expanded" ? "Expanded height" : "True physical scale"}`;
+  }
+  const lens = state.lens_id
+    .split("_")
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(" ");
+  return `${lens} · ${time} · ${sliceOrientationLabel(state.evidence_view)}`;
+}
+
+function sliceOrientationLabel(orientation: string): string {
+  if (orientation === "plan" || orientation === "horizontal") return "Horizontal x-y";
+  if (orientation === "xz" || orientation === "vertical_x") return "Vertical x-z";
+  return "Vertical y-z";
+}
+
+function formatSavedTime(seconds: number): string {
+  return `${Math.round(seconds).toLocaleString()} s`;
+}
+
+function exploreStateUrl(worldId: string, simulationId: string): string {
+  return `/api/worlds/${worldId.replaceAll("_", "-")}/simulations/${encodeURIComponent(
+    simulationId,
+  )}/explore-state`;
+}
+
+function savedViewsUrl(worldId: string, simulationId: string): string {
+  return `/api/worlds/${worldId.replaceAll("_", "-")}/simulations/${encodeURIComponent(
+    simulationId,
+  )}/saved-views`;
+}
+
+async function exploreRequest(
+  url: string,
+  init?: RequestInit,
+): Promise<ExploreStateLibraryResponse> {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    throw new Error(await responseMessage(response, "Explore state request failed."));
+  }
+  return (await response.json()) as ExploreStateLibraryResponse;
+}
+
+async function responseMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await response.json()) as { detail?: string };
+    return payload.detail || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function exploreErrorMessage(caught: unknown, fallback: string): string {
+  return caught instanceof Error ? caught.message : fallback;
+}

--- a/app/frontend/src/IntegratedExploreWorkspace.tsx
+++ b/app/frontend/src/IntegratedExploreWorkspace.tsx
@@ -20,6 +20,7 @@ export function IntegratedExploreWorkspace({
   backLabel,
   onBack,
   onCompare,
+  onUserInteractionCapture,
   headerActions,
   children,
 }: {
@@ -28,11 +29,19 @@ export function IntegratedExploreWorkspace({
   backLabel?: string;
   onBack?: () => void;
   onCompare?: () => void;
+  onUserInteractionCapture?: () => void;
   headerActions?: ReactNode;
   children: ReactNode;
 }) {
   return (
-    <section className="integrated-explore-workspace" aria-label={`${simulationName} Explore`}>
+    <section
+      className="integrated-explore-workspace"
+      aria-label={`${simulationName} Explore`}
+      onPointerDownCapture={onUserInteractionCapture}
+      onClickCapture={onUserInteractionCapture}
+      onKeyDownCapture={onUserInteractionCapture}
+      onInputCapture={onUserInteractionCapture}
+    >
       <header className="integrated-explore-header">
         <div className="integrated-explore-identity">
           {onBack && (

--- a/app/frontend/src/MountainWavesExplore.test.tsx
+++ b/app/frontend/src/MountainWavesExplore.test.tsx
@@ -335,6 +335,47 @@ describe("MountainWavesExplore", () => {
     expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute("aria-selected", "true");
   });
 
+  it("keeps a user edit made before the delayed startup state arrives", async () => {
+    let resolveStartupState!: (response: Response) => void;
+    const startupState = new Promise<Response>((resolve) => {
+      resolveStartupState = resolve;
+    });
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/explore-state") && !init?.method) return startupState;
+      if (url.includes("/explore-state") || url.includes("/saved-views")) {
+        return Promise.resolve(ok(mountainExploreLibrary()));
+      }
+      const requestedIndex = Number(
+        new URL(url, "http://localhost").searchParams.get("time_index"),
+      );
+      const resolvedIndex = requestedIndex < 0 ? frame.time_index : requestedIndex;
+      return Promise.resolve(
+        ok({
+          ...frame,
+          time_index: resolvedIndex,
+          time_seconds: frame.times_seconds[resolvedIndex] ?? frame.time_seconds,
+        }),
+      );
+    });
+
+    render(<MountainWavesExplore simulation={simulation} onBack={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Wave Structure Lens" }));
+    expect(screen.getByRole("button", { name: "Wave Structure Lens" })).toHaveClass(
+      "active-control",
+    );
+
+    act(() => resolveStartupState(ok(mountainExploreLibrary(mountainResumeState))));
+    await waitFor(() =>
+      expect(screen.queryByText("Loading Saved Views...")).not.toBeInTheDocument(),
+    );
+
+    expect(screen.getByRole("button", { name: "Wave Structure Lens" })).toHaveClass(
+      "active-control",
+    );
+    expect(screen.queryByText("Last active view restored.")).not.toBeInTheDocument();
+  });
+
   it("falls back visibly when a retained Simulation no longer has the saved Field", async () => {
     const incompatibleState: MountainWavesExploreState = {
       ...mountainResumeState,
@@ -465,6 +506,11 @@ describe("MountainWavesExplore", () => {
   it("switches to direct Field inspection and preserves the geometry choice", async () => {
     render(<MountainWavesExplore simulation={simulation} onBack={vi.fn()} />);
     await screen.findByRole("heading", { name: "Wave Cloud Lens" });
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("field=cloud_over_wave&time_index=1"),
+      ),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Field" }));
     await waitFor(() =>
       expect(fetch).toHaveBeenCalledWith(expect.stringContaining("field=w&time_index=1")),

--- a/app/frontend/src/MountainWavesExplore.test.tsx
+++ b/app/frontend/src/MountainWavesExplore.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MountainWavesExplore, mountainWavesCloudPointRendering } from "./MountainWavesExplore";
 import type { MountainWavesSimulation } from "./MountainWavesWorld";
+import type { MountainWavesExploreState } from "./ExploreStatePersistence";
 
 const { cloudPointColor, cloudPointOpacity, nativeCloudCellPoints } =
   mountainWavesCloudPointRendering;
@@ -188,6 +189,51 @@ const frame = {
   },
 };
 
+const mountainResumeState: MountainWavesExploreState = {
+  state_version: 1,
+  world_id: "mountain_waves",
+  model_time_seconds: 7_200,
+  context_collapsed: true,
+  secondary_section: "details",
+  selected_point: null,
+  view_id: "wave_cloud",
+  field_id: "w",
+  fixed_scale_id: "mountain_waves_vertical_velocity_v1",
+  viewport_id: "full",
+  geometry_id: "physical",
+  overlays: {
+    cloud_points: true,
+    cloud_boundary: true,
+    saturation_contour: false,
+    horizontal_wind: true,
+    potential_temperature_contours: false,
+  },
+  cloud_opacity: 0.5,
+  cloud_point_size_px: 9,
+  playback_speed: 2,
+};
+
+function mountainExploreLibrary(lastActive: MountainWavesExploreState | null = null) {
+  return {
+    library: {
+      schema_version: 1,
+      world_id: "mountain_waves",
+      simulation_id: simulation.simulation_id,
+      last_active: lastActive
+        ? {
+            schema_version: 1,
+            world_id: "mountain_waves",
+            simulation_id: simulation.simulation_id,
+            captured_at: "2026-07-26T12:00:00Z",
+            state: lastActive,
+          }
+        : null,
+      saved_views: [],
+    },
+    backing_simulation_available: true,
+  };
+}
+
 describe("MountainWavesExplore", () => {
   const originalGetContext = HTMLCanvasElement.prototype.getContext;
 
@@ -196,6 +242,9 @@ describe("MountainWavesExplore", () => {
       "fetch",
       vi.fn((input: RequestInfo | URL) => {
         const url = String(input);
+        if (url.includes("/explore-state") || url.includes("/saved-views")) {
+          return Promise.resolve(ok(mountainExploreLibrary()));
+        }
         if (!url.includes("/frame?")) return Promise.resolve(ok(frame));
         const requestedIndex = Number(
           new URL(url, "http://localhost").searchParams.get("time_index"),
@@ -253,6 +302,89 @@ describe("MountainWavesExplore", () => {
     expect(screen.getByRole("slider", { name: /Saved output/ })).toHaveAttribute("max", "1");
     expect(screen.getByText(/Select a point in the cross-section/)).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Wave Cloud Lens" })).toHaveLength(1);
+  });
+
+  it("resumes the last coherent Mountain Waves examination after reload", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/explore-state") || url.includes("/saved-views")) {
+        return Promise.resolve(ok(mountainExploreLibrary(mountainResumeState)));
+      }
+      const requestedIndex = Number(
+        new URL(url, "http://localhost").searchParams.get("time_index"),
+      );
+      const resolvedIndex = requestedIndex < 0 ? frame.time_index : requestedIndex;
+      return Promise.resolve(
+        ok({
+          ...frame,
+          time_index: resolvedIndex,
+          time_seconds: frame.times_seconds[resolvedIndex] ?? frame.time_seconds,
+        }),
+      );
+    });
+
+    render(<MountainWavesExplore simulation={simulation} onBack={vi.fn()} />);
+
+    expect(await screen.findByText("Last active view restored.")).toBeVisible();
+    expect(screen.getByLabelText("Saved output time")).toHaveValue("1");
+    expect(screen.getByRole("button", { name: "Full domain" })).toHaveClass("active-control");
+    expect(screen.getByRole("button", { name: "True physical scale" })).toHaveClass(
+      "active-control",
+    );
+    expect(screen.getByRole("button", { name: "Show Context" })).toBeVisible();
+    expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("falls back visibly when a retained Simulation no longer has the saved Field", async () => {
+    const incompatibleState: MountainWavesExploreState = {
+      ...mountainResumeState,
+      view_id: "field",
+      field_id: "cloud_liquid",
+    };
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/explore-state")) {
+        const response = mountainExploreLibrary(incompatibleState);
+        response.library.simulation_id = drySimulation.simulation_id;
+        if (response.library.last_active) {
+          response.library.last_active.simulation_id = drySimulation.simulation_id;
+        }
+        return Promise.resolve(ok(response));
+      }
+      return Promise.resolve(ok({ ...frame, dry_case: true, overlay: null }));
+    });
+
+    render(<MountainWavesExplore simulation={drySimulation} onBack={vi.fn()} />);
+
+    expect(
+      await screen.findByText(/saved Field cloud_liquid is unavailable in the retained output/),
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "Wave Structure Lens" })).toHaveClass(
+      "active-control",
+    );
+  });
+
+  it("falls back visibly when the saved model time is no longer retained", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/explore-state")) {
+        return Promise.resolve(
+          ok(
+            mountainExploreLibrary({
+              ...mountainResumeState,
+              model_time_seconds: 99_999,
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(ok(frame));
+    });
+
+    render(<MountainWavesExplore simulation={simulation} onBack={vi.fn()} />);
+
+    expect(
+      await screen.findByText(/saved model time is outside the retained output's compatible range/),
+    ).toBeVisible();
   });
 
   it("uses the shared live Context and below-workspace support sections", async () => {

--- a/app/frontend/src/MountainWavesExplore.tsx
+++ b/app/frontend/src/MountainWavesExplore.tsx
@@ -13,6 +13,15 @@ import {
   type ExploreSecondarySection,
 } from "./IntegratedExploreWorkspace";
 import {
+  nearestSavedCoordinate,
+  SavedViewsControl,
+  useExploreStateLibrary,
+  type ExploreRestorationResult,
+  type ExploreWorldState,
+  type MountainWavesExploreState,
+  type SavedViewRecord,
+} from "./ExploreStatePersistence";
+import {
   curatedResolutionExplanation,
   mountainWavesCuratedView,
   mountainWavesInitialView,
@@ -245,6 +254,12 @@ type PendingMountainCuratedRestore = {
   source: "initial" | "return";
 };
 
+type PendingMountainSavedRestore = {
+  state: MountainWavesExploreState;
+  result: ExploreRestorationResult;
+  savedViewId: string | null;
+};
+
 function mountainWaveAvailableOverlayIds(frame: MountainWaveFrame | null): string[] {
   if (!frame) return [];
   const available: string[] = [];
@@ -322,10 +337,15 @@ export function MountainWavesExplore({
   const [curatedNotice, setCuratedNotice] = useState<ExploreCuratedNotice | null>(null);
   const [pendingCuratedRestore, setPendingCuratedRestore] =
     useState<PendingMountainCuratedRestore | null>(null);
+  const [pendingSavedRestore, setPendingSavedRestore] =
+    useState<PendingMountainSavedRestore | null>(null);
   const [retryNonce, setRetryNonce] = useState(0);
   const requestSequence = useRef(0);
   const initialCuratedSimulationRef = useRef<string | null>(null);
   const curatedNoticeSignatureRef = useRef<string | null>(null);
+  const exploreState = useExploreStateLibrary("mountain_waves", simulation.simulation_id);
+  const saveExploreResume = exploreState.saveResume;
+  const updateExploreSavedView = exploreState.updateSavedView;
 
   const requestedField: MountainWaveField =
     viewMode === "cloud" ? "cloud_over_wave" : viewMode === "structure" ? "w" : field;
@@ -432,6 +452,7 @@ export function MountainWavesExplore({
     setSecondarySection("science");
     setCuratedNotice(null);
     setPendingCuratedRestore(null);
+    setPendingSavedRestore(null);
     curatedNoticeSignatureRef.current = null;
   }, [simulation.moist_fields_available, simulation.simulation_id]);
 
@@ -439,11 +460,75 @@ export function MountainWavesExplore({
     () =>
       (frame?.field_options ?? []).filter(
         (option): option is Exclude<MountainWaveField, "cloud_over_wave"> =>
-          ["w", "cloud_liquid", "relative_humidity", "theta_perturbation"].includes(option),
+          ["w", "cloud_liquid", "relative_humidity", "theta_perturbation"].includes(option) &&
+          (simulation.moist_fields_available ||
+            (option !== "cloud_liquid" && option !== "relative_humidity")),
       ),
-    [frame?.field_options],
+    [frame?.field_options, simulation.moist_fields_available],
   );
   const selectedEvidence = selectedPoint && frame ? pointEvidence(frame, selectedPoint) : null;
+  const capturedExploreState = useMemo<MountainWavesExploreState | null>(() => {
+    if (!frame || !viewportMode) return null;
+    const selectedXKm =
+      selectedPoint === null ? null : frame.geometry.x_center_m[selectedPoint.xIndex] / 1_000;
+    const selectedZKm =
+      selectedPoint === null
+        ? null
+        : frame.geometry.scalar_height_m[selectedPoint.zIndex]?.[selectedPoint.xIndex] / 1_000;
+    return {
+      state_version: 1,
+      world_id: "mountain_waves",
+      model_time_seconds: frame.time_seconds,
+      context_collapsed: contextCollapsed,
+      secondary_section: secondarySection,
+      selected_point:
+        selectedXKm !== null &&
+        selectedZKm !== null &&
+        Number.isFinite(selectedXKm) &&
+        Number.isFinite(selectedZKm)
+          ? { x_km: selectedXKm, y_km: null, z_km: selectedZKm }
+          : null,
+      view_id: mountainCuratedViewId(viewMode),
+      field_id: field,
+      fixed_scale_id: frame.scale.scale_id,
+      viewport_id: viewportMode,
+      geometry_id: geometryMode,
+      overlays: {
+        cloud_points: cloudPoints,
+        cloud_boundary: cloudBoundary,
+        saturation_contour: saturationContour,
+        horizontal_wind: horizontalWind,
+        potential_temperature_contours: potentialTemperatureContours,
+      },
+      cloud_opacity: cloudOpacity,
+      cloud_point_size_px: cloudPointSize,
+      playback_speed: playbackSpeed,
+    };
+  }, [
+    cloudBoundary,
+    cloudOpacity,
+    cloudPointSize,
+    cloudPoints,
+    contextCollapsed,
+    field,
+    frame,
+    geometryMode,
+    horizontalWind,
+    playbackSpeed,
+    potentialTemperatureContours,
+    saturationContour,
+    secondarySection,
+    selectedPoint,
+    viewMode,
+    viewportMode,
+  ]);
+  const exploreStateCoherent =
+    capturedExploreState !== null &&
+    !loading &&
+    !error &&
+    !playing &&
+    !maximized &&
+    frame?.time_index === (timeIndex ?? frame?.time_index);
   const curatedStateSignature = useMemo(
     () =>
       JSON.stringify({
@@ -566,11 +651,246 @@ export function MountainWavesExplore({
     ],
   );
 
+  const applySavedExploreState = useCallback(
+    (
+      savedState: ExploreWorldState,
+      savedView: SavedViewRecord | null,
+    ): ExploreRestorationResult => {
+      if (savedState.world_id !== "mountain_waves") {
+        const result = {
+          status: "unavailable" as const,
+          message: "This Saved View belongs to another Cloud World.",
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+      const availableViews = simulation.moist_fields_available
+        ? ["field", "wave_structure", "wave_cloud"]
+        : ["field", "wave_structure"];
+      if (!availableViews.includes(savedState.view_id)) {
+        const result = {
+          status: "unavailable" as const,
+          message: "The saved Lens is unavailable for this Simulation.",
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+      if (!fieldOptions.includes(savedState.field_id)) {
+        const result = {
+          status: "unavailable" as const,
+          message: `The saved Field ${savedState.field_id} is unavailable in the retained output.`,
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+      const mappedTime = nearestSavedCoordinate(
+        frame?.times_seconds ?? [],
+        savedState.model_time_seconds,
+        180,
+      );
+      if (!mappedTime) {
+        const result = {
+          status: "unavailable" as const,
+          message: "The saved model time is outside the retained output's compatible range.",
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+
+      const partialMessages: string[] = [];
+      if (!mappedTime.exact) {
+        partialMessages.push(
+          `time ${Math.round(savedState.model_time_seconds).toLocaleString()} s mapped to ${Math.round(mappedTime.value).toLocaleString()} s`,
+        );
+      }
+      let mappedSelection: PointSelection | null = null;
+      if (savedState.selected_point && frame) {
+        const xCoordinatesKm = frame.geometry.x_center_m.map((value) => value / 1_000);
+        const mappedX = nearestSavedCoordinate(xCoordinatesKm, savedState.selected_point.x_km, 2);
+        if (mappedX) {
+          const zCoordinatesKm = frame.geometry.scalar_height_m.map(
+            (row) => row[mappedX.index] / 1_000,
+          );
+          const mappedZ = nearestSavedCoordinate(zCoordinatesKm, savedState.selected_point.z_km, 2);
+          if (mappedZ) {
+            mappedSelection = { xIndex: mappedX.index, zIndex: mappedZ.index };
+            if (!mappedX.exact || !mappedZ.exact) {
+              partialMessages.push("selected point mapped to the nearest native cell");
+            }
+          }
+        }
+        if (!mappedSelection) partialMessages.push("selected point could not be restored");
+      }
+
+      const result: ExploreRestorationResult = {
+        status: partialMessages.length > 0 ? "partially_restorable" : "healthy",
+        message:
+          partialMessages.length > 0
+            ? `Saved View restored with adjustments: ${partialMessages.join("; ")}.`
+            : "Saved View restored.",
+      };
+      setPendingCuratedRestore(null);
+      setPlaying(false);
+      setMaximized(false);
+      setViewMode(mountainViewMode(savedState.view_id));
+      setField(savedState.field_id);
+      setGeometryMode(savedState.geometry_id);
+      setViewportMode(savedState.viewport_id);
+      setTimeIndex(mappedTime.index);
+      setPlaybackSpeed(savedState.playback_speed);
+      setSelectedPoint(mappedSelection);
+      setCloudPoints(savedState.overlays.cloud_points);
+      setCloudBoundary(savedState.overlays.cloud_boundary);
+      setSaturationContour(savedState.overlays.saturation_contour);
+      setHorizontalWind(savedState.overlays.horizontal_wind);
+      if (savedState.view_id === "wave_cloud") {
+        setCloudPotentialTemperatureContours(savedState.overlays.potential_temperature_contours);
+      } else if (savedState.view_id === "wave_structure") {
+        setStructurePotentialTemperatureContours(
+          savedState.overlays.potential_temperature_contours,
+        );
+      }
+      setCloudOpacity(savedState.cloud_opacity);
+      setCloudPointSize(savedState.cloud_point_size_px);
+      setContextCollapsed(savedState.context_collapsed);
+      setSecondarySection(savedState.secondary_section);
+      setError(null);
+      setFrame(null);
+      setRetryNonce((current) => current + 1);
+      setCuratedNotice({
+        status: "applying",
+        message: "Restoring the saved Mountain Waves examination and loading its evidence...",
+      });
+      setPendingSavedRestore({
+        state: savedState,
+        result,
+        savedViewId: savedView?.saved_view_id ?? null,
+      });
+      return result;
+    },
+    [fieldOptions, frame, simulation.moist_fields_available],
+  );
+
   useEffect(() => {
-    if (!frame || initialCuratedSimulationRef.current === simulation.simulation_id) return;
+    if (
+      !frame ||
+      exploreState.loading ||
+      initialCuratedSimulationRef.current === simulation.simulation_id
+    ) {
+      return;
+    }
     initialCuratedSimulationRef.current = simulation.simulation_id;
+    const resumeState = exploreState.library?.last_active?.state;
+    if (resumeState?.world_id === "mountain_waves") {
+      applySavedExploreState(resumeState, null);
+      return;
+    }
     applyCuratedView(initialViewId, "initial");
-  }, [applyCuratedView, frame, initialViewId, simulation.simulation_id]);
+  }, [
+    applyCuratedView,
+    applySavedExploreState,
+    exploreState.library?.last_active?.state,
+    exploreState.loading,
+    frame,
+    initialViewId,
+    simulation.simulation_id,
+  ]);
+
+  useEffect(() => {
+    if (!pendingSavedRestore) return;
+    if (error) {
+      const message = `The saved Mountain Waves examination could not be restored: ${error}`;
+      setPendingSavedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
+      if (pendingSavedRestore.savedViewId) {
+        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
+          restoration_status: "unavailable",
+          restoration_message: message,
+        });
+      }
+      return;
+    }
+    const expectedField =
+      pendingSavedRestore.state.view_id === "wave_cloud"
+        ? "cloud_over_wave"
+        : pendingSavedRestore.state.view_id === "wave_structure"
+          ? "w"
+          : pendingSavedRestore.state.field_id;
+    if (loading || !frame || frame.time_index !== timeIndex || frame.field.key !== expectedField) {
+      return;
+    }
+    if (frame.scale.scale_id !== pendingSavedRestore.state.fixed_scale_id) {
+      const message = `The saved scale ${pendingSavedRestore.state.fixed_scale_id} is unavailable for this output.`;
+      setPendingSavedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
+      if (pendingSavedRestore.savedViewId) {
+        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
+          restoration_status: "unavailable",
+          restoration_message: message,
+        });
+      }
+      return;
+    }
+    if (
+      pendingSavedRestore.state.view_id === "wave_cloud" &&
+      (!frame.overlay || !frame.pointer_context.relative_humidity_percent)
+    ) {
+      const message = "The saved Wave Cloud Lens requires cloud and relative-humidity evidence.";
+      setPendingSavedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
+      if (pendingSavedRestore.savedViewId) {
+        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
+          restoration_status: "unavailable",
+          restoration_message: message,
+        });
+      }
+      return;
+    }
+    setPendingSavedRestore(null);
+    curatedNoticeSignatureRef.current = curatedStateSignature;
+    setCuratedNotice({
+      status:
+        pendingSavedRestore.result.status === "healthy" ? "applied" : "partially_incompatible",
+      message:
+        pendingSavedRestore.savedViewId === null
+          ? pendingSavedRestore.result.message.replace("Saved View", "Last active view")
+          : pendingSavedRestore.result.message,
+    });
+  }, [
+    curatedStateSignature,
+    error,
+    frame,
+    loading,
+    pendingSavedRestore,
+    timeIndex,
+    updateExploreSavedView,
+  ]);
+
+  useEffect(() => {
+    if (
+      initialCuratedSimulationRef.current !== simulation.simulation_id ||
+      !exploreStateCoherent ||
+      !capturedExploreState ||
+      pendingCuratedRestore ||
+      pendingSavedRestore
+    ) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      void saveExploreResume(capturedExploreState);
+    }, 800);
+    return () => window.clearTimeout(timer);
+  }, [
+    capturedExploreState,
+    exploreStateCoherent,
+    pendingCuratedRestore,
+    pendingSavedRestore,
+    saveExploreResume,
+    simulation.simulation_id,
+  ]);
 
   useEffect(() => {
     if (!pendingCuratedRestore) return;
@@ -675,9 +995,17 @@ export function MountainWavesExplore({
       simulationName={simulation.display_name}
       onBack={onBack}
       headerActions={
-        <ReturnToCuratedViewControl
-          onReturn={() => applyCuratedView(mountainCuratedViewId(viewMode), "return")}
-        />
+        <>
+          <SavedViewsControl
+            controller={exploreState}
+            currentState={capturedExploreState}
+            coherent={exploreStateCoherent}
+            onOpen={(state, savedView) => applySavedExploreState(state, savedView)}
+          />
+          <ReturnToCuratedViewControl
+            onReturn={() => applyCuratedView(mountainCuratedViewId(viewMode), "return")}
+          />
+        </>
       }
     >
       <section
@@ -1248,6 +1576,7 @@ function TimelineControls({
         <span className="timeline-label">Saved output</span>
         <input
           id="mountain-waves-time-scrubber"
+          aria-label="Saved output time"
           type="range"
           min="0"
           max={Math.max(0, times.length - 1)}

--- a/app/frontend/src/MountainWavesExplore.tsx
+++ b/app/frontend/src/MountainWavesExplore.tsx
@@ -257,7 +257,8 @@ type PendingMountainCuratedRestore = {
 type PendingMountainSavedRestore = {
   state: MountainWavesExploreState;
   result: ExploreRestorationResult;
-  savedViewId: string | null;
+  source: "saved_view" | "last_active";
+  resolve: (result: ExploreRestorationResult) => void;
 };
 
 function mountainWaveAvailableOverlayIds(frame: MountainWaveFrame | null): string[] {
@@ -342,10 +343,10 @@ export function MountainWavesExplore({
   const [retryNonce, setRetryNonce] = useState(0);
   const requestSequence = useRef(0);
   const initialCuratedSimulationRef = useRef<string | null>(null);
+  const startupUserEditedRef = useRef(false);
   const curatedNoticeSignatureRef = useRef<string | null>(null);
   const exploreState = useExploreStateLibrary("mountain_waves", simulation.simulation_id);
   const saveExploreResume = exploreState.saveResume;
-  const updateExploreSavedView = exploreState.updateSavedView;
 
   const requestedField: MountainWaveField =
     viewMode === "cloud" ? "cloud_over_wave" : viewMode === "structure" ? "w" : field;
@@ -423,6 +424,7 @@ export function MountainWavesExplore({
       (simulation.moist_fields_available ? "wave_cloud" : "wave_structure");
     const nextDefinition = mountainWavesCuratedView(simulation.simulation_id, nextInitialView, "w");
     initialCuratedSimulationRef.current = null;
+    startupUserEditedRef.current = false;
     setViewMode(mountainViewMode(nextInitialView));
     setField(nextDefinition?.fieldId ?? "w");
     setGeometryMode(nextDefinition?.geometry ?? "expanded");
@@ -655,14 +657,14 @@ export function MountainWavesExplore({
     (
       savedState: ExploreWorldState,
       savedView: SavedViewRecord | null,
-    ): ExploreRestorationResult => {
+    ): Promise<ExploreRestorationResult> => {
       if (savedState.world_id !== "mountain_waves") {
         const result = {
           status: "unavailable" as const,
           message: "This Saved View belongs to another Cloud World.",
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
       const availableViews = simulation.moist_fields_available
         ? ["field", "wave_structure", "wave_cloud"]
@@ -673,7 +675,7 @@ export function MountainWavesExplore({
           message: "The saved Lens is unavailable for this Simulation.",
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
       if (!fieldOptions.includes(savedState.field_id)) {
         const result = {
@@ -681,7 +683,7 @@ export function MountainWavesExplore({
           message: `The saved Field ${savedState.field_id} is unavailable in the retained output.`,
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
       const mappedTime = nearestSavedCoordinate(
         frame?.times_seconds ?? [],
@@ -694,7 +696,7 @@ export function MountainWavesExplore({
           message: "The saved model time is outside the retained output's compatible range.",
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
 
       const partialMessages: string[] = [];
@@ -761,12 +763,14 @@ export function MountainWavesExplore({
         status: "applying",
         message: "Restoring the saved Mountain Waves examination and loading its evidence...",
       });
-      setPendingSavedRestore({
-        state: savedState,
-        result,
-        savedViewId: savedView?.saved_view_id ?? null,
+      return new Promise((resolve) => {
+        setPendingSavedRestore({
+          state: savedState,
+          result,
+          source: savedView ? "saved_view" : "last_active",
+          resolve,
+        });
       });
-      return result;
     },
     [fieldOptions, frame, simulation.moist_fields_available],
   );
@@ -780,9 +784,12 @@ export function MountainWavesExplore({
       return;
     }
     initialCuratedSimulationRef.current = simulation.simulation_id;
+    if (startupUserEditedRef.current) {
+      return;
+    }
     const resumeState = exploreState.library?.last_active?.state;
     if (resumeState?.world_id === "mountain_waves") {
-      applySavedExploreState(resumeState, null);
+      void applySavedExploreState(resumeState, null);
       return;
     }
     applyCuratedView(initialViewId, "initial");
@@ -800,15 +807,25 @@ export function MountainWavesExplore({
     if (!pendingSavedRestore) return;
     if (error) {
       const message = `The saved Mountain Waves examination could not be restored: ${error}`;
+      pendingSavedRestore.resolve({ status: "unavailable", message });
       setPendingSavedRestore(null);
       curatedNoticeSignatureRef.current = curatedStateSignature;
       setCuratedNotice({ status: "technical_fallback", message });
-      if (pendingSavedRestore.savedViewId) {
-        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
-          restoration_status: "unavailable",
-          restoration_message: message,
-        });
-      }
+      return;
+    }
+    const targetViewMode = mountainViewMode(pendingSavedRestore.state.view_id);
+    const controlsMatch =
+      viewMode === targetViewMode &&
+      field === pendingSavedRestore.state.field_id &&
+      geometryMode === pendingSavedRestore.state.geometry_id &&
+      viewportMode === pendingSavedRestore.state.viewport_id &&
+      timeIndex !== null;
+    if (!controlsMatch) {
+      const message = "The saved Mountain Waves examination was interrupted before it loaded.";
+      pendingSavedRestore.resolve({ status: "unavailable", message });
+      setPendingSavedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
       return;
     }
     const expectedField =
@@ -822,15 +839,10 @@ export function MountainWavesExplore({
     }
     if (frame.scale.scale_id !== pendingSavedRestore.state.fixed_scale_id) {
       const message = `The saved scale ${pendingSavedRestore.state.fixed_scale_id} is unavailable for this output.`;
+      pendingSavedRestore.resolve({ status: "unavailable", message });
       setPendingSavedRestore(null);
       curatedNoticeSignatureRef.current = curatedStateSignature;
       setCuratedNotice({ status: "technical_fallback", message });
-      if (pendingSavedRestore.savedViewId) {
-        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
-          restoration_status: "unavailable",
-          restoration_message: message,
-        });
-      }
       return;
     }
     if (
@@ -838,35 +850,34 @@ export function MountainWavesExplore({
       (!frame.overlay || !frame.pointer_context.relative_humidity_percent)
     ) {
       const message = "The saved Wave Cloud Lens requires cloud and relative-humidity evidence.";
+      pendingSavedRestore.resolve({ status: "unavailable", message });
       setPendingSavedRestore(null);
       curatedNoticeSignatureRef.current = curatedStateSignature;
       setCuratedNotice({ status: "technical_fallback", message });
-      if (pendingSavedRestore.savedViewId) {
-        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
-          restoration_status: "unavailable",
-          restoration_message: message,
-        });
-      }
       return;
     }
+    pendingSavedRestore.resolve(pendingSavedRestore.result);
     setPendingSavedRestore(null);
     curatedNoticeSignatureRef.current = curatedStateSignature;
     setCuratedNotice({
       status:
         pendingSavedRestore.result.status === "healthy" ? "applied" : "partially_incompatible",
       message:
-        pendingSavedRestore.savedViewId === null
+        pendingSavedRestore.source === "last_active"
           ? pendingSavedRestore.result.message.replace("Saved View", "Last active view")
           : pendingSavedRestore.result.message,
     });
   }, [
     curatedStateSignature,
     error,
+    field,
     frame,
+    geometryMode,
     loading,
     pendingSavedRestore,
     timeIndex,
-    updateExploreSavedView,
+    viewMode,
+    viewportMode,
   ]);
 
   useEffect(() => {
@@ -994,6 +1005,9 @@ export function MountainWavesExplore({
       worldName="Mountain Waves"
       simulationName={simulation.display_name}
       onBack={onBack}
+      onUserInteractionCapture={() => {
+        if (exploreState.loading) startupUserEditedRef.current = true;
+      }}
       headerActions={
         <>
           <SavedViewsControl

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -651,6 +651,39 @@ describe("SupercellsExplore", () => {
     ).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: "Open Context" })).toBeVisible();
     expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("keeps a user edit made before the delayed startup state arrives", async () => {
+    let resolveStartupState!: (response: Response) => void;
+    const startupState = new Promise<Response>((resolve) => {
+      resolveStartupState = resolve;
+    });
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/explore-state") && !init?.method) return startupState;
+      if (url.includes("/explore-state") || url.includes("/saved-views")) {
+        return Promise.resolve(ok(supercellsExploreLibrary()));
+      }
+      return Promise.resolve(ok(frameFor(url)));
+    });
+
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Cloud and Precipitation" }));
+    expect(screen.getByRole("button", { name: "Cloud and Precipitation" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    act(() => resolveStartupState(ok(supercellsExploreLibrary(supercellsResumeState))));
+    await waitFor(() =>
+      expect(screen.queryByText("Loading Saved Views...")).not.toBeInTheDocument(),
+    );
+
+    expect(screen.getByRole("button", { name: "Cloud and Precipitation" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.queryByText("Last active view restored.")).not.toBeInTheDocument();
   });
 
   it("reports removed layers and changed coordinate inventories as unavailable", async () => {

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SupercellsExplore } from "./SupercellsExplore";
+import type { SupercellsExploreState } from "./ExploreStatePersistence";
 import type {
   FieldLayer,
   LensId,
@@ -100,6 +101,60 @@ const simulation: SupercellSimulation = {
   default_explore_time_index: 37,
   lineage_state: "known",
 };
+
+const supercellsResumeState: SupercellsExploreState = {
+  state_version: 1,
+  world_id: "supercells",
+  model_time_seconds: 4_560,
+  context_collapsed: true,
+  secondary_section: "details",
+  selected_point: { x_km: 0, y_km: -10, z_km: 8 },
+  lens_id: "rotating_updraft",
+  viewport_id: "full",
+  evidence_view: "xz",
+  plane_coordinate_km: -10,
+  visible_layer_ids: ["storm_cloud_body", "rising_core", "cyclonic_rotation", "updraft_helicity"],
+  fixed_scale_ids: ["supercell_midlevel_vertical_velocity_v1"],
+  overlays: {
+    rotation: true,
+    updraft_helicity: true,
+    reflectivity: false,
+    condensate: false,
+    rain: false,
+    wind: false,
+    precipitating_condensate: false,
+    vertical_motion: true,
+  },
+  hydrometeor_category_codes: [1, 2, 3, 4, 5],
+  camera_preset: "look_along_x",
+  camera_transform: null,
+  scene_opacity: 0.6,
+  scene_point_size: 1.2,
+  selected_evidence_visible: true,
+  playback_speed: 2,
+  display_controls_open: false,
+};
+
+function supercellsExploreLibrary(lastActive: SupercellsExploreState | null = null) {
+  return {
+    library: {
+      schema_version: 1,
+      world_id: "supercells",
+      simulation_id: simulation.simulation_id,
+      last_active: lastActive
+        ? {
+            schema_version: 1,
+            world_id: "supercells",
+            simulation_id: simulation.simulation_id,
+            captured_at: "2026-07-26T12:00:00Z",
+            state: lastActive,
+          }
+        : null,
+      saved_views: [],
+    },
+    backing_simulation_available: true,
+  };
+}
 
 const wScale = {
   scale_id: "supercells_vertical_velocity_v1",
@@ -516,7 +571,13 @@ describe("SupercellsExplore", () => {
   beforeEach(() => {
     vi.stubGlobal(
       "fetch",
-      vi.fn((input: RequestInfo | URL) => Promise.resolve(ok(frameFor(String(input))))),
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/explore-state") || url.includes("/saved-views")) {
+          return Promise.resolve(ok(supercellsExploreLibrary()));
+        }
+        return Promise.resolve(ok(frameFor(url)));
+      }),
     );
     vi.stubGlobal(
       "ResizeObserver",
@@ -564,6 +625,75 @@ describe("SupercellsExplore", () => {
       "true",
     );
     expect(screen.getByLabelText("Mock 3-D storm scene")).toHaveTextContent("Camera: look_along_y");
+  });
+
+  it("resumes the last coherent Supercells examination after reload", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/explore-state") || url.includes("/saved-views")) {
+        return Promise.resolve(ok(supercellsExploreLibrary(supercellsResumeState)));
+      }
+      return Promise.resolve(ok(frameFor(url)));
+    });
+
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+
+    expect(await screen.findByText("Last active view restored.")).toBeVisible();
+    expect(screen.getByLabelText("Saved output time")).toHaveValue("38");
+    expect(screen.getByRole("button", { name: "Full domain" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      within(screen.getByLabelText("Slice orientation")).getByRole("button", {
+        name: "Vertical x-z",
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Open Context" })).toBeVisible();
+    expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("reports removed layers and changed coordinate inventories as unavailable", async () => {
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/explore-state")) {
+        return Promise.resolve(
+          ok(
+            supercellsExploreLibrary({
+              ...supercellsResumeState,
+              plane_coordinate_km: -10,
+              visible_layer_ids: [...supercellsResumeState.visible_layer_ids, "renamed_core"],
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(ok(frameFor(url)));
+    });
+
+    const { unmount } = render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    expect(await screen.findByText(/layer renamed_core could not be restored/)).toBeVisible();
+    unmount();
+
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/explore-state")) {
+        return Promise.resolve(
+          ok(
+            supercellsExploreLibrary({
+              ...supercellsResumeState,
+              plane_coordinate_km: 200,
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(ok(frameFor(url)));
+    });
+    render(<SupercellsExplore simulation={simulation} onBack={vi.fn()} />);
+    expect(
+      await screen.findByText(
+        /saved time or physical section is outside the compatible output range/,
+      ),
+    ).toBeVisible();
   });
 
   it("moves each evidence orientation through native planes and keeps a user plane across time", async () => {

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -12,6 +12,15 @@ import {
   type ExploreSecondarySection,
 } from "./IntegratedExploreWorkspace";
 import {
+  nearestSavedCoordinate,
+  SavedViewsControl,
+  useExploreStateLibrary,
+  type ExploreRestorationResult,
+  type ExploreWorldState,
+  type SavedViewRecord,
+  type SupercellsExploreState,
+} from "./ExploreStatePersistence";
+import {
   curatedResolutionExplanation,
   resolveCuratedView,
   SUPERCELLS_CURATED_VIEWS,
@@ -75,6 +84,13 @@ type PendingSupercellsCuratedRestore = {
   source: "initial" | "return";
 };
 
+type PendingSupercellsSavedRestore = {
+  state: SupercellsExploreState;
+  result: ExploreRestorationResult;
+  savedViewId: string | null;
+  planeNativeIndex: number;
+};
+
 const LENSES: Array<{ id: LensId; label: string }> = [
   { id: "rotating_updraft", label: "Rotating Updraft" },
   { id: "cloud_precipitation", label: "Cloud and Precipitation" },
@@ -128,6 +144,45 @@ function supercellsCuratedCapabilities(frame: StormExaminationFrame | null) {
   };
 }
 
+function enabledSupercellsOverlayIds(overlays: OverlayState): string[] {
+  return [
+    overlays.rotation ? "vertical_vorticity" : null,
+    overlays.updraftHelicity ? "updraft_helicity" : null,
+    overlays.reflectivity ? "reflectivity" : null,
+    overlays.condensate ? "total_condensate" : null,
+    overlays.rain ? "accumulated_surface_rain" : null,
+    overlays.wind ? "model_relative_wind" : null,
+    overlays.precipitatingCondensate ? "low_level_precipitating_condensate" : null,
+    overlays.verticalMotion ? "vertical_velocity" : null,
+  ].filter((overlayId): overlayId is string => overlayId !== null);
+}
+
+function persistedSupercellsOverlays(overlays: OverlayState): SupercellsExploreState["overlays"] {
+  return {
+    rotation: overlays.rotation,
+    updraft_helicity: overlays.updraftHelicity,
+    reflectivity: overlays.reflectivity,
+    condensate: overlays.condensate,
+    rain: overlays.rain,
+    wind: overlays.wind,
+    precipitating_condensate: overlays.precipitatingCondensate,
+    vertical_motion: overlays.verticalMotion,
+  };
+}
+
+function runtimeSupercellsOverlays(overlays: SupercellsExploreState["overlays"]): OverlayState {
+  return {
+    rotation: overlays.rotation,
+    updraftHelicity: overlays.updraft_helicity,
+    reflectivity: overlays.reflectivity,
+    condensate: overlays.condensate,
+    rain: overlays.rain,
+    wind: overlays.wind,
+    precipitatingCondensate: overlays.precipitating_condensate,
+    verticalMotion: overlays.vertical_motion,
+  };
+}
+
 export function SupercellsExplore({
   simulation,
   onBack,
@@ -164,6 +219,8 @@ export function SupercellsExplore({
   const [curatedNotice, setCuratedNotice] = useState<ExploreCuratedNotice | null>(null);
   const [pendingCuratedRestore, setPendingCuratedRestore] =
     useState<PendingSupercellsCuratedRestore | null>(null);
+  const [pendingSavedRestore, setPendingSavedRestore] =
+    useState<PendingSupercellsSavedRestore | null>(null);
   const [playing, setPlaying] = useState(false);
   const [playbackSpeed, setPlaybackSpeed] = useState(1);
   const [loading, setLoading] = useState(true);
@@ -173,6 +230,9 @@ export function SupercellsExplore({
   const contextBeforeEvidenceFocus = useRef(false);
   const initialCuratedSimulationRef = useRef<string | null>(null);
   const curatedNoticeSignatureRef = useRef<string | null>(null);
+  const exploreState = useExploreStateLibrary("supercells", simulation.simulation_id);
+  const saveExploreResume = exploreState.saveResume;
+  const updateExploreSavedView = exploreState.updateSavedView;
 
   const requestKey = frameRequestKey(lens, viewport, timeIndex, selection);
   const loadFrame = useCallback(
@@ -248,6 +308,83 @@ export function SupercellsExplore({
     (item) => item.time_seconds === frame.time_seconds,
   );
   const windVectors = frame?.scene?.wind_vectors ?? [];
+  const capturedExploreState = useMemo<SupercellsExploreState | null>(() => {
+    if (!frame) return null;
+    const activeEvidence =
+      evidenceView === "plan"
+        ? frame.plan
+        : evidenceView === "xz"
+          ? frame.xz_section
+          : frame.yz_section;
+    const visibleLayerScales =
+      frame.scene?.layers
+        .filter((layer) => visibleLayerKeys.includes(layer.key))
+        .map((layer) => layer.scale?.scale_id)
+        .filter((scaleId): scaleId is string => Boolean(scaleId)) ?? [];
+    const planeCoordinateKm =
+      slicePosition?.coordinatesKm[slicePosition.positionIndex] ??
+      (evidenceView === "plan"
+        ? frame.plan.level_km
+        : evidenceView === "xz"
+          ? frame.xz_section.cross_section_coordinate_km
+          : frame.yz_section.cross_section_coordinate_km);
+    return {
+      state_version: 1,
+      world_id: "supercells",
+      model_time_seconds: frame.time_seconds,
+      context_collapsed: contextCollapsed,
+      secondary_section: secondarySection,
+      selected_point:
+        selection === null
+          ? null
+          : {
+              x_km: frame.selected_point.x_km,
+              y_km: frame.selected_point.y_km,
+              z_km: frame.selected_point.z_km,
+            },
+      lens_id: lens,
+      viewport_id: viewport,
+      evidence_view: evidenceView,
+      plane_coordinate_km: planeCoordinateKm,
+      visible_layer_ids: [...visibleLayerKeys],
+      fixed_scale_ids: [...new Set([activeEvidence.primary.scale.scale_id, ...visibleLayerScales])],
+      overlays: persistedSupercellsOverlays(overlays),
+      hydrometeor_category_codes: [...categoryCodes],
+      camera_preset: cameraPreset,
+      camera_transform: cameraTransform,
+      scene_opacity: sceneOpacity,
+      scene_point_size: scenePointSize,
+      selected_evidence_visible: selectedEvidenceVisible,
+      playback_speed: playbackSpeed,
+      display_controls_open: displayControlsOpen,
+    };
+  }, [
+    cameraPreset,
+    cameraTransform,
+    categoryCodes,
+    contextCollapsed,
+    displayControlsOpen,
+    evidenceView,
+    frame,
+    lens,
+    overlays,
+    playbackSpeed,
+    sceneOpacity,
+    scenePointSize,
+    secondarySection,
+    selectedEvidenceVisible,
+    selection,
+    slicePosition,
+    viewport,
+    visibleLayerKeys,
+  ]);
+  const exploreStateCoherent =
+    capturedExploreState !== null &&
+    !loading &&
+    !error &&
+    !playing &&
+    !focusedViewer &&
+    frame?.time_index === timeIndex;
   const curatedStateSignature = useMemo(
     () =>
       JSON.stringify({
@@ -429,11 +566,270 @@ export function SupercellsExplore({
     [curatedStateSignature, evidenceView, frame, lens, simulation.simulation_id],
   );
 
+  const applySavedExploreState = useCallback(
+    (
+      savedState: ExploreWorldState,
+      savedView: SavedViewRecord | null,
+    ): ExploreRestorationResult => {
+      if (savedState.world_id !== "supercells") {
+        const result = {
+          status: "unavailable" as const,
+          message: "This Saved View belongs to another Cloud World.",
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+      if (!LENSES.some((item) => item.id === savedState.lens_id) || !frame?.scene) {
+        const result = {
+          status: "unavailable" as const,
+          message: "The saved Supercells Lens or its 3-D evidence is unavailable.",
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+      const mappedTime = nearestSavedCoordinate(
+        frame.times_seconds,
+        savedState.model_time_seconds,
+        180,
+      );
+      const targetSlice = slicePositionState(frame, savedState.evidence_view, null);
+      const mappedPlane = targetSlice
+        ? nearestSavedCoordinate(targetSlice.coordinatesKm, savedState.plane_coordinate_km, 0.2)
+        : null;
+      if (!mappedTime || !targetSlice || !mappedPlane) {
+        const result = {
+          status: "unavailable" as const,
+          message: "The saved time or physical section is outside the compatible output range.",
+        };
+        setCuratedNotice({ status: "technical_fallback", message: result.message });
+        return result;
+      }
+
+      const partialMessages: string[] = [];
+      if (!mappedTime.exact) {
+        partialMessages.push(
+          `time ${Math.round(savedState.model_time_seconds).toLocaleString()} s mapped to ${Math.round(mappedTime.value).toLocaleString()} s`,
+        );
+      }
+      if (!mappedPlane.exact) {
+        partialMessages.push(
+          `section ${savedState.plane_coordinate_km.toFixed(2)} km mapped to ${mappedPlane.value.toFixed(2)} km`,
+        );
+      }
+      let nextSelection: Selection = {
+        xIndex: frame.selected_point.x_index,
+        yIndex: frame.selected_point.y_index,
+        zIndex: frame.selected_point.z_index,
+      };
+      const planeNativeIndex = targetSlice.nativeIndices[mappedPlane.index];
+      if (targetSlice.axis === "x") nextSelection.xIndex = planeNativeIndex;
+      if (targetSlice.axis === "y") nextSelection.yIndex = planeNativeIndex;
+      if (targetSlice.axis === "z") nextSelection.zIndex = planeNativeIndex;
+      if (savedState.selected_point) {
+        const x = nearestSavedCoordinate(
+          frame.scene.coordinate_values_km.x,
+          savedState.selected_point.x_km,
+          2,
+        );
+        const y = nearestSavedCoordinate(
+          frame.scene.coordinate_values_km.y,
+          savedState.selected_point.y_km ?? frame.selected_point.y_km,
+          2,
+        );
+        const z = nearestSavedCoordinate(
+          frame.scene.coordinate_values_km.z,
+          savedState.selected_point.z_km,
+          2,
+        );
+        if (x && y && z) {
+          nextSelection = {
+            xIndex: frame.scene.coordinate_indices.x[x.index],
+            yIndex: frame.scene.coordinate_indices.y[y.index],
+            zIndex: frame.scene.coordinate_indices.z[z.index],
+          };
+          if (!x.exact || !y.exact || !z.exact) {
+            partialMessages.push("selected point mapped to the nearest native cell");
+          }
+        } else {
+          partialMessages.push("selected point could not be restored");
+        }
+      }
+
+      const result: ExploreRestorationResult = {
+        status: partialMessages.length > 0 ? "partially_restorable" : "healthy",
+        message:
+          partialMessages.length > 0
+            ? `Saved View restored with adjustments: ${partialMessages.join("; ")}.`
+            : "Saved View restored.",
+      };
+      setPendingCuratedRestore(null);
+      setPlaying(false);
+      setFocusedViewer(null);
+      setLens(savedState.lens_id);
+      setTimeIndex(mappedTime.index);
+      setPlaybackSpeed(savedState.playback_speed);
+      setContextCollapsed(savedState.context_collapsed);
+      setSecondarySection(savedState.secondary_section);
+      setPresentations((current) => ({
+        ...current,
+        [savedState.lens_id]: {
+          viewport: savedState.viewport_id,
+          evidenceView: savedState.evidence_view,
+          overlays: runtimeSupercellsOverlays(savedState.overlays),
+          visibleLayerKeys: [...savedState.visible_layer_ids],
+          categoryCodes: [...savedState.hydrometeor_category_codes],
+          cameraPreset: savedState.camera_preset,
+          cameraTransform: savedState.camera_transform,
+          displayControlsOpen: savedState.display_controls_open,
+          sceneOpacity: savedState.scene_opacity,
+          scenePointSize: savedState.scene_point_size,
+          selection: nextSelection,
+          selectedEvidenceVisible: savedState.selected_evidence_visible,
+        },
+      }));
+      setError(null);
+      setFrame(null);
+      setRetryNonce((current) => current + 1);
+      setCuratedNotice({
+        status: "applying",
+        message: "Restoring the saved Supercells examination and loading its evidence...",
+      });
+      setPendingSavedRestore({
+        state: savedState,
+        result,
+        savedViewId: savedView?.saved_view_id ?? null,
+        planeNativeIndex,
+      });
+      return result;
+    },
+    [frame],
+  );
+
   useEffect(() => {
-    if (!frame || initialCuratedSimulationRef.current === simulation.simulation_id) return;
+    if (
+      !frame ||
+      exploreState.loading ||
+      initialCuratedSimulationRef.current === simulation.simulation_id
+    ) {
+      return;
+    }
     initialCuratedSimulationRef.current = simulation.simulation_id;
+    const resumeState = exploreState.library?.last_active?.state;
+    if (resumeState?.world_id === "supercells") {
+      applySavedExploreState(resumeState, null);
+      return;
+    }
     applyCuratedView("initial");
-  }, [applyCuratedView, frame, simulation.simulation_id]);
+  }, [
+    applyCuratedView,
+    applySavedExploreState,
+    exploreState.library?.last_active?.state,
+    exploreState.loading,
+    frame,
+    simulation.simulation_id,
+  ]);
+
+  useEffect(() => {
+    if (!pendingSavedRestore) return;
+    if (error) {
+      const message = `The saved Supercells examination could not be restored: ${error}`;
+      setPendingSavedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
+      if (pendingSavedRestore.savedViewId) {
+        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
+          restoration_status: "unavailable",
+          restoration_message: message,
+        });
+      }
+      return;
+    }
+    if (
+      loading ||
+      !frame ||
+      frame.time_index !== timeIndex ||
+      frame.lens_id !== pendingSavedRestore.state.lens_id ||
+      frame.viewport !== pendingSavedRestore.state.viewport_id
+    ) {
+      return;
+    }
+    const capabilities = supercellsCuratedCapabilities(frame);
+    const missingLayers = pendingSavedRestore.state.visible_layer_ids.filter(
+      (layerId) => !capabilities.availableLayerIds.includes(layerId),
+    );
+    const missingScales = pendingSavedRestore.state.fixed_scale_ids.filter(
+      (scaleId) => !capabilities.availableScaleIds.includes(scaleId),
+    );
+    const missingOverlays = enabledSupercellsOverlayIds(
+      runtimeSupercellsOverlays(pendingSavedRestore.state.overlays),
+    ).filter((overlayId) => !capabilities.availableOverlayIds.includes(overlayId));
+    if (missingLayers.length > 0 || missingScales.length > 0 || missingOverlays.length > 0) {
+      const missing = [
+        ...missingLayers.map((item) => `layer ${item}`),
+        ...missingScales.map((item) => `scale ${item}`),
+        ...missingOverlays.map((item) => `overlay ${item}`),
+      ];
+      const message = `The saved Supercells examination is unavailable because ${missing.join(", ")} could not be restored.`;
+      setPendingSavedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
+      if (pendingSavedRestore.savedViewId) {
+        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
+          restoration_status: "unavailable",
+          restoration_message: message,
+        });
+      }
+      return;
+    }
+    const loadedPlaneMatches =
+      pendingSavedRestore.state.evidence_view === "plan"
+        ? frame.plan.level_index === pendingSavedRestore.planeNativeIndex
+        : pendingSavedRestore.state.evidence_view === "xz"
+          ? frame.selected_point.y_index === pendingSavedRestore.planeNativeIndex
+          : frame.selected_point.x_index === pendingSavedRestore.planeNativeIndex;
+    if (!loadedPlaneMatches) return;
+    setPendingSavedRestore(null);
+    curatedNoticeSignatureRef.current = curatedStateSignature;
+    setCuratedNotice({
+      status:
+        pendingSavedRestore.result.status === "healthy" ? "applied" : "partially_incompatible",
+      message:
+        pendingSavedRestore.savedViewId === null
+          ? pendingSavedRestore.result.message.replace("Saved View", "Last active view")
+          : pendingSavedRestore.result.message,
+    });
+  }, [
+    curatedStateSignature,
+    error,
+    frame,
+    loading,
+    pendingSavedRestore,
+    timeIndex,
+    updateExploreSavedView,
+  ]);
+
+  useEffect(() => {
+    if (
+      initialCuratedSimulationRef.current !== simulation.simulation_id ||
+      !exploreStateCoherent ||
+      !capturedExploreState ||
+      pendingCuratedRestore ||
+      pendingSavedRestore
+    ) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      void saveExploreResume(capturedExploreState);
+    }, 800);
+    return () => window.clearTimeout(timer);
+  }, [
+    capturedExploreState,
+    exploreStateCoherent,
+    pendingCuratedRestore,
+    pendingSavedRestore,
+    saveExploreResume,
+    simulation.simulation_id,
+  ]);
 
   useEffect(() => {
     if (!pendingCuratedRestore) return;
@@ -565,7 +961,17 @@ export function SupercellsExplore({
       simulationName={simulation.display_name}
       backLabel="Back to Supercells"
       onBack={onBack}
-      headerActions={<ReturnToCuratedViewControl onReturn={() => applyCuratedView("return")} />}
+      headerActions={
+        <>
+          <SavedViewsControl
+            controller={exploreState}
+            currentState={capturedExploreState}
+            coherent={exploreStateCoherent}
+            onOpen={(state, savedView) => applySavedExploreState(state, savedView)}
+          />
+          <ReturnToCuratedViewControl onReturn={() => applyCuratedView("return")} />
+        </>
+      }
     >
       <section
         className={`supercells-explore-shell${

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -87,7 +87,8 @@ type PendingSupercellsCuratedRestore = {
 type PendingSupercellsSavedRestore = {
   state: SupercellsExploreState;
   result: ExploreRestorationResult;
-  savedViewId: string | null;
+  source: "saved_view" | "last_active";
+  resolve: (result: ExploreRestorationResult) => void;
   planeNativeIndex: number;
 };
 
@@ -229,10 +230,15 @@ export function SupercellsExplore({
   const frameCache = useRef(new Map<string, StormExaminationFrame>());
   const contextBeforeEvidenceFocus = useRef(false);
   const initialCuratedSimulationRef = useRef<string | null>(null);
+  const startupUserEditedRef = useRef(false);
   const curatedNoticeSignatureRef = useRef<string | null>(null);
   const exploreState = useExploreStateLibrary("supercells", simulation.simulation_id);
   const saveExploreResume = exploreState.saveResume;
-  const updateExploreSavedView = exploreState.updateSavedView;
+
+  useEffect(() => {
+    startupUserEditedRef.current = false;
+    initialCuratedSimulationRef.current = null;
+  }, [simulation.simulation_id]);
 
   const requestKey = frameRequestKey(lens, viewport, timeIndex, selection);
   const loadFrame = useCallback(
@@ -570,14 +576,14 @@ export function SupercellsExplore({
     (
       savedState: ExploreWorldState,
       savedView: SavedViewRecord | null,
-    ): ExploreRestorationResult => {
+    ): Promise<ExploreRestorationResult> => {
       if (savedState.world_id !== "supercells") {
         const result = {
           status: "unavailable" as const,
           message: "This Saved View belongs to another Cloud World.",
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
       if (!LENSES.some((item) => item.id === savedState.lens_id) || !frame?.scene) {
         const result = {
@@ -585,7 +591,7 @@ export function SupercellsExplore({
           message: "The saved Supercells Lens or its 3-D evidence is unavailable.",
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
       const mappedTime = nearestSavedCoordinate(
         frame.times_seconds,
@@ -602,7 +608,7 @@ export function SupercellsExplore({
           message: "The saved time or physical section is outside the compatible output range.",
         };
         setCuratedNotice({ status: "technical_fallback", message: result.message });
-        return result;
+        return Promise.resolve(result);
       }
 
       const partialMessages: string[] = [];
@@ -694,13 +700,15 @@ export function SupercellsExplore({
         status: "applying",
         message: "Restoring the saved Supercells examination and loading its evidence...",
       });
-      setPendingSavedRestore({
-        state: savedState,
-        result,
-        savedViewId: savedView?.saved_view_id ?? null,
-        planeNativeIndex,
+      return new Promise((resolve) => {
+        setPendingSavedRestore({
+          state: savedState,
+          result,
+          source: savedView ? "saved_view" : "last_active",
+          resolve,
+          planeNativeIndex,
+        });
       });
-      return result;
     },
     [frame],
   );
@@ -714,9 +722,12 @@ export function SupercellsExplore({
       return;
     }
     initialCuratedSimulationRef.current = simulation.simulation_id;
+    if (startupUserEditedRef.current) {
+      return;
+    }
     const resumeState = exploreState.library?.last_active?.state;
     if (resumeState?.world_id === "supercells") {
-      applySavedExploreState(resumeState, null);
+      void applySavedExploreState(resumeState, null);
       return;
     }
     applyCuratedView("initial");
@@ -733,15 +744,23 @@ export function SupercellsExplore({
     if (!pendingSavedRestore) return;
     if (error) {
       const message = `The saved Supercells examination could not be restored: ${error}`;
+      pendingSavedRestore.resolve({ status: "unavailable", message });
       setPendingSavedRestore(null);
       curatedNoticeSignatureRef.current = curatedStateSignature;
       setCuratedNotice({ status: "technical_fallback", message });
-      if (pendingSavedRestore.savedViewId) {
-        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
-          restoration_status: "unavailable",
-          restoration_message: message,
-        });
-      }
+      return;
+    }
+    const controlsMatch =
+      lens === pendingSavedRestore.state.lens_id &&
+      viewport === pendingSavedRestore.state.viewport_id &&
+      evidenceView === pendingSavedRestore.state.evidence_view &&
+      timeIndex >= 0;
+    if (!controlsMatch) {
+      const message = "The saved Supercells examination was interrupted before it loaded.";
+      pendingSavedRestore.resolve({ status: "unavailable", message });
+      setPendingSavedRestore(null);
+      curatedNoticeSignatureRef.current = curatedStateSignature;
+      setCuratedNotice({ status: "technical_fallback", message });
       return;
     }
     if (
@@ -770,15 +789,10 @@ export function SupercellsExplore({
         ...missingOverlays.map((item) => `overlay ${item}`),
       ];
       const message = `The saved Supercells examination is unavailable because ${missing.join(", ")} could not be restored.`;
+      pendingSavedRestore.resolve({ status: "unavailable", message });
       setPendingSavedRestore(null);
       curatedNoticeSignatureRef.current = curatedStateSignature;
       setCuratedNotice({ status: "technical_fallback", message });
-      if (pendingSavedRestore.savedViewId) {
-        void updateExploreSavedView(pendingSavedRestore.savedViewId, {
-          restoration_status: "unavailable",
-          restoration_message: message,
-        });
-      }
       return;
     }
     const loadedPlaneMatches =
@@ -788,24 +802,27 @@ export function SupercellsExplore({
           ? frame.selected_point.y_index === pendingSavedRestore.planeNativeIndex
           : frame.selected_point.x_index === pendingSavedRestore.planeNativeIndex;
     if (!loadedPlaneMatches) return;
+    pendingSavedRestore.resolve(pendingSavedRestore.result);
     setPendingSavedRestore(null);
     curatedNoticeSignatureRef.current = curatedStateSignature;
     setCuratedNotice({
       status:
         pendingSavedRestore.result.status === "healthy" ? "applied" : "partially_incompatible",
       message:
-        pendingSavedRestore.savedViewId === null
+        pendingSavedRestore.source === "last_active"
           ? pendingSavedRestore.result.message.replace("Saved View", "Last active view")
           : pendingSavedRestore.result.message,
     });
   }, [
     curatedStateSignature,
+    evidenceView,
     error,
     frame,
+    lens,
     loading,
     pendingSavedRestore,
     timeIndex,
-    updateExploreSavedView,
+    viewport,
   ]);
 
   useEffect(() => {
@@ -961,6 +978,9 @@ export function SupercellsExplore({
       simulationName={simulation.display_name}
       backLabel="Back to Supercells"
       onBack={onBack}
+      onUserInteractionCapture={() => {
+        if (exploreState.loading) startupUserEditedRef.current = true;
+      }}
       headerActions={
         <>
           <SavedViewsControl

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -46,11 +46,11 @@ Keep product approval separate from software availability:
 | --- | --- | --- |
 | Cloud Worlds | A growing collection of explorable cloud regimes | Trade Cumulus, Mountain Waves, and Supercells are accessible |
 | Fun With Soundings | A separate first-class atmospheric workbench | Accessible with five jobs, direct non-World Explore, and conservative World ownership |
-| Saved Views | Durable user-curated views | Placeholder only; no durable Saved Views |
+| Saved Views | Durable user-curated views | Implemented across all three accessible Worlds as named live examinations with bounded restoration status |
 | Compare | Related Simulations can be compared | One featured Trade Cumulus Comparison; no ordinary World-aware Compare |
 | Variation | Create a related Simulation from a World Simulation | Working Mountain Waves Lab path; no shared three-World workflow |
 | Explore | World-specific science in a shared application vocabulary | Implemented separately for all three accessible Worlds |
-| Curated Explore defaults | Authored Simulation and Field/Lens starting states with complete reset and visible fallback | Implemented across all three accessible Worlds; not durable user state |
+| Curated Explore defaults | Authored Simulation and Field/Lens starting states with complete reset and visible fallback | Implemented across all three accessible Worlds as the fallback below explicit Saved Views and last-active state |
 
 The three Worlds share product vocabulary and core workspace behavior but may
 legitimately differ in geometry, Lenses, controls, comparison questions, and
@@ -84,17 +84,17 @@ The presentation-quality and three-World foundation is complete through #420,
 #423, #421, #429, and #428. The first-class Fun With Soundings workbench is
 complete through #395. All three Explore implementations now use one
 collapsible Context and shared below-the-fold Science, Notes, and Details
-structure. Per-Simulation Notes are the first durable content contract; complete
-Explore state and Saved Views remain unimplemented.
+structure. Per-Simulation Notes remain a separate durable content contract.
 
 The authored curated-default and complete reset contract is complete through
-#438. The next approved program is #432, personal scientific memory: define one
-versioned, World-aware serializable Explore-state contract and make durable
-resume and named Saved Views consume the authored fallback before Compare work.
+#438. Issue #432 completes the next personal-scientific-memory increment: one
+versioned World-aware Explore-state contract, ordinary last-active resume, and
+named Saved Views across all three Worlds. The next program in the approved
+sequence is #433, ordinary World-aware Compare. Saved Comparisons are explicitly
+outside #433 and remain unimplemented.
 
-Rewritten issue #394 and issues #432 through #437 record bounded
-follow-on product work for Activity and History, durable Explore state and
-Saved Views, Compare and Saved Comparisons, variation
+Rewritten issue #394 and issues #433 through #437 record bounded
+follow-on product work for Activity and History, Compare and Saved Comparisons, variation
 contracts, and retained assets. Their presence does not
 activate them or replace the sequencing authority. Issues #389, #390, and #391
 were closed as superseded and are not current assignment authority.

--- a/docs/current/CURRENT_ARCHITECTURE.md
+++ b/docs/current/CURRENT_ARCHITECTURE.md
@@ -213,7 +213,7 @@ Missing data does not mutate the authored definition or silently promote a
 different Field, Lens, scale, time, or plane. Initial open and complete reset
 both consume the same definition.
 
-Future durable state from #432 must use this precedence:
+Durable Explore state from #432 uses this precedence:
 
 ```text
 explicit Saved View
@@ -222,8 +222,54 @@ explicit Saved View
 > technical fallback
 ```
 
-This contract does not persist state, create Saved Views, or serialize
-arbitrary component internals.
+The durable contract consumes these authored definitions as its fallback. It
+does not duplicate authored scientific defaults or serialize arbitrary
+component internals.
+
+### Durable Explore-state contract
+
+`app/backend/cloud_chamber/explore_state.py` owns one versioned local library
+per stable World and Simulation:
+
+```text
+<runtime-home>/explore-state/<world_id>/<simulation_id>.json
+```
+
+The v1 library envelope contains a last-active snapshot and up to 100 Saved
+Views. Each snapshot has a common identity, modeled time, Context, secondary
+section, and selected-point vocabulary plus one explicit World-specific state:
+
+- Trade Cumulus Field or Updraft Lens, physical planes, 3-D display, wind,
+  scale, and camera state;
+- Mountain Waves Field or Lens, viewport, geometry, overlays, and cloud display
+  state;
+- Supercells Lens, evidence orientation and physical plane, layers, scales,
+  overlays, hydrometeor categories, and camera state.
+
+The backend rejects unknown fields, non-finite numeric values, unbounded
+collections, invalid identifiers, unsupported schemas, more than 100 Saved
+Views, and files larger than 2 MB. Writes use a temporary file, filesystem
+synchronization, and atomic replacement.
+
+The frontend loads the library once for the active stable Simulation. A delayed
+startup response cannot override an intervening user edit. Last-active writes
+are serialized and coalesced so only the newest queued coherent state remains
+authoritative. The state controls expose create, list, live reopen, rename, and
+delete for Saved Views.
+
+Opening a Saved View is transactional at the scientific-workspace boundary:
+the action remains pending until required time, coordinate, Field or Lens,
+scale, overlay, and selected-point evidence has loaded. Only the final
+`healthy`, `partially_restorable`, or `unavailable` result is written to Saved
+View metadata. Metadata persistence failure does not invalidate an otherwise
+usable restored examination.
+
+Restoration maps modeled time by seconds and planes and selections by physical
+native-grid coordinates within bounded tolerances. Native indices are only a
+provisional fallback while coordinate evidence loads. Missing fields, scales,
+coordinates, layers, or retained output fail visibly without silently changing
+scientific meaning. A missing backing Simulation preserves its Saved View
+library and reports those records unavailable.
 
 ## Scientific Payload Rules
 
@@ -347,9 +393,11 @@ Blank content clears the note. Read and write failures stay local to Notes and
 are reported in the interface. Notes do not become run identity, result
 metadata, or a general annotation model.
 
-Saved Views and complete Explore workspace state are not durably persisted.
-Authored curated defaults are source-controlled product definitions, not user
-state or persistence records.
+Saved Views and last-active Explore state are durably persisted through the
+versioned World-aware contract above. Authored curated defaults remain
+source-controlled product definitions rather than user state. Per-Simulation
+Notes remain independently stored under `simulation-notes` and are not copied
+into Saved Views.
 The only product Comparison currently exposed is the featured Trade Cumulus
 pair. World-aware variation exists for Mountain Waves but is not yet one shared
 cross-World system.
@@ -370,7 +418,7 @@ reused.
 
 - World shells and Explore implementations share vocabulary but still contain
   World-specific state and rendering code.
-- Durable resume, Saved Views, and general World-aware Compare are absent.
+- General World-aware Compare and Saved Comparisons are absent.
 - Variation is implemented only for Mountain Waves.
 - Legacy run, result, and sounding surfaces remain interleaved with the newer
   World application.

--- a/docs/current/CURRENT_STATE.md
+++ b/docs/current/CURRENT_STATE.md
@@ -69,9 +69,9 @@ Explore.
 
 | World | Current content | Current surfaces | Current limitation |
 | --- | --- | --- | --- |
-| **Trade Cumulus** | Canonical BOMEX Baseline and More Moisture retained Simulations | Overview, Simulations, Saved Views placeholder, featured Comparison, Lab, and Explore | Saved Views are not durable; ordinary World-aware Compare is not implemented; Lab still embeds transitional Build and Results |
-| **Mountain Waves** | Dry Ridge and Boulder Windstorm retained Simulations | Overview, Simulations, variation Lab, and Explore | Variation is World-specific rather than shared; no ordinary Compare or Saved Views |
-| **Supercells** | Quarter-Circle Supercell retained Simulation | Overview, Simulations, and Explore | No variation Lab, ordinary Compare, or Saved Views |
+| **Trade Cumulus** | Canonical BOMEX Baseline and More Moisture retained Simulations | Overview, Simulations, featured Comparison, Lab, Explore resume, and Saved Views | Ordinary World-aware Compare is not implemented; Lab still embeds transitional Build and Results |
+| **Mountain Waves** | Dry Ridge and Boulder Windstorm retained Simulations | Overview, Simulations, variation Lab, Explore resume, and Saved Views | Variation is World-specific rather than shared; no ordinary Compare |
+| **Supercells** | Quarter-Circle Supercell retained Simulation | Overview, Simulations, Explore resume, and Saved Views | No variation Lab or ordinary Compare |
 
 The World Overview and Simulations surfaces use stable content identities and
 explicit availability states. Missing, invalid, or conflicting retained
@@ -151,6 +151,45 @@ a technical fallback. Missing times, planes, fields, scales, or layers are
 explained visibly; fallback does not rewrite the authored definition or claim
 that a substituted scientific presentation is equivalent.
 
+## Durable Explore State And Saved Views
+
+Each supported Simulation now stores the last coherent Explore examination and
+an explicitly managed list of named Saved Views. The common envelope is
+versioned and keyed to stable World and Simulation identity; Trade Cumulus,
+Mountain Waves, and Supercells retain explicit World-specific payloads rather
+than one flattened control inventory.
+
+Startup precedence is:
+
+```text
+explicitly opened Saved View
+> last active state
+> curated Simulation / active Field-or-Lens default
+> technical fallback
+```
+
+Resume waits for a coherent loaded target and does not persist transient
+loading, playback-running, maximize-only, or error state. User interaction made
+before a delayed resume response wins. Resume writes are serialized and
+coalesced so an older request cannot overwrite newer examination state.
+
+Saved Views can be created, listed, opened as live examinations, renamed, and
+deleted. Open remains visibly in progress until the required scientific
+evidence loads. Restoration status is recorded only after that result is known;
+a metadata-write failure is reported without invalidating the usable restored
+view. Missing retained output preserves the Saved View record and marks it
+unavailable.
+
+State is stored locally at:
+
+```text
+<runtime-home>/explore-state/<world_id>/<simulation_id>.json
+```
+
+Writes are atomic and bounded. Unsupported schemas, invalid values, oversized
+files, and persistence failures are visible local failures. Per-Simulation
+Notes remain separate and are not copied into Saved Views.
+
 ## Shared Scientific Presentation
 
 Current Explore surfaces use:
@@ -211,16 +250,13 @@ information architecture.
 
 The implemented application does not yet provide:
 
-- durable Saved Views;
-- ordinary last-active Explore-state resume;
 - ordinary World-aware Compare beyond the featured Trade Cumulus Comparison;
 - one shared World-aware variation workflow across all accessible Worlds;
-- durable persistence for complete Explore or comparison workspaces.
+- Saved Comparisons or durable comparison workspaces.
 
-Per-Simulation Notes are durable content, but camera, time, Lens, overlay,
-selection, and other complete Explore workspace state are not yet persisted.
-The authored curated-default contract is implemented and is the fallback that
-future resume and Saved Views must consume.
+Per-Simulation Notes and Explore state are separate durable contracts. Saved
+Views persist the live scientific examination dimensions owned by issue #432;
+they do not create Saved Comparisons or certify scientific validity.
 Older issues #389, #390, and #391 are closed as superseded by the current
 three-World implementation sequence; they should not be read as active roadmap
 authority.

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -85,6 +85,10 @@ The presentation-quality and third-World program established:
 
 #438 — typed World-aware curated Explore defaults, complete current-view
        Return to curated view, and visible bounded fallback — complete
+
+#432 — versioned World-aware Explore state, last-active resume, and named
+       Saved Views across Trade Cumulus, Mountain Waves, and Supercells
+       — complete
 ```
 
 The completed work preserves stable World and Simulation identities while allowing backing run assets to improve.
@@ -101,7 +105,10 @@ below the fold
 
 World-specific scientific content remains legitimate. Shared structure must not erase scientific or geometric differences.
 
-Per-Simulation Notes are the first bounded durable-content contract. They use stable World and Simulation identity, persist across reloads, and fail visibly. They do not serialize complete Explore state, implement resume, create Saved Views, or establish a generic annotation framework.
+Per-Simulation Notes are a bounded durable-content contract. They use stable
+World and Simulation identity, persist across reloads, and fail visibly. They
+remain separate from complete Explore state and Saved Views rather than
+becoming a generic annotation framework.
 
 Curated Explore defaults now define the intentional source-controlled
 presentation for each supported Simulation and Field or Lens. Initial open and
@@ -110,16 +117,14 @@ current Field or Lens without changing Simulation, erasing Notes, or starting
 playback. A visible technical fallback remains distinct from an authored
 scientific presentation.
 
-## Next program: personal scientific memory
+## Completed program: personal scientific memory
 
-Issue #432 is the next approved program in this sequence. Issue #394 remains
-queued and incomplete; it still depends on #435 and explicit PM activation.
-Completing #395 satisfies only the Fun With Soundings dependency named by
-#394.
+Issue #432 establishes one versioned, World-aware Explore-state contract before
+ordinary Compare. Issue #394 remains queued and incomplete; it still depends on
+#435 and explicit PM activation. Completing #395 satisfies only the Fun With
+Soundings dependency named by #394.
 
-Establish one versioned, World-aware Explore-state contract before implementing Compare.
-
-The contract should represent, as applicable:
+The implemented contract represents, as applicable:
 
 - World and stable Simulation identity;
 - model time or playback range;
@@ -129,10 +134,10 @@ The contract should represent, as applicable:
 - selected point or region;
 - overlays and meaningful display settings;
 - Context collapse state and active secondary-information section;
-- title and optional note;
+- Saved View title and optional short description;
 - schema version and bounded migration or failure behavior.
 
-Implement in this order:
+Implementation followed this order:
 
 ```text
 serializable Explore state
@@ -157,7 +162,15 @@ The curated-default tier and complete return behavior are implemented through
 #438. Issue #432 owns the durable state above that tier; it must consume rather
 than recreate these defaults.
 
-## Then: ordinary Compare and Saved Comparisons
+State is stored in bounded local libraries at
+`<runtime-home>/explore-state/<world_id>/<simulation_id>.json`. Saved Views
+reopen as live examinations, support rename and delete, preserve records when
+backing output is unavailable, and report healthy, partially restorable, or
+unavailable restoration. Notes remain separate.
+
+## Next program: ordinary World-aware Compare
+
+Issue #433 is the next program in this sequence.
 
 Build ordinary Compare from two compatible Explore states rather than creating a parallel examination model.
 
@@ -171,7 +184,7 @@ The current MVP decisions remain useful:
 - aligned, independent, and mixed states are supported;
 - no interpolation is presented as model output.
 
-Implement in this order:
+The current sequence remains:
 
 ```text
 ordinary World-aware Compare
@@ -179,6 +192,8 @@ ordinary World-aware Compare
 ```
 
 Trade Cumulus, Mountain Waves, and Supercells ask different comparison questions and may support different linked states.
+Issue #433 implements only ordinary Compare. It does not implement or claim
+Saved Comparisons; that later step requires separate approval and work.
 
 ## Variations require a fresh review
 


### PR DESCRIPTION
Closes #432

## Review posture

Manual PM review was required throughout repository recovery. The two review rounds have been addressed on this branch; auto-merge was not enabled.

Stable vision: Cloud Chamber keeps the established Explore workspaces for Trade Cumulus, Mountain Waves, and Supercells.

Current task: add durable, per-Simulation continuity and named Saved Views without changing the scientific views.

Non-implications: this does not add science, Compare behavior, run execution, CM1 changes, or a new Explore design system.

Portfolio effect: preserves each World-specific workspace while adding one shared persistence contract and control vocabulary.

## What changed

- Adds a versioned backend Explore-state contract with explicit Trade Cumulus, Mountain Waves, and Supercells payloads.
- Persists each Simulation's last coherent state and named Saved Views with atomic local writes, bounded migration, stable identity checks, and unavailable-state handling when backing output disappears.
- Restores time, coordinates, fields, Lens state, overlays, scales, selections, camera state, Context state, and World-specific controls using physical coordinates and bounded nearest-coordinate fallback.
- Adds shared Saved Views UI for create, open, rename, and delete, plus Return to curated view in all three Explore workspaces.
- Keeps Notes separate from Saved Views and exposes persistence failures without disrupting scientific inspection.

## Review corrections

- Saved View opening is transactional and restoration-status persistence failure no longer invalidates a successfully restored examination.
- Startup user edits take precedence over delayed resume loading.
- Resume writes are serialized/coalesced with true latest-state-wins semantics, including `active A -> queued B -> latest A` and `persisted A -> active B -> latest A` signature reversals.
- Trade Cumulus direct Field selection and planes restore by physical coordinates across changed inventories.
- Durable records bound file size, view count, collection sizes, identifiers, codes, and all numerical values.
- Current repository documentation records #432 as complete and identifies ordinary World-aware Compare (#433) as next without claiming Saved Comparisons.

## Verification

- `git diff --check`
- `BACKEND_PYTHON="$PWD/app/backend/.venv/bin/python" scripts/check.sh`
  - 208 frontend tests passed
  - production build passed
  - 696 backend tests passed
  - formatting, lint, type, script, forbidden-artifact, and documentation checks passed
- `scripts/check-e2e.sh`
  - 31/31 Playwright desktop tests passed
- GitHub Frontend, Backend, and Scripts/config CI checks passed at final head `37648b98`.

## Desktop review

The accepted rereview packet contains 20 screenshots at 1440x900 and 1024x856 covering CRUD, automatic resume, two Saved Views per World, partial restoration, unavailable backing output, persistence failure with Explore remaining usable, and Notes remaining separate. Live browser review also exercised the Mountain Waves create, rename, open, resume, and delete path.

No mobile review was performed, per product direction.
