### PR TITLE
Implement ordinary World-aware Compare across Cloud Worlds

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -55,8 +55,10 @@ from cloud_chamber.lan_worker import (
 from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError, RunStatus
 from cloud_chamber.local_run_queue import LocalRunQueueError, LocalRunQueueManager
 from cloud_chamber.mountain_wave_terrain_visualization import (
+    MountainWavesCompareFrame,
     MountainWaveTerrainField,
     MountainWaveTerrainVisualizationError,
+    mountain_waves_compare_frame_from_native_outputs,
     mountain_waves_frame_from_native_outputs,
     preserved_mountain_wave_terrain_frame,
 )
@@ -183,6 +185,10 @@ from cloud_chamber.visualization_data import (
     time_series_product,
     vertical_profile,
     view_defaults,
+)
+from cloud_chamber.world_compare import (
+    WorldCompareDescriptor,
+    world_compare_descriptor,
 )
 
 app = FastAPI(
@@ -655,6 +661,26 @@ def get_supercells_world() -> SupercellsWorldDetail:
 
 
 @app.get(
+    "/api/worlds/{world_slug}/compare",
+    response_model=WorldCompareDescriptor,
+)
+def get_world_compare_descriptor(
+    world_slug: str,
+    left_simulation_id: str | None = None,
+    right_simulation_id: str | None = None,
+) -> WorldCompareDescriptor:
+    try:
+        return world_compare_descriptor(
+            load_settings(),
+            world_slug=world_slug,
+            left_simulation_id=left_simulation_id,
+            right_simulation_id=right_simulation_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get(
     "/api/worlds/{world_id}/simulations/{simulation_id}/note",
     response_model=SimulationNoteResponse,
 )
@@ -970,6 +996,40 @@ def get_mountain_waves_simulation_frame(
     except (OSError, MountainWaveTerrainVisualizationError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return response.model_dump(mode="json")
+
+
+@app.get(
+    "/api/worlds/mountain-waves/simulations/{simulation_id}/compare-frame",
+    response_model=MountainWavesCompareFrame,
+)
+def get_mountain_waves_compare_frame(
+    simulation_id: str,
+    field: MountainWaveTerrainField = "w",
+    time_index: int = 0,
+) -> MountainWavesCompareFrame:
+    try:
+        record, manifest, _manifest_path = mountain_waves_run_manifest(
+            load_settings(), simulation_id
+        )
+        if not record.inspectable:
+            raise MountainWaveTerrainVisualizationError(
+                f"Simulation {simulation_id} does not have inspectable completed output."
+            )
+        return mountain_waves_compare_frame_from_native_outputs(
+            output_paths=[Path(value).expanduser() for value in manifest.outputs.netcdf_paths],
+            namelist_path=Path(manifest.generated_inputs.namelist_input or "").expanduser(),
+            field=field,
+            time_index=time_index,
+            run_id=manifest.run_id,
+            case_label=record.display_name,
+            implementation_commit=manifest.app.commit or "unknown",
+            dry_case=not record.moist_fields_available,
+            caveats=[*record.caveats, *record.warnings],
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (OSError, MountainWaveTerrainVisualizationError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @app.post("/api/storage/delete-run")

--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -155,6 +155,9 @@ from cloud_chamber.supercells_world import (
     REFERENCE_SIMULATION_ID as SUPERCELLS_REFERENCE_SIMULATION_ID,
 )
 from cloud_chamber.supercells_world import (
+    STRAIGHT_LINE_SIMULATION_ID as SUPERCELLS_STRAIGHT_LINE_SIMULATION_ID,
+)
+from cloud_chamber.supercells_world import (
     SupercellsWorldDetail,
     SupercellsWorldSummary,
     supercells_world_detail,
@@ -1251,11 +1254,10 @@ def get_supercells_simulation_frame(
     y_index: int | None = None,
     z_index: int | None = None,
 ) -> dict[str, object]:
-    if simulation_id != SUPERCELLS_REFERENCE_SIMULATION_ID:
-        raise HTTPException(status_code=404, detail="Supercell Simulation not found.")
     try:
         frame = supercells_explore_frame(
             load_settings(),
+            simulation_id=simulation_id,
             lens=lens,
             time_index=time_index,
             viewport=viewport,
@@ -1264,7 +1266,8 @@ def get_supercells_simulation_frame(
             z_index=z_index,
         )
     except StormExaminationError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        status_code = 404 if "Simulation is unavailable" in str(exc) else 400
+        raise HTTPException(status_code=status_code, detail=str(exc)) from exc
     return frame.model_dump(mode="json")
 
 
@@ -1317,7 +1320,10 @@ def _simulation_target_exists(
     if world_id == "mountain_waves":
         return mountain_waves_simulation(settings, simulation_id) is not None
     if world_id == "supercells":
-        return simulation_id == SUPERCELLS_REFERENCE_SIMULATION_ID
+        return simulation_id in {
+            SUPERCELLS_REFERENCE_SIMULATION_ID,
+            SUPERCELLS_STRAIGHT_LINE_SIMULATION_ID,
+        }
     return False
 
 

--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -1253,6 +1253,9 @@ def get_supercells_simulation_frame(
     x_index: int | None = None,
     y_index: int | None = None,
     z_index: int | None = None,
+    selected_x_index: int | None = None,
+    selected_y_index: int | None = None,
+    selected_z_index: int | None = None,
 ) -> dict[str, object]:
     try:
         frame = supercells_explore_frame(
@@ -1264,6 +1267,9 @@ def get_supercells_simulation_frame(
             x_index=x_index,
             y_index=y_index,
             z_index=z_index,
+            selected_x_index=selected_x_index,
+            selected_y_index=selected_y_index,
+            selected_z_index=selected_z_index,
         )
     except StormExaminationError as exc:
         status_code = 404 if "Simulation is unavailable" in str(exc) else 400

--- a/app/backend/cloud_chamber/cloud_worlds.py
+++ b/app/backend/cloud_chamber/cloud_worlds.py
@@ -140,7 +140,7 @@ class WorldCapabilities(BaseModel):
     featured_comparison: bool
     lab: Literal[True] = True
     saved_views: Literal[False] = False
-    ordinary_compare: Literal[False] = False
+    ordinary_compare: Literal[True] = True
 
 
 class CloudWorldSummary(BaseModel):

--- a/app/backend/cloud_chamber/cm1_source_customization.py
+++ b/app/backend/cloud_chamber/cm1_source_customization.py
@@ -1,12 +1,4 @@
-"""Apply Cloud Chamber CM1 source customizations outside the repo.
-
-CM1 remains an external dependency. Differential surface forcing needs a small
-source customization because the stock ``set_flx=1`` path writes uniform
-``thflux``/``qvflux`` fields from namelist constants. This module copies the
-configured external CM1 tree into an isolated runtime build tree, patches that
-copy, rebuilds ``cm1.exe``, copies the exact customized executable into the run
-directory, and records the operation beside the generated package.
-"""
+"""Apply source-locked Cloud Chamber CM1 customizations outside the repo."""
 
 from __future__ import annotations
 
@@ -23,6 +15,14 @@ from pathlib import Path
 
 from cloud_chamber.run_manifest import RunManifest
 from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.supercell_hodograph import (
+    STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND,
+    STRAIGHT_LINE_HODOGRAPH_MARKER,
+    STRAIGHT_LINE_HODOGRAPH_SCHEMA_VERSION,
+    STRAIGHT_LINE_HODOGRAPH_TARGET,
+    StraightLineHodographError,
+    render_straight_line_hodograph_source,
+)
 from cloud_chamber.surface_forcing import (
     CM1_SOURCE_CUSTOMIZATION_FILENAME,
     DIFFERENTIAL_SURFACE_FORCING_MODE,
@@ -32,6 +32,7 @@ from cloud_chamber.surface_forcing import (
 CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
 
 SOURCE_CUSTOMIZATION_STATUS_FILENAME = "cm1_source_customization_applied.json"
+SURFACE_FORCING_CUSTOMIZATION_KIND = "differential_surface_forcing_v0"
 SFCPHYS_MARKER = "CLOUD_CHAMBER_SURFACE_FORCING_PATCH_V0_SFCPHYS"
 
 SFCPHYS_TARGET = Path("src/sfcphys.F")
@@ -39,7 +40,7 @@ CUSTOM_EXECUTABLE_FILENAME = "cm1_cloud_chamber_custom.exe"
 
 
 class CM1SourceCustomizationError(RuntimeError):
-    """Raised when differential surface forcing cannot customize local CM1."""
+    """Raised when a declared source customization cannot rebuild local CM1."""
 
 
 @dataclass(frozen=True)
@@ -54,7 +55,10 @@ class CM1SourceCustomizationResult:
 
 
 def manifest_requires_cm1_source_customization(manifest: RunManifest) -> bool:
-    return manifest.run_configuration.get("surface_flux_mode") == DIFFERENTIAL_SURFACE_FORCING_MODE
+    return (
+        manifest.run_configuration.get("surface_flux_mode") == DIFFERENTIAL_SURFACE_FORCING_MODE
+        or manifest.run_configuration.get("cm1_source_customization_kind") is not None
+    )
 
 
 def prepare_cm1_source_customization(
@@ -63,36 +67,65 @@ def prepare_cm1_source_customization(
     manifest: RunManifest,
     command_runner: CommandRunner = subprocess.run,
 ) -> CM1SourceCustomizationResult | None:
-    """Patch and rebuild the external CM1 tree for differential surface forcing."""
+    """Patch and rebuild an isolated copy of the configured external CM1 tree."""
 
     if not manifest_requires_cm1_source_customization(manifest):
         return None
 
+    customization_kind = _customization_kind(manifest)
     if settings.cm1_root is None:
         raise CM1SourceCustomizationError(
-            "Differential surface forcing requires a configured CM1 root with source files."
+            "CM1 source customization requires a configured CM1 root with source files."
         )
     if settings.cm1_run_dir is None:
         raise CM1SourceCustomizationError(
-            "Differential surface forcing requires a configured CM1 run directory."
+            "CM1 source customization requires a configured CM1 run directory."
         )
 
     run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
-    patch_path = _required_generated_path(
-        manifest.generated_inputs.surface_forcing_patch,
-        run_dir / SURFACE_FORCING_PATCH_FILENAME,
-        "surface forcing patch file",
-    )
     customization_path = _required_generated_path(
         manifest.generated_inputs.cm1_source_customization,
         run_dir / CM1_SOURCE_CUSTOMIZATION_FILENAME,
         "CM1 source customization manifest",
     )
-    _validate_patch_provenance(
-        manifest=manifest,
-        patch_path=patch_path,
-        customization_path=customization_path,
-    )
+    if customization_kind == SURFACE_FORCING_CUSTOMIZATION_KIND:
+        patch_path = _required_generated_path(
+            manifest.generated_inputs.surface_forcing_patch,
+            run_dir / SURFACE_FORCING_PATCH_FILENAME,
+            "surface forcing patch file",
+        )
+        _validate_patch_provenance(
+            manifest=manifest,
+            patch_path=patch_path,
+            customization_path=customization_path,
+        )
+        target_relative_path = SFCPHYS_TARGET
+        patch_source = _patch_sfcphys_text
+        expected_original_sha256 = None
+        expected_patched_sha256 = None
+        status_details: dict[str, object] = {
+            "surface_flux_mode": DIFFERENTIAL_SURFACE_FORCING_MODE,
+            "patch_file": str(patch_path),
+            "no_silent_uniform_fallback": True,
+        }
+    elif customization_kind == STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND:
+        customization = _validate_straight_line_hodograph_provenance(
+            manifest=manifest,
+            customization_path=customization_path,
+        )
+        target_relative_path = STRAIGHT_LINE_HODOGRAPH_TARGET
+        patch_source = render_straight_line_hodograph_source
+        expected_original_sha256 = str(customization["original_source_sha256"])
+        expected_patched_sha256 = str(customization["patched_source_sha256"])
+        status_details = {
+            "hodograph_profile": customization["wind_profile"],
+            "no_silent_hodograph_fallback": True,
+        }
+    else:
+        raise CM1SourceCustomizationError(
+            f"Unsupported CM1 source customization kind: {customization_kind}"
+        )
+
     src_dir = settings.cm1_root / "src"
     if not src_dir.exists():
         raise CM1SourceCustomizationError(f"CM1 source directory does not exist: {src_dir}")
@@ -111,11 +144,30 @@ def prepare_cm1_source_customization(
             shutil.rmtree(build_root)
         shutil.copytree(settings.cm1_root, build_root, ignore=_copytree_ignore)
         build_src_dir = build_root / "src"
-        target = build_root / SFCPHYS_TARGET
+        target = build_root / target_relative_path
         if not target.exists():
             raise CM1SourceCustomizationError(f"CM1 source file does not exist: {target}")
-        target.write_text(_patch_sfcphys_text(target.read_text()))
-        patched_files.append(str(SFCPHYS_TARGET))
+        original_source = target.read_text()
+        original_source_sha256 = _text_sha256(original_source)
+        if (
+            expected_original_sha256 is not None
+            and original_source_sha256 != expected_original_sha256
+        ):
+            raise CM1SourceCustomizationError(
+                "Configured CM1 source target does not match the packaged source lock: "
+                f"{original_source_sha256} != {expected_original_sha256}."
+            )
+        try:
+            patched_source = patch_source(original_source)
+        except StraightLineHodographError as exc:
+            raise CM1SourceCustomizationError(str(exc)) from exc
+        patched_source_sha256 = _text_sha256(patched_source)
+        if expected_patched_sha256 is not None and patched_source_sha256 != expected_patched_sha256:
+            raise CM1SourceCustomizationError(
+                "Rendered CM1 source target does not match the packaged customization identity."
+            )
+        target.write_text(patched_source)
+        patched_files.append(str(target_relative_path))
         build_command = ("make",)
         try:
             command_runner(
@@ -127,7 +179,7 @@ def prepare_cm1_source_customization(
             )
         except subprocess.CalledProcessError as exc:
             raise CM1SourceCustomizationError(
-                "Failed to rebuild CM1 after applying differential surface-forcing source "
+                "Failed to rebuild CM1 after applying the declared source "
                 f"customization in isolated build tree: {exc.stderr or exc.stdout or exc}"
             ) from exc
 
@@ -146,24 +198,25 @@ def prepare_cm1_source_customization(
     executable_sha256 = _file_sha256(executable_path)
 
     status_path = run_dir / SOURCE_CUSTOMIZATION_STATUS_FILENAME
-    status_payload = {
-        "schema_version": "cm1_source_customization_status_v0",
-        "surface_flux_mode": DIFFERENTIAL_SURFACE_FORCING_MODE,
+    status_payload: dict[str, object] = {
+        "schema_version": "cm1_source_customization_status_v1",
+        "customization_kind": customization_kind,
         "run_id": manifest.run_id,
         "applied_at": datetime.now(UTC).isoformat(),
         "cm1_root": str(settings.cm1_root),
         "cm1_run_dir": str(settings.cm1_run_dir),
         "source_hash": source_hash,
         "build_root": str(build_root),
-        "patch_file": str(patch_path),
         "customization_manifest": str(customization_path),
+        "original_target_sha256": original_source_sha256,
+        "patched_target_sha256": patched_source_sha256,
         "patched_files": patched_files,
         "source_restored_after_build": "not_modified_isolated_build_tree",
         "build_command": ["make"],
         "custom_executable": str(executable_path),
         "custom_executable_sha256": executable_sha256,
-        "no_silent_uniform_fallback": True,
     }
+    status_payload.update(status_details)
     status_path.write_text(json.dumps(status_payload, indent=2, sort_keys=True) + "\n")
     return CM1SourceCustomizationResult(
         status_path=status_path,
@@ -174,6 +227,17 @@ def prepare_cm1_source_customization(
         patched_files=tuple(patched_files),
         build_command=("make",),
     )
+
+
+def _customization_kind(manifest: RunManifest) -> str:
+    if manifest.run_configuration.get("surface_flux_mode") == DIFFERENTIAL_SURFACE_FORCING_MODE:
+        return SURFACE_FORCING_CUSTOMIZATION_KIND
+    kind = manifest.run_configuration.get("cm1_source_customization_kind")
+    if not isinstance(kind, str) or not kind:
+        raise CM1SourceCustomizationError(
+            "Run manifest declares source customization without a valid customization kind."
+        )
+    return kind
 
 
 def _required_generated_path(value: str | None, fallback: Path, label: str) -> Path:
@@ -228,16 +292,71 @@ def _validate_patch_provenance(
         )
 
 
+def _validate_straight_line_hodograph_provenance(
+    *,
+    manifest: RunManifest,
+    customization_path: Path,
+) -> dict[str, object]:
+    try:
+        customization = json.loads(customization_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise CM1SourceCustomizationError(
+            f"Generated straight-line hodograph customization is invalid JSON: {customization_path}"
+        ) from exc
+    if not isinstance(customization, dict):
+        raise CM1SourceCustomizationError(
+            "Generated straight-line hodograph customization is not an object."
+        )
+    expected = {
+        "schema_version": STRAIGHT_LINE_HODOGRAPH_SCHEMA_VERSION,
+        "customization_kind": STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND,
+        "target_relative_path": str(STRAIGHT_LINE_HODOGRAPH_TARGET),
+        "marker": STRAIGHT_LINE_HODOGRAPH_MARKER,
+    }
+    mismatched = {
+        name: (customization.get(name), value)
+        for name, value in expected.items()
+        if customization.get(name) != value
+    }
+    if mismatched:
+        raise CM1SourceCustomizationError(
+            f"Straight-line hodograph customization identity changed: {mismatched}."
+        )
+    if (
+        manifest.run_configuration.get("cm1_source_customization_kind")
+        != STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND
+    ):
+        raise CM1SourceCustomizationError(
+            "Run manifest and generated straight-line hodograph customization disagree."
+        )
+    for name in ("original_source_sha256", "patched_source_sha256"):
+        value = customization.get(name)
+        if not isinstance(value, str) or len(value) != 64:
+            raise CM1SourceCustomizationError(
+                f"Straight-line hodograph customization is missing {name}."
+            )
+    wind_profile = customization.get("wind_profile")
+    if not isinstance(wind_profile, dict):
+        raise CM1SourceCustomizationError(
+            "Straight-line hodograph customization is missing its wind profile."
+        )
+    return customization
+
+
 def _fail_if_source_already_customized(cm1_root: Path) -> None:
     dirty_files = []
-    for relative_path in (SFCPHYS_TARGET,):
+    targets = (
+        (SFCPHYS_TARGET, SFCPHYS_MARKER),
+        (STRAIGHT_LINE_HODOGRAPH_TARGET, STRAIGHT_LINE_HODOGRAPH_MARKER),
+    )
+    for relative_path, marker in targets:
         path = cm1_root / relative_path
-        if path.exists() and SFCPHYS_MARKER in path.read_text(errors="replace"):
+        if path.exists() and marker in path.read_text(errors="replace"):
             dirty_files.append(str(relative_path))
     if dirty_files:
         raise CM1SourceCustomizationError(
-            "Configured CM1 source tree already contains Cloud Chamber differential "
-            "surface-forcing customization markers. Refusing to build from a dirty "
+            "Configured CM1 source tree already contains Cloud Chamber customization "
+            "markers. Refusing to build from a dirty "
             "source tree: " + ", ".join(dirty_files)
         )
 
@@ -284,7 +403,7 @@ def _built_executable_path(
         relative_run_dir = original_cm1_run_dir.relative_to(original_cm1_root)
     except ValueError as exc:
         raise CM1SourceCustomizationError(
-            "Differential surface forcing currently requires cm1_run_dir to live under cm1_root "
+            "CM1 source customization requires cm1_run_dir to live under cm1_root "
             "so the isolated build tree can identify the generated executable."
         ) from exc
     return build_root / relative_run_dir / "cm1.exe"
@@ -294,6 +413,10 @@ def _file_sha256(path: Path) -> str:
     digest = hashlib.sha256()
     digest.update(path.read_bytes())
     return digest.hexdigest()
+
+
+def _text_sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
 def _patch_sfcphys_text(source: str) -> str:
@@ -406,6 +529,7 @@ __all__ = [
     "CM1SourceCustomizationResult",
     "CUSTOM_EXECUTABLE_FILENAME",
     "SOURCE_CUSTOMIZATION_STATUS_FILENAME",
+    "SURFACE_FORCING_CUSTOMIZATION_KIND",
     "manifest_requires_cm1_source_customization",
     "prepare_cm1_source_customization",
 ]

--- a/app/backend/cloud_chamber/mountain_wave_terrain_visualization.py
+++ b/app/backend/cloud_chamber/mountain_wave_terrain_visualization.py
@@ -250,6 +250,59 @@ class MountainWaveTerrainFrame(BaseModel):
     )
 
 
+class MountainWavesComparePointerContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    horizontal_wind_m_s: list[list[float]]
+    vertical_velocity_m_s: list[list[float]]
+    potential_temperature_k: list[list[float]]
+    theta_perturbation_k: list[list[float]]
+    cloud_liquid_g_kg: list[list[float]] | None = None
+    relative_humidity_percent: list[list[float]] | None = None
+
+
+class MountainWavesCompareCloudOverlay(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    values: list[list[float]]
+    threshold_g_kg: float
+    maximum_g_kg: float
+
+
+class MountainWavesCompareFrame(BaseModel):
+    """Display-bounded native-cell samples for linked dual-view Compare."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["mountain_waves_compare_v1"] = "mountain_waves_compare_v1"
+    run_id: str
+    case_label: str
+    time_index: int
+    time_seconds: int
+    times_seconds: list[int]
+    dry_case: bool
+    field: TerrainFieldMetadata
+    field_options: list[MountainWaveTerrainField]
+    values: list[list[float]]
+    native_x_indices: list[int]
+    native_z_indices: list[int]
+    x_center_km: list[float]
+    terrain_km: list[float]
+    scalar_height_km: list[list[float]]
+    pointer_context: MountainWavesComparePointerContext
+    cloud_overlay: MountainWavesCompareCloudOverlay | None
+    viewport: TerrainViewportMetadata
+    lens: TerrainLensMetadata
+    scale: TerrainScale
+    source_shape: tuple[int, int]
+    display_shape: tuple[int, int]
+    display_sampling: Literal["ordered_native_cell_subset_no_interpolation"] = (
+        "ordered_native_cell_subset_no_interpolation"
+    )
+    performance: TerrainPerformance
+    caveats: list[str] = Field(default_factory=list)
+
+
 @dataclass(frozen=True)
 class _MountainWavesRunMetadata:
     fingerprint: tuple[tuple[str, int, int, int], ...]
@@ -675,6 +728,176 @@ def mountain_waves_frame_from_native_outputs(
         caveats=caveats,
     )
     return _measure_serialization(response) if measure_serialization else response
+
+
+def mountain_waves_compare_frame_from_native_outputs(
+    *,
+    output_paths: list[Path],
+    namelist_path: Path,
+    field: MountainWaveTerrainField,
+    time_index: int,
+    run_id: str,
+    case_label: str,
+    implementation_commit: str,
+    dry_case: bool,
+    caveats: list[str],
+    maximum_columns: int = 120,
+    maximum_rows: int = 80,
+) -> MountainWavesCompareFrame:
+    """Return a bounded display subset while preserving native cell identity."""
+    source = mountain_waves_frame_from_native_outputs(
+        output_paths=output_paths,
+        namelist_path=namelist_path,
+        field=field,
+        time_index=time_index,
+        run_id=run_id,
+        case_label=case_label,
+        implementation_commit=implementation_commit,
+        dry_case=dry_case,
+        caveats=caveats,
+        measure_serialization=False,
+    )
+    source_rows = len(source.values)
+    source_columns = len(source.values[0]) if source.values else 0
+    if source_rows == 0 or source_columns == 0 or source.pointer_context is None:
+        raise MountainWaveTerrainVisualizationError(
+            "Mountain Waves Compare requires a non-empty native x-z frame."
+        )
+    if source.viewport is None or source.lens is None:
+        raise MountainWaveTerrainVisualizationError(
+            "Mountain Waves Compare metadata is unavailable."
+        )
+    x_indices = _ordered_sample_indices(source_columns, maximum_columns)
+    z_indices = _ordered_sample_indices(source_rows, maximum_rows)
+    overlay = source.overlay
+    compact = MountainWavesCompareFrame(
+        run_id=source.run_id,
+        case_label=source.case_label,
+        time_index=source.time_index,
+        time_seconds=source.time_seconds,
+        times_seconds=source.times_seconds,
+        dry_case=source.dry_case,
+        field=source.field,
+        field_options=source.field_options,
+        values=_sample_native_grid(source.values, z_indices, x_indices),
+        native_x_indices=x_indices,
+        native_z_indices=z_indices,
+        x_center_km=[source.geometry.x_center_m[index] / 1_000.0 for index in x_indices],
+        terrain_km=[source.geometry.terrain_m[index] / 1_000.0 for index in x_indices],
+        scalar_height_km=[
+            [source.geometry.scalar_height_m[z_index][x_index] / 1_000.0 for x_index in x_indices]
+            for z_index in z_indices
+        ],
+        pointer_context=MountainWavesComparePointerContext(
+            horizontal_wind_m_s=_sample_native_grid(
+                source.pointer_context.horizontal_wind_m_s,
+                z_indices,
+                x_indices,
+            ),
+            vertical_velocity_m_s=_sample_native_grid(
+                source.pointer_context.vertical_velocity_m_s,
+                z_indices,
+                x_indices,
+            ),
+            potential_temperature_k=_sample_native_grid(
+                source.pointer_context.potential_temperature_k,
+                z_indices,
+                x_indices,
+            ),
+            theta_perturbation_k=_sample_native_grid(
+                source.pointer_context.theta_perturbation_k,
+                z_indices,
+                x_indices,
+            ),
+            cloud_liquid_g_kg=(
+                _sample_native_grid(
+                    source.pointer_context.cloud_liquid_g_kg,
+                    z_indices,
+                    x_indices,
+                )
+                if source.pointer_context.cloud_liquid_g_kg is not None
+                else None
+            ),
+            relative_humidity_percent=(
+                _sample_native_grid(
+                    source.pointer_context.relative_humidity_percent,
+                    z_indices,
+                    x_indices,
+                )
+                if source.pointer_context.relative_humidity_percent is not None
+                else None
+            ),
+        ),
+        cloud_overlay=(
+            MountainWavesCompareCloudOverlay(
+                values=_sample_native_grid(overlay.values, z_indices, x_indices),
+                threshold_g_kg=overlay.threshold,
+                maximum_g_kg=overlay.maximum,
+            )
+            if overlay is not None
+            else None
+        ),
+        viewport=source.viewport,
+        lens=source.lens,
+        scale=source.scale,
+        source_shape=(source_rows, source_columns),
+        display_shape=(len(z_indices), len(x_indices)),
+        performance=TerrainPerformance(extraction_ms=source.performance.extraction_ms),
+        caveats=[
+            *source.caveats,
+            (
+                "Compare paints an ordered subset of native scalar cells for display; "
+                "values and coordinates are not interpolated."
+            ),
+        ],
+    )
+    return _measure_compare_serialization(compact)
+
+
+def _ordered_sample_indices(length: int, maximum_count: int) -> list[int]:
+    if length <= 0:
+        return []
+    if maximum_count <= 1 or length <= maximum_count:
+        return list(range(length))
+    return sorted(
+        {int(round(index * (length - 1) / (maximum_count - 1))) for index in range(maximum_count)}
+    )
+
+
+def _sample_native_grid(
+    values: list[list[float]],
+    row_indices: list[int],
+    column_indices: list[int],
+) -> list[list[float]]:
+    return [
+        [values[row_index][column_index] for column_index in column_indices]
+        for row_index in row_indices
+    ]
+
+
+def _measure_compare_serialization(
+    response: MountainWavesCompareFrame,
+) -> MountainWavesCompareFrame:
+    started = perf_counter()
+    response.model_dump_json()
+    elapsed_ms = (perf_counter() - started) * 1_000.0
+    measured = response.model_copy(
+        update={
+            "performance": response.performance.model_copy(update={"serialization_ms": elapsed_ms})
+        }
+    )
+    for _attempt in range(4):
+        payload_bytes = len(measured.model_dump_json().encode("utf-8"))
+        if payload_bytes == measured.performance.serialized_payload_bytes:
+            break
+        measured = measured.model_copy(
+            update={
+                "performance": measured.performance.model_copy(
+                    update={"serialized_payload_bytes": payload_bytes}
+                )
+            }
+        )
+    return measured
 
 
 def clear_mountain_waves_run_metadata_cache() -> None:

--- a/app/backend/cloud_chamber/storm_examination.py
+++ b/app/backend/cloud_chamber/storm_examination.py
@@ -359,6 +359,9 @@ def preserved_storm_examination_frame(
         x_index=x_index,
         y_index=y_index,
         z_index=z_index,
+        selected_x_index=None,
+        selected_y_index=None,
+        selected_z_index=None,
         purpose="research",
     )
 
@@ -380,6 +383,9 @@ def supercells_explore_frame(
     x_index: int | None = None,
     y_index: int | None = None,
     z_index: int | None = None,
+    selected_x_index: int | None = None,
+    selected_y_index: int | None = None,
+    selected_z_index: int | None = None,
 ) -> StormExaminationFrame:
     """Return the production Supercells frame from the accepted Gate C science path."""
     return _storm_frame(
@@ -390,6 +396,9 @@ def supercells_explore_frame(
         x_index=x_index,
         y_index=y_index,
         z_index=z_index,
+        selected_x_index=selected_x_index,
+        selected_y_index=selected_y_index,
+        selected_z_index=selected_z_index,
         purpose="product",
         product_contract=_product_contract(simulation_id),
     )
@@ -414,6 +423,9 @@ def _storm_frame(
     x_index: int | None,
     y_index: int | None,
     z_index: int | None,
+    selected_x_index: int | None,
+    selected_y_index: int | None,
+    selected_z_index: int | None,
     purpose: FramePurpose,
     product_contract: _RunContract | None = None,
 ) -> StormExaminationFrame:
@@ -473,10 +485,25 @@ def _storm_frame(
         )
     primary_z, primary_y, primary_x = primary_index
     default_level = _default_level_index(lens, z_km, primary_z)
-    selected_x = _checked_index(x_index if x_index is not None else primary_x, len(x_km), "x_index")
-    selected_y = _checked_index(y_index if y_index is not None else primary_y, len(y_km), "y_index")
-    selected_z = _checked_index(
+    section_x = _checked_index(x_index if x_index is not None else primary_x, len(x_km), "x_index")
+    section_y = _checked_index(y_index if y_index is not None else primary_y, len(y_km), "y_index")
+    section_z = _checked_index(
         z_index if z_index is not None else default_level, len(z_km), "z_index"
+    )
+    selected_x = _checked_index(
+        selected_x_index if selected_x_index is not None else section_x,
+        len(x_km),
+        "selected_x_index",
+    )
+    selected_y = _checked_index(
+        selected_y_index if selected_y_index is not None else section_y,
+        len(y_km),
+        "selected_y_index",
+    )
+    selected_z = _checked_index(
+        selected_z_index if selected_z_index is not None else section_z,
+        len(z_km),
+        "selected_z_index",
     )
 
     primary = PointMarker(
@@ -493,7 +520,7 @@ def _storm_frame(
     if purpose == "product" and viewport == "full":
         x_indices = x_indices[::2]
         y_indices = y_indices[::2]
-    plan = _plan_view(lens, fields, x_km, y_km, z_km, selected_z, x_indices, y_indices)
+    plan = _plan_view(lens, fields, x_km, y_km, z_km, section_z, x_indices, y_indices)
     xz_section = _vertical_section(
         lens,
         "xz",
@@ -501,8 +528,8 @@ def _storm_frame(
         x_km,
         y_km,
         z_km,
-        selected_x,
-        selected_y,
+        section_x,
+        section_y,
         x_indices,
         y_indices,
     )
@@ -513,8 +540,8 @@ def _storm_frame(
         x_km,
         y_km,
         z_km,
-        selected_x,
-        selected_y,
+        section_x,
+        section_y,
         x_indices,
         y_indices,
     )
@@ -545,7 +572,7 @@ def _storm_frame(
             y_indices,
             native_x_indices,
             native_y_indices,
-            selected_z,
+            section_z,
             history_path.name,
             viewport,
         )

--- a/app/backend/cloud_chamber/storm_examination.py
+++ b/app/backend/cloud_chamber/storm_examination.py
@@ -21,6 +21,18 @@ EXPECTED_TIMES_SECONDS = tuple(range(0, 7_201, 900))
 HISTORY_FILENAMES = tuple(f"cm1out_{index:06d}.nc" for index in range(1, 10))
 PRESENTATION_RUN_ID = "quarter-circle-supercell-presentation-v1-20260723"
 PRESENTATION_CASE_ID = "cm1_r21_1_quarter_circle_supercell_presentation_v1"
+STRAIGHT_LINE_PRESENTATION_RUN_ID = "straight-line-supercell-presentation-v1-20260726"
+STRAIGHT_LINE_PRESENTATION_CASE_ID = "cm1_r21_1_straight_line_supercell_presentation_v1"
+SupercellSimulationId = Literal[
+    "supercells_quarter_circle_reference",
+    "supercells_straight_line_hodograph",
+]
+QUARTER_CIRCLE_SIMULATION_ID: Literal["supercells_quarter_circle_reference"] = (
+    "supercells_quarter_circle_reference"
+)
+STRAIGHT_LINE_SIMULATION_ID: Literal["supercells_straight_line_hodograph"] = (
+    "supercells_straight_line_hodograph"
+)
 PRESENTATION_TIMES_SECONDS = tuple(range(0, 10_801, 120))
 PRESENTATION_HISTORY_FILENAMES = tuple(f"cm1out_{index:06d}.nc" for index in range(1, 92))
 PRESENTATION_EVIDENCE_FILENAME = "supercell_presentation_evidence.json"
@@ -75,6 +87,9 @@ GATE_C_STORM_VIEW_BOUNDS_KM = {
 class _RunContract:
     run_id: str
     case_id: str
+    simulation_id: str | None
+    simulation_label: str
+    hodograph: Literal["quarter_circle", "straight_line"]
     expected_times_seconds: tuple[int, ...]
     history_filenames: tuple[str, ...]
     evidence_filename: str | None
@@ -84,6 +99,9 @@ class _RunContract:
 GATE_C_RUN = _RunContract(
     run_id=PRESERVED_RUN_ID,
     case_id=PRESERVED_CASE_ID,
+    simulation_id=None,
+    simulation_label="Official CM1 r21.1 quarter-circle benchmark",
+    hodograph="quarter_circle",
     expected_times_seconds=EXPECTED_TIMES_SECONDS,
     history_filenames=HISTORY_FILENAMES,
     evidence_filename=None,
@@ -92,11 +110,29 @@ GATE_C_RUN = _RunContract(
 PRESENTATION_RUN = _RunContract(
     run_id=PRESENTATION_RUN_ID,
     case_id=PRESENTATION_CASE_ID,
+    simulation_id=QUARTER_CIRCLE_SIMULATION_ID,
+    simulation_label="Quarter-Circle Supercell presentation simulation",
+    hodograph="quarter_circle",
     expected_times_seconds=PRESENTATION_TIMES_SECONDS,
     history_filenames=PRESENTATION_HISTORY_FILENAMES,
     evidence_filename=PRESENTATION_EVIDENCE_FILENAME,
     unavailable_label="accepted presentation output",
 )
+STRAIGHT_LINE_PRESENTATION_RUN = _RunContract(
+    run_id=STRAIGHT_LINE_PRESENTATION_RUN_ID,
+    case_id=STRAIGHT_LINE_PRESENTATION_CASE_ID,
+    simulation_id=STRAIGHT_LINE_SIMULATION_ID,
+    simulation_label="Straight-Line Hodograph Supercell presentation simulation",
+    hodograph="straight_line",
+    expected_times_seconds=PRESENTATION_TIMES_SECONDS,
+    history_filenames=PRESENTATION_HISTORY_FILENAMES,
+    evidence_filename=PRESENTATION_EVIDENCE_FILENAME,
+    unavailable_label="controlled straight-line presentation output",
+)
+PRODUCT_RUNS: dict[str, _RunContract] = {
+    QUARTER_CIRCLE_SIMULATION_ID: PRESENTATION_RUN,
+    STRAIGHT_LINE_SIMULATION_ID: STRAIGHT_LINE_PRESENTATION_RUN,
+}
 
 W_COLORS = (
     "#4b0082",
@@ -277,7 +313,7 @@ class StormExaminationFrame(BaseModel):
         "issue_418_gate_c_research_not_product", "supercells_product_world"
     ] = "issue_418_gate_c_research_not_product"
     world_id: Literal["supercells"] | None = None
-    simulation_id: Literal["supercells_quarter_circle_reference"] | None = None
+    simulation_id: str | None = None
     run_id: str
     case_id: str
     simulation_label: str
@@ -327,9 +363,17 @@ def preserved_storm_examination_frame(
     )
 
 
+def _product_contract(simulation_id: str) -> _RunContract:
+    contract = PRODUCT_RUNS.get(simulation_id)
+    if contract is None:
+        raise StormExaminationError(f"Supercell Simulation is unavailable: {simulation_id}.")
+    return contract
+
+
 def supercells_explore_frame(
     settings: CloudChamberSettings,
     *,
+    simulation_id: str = QUARTER_CIRCLE_SIMULATION_ID,
     lens: LensId = "rotating_updraft",
     time_index: int = DEFAULT_PRESENTATION_TIME_INDEX,
     viewport: ViewportId = "storm",
@@ -347,15 +391,18 @@ def supercells_explore_frame(
         y_index=y_index,
         z_index=z_index,
         purpose="product",
+        product_contract=_product_contract(simulation_id),
     )
 
 
 def storm_examination_inventory(
     settings: CloudChamberSettings,
+    simulation_id: str = QUARTER_CIRCLE_SIMULATION_ID,
 ) -> tuple[tuple[Path, float], ...]:
     """Return the cached, identity-validated production history inventory."""
-    run_dir = settings.runtime_home.expanduser() / "runs" / PRESENTATION_RUN_ID
-    return _validated_inventory(run_dir, PRESENTATION_RUN)
+    contract = _product_contract(simulation_id)
+    run_dir = settings.runtime_home.expanduser() / "runs" / contract.run_id
+    return _validated_inventory(run_dir, contract)
 
 
 def _storm_frame(
@@ -368,10 +415,13 @@ def _storm_frame(
     y_index: int | None,
     z_index: int | None,
     purpose: FramePurpose,
+    product_contract: _RunContract | None = None,
 ) -> StormExaminationFrame:
     """Extract coordinated, bounded views from one retained native history."""
     started = time.perf_counter()
-    contract = PRESENTATION_RUN if purpose == "product" else GATE_C_RUN
+    contract = product_contract if purpose == "product" else GATE_C_RUN
+    if contract is None:
+        raise StormExaminationError("A product Simulation contract is required.")
     run_dir = settings.runtime_home.expanduser() / "runs" / contract.run_id
     inventory = _validated_inventory(run_dir, contract)
     checked_time_index = _checked_index(time_index, len(inventory), "time_index")
@@ -512,14 +562,10 @@ def _storm_frame(
             else "issue_418_gate_c_research_not_product"
         ),
         world_id="supercells" if purpose == "product" else None,
-        simulation_id="supercells_quarter_circle_reference" if purpose == "product" else None,
+        simulation_id=contract.simulation_id if purpose == "product" else None,
         run_id=contract.run_id,
         case_id=contract.case_id,
-        simulation_label=(
-            "Quarter-Circle Supercell presentation simulation"
-            if purpose == "product"
-            else "Official CM1 r21.1 quarter-circle benchmark"
-        ),
+        simulation_label=contract.simulation_label,
         lens_id=lens,
         lens_name=lens_name,
         lens_question=lens_question,
@@ -696,7 +742,11 @@ def _presentation_evidence_inventory(
         or evidence.get("kind") != "final"
         or evidence.get("run_id") != contract.run_id
         or evidence.get("case_id") != contract.case_id
+        or evidence.get("simulation_id") != contract.simulation_id
+        or evidence.get("hodograph") != contract.hodograph
         or evidence.get("source_run_id") != PRESERVED_RUN_ID
+        or case_manifest.get("simulation_id") != contract.simulation_id
+        or case_manifest.get("hodograph") != contract.hodograph
         or evidence.get("implementation_commit") != case_manifest.get("implementation_commit")
         or evidence.get("grid")
         != {

--- a/app/backend/cloud_chamber/supercell_hodograph.py
+++ b/app/backend/cloud_chamber/supercell_hodograph.py
@@ -1,0 +1,145 @@
+"""Source-locked straight-line hodograph customization for Supercells Compare."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND = "straight_line_hodograph_v1"
+STRAIGHT_LINE_HODOGRAPH_SCHEMA_VERSION = "supercell_straight_line_hodograph_v1"
+STRAIGHT_LINE_HODOGRAPH_ARTIFACT_FILENAME = "straight_line_hodograph_customization.json"
+STRAIGHT_LINE_HODOGRAPH_MARKER = "CLOUD_CHAMBER_STRAIGHT_LINE_HODOGRAPH_V1"
+STRAIGHT_LINE_HODOGRAPH_TARGET = Path("src/base.F")
+PINNED_BASE_F_SHA256 = "9c88a1021ddde22d02680786246c52bcffb040cbd72c3c4708f24fe24eec32ef"
+
+# The stock iwnd=2 profile has a 0-6 km endpoint shear of (31, 7) m/s and
+# a layer-mean wind of (13.5145538645, 6.1521128022) m/s. These endpoints
+# preserve both quantities while removing the quarter-circle curvature.
+SURFACE_U_M_S = -1.9854461355
+SURFACE_V_M_S = 2.6521128022
+SIX_KM_U_M_S = 29.0145538645
+SIX_KM_V_M_S = 9.6521128022
+SHEAR_TOP_M = 6000.0
+
+_WIND_BRANCH_ANCHOR = """!-----------------------------------------------------------------------
+
+      ENDIF    ! endif for iwnd options
+"""
+
+
+class StraightLineHodographError(RuntimeError):
+    """Raised when the pinned CM1 hodograph customization cannot be reproduced."""
+
+
+def render_straight_line_hodograph_source(source: str) -> str:
+    if STRAIGHT_LINE_HODOGRAPH_MARKER in source:
+        raise StraightLineHodographError(
+            "CM1 base.F already contains the straight-line hodograph customization."
+        )
+    if source.count(_WIND_BRANCH_ANCHOR) != 1:
+        raise StraightLineHodographError(
+            "Unable to locate the pinned CM1 iwnd branch terminator in base.F."
+        )
+    branch = f"""!-----------------------------------------------------------------------
+!  iwnd = 12
+!  Cloud Chamber controlled straight-line hodograph.
+!  Preserves iwnd=2 0-6 km shear and layer-mean wind.
+
+      ELSEIF(iwnd.eq.12)THEN
+
+        do k=1,nk
+        do j=1,nj
+        do i=1,ni+1
+          zu=0.5*(zh(i-1,j,k)+zh(i,j,k))
+          u0(i,j,k)={SURFACE_U_M_S:.10f}                                  &
+     &      +min(max(zu,0.0),{SHEAR_TOP_M:.1f})/{SHEAR_TOP_M:.1f}*31.0
+        enddo
+        enddo
+        enddo
+
+        do k=1,nk
+        do j=1,nj+1
+        do i=1,ni
+          zv=0.5*(zh(i,j-1,k)+zh(i,j,k))
+          v0(i,j,k)={SURFACE_V_M_S:.10f}                                  &
+     &      +min(max(zv,0.0),{SHEAR_TOP_M:.1f})/{SHEAR_TOP_M:.1f}*7.0
+        enddo
+        enddo
+        enddo
+
+!  {STRAIGHT_LINE_HODOGRAPH_MARKER}
+
+!-----------------------------------------------------------------------
+
+      ENDIF    ! endif for iwnd options
+"""
+    return source.replace(_WIND_BRANCH_ANCHOR, branch, 1)
+
+
+def straight_line_hodograph_artifact(source: str) -> dict[str, object]:
+    source_sha256 = _sha256_text(source)
+    if source_sha256 != PINNED_BASE_F_SHA256:
+        raise StraightLineHodographError(
+            "Configured CM1 base.F does not match the accepted r21.1 source lock: "
+            f"{source_sha256} != {PINNED_BASE_F_SHA256}."
+        )
+    patched = render_straight_line_hodograph_source(source)
+    return {
+        "schema_version": STRAIGHT_LINE_HODOGRAPH_SCHEMA_VERSION,
+        "customization_kind": STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND,
+        "target_relative_path": str(STRAIGHT_LINE_HODOGRAPH_TARGET),
+        "marker": STRAIGHT_LINE_HODOGRAPH_MARKER,
+        "original_source_sha256": source_sha256,
+        "patched_source_sha256": _sha256_text(patched),
+        "wind_profile": {
+            "vertical_extent_m": [0.0, SHEAR_TOP_M],
+            "surface_wind_m_s": [SURFACE_U_M_S, SURFACE_V_M_S],
+            "six_km_wind_m_s": [SIX_KM_U_M_S, SIX_KM_V_M_S],
+            "endpoint_shear_m_s": [31.0, 7.0],
+            "layer_mean_wind_m_s": [13.5145538645, 6.1521128022],
+            "above_six_km": "constant",
+            "model_translation_m_s": [12.5, 3.0],
+        },
+        "scientific_scope": {
+            "changed": ["hodograph_geometry"],
+            "preserved": [
+                "thermodynamic_profile",
+                "deterministic_warm_bubble",
+                "domain_and_grid",
+                "time_step_and_duration",
+                "output_contract",
+                "microphysics",
+                "boundaries",
+                "damping",
+                "numerical_options",
+                "model_translation",
+            ],
+        },
+        "source_policy": {
+            "isolated_external_build": True,
+            "original_cm1_tree_modified": False,
+            "cm1_source_committed_to_repo": False,
+        },
+    }
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "PINNED_BASE_F_SHA256",
+    "SHEAR_TOP_M",
+    "SIX_KM_U_M_S",
+    "SIX_KM_V_M_S",
+    "STRAIGHT_LINE_HODOGRAPH_ARTIFACT_FILENAME",
+    "STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND",
+    "STRAIGHT_LINE_HODOGRAPH_MARKER",
+    "STRAIGHT_LINE_HODOGRAPH_SCHEMA_VERSION",
+    "STRAIGHT_LINE_HODOGRAPH_TARGET",
+    "SURFACE_U_M_S",
+    "SURFACE_V_M_S",
+    "StraightLineHodographError",
+    "render_straight_line_hodograph_source",
+    "straight_line_hodograph_artifact",
+]

--- a/app/backend/cloud_chamber/supercell_presentation.py
+++ b/app/backend/cloud_chamber/supercell_presentation.py
@@ -51,6 +51,12 @@ from cloud_chamber.supercell_benchmark import (
     sha256_file,
     verify_gate_a_source_lock,
 )
+from cloud_chamber.supercell_hodograph import (
+    STRAIGHT_LINE_HODOGRAPH_ARTIFACT_FILENAME,
+    STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND,
+    STRAIGHT_LINE_HODOGRAPH_TARGET,
+    straight_line_hodograph_artifact,
+)
 
 SOURCE_RUN_ID = "quarter-circle-supercell-official-20260722T142521Z"
 SOURCE_EVIDENCE_FILENAME = "supercell_gate_b_evidence.json"
@@ -59,7 +65,21 @@ PRESENTATION_RUN_ID = "quarter-circle-supercell-presentation-v1-20260723"
 PRESENTATION_CASE_ID = "cm1_r21_1_quarter_circle_supercell_presentation_v1"
 CHARACTERIZATION_RUN_ID = "quarter-circle-supercell-presentation-characterization-20260723"
 CHARACTERIZATION_CASE_ID = "cm1_r21_1_quarter_circle_supercell_characterization_v1"
+STRAIGHT_LINE_PRESENTATION_RUN_ID = "straight-line-supercell-presentation-v1-20260726"
+STRAIGHT_LINE_PRESENTATION_CASE_ID = "cm1_r21_1_straight_line_supercell_presentation_v1"
+STRAIGHT_LINE_CHARACTERIZATION_RUN_ID = (
+    "straight-line-supercell-presentation-characterization-20260726"
+)
+STRAIGHT_LINE_CHARACTERIZATION_CASE_ID = "cm1_r21_1_straight_line_supercell_characterization_v1"
+QUARTER_CIRCLE_SIMULATION_ID = "supercells_quarter_circle_reference"
+STRAIGHT_LINE_SIMULATION_ID = "supercells_straight_line_hodograph"
 MINIMUM_POST_RUN_FREE_BYTES = 5 * 1024**3
+MEASURED_REFERENCE_RETAINED_BYTES = 8_873_437_520
+FINAL_RUN_STORAGE_RESERVATION_BYTES = 12 * 1024**3
+FINAL_CAMPAIGN_RUN_IDS = (
+    PRESENTATION_RUN_ID,
+    STRAIGHT_LINE_PRESENTATION_RUN_ID,
+)
 
 REQUIRED_3D_FIELDS = (
     "th",
@@ -181,6 +201,7 @@ class SupercellPresentationSpec:
     case_id: str
     duration_seconds: int
     output_cadence_seconds: int
+    hodograph: Literal["quarter_circle", "straight_line"] = "quarter_circle"
 
     @property
     def expected_times_seconds(self) -> tuple[int, ...]:
@@ -188,11 +209,33 @@ class SupercellPresentationSpec:
 
     @property
     def changed_assignments(self) -> dict[str, str]:
-        return {
+        assignments = {
             **BASE_PRESENTATION_ASSIGNMENTS,
             "timax": _fortran_float(self.duration_seconds),
             "tapfrq": _fortran_float(self.output_cadence_seconds),
         }
+        if self.hodograph == "straight_line":
+            assignments["iwnd"] = "12"
+        return assignments
+
+    @property
+    def expected_science_assignments(self) -> dict[str, str]:
+        return {
+            **LOCKED_SCIENCE_ASSIGNMENTS,
+            "iwnd": "12" if self.hodograph == "straight_line" else "2",
+        }
+
+    @property
+    def simulation_id(self) -> str:
+        if self.hodograph == "straight_line":
+            return STRAIGHT_LINE_SIMULATION_ID
+        return QUARTER_CIRCLE_SIMULATION_ID
+
+    @property
+    def display_name(self) -> str:
+        if self.hodograph == "straight_line":
+            return "Straight-Line Hodograph Supercell"
+        return "Quarter-Circle Supercell"
 
     @property
     def scalar_cells(self) -> int:
@@ -217,6 +260,22 @@ PRESENTATION_SPEC = SupercellPresentationSpec(
     duration_seconds=10_800,
     output_cadence_seconds=120,
 )
+STRAIGHT_LINE_CHARACTERIZATION_SPEC = SupercellPresentationSpec(
+    kind="characterization",
+    run_id=STRAIGHT_LINE_CHARACTERIZATION_RUN_ID,
+    case_id=STRAIGHT_LINE_CHARACTERIZATION_CASE_ID,
+    duration_seconds=300,
+    output_cadence_seconds=300,
+    hodograph="straight_line",
+)
+STRAIGHT_LINE_PRESENTATION_SPEC = SupercellPresentationSpec(
+    kind="final",
+    run_id=STRAIGHT_LINE_PRESENTATION_RUN_ID,
+    case_id=STRAIGHT_LINE_PRESENTATION_CASE_ID,
+    duration_seconds=10_800,
+    output_cadence_seconds=120,
+    hodograph="straight_line",
+)
 
 
 class NamelistDifference(BaseModel):
@@ -230,6 +289,7 @@ class NamelistDifference(BaseModel):
         "presentation_grid",
         "presentation_timing",
         "bounded_output_inventory",
+        "controlled_hodograph_geometry",
     ]
 
 
@@ -244,6 +304,14 @@ class PresentationStorageEstimate(BaseModel):
     uncompressed_numeric_history_floor_bytes: int
     compression_credit_bytes: Literal[0] = 0
     minimum_post_run_free_bytes: int = MINIMUM_POST_RUN_FREE_BYTES
+    gate_basis: Literal[
+        "uncompressed_numeric_floor",
+        "measured_retained_campaign_reservation",
+    ] = "uncompressed_numeric_floor"
+    measured_reference_retained_bytes: int | None = None
+    per_final_run_reservation_bytes: int | None = None
+    final_campaign_run_ids: list[str] = Field(default_factory=list)
+    final_campaign_runs_remaining: int = 1
     required_free_bytes: int
     available_free_bytes: int
     passed: bool
@@ -269,6 +337,8 @@ class SupercellPresentationEvidence(BaseModel):
     kind: Literal["characterization", "final"]
     run_id: str
     case_id: str
+    simulation_id: str
+    hodograph: Literal["quarter_circle", "straight_line"]
     source_run_id: str = SOURCE_RUN_ID
     implementation_commit: str
     grid: dict[str, int | float]
@@ -286,6 +356,7 @@ class SupercellPresentationEvidence(BaseModel):
     numbered_history_bytes: int
     retained_run_bytes: int
     available_free_bytes_after_validation: int
+    source_customization: dict[str, Any] | None = None
     runtime_warnings: list[str] = Field(default_factory=list)
     normal_completion: bool
 
@@ -300,12 +371,22 @@ class SupercellPresentationPackage:
     implementation_commit: str
 
 
-def spec_for_kind(kind: str) -> SupercellPresentationSpec:
+def spec_for_kind(
+    kind: str,
+    hodograph: str = "quarter_circle",
+) -> SupercellPresentationSpec:
+    if hodograph == "straight_line":
+        if kind == "characterization":
+            return STRAIGHT_LINE_CHARACTERIZATION_SPEC
+        if kind == "final":
+            return STRAIGHT_LINE_PRESENTATION_SPEC
     if kind == "characterization":
         return CHARACTERIZATION_SPEC
     if kind == "final":
         return PRESENTATION_SPEC
-    raise SupercellPresentationError(f"Unknown presentation-run kind: {kind}")
+    raise SupercellPresentationError(
+        f"Unknown presentation-run selection: kind={kind}, hodograph={hodograph}."
+    )
 
 
 def render_presentation_namelist(
@@ -356,7 +437,7 @@ def render_presentation_namelist(
 
     if {item.name for item in differences} != set(spec.changed_assignments):
         raise SupercellPresentationError("Presentation namelist differences are incomplete.")
-    for name, expected in LOCKED_SCIENCE_ASSIGNMENTS.items():
+    for name, expected in spec.expected_science_assignments.items():
         if not _same_assignment(generated.get(name), expected):
             raise SupercellPresentationError(f"Scientific assignment {name} did not remain fixed.")
 
@@ -383,13 +464,37 @@ def estimate_storage(
     ) * 4
     floor = history_bytes * len(spec.expected_times_seconds)
     available = shutil.disk_usage(target_dir).free
+    gate_basis: Literal[
+        "uncompressed_numeric_floor",
+        "measured_retained_campaign_reservation",
+    ] = "uncompressed_numeric_floor"
+    measured_reference_retained_bytes = None
+    per_final_run_reservation_bytes = None
+    campaign_run_ids: list[str] = []
+    campaign_runs_remaining = 1
     required = floor + MINIMUM_POST_RUN_FREE_BYTES
+    if spec.kind == "final":
+        gate_basis = "measured_retained_campaign_reservation"
+        measured_reference_retained_bytes = MEASURED_REFERENCE_RETAINED_BYTES
+        per_final_run_reservation_bytes = FINAL_RUN_STORAGE_RESERVATION_BYTES
+        campaign_run_ids = list(FINAL_CAMPAIGN_RUN_IDS)
+        completed = _completed_final_campaign_runs(target_dir.parent)
+        campaign_runs_remaining = len(set(FINAL_CAMPAIGN_RUN_IDS) - completed)
+        required = (
+            campaign_runs_remaining * FINAL_RUN_STORAGE_RESERVATION_BYTES
+            + MINIMUM_POST_RUN_FREE_BYTES
+        )
     return PresentationStorageEstimate(
         expected_history_count=len(spec.expected_times_seconds),
         scalar_grid=[240, 240, 60],
         scalar_3d_array_count=len(REQUIRED_3D_FIELDS),
         scalar_2d_array_count=len(REQUIRED_2D_FIELDS),
         uncompressed_numeric_history_floor_bytes=floor,
+        gate_basis=gate_basis,
+        measured_reference_retained_bytes=measured_reference_retained_bytes,
+        per_final_run_reservation_bytes=per_final_run_reservation_bytes,
+        final_campaign_run_ids=campaign_run_ids,
+        final_campaign_runs_remaining=campaign_runs_remaining,
         required_free_bytes=required,
         available_free_bytes=available,
         passed=available >= required,
@@ -419,22 +524,48 @@ def generate_presentation_package(
         "storage": target_dir / "storage_estimate.json",
         "package_report": target_dir / "presentation_package_report.json",
     }
+    if spec.hodograph == "straight_line":
+        paths["hodograph_customization"] = target_dir / STRAIGHT_LINE_HODOGRAPH_ARTIFACT_FILENAME
     try:
         generated_text, differences = render_presentation_namelist(
             provenance.supercell_namelist_path.read_text(),
             spec,
         )
         paths["namelist"].write_text(generated_text)
+        if spec.hodograph == "straight_line":
+            source_path = provenance.source_root / STRAIGHT_LINE_HODOGRAPH_TARGET
+            _write_json(
+                paths["hodograph_customization"],
+                straight_line_hodograph_artifact(source_path.read_text()),
+            )
+        wind_source = (
+            "a source-locked Cloud Chamber straight-line profile that preserves the "
+            "accepted iwnd=2 endpoint shear and layer-mean wind"
+            if spec.hodograph == "straight_line"
+            else "CM1 src/base.F iwnd=2 analytic quarter-circle wind profile"
+        )
         _write_json(
             paths["runtime_checklist"],
             {
-                "status": "empty_external_scientific_runtime_file_inventory",
-                "consumed_files": [],
-                "required_files": [],
+                "status": (
+                    "source_locked_hodograph_customization_declared"
+                    if spec.hodograph == "straight_line"
+                    else "empty_external_scientific_runtime_file_inventory"
+                ),
+                "consumed_files": (
+                    [STRAIGHT_LINE_HODOGRAPH_ARTIFACT_FILENAME]
+                    if spec.hodograph == "straight_line"
+                    else []
+                ),
+                "required_files": (
+                    [STRAIGHT_LINE_HODOGRAPH_ARTIFACT_FILENAME]
+                    if spec.hodograph == "straight_line"
+                    else []
+                ),
                 "source_candidates": {},
                 "scientific_state_sources": [
                     "CM1 src/base.F isnd=5 analytic Weisman-Klemp sounding",
-                    "CM1 src/base.F iwnd=2 analytic quarter-circle wind profile",
+                    wind_source,
                     "CM1 src/init3d.F iinit=1 deterministic warm bubble",
                 ],
             },
@@ -445,7 +576,18 @@ def generate_presentation_package(
                 "official_sha256": _sha256_text(provenance.supercell_namelist_path.read_text()),
                 "generated_sha256": _sha256_text(generated_text),
                 "differences": [item.model_dump() for item in differences],
-                "unchanged_scientific_assignments": LOCKED_SCIENCE_ASSIGNMENTS,
+                "expected_scientific_assignments": spec.expected_science_assignments,
+                "controlled_atmospheric_difference": (
+                    {
+                        "name": "hodograph_geometry",
+                        "official_iwnd": "2",
+                        "generated_iwnd": "12",
+                        "preserved_endpoint_shear_m_s": [31.0, 7.0],
+                        "preserved_layer_mean_wind_m_s": [13.5145538645, 6.1521128022],
+                    }
+                    if spec.hodograph == "straight_line"
+                    else None
+                ),
             },
         )
         storage = estimate_storage(spec, target_dir)
@@ -470,6 +612,8 @@ def generate_presentation_package(
             "kind": spec.kind,
             "run_id": spec.run_id,
             "case_id": spec.case_id,
+            "simulation_id": spec.simulation_id,
+            "hodograph": spec.hodograph,
             "source_run": source,
             "gate_a_source_lock": verify_gate_a_source_lock(),
             "cm1_provenance": provenance.report_record(),
@@ -497,6 +641,12 @@ def generate_presentation_package(
                 "profile_id": PRESENTATION_PROFILE_ID,
                 "kind": spec.kind,
                 "case_id": spec.case_id,
+                "simulation_id": spec.simulation_id,
+                "parent_simulation_id": (
+                    QUARTER_CIRCLE_SIMULATION_ID if spec.hodograph == "straight_line" else None
+                ),
+                "reference_simulation_id": QUARTER_CIRCLE_SIMULATION_ID,
+                "hodograph": spec.hodograph,
                 "source_run": source,
                 "source_lock": provenance.report_record(),
                 "gate_a_source_lock": verify_gate_a_source_lock(),
@@ -517,10 +667,23 @@ def generate_presentation_package(
                 "changed_namelist_assignments": spec.changed_assignments,
                 "generated_input_sha256": generated_hashes,
                 "storage_estimate": storage.model_dump(),
+                **(
+                    {"cm1_source_customization_kind": (STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND)}
+                    if spec.hodograph == "straight_line"
+                    else {}
+                ),
             },
             physical_question=(
-                "Does the accepted quarter-circle Supercell produce a materially more "
-                "detailed, smoother, and longer presentation Simulation?"
+                (
+                    "How does hodograph curvature change storm organization, rotating-updraft "
+                    "structure, precipitation, and low-level flow when the thermodynamic "
+                    "environment and numerical experiment remain otherwise matched?"
+                )
+                if spec.hodograph == "straight_line"
+                else (
+                    "Does the accepted quarter-circle Supercell produce a materially more "
+                    "detailed, smoother, and longer presentation Simulation?"
+                )
             ),
             expected_diagnostics=[
                 "three_accepted_supercell_lenses",
@@ -535,6 +698,11 @@ def generate_presentation_package(
                 input_sounding=None,
                 dry_run_report=str(paths["package_report"]),
                 runtime_file_checklist=[str(paths["runtime_checklist"])],
+                cm1_source_customization=(
+                    str(paths["hodograph_customization"])
+                    if spec.hodograph == "straight_line"
+                    else None
+                ),
             ),
             runtime_paths=RuntimePaths(runtime_home=str(settings.runtime_home.expanduser())),
             app=AppMetadata(app_version=__version__, commit=implementation_commit),
@@ -543,9 +711,13 @@ def generate_presentation_package(
             provenance=ProvenanceMetadata(product_state=ProductState.PACKAGED_DRY_RUN_OUTPUT),
             created_at=now,
             updated_at=now,
-            user=UserMetadata(name=f"Quarter-Circle Supercell {spec.kind}"),
+            user=UserMetadata(name=f"{spec.display_name} {spec.kind}"),
             required_output_fields=list(REQUIRED_OUTPUT_FIELDS),
-            input_source="CM1_r21.1_analytic_isnd5_iwnd2_iinit1",
+            input_source=(
+                "CM1_r21.1_analytic_isnd5_source_locked_straight_line_iwnd12_iinit1"
+                if spec.hodograph == "straight_line"
+                else "CM1_r21.1_analytic_isnd5_iwnd2_iinit1"
+            ),
             trigger_type="source_defined_deterministic_warm_bubble",
             trigger_parameters={
                 "center": "domain_center",
@@ -559,13 +731,21 @@ def generate_presentation_package(
                 "one_statistics_netcdf",
             ],
             run_limitations=[
-                "idealized_source_locked_quarter_circle_supercell",
+                (
+                    "idealized_source_locked_straight_line_hodograph_supercell"
+                    if spec.hodograph == "straight_line"
+                    else "idealized_source_locked_quarter_circle_supercell"
+                ),
                 "presentation_grid_and_timing_adaptation_not_exact_gate_b_reproduction",
                 "one_authorized_process_without_retry",
                 "translating_model_frame",
                 "15_to_20_km_rayleigh_layer",
             ],
-            manual_validation_status=f"issue_421_{spec.kind}_pending",
+            manual_validation_status=(
+                f"issue_444_straight_line_{spec.kind}_pending"
+                if spec.hodograph == "straight_line"
+                else f"issue_421_{spec.kind}_pending"
+            ),
         )
         write_run_manifest(paths["manifest"], manifest)
         _write_json(
@@ -576,6 +756,8 @@ def generate_presentation_package(
                 "kind": spec.kind,
                 "run_id": spec.run_id,
                 "case_id": spec.case_id,
+                "simulation_id": spec.simulation_id,
+                "hodograph": spec.hodograph,
                 "implementation_commit": implementation_commit,
                 "source_run": source,
                 "configuration_differences": [item.model_dump() for item in differences],
@@ -669,6 +851,15 @@ def verify_presentation_package(
         "configuration_differences"
     ):
         raise SupercellPresentationError("Presentation configuration audit changed.")
+    if package.spec.hodograph == "straight_line":
+        customization_path = Path(manifest.generated_inputs.cm1_source_customization or "")
+        expected_customization = straight_line_hodograph_artifact(
+            (provenance.source_root / STRAIGHT_LINE_HODOGRAPH_TARGET).read_text()
+        )
+        if json.loads(customization_path.read_text()) != expected_customization:
+            raise SupercellPresentationError(
+                "Straight-line hodograph source customization changed after packaging."
+            )
     if active_cm1_processes():
         raise SupercellPresentationError("Another CM1 or MPI process is active.")
     prior = _prior_execution(settings, package.spec)
@@ -697,16 +888,29 @@ def verify_presentation_package(
         "pinned_cm1_source_and_executable": True,
         "generated_input_hashes": bool(verified_inputs),
         "exact_declared_namelist_differences": True,
-        "scientific_setup_unchanged": True,
+        "unrelated_scientific_setup_unchanged": True,
+        "controlled_hodograph_identity": (
+            manifest.run_configuration.get("hodograph") == package.spec.hodograph
+        ),
         "expected_timeline": (
             tuple(manifest.run_configuration.get("expected_times_seconds", []))
             == package.spec.expected_times_seconds
         ),
-        "no_external_scientific_runtime_files": (manifest.generated_inputs.input_sounding is None),
+        "no_untracked_external_scientific_runtime_files": (
+            manifest.generated_inputs.input_sounding is None
+        ),
         "no_active_cm1_or_mpi_process": True,
         "no_prior_same_kind_process": True,
         "target_contains_no_output": True,
-        "no_compression_credit": storage.compression_credit_bytes == 0,
+        "no_unproven_compression_assumption": storage.compression_credit_bytes == 0,
+        "explicit_storage_gate_basis": (
+            storage.gate_basis == "uncompressed_numeric_floor"
+            or (
+                storage.gate_basis == "measured_retained_campaign_reservation"
+                and storage.measured_reference_retained_bytes == MEASURED_REFERENCE_RETAINED_BYTES
+                and storage.per_final_run_reservation_bytes == FINAL_RUN_STORAGE_RESERVATION_BYTES
+            )
+        ),
         "adequate_free_space": storage.passed,
     }
     preflight = PresentationPreflight(
@@ -740,6 +944,10 @@ def validate_completed_presentation_run(
     except GeneratedInputIdentityError as exc:
         raise SupercellPresentationError(str(exc)) from exc
     collect_cm1_provenance(settings)
+    source_customization = _validate_completed_source_customization(
+        manifest=manifest,
+        spec=package.spec,
+    )
     histories = _numbered_histories(package.package_dir)
     if len(histories) != len(package.spec.expected_times_seconds):
         raise SupercellPresentationError(
@@ -821,6 +1029,8 @@ def validate_completed_presentation_run(
         kind=package.spec.kind,
         run_id=package.spec.run_id,
         case_id=package.spec.case_id,
+        simulation_id=package.spec.simulation_id,
+        hodograph=package.spec.hodograph,
         implementation_commit=package.implementation_commit,
         grid={
             "nx": 240,
@@ -844,6 +1054,7 @@ def validate_completed_presentation_run(
         numbered_history_bytes=sum(path.stat().st_size for path in histories),
         retained_run_bytes=_directory_bytes(package.package_dir),
         available_free_bytes_after_validation=shutil.disk_usage(package.package_dir).free,
+        source_customization=source_customization,
         runtime_warnings=warnings,
         normal_completion=True,
     )
@@ -857,7 +1068,11 @@ def validate_completed_presentation_run(
             update={
                 "outputs": current.outputs.model_copy(update={"processed_artifacts": processed}),
                 "validation_status": ValidationStatus.VALID,
-                "manual_validation_status": f"issue_421_{package.spec.kind}_native_validated",
+                "manual_validation_status": (
+                    f"issue_444_straight_line_{package.spec.kind}_native_validated"
+                    if package.spec.hodograph == "straight_line"
+                    else f"issue_421_{package.spec.kind}_native_validated"
+                ),
                 "updated_at": datetime.now(UTC),
             }
         ),
@@ -911,6 +1126,79 @@ def _prior_execution(
         if manifest.lifecycle_state not in {LifecycleState.CREATED, LifecycleState.PACKAGED}:
             prior.append(manifest.run_id)
     return prior
+
+
+def _completed_final_campaign_runs(runs_dir: Path) -> set[str]:
+    completed: set[str] = set()
+    for run_id in FINAL_CAMPAIGN_RUN_IDS:
+        run_dir = runs_dir / run_id
+        manifest_path = run_dir / "run_manifest.json"
+        evidence_path = run_dir / "supercell_presentation_evidence.json"
+        if not manifest_path.is_file() or not evidence_path.is_file():
+            continue
+        try:
+            manifest = load_run_manifest(manifest_path)
+            evidence = json.loads(evidence_path.read_text())
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if (
+            manifest.lifecycle_state == LifecycleState.COMPLETED
+            and manifest.execution.exit_code == 0
+            and manifest.validation_status == ValidationStatus.VALID
+            and evidence.get("run_id") == run_id
+            and evidence.get("normal_completion") is True
+        ):
+            completed.add(run_id)
+    return completed
+
+
+def _validate_completed_source_customization(
+    *,
+    manifest: RunManifest,
+    spec: SupercellPresentationSpec,
+) -> dict[str, Any] | None:
+    status = manifest.cm1_source_customization_status
+    if spec.hodograph == "quarter_circle":
+        if status is not None:
+            raise SupercellPresentationError(
+                "Quarter-circle reference unexpectedly reports a source customization."
+            )
+        return None
+    if not isinstance(status, dict):
+        raise SupercellPresentationError(
+            "Straight-line result has no applied source-customization evidence."
+        )
+    expected_artifact = json.loads(
+        Path(manifest.generated_inputs.cm1_source_customization or "").read_text()
+    )
+    expected = {
+        "schema_version": "cm1_source_customization_status_v1",
+        "customization_kind": STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND,
+        "original_target_sha256": expected_artifact.get("original_source_sha256"),
+        "patched_target_sha256": expected_artifact.get("patched_source_sha256"),
+        "patched_files": [str(STRAIGHT_LINE_HODOGRAPH_TARGET)],
+        "no_silent_hodograph_fallback": True,
+    }
+    mismatched = {
+        name: (status.get(name), value)
+        for name, value in expected.items()
+        if status.get(name) != value
+    }
+    if mismatched:
+        raise SupercellPresentationError(
+            f"Applied straight-line source customization changed: {mismatched}."
+        )
+    executable = Path(str(status.get("custom_executable", "")))
+    expected_executable_sha256 = status.get("custom_executable_sha256")
+    if (
+        not executable.is_file()
+        or not isinstance(expected_executable_sha256, str)
+        or sha256_file(executable) != expected_executable_sha256
+    ):
+        raise SupercellPresentationError(
+            "Applied straight-line custom executable identity is invalid."
+        )
+    return status
 
 
 def _numbered_histories(run_dir: Path) -> list[Path]:
@@ -989,7 +1277,10 @@ def _difference_reason(
     "presentation_grid",
     "presentation_timing",
     "bounded_output_inventory",
+    "controlled_hodograph_geometry",
 ]:
+    if name == "iwnd":
+        return "controlled_hodograph_geometry"
     if name in {"output_format", "output_filetype"}:
         return "output_transport"
     if name in {"nx", "ny", "nz", "dx", "dy", "dz"}:

--- a/app/backend/cloud_chamber/supercell_presentation.py
+++ b/app/backend/cloud_chamber/supercell_presentation.py
@@ -552,15 +552,12 @@ def generate_presentation_package(
                     if spec.hodograph == "straight_line"
                     else "empty_external_scientific_runtime_file_inventory"
                 ),
-                "consumed_files": (
-                    [STRAIGHT_LINE_HODOGRAPH_ARTIFACT_FILENAME]
+                "consumed_files": [],
+                "required_files": [],
+                "packaged_source_customization": (
+                    STRAIGHT_LINE_HODOGRAPH_ARTIFACT_FILENAME
                     if spec.hodograph == "straight_line"
-                    else []
-                ),
-                "required_files": (
-                    [STRAIGHT_LINE_HODOGRAPH_ARTIFACT_FILENAME]
-                    if spec.hodograph == "straight_line"
-                    else []
+                    else None
                 ),
                 "source_candidates": {},
                 "scientific_state_sources": [

--- a/app/backend/cloud_chamber/supercell_presentation.py
+++ b/app/backend/cloud_chamber/supercell_presentation.py
@@ -870,13 +870,17 @@ def verify_presentation_package(
     stored = PresentationStorageEstimate.model_validate_json(
         package.storage_estimate_path.read_text()
     )
-    available = shutil.disk_usage(package.package_dir).free
-    storage = stored.model_copy(
-        update={
-            "available_free_bytes": available,
-            "passed": available >= stored.required_free_bytes,
-        }
-    )
+    storage = estimate_storage(package.spec, package.package_dir)
+    mutable_storage_fields = {
+        "final_campaign_runs_remaining",
+        "required_free_bytes",
+        "available_free_bytes",
+        "passed",
+    }
+    if stored.model_dump(exclude=mutable_storage_fields) != storage.model_dump(
+        exclude=mutable_storage_fields
+    ):
+        raise SupercellPresentationError("Presentation storage contract changed after packaging.")
     checks = {
         "clean_implementation_head": (
             not require_clean_head or verified_clean_git_commit() == package.implementation_commit

--- a/app/backend/cloud_chamber/supercells_world.py
+++ b/app/backend/cloud_chamber/supercells_world.py
@@ -11,14 +11,23 @@ from cloud_chamber.storm_examination import (
     DEFAULT_PRESENTATION_TIME_INDEX,
     PRESENTATION_CASE_ID,
     PRESENTATION_RUN_ID,
+    QUARTER_CIRCLE_SIMULATION_ID,
+    STRAIGHT_LINE_PRESENTATION_CASE_ID,
+    STRAIGHT_LINE_PRESENTATION_RUN_ID,
     StormExaminationError,
     storm_examination_inventory,
+)
+from cloud_chamber.storm_examination import (
+    STRAIGHT_LINE_SIMULATION_ID as STORM_STRAIGHT_LINE_SIMULATION_ID,
 )
 
 WORLD_ID: Literal["supercells"] = "supercells"
 WORLD_DISPLAY_NAME: Literal["Supercells"] = "Supercells"
 REFERENCE_SIMULATION_ID: Literal["supercells_quarter_circle_reference"] = (
-    "supercells_quarter_circle_reference"
+    QUARTER_CIRCLE_SIMULATION_ID
+)
+STRAIGHT_LINE_SIMULATION_ID: Literal["supercells_straight_line_hodograph"] = (
+    STORM_STRAIGHT_LINE_SIMULATION_ID
 )
 REFERENCE_DISPLAY_NAME: Literal["Quarter-Circle Supercell"] = "Quarter-Circle Supercell"
 WORLD_SHORT_DESCRIPTION = (
@@ -28,17 +37,23 @@ WORLD_SHORT_DESCRIPTION = (
 
 AvailabilityState = Literal["available", "partial", "unavailable"]
 TechnicalState = Literal["available", "missing", "invalid"]
+SupercellSimulationId = Literal[
+    "supercells_quarter_circle_reference",
+    "supercells_straight_line_hodograph",
+]
 
 
 class SupercellSimulationRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    simulation_id: Literal["supercells_quarter_circle_reference"] = REFERENCE_SIMULATION_ID
-    display_name: Literal["Quarter-Circle Supercell"] = REFERENCE_DISPLAY_NAME
-    role: Literal["reference"] = "reference"
+    simulation_id: SupercellSimulationId
+    display_name: str
+    role: Literal["reference", "variation"]
     world_id: Literal["supercells"] = WORLD_ID
-    run_id: str = PRESENTATION_RUN_ID
-    case_id: str = PRESENTATION_CASE_ID
+    run_id: str
+    case_id: str
+    parent_simulation_id: str | None = None
+    reference_simulation_id: str = REFERENCE_SIMULATION_ID
     technical_state: TechnicalState
     technical_state_message: str
     explore_available: bool
@@ -55,7 +70,7 @@ class SupercellsCapabilities(BaseModel):
 
     reference_explore: bool
     lab: Literal[False] = False
-    compare: Literal[False] = False
+    compare: bool
     saved_views: Literal[False] = False
 
 
@@ -93,23 +108,95 @@ class SupercellsWorldDetail(BaseModel):
     caveats: list[str] = Field(default_factory=list)
 
     def summary(self) -> SupercellsWorldSummary:
-        available = self.reference_simulation.technical_state == "available"
+        available = [item for item in self.simulations if item.technical_state == "available"]
         return SupercellsWorldSummary(
-            reference_available=available,
-            simulation_count=1 if available else 0,
+            reference_available=self.reference_simulation.technical_state == "available",
+            simulation_count=len(available),
             availability_state=self.availability_state,
             availability_message=self.availability_message,
         )
 
 
 def supercells_world_detail(settings: CloudChamberSettings) -> SupercellsWorldDetail:
-    """Resolve the one approved built-in without exposing its machine-private path."""
+    """Resolve retained Supercell Simulations without exposing machine-private paths."""
+    simulations = [
+        _simulation_record(
+            settings,
+            simulation_id=REFERENCE_SIMULATION_ID,
+            display_name=REFERENCE_DISPLAY_NAME,
+            role="reference",
+            run_id=PRESENTATION_RUN_ID,
+            case_id=PRESENTATION_CASE_ID,
+            parent_simulation_id=None,
+        ),
+        _simulation_record(
+            settings,
+            simulation_id=STRAIGHT_LINE_SIMULATION_ID,
+            display_name="Straight-Line Hodograph Supercell",
+            role="variation",
+            run_id=STRAIGHT_LINE_PRESENTATION_RUN_ID,
+            case_id=STRAIGHT_LINE_PRESENTATION_CASE_ID,
+            parent_simulation_id=REFERENCE_SIMULATION_ID,
+        ),
+    ]
+    reference = simulations[0]
+    available_count = sum(item.technical_state == "available" for item in simulations)
+    if available_count == len(simulations):
+        availability_state: AvailabilityState = "available"
+        availability_message = (
+            "Quarter-Circle and Straight-Line Hodograph Supercells are available "
+            "for Explore and Compare."
+        )
+    elif available_count:
+        availability_state = "partial"
+        availability_message = (
+            "Only one retained Supercell Simulation is currently available for Explore."
+        )
+    else:
+        availability_state = "unavailable"
+        availability_message = "Retained Supercell output is not available for Explore."
+    return SupercellsWorldDetail(
+        availability_state=availability_state,
+        availability_message=availability_message,
+        reference_simulation=reference,
+        simulations=simulations,
+        capabilities=SupercellsCapabilities(
+            reference_explore=reference.explore_available,
+            compare=available_count >= 2,
+        ),
+        caveats=[
+            "These are idealized matched simulations, not observed storms.",
+            "The controlled atmospheric difference is hodograph curvature; thermodynamics, "
+            "trigger, grid, timing, output inventory, and numerical experiment are matched.",
+            "Horizontal coordinates and winds use the same translating model frame.",
+            "Coordinates and local evidence are comparable; storm objects and split lineage "
+            "are not inferred between Simulations.",
+        ],
+    )
+
+
+def _simulation_record(
+    settings: CloudChamberSettings,
+    *,
+    simulation_id: SupercellSimulationId,
+    display_name: str,
+    role: Literal["reference", "variation"],
+    run_id: str,
+    case_id: str,
+    parent_simulation_id: str | None,
+) -> SupercellSimulationRecord:
     try:
-        inventory = storm_examination_inventory(settings)
+        inventory = storm_examination_inventory(settings, simulation_id)
     except StormExaminationError as exc:
         message = str(exc)
         state: TechnicalState = "missing" if "unavailable" in message.lower() else "invalid"
-        simulation = SupercellSimulationRecord(
+        return SupercellSimulationRecord(
+            simulation_id=simulation_id,
+            display_name=display_name,
+            role=role,
+            run_id=run_id,
+            case_id=case_id,
+            parent_simulation_id=parent_simulation_id,
             technical_state=state,
             technical_state_message=message,
             explore_available=False,
@@ -118,20 +205,16 @@ def supercells_world_detail(settings: CloudChamberSettings) -> SupercellsWorldDe
             model_end_seconds=None,
             history_cadence_seconds=None,
         )
-        return SupercellsWorldDetail(
-            availability_state="unavailable",
-            availability_message=(
-                "The Quarter-Circle Supercell output is not available for Explore."
-            ),
-            reference_simulation=simulation,
-            simulations=[simulation],
-            capabilities=SupercellsCapabilities(reference_explore=False),
-            caveats=[message],
-        )
 
     times = [item[1] for item in inventory]
     cadence = times[1] - times[0] if len(times) > 1 else None
-    simulation = SupercellSimulationRecord(
+    return SupercellSimulationRecord(
+        simulation_id=simulation_id,
+        display_name=display_name,
+        role=role,
+        run_id=run_id,
+        case_id=case_id,
+        parent_simulation_id=parent_simulation_id,
         technical_state="available",
         technical_state_message="Retained native CM1 output is ready for inspection.",
         explore_available=True,
@@ -139,16 +222,4 @@ def supercells_world_detail(settings: CloudChamberSettings) -> SupercellsWorldDe
         model_start_seconds=times[0],
         model_end_seconds=times[-1],
         history_cadence_seconds=cadence,
-    )
-    return SupercellsWorldDetail(
-        availability_state="available",
-        availability_message="Quarter-Circle Supercell is available for Explore.",
-        reference_simulation=simulation,
-        simulations=[simulation],
-        capabilities=SupercellsCapabilities(reference_explore=True),
-        caveats=[
-            "This is an idealized presentation simulation derived from the accepted stock "
-            "CM1 quarter-circle benchmark, not an observed storm.",
-            "Horizontal coordinates and winds use the translating model frame.",
-        ],
     )

--- a/app/backend/cloud_chamber/world_compare.py
+++ b/app/backend/cloud_chamber/world_compare.py
@@ -1,0 +1,803 @@
+"""Lightweight World-owned descriptors for transient ordinary Compare."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.cloud_worlds import (
+    SimulationRecord,
+    trade_cumulus_world_detail,
+)
+from cloud_chamber.explore_state import (
+    ExploreWorldState,
+    MountainWavesExploreState,
+    MountainWavesOverlayState,
+    SupercellsExploreState,
+    SupercellsOverlayState,
+    TradeCumulusExploreState,
+)
+from cloud_chamber.mountain_waves_world import (
+    MountainWavesSimulationRecord,
+    mountain_waves_world_detail,
+)
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.supercells_world import (
+    SupercellSimulationRecord,
+    supercells_world_detail,
+)
+
+WorldId = Literal["trade_cumulus", "mountain_waves", "supercells"]
+WorldSlug = Literal["trade-cumulus", "mountain-waves", "supercells"]
+CompareTopology = Literal["native_3d", "native_2d_xz"]
+
+WORLD_SLUG_TO_ID: dict[str, WorldId] = {
+    "trade-cumulus": "trade_cumulus",
+    "mountain-waves": "mountain_waves",
+    "supercells": "supercells",
+}
+
+
+class CompareDifference(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    label: str
+    category: Literal["atmospheric", "numerical", "output", "operational", "metadata"]
+    left_value: Any = None
+    right_value: Any = None
+    left_known: bool = True
+    right_known: bool = True
+    units: str | None = None
+    material: bool = True
+
+
+class CompareGridDescriptor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    topology: CompareTopology
+    nx: int
+    ny: int
+    nz: int
+    dx_m: float
+    dy_m: float
+    dz_m: float
+    x_extent_km: tuple[float, float]
+    y_extent_km: tuple[float, float] | None
+    z_extent_km: tuple[float, float]
+
+
+class CompareTimeDescriptor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    times_seconds: list[float]
+    start_seconds: float
+    end_seconds: float
+    cadence_seconds: float
+    saved_output_count: int
+    interpolation_allowed: Literal[False] = False
+
+
+class CompareSimulationDescriptor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    simulation_id: str
+    display_name: str
+    world_id: WorldId
+    role: str
+    run_id: str
+    result_id: str | None = None
+    case_id: str
+    parent_simulation_id: str | None = None
+    reference_simulation_id: str | None = None
+    lineage_state: str
+    availability_state: str
+    availability_message: str
+    inspectable: bool
+    grid: CompareGridDescriptor
+    time: CompareTimeDescriptor
+    available_field_ids: list[str]
+    available_view_ids: list[str]
+    fixed_scale_ids: list[str]
+    plane_orientations: list[Literal["horizontal", "vertical_x", "vertical_y"]]
+    camera_mapping: Literal["normalized_3d", "native_2d_xz"]
+    initial_state: ExploreWorldState
+    caveats: list[str] = Field(default_factory=list)
+
+
+class CompareCompatibility(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    same_world: bool
+    both_inspectable: bool
+    relationship: str
+    controlled_pair: bool
+    controlled_pair_message: str
+    shared_field_ids: list[str]
+    shared_view_ids: list[str]
+    shared_fixed_scale_ids: list[str]
+    exact_time_link_available: bool
+    nearest_time_link_available: bool
+    time_tolerance_seconds: float
+    physical_plane_link_available: bool
+    camera_link_available: bool
+    selection_link_available: bool
+    blockers: list[str] = Field(default_factory=list)
+
+
+class WorldCompareDescriptor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["world_compare_v1"] = "world_compare_v1"
+    world_id: WorldId
+    display_name: str
+    simulations: list[CompareSimulationDescriptor]
+    default_left_simulation_id: str | None
+    default_right_simulation_id: str | None
+    selected_left_simulation_id: str | None
+    selected_right_simulation_id: str | None
+    material_differences: list[CompareDifference]
+    compatibility: CompareCompatibility | None
+    no_second_simulation_message: str | None = None
+    persistence: Literal["transient_only"] = "transient_only"
+
+
+def world_compare_descriptor(
+    settings: CloudChamberSettings,
+    *,
+    world_slug: str,
+    left_simulation_id: str | None = None,
+    right_simulation_id: str | None = None,
+) -> WorldCompareDescriptor:
+    """Return bounded Compare metadata without reading visualization volumes."""
+    world_id = WORLD_SLUG_TO_ID.get(world_slug)
+    if world_id is None:
+        raise ValueError(f"Unknown Cloud World: {world_slug}")
+    if world_id == "trade_cumulus":
+        return _trade_descriptor(
+            settings,
+            left_simulation_id=left_simulation_id,
+            right_simulation_id=right_simulation_id,
+        )
+    if world_id == "mountain_waves":
+        return _mountain_descriptor(
+            settings,
+            left_simulation_id=left_simulation_id,
+            right_simulation_id=right_simulation_id,
+        )
+    return _supercells_descriptor(
+        settings,
+        left_simulation_id=left_simulation_id,
+        right_simulation_id=right_simulation_id,
+    )
+
+
+def _trade_descriptor(
+    settings: CloudChamberSettings,
+    *,
+    left_simulation_id: str | None,
+    right_simulation_id: str | None,
+) -> WorldCompareDescriptor:
+    world = trade_cumulus_world_detail(settings)
+    simulations = [_trade_simulation(item) for item in world.simulations if item.simulation_id]
+    default_left = world.reference_simulation.simulation_id
+    if default_left is None:
+        raise ValueError("Trade Cumulus Compare requires a stable reference Simulation.")
+    default_right = world.featured_comparison.more_moisture_simulation_id
+    left, right = _selected_pair(
+        simulations,
+        left_simulation_id or default_left,
+        right_simulation_id or default_right,
+    )
+    differences = _trade_differences(left, right, world.simulations)
+    compatibility = _compatibility(
+        left,
+        right,
+        relationship=_relationship(left, right),
+        controlled_pair=bool(
+            {left.simulation_id, right.simulation_id} == {default_left, default_right}
+        ),
+        controlled_message=(
+            "Only surface moisture supply changed; the retained pair is a controlled comparison."
+            if {left.simulation_id, right.simulation_id} == {default_left, default_right}
+            else "The selected Trade Cumulus relationship is not the approved controlled pair."
+        ),
+    )
+    return WorldCompareDescriptor(
+        world_id="trade_cumulus",
+        display_name=world.display_name,
+        simulations=simulations,
+        default_left_simulation_id=default_left,
+        default_right_simulation_id=default_right,
+        selected_left_simulation_id=left.simulation_id,
+        selected_right_simulation_id=right.simulation_id,
+        material_differences=differences,
+        compatibility=compatibility,
+    )
+
+
+def _mountain_descriptor(
+    settings: CloudChamberSettings,
+    *,
+    left_simulation_id: str | None,
+    right_simulation_id: str | None,
+) -> WorldCompareDescriptor:
+    world = mountain_waves_world_detail(settings)
+    simulations = [_mountain_simulation(item) for item in world.simulations]
+    default_left = "mountain_waves_dry_ridge"
+    default_right = "mountain_waves_boulder_moist_reference"
+    left, right = _selected_pair(
+        simulations,
+        left_simulation_id or default_left,
+        right_simulation_id or default_right,
+    )
+    records = {item.simulation_id: item for item in world.simulations}
+    differences = _mapping_differences(
+        _mountain_comparison_configuration(records[left.simulation_id]),
+        _mountain_comparison_configuration(records[right.simulation_id]),
+    )
+    compatibility = _compatibility(
+        left,
+        right,
+        relationship=(
+            "Both are retained built-in Mountain Waves Simulations; no controlled "
+            "experimental relationship is declared."
+        ),
+        controlled_pair=False,
+        controlled_message=(
+            "Dry Ridge and Boulder Windstorm differ in moisture, atmosphere, terrain, "
+            "domain, grid, and duration. This is a structural comparison, not a "
+            "one-variable experiment."
+        ),
+    )
+    return WorldCompareDescriptor(
+        world_id="mountain_waves",
+        display_name=world.display_name,
+        simulations=simulations,
+        default_left_simulation_id=default_left,
+        default_right_simulation_id=default_right,
+        selected_left_simulation_id=left.simulation_id,
+        selected_right_simulation_id=right.simulation_id,
+        material_differences=differences,
+        compatibility=compatibility,
+    )
+
+
+def _supercells_descriptor(
+    settings: CloudChamberSettings,
+    *,
+    left_simulation_id: str | None,
+    right_simulation_id: str | None,
+) -> WorldCompareDescriptor:
+    world = supercells_world_detail(settings)
+    simulations = [_supercell_simulation(item) for item in world.simulations]
+    selected_left = left_simulation_id or world.reference_simulation.simulation_id
+    left = _simulation_by_id(simulations, selected_left)
+    if right_simulation_id:
+        _simulation_by_id(simulations, right_simulation_id)
+        raise ValueError("Supercells has no distinct second Simulation to compare.")
+    return WorldCompareDescriptor(
+        world_id="supercells",
+        display_name=world.display_name,
+        simulations=simulations,
+        default_left_simulation_id=left.simulation_id,
+        default_right_simulation_id=None,
+        selected_left_simulation_id=left.simulation_id,
+        selected_right_simulation_id=None,
+        material_differences=[],
+        compatibility=None,
+        no_second_simulation_message=(
+            "Supercells currently has one retained Simulation. Compare requires two "
+            "distinct Simulations in the same World; this reference is not cloned."
+        ),
+    )
+
+
+def _trade_simulation(record: SimulationRecord) -> CompareSimulationDescriptor:
+    if record.simulation_id is None:
+        raise ValueError("Trade Cumulus Compare requires stable Simulation identity.")
+    is_more_moisture = record.simulation_id == "trade_cumulus_more_moisture"
+    time_seconds = 13_920.0 if is_more_moisture else 12_060.0
+    plane_index = 72 if is_more_moisture else 83
+    plane_coordinate = 1.6333333253860474 if is_more_moisture else 2.366666555404663
+    return CompareSimulationDescriptor(
+        simulation_id=record.simulation_id,
+        display_name=record.display_name,
+        world_id="trade_cumulus",
+        role=record.role,
+        run_id=record.run_id,
+        result_id=record.result_id,
+        case_id=record.case_id,
+        parent_simulation_id=record.parent_simulation_id,
+        reference_simulation_id=record.reference_simulation_id,
+        lineage_state=record.lineage_state,
+        availability_state=record.technical_state,
+        availability_message=record.technical_state_message,
+        inspectable=record.explore_available,
+        grid=CompareGridDescriptor(
+            topology="native_3d",
+            nx=96,
+            ny=96,
+            nz=100,
+            dx_m=66.6666667,
+            dy_m=66.6666667,
+            dz_m=30.0,
+            x_extent_km=(-3.2, 3.2),
+            y_extent_km=(-3.2, 3.2),
+            z_extent_km=(0.0, 3.0),
+        ),
+        time=_regular_time_descriptor(14_400, 60),
+        available_field_ids=["ql"],
+        available_view_ids=["field", "updraft_lens"],
+        fixed_scale_ids=["trade_cumulus_updraft_velocity_v1"],
+        plane_orientations=["horizontal", "vertical_x", "vertical_y"],
+        camera_mapping="normalized_3d",
+        initial_state=TradeCumulusExploreState(
+            world_id="trade_cumulus",
+            model_time_seconds=time_seconds,
+            view_id="updraft_lens",
+            scene_field_id="ql",
+            slice_field_id="w",
+            fixed_scale_id="trade_cumulus_updraft_velocity_v1",
+            active_slice_plane="vertical_x",
+            slice_coordinate_km=plane_coordinate,
+            slice_native_index=plane_index,
+            horizontal_slice_coordinate_km=0.0,
+            threshold_native=1e-6,
+            layer_opacity=0.68,
+            point_size_px=11,
+            lens_opacity=0.9,
+            show_slice_plane=True,
+            show_cloud_boundary=True,
+            show_horizontal_wind=True,
+            wind_mode="perturbation",
+            camera_preset="overview",
+            camera_transform=None,
+            playback_speed=1,
+        ),
+        caveats=[],
+    )
+
+
+def _mountain_simulation(
+    record: MountainWavesSimulationRecord,
+) -> CompareSimulationDescriptor:
+    configuration = record.configuration or {}
+    domain = configuration.get("domain") if isinstance(configuration, Mapping) else {}
+    domain = domain if isinstance(domain, Mapping) else {}
+    duration = _number(configuration.get("duration_seconds"), 0)
+    cadence = _number(configuration.get("output_cadence_seconds"), 1)
+    nx = int(_number(domain.get("nx"), 1))
+    ny = int(_number(domain.get("ny"), 1))
+    nz = int(_number(domain.get("nz"), 1))
+    dx = _number(domain.get("dx_m"), 1)
+    dy = _number(domain.get("dy_m"), 1)
+    dz = _number(domain.get("dz_m"), 1)
+    active_top = _number(
+        domain.get("active_model_top_m", domain.get("active_top_m")),
+        nz * dz,
+    )
+    fields = ["w", "theta_perturbation"]
+    views = ["field", "wave_structure"]
+    scales = [
+        "mountain_waves_vertical_velocity_v1",
+        "mountain_waves_theta_perturbation_v1",
+    ]
+    if record.moist_fields_available:
+        fields.extend(["cloud_liquid", "relative_humidity"])
+        views.append("wave_cloud")
+        scales.extend(
+            [
+                "mountain_waves_cloud_liquid_v1",
+                "mountain_waves_relative_humidity_v1",
+            ]
+        )
+    is_independent_dry_builtin = (
+        record.role == "built_in" and record.simulation_id == "mountain_waves_dry_ridge"
+    )
+    return CompareSimulationDescriptor(
+        simulation_id=record.simulation_id,
+        display_name=record.display_name,
+        world_id="mountain_waves",
+        role=record.role,
+        run_id=record.run_id,
+        case_id=record.case_id,
+        parent_simulation_id=record.parent_simulation_id,
+        reference_simulation_id=(
+            None if is_independent_dry_builtin else record.reference_simulation_id
+        ),
+        lineage_state=(
+            "independent_built_in"
+            if is_independent_dry_builtin
+            else ("known" if record.role == "built_in" else "retained_variation")
+        ),
+        availability_state=record.state,
+        availability_message=record.state_message,
+        inspectable=record.inspectable,
+        grid=CompareGridDescriptor(
+            topology="native_2d_xz",
+            nx=nx,
+            ny=ny,
+            nz=nz,
+            dx_m=dx,
+            dy_m=dy,
+            dz_m=dz,
+            x_extent_km=(-0.5 * nx * dx / 1_000, 0.5 * nx * dx / 1_000),
+            y_extent_km=None,
+            z_extent_km=(0.0, active_top / 1_000),
+        ),
+        time=_regular_time_descriptor(duration, cadence),
+        available_field_ids=fields,
+        available_view_ids=views,
+        fixed_scale_ids=scales,
+        plane_orientations=[],
+        camera_mapping="native_2d_xz",
+        initial_state=MountainWavesExploreState(
+            world_id="mountain_waves",
+            model_time_seconds=duration,
+            view_id="wave_structure",
+            field_id="w",
+            fixed_scale_id="mountain_waves_vertical_velocity_v1",
+            viewport_id="full" if record.simulation_id == "mountain_waves_dry_ridge" else "focus",
+            geometry_id="expanded",
+            overlays=MountainWavesOverlayState(
+                cloud_points=False,
+                cloud_boundary=False,
+                saturation_contour=False,
+                horizontal_wind=True,
+                potential_temperature_contours=True,
+            ),
+            cloud_opacity=0.68,
+            cloud_point_size_px=11,
+            playback_speed=1,
+        ),
+        caveats=[*record.caveats, *record.warnings],
+    )
+
+
+def _supercell_simulation(
+    record: SupercellSimulationRecord,
+) -> CompareSimulationDescriptor:
+    start = record.model_start_seconds or 0.0
+    end = record.model_end_seconds or start
+    cadence = record.history_cadence_seconds or 1.0
+    times = [start + index * cadence for index in range(record.saved_output_count)]
+    return CompareSimulationDescriptor(
+        simulation_id=record.simulation_id,
+        display_name=record.display_name,
+        world_id="supercells",
+        role=record.role,
+        run_id=record.run_id,
+        case_id=record.case_id,
+        reference_simulation_id=record.simulation_id,
+        lineage_state=record.lineage_state,
+        availability_state=record.technical_state,
+        availability_message=record.technical_state_message,
+        inspectable=record.explore_available,
+        grid=CompareGridDescriptor(
+            topology="native_3d",
+            nx=240,
+            ny=240,
+            nz=60,
+            dx_m=500,
+            dy_m=500,
+            dz_m=333.3333333,
+            x_extent_km=(-60.0, 60.0),
+            y_extent_km=(-60.0, 60.0),
+            z_extent_km=(0.0, 20.0),
+        ),
+        time=CompareTimeDescriptor(
+            times_seconds=times,
+            start_seconds=start,
+            end_seconds=end,
+            cadence_seconds=cadence,
+            saved_output_count=record.saved_output_count,
+        ),
+        available_field_ids=["winterp", "total_condensate"],
+        available_view_ids=[
+            "rotating_updraft",
+            "cloud_precipitation",
+            "low_level_interactions",
+        ],
+        fixed_scale_ids=[
+            "supercell_midlevel_vertical_velocity_v1",
+            "supercell_total_condensate_v2",
+            "supercell_low_level_vertical_velocity_v1",
+        ],
+        plane_orientations=["horizontal", "vertical_x", "vertical_y"],
+        camera_mapping="normalized_3d",
+        initial_state=SupercellsExploreState(
+            world_id="supercells",
+            model_time_seconds=4_440,
+            lens_id="rotating_updraft",
+            viewport_id="storm",
+            evidence_view="plan",
+            plane_coordinate_km=3.1666669845581055,
+            visible_layer_ids=[
+                "storm_cloud_body",
+                "rising_core",
+                "cyclonic_rotation",
+                "updraft_helicity",
+            ],
+            fixed_scale_ids=["supercell_midlevel_vertical_velocity_v1"],
+            overlays=SupercellsOverlayState(
+                rotation=True,
+                updraft_helicity=True,
+                reflectivity=False,
+                condensate=True,
+                rain=False,
+                wind=False,
+                precipitating_condensate=False,
+                vertical_motion=True,
+            ),
+            hydrometeor_category_codes=[1, 2, 3, 4, 5],
+            camera_preset="look_along_y",
+            camera_transform=None,
+            scene_opacity=1,
+            scene_point_size=1,
+            selected_evidence_visible=False,
+            playback_speed=1,
+        ),
+        caveats=[],
+    )
+
+
+def _regular_time_descriptor(
+    duration_seconds: float,
+    cadence_seconds: float,
+) -> CompareTimeDescriptor:
+    count = int(round(duration_seconds / cadence_seconds)) + 1
+    times = [index * cadence_seconds for index in range(count)]
+    return CompareTimeDescriptor(
+        times_seconds=times,
+        start_seconds=0,
+        end_seconds=duration_seconds,
+        cadence_seconds=cadence_seconds,
+        saved_output_count=count,
+    )
+
+
+def _selected_pair(
+    simulations: list[CompareSimulationDescriptor],
+    left_simulation_id: str,
+    right_simulation_id: str,
+) -> tuple[CompareSimulationDescriptor, CompareSimulationDescriptor]:
+    if left_simulation_id == right_simulation_id:
+        raise ValueError("Compare requires two distinct Simulations.")
+    return (
+        _simulation_by_id(simulations, left_simulation_id),
+        _simulation_by_id(simulations, right_simulation_id),
+    )
+
+
+def _simulation_by_id(
+    simulations: list[CompareSimulationDescriptor],
+    simulation_id: str,
+) -> CompareSimulationDescriptor:
+    simulation = next(
+        (item for item in simulations if item.simulation_id == simulation_id),
+        None,
+    )
+    if simulation is None:
+        raise ValueError(f"Simulation is not available in this World: {simulation_id}")
+    return simulation
+
+
+def _compatibility(
+    left: CompareSimulationDescriptor,
+    right: CompareSimulationDescriptor,
+    *,
+    relationship: str,
+    controlled_pair: bool,
+    controlled_message: str,
+) -> CompareCompatibility:
+    fields = sorted(set(left.available_field_ids) & set(right.available_field_ids))
+    views = sorted(set(left.available_view_ids) & set(right.available_view_ids))
+    scales = sorted(set(left.fixed_scale_ids) & set(right.fixed_scale_ids))
+    inspectable = left.inspectable and right.inspectable
+    blockers = []
+    if not inspectable:
+        blockers.append("Both Simulations must have inspectable retained output.")
+    if not views:
+        blockers.append("The selected Simulations do not share a compatible Field or Lens.")
+    exact_times = bool(set(left.time.times_seconds) & set(right.time.times_seconds))
+    if not exact_times:
+        blockers.append("The retained output histories have no exact modeled time in common.")
+    native_3d = left.grid.topology == right.grid.topology == "native_3d"
+    plane_link = native_3d and bool(set(left.plane_orientations) & set(right.plane_orientations))
+    return CompareCompatibility(
+        same_world=left.world_id == right.world_id,
+        both_inspectable=inspectable,
+        relationship=relationship,
+        controlled_pair=controlled_pair,
+        controlled_pair_message=controlled_message,
+        shared_field_ids=fields,
+        shared_view_ids=views,
+        shared_fixed_scale_ids=scales,
+        exact_time_link_available=exact_times,
+        nearest_time_link_available=inspectable,
+        time_tolerance_seconds=max(left.time.cadence_seconds, right.time.cadence_seconds) * 1.5,
+        physical_plane_link_available=plane_link,
+        camera_link_available=native_3d,
+        selection_link_available=inspectable,
+        blockers=blockers,
+    )
+
+
+def _relationship(
+    left: CompareSimulationDescriptor,
+    right: CompareSimulationDescriptor,
+) -> str:
+    if right.parent_simulation_id == left.simulation_id:
+        return f"{right.display_name} is a child of {left.display_name}."
+    if left.parent_simulation_id == right.simulation_id:
+        return f"{left.display_name} is a child of {right.display_name}."
+    if (
+        left.reference_simulation_id
+        and left.reference_simulation_id == right.reference_simulation_id
+    ):
+        return "Both Simulations share the same retained reference lineage."
+    return "Both Simulations belong to the same Cloud World; no direct lineage is declared."
+
+
+def _trade_differences(
+    left: CompareSimulationDescriptor,
+    right: CompareSimulationDescriptor,
+    records: list[SimulationRecord],
+) -> list[CompareDifference]:
+    if right.simulation_id == "trade_cumulus_more_moisture":
+        source = next(
+            item for item in records if item.simulation_id == "trade_cumulus_more_moisture"
+        )
+        reverse = False
+    elif left.simulation_id == "trade_cumulus_more_moisture":
+        source = next(
+            item for item in records if item.simulation_id == "trade_cumulus_more_moisture"
+        )
+        reverse = True
+    else:
+        return []
+    differences = []
+    for item in source.configuration_difference_from_reference or []:
+        if not item.material:
+            continue
+        differences.append(
+            CompareDifference(
+                path=item.path,
+                label=item.label,
+                category=item.category,
+                left_value=item.right_value if reverse else item.left_value,
+                right_value=item.left_value if reverse else item.right_value,
+                units=item.units,
+                material=True,
+            )
+        )
+    return differences
+
+
+def _mapping_differences(
+    left: Mapping[str, Any] | None,
+    right: Mapping[str, Any] | None,
+) -> list[CompareDifference]:
+    flattened_left = _flatten_mapping(left or {})
+    flattened_right = _flatten_mapping(right or {})
+    differences: list[CompareDifference] = []
+    for path in sorted(set(flattened_left) | set(flattened_right)):
+        left_known = path in flattened_left
+        right_known = path in flattened_right
+        left_value = flattened_left.get(path)
+        right_value = flattened_right.get(path)
+        if left_known and right_known and left_value == right_value:
+            continue
+        differences.append(
+            CompareDifference(
+                path=path,
+                label=_difference_label(path),
+                category=_difference_category(path),
+                left_value=left_value,
+                right_value=right_value,
+                left_known=left_known,
+                right_known=right_known,
+                units=_difference_units(path),
+            )
+        )
+    return differences
+
+
+def _mountain_comparison_configuration(
+    record: MountainWavesSimulationRecord,
+) -> dict[str, Any]:
+    configuration = record.configuration or {}
+    domain = configuration.get("domain")
+    domain = domain if isinstance(domain, Mapping) else {}
+    terrain = configuration.get("terrain")
+    terrain = terrain if isinstance(terrain, Mapping) else {}
+    active_top = domain.get("active_model_top_m", domain.get("active_top_m"))
+    return {
+        "atmosphere": {
+            "moisture_state": "Moist" if record.moist else "Dry",
+        },
+        "duration_seconds": configuration.get("duration_seconds"),
+        "output_cadence_seconds": configuration.get("output_cadence_seconds"),
+        "domain": {
+            "nx": domain.get("nx"),
+            "ny": domain.get("ny"),
+            "nz": domain.get("nz"),
+            "dx_m": domain.get("dx_m"),
+            "dy_m": domain.get("dy_m"),
+            "dz_m": domain.get("dz_m"),
+            "active_top_m": active_top,
+        },
+        "terrain": {
+            key: terrain[key]
+            for key in (
+                "type",
+                "terrain_flag",
+                "itern",
+                "height_m",
+                "half_width_m",
+                "center_m",
+                "native_dx_m",
+            )
+            if key in terrain
+        },
+    }
+
+
+def _flatten_mapping(value: Mapping[str, Any], prefix: str = "") -> dict[str, Any]:
+    flattened: dict[str, Any] = {}
+    for key, item in value.items():
+        path = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(item, Mapping):
+            flattened.update(_flatten_mapping(item, path))
+        else:
+            flattened[path] = item
+    return flattened
+
+
+def _difference_label(path: str) -> str:
+    labels = {
+        "duration_seconds": "Simulation duration",
+        "output_cadence_seconds": "Saved-output cadence",
+        "domain.nx": "Grid cells along x",
+        "domain.ny": "Grid cells along y",
+        "domain.nz": "Grid cells along z",
+        "domain.dx_m": "Grid spacing along x",
+        "domain.dy_m": "Grid spacing along y",
+        "domain.dz_m": "Grid spacing along z",
+        "domain.active_model_top_m": "Active model top",
+        "domain.active_top_m": "Active model top",
+        "atmosphere.moisture_state": "Atmosphere moisture state",
+        "terrain.height_m": "Terrain height",
+        "terrain.half_width_m": "Terrain half-width",
+        "terrain.center_m": "Terrain center",
+        "terrain.native_dx_m": "Terrain native grid spacing",
+        "terrain.type": "Terrain function",
+        "terrain.itern": "CM1 terrain option",
+        "terrain.terrain_flag": "Terrain enabled",
+    }
+    return labels.get(path, path.replace(".", " / ").replace("_", " ").title())
+
+
+def _difference_category(
+    path: str,
+) -> Literal["atmospheric", "numerical", "output", "operational", "metadata"]:
+    if path.startswith("domain.") or path.startswith("terrain."):
+        return "numerical"
+    if "cadence" in path or "duration" in path:
+        return "output"
+    return "atmospheric"
+
+
+def _difference_units(path: str) -> str | None:
+    if path.endswith("_seconds"):
+        return "s"
+    if path.endswith("_m"):
+        return "m"
+    return None
+
+
+def _number(value: Any, fallback: float) -> float:
+    return float(value) if isinstance(value, (int, float)) else fallback

--- a/app/backend/cloud_chamber/world_compare.py
+++ b/app/backend/cloud_chamber/world_compare.py
@@ -273,25 +273,74 @@ def _supercells_descriptor(
 ) -> WorldCompareDescriptor:
     world = supercells_world_detail(settings)
     simulations = [_supercell_simulation(item) for item in world.simulations]
-    selected_left = left_simulation_id or world.reference_simulation.simulation_id
-    left = _simulation_by_id(simulations, selected_left)
-    if right_simulation_id:
-        _simulation_by_id(simulations, right_simulation_id)
-        raise ValueError("Supercells has no distinct second Simulation to compare.")
+    available = [item for item in simulations if item.inspectable]
+    if len(available) < 2:
+        requested_left = left_simulation_id or world.reference_simulation.simulation_id
+        requested = _simulation_by_id(simulations, requested_left)
+        left = requested if requested.inspectable or not available else available[0]
+        if right_simulation_id is not None:
+            requested_right = _simulation_by_id(simulations, right_simulation_id)
+            if requested_right.inspectable and requested_right.simulation_id != left.simulation_id:
+                raise ValueError(
+                    "Supercells Compare requires two retained, inspectable Simulations."
+                )
+        return WorldCompareDescriptor(
+            world_id="supercells",
+            display_name=world.display_name,
+            simulations=simulations,
+            default_left_simulation_id=left.simulation_id,
+            default_right_simulation_id=None,
+            selected_left_simulation_id=left.simulation_id,
+            selected_right_simulation_id=None,
+            material_differences=[],
+            compatibility=None,
+            no_second_simulation_message=(
+                "Supercells currently has one retained Simulation. Compare requires two "
+                "distinct Simulations in the same World; this reference is not cloned."
+            ),
+        )
+    left, right = _selected_pair(
+        available,
+        left_simulation_id or "supercells_quarter_circle_reference",
+        right_simulation_id or "supercells_straight_line_hodograph",
+    )
+    reverse = left.simulation_id == "supercells_straight_line_hodograph"
+    differences = [
+        CompareDifference(
+            path="atmosphere.hodograph_geometry",
+            label="Hodograph geometry",
+            category="atmospheric",
+            left_value="Straight line" if reverse else "Quarter circle",
+            right_value="Quarter circle" if reverse else "Straight line",
+        )
+    ]
+    compatibility = _compatibility(
+        left,
+        right,
+        relationship=_relationship(left, right),
+        controlled_pair=(
+            {left.simulation_id, right.simulation_id}
+            == {
+                "supercells_quarter_circle_reference",
+                "supercells_straight_line_hodograph",
+            }
+        ),
+        controlled_message=(
+            "Only hodograph curvature changed; thermodynamics, trigger, grid, timing, "
+            "output inventory, model translation, and numerical options are matched. "
+            "Coordinates and local evidence are compared without claiming storm-object lineage."
+        ),
+    )
     return WorldCompareDescriptor(
         world_id="supercells",
         display_name=world.display_name,
         simulations=simulations,
-        default_left_simulation_id=left.simulation_id,
-        default_right_simulation_id=None,
+        default_left_simulation_id="supercells_quarter_circle_reference",
+        default_right_simulation_id="supercells_straight_line_hodograph",
         selected_left_simulation_id=left.simulation_id,
-        selected_right_simulation_id=None,
-        material_differences=[],
-        compatibility=None,
-        no_second_simulation_message=(
-            "Supercells currently has one retained Simulation. Compare requires two "
-            "distinct Simulations in the same World; this reference is not cloned."
-        ),
+        selected_right_simulation_id=right.simulation_id,
+        material_differences=differences,
+        compatibility=compatibility,
     )
 
 
@@ -471,7 +520,8 @@ def _supercell_simulation(
         role=record.role,
         run_id=record.run_id,
         case_id=record.case_id,
-        reference_simulation_id=record.simulation_id,
+        parent_simulation_id=record.parent_simulation_id,
+        reference_simulation_id=record.reference_simulation_id,
         lineage_state=record.lineage_state,
         availability_state=record.technical_state,
         availability_message=record.technical_state_message,

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -310,7 +310,7 @@ def _world_detail_payload() -> dict[str, object]:
             "featured_comparison": True,
             "lab": True,
             "saved_views": False,
-            "ordinary_compare": False,
+            "ordinary_compare": True,
         },
         "caveats": [],
     }

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -459,6 +459,9 @@ def test_supercells_product_api_defaults_to_presentation_mature_frame(
             "x_index": None,
             "y_index": None,
             "z_index": None,
+            "selected_x_index": None,
+            "selected_y_index": None,
+            "selected_z_index": None,
         }
     ]
 

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -452,6 +452,7 @@ def test_supercells_product_api_defaults_to_presentation_mature_frame(
     assert response.json()["time_index"] == 37
     assert calls == [
         {
+            "simulation_id": "supercells_quarter_circle_reference",
             "lens": "rotating_updraft",
             "time_index": 37,
             "viewport": "storm",

--- a/app/backend/tests/test_local_run_manager.py
+++ b/app/backend/tests/test_local_run_manager.py
@@ -25,6 +25,12 @@ from cloud_chamber.run_manifest import (
     write_run_manifest,
 )
 from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.supercell_hodograph import (
+    STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND,
+    STRAIGHT_LINE_HODOGRAPH_MARKER,
+    STRAIGHT_LINE_HODOGRAPH_SCHEMA_VERSION,
+    render_straight_line_hodograph_source,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
@@ -188,6 +194,14 @@ def write_fake_cm1_source_tree(settings: CloudChamberSettings) -> None:
 
   ENDIF
       end subroutine sfcflux
+"""
+    )
+    (src_dir / "base.F").write_text(
+        """      subroutine base
+!-----------------------------------------------------------------------
+
+      ENDIF    ! endif for iwnd options
+      end subroutine base
 """
     )
 
@@ -373,6 +387,81 @@ def test_launch_applies_differential_surface_source_customization_before_cm1(
     assert launched_manifest.cm1_source_customization_status == status_payload
     assert SFCPHYS_MARKER not in (cm1_root / "src" / "sfcphys.F").read_text()
     assert custom_executable.exists()
+
+
+def test_launch_applies_straight_line_hodograph_source_customization_before_cm1(
+    tmp_path: Path,
+) -> None:
+    settings = fake_settings(tmp_path)
+    assert settings.cm1_root is not None
+    cm1_root = settings.cm1_root
+    write_fake_cm1_source_tree(settings)
+    manifest_path = dry_run_manifest_path(tmp_path, run_id="straight-line")
+    manifest = load_run_manifest(manifest_path)
+    run_dir = Path(manifest.generated_inputs.run_directory)
+    source = (cm1_root / "src" / "base.F").read_text()
+    patched = render_straight_line_hodograph_source(source)
+    customization_path = run_dir / "straight_line_hodograph_customization.json"
+    customization_path.write_text(
+        json.dumps(
+            {
+                "schema_version": STRAIGHT_LINE_HODOGRAPH_SCHEMA_VERSION,
+                "customization_kind": STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND,
+                "target_relative_path": "src/base.F",
+                "marker": STRAIGHT_LINE_HODOGRAPH_MARKER,
+                "original_source_sha256": hashlib.sha256(source.encode()).hexdigest(),
+                "patched_source_sha256": hashlib.sha256(patched.encode()).hexdigest(),
+                "wind_profile": {"profile": "test"},
+            }
+        )
+    )
+    generated_hashes = dict(manifest.run_configuration.get("generated_input_sha256", {}))
+    generated_hashes[customization_path.name] = hashlib.sha256(
+        customization_path.read_bytes()
+    ).hexdigest()
+    write_run_manifest(
+        manifest_path,
+        manifest.model_copy(
+            update={
+                "generated_inputs": manifest.generated_inputs.model_copy(
+                    update={"cm1_source_customization": str(customization_path)}
+                ),
+                "run_configuration": {
+                    **manifest.run_configuration,
+                    "cm1_source_customization_kind": (STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND),
+                    "generated_input_sha256": generated_hashes,
+                },
+            }
+        ),
+    )
+    factory = FakeProcessFactory(FakeProcess())
+
+    def fake_build(
+        command: list[str],
+        *,
+        cwd: Path,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        assert STRAIGHT_LINE_HODOGRAPH_MARKER in (cwd / "base.F").read_text()
+        assert STRAIGHT_LINE_HODOGRAPH_MARKER not in (cm1_root / "src" / "base.F").read_text()
+        return subprocess.CompletedProcess(command, 0, stdout="built\n", stderr="")
+
+    status = LocalRunManager(
+        settings=settings,
+        process_factory=factory,
+        source_build_runner=fake_build,
+    ).launch(manifest_path)
+
+    assert status.lifecycle_state == LifecycleState.RUNNING
+    custom_executable = run_dir / CUSTOM_EXECUTABLE_FILENAME
+    assert factory.commands == [[str(custom_executable)]]
+    status_payload = json.loads((run_dir / SOURCE_CUSTOMIZATION_STATUS_FILENAME).read_text())
+    assert status_payload["customization_kind"] == STRAIGHT_LINE_HODOGRAPH_CUSTOMIZATION_KIND
+    assert status_payload["patched_files"] == ["src/base.F"]
+    assert status_payload["no_silent_hodograph_fallback"] is True
+    assert status_payload["custom_executable_sha256"]
 
 
 def test_launch_refuses_tampered_differential_patch_data(tmp_path: Path) -> None:

--- a/app/backend/tests/test_storm_examination.py
+++ b/app/backend/tests/test_storm_examination.py
@@ -52,6 +52,8 @@ def _write_retained_fixture(
                 "run_id": run_id,
                 "case_id": case_id,
                 "implementation_commit": implementation_commit,
+                "simulation_id": ("supercells_quarter_circle_reference" if presentation else None),
+                "hodograph": "quarter_circle",
             }
         )
     )
@@ -129,6 +131,8 @@ def _write_retained_fixture(
                     "kind": "final",
                     "run_id": run_id,
                     "case_id": case_id,
+                    "simulation_id": "supercells_quarter_circle_reference",
+                    "hodograph": "quarter_circle",
                     "source_run_id": PRESERVED_RUN_ID,
                     "implementation_commit": implementation_commit,
                     "grid": {

--- a/app/backend/tests/test_storm_examination.py
+++ b/app/backend/tests/test_storm_examination.py
@@ -391,6 +391,35 @@ def test_product_frame_exposes_native_plane_inventory_and_honors_selected_height
     assert frame.scene.coordinate_values_km["z"] == pytest.approx([0.25, 1.25, 3.25, 10.25, 15.25])
 
 
+def test_product_frame_keeps_section_position_separate_from_selected_point(
+    tmp_path: Path,
+) -> None:
+    _write_retained_fixture(tmp_path, presentation=True)
+
+    frame = supercells_explore_frame(
+        _settings(tmp_path),
+        lens="rotating_updraft",
+        time_index=5,
+        viewport="storm",
+        x_index=2,
+        y_index=1,
+        z_index=4,
+        selected_x_index=3,
+        selected_y_index=2,
+        selected_z_index=1,
+    )
+
+    assert frame.plan.level_index == 4
+    assert frame.xz_section.cross_section_coordinate_km == pytest.approx(-30)
+    assert frame.yz_section.cross_section_coordinate_km == pytest.approx(0)
+    assert frame.selected_point.x_index == 3
+    assert frame.selected_point.y_index == 2
+    assert frame.selected_point.z_index == 1
+    assert frame.selected_point.x_km == pytest.approx(30)
+    assert frame.selected_point.y_km == pytest.approx(0)
+    assert frame.selected_point.z_km == pytest.approx(1.25)
+
+
 def test_product_hydrometeor_scene_keeps_exact_large_ice_label(tmp_path: Path) -> None:
     _write_retained_fixture(tmp_path, presentation=True)
 

--- a/app/backend/tests/test_supercell_hodograph.py
+++ b/app/backend/tests/test_supercell_hodograph.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from cloud_chamber import supercell_hodograph
+from cloud_chamber.supercell_hodograph import (
+    STRAIGHT_LINE_HODOGRAPH_MARKER,
+    StraightLineHodographError,
+    render_straight_line_hodograph_source,
+    straight_line_hodograph_artifact,
+)
+
+
+def _source() -> str:
+    return """      subroutine base
+!-----------------------------------------------------------------------
+
+      ENDIF    ! endif for iwnd options
+      end subroutine base
+"""
+
+
+def test_render_adds_only_one_source_locked_straight_line_branch() -> None:
+    source = _source()
+
+    rendered = render_straight_line_hodograph_source(source)
+
+    assert rendered.count(STRAIGHT_LINE_HODOGRAPH_MARKER) == 1
+    assert "ELSEIF(iwnd.eq.12)THEN" in rendered
+    assert "+min(max(zu,0.0),6000.0)/6000.0*31.0" in rendered
+    assert "+min(max(zv,0.0),6000.0)/6000.0*7.0" in rendered
+    assert rendered.endswith("      end subroutine base\n")
+
+
+def test_artifact_records_original_and_patched_source_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source()
+    monkeypatch.setattr(
+        supercell_hodograph,
+        "PINNED_BASE_F_SHA256",
+        hashlib.sha256(source.encode()).hexdigest(),
+    )
+
+    artifact = straight_line_hodograph_artifact(source)
+
+    assert artifact["original_source_sha256"] == hashlib.sha256(source.encode()).hexdigest()
+    assert (
+        artifact["patched_source_sha256"]
+        == hashlib.sha256(render_straight_line_hodograph_source(source).encode()).hexdigest()
+    )
+    scientific_scope = artifact["scientific_scope"]
+    wind_profile = artifact["wind_profile"]
+    assert isinstance(scientific_scope, dict)
+    assert isinstance(wind_profile, dict)
+    assert scientific_scope["changed"] == ["hodograph_geometry"]
+    assert wind_profile["endpoint_shear_m_s"] == [31.0, 7.0]
+
+
+def test_render_fails_closed_when_source_anchor_changes() -> None:
+    with pytest.raises(StraightLineHodographError, match="branch terminator"):
+        render_straight_line_hodograph_source("changed source")

--- a/app/backend/tests/test_supercell_presentation.py
+++ b/app/backend/tests/test_supercell_presentation.py
@@ -21,6 +21,7 @@ from cloud_chamber.run_manifest import (
     ScenarioReference,
     UserMetadata,
     ValidationStatus,
+    load_run_manifest,
     write_run_manifest,
 )
 from cloud_chamber.settings import CloudChamberSettings
@@ -33,8 +34,10 @@ from cloud_chamber.supercell_benchmark import (
 )
 from cloud_chamber.supercell_presentation import (
     CHARACTERIZATION_SPEC,
+    FINAL_RUN_STORAGE_RESERVATION_BYTES,
     MINIMUM_POST_RUN_FREE_BYTES,
     PRESENTATION_SPEC,
+    STRAIGHT_LINE_CHARACTERIZATION_SPEC,
     PresentationStorageEstimate,
     estimate_storage,
     generate_presentation_package,
@@ -71,6 +74,8 @@ def _settings(tmp_path: Path) -> CloudChamberSettings:
 def _provenance(tmp_path: Path) -> CM1Provenance:
     root = tmp_path / "cm1"
     run_dir = root / "run"
+    (root / "src").mkdir(parents=True, exist_ok=True)
+    (root / "src/base.F").write_text("fake source\n")
     namelist = root / "official-namelist.input"
     namelist.write_text(_official_namelist())
     executable = run_dir / "cm1.exe"
@@ -167,7 +172,39 @@ def test_namelist_changes_only_declared_presentation_assignments() -> None:
     assert " timax = 10800.0," in rendered
 
 
-def test_storage_floor_uses_no_compression_credit(tmp_path: Path) -> None:
+def test_straight_line_namelist_changes_only_hodograph_beyond_reference() -> None:
+    rendered, differences = render_presentation_namelist(
+        _official_namelist(),
+        STRAIGHT_LINE_CHARACTERIZATION_SPEC,
+    )
+
+    assert " iwnd = 12," in rendered
+    assert {item.name for item in differences} == set(
+        STRAIGHT_LINE_CHARACTERIZATION_SPEC.changed_assignments
+    )
+    assert next(item for item in differences if item.name == "iwnd").reason == (
+        "controlled_hodograph_geometry"
+    )
+    assert {
+        name: value
+        for name, value in STRAIGHT_LINE_CHARACTERIZATION_SPEC.expected_science_assignments.items()
+        if name != "iwnd"
+    } == {
+        name: value
+        for name, value in supercell_presentation.LOCKED_SCIENCE_ASSIGNMENTS.items()
+        if name != "iwnd"
+    }
+
+
+def test_storage_floor_uses_no_compression_credit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        supercell_presentation,
+        "_completed_final_campaign_runs",
+        lambda _runs_dir: set(),
+    )
     storage = estimate_storage(PRESENTATION_SPEC, tmp_path)
     expected_history_bytes = (
         len(supercell_presentation.REQUIRED_3D_FIELDS) * 240 * 240 * 60
@@ -177,8 +214,33 @@ def test_storage_floor_uses_no_compression_credit(tmp_path: Path) -> None:
     assert storage.expected_history_count == 91
     assert storage.uncompressed_numeric_history_floor_bytes == expected_history_bytes * 91
     assert storage.compression_credit_bytes == 0
+    assert storage.gate_basis == "measured_retained_campaign_reservation"
+    assert storage.final_campaign_runs_remaining == 2
     assert storage.required_free_bytes == (
-        storage.uncompressed_numeric_history_floor_bytes + MINIMUM_POST_RUN_FREE_BYTES
+        2 * FINAL_RUN_STORAGE_RESERVATION_BYTES + MINIMUM_POST_RUN_FREE_BYTES
+    )
+
+
+def test_second_final_run_gate_reserves_only_the_remaining_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        supercell_presentation,
+        "_completed_final_campaign_runs",
+        lambda _runs_dir: {supercell_presentation.PRESENTATION_RUN_ID},
+    )
+
+    storage = estimate_storage(STRAIGHT_LINE_CHARACTERIZATION_SPEC, tmp_path)
+    final_storage = estimate_storage(
+        supercell_presentation.STRAIGHT_LINE_PRESENTATION_SPEC,
+        tmp_path,
+    )
+
+    assert storage.gate_basis == "uncompressed_numeric_floor"
+    assert final_storage.final_campaign_runs_remaining == 1
+    assert final_storage.required_free_bytes == (
+        FINAL_RUN_STORAGE_RESERVATION_BYTES + MINIMUM_POST_RUN_FREE_BYTES
     )
 
 
@@ -239,6 +301,86 @@ def test_package_and_preflight_are_nonexecuting_and_fail_closed(
         "retry_allowed": False,
         "tuning_matrix_allowed": False,
     }
+
+
+def test_straight_line_package_declares_hashed_source_customization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_accepted_source(settings)
+    provenance = _provenance(tmp_path)
+    artifact = {
+        "schema_version": "supercell_straight_line_hodograph_v1",
+        "customization_kind": "straight_line_hodograph_v1",
+        "target_relative_path": "src/base.F",
+        "marker": "CLOUD_CHAMBER_STRAIGHT_LINE_HODOGRAPH_V1",
+        "original_source_sha256": "1" * 64,
+        "patched_source_sha256": "2" * 64,
+        "wind_profile": {"profile": "test"},
+    }
+    monkeypatch.setattr(
+        supercell_presentation,
+        "verified_clean_git_commit",
+        lambda: "implementation",
+    )
+    monkeypatch.setattr(supercell_presentation, "active_cm1_processes", lambda: [])
+    monkeypatch.setattr(
+        supercell_presentation,
+        "verify_gate_a_source_lock",
+        lambda: {"logical_path": "gate-a.md", "sha256": "source-lock"},
+    )
+    monkeypatch.setattr(
+        supercell_presentation,
+        "collect_cm1_provenance",
+        lambda _settings: provenance,
+    )
+    monkeypatch.setattr(
+        supercell_presentation,
+        "straight_line_hodograph_artifact",
+        lambda _source: artifact,
+    )
+    monkeypatch.setattr(
+        supercell_presentation,
+        "estimate_storage",
+        lambda _spec, _path: PresentationStorageEstimate(
+            expected_history_count=2,
+            scalar_grid=[240, 240, 60],
+            scalar_3d_array_count=19,
+            scalar_2d_array_count=4,
+            uncompressed_numeric_history_floor_bytes=1,
+            required_free_bytes=1,
+            available_free_bytes=10,
+            passed=True,
+        ),
+    )
+
+    package = generate_presentation_package(
+        settings=settings,
+        spec=STRAIGHT_LINE_CHARACTERIZATION_SPEC,
+    )
+    manifest = load_run_manifest(package.manifest_path)
+    case_manifest = json.loads(package.case_manifest_path.read_text())
+
+    assert manifest.run_configuration["simulation_id"] == (
+        supercell_presentation.STRAIGHT_LINE_SIMULATION_ID
+    )
+    assert manifest.run_configuration["parent_simulation_id"] == (
+        supercell_presentation.QUARTER_CIRCLE_SIMULATION_ID
+    )
+    assert manifest.run_configuration["cm1_source_customization_kind"] == (
+        "straight_line_hodograph_v1"
+    )
+    assert (
+        Path(manifest.generated_inputs.cm1_source_customization or "").name
+        == "straight_line_hodograph_customization.json"
+    )
+    assert case_manifest["hodograph"] == "straight_line"
+    assert verify_presentation_package(
+        settings=settings,
+        package=package,
+        require_clean_head=True,
+    ).passed
 
 
 def test_completed_validation_rejects_non_finite_required_field(

--- a/app/backend/tests/test_supercell_presentation.py
+++ b/app/backend/tests/test_supercell_presentation.py
@@ -267,19 +267,44 @@ def test_package_and_preflight_are_nonexecuting_and_fail_closed(
         "collect_cm1_provenance",
         lambda _settings: provenance,
     )
+    storage_estimates = iter(
+        [
+            PresentationStorageEstimate(
+                expected_history_count=2,
+                scalar_grid=[240, 240, 60],
+                scalar_3d_array_count=19,
+                scalar_2d_array_count=4,
+                uncompressed_numeric_history_floor_bytes=1,
+                required_free_bytes=2,
+                available_free_bytes=10,
+                passed=True,
+            ),
+            PresentationStorageEstimate(
+                expected_history_count=2,
+                scalar_grid=[240, 240, 60],
+                scalar_3d_array_count=19,
+                scalar_2d_array_count=4,
+                uncompressed_numeric_history_floor_bytes=1,
+                required_free_bytes=2,
+                available_free_bytes=10,
+                passed=True,
+            ),
+            PresentationStorageEstimate(
+                expected_history_count=2,
+                scalar_grid=[240, 240, 60],
+                scalar_3d_array_count=19,
+                scalar_2d_array_count=4,
+                uncompressed_numeric_history_floor_bytes=1,
+                required_free_bytes=1,
+                available_free_bytes=9,
+                passed=True,
+            ),
+        ]
+    )
     monkeypatch.setattr(
         supercell_presentation,
         "estimate_storage",
-        lambda _spec, _path: PresentationStorageEstimate(
-            expected_history_count=2,
-            scalar_grid=[240, 240, 60],
-            scalar_3d_array_count=19,
-            scalar_2d_array_count=4,
-            uncompressed_numeric_history_floor_bytes=1,
-            required_free_bytes=1,
-            available_free_bytes=10,
-            passed=True,
-        ),
+        lambda _spec, _path: next(storage_estimates),
     )
 
     package = generate_presentation_package(
@@ -294,6 +319,8 @@ def test_package_and_preflight_are_nonexecuting_and_fail_closed(
 
     assert preflight.passed is True
     assert all(preflight.checks.values())
+    assert preflight.storage.required_free_bytes == 1
+    assert preflight.storage.available_free_bytes == 9
     assert not list(package.package_dir.glob("cm1out_*.nc"))
     assert json.loads(package.case_manifest_path.read_text())["execution_authorization"] == {
         "duration_seconds": 300,

--- a/app/backend/tests/test_supercell_presentation.py
+++ b/app/backend/tests/test_supercell_presentation.py
@@ -375,6 +375,15 @@ def test_straight_line_package_declares_hashed_source_customization(
         Path(manifest.generated_inputs.cm1_source_customization or "").name
         == "straight_line_hodograph_customization.json"
     )
+    runtime_checklist = json.loads(
+        Path(manifest.generated_inputs.runtime_file_checklist[0]).read_text()
+    )
+    assert runtime_checklist["consumed_files"] == []
+    assert runtime_checklist["required_files"] == []
+    assert (
+        runtime_checklist["packaged_source_customization"]
+        == "straight_line_hodograph_customization.json"
+    )
     assert case_manifest["hodograph"] == "straight_line"
     assert verify_presentation_package(
         settings=settings,

--- a/app/backend/tests/test_supercells_world.py
+++ b/app/backend/tests/test_supercells_world.py
@@ -22,7 +22,7 @@ def test_world_exposes_stable_identity_and_data_driven_timeline(
 ) -> None:
     monkeypatch.setattr(
         "cloud_chamber.supercells_world.storm_examination_inventory",
-        lambda _settings: tuple(
+        lambda _settings, _simulation_id: tuple(
             (tmp_path / f"cm1out_{index + 1:06d}.nc", float(index * 120)) for index in range(91)
         ),
     )
@@ -31,7 +31,7 @@ def test_world_exposes_stable_identity_and_data_driven_timeline(
 
     assert detail.world_id == "supercells"
     assert detail.display_name == "Supercells"
-    assert len(detail.simulations) == 1
+    assert len(detail.simulations) == 2
     simulation = detail.reference_simulation
     assert simulation.simulation_id == "supercells_quarter_circle_reference"
     assert simulation.display_name == "Quarter-Circle Supercell"
@@ -43,14 +43,19 @@ def test_world_exposes_stable_identity_and_data_driven_timeline(
     assert simulation.history_cadence_seconds == 120
     assert simulation.default_explore_time_index == 37
     assert detail.capabilities.lab is False
-    assert detail.capabilities.compare is False
-    assert detail.summary().simulation_count == 1
+    variation = detail.simulations[1]
+    assert variation.simulation_id == "supercells_straight_line_hodograph"
+    assert variation.display_name == "Straight-Line Hodograph Supercell"
+    assert variation.role == "variation"
+    assert variation.parent_simulation_id == simulation.simulation_id
+    assert detail.capabilities.compare is True
+    assert detail.summary().simulation_count == 2
 
 
 def test_world_remains_usable_when_retained_output_is_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    def unavailable(_settings: CloudChamberSettings) -> None:
+    def unavailable(_settings: CloudChamberSettings, _simulation_id: str) -> None:
         raise StormExaminationError("The accepted Gate B retained output is unavailable.")
 
     monkeypatch.setattr("cloud_chamber.supercells_world.storm_examination_inventory", unavailable)
@@ -61,4 +66,30 @@ def test_world_remains_usable_when_retained_output_is_missing(
     assert detail.reference_simulation.technical_state == "missing"
     assert detail.reference_simulation.explore_available is False
     assert detail.simulations[0].simulation_id == "supercells_quarter_circle_reference"
+    assert detail.simulations[1].simulation_id == "supercells_straight_line_hodograph"
     assert detail.summary().simulation_count == 0
+
+
+def test_world_exposes_one_run_without_inventing_a_compare_pair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def inventory(
+        _settings: CloudChamberSettings, simulation_id: str
+    ) -> tuple[tuple[Path, float], ...]:
+        if simulation_id == "supercells_straight_line_hodograph":
+            raise StormExaminationError(
+                "The controlled straight-line presentation output is unavailable."
+            )
+        return tuple(
+            (tmp_path / f"cm1out_{index + 1:06d}.nc", float(index * 120)) for index in range(91)
+        )
+
+    monkeypatch.setattr("cloud_chamber.supercells_world.storm_examination_inventory", inventory)
+
+    detail = supercells_world_detail(_settings(tmp_path))
+
+    assert detail.availability_state == "partial"
+    assert detail.reference_simulation.explore_available is True
+    assert detail.simulations[1].explore_available is False
+    assert detail.capabilities.compare is False
+    assert detail.summary().simulation_count == 1

--- a/app/backend/tests/test_world_compare.py
+++ b/app/backend/tests/test_world_compare.py
@@ -230,6 +230,11 @@ def test_supercells_compare_does_not_clone_the_only_simulation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     reference = SupercellSimulationRecord(
+        simulation_id="supercells_quarter_circle_reference",
+        display_name="Quarter-Circle Supercell",
+        role="reference",
+        run_id="quarter-circle",
+        case_id="quarter-circle-case",
         technical_state="available",
         technical_state_message="Available",
         explore_available=True,
@@ -257,6 +262,73 @@ def test_supercells_compare_does_not_clone_the_only_simulation(
     assert len(descriptor.simulations) == 1
     assert descriptor.simulations[0].grid.nx == 240
     assert descriptor.simulations[0].grid.z_extent_km == (0.0, 20.0)
+
+
+def test_supercells_compare_uses_real_controlled_hodograph_pair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reference = SupercellSimulationRecord(
+        simulation_id="supercells_quarter_circle_reference",
+        display_name="Quarter-Circle Supercell",
+        role="reference",
+        run_id="quarter-circle",
+        case_id="quarter-circle-case",
+        technical_state="available",
+        technical_state_message="Available",
+        explore_available=True,
+        saved_output_count=91,
+        model_start_seconds=0,
+        model_end_seconds=10_800,
+        history_cadence_seconds=120,
+    )
+    straight = SupercellSimulationRecord(
+        simulation_id="supercells_straight_line_hodograph",
+        display_name="Straight-Line Hodograph Supercell",
+        role="variation",
+        run_id="straight-line",
+        case_id="straight-line-case",
+        parent_simulation_id=reference.simulation_id,
+        technical_state="available",
+        technical_state_message="Available",
+        explore_available=True,
+        saved_output_count=91,
+        model_start_seconds=0,
+        model_end_seconds=10_800,
+        history_cadence_seconds=120,
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.world_compare.supercells_world_detail",
+        lambda _settings: SimpleNamespace(
+            display_name="Supercells",
+            simulations=[reference, straight],
+            reference_simulation=reference,
+        ),
+    )
+
+    descriptor = world_compare_descriptor(_settings(tmp_path), world_slug="supercells")
+
+    assert descriptor.selected_left_simulation_id == reference.simulation_id
+    assert descriptor.selected_right_simulation_id == straight.simulation_id
+    assert descriptor.compatibility is not None
+    assert descriptor.compatibility.controlled_pair is True
+    assert descriptor.compatibility.camera_link_available is True
+    assert descriptor.compatibility.physical_plane_link_available is True
+    assert descriptor.compatibility.selection_link_available is True
+    assert descriptor.compatibility.shared_view_ids == [
+        "cloud_precipitation",
+        "low_level_interactions",
+        "rotating_updraft",
+    ]
+    assert len(descriptor.material_differences) == 1
+    difference = descriptor.material_differences[0]
+    assert difference.path == "atmosphere.hodograph_geometry"
+    assert (difference.left_value, difference.right_value) == (
+        "Quarter circle",
+        "Straight line",
+    )
+    assert "without claiming storm-object lineage" in (
+        descriptor.compatibility.controlled_pair_message
+    )
 
 
 def test_native_subset_is_bounded_ordered_and_never_interpolated() -> None:

--- a/app/backend/tests/test_world_compare.py
+++ b/app/backend/tests/test_world_compare.py
@@ -1,0 +1,313 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Literal
+
+import pytest
+
+from cloud_chamber.cloud_worlds import (
+    ConfigurationDifference,
+    SimulationRecord,
+)
+from cloud_chamber.mountain_wave_terrain_visualization import (
+    _ordered_sample_indices,
+    _sample_native_grid,
+)
+from cloud_chamber.mountain_waves_world import MountainWavesSimulationRecord
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.supercells_world import SupercellSimulationRecord
+from cloud_chamber.world_compare import world_compare_descriptor
+
+
+def _settings(tmp_path: Path) -> CloudChamberSettings:
+    return CloudChamberSettings(
+        runtime_home=tmp_path,
+        cm1_root=None,
+        cm1_run_dir=None,
+        cache_dir=tmp_path / "cache",
+        log_dir=tmp_path / "logs",
+    )
+
+
+def _trade_record(
+    *,
+    simulation_id: str,
+    display_name: str,
+    role: Literal["reference", "variation", "lab_history"],
+    run_id: str,
+    parent_simulation_id: str | None = None,
+    difference: ConfigurationDifference | None = None,
+) -> SimulationRecord:
+    return SimulationRecord(
+        simulation_id=simulation_id,
+        display_name=display_name,
+        role=role,
+        product_slice_id="trade_cumulus_v1",
+        case_id="bomex_trade_cumulus_baseline_v0",
+        result_id=f"result-{run_id}",
+        run_id=run_id,
+        parent_simulation_id=parent_simulation_id,
+        reference_simulation_id="trade_cumulus_canonical_bomex",
+        technical_state="available",
+        technical_state_message="Available",
+        technical_trust_state="caveated",
+        explore_available=True,
+        configuration_difference_from_reference=[difference] if difference else None,
+        lineage_state="known",
+    )
+
+
+def _mountain_record(
+    *,
+    simulation_id: str,
+    display_name: str,
+    run_id: str,
+    moist: bool,
+    configuration: dict[str, object],
+) -> MountainWavesSimulationRecord:
+    return MountainWavesSimulationRecord(
+        simulation_id=simulation_id,
+        display_name=display_name,
+        role="built_in",
+        run_id=run_id,
+        case_id=f"{simulation_id}_case",
+        state="available",
+        state_message="Available",
+        inspectable=True,
+        can_create_variation=moist,
+        moist=moist,
+        moist_fields_available=moist,
+        purpose="Test retained output.",
+        configuration=configuration,
+    )
+
+
+def test_trade_compare_uses_the_approved_pair_and_exact_material_difference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    difference = ConfigurationDifference(
+        path="surface_moisture_flux_g_g_m_s",
+        label="Surface moisture supply",
+        category="atmospheric",
+        left_value=0.052,
+        right_value=0.078,
+        units="g/kg m/s",
+        material=True,
+    )
+    baseline = _trade_record(
+        simulation_id="trade_cumulus_canonical_bomex",
+        display_name="Canonical BOMEX Baseline",
+        role="reference",
+        run_id="baseline",
+    )
+    moisture = _trade_record(
+        simulation_id="trade_cumulus_more_moisture",
+        display_name="More Moisture",
+        role="variation",
+        run_id="moisture",
+        parent_simulation_id=baseline.simulation_id,
+        difference=difference,
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.world_compare.trade_cumulus_world_detail",
+        lambda _settings: SimpleNamespace(
+            display_name="Trade Cumulus",
+            simulations=[baseline, moisture],
+            reference_simulation=baseline,
+            featured_comparison=SimpleNamespace(more_moisture_simulation_id=moisture.simulation_id),
+        ),
+    )
+
+    descriptor = world_compare_descriptor(_settings(tmp_path), world_slug="trade-cumulus")
+
+    assert descriptor.persistence == "transient_only"
+    assert descriptor.selected_left_simulation_id == baseline.simulation_id
+    assert descriptor.selected_right_simulation_id == moisture.simulation_id
+    assert descriptor.compatibility is not None
+    assert descriptor.compatibility.controlled_pair is True
+    assert (
+        descriptor.compatibility.relationship
+        == "More Moisture is a child of Canonical BOMEX Baseline."
+    )
+    assert descriptor.compatibility.shared_view_ids == ["field", "updraft_lens"]
+    assert descriptor.compatibility.physical_plane_link_available is True
+    assert len(descriptor.material_differences) == 1
+    material_difference = descriptor.material_differences[0]
+    assert material_difference.path == difference.path
+    assert material_difference.left_value == 0.052
+    assert material_difference.right_value == 0.078
+    assert material_difference.units == "g/kg m/s"
+    assert all(
+        simulation.initial_state.world_id == "trade_cumulus"
+        for simulation in descriptor.simulations
+    )
+
+
+def test_mountain_compare_is_structural_and_keeps_unknown_distinct_from_equal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dry = _mountain_record(
+        simulation_id="mountain_waves_dry_ridge",
+        display_name="Dry Ridge",
+        run_id="dry",
+        moist=False,
+        configuration={
+            "duration_seconds": 2_160,
+            "output_cadence_seconds": 120,
+            "domain": {
+                "nx": 800,
+                "ny": 1,
+                "nz": 100,
+                "dx_m": 100,
+                "dy_m": 100,
+                "dz_m": 200,
+                "active_model_top_m": 20_000,
+            },
+            "terrain": {"height_m": 1_500},
+        },
+    )
+    moist = _mountain_record(
+        simulation_id="mountain_waves_boulder_moist_reference",
+        display_name="Boulder Windstorm",
+        run_id="moist",
+        moist=True,
+        configuration={
+            "duration_seconds": 7_200,
+            "output_cadence_seconds": 200,
+            "domain": {
+                "nx": 800,
+                "ny": 1,
+                "nz": 126,
+                "dx_m": 100,
+                "dy_m": 100,
+                "dz_m": 200,
+                "active_model_top_m": 25_200,
+            },
+            "terrain": {"half_width_m": 10_000},
+        },
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.world_compare.mountain_waves_world_detail",
+        lambda _settings: SimpleNamespace(
+            display_name="Mountain Waves",
+            simulations=[dry, moist],
+        ),
+    )
+
+    descriptor = world_compare_descriptor(_settings(tmp_path), world_slug="mountain-waves")
+
+    assert descriptor.compatibility is not None
+    assert descriptor.compatibility.controlled_pair is False
+    assert (
+        descriptor.compatibility.relationship
+        == "Both are retained built-in Mountain Waves Simulations; no controlled "
+        "experimental relationship is declared."
+    )
+    assert descriptor.compatibility.camera_link_available is False
+    assert descriptor.compatibility.physical_plane_link_available is False
+    assert descriptor.compatibility.shared_view_ids == ["field", "wave_structure"]
+    assert "structural comparison" in descriptor.compatibility.controlled_pair_message
+    moisture_row = next(
+        item for item in descriptor.material_differences if item.path == "atmosphere.moisture_state"
+    )
+    assert (moisture_row.left_value, moisture_row.right_value) == ("Dry", "Moist")
+    missing_height = next(
+        item for item in descriptor.material_differences if item.path == "terrain.height_m"
+    )
+    assert missing_height.left_known is True
+    assert missing_height.right_known is False
+    assert missing_height.right_value is None
+    assert all(simulation.grid.topology == "native_2d_xz" for simulation in descriptor.simulations)
+    dry_descriptor = next(
+        simulation
+        for simulation in descriptor.simulations
+        if simulation.simulation_id == "mountain_waves_dry_ridge"
+    )
+    assert dry_descriptor.reference_simulation_id is None
+    assert dry_descriptor.lineage_state == "independent_built_in"
+
+
+def test_supercells_compare_does_not_clone_the_only_simulation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reference = SupercellSimulationRecord(
+        technical_state="available",
+        technical_state_message="Available",
+        explore_available=True,
+        saved_output_count=91,
+        model_start_seconds=0,
+        model_end_seconds=10_800,
+        history_cadence_seconds=120,
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.world_compare.supercells_world_detail",
+        lambda _settings: SimpleNamespace(
+            display_name="Supercells",
+            simulations=[reference],
+            reference_simulation=reference,
+        ),
+    )
+
+    descriptor = world_compare_descriptor(_settings(tmp_path), world_slug="supercells")
+
+    assert descriptor.selected_left_simulation_id == reference.simulation_id
+    assert descriptor.selected_right_simulation_id is None
+    assert descriptor.compatibility is None
+    assert descriptor.no_second_simulation_message is not None
+    assert "not cloned" in descriptor.no_second_simulation_message
+    assert len(descriptor.simulations) == 1
+    assert descriptor.simulations[0].grid.nx == 240
+    assert descriptor.simulations[0].grid.z_extent_km == (0.0, 20.0)
+
+
+def test_native_subset_is_bounded_ordered_and_never_interpolated() -> None:
+    grid = [[float(row * 100 + column) for column in range(300)] for row in range(180)]
+    rows = _ordered_sample_indices(180, 80)
+    columns = _ordered_sample_indices(300, 120)
+    sampled = _sample_native_grid(grid, rows, columns)
+
+    assert len(rows) == 80
+    assert len(columns) == 120
+    assert rows == sorted(set(rows))
+    assert columns == sorted(set(columns))
+    assert sampled[17][31] == grid[rows[17]][columns[31]]
+    assert all(
+        value in grid[row] for row, values in zip(rows, sampled, strict=True) for value in values
+    )
+
+
+def test_compare_rejects_unknown_world_and_same_simulation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with pytest.raises(ValueError, match="Unknown Cloud World"):
+        world_compare_descriptor(_settings(tmp_path), world_slug="not-a-world")
+
+    baseline = _trade_record(
+        simulation_id="trade_cumulus_canonical_bomex",
+        display_name="Canonical BOMEX Baseline",
+        role="reference",
+        run_id="baseline",
+    )
+    moisture = _trade_record(
+        simulation_id="trade_cumulus_more_moisture",
+        display_name="More Moisture",
+        role="variation",
+        run_id="moisture",
+        parent_simulation_id=baseline.simulation_id,
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.world_compare.trade_cumulus_world_detail",
+        lambda _settings: SimpleNamespace(
+            display_name="Trade Cumulus",
+            simulations=[baseline, moisture],
+            reference_simulation=baseline,
+            featured_comparison=SimpleNamespace(more_moisture_simulation_id=moisture.simulation_id),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="two distinct Simulations"):
+        world_compare_descriptor(
+            _settings(tmp_path),
+            world_slug="trade-cumulus",
+            left_simulation_id=baseline.simulation_id,
+            right_simulation_id=baseline.simulation_id,
+        )

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -300,9 +300,137 @@ const tradeCumulusWorld = {
     featured_comparison: true,
     lab: true,
     saved_views: false,
-    ordinary_compare: false,
+    ordinary_compare: true,
   },
   caveats: [],
+};
+
+function compareTradeState(
+  member: typeof comparisonStory.baseline | typeof comparisonStory.more_moisture,
+) {
+  return {
+    state_version: 1,
+    world_id: "trade_cumulus",
+    model_time_seconds: member.curated_view.time_seconds,
+    context_collapsed: true,
+    secondary_section: "notes",
+    selected_point: null,
+    view_id: "updraft_lens",
+    scene_field_id: "ql",
+    slice_field_id: "w",
+    fixed_scale_id: "trade_cumulus_updraft_velocity_v1",
+    active_slice_plane: "vertical_x",
+    slice_coordinate_km: member.curated_view.plane_coordinate,
+    slice_native_index: member.curated_view.plane_index,
+    horizontal_slice_coordinate_km: 1,
+    threshold_native: 1e-6,
+    layer_opacity: 0.68,
+    point_size_px: 11,
+    lens_opacity: 0.9,
+    show_slice_plane: true,
+    show_cloud_boundary: true,
+    show_horizontal_wind: true,
+    wind_mode: "perturbation",
+    camera_preset: "overview",
+    camera_transform: null,
+    playback_speed: 1,
+    display_controls_open: false,
+  };
+}
+
+function compareTradeSimulation(
+  simulation: typeof worldBaselineSimulation,
+  member: typeof comparisonStory.baseline | typeof comparisonStory.more_moisture,
+) {
+  return {
+    simulation_id: simulation.simulation_id,
+    display_name: simulation.display_name,
+    world_id: "trade_cumulus",
+    role: simulation.role,
+    run_id: simulation.run_id,
+    result_id: simulation.result_id,
+    case_id: simulation.case_id,
+    parent_simulation_id: simulation.parent_simulation_id,
+    reference_simulation_id: simulation.reference_simulation_id,
+    lineage_state: simulation.lineage_state,
+    availability_state: simulation.technical_state,
+    availability_message: simulation.technical_state_message,
+    inspectable: simulation.explore_available,
+    grid: {
+      topology: "native_3d",
+      nx: 96,
+      ny: 96,
+      nz: 100,
+      dx_m: 6400 / 96,
+      dy_m: 6400 / 96,
+      dz_m: 30,
+      x_extent_km: [-3.2, 3.2],
+      y_extent_km: [-3.2, 3.2],
+      z_extent_km: [0, 3],
+    },
+    time: {
+      times_seconds: Array.from({ length: 181 }, (_, index) => index * 120),
+      start_seconds: 0,
+      end_seconds: 21_600,
+      cadence_seconds: 120,
+      saved_output_count: 181,
+      interpolation_allowed: false,
+    },
+    available_field_ids: ["ql"],
+    available_view_ids: ["field", "updraft_lens"],
+    fixed_scale_ids: ["trade_cumulus_updraft_velocity_v1"],
+    plane_orientations: ["horizontal", "vertical_x", "vertical_y"],
+    camera_mapping: "normalized_3d",
+    initial_state: compareTradeState(member),
+    caveats: [],
+  };
+}
+
+const tradeCumulusCompareDescriptor = {
+  schema_version: "world_compare_v1",
+  world_id: "trade_cumulus",
+  display_name: "Trade Cumulus",
+  simulations: [
+    compareTradeSimulation(worldBaselineSimulation, comparisonStory.baseline),
+    compareTradeSimulation(worldMoreMoistureSimulation, comparisonStory.more_moisture),
+  ],
+  default_left_simulation_id: worldBaselineSimulation.simulation_id,
+  default_right_simulation_id: worldMoreMoistureSimulation.simulation_id,
+  selected_left_simulation_id: worldBaselineSimulation.simulation_id,
+  selected_right_simulation_id: worldMoreMoistureSimulation.simulation_id,
+  material_differences: [
+    {
+      path: "run_configuration.surface_moisture_flux_g_g_m_s",
+      label: "Surface moisture supply",
+      category: "atmospheric",
+      left_value: 0.052,
+      right_value: 0.078,
+      left_known: true,
+      right_known: true,
+      units: "g/kg m/s",
+      material: true,
+    },
+  ],
+  compatibility: {
+    same_world: true,
+    both_inspectable: true,
+    relationship: "More Moisture is a child of Canonical BOMEX Baseline.",
+    controlled_pair: true,
+    controlled_pair_message:
+      "Only surface moisture supply changed; the retained pair is a controlled comparison.",
+    shared_field_ids: ["ql"],
+    shared_view_ids: ["field", "updraft_lens"],
+    shared_fixed_scale_ids: ["trade_cumulus_updraft_velocity_v1"],
+    exact_time_link_available: true,
+    nearest_time_link_available: true,
+    time_tolerance_seconds: 180,
+    physical_plane_link_available: true,
+    camera_link_available: true,
+    selection_link_available: true,
+    blockers: [],
+  },
+  no_second_simulation_message: null,
+  persistence: "transient_only",
 };
 
 const cloudWorldSummary = {
@@ -718,6 +846,13 @@ async function mockTradeCumulusWorld(page: Parameters<typeof mockCloudChamberApi
       body: JSON.stringify(tradeCumulusWorld),
     }),
   );
+  await page.route("**/api/worlds/trade-cumulus/compare**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(tradeCumulusCompareDescriptor),
+    }),
+  );
 }
 
 test.describe("mocked smoke: Build, Results, Explore path", () => {
@@ -790,14 +925,29 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("button", { name: "Show Context" })).toBeVisible();
     await page.getByRole("button", { name: "Show Context" }).click();
     await expect(page.getByLabel("Current scientific context")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Compare" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Compare" })).toBeVisible();
     await page.getByRole("button", { name: "Back to Trade Cumulus" }).click();
 
     await page.getByRole("button", { name: "Open Comparison" }).click();
     await expect(
-      page.getByRole("heading", { name: "Trade Cumulus: Baseline and More Moisture" }),
+      page.getByRole("heading", {
+        name: "Review the two Simulations before loading frames",
+      }),
     ).toBeVisible();
-    await expect(page.getByLabel("More Moisture versus Baseline workspace")).toBeVisible();
+    await expect(page.getByText("0.0520 g/kg m/s")).toBeVisible();
+    await expect(page.getByText("0.0780 g/kg m/s")).toBeVisible();
+    await page.getByRole("button", { name: "Open dual view" }).click();
+    await expect(page.getByLabel("Trade Cumulus Compare")).toBeVisible();
+    await expect(page.getByLabel("Canonical BOMEX Baseline comparison side")).toBeVisible();
+    await expect(page.getByLabel("More Moisture comparison side")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Independent" })).toHaveClass(
+      /active-control/,
+    );
+    await page.getByRole("button", { name: "Aligned" }).click();
+    await expect(page.getByRole("checkbox", { name: "Time", exact: true })).toBeChecked();
+    await expect(
+      page.getByRole("checkbox", { name: "Field / Lens", exact: true }),
+    ).toBeChecked();
     await page.getByRole("button", { name: "Back to Trade Cumulus" }).click();
 
     await page.getByRole("button", { name: "Lab", exact: true }).click();

--- a/app/frontend/e2e/mocked-smoke/supercells-compare.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/supercells-compare.spec.ts
@@ -1,0 +1,753 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { mockCloudChamberApis } from "../fixtures";
+import { gotoApp } from "../helpers";
+
+const REFERENCE_ID = "supercells_quarter_circle_reference";
+const VARIATION_ID = "supercells_straight_line_hodograph";
+const TIMES = Array.from({ length: 91 }, (_, index) => index * 120);
+const W_SCALE = {
+  scale_id: "supercell_midlevel_vertical_velocity_v1",
+  display_name: "Vertical velocity",
+  units: "m/s",
+  scale_type: "fixed_discrete",
+  minimum: -30,
+  maximum: 30,
+  breakpoints: [-20, -10, -2, 2, 10, 20],
+  colors: ["#4b0082", "#0057d9", "#00c9d8", "#ffffff", "#00d63b", "#ff9800", "#c40000"],
+  fixed_across_time: true,
+};
+const CONDENSATE_SCALE = {
+  scale_id: "supercell_total_condensate_v2",
+  display_name: "Total condensate",
+  units: "g/kg",
+  scale_type: "fixed_continuous",
+  minimum: 0,
+  maximum: 15,
+  breakpoints: [],
+  colors: ["#ffffff", "#8bd8e7", "#3575b8"],
+  fixed_across_time: true,
+};
+const HYDROMETEORS = [
+  { code: 0, key: "clear", label: "Clear", color: "#ffffff" },
+  { code: 1, key: "cloud_liquid", label: "Cloud liquid", color: "#72d7df" },
+  { code: 2, key: "rain", label: "Rain", color: "#1987bd" },
+  { code: 3, key: "cloud_ice", label: "Cloud ice", color: "#c5b8ec" },
+  { code: 4, key: "snow", label: "Snow", color: "#8586c6" },
+  { code: 5, key: "hail_treated_large_ice", label: "Hail-treated large ice", color: "#e49a4c" },
+];
+type FrameCategories = null | {
+  key: string;
+  display_name: string;
+  evidence_kind: string;
+  source_fields: string[];
+  derivation: string;
+  values: number[][];
+  magnitude: ReturnType<typeof field>;
+  categories: typeof HYDROMETEORS;
+};
+
+test.describe("mocked smoke: real Supercells Compare adapter", () => {
+  test("coordinates all three Lenses and physical sections at both desktop review sizes", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    const browserErrors: string[] = [];
+    page.on("pageerror", (error) => {
+      browserErrors.push(error.message);
+      console.error(error.message);
+    });
+    page.on("console", (message) => {
+      if (message.type() !== "error") return;
+      browserErrors.push(message.text());
+      console.error(message.text());
+    });
+    await page.setViewportSize({ width: 1728, height: 1117 });
+    await mockCloudChamberApis(page);
+    await mockSupercellsPair(page);
+    await gotoApp(page);
+
+    await page.getByRole("button", { name: "Enter Supercells" }).click();
+    const variation = page
+      .locator("article")
+      .filter({ hasText: "Straight-Line Hodograph Supercell" });
+    await variation.getByRole("button", { name: "Compare" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Review the two Simulations before loading frames" }),
+    ).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Hodograph geometry" })).toBeVisible();
+    await page.getByRole("button", { name: "Open dual view" }).click();
+
+    await expect(page.getByLabel("Supercells Compare")).toBeVisible();
+    await page.getByRole("button", { name: "Aligned" }).click();
+    await expect(page.getByLabel("Vertical velocity legend")).toHaveCount(2);
+    await expect(page.getByLabel("Quarter-Circle Supercell saved output time")).toBeVisible();
+    await page.screenshot({
+      path: "test-results/supercells-compare-preview-1728x1117.png",
+      fullPage: true,
+    });
+
+    const left = page.getByLabel("Quarter-Circle Supercell comparison side");
+    await left.getByRole("button", { name: "Cloud and Precipitation" }).click();
+    await expect(page.getByLabel("Hydrometeor legend")).toHaveCount(2);
+    await left.getByRole("button", { name: "Low-Level Interactions" }).click();
+    await expect(page.getByLabel("Vertical velocity legend")).toHaveCount(2);
+    await left.getByRole("button", { name: "Vertical x-z" }).click();
+    await expect(page.getByLabel("xz native section")).toHaveCount(2);
+
+    await page.setViewportSize({ width: 1024, height: 856 });
+    await expect(page.getByLabel("Supercells Compare")).toBeVisible();
+    await page.screenshot({
+      path: "test-results/supercells-compare-preview-1024x856.png",
+      fullPage: true,
+    });
+    expect(await horizontalOverflow(page)).toBeLessThanOrEqual(1);
+    expect(browserErrors).toEqual([]);
+  });
+});
+
+async function mockSupercellsPair(page: Page) {
+  await page.unroute("**/api/worlds");
+  await page.route("**/api/worlds", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          world_id: "supercells",
+          display_name: "Supercells",
+          status: "available",
+          short_description:
+            "A deep rotating thunderstorm for seeing organized ascent and precipitation.",
+          reference_simulation_id: REFERENCE_ID,
+          reference_available: true,
+          simulation_count: 2,
+          saved_view_count: 0,
+          saved_comparison_count: 0,
+          featured_comparison_count: 0,
+          active_run_count: 0,
+          completed_uninspected_run_count: 0,
+          availability_state: "available",
+          availability_message: "Two retained Simulations are available.",
+        },
+      ]),
+    }),
+  );
+  await page.route("**/api/worlds/supercells", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(worldPayload()),
+    }),
+  );
+  await page.route("**/api/worlds/supercells/compare**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(compareDescriptor()),
+    }),
+  );
+  await page.route("**/api/worlds/supercells/simulations/*/frame**", (route) => {
+    const url = new URL(route.request().url());
+    const simulationId = url.pathname.includes(VARIATION_ID) ? VARIATION_ID : REFERENCE_ID;
+    const lens = url.searchParams.get("lens") ?? "rotating_updraft";
+    const timeIndex = Number(url.searchParams.get("time_index") ?? 37);
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(framePayload(simulationId, lens, timeIndex)),
+    });
+  });
+}
+
+function worldPayload() {
+  const reference = worldSimulation(REFERENCE_ID, "Quarter-Circle Supercell", "reference");
+  const variation = worldSimulation(VARIATION_ID, "Straight-Line Hodograph Supercell", "variation");
+  return {
+    world_id: "supercells",
+    display_name: "Supercells",
+    short_description:
+      "A deep rotating thunderstorm for seeing organized ascent, rotation, hydrometeors, precipitation, and low-level flow evolve together.",
+    availability_state: "available",
+    availability_message: "Two retained Simulations are available for Explore and Compare.",
+    reference_simulation: reference,
+    simulations: [reference, variation],
+    capabilities: {
+      reference_explore: true,
+      lab: false,
+      compare: true,
+      saved_views: false,
+    },
+    caveats: [
+      "Coordinates and local evidence are comparable; storm-object lineage is not inferred.",
+    ],
+  };
+}
+
+function worldSimulation(
+  simulationId: string,
+  displayName: string,
+  role: "reference" | "variation",
+) {
+  const reference = role === "reference";
+  return {
+    simulation_id: simulationId,
+    display_name: displayName,
+    role,
+    world_id: "supercells",
+    run_id: reference
+      ? "quarter-circle-supercell-presentation-v1-20260723"
+      : "straight-line-supercell-presentation-v1-20260726",
+    case_id: reference
+      ? "cm1_r21_1_quarter_circle_supercell_presentation_v1"
+      : "cm1_r21_1_straight_line_supercell_presentation_v1",
+    parent_simulation_id: reference ? null : REFERENCE_ID,
+    reference_simulation_id: REFERENCE_ID,
+    technical_state: "available",
+    technical_state_message: "Ninety-one retained histories are available.",
+    explore_available: true,
+    saved_output_count: 91,
+    model_start_seconds: 0,
+    model_end_seconds: 10_800,
+    history_cadence_seconds: 120,
+    default_explore_time_index: 37,
+    lineage_state: "known",
+  };
+}
+
+function compareDescriptor() {
+  const reference = compareSimulation(REFERENCE_ID, "Quarter-Circle Supercell", "reference");
+  const variation = compareSimulation(
+    VARIATION_ID,
+    "Straight-Line Hodograph Supercell",
+    "variation",
+  );
+  return {
+    schema_version: "world_compare_v1",
+    world_id: "supercells",
+    display_name: "Supercells",
+    simulations: [reference, variation],
+    default_left_simulation_id: REFERENCE_ID,
+    default_right_simulation_id: VARIATION_ID,
+    selected_left_simulation_id: REFERENCE_ID,
+    selected_right_simulation_id: VARIATION_ID,
+    material_differences: [
+      {
+        path: "atmosphere.hodograph",
+        label: "Hodograph geometry",
+        category: "atmospheric",
+        left_value: "quarter circle",
+        right_value: "straight line",
+        left_known: true,
+        right_known: true,
+        units: null,
+        material: true,
+      },
+    ],
+    compatibility: {
+      same_world: true,
+      both_inspectable: true,
+      relationship:
+        "Straight-Line Hodograph Supercell is a controlled variation of Quarter-Circle Supercell.",
+      controlled_pair: true,
+      controlled_pair_message:
+        "Hodograph geometry changed; thermodynamics and the numerical experiment are matched.",
+      shared_field_ids: ["winterp", "total_condensate"],
+      shared_view_ids: ["rotating_updraft", "cloud_precipitation", "low_level_interactions"],
+      shared_fixed_scale_ids: [
+        "supercell_midlevel_vertical_velocity_v1",
+        "supercell_total_condensate_v2",
+        "supercell_low_level_vertical_velocity_v1",
+      ],
+      exact_time_link_available: true,
+      nearest_time_link_available: true,
+      time_tolerance_seconds: 180,
+      physical_plane_link_available: true,
+      camera_link_available: true,
+      selection_link_available: true,
+      blockers: [],
+    },
+    no_second_simulation_message: null,
+    persistence: "transient_only",
+  };
+}
+
+function compareSimulation(
+  simulationId: string,
+  displayName: string,
+  role: "reference" | "variation",
+) {
+  const record = worldSimulation(simulationId, displayName, role);
+  return {
+    simulation_id: simulationId,
+    display_name: displayName,
+    world_id: "supercells",
+    role,
+    run_id: record.run_id,
+    result_id: null,
+    case_id: record.case_id,
+    parent_simulation_id: record.parent_simulation_id,
+    reference_simulation_id: REFERENCE_ID,
+    lineage_state: "known",
+    availability_state: "available",
+    availability_message: "Available",
+    inspectable: true,
+    grid: {
+      topology: "native_3d",
+      nx: 240,
+      ny: 240,
+      nz: 60,
+      dx_m: 500,
+      dy_m: 500,
+      dz_m: 333.3333333,
+      x_extent_km: [-60, 60],
+      y_extent_km: [-60, 60],
+      z_extent_km: [0, 20],
+    },
+    time: {
+      times_seconds: TIMES,
+      start_seconds: 0,
+      end_seconds: 10_800,
+      cadence_seconds: 120,
+      saved_output_count: 91,
+      interpolation_allowed: false,
+    },
+    available_field_ids: ["winterp", "total_condensate"],
+    available_view_ids: ["rotating_updraft", "cloud_precipitation", "low_level_interactions"],
+    fixed_scale_ids: [
+      "supercell_midlevel_vertical_velocity_v1",
+      "supercell_total_condensate_v2",
+      "supercell_low_level_vertical_velocity_v1",
+    ],
+    plane_orientations: ["horizontal", "vertical_x", "vertical_y"],
+    camera_mapping: "normalized_3d",
+    initial_state: {
+      state_version: 1,
+      world_id: "supercells",
+      model_time_seconds: 4_440,
+      lens_id: "rotating_updraft",
+      viewport_id: "storm",
+      evidence_view: "plan",
+      plane_coordinate_km: 3.1666669845581055,
+      visible_layer_ids: ["storm_cloud_body", "rising_core"],
+      fixed_scale_ids: ["supercell_midlevel_vertical_velocity_v1"],
+      overlays: {
+        rotation: true,
+        updraft_helicity: true,
+        reflectivity: false,
+        condensate: true,
+        rain: false,
+        wind: false,
+        precipitating_condensate: false,
+        vertical_motion: true,
+      },
+      hydrometeor_category_codes: [1, 2, 3, 4, 5],
+      camera_preset: "overview",
+      camera_transform: null,
+      scene_opacity: 1,
+      scene_point_size: 1,
+      selected_evidence_visible: false,
+      context_collapsed: true,
+      secondary_section: "notes",
+      selected_point: null,
+      playback_speed: 1,
+      display_controls_open: false,
+    },
+    caveats: ["Storm-object lineage is not inferred between the two Simulations."],
+  };
+}
+
+function framePayload(simulationId: string, lens: string, timeIndex: number) {
+  const variation = simulationId === VARIATION_ID;
+  const cloudLens = lens === "cloud_precipitation";
+  const lowLevelLens = lens === "low_level_interactions";
+  const x = coordinates(32, -38, 22);
+  const y = coordinates(32, -28, 32);
+  const z = coordinates(24, 0.1667, 19.8333);
+  const planValues = matrix(y.length, x.length, (row, column) =>
+    stormValue(x[column], y[row], variation, lowLevelLens),
+  );
+  const sectionValues = matrix(z.length, x.length, (row, column) =>
+    sectionValue(x[column], z[row], variation),
+  );
+  const primary = field(
+    cloudLens ? "total_condensate" : "winterp",
+    cloudLens ? "Total condensate" : "Vertical velocity",
+    cloudLens ? "g/kg" : "m/s",
+    cloudLens ? planValues.map((row) => row.map((value) => Math.max(0, value / 2))) : planValues,
+    cloudLens ? CONDENSATE_SCALE : W_SCALE,
+  );
+  const sectionPrimary = field(
+    cloudLens ? "total_condensate" : "winterp",
+    cloudLens ? "Total condensate" : "Vertical velocity",
+    cloudLens ? "g/kg" : "m/s",
+    cloudLens
+      ? sectionValues.map((row) => row.map((value) => Math.max(0, value / 2)))
+      : sectionValues,
+    cloudLens ? CONDENSATE_SCALE : W_SCALE,
+  );
+  const planOverlays = {
+    total_condensate: overlayField(
+      "total_condensate",
+      "Total condensate",
+      "g/kg",
+      planValues.map((row) => row.map((value) => Math.max(0, value / 4))),
+      CONDENSATE_SCALE,
+    ),
+    vertical_vorticity: overlayField(
+      "vertical_vorticity",
+      "Vertical vorticity",
+      "s^-1",
+      planValues.map((row) => row.map((value) => Math.max(0, value / 900))),
+      W_SCALE,
+    ),
+    updraft_helicity: overlayField(
+      "updraft_helicity",
+      "Updraft helicity",
+      "m^2/s^2",
+      planValues.map((row) => row.map((value) => Math.max(0, value * 24))),
+      W_SCALE,
+    ),
+    composite_reflectivity: overlayField(
+      "composite_reflectivity",
+      "Composite reflectivity",
+      "dBZ",
+      planValues.map((row) => row.map((value) => Math.max(0, value * 3))),
+      W_SCALE,
+    ),
+    vertical_velocity: overlayField(
+      "vertical_velocity",
+      "Vertical velocity",
+      "m/s",
+      planValues,
+      W_SCALE,
+    ),
+    accumulated_surface_rain: overlayField(
+      "accumulated_surface_rain",
+      "Accumulated surface rain",
+      "mm",
+      planValues.map((row) => row.map((value) => Math.max(0, value / 2))),
+      CONDENSATE_SCALE,
+    ),
+    low_level_precipitating_condensate: overlayField(
+      "low_level_precipitating_condensate",
+      "Low-level precipitating condensate",
+      "g/kg",
+      planValues.map((row) => row.map((value) => Math.max(0, value / 8))),
+      CONDENSATE_SCALE,
+    ),
+  };
+  const sectionOverlays = {
+    vertical_velocity: overlayField(
+      "vertical_velocity",
+      "Vertical velocity",
+      "m/s",
+      sectionValues,
+      W_SCALE,
+    ),
+    vertical_vorticity: overlayField(
+      "vertical_vorticity",
+      "Vertical vorticity",
+      "s^-1",
+      sectionValues.map((row) => row.map((value) => Math.max(0, value / 900))),
+      W_SCALE,
+    ),
+    total_condensate: overlayField(
+      "total_condensate",
+      "Total condensate",
+      "g/kg",
+      sectionValues.map((row) => row.map((value) => Math.max(0, value / 4))),
+      CONDENSATE_SCALE,
+    ),
+    precipitating_condensate: overlayField(
+      "precipitating_condensate",
+      "Precipitating condensate",
+      "g/kg",
+      sectionValues.map((row) => row.map((value) => Math.max(0, value / 8))),
+      CONDENSATE_SCALE,
+    ),
+    reflectivity: overlayField(
+      "reflectivity",
+      "Reflectivity",
+      "dBZ",
+      sectionValues.map((row) => row.map((value) => Math.max(0, value * 3))),
+      W_SCALE,
+    ),
+  };
+  const categories = cloudLens
+    ? {
+        key: "dominant_hydrometeor",
+        display_name: "Dominant hydrometeor",
+        evidence_kind: "derived",
+        source_fields: ["qc", "qr", "qi", "qs", "qg"],
+        derivation: "largest native condensate mixing ratio",
+        values: primary.values.map((row) =>
+          row.map((value) => (value > 7 ? 5 : value > 4 ? 4 : value > 2 ? 2 : value > 0.2 ? 1 : 0)),
+        ),
+        magnitude: primary,
+        categories: HYDROMETEORS,
+      }
+    : null;
+  const selected = {
+    x_index: 120,
+    y_index: 120,
+    z_index: lowLevelLens ? 3 : 10,
+    x_km: 0.25,
+    y_km: 0.25,
+    z_km: lowLevelLens ? 1.1667 : 3.5,
+    model_time_seconds: TIMES[timeIndex],
+    coordinate_frame: "translating model frame",
+    values: {
+      vertical_velocity: variation ? 9.4 : 14.8,
+      vertical_vorticity: variation ? 0.008 : 0.024,
+      updraft_helicity: variation ? 190 : 430,
+      total_condensate: cloudLens ? 8.2 : 3.7,
+      reflectivity: 51,
+      accumulated_rain: lowLevelLens ? 13.2 : 4.1,
+    },
+    units: {
+      vertical_velocity: "m/s",
+      vertical_vorticity: "s^-1",
+      updraft_helicity: "m^2/s^2",
+      total_condensate: "g/kg",
+      reflectivity: "dBZ",
+      accumulated_rain: "mm",
+    },
+    evidence_kind: {},
+    states: variation ? ["Rising", "Condensate present"] : ["Rising", "Rotating"],
+    distance_to_primary_updraft_km: 0,
+  };
+  return {
+    schema_version: "supercells_explore_v1",
+    authority_state: "supercells_product_world",
+    world_id: "supercells",
+    simulation_id: simulationId,
+    run_id:
+      simulationId === REFERENCE_ID
+        ? "quarter-circle-supercell-presentation-v1-20260723"
+        : "straight-line-supercell-presentation-v1-20260726",
+    case_id:
+      simulationId === REFERENCE_ID
+        ? "cm1_r21_1_quarter_circle_supercell_presentation_v1"
+        : "cm1_r21_1_straight_line_supercell_presentation_v1",
+    simulation_label:
+      simulationId === REFERENCE_ID
+        ? "Quarter-Circle Supercell"
+        : "Straight-Line Hodograph Supercell",
+    lens_id: lens,
+    lens_name: cloudLens
+      ? "Cloud and Precipitation"
+      : lowLevelLens
+        ? "Low-Level Interactions"
+        : "Rotating Updraft",
+    lens_question: cloudLens
+      ? "How are cloud and precipitation organized?"
+      : lowLevelLens
+        ? "How do near-surface ascent, descent, and rain interact?"
+        : "Where is the storm rising and rotating as one organized structure?",
+    what_to_notice_now: "Compare coordinates and local evidence without assigning feature lineage.",
+    time_index: timeIndex,
+    time_seconds: TIMES[timeIndex],
+    times_seconds: TIMES,
+    mature_checkpoint_indices: [25, 37, 50, 75, 90],
+    timeline_checkpoints: [],
+    viewport: "storm",
+    viewport_bounds_km: { x_min: -38, x_max: 22, y_min: -28, y_max: 32 },
+    primary_updraft: {
+      x_index: selected.x_index,
+      y_index: selected.y_index,
+      z_index: selected.z_index,
+      x_km: selected.x_km,
+      y_km: selected.y_km,
+      z_km: selected.z_km,
+      w_m_s: selected.values.vertical_velocity,
+    },
+    selected_point: selected,
+    plan: {
+      title: cloudLens
+        ? "Cloud and precipitation structure"
+        : lowLevelLens
+          ? "Low-level motion and rain footprint"
+          : "Midlevel updraft and rotation",
+      subtitle: "Native-grid evidence in the translating model frame",
+      x_indices: x.map((_, index) => index * 7),
+      y_indices: y.map((_, index) => index * 7),
+      x_km: x,
+      y_km: y,
+      level_index: selected.z_index,
+      level_km: selected.z_km,
+      selection_z_indices: cloudLens ? matrix(y.length, x.length, () => 10) : null,
+      primary,
+      overlays: planOverlays,
+      categories,
+      wind_vectors: [],
+    },
+    xz_section: section("xz", x, z, sectionPrimary, sectionOverlays, categories, selected.y_km),
+    yz_section: section("yz", y, z, sectionPrimary, sectionOverlays, categories, selected.x_km),
+    scene: {
+      coordinate_extents_km: {
+        x: { min: -38, max: 22 },
+        y: { min: -28, max: 32 },
+        z: { min: 0.1667, max: 19.8333 },
+      },
+      coordinate_sizes: { x: 120, y: 120, z: 60 },
+      coordinate_indices: {
+        x: x.map((_, index) => index),
+        y: y.map((_, index) => index),
+        z: z.map((_, index) => index),
+      },
+      coordinate_values_km: { x, y, z },
+      layers: [
+        {
+          key: "storm_cloud_body",
+          display_name: "Storm cloud body",
+          units: "g/kg",
+          evidence_kind: "derived",
+          source_fields: ["qc", "qr", "qi", "qs", "qg"],
+          derivation: "total condensate",
+          rendering: "neutral_cloud",
+          points: scenePoints(variation),
+          source_count: 256,
+          returned_count: 256,
+          threshold_label: "0.05 g/kg",
+          default_visible: true,
+          default_opacity: 0.22,
+          default_point_size: 4.5,
+          scale: null,
+          categories: [],
+        },
+      ],
+      wind_vectors: [],
+      wind_reference_m_s: 25,
+      point_budget: 20_000,
+      source_history_file: `cm1out_${String(timeIndex + 1).padStart(6, "0")}.nc`,
+    },
+    caveats: ["Storm-object lineage is not inferred between Simulations."],
+    provenance: { source: "mocked native-grid acceptance fixture" },
+    extraction_milliseconds: variation ? 16 : 14,
+  };
+}
+
+function section(
+  orientation: "xz" | "yz",
+  horizontal: number[],
+  z: number[],
+  primary: ReturnType<typeof field>,
+  overlays: Record<string, ReturnType<typeof field>>,
+  categories: FrameCategories,
+  coordinate: number,
+) {
+  return {
+    orientation,
+    title: `${orientation} native section`,
+    horizontal_dimension: orientation === "xz" ? "x" : "y",
+    horizontal_indices: horizontal.map((_, index) => index * 7),
+    horizontal_km: horizontal,
+    z_km: z,
+    cross_section_coordinate_km: coordinate,
+    primary,
+    overlays,
+    categories,
+  };
+}
+
+function field(
+  key: string,
+  displayName: string,
+  units: string,
+  values: number[][],
+  scale: typeof W_SCALE | typeof CONDENSATE_SCALE,
+) {
+  const flattened = values.flat();
+  return {
+    key,
+    display_name: displayName,
+    units,
+    evidence_kind: "native",
+    source_fields: [key],
+    derivation: null,
+    values,
+    selected_frame_minimum: Math.min(...flattened),
+    selected_frame_maximum: Math.max(...flattened),
+    scale,
+  };
+}
+
+function overlayField(
+  key: string,
+  displayName: string,
+  units: string,
+  values: number[][],
+  scale: typeof W_SCALE | typeof CONDENSATE_SCALE,
+) {
+  return {
+    ...field(key, displayName, units, values, scale),
+    evidence_kind: "derived",
+    derivation: "mocked deterministic overlay",
+  };
+}
+
+function matrix(rows: number, columns: number, value: (row: number, column: number) => number) {
+  return Array.from({ length: rows }, (_, row) =>
+    Array.from({ length: columns }, (_, column) => value(row, column)),
+  );
+}
+
+function coordinates(count: number, minimum: number, maximum: number) {
+  return Array.from(
+    { length: count },
+    (_, index) => minimum + (index / Math.max(1, count - 1)) * (maximum - minimum),
+  );
+}
+
+function stormValue(x: number, y: number, variation: boolean, lowLevel: boolean) {
+  const centerX = variation ? -5 : -11;
+  const centerY = variation ? 4 : 8;
+  const updraft = 24 * gaussian(x, y, centerX, centerY, 7, 9);
+  const descent = -13 * gaussian(x, y, centerX + 9, centerY - 4, 9, 11);
+  const secondary = variation ? 10 * gaussian(x, y, 7, -7, 7, 8) : 0;
+  return (lowLevel ? 0.55 : 1) * (updraft + descent + secondary);
+}
+
+function sectionValue(horizontal: number, z: number, variation: boolean) {
+  const center = variation ? -5 : -11;
+  const primary = 25 * gaussian(horizontal, z, center, 6.5, 7, 4);
+  const descent = -12 * gaussian(horizontal, z, center + 10, 5.5, 8, 5);
+  return primary + descent;
+}
+
+function gaussian(
+  x: number,
+  y: number,
+  centerX: number,
+  centerY: number,
+  spreadX: number,
+  spreadY: number,
+) {
+  return Math.exp(
+    -(
+      ((x - centerX) * (x - centerX)) / (2 * spreadX * spreadX) +
+      ((y - centerY) * (y - centerY)) / (2 * spreadY * spreadY)
+    ),
+  );
+}
+
+function scenePoints(variation: boolean): Array<[number, number, number, number, number]> {
+  return Array.from({ length: 256 }, (_, index) => {
+    const angle = (index / 32) * Math.PI * 2;
+    const ring = 3 + (index % 8);
+    return [
+      (variation ? -5 : -11) + Math.cos(angle) * ring,
+      (variation ? 4 : 8) + Math.sin(angle) * ring,
+      1 + (index % 18) * 0.65,
+      0.2 + (index % 12) * 0.15,
+      0,
+    ];
+  });
+}
+
+async function horizontalOverflow(page: Page) {
+  return page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+}

--- a/app/frontend/e2e/mocked-smoke/supercells-compare.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/supercells-compare.spec.ts
@@ -82,12 +82,39 @@ test.describe("mocked smoke: real Supercells Compare adapter", () => {
     await page.getByRole("button", { name: "Aligned" }).click();
     await expect(page.getByLabel("Vertical velocity legend")).toHaveCount(2);
     await expect(page.getByLabel("Quarter-Circle Supercell saved output time")).toBeVisible();
+
+    const left = page.getByLabel("Quarter-Circle Supercell comparison side");
+    const right = page.getByLabel("Straight-Line Hodograph Supercell comparison side");
+    await left.getByRole("button", { name: "3-D", exact: true }).click();
+    await right.getByRole("button", { name: "3-D", exact: true }).click();
+    await expect(page.locator(".true3d-canvas")).toHaveCount(2);
+    await expect
+      .poll(() =>
+        page.locator(".true3d-canvas").evaluateAll((canvases) =>
+          canvases.map((canvas) => ({
+            width: (canvas as HTMLCanvasElement).width,
+            height: (canvas as HTMLCanvasElement).height,
+          })),
+        ),
+      )
+      .toEqual([
+        expect.objectContaining({ width: expect.any(Number), height: expect.any(Number) }),
+        expect.objectContaining({ width: expect.any(Number), height: expect.any(Number) }),
+      ]);
+    const canvasDimensions = await page.locator(".true3d-canvas").evaluateAll((canvases) =>
+      canvases.map((canvas) => ({
+        width: (canvas as HTMLCanvasElement).width,
+        height: (canvas as HTMLCanvasElement).height,
+      })),
+    );
+    expect(canvasDimensions.every(({ width, height }) => width >= 400 && height >= 280)).toBe(true);
+    await left.getByRole("button", { name: "Horizontal x-y", exact: true }).click();
+    await right.getByRole("button", { name: "Horizontal x-y", exact: true }).click();
     await page.screenshot({
       path: "test-results/supercells-compare-preview-1728x1117.png",
       fullPage: true,
     });
 
-    const left = page.getByLabel("Quarter-Circle Supercell comparison side");
     await left.getByRole("button", { name: "Cloud and Precipitation" }).click();
     await expect(page.getByLabel("Hydrometeor legend")).toHaveCount(2);
     await left.getByRole("button", { name: "Low-Level Interactions" }).click();

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -4401,9 +4401,137 @@ const tradeCumulusWorldDetail = {
     featured_comparison: true,
     lab: true,
     saved_views: false,
-    ordinary_compare: false,
+    ordinary_compare: true,
   },
   caveats: [],
+};
+
+const tradeCumulusCompareDescriptor = {
+  schema_version: "world_compare_v1",
+  world_id: "trade_cumulus",
+  display_name: "Trade Cumulus",
+  simulations: [
+    {
+      simulation_id: "trade_cumulus_canonical_bomex",
+      display_name: "Canonical BOMEX Baseline",
+      world_id: "trade_cumulus",
+      role: "reference",
+      run_id: comparisonBaselineResultCard.run_id,
+      result_id: comparisonBaselineResultCard.result_id,
+      case_id: "bomex_trade_cumulus_baseline_v0",
+      parent_simulation_id: null,
+      reference_simulation_id: null,
+      lineage_state: "canonical",
+      availability_state: "available",
+      availability_message: "Available",
+      inspectable: true,
+      grid: {
+        topology: "native_3d",
+        nx: 96,
+        ny: 96,
+        nz: 100,
+        dx_m: 66.67,
+        dy_m: 66.67,
+        dz_m: 30,
+        x_extent_km: [-3.2, 3.2],
+        y_extent_km: [-3.2, 3.2],
+        z_extent_km: [0, 3],
+      },
+      time: {
+        times_seconds: [0, 60, 120],
+        start_seconds: 0,
+        end_seconds: 120,
+        cadence_seconds: 60,
+        saved_output_count: 3,
+        interpolation_allowed: false,
+      },
+      available_field_ids: ["ql"],
+      available_view_ids: ["field", "updraft_lens"],
+      fixed_scale_ids: ["trade_cumulus_updraft_velocity_v1"],
+      plane_orientations: ["horizontal", "vertical_x", "vertical_y"],
+      camera_mapping: "normalized_3d",
+      initial_state: { world_id: "trade_cumulus" },
+      caveats: [],
+    },
+    {
+      simulation_id: "trade_cumulus_more_moisture",
+      display_name: "More Moisture",
+      world_id: "trade_cumulus",
+      role: "variation",
+      run_id: comparisonMoreResultCard.run_id,
+      result_id: comparisonMoreResultCard.result_id,
+      case_id: "bomex_trade_cumulus_baseline_v0",
+      parent_simulation_id: "trade_cumulus_canonical_bomex",
+      reference_simulation_id: "trade_cumulus_canonical_bomex",
+      lineage_state: "known",
+      availability_state: "available",
+      availability_message: "Available",
+      inspectable: true,
+      grid: {
+        topology: "native_3d",
+        nx: 96,
+        ny: 96,
+        nz: 100,
+        dx_m: 66.67,
+        dy_m: 66.67,
+        dz_m: 30,
+        x_extent_km: [-3.2, 3.2],
+        y_extent_km: [-3.2, 3.2],
+        z_extent_km: [0, 3],
+      },
+      time: {
+        times_seconds: [0, 60, 120],
+        start_seconds: 0,
+        end_seconds: 120,
+        cadence_seconds: 60,
+        saved_output_count: 3,
+        interpolation_allowed: false,
+      },
+      available_field_ids: ["ql"],
+      available_view_ids: ["field", "updraft_lens"],
+      fixed_scale_ids: ["trade_cumulus_updraft_velocity_v1"],
+      plane_orientations: ["horizontal", "vertical_x", "vertical_y"],
+      camera_mapping: "normalized_3d",
+      initial_state: { world_id: "trade_cumulus" },
+      caveats: [],
+    },
+  ],
+  default_left_simulation_id: "trade_cumulus_canonical_bomex",
+  default_right_simulation_id: "trade_cumulus_more_moisture",
+  selected_left_simulation_id: "trade_cumulus_canonical_bomex",
+  selected_right_simulation_id: "trade_cumulus_more_moisture",
+  material_differences: [
+    {
+      path: "surface_moisture_flux",
+      label: "Surface moisture supply",
+      category: "atmospheric",
+      left_value: 0.052,
+      right_value: 0.078,
+      left_known: true,
+      right_known: true,
+      units: "g/kg m/s",
+      material: true,
+    },
+  ],
+  compatibility: {
+    same_world: true,
+    both_inspectable: true,
+    relationship: "Reference and approved variation",
+    controlled_pair: true,
+    controlled_pair_message: "Surface moisture supply is the declared material difference.",
+    shared_field_ids: ["ql"],
+    shared_view_ids: ["field", "updraft_lens"],
+    shared_fixed_scale_ids: ["trade_cumulus_updraft_velocity_v1"],
+    exact_time_link_available: true,
+    nearest_time_link_available: true,
+    time_tolerance_seconds: 30,
+    physical_plane_link_available: true,
+    camera_link_available: true,
+    selection_link_available: true,
+    blockers: [],
+  },
+  no_second_simulation_message: null,
+  persistence: "transient_only",
 };
 
 function mockWorldScopedApp(storyStatus = 200) {
@@ -4417,6 +4545,11 @@ function mockWorldScopedApp(storyStatus = 200) {
     if (url === "/api/worlds/trade-cumulus") {
       return Promise.resolve(
         new Response(JSON.stringify(tradeCumulusWorldDetail), { status: 200 }),
+      );
+    }
+    if (url.startsWith("/api/worlds/trade-cumulus/compare")) {
+      return Promise.resolve(
+        new Response(JSON.stringify(tradeCumulusCompareDescriptor), { status: 200 }),
       );
     }
     return (
@@ -4780,13 +4913,13 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Open Comparison" }));
     expect(
-      await screen.findByLabelText("More Moisture versus Baseline workspace"),
+      await screen.findByRole("heading", {
+        name: "Review the two Simulations before loading frames",
+      }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { name: "Trade Cumulus: Baseline and More Moisture" }),
-    ).toBeInTheDocument();
-    expect(screen.getAllByText("0.052 g/kg m/s")).toHaveLength(2);
-    expect(screen.getAllByText("0.078 g/kg m/s")).toHaveLength(2);
+    expect(screen.getByText("Surface moisture supply")).toBeInTheDocument();
+    expect(screen.getByText("0.0520 g/kg m/s")).toBeInTheDocument();
+    expect(screen.getByText("0.0780 g/kg m/s")).toBeInTheDocument();
     expect(screen.queryByText(/g\/g m\/s/)).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Back to Trade Cumulus" }));
     expect(
@@ -4833,16 +4966,18 @@ describe("App", () => {
     expect(screen.queryByText(/Select an ingested result/)).not.toBeInTheDocument();
   });
 
-  it("fails closed when World Comparison availability disagrees with the story endpoint", async () => {
+  it("opens ordinary Compare even when the retired featured-story endpoint is unavailable", async () => {
     mockWorldScopedApp(409);
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Enter Trade Cumulus" }));
     fireEvent.click(await screen.findByRole("button", { name: "Open Comparison" }));
 
     expect(
-      await screen.findByText("The featured Comparison evidence is inconsistent."),
+      await screen.findByRole("heading", {
+        name: "Review the two Simulations before loading frames",
+      }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText("More Moisture versus Baseline workspace")).toBeInTheDocument();
+    expect(screen.getByText("Reference and approved variation")).toBeInTheDocument();
     expect(screen.queryByLabelText("Selected Explore result")).not.toBeInTheDocument();
   });
 

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -4720,6 +4720,65 @@ describe("App", () => {
     expect(screen.getByRole("heading", { name: secondObservedResult.name })).toBeInTheDocument();
   });
 
+  it("recovers a stale Soundings Explore URL into the empty Explore landing", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/fun-with-soundings/explore/result-deleted-soundings-run",
+    );
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/results") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ results: [] }), { status: 200 }),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "No Soundings Experiment is ready to explore yet",
+      }),
+    ).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/fun-with-soundings");
+    expect(screen.getByRole("button", { name: "5 Explore" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("keeps the empty Explore tab inside the Soundings workbench", async () => {
+    mockWorldScopedApp();
+    const defaultFetch = vi.mocked(fetch).getMockImplementation();
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/results") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ results: [] }), { status: 200 }),
+        );
+      }
+      return (
+        defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
+      );
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: "Open Fun With Soundings" }));
+    fireEvent.click(await screen.findByRole("button", { name: "5 Explore" }));
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "No Soundings Experiment is ready to explore yet",
+      }),
+    ).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/fun-with-soundings");
+    expect(screen.getByRole("button", { name: "View current runs" })).toBeInTheDocument();
+  });
+
   it("reports a non-Soundings global runner without claiming it as Soundings work", async () => {
     mockWorldScopedApp();
     const worldRun = {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -66,6 +66,8 @@ import {
   updraftLensBoundaryPath,
   updraftLensColor,
 } from "./UpdraftLensSlice";
+import { WorldCompare } from "./WorldCompare";
+import type { CompareWorldSlug } from "./WorldCompare.types";
 
 type ControlOption = {
   value: string;
@@ -1369,6 +1371,12 @@ function soundingsExploreResultIdFromPath(pathname: string): string | null {
 type WorldExploreContext =
   | { kind: "simulation"; displayName: string }
   | { kind: "lab_result"; displayName: string };
+type WorldCompareNavigation = {
+  worldSlug: CompareWorldSlug;
+  leftSimulationId: string | null;
+  rightSimulationId: string | null;
+  resumeExistingState: boolean;
+};
 type ScenarioLoadState = "loading" | "loaded" | "failed" | "empty";
 
 type ProvenancePayload = {
@@ -2480,7 +2488,13 @@ export function App() {
   const [worldLabSection, setWorldLabSection] = useState<TradeCumulusLabSection>("results");
   const [worldDetail, setWorldDetail] = useState<TradeCumulusWorldDetail | null>(null);
   const [worldExploreContext, setWorldExploreContext] = useState<WorldExploreContext | null>(null);
-  const [worldComparisonStatus, setWorldComparisonStatus] = useState<string | null>(null);
+  const [worldCompareNavigation, setWorldCompareNavigation] =
+    useState<WorldCompareNavigation>({
+      worldSlug: "trade-cumulus",
+      leftSimulationId: null,
+      rightSimulationId: null,
+      resumeExistingState: false,
+    });
   const [activeSection, setActiveSection] = useState<WorkspaceSection>("results");
   const [scenarios, setScenarios] = useState<Scenario[]>([]);
   const [selectedScenarioId, setSelectedScenarioId] = useState(OBSERVED_SOUNDING_EXPERIMENT_ID);
@@ -4029,34 +4043,74 @@ export function App() {
     enterWorldExplore(simulation.result_id, simulation);
   }
 
-  async function openWorldComparison() {
+  function openWorldComparison(
+    worldSlug: CompareWorldSlug = "trade-cumulus",
+    leftSimulationId: string | null = null,
+    rightSimulationId: string | null = null,
+    resumeExistingState = false,
+  ) {
     setComparisonStoryActive(false);
-    setWorldComparisonStatus("Loading featured Comparison...");
+    setWorldCompareNavigation({
+      worldSlug,
+      leftSimulationId,
+      rightSimulationId,
+      resumeExistingState,
+    });
     setProductLocation("comparison");
-    const comparison = comparisonStory
-      ? { story: comparisonStory, status: null }
-      : await fetchTradeCumulusComparisonStory();
-    setComparisonStory(comparison.story);
-    setComparisonStoryStatus(comparison.status);
-    if (!comparison.story) {
-      setComparisonStoryMemberIds([]);
-      setWorldComparisonStatus(
-        comparison.status ?? "The featured Comparison is currently unavailable.",
+  }
+
+  async function openCompareSimulation(worldSlug: CompareWorldSlug, simulationId: string) {
+    if (worldSlug === "trade-cumulus") {
+      const simulation = worldDetail?.simulations.find(
+        (candidate) => candidate.simulation_id === simulationId,
       );
+      if (simulation) await openWorldSimulation(simulation);
       return;
     }
-    setComparisonStoryMemberIds([
-      comparison.story.baseline.result_id,
-      comparison.story.more_moisture.result_id,
-    ]);
-    setComparisonStoryActive(true);
-    setWorldComparisonStatus(null);
+    if (worldSlug === "mountain-waves") {
+      const response = await fetch("/api/worlds/mountain-waves");
+      if (!response.ok) return;
+      const world = (await response.json()) as {
+        simulations: MountainWavesSimulation[];
+      };
+      const simulation = world.simulations.find(
+        (candidate) => candidate.simulation_id === simulationId,
+      );
+      if (simulation) {
+        setMountainWavesSimulation(simulation);
+        setProductLocation("mountain-explore");
+      }
+      return;
+    }
+    const response = await fetch("/api/worlds/supercells");
+    if (!response.ok) return;
+    const world = (await response.json()) as {
+      simulations: SupercellSimulation[];
+    };
+    const simulation = world.simulations.find(
+      (candidate) => candidate.simulation_id === simulationId,
+    );
+    if (simulation) {
+      setSupercellSimulation(simulation);
+      setProductLocation("supercells-explore");
+    }
+  }
+
+  function returnFromWorldCompare() {
+    if (worldCompareNavigation.worldSlug === "mountain-waves") {
+      setProductLocation("mountain-world");
+      return;
+    }
+    if (worldCompareNavigation.worldSlug === "supercells") {
+      setProductLocation("supercells-world");
+      return;
+    }
+    returnToTradeCumulus();
   }
 
   function returnToTradeCumulus() {
     setComparisonStoryActive(false);
     setWorldExploreContext(null);
-    setWorldComparisonStatus(null);
     setProductLocation("world");
   }
 
@@ -4551,10 +4605,8 @@ export function App() {
   );
 
   const worldContextName =
-    productLocation === "comparison"
-      ? "More Moisture versus Baseline"
-      : (worldExploreContext?.displayName ??
-        worldSimulationDisplayName(selectedResult?.result_id, selectedResult?.name));
+    worldExploreContext?.displayName ??
+    worldSimulationDisplayName(selectedResult?.result_id, selectedResult?.name);
   const labResultContext =
     productLocation === "explore" && worldExploreContext?.kind === "lab_result";
   const activeWorldSimulation =
@@ -4565,8 +4617,25 @@ export function App() {
       : null;
   const activeResultAssetPath =
     storageInventory?.runs.find((run) => run.run_id === selectedResult?.run_id)?.path ?? null;
+  const worldCompareTargetId = (() => {
+    if (!activeWorldSimulation || !worldDetail) return null;
+    const featuredComparison = worldDetail.featured_comparison;
+    if (
+      activeWorldSimulation.simulation_id ===
+      featuredComparison.baseline_simulation_id
+    ) {
+      return featuredComparison.more_moisture_simulation_id;
+    }
+    if (
+      activeWorldSimulation.simulation_id ===
+      featuredComparison.more_moisture_simulation_id
+    ) {
+      return featuredComparison.baseline_simulation_id;
+    }
+    return activeWorldSimulation.compare_suggestions?.[0]?.target_simulation_id ?? null;
+  })();
   const worldCompareAvailable = Boolean(
-    activeWorldSimulation?.compare_suggestions.length &&
+    worldCompareTargetId &&
     worldDetail?.featured_comparison.open_available,
   );
   const selectedAtmosphere = selectedAtmosphereSummary(
@@ -4584,6 +4653,7 @@ export function App() {
     <main
       className={`app-shell${
         productLocation === "explore" ||
+        productLocation === "comparison" ||
         productLocation === "mountain-explore" ||
         productLocation === "supercells-explore" ||
         productLocation === "soundings-explore"
@@ -4648,7 +4718,14 @@ export function App() {
           onLabSectionChange={setWorldLabSection}
           onBackToWorlds={() => setProductLocation("worlds")}
           onExploreSimulation={openWorldSimulation}
-          onOpenFeaturedComparison={openWorldComparison}
+          onOpenFeaturedComparison={(simulation) =>
+            openWorldComparison(
+              "trade-cumulus",
+              simulation?.simulation_id ?? null,
+              simulation?.compare_suggestions?.[0]?.target_simulation_id ?? null,
+              false,
+            )
+          }
           onWorldDetailChange={setWorldDetail}
           buildContent={buildWorkspace}
           resultsContent={resultsWorkspace}
@@ -4662,6 +4739,13 @@ export function App() {
             setMountainWavesSimulation(simulation);
             setProductLocation("mountain-explore");
           }}
+          onCompareSimulation={(simulation, targetSimulationId) =>
+            openWorldComparison(
+              "mountain-waves",
+              simulation.simulation_id,
+              targetSimulationId,
+            )
+          }
         />
       )}
 
@@ -4673,6 +4757,13 @@ export function App() {
           <MountainWavesExplore
             simulation={mountainWavesSimulation}
             onBack={() => setProductLocation("mountain-world")}
+            onCompare={() =>
+              openWorldComparison(
+                "mountain-waves",
+                mountainWavesSimulation.simulation_id,
+                mountainWavesSimulation.parent_simulation_id,
+              )
+            }
           />
         </section>
       )}
@@ -4684,6 +4775,12 @@ export function App() {
             setSupercellSimulation(simulation);
             setProductLocation("supercells-explore");
           }}
+          onCompare={() =>
+            openWorldComparison(
+              "supercells",
+              "supercells_quarter_circle_reference",
+            )
+          }
         />
       )}
 
@@ -4695,6 +4792,9 @@ export function App() {
           <SupercellsExplore
             simulation={supercellSimulation}
             onBack={() => setProductLocation("supercells-world")}
+            onCompare={() =>
+              openWorldComparison("supercells", supercellSimulation.simulation_id)
+            }
           />
         </section>
       )}
@@ -4730,51 +4830,52 @@ export function App() {
         </section>
       )}
 
-      {(productLocation === "explore" || productLocation === "comparison") && (
+      {productLocation === "comparison" && (
+        <section className="world-context-workspace" aria-label="World Compare workspace">
+          <WorldCompare
+            worldSlug={worldCompareNavigation.worldSlug}
+            initialLeftSimulationId={worldCompareNavigation.leftSimulationId}
+            initialRightSimulationId={worldCompareNavigation.rightSimulationId}
+            resumeExistingState={worldCompareNavigation.resumeExistingState}
+            onBack={returnFromWorldCompare}
+            onOpenSimulation={(simulationId) =>
+              void openCompareSimulation(worldCompareNavigation.worldSlug, simulationId)
+            }
+          />
+        </section>
+      )}
+
+      {productLocation === "explore" && (
         <section
           className="world-context-workspace"
           aria-label={`${worldContextName}${labResultContext ? " Lab result" : ""} workspace`}
         >
-          {productLocation === "comparison" && (
-            <header className="world-context-header">
-              <nav className="world-breadcrumb" aria-label="Breadcrumb">
-                <button type="button" onClick={() => setProductLocation("worlds")}>
-                  Cloud Worlds
-                </button>
-                <span aria-hidden="true">/</span>
-                <button type="button" onClick={returnToTradeCumulus}>
-                  Trade Cumulus
-                </button>
-                <span aria-hidden="true">/</span>
-                <span>{worldContextName}</span>
-              </nav>
-              <button type="button" onClick={returnToTradeCumulus}>
-                Back to Trade Cumulus
-              </button>
-            </header>
-          )}
-          {productLocation === "comparison" && (!comparisonStoryActive || !comparisonStory) ? (
-            <section className="status-panel" role="status">
-              <p>{worldComparisonStatus ?? "Loading featured Comparison..."}</p>
-            </section>
-          ) : (
-            <ExploreWorkspace
-              selectedResult={selectedResult}
-              comparisonStory={productLocation === "comparison" ? comparisonStory : null}
-              onBackToResults={returnToTradeCumulus}
-              onOpenResult={(resultId) => {
-                selectOrdinaryResult(resultId);
-                enterWorldExplore(resultId);
-              }}
-              worldName={labResultContext ? "Trade Cumulus Lab" : "Trade Cumulus"}
-              simulationName={worldContextName}
-              simulationRecord={activeWorldSimulation}
-              assetPath={activeResultAssetPath}
-              backLabel={labResultContext ? "Back to Lab Results" : "Back to Trade Cumulus"}
-              onBack={labResultContext ? returnToLabResults : returnToTradeCumulus}
-              onCompare={worldCompareAvailable ? () => void openWorldComparison() : undefined}
-            />
-          )}
+          <ExploreWorkspace
+            selectedResult={selectedResult}
+            comparisonStory={null}
+            onBackToResults={returnToTradeCumulus}
+            onOpenResult={(resultId) => {
+              selectOrdinaryResult(resultId);
+              enterWorldExplore(resultId);
+            }}
+            worldName={labResultContext ? "Trade Cumulus Lab" : "Trade Cumulus"}
+            simulationName={worldContextName}
+            simulationRecord={activeWorldSimulation}
+            assetPath={activeResultAssetPath}
+            backLabel={labResultContext ? "Back to Lab Results" : "Back to Trade Cumulus"}
+            onBack={labResultContext ? returnToLabResults : returnToTradeCumulus}
+            onCompare={
+              worldCompareAvailable && activeWorldSimulation
+                ? () =>
+                    openWorldComparison(
+                      "trade-cumulus",
+                      activeWorldSimulation.simulation_id,
+                      worldCompareTargetId,
+                      true,
+                    )
+                : undefined
+            }
+          />
         </section>
       )}
     </main>

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -2572,6 +2572,7 @@ export function App() {
   const [ingestedResultId, setIngestedResultId] = useState<string | null>(null);
   const [results, setResults] = useState<ResultCard[]>([]);
   const [selectedResultId, setSelectedResultId] = useState<string | null>(null);
+  const [initialResultsLoadComplete, setInitialResultsLoadComplete] = useState(false);
   const selectedResultIdRef = useRef<string | null>(null);
   const worldResultOwnershipRef = useRef<WorldResultOwnershipIndex>(EMPTY_WORLD_RESULT_OWNERSHIP);
   const worldOwnershipLoadStartedRef = useRef(false);
@@ -2661,6 +2662,7 @@ export function App() {
           return current ?? prioritized[0]?.result_id ?? null;
         });
         setResultsStatus(payload.results.length > 0 ? "Results loaded" : "No ingested results");
+        setInitialResultsLoadComplete(true);
       })
       .catch((caught: unknown) => {
         if (!active) return;
@@ -2673,6 +2675,7 @@ export function App() {
         setComparisonStoryActive(false);
         setResultsError(caught instanceof Error ? caught.message : "Could not load results.");
         setResultsStatus("Results unavailable");
+        setInitialResultsLoadComplete(true);
       });
     fetchTradeCumulusComparisonStory().then((comparison) => {
       if (!active || resultsFailed) return;
@@ -2793,6 +2796,19 @@ export function App() {
   const selectedSoundingsExploreResult = soundingsExploreResults.find(
     (result) => result.result_id === selectedResultId,
   );
+
+  useEffect(() => {
+    if (
+      productLocation !== "soundings-explore" ||
+      !initialResultsLoadComplete ||
+      selectedSoundingsExploreResult
+    ) {
+      return;
+    }
+    setSoundingsSection("explore");
+    setProductLocation("soundings");
+    window.history.replaceState({ productLocation: "soundings" }, "", "/fun-with-soundings");
+  }, [initialResultsLoadComplete, productLocation, selectedSoundingsExploreResult]);
 
   useEffect(() => {
     selectedResultIdRef.current = selectedResultId;
@@ -4806,7 +4822,12 @@ export function App() {
             selectedSoundingsExploreResult?.name ?? "Soundings Explore"
           } atmospheric experiment workspace`}
         >
-          {selectedSoundingsExploreResult ? (
+          {!initialResultsLoadComplete ? (
+            <ScenarioStatePanel
+              title="Loading Soundings Explore"
+              body="Cloud Chamber is checking the retained Soundings experiment inventory."
+            />
+          ) : selectedSoundingsExploreResult ? (
             <ExploreWorkspace
               selectedResult={selectedSoundingsExploreResult}
               comparisonStory={null}

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -4791,12 +4791,7 @@ export function App() {
             setSupercellSimulation(simulation);
             setProductLocation("supercells-explore");
           }}
-          onCompare={() =>
-            openWorldComparison(
-              "supercells",
-              "supercells_quarter_circle_reference",
-            )
-          }
+          onCompare={(simulation) => openWorldComparison("supercells", simulation.simulation_id)}
         />
       )}
 

--- a/app/frontend/src/MountainWavesExplore.tsx
+++ b/app/frontend/src/MountainWavesExplore.tsx
@@ -35,15 +35,18 @@ import type { MountainWavesSimulation } from "./MountainWavesWorld";
 import { SimulationNotes } from "./SimulationNotes";
 import { scalarPointPixelSize } from "./True3DViewer.utils";
 
-type MountainWaveField =
+export type MountainWaveField =
   | "w"
   | "theta_perturbation"
   | "cloud_liquid"
   | "relative_humidity"
   | "cloud_over_wave";
-type ViewMode = "field" | "structure" | "cloud";
-type GeometryMode = "expanded" | "physical";
-type ViewportMode = "focus" | "full";
+export type MountainWavesViewMode = "field" | "structure" | "cloud";
+export type MountainWavesGeometryMode = "expanded" | "physical";
+export type MountainWavesViewportMode = "focus" | "full";
+type ViewMode = MountainWavesViewMode;
+type GeometryMode = MountainWavesGeometryMode;
+type ViewportMode = MountainWavesViewportMode;
 
 type FieldMetadata = {
   key: MountainWaveField;
@@ -116,7 +119,7 @@ type CloudOverlay = {
   maximum: number;
 };
 
-type MountainWaveFrame = {
+export type MountainWaveFrame = {
   schema_version: "mountain_waves_explore_v1";
   run_id: string;
   case_label: string;
@@ -276,9 +279,11 @@ function mountainWaveAvailableOverlayIds(frame: MountainWaveFrame | null): strin
 export function MountainWavesExplore({
   simulation,
   onBack,
+  onCompare,
 }: {
   simulation: MountainWavesSimulation;
   onBack: () => void;
+  onCompare?: () => void;
 }) {
   const initialViewId =
     mountainWavesInitialView(simulation.simulation_id) ??
@@ -1005,6 +1010,7 @@ export function MountainWavesExplore({
       worldName="Mountain Waves"
       simulationName={simulation.display_name}
       onBack={onBack}
+      onCompare={onCompare}
       onUserInteractionCapture={() => {
         if (exploreState.loading) startupUserEditedRef.current = true;
       }}
@@ -1102,7 +1108,7 @@ export function MountainWavesExplore({
               </section>
             ) : frame ? (
               <>
-                <TerrainPlot
+                <MountainWavesTerrainPlot
                   frame={frame}
                   geometryMode={geometryMode}
                   viewportMode={viewportMode ?? frame.viewport.default_mode}
@@ -1332,7 +1338,7 @@ export function MountainWavesExplore({
   );
 }
 
-function TerrainPlot({
+export function MountainWavesTerrainPlot({
   frame,
   geometryMode,
   viewportMode,
@@ -1460,18 +1466,20 @@ function TerrainPlot({
   );
 }
 
-function MountainWavesLegend({
+export function MountainWavesLegend({
   frame,
   viewMode,
   cloudPoints,
   horizontalWind,
   potentialTemperatureContours,
+  fixedScaleLabel = "Fixed across this Simulation",
 }: {
   frame: MountainWaveFrame;
   viewMode: ViewMode;
   cloudPoints: boolean;
   horizontalWind: boolean;
   potentialTemperatureContours: boolean;
+  fixedScaleLabel?: string;
 }) {
   const title =
     viewMode !== "field" || frame.field.key === "w"
@@ -1491,7 +1499,7 @@ function MountainWavesLegend({
         ))}
       </ol>
       <p>Frame min {formatSigned(frame.scale.selected_time_minimum)}</p>
-      <small>Fixed across this Simulation</small>
+      <small>{fixedScaleLabel}</small>
       {viewMode === "cloud" && cloudPoints && frame.overlay && (
         <div className="mountain-waves-cloud-key">
           <span className="mountain-waves-cloud-point-key" aria-hidden="true" />

--- a/app/frontend/src/MountainWavesWorld.tsx
+++ b/app/frontend/src/MountainWavesWorld.tsx
@@ -72,9 +72,14 @@ type LabSection = "activity" | "create" | "history";
 export function MountainWavesWorld({
   onBackToWorlds,
   onExploreSimulation,
+  onCompareSimulation,
 }: {
   onBackToWorlds: () => void;
   onExploreSimulation: (simulation: MountainWavesSimulation) => void;
+  onCompareSimulation?: (
+    simulation: MountainWavesSimulation,
+    targetSimulationId: string | null,
+  ) => void;
 }) {
   const [section, setSection] = useState<WorldSection>("overview");
   const [labSection, setLabSection] = useState<LabSection>("create");
@@ -203,6 +208,15 @@ export function MountainWavesWorld({
                   simulation={simulation}
                   onExplore={onExploreSimulation}
                   onCreateVariation={openVariation}
+                  onCompare={
+                    onCompareSimulation
+                      ? (candidate) =>
+                          onCompareSimulation(
+                            candidate,
+                            mountainWavesCompareTarget(world.simulations, candidate),
+                          )
+                      : undefined
+                  }
                 />
               ))}
           </div>
@@ -239,6 +253,15 @@ export function MountainWavesWorld({
                 simulation={simulation}
                 onExplore={onExploreSimulation}
                 onCreateVariation={openVariation}
+                onCompare={
+                  onCompareSimulation
+                    ? (candidate) =>
+                        onCompareSimulation(
+                          candidate,
+                          mountainWavesCompareTarget(world.simulations, candidate),
+                        )
+                    : undefined
+                }
               />
             ))}
           </div>
@@ -351,10 +374,12 @@ function MountainWavesSimulationCard({
   simulation,
   onExplore,
   onCreateVariation,
+  onCompare,
 }: {
   simulation: MountainWavesSimulation;
   onExplore: (simulation: MountainWavesSimulation) => void;
   onCreateVariation: (simulationId: string) => void;
+  onCompare?: (simulation: MountainWavesSimulation) => void;
 }) {
   return (
     <article className="simulation-card">
@@ -410,6 +435,16 @@ function MountainWavesSimulationCard({
         >
           Explore
         </button>
+        {onCompare && (
+          <button
+            type="button"
+            className="secondary-button"
+            disabled={!simulation.inspectable}
+            onClick={() => onCompare(simulation)}
+          >
+            Compare
+          </button>
+        )}
         {simulation.can_create_variation && (
           <button
             type="button"
@@ -421,6 +456,24 @@ function MountainWavesSimulationCard({
         )}
       </div>
     </article>
+  );
+}
+
+function mountainWavesCompareTarget(
+  simulations: MountainWavesSimulation[],
+  simulation: MountainWavesSimulation,
+): string | null {
+  if (simulation.parent_simulation_id) return simulation.parent_simulation_id;
+  const child = simulations.find(
+    (candidate) =>
+      candidate.inspectable && candidate.parent_simulation_id === simulation.simulation_id,
+  );
+  if (child) return child.simulation_id;
+  return (
+    simulations.find(
+      (candidate) =>
+        candidate.inspectable && candidate.simulation_id !== simulation.simulation_id,
+    )?.simulation_id ?? null
   );
 }
 

--- a/app/frontend/src/StormExaminationResearch.tsx
+++ b/app/frontend/src/StormExaminationResearch.tsx
@@ -152,7 +152,10 @@ export type StormExaminationFrame = {
   schema_version: "storm_examination_gate_c_v1" | "supercells_explore_v1";
   authority_state: "issue_418_gate_c_research_not_product" | "supercells_product_world";
   world_id: "supercells" | null;
-  simulation_id: "supercells_quarter_circle_reference" | null;
+  simulation_id:
+    | "supercells_quarter_circle_reference"
+    | "supercells_straight_line_hodograph"
+    | null;
   run_id: string;
   case_id: string;
   simulation_label: string;

--- a/app/frontend/src/SupercellsExplore.test.tsx
+++ b/app/frontend/src/SupercellsExplore.test.tsx
@@ -91,6 +91,8 @@ const simulation: SupercellSimulation = {
   world_id: "supercells",
   run_id: "quarter-circle-supercell-presentation-v1-20260723",
   case_id: "cm1_r21_1_quarter_circle_supercell_presentation_v1",
+  parent_simulation_id: null,
+  reference_simulation_id: "supercells_quarter_circle_reference",
   technical_state: "available",
   technical_state_message: "Available",
   explore_available: true,

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -1701,7 +1701,7 @@ function SupercellExplanation({
         ) : undefined
       }
       orientation={[
-        { label: "Simulation", value: "Quarter-Circle Supercell" },
+        { label: "Simulation", value: frame?.simulation_label ?? "Supercell Simulation" },
         { label: "View", value: sliceControlLabel(evidenceView) },
         { label: "Viewport", value: viewport === "storm" ? "Storm region" : "Full domain" },
         { label: "Model time", value: formatTime(frame?.time_seconds ?? 0) },
@@ -2123,7 +2123,7 @@ async function fetchSupercellFrame(
   if (
     payload.schema_version !== "supercells_explore_v1" ||
     payload.world_id !== "supercells" ||
-    payload.simulation_id !== "supercells_quarter_circle_reference"
+    payload.simulation_id !== simulationId
   ) {
     throw new Error("Supercell frame response does not match the production World contract.");
   }

--- a/app/frontend/src/SupercellsExplore.tsx
+++ b/app/frontend/src/SupercellsExplore.tsx
@@ -187,9 +187,11 @@ function runtimeSupercellsOverlays(overlays: SupercellsExploreState["overlays"])
 export function SupercellsExplore({
   simulation,
   onBack,
+  onCompare,
 }: {
   simulation: SupercellSimulation;
   onBack: () => void;
+  onCompare?: () => void;
 }) {
   const [lens, setLens] = useState<LensId>(SUPERCELLS_INITIAL_LENS);
   const [timeIndex, setTimeIndex] = useState(simulation.default_explore_time_index);
@@ -978,6 +980,7 @@ export function SupercellsExplore({
       simulationName={simulation.display_name}
       backLabel="Back to Supercells"
       onBack={onBack}
+      onCompare={onCompare}
       onUserInteractionCapture={() => {
         if (exploreState.loading) startupUserEditedRef.current = true;
       }}

--- a/app/frontend/src/SupercellsWorld.test.tsx
+++ b/app/frontend/src/SupercellsWorld.test.tsx
@@ -8,7 +8,8 @@ const world: SupercellsWorldDetail = {
   display_name: "Supercells",
   short_description: "Inspect an evolving idealized rotating storm.",
   availability_state: "available",
-  availability_message: "The Quarter-Circle Supercell is available.",
+  availability_message:
+    "Quarter-Circle and Straight-Line Hodograph Supercells are available for Explore and Compare.",
   reference_simulation: {
     simulation_id: "supercells_quarter_circle_reference",
     display_name: "Quarter-Circle Supercell",
@@ -16,6 +17,8 @@ const world: SupercellsWorldDetail = {
     world_id: "supercells",
     run_id: "quarter-circle-supercell-presentation-v1-20260723",
     case_id: "cm1_r21_1_quarter_circle_supercell_presentation_v1",
+    parent_simulation_id: null,
+    reference_simulation_id: "supercells_quarter_circle_reference",
     technical_state: "available",
     technical_state_message: "Ninety-one retained histories are available.",
     explore_available: true,
@@ -30,12 +33,21 @@ const world: SupercellsWorldDetail = {
   capabilities: {
     reference_explore: true,
     lab: false,
-    compare: false,
+    compare: true,
     saved_views: false,
   },
   caveats: ["This idealized benchmark is not a forecast or a reconstruction of a real storm."],
 };
-world.simulations = [world.reference_simulation];
+const straightLineSimulation: SupercellsWorldDetail["simulations"][number] = {
+  ...world.reference_simulation,
+  simulation_id: "supercells_straight_line_hodograph",
+  display_name: "Straight-Line Hodograph Supercell",
+  role: "variation",
+  run_id: "straight-line-supercell-presentation-v1-20260726",
+  case_id: "cm1_r21_1_straight_line_supercell_presentation_v1",
+  parent_simulation_id: "supercells_quarter_circle_reference",
+};
+world.simulations = [world.reference_simulation, straightLineSimulation];
 
 describe("SupercellsWorld", () => {
   beforeEach(() => {
@@ -47,20 +59,32 @@ describe("SupercellsWorld", () => {
     vi.unstubAllGlobals();
   });
 
-  it("exposes only the approved Overview, Simulations, and Explore path", async () => {
+  it("exposes the real controlled pair for Explore and Compare", async () => {
     vi.mocked(fetch).mockResolvedValue(ok(world));
     const onExplore = vi.fn();
+    const onCompare = vi.fn();
     const onBack = vi.fn();
-    render(<SupercellsWorld onBackToWorlds={onBack} onExploreSimulation={onExplore} />);
+    render(
+      <SupercellsWorld
+        onBackToWorlds={onBack}
+        onExploreSimulation={onExplore}
+        onCompare={onCompare}
+      />,
+    );
 
     expect(await screen.findByRole("heading", { name: "Supercells" })).toBeInTheDocument();
     const navigation = screen.getByRole("navigation", { name: "Supercells sections" });
     expect(within(navigation).getByRole("button", { name: "Overview" })).toBeVisible();
     expect(within(navigation).getByRole("button", { name: "Simulations" })).toBeVisible();
     expect(within(navigation).queryByRole("button", { name: /Lab|Compare|Saved/ })).toBeNull();
+    expect(
+      screen.getByRole("heading", { name: "Straight-Line Hodograph Supercell" }),
+    ).toBeVisible();
 
-    fireEvent.click(screen.getByRole("button", { name: "Explore" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Explore" })[0]);
     expect(onExplore).toHaveBeenCalledWith(world.reference_simulation);
+    fireEvent.click(screen.getAllByRole("button", { name: "Compare" })[1]);
+    expect(onCompare).toHaveBeenCalledWith(straightLineSimulation);
 
     fireEvent.click(
       within(screen.getByRole("navigation", { name: "Breadcrumb" })).getByRole("button"),
@@ -73,6 +97,7 @@ describe("SupercellsWorld", () => {
       ...world,
       availability_state: "unavailable",
       availability_message: "The retained Supercell output is missing.",
+      capabilities: { ...world.capabilities, reference_explore: false, compare: false },
       reference_simulation: {
         ...world.reference_simulation,
         technical_state: "missing",
@@ -85,7 +110,19 @@ describe("SupercellsWorld", () => {
       },
       simulations: [],
     };
-    unavailable.simulations = [unavailable.reference_simulation];
+    unavailable.simulations = [
+      unavailable.reference_simulation,
+      {
+        ...straightLineSimulation,
+        technical_state: "missing",
+        technical_state_message: "The retained run directory could not be found.",
+        explore_available: false,
+        saved_output_count: 0,
+        model_start_seconds: null,
+        model_end_seconds: null,
+        history_cadence_seconds: null,
+      },
+    ];
     vi.mocked(fetch).mockResolvedValue(ok(unavailable));
     render(<SupercellsWorld onBackToWorlds={vi.fn()} onExploreSimulation={vi.fn()} />);
 

--- a/app/frontend/src/SupercellsWorld.tsx
+++ b/app/frontend/src/SupercellsWorld.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
 
 export type SupercellSimulation = {
-  simulation_id: "supercells_quarter_circle_reference";
-  display_name: "Quarter-Circle Supercell";
-  role: "reference";
+  simulation_id: "supercells_quarter_circle_reference" | "supercells_straight_line_hodograph";
+  display_name: string;
+  role: "reference" | "variation";
   world_id: "supercells";
   run_id: string;
   case_id: string;
+  parent_simulation_id: string | null;
+  reference_simulation_id: "supercells_quarter_circle_reference";
   technical_state: "available" | "missing" | "invalid";
   technical_state_message: string;
   explore_available: boolean;
@@ -29,7 +31,7 @@ export type SupercellsWorldDetail = {
   capabilities: {
     reference_explore: boolean;
     lab: false;
-    compare: false;
+    compare: boolean;
     saved_views: false;
   };
   caveats: string[];
@@ -44,7 +46,7 @@ export function SupercellsWorld({
 }: {
   onBackToWorlds: () => void;
   onExploreSimulation: (simulation: SupercellSimulation) => void;
-  onCompare?: () => void;
+  onCompare?: (simulation: SupercellSimulation) => void;
 }) {
   const [section, setSection] = useState<WorldSection>("overview");
   const [world, setWorld] = useState<SupercellsWorldDetail | null>(null);
@@ -101,7 +103,15 @@ export function SupercellsWorld({
     );
   }
 
-  const simulation = world.reference_simulation;
+  const inspectableSimulations = world.simulations.filter(
+    (simulation) => simulation.explore_available,
+  );
+  const simulations =
+    section === "overview"
+      ? inspectableSimulations.length
+        ? inspectableSimulations
+        : [world.reference_simulation]
+      : world.simulations;
   return (
     <section className="world-shell" aria-label="Supercells World">
       <WorldBreadcrumb onBackToWorlds={onBackToWorlds} />
@@ -135,19 +145,20 @@ export function SupercellsWorld({
                 : "Retained Supercell Simulations"}
             </h3>
           </div>
-          {section === "simulations" && (
-            <p>{simulation.explore_available ? "1 inspectable" : "0 inspectable"}</p>
-          )}
+          {section === "simulations" && <p>{inspectableSimulations.length} inspectable</p>}
         </div>
         {world.availability_state !== "available" && (
           <p className="world-availability-message">{world.availability_message}</p>
         )}
         <div className="simulation-card-grid supercells-simulation-grid">
-          <SupercellSimulationCard
-            simulation={simulation}
-            onExplore={onExploreSimulation}
-            onCompare={onCompare}
-          />
+          {simulations.map((simulation) => (
+            <SupercellSimulationCard
+              key={simulation.simulation_id}
+              simulation={simulation}
+              onExplore={onExploreSimulation}
+              onCompare={world.capabilities.compare ? onCompare : undefined}
+            />
+          ))}
         </div>
         {section === "overview" && <p className="world-science-note">{world.caveats[0]}</p>}
       </section>
@@ -162,13 +173,15 @@ function SupercellSimulationCard({
 }: {
   simulation: SupercellSimulation;
   onExplore: (simulation: SupercellSimulation) => void;
-  onCompare?: () => void;
+  onCompare?: (simulation: SupercellSimulation) => void;
 }) {
   return (
     <article className="simulation-card supercell-simulation-card">
       <div className="simulation-card-heading">
         <div>
-          <p className="eyebrow">Reference Simulation</p>
+          <p className="eyebrow">
+            {simulation.role === "reference" ? "Reference Simulation" : "Controlled Variation"}
+          </p>
           <h3>{simulation.display_name}</h3>
         </div>
         {simulation.technical_state !== "available" && (
@@ -208,7 +221,7 @@ function SupercellSimulationCard({
           Explore
         </button>
         {onCompare && (
-          <button type="button" className="secondary-button" onClick={onCompare}>
+          <button type="button" className="secondary-button" onClick={() => onCompare(simulation)}>
             Compare
           </button>
         )}
@@ -252,6 +265,21 @@ function validateSupercellsWorld(payload: unknown): SupercellsWorldDetail {
     typeof reference.default_explore_time_index !== "number"
   ) {
     throw new Error("Supercells reference Simulation identity is invalid.");
+  }
+  const simulationIds = new Set([
+    "supercells_quarter_circle_reference",
+    "supercells_straight_line_hodograph",
+  ]);
+  if (
+    payload.simulations.some(
+      (simulation) =>
+        !isRecord(simulation) ||
+        !simulationIds.has(String(simulation.simulation_id)) ||
+        typeof simulation.display_name !== "string" ||
+        (simulation.role !== "reference" && simulation.role !== "variation"),
+    )
+  ) {
+    throw new Error("Supercells Simulation inventory is invalid.");
   }
   return payload as SupercellsWorldDetail;
 }

--- a/app/frontend/src/SupercellsWorld.tsx
+++ b/app/frontend/src/SupercellsWorld.tsx
@@ -40,9 +40,11 @@ type WorldSection = "overview" | "simulations";
 export function SupercellsWorld({
   onBackToWorlds,
   onExploreSimulation,
+  onCompare,
 }: {
   onBackToWorlds: () => void;
   onExploreSimulation: (simulation: SupercellSimulation) => void;
+  onCompare?: () => void;
 }) {
   const [section, setSection] = useState<WorldSection>("overview");
   const [world, setWorld] = useState<SupercellsWorldDetail | null>(null);
@@ -141,7 +143,11 @@ export function SupercellsWorld({
           <p className="world-availability-message">{world.availability_message}</p>
         )}
         <div className="simulation-card-grid supercells-simulation-grid">
-          <SupercellSimulationCard simulation={simulation} onExplore={onExploreSimulation} />
+          <SupercellSimulationCard
+            simulation={simulation}
+            onExplore={onExploreSimulation}
+            onCompare={onCompare}
+          />
         </div>
         {section === "overview" && <p className="world-science-note">{world.caveats[0]}</p>}
       </section>
@@ -152,9 +158,11 @@ export function SupercellsWorld({
 function SupercellSimulationCard({
   simulation,
   onExplore,
+  onCompare,
 }: {
   simulation: SupercellSimulation;
   onExplore: (simulation: SupercellSimulation) => void;
+  onCompare?: () => void;
 }) {
   return (
     <article className="simulation-card supercell-simulation-card">
@@ -199,6 +207,11 @@ function SupercellSimulationCard({
         >
           Explore
         </button>
+        {onCompare && (
+          <button type="button" className="secondary-button" onClick={onCompare}>
+            Compare
+          </button>
+        )}
       </div>
     </article>
   );

--- a/app/frontend/src/TradeCumulusWorld.test.tsx
+++ b/app/frontend/src/TradeCumulusWorld.test.tsx
@@ -93,7 +93,7 @@ const world: TradeCumulusWorldDetail = {
     featured_comparison: true,
     lab: true,
     saved_views: false,
-    ordinary_compare: false,
+    ordinary_compare: true,
   },
   caveats: [],
 };

--- a/app/frontend/src/TradeCumulusWorld.tsx
+++ b/app/frontend/src/TradeCumulusWorld.tsx
@@ -67,7 +67,7 @@ export type TradeCumulusWorldDetail = {
     featured_comparison: boolean;
     lab: true;
     saved_views: false;
-    ordinary_compare: false;
+    ordinary_compare: true;
   };
   caveats: string[];
 };
@@ -96,7 +96,7 @@ export function TradeCumulusWorld({
 }: {
   onBackToWorlds: () => void;
   onExploreSimulation: (simulation: SimulationRecord) => void;
-  onOpenFeaturedComparison: () => void;
+  onOpenFeaturedComparison: (simulation?: SimulationRecord) => void;
   buildContent: ReactNode;
   resultsContent: ReactNode;
   section?: TradeCumulusWorldSection;
@@ -277,7 +277,7 @@ function Overview({
 }: {
   world: TradeCumulusWorldDetail;
   onExploreSimulation: (simulation: SimulationRecord) => void;
-  onOpenFeaturedComparison: () => void;
+  onOpenFeaturedComparison: (simulation?: SimulationRecord) => void;
   onOpenLab: () => void;
 }) {
   const moreMoisture = world.simulations.find(
@@ -302,14 +302,14 @@ function Overview({
           simulation={world.reference_simulation}
           comparisonAvailable={world.featured_comparison.open_available}
           onExplore={onExploreSimulation}
-          onCompare={onOpenFeaturedComparison}
+          onCompare={() => onOpenFeaturedComparison(world.reference_simulation)}
         />
         {moreMoisture && moreMoisture.technical_state !== "missing" && (
           <SimulationCard
             simulation={moreMoisture}
             comparisonAvailable={world.featured_comparison.open_available}
             onExplore={onExploreSimulation}
-            onCompare={onOpenFeaturedComparison}
+            onCompare={() => onOpenFeaturedComparison(moreMoisture)}
           />
         )}
         {comparisonMatchesReference && (
@@ -345,7 +345,7 @@ function SimulationsSection({
 }: {
   world: TradeCumulusWorldDetail;
   onExploreSimulation: (simulation: SimulationRecord) => void;
-  onOpenFeaturedComparison: () => void;
+  onOpenFeaturedComparison: (simulation?: SimulationRecord) => void;
 }) {
   return (
     <section className="world-section" aria-labelledby="world-simulations-title">
@@ -366,7 +366,7 @@ function SimulationsSection({
             simulation={simulation}
             comparisonAvailable={world.featured_comparison.open_available}
             onExplore={onExploreSimulation}
-            onCompare={onOpenFeaturedComparison}
+            onCompare={() => onOpenFeaturedComparison(simulation)}
           />
         ))}
       </div>
@@ -478,7 +478,7 @@ function ComparisonsSection({
   onOpenFeaturedComparison,
 }: {
   world: TradeCumulusWorldDetail;
-  onOpenFeaturedComparison: () => void;
+  onOpenFeaturedComparison: (simulation?: SimulationRecord) => void;
 }) {
   return (
     <section className="world-section" aria-labelledby="world-comparisons-title">
@@ -678,7 +678,7 @@ function isCapabilities(value: unknown): boolean {
     typeof value.featured_comparison === "boolean" &&
     value.lab === true &&
     value.saved_views === false &&
-    value.ordinary_compare === false
+    value.ordinary_compare === true
   );
 }
 

--- a/app/frontend/src/WorldCompare.css
+++ b/app/frontend/src/WorldCompare.css
@@ -299,9 +299,7 @@
   width: 38px;
 }
 
-.world-compare-workspace-grid
-  > .explore-inspector-collapsed
-  .explore-inspector-header {
+.world-compare-workspace-grid > .explore-inspector-collapsed .explore-inspector-header {
   justify-content: center;
   padding-inline: 3px;
   border-bottom: 0;
@@ -376,10 +374,30 @@
 }
 
 .compare-side-controls .segmented-control button,
-.compare-toolbar .segmented-control button {
+.compare-toolbar .segmented-control button,
+.compare-supercell-surface-tabs button {
   min-height: 32px;
+  border: 1px solid transparent;
+  border-radius: 4px;
   padding: 5px 8px;
+  background: transparent;
+  box-shadow: none;
+  color: var(--compare-muted);
   white-space: nowrap;
+}
+
+.compare-side-controls .segmented-control button:hover,
+.compare-side-controls .segmented-control button:focus-visible,
+.compare-toolbar .segmented-control button:hover,
+.compare-toolbar .segmented-control button:focus-visible,
+.compare-supercell-surface-tabs button:hover,
+.compare-supercell-surface-tabs button:focus-visible,
+.compare-side-controls .segmented-control .active-control,
+.compare-toolbar .segmented-control .active-control,
+.compare-supercell-surface-tabs .active-control {
+  border-color: #bdd8e8;
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
 }
 
 .compare-side-controls input[type="range"] {
@@ -487,6 +505,150 @@
   align-items: center;
   padding-top: 3px;
   border-top: 1px solid #dbe6ec;
+}
+
+.compare-supercell-view {
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 510px;
+}
+
+.compare-supercell-surface-tabs {
+  z-index: 2;
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--compare-line);
+  background: #f8fbfd;
+}
+
+.compare-supercell-surface-tabs button {
+  min-height: 31px;
+  padding: 4px 8px;
+  font-size: 0.7rem;
+}
+
+.compare-supercell-scene,
+.compare-supercell-scene .visualizer-shell,
+.compare-supercell-scene .three-d-viewer-shell {
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+}
+
+.compare-supercell-evidence {
+  display: grid;
+  grid-template-rows: minmax(350px, 1fr) auto;
+  gap: 7px;
+  min-width: 0;
+  min-height: 0;
+  padding: 9px;
+}
+
+.compare-supercell-plot {
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  min-height: 0;
+}
+
+.compare-supercell-plot .storm-plot {
+  width: auto;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  margin: auto;
+  aspect-ratio: var(--storm-data-aspect);
+}
+
+.compare-supercell-evidence > .storm-legend {
+  align-self: stretch;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 4px 9px;
+  padding: 7px 0 0;
+  border-top: 1px solid var(--compare-line);
+  border-left: 0;
+}
+
+.compare-supercell-evidence .storm-legend-heading {
+  align-self: center;
+}
+
+.compare-supercell-evidence .storm-legend-scale {
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 3px 7px;
+  margin: 0;
+}
+
+.compare-supercell-evidence .storm-legend-scale li {
+  grid-template-columns: 7px minmax(0, 1fr);
+  gap: 3px;
+  min-width: 0;
+  font-size: 0.52rem;
+}
+
+.compare-supercell-evidence .storm-legend-range {
+  align-self: center;
+  white-space: nowrap;
+}
+
+.compare-supercell-evidence .storm-legend-note {
+  align-self: center;
+}
+
+.compare-supercell-evidence .storm-overlay-key {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+  align-items: center;
+  margin: 0;
+  padding-top: 5px;
+}
+
+.compare-supercell-evidence .storm-overlay-key > div {
+  grid-template-columns: 18px auto;
+}
+
+.compare-storm-layer-controls {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 5px 12px;
+  min-width: 270px;
+}
+
+.compare-storm-layer-controls label {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  min-width: 0;
+  font-size: 0.72rem;
+}
+
+.compare-side-controls .native-slice-position-range {
+  display: grid;
+  grid-template-columns: minmax(130px, 1fr) auto;
+  gap: 6px;
+  min-width: 250px;
+}
+
+.compare-side-controls .native-slice-position-range input {
+  width: 100%;
+}
+
+.compare-side-controls .slice-position-label {
+  display: grid;
+  min-width: 86px;
+  font-size: 0.68rem;
+}
+
+.compare-side-controls .slice-position-label small {
+  color: var(--compare-muted);
+}
+
+.compare-side-controls .slice-move-buttons {
+  display: none;
 }
 
 .compare-trade-field .visualizer-shell,
@@ -648,9 +810,7 @@
     max-height: 40px;
   }
 
-  .world-compare-workspace-grid
-    > .explore-inspector-collapsed
-    .explore-inspector-header {
+  .world-compare-workspace-grid > .explore-inspector-collapsed .explore-inspector-header {
     justify-content: flex-end;
     padding-inline: 8px;
   }
@@ -733,6 +893,14 @@
 
   .compare-mountain-plot .mountain-waves-canvas-wrap {
     height: 202px;
+  }
+
+  .compare-supercell-view {
+    min-height: 460px;
+  }
+
+  .compare-supercell-evidence {
+    grid-template-rows: minmax(300px, 1fr) auto;
   }
 
   .compare-side-header {

--- a/app/frontend/src/WorldCompare.css
+++ b/app/frontend/src/WorldCompare.css
@@ -1,0 +1,757 @@
+.world-compare-shell {
+  --compare-line: #c6d8e4;
+  --compare-muted: #5f7282;
+  --compare-surface: #f8fbfd;
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.compare-pair-review {
+  display: grid;
+  gap: 16px;
+  max-width: 1280px;
+  margin: 20px auto 48px;
+  padding: 0 16px;
+}
+
+.compare-pair-review > header h3,
+.compare-pair-review > header p,
+.compare-simulation-facts h4,
+.compare-simulation-facts p,
+.compare-relationship-summary p,
+.compare-difference-preview h4,
+.compare-difference-preview p,
+.compare-compatibility-summary h4 {
+  margin: 0;
+}
+
+.compare-pair-selectors {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) 40px minmax(260px, 1fr);
+  gap: 10px;
+  align-items: end;
+}
+
+.compare-pair-selectors label,
+.compare-control-group,
+.compare-side-controls > label {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  color: #263b4b;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.compare-pair-selectors select,
+.compare-side-controls select {
+  width: 100%;
+  min-width: 0;
+  height: 36px;
+  padding: 0 30px 0 10px;
+  border: 1px solid var(--compare-line);
+  border-radius: 6px;
+  background: #fff;
+  color: #192d3c;
+}
+
+.compare-swap-button {
+  width: 40px;
+  height: 36px;
+  padding: 0;
+  font-size: 1.15rem;
+}
+
+.compare-relationship-summary,
+.compare-compatibility-summary,
+.compare-simulation-facts,
+.compare-difference-preview {
+  border: 1px solid var(--compare-line);
+  border-radius: 6px;
+  background: #fff;
+}
+
+.compare-relationship-summary {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-left: 4px solid #2f7fb4;
+}
+
+.compare-caveat-chip {
+  flex: 0 0 auto;
+  padding: 4px 7px;
+  border: 1px solid #d5a54f;
+  border-radius: 4px;
+  background: #fff8e8;
+  color: #68480e;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.compare-review-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.compare-simulation-facts {
+  padding: 14px;
+}
+
+.compare-simulation-facts dl,
+.compare-compatibility-summary dl,
+.compare-technical-details dl {
+  display: grid;
+  gap: 8px;
+  margin: 12px 0 0;
+}
+
+.compare-simulation-facts dl > div,
+.compare-compatibility-summary dl > div,
+.compare-technical-details dl > div {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.35fr) minmax(0, 1fr);
+  gap: 12px;
+  padding-top: 8px;
+  border-top: 1px solid #dde7ed;
+}
+
+.compare-simulation-facts dt,
+.compare-compatibility-summary dt,
+.compare-technical-details dt {
+  color: #263b4b;
+  font-weight: 800;
+}
+
+.compare-simulation-facts dd,
+.compare-compatibility-summary dd,
+.compare-technical-details dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--compare-muted);
+}
+
+.compare-difference-preview,
+.compare-compatibility-summary {
+  padding: 14px;
+}
+
+.compare-difference-table {
+  display: grid;
+  margin-top: 10px;
+  border-top: 1px solid #d8e4eb;
+}
+
+.compare-difference-table [role="row"] {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.65fr) repeat(2, minmax(0, 1fr));
+}
+
+.compare-difference-table [role="row"] > * {
+  min-width: 0;
+  padding: 8px 10px;
+  border-right: 1px solid #e0e8ed;
+  border-bottom: 1px solid #e0e8ed;
+  overflow-wrap: anywhere;
+}
+
+.compare-difference-table [role="row"] > :last-child {
+  border-right: 0;
+}
+
+.compare-difference-header {
+  background: #edf5f9;
+  color: #294a60;
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.compare-review-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.compare-empty-state {
+  align-self: start;
+  min-height: 0 !important;
+  max-width: 720px;
+  height: auto;
+  margin: 56px auto;
+  padding: 22px;
+  border: 1px solid var(--compare-line, #c6d8e4);
+  border-left: 4px solid #2f7fb4;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.compare-toolbar {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 10px;
+  border: 1px solid var(--compare-line);
+  border-radius: 6px;
+  background: var(--compare-surface);
+}
+
+.compare-presets {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.compare-link-controls,
+.compare-overlay-controls,
+.compare-cloud-render-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 14px;
+  align-items: center;
+}
+
+.compare-link-controls label,
+.compare-overlay-controls label,
+.compare-cloud-render-controls label {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  white-space: nowrap;
+  color: #344d5f;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.compare-cloud-render-controls label {
+  display: grid;
+  grid-template-columns: auto minmax(72px, 112px) auto;
+}
+
+.compare-cloud-render-controls output {
+  min-width: 34px;
+  color: var(--compare-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.compare-link-controls label:has(input:disabled) {
+  color: #8a98a2;
+}
+
+.compare-mapping-notices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 14px;
+  padding: 7px 10px;
+  border-left: 3px solid #c98d1d;
+  background: #fff9ea;
+  color: #604716;
+  font-size: 0.76rem;
+}
+
+.world-compare-workspace-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-width: 0;
+  border: 1px solid var(--compare-line);
+  background: #edf6fa;
+}
+
+.world-compare-workspace-grid > .explore-inspector {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  width: 320px;
+  min-width: 0;
+  max-height: 590px;
+  overflow: hidden;
+  border-left: 1px solid var(--compare-line);
+  background: #f8fbfd;
+}
+
+.world-compare-workspace-grid > .explore-inspector > div {
+  min-height: 0;
+  overflow: auto;
+}
+
+.world-compare-workspace-grid .explore-inspector-header {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 38px;
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--compare-line);
+}
+
+.world-compare-workspace-grid .explore-inspector-panel {
+  display: grid;
+  gap: 10px;
+  padding: 10px;
+}
+
+.world-compare-workspace-grid > .explore-inspector-collapsed {
+  width: 38px;
+}
+
+.world-compare-workspace-grid
+  > .explore-inspector-collapsed
+  .explore-inspector-header {
+  justify-content: center;
+  padding-inline: 3px;
+  border-bottom: 0;
+}
+
+.compare-side-pair {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  min-width: 0;
+}
+
+.compare-side-panel {
+  display: grid;
+  grid-template-rows: auto auto minmax(390px, 1fr);
+  min-width: 0;
+  min-height: 590px;
+  border-right: 1px solid var(--compare-line);
+  background: #f7fbfd;
+}
+
+.compare-side-header {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--compare-line);
+  background: #fff;
+}
+
+.compare-side-header > div {
+  min-width: 0;
+}
+
+.compare-side-header h3,
+.compare-side-header p {
+  margin: 0;
+}
+
+.compare-side-header h3 {
+  overflow: hidden;
+  font-size: 0.98rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-side-header > div > p:last-child {
+  color: var(--compare-muted);
+  font-size: 0.75rem;
+}
+
+.compare-side-header .secondary-button {
+  flex: 0 0 auto;
+  padding: 6px 8px;
+  font-size: 0.72rem;
+}
+
+.compare-side-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px 14px;
+  align-items: end;
+  min-width: 0;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--compare-line);
+  background: #f8fbfd;
+}
+
+.compare-side-controls .segmented-control {
+  display: flex;
+}
+
+.compare-side-controls .segmented-control button,
+.compare-toolbar .segmented-control button {
+  min-height: 32px;
+  padding: 5px 8px;
+  white-space: nowrap;
+}
+
+.compare-side-controls input[type="range"] {
+  width: 112px;
+}
+
+.compare-scientific-view {
+  position: relative;
+  display: grid;
+  place-items: stretch;
+  min-width: 0;
+  min-height: 390px;
+  overflow: hidden;
+  background: #e8f5fa;
+}
+
+.compare-trade-lens .updraft-lens-slice,
+.compare-mountain-view .mountain-waves-plot-column {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+}
+
+.compare-trade-lens .updraft-lens-slice {
+  min-height: 390px;
+}
+
+.compare-trade-lens {
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.compare-trade-lens .compare-plane-controls {
+  position: static;
+  inset: auto;
+  width: auto;
+  margin: 0 10px 10px;
+}
+
+.compare-mountain-plot {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 4px;
+  min-width: 0;
+  height: 390px;
+  padding: 10px;
+  contain: size layout paint;
+}
+
+.compare-mountain-plot .mountain-waves-plot-column {
+  width: auto;
+  height: 286px;
+  box-sizing: border-box;
+}
+
+.compare-mountain-plot .mountain-waves-canvas-wrap {
+  height: 238px;
+  min-height: 0;
+}
+
+.compare-mountain-plot .mountain-waves-legend {
+  align-self: stretch;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  gap: 3px 8px;
+  max-width: none;
+  padding: 5px 0 0;
+  border-top: 1px solid var(--compare-line);
+  border-left: 0;
+  font-size: 0.7rem;
+}
+
+.compare-mountain-plot .mountain-waves-legend > p {
+  align-self: center;
+  white-space: nowrap;
+}
+
+.compare-mountain-plot .mountain-waves-legend ol {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(11, minmax(0, 1fr));
+  gap: 0;
+  margin: 0;
+}
+
+.compare-mountain-plot .mountain-waves-legend li {
+  grid-template-columns: 7px minmax(0, 1fr);
+  gap: 2px;
+  min-width: 0;
+  font-size: 0.5rem;
+}
+
+.compare-mountain-plot .mountain-waves-legend li span {
+  min-height: 19px;
+}
+
+.compare-mountain-plot .mountain-waves-legend li b {
+  overflow: hidden;
+  line-height: 1.05;
+}
+
+.compare-mountain-plot .mountain-waves-lens-keys,
+.compare-mountain-plot .mountain-waves-cloud-key {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 6px 12px;
+  align-items: center;
+  padding-top: 3px;
+  border-top: 1px solid #dbe6ec;
+}
+
+.compare-trade-field .visualizer-shell,
+.compare-trade-field .three-d-viewer-shell,
+.compare-trade-field canvas {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.compare-side-loading,
+.compare-side-error {
+  position: absolute;
+  inset: auto 10px 10px;
+  z-index: 4;
+  padding: 7px 9px;
+  border: 1px solid #b7ccd9;
+  border-radius: 5px;
+  background: rgb(255 255 255 / 94%);
+  box-shadow: 0 3px 10px rgb(39 75 96 / 12%);
+  color: #314d5e;
+  font-size: 0.74rem;
+}
+
+.compare-side-error {
+  border-color: #d89b91;
+  color: #7b2b1f;
+}
+
+.compare-side-error p {
+  margin: 0 0 6px;
+}
+
+.compare-plane-controls {
+  position: absolute;
+  inset: auto 10px 10px;
+  z-index: 3;
+  width: min(440px, calc(100% - 20px));
+  padding: 7px 9px;
+  border: 1px solid #b7ccd9;
+  border-radius: 5px;
+  background: rgb(255 255 255 / 94%);
+}
+
+.compare-plane-controls input {
+  width: 100%;
+}
+
+.compare-timeline {
+  display: grid;
+  gap: 8px;
+  padding: 9px 10px;
+  border: 1px solid var(--compare-line);
+  border-radius: 6px;
+  background: #f8fbfd;
+}
+
+.compare-timeline > header {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.compare-timeline > header span {
+  color: var(--compare-muted);
+  font-size: 0.75rem;
+}
+
+.compare-timeline-rows {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.compare-timeline-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.8fr) 30px 34px 30px minmax(120px, 1.8fr) auto 58px;
+  gap: 5px;
+  align-items: center;
+  min-width: 0;
+}
+
+.compare-timeline-row > span {
+  overflow: hidden;
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-timeline-row button {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+}
+
+.compare-timeline-row input {
+  width: 100%;
+  min-width: 0;
+}
+
+.compare-timeline-row select {
+  width: 58px;
+  height: 30px;
+}
+
+.compare-technical-details {
+  padding: 9px 11px;
+  border-top: 1px solid var(--compare-line);
+  color: #425c6d;
+  font-size: 0.78rem;
+}
+
+.compare-technical-details summary {
+  cursor: pointer;
+  color: #233d4e;
+  font-weight: 800;
+}
+
+.compare-selected-evidence {
+  display: grid;
+  gap: 10px;
+}
+
+.compare-selection-empty,
+.compare-evidence-difference {
+  padding: 10px 0;
+  border-bottom: 1px solid #d4e2ea;
+}
+
+.compare-selection-empty p,
+.compare-evidence-difference p {
+  margin: 4px 0 0;
+  color: var(--compare-muted);
+}
+
+@media (max-width: 1160px) {
+  .compare-toolbar {
+    align-items: flex-start;
+  }
+
+  .compare-link-controls {
+    justify-content: flex-end;
+  }
+
+  .world-compare-workspace-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .world-compare-workspace-grid > .explore-inspector,
+  .world-compare-workspace-grid > .explore-inspector-collapsed {
+    grid-column: 1;
+    width: auto;
+    max-height: 480px;
+    border-top: 1px solid var(--compare-line);
+    border-left: 0;
+  }
+
+  .world-compare-workspace-grid > .explore-inspector-collapsed {
+    max-height: 40px;
+  }
+
+  .world-compare-workspace-grid
+    > .explore-inspector-collapsed
+    .explore-inspector-header {
+    justify-content: flex-end;
+    padding-inline: 8px;
+  }
+
+  .compare-side-panel {
+    grid-template-rows: auto auto minmax(330px, 1fr);
+    min-height: 540px;
+  }
+
+  .compare-scientific-view,
+  .compare-trade-lens .updraft-lens-slice {
+    min-height: 330px;
+  }
+
+  .compare-trade-lens .updraft-lens-slice {
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: auto auto auto;
+  }
+
+  .compare-trade-lens .updraft-lens-axis-z {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .compare-trade-lens .updraft-lens-svg {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .compare-trade-lens .updraft-lens-axis-x {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .compare-trade-lens .updraft-lens-scale-legend-2d {
+    grid-column: 1 / -1;
+    grid-row: 3;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 4px 8px;
+    padding: 6px;
+  }
+
+  .compare-trade-lens .updraft-lens-scale-heading {
+    align-self: center;
+  }
+
+  .compare-trade-lens .updraft-lens-scale-intervals,
+  .compare-trade-lens .updraft-lens-scale-legend-2d .updraft-lens-scale-intervals {
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 2px 5px;
+  }
+
+  .compare-trade-lens .updraft-lens-scale-intervals li {
+    grid-template-columns: 6px minmax(0, 1fr);
+    gap: 2px;
+    font-size: 0.5rem;
+    line-height: 1.05;
+  }
+
+  .compare-trade-lens .updraft-lens-scale-swatch {
+    width: 6px;
+    min-height: 16px;
+  }
+
+  .compare-trade-lens .updraft-lens-slice-range {
+    align-self: center;
+    padding: 0;
+    border: 0;
+    font-size: 0.55rem;
+  }
+
+  .compare-mountain-plot {
+    height: 350px;
+  }
+
+  .compare-mountain-plot .mountain-waves-plot-column {
+    height: 250px;
+  }
+
+  .compare-mountain-plot .mountain-waves-canvas-wrap {
+    height: 202px;
+  }
+
+  .compare-side-header {
+    align-items: flex-start;
+  }
+
+  .compare-side-header .secondary-button {
+    width: 32px;
+    height: 32px;
+    overflow: hidden;
+    color: transparent;
+  }
+
+  .compare-side-header .secondary-button::before {
+    content: "↗";
+    color: #286f9f;
+  }
+
+  .compare-timeline-rows {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/frontend/src/WorldCompare.css
+++ b/app/frontend/src/WorldCompare.css
@@ -529,11 +529,25 @@
 }
 
 .compare-supercell-scene,
-.compare-supercell-scene .visualizer-shell,
-.compare-supercell-scene .three-d-viewer-shell {
+.compare-supercell-scene > .true3d-viewer {
   min-width: 0;
   min-height: 0;
   height: 100%;
+}
+
+.compare-supercell-scene > .true3d-viewer {
+  grid-template-rows: minmax(0, 1fr) auto;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+}
+
+.compare-supercell-scene .true3d-scene-frame {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  border: 0;
+  border-radius: 0;
 }
 
 .compare-supercell-evidence {
@@ -673,8 +687,14 @@
 }
 
 .compare-side-error {
+  inset: 50% 16px auto;
+  transform: translateY(-50%);
   border-color: #d89b91;
   color: #7b2b1f;
+}
+
+.compare-side-error h4 {
+  margin: 0 0 3px;
 }
 
 .compare-side-error p {

--- a/app/frontend/src/WorldCompare.logic.test.ts
+++ b/app/frontend/src/WorldCompare.logic.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  MountainWavesExploreState,
+  TradeCumulusExploreState,
+} from "./ExploreStatePersistence";
+import {
+  mapCamera,
+  nearestCompareTime,
+  timeIndexForSeconds,
+  validateWorldCompareDescriptor,
+  WORLD_COMPARE_ADAPTERS,
+} from "./WorldCompare.logic";
+import type { CompareSimulationDescriptor } from "./WorldCompare.types";
+
+const commonState = {
+  state_version: 1 as const,
+  context_collapsed: true,
+  secondary_section: "notes" as const,
+  selected_point: null,
+};
+
+const tradeState: TradeCumulusExploreState = {
+  ...commonState,
+  world_id: "trade_cumulus",
+  model_time_seconds: 120,
+  view_id: "field",
+  scene_field_id: "ql",
+  slice_field_id: "ql",
+  fixed_scale_id: null,
+  active_slice_plane: "vertical_x",
+  slice_coordinate_km: 1,
+  slice_native_index: 50,
+  horizontal_slice_coordinate_km: 1,
+  threshold_native: 1e-6,
+  layer_opacity: 0.68,
+  point_size_px: 11,
+  lens_opacity: 0.9,
+  show_slice_plane: true,
+  show_cloud_boundary: false,
+  show_horizontal_wind: false,
+  wind_mode: "perturbation",
+  camera_preset: "overview",
+  camera_transform: null,
+  playback_speed: 1,
+  display_controls_open: false,
+};
+
+const mountainState: MountainWavesExploreState = {
+  ...commonState,
+  world_id: "mountain_waves",
+  model_time_seconds: 200,
+  view_id: "wave_structure",
+  field_id: "w",
+  fixed_scale_id: "mountain_waves_vertical_velocity_v1",
+  viewport_id: "focus",
+  geometry_id: "expanded",
+  overlays: {
+    cloud_points: false,
+    cloud_boundary: false,
+    saturation_contour: false,
+    horizontal_wind: true,
+    potential_temperature_contours: true,
+  },
+  cloud_opacity: 0.68,
+  cloud_point_size_px: 11,
+  playback_speed: 1,
+};
+
+function simulation(
+  updates: Partial<CompareSimulationDescriptor> = {},
+): CompareSimulationDescriptor {
+  return {
+    simulation_id: "left",
+    display_name: "Left",
+    world_id: "trade_cumulus",
+    role: "reference",
+    run_id: "left-run",
+    result_id: "left-result",
+    case_id: "case",
+    parent_simulation_id: null,
+    reference_simulation_id: null,
+    lineage_state: "known",
+    availability_state: "available",
+    availability_message: "Available",
+    inspectable: true,
+    grid: {
+      topology: "native_3d",
+      nx: 96,
+      ny: 96,
+      nz: 100,
+      dx_m: 66.67,
+      dy_m: 66.67,
+      dz_m: 30,
+      x_extent_km: [-3.2, 3.2],
+      y_extent_km: [-3.2, 3.2],
+      z_extent_km: [0, 3],
+    },
+    time: {
+      times_seconds: [0, 60, 120, 180],
+      start_seconds: 0,
+      end_seconds: 180,
+      cadence_seconds: 60,
+      saved_output_count: 4,
+      interpolation_allowed: false,
+    },
+    available_field_ids: ["ql"],
+    available_view_ids: ["field", "updraft_lens"],
+    fixed_scale_ids: ["trade_cumulus_updraft_velocity_v1"],
+    plane_orientations: ["horizontal", "vertical_x", "vertical_y"],
+    camera_mapping: "normalized_3d",
+    initial_state: tradeState,
+    caveats: [],
+    ...updates,
+  };
+}
+
+describe("World Compare adapter logic", () => {
+  it("uses exact modeled seconds and labels bounded nearest-output mappings", () => {
+    const descriptor = simulation();
+
+    expect(nearestCompareTime(descriptor, 120, 90)).toEqual({
+      value: 120,
+      exact: true,
+      message: null,
+    });
+    expect(nearestCompareTime(descriptor, 95, 30)).toEqual({
+      value: 120,
+      exact: false,
+      message: "Requested 95 s; showing nearest saved output at 120 s.",
+    });
+    expect(nearestCompareTime(descriptor, 95, 20)).toBeNull();
+    expect(timeIndexForSeconds(descriptor, 95)).toBe(2);
+  });
+
+  it("maps 3-D camera coordinates by normalized domain position", () => {
+    const source = simulation();
+    const target = simulation({
+      simulation_id: "right",
+      grid: {
+        topology: "native_3d",
+        nx: 240,
+        ny: 240,
+        nz: 60,
+        dx_m: 500,
+        dy_m: 500,
+        dz_m: 333.33,
+        x_extent_km: [-60, 60],
+        y_extent_km: [-60, 60],
+        z_extent_km: [0, 20],
+      },
+    });
+
+    expect(
+      mapCamera(
+        "overview",
+        {
+          position: [3.2, 3, 3.2],
+          target: [0, 1.5, 0],
+          up: [0, 1, 0],
+        },
+        source,
+        target,
+      ),
+    ).toEqual({
+      preset: "overview",
+      transform: {
+        position: [60, 20, 60],
+        target: [0, 10, 0],
+        up: [0, 1, 0],
+      },
+      message: "Camera mapped by normalized domain position; physical coordinates differ.",
+    });
+    expect(
+      mapCamera(
+        "overview",
+        null,
+        source,
+        simulation({
+          camera_mapping: "native_2d_xz",
+          grid: { ...source.grid, topology: "native_2d_xz", y_extent_km: null },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("reuses each World's established view semantics", () => {
+    const tradeLens = WORLD_COMPARE_ADAPTERS.trade_cumulus.setView(
+      tradeState,
+      "updraft_lens",
+    );
+    expect(tradeLens).toMatchObject({
+      view_id: "updraft_lens",
+      slice_field_id: "w",
+      fixed_scale_id: "trade_cumulus_updraft_velocity_v1",
+      show_cloud_boundary: true,
+      show_horizontal_wind: true,
+    });
+
+    const cloudLens = WORLD_COMPARE_ADAPTERS.mountain_waves.setView(
+      mountainState,
+      "wave_cloud",
+    );
+    expect(cloudLens).toMatchObject({
+      view_id: "wave_cloud",
+      field_id: "w",
+      overlays: {
+        cloud_points: true,
+        cloud_boundary: true,
+        saturation_contour: true,
+        horizontal_wind: true,
+        potential_temperature_contours: false,
+      },
+    });
+    expect(
+      WORLD_COMPARE_ADAPTERS.mountain_waves.setField(cloudLens, "relative_humidity"),
+    ).toMatchObject({
+      field_id: "relative_humidity",
+      fixed_scale_id: "mountain_waves_relative_humidity_v1",
+    });
+  });
+
+  it("rejects malformed descriptor envelopes", () => {
+    expect(() => validateWorldCompareDescriptor({})).toThrow(
+      "World Compare metadata does not match the required contract.",
+    );
+    expect(
+      validateWorldCompareDescriptor({
+        schema_version: "world_compare_v1",
+        world_id: "supercells",
+        simulations: [],
+      }),
+    ).toMatchObject({ world_id: "supercells" });
+  });
+});

--- a/app/frontend/src/WorldCompare.logic.ts
+++ b/app/frontend/src/WorldCompare.logic.ts
@@ -1,5 +1,6 @@
 import type { CameraPreset, CameraTransform } from "./True3DViewer";
 import { SUPERCELLS_CURATED_VIEWS } from "./exploreCuratedDefaults";
+import type { ExplorePoint, SupercellsExploreState } from "./ExploreStatePersistence";
 import {
   isMountainState,
   isSupercellsState,
@@ -201,7 +202,8 @@ export const WORLD_COMPARE_ADAPTERS: Record<CompareWorldId, WorldCompareAdapter>
     modelTime: (state) => state.model_time_seconds,
     setModelTime: (state, seconds) => ({ ...state, model_time_seconds: seconds }),
     selectedPoint: (state) => state.selected_point,
-    setSelectedPoint: (state, point) => ({ ...state, selected_point: point }),
+    setSelectedPoint: (state, point) =>
+      isSupercellsState(state) ? setSupercellSelectedPoint(state, point) : state,
     cameraPreset: (state) => (isSupercellsState(state) ? state.camera_preset : null),
     setCamera: (state, preset, transform) =>
       isSupercellsState(state)
@@ -210,6 +212,25 @@ export const WORLD_COMPARE_ADAPTERS: Record<CompareWorldId, WorldCompareAdapter>
     cameraTransform: (state) => (isSupercellsState(state) ? state.camera_transform : null),
   },
 };
+
+export function setSupercellSelectedPoint(
+  state: SupercellsExploreState,
+  point: ExplorePoint | null,
+): SupercellsExploreState {
+  return {
+    ...state,
+    selected_point: point,
+    selected_evidence_visible: point !== null,
+    plane_coordinate_km:
+      point === null
+        ? state.plane_coordinate_km
+        : state.evidence_view === "plan"
+          ? point.z_km
+          : state.evidence_view === "xz"
+            ? (point.y_km ?? state.plane_coordinate_km)
+            : point.x_km,
+  };
+}
 
 export function nearestCompareTime(
   descriptor: CompareSimulationDescriptor,

--- a/app/frontend/src/WorldCompare.logic.ts
+++ b/app/frontend/src/WorldCompare.logic.ts
@@ -1,0 +1,331 @@
+import type { CameraPreset, CameraTransform } from "./True3DViewer";
+import {
+  isMountainState,
+  isSupercellsState,
+  isTradeState,
+  type CompareMappingResult,
+  type CompareSimulationDescriptor,
+  type CompareWorldId,
+  type WorldCompareAdapter,
+  type WorldCompareDescriptor,
+} from "./WorldCompare.types";
+
+const TRADE_VIEW_LABELS = {
+  updraft_lens: "Updraft Lens",
+  field: "Cloud field",
+} as const;
+
+const MOUNTAIN_VIEW_LABELS = {
+  wave_structure: "Wave Structure Lens",
+  wave_cloud: "Wave Cloud Lens",
+  field: "Field",
+} as const;
+
+const SUPERCELLS_VIEW_LABELS = {
+  rotating_updraft: "Rotating Updraft",
+  cloud_precipitation: "Cloud and Precipitation",
+  low_level_interactions: "Low-Level Interactions",
+} as const;
+
+export const WORLD_COMPARE_ADAPTERS: Record<CompareWorldId, WorldCompareAdapter> = {
+  trade_cumulus: {
+    worldId: "trade_cumulus",
+    viewLabel: "View",
+    viewOptions: (simulation) =>
+      simulation.available_view_ids.map((id) => ({
+        id,
+        label: TRADE_VIEW_LABELS[id as keyof typeof TRADE_VIEW_LABELS] ?? id,
+      })),
+    viewId: (state) => (isTradeState(state) ? state.view_id : ""),
+    setView: (state, viewId) => {
+      if (!isTradeState(state) || (viewId !== "field" && viewId !== "updraft_lens")) return state;
+      return viewId === "updraft_lens"
+        ? {
+            ...state,
+            view_id: "updraft_lens",
+            scene_field_id: "ql",
+            slice_field_id: "w",
+            fixed_scale_id: "trade_cumulus_updraft_velocity_v1",
+            show_cloud_boundary: true,
+            show_horizontal_wind: true,
+          }
+        : {
+            ...state,
+            view_id: "field",
+            scene_field_id: "ql",
+            slice_field_id: "ql",
+            fixed_scale_id: null,
+          };
+    },
+    fieldId: (state) => (isTradeState(state) ? state.slice_field_id : null),
+    setField: (state, fieldId) =>
+      isTradeState(state) ? { ...state, scene_field_id: fieldId, slice_field_id: fieldId } : state,
+    modelTime: (state) => state.model_time_seconds,
+    setModelTime: (state, seconds) => ({ ...state, model_time_seconds: seconds }),
+    selectedPoint: (state) => state.selected_point,
+    setSelectedPoint: (state, point) => ({ ...state, selected_point: point }),
+    cameraPreset: (state) => (isTradeState(state) ? state.camera_preset : null),
+    setCamera: (state, preset, transform) =>
+      isTradeState(state)
+        ? { ...state, camera_preset: preset, camera_transform: transform }
+        : state,
+    cameraTransform: (state) => (isTradeState(state) ? state.camera_transform : null),
+  },
+  mountain_waves: {
+    worldId: "mountain_waves",
+    viewLabel: "View",
+    viewOptions: (simulation) =>
+      simulation.available_view_ids.map((id) => ({
+        id,
+        label: MOUNTAIN_VIEW_LABELS[id as keyof typeof MOUNTAIN_VIEW_LABELS] ?? id,
+      })),
+    viewId: (state) => (isMountainState(state) ? state.view_id : ""),
+    setView: (state, viewId) => {
+      if (
+        !isMountainState(state) ||
+        (viewId !== "field" && viewId !== "wave_structure" && viewId !== "wave_cloud")
+      ) {
+        return state;
+      }
+      if (viewId === "wave_cloud") {
+        return {
+          ...state,
+          view_id: "wave_cloud",
+          field_id: "w",
+          fixed_scale_id: "mountain_waves_vertical_velocity_v1",
+          overlays: {
+            cloud_points: true,
+            cloud_boundary: true,
+            saturation_contour: true,
+            horizontal_wind: true,
+            potential_temperature_contours: false,
+          },
+        };
+      }
+      if (viewId === "wave_structure") {
+        return {
+          ...state,
+          view_id: "wave_structure",
+          field_id: "w",
+          fixed_scale_id: "mountain_waves_vertical_velocity_v1",
+          overlays: {
+            cloud_points: false,
+            cloud_boundary: false,
+            saturation_contour: false,
+            horizontal_wind: true,
+            potential_temperature_contours: true,
+          },
+        };
+      }
+      return {
+        ...state,
+        view_id: "field",
+        overlays: {
+          cloud_points: false,
+          cloud_boundary: false,
+          saturation_contour: false,
+          horizontal_wind: false,
+          potential_temperature_contours: false,
+        },
+      };
+    },
+    fieldId: (state) => (isMountainState(state) ? state.field_id : null),
+    setField: (state, fieldId) => {
+      if (
+        !isMountainState(state) ||
+        !["w", "theta_perturbation", "cloud_liquid", "relative_humidity"].includes(fieldId)
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        field_id: fieldId as typeof state.field_id,
+        fixed_scale_id: mountainScaleId(fieldId),
+      };
+    },
+    modelTime: (state) => state.model_time_seconds,
+    setModelTime: (state, seconds) => ({ ...state, model_time_seconds: seconds }),
+    selectedPoint: (state) => state.selected_point,
+    setSelectedPoint: (state, point) => ({ ...state, selected_point: point }),
+    cameraPreset: () => null,
+    setCamera: (state) => state,
+    cameraTransform: () => null,
+  },
+  supercells: {
+    worldId: "supercells",
+    viewLabel: "Lens",
+    viewOptions: (simulation) =>
+      simulation.available_view_ids.map((id) => ({
+        id,
+        label: SUPERCELLS_VIEW_LABELS[id as keyof typeof SUPERCELLS_VIEW_LABELS] ?? id,
+      })),
+    viewId: (state) => (isSupercellsState(state) ? state.lens_id : ""),
+    setView: (state, viewId) => {
+      if (
+        !isSupercellsState(state) ||
+        !["rotating_updraft", "cloud_precipitation", "low_level_interactions"].includes(viewId)
+      ) {
+        return state;
+      }
+      return { ...state, lens_id: viewId as typeof state.lens_id };
+    },
+    fieldId: () => null,
+    setField: (state) => state,
+    modelTime: (state) => state.model_time_seconds,
+    setModelTime: (state, seconds) => ({ ...state, model_time_seconds: seconds }),
+    selectedPoint: (state) => state.selected_point,
+    setSelectedPoint: (state, point) => ({ ...state, selected_point: point }),
+    cameraPreset: (state) => (isSupercellsState(state) ? state.camera_preset : null),
+    setCamera: (state, preset, transform) =>
+      isSupercellsState(state)
+        ? { ...state, camera_preset: preset, camera_transform: transform }
+        : state,
+    cameraTransform: (state) => (isSupercellsState(state) ? state.camera_transform : null),
+  },
+};
+
+export function nearestCompareTime(
+  descriptor: CompareSimulationDescriptor,
+  requestedSeconds: number,
+  toleranceSeconds: number,
+): CompareMappingResult<number> | null {
+  const values = descriptor.time.times_seconds;
+  if (!values.length || !Number.isFinite(requestedSeconds)) return null;
+  let closest = values[0];
+  let distance = Math.abs(closest - requestedSeconds);
+  values.forEach((value) => {
+    const candidateDistance = Math.abs(value - requestedSeconds);
+    if (candidateDistance < distance) {
+      closest = value;
+      distance = candidateDistance;
+    }
+  });
+  if (distance > toleranceSeconds + Number.EPSILON) return null;
+  const exact = distance <= Number.EPSILON;
+  return {
+    value: closest,
+    exact,
+    message: exact
+      ? null
+      : `Requested ${formatSeconds(requestedSeconds)}; showing nearest saved output at ${formatSeconds(closest)}.`,
+  };
+}
+
+export function timeIndexForSeconds(
+  descriptor: CompareSimulationDescriptor,
+  seconds: number,
+): number {
+  const exactIndex = descriptor.time.times_seconds.indexOf(seconds);
+  if (exactIndex >= 0) return exactIndex;
+  const nearest = nearestCompareTime(
+    descriptor,
+    seconds,
+    Number.POSITIVE_INFINITY,
+  );
+  return nearest ? descriptor.time.times_seconds.indexOf(nearest.value) : 0;
+}
+
+export function mapCamera(
+  preset: CameraPreset,
+  transform: CameraTransform | null,
+  source: CompareSimulationDescriptor,
+  target: CompareSimulationDescriptor,
+): { preset: CameraPreset; transform: CameraTransform | null; message: string | null } | null {
+  if (source.camera_mapping !== "normalized_3d" || target.camera_mapping !== "normalized_3d") {
+    return null;
+  }
+  if (!transform) return { preset, transform: null, message: null };
+  const normalized = normalizeCameraTransform(transform, source.grid);
+  return {
+    preset,
+    transform: denormalizeCameraTransform(normalized, target.grid),
+    message: "Camera mapped by normalized domain position; physical coordinates differ.",
+  };
+}
+
+export function validateWorldCompareDescriptor(value: unknown): WorldCompareDescriptor {
+  if (
+    !isRecord(value) ||
+    value.schema_version !== "world_compare_v1" ||
+    !Array.isArray(value.simulations) ||
+    typeof value.world_id !== "string"
+  ) {
+    throw new Error("World Compare metadata does not match the required contract.");
+  }
+  return value as WorldCompareDescriptor;
+}
+
+export function worldSlug(worldId: CompareWorldId): string {
+  return worldId.replaceAll("_", "-");
+}
+
+function mountainScaleId(fieldId: string): string {
+  const values: Record<string, string> = {
+    w: "mountain_waves_vertical_velocity_v1",
+    theta_perturbation: "mountain_waves_theta_perturbation_v1",
+    cloud_liquid: "mountain_waves_cloud_liquid_v1",
+    relative_humidity: "mountain_waves_relative_humidity_v1",
+  };
+  return values[fieldId] ?? "mountain_waves_vertical_velocity_v1";
+}
+
+function normalizeCameraTransform(
+  transform: CameraTransform,
+  grid: CompareSimulationDescriptor["grid"],
+): CameraTransform {
+  return {
+    position: normalizePoint(transform.position, grid),
+    target: normalizePoint(transform.target, grid),
+    up: transform.up,
+  };
+}
+
+function denormalizeCameraTransform(
+  transform: CameraTransform,
+  grid: CompareSimulationDescriptor["grid"],
+): CameraTransform {
+  return {
+    position: denormalizePoint(transform.position, grid),
+    target: denormalizePoint(transform.target, grid),
+    up: transform.up,
+  };
+}
+
+function normalizePoint(
+  point: [number, number, number],
+  grid: CompareSimulationDescriptor["grid"],
+): [number, number, number] {
+  return [
+    normalizeAxis(point[0], grid.x_extent_km),
+    normalizeAxis(point[1], grid.z_extent_km),
+    normalizeAxis(point[2], grid.y_extent_km ?? grid.x_extent_km),
+  ];
+}
+
+function denormalizePoint(
+  point: [number, number, number],
+  grid: CompareSimulationDescriptor["grid"],
+): [number, number, number] {
+  return [
+    denormalizeAxis(point[0], grid.x_extent_km),
+    denormalizeAxis(point[1], grid.z_extent_km),
+    denormalizeAxis(point[2], grid.y_extent_km ?? grid.x_extent_km),
+  ];
+}
+
+function normalizeAxis(value: number, extent: [number, number]): number {
+  const span = extent[1] - extent[0];
+  return span ? (value - extent[0]) / span : 0.5;
+}
+
+function denormalizeAxis(value: number, extent: [number, number]): number {
+  return extent[0] + value * (extent[1] - extent[0]);
+}
+
+function formatSeconds(value: number): string {
+  return `${Math.round(value).toLocaleString()} s`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/app/frontend/src/WorldCompare.logic.ts
+++ b/app/frontend/src/WorldCompare.logic.ts
@@ -1,4 +1,5 @@
 import type { CameraPreset, CameraTransform } from "./True3DViewer";
+import { SUPERCELLS_CURATED_VIEWS } from "./exploreCuratedDefaults";
 import {
   isMountainState,
   isSupercellsState,
@@ -167,7 +168,33 @@ export const WORLD_COMPARE_ADAPTERS: Record<CompareWorldId, WorldCompareAdapter>
       ) {
         return state;
       }
-      return { ...state, lens_id: viewId as typeof state.lens_id };
+      const lensId = viewId as typeof state.lens_id;
+      const curated = SUPERCELLS_CURATED_VIEWS[lensId];
+      return {
+        ...state,
+        lens_id: lensId,
+        evidence_view: curated.evidenceOrientation,
+        plane_coordinate_km: curated.plane.coordinateKm,
+        visible_layer_ids: [...curated.visibleLayerIds],
+        fixed_scale_ids: [...curated.fixedScaleIds],
+        overlays: {
+          rotation: curated.overlays.rotation,
+          updraft_helicity: curated.overlays.updraftHelicity,
+          reflectivity: curated.overlays.reflectivity,
+          condensate: curated.overlays.condensate,
+          rain: curated.overlays.rain,
+          wind: curated.overlays.wind,
+          precipitating_condensate: curated.overlays.precipitatingCondensate,
+          vertical_motion: curated.overlays.verticalMotion,
+        },
+        hydrometeor_category_codes: [...curated.hydrometeorCategoryCodes],
+        camera_preset: curated.cameraPreset,
+        camera_transform: curated.cameraTransform,
+        scene_opacity: curated.sceneOpacity,
+        scene_point_size: curated.scenePointSize,
+        selected_point: null,
+        selected_evidence_visible: false,
+      };
     },
     fieldId: () => null,
     setField: (state) => state,
@@ -217,11 +244,7 @@ export function timeIndexForSeconds(
 ): number {
   const exactIndex = descriptor.time.times_seconds.indexOf(seconds);
   if (exactIndex >= 0) return exactIndex;
-  const nearest = nearestCompareTime(
-    descriptor,
-    seconds,
-    Number.POSITIVE_INFINITY,
-  );
+  const nearest = nearestCompareTime(descriptor, seconds, Number.POSITIVE_INFINITY);
   return nearest ? descriptor.time.times_seconds.indexOf(nearest.value) : 0;
 }
 

--- a/app/frontend/src/WorldCompare.test.tsx
+++ b/app/frontend/src/WorldCompare.test.tsx
@@ -1,0 +1,714 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ExploreWorldState,
+  MountainWavesExploreState,
+  SupercellsExploreState,
+  TradeCumulusExploreState,
+} from "./ExploreStatePersistence";
+import { WorldCompare } from "./WorldCompare";
+import type {
+  CompareSimulationDescriptor,
+  WorldCompareDescriptor,
+} from "./WorldCompare.types";
+
+vi.mock("./WorldCompareAdapters", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./WorldCompareAdapters")>();
+  return {
+    ...original,
+    WorldCompareSideVisual: (props: {
+      side: "left" | "right";
+      simulation: CompareSimulationDescriptor;
+      state: ExploreWorldState;
+      onStateChange: (state: ExploreWorldState) => void;
+      onFrameState: (side: "left" | "right", state: "ready" | "error") => void;
+      onPerformance: (sample: {
+        side: "left" | "right";
+        key: string;
+        request_ms: number;
+        payload_bytes: number;
+        cache_hit: boolean;
+      }) => void;
+      onEvidence: (
+        side: "left" | "right",
+        evidence: {
+          title: string;
+          states: string[];
+          metrics: Array<{
+            label: string;
+            value: string;
+            numericValue?: number;
+            units?: string;
+          }>;
+        } | null,
+      ) => void;
+    }) => {
+      const failed = props.simulation.simulation_id.endsWith("-failed");
+      const { onFrameState, onPerformance, side } = props;
+      useEffect(() => {
+        onFrameState(side, failed ? "error" : "ready");
+        if (!failed) {
+          onPerformance({
+            side,
+            key: `${props.simulation.simulation_id}-${props.state.model_time_seconds}`,
+            request_ms: 12,
+            payload_bytes: 1024,
+            cache_hit: false,
+          });
+        }
+      }, [
+        failed,
+        onFrameState,
+        onPerformance,
+        props.simulation.simulation_id,
+        props.state.model_time_seconds,
+        side,
+      ]);
+      if (failed) {
+        return (
+          <section role="alert" aria-label={`${props.simulation.display_name} frame failure`}>
+            This side failed without removing its partner.
+            <button type="button">Retry failed side</button>
+          </section>
+        );
+      }
+      return (
+        <section aria-label={`${props.simulation.display_name} test frame`}>
+          Native frame at {props.state.model_time_seconds} s ·{" "}
+          {"lens_id" in props.state
+            ? props.state.lens_id
+            : "view_id" in props.state
+              ? props.state.view_id
+              : "field"}
+          <button
+            type="button"
+            onClick={() => {
+              props.onStateChange({
+                ...props.state,
+                selected_point: { x_km: 1, y_km: 2, z_km: 0.5 },
+              });
+              props.onEvidence(props.side, {
+                title: `${props.simulation.display_name} selected point`,
+                states: ["Rising", "Cloudy"],
+                metrics: [
+                  { label: "Vertical velocity", value: "2.0 m/s", numericValue: 2, units: "m/s" },
+                ],
+              });
+            }}
+          >
+            Select {props.simulation.display_name} point
+          </button>
+        </section>
+      );
+    },
+  };
+});
+
+const commonState = {
+  state_version: 1 as const,
+  context_collapsed: true,
+  secondary_section: "notes" as const,
+  selected_point: null,
+};
+
+function tradeState(modelTimeSeconds: number): TradeCumulusExploreState {
+  return {
+    ...commonState,
+    world_id: "trade_cumulus",
+    model_time_seconds: modelTimeSeconds,
+    view_id: "updraft_lens",
+    scene_field_id: "ql",
+    slice_field_id: "w",
+    fixed_scale_id: "trade_cumulus_updraft_velocity_v1",
+    active_slice_plane: "vertical_x",
+    slice_coordinate_km: 1,
+    slice_native_index: 50,
+    horizontal_slice_coordinate_km: 1,
+    threshold_native: 1e-6,
+    layer_opacity: 0.68,
+    point_size_px: 11,
+    lens_opacity: 0.9,
+    show_slice_plane: true,
+    show_cloud_boundary: true,
+    show_horizontal_wind: true,
+    wind_mode: "perturbation",
+    camera_preset: "overview",
+    camera_transform: null,
+    playback_speed: 1,
+    display_controls_open: false,
+  };
+}
+
+function tradeSimulation(
+  simulationId: string,
+  displayName: string,
+  timeSeconds: number,
+): CompareSimulationDescriptor {
+  return {
+    simulation_id: simulationId,
+    display_name: displayName,
+    world_id: "trade_cumulus",
+    role: simulationId === "baseline" ? "reference" : "variation",
+    run_id: `${simulationId}-run`,
+    result_id: `${simulationId}-result`,
+    case_id: "bomex",
+    parent_simulation_id: simulationId === "baseline" ? null : "baseline",
+    reference_simulation_id: "baseline",
+    lineage_state: "known",
+    availability_state: "available",
+    availability_message: "Available",
+    inspectable: true,
+    grid: {
+      topology: "native_3d",
+      nx: 96,
+      ny: 96,
+      nz: 100,
+      dx_m: 66.67,
+      dy_m: 66.67,
+      dz_m: 30,
+      x_extent_km: [-3.2, 3.2],
+      y_extent_km: [-3.2, 3.2],
+      z_extent_km: [0, 3],
+    },
+    time: {
+      times_seconds: [0, 60, 120],
+      start_seconds: 0,
+      end_seconds: 120,
+      cadence_seconds: 60,
+      saved_output_count: 3,
+      interpolation_allowed: false,
+    },
+    available_field_ids: ["ql"],
+    available_view_ids: ["field", "updraft_lens"],
+    fixed_scale_ids: ["trade_cumulus_updraft_velocity_v1"],
+    plane_orientations: ["horizontal", "vertical_x", "vertical_y"],
+    camera_mapping: "normalized_3d",
+    initial_state: tradeState(timeSeconds),
+    caveats: [],
+  };
+}
+
+function tradeDescriptor(rightId = "moisture"): WorldCompareDescriptor {
+  const left = tradeSimulation("baseline", "Canonical BOMEX Baseline", 0);
+  const right = tradeSimulation(rightId, "More Moisture", 120);
+  return {
+    schema_version: "world_compare_v1",
+    world_id: "trade_cumulus",
+    display_name: "Trade Cumulus",
+    simulations: [left, right],
+    default_left_simulation_id: left.simulation_id,
+    default_right_simulation_id: right.simulation_id,
+    selected_left_simulation_id: left.simulation_id,
+    selected_right_simulation_id: right.simulation_id,
+    material_differences: [
+      {
+        path: "surface_moisture_flux",
+        label: "Surface moisture supply",
+        category: "atmospheric",
+        left_value: 0.052,
+        right_value: 0.078,
+        left_known: true,
+        right_known: true,
+        units: "g/kg m/s",
+        material: true,
+      },
+    ],
+    compatibility: {
+      same_world: true,
+      both_inspectable: true,
+      relationship: "More Moisture is a child of Canonical BOMEX Baseline.",
+      controlled_pair: true,
+      controlled_pair_message: "Only surface moisture supply changed.",
+      shared_field_ids: ["ql"],
+      shared_view_ids: ["field", "updraft_lens"],
+      shared_fixed_scale_ids: ["trade_cumulus_updraft_velocity_v1"],
+      exact_time_link_available: true,
+      nearest_time_link_available: true,
+      time_tolerance_seconds: 90,
+      physical_plane_link_available: true,
+      camera_link_available: true,
+      selection_link_available: true,
+      blockers: [],
+    },
+    no_second_simulation_message: null,
+    persistence: "transient_only",
+  };
+}
+
+function mountainState(
+  viewId: MountainWavesExploreState["view_id"],
+  modelTimeSeconds: number,
+): MountainWavesExploreState {
+  return {
+    ...commonState,
+    world_id: "mountain_waves",
+    model_time_seconds: modelTimeSeconds,
+    view_id: viewId,
+    field_id: "w",
+    fixed_scale_id: "mountain_waves_vertical_velocity_v1",
+    viewport_id: "focus",
+    geometry_id: "expanded",
+    overlays: {
+      cloud_points: viewId === "wave_cloud",
+      cloud_boundary: viewId === "wave_cloud",
+      saturation_contour: viewId === "wave_cloud",
+      horizontal_wind: true,
+      potential_temperature_contours: viewId === "wave_structure",
+    },
+    cloud_opacity: 0.68,
+    cloud_point_size_px: 11,
+    playback_speed: 1,
+  };
+}
+
+function mountainSimulation(
+  simulationId: string,
+  displayName: string,
+  moist: boolean,
+): CompareSimulationDescriptor {
+  return {
+    simulation_id: simulationId,
+    display_name: displayName,
+    world_id: "mountain_waves",
+    role: "built_in",
+    run_id: `${simulationId}-run`,
+    result_id: null,
+    case_id: `${simulationId}-case`,
+    parent_simulation_id: null,
+    reference_simulation_id: moist ? simulationId : null,
+    lineage_state: moist ? "known" : "independent_built_in",
+    availability_state: "available",
+    availability_message: "Available",
+    inspectable: true,
+    grid: {
+      topology: "native_2d_xz",
+      nx: moist ? 440 : 200,
+      ny: 1,
+      nz: moist ? 250 : 200,
+      dx_m: moist ? 500 : 100,
+      dy_m: moist ? 500 : 100,
+      dz_m: 100,
+      x_extent_km: moist ? [-110, 110] : [-10, 10],
+      y_extent_km: null,
+      z_extent_km: moist ? [0, 25] : [0, 20],
+    },
+    time: {
+      times_seconds: [0, 30, 60],
+      start_seconds: 0,
+      end_seconds: 60,
+      cadence_seconds: 30,
+      saved_output_count: 3,
+      interpolation_allowed: false,
+    },
+    available_field_ids: moist
+      ? ["w", "theta_perturbation", "cloud_liquid", "relative_humidity"]
+      : ["w", "theta_perturbation"],
+    available_view_ids: moist
+      ? ["field", "wave_structure", "wave_cloud"]
+      : ["field", "wave_structure"],
+    fixed_scale_ids: ["mountain_waves_vertical_velocity_v1"],
+    plane_orientations: [],
+    camera_mapping: "native_2d_xz",
+    initial_state: mountainState(moist ? "wave_cloud" : "wave_structure", 60),
+    caveats: [],
+  };
+}
+
+function mountainDescriptor(): WorldCompareDescriptor {
+  const dry = mountainSimulation(
+    "mountain_waves_dry_ridge",
+    "Dry Ridge — Wave Mechanics",
+    false,
+  );
+  const moist = mountainSimulation(
+    "mountain_waves_boulder_moist_reference",
+    "Boulder Windstorm — Moist Reference",
+    true,
+  );
+  return {
+    schema_version: "world_compare_v1",
+    world_id: "mountain_waves",
+    display_name: "Mountain Waves",
+    simulations: [dry, moist],
+    default_left_simulation_id: dry.simulation_id,
+    default_right_simulation_id: moist.simulation_id,
+    selected_left_simulation_id: dry.simulation_id,
+    selected_right_simulation_id: moist.simulation_id,
+    material_differences: [],
+    compatibility: {
+      same_world: true,
+      both_inspectable: true,
+      relationship:
+        "Both are retained built-in Mountain Waves Simulations; no controlled experimental relationship is declared.",
+      controlled_pair: false,
+      controlled_pair_message: "This is a structural comparison.",
+      shared_field_ids: ["theta_perturbation", "w"],
+      shared_view_ids: ["field", "wave_structure"],
+      shared_fixed_scale_ids: ["mountain_waves_vertical_velocity_v1"],
+      exact_time_link_available: true,
+      nearest_time_link_available: true,
+      time_tolerance_seconds: 45,
+      physical_plane_link_available: false,
+      camera_link_available: false,
+      selection_link_available: true,
+      blockers: [],
+    },
+    no_second_simulation_message: null,
+    persistence: "transient_only",
+  };
+}
+
+function supercellsState(
+  lensId: SupercellsExploreState["lens_id"],
+  modelTimeSeconds: number,
+): SupercellsExploreState {
+  return {
+    ...commonState,
+    world_id: "supercells",
+    model_time_seconds: modelTimeSeconds,
+    lens_id: lensId,
+    viewport_id: "storm",
+    evidence_view: "plan",
+    plane_coordinate_km: 3.25,
+    visible_layer_ids: ["vertical_motion"],
+    fixed_scale_ids: ["supercells_vertical_velocity_v1"],
+    overlays: {
+      rotation: true,
+      updraft_helicity: true,
+      reflectivity: false,
+      condensate: true,
+      rain: false,
+      wind: false,
+      precipitating_condensate: false,
+      vertical_motion: true,
+    },
+    hydrometeor_category_codes: [1, 2, 3, 4, 5],
+    camera_preset: "overview",
+    camera_transform: null,
+    scene_opacity: 1,
+    scene_point_size: 1,
+    selected_evidence_visible: false,
+    playback_speed: 1,
+    display_controls_open: false,
+  };
+}
+
+function supercellsSimulation(
+  simulationId: string,
+  displayName: string,
+  modelTimeSeconds: number,
+): CompareSimulationDescriptor {
+  return {
+    simulation_id: simulationId,
+    display_name: displayName,
+    world_id: "supercells",
+    role: simulationId === "reference" ? "reference" : "variation",
+    run_id: `${simulationId}-run`,
+    result_id: `${simulationId}-result`,
+    case_id: "quarter-circle",
+    parent_simulation_id: simulationId === "reference" ? null : "reference",
+    reference_simulation_id: "reference",
+    lineage_state: "known",
+    availability_state: "available",
+    availability_message: "Available",
+    inspectable: true,
+    grid: {
+      topology: "native_3d",
+      nx: 240,
+      ny: 240,
+      nz: 100,
+      dx_m: 250,
+      dy_m: 250,
+      dz_m: 200,
+      x_extent_km: [-38, 22],
+      y_extent_km: [-28, 32],
+      z_extent_km: [0, 20],
+    },
+    time: {
+      times_seconds: [0, 120, 240],
+      start_seconds: 0,
+      end_seconds: 240,
+      cadence_seconds: 120,
+      saved_output_count: 3,
+      interpolation_allowed: false,
+    },
+    available_field_ids: [],
+    available_view_ids: [
+      "rotating_updraft",
+      "cloud_precipitation",
+      "low_level_interactions",
+    ],
+    fixed_scale_ids: ["supercells_vertical_velocity_v1"],
+    plane_orientations: ["horizontal", "vertical_x", "vertical_y"],
+    camera_mapping: "normalized_3d",
+    initial_state: supercellsState("rotating_updraft", modelTimeSeconds),
+    caveats: [],
+  };
+}
+
+function supercellsFixtureDescriptor(): WorldCompareDescriptor {
+  const left = supercellsSimulation("reference", "Reference Supercell", 0);
+  const right = supercellsSimulation("fixture-variation", "Fixture Variation", 240);
+  return {
+    schema_version: "world_compare_v1",
+    world_id: "supercells",
+    display_name: "Supercells",
+    simulations: [left, right],
+    default_left_simulation_id: left.simulation_id,
+    default_right_simulation_id: right.simulation_id,
+    selected_left_simulation_id: left.simulation_id,
+    selected_right_simulation_id: right.simulation_id,
+    material_differences: [],
+    compatibility: {
+      same_world: true,
+      both_inspectable: true,
+      relationship: "Fixture Variation is a child of Reference Supercell.",
+      controlled_pair: false,
+      controlled_pair_message: "Deterministic test fixture only.",
+      shared_field_ids: [],
+      shared_view_ids: [
+        "cloud_precipitation",
+        "low_level_interactions",
+        "rotating_updraft",
+      ],
+      shared_fixed_scale_ids: ["supercells_vertical_velocity_v1"],
+      exact_time_link_available: true,
+      nearest_time_link_available: true,
+      time_tolerance_seconds: 180,
+      physical_plane_link_available: true,
+      camera_link_available: true,
+      selection_link_available: true,
+      blockers: [],
+    },
+    no_second_simulation_message: null,
+    persistence: "transient_only",
+  };
+}
+
+describe("WorldCompare", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(new Response(JSON.stringify(tradeDescriptor()), { status: 200 })),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reviews lineage and exact material differences before loading frames", async () => {
+    render(
+      <WorldCompare
+        worldSlug="trade-cumulus"
+        onBack={vi.fn()}
+        onOpenSimulation={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Review the two Simulations before loading frames",
+      }),
+    ).toBeVisible();
+    expect(screen.getByText("More Moisture is a child of Canonical BOMEX Baseline.")).toBeVisible();
+    expect(screen.getByText("0.0520 g/kg m/s")).toBeVisible();
+    expect(screen.getByText("0.0780 g/kg m/s")).toBeVisible();
+    expect(screen.queryByLabelText(/test frame/)).not.toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports aligned and independent state plus per-side selected evidence", async () => {
+    render(
+      <WorldCompare
+        worldSlug="trade-cumulus"
+        onBack={vi.fn()}
+        onOpenSimulation={vi.fn()}
+      />,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Open dual view" }));
+
+    expect(await screen.findByLabelText("Canonical BOMEX Baseline test frame")).toBeVisible();
+    expect(screen.getByLabelText("More Moisture test frame")).toHaveTextContent("120 s");
+    fireEvent.click(screen.getByRole("button", { name: "Aligned" }));
+    await waitFor(() =>
+      expect(screen.getByLabelText("More Moisture test frame")).toHaveTextContent("0 s"),
+    );
+    expect(screen.getByLabelText("Time")).toBeChecked();
+    expect(screen.getByLabelText("Field / Lens")).toBeChecked();
+
+    fireEvent.click(
+      within(screen.getByLabelText("Canonical BOMEX Baseline test frame")).getByRole("button"),
+    );
+    expect(await screen.findByLabelText("Context")).toBeVisible();
+    expect(screen.getByText("Canonical BOMEX Baseline selected point")).toBeVisible();
+    expect(screen.getByText("2.0 m/s")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Independent" }));
+    expect(screen.getByLabelText("Time")).not.toBeChecked();
+    expect(screen.getByLabelText("Field / Lens")).not.toBeChecked();
+  });
+
+  it("keeps one side usable when the other adapter fails", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(tradeDescriptor("moisture-failed")), { status: 200 }),
+    );
+    render(
+      <WorldCompare
+        worldSlug="trade-cumulus"
+        onBack={vi.fn()}
+        onOpenSimulation={vi.fn()}
+      />,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Open dual view" }));
+
+    expect(await screen.findByLabelText("Canonical BOMEX Baseline test frame")).toBeVisible();
+    expect(screen.getByLabelText("More Moisture frame failure")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Retry failed side" })).toBeVisible();
+  });
+
+  it("exposes Wave Cloud point controls only while cloud points are enabled", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(mountainDescriptor()), { status: 200 }),
+    );
+    render(
+      <WorldCompare
+        worldSlug="mountain-waves"
+        onBack={vi.fn()}
+        onOpenSimulation={vi.fn()}
+      />,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Open dual view" }));
+
+    const rightSide = await screen.findByRole("article", {
+      name: "Boulder Windstorm — Moist Reference comparison side",
+    });
+    expect(within(rightSide).getByLabelText("Cloud points")).toBeChecked();
+    expect(within(rightSide).getByLabelText("Cloud boundary")).toBeChecked();
+    expect(within(rightSide).getByLabelText("RH = 100%")).toBeChecked();
+    expect(
+      within(rightSide).getByLabelText("Boulder Windstorm — Moist Reference cloud opacity"),
+    ).toHaveValue("0.68");
+    expect(
+      within(rightSide).getByLabelText("Boulder Windstorm — Moist Reference cloud point size"),
+    ).toHaveValue("11");
+
+    fireEvent.click(within(rightSide).getByLabelText("Cloud points"));
+    expect(
+      within(rightSide).queryByLabelText("Boulder Windstorm — Moist Reference cloud opacity"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(rightSide).queryByLabelText(
+        "Boulder Windstorm — Moist Reference cloud point size",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("coordinates two deterministic Supercells fixture states through the shared shell", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(supercellsFixtureDescriptor()), { status: 200 }),
+    );
+    render(
+      <WorldCompare worldSlug="supercells" onBack={vi.fn()} onOpenSimulation={vi.fn()} />,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Open dual view" }));
+
+    expect(await screen.findByLabelText("Reference Supercell test frame")).toHaveTextContent(
+      "0 s",
+    );
+    expect(screen.getByLabelText("Fixture Variation test frame")).toHaveTextContent("240 s");
+    fireEvent.click(screen.getByRole("button", { name: "Aligned" }));
+    await waitFor(() =>
+      expect(screen.getByLabelText("Fixture Variation test frame")).toHaveTextContent("0 s"),
+    );
+    expect(screen.getByRole("checkbox", { name: /^Time$/ })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /^Field \/ Lens$/ })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /^Camera$/ })).toBeChecked();
+
+    const leftSide = screen.getByRole("article", {
+      name: "Reference Supercell comparison side",
+    });
+    fireEvent.click(
+      within(leftSide).getByRole("button", { name: "Cloud and Precipitation" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText("Fixture Variation test frame")).toHaveTextContent(
+        "cloud_precipitation",
+      ),
+    );
+
+    fireEvent.click(screen.getByText("Compare technical details", { exact: true }));
+    expect(screen.getByText(/right: 12 ms, 1.0 KB/)).toBeVisible();
+    expect(screen.getByText("transient only")).toBeVisible();
+  });
+
+  it("shows an honest no-second-Simulation state for Supercells", async () => {
+    const reference = tradeSimulation(
+      "supercells_quarter_circle_reference",
+      "Quarter-Circle Supercell",
+      0,
+    );
+    reference.world_id = "supercells";
+    reference.initial_state = {
+      ...commonState,
+      world_id: "supercells",
+      model_time_seconds: 0,
+      lens_id: "rotating_updraft",
+      viewport_id: "storm",
+      evidence_view: "plan",
+      plane_coordinate_km: 3,
+      visible_layer_ids: [],
+      fixed_scale_ids: [],
+      overlays: {
+        rotation: true,
+        updraft_helicity: true,
+        reflectivity: false,
+        condensate: true,
+        rain: false,
+        wind: false,
+        precipitating_condensate: false,
+        vertical_motion: true,
+      },
+      hydrometeor_category_codes: [1, 2, 3, 4, 5],
+      camera_preset: "overview",
+      camera_transform: null,
+      scene_opacity: 1,
+      scene_point_size: 1,
+      selected_evidence_visible: false,
+      playback_speed: 1,
+      display_controls_open: false,
+    };
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          schema_version: "world_compare_v1",
+          world_id: "supercells",
+          display_name: "Supercells",
+          simulations: [reference],
+          default_left_simulation_id: reference.simulation_id,
+          default_right_simulation_id: null,
+          selected_left_simulation_id: reference.simulation_id,
+          selected_right_simulation_id: null,
+          material_differences: [],
+          compatibility: null,
+          no_second_simulation_message:
+            "Supercells currently has one retained Simulation; it is not cloned.",
+          persistence: "transient_only",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    render(
+      <WorldCompare worldSlug="supercells" onBack={vi.fn()} onOpenSimulation={vi.fn()} />,
+    );
+
+    expect(await screen.findByLabelText("No second Simulation")).toBeVisible();
+    expect(screen.getByText(/it is not cloned/)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Open dual view" })).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/WorldCompare.test.tsx
+++ b/app/frontend/src/WorldCompare.test.tsx
@@ -9,10 +9,7 @@ import type {
   TradeCumulusExploreState,
 } from "./ExploreStatePersistence";
 import { WorldCompare } from "./WorldCompare";
-import type {
-  CompareSimulationDescriptor,
-  WorldCompareDescriptor,
-} from "./WorldCompare.types";
+import type { CompareSimulationDescriptor, WorldCompareDescriptor } from "./WorldCompare.types";
 
 vi.mock("./WorldCompareAdapters", async (importOriginal) => {
   const original = await importOriginal<typeof import("./WorldCompareAdapters")>();
@@ -74,14 +71,24 @@ vi.mock("./WorldCompareAdapters", async (importOriginal) => {
           </section>
         );
       }
+      const supercellsState = props.state.world_id === "supercells" ? props.state : null;
       return (
         <section aria-label={`${props.simulation.display_name} test frame`}>
           Native frame at {props.state.model_time_seconds} s ·{" "}
-          {"lens_id" in props.state
-            ? props.state.lens_id
+          {supercellsState
+            ? supercellsState.lens_id
             : "view_id" in props.state
               ? props.state.view_id
               : "field"}
+          {supercellsState && (
+            <span>
+              {" "}
+              · {supercellsState.evidence_view} at {supercellsState.plane_coordinate_km} km · camera{" "}
+              {supercellsState.camera_transform?.position.join(",") ??
+                supercellsState.camera_preset}{" "}
+              · selected {supercellsState.selected_point?.x_km ?? "none"}
+            </span>
+          )}
           <button
             type="button"
             onClick={() => {
@@ -100,6 +107,38 @@ vi.mock("./WorldCompareAdapters", async (importOriginal) => {
           >
             Select {props.simulation.display_name} point
           </button>
+          {supercellsState && (
+            <>
+              <button
+                type="button"
+                onClick={() =>
+                  props.onStateChange({
+                    ...supercellsState,
+                    evidence_view: "xz",
+                    plane_coordinate_km: -10,
+                  })
+                }
+              >
+                Move {props.simulation.display_name} section
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  props.onStateChange({
+                    ...supercellsState,
+                    camera_preset: "look_along_x",
+                    camera_transform: {
+                      position: [10, 12, 14],
+                      target: [1, 2, 3],
+                      up: [0, 1, 0],
+                    },
+                  })
+                }
+              >
+                Move {props.simulation.display_name} camera
+              </button>
+            </>
+          )}
         </section>
       );
     },
@@ -317,11 +356,7 @@ function mountainSimulation(
 }
 
 function mountainDescriptor(): WorldCompareDescriptor {
-  const dry = mountainSimulation(
-    "mountain_waves_dry_ridge",
-    "Dry Ridge — Wave Mechanics",
-    false,
-  );
+  const dry = mountainSimulation("mountain_waves_dry_ridge", "Dry Ridge — Wave Mechanics", false);
   const moist = mountainSimulation(
     "mountain_waves_boulder_moist_reference",
     "Boulder Windstorm — Moist Reference",
@@ -371,9 +406,9 @@ function supercellsState(
     lens_id: lensId,
     viewport_id: "storm",
     evidence_view: "plan",
-    plane_coordinate_km: 3.25,
-    visible_layer_ids: ["vertical_motion"],
-    fixed_scale_ids: ["supercells_vertical_velocity_v1"],
+    plane_coordinate_km: 3.1666669845581055,
+    visible_layer_ids: ["storm_cloud_body", "rising_core"],
+    fixed_scale_ids: ["supercell_midlevel_vertical_velocity_v1"],
     overlays: {
       rotation: true,
       updraft_helicity: true,
@@ -400,16 +435,19 @@ function supercellsSimulation(
   displayName: string,
   modelTimeSeconds: number,
 ): CompareSimulationDescriptor {
+  const reference = simulationId === "supercells_quarter_circle_reference";
   return {
     simulation_id: simulationId,
     display_name: displayName,
     world_id: "supercells",
-    role: simulationId === "reference" ? "reference" : "variation",
+    role: reference ? "reference" : "variation",
     run_id: `${simulationId}-run`,
     result_id: `${simulationId}-result`,
-    case_id: "quarter-circle",
-    parent_simulation_id: simulationId === "reference" ? null : "reference",
-    reference_simulation_id: "reference",
+    case_id: reference
+      ? "cm1_r21_1_quarter_circle_supercell_presentation_v1"
+      : "cm1_r21_1_straight_line_supercell_presentation_v1",
+    parent_simulation_id: reference ? null : "supercells_quarter_circle_reference",
+    reference_simulation_id: "supercells_quarter_circle_reference",
     lineage_state: "known",
     availability_state: "available",
     availability_message: "Available",
@@ -418,12 +456,12 @@ function supercellsSimulation(
       topology: "native_3d",
       nx: 240,
       ny: 240,
-      nz: 100,
-      dx_m: 250,
-      dy_m: 250,
-      dz_m: 200,
-      x_extent_km: [-38, 22],
-      y_extent_km: [-28, 32],
+      nz: 60,
+      dx_m: 500,
+      dy_m: 500,
+      dz_m: 333.3333333,
+      x_extent_km: [-60, 60],
+      y_extent_km: [-60, 60],
       z_extent_km: [0, 20],
     },
     time: {
@@ -434,13 +472,13 @@ function supercellsSimulation(
       saved_output_count: 3,
       interpolation_allowed: false,
     },
-    available_field_ids: [],
-    available_view_ids: [
-      "rotating_updraft",
-      "cloud_precipitation",
-      "low_level_interactions",
+    available_field_ids: ["winterp", "total_condensate"],
+    available_view_ids: ["rotating_updraft", "cloud_precipitation", "low_level_interactions"],
+    fixed_scale_ids: [
+      "supercell_midlevel_vertical_velocity_v1",
+      "supercell_total_condensate_v2",
+      "supercell_low_level_vertical_velocity_v1",
     ],
-    fixed_scale_ids: ["supercells_vertical_velocity_v1"],
     plane_orientations: ["horizontal", "vertical_x", "vertical_y"],
     camera_mapping: "normalized_3d",
     initial_state: supercellsState("rotating_updraft", modelTimeSeconds),
@@ -449,8 +487,16 @@ function supercellsSimulation(
 }
 
 function supercellsFixtureDescriptor(): WorldCompareDescriptor {
-  const left = supercellsSimulation("reference", "Reference Supercell", 0);
-  const right = supercellsSimulation("fixture-variation", "Fixture Variation", 240);
+  const left = supercellsSimulation(
+    "supercells_quarter_circle_reference",
+    "Quarter-Circle Supercell",
+    0,
+  );
+  const right = supercellsSimulation(
+    "supercells_straight_line_hodograph",
+    "Straight-Line Hodograph Supercell",
+    240,
+  );
   return {
     schema_version: "world_compare_v1",
     world_id: "supercells",
@@ -464,15 +510,11 @@ function supercellsFixtureDescriptor(): WorldCompareDescriptor {
     compatibility: {
       same_world: true,
       both_inspectable: true,
-      relationship: "Fixture Variation is a child of Reference Supercell.",
-      controlled_pair: false,
-      controlled_pair_message: "Deterministic test fixture only.",
+      relationship: "Straight-Line Hodograph Supercell is a child of Quarter-Circle Supercell.",
+      controlled_pair: true,
+      controlled_pair_message: "Only hodograph curvature changed in this controlled pair.",
       shared_field_ids: [],
-      shared_view_ids: [
-        "cloud_precipitation",
-        "low_level_interactions",
-        "rotating_updraft",
-      ],
+      shared_view_ids: ["cloud_precipitation", "low_level_interactions", "rotating_updraft"],
       shared_fixed_scale_ids: ["supercells_vertical_velocity_v1"],
       exact_time_link_available: true,
       nearest_time_link_available: true,
@@ -502,13 +544,7 @@ describe("WorldCompare", () => {
   });
 
   it("reviews lineage and exact material differences before loading frames", async () => {
-    render(
-      <WorldCompare
-        worldSlug="trade-cumulus"
-        onBack={vi.fn()}
-        onOpenSimulation={vi.fn()}
-      />,
-    );
+    render(<WorldCompare worldSlug="trade-cumulus" onBack={vi.fn()} onOpenSimulation={vi.fn()} />);
 
     expect(
       await screen.findByRole("heading", {
@@ -523,13 +559,7 @@ describe("WorldCompare", () => {
   });
 
   it("supports aligned and independent state plus per-side selected evidence", async () => {
-    render(
-      <WorldCompare
-        worldSlug="trade-cumulus"
-        onBack={vi.fn()}
-        onOpenSimulation={vi.fn()}
-      />,
-    );
+    render(<WorldCompare worldSlug="trade-cumulus" onBack={vi.fn()} onOpenSimulation={vi.fn()} />);
     fireEvent.click(await screen.findByRole("button", { name: "Open dual view" }));
 
     expect(await screen.findByLabelText("Canonical BOMEX Baseline test frame")).toBeVisible();
@@ -557,13 +587,7 @@ describe("WorldCompare", () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(JSON.stringify(tradeDescriptor("moisture-failed")), { status: 200 }),
     );
-    render(
-      <WorldCompare
-        worldSlug="trade-cumulus"
-        onBack={vi.fn()}
-        onOpenSimulation={vi.fn()}
-      />,
-    );
+    render(<WorldCompare worldSlug="trade-cumulus" onBack={vi.fn()} onOpenSimulation={vi.fn()} />);
     fireEvent.click(await screen.findByRole("button", { name: "Open dual view" }));
 
     expect(await screen.findByLabelText("Canonical BOMEX Baseline test frame")).toBeVisible();
@@ -575,13 +599,7 @@ describe("WorldCompare", () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(JSON.stringify(mountainDescriptor()), { status: 200 }),
     );
-    render(
-      <WorldCompare
-        worldSlug="mountain-waves"
-        onBack={vi.fn()}
-        onOpenSimulation={vi.fn()}
-      />,
-    );
+    render(<WorldCompare worldSlug="mountain-waves" onBack={vi.fn()} onOpenSimulation={vi.fn()} />);
     fireEvent.click(await screen.findByRole("button", { name: "Open dual view" }));
 
     const rightSide = await screen.findByRole("article", {
@@ -602,43 +620,67 @@ describe("WorldCompare", () => {
       within(rightSide).queryByLabelText("Boulder Windstorm — Moist Reference cloud opacity"),
     ).not.toBeInTheDocument();
     expect(
-      within(rightSide).queryByLabelText(
-        "Boulder Windstorm — Moist Reference cloud point size",
-      ),
+      within(rightSide).queryByLabelText("Boulder Windstorm — Moist Reference cloud point size"),
     ).not.toBeInTheDocument();
   });
 
-  it("coordinates two deterministic Supercells fixture states through the shared shell", async () => {
+  it("coordinates the controlled Supercells pair through the shared shell", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(JSON.stringify(supercellsFixtureDescriptor()), { status: 200 }),
     );
-    render(
-      <WorldCompare worldSlug="supercells" onBack={vi.fn()} onOpenSimulation={vi.fn()} />,
-    );
+    render(<WorldCompare worldSlug="supercells" onBack={vi.fn()} onOpenSimulation={vi.fn()} />);
     fireEvent.click(await screen.findByRole("button", { name: "Open dual view" }));
 
-    expect(await screen.findByLabelText("Reference Supercell test frame")).toHaveTextContent(
+    expect(await screen.findByLabelText("Quarter-Circle Supercell test frame")).toHaveTextContent(
       "0 s",
     );
-    expect(screen.getByLabelText("Fixture Variation test frame")).toHaveTextContent("240 s");
+    expect(screen.getByLabelText("Straight-Line Hodograph Supercell test frame")).toHaveTextContent(
+      "240 s",
+    );
     fireEvent.click(screen.getByRole("button", { name: "Aligned" }));
     await waitFor(() =>
-      expect(screen.getByLabelText("Fixture Variation test frame")).toHaveTextContent("0 s"),
+      expect(
+        screen.getByLabelText("Straight-Line Hodograph Supercell test frame"),
+      ).toHaveTextContent("0 s"),
     );
     expect(screen.getByRole("checkbox", { name: /^Time$/ })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: /^Field \/ Lens$/ })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: /^Camera$/ })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /^Slice plane$/ })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /^Selection$/ })).toBeChecked();
 
     const leftSide = screen.getByRole("article", {
-      name: "Reference Supercell comparison side",
+      name: "Quarter-Circle Supercell comparison side",
     });
     fireEvent.click(
-      within(leftSide).getByRole("button", { name: "Cloud and Precipitation" }),
+      within(leftSide).getByRole("button", { name: "Move Quarter-Circle Supercell section" }),
     );
     await waitFor(() =>
-      expect(screen.getByLabelText("Fixture Variation test frame")).toHaveTextContent(
-        "cloud_precipitation",
-      ),
+      expect(
+        screen.getByLabelText("Straight-Line Hodograph Supercell test frame"),
+      ).toHaveTextContent("xz at -10 km"),
+    );
+    fireEvent.click(
+      within(leftSide).getByRole("button", { name: "Move Quarter-Circle Supercell camera" }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText("Straight-Line Hodograph Supercell test frame"),
+      ).toHaveTextContent("camera 10,12,14"),
+    );
+    fireEvent.click(
+      within(leftSide).getByRole("button", { name: "Select Quarter-Circle Supercell point" }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText("Straight-Line Hodograph Supercell test frame"),
+      ).toHaveTextContent("selected 1"),
+    );
+    fireEvent.click(within(leftSide).getByRole("button", { name: "Cloud and Precipitation" }));
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText("Straight-Line Hodograph Supercell test frame"),
+      ).toHaveTextContent("cloud_precipitation"),
     );
 
     fireEvent.click(screen.getByText("Compare technical details", { exact: true }));
@@ -703,9 +745,7 @@ describe("WorldCompare", () => {
       ),
     );
 
-    render(
-      <WorldCompare worldSlug="supercells" onBack={vi.fn()} onOpenSimulation={vi.fn()} />,
-    );
+    render(<WorldCompare worldSlug="supercells" onBack={vi.fn()} onOpenSimulation={vi.fn()} />);
 
     expect(await screen.findByLabelText("No second Simulation")).toBeVisible();
     expect(screen.getByText(/it is not cloned/)).toBeVisible();

--- a/app/frontend/src/WorldCompare.test.tsx
+++ b/app/frontend/src/WorldCompare.test.tsx
@@ -86,15 +86,31 @@ vi.mock("./WorldCompareAdapters", async (importOriginal) => {
               · {supercellsState.evidence_view} at {supercellsState.plane_coordinate_km} km · camera{" "}
               {supercellsState.camera_transform?.position.join(",") ??
                 supercellsState.camera_preset}{" "}
-              · selected {supercellsState.selected_point?.x_km ?? "none"}
+              · selected{" "}
+              {supercellsState.selected_point
+                ? `${supercellsState.selected_point.x_km},${supercellsState.selected_point.y_km},${supercellsState.selected_point.z_km}`
+                : "none"}{" "}
+              · evidence {supercellsState.selected_evidence_visible ? "visible" : "hidden"}
             </span>
           )}
           <button
             type="button"
             onClick={() => {
+              const selectedPoint = { x_km: 1, y_km: 2, z_km: 0.5 };
               props.onStateChange({
                 ...props.state,
-                selected_point: { x_km: 1, y_km: 2, z_km: 0.5 },
+                selected_point: selectedPoint,
+                ...(supercellsState
+                  ? {
+                      selected_evidence_visible: true,
+                      plane_coordinate_km:
+                        supercellsState.evidence_view === "plan"
+                          ? selectedPoint.z_km
+                          : supercellsState.evidence_view === "xz"
+                            ? selectedPoint.y_km
+                            : selectedPoint.x_km,
+                    }
+                  : {}),
               });
               props.onEvidence(props.side, {
                 title: `${props.simulation.display_name} selected point`,
@@ -120,6 +136,18 @@ vi.mock("./WorldCompareAdapters", async (importOriginal) => {
                 }
               >
                 Move {props.simulation.display_name} section
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  props.onStateChange({
+                    ...supercellsState,
+                    evidence_view: "yz",
+                    plane_coordinate_km: -12,
+                  })
+                }
+              >
+                Use {props.simulation.display_name} y-z section
               </button>
               <button
                 type="button"
@@ -686,6 +714,88 @@ describe("WorldCompare", () => {
     fireEvent.click(screen.getByText("Compare technical details", { exact: true }));
     expect(screen.getByText(/right: 12 ms, 1.0 KB/)).toBeVisible();
     expect(screen.getByText("transient only")).toBeVisible();
+  });
+
+  it("moves a Supercells section without creating selected evidence", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(supercellsFixtureDescriptor()), { status: 200 }),
+    );
+    render(<WorldCompare worldSlug="supercells" onBack={vi.fn()} onOpenSimulation={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Open dual view" }));
+
+    const leftSide = await screen.findByRole("article", {
+      name: "Quarter-Circle Supercell comparison side",
+    });
+    fireEvent.change(
+      within(leftSide).getByLabelText("Quarter-Circle Supercell slice position"),
+      { target: { value: "10" } },
+    );
+
+    expect(screen.getByLabelText("Quarter-Circle Supercell test frame")).toHaveTextContent(
+      "selected none · evidence hidden",
+    );
+    expect(screen.queryByLabelText("Selected native-grid evidence")).not.toBeInTheDocument();
+  });
+
+  it("keeps linked Supercells selection coherent while plane linking is independent", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(supercellsFixtureDescriptor()), { status: 200 }),
+    );
+    render(<WorldCompare worldSlug="supercells" onBack={vi.fn()} onOpenSimulation={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Open dual view" }));
+
+    const leftSide = await screen.findByRole("article", {
+      name: "Quarter-Circle Supercell comparison side",
+    });
+    const rightSide = screen.getByRole("article", {
+      name: "Straight-Line Hodograph Supercell comparison side",
+    });
+    const selectionLink = screen.getByRole("checkbox", { name: /^Selection$/ });
+    const planeLink = screen.getByRole("checkbox", { name: /^Slice plane$/ });
+    fireEvent.click(selectionLink);
+    expect(selectionLink).toBeChecked();
+    expect(planeLink).not.toBeChecked();
+
+    fireEvent.click(
+      within(rightSide).getByRole("button", {
+        name: "Use Straight-Line Hodograph Supercell y-z section",
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText("Straight-Line Hodograph Supercell test frame"),
+      ).toHaveTextContent("yz at -12 km"),
+    );
+
+    fireEvent.click(
+      within(leftSide).getByRole("button", { name: "Select Quarter-Circle Supercell point" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Quarter-Circle Supercell test frame")).toHaveTextContent(
+        "selected 1,2,0.5 · evidence visible",
+      );
+      expect(
+        screen.getByLabelText("Straight-Line Hodograph Supercell test frame"),
+      ).toHaveTextContent("yz at 1 km");
+      expect(
+        screen.getByLabelText("Straight-Line Hodograph Supercell test frame"),
+      ).toHaveTextContent("selected 1,2,0.5 · evidence visible");
+    });
+    expect(planeLink).not.toBeChecked();
+
+    fireEvent.click(
+      within(screen.getByLabelText("Selected native-grid evidence")).getByRole("button", {
+        name: "Clear",
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Quarter-Circle Supercell test frame")).toHaveTextContent(
+        "selected none · evidence hidden",
+      );
+      expect(
+        screen.getByLabelText("Straight-Line Hodograph Supercell test frame"),
+      ).toHaveTextContent("selected none · evidence hidden");
+    });
   });
 
   it("shows an honest no-second-Simulation state for Supercells", async () => {

--- a/app/frontend/src/WorldCompare.tsx
+++ b/app/frontend/src/WorldCompare.tsx
@@ -289,11 +289,17 @@ export function WorldCompare({
         Math.max(0, index + offset),
       );
       if (nextIndex === index) return false;
-      updateSideState(side, {
-        ...current,
-        model_time_seconds: simulation.time.times_seconds[nextIndex],
-        selected_point: null,
-      });
+      const adapter = WORLD_COMPARE_ADAPTERS[descriptor.world_id];
+      updateSideState(
+        side,
+        adapter.setSelectedPoint(
+          {
+            ...current,
+            model_time_seconds: simulation.time.times_seconds[nextIndex],
+          },
+          null,
+        ),
+      );
       return true;
     },
     [descriptor, leftSimulation, rightSimulation, states, updateSideState],
@@ -448,7 +454,13 @@ export function WorldCompare({
               right={rightSimulation}
               evidence={evidence}
               onClear={(side) => {
-                updateSideState(side, { ...states[side], selected_point: null });
+                updateSideState(
+                  side,
+                  WORLD_COMPARE_ADAPTERS[descriptor.world_id].setSelectedPoint(
+                    states[side],
+                    null,
+                  ),
+                );
                 setEvidence((current) => ({ ...current, [side]: null }));
               }}
             />
@@ -951,16 +963,9 @@ function WorldSpecificControls({
             onPositionChange={(nextIndex) => {
               const coordinate = planeValues[nextIndex];
               if (!Number.isFinite(coordinate)) return;
-              const selected = state.selected_point ?? { x_km: 0, y_km: 0, z_km: 0 };
               onStateChange({
                 ...state,
                 plane_coordinate_km: coordinate,
-                selected_point:
-                  state.evidence_view === "plan"
-                    ? { ...selected, z_km: coordinate }
-                    : state.evidence_view === "xz"
-                      ? { ...selected, y_km: coordinate }
-                      : { ...selected, x_km: coordinate },
               });
             }}
             compact
@@ -1338,11 +1343,16 @@ function CompareTimeline({
                 value={index}
                 onChange={(event) => {
                   const nextIndex = Number(event.currentTarget.value);
-                  onStateChange(side, {
-                    ...state,
-                    model_time_seconds: simulation.time.times_seconds[nextIndex],
-                    selected_point: null,
-                  });
+                  onStateChange(
+                    side,
+                    WORLD_COMPARE_ADAPTERS[descriptor.world_id].setSelectedPoint(
+                      {
+                        ...state,
+                        model_time_seconds: simulation.time.times_seconds[nextIndex],
+                      },
+                      null,
+                    ),
+                  );
                 }}
               />
               <strong>{formatSeconds(state.model_time_seconds)}</strong>

--- a/app/frontend/src/WorldCompare.tsx
+++ b/app/frontend/src/WorldCompare.tsx
@@ -7,6 +7,7 @@ import {
   ExploreSelectedEvidence,
   IntegratedExploreWorkspace,
 } from "./IntegratedExploreWorkspace";
+import { NativeSlicePositionControl } from "./NativeSlicePositionControl";
 import {
   CompareControlGroup,
   type CompareSelectedEvidence,
@@ -22,6 +23,7 @@ import {
 } from "./WorldCompare.logic";
 import {
   isMountainState,
+  isSupercellsState,
   isTradeState,
   type CompareDifference,
   type CompareLinkModes,
@@ -242,13 +244,7 @@ export function WorldCompare({
   const applyAlignedPreset = useCallback(() => {
     if (!descriptor || !states) return;
     const nextLinks = alignedLinks(descriptor);
-    const synchronized = synchronizeState(
-      descriptor,
-      "left",
-      states.left,
-      states.right,
-      nextLinks,
-    );
+    const synchronized = synchronizeState(descriptor, "left", states.left, states.right, nextLinks);
     setLinks(nextLinks);
     setStates({ left: states.left, right: synchronized.state });
     setMappingNotices(synchronized.notices);
@@ -327,22 +323,17 @@ export function WorldCompare({
   }, [descriptor?.world_id, links.view, sideScales]);
 
   const handleScale = useCallback((side: CompareSide, scale: TerrainScale | null) => {
-    setSideScales((current) =>
-      current[side] === scale ? current : { ...current, [side]: scale },
-    );
+    setSideScales((current) => (current[side] === scale ? current : { ...current, [side]: scale }));
   }, []);
 
-  const handleEvidence = useCallback(
-    (side: CompareSide, item: CompareSelectedEvidence | null) => {
-      setEvidence((current) =>
-        evidenceSignature(current[side]) === evidenceSignature(item)
-          ? current
-          : { ...current, [side]: item },
-      );
-      if (item) setContextCollapsed(false);
-    },
-    [],
-  );
+  const handleEvidence = useCallback((side: CompareSide, item: CompareSelectedEvidence | null) => {
+    setEvidence((current) =>
+      evidenceSignature(current[side]) === evidenceSignature(item)
+        ? current
+        : { ...current, [side]: item },
+    );
+    if (item) setContextCollapsed(false);
+  }, []);
 
   if (descriptorLoading) {
     return <CompareStatus title="Loading Compare" body="Reading bounded World metadata..." />;
@@ -379,7 +370,9 @@ export function WorldCompare({
     );
   }
   if (!leftSimulation || !adapter) {
-    return <CompareStatus title="Compare is unavailable" body="Simulation identity is incomplete." />;
+    return (
+      <CompareStatus title="Compare is unavailable" body="Simulation identity is incomplete." />
+    );
   }
 
   if (phase === "review" || !states) {
@@ -448,10 +441,7 @@ export function WorldCompare({
               );
             })}
           </div>
-          <ExploreInspector
-            collapsed={contextCollapsed}
-            onCollapsedChange={setContextCollapsed}
-          >
+          <ExploreInspector collapsed={contextCollapsed} onCollapsedChange={setContextCollapsed}>
             <CompareContext
               descriptor={descriptor}
               left={leftSimulation}
@@ -499,8 +489,7 @@ function ComparePairReview({
         <p className="eyebrow">Compare setup</p>
         <h3 id="compare-review-title">Review the two Simulations before loading frames</h3>
         <p>
-          Compare is transient. It does not create a Saved Comparison or change either
-          Simulation.
+          Compare is transient. It does not create a Saved Comparison or change either Simulation.
         </p>
       </header>
       <div className="compare-pair-selectors">
@@ -566,7 +555,9 @@ function ComparePairReview({
             </div>
             <div>
               <dt>Physical slice plane</dt>
-              <dd>{compatibility.physical_plane_link_available ? "Available" : "Not applicable"}</dd>
+              <dd>
+                {compatibility.physical_plane_link_available ? "Available" : "Not applicable"}
+              </dd>
             </div>
             <div>
               <dt>Camera</dt>
@@ -806,12 +797,17 @@ function CompareSidePanel({
   const currentView = adapter.viewId(state);
   const fieldOptions = simulation.available_field_ids;
   return (
-    <article className="compare-side-panel" aria-label={`${simulation.display_name} comparison side`}>
+    <article
+      className="compare-side-panel"
+      aria-label={`${simulation.display_name} comparison side`}
+    >
       <header className="compare-side-header">
         <div>
           <p className="eyebrow">{side === "left" ? "Left Simulation" : "Right Simulation"}</p>
           <h3>{simulation.display_name}</h3>
-          <p>{formatSeconds(state.model_time_seconds)} · {viewDisplayName(currentView)}</p>
+          <p>
+            {formatSeconds(state.model_time_seconds)} · {viewDisplayName(currentView)}
+          </p>
         </div>
         <button type="button" className="secondary-button" onClick={onOpen}>
           Open in Explore
@@ -837,7 +833,9 @@ function CompareSidePanel({
             <select
               aria-label={`${simulation.display_name} Field`}
               value={adapter.fieldId(state) ?? fieldOptions[0]}
-              onChange={(event) => onStateChange(adapter.setField(state, event.currentTarget.value))}
+              onChange={(event) =>
+                onStateChange(adapter.setField(state, event.currentTarget.value))
+              }
             >
               {fieldOptions.map((field) => (
                 <option key={field} value={field}>
@@ -906,6 +904,130 @@ function WorldSpecificControls({
             }
           />
         </label>
+      </>
+    );
+  }
+  if (isSupercellsState(state)) {
+    const planeValues = supercellPlaneCoordinates(simulation, state.evidence_view);
+    const positionIndex = nearestNumberIndex(planeValues, state.plane_coordinate_km);
+    const overlayOptions = supercellOverlayOptions(state.lens_id, state.evidence_view);
+    return (
+      <>
+        <CompareControlGroup label="Viewport">
+          <div className="segmented-control">
+            <button
+              type="button"
+              className={state.viewport_id === "storm" ? "active-control" : ""}
+              onClick={() => onStateChange({ ...state, viewport_id: "storm" })}
+            >
+              Storm region
+            </button>
+            <button
+              type="button"
+              className={state.viewport_id === "full" ? "active-control" : ""}
+              onClick={() => onStateChange({ ...state, viewport_id: "full" })}
+            >
+              Full domain
+            </button>
+          </div>
+        </CompareControlGroup>
+        <CompareControlGroup label="Slice position">
+          <NativeSlicePositionControl
+            id={`compare-${simulation.simulation_id}-supercell-plane`}
+            ariaLabel={`${simulation.display_name} slice position`}
+            plane={
+              state.evidence_view === "plan"
+                ? "horizontal"
+                : state.evidence_view === "xz"
+                  ? "vertical_x"
+                  : "vertical_y"
+            }
+            positionIndex={positionIndex}
+            positionCount={planeValues.length}
+            positionLabel={`${supercellPlaneAxis(state.evidence_view)} ${(
+              planeValues[positionIndex] ?? 0
+            ).toFixed(2)} km`}
+            indexLabel={`native index ${positionIndex}`}
+            onPositionChange={(nextIndex) => {
+              const coordinate = planeValues[nextIndex];
+              if (!Number.isFinite(coordinate)) return;
+              const selected = state.selected_point ?? { x_km: 0, y_km: 0, z_km: 0 };
+              onStateChange({
+                ...state,
+                plane_coordinate_km: coordinate,
+                selected_point:
+                  state.evidence_view === "plan"
+                    ? { ...selected, z_km: coordinate }
+                    : state.evidence_view === "xz"
+                      ? { ...selected, y_km: coordinate }
+                      : { ...selected, x_km: coordinate },
+              });
+            }}
+            compact
+          />
+        </CompareControlGroup>
+        <CompareControlGroup label="Evidence overlays">
+          <div className="compare-overlay-controls">
+            {overlayOptions.map((option) => (
+              <label key={option.key}>
+                <input
+                  type="checkbox"
+                  checked={state.overlays[option.key]}
+                  onChange={(event) =>
+                    onStateChange({
+                      ...state,
+                      overlays: {
+                        ...state.overlays,
+                        [option.key]: event.currentTarget.checked,
+                      },
+                    })
+                  }
+                />
+                {option.label}
+              </label>
+            ))}
+          </div>
+        </CompareControlGroup>
+        <CompareControlGroup label="3-D rendering">
+          <div className="compare-cloud-render-controls">
+            <label>
+              <span>Opacity</span>
+              <input
+                type="range"
+                aria-label={`${simulation.display_name} scene opacity`}
+                min={0.25}
+                max={1.25}
+                step={0.05}
+                value={state.scene_opacity}
+                onChange={(event) =>
+                  onStateChange({
+                    ...state,
+                    scene_opacity: Number(event.currentTarget.value),
+                  })
+                }
+              />
+              <output>{state.scene_opacity.toFixed(2)}x</output>
+            </label>
+            <label>
+              <span>Point size</span>
+              <input
+                type="range"
+                aria-label={`${simulation.display_name} scene point size`}
+                min={0.5}
+                max={1.8}
+                step={0.1}
+                value={state.scene_point_size}
+                onChange={(event) =>
+                  onStateChange({
+                    ...state,
+                    scene_point_size: Number(event.currentTarget.value),
+                  })
+                }
+              />
+              <output>{state.scene_point_size.toFixed(1)}x</output>
+            </label>
+          </div>
+        </CompareControlGroup>
       </>
     );
   }
@@ -1074,6 +1196,74 @@ function WorldSpecificControls({
       )}
     </>
   );
+}
+
+function supercellPlaneAxis(view: "plan" | "xz" | "yz"): "x" | "y" | "z" {
+  return view === "plan" ? "z" : view === "xz" ? "y" : "x";
+}
+
+function supercellPlaneCoordinates(
+  simulation: CompareSimulationDescriptor,
+  view: "plan" | "xz" | "yz",
+): number[] {
+  const axis = supercellPlaneAxis(view);
+  const extent =
+    axis === "x"
+      ? simulation.grid.x_extent_km
+      : axis === "y"
+        ? (simulation.grid.y_extent_km ?? simulation.grid.x_extent_km)
+        : simulation.grid.z_extent_km;
+  const count =
+    axis === "x" ? simulation.grid.nx : axis === "y" ? simulation.grid.ny : simulation.grid.nz;
+  const spacing = (extent[1] - extent[0]) / count;
+  return Array.from({ length: count }, (_, index) => extent[0] + (index + 0.5) * spacing);
+}
+
+function nearestNumberIndex(values: number[], target: number): number {
+  return values.reduce(
+    (nearest, value, index) =>
+      Math.abs(value - target) < Math.abs(values[nearest] - target) ? index : nearest,
+    0,
+  );
+}
+
+function supercellOverlayOptions(
+  lens: "rotating_updraft" | "cloud_precipitation" | "low_level_interactions",
+  evidenceView: "plan" | "xz" | "yz",
+): Array<{
+  key:
+    | "rotation"
+    | "updraft_helicity"
+    | "reflectivity"
+    | "condensate"
+    | "rain"
+    | "wind"
+    | "precipitating_condensate"
+    | "vertical_motion";
+  label: string;
+}> {
+  if (lens === "rotating_updraft") {
+    return [
+      { key: "condensate", label: "Cloud boundary" },
+      { key: "rotation", label: "Rotation contour" },
+      ...(evidenceView === "plan"
+        ? [{ key: "updraft_helicity" as const, label: "2-5 km UH footprint" }]
+        : []),
+      { key: "reflectivity", label: "Reflectivity contour" },
+    ];
+  }
+  if (lens === "cloud_precipitation") {
+    return [
+      { key: "vertical_motion", label: "Vertical-motion contours" },
+      { key: "reflectivity", label: "Reflectivity contour" },
+    ];
+  }
+  return [
+    { key: "precipitating_condensate", label: "Current precipitation" },
+    { key: "rain", label: "Accumulated rain" },
+    { key: "wind", label: "Model-relative flow" },
+    { key: "reflectivity", label: "Reflectivity contour" },
+  ];
 }
 
 function CompareTimeline({
@@ -1280,8 +1470,8 @@ function CompareTechnicalDetails({
         <div>
           <dt>Bounded frame cache</dt>
           <dd>
-            {performance.cache_entries.left} left / {performance.cache_entries.right} right · max
-            6 per side
+            {performance.cache_entries.left} left / {performance.cache_entries.right} right · max 6
+            per side
           </dd>
         </div>
         <div>
@@ -1409,6 +1599,13 @@ function synchronizeState(
       slice_native_index: source.slice_native_index,
     };
   }
+  if (links.plane && isSupercellsState(source) && isSupercellsState(next)) {
+    next = {
+      ...next,
+      evidence_view: source.evidence_view,
+      plane_coordinate_km: source.plane_coordinate_km,
+    };
+  }
   if (links.camera) {
     const preset = adapter.cameraPreset(source);
     if (preset) {
@@ -1525,19 +1722,14 @@ function formatSpacing(grid: CompareSimulationDescriptor["grid"]): string {
   if (grid.topology === "native_2d_xz") {
     return `${formatMeters(grid.dx_m)} x / ${formatMeters(grid.dz_m)} z · native 2-D x-z`;
   }
-  return `${formatMeters(grid.dx_m)} × ${formatMeters(grid.dy_m)} × ${formatMeters(
-    grid.dz_m,
-  )}`;
+  return `${formatMeters(grid.dx_m)} × ${formatMeters(grid.dy_m)} × ${formatMeters(grid.dz_m)}`;
 }
 
 function formatMeters(value: number): string {
   return value >= 1_000 ? `${formatNumber(value / 1_000)} km` : `${formatNumber(value)} m`;
 }
 
-function formatDifferenceValue(
-  difference: CompareDifference,
-  side: "left" | "right",
-): string {
+function formatDifferenceValue(difference: CompareDifference, side: "left" | "right"): string {
   const known = side === "left" ? difference.left_known : difference.right_known;
   if (!known) return "Unknown";
   const value = side === "left" ? difference.left_value : difference.right_value;

--- a/app/frontend/src/WorldCompare.tsx
+++ b/app/frontend/src/WorldCompare.tsx
@@ -1,0 +1,1610 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { ExploreWorldState } from "./ExploreStatePersistence";
+import {
+  ExploreContextContent,
+  ExploreInspector,
+  ExploreSelectedEvidence,
+  IntegratedExploreWorkspace,
+} from "./IntegratedExploreWorkspace";
+import {
+  CompareControlGroup,
+  type CompareSelectedEvidence,
+  type TerrainScale,
+  WorldCompareSideVisual,
+} from "./WorldCompareAdapters";
+import {
+  mapCamera,
+  nearestCompareTime,
+  timeIndexForSeconds,
+  validateWorldCompareDescriptor,
+  WORLD_COMPARE_ADAPTERS,
+} from "./WorldCompare.logic";
+import {
+  isMountainState,
+  isTradeState,
+  type CompareDifference,
+  type CompareLinkModes,
+  type ComparePerformanceSample,
+  type ComparePerformanceSummary,
+  type CompareSide,
+  type CompareSimulationDescriptor,
+  type CompareWorldSlug,
+  type WorldCompareDescriptor,
+} from "./WorldCompare.types";
+
+import "./WorldCompare.css";
+
+type WorldCompareProps = {
+  worldSlug: CompareWorldSlug;
+  initialLeftSimulationId?: string | null;
+  initialRightSimulationId?: string | null;
+  resumeExistingState?: boolean;
+  onBack: () => void;
+  onOpenSimulation: (simulationId: string) => void;
+};
+
+type SideStates = Record<CompareSide, ExploreWorldState>;
+type SideStatus = Record<CompareSide, "loading" | "ready" | "error">;
+type SideEvidence = Record<CompareSide, CompareSelectedEvidence | null>;
+type SideScales = Record<CompareSide, TerrainScale | null>;
+type PlaybackTarget = "linked" | CompareSide | null;
+
+const INDEPENDENT_LINKS: CompareLinkModes = {
+  time: false,
+  view: false,
+  plane: false,
+  camera: false,
+  selection: false,
+};
+
+export function WorldCompare({
+  worldSlug,
+  initialLeftSimulationId = null,
+  initialRightSimulationId = null,
+  resumeExistingState = false,
+  onBack,
+  onOpenSimulation,
+}: WorldCompareProps) {
+  const [descriptor, setDescriptor] = useState<WorldCompareDescriptor | null>(null);
+  const [descriptorLoading, setDescriptorLoading] = useState(true);
+  const [descriptorError, setDescriptorError] = useState<string | null>(null);
+  const [phase, setPhase] = useState<"review" | "workspace">("review");
+  const [states, setStates] = useState<SideStates | null>(null);
+  const [links, setLinks] = useState<CompareLinkModes>(INDEPENDENT_LINKS);
+  const [mappingNotices, setMappingNotices] = useState<string[]>([]);
+  const [sideStatus, setSideStatus] = useState<SideStatus>({
+    left: "loading",
+    right: "loading",
+  });
+  const [evidence, setEvidence] = useState<SideEvidence>({ left: null, right: null });
+  const [sideScales, setSideScales] = useState<SideScales>({ left: null, right: null });
+  const [contextCollapsed, setContextCollapsed] = useState(true);
+  const [playbackTarget, setPlaybackTarget] = useState<PlaybackTarget>(null);
+  const [performance, setPerformance] = useState<ComparePerformanceSummary>({
+    first_useful_dual_view_ms: null,
+    cache_entries: { left: 0, right: 0 },
+    estimated_cached_payload_bytes: { left: 0, right: 0 },
+    samples: [],
+  });
+  const workspaceStartedAt = useRef<number | null>(null);
+
+  const loadDescriptor = useCallback(
+    async (leftId?: string | null, rightId?: string | null) => {
+      setDescriptorLoading(true);
+      setDescriptorError(null);
+      const search = new URLSearchParams();
+      if (leftId) search.set("left_simulation_id", leftId);
+      if (rightId) search.set("right_simulation_id", rightId);
+      try {
+        const response = await fetch(
+          `/api/worlds/${worldSlug}/compare${search.size ? `?${search}` : ""}`,
+        );
+        if (!response.ok) {
+          throw new Error(await responseMessage(response, "World Compare could not be loaded."));
+        }
+        const payload = validateWorldCompareDescriptor(await response.json());
+        setDescriptor(payload);
+        setPhase("review");
+        setStates(null);
+        setPlaybackTarget(null);
+        setMappingNotices([]);
+      } catch (caught) {
+        setDescriptor(null);
+        setDescriptorError(
+          caught instanceof Error ? caught.message : "World Compare could not be loaded.",
+        );
+      } finally {
+        setDescriptorLoading(false);
+      }
+    },
+    [worldSlug],
+  );
+
+  useEffect(() => {
+    void loadDescriptor(initialLeftSimulationId, initialRightSimulationId);
+  }, [initialLeftSimulationId, initialRightSimulationId, loadDescriptor]);
+
+  const leftSimulation = descriptor
+    ? selectedSimulation(descriptor, descriptor.selected_left_simulation_id)
+    : null;
+  const rightSimulation = descriptor
+    ? selectedSimulation(descriptor, descriptor.selected_right_simulation_id)
+    : null;
+  const adapter = descriptor ? WORLD_COMPARE_ADAPTERS[descriptor.world_id] : null;
+
+  const startWorkspace = useCallback(async () => {
+    if (!descriptor || !leftSimulation || !rightSimulation || !descriptor.compatibility) return;
+    const [leftState, rightState] = await Promise.all([
+      initialCompareState(leftSimulation, resumeExistingState),
+      initialCompareState(rightSimulation, resumeExistingState),
+    ]);
+    workspaceStartedAt.current = window.performance.now();
+    setPerformance({
+      first_useful_dual_view_ms: null,
+      cache_entries: { left: 0, right: 0 },
+      estimated_cached_payload_bytes: { left: 0, right: 0 },
+      samples: [],
+    });
+    setStates({ left: leftState, right: rightState });
+    setLinks(INDEPENDENT_LINKS);
+    setMappingNotices([]);
+    setPhase("workspace");
+    setSideStatus({ left: "loading", right: "loading" });
+  }, [descriptor, leftSimulation, resumeExistingState, rightSimulation]);
+
+  const handleFrameState = useCallback(
+    (side: CompareSide, status: "loading" | "ready" | "error") => {
+      setSideStatus((current) => ({ ...current, [side]: status }));
+      if (status === "error") {
+        setPlaybackTarget((current) => (current === "linked" || current === side ? null : current));
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (
+      phase !== "workspace" ||
+      performance.first_useful_dual_view_ms !== null ||
+      sideStatus.left !== "ready" ||
+      sideStatus.right !== "ready" ||
+      workspaceStartedAt.current === null
+    ) {
+      return;
+    }
+    const elapsed = window.performance.now() - workspaceStartedAt.current;
+    setPerformance((current) => ({ ...current, first_useful_dual_view_ms: elapsed }));
+  }, [performance.first_useful_dual_view_ms, phase, sideStatus]);
+
+  const handlePerformance = useCallback((sample: ComparePerformanceSample) => {
+    setPerformance((current) => {
+      const samples = [...current.samples, sample].slice(-30);
+      const uniqueBySide = (side: CompareSide) => {
+        const values = new Map<string, number>();
+        samples
+          .filter((item) => item.side === side)
+          .forEach((item) => {
+            values.delete(item.key);
+            values.set(item.key, item.payload_bytes);
+            while (values.size > 6) {
+              const oldest = values.keys().next().value;
+              if (typeof oldest !== "string") break;
+              values.delete(oldest);
+            }
+          });
+        return values;
+      };
+      const left = uniqueBySide("left");
+      const right = uniqueBySide("right");
+      const next = {
+        ...current,
+        samples,
+        cache_entries: { left: left.size, right: right.size },
+        estimated_cached_payload_bytes: {
+          left: [...left.values()].reduce((sum, value) => sum + value, 0),
+          right: [...right.values()].reduce((sum, value) => sum + value, 0),
+        },
+      };
+      (
+        window as typeof window & {
+          __CLOUD_CHAMBER_COMPARE_METRICS__?: ComparePerformanceSummary;
+        }
+      ).__CLOUD_CHAMBER_COMPARE_METRICS__ = next;
+      return next;
+    });
+  }, []);
+
+  const updateSideState = useCallback(
+    (side: CompareSide, nextState: ExploreWorldState) => {
+      if (!descriptor) return;
+      setStates((current) => {
+        if (!current) return current;
+        const targetSide = otherSide(side);
+        const synchronized = synchronizeState(
+          descriptor,
+          side,
+          nextState,
+          current[targetSide],
+          links,
+        );
+        setMappingNotices(synchronized.notices);
+        return {
+          ...current,
+          [side]: nextState,
+          [targetSide]: synchronized.state,
+        };
+      });
+    },
+    [descriptor, links],
+  );
+
+  const applyAlignedPreset = useCallback(() => {
+    if (!descriptor || !states) return;
+    const nextLinks = alignedLinks(descriptor);
+    const synchronized = synchronizeState(
+      descriptor,
+      "left",
+      states.left,
+      states.right,
+      nextLinks,
+    );
+    setLinks(nextLinks);
+    setStates({ left: states.left, right: synchronized.state });
+    setMappingNotices(synchronized.notices);
+  }, [descriptor, states]);
+
+  const applyIndependentPreset = useCallback(() => {
+    setLinks(INDEPENDENT_LINKS);
+    setMappingNotices([]);
+    setPlaybackTarget(null);
+  }, []);
+
+  const toggleLink = useCallback(
+    (key: keyof CompareLinkModes) => {
+      if (!descriptor || !states) return;
+      const nextLinks = { ...links, [key]: !links[key] };
+      setLinks(nextLinks);
+      if (nextLinks[key]) {
+        const synchronized = synchronizeState(
+          descriptor,
+          "left",
+          states.left,
+          states.right,
+          nextLinks,
+        );
+        setStates({ left: states.left, right: synchronized.state });
+        setMappingNotices(synchronized.notices);
+      }
+      if (key === "time" && !nextLinks.time) setPlaybackTarget(null);
+    },
+    [descriptor, links, states],
+  );
+
+  const stepSide = useCallback(
+    (side: CompareSide, offset: number) => {
+      if (!descriptor || !states) return false;
+      const simulation = side === "left" ? leftSimulation : rightSimulation;
+      if (!simulation) return false;
+      const current = states[side];
+      const index = timeIndexForSeconds(simulation, current.model_time_seconds);
+      const nextIndex = Math.min(
+        simulation.time.times_seconds.length - 1,
+        Math.max(0, index + offset),
+      );
+      if (nextIndex === index) return false;
+      updateSideState(side, {
+        ...current,
+        model_time_seconds: simulation.time.times_seconds[nextIndex],
+        selected_point: null,
+      });
+      return true;
+    },
+    [descriptor, leftSimulation, rightSimulation, states, updateSideState],
+  );
+
+  useEffect(() => {
+    if (!playbackTarget || !states) return;
+    const side = playbackTarget === "right" ? "right" : "left";
+    const speed = Math.max(0.25, states[side].playback_speed);
+    const timer = window.setInterval(() => {
+      if (!stepSide(side, 1)) setPlaybackTarget(null);
+    }, 900 / speed);
+    return () => window.clearInterval(timer);
+  }, [playbackTarget, states, stepSide]);
+
+  const commonMountainScale = useMemo(() => {
+    if (
+      descriptor?.world_id !== "mountain_waves" ||
+      !links.view ||
+      !sideScales.left ||
+      !sideScales.right ||
+      sideScales.left.scale_id !== sideScales.right.scale_id
+    ) {
+      return null;
+    }
+    return combinedMountainScale(sideScales.left, sideScales.right);
+  }, [descriptor?.world_id, links.view, sideScales]);
+
+  const handleScale = useCallback((side: CompareSide, scale: TerrainScale | null) => {
+    setSideScales((current) =>
+      current[side] === scale ? current : { ...current, [side]: scale },
+    );
+  }, []);
+
+  const handleEvidence = useCallback(
+    (side: CompareSide, item: CompareSelectedEvidence | null) => {
+      setEvidence((current) =>
+        evidenceSignature(current[side]) === evidenceSignature(item)
+          ? current
+          : { ...current, [side]: item },
+      );
+      if (item) setContextCollapsed(false);
+    },
+    [],
+  );
+
+  if (descriptorLoading) {
+    return <CompareStatus title="Loading Compare" body="Reading bounded World metadata..." />;
+  }
+  if (!descriptor || descriptorError) {
+    return (
+      <CompareStatus
+        title="Compare is unavailable"
+        body={descriptorError ?? "World Compare metadata is unavailable."}
+        actionLabel="Retry"
+        onAction={() => void loadDescriptor(initialLeftSimulationId, initialRightSimulationId)}
+      />
+    );
+  }
+  if (descriptor.no_second_simulation_message || !rightSimulation) {
+    return (
+      <IntegratedExploreWorkspace
+        worldName={descriptor.display_name}
+        simulationName="Compare"
+        onBack={onBack}
+      >
+        <section className="compare-empty-state" aria-label="No second Simulation">
+          <p className="eyebrow">Compare</p>
+          <h3>Choose two distinct Simulations</h3>
+          <p>{descriptor.no_second_simulation_message}</p>
+          <p>The existing reference remains available in Explore and is not duplicated.</p>
+          {leftSimulation && (
+            <button type="button" onClick={() => onOpenSimulation(leftSimulation.simulation_id)}>
+              Open {leftSimulation.display_name}
+            </button>
+          )}
+        </section>
+      </IntegratedExploreWorkspace>
+    );
+  }
+  if (!leftSimulation || !adapter) {
+    return <CompareStatus title="Compare is unavailable" body="Simulation identity is incomplete." />;
+  }
+
+  if (phase === "review" || !states) {
+    return (
+      <IntegratedExploreWorkspace
+        worldName={descriptor.display_name}
+        simulationName="Compare"
+        onBack={onBack}
+      >
+        <ComparePairReview
+          descriptor={descriptor}
+          left={leftSimulation}
+          right={rightSimulation}
+          onPairChange={(leftId, rightId) => void loadDescriptor(leftId, rightId)}
+          onStart={() => void startWorkspace()}
+        />
+      </IntegratedExploreWorkspace>
+    );
+  }
+
+  return (
+    <IntegratedExploreWorkspace
+      worldName={descriptor.display_name}
+      simulationName={`${leftSimulation.display_name} and ${rightSimulation.display_name}`}
+      onBack={onBack}
+      headerActions={
+        <button type="button" className="secondary-button" onClick={() => setPhase("review")}>
+          Change pair
+        </button>
+      }
+    >
+      <section className="world-compare-shell" aria-label={`${descriptor.display_name} Compare`}>
+        <CompareToolbar
+          descriptor={descriptor}
+          links={links}
+          onAligned={applyAlignedPreset}
+          onIndependent={applyIndependentPreset}
+          onToggleLink={toggleLink}
+        />
+        {mappingNotices.length > 0 && (
+          <div className="compare-mapping-notices" role="status">
+            {mappingNotices.map((notice) => (
+              <span key={notice}>{notice}</span>
+            ))}
+          </div>
+        )}
+        <div className="world-compare-workspace-grid">
+          <div className="compare-side-pair">
+            {(["left", "right"] as CompareSide[]).map((side) => {
+              const simulation = side === "left" ? leftSimulation : rightSimulation;
+              return (
+                <CompareSidePanel
+                  key={side}
+                  side={side}
+                  simulation={simulation}
+                  state={states[side]}
+                  descriptor={descriptor}
+                  onStateChange={(state) => updateSideState(side, state)}
+                  onOpen={() => onOpenSimulation(simulation.simulation_id)}
+                  onFrameState={handleFrameState}
+                  onPerformance={handlePerformance}
+                  commonMountainScale={commonMountainScale}
+                  onMountainScale={handleScale}
+                  onEvidence={handleEvidence}
+                />
+              );
+            })}
+          </div>
+          <ExploreInspector
+            collapsed={contextCollapsed}
+            onCollapsedChange={setContextCollapsed}
+          >
+            <CompareContext
+              descriptor={descriptor}
+              left={leftSimulation}
+              right={rightSimulation}
+              evidence={evidence}
+              onClear={(side) => {
+                updateSideState(side, { ...states[side], selected_point: null });
+                setEvidence((current) => ({ ...current, [side]: null }));
+              }}
+            />
+          </ExploreInspector>
+        </div>
+        <CompareTimeline
+          descriptor={descriptor}
+          states={states}
+          links={links}
+          playbackTarget={playbackTarget}
+          onPlaybackTarget={setPlaybackTarget}
+          onStateChange={updateSideState}
+          onStep={stepSide}
+        />
+        <CompareTechnicalDetails performance={performance} descriptor={descriptor} />
+      </section>
+    </IntegratedExploreWorkspace>
+  );
+}
+
+function ComparePairReview({
+  descriptor,
+  left,
+  right,
+  onPairChange,
+  onStart,
+}: {
+  descriptor: WorldCompareDescriptor;
+  left: CompareSimulationDescriptor;
+  right: CompareSimulationDescriptor;
+  onPairChange: (leftId: string, rightId: string) => void;
+  onStart: () => void;
+}) {
+  const compatibility = descriptor.compatibility;
+  return (
+    <section className="compare-pair-review" aria-labelledby="compare-review-title">
+      <header>
+        <p className="eyebrow">Compare setup</p>
+        <h3 id="compare-review-title">Review the two Simulations before loading frames</h3>
+        <p>
+          Compare is transient. It does not create a Saved Comparison or change either
+          Simulation.
+        </p>
+      </header>
+      <div className="compare-pair-selectors">
+        <SimulationSelector
+          label="Left Simulation"
+          value={left.simulation_id}
+          simulations={descriptor.simulations}
+          exclude={right.simulation_id}
+          onChange={(value) => onPairChange(value, right.simulation_id)}
+        />
+        <button
+          type="button"
+          className="compare-swap-button"
+          aria-label="Swap left and right Simulations"
+          title="Swap Simulations"
+          onClick={() => onPairChange(right.simulation_id, left.simulation_id)}
+        >
+          ⇄
+        </button>
+        <SimulationSelector
+          label="Right Simulation"
+          value={right.simulation_id}
+          simulations={descriptor.simulations}
+          exclude={left.simulation_id}
+          onChange={(value) => onPairChange(left.simulation_id, value)}
+        />
+      </div>
+      {compatibility && (
+        <section className="compare-relationship-summary">
+          <div>
+            <strong>{compatibility.relationship}</strong>
+            <p>{compatibility.controlled_pair_message}</p>
+          </div>
+          <span className={compatibility.controlled_pair ? "state-chip" : "compare-caveat-chip"}>
+            {compatibility.controlled_pair ? "Controlled pair" : "Structural comparison"}
+          </span>
+        </section>
+      )}
+      <div className="compare-review-columns">
+        <SimulationFacts simulation={left} />
+        <SimulationFacts simulation={right} />
+      </div>
+      <DifferenceTable
+        differences={descriptor.material_differences}
+        leftLabel={left.display_name}
+        rightLabel={right.display_name}
+      />
+      {compatibility && (
+        <section className="compare-compatibility-summary">
+          <h4>Coordination available</h4>
+          <dl>
+            <div>
+              <dt>Modeled time</dt>
+              <dd>
+                {compatibility.exact_time_link_available
+                  ? "Exact saved seconds; nearest is labeled when requested"
+                  : "Independent only"}
+              </dd>
+            </div>
+            <div>
+              <dt>Shared views</dt>
+              <dd>{compatibility.shared_view_ids.join(", ") || "None"}</dd>
+            </div>
+            <div>
+              <dt>Physical slice plane</dt>
+              <dd>{compatibility.physical_plane_link_available ? "Available" : "Not applicable"}</dd>
+            </div>
+            <div>
+              <dt>Camera</dt>
+              <dd>
+                {compatibility.camera_link_available
+                  ? "Normalized domain mapping"
+                  : "Independent native 2-D framing"}
+              </dd>
+            </div>
+          </dl>
+          {compatibility.blockers.map((blocker) => (
+            <p role="alert" key={blocker}>
+              {blocker}
+            </p>
+          ))}
+        </section>
+      )}
+      <div className="compare-review-actions">
+        <button
+          type="button"
+          disabled={!compatibility || compatibility.blockers.length > 0}
+          onClick={onStart}
+        >
+          Open dual view
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function SimulationSelector({
+  label,
+  value,
+  simulations,
+  exclude,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  simulations: CompareSimulationDescriptor[];
+  exclude: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label>
+      <span>{label}</span>
+      <select value={value} onChange={(event) => onChange(event.currentTarget.value)}>
+        {simulations.map((simulation) => (
+          <option
+            key={simulation.simulation_id}
+            value={simulation.simulation_id}
+            disabled={simulation.simulation_id === exclude || !simulation.inspectable}
+          >
+            {simulation.display_name}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function SimulationFacts({ simulation }: { simulation: CompareSimulationDescriptor }) {
+  return (
+    <article className="compare-simulation-facts">
+      <p className="eyebrow">{simulation.role.replaceAll("_", " ")}</p>
+      <h4>{simulation.display_name}</h4>
+      <dl>
+        <div>
+          <dt>Lineage</dt>
+          <dd>{lineageLabel(simulation)}</dd>
+        </div>
+        <div>
+          <dt>Domain / grid</dt>
+          <dd>
+            {simulation.grid.nx} × {simulation.grid.ny} × {simulation.grid.nz} ·{" "}
+            {formatSpacing(simulation.grid)}
+          </dd>
+        </div>
+        <div>
+          <dt>Retained output</dt>
+          <dd>
+            {formatSeconds(simulation.time.end_seconds)} · every{" "}
+            {formatSeconds(simulation.time.cadence_seconds)} ·{" "}
+            {simulation.time.saved_output_count.toLocaleString()} frames
+          </dd>
+        </div>
+        <div>
+          <dt>Available science</dt>
+          <dd>{simulation.available_view_ids.map(viewDisplayName).join(", ")}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+function DifferenceTable({
+  differences,
+  leftLabel,
+  rightLabel,
+}: {
+  differences: CompareDifference[];
+  leftLabel: string;
+  rightLabel: string;
+}) {
+  return (
+    <section className="compare-difference-preview" aria-labelledby="material-differences-title">
+      <h4 id="material-differences-title">Material configuration differences</h4>
+      {differences.length === 0 ? (
+        <p>No material difference is declared in retained World metadata.</p>
+      ) : (
+        <div className="compare-difference-table" role="table">
+          <div role="row" className="compare-difference-header">
+            <span role="columnheader">Setting</span>
+            <span role="columnheader">{leftLabel}</span>
+            <span role="columnheader">{rightLabel}</span>
+          </div>
+          {differences.map((difference) => (
+            <div role="row" key={difference.path}>
+              <strong role="cell">{difference.label}</strong>
+              <span role="cell">{formatDifferenceValue(difference, "left")}</span>
+              <span role="cell">{formatDifferenceValue(difference, "right")}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function CompareToolbar({
+  descriptor,
+  links,
+  onAligned,
+  onIndependent,
+  onToggleLink,
+}: {
+  descriptor: WorldCompareDescriptor;
+  links: CompareLinkModes;
+  onAligned: () => void;
+  onIndependent: () => void;
+  onToggleLink: (key: keyof CompareLinkModes) => void;
+}) {
+  const compatibility = descriptor.compatibility!;
+  const controls: Array<{
+    key: keyof CompareLinkModes;
+    label: string;
+    available: boolean;
+    title?: string;
+  }> = [
+    { key: "time", label: "Time", available: compatibility.nearest_time_link_available },
+    { key: "view", label: "Field / Lens", available: compatibility.shared_view_ids.length > 0 },
+    {
+      key: "plane",
+      label: "Slice plane",
+      available: compatibility.physical_plane_link_available,
+      title: compatibility.physical_plane_link_available
+        ? undefined
+        : "This pair has no compatible physical slice-plane control.",
+    },
+    {
+      key: "camera",
+      label: "Camera",
+      available: compatibility.camera_link_available,
+      title: compatibility.camera_link_available
+        ? undefined
+        : "Native 2-D Mountain Waves framing is not a 3-D camera.",
+    },
+    { key: "selection", label: "Selection", available: compatibility.selection_link_available },
+  ];
+  const allAvailableLinked = controls.every((item) => !item.available || links[item.key]);
+  const allIndependent = Object.values(links).every((value) => !value);
+  return (
+    <section className="compare-toolbar" aria-label="Compare coordination">
+      <div className="compare-presets">
+        <span>Coordination</span>
+        <div className="segmented-control">
+          <button
+            type="button"
+            className={allAvailableLinked ? "active-control" : ""}
+            onClick={onAligned}
+          >
+            Aligned
+          </button>
+          <button
+            type="button"
+            className={allIndependent ? "active-control" : ""}
+            onClick={onIndependent}
+          >
+            Independent
+          </button>
+        </div>
+      </div>
+      <div className="compare-link-controls">
+        {controls.map((item) => (
+          <label key={item.key} title={item.title}>
+            <input
+              type="checkbox"
+              checked={links[item.key]}
+              disabled={!item.available}
+              onChange={() => onToggleLink(item.key)}
+            />
+            {item.label}
+          </label>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function CompareSidePanel({
+  side,
+  simulation,
+  state,
+  descriptor,
+  onStateChange,
+  onOpen,
+  onFrameState,
+  onPerformance,
+  commonMountainScale,
+  onMountainScale,
+  onEvidence,
+}: {
+  side: CompareSide;
+  simulation: CompareSimulationDescriptor;
+  state: ExploreWorldState;
+  descriptor: WorldCompareDescriptor;
+  onStateChange: (state: ExploreWorldState) => void;
+  onOpen: () => void;
+  onFrameState: (side: CompareSide, status: "loading" | "ready" | "error") => void;
+  onPerformance: (sample: ComparePerformanceSample) => void;
+  commonMountainScale: TerrainScale | null;
+  onMountainScale: (side: CompareSide, scale: TerrainScale | null) => void;
+  onEvidence: (side: CompareSide, evidence: CompareSelectedEvidence | null) => void;
+}) {
+  const adapter = WORLD_COMPARE_ADAPTERS[descriptor.world_id];
+  const viewOptions = adapter.viewOptions(simulation);
+  const currentView = adapter.viewId(state);
+  const fieldOptions = simulation.available_field_ids;
+  return (
+    <article className="compare-side-panel" aria-label={`${simulation.display_name} comparison side`}>
+      <header className="compare-side-header">
+        <div>
+          <p className="eyebrow">{side === "left" ? "Left Simulation" : "Right Simulation"}</p>
+          <h3>{simulation.display_name}</h3>
+          <p>{formatSeconds(state.model_time_seconds)} · {viewDisplayName(currentView)}</p>
+        </div>
+        <button type="button" className="secondary-button" onClick={onOpen}>
+          Open in Explore
+        </button>
+      </header>
+      <div className="compare-side-controls">
+        <CompareControlGroup label={adapter.viewLabel}>
+          <div className="segmented-control">
+            {viewOptions.map((option) => (
+              <button
+                type="button"
+                key={option.id}
+                className={currentView === option.id ? "active-control" : ""}
+                onClick={() => onStateChange(adapter.setView(state, option.id))}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </CompareControlGroup>
+        {currentView === "field" && (
+          <CompareControlGroup label="Field">
+            <select
+              aria-label={`${simulation.display_name} Field`}
+              value={adapter.fieldId(state) ?? fieldOptions[0]}
+              onChange={(event) => onStateChange(adapter.setField(state, event.currentTarget.value))}
+            >
+              {fieldOptions.map((field) => (
+                <option key={field} value={field}>
+                  {fieldDisplayName(field)}
+                </option>
+              ))}
+            </select>
+          </CompareControlGroup>
+        )}
+        <WorldSpecificControls
+          simulation={simulation}
+          state={state}
+          onStateChange={onStateChange}
+        />
+      </div>
+      <WorldCompareSideVisual
+        side={side}
+        simulation={simulation}
+        state={state}
+        onStateChange={onStateChange}
+        onFrameState={onFrameState}
+        onPerformance={onPerformance}
+        commonMountainScale={commonMountainScale}
+        onMountainScale={onMountainScale}
+        onEvidence={onEvidence}
+      />
+    </article>
+  );
+}
+
+function WorldSpecificControls({
+  simulation,
+  state,
+  onStateChange,
+}: {
+  simulation: CompareSimulationDescriptor;
+  state: ExploreWorldState;
+  onStateChange: (state: ExploreWorldState) => void;
+}) {
+  if (isTradeState(state) && state.view_id === "field") {
+    return (
+      <>
+        <label>
+          <span>Cloud opacity</span>
+          <input
+            type="range"
+            min={0.15}
+            max={1}
+            step={0.05}
+            value={state.layer_opacity}
+            onChange={(event) =>
+              onStateChange({ ...state, layer_opacity: Number(event.currentTarget.value) })
+            }
+          />
+        </label>
+        <label>
+          <span>Point size</span>
+          <input
+            type="range"
+            min={4}
+            max={18}
+            step={1}
+            value={state.point_size_px}
+            onChange={(event) =>
+              onStateChange({ ...state, point_size_px: Number(event.currentTarget.value) })
+            }
+          />
+        </label>
+      </>
+    );
+  }
+  if (!isMountainState(state)) return null;
+  return (
+    <>
+      <CompareControlGroup label="Viewport">
+        <div className="segmented-control">
+          <button
+            type="button"
+            disabled={simulation.simulation_id === "mountain_waves_dry_ridge"}
+            className={state.viewport_id === "focus" ? "active-control" : ""}
+            onClick={() => onStateChange({ ...state, viewport_id: "focus" })}
+          >
+            Focus region
+          </button>
+          <button
+            type="button"
+            className={state.viewport_id === "full" ? "active-control" : ""}
+            onClick={() => onStateChange({ ...state, viewport_id: "full" })}
+          >
+            Full domain
+          </button>
+        </div>
+      </CompareControlGroup>
+      <CompareControlGroup label="Geometry">
+        <div className="segmented-control">
+          <button
+            type="button"
+            className={state.geometry_id === "expanded" ? "active-control" : ""}
+            onClick={() => onStateChange({ ...state, geometry_id: "expanded" })}
+          >
+            Expanded height
+          </button>
+          <button
+            type="button"
+            className={state.geometry_id === "physical" ? "active-control" : ""}
+            onClick={() => onStateChange({ ...state, geometry_id: "physical" })}
+          >
+            True physical scale
+          </button>
+        </div>
+      </CompareControlGroup>
+      {state.view_id !== "field" && (
+        <CompareControlGroup label="Overlays">
+          <div className="compare-overlay-controls">
+            <label>
+              <input
+                type="checkbox"
+                checked={state.overlays.horizontal_wind}
+                onChange={(event) =>
+                  onStateChange({
+                    ...state,
+                    overlays: { ...state.overlays, horizontal_wind: event.currentTarget.checked },
+                  })
+                }
+              />
+              Horizontal wind
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={state.overlays.potential_temperature_contours}
+                onChange={(event) =>
+                  onStateChange({
+                    ...state,
+                    overlays: {
+                      ...state.overlays,
+                      potential_temperature_contours: event.currentTarget.checked,
+                    },
+                  })
+                }
+              />
+              Potential temperature
+            </label>
+            {state.view_id === "wave_cloud" && (
+              <>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={state.overlays.cloud_points}
+                    onChange={(event) =>
+                      onStateChange({
+                        ...state,
+                        overlays: { ...state.overlays, cloud_points: event.currentTarget.checked },
+                      })
+                    }
+                  />
+                  Cloud points
+                </label>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={state.overlays.cloud_boundary}
+                    onChange={(event) =>
+                      onStateChange({
+                        ...state,
+                        overlays: {
+                          ...state.overlays,
+                          cloud_boundary: event.currentTarget.checked,
+                        },
+                      })
+                    }
+                  />
+                  Cloud boundary
+                </label>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={state.overlays.saturation_contour}
+                    onChange={(event) =>
+                      onStateChange({
+                        ...state,
+                        overlays: {
+                          ...state.overlays,
+                          saturation_contour: event.currentTarget.checked,
+                        },
+                      })
+                    }
+                  />
+                  RH = 100%
+                </label>
+              </>
+            )}
+          </div>
+        </CompareControlGroup>
+      )}
+      {state.view_id === "wave_cloud" && state.overlays.cloud_points && (
+        <CompareControlGroup label="Cloud points">
+          <div className="compare-cloud-render-controls">
+            <label>
+              <span>Opacity</span>
+              <input
+                type="range"
+                aria-label={`${simulation.display_name} cloud opacity`}
+                min={0.15}
+                max={1}
+                step={0.05}
+                value={state.cloud_opacity}
+                onChange={(event) =>
+                  onStateChange({ ...state, cloud_opacity: Number(event.currentTarget.value) })
+                }
+              />
+              <output>{state.cloud_opacity.toFixed(2)}</output>
+            </label>
+            <label>
+              <span>Point size</span>
+              <input
+                type="range"
+                aria-label={`${simulation.display_name} cloud point size`}
+                min={4}
+                max={18}
+                step={1}
+                value={state.cloud_point_size_px}
+                onChange={(event) =>
+                  onStateChange({
+                    ...state,
+                    cloud_point_size_px: Number(event.currentTarget.value),
+                  })
+                }
+              />
+              <output>{state.cloud_point_size_px}px</output>
+            </label>
+          </div>
+        </CompareControlGroup>
+      )}
+    </>
+  );
+}
+
+function CompareTimeline({
+  descriptor,
+  states,
+  links,
+  playbackTarget,
+  onPlaybackTarget,
+  onStateChange,
+  onStep,
+}: {
+  descriptor: WorldCompareDescriptor;
+  states: SideStates;
+  links: CompareLinkModes;
+  playbackTarget: PlaybackTarget;
+  onPlaybackTarget: (target: PlaybackTarget) => void;
+  onStateChange: (side: CompareSide, state: ExploreWorldState) => void;
+  onStep: (side: CompareSide, offset: number) => boolean;
+}) {
+  return (
+    <section className="compare-timeline" aria-label="Compare time controls">
+      <header>
+        <strong>Saved output time</strong>
+        <span>
+          {links.time
+            ? "Linked by modeled seconds; nearest saved output is labeled."
+            : "Each Simulation uses its own retained output history."}
+        </span>
+      </header>
+      <div className="compare-timeline-rows">
+        {(["left", "right"] as CompareSide[]).map((side) => {
+          const simulation = selectedSimulation(
+            descriptor,
+            side === "left"
+              ? descriptor.selected_left_simulation_id
+              : descriptor.selected_right_simulation_id,
+          )!;
+          const state = states[side];
+          const index = timeIndexForSeconds(simulation, state.model_time_seconds);
+          const target = links.time ? "linked" : side;
+          const playing = playbackTarget === target;
+          return (
+            <div className="compare-timeline-row" key={side}>
+              <span>{simulation.display_name}</span>
+              <button
+                type="button"
+                aria-label={`Previous ${simulation.display_name} output`}
+                onClick={() => onStep(side, -1)}
+              >
+                ‹
+              </button>
+              <button
+                type="button"
+                aria-label={`${playing ? "Pause" : "Play"} ${simulation.display_name}`}
+                onClick={() => onPlaybackTarget(playing ? null : target)}
+              >
+                <span aria-hidden="true">{playing ? "❚❚" : "▶"}</span>
+              </button>
+              <button
+                type="button"
+                aria-label={`Next ${simulation.display_name} output`}
+                onClick={() => onStep(side, 1)}
+              >
+                ›
+              </button>
+              <input
+                type="range"
+                aria-label={`${simulation.display_name} saved output time`}
+                min={0}
+                max={Math.max(0, simulation.time.times_seconds.length - 1)}
+                step={1}
+                value={index}
+                onChange={(event) => {
+                  const nextIndex = Number(event.currentTarget.value);
+                  onStateChange(side, {
+                    ...state,
+                    model_time_seconds: simulation.time.times_seconds[nextIndex],
+                    selected_point: null,
+                  });
+                }}
+              />
+              <strong>{formatSeconds(state.model_time_seconds)}</strong>
+              <select
+                aria-label={`${simulation.display_name} playback speed`}
+                value={state.playback_speed}
+                onChange={(event) =>
+                  onStateChange(side, {
+                    ...state,
+                    playback_speed: Number(event.currentTarget.value),
+                  })
+                }
+              >
+                {[0.5, 1, 2, 4].map((speed) => (
+                  <option key={speed} value={speed}>
+                    {speed}x
+                  </option>
+                ))}
+              </select>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function CompareContext({
+  descriptor,
+  left,
+  right,
+  evidence,
+  onClear,
+}: {
+  descriptor: WorldCompareDescriptor;
+  left: CompareSimulationDescriptor;
+  right: CompareSimulationDescriptor;
+  evidence: SideEvidence;
+  onClear: (side: CompareSide) => void;
+}) {
+  const difference = selectedEvidenceDifference(evidence.left, evidence.right);
+  return (
+    <ExploreContextContent
+      identity="Comparison"
+      question="What is aligned, and what remains different?"
+      explanation={
+        <p>
+          {descriptor.compatibility?.controlled_pair_message} Each side keeps its own native
+          evidence and retained output time.
+        </p>
+      }
+      selectedEvidence={
+        evidence.left || evidence.right ? (
+          <div className="compare-selected-evidence">
+            {(["left", "right"] as CompareSide[]).map((side) => {
+              const item = evidence[side];
+              const simulation = side === "left" ? left : right;
+              return item ? (
+                <ExploreSelectedEvidence
+                  key={side}
+                  eyebrow={simulation.display_name}
+                  title={item.title}
+                  states={item.states}
+                  metrics={item.metrics.map((metric) => ({
+                    label: metric.label,
+                    value: metric.value,
+                  }))}
+                  onClear={() => onClear(side)}
+                />
+              ) : (
+                <section className="compare-selection-empty" key={side}>
+                  <strong>{simulation.display_name}</strong>
+                  <p>No point selected.</p>
+                </section>
+              );
+            })}
+            <section className="compare-evidence-difference" aria-label="Selected point difference">
+              <strong>Difference summary</strong>
+              <p>{difference}</p>
+            </section>
+          </div>
+        ) : undefined
+      }
+      orientation={[
+        { label: "Left", value: left.display_name },
+        { label: "Right", value: right.display_name },
+        {
+          label: "Relationship",
+          value: descriptor.compatibility?.relationship ?? "Unknown",
+        },
+        {
+          label: "Time rule",
+          value: "Exact modeled seconds or explicitly labeled nearest saved output",
+        },
+      ]}
+      selectionPrompt={
+        evidence.left || evidence.right
+          ? undefined
+          : "Select a cell in either scientific view to compare native or explicitly derived evidence."
+      }
+    />
+  );
+}
+
+function CompareTechnicalDetails({
+  performance,
+  descriptor,
+}: {
+  performance: ComparePerformanceSummary;
+  descriptor: WorldCompareDescriptor;
+}) {
+  const latestRequests = performance.samples.filter((sample) => !sample.cache_hit).slice(-2);
+  return (
+    <details className="compare-technical-details">
+      <summary>Compare technical details</summary>
+      <dl>
+        <div>
+          <dt>First useful dual view</dt>
+          <dd>
+            {performance.first_useful_dual_view_ms === null
+              ? "Not measured yet"
+              : `${Math.round(performance.first_useful_dual_view_ms).toLocaleString()} ms`}
+          </dd>
+        </div>
+        <div>
+          <dt>Bounded frame cache</dt>
+          <dd>
+            {performance.cache_entries.left} left / {performance.cache_entries.right} right · max
+            6 per side
+          </dd>
+        </div>
+        <div>
+          <dt>Estimated serialized cache</dt>
+          <dd>
+            {formatBytes(performance.estimated_cached_payload_bytes.left)} left /{" "}
+            {formatBytes(performance.estimated_cached_payload_bytes.right)} right
+          </dd>
+        </div>
+        <div>
+          <dt>Latest side requests</dt>
+          <dd>
+            {latestRequests.length
+              ? latestRequests
+                  .map(
+                    (sample) =>
+                      `${sample.side}: ${Math.round(sample.request_ms)} ms, ${formatBytes(
+                        sample.payload_bytes,
+                      )}`,
+                  )
+                  .join(" · ")
+              : "No uncached frames requested yet"}
+          </dd>
+        </div>
+        <div>
+          <dt>Persistence</dt>
+          <dd>{descriptor.persistence.replace("_", " ")}</dd>
+        </div>
+      </dl>
+    </details>
+  );
+}
+
+function CompareStatus({
+  title,
+  body,
+  actionLabel,
+  onAction,
+}: {
+  title: string;
+  body: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}) {
+  return (
+    <section className="status-panel" role="status">
+      <h2>{title}</h2>
+      <p>{body}</p>
+      {actionLabel && onAction && (
+        <button type="button" onClick={onAction}>
+          {actionLabel}
+        </button>
+      )}
+    </section>
+  );
+}
+
+function alignedLinks(descriptor: WorldCompareDescriptor): CompareLinkModes {
+  const compatibility = descriptor.compatibility;
+  if (!compatibility) return INDEPENDENT_LINKS;
+  return {
+    time: compatibility.nearest_time_link_available,
+    view: compatibility.shared_view_ids.length > 0,
+    plane: compatibility.physical_plane_link_available,
+    camera: compatibility.camera_link_available,
+    selection: compatibility.selection_link_available,
+  };
+}
+
+function synchronizeState(
+  descriptor: WorldCompareDescriptor,
+  sourceSide: CompareSide,
+  source: ExploreWorldState,
+  target: ExploreWorldState,
+  links: CompareLinkModes,
+): { state: ExploreWorldState; notices: string[] } {
+  const adapter = WORLD_COMPARE_ADAPTERS[descriptor.world_id];
+  const targetSimulation = selectedSimulation(
+    descriptor,
+    sourceSide === "left"
+      ? descriptor.selected_right_simulation_id
+      : descriptor.selected_left_simulation_id,
+  );
+  const sourceSimulation = selectedSimulation(
+    descriptor,
+    sourceSide === "left"
+      ? descriptor.selected_left_simulation_id
+      : descriptor.selected_right_simulation_id,
+  );
+  if (!targetSimulation || !sourceSimulation || source.world_id !== target.world_id) {
+    return { state: target, notices: [] };
+  }
+  const notices: string[] = [];
+  let next = target;
+  if (links.time) {
+    const mapped = nearestCompareTime(
+      targetSimulation,
+      adapter.modelTime(source),
+      descriptor.compatibility?.time_tolerance_seconds ?? 0,
+    );
+    if (mapped) {
+      next = adapter.setModelTime(next, mapped.value);
+      if (mapped.message) notices.push(`${targetSimulation.display_name}: ${mapped.message}`);
+    } else {
+      notices.push(
+        `${targetSimulation.display_name}: no saved output is within the approved time tolerance.`,
+      );
+    }
+  }
+  if (links.view) {
+    const sourceView = adapter.viewId(source);
+    if (descriptor.compatibility?.shared_view_ids.includes(sourceView)) {
+      next = adapter.setView(next, sourceView);
+      const field = adapter.fieldId(source);
+      if (field && descriptor.compatibility.shared_field_ids.includes(field)) {
+        next = adapter.setField(next, field);
+      }
+    }
+  }
+  if (links.plane && isTradeState(source) && isTradeState(next)) {
+    next = {
+      ...next,
+      active_slice_plane: source.active_slice_plane,
+      slice_coordinate_km: source.slice_coordinate_km,
+      slice_native_index: source.slice_native_index,
+    };
+  }
+  if (links.camera) {
+    const preset = adapter.cameraPreset(source);
+    if (preset) {
+      const mapped = mapCamera(
+        preset,
+        adapter.cameraTransform(source),
+        sourceSimulation,
+        targetSimulation,
+      );
+      if (mapped) {
+        next = adapter.setCamera(next, mapped.preset, mapped.transform);
+        if (mapped.message) notices.push(mapped.message);
+      }
+    }
+  }
+  if (links.selection) {
+    next = adapter.setSelectedPoint(next, adapter.selectedPoint(source));
+  }
+  return { state: next, notices: [...new Set(notices)] };
+}
+
+async function initialCompareState(
+  simulation: CompareSimulationDescriptor,
+  resumeExistingState: boolean,
+): Promise<ExploreWorldState> {
+  if (!resumeExistingState) return simulation.initial_state;
+  try {
+    const response = await fetch(
+      `/api/worlds/${simulation.world_id}/simulations/${simulation.simulation_id}/explore-state`,
+    );
+    if (!response.ok) return simulation.initial_state;
+    const payload = (await response.json()) as {
+      library?: { last_active?: { state?: ExploreWorldState } | null };
+    };
+    const restored = payload.library?.last_active?.state;
+    return restored?.world_id === simulation.world_id ? restored : simulation.initial_state;
+  } catch {
+    return simulation.initial_state;
+  }
+}
+
+function selectedSimulation(
+  descriptor: WorldCompareDescriptor,
+  simulationId: string | null,
+): CompareSimulationDescriptor | null {
+  return (
+    descriptor.simulations.find((simulation) => simulation.simulation_id === simulationId) ?? null
+  );
+}
+
+function otherSide(side: CompareSide): CompareSide {
+  return side === "left" ? "right" : "left";
+}
+
+function combinedMountainScale(left: TerrainScale, right: TerrainScale): TerrainScale {
+  const limit = Math.max(
+    Math.abs(left.minimum),
+    Math.abs(left.maximum),
+    Math.abs(right.minimum),
+    Math.abs(right.maximum),
+  );
+  const fractions = [-0.8, -0.6, -0.4, -0.2, -0.1, 0.1, 0.2, 0.4, 0.6, 0.8];
+  return {
+    ...left,
+    minimum: -limit,
+    maximum: limit,
+    selected_time_minimum: left.selected_time_minimum,
+    selected_time_maximum: left.selected_time_maximum,
+    breakpoints: fractions.map((fraction) => fraction * limit),
+    scale_id: left.scale_id,
+  };
+}
+
+function selectedEvidenceDifference(
+  left: CompareSelectedEvidence | null,
+  right: CompareSelectedEvidence | null,
+): string {
+  if (!left || !right) return "Select a point on both sides to calculate like-unit differences.";
+  const differences: string[] = [];
+  left.metrics.forEach((leftMetric) => {
+    if (leftMetric.numericValue === undefined || !leftMetric.units) return;
+    const rightMetric = right.metrics.find(
+      (candidate) =>
+        candidate.label === leftMetric.label &&
+        candidate.units === leftMetric.units &&
+        candidate.numericValue !== undefined,
+    );
+    if (!rightMetric || rightMetric.numericValue === undefined) return;
+    const delta = rightMetric.numericValue - leftMetric.numericValue;
+    differences.push(
+      `${leftMetric.label}: ${formatSigned(delta)} ${leftMetric.units} (right minus left)`,
+    );
+  });
+  return differences.length
+    ? differences.join(" · ")
+    : "The selected points do not expose directly comparable numeric evidence.";
+}
+
+function evidenceSignature(value: CompareSelectedEvidence | null): string {
+  return value ? JSON.stringify(value) : "";
+}
+
+function lineageLabel(simulation: CompareSimulationDescriptor): string {
+  if (simulation.parent_simulation_id) return `Child of ${simulation.parent_simulation_id}`;
+  if (simulation.reference_simulation_id === simulation.simulation_id) return "Retained reference";
+  if (simulation.reference_simulation_id) {
+    return `Reference: ${simulation.reference_simulation_id}`;
+  }
+  if (simulation.lineage_state === "independent_built_in") return "Independent built-in";
+  return simulation.lineage_state === "known" ? "Known" : simulation.lineage_state;
+}
+
+function formatSpacing(grid: CompareSimulationDescriptor["grid"]): string {
+  if (grid.topology === "native_2d_xz") {
+    return `${formatMeters(grid.dx_m)} x / ${formatMeters(grid.dz_m)} z · native 2-D x-z`;
+  }
+  return `${formatMeters(grid.dx_m)} × ${formatMeters(grid.dy_m)} × ${formatMeters(
+    grid.dz_m,
+  )}`;
+}
+
+function formatMeters(value: number): string {
+  return value >= 1_000 ? `${formatNumber(value / 1_000)} km` : `${formatNumber(value)} m`;
+}
+
+function formatDifferenceValue(
+  difference: CompareDifference,
+  side: "left" | "right",
+): string {
+  const known = side === "left" ? difference.left_known : difference.right_known;
+  if (!known) return "Unknown";
+  const value = side === "left" ? difference.left_value : difference.right_value;
+  if (difference.path === "controls.surface_moisture_flux_g_g_m_s" && typeof value === "number") {
+    return `${(value * 1_000).toFixed(5)} g/kg m/s`;
+  }
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "number") {
+    if (Number.isInteger(value)) {
+      return `${value.toLocaleString()}${difference.units ? ` ${difference.units}` : ""}`;
+    }
+    return `${formatNumber(value)}${difference.units ? ` ${difference.units}` : ""}`;
+  }
+  return `${String(value)}${difference.units ? ` ${difference.units}` : ""}`;
+}
+
+function fieldDisplayName(value: string): string {
+  const labels: Record<string, string> = {
+    ql: "Cloud water",
+    w: "Vertical velocity",
+    theta_perturbation: "Potential-temperature perturbation",
+    cloud_liquid: "Cloud liquid water",
+    relative_humidity: "Relative humidity",
+  };
+  return labels[value] ?? value.replaceAll("_", " ");
+}
+
+function viewDisplayName(value: string): string {
+  const labels: Record<string, string> = {
+    field: "Field",
+    updraft_lens: "Updraft Lens",
+    wave_structure: "Wave Structure Lens",
+    wave_cloud: "Wave Cloud Lens",
+    rotating_updraft: "Rotating Updraft",
+    cloud_precipitation: "Cloud and Precipitation",
+    low_level_interactions: "Low-Level Interactions",
+  };
+  return labels[value] ?? value.replaceAll("_", " ");
+}
+
+function formatSeconds(value: number): string {
+  return `${Math.round(value).toLocaleString()} s`;
+}
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) >= 1_000) return Math.round(value).toLocaleString();
+  if (Math.abs(value) >= 100) return value.toFixed(0);
+  if (Math.abs(value) >= 10) return value.toFixed(1);
+  if (Math.abs(value) >= 1) return value.toFixed(2);
+  return value.toPrecision(3);
+}
+
+function formatSigned(value: number): string {
+  return `${value >= 0 ? "+" : ""}${formatNumber(value)}`;
+}
+
+function formatBytes(value: number): string {
+  if (value < 1_024) return `${value} B`;
+  if (value < 1_048_576) return `${(value / 1_024).toFixed(1)} KB`;
+  return `${(value / 1_048_576).toFixed(1)} MB`;
+}
+
+async function responseMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await response.json()) as { detail?: unknown };
+    return typeof payload.detail === "string" ? payload.detail : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/app/frontend/src/WorldCompare.types.ts
+++ b/app/frontend/src/WorldCompare.types.ts
@@ -1,0 +1,169 @@
+import type {
+  ExplorePoint,
+  ExploreWorldState,
+  MountainWavesExploreState,
+  SupercellsExploreState,
+  TradeCumulusExploreState,
+} from "./ExploreStatePersistence";
+import type { CameraPreset, CameraTransform } from "./True3DViewer";
+
+export type CompareWorldId = ExploreWorldState["world_id"];
+export type CompareWorldSlug = "trade-cumulus" | "mountain-waves" | "supercells";
+
+export type CompareDifference = {
+  path: string;
+  label: string;
+  category: "atmospheric" | "numerical" | "output" | "operational" | "metadata";
+  left_value: unknown;
+  right_value: unknown;
+  left_known: boolean;
+  right_known: boolean;
+  units: string | null;
+  material: boolean;
+};
+
+export type CompareGridDescriptor = {
+  topology: "native_3d" | "native_2d_xz";
+  nx: number;
+  ny: number;
+  nz: number;
+  dx_m: number;
+  dy_m: number;
+  dz_m: number;
+  x_extent_km: [number, number];
+  y_extent_km: [number, number] | null;
+  z_extent_km: [number, number];
+};
+
+export type CompareTimeDescriptor = {
+  times_seconds: number[];
+  start_seconds: number;
+  end_seconds: number;
+  cadence_seconds: number;
+  saved_output_count: number;
+  interpolation_allowed: false;
+};
+
+export type CompareSimulationDescriptor = {
+  simulation_id: string;
+  display_name: string;
+  world_id: CompareWorldId;
+  role: string;
+  run_id: string;
+  result_id: string | null;
+  case_id: string;
+  parent_simulation_id: string | null;
+  reference_simulation_id: string | null;
+  lineage_state: string;
+  availability_state: string;
+  availability_message: string;
+  inspectable: boolean;
+  grid: CompareGridDescriptor;
+  time: CompareTimeDescriptor;
+  available_field_ids: string[];
+  available_view_ids: string[];
+  fixed_scale_ids: string[];
+  plane_orientations: Array<"horizontal" | "vertical_x" | "vertical_y">;
+  camera_mapping: "normalized_3d" | "native_2d_xz";
+  initial_state: ExploreWorldState;
+  caveats: string[];
+};
+
+export type CompareCompatibility = {
+  same_world: boolean;
+  both_inspectable: boolean;
+  relationship: string;
+  controlled_pair: boolean;
+  controlled_pair_message: string;
+  shared_field_ids: string[];
+  shared_view_ids: string[];
+  shared_fixed_scale_ids: string[];
+  exact_time_link_available: boolean;
+  nearest_time_link_available: boolean;
+  time_tolerance_seconds: number;
+  physical_plane_link_available: boolean;
+  camera_link_available: boolean;
+  selection_link_available: boolean;
+  blockers: string[];
+};
+
+export type WorldCompareDescriptor = {
+  schema_version: "world_compare_v1";
+  world_id: CompareWorldId;
+  display_name: string;
+  simulations: CompareSimulationDescriptor[];
+  default_left_simulation_id: string | null;
+  default_right_simulation_id: string | null;
+  selected_left_simulation_id: string | null;
+  selected_right_simulation_id: string | null;
+  material_differences: CompareDifference[];
+  compatibility: CompareCompatibility | null;
+  no_second_simulation_message: string | null;
+  persistence: "transient_only";
+};
+
+export type CompareLinkModes = {
+  time: boolean;
+  view: boolean;
+  plane: boolean;
+  camera: boolean;
+  selection: boolean;
+};
+
+export type CompareSide = "left" | "right";
+
+export type CompareMappingResult<T> = {
+  value: T;
+  exact: boolean;
+  message: string | null;
+};
+
+export type ComparePerformanceSample = {
+  side: CompareSide;
+  key: string;
+  request_ms: number;
+  payload_bytes: number;
+  cache_hit: boolean;
+};
+
+export type ComparePerformanceSummary = {
+  first_useful_dual_view_ms: number | null;
+  cache_entries: Record<CompareSide, number>;
+  estimated_cached_payload_bytes: Record<CompareSide, number>;
+  samples: ComparePerformanceSample[];
+};
+
+export type WorldCompareAdapter = {
+  worldId: CompareWorldId;
+  viewLabel: string;
+  viewOptions: (
+    simulation: CompareSimulationDescriptor,
+  ) => Array<{ id: string; label: string }>;
+  viewId: (state: ExploreWorldState) => string;
+  setView: (state: ExploreWorldState, viewId: string) => ExploreWorldState;
+  fieldId: (state: ExploreWorldState) => string | null;
+  setField: (state: ExploreWorldState, fieldId: string) => ExploreWorldState;
+  modelTime: (state: ExploreWorldState) => number;
+  setModelTime: (state: ExploreWorldState, seconds: number) => ExploreWorldState;
+  selectedPoint: (state: ExploreWorldState) => ExplorePoint | null;
+  setSelectedPoint: (state: ExploreWorldState, point: ExplorePoint | null) => ExploreWorldState;
+  cameraPreset: (state: ExploreWorldState) => CameraPreset | null;
+  setCamera: (
+    state: ExploreWorldState,
+    preset: CameraPreset,
+    transform: CameraTransform | null,
+  ) => ExploreWorldState;
+  cameraTransform: (state: ExploreWorldState) => CameraTransform | null;
+};
+
+export function isTradeState(state: ExploreWorldState): state is TradeCumulusExploreState {
+  return state.world_id === "trade_cumulus";
+}
+
+export function isMountainState(state: ExploreWorldState): state is MountainWavesExploreState {
+  return state.world_id === "mountain_waves";
+}
+
+export function isSupercellsState(state: ExploreWorldState): state is SupercellsExploreState {
+  return state.world_id === "supercells";
+}

--- a/app/frontend/src/WorldCompareAdapters.test.tsx
+++ b/app/frontend/src/WorldCompareAdapters.test.tsx
@@ -1,22 +1,55 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { TradeCumulusExploreState } from "./ExploreStatePersistence";
+import type { SupercellsExploreState, TradeCumulusExploreState } from "./ExploreStatePersistence";
 import type { CompareSimulationDescriptor } from "./WorldCompare.types";
 import { WorldCompareSideVisual } from "./WorldCompareAdapters";
 
 vi.mock("./True3DViewer", () => ({
   True3DViewer: ({
     pointCloud,
+    stormScene,
     status,
+    compactDisplayControls,
   }: {
     pointCloud: { frame_marker?: string } | null;
+    stormScene?: { layers: Array<{ key: string }> } | null;
     status: string;
+    compactDisplayControls?: ReactNode;
   }) => (
     <section aria-label="mock 3-D field">
       <span>{status}</span>
-      <span>{pointCloud?.frame_marker ?? "no frame"}</span>
+      <span>
+        {pointCloud?.frame_marker ??
+          (stormScene ? `storm scene ${stormScene.layers.length}` : "no frame")}
+      </span>
+      {compactDisplayControls}
     </section>
+  ),
+}));
+
+vi.mock("./StormExaminationResearch", () => ({
+  StormPlanPlot: ({
+    frame,
+    onSelect,
+  }: {
+    frame: { plan: { title: string }; selected_point: Record<string, number> };
+    onSelect: (selection: { xIndex: number; yIndex: number; zIndex: number }) => void;
+  }) => (
+    <button
+      type="button"
+      aria-label="mock Supercell plan"
+      onClick={() => onSelect({ xIndex: 1, yIndex: 1, zIndex: 1 })}
+    >
+      {frame.plan.title}
+    </button>
+  ),
+  StormSectionPlot: ({ section }: { section: { title: string } }) => (
+    <div aria-label="mock Supercell section">{section.title}</div>
+  ),
+  StormLegend: ({ frame }: { frame: { lens_name: string } }) => (
+    <div aria-label="mock Supercell legend">{frame.lens_name} legend</div>
   ),
 }));
 
@@ -98,11 +131,238 @@ const simulation: CompareSimulationDescriptor = {
   caveats: [],
 };
 
+const supercellState: SupercellsExploreState = {
+  ...commonState,
+  world_id: "supercells",
+  model_time_seconds: 120,
+  lens_id: "rotating_updraft",
+  viewport_id: "storm",
+  evidence_view: "plan",
+  plane_coordinate_km: 3.1666669845581055,
+  visible_layer_ids: ["storm_cloud_body", "rising_core"],
+  fixed_scale_ids: ["supercell_midlevel_vertical_velocity_v1"],
+  overlays: {
+    rotation: true,
+    updraft_helicity: true,
+    reflectivity: false,
+    condensate: true,
+    rain: false,
+    wind: false,
+    precipitating_condensate: false,
+    vertical_motion: true,
+  },
+  hydrometeor_category_codes: [1, 2, 3, 4, 5],
+  camera_preset: "look_along_y",
+  camera_transform: null,
+  scene_opacity: 1,
+  scene_point_size: 1,
+  selected_evidence_visible: false,
+  playback_speed: 1,
+  display_controls_open: false,
+};
+
+const supercellSimulation: CompareSimulationDescriptor = {
+  ...simulation,
+  simulation_id: "supercells_straight_line_hodograph",
+  display_name: "Straight-Line Hodograph Supercell",
+  world_id: "supercells",
+  role: "variation",
+  run_id: "straight-line-supercell-presentation-v1-20260726",
+  result_id: null,
+  case_id: "cm1_r21_1_straight_line_supercell_presentation_v1",
+  parent_simulation_id: "supercells_quarter_circle_reference",
+  reference_simulation_id: "supercells_quarter_circle_reference",
+  grid: {
+    topology: "native_3d",
+    nx: 240,
+    ny: 240,
+    nz: 60,
+    dx_m: 500,
+    dy_m: 500,
+    dz_m: 333.3333333,
+    x_extent_km: [-60, 60],
+    y_extent_km: [-60, 60],
+    z_extent_km: [0, 20],
+  },
+  time: {
+    times_seconds: [0, 120, 240],
+    start_seconds: 0,
+    end_seconds: 240,
+    cadence_seconds: 120,
+    saved_output_count: 3,
+    interpolation_allowed: false,
+  },
+  available_field_ids: ["winterp", "total_condensate"],
+  available_view_ids: ["rotating_updraft", "cloud_precipitation", "low_level_interactions"],
+  fixed_scale_ids: [
+    "supercell_midlevel_vertical_velocity_v1",
+    "supercell_total_condensate_v2",
+    "supercell_low_level_vertical_velocity_v1",
+  ],
+  plane_orientations: ["horizontal", "vertical_x", "vertical_y"],
+  camera_mapping: "normalized_3d",
+  initial_state: supercellState,
+};
+
 function payload(marker: string, seconds: number) {
   return {
     frame_marker: marker,
     selection: { time_seconds: seconds },
     provenance: { provenance_label: "Native CM1 scalar cells" },
+  };
+}
+
+function supercellPayload() {
+  const primary = {
+    key: "winterp",
+    display_name: "Vertical velocity",
+    units: "m/s",
+    evidence_kind: "native",
+    source_fields: ["winterp"],
+    derivation: null,
+    values: [
+      [-2, 3],
+      [1, 8],
+    ],
+    selected_frame_minimum: -2,
+    selected_frame_maximum: 8,
+    scale: {
+      scale_id: "supercell_midlevel_vertical_velocity_v1",
+      display_name: "Vertical velocity",
+      units: "m/s",
+      scale_type: "fixed_discrete",
+      minimum: -30,
+      maximum: 30,
+      breakpoints: [-20, -10, -2, 2, 10, 20],
+      colors: ["#4b0082", "#0057d9", "#00c9d8", "#ffffff", "#00d63b", "#ff9800", "#c40000"],
+      fixed_across_time: true,
+    },
+  };
+  const section = (orientation: "xz" | "yz") => ({
+    orientation,
+    title: `${orientation} native section`,
+    horizontal_dimension: orientation === "xz" ? "x" : "y",
+    horizontal_indices: [0, 1],
+    horizontal_km: [-0.25, 0.25],
+    z_km: [0.1667, 0.5],
+    cross_section_coordinate_km: 0.25,
+    primary,
+    overlays: {},
+    categories: null,
+  });
+  return {
+    schema_version: "supercells_explore_v1",
+    authority_state: "supercells_product_world",
+    world_id: "supercells",
+    simulation_id: "supercells_straight_line_hodograph",
+    run_id: supercellSimulation.run_id,
+    case_id: supercellSimulation.case_id,
+    simulation_label: supercellSimulation.display_name,
+    lens_id: "rotating_updraft",
+    lens_name: "Rotating Updraft",
+    lens_question: "Where is the storm rising and rotating as one organized structure?",
+    what_to_notice_now: "Compare coordinates and local evidence without assigning storm lineage.",
+    time_index: 1,
+    time_seconds: 120,
+    times_seconds: [0, 120, 240],
+    mature_checkpoint_indices: [1],
+    timeline_checkpoints: [],
+    viewport: "storm",
+    viewport_bounds_km: { x_min: -40, x_max: 40, y_min: -45, y_max: 35 },
+    primary_updraft: {
+      x_index: 1,
+      y_index: 1,
+      z_index: 1,
+      x_km: 0.25,
+      y_km: 0.25,
+      z_km: 0.5,
+      w_m_s: 8,
+    },
+    selected_point: {
+      x_index: 1,
+      y_index: 1,
+      z_index: 1,
+      x_km: 0.25,
+      y_km: 0.25,
+      z_km: 0.5,
+      model_time_seconds: 120,
+      coordinate_frame: "translating model frame",
+      values: {
+        vertical_velocity: 8,
+        vertical_vorticity: 0.02,
+        updraft_helicity: 450,
+        total_condensate: 2,
+        reflectivity: 48,
+      },
+      units: {
+        vertical_velocity: "m/s",
+        vertical_vorticity: "s^-1",
+        updraft_helicity: "m^2/s^2",
+        total_condensate: "g/kg",
+        reflectivity: "dBZ",
+      },
+      evidence_kind: {},
+      states: ["Rising", "Condensate present"],
+      distance_to_primary_updraft_km: 0,
+    },
+    plan: {
+      title: "Updraft and rotation",
+      subtitle: "Native-grid plan evidence",
+      x_indices: [0, 1],
+      y_indices: [0, 1],
+      x_km: [-0.25, 0.25],
+      y_km: [-0.25, 0.25],
+      level_index: 1,
+      level_km: 0.5,
+      selection_z_indices: null,
+      primary,
+      overlays: {},
+      categories: null,
+      wind_vectors: [],
+    },
+    xz_section: section("xz"),
+    yz_section: section("yz"),
+    scene: {
+      coordinate_extents_km: {
+        x: { min: -40, max: 40 },
+        y: { min: -45, max: 35 },
+        z: { min: 0.1667, max: 19.8333 },
+      },
+      coordinate_sizes: { x: 160, y: 160, z: 60 },
+      coordinate_indices: { x: [0, 1], y: [0, 1], z: [0, 1] },
+      coordinate_values_km: {
+        x: [-0.25, 0.25],
+        y: [-0.25, 0.25],
+        z: [0.1667, 0.5],
+      },
+      layers: [
+        {
+          key: "storm_cloud_body",
+          display_name: "Storm cloud body",
+          units: "g/kg",
+          evidence_kind: "derived",
+          source_fields: ["qc", "qr", "qi", "qs", "qg"],
+          derivation: "total condensate",
+          rendering: "neutral_cloud",
+          points: [[0.25, 0.25, 0.5, 2, 0]],
+          source_count: 1,
+          returned_count: 1,
+          threshold_label: "0.05 g/kg",
+          default_visible: true,
+          default_opacity: 0.22,
+          default_point_size: 4.5,
+          scale: null,
+          categories: [],
+        },
+      ],
+      wind_vectors: [],
+      wind_reference_m_s: 25,
+      point_budget: 20_000,
+      source_history_file: "cm1out_000002.nc",
+    },
+    caveats: [],
+    provenance: {},
+    extraction_milliseconds: 12,
   };
 }
 
@@ -135,6 +395,49 @@ afterEach(() => {
 });
 
 describe("WorldCompareSideVisual request lifecycle", () => {
+  it("loads the real Supercells frame contract and exposes 3-D plus physical sections", async () => {
+    const onStateChange = vi.fn();
+    const onEvidence = vi.fn();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify(supercellPayload()), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <WorldCompareSideVisual
+        side="right"
+        simulation={supercellSimulation}
+        state={supercellState}
+        onStateChange={onStateChange}
+        onFrameState={vi.fn()}
+        onPerformance={vi.fn()}
+        onEvidence={onEvidence}
+      />,
+    );
+
+    expect(await screen.findByLabelText("mock Supercell plan")).toHaveTextContent(
+      "Updraft and rotation",
+    );
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      "/api/worlds/supercells/simulations/supercells_straight_line_hodograph/frame?",
+    );
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      "lens=rotating_updraft&viewport=storm&time_index=1",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "3-D" }));
+    expect(screen.getByText("storm scene 1")).toBeVisible();
+    expect(screen.getByRole("checkbox", { name: "Storm cloud body" })).toBeChecked();
+
+    fireEvent.click(screen.getByRole("button", { name: "Vertical x-z" }));
+    expect(onStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        evidence_view: "xz",
+        plane_coordinate_km: 0,
+      }),
+    );
+    expect(onEvidence).toHaveBeenCalledWith("right", null);
+  });
+
   it("retries a failed side without replacing its adapter", async () => {
     vi.stubGlobal(
       "fetch",
@@ -185,9 +488,7 @@ describe("WorldCompareSideVisual request lifecycle", () => {
     expect(await screen.findByText("current frame")).toBeVisible();
     expect(firstSignal?.aborted).toBe(true);
     await act(async () => {
-      stale.resolve(
-        new Response(JSON.stringify(payload("stale frame", 0)), { status: 200 }),
-      );
+      stale.resolve(new Response(JSON.stringify(payload("stale frame", 0)), { status: 200 }));
       await stale.promise;
     });
     await waitFor(() => expect(screen.queryByText("stale frame")).not.toBeInTheDocument());

--- a/app/frontend/src/WorldCompareAdapters.test.tsx
+++ b/app/frontend/src/WorldCompareAdapters.test.tsx
@@ -12,11 +12,13 @@ vi.mock("./True3DViewer", () => ({
     stormScene,
     status,
     compactDisplayControls,
+    onSelectStormPoint,
   }: {
     pointCloud: { frame_marker?: string } | null;
     stormScene?: { layers: Array<{ key: string }> } | null;
     status: string;
     compactDisplayControls?: ReactNode;
+    onSelectStormPoint?: (point: [number, number, number, number, number]) => void;
   }) => (
     <section aria-label="mock 3-D field">
       <span>{status}</span>
@@ -24,6 +26,14 @@ vi.mock("./True3DViewer", () => ({
         {pointCloud?.frame_marker ??
           (stormScene ? `storm scene ${stormScene.layers.length}` : "no frame")}
       </span>
+      {onSelectStormPoint && (
+        <button
+          type="button"
+          onClick={() => onSelectStormPoint([1.25, 2.25, 3.1666667, 8, 1])}
+        >
+          Select mock 3-D point
+        </button>
+      )}
       {compactDisplayControls}
     </section>
   ),
@@ -403,7 +413,7 @@ describe("WorldCompareSideVisual request lifecycle", () => {
       .mockResolvedValue(new Response(JSON.stringify(supercellPayload()), { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    render(
+    const { rerender } = render(
       <WorldCompareSideVisual
         side="right"
         simulation={supercellSimulation}
@@ -428,11 +438,62 @@ describe("WorldCompareSideVisual request lifecycle", () => {
     expect(screen.getByText("storm scene 1")).toBeVisible();
     expect(screen.getByRole("checkbox", { name: "Storm cloud body" })).toBeChecked();
 
+    fireEvent.click(screen.getByRole("button", { name: "Select mock 3-D point" }));
+    const selectedState = onStateChange.mock.lastCall?.[0] as SupercellsExploreState;
+    expect(selectedState).toEqual(
+      expect.objectContaining({
+        selected_point: {
+          x_km: 1.25,
+          y_km: 2.25,
+          z_km: 3.1666667,
+        },
+        selected_evidence_visible: true,
+        plane_coordinate_km: 3.1666667,
+      }),
+    );
+    rerender(
+      <WorldCompareSideVisual
+        side="right"
+        simulation={supercellSimulation}
+        state={selectedState}
+        onStateChange={onStateChange}
+        onFrameState={vi.fn()}
+        onPerformance={vi.fn()}
+        onEvidence={onEvidence}
+      />,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const selectedRequest = String(fetchMock.mock.calls[1][0]);
+    expect(selectedRequest).toContain("z_index=9");
+    expect(selectedRequest).toContain("selected_x_index=122");
+    expect(selectedRequest).toContain("selected_y_index=124");
+    expect(selectedRequest).toContain("selected_z_index=9");
+
+    rerender(
+      <WorldCompareSideVisual
+        side="right"
+        simulation={supercellSimulation}
+        state={{
+          ...selectedState,
+          evidence_view: "xz",
+          plane_coordinate_km: -10,
+        }}
+        onStateChange={onStateChange}
+        onFrameState={vi.fn()}
+        onPerformance={vi.fn()}
+        onEvidence={onEvidence}
+      />,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    const independentSectionRequest = String(fetchMock.mock.calls[2][0]);
+    expect(independentSectionRequest).toContain("y_index=100");
+    expect(independentSectionRequest).toContain("selected_y_index=124");
+
     fireEvent.click(screen.getByRole("button", { name: "Vertical x-z" }));
     expect(onStateChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
         evidence_view: "xz",
-        plane_coordinate_km: 0,
+        plane_coordinate_km: 2.25,
       }),
     );
     expect(onEvidence).toHaveBeenCalledWith("right", null);

--- a/app/frontend/src/WorldCompareAdapters.test.tsx
+++ b/app/frontend/src/WorldCompareAdapters.test.tsx
@@ -1,0 +1,239 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { TradeCumulusExploreState } from "./ExploreStatePersistence";
+import type { CompareSimulationDescriptor } from "./WorldCompare.types";
+import { WorldCompareSideVisual } from "./WorldCompareAdapters";
+
+vi.mock("./True3DViewer", () => ({
+  True3DViewer: ({
+    pointCloud,
+    status,
+  }: {
+    pointCloud: { frame_marker?: string } | null;
+    status: string;
+  }) => (
+    <section aria-label="mock 3-D field">
+      <span>{status}</span>
+      <span>{pointCloud?.frame_marker ?? "no frame"}</span>
+    </section>
+  ),
+}));
+
+const commonState = {
+  state_version: 1 as const,
+  context_collapsed: true,
+  secondary_section: "notes" as const,
+  selected_point: null,
+};
+
+function state(modelTimeSeconds: number): TradeCumulusExploreState {
+  return {
+    ...commonState,
+    world_id: "trade_cumulus",
+    model_time_seconds: modelTimeSeconds,
+    view_id: "field",
+    scene_field_id: "ql",
+    slice_field_id: "ql",
+    fixed_scale_id: null,
+    active_slice_plane: "vertical_x",
+    slice_coordinate_km: 1,
+    slice_native_index: 50,
+    horizontal_slice_coordinate_km: 1,
+    threshold_native: 1e-6,
+    layer_opacity: 0.68,
+    point_size_px: 11,
+    lens_opacity: 0.9,
+    show_slice_plane: true,
+    show_cloud_boundary: false,
+    show_horizontal_wind: false,
+    wind_mode: "perturbation",
+    camera_preset: "overview",
+    camera_transform: null,
+    playback_speed: 1,
+    display_controls_open: false,
+  };
+}
+
+const simulation: CompareSimulationDescriptor = {
+  simulation_id: "baseline",
+  display_name: "Canonical BOMEX Baseline",
+  world_id: "trade_cumulus",
+  role: "reference",
+  run_id: "baseline-run",
+  result_id: "baseline-result",
+  case_id: "bomex",
+  parent_simulation_id: null,
+  reference_simulation_id: "baseline",
+  lineage_state: "known",
+  availability_state: "available",
+  availability_message: "Available",
+  inspectable: true,
+  grid: {
+    topology: "native_3d",
+    nx: 96,
+    ny: 96,
+    nz: 100,
+    dx_m: 66.67,
+    dy_m: 66.67,
+    dz_m: 30,
+    x_extent_km: [-3.2, 3.2],
+    y_extent_km: [-3.2, 3.2],
+    z_extent_km: [0, 3],
+  },
+  time: {
+    times_seconds: [0, 60, 120],
+    start_seconds: 0,
+    end_seconds: 120,
+    cadence_seconds: 60,
+    saved_output_count: 3,
+    interpolation_allowed: false,
+  },
+  available_field_ids: ["ql"],
+  available_view_ids: ["field", "updraft_lens"],
+  fixed_scale_ids: ["trade_cumulus_updraft_velocity_v1"],
+  plane_orientations: ["horizontal", "vertical_x", "vertical_y"],
+  camera_mapping: "normalized_3d",
+  initial_state: state(0),
+  caveats: [],
+};
+
+function payload(marker: string, seconds: number) {
+  return {
+    frame_marker: marker,
+    selection: { time_seconds: seconds },
+    provenance: { provenance_label: "Native CM1 scalar cells" },
+  };
+}
+
+function deferredResponse() {
+  let resolve!: (response: Response) => void;
+  const promise = new Promise<Response>((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}
+
+function renderSide(exploreState: TradeCumulusExploreState) {
+  const onFrameState = vi.fn();
+  const onPerformance = vi.fn();
+  const result = render(
+    <WorldCompareSideVisual
+      side="left"
+      simulation={simulation}
+      state={exploreState}
+      onStateChange={vi.fn()}
+      onFrameState={onFrameState}
+      onPerformance={onPerformance}
+    />,
+  );
+  return { ...result, onFrameState, onPerformance };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("WorldCompareSideVisual request lifecycle", () => {
+  it("retries a failed side without replacing its adapter", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(new Response("temporary failure", { status: 503 }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(payload("recovered frame", 0)), { status: 200 }),
+        ),
+    );
+    const { onFrameState } = renderSide(state(0));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Retry this side" }));
+
+    expect(await screen.findByText("recovered frame")).toBeVisible();
+    expect(onFrameState).toHaveBeenCalledWith("left", "error");
+    expect(onFrameState).toHaveBeenLastCalledWith("left", "ready");
+  });
+
+  it("aborts and ignores a stale response when the requested time changes", async () => {
+    const stale = deferredResponse();
+    let firstSignal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input).includes("time_index=0")) {
+          firstSignal = init?.signal ?? undefined;
+          return stale.promise;
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify(payload("current frame", 60)), { status: 200 }),
+        );
+      }),
+    );
+    const rendered = renderSide(state(0));
+
+    rendered.rerender(
+      <WorldCompareSideVisual
+        side="left"
+        simulation={simulation}
+        state={state(60)}
+        onStateChange={vi.fn()}
+        onFrameState={rendered.onFrameState}
+        onPerformance={rendered.onPerformance}
+      />,
+    );
+
+    expect(await screen.findByText("current frame")).toBeVisible();
+    expect(firstSignal?.aborted).toBe(true);
+    await act(async () => {
+      stale.resolve(
+        new Response(JSON.stringify(payload("stale frame", 0)), { status: 200 }),
+      );
+      await stale.promise;
+    });
+    await waitFor(() => expect(screen.queryByText("stale frame")).not.toBeInTheDocument());
+    expect(screen.getByText("current frame")).toBeVisible();
+  });
+
+  it("reuses a bounded side cache when returning to a prior saved output", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const isFirst = String(input).includes("time_index=0");
+      return Promise.resolve(
+        new Response(
+          JSON.stringify(payload(isFirst ? "first frame" : "second frame", isFirst ? 0 : 60)),
+          { status: 200 },
+        ),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const rendered = renderSide(state(0));
+    expect(await screen.findByText("first frame")).toBeVisible();
+
+    rendered.rerender(
+      <WorldCompareSideVisual
+        side="left"
+        simulation={simulation}
+        state={state(60)}
+        onStateChange={vi.fn()}
+        onFrameState={rendered.onFrameState}
+        onPerformance={rendered.onPerformance}
+      />,
+    );
+    expect(await screen.findByText("second frame")).toBeVisible();
+
+    rendered.rerender(
+      <WorldCompareSideVisual
+        side="left"
+        simulation={simulation}
+        state={state(0)}
+        onStateChange={vi.fn()}
+        onFrameState={rendered.onFrameState}
+        onPerformance={rendered.onPerformance}
+      />,
+    );
+    expect(await screen.findByText("first frame")).toBeVisible();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(rendered.onPerformance).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cache_hit: true, side: "left" }),
+    );
+  });
+});

--- a/app/frontend/src/WorldCompareAdapters.tsx
+++ b/app/frontend/src/WorldCompareAdapters.tsx
@@ -1,0 +1,884 @@
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  type ExplorePoint,
+  type ExploreWorldState,
+  type MountainWavesExploreState,
+  type TradeCumulusExploreState,
+} from "./ExploreStatePersistence";
+import {
+  type MountainWaveFrame,
+  MountainWavesLegend,
+  MountainWavesTerrainPlot,
+  type MountainWavesViewMode,
+} from "./MountainWavesExplore";
+import { NativeSlicePositionControl } from "./NativeSlicePositionControl";
+import { True3DViewer } from "./True3DViewer";
+import {
+  type UpdraftLensFrame,
+  type UpdraftLensPointSelection,
+  UpdraftLensSlice,
+} from "./UpdraftLensSlice";
+import { timeIndexForSeconds } from "./WorldCompare.logic";
+import {
+  isMountainState,
+  isTradeState,
+  type ComparePerformanceSample,
+  type CompareSide,
+  type CompareSimulationDescriptor,
+} from "./WorldCompare.types";
+
+type SideVisualProps = {
+  side: CompareSide;
+  simulation: CompareSimulationDescriptor;
+  state: ExploreWorldState;
+  onStateChange: (state: ExploreWorldState) => void;
+  onFrameState: (side: CompareSide, state: "loading" | "ready" | "error") => void;
+  onPerformance: (sample: ComparePerformanceSample) => void;
+  commonMountainScale?: TerrainScale | null;
+  onMountainScale?: (side: CompareSide, scale: TerrainScale | null) => void;
+  onEvidence?: (side: CompareSide, evidence: CompareSelectedEvidence | null) => void;
+};
+
+export type TerrainScale = MountainWaveFrame["scale"];
+export type CompareSelectedEvidence = {
+  title: string;
+  states: string[];
+  metrics: Array<{ label: string; value: string; numericValue?: number; units?: string }>;
+};
+
+export function WorldCompareSideVisual(props: SideVisualProps) {
+  if (props.simulation.world_id === "trade_cumulus" && isTradeState(props.state)) {
+    return <TradeCumulusCompareVisual {...props} state={props.state} />;
+  }
+  if (props.simulation.world_id === "mountain_waves" && isMountainState(props.state)) {
+    return <MountainWavesCompareVisual {...props} state={props.state} />;
+  }
+  return (
+    <section className="compare-side-error" role="alert">
+      <h4>View unavailable</h4>
+      <p>This World adapter cannot render the selected transient state.</p>
+    </section>
+  );
+}
+
+function TradeCumulusCompareVisual({
+  side,
+  simulation,
+  state,
+  onStateChange,
+  onFrameState,
+  onPerformance,
+  onEvidence,
+}: Omit<SideVisualProps, "state"> & { state: TradeCumulusExploreState }) {
+  const timeIndex = timeIndexForSeconds(simulation, state.model_time_seconds);
+  const lensUrl =
+    state.view_id === "updraft_lens" && simulation.result_id
+      ? `/api/results/${simulation.result_id}/visualization/trade-cumulus-updraft-lens/frame?${new URLSearchParams(
+          {
+            time_index: String(timeIndex),
+            orientation: state.active_slice_plane,
+            plane_index: String(state.slice_native_index),
+            wind_mode: state.wind_mode,
+          },
+        )}`
+      : null;
+  const cloudUrl =
+    state.view_id === "field" && simulation.result_id
+      ? `/api/results/${simulation.result_id}/visualization/point-cloud?${new URLSearchParams({
+          field: state.scene_field_id,
+          time_index: String(timeIndex),
+          threshold: String(state.threshold_native),
+          max_points: "18000",
+          encoding: "json",
+        })}`
+      : null;
+  const lens = useBoundedJson<UpdraftLensFrame>(side, lensUrl, onFrameState, onPerformance);
+  const cloud = useBoundedJson<TradePointCloud>(side, cloudUrl, onFrameState, onPerformance);
+  const frame = lens.data;
+  const planeValues = useMemo(
+    () => (frame ? coordinateValues(frame, frame.plane_dimension) : []),
+    [frame],
+  );
+  const planeIndex = frame
+    ? Math.max(0, planeValues.findIndex((value) => value === frame.plane_coordinate))
+    : state.slice_native_index;
+  const selectedLensEvidence = useMemo(
+    () => (frame ? tradeSelectedEvidence(frame, state.selected_point) : null),
+    [frame, state.selected_point],
+  );
+
+  useEffect(() => {
+    onEvidence?.(side, selectedLensEvidence);
+  }, [onEvidence, selectedLensEvidence, side]);
+
+  const updatePlanePosition = useCallback(
+    (positionIndex: number) => {
+      const coordinate = planeValues[positionIndex];
+      if (!Number.isFinite(coordinate)) return;
+      onStateChange({
+        ...state,
+        slice_native_index: nativePlaneIndex(frame, positionIndex),
+        slice_coordinate_km: coordinate,
+      });
+    },
+    [frame, onStateChange, planeValues, state],
+  );
+
+  if (state.view_id === "field") {
+    return (
+      <section className="compare-scientific-view compare-trade-field">
+        <True3DViewer
+          resultName={simulation.display_name}
+          pointCloud={cloud.data}
+          fieldLabel="Cloud water"
+          valueChannelLabel="ql (kg/kg)"
+          activeSlice={null}
+          activeSliceLabel="No linked slice in Field mode"
+          showSlicePlane={false}
+          selectedRegion={null}
+          coordinateSizes={{
+            x: simulation.grid.nx,
+            y: simulation.grid.ny,
+            z: simulation.grid.nz,
+          }}
+          selectedTimeLabel={formatSeconds(state.model_time_seconds)}
+          sceneTimeLabel={formatSeconds(cloud.data?.selection.time_seconds ?? null)}
+          thresholdLabel={`${formatNumber(state.threshold_native * 1_000)} g/kg`}
+          opacity={state.layer_opacity}
+          pointSize={state.point_size_px}
+          status={cloud.error ? "Cloud field unavailable" : cloud.loading ? "Loading cloud field" : "Cloud field ready"}
+          provenanceLabel={cloud.data?.provenance.provenance_label ?? "Native CM1 scalar cells"}
+          noCloudMessage="No cloud cells meet the selected threshold."
+          compactWorkspace
+          compactAxisLabels
+          cameraPreset={state.camera_preset}
+          cameraTransform={state.camera_transform}
+          onCameraPresetChange={(cameraPreset) =>
+            onStateChange({ ...state, camera_preset: cameraPreset })
+          }
+          onCameraTransformChange={(cameraTransform) =>
+            onStateChange({ ...state, camera_transform: cameraTransform })
+          }
+        />
+        <CompareLoadState loading={cloud.loading} error={cloud.error} onRetry={cloud.retry} />
+      </section>
+    );
+  }
+
+  return (
+    <section className="compare-scientific-view compare-trade-lens">
+      {frame && (
+        <>
+          <UpdraftLensSlice
+            frame={frame}
+            showCloudBoundary={state.show_cloud_boundary}
+            selectedPoint={tradeSelection(frame, state.selected_point)}
+            onSelectPoint={(selection) =>
+              onStateChange({
+                ...state,
+                selected_point: tradePhysicalPoint(frame, selection),
+              })
+            }
+          />
+          <div className="compare-plane-controls">
+            <div className="segmented-control" aria-label={`${simulation.display_name} slice plane`}>
+              {(
+                [
+                  ["horizontal", "Horizontal x-y"],
+                  ["vertical_x", "Vertical x-z"],
+                  ["vertical_y", "Vertical y-z"],
+                ] as const
+              ).map(([orientation, label]) => (
+                <button
+                  type="button"
+                  key={orientation}
+                  className={state.active_slice_plane === orientation ? "active-control" : ""}
+                  onClick={() => {
+                    const dimension =
+                      orientation === "horizontal" ? "z" : orientation === "vertical_x" ? "y" : "x";
+                    const coordinates = coordinateValues(frame, dimension);
+                    const mapped = nearestValueIndex(coordinates, state.slice_coordinate_km);
+                    onStateChange({
+                      ...state,
+                      active_slice_plane: orientation,
+                      slice_native_index: nativePlaneIndexForDimension(frame, dimension, mapped),
+                      slice_coordinate_km: coordinates[mapped] ?? 0,
+                    });
+                  }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <NativeSlicePositionControl
+              id={`compare-${side}-trade-plane`}
+              ariaLabel={`${simulation.display_name} slice position`}
+              plane={state.active_slice_plane}
+              positionIndex={Math.max(0, planeIndex)}
+              positionCount={planeValues.length}
+              positionLabel={planePositionLabel(frame)}
+              indexLabel={`native index ${frame.plane_index}`}
+              onPositionChange={updatePlanePosition}
+              compact
+            />
+          </div>
+        </>
+      )}
+      <CompareLoadState loading={lens.loading} error={lens.error} onRetry={lens.retry} />
+    </section>
+  );
+}
+
+function MountainWavesCompareVisual({
+  side,
+  simulation,
+  state,
+  onStateChange,
+  onFrameState,
+  onPerformance,
+  commonMountainScale,
+  onMountainScale,
+  onEvidence,
+}: Omit<SideVisualProps, "state"> & { state: MountainWavesExploreState }) {
+  const field =
+    state.view_id === "wave_structure"
+      ? "w"
+      : state.view_id === "wave_cloud"
+        ? "cloud_over_wave"
+        : state.field_id;
+  const timeIndex = timeIndexForSeconds(simulation, state.model_time_seconds);
+  const url = `/api/worlds/mountain-waves/simulations/${
+    simulation.simulation_id
+  }/compare-frame?${new URLSearchParams({
+    field,
+    time_index: String(timeIndex),
+  })}`;
+  const response = useBoundedJson<MountainCompareFrame>(
+    side,
+    url,
+    onFrameState,
+    onPerformance,
+  );
+  const sourceFrame = useMemo(
+    () => (response.data ? expandMountainCompareFrame(response.data) : null),
+    [response.data],
+  );
+  const frame = useMemo(
+    () =>
+      sourceFrame && commonMountainScale
+        ? {
+            ...sourceFrame,
+            scale: {
+              ...commonMountainScale,
+              selected_time_minimum: sourceFrame.scale.selected_time_minimum,
+              selected_time_maximum: sourceFrame.scale.selected_time_maximum,
+            },
+          }
+        : sourceFrame,
+    [commonMountainScale, sourceFrame],
+  );
+
+  useEffect(() => {
+    onMountainScale?.(side, sourceFrame?.scale ?? null);
+  }, [onMountainScale, side, sourceFrame?.scale]);
+
+  const selectedPoint = useMemo(
+    () => (frame ? nearestMountainSelection(frame, state.selected_point) : null),
+    [frame, state.selected_point],
+  );
+  const selectedMountainEvidence = useMemo(
+    () => (frame ? mountainSelectedEvidence(frame, selectedPoint) : null),
+    [frame, selectedPoint],
+  );
+  const viewMode: MountainWavesViewMode =
+    state.view_id === "wave_cloud"
+      ? "cloud"
+      : state.view_id === "wave_structure"
+        ? "structure"
+        : "field";
+
+  useEffect(() => {
+    onEvidence?.(side, selectedMountainEvidence);
+  }, [onEvidence, selectedMountainEvidence, side]);
+
+  return (
+    <section className="compare-scientific-view compare-mountain-view">
+      {frame && (
+        <div className="compare-mountain-plot">
+          <MountainWavesTerrainPlot
+            frame={frame}
+            geometryMode={state.geometry_id}
+            viewportMode={state.viewport_id}
+            viewMode={viewMode}
+            cloudPoints={state.overlays.cloud_points}
+            cloudBoundary={state.overlays.cloud_boundary}
+            cloudOpacity={state.cloud_opacity}
+            cloudPointSize={state.cloud_point_size_px}
+            saturationContour={state.overlays.saturation_contour}
+            horizontalWind={state.overlays.horizontal_wind}
+            potentialTemperatureContours={state.overlays.potential_temperature_contours}
+            selectedPoint={selectedPoint}
+            onSelectPoint={(point) =>
+              onStateChange({
+                ...state,
+                selected_point: point ? mountainPhysicalPoint(frame, point) : null,
+              })
+            }
+          />
+          <MountainWavesLegend
+            frame={frame}
+            viewMode={viewMode}
+            cloudPoints={state.overlays.cloud_points}
+            horizontalWind={state.overlays.horizontal_wind}
+            potentialTemperatureContours={state.overlays.potential_temperature_contours}
+            fixedScaleLabel={
+              commonMountainScale
+                ? "Fixed across both Simulations"
+                : "Fixed across this Simulation"
+            }
+          />
+        </div>
+      )}
+      <CompareLoadState loading={response.loading} error={response.error} onRetry={response.retry} />
+    </section>
+  );
+}
+
+function CompareLoadState({
+  loading,
+  error,
+  onRetry,
+}: {
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  if (error) {
+    return (
+      <section className="compare-side-error" role="alert">
+        <h4>This side could not load</h4>
+        <p>{error}</p>
+        <button type="button" onClick={onRetry}>
+          Retry this side
+        </button>
+      </section>
+    );
+  }
+  if (loading) {
+    return (
+      <div className="compare-side-loading" role="status">
+        Loading saved output...
+      </div>
+    );
+  }
+  return null;
+}
+
+function useBoundedJson<T>(
+  side: CompareSide,
+  url: string | null,
+  onFrameState: SideVisualProps["onFrameState"],
+  onPerformance: SideVisualProps["onPerformance"],
+) {
+  const cache = useRef(new Map<string, { data: T; bytes: number }>());
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(Boolean(url));
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  useEffect(() => {
+    if (!url) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    const cached = cache.current.get(url);
+    if (cached) {
+      cache.current.delete(url);
+      cache.current.set(url, cached);
+      setData(cached.data);
+      setError(null);
+      setLoading(false);
+      onFrameState(side, "ready");
+      onPerformance({
+        side,
+        key: url,
+        request_ms: 0,
+        payload_bytes: cached.bytes,
+        cache_hit: true,
+      });
+      return;
+    }
+    const controller = new AbortController();
+    const started = window.performance.now();
+    setLoading(true);
+    setError(null);
+    onFrameState(side, "loading");
+    void fetch(url, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(await responseMessage(response, "Saved output could not be loaded."));
+        }
+        const text = await response.text();
+        if (controller.signal.aborted) return;
+        const parsed = JSON.parse(text) as T;
+        cache.current.set(url, { data: parsed, bytes: text.length });
+        while (cache.current.size > 6) {
+          const oldest = cache.current.keys().next().value;
+          if (typeof oldest !== "string") break;
+          cache.current.delete(oldest);
+        }
+        setData(parsed);
+        setError(null);
+        onFrameState(side, "ready");
+        onPerformance({
+          side,
+          key: url,
+          request_ms: window.performance.now() - started,
+          payload_bytes: text.length,
+          cache_hit: false,
+        });
+      })
+      .catch((caught: unknown) => {
+        if (controller.signal.aborted) return;
+        setData(null);
+        setError(caught instanceof Error ? caught.message : "Saved output could not be loaded.");
+        onFrameState(side, "error");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [onFrameState, onPerformance, retryNonce, side, url]);
+
+  return {
+    data,
+    error,
+    loading,
+    retry: () => setRetryNonce((value) => value + 1),
+  };
+}
+
+type TradePointCloud = {
+  field: {
+    raw_field_name: string;
+    display_name: string;
+    units: string | null;
+  };
+  selection: {
+    field: string;
+    time_index: number;
+    time_seconds: number | null;
+    threshold: number;
+    max_points: number;
+  };
+  coordinate_units: Record<string, string | null>;
+  coordinate_extents: Record<string, { min: number; max: number; units: string | null }>;
+  points: Array<[number, number, number, number]>;
+  stats: {
+    source_count: number;
+    returned_count: number;
+    field_min_value: number | null;
+    field_max_value: number | null;
+    field_mean_value: number | null;
+    field_finite_count: number;
+    field_non_finite_count: number;
+    min_value: number | null;
+    max_value: number | null;
+    active_z_min: number | null;
+    active_z_max: number | null;
+    downsampled: boolean;
+    downsample_stride: number;
+  };
+  provenance: {
+    source_model: string;
+    run_id: string;
+    result_id?: string;
+    scenario_id: string;
+    processing_method: string;
+    rendering_method: string;
+    provenance_label: string;
+  };
+  caveats: string[];
+};
+
+type TerrainField = MountainWaveFrame["field"];
+type TerrainViewport = MountainWaveFrame["viewport"];
+type TerrainLens = MountainWaveFrame["lens"];
+
+type MountainCompareFrame = {
+  schema_version: "mountain_waves_compare_v1";
+  run_id: string;
+  case_label: string;
+  time_index: number;
+  time_seconds: number;
+  times_seconds: number[];
+  dry_case: boolean;
+  field: TerrainField;
+  field_options: MountainWaveFrame["field_options"];
+  values: number[][];
+  native_x_indices: number[];
+  native_z_indices: number[];
+  x_center_km: number[];
+  terrain_km: number[];
+  scalar_height_km: number[][];
+  pointer_context: {
+    horizontal_wind_m_s: number[][];
+    vertical_velocity_m_s: number[][];
+    potential_temperature_k: number[][];
+    theta_perturbation_k: number[][];
+    cloud_liquid_g_kg: number[][] | null;
+    relative_humidity_percent: number[][] | null;
+  };
+  cloud_overlay: {
+    values: number[][];
+    threshold_g_kg: number;
+    maximum_g_kg: number;
+  } | null;
+  viewport: TerrainViewport;
+  lens: TerrainLens;
+  scale: TerrainScale;
+  source_shape: [number, number];
+  display_shape: [number, number];
+  performance: {
+    extraction_ms: number;
+    serialization_ms: number;
+    serialized_payload_bytes: number;
+  };
+  caveats: string[];
+};
+
+function expandMountainCompareFrame(compact: MountainCompareFrame): MountainWaveFrame {
+  const xCentersM = compact.x_center_km.map((value) => value * 1_000);
+  const terrainM = compact.terrain_km.map((value) => value * 1_000);
+  const scalarHeightM = compact.scalar_height_km.map((row) =>
+    row.map((value) => value * 1_000),
+  );
+  const xEdgesM = coordinateEdges(xCentersM);
+  const fullHeightM = fullLevelHeights(scalarHeightM, terrainM);
+  return {
+    schema_version: "mountain_waves_explore_v1",
+    run_id: compact.run_id,
+    case_label: compact.case_label,
+    time_index: compact.time_index,
+    time_seconds: compact.time_seconds,
+    times_seconds: compact.times_seconds,
+    dry_case: compact.dry_case,
+    field: compact.field,
+    values: compact.values,
+    field_options: compact.field_options,
+    overlay: compact.cloud_overlay
+      ? {
+          values: compact.cloud_overlay.values,
+          threshold: compact.cloud_overlay.threshold_g_kg,
+          maximum: compact.cloud_overlay.maximum_g_kg,
+        }
+      : null,
+    pointer_context: compact.pointer_context,
+    viewport: compact.viewport,
+    lens: compact.lens,
+    geometry: {
+      x_center_m: xCentersM,
+      x_edge_m: xEdgesM,
+      terrain_m: terrainM,
+      scalar_height_m: scalarHeightM,
+      full_height_m: fullHeightM,
+      nominal_scalar_height_m: scalarHeightM.map((row) => row[0] ?? 0),
+      nominal_full_height_m: fullHeightM.map((row) => row[0] ?? 0),
+      active_top_m: compact.viewport.full.z_maximum_m,
+      singleton_y_m: 0,
+    },
+    scale: compact.scale,
+    caveats: compact.caveats,
+    provenance: {
+      source_history_file: "retained native history",
+      topology: "native_2d_x_z_singleton_y",
+      interpolation: "none",
+      display_binning: "ordered native-cell display subset",
+      physical_height_source: "native terrain-following scalar height",
+    },
+    active_top_evidence: {
+      transform_top_source: "Compare descriptor",
+      all_sources_agree: true,
+      inactive_namelist_ztop_m: compact.viewport.full.z_maximum_m,
+    },
+  };
+}
+
+function fullLevelHeights(scalar: number[][], terrain: number[]): number[][] {
+  if (!scalar.length) return [terrain];
+  const columns = scalar[0]?.length ?? 0;
+  const rows: number[][] = [terrain.slice()];
+  for (let z = 1; z < scalar.length; z += 1) {
+    rows.push(
+      Array.from({ length: columns }, (_, x) => (scalar[z - 1][x] + scalar[z][x]) / 2),
+    );
+  }
+  rows.push(
+    Array.from({ length: columns }, (_, x) => {
+      const last = scalar.at(-1)?.[x] ?? terrain[x] ?? 0;
+      const previous = scalar.at(-2)?.[x] ?? terrain[x] ?? 0;
+      return last + Math.max(1, (last - previous) / 2);
+    }),
+  );
+  return rows;
+}
+
+function coordinateEdges(values: number[]): number[] {
+  if (!values.length) return [0, 1];
+  if (values.length === 1) return [values[0] - 0.5, values[0] + 0.5];
+  const edges = [values[0] - (values[1] - values[0]) / 2];
+  for (let index = 1; index < values.length; index += 1) {
+    edges.push((values[index - 1] + values[index]) / 2);
+  }
+  edges.push(values.at(-1)! + (values.at(-1)! - values.at(-2)!) / 2);
+  return edges;
+}
+
+function coordinateValues(frame: UpdraftLensFrame, dimension: string): number[] {
+  if (dimension === "x") return frame.x_values_km;
+  if (dimension === "y") return frame.y_values_km;
+  return frame.z_values_km;
+}
+
+function nativePlaneIndex(frame: UpdraftLensFrame | null, positionIndex: number): number {
+  if (!frame) return positionIndex;
+  return nativePlaneIndexForDimension(frame, frame.plane_dimension, positionIndex);
+}
+
+function nativePlaneIndexForDimension(
+  frame: UpdraftLensFrame,
+  dimension: string,
+  positionIndex: number,
+): number {
+  const indices =
+    dimension === "x" ? frame.x_indices : dimension === "y" ? frame.y_indices : frame.z_indices;
+  return indices[positionIndex] ?? positionIndex;
+}
+
+function planePositionLabel(frame: UpdraftLensFrame): string {
+  const axis = frame.plane_dimension;
+  return `${axis} = ${formatNumber(frame.plane_coordinate)} ${frame.plane_units ?? "km"}`;
+}
+
+function tradeSelection(
+  frame: UpdraftLensFrame,
+  point: ExplorePoint | null,
+): UpdraftLensPointSelection | null {
+  if (!point) return null;
+  return {
+    xIndex: nearestValueIndex(frame.x_values_km, point.x_km),
+    yIndex: nearestValueIndex(frame.y_values_km, point.y_km ?? 0),
+    zIndex: nearestValueIndex(frame.z_values_km, point.z_km),
+  };
+}
+
+function tradePhysicalPoint(
+  frame: UpdraftLensFrame,
+  selection: UpdraftLensPointSelection,
+): ExplorePoint {
+  return {
+    x_km: frame.x_values_km[selection.xIndex] ?? 0,
+    y_km: frame.y_values_km[selection.yIndex] ?? null,
+    z_km: frame.z_values_km[selection.zIndex] ?? 0,
+  };
+}
+
+function tradeSelectedEvidence(
+  frame: UpdraftLensFrame,
+  point: ExplorePoint | null,
+): CompareSelectedEvidence | null {
+  const selection = tradeSelection(frame, point);
+  if (!selection || !point) return null;
+  const rowIndex = lensDimensionIndex(selection, frame.dimension_order[0]);
+  const columnIndex = lensDimensionIndex(selection, frame.dimension_order[1]);
+  const verticalVelocity = frame.w_values_m_s[rowIndex]?.[columnIndex] ?? null;
+  const cloudy = frame.cloud_mask[rowIndex]?.[columnIndex] ?? false;
+  return {
+    title: `x ${formatNumber(point.x_km)} · ${
+      point.y_km === null ? "" : `y ${formatNumber(point.y_km)} · `
+    }z ${formatNumber(point.z_km)} km`,
+    states: [motionState(verticalVelocity), cloudy ? "Cloudy" : "Clear"],
+    metrics: [
+      {
+        label: "Model time",
+        value: formatSeconds(frame.time_seconds),
+        numericValue: frame.time_seconds ?? undefined,
+        units: "s",
+      },
+      {
+        label: "Vertical velocity",
+        value: `${formatNumber(verticalVelocity)} m/s`,
+        numericValue: verticalVelocity ?? undefined,
+        units: "m/s",
+      },
+      {
+        label: "Cloud threshold",
+        value: `${cloudy ? "At or above" : "Below"} ${formatNumber(
+          frame.cloud_threshold_kg_kg * 1_000,
+        )} g/kg`,
+      },
+    ],
+  };
+}
+
+function mountainSelectedEvidence(
+  frame: MountainWaveFrame,
+  point: { xIndex: number; zIndex: number } | null,
+): CompareSelectedEvidence | null {
+  if (!point) return null;
+  const xKm = (frame.geometry.x_center_m[point.xIndex] ?? 0) / 1_000;
+  const zKm = (frame.geometry.scalar_height_m[point.zIndex]?.[point.xIndex] ?? 0) / 1_000;
+  const verticalVelocity =
+    frame.pointer_context.vertical_velocity_m_s[point.zIndex]?.[point.xIndex] ?? null;
+  const thetaPerturbation =
+    frame.pointer_context.theta_perturbation_k[point.zIndex]?.[point.xIndex] ?? null;
+  const cloud =
+    frame.pointer_context.cloud_liquid_g_kg?.[point.zIndex]?.[point.xIndex] ?? null;
+  const relativeHumidity =
+    frame.pointer_context.relative_humidity_percent?.[point.zIndex]?.[point.xIndex] ?? null;
+  const states = [motionState(verticalVelocity)];
+  if (cloud !== null) states.push(cloud >= 0.001 ? "Cloudy" : "Clear");
+  if (relativeHumidity !== null) states.push(relativeHumidity >= 100 ? "Saturated" : "Unsaturated");
+  return {
+    title: `x ${formatNumber(xKm)} km · z ${formatNumber(zKm)} km`,
+    states,
+    metrics: [
+      {
+        label: "Model time",
+        value: formatSeconds(frame.time_seconds),
+        numericValue: frame.time_seconds,
+        units: "s",
+      },
+      {
+        label: "Vertical velocity",
+        value: `${formatNumber(verticalVelocity)} m/s`,
+        numericValue: verticalVelocity ?? undefined,
+        units: "m/s",
+      },
+      {
+        label: "Potential-temperature perturbation",
+        value: `${formatNumber(thetaPerturbation)} K`,
+        numericValue: thetaPerturbation ?? undefined,
+        units: "K",
+      },
+      ...(cloud === null
+        ? []
+        : [
+            {
+              label: "Cloud liquid water",
+              value: `${formatNumber(cloud)} g/kg`,
+              numericValue: cloud,
+              units: "g/kg",
+            },
+          ]),
+      ...(relativeHumidity === null
+        ? []
+        : [
+            {
+              label: "Relative humidity",
+              value: `${formatNumber(relativeHumidity)}%`,
+              numericValue: relativeHumidity,
+              units: "%",
+            },
+          ]),
+    ],
+  };
+}
+
+function lensDimensionIndex(
+  selection: UpdraftLensPointSelection,
+  dimension: string | undefined,
+): number {
+  if (dimension === "x") return selection.xIndex;
+  if (dimension === "y") return selection.yIndex;
+  return selection.zIndex;
+}
+
+function motionState(value: number | null): string {
+  if (value === null) return "Motion unavailable";
+  if (value > 0.1) return "Rising";
+  if (value < -0.1) return "Descending";
+  return "Near neutral";
+}
+
+function nearestMountainSelection(
+  frame: MountainWaveFrame,
+  point: ExplorePoint | null,
+): { xIndex: number; zIndex: number } | null {
+  if (!point) return null;
+  const xIndex = nearestValueIndex(
+    frame.geometry.x_center_m.map((value) => value / 1_000),
+    point.x_km,
+  );
+  return {
+    xIndex,
+    zIndex: nearestValueIndex(
+      frame.geometry.scalar_height_m.map((row) => (row[xIndex] ?? 0) / 1_000),
+      point.z_km,
+    ),
+  };
+}
+
+function mountainPhysicalPoint(
+  frame: MountainWaveFrame,
+  point: { xIndex: number; zIndex: number },
+): ExplorePoint {
+  return {
+    x_km: (frame.geometry.x_center_m[point.xIndex] ?? 0) / 1_000,
+    y_km: null,
+    z_km: (frame.geometry.scalar_height_m[point.zIndex]?.[point.xIndex] ?? 0) / 1_000,
+  };
+}
+
+function nearestValueIndex(values: number[], target: number): number {
+  let selected = 0;
+  let distance = Number.POSITIVE_INFINITY;
+  values.forEach((value, index) => {
+    const candidate = Math.abs(value - target);
+    if (candidate < distance) {
+      selected = index;
+      distance = candidate;
+    }
+  });
+  return selected;
+}
+
+function formatSeconds(value: number | null): string {
+  return value === null ? "Time unavailable" : `${Math.round(value).toLocaleString()} s`;
+}
+
+function formatNumber(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "unavailable";
+  if (Math.abs(value) >= 100) return value.toFixed(0);
+  if (Math.abs(value) >= 10) return value.toFixed(1);
+  if (Math.abs(value) > 0 && Math.abs(value) < 0.001) return value.toExponential(2);
+  if (Math.abs(value) > 0 && Math.abs(value) < 0.01) return value.toFixed(3);
+  return value.toFixed(2);
+}
+
+async function responseMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await response.json()) as { detail?: unknown };
+    return typeof payload.detail === "string" ? payload.detail : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function CompareControlGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="compare-control-group">
+      <span>{label}</span>
+      {children}
+    </div>
+  );
+}

--- a/app/frontend/src/WorldCompareAdapters.tsx
+++ b/app/frontend/src/WorldCompareAdapters.tsx
@@ -28,7 +28,7 @@ import {
   type UpdraftLensPointSelection,
   UpdraftLensSlice,
 } from "./UpdraftLensSlice";
-import { timeIndexForSeconds } from "./WorldCompare.logic";
+import { setSupercellSelectedPoint, timeIndexForSeconds } from "./WorldCompare.logic";
 import {
   isMountainState,
   isSupercellsState,
@@ -387,6 +387,9 @@ function SupercellsCompareVisual({
   if (indices.x !== null) search.set("x_index", String(indices.x));
   if (indices.y !== null) search.set("y_index", String(indices.y));
   if (indices.z !== null) search.set("z_index", String(indices.z));
+  if (indices.selectedX !== null) search.set("selected_x_index", String(indices.selectedX));
+  if (indices.selectedY !== null) search.set("selected_y_index", String(indices.selectedY));
+  if (indices.selectedZ !== null) search.set("selected_z_index", String(indices.selectedZ));
   const url = `/api/worlds/supercells/simulations/${simulation.simulation_id}/frame?${search}`;
   const response = useBoundedJson<StormExaminationFrame>(side, url, onFrameState, onPerformance);
   const frame = response.data;
@@ -396,8 +399,11 @@ function SupercellsCompareVisual({
     [frame?.scene, state.hydrometeor_category_codes],
   );
   const evidence = useMemo(
-    () => (frame && state.selected_point ? supercellSelectedEvidence(frame) : null),
-    [frame, state.selected_point],
+    () =>
+      frame && state.selected_point && state.selected_evidence_visible
+        ? supercellSelectedEvidence(frame)
+        : null,
+    [frame, state.selected_evidence_visible, state.selected_point],
   );
 
   useEffect(() => {
@@ -407,29 +413,21 @@ function SupercellsCompareVisual({
   function select(selection: Selection) {
     if (!frame) return;
     const point = supercellPhysicalPoint(frame, selection);
-    onStateChange({
-      ...state,
-      selected_point: point,
-      selected_evidence_visible: true,
-      plane_coordinate_km:
-        state.evidence_view === "plan"
-          ? point.z_km
-          : state.evidence_view === "xz"
-            ? (point.y_km ?? state.plane_coordinate_km)
-            : point.x_km,
-    });
+    onStateChange(setSupercellSelectedPoint(state, point));
   }
 
   function selectScenePoint(point: StormScenePoint) {
-    onStateChange({
-      ...state,
-      selected_point: { x_km: point[0], y_km: point[1], z_km: point[2] },
-      selected_evidence_visible: true,
-    });
+    onStateChange(
+      setSupercellSelectedPoint(state, {
+        x_km: point[0],
+        y_km: point[1],
+        z_km: point[2],
+      }),
+    );
   }
 
   function showEvidence(view: SupercellsExploreState["evidence_view"]) {
-    const selected = state.selected_point;
+    const selected = state.selected_evidence_visible ? state.selected_point : null;
     const coordinate =
       view === "plan"
         ? (selected?.z_km ?? frame?.plan.level_km ?? state.plane_coordinate_km)
@@ -490,7 +488,7 @@ function SupercellsCompareVisual({
               state.evidence_view !== "plan" || frame.plan.selection_z_indices === null
             }
             selectedRegion={
-              state.selected_point
+              state.selected_point && state.selected_evidence_visible
                 ? {
                     xIndex: frame.selected_point.x_index,
                     yIndex: frame.selected_point.y_index,
@@ -525,7 +523,7 @@ function SupercellsCompareVisual({
             stormPointSize={state.scene_point_size}
             compactAxisLabels
             selectedPointCoordinates={
-              state.selected_point
+              state.selected_point && state.selected_evidence_visible
                 ? {
                     x: frame.selected_point.x_km,
                     y: frame.selected_point.y_km,
@@ -553,13 +551,19 @@ function SupercellsCompareVisual({
         <div className="compare-supercell-evidence">
           <div className="compare-supercell-plot">
             {state.evidence_view === "plan" ? (
-              <StormPlanPlot frame={frame} overlays={overlays} onSelect={select} />
+              <StormPlanPlot
+                frame={frame}
+                overlays={overlays}
+                onSelect={select}
+                showSelection={state.selected_evidence_visible}
+              />
             ) : (
               <StormSectionPlot
                 frame={frame}
                 section={state.evidence_view === "xz" ? frame.xz_section : frame.yz_section}
                 overlays={overlays}
                 onSelect={select}
+                showSelection={state.selected_evidence_visible}
               />
             )}
           </div>
@@ -625,13 +629,23 @@ function CompareStormLayerControls({
 function supercellRequestIndices(
   simulation: CompareSimulationDescriptor,
   state: SupercellsExploreState,
-): { x: number | null; y: number | null; z: number | null } {
-  const selected = state.selected_point;
+): {
+  x: number | null;
+  y: number | null;
+  z: number | null;
+  selectedX: number | null;
+  selectedY: number | null;
+  selectedZ: number | null;
+} {
+  const selected = state.selected_evidence_visible ? state.selected_point : null;
   const indices = {
-    x: selected
+    x: null as number | null,
+    y: null as number | null,
+    z: null as number | null,
+    selectedX: selected
       ? coordinateIndex(selected.x_km, simulation.grid.x_extent_km, simulation.grid.nx)
       : null,
-    y:
+    selectedY:
       selected?.y_km !== null && selected?.y_km !== undefined
         ? coordinateIndex(
             selected.y_km,
@@ -639,7 +653,7 @@ function supercellRequestIndices(
             simulation.grid.ny,
           )
         : null,
-    z: selected
+    selectedZ: selected
       ? coordinateIndex(selected.z_km, simulation.grid.z_extent_km, simulation.grid.nz)
       : null,
   };

--- a/app/frontend/src/WorldCompareAdapters.tsx
+++ b/app/frontend/src/WorldCompareAdapters.tsx
@@ -4,6 +4,7 @@ import {
   type ExplorePoint,
   type ExploreWorldState,
   type MountainWavesExploreState,
+  type SupercellsExploreState,
   type TradeCumulusExploreState,
 } from "./ExploreStatePersistence";
 import {
@@ -13,7 +14,15 @@ import {
   type MountainWavesViewMode,
 } from "./MountainWavesExplore";
 import { NativeSlicePositionControl } from "./NativeSlicePositionControl";
-import { True3DViewer } from "./True3DViewer";
+import { type StormScenePayload, type StormScenePoint, True3DViewer } from "./True3DViewer";
+import {
+  type OverlayState,
+  type Selection,
+  type StormExaminationFrame,
+  StormLegend,
+  StormPlanPlot,
+  StormSectionPlot,
+} from "./StormExaminationResearch";
 import {
   type UpdraftLensFrame,
   type UpdraftLensPointSelection,
@@ -22,6 +31,7 @@ import {
 import { timeIndexForSeconds } from "./WorldCompare.logic";
 import {
   isMountainState,
+  isSupercellsState,
   isTradeState,
   type ComparePerformanceSample,
   type CompareSide,
@@ -53,6 +63,9 @@ export function WorldCompareSideVisual(props: SideVisualProps) {
   }
   if (props.simulation.world_id === "mountain_waves" && isMountainState(props.state)) {
     return <MountainWavesCompareVisual {...props} state={props.state} />;
+  }
+  if (props.simulation.world_id === "supercells" && isSupercellsState(props.state)) {
+    return <SupercellsCompareVisual {...props} state={props.state} />;
   }
   return (
     <section className="compare-side-error" role="alert">
@@ -101,7 +114,10 @@ function TradeCumulusCompareVisual({
     [frame],
   );
   const planeIndex = frame
-    ? Math.max(0, planeValues.findIndex((value) => value === frame.plane_coordinate))
+    ? Math.max(
+        0,
+        planeValues.findIndex((value) => value === frame.plane_coordinate),
+      )
     : state.slice_native_index;
   const selectedLensEvidence = useMemo(
     () => (frame ? tradeSelectedEvidence(frame, state.selected_point) : null),
@@ -147,7 +163,13 @@ function TradeCumulusCompareVisual({
           thresholdLabel={`${formatNumber(state.threshold_native * 1_000)} g/kg`}
           opacity={state.layer_opacity}
           pointSize={state.point_size_px}
-          status={cloud.error ? "Cloud field unavailable" : cloud.loading ? "Loading cloud field" : "Cloud field ready"}
+          status={
+            cloud.error
+              ? "Cloud field unavailable"
+              : cloud.loading
+                ? "Loading cloud field"
+                : "Cloud field ready"
+          }
           provenanceLabel={cloud.data?.provenance.provenance_label ?? "Native CM1 scalar cells"}
           noCloudMessage="No cloud cells meet the selected threshold."
           compactWorkspace
@@ -182,7 +204,10 @@ function TradeCumulusCompareVisual({
             }
           />
           <div className="compare-plane-controls">
-            <div className="segmented-control" aria-label={`${simulation.display_name} slice plane`}>
+            <div
+              className="segmented-control"
+              aria-label={`${simulation.display_name} slice plane`}
+            >
               {(
                 [
                   ["horizontal", "Horizontal x-y"],
@@ -254,12 +279,7 @@ function MountainWavesCompareVisual({
     field,
     time_index: String(timeIndex),
   })}`;
-  const response = useBoundedJson<MountainCompareFrame>(
-    side,
-    url,
-    onFrameState,
-    onPerformance,
-  );
+  const response = useBoundedJson<MountainCompareFrame>(side, url, onFrameState, onPerformance);
   const sourceFrame = useMemo(
     () => (response.data ? expandMountainCompareFrame(response.data) : null),
     [response.data],
@@ -333,16 +353,492 @@ function MountainWavesCompareVisual({
             horizontalWind={state.overlays.horizontal_wind}
             potentialTemperatureContours={state.overlays.potential_temperature_contours}
             fixedScaleLabel={
-              commonMountainScale
-                ? "Fixed across both Simulations"
-                : "Fixed across this Simulation"
+              commonMountainScale ? "Fixed across both Simulations" : "Fixed across this Simulation"
             }
           />
         </div>
       )}
-      <CompareLoadState loading={response.loading} error={response.error} onRetry={response.retry} />
+      <CompareLoadState
+        loading={response.loading}
+        error={response.error}
+        onRetry={response.retry}
+      />
     </section>
   );
+}
+
+function SupercellsCompareVisual({
+  side,
+  simulation,
+  state,
+  onStateChange,
+  onFrameState,
+  onPerformance,
+  onEvidence,
+}: Omit<SideVisualProps, "state"> & { state: SupercellsExploreState }) {
+  const [surface, setSurface] = useState<"scene" | "evidence">("evidence");
+  const timeIndex = timeIndexForSeconds(simulation, state.model_time_seconds);
+  const indices = supercellRequestIndices(simulation, state);
+  const search = new URLSearchParams({
+    lens: state.lens_id,
+    viewport: state.viewport_id,
+    time_index: String(timeIndex),
+  });
+  if (indices.x !== null) search.set("x_index", String(indices.x));
+  if (indices.y !== null) search.set("y_index", String(indices.y));
+  if (indices.z !== null) search.set("z_index", String(indices.z));
+  const url = `/api/worlds/supercells/simulations/${simulation.simulation_id}/frame?${search}`;
+  const response = useBoundedJson<StormExaminationFrame>(side, url, onFrameState, onPerformance);
+  const frame = response.data;
+  const overlays = supercellOverlayState(state);
+  const scene = useMemo(
+    () => filterSupercellScene(frame?.scene ?? null, state.hydrometeor_category_codes),
+    [frame?.scene, state.hydrometeor_category_codes],
+  );
+  const evidence = useMemo(
+    () => (frame && state.selected_point ? supercellSelectedEvidence(frame) : null),
+    [frame, state.selected_point],
+  );
+
+  useEffect(() => {
+    onEvidence?.(side, evidence);
+  }, [evidence, onEvidence, side]);
+
+  function select(selection: Selection) {
+    if (!frame) return;
+    const point = supercellPhysicalPoint(frame, selection);
+    onStateChange({
+      ...state,
+      selected_point: point,
+      selected_evidence_visible: true,
+      plane_coordinate_km:
+        state.evidence_view === "plan"
+          ? point.z_km
+          : state.evidence_view === "xz"
+            ? (point.y_km ?? state.plane_coordinate_km)
+            : point.x_km,
+    });
+  }
+
+  function selectScenePoint(point: StormScenePoint) {
+    onStateChange({
+      ...state,
+      selected_point: { x_km: point[0], y_km: point[1], z_km: point[2] },
+      selected_evidence_visible: true,
+    });
+  }
+
+  function showEvidence(view: SupercellsExploreState["evidence_view"]) {
+    const selected = state.selected_point;
+    const coordinate =
+      view === "plan"
+        ? (selected?.z_km ?? frame?.plan.level_km ?? state.plane_coordinate_km)
+        : view === "xz"
+          ? (selected?.y_km ?? 0)
+          : (selected?.x_km ?? 0);
+    onStateChange({
+      ...state,
+      evidence_view: view,
+      plane_coordinate_km: coordinate,
+    });
+    setSurface("evidence");
+  }
+
+  return (
+    <section className="compare-scientific-view compare-supercell-view">
+      <nav
+        className="compare-supercell-surface-tabs segmented-control"
+        aria-label={`${simulation.display_name} scientific surface`}
+      >
+        <button
+          type="button"
+          className={surface === "scene" ? "active-control" : ""}
+          onClick={() => setSurface("scene")}
+        >
+          3-D
+        </button>
+        {(
+          [
+            ["plan", "Horizontal x-y"],
+            ["xz", "Vertical x-z"],
+            ["yz", "Vertical y-z"],
+          ] as const
+        ).map(([view, label]) => (
+          <button
+            type="button"
+            key={view}
+            className={
+              surface === "evidence" && state.evidence_view === view ? "active-control" : ""
+            }
+            onClick={() => showEvidence(view)}
+          >
+            {label}
+          </button>
+        ))}
+      </nav>
+
+      {frame && surface === "scene" && frame.scene ? (
+        <div className="compare-supercell-scene">
+          <True3DViewer
+            resultName={simulation.display_name}
+            pointCloud={null}
+            fieldLabel={frame.lens_name}
+            valueChannelLabel="Native and explicitly derived Supercell layers."
+            activeSlice={supercellEvidenceSlice(frame, state.evidence_view)}
+            activeSliceLabel={supercellEvidenceLabel(frame, state.evidence_view)}
+            showSlicePlane={
+              state.evidence_view !== "plan" || frame.plan.selection_z_indices === null
+            }
+            selectedRegion={
+              state.selected_point
+                ? {
+                    xIndex: frame.selected_point.x_index,
+                    yIndex: frame.selected_point.y_index,
+                    zIndex: frame.selected_point.z_index,
+                  }
+                : null
+            }
+            coordinateSizes={frame.scene.coordinate_sizes}
+            selectedTimeLabel={formatSeconds(frame.time_seconds)}
+            sceneTimeLabel={formatSeconds(frame.time_seconds)}
+            thresholdLabel="Lens-owned fixed thresholds"
+            opacity={1}
+            pointSize={1}
+            status={response.loading ? "Loading frame" : "Scene synchronized"}
+            provenanceLabel="Retained native CM1 history; deterministic bounded selection."
+            noCloudMessage="No visible storm layers at this saved output."
+            windVectors={frame.scene.wind_vectors}
+            showWindVectors={state.overlays.wind}
+            windMode="total"
+            windReferenceMps={frame.scene.wind_reference_m_s}
+            windOverlayLabel={`Model-relative wind at z = ${frame.plan.level_km.toFixed(2)} km`}
+            windArrowDomainFraction={0.055}
+            compactWorkspace
+            compactDisplayLabel="3-D layers"
+            compactDisplayControlsOpen={state.display_controls_open}
+            onCompactDisplayControlsOpenChange={(display_controls_open) =>
+              onStateChange({ ...state, display_controls_open })
+            }
+            stormScene={scene}
+            visibleStormLayerKeys={state.visible_layer_ids}
+            stormOpacity={state.scene_opacity}
+            stormPointSize={state.scene_point_size}
+            compactAxisLabels
+            selectedPointCoordinates={
+              state.selected_point
+                ? {
+                    x: frame.selected_point.x_km,
+                    y: frame.selected_point.y_km,
+                    z: frame.selected_point.z_km,
+                  }
+                : null
+            }
+            onSelectStormPoint={selectScenePoint}
+            cameraPreset={state.camera_preset}
+            onCameraPresetChange={(camera_preset) => onStateChange({ ...state, camera_preset })}
+            cameraTransform={state.camera_transform}
+            onCameraTransformChange={(camera_transform) =>
+              onStateChange({ ...state, camera_transform })
+            }
+            compactDisplayControls={
+              <CompareStormLayerControls
+                frame={frame}
+                state={state}
+                onStateChange={onStateChange}
+              />
+            }
+          />
+        </div>
+      ) : frame && surface === "evidence" ? (
+        <div className="compare-supercell-evidence">
+          <div className="compare-supercell-plot">
+            {state.evidence_view === "plan" ? (
+              <StormPlanPlot frame={frame} overlays={overlays} onSelect={select} />
+            ) : (
+              <StormSectionPlot
+                frame={frame}
+                section={state.evidence_view === "xz" ? frame.xz_section : frame.yz_section}
+                overlays={overlays}
+                onSelect={select}
+              />
+            )}
+          </div>
+          <StormLegend frame={frame} overlays={overlays} evidenceView={state.evidence_view} />
+        </div>
+      ) : null}
+      <CompareLoadState
+        loading={response.loading}
+        error={response.error}
+        onRetry={response.retry}
+      />
+    </section>
+  );
+}
+
+function CompareStormLayerControls({
+  frame,
+  state,
+  onStateChange,
+}: {
+  frame: StormExaminationFrame;
+  state: SupercellsExploreState;
+  onStateChange: (state: ExploreWorldState) => void;
+}) {
+  return (
+    <section className="compare-storm-layer-controls" aria-label="3-D storm layers">
+      {frame.scene?.layers.map((layer) => (
+        <label key={layer.key}>
+          <input
+            type="checkbox"
+            checked={state.visible_layer_ids.includes(layer.key)}
+            onChange={(event) =>
+              onStateChange({
+                ...state,
+                visible_layer_ids: event.currentTarget.checked
+                  ? [...state.visible_layer_ids, layer.key]
+                  : state.visible_layer_ids.filter((key) => key !== layer.key),
+              })
+            }
+          />
+          {layer.display_name}
+        </label>
+      ))}
+      {Boolean(frame.scene?.wind_vectors.length) && (
+        <label>
+          <input
+            type="checkbox"
+            checked={state.overlays.wind}
+            onChange={(event) =>
+              onStateChange({
+                ...state,
+                overlays: { ...state.overlays, wind: event.currentTarget.checked },
+              })
+            }
+          />
+          Model-relative wind
+        </label>
+      )}
+    </section>
+  );
+}
+
+function supercellRequestIndices(
+  simulation: CompareSimulationDescriptor,
+  state: SupercellsExploreState,
+): { x: number | null; y: number | null; z: number | null } {
+  const selected = state.selected_point;
+  const indices = {
+    x: selected
+      ? coordinateIndex(selected.x_km, simulation.grid.x_extent_km, simulation.grid.nx)
+      : null,
+    y:
+      selected?.y_km !== null && selected?.y_km !== undefined
+        ? coordinateIndex(
+            selected.y_km,
+            simulation.grid.y_extent_km ?? simulation.grid.x_extent_km,
+            simulation.grid.ny,
+          )
+        : null,
+    z: selected
+      ? coordinateIndex(selected.z_km, simulation.grid.z_extent_km, simulation.grid.nz)
+      : null,
+  };
+  if (state.evidence_view === "plan") {
+    indices.z = coordinateIndex(
+      state.plane_coordinate_km,
+      simulation.grid.z_extent_km,
+      simulation.grid.nz,
+    );
+  } else if (state.evidence_view === "xz") {
+    indices.y = coordinateIndex(
+      state.plane_coordinate_km,
+      simulation.grid.y_extent_km ?? simulation.grid.x_extent_km,
+      simulation.grid.ny,
+    );
+  } else {
+    indices.x = coordinateIndex(
+      state.plane_coordinate_km,
+      simulation.grid.x_extent_km,
+      simulation.grid.nx,
+    );
+  }
+  return indices;
+}
+
+function coordinateIndex(coordinate: number, extent: [number, number], count: number): number {
+  const spacing = (extent[1] - extent[0]) / count;
+  return Math.max(
+    0,
+    Math.min(count - 1, Math.round((coordinate - extent[0] - spacing / 2) / spacing)),
+  );
+}
+
+function supercellOverlayState(state: SupercellsExploreState): OverlayState {
+  return {
+    rotation: state.overlays.rotation,
+    updraftHelicity: state.overlays.updraft_helicity,
+    reflectivity: state.overlays.reflectivity,
+    condensate: state.overlays.condensate,
+    rain: state.overlays.rain,
+    wind: state.overlays.wind,
+    precipitatingCondensate: state.overlays.precipitating_condensate,
+    verticalMotion: state.overlays.vertical_motion,
+  };
+}
+
+function filterSupercellScene(
+  source: StormExaminationFrame["scene"],
+  categoryCodes: number[],
+): StormScenePayload | null {
+  if (!source) return null;
+  return {
+    coordinate_extents_km: source.coordinate_extents_km,
+    layers: source.layers.map((layer) =>
+      layer.key === "hydrometeor_categories"
+        ? {
+            ...layer,
+            points: layer.points.filter((point) => categoryCodes.includes(point[4])),
+          }
+        : layer,
+    ),
+  };
+}
+
+function supercellPhysicalPoint(frame: StormExaminationFrame, selection: Selection): ExplorePoint {
+  return {
+    x_km: supercellCoordinate(frame, "x", selection.xIndex),
+    y_km: supercellCoordinate(frame, "y", selection.yIndex),
+    z_km: supercellCoordinate(frame, "z", selection.zIndex),
+  };
+}
+
+function supercellCoordinate(
+  frame: StormExaminationFrame,
+  axis: "x" | "y" | "z",
+  nativeIndex: number,
+): number {
+  const indices = frame.scene?.coordinate_indices[axis] ?? [];
+  const values = frame.scene?.coordinate_values_km[axis] ?? [];
+  const position = indices.indexOf(nativeIndex);
+  if (position >= 0 && Number.isFinite(values[position])) return values[position];
+  if (axis === "x") {
+    const planPosition = frame.plan.x_indices.indexOf(nativeIndex);
+    return frame.plan.x_km[planPosition] ?? frame.selected_point.x_km;
+  }
+  if (axis === "y") {
+    const planPosition = frame.plan.y_indices.indexOf(nativeIndex);
+    return frame.plan.y_km[planPosition] ?? frame.selected_point.y_km;
+  }
+  return frame.xz_section.z_km[nativeIndex] ?? frame.selected_point.z_km;
+}
+
+function supercellSelectedEvidence(frame: StormExaminationFrame): CompareSelectedEvidence {
+  const point = frame.selected_point;
+  const keys =
+    frame.lens_id === "rotating_updraft"
+      ? [
+          ["vertical_velocity", "Vertical velocity"],
+          ["vertical_vorticity", "Vertical vorticity"],
+          ["updraft_helicity", "2-5 km AGL updraft helicity"],
+          ["total_condensate", "Total condensate"],
+          ["reflectivity", "Reflectivity"],
+        ]
+      : frame.lens_id === "cloud_precipitation"
+        ? [
+            ["vertical_velocity", "Vertical velocity"],
+            ["total_condensate", "Total condensate"],
+            ["cloud_liquid", "Cloud liquid"],
+            ["rain_water", "Rain water"],
+            ["cloud_ice", "Cloud ice"],
+            ["snow", "Snow"],
+            ["hail_treated_large_ice", "Hail-treated large ice"],
+            ["reflectivity", "Reflectivity"],
+          ]
+        : [
+            ["vertical_velocity", "Vertical velocity"],
+            ["total_condensate", "Total condensate"],
+            ["accumulated_surface_rain", "Accumulated rain"],
+            ["model_relative_u", "Model-relative u"],
+            ["model_relative_v", "Model-relative v"],
+            ["reflectivity", "Reflectivity"],
+          ];
+  return {
+    title: `Native cell at x ${point.x_km.toFixed(1)}, y ${point.y_km.toFixed(
+      1,
+    )}, z ${point.z_km.toFixed(2)} km`,
+    states: point.states,
+    metrics: [
+      {
+        label: "Model time",
+        value: formatSeconds(point.model_time_seconds),
+        numericValue: point.model_time_seconds,
+        units: "s",
+      },
+      ...keys.map(([key, label]) => {
+        const value = point.values[key];
+        const units = point.units[key] ?? "";
+        return {
+          label,
+          value: `${formatNumber(value)}${units ? ` ${units}` : ""}`,
+          numericValue: value,
+          units,
+        };
+      }),
+    ],
+  };
+}
+
+function supercellEvidenceSlice(
+  frame: StormExaminationFrame,
+  view: SupercellsExploreState["evidence_view"],
+) {
+  if (view === "plan") {
+    return {
+      field: {
+        raw_field_name: frame.plan.primary.key,
+        display_name: frame.plan.primary.display_name,
+        units: frame.plan.primary.units,
+      },
+      selection: {
+        orientation: "horizontal" as const,
+        selected_dimension: "zh",
+        selected_index: frame.plan.level_index,
+        selected_coordinate_value: frame.plan.level_km,
+        level_coordinate_value: frame.plan.level_km,
+        level_units: "km",
+        level_meters: frame.plan.level_km * 1_000,
+      },
+    };
+  }
+  const section = view === "xz" ? frame.xz_section : frame.yz_section;
+  return {
+    field: {
+      raw_field_name: section.primary.key,
+      display_name: section.primary.display_name,
+      units: section.primary.units,
+    },
+    selection: {
+      orientation: view === "xz" ? ("vertical_x" as const) : ("vertical_y" as const),
+      selected_dimension: view === "xz" ? "yh" : "xh",
+      selected_index: view === "xz" ? frame.selected_point.y_index : frame.selected_point.x_index,
+      selected_coordinate_value: section.cross_section_coordinate_km,
+      level_coordinate_value: null,
+      level_units: "km",
+      level_meters: null,
+    },
+  };
+}
+
+function supercellEvidenceLabel(
+  frame: StormExaminationFrame,
+  view: SupercellsExploreState["evidence_view"],
+): string {
+  if (view === "plan") {
+    return frame.plan.selection_z_indices
+      ? `${frame.plan.title} · column-derived at each cell's condensate maximum`
+      : `${frame.plan.title} · z = ${frame.plan.level_km.toFixed(2)} km`;
+  }
+  return view === "xz" ? frame.xz_section.title : frame.yz_section.title;
 }
 
 function CompareLoadState({
@@ -553,9 +1049,7 @@ type MountainCompareFrame = {
 function expandMountainCompareFrame(compact: MountainCompareFrame): MountainWaveFrame {
   const xCentersM = compact.x_center_km.map((value) => value * 1_000);
   const terrainM = compact.terrain_km.map((value) => value * 1_000);
-  const scalarHeightM = compact.scalar_height_km.map((row) =>
-    row.map((value) => value * 1_000),
-  );
+  const scalarHeightM = compact.scalar_height_km.map((row) => row.map((value) => value * 1_000));
   const xEdgesM = coordinateEdges(xCentersM);
   const fullHeightM = fullLevelHeights(scalarHeightM, terrainM);
   return {
@@ -612,9 +1106,7 @@ function fullLevelHeights(scalar: number[][], terrain: number[]): number[][] {
   const columns = scalar[0]?.length ?? 0;
   const rows: number[][] = [terrain.slice()];
   for (let z = 1; z < scalar.length; z += 1) {
-    rows.push(
-      Array.from({ length: columns }, (_, x) => (scalar[z - 1][x] + scalar[z][x]) / 2),
-    );
+    rows.push(Array.from({ length: columns }, (_, x) => (scalar[z - 1][x] + scalar[z][x]) / 2));
   }
   rows.push(
     Array.from({ length: columns }, (_, x) => {
@@ -735,8 +1227,7 @@ function mountainSelectedEvidence(
     frame.pointer_context.vertical_velocity_m_s[point.zIndex]?.[point.xIndex] ?? null;
   const thetaPerturbation =
     frame.pointer_context.theta_perturbation_k[point.zIndex]?.[point.xIndex] ?? null;
-  const cloud =
-    frame.pointer_context.cloud_liquid_g_kg?.[point.zIndex]?.[point.xIndex] ?? null;
+  const cloud = frame.pointer_context.cloud_liquid_g_kg?.[point.zIndex]?.[point.xIndex] ?? null;
   const relativeHumidity =
     frame.pointer_context.relative_humidity_percent?.[point.zIndex]?.[point.xIndex] ?? null;
   const states = [motionState(verticalVelocity)];
@@ -868,13 +1359,7 @@ async function responseMessage(response: Response, fallback: string): Promise<st
   }
 }
 
-export function CompareControlGroup({
-  label,
-  children,
-}: {
-  label: string;
-  children: ReactNode;
-}) {
+export function CompareControlGroup({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="compare-control-group">
       <span>{label}</span>

--- a/app/frontend/src/exploreCuratedDefaults.ts
+++ b/app/frontend/src/exploreCuratedDefaults.ts
@@ -100,6 +100,9 @@ export type SupercellsLensId =
   | "rotating_updraft"
   | "cloud_precipitation"
   | "low_level_interactions";
+export type SupercellsSimulationId =
+  | "supercells_quarter_circle_reference"
+  | "supercells_straight_line_hodograph";
 
 export type SupercellsOverlayState = {
   rotation: boolean;
@@ -114,7 +117,7 @@ export type SupercellsOverlayState = {
 
 export type SupercellsCuratedView = CuratedCommonState & {
   worldId: "supercells";
-  simulationId: "supercells_quarter_circle_reference";
+  simulationId: SupercellsSimulationId;
   viewId: SupercellsLensId;
   viewport: "storm";
   evidenceOrientation: "plan" | "xz" | "yz";
@@ -452,8 +455,16 @@ export function supercellsCuratedView(
   simulationId: string,
   lensId: SupercellsLensId,
 ): SupercellsCuratedView | null {
-  if (simulationId !== "supercells_quarter_circle_reference") return null;
-  return SUPERCELLS_CURATED_VIEWS[lensId];
+  if (
+    simulationId !== "supercells_quarter_circle_reference" &&
+    simulationId !== "supercells_straight_line_hodograph"
+  ) {
+    return null;
+  }
+  return {
+    ...SUPERCELLS_CURATED_VIEWS[lensId],
+    simulationId,
+  };
 }
 
 export function resolveCuratedView<T extends WorldCuratedView>(

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -47,7 +47,7 @@ Keep product approval separate from software availability:
 | Cloud Worlds | A growing collection of explorable cloud regimes | Trade Cumulus, Mountain Waves, and Supercells are accessible |
 | Fun With Soundings | A separate first-class atmospheric workbench | Accessible with five jobs, direct non-World Explore, and conservative World ownership |
 | Saved Views | Durable user-curated views | Implemented across all three accessible Worlds as named live examinations with bounded restoration status |
-| Compare | Related Simulations can be compared | One featured Trade Cumulus Comparison; no ordinary World-aware Compare |
+| Compare | Related Simulations can be compared | Ordinary transient Compare is implemented for real pairs across all three Worlds; Saved Comparisons are absent |
 | Variation | Create a related Simulation from a World Simulation | Working Mountain Waves Lab path; no shared three-World workflow |
 | Explore | World-specific science in a shared application vocabulary | Implemented separately for all three accessible Worlds |
 | Curated Explore defaults | Authored Simulation and Field/Lens starting states with complete reset and visible fallback | Implemented across all three accessible Worlds as the fallback below explicit Saved Views and last-active state |
@@ -89,9 +89,10 @@ structure. Per-Simulation Notes remain a separate durable content contract.
 The authored curated-default and complete reset contract is complete through
 #438. Issue #432 completes the next personal-scientific-memory increment: one
 versioned World-aware Explore-state contract, ordinary last-active resume, and
-named Saved Views across all three Worlds. The next program in the approved
-sequence is #433, ordinary World-aware Compare. Saved Comparisons are explicitly
-outside #433 and remain unimplemented.
+named Saved Views across all three Worlds. Issue #433 completes ordinary
+World-aware Compare, including a real controlled Supercells pair. Compare
+state remains transient. Saved Comparisons are explicitly outside #433 and
+remain unimplemented.
 
 Rewritten issue #394 and issues #433 through #437 record bounded
 follow-on product work for Activity and History, Compare and Saved Comparisons, variation

--- a/docs/current/CURRENT_ARCHITECTURE.md
+++ b/docs/current/CURRENT_ARCHITECTURE.md
@@ -398,9 +398,36 @@ versioned World-aware contract above. Authored curated defaults remain
 source-controlled product definitions rather than user state. Per-Simulation
 Notes remain independently stored under `simulation-notes` and are not copied
 into Saved Views.
-The only product Comparison currently exposed is the featured Trade Cumulus
-pair. World-aware variation exists for Mountain Waves but is not yet one shared
-cross-World system.
+
+## Ordinary Compare Architecture
+
+Each World exposes a lightweight comparison descriptor through:
+
+```text
+GET /api/worlds/{world_id}/compare
+```
+
+The descriptor resolves stable Simulation identity, retained-output
+availability, lineage, material configuration differences, compatibility, and
+the supported coordination dimensions before the frontend requests scientific
+frames. The frontend then composes the existing World frame APIs and
+World-specific renderers into a shared pair-review and dual-workspace shell.
+
+Compare state uses the same versioned World-specific Explore vocabulary but is
+held only in the current browser session. Aligned, independent, and mixed
+coordination can link modeled seconds, compatible Field or Lens state,
+physical plane coordinates, normalized cameras where honest, and selected
+native evidence. There is no interpolation presented as model output.
+
+Each side owns bounded frame caching, request cancellation, loading, failure,
+and retry behavior. One failed request does not discard the other side.
+Supercells additionally exercises the architecture with two real retained
+Simulations and all three Lenses. Physical coordinates and local evidence are
+compared without assigning lineage to changing storm objects.
+
+Ordinary Compare does not write the Explore-state library, create a Saved
+Comparison, or mutate either Simulation. World-aware variation exists for
+Mountain Waves but is not yet one shared cross-World system.
 
 ## Product and Research Boundaries
 
@@ -418,7 +445,7 @@ reused.
 
 - World shells and Explore implementations share vocabulary but still contain
   World-specific state and rendering code.
-- General World-aware Compare and Saved Comparisons are absent.
+- Ordinary World-aware Compare is transient; Saved Comparisons are absent.
 - Variation is implemented only for Mountain Waves.
 - Legacy run, result, and sounding surfaces remain interleaved with the newer
   World application.

--- a/docs/current/CURRENT_STATE.md
+++ b/docs/current/CURRENT_STATE.md
@@ -69,9 +69,9 @@ Explore.
 
 | World | Current content | Current surfaces | Current limitation |
 | --- | --- | --- | --- |
-| **Trade Cumulus** | Canonical BOMEX Baseline and More Moisture retained Simulations | Overview, Simulations, featured Comparison, Lab, Explore resume, and Saved Views | Ordinary World-aware Compare is not implemented; Lab still embeds transitional Build and Results |
-| **Mountain Waves** | Dry Ridge and Boulder Windstorm retained Simulations | Overview, Simulations, variation Lab, Explore resume, and Saved Views | Variation is World-specific rather than shared; no ordinary Compare |
-| **Supercells** | Quarter-Circle Supercell retained Simulation | Overview, Simulations, Explore resume, and Saved Views | No variation Lab or ordinary Compare |
+| **Trade Cumulus** | Canonical BOMEX Baseline and More Moisture retained Simulations | Overview, Simulations, featured and ordinary Compare, Lab, Explore resume, and Saved Views | Lab still embeds transitional Build and Results; Saved Comparisons are absent |
+| **Mountain Waves** | Dry Ridge and Boulder Windstorm retained Simulations | Overview, Simulations, ordinary Compare, variation Lab, Explore resume, and Saved Views | Variation remains World-specific; Saved Comparisons are absent |
+| **Supercells** | Quarter-Circle and Straight-Line Hodograph retained Simulations | Overview, Simulations, ordinary Compare, Explore resume, and Saved Views | No variation Lab or Saved Comparisons |
 
 The World Overview and Simulations surfaces use stable content identities and
 explicit availability states. Missing, invalid, or conflicting retained
@@ -190,6 +190,26 @@ Writes are atomic and bounded. Unsupported schemas, invalid values, oversized
 files, and persistence failures are visible local failures. Per-Simulation
 Notes remain separate and are not copied into Saved Views.
 
+## Ordinary Compare
+
+Each accessible World can compare two compatible retained Simulations through
+one ordinary Compare workflow. The pair-review step presents lineage,
+configuration differences, retained-output compatibility, and caveats before
+loading frames. The live workspace supports aligned, independent, and mixed
+coordination of modeled time, Field or Lens, physical slice plane, compatible
+camera state, and selected-point evidence.
+
+Compare coordinates existing Simulation and Explore state without creating a
+new scientific object. Its state is transient: it does not create a Saved
+Comparison or alter either Simulation or its Saved Views.
+
+Supercells now exercises the complete workflow with a controlled real pair:
+Quarter-Circle Supercell and Straight-Line Hodograph Supercell. The two
+Simulations retain matched thermodynamics, trigger, grid, timing, output
+inventory, model translation, and numerical options while changing hodograph
+curvature. Compare maps physical coordinates and local native evidence; it
+does not claim that storm structures on the two sides have object lineage.
+
 ## Shared Scientific Presentation
 
 Current Explore surfaces use:
@@ -224,6 +244,7 @@ CM1 output:
 | Mountain Waves | Dry Ridge | `dry-mountain-wave-presentation-v1-20260722` |
 | Mountain Waves | Boulder Windstorm | `moist-mountain-wave-presentation-v1-20260722` |
 | Supercells | Quarter-Circle Supercell | `quarter-circle-supercell-presentation-v1-20260723` |
+| Supercells | Straight-Line Hodograph Supercell | `straight-line-supercell-presentation-v1-20260726` |
 
 These run IDs identify current local artifacts, not permanent product identity.
 The large NetCDF histories remain outside Git under the runtime home.
@@ -250,7 +271,6 @@ information architecture.
 
 The implemented application does not yet provide:
 
-- ordinary World-aware Compare beyond the featured Trade Cumulus Comparison;
 - one shared World-aware variation workflow across all accessible Worlds;
 - Saved Comparisons or durable comparison workspaces.
 

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -168,11 +168,11 @@ reopen as live examinations, support rename and delete, preserve records when
 backing output is unavailable, and report healthy, partially restorable, or
 unavailable restoration. Notes remain separate.
 
-## Next program: ordinary World-aware Compare
+## Completed program: ordinary World-aware Compare
 
-Issue #433 is the next program in this sequence.
-
-Build ordinary Compare from two compatible Explore states rather than creating a parallel examination model.
+Issue #433 establishes ordinary Compare across the three accessible Worlds.
+It builds comparison from two compatible Explore states rather than creating a
+parallel examination model.
 
 The current MVP decisions remain useful:
 
@@ -194,6 +194,15 @@ ordinary World-aware Compare
 Trade Cumulus, Mountain Waves, and Supercells ask different comparison questions and may support different linked states.
 Issue #433 implements only ordinary Compare. It does not implement or claim
 Saved Comparisons; that later step requires separate approval and work.
+
+The Supercells acceptance endpoint is the real retained Quarter-Circle
+Supercell and Straight-Line Hodograph Supercell pair. It exercises all three
+Lenses, physical horizontal and vertical sections, selected native evidence,
+compatible camera mapping, aligned and independent operation, request
+cancellation, and one-sided failure recovery. The controlled pair changes
+hodograph curvature while retaining the other presentation-run contract.
+Coordinates and local evidence are comparable; storm objects are not assigned
+cross-Simulation lineage.
 
 ## Variations require a fresh review
 

--- a/scripts/run_supercell_presentation.py
+++ b/scripts/run_supercell_presentation.py
@@ -43,13 +43,18 @@ def main(argv: list[str] | None = None) -> int:
     mode.add_argument("--execute", action="store_true")
     mode.add_argument("--validate", action="store_true")
     parser.add_argument("--kind", choices=("characterization", "final"), required=True)
+    parser.add_argument(
+        "--hodograph",
+        choices=("quarter_circle", "straight_line"),
+        default="quarter_circle",
+    )
     parser.add_argument("--runtime-home")
     parser.add_argument("--poll-seconds", type=float, default=5.0)
     args = parser.parse_args(argv)
     settings = load_settings(
         home=Path(args.runtime_home).expanduser() if args.runtime_home else None
     )
-    spec = spec_for_kind(args.kind)
+    spec = spec_for_kind(args.kind, args.hodograph)
     try:
         if args.package:
             package = generate_presentation_package(settings=settings, spec=spec)


### PR DESCRIPTION
Closes #433.

## What changed

Implements one transient, same-World Compare workflow built from the versioned
Explore-state contract introduced by #443.

### Shared shell

- stable left/right World and Simulation identity with a preflight pair review
- authoritative lineage, configuration, grid, duration, cadence, availability,
  and exact/unknown difference reporting
- linked, independent, and mixed coordination modes
- side-isolated loading, retry, stale-response cancellation, and bounded
  six-frame-per-side caches
- shared layout, Context, selection evidence, accessibility, and performance
  instrumentation
- ordinary Compare entry from World, Simulation, and Explore surfaces

### World adapters

- **Trade Cumulus:** real Canonical BOMEX Baseline / More Moisture pair; cloud,
  lifecycle, Updraft Lens, physical slice, fixed-scale, camera, and selected-cell
  semantics
- **Mountain Waves:** real Dry Ridge / Boulder Windstorm structural comparison;
  explicit non-controlled-comparison caveat; native terrain-aware x-z geometry;
  World-owned Field/Lens, geometry, overlay, scale, time, and selected-point
  semantics
- **Supercells:** real controlled Quarter-Circle / Straight-Line Hodograph pair;
  all three Lenses, native horizontal and vertical sections, paired Three.js
  views, camera mapping, and selected native evidence

The former featured Trade Cumulus comparison now enters this ordinary shared
shell instead of maintaining a separate featured-comparison workspace.

## Real Supercells acceptance pair

The controlled scientific question is how hodograph curvature changes storm
organization, rotating-updraft structure, precipitation, and low-level flow
when the thermodynamic environment and numerical experiment remain matched.

| Simulation | Runtime | Histories | Retained output |
| --- | ---: | ---: | ---: |
| Quarter-Circle Supercell | 13,327 s | 91 | 8.87 GB |
| Straight-Line Hodograph Supercell | 13,438 s | 91 | 8.63 GB |

Both real CM1 runs:

- completed normally on the first attempt
- retained 10,800 s at 120 s cadence
- contain finite required fields
- report only the expected IEEE underflow flag

Matched contract:

- thermodynamic profile and deterministic warm bubble
- 240 x 240 x 60 grid at 500 m x 500 m x 333 m
- 3 s timestep and 10,800 s duration
- output cadence and field inventory
- Morrison microphysics, boundaries, damping, model translation, and numerical
  options

The material atmospheric difference is hodograph curvature. Compare maps
physical coordinates and local native evidence; it does not invent split
lineage, storm IDs, parent-child storm relationships, or cross-Simulation
storm-object equivalence.

## Coordination contract

Supported:

- time linked by modeled seconds, with exact or explicitly labeled nearest
  retained output
- sections linked by physical coordinate rather than array index
- Field/Lens, overlays, and fixed scales linked only through explicit
  World-adapter compatibility
- normalized 3-D camera mapping for compatible views
- selected-point mapping by physical coordinates with native evidence retained
  per side
- one-sided failure, retry, and recovery without discarding the usable side

Intentionally unsupported:

- cross-World comparison
- interpolation presented as model output
- durable Compare state or Saved Comparisons
- comparison notes or paired records
- invented fields, Lenses, scales, or storm-object lineage

## Performance

Measured locally against the real Supercells pair:

- World inventory: 2.9 KB in about 0.02 s
- Compare descriptor: 7.1 KB in about 0.03 s
- individual frame: about 3.0 MB; roughly 0.7-1.1 s direct API latency
- first useful dual view: 2.6-3.0 s in the full browser exercise
- three rapid linked steps: about 4.2 s, with superseded requests cancelled
- bounded cache observed at five left / six right frames, with a maximum of six
  per side and about 14.7 MB / 17.7 MB estimated serialized memory
- paired real Three.js canvases: 690 x 464 each with non-background pixels
  confirmed

The hard launch preflight now recomputes remaining campaign storage at launch,
so a completed retained run is no longer counted as still pending. Package
contract fields remain immutable while available storage and remaining-run
requirements are refreshed.

## Visual review packet

`/Users/timpeterson/CloudChamber/review-packets/pr-444-supercells-real-pair-20260727.zip`

The packet contains 15 real-browser screenshots and a machine-readable report:

- pair review at 1728 x 1117 and 1024 x 856
- all three Lenses in aligned mode
- horizontal, x-z, and y-z physical sections
- paired linked 3-D cameras
- selected native evidence
- independent mixed state
- one-sided failure and recovery
- all three Lenses at 1024 x 856

Horizontal overflow is zero at 1024 x 856 for pair review and all three Lenses.
The intentionally injected 503 is retained as failure/retry evidence.

## Documentation

Current State, Current Architecture, Documentation Status, and Current Product
Sequence now distinguish:

- ordinary Compare implemented for real pairs
- the real controlled Supercells pair
- transient Compare state
- Saved Comparisons still absent

## Verification

Final head: `f8518e1e`

- `git diff --check`
- `scripts/check.sh`
  - 224 frontend tests
  - production build
  - backend format, Ruff, and MyPy
  - 710 backend tests
  - shell, forbidden-artifact, and docs/config checks
- focused mocked Playwright Supercells Compare test
- full real Playwright exercise across both required desktop sizes
- live-browser inspection of the pair review, all three Lenses, horizontal and
  vertical sections, linked 3-D cameras, selected evidence, independent mixed
  mode, and one-sided failure/recovery

Known non-blocking output: the existing Vite chunk-size warning and existing
NumPy ABI warning in one backend ingest test.

No generated run directory, NetCDF output, screenshot, or machine-private
runtime asset is committed. Compare remains transient and this PR remains draft
for manual review.
