### PR TITLE
Reconcile Activity and History across Cloud Worlds and experiments

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -58,6 +58,7 @@ from cloud_chamber.lan_worker import (
     lan_worker_run_status,
     start_lan_worker_run,
 )
+from cloud_chamber.lifecycle import LifecycleProjection, lifecycle_projection
 from cloud_chamber.local_run_manager import LocalRunManager, LocalRunManagerError, RunStatus
 from cloud_chamber.local_run_queue import LocalRunQueueError, LocalRunQueueManager
 from cloud_chamber.mountain_wave_terrain_visualization import (
@@ -585,6 +586,21 @@ def run_queue_status() -> dict[str, object]:
     except LocalRunQueueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return state.model_dump(mode="json")
+
+
+@app.get("/api/lifecycle", response_model=LifecycleProjection)
+def get_lifecycle_projection() -> LifecycleProjection:
+    try:
+        return lifecycle_projection(
+            load_settings(),
+            queue=_get_local_run_queue().snapshot(),
+        )
+    except (OSError, ValueError) as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Activity and History are unavailable because retained lifecycle data "
+            "could not be read.",
+        ) from exc
 
 
 @app.get("/api/runs/status")

--- a/app/backend/cloud_chamber/lifecycle.py
+++ b/app/backend/cloud_chamber/lifecycle.py
@@ -1,0 +1,1487 @@
+"""Owner-aware Activity and History projection over retained runtime records."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.cloud_worlds import (
+    MORE_MOISTURE_DISPLAY_NAME,
+    MORE_MOISTURE_SIMULATION_ID,
+    PRESENTATION_BASELINE_RESULT_ID,
+    PRESENTATION_BASELINE_RUN_ID,
+    PRESENTATION_MORE_MOISTURE_RESULT_ID,
+    PRESENTATION_MORE_MOISTURE_RUN_ID,
+    REFERENCE_DISPLAY_NAME,
+    REFERENCE_SIMULATION_ID,
+)
+from cloud_chamber.local_run_queue import RunQueueEntry, RunQueueState
+from cloud_chamber.mountain_waves_variations import VARIATION_CASE_ID
+from cloud_chamber.mountain_waves_world import (
+    DRY_CASE_ID,
+    DRY_RUN_ID,
+    DRY_SIMULATION_ID,
+    MOIST_CASE_ID,
+    MOIST_RUN_ID,
+    MOIST_SIMULATION_ID,
+)
+from cloud_chamber.result_cards import ResultCard, list_result_cards
+from cloud_chamber.runtime_storage import (
+    RunStorageEntry,
+    RuntimeStorageInventory,
+    runtime_lifecycle_inventory,
+)
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.storm_examination import (
+    PRESENTATION_CASE_ID as SUPERCELLS_REFERENCE_CASE_ID,
+)
+from cloud_chamber.storm_examination import (
+    PRESENTATION_RUN_ID as SUPERCELLS_REFERENCE_RUN_ID,
+)
+from cloud_chamber.storm_examination import (
+    STRAIGHT_LINE_PRESENTATION_CASE_ID,
+    STRAIGHT_LINE_PRESENTATION_RUN_ID,
+)
+from cloud_chamber.supercells_world import (
+    REFERENCE_SIMULATION_ID as SUPERCELLS_REFERENCE_SIMULATION_ID,
+)
+from cloud_chamber.supercells_world import (
+    STRAIGHT_LINE_SIMULATION_ID as SUPERCELLS_STRAIGHT_LINE_SIMULATION_ID,
+)
+
+OwnerId = Literal[
+    "trade_cumulus",
+    "mountain_waves",
+    "supercells",
+    "fun_with_soundings",
+    "legacy_unassigned",
+]
+WorldOwnerId = Literal["trade_cumulus", "mountain_waves", "supercells"]
+RecordKind = Literal["simulation", "experiment"]
+AttemptRelationship = Literal[
+    "initial",
+    "unchanged_retry",
+    "checkpoint_restart",
+    "alternate_observation_attempt",
+    "extension",
+    "later_backing_candidate",
+]
+ActivityGroup = Literal[
+    "needs_attention",
+    "ready_to_run",
+    "queued",
+    "running",
+    "awaiting_validation_or_ingest",
+    "ready_to_inspect",
+    "available_with_caveats",
+    "recently_completed",
+]
+TrustState = Literal["trusted", "caveated", "failed", "unassessed", "unavailable"]
+FactState = Literal[
+    "not_applicable",
+    "unknown",
+    "absent",
+    "present",
+    "pending",
+    "passed",
+    "caveated",
+    "failed",
+    "conflict",
+    "missing",
+    "eligible",
+    "ineligible",
+]
+ActionKind = Literal[
+    "run",
+    "cancel",
+    "ingest",
+    "explore",
+    "compare_parent",
+    "compare_reference",
+    "review",
+    "open_run_controls",
+]
+DependencyKind = Literal["saved_view", "saved_comparison"]
+
+OWNER_LABELS: dict[OwnerId, str] = {
+    "trade_cumulus": "Trade Cumulus",
+    "mountain_waves": "Mountain Waves",
+    "supercells": "Supercells",
+    "fun_with_soundings": "Fun With Soundings",
+    "legacy_unassigned": "Legacy / unassigned",
+}
+_WORLD_OWNER_IDS: set[OwnerId] = {"trade_cumulus", "mountain_waves", "supercells"}
+_ATTEMPT_RELATIONSHIPS: set[str] = {
+    "initial",
+    "unchanged_retry",
+    "checkpoint_restart",
+    "alternate_observation_attempt",
+    "extension",
+    "later_backing_candidate",
+}
+_ACTIVE_QUEUE_STATES = {"queued", "running"}
+_ATTENTION_STATES = {
+    "failed",
+    "canceled",
+    "launch_failed",
+    "ingest_failed",
+    "completed_no_output",
+}
+
+
+class LifecycleDifference(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    category: str
+    label: str
+    before: Any = None
+    after: Any = None
+    units: str | None = None
+    material: bool = True
+
+
+class LifecycleFacts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scientific_work: FactState
+    package: FactState
+    attempt: FactState
+    queue: FactState
+    process: FactState
+    expected_output: FactState
+    technical_integrity: FactState
+    ingest: FactState
+    world_inspectability: FactState
+    simulation_availability: FactState
+    parent_eligibility: FactState
+    retained_assets: FactState
+
+
+class LifecycleAttempt(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    attempt_id: str
+    run_id: str
+    relationship: AttemptRelationship
+    accepted_backing: bool = False
+    manifest_path: str | None = None
+    lifecycle_state: str | None = None
+    queue_state: str | None = None
+    product_state: str | None = None
+    validation_status: str | None = None
+    result_id: str | None = None
+    output_artifact_count: int = 0
+    size_bytes: int | None = None
+    retained_state: Literal["retained", "missing", "conflict", "unknown"] = "unknown"
+    created_at: str | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    updated_at: str | None = None
+    message: str | None = None
+    failure_reason: str | None = None
+
+
+class LifecycleAction(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: ActionKind
+    label: str
+    run_id: str | None = None
+    manifest_path: str | None = None
+    result_id: str | None = None
+    world_id: str | None = None
+    simulation_id: str | None = None
+    target_simulation_id: str | None = None
+
+
+class LifecycleDependency(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: DependencyKind
+    dependency_id: str
+    title: str
+    relationship: str
+
+
+class WorldLifecycleSource(BaseModel):
+    """Normalized current World inventory fact used by the projection."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    owner_id: WorldOwnerId
+    simulation_id: str
+    display_name: str
+    role: str
+    run_id: str
+    result_id: str | None = None
+    case_id: str | None = None
+    recipe_id: str | None = None
+    recipe_version: str | None = None
+    parent_simulation_id: str | None = None
+    reference_simulation_id: str | None = None
+    question: str | None = None
+    differences: list[LifecycleDifference] = Field(default_factory=list)
+    accepted_backing: bool = True
+    availability_state: Literal["available", "missing", "unavailable", "conflict"]
+    inspectability_state: Literal["passed", "failed", "missing", "conflict"]
+    parent_eligibility_state: Literal["eligible", "ineligible", "unknown"]
+    trust_state: TrustState = "unassessed"
+    caveats: list[str] = Field(default_factory=list)
+    created_at: str | None = None
+    completed_at: str | None = None
+
+
+class LifecycleRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    record_id: str
+    record_kind: RecordKind
+    owner_id: OwnerId
+    owner_label: str
+    simulation_id: str | None = None
+    experiment_id: str | None = None
+    world_id: str | None = None
+    recipe_id: str | None = None
+    recipe_version: str | None = None
+    parent_simulation_id: str | None = None
+    reference_simulation_id: str | None = None
+    display_name: str
+    question: str | None = None
+    role: str | None = None
+    case_id: str | None = None
+    differences: list[LifecycleDifference] = Field(default_factory=list)
+    attempts: list[LifecycleAttempt] = Field(default_factory=list)
+    facts: LifecycleFacts
+    trust_state: TrustState
+    caveats: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    notes: str | None = None
+    lifecycle_label: str
+    lifecycle_detail: str
+    activity_group: ActivityGroup | None = None
+    in_activity: bool = False
+    created_at: str | None = None
+    updated_at: str | None = None
+    size_bytes: int | None = None
+    dependencies: list[LifecycleDependency] = Field(default_factory=list)
+    actions: list[LifecycleAction] = Field(default_factory=list)
+
+
+class LifecycleProjection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["1"] = "1"
+    generated_at: str
+    records: list[LifecycleRecord]
+    warnings: list[str] = Field(default_factory=list)
+
+
+def lifecycle_projection(
+    settings: CloudChamberSettings,
+    *,
+    queue: RunQueueState,
+    now: datetime | None = None,
+) -> LifecycleProjection:
+    """Build the canonical read-only lifecycle projection from current sources."""
+    storage = runtime_lifecycle_inventory(settings)
+    results = list_result_cards(settings)
+    sources, warnings = _lightweight_world_sources(storage, results)
+    return build_lifecycle_projection(
+        storage=storage,
+        results=results,
+        queue=queue,
+        world_sources=sources,
+        dependencies=_dependency_index(settings),
+        warnings=warnings,
+        now=now,
+    )
+
+
+def build_lifecycle_projection(
+    *,
+    storage: RuntimeStorageInventory,
+    results: list[ResultCard],
+    queue: RunQueueState,
+    world_sources: list[WorldLifecycleSource],
+    dependencies: dict[tuple[str, str], list[LifecycleDependency]] | None = None,
+    warnings: list[str] | None = None,
+    now: datetime | None = None,
+) -> LifecycleProjection:
+    """Project normalized fixtures or live adapters into canonical records."""
+    generated_at = now or datetime.now(UTC)
+    dependency_index = dependencies or {}
+    source_by_run = {source.run_id: source for source in world_sources}
+    source_by_result = {
+        source.result_id: source for source in world_sources if source.result_id is not None
+    }
+    source_by_identity = {
+        (source.owner_id, source.simulation_id): source for source in world_sources
+    }
+    result_by_run = {result.run_id: result for result in results}
+    queue_by_run = {entry.run_id: entry for entry in queue.entries}
+    grouped_runs: dict[str, list[RunStorageEntry]] = defaultdict(list)
+    group_source: dict[str, WorldLifecycleSource] = {}
+    group_result: dict[str, ResultCard] = {}
+
+    for run in storage.runs:
+        result = result_by_run.get(run.run_id)
+        source = source_by_run.get(run.run_id)
+        if source is None and result is not None:
+            source = source_by_result.get(result.result_id)
+        if source is None:
+            source = _declared_world_source(run, source_by_identity)
+        key = _record_key(run.run_id, result, source)
+        grouped_runs[key].append(run)
+        if source is not None:
+            group_source[key] = source
+        if result is not None:
+            group_result[key] = result
+
+    for result in results:
+        source = source_by_result.get(result.result_id)
+        key = _record_key(result.run_id, result, source)
+        group_result[key] = result
+        if source is not None:
+            group_source[key] = source
+        grouped_runs.setdefault(key, [])
+
+    for source in world_sources:
+        key = _record_key(source.run_id, None, source)
+        group_source[key] = source
+        grouped_runs.setdefault(key, [])
+
+    for entry in queue.entries:
+        if any(entry.run_id == run.run_id for runs in grouped_runs.values() for run in runs):
+            continue
+        source = source_by_run.get(entry.run_id)
+        key = _record_key(entry.run_id, None, source)
+        if source is not None:
+            group_source[key] = source
+        grouped_runs.setdefault(key, [])
+
+    records = [
+        _project_record(
+            key=key,
+            runs=runs,
+            result=group_result.get(key),
+            source=group_source.get(key),
+            queue_by_run=queue_by_run,
+            dependencies=dependency_index,
+            now=generated_at,
+        )
+        for key, runs in grouped_runs.items()
+    ]
+    records.sort(key=lambda record: (record.updated_at or "", record.display_name), reverse=True)
+    return LifecycleProjection(
+        generated_at=generated_at.isoformat(),
+        records=records,
+        warnings=warnings or [],
+    )
+
+
+def _project_record(
+    *,
+    key: str,
+    runs: list[RunStorageEntry],
+    result: ResultCard | None,
+    source: WorldLifecycleSource | None,
+    queue_by_run: dict[str, RunQueueEntry],
+    dependencies: dict[tuple[str, str], list[LifecycleDependency]],
+    now: datetime,
+) -> LifecycleRecord:
+    owner_id = source.owner_id if source is not None else _experiment_owner(result, runs)
+    world_id = source.owner_id if source is not None else None
+    attempts = [
+        _attempt_from_run(
+            run,
+            queue_by_run.get(run.run_id),
+            result if result is not None and result.run_id == run.run_id else None,
+            source,
+        )
+        for run in runs
+    ]
+    for entry in queue_by_run.values():
+        if any(attempt.run_id == entry.run_id for attempt in attempts):
+            continue
+        belongs_to_record = (
+            (source is not None and entry.run_id == source.run_id)
+            or (result is not None and entry.run_id == result.run_id)
+            or (source is None and result is None and key == f"experiment:{entry.run_id}")
+        )
+        if not belongs_to_record:
+            continue
+        attempts.append(_attempt_from_queue(entry, source))
+    if not attempts and source is not None:
+        attempts.append(_missing_source_attempt(source))
+    attempts.sort(key=lambda attempt: (attempt.created_at or "", attempt.run_id))
+
+    tags = result.tags if result is not None else _manifest_tags(runs)
+    caveats = _caveats(result, source, runs)
+    trust = _trust_state(result, source)
+    facts = _facts(attempts, result, source, trust)
+    lifecycle_label, lifecycle_detail, activity_group = _lifecycle_summary(
+        attempts, result, source, facts, trust
+    )
+    created_at = _earliest(
+        [attempt.created_at for attempt in attempts]
+        + ([source.created_at] if source is not None else [])
+        + ([result.created_at.isoformat()] if result is not None else [])
+    )
+    updated_at = _latest(
+        [attempt.updated_at for attempt in attempts]
+        + ([source.completed_at] if source is not None else [])
+        + ([result.updated_at.isoformat()] if result is not None else [])
+    )
+    recent = _is_recent(updated_at, now=now)
+    in_activity = activity_group is not None and (
+        activity_group
+        in {
+            "needs_attention",
+            "ready_to_run",
+            "queued",
+            "running",
+            "awaiting_validation_or_ingest",
+        }
+        or recent
+    )
+    if not in_activity:
+        activity_group = None
+    simulation_id = source.simulation_id if source is not None else None
+    record_dependencies = (
+        dependencies.get((source.owner_id, source.simulation_id), []) if source is not None else []
+    )
+    actions = _actions(attempts, result, source, facts)
+    display_name = (
+        source.display_name
+        if source is not None
+        else result.name
+        if result is not None
+        else _run_display_name(runs, key)
+    )
+    question = (
+        source.question
+        if source is not None and source.question
+        else result.physical_question
+        if result is not None
+        else _run_question(runs)
+    )
+    return LifecycleRecord(
+        record_id=key,
+        record_kind="simulation" if source is not None else "experiment",
+        owner_id=owner_id,
+        owner_label=OWNER_LABELS[owner_id],
+        simulation_id=simulation_id,
+        experiment_id=(
+            None if source is not None else (result.result_id if result else _run_id(runs))
+        ),
+        world_id=world_id,
+        recipe_id=(
+            source.recipe_id
+            if source is not None
+            else result.recipe_id
+            if result is not None
+            else _run_recipe_id(runs)
+        ),
+        recipe_version=source.recipe_version if source is not None else None,
+        parent_simulation_id=source.parent_simulation_id if source is not None else None,
+        reference_simulation_id=source.reference_simulation_id if source is not None else None,
+        display_name=display_name,
+        question=question,
+        role=source.role if source is not None else "experiment",
+        case_id=(
+            source.case_id
+            if source is not None
+            else result.scenario_id
+            if result is not None
+            else _run_case_id(runs)
+        ),
+        differences=source.differences if source is not None else [],
+        attempts=attempts,
+        facts=facts,
+        trust_state=trust,
+        caveats=caveats,
+        tags=tags,
+        notes=result.notes if result is not None else _manifest_notes(runs),
+        lifecycle_label=lifecycle_label,
+        lifecycle_detail=lifecycle_detail,
+        activity_group=activity_group,
+        in_activity=in_activity,
+        created_at=created_at,
+        updated_at=updated_at,
+        size_bytes=(sum(run.size_bytes for run in runs) or None) if runs else None,
+        dependencies=record_dependencies,
+        actions=actions,
+    )
+
+
+def _attempt_from_run(
+    run: RunStorageEntry,
+    queue: RunQueueEntry | None,
+    result: ResultCard | None,
+    source: WorldLifecycleSource | None,
+) -> LifecycleAttempt:
+    configuration = run.run_configuration or {}
+    relationship = _attempt_relationship(configuration, run.run_id, source)
+    queue_state = queue.state if queue is not None else _queue_state_from_lifecycle(run)
+    failure_reason = (
+        queue.error
+        if queue is not None and queue.error
+        else run.manifest_error
+        if run.manifest_error
+        else run.worker_message
+        if run.category in {"failed", "canceled", "malformed_manifest", "missing_manifest"}
+        else None
+    )
+    return LifecycleAttempt(
+        attempt_id=_string(configuration.get("attempt_id")) or run.run_id,
+        run_id=run.run_id,
+        relationship=relationship,
+        accepted_backing=bool(source and source.run_id == run.run_id and source.accepted_backing),
+        manifest_path=run.manifest_path,
+        lifecycle_state=run.lifecycle_state,
+        queue_state=queue_state,
+        product_state=run.product_state,
+        validation_status=run.validation_status,
+        result_id=result.result_id if result is not None else queue.result_id if queue else None,
+        output_artifact_count=run.output_artifact_count,
+        size_bytes=run.size_bytes or None,
+        retained_state=(
+            "conflict"
+            if run.category == "malformed_manifest"
+            else "missing"
+            if run.category == "missing_manifest"
+            else "retained"
+        ),
+        created_at=run.created_at or (queue.queued_at if queue else None),
+        started_at=queue.started_at if queue else run.worker_started_at,
+        finished_at=queue.finished_at if queue else run.worker_finished_at,
+        updated_at=(queue.updated_at if queue else None)
+        or run.worker_status_updated_at
+        or run.updated_at,
+        message=queue.message if queue is not None else run.worker_message,
+        failure_reason=failure_reason,
+    )
+
+
+def _attempt_from_queue(
+    entry: RunQueueEntry,
+    source: WorldLifecycleSource | None,
+) -> LifecycleAttempt:
+    return LifecycleAttempt(
+        attempt_id=entry.run_id,
+        run_id=entry.run_id,
+        relationship="initial",
+        accepted_backing=bool(source and source.run_id == entry.run_id),
+        manifest_path=entry.manifest_path,
+        lifecycle_state=entry.state,
+        queue_state=entry.state,
+        result_id=entry.result_id,
+        retained_state="retained" if Path(entry.manifest_path).exists() else "missing",
+        created_at=entry.queued_at,
+        started_at=entry.started_at,
+        finished_at=entry.finished_at,
+        updated_at=entry.updated_at,
+        message=entry.message,
+        failure_reason=entry.error,
+    )
+
+
+def _missing_source_attempt(source: WorldLifecycleSource) -> LifecycleAttempt:
+    return LifecycleAttempt(
+        attempt_id=source.run_id,
+        run_id=source.run_id,
+        relationship="initial",
+        accepted_backing=source.accepted_backing,
+        lifecycle_state="missing",
+        retained_state="missing",
+        created_at=source.created_at,
+        finished_at=source.completed_at,
+        updated_at=source.completed_at or source.created_at,
+        failure_reason="The accepted backing run is not present in retained runtime storage.",
+    )
+
+
+def _facts(
+    attempts: list[LifecycleAttempt],
+    result: ResultCard | None,
+    source: WorldLifecycleSource | None,
+    trust: TrustState,
+) -> LifecycleFacts:
+    queue_states = {attempt.queue_state for attempt in attempts if attempt.queue_state}
+    lifecycle_states = {attempt.lifecycle_state for attempt in attempts if attempt.lifecycle_state}
+    output_count = sum(attempt.output_artifact_count for attempt in attempts)
+    retained_states = {attempt.retained_state for attempt in attempts}
+    process_state: FactState = "unknown"
+    if "running" in queue_states or "running" in lifecycle_states:
+        process_state = "pending"
+    elif (
+        "completed" in lifecycle_states
+        or result is not None
+        or (source is not None and source.availability_state == "available")
+    ):
+        process_state = "passed"
+    elif lifecycle_states & {"failed", "canceled", "launch_failed"}:
+        process_state = "failed"
+    elif lifecycle_states & {"packaged", "queued"}:
+        process_state = "pending"
+    expected_output: FactState = "present" if output_count > 0 or result is not None else "unknown"
+    if (
+        any(state in {"completed_no_output", "missing"} for state in lifecycle_states)
+        or "missing" in retained_states
+        or ("completed" in lifecycle_states and output_count == 0 and result is None)
+    ):
+        expected_output = "missing"
+    inspectability: FactState = "not_applicable"
+    availability: FactState = "not_applicable"
+    parent_eligibility: FactState = "not_applicable"
+    if source is not None:
+        inspectability = source.inspectability_state
+        availability = (
+            "present"
+            if source.availability_state == "available"
+            else "conflict"
+            if source.availability_state == "conflict"
+            else "missing"
+        )
+        parent_eligibility = (
+            "eligible"
+            if source.parent_eligibility_state == "eligible"
+            else "ineligible"
+            if source.parent_eligibility_state == "ineligible"
+            else "unknown"
+        )
+    return LifecycleFacts(
+        scientific_work="present",
+        package="present" if any(attempt.manifest_path for attempt in attempts) else "missing",
+        attempt="present" if attempts else "absent",
+        queue=(
+            "pending"
+            if queue_states & _ACTIVE_QUEUE_STATES
+            else "failed"
+            if queue_states & _ATTENTION_STATES
+            else "not_applicable"
+        ),
+        process=process_state,
+        expected_output=expected_output,
+        technical_integrity=(
+            "passed"
+            if trust == "trusted"
+            else "caveated"
+            if trust == "caveated"
+            else "failed"
+            if trust == "failed"
+            else "unknown"
+        ),
+        ingest="present" if result is not None else "pending" if output_count else "not_applicable",
+        world_inspectability=inspectability,
+        simulation_availability=availability,
+        parent_eligibility=parent_eligibility,
+        retained_assets=(
+            "conflict"
+            if "conflict" in retained_states
+            else "missing"
+            if "missing" in retained_states and "retained" not in retained_states
+            else "present"
+            if "retained" in retained_states
+            else "unknown"
+        ),
+    )
+
+
+def _lifecycle_summary(
+    attempts: list[LifecycleAttempt],
+    result: ResultCard | None,
+    source: WorldLifecycleSource | None,
+    facts: LifecycleFacts,
+    trust: TrustState,
+) -> tuple[str, str, ActivityGroup | None]:
+    queue_states = {attempt.queue_state for attempt in attempts if attempt.queue_state}
+    lifecycle_states = {attempt.lifecycle_state for attempt in attempts if attempt.lifecycle_state}
+    if source is not None and source.availability_state == "conflict":
+        return (
+            "Identity conflict",
+            "The claimed Simulation identity conflicts with current World inventory.",
+            "needs_attention",
+        )
+    if queue_states & {"running"} or lifecycle_states & {"running"}:
+        return "Running", "CM1 execution is in progress.", "running"
+    if queue_states & {"queued"} or lifecycle_states & {"queued"}:
+        return "Queued", "The package is waiting for local CM1 execution.", "queued"
+    if lifecycle_states & {"packaged"}:
+        return (
+            "Ready to run",
+            "The deterministic package is retained and can be run.",
+            "ready_to_run",
+        )
+    if lifecycle_states & _ATTENTION_STATES:
+        state = next(iter(lifecycle_states & _ATTENTION_STATES))
+        return (
+            _humanize(state),
+            _attempt_failure_detail(attempts),
+            "needs_attention",
+        )
+    if facts.retained_assets == "missing" or facts.expected_output == "missing":
+        return (
+            "Output missing",
+            "The scientific record remains, but retained backing output is unavailable.",
+            "needs_attention",
+        )
+    if (
+        facts.process == "passed"
+        and result is None
+        and (source is None or source.availability_state != "available")
+    ):
+        return (
+            "Awaiting validation or ingest",
+            "CM1 completed, but no inspectable Result or available Simulation is recorded.",
+            "awaiting_validation_or_ingest",
+        )
+    if source is not None and source.availability_state == "available":
+        if trust == "caveated" or source.caveats:
+            return (
+                "Available with caveats",
+                "The Simulation is inspectable; visible caveats remain attached.",
+                "available_with_caveats",
+            )
+        return (
+            "Available",
+            "The Simulation is inspectable in its Cloud World.",
+            "recently_completed",
+        )
+    if result is not None:
+        return (
+            "Ready to inspect",
+            "The ingested Experiment is available in Explore.",
+            "ready_to_inspect",
+        )
+    return "Retained", "The record remains available in History.", None
+
+
+def _actions(
+    attempts: list[LifecycleAttempt],
+    result: ResultCard | None,
+    source: WorldLifecycleSource | None,
+    facts: LifecycleFacts,
+) -> list[LifecycleAction]:
+    actions: list[LifecycleAction] = []
+    current = attempts[-1] if attempts else None
+    if current is not None and current.lifecycle_state == "packaged" and current.manifest_path:
+        actions.append(
+            LifecycleAction(
+                kind="run",
+                label="Run",
+                run_id=current.run_id,
+                manifest_path=current.manifest_path,
+            )
+        )
+    if current is not None and (
+        current.lifecycle_state == "running" or current.queue_state == "running"
+    ):
+        actions.append(LifecycleAction(kind="cancel", label="Cancel", run_id=current.run_id))
+    if (
+        current is not None
+        and facts.process == "passed"
+        and facts.expected_output == "present"
+        and result is None
+        and current.manifest_path
+        and (source is None or source.availability_state != "available")
+    ):
+        actions.append(
+            LifecycleAction(
+                kind="ingest",
+                label="Validate and ingest",
+                run_id=current.run_id,
+                manifest_path=current.manifest_path,
+            )
+        )
+    if source is not None and source.availability_state == "available":
+        actions.append(
+            LifecycleAction(
+                kind="explore",
+                label="Explore",
+                world_id=source.owner_id,
+                simulation_id=source.simulation_id,
+                result_id=source.result_id,
+            )
+        )
+        if source.parent_simulation_id:
+            actions.append(
+                LifecycleAction(
+                    kind="compare_parent",
+                    label="Compare to parent",
+                    world_id=source.owner_id,
+                    simulation_id=source.simulation_id,
+                    target_simulation_id=source.parent_simulation_id,
+                )
+            )
+        if (
+            source.reference_simulation_id
+            and source.reference_simulation_id != source.simulation_id
+            and source.reference_simulation_id != source.parent_simulation_id
+        ):
+            actions.append(
+                LifecycleAction(
+                    kind="compare_reference",
+                    label="Compare to reference",
+                    world_id=source.owner_id,
+                    simulation_id=source.simulation_id,
+                    target_simulation_id=source.reference_simulation_id,
+                )
+            )
+    elif result is not None:
+        actions.append(
+            LifecycleAction(
+                kind="explore",
+                label="Explore",
+                result_id=result.result_id,
+            )
+        )
+    if any(attempt.failure_reason for attempt in attempts) or facts.retained_assets in {
+        "missing",
+        "conflict",
+    }:
+        actions.append(
+            LifecycleAction(
+                kind="review",
+                label="Review issue",
+                run_id=current.run_id if current else None,
+            )
+        )
+    if source is None:
+        actions.append(
+            LifecycleAction(
+                kind="open_run_controls",
+                label="Open run controls",
+                run_id=current.run_id if current else result.run_id if result else None,
+            )
+        )
+    return actions
+
+
+def _lightweight_world_sources(
+    storage: RuntimeStorageInventory,
+    results: list[ResultCard],
+) -> tuple[list[WorldLifecycleSource], list[str]]:
+    runs = {run.run_id: run for run in storage.runs}
+    result_by_run = {result.run_id: result for result in results}
+    sources = [
+        _known_source(
+            owner_id="trade_cumulus",
+            simulation_id=REFERENCE_SIMULATION_ID,
+            display_name=REFERENCE_DISPLAY_NAME,
+            role="reference",
+            run_id=PRESENTATION_BASELINE_RUN_ID,
+            result_id=PRESENTATION_BASELINE_RESULT_ID,
+            case_id=None,
+            parent_simulation_id=None,
+            reference_simulation_id=REFERENCE_SIMULATION_ID,
+            parent_eligibility_state="unknown",
+            run=runs.get(PRESENTATION_BASELINE_RUN_ID),
+            result=result_by_run.get(PRESENTATION_BASELINE_RUN_ID),
+            question="How does the canonical BOMEX trade-cumulus field evolve?",
+        ),
+        _known_source(
+            owner_id="trade_cumulus",
+            simulation_id=MORE_MOISTURE_SIMULATION_ID,
+            display_name=MORE_MOISTURE_DISPLAY_NAME,
+            role="variation",
+            run_id=PRESENTATION_MORE_MOISTURE_RUN_ID,
+            result_id=PRESENTATION_MORE_MOISTURE_RESULT_ID,
+            case_id=None,
+            parent_simulation_id=REFERENCE_SIMULATION_ID,
+            reference_simulation_id=REFERENCE_SIMULATION_ID,
+            parent_eligibility_state="unknown",
+            run=runs.get(PRESENTATION_MORE_MOISTURE_RUN_ID),
+            result=result_by_run.get(PRESENTATION_MORE_MOISTURE_RUN_ID),
+            differences=_trade_moisture_difference(
+                runs.get(PRESENTATION_BASELINE_RUN_ID),
+                runs.get(PRESENTATION_MORE_MOISTURE_RUN_ID),
+            ),
+        ),
+        _known_source(
+            owner_id="mountain_waves",
+            simulation_id=DRY_SIMULATION_ID,
+            display_name="Dry Ridge — Wave Mechanics",
+            role="built_in",
+            run_id=DRY_RUN_ID,
+            result_id=None,
+            case_id=DRY_CASE_ID,
+            parent_simulation_id=None,
+            reference_simulation_id=MOIST_SIMULATION_ID,
+            parent_eligibility_state="ineligible",
+            run=runs.get(DRY_RUN_ID),
+            result=None,
+            question="How does terrain force a dry gravity wave?",
+            authored_caveats=["This dry benchmark does not simulate moisture or cloud formation."],
+        ),
+        _known_source(
+            owner_id="mountain_waves",
+            simulation_id=MOIST_SIMULATION_ID,
+            display_name="Boulder Windstorm — Moist Reference",
+            role="built_in",
+            run_id=MOIST_RUN_ID,
+            result_id=None,
+            case_id=MOIST_CASE_ID,
+            parent_simulation_id=None,
+            reference_simulation_id=MOIST_SIMULATION_ID,
+            parent_eligibility_state="eligible",
+            run=runs.get(MOIST_RUN_ID),
+            result=None,
+            question="Where does terrain-forced flow create and erode wave cloud?",
+            authored_caveats=["This is a native two-dimensional x-z Simulation."],
+        ),
+        _known_source(
+            owner_id="supercells",
+            simulation_id=SUPERCELLS_REFERENCE_SIMULATION_ID,
+            display_name="Quarter-Circle Supercell",
+            role="reference",
+            run_id=SUPERCELLS_REFERENCE_RUN_ID,
+            result_id=None,
+            case_id=SUPERCELLS_REFERENCE_CASE_ID,
+            parent_simulation_id=None,
+            reference_simulation_id=SUPERCELLS_REFERENCE_SIMULATION_ID,
+            parent_eligibility_state="unknown",
+            run=runs.get(SUPERCELLS_REFERENCE_RUN_ID),
+            result=None,
+            question="How do rotating ascent, hydrometeors, and low-level flow evolve?",
+        ),
+        _known_source(
+            owner_id="supercells",
+            simulation_id=SUPERCELLS_STRAIGHT_LINE_SIMULATION_ID,
+            display_name="Straight-Line Hodograph Supercell",
+            role="variation",
+            run_id=STRAIGHT_LINE_PRESENTATION_RUN_ID,
+            result_id=None,
+            case_id=STRAIGHT_LINE_PRESENTATION_CASE_ID,
+            parent_simulation_id=SUPERCELLS_REFERENCE_SIMULATION_ID,
+            reference_simulation_id=SUPERCELLS_REFERENCE_SIMULATION_ID,
+            parent_eligibility_state="unknown",
+            run=runs.get(STRAIGHT_LINE_PRESENTATION_RUN_ID),
+            result=None,
+            question="How does hodograph curvature change storm organization?",
+            differences=[
+                LifecycleDifference(
+                    category="atmospheric",
+                    label="Hodograph geometry",
+                    before="Quarter-circle",
+                    after="Straight-line",
+                )
+            ],
+        ),
+    ]
+    known_run_ids = {source.run_id for source in sources}
+    for run in storage.runs:
+        if run.run_id in known_run_ids:
+            continue
+        source = _variation_source(run, result_by_run.get(run.run_id))
+        if source is not None:
+            sources.append(source)
+    warnings: list[str] = []
+    return sources, warnings
+
+
+def _known_source(
+    *,
+    owner_id: WorldOwnerId,
+    simulation_id: str,
+    display_name: str,
+    role: str,
+    run_id: str,
+    result_id: str | None,
+    case_id: str | None,
+    parent_simulation_id: str | None,
+    reference_simulation_id: str | None,
+    parent_eligibility_state: Literal["eligible", "ineligible", "unknown"],
+    run: RunStorageEntry | None,
+    result: ResultCard | None,
+    question: str | None = None,
+    differences: list[LifecycleDifference] | None = None,
+    authored_caveats: list[str] | None = None,
+) -> WorldLifecycleSource:
+    availability, inspectability = _source_availability(run, expected_case_id=case_id)
+    caveats = [
+        *(authored_caveats or []),
+        *(run.run_caveats if run is not None else []),
+        *(result.caveats if result is not None else []),
+    ]
+    return WorldLifecycleSource(
+        owner_id=owner_id,
+        simulation_id=simulation_id,
+        display_name=display_name,
+        role=role,
+        run_id=run_id,
+        result_id=result_id if result is not None else None,
+        case_id=case_id or (run.scenario_id if run is not None else None),
+        recipe_id=(
+            run.recipe_id if run is not None else result.recipe_id if result is not None else None
+        ),
+        parent_simulation_id=parent_simulation_id,
+        reference_simulation_id=reference_simulation_id,
+        question=question or (run.physical_question if run is not None else None),
+        differences=differences or [],
+        availability_state=availability,
+        inspectability_state=inspectability,
+        parent_eligibility_state=(
+            parent_eligibility_state if availability == "available" else "unknown"
+        ),
+        trust_state=_source_trust(run, result, caveats),
+        caveats=list(dict.fromkeys(caveats)),
+        created_at=run.created_at if run is not None else None,
+        completed_at=run.updated_at if run is not None else None,
+    )
+
+
+def _variation_source(
+    run: RunStorageEntry,
+    result: ResultCard | None,
+) -> WorldLifecycleSource | None:
+    configuration = run.run_configuration or {}
+    owner = _string(configuration.get("cloud_world_id"))
+    simulation_id = _string(configuration.get("simulation_id"))
+    display_name = _string(configuration.get("simulation_display_name"))
+    if not _is_current_mountain_waves_variation(
+        run,
+        owner=owner,
+        simulation_id=simulation_id,
+        display_name=display_name,
+    ):
+        return None
+    assert simulation_id is not None
+    assert display_name is not None
+    parent_id = _string(configuration.get("parent_simulation_id"))
+    reference_id = _string(configuration.get("reference_simulation_id"))
+    availability, inspectability = _source_availability(run, expected_case_id=None)
+    caveats = [*run.run_caveats, *(result.caveats if result is not None else [])]
+    differences = _configuration_differences(configuration.get("configuration_difference"))
+    return WorldLifecycleSource(
+        owner_id="mountain_waves",
+        simulation_id=simulation_id,
+        display_name=display_name,
+        role="variation",
+        run_id=run.run_id,
+        result_id=result.result_id if result is not None else None,
+        case_id=run.scenario_id,
+        recipe_id=run.recipe_id or _string(configuration.get("recipe_id")),
+        recipe_version=_string(configuration.get("recipe_version")),
+        parent_simulation_id=parent_id,
+        reference_simulation_id=reference_id,
+        question=_string(configuration.get("user_question")) or run.physical_question,
+        differences=differences,
+        availability_state=availability,
+        inspectability_state=inspectability,
+        parent_eligibility_state=("eligible" if availability == "available" else "unknown"),
+        trust_state=_source_trust(run, result, caveats),
+        caveats=list(dict.fromkeys(caveats)),
+        created_at=run.created_at,
+        completed_at=run.updated_at,
+    )
+
+
+def _is_current_mountain_waves_variation(
+    run: RunStorageEntry,
+    *,
+    owner: str | None,
+    simulation_id: str | None,
+    display_name: str | None,
+) -> bool:
+    configuration = run.run_configuration or {}
+    return (
+        owner == "mountain_waves"
+        and run.scenario_id == VARIATION_CASE_ID
+        and bool(simulation_id)
+        and bool(display_name)
+        and bool(_string(configuration.get("parent_simulation_id")))
+        and _string(configuration.get("reference_simulation_id")) == MOIST_SIMULATION_ID
+        and isinstance(configuration.get("mountain_waves_configuration"), dict)
+        and isinstance(configuration.get("configuration_difference"), dict)
+        and bool(configuration.get("generated_input_sha256"))
+        and isinstance(configuration.get("generated_input_sha256"), dict)
+    )
+
+
+def _source_availability(
+    run: RunStorageEntry | None,
+    *,
+    expected_case_id: str | None,
+) -> tuple[
+    Literal["available", "missing", "unavailable", "conflict"],
+    Literal["passed", "failed", "missing", "conflict"],
+]:
+    if run is None or run.category == "missing_manifest":
+        return "missing", "missing"
+    if run.category == "malformed_manifest":
+        return "conflict", "conflict"
+    if expected_case_id is not None and run.scenario_id != expected_case_id:
+        return "conflict", "conflict"
+    if run.validation_status == "failed":
+        return "conflict", "conflict"
+    if (
+        run.lifecycle_state == "completed"
+        and run.output_artifact_count > 0
+        and run.validation_status in {"valid", "needs_review"}
+        and bool(run.manual_validation_status)
+    ):
+        return "available", "passed"
+    if run.lifecycle_state in {"failed", "canceled"}:
+        return "unavailable", "failed"
+    return "unavailable", "failed"
+
+
+def _source_trust(
+    run: RunStorageEntry | None,
+    result: ResultCard | None,
+    caveats: list[str],
+) -> TrustState:
+    if result is not None:
+        state = result.runtime_integrity.state
+        if state == "trusted":
+            return "caveated" if caveats else "trusted"
+        if state == "caveated":
+            return "caveated"
+        if state == "failed":
+            return "failed"
+    if run is None:
+        return "unavailable"
+    if run.validation_status == "failed":
+        return "failed"
+    if run.validation_status in {"valid", "needs_review"} and run.manual_validation_status:
+        return "caveated" if caveats or run.validation_status == "needs_review" else "trusted"
+    return "unassessed"
+
+
+def _trade_moisture_difference(
+    baseline: RunStorageEntry | None,
+    variation: RunStorageEntry | None,
+) -> list[LifecycleDifference]:
+    before = (
+        (baseline.run_configuration or {}).get("surface_moisture_flux_g_g_m_s")
+        if baseline is not None
+        else None
+    )
+    after = (
+        (variation.run_configuration or {}).get("surface_moisture_flux_g_g_m_s")
+        if variation is not None
+        else None
+    )
+    if not isinstance(before, int | float) or not isinstance(after, int | float):
+        return []
+    return [
+        LifecycleDifference(
+            category="atmospheric",
+            label="Surface moisture supply",
+            before=float(before) * 1_000,
+            after=float(after) * 1_000,
+            units="g/kg m/s",
+        )
+    ]
+
+
+def _configuration_differences(value: object) -> list[LifecycleDifference]:
+    if not isinstance(value, dict):
+        return []
+    differences: list[LifecycleDifference] = []
+    for category, items in value.items():
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            differences.append(
+                LifecycleDifference(
+                    category=str(category),
+                    label=str(item.get("label") or category),
+                    before=item.get("before"),
+                    after=item.get("after"),
+                    units=_string(item.get("units")),
+                )
+            )
+    return differences
+
+
+def _declared_world_source(
+    run: RunStorageEntry,
+    sources: dict[tuple[WorldOwnerId, str], WorldLifecycleSource],
+) -> WorldLifecycleSource | None:
+    configuration = run.run_configuration or {}
+    owner = _string(configuration.get("cloud_world_id"))
+    simulation_id = _string(configuration.get("simulation_id"))
+    if owner not in _WORLD_OWNER_IDS or not simulation_id:
+        return None
+    source = sources.get((owner, simulation_id))  # type: ignore[arg-type]
+    if source is None:
+        return None
+    return source
+
+
+def _dependency_index(
+    settings: CloudChamberSettings,
+) -> dict[tuple[str, str], list[LifecycleDependency]]:
+    index: dict[tuple[str, str], list[LifecycleDependency]] = defaultdict(list)
+    state_root = settings.runtime_home.expanduser() / "explore-state"
+    if state_root.is_dir():
+        for path in sorted(state_root.glob("*/*.json")):
+            payload = _read_json(path)
+            world_id = _string(payload.get("world_id"))
+            simulation_id = _string(payload.get("simulation_id"))
+            if not world_id or not simulation_id:
+                continue
+            saved_views = payload.get("saved_views")
+            if not isinstance(saved_views, list):
+                continue
+            for item in saved_views:
+                if not isinstance(item, dict):
+                    continue
+                saved_view_id = _string(item.get("saved_view_id"))
+                title = _string(item.get("title"))
+                if saved_view_id and title:
+                    index[(world_id, simulation_id)].append(
+                        LifecycleDependency(
+                            kind="saved_view",
+                            dependency_id=saved_view_id,
+                            title=title,
+                            relationship="Saved View",
+                        )
+                    )
+    comparison_root = settings.runtime_home.expanduser() / "saved-comparisons"
+    if comparison_root.is_dir():
+        for path in sorted(comparison_root.glob("*.json")):
+            payload = _read_json(path)
+            world_id = _string(payload.get("world_id"))
+            records = payload.get("saved_comparisons")
+            if not world_id or not isinstance(records, list):
+                continue
+            for item in records:
+                if not isinstance(item, dict):
+                    continue
+                comparison_id = _string(item.get("saved_comparison_id"))
+                title = _string(item.get("title"))
+                workspace = item.get("workspace")
+                if not comparison_id or not title or not isinstance(workspace, dict):
+                    continue
+                for side in ("left", "right"):
+                    simulation_id = _string(workspace.get(f"{side}_simulation_id"))
+                    if simulation_id:
+                        index[(world_id, simulation_id)].append(
+                            LifecycleDependency(
+                                kind="saved_comparison",
+                                dependency_id=comparison_id,
+                                title=title,
+                                relationship=f"Saved Comparison ({side})",
+                            )
+                        )
+    return dict(index)
+
+
+def _record_key(
+    run_id: str,
+    result: ResultCard | None,
+    source: WorldLifecycleSource | None,
+) -> str:
+    if source is not None:
+        return f"simulation:{source.owner_id}:{source.simulation_id}"
+    stable_id = result.run_id if result is not None else run_id
+    return f"experiment:{stable_id}"
+
+
+def _experiment_owner(
+    result: ResultCard | None,
+    runs: list[RunStorageEntry],
+) -> OwnerId:
+    if result is not None and (
+        result.observed_sounding is not None
+        or result.input_source
+        in {
+            "observed_sounding",
+            "uploaded_igra_text",
+            "local_igra_period_of_record_cache",
+        }
+    ):
+        return "fun_with_soundings"
+    if any(
+        run.has_observed_sounding
+        or run.input_source
+        in {
+            "observed_sounding",
+            "uploaded_igra_text",
+            "local_igra_period_of_record_cache",
+        }
+        for run in runs
+    ):
+        return "fun_with_soundings"
+    return "legacy_unassigned"
+
+
+def _attempt_relationship(
+    configuration: dict[str, object],
+    run_id: str,
+    source: WorldLifecycleSource | None,
+) -> AttemptRelationship:
+    declared = _string(configuration.get("attempt_relationship"))
+    if declared in _ATTEMPT_RELATIONSHIPS:
+        return declared  # type: ignore[return-value]
+    if source is not None and run_id != source.run_id:
+        return "later_backing_candidate"
+    return "initial"
+
+
+def _queue_state_from_lifecycle(run: RunStorageEntry) -> str | None:
+    if run.lifecycle_state in {"queued", "running"}:
+        return run.lifecycle_state
+    return None
+
+
+def _trust_state(
+    result: ResultCard | None,
+    source: WorldLifecycleSource | None,
+) -> TrustState:
+    if source is not None and source.trust_state != "unassessed":
+        return source.trust_state
+    if result is None:
+        return "unassessed"
+    state = result.runtime_integrity.state
+    if state == "trusted":
+        return "trusted"
+    if state == "caveated":
+        return "caveated"
+    if state == "failed":
+        return "failed"
+    return "unassessed"
+
+
+def _caveats(
+    result: ResultCard | None,
+    source: WorldLifecycleSource | None,
+    runs: list[RunStorageEntry],
+) -> list[str]:
+    values: list[str] = []
+    if source is not None:
+        values.extend(source.caveats)
+    if result is not None:
+        values.extend(result.caveats)
+        values.extend(result.runtime_integrity.caveats)
+    if source is None and any(
+        _string((run.run_configuration or {}).get("cloud_world_id")) for run in runs
+    ):
+        values.append(
+            "A World identity was claimed, but current stable World/Simulation evidence "
+            "did not verify ownership."
+        )
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def _attempt_failure_detail(attempts: list[LifecycleAttempt]) -> str:
+    for attempt in reversed(attempts):
+        if attempt.failure_reason:
+            return attempt.failure_reason
+    return "The latest technical attempt needs review."
+
+
+def _run_display_name(runs: list[RunStorageEntry], key: str) -> str:
+    for run in runs:
+        if run.scenario_name:
+            return run.scenario_name
+        configuration = run.run_configuration or {}
+        configured = _string(configuration.get("simulation_display_name")) or _string(
+            configuration.get("experiment_display_name")
+        )
+        if configured:
+            return configured
+        if run.scenario_id:
+            return _humanize(run.scenario_id)
+    return _humanize(key.split(":", 1)[-1])
+
+
+def _run_question(runs: list[RunStorageEntry]) -> str | None:
+    for run in runs:
+        configuration = run.run_configuration or {}
+        question = _string(configuration.get("user_question")) or _string(
+            configuration.get("physical_question")
+        )
+        if question:
+            return question
+    return None
+
+
+def _run_id(runs: list[RunStorageEntry]) -> str | None:
+    return runs[0].run_id if runs else None
+
+
+def _run_case_id(runs: list[RunStorageEntry]) -> str | None:
+    return runs[0].scenario_id if runs else None
+
+
+def _run_recipe_id(runs: list[RunStorageEntry]) -> str | None:
+    for run in runs:
+        value = _string((run.run_configuration or {}).get("recipe_id"))
+        if value:
+            return value
+    return None
+
+
+def _manifest_tags(runs: list[RunStorageEntry]) -> list[str]:
+    for run in runs:
+        if run.user_tags:
+            return run.user_tags
+    return []
+
+
+def _manifest_notes(runs: list[RunStorageEntry]) -> str | None:
+    for run in runs:
+        if run.user_notes:
+            return run.user_notes
+    return None
+
+
+def _earliest(values: list[str | None]) -> str | None:
+    populated = [value for value in values if value]
+    return min(populated) if populated else None
+
+
+def _latest(values: list[str | None]) -> str | None:
+    populated = [value for value in values if value]
+    return max(populated) if populated else None
+
+
+def _is_recent(value: str | None, *, now: datetime) -> bool:
+    if value is None:
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed >= now - timedelta(days=14)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _string(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _humanize(value: str) -> str:
+    return (
+        value.replace("_", " ")
+        .replace("-", " ")
+        .strip()
+        .title()
+        .replace("Cm1", "CM1")
+        .replace("Bomex", "BOMEX")
+        .replace("Quarter Circle", "Quarter-Circle")
+        .replace("Straight Line", "Straight-Line")
+        .replace("R21 1", "r21.1")
+        .replace(" V0", " v0")
+        .replace(" V1", " v1")
+    )

--- a/app/backend/cloud_chamber/local_run_queue.py
+++ b/app/backend/cloud_chamber/local_run_queue.py
@@ -141,6 +141,13 @@ class LocalRunQueueManager:
             self._save_entries(entries)
             return self._state(entries)
 
+    def snapshot(self) -> RunQueueState:
+        """Read persisted queue state without launching or advancing work."""
+        with self._lock:
+            entries = self._load_entries()
+            self._recover_open_entries_from_manifests(entries)
+            return self._state(entries)
+
     def _recover_open_entries_from_manifests(self, entries: list[RunQueueEntry]) -> None:
         for entry in entries:
             if entry.state in OPEN_ENTRY_STATES or entry.state == "ingested":

--- a/app/backend/cloud_chamber/runtime_storage.py
+++ b/app/backend/cloud_chamber/runtime_storage.py
@@ -44,6 +44,15 @@ class RunStorageEntry(BaseModel):
     has_observed_sounding: bool = False
     run_configuration: dict[str, object] | None = None
     pre_run_validation_report: dict[str, object] | None = None
+    physical_question: str | None = None
+    run_recipe: str | None = None
+    recipe_id: str | None = None
+    recipe_display_name: str | None = None
+    run_caveats: list[str] = Field(default_factory=list)
+    manual_validation_status: str | None = None
+    user_name: str | None = None
+    user_tags: list[str] = Field(default_factory=list)
+    user_notes: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
     saved: bool = False
@@ -136,6 +145,25 @@ def runtime_storage_inventory(settings: CloudChamberSettings) -> RuntimeStorageI
         ),
         runs=run_entries,
         largest_runs=largest,
+    )
+
+
+def runtime_lifecycle_inventory(settings: CloudChamberSettings) -> RuntimeStorageInventory:
+    """Return manifest-level run inventory without traversing retained output sizes."""
+    runtime_home = settings.runtime_home.expanduser()
+    runs_dir = runtime_home / "runs"
+    run_entries = [
+        _run_storage_entry(path, reconcile=False, size_bytes=0)
+        for path in _run_directories(runs_dir)
+    ]
+    return RuntimeStorageInventory(
+        runtime_home=str(runtime_home),
+        runs_directory=str(runs_dir),
+        total_size_bytes=0,
+        warning_threshold_bytes=DEFAULT_STORAGE_WARNING_THRESHOLD_BYTES,
+        above_warning_threshold=False,
+        runs=run_entries,
+        largest_runs=[],
     )
 
 
@@ -263,13 +291,18 @@ def _run_directories(runs_dir: Path) -> list[Path]:
     return sorted(path for path in runs_dir.iterdir() if path.is_dir() or path.is_symlink())
 
 
-def _run_storage_entry(run_dir: Path, *, reconcile: bool = True) -> RunStorageEntry:
+def _run_storage_entry(
+    run_dir: Path,
+    *,
+    reconcile: bool = True,
+    size_bytes: int | None = None,
+) -> RunStorageEntry:
     manifest_path = run_dir / "run_manifest.json"
-    size_bytes = _directory_size(run_dir)
+    resolved_size_bytes = _directory_size(run_dir) if size_bytes is None else size_bytes
     if not manifest_path.exists():
         return RunStorageEntry(
             run_id=run_dir.name,
-            size_bytes=size_bytes,
+            size_bytes=resolved_size_bytes,
             path=str(run_dir),
             category="missing_manifest",
         )
@@ -283,14 +316,14 @@ def _run_storage_entry(run_dir: Path, *, reconcile: bool = True) -> RunStorageEn
     except (RunManifestError, OSError, ValueError) as exc:
         return RunStorageEntry(
             run_id=run_dir.name,
-            size_bytes=size_bytes,
+            size_bytes=resolved_size_bytes,
             path=str(run_dir),
             category="malformed_manifest",
             manifest_path=str(manifest_path),
             manifest_error=str(exc),
         )
 
-    return _entry_from_manifest(run_dir, manifest_path, manifest, size_bytes)
+    return _entry_from_manifest(run_dir, manifest_path, manifest, resolved_size_bytes)
 
 
 def _entry_from_manifest(
@@ -315,6 +348,15 @@ def _entry_from_manifest(
         has_observed_sounding=manifest.observed_sounding is not None,
         run_configuration=manifest.run_configuration,
         pre_run_validation_report=manifest.pre_run_validation_report,
+        physical_question=manifest.physical_question,
+        run_recipe=manifest.run_recipe,
+        recipe_id=manifest.recipe_id,
+        recipe_display_name=manifest.recipe_display_name,
+        run_caveats=manifest.run_caveats,
+        manual_validation_status=manifest.manual_validation_status,
+        user_name=manifest.user.name,
+        user_tags=manifest.user.tags,
+        user_notes=manifest.user.notes,
         created_at=manifest.created_at.isoformat(),
         updated_at=manifest.updated_at.isoformat(),
         saved=manifest.user.saved,

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -17,6 +17,7 @@ from cloud_chamber.igra_catalog import (
     IGRARegionDefinition,
     IGRAStationZipReference,
 )
+from cloud_chamber.lifecycle import LifecycleProjection
 from cloud_chamber.local_run_manager import LocalRunManagerError, RunStatus
 from cloud_chamber.local_run_queue import RunQueueEntry, RunQueueState
 from cloud_chamber.observed_sounding import parse_igra_station_text
@@ -112,6 +113,70 @@ def test_simulation_note_api_fails_closed_for_unknown_simulation(
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Cloud World Simulation not found."
+
+
+def test_lifecycle_api_uses_read_only_queue_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_state = RunQueueState(
+        entries=[],
+        queued_count=0,
+        updated_at="2026-07-27T18:00:00+00:00",
+    )
+    fake_queue = SimpleNamespace(snapshot=lambda: queue_state)
+    captured: dict[str, object] = {}
+
+    def projection(settings: object, *, queue: RunQueueState) -> LifecycleProjection:
+        captured["settings"] = settings
+        captured["queue"] = queue
+        return LifecycleProjection(
+            generated_at="2026-07-27T18:00:00+00:00",
+            records=[],
+            warnings=["Fixture warning."],
+        )
+
+    settings = SimpleNamespace(runtime_home=tmp_path)
+    monkeypatch.setattr("cloud_chamber.app.load_settings", lambda: settings)
+    monkeypatch.setattr("cloud_chamber.app._get_local_run_queue", lambda: fake_queue)
+    monkeypatch.setattr("cloud_chamber.app.lifecycle_projection", projection)
+
+    response = TestClient(app).get("/api/lifecycle")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "schema_version": "1",
+        "generated_at": "2026-07-27T18:00:00+00:00",
+        "records": [],
+        "warnings": ["Fixture warning."],
+    }
+    assert captured == {"settings": settings, "queue": queue_state}
+
+
+def test_lifecycle_api_reports_local_metadata_read_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "cloud_chamber.app._get_local_run_queue",
+        lambda: SimpleNamespace(
+            snapshot=lambda: RunQueueState(
+                entries=[],
+                queued_count=0,
+                updated_at="2026-07-27T18:00:00+00:00",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.app.lifecycle_projection",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("missing drive")),
+    )
+
+    response = TestClient(app).get("/api/lifecycle")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == (
+        "Activity and History are unavailable because retained lifecycle data could not be read."
+    )
 
 
 def _trade_explore_state_payload() -> dict[str, object]:

--- a/app/backend/tests/test_lifecycle.py
+++ b/app/backend/tests/test_lifecycle.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from cloud_chamber.lifecycle import (
+    LifecycleDifference,
+    WorldLifecycleSource,
+    _humanize,
+    _variation_source,
+    build_lifecycle_projection,
+)
+from cloud_chamber.local_run_queue import RunQueueEntry, RunQueueState
+from cloud_chamber.mountain_waves_variations import VARIATION_CASE_ID
+from cloud_chamber.mountain_waves_world import MOIST_SIMULATION_ID
+from cloud_chamber.result_cards import ResultCard
+from cloud_chamber.runtime_integrity import RuntimeIntegrity
+from cloud_chamber.runtime_storage import RunStorageEntry, RuntimeStorageInventory
+
+NOW = datetime(2026, 7, 27, 18, 0, tzinfo=UTC)
+
+
+def test_humanize_preserves_common_scientific_identifiers() -> None:
+    assert (
+        _humanize("cm1_r21_1_straight_line_supercell_characterization_v1")
+        == "CM1 r21.1 Straight-Line Supercell Characterization v1"
+    )
+
+
+def inventory(*runs: RunStorageEntry) -> RuntimeStorageInventory:
+    return RuntimeStorageInventory(
+        runtime_home="/runtime",
+        runs_directory="/runtime/runs",
+        total_size_bytes=sum(run.size_bytes for run in runs),
+        warning_threshold_bytes=50 * 1024**3,
+        above_warning_threshold=False,
+        runs=list(runs),
+        largest_runs=sorted(runs, key=lambda run: run.size_bytes, reverse=True),
+    )
+
+
+def run(
+    run_id: str,
+    state: str,
+    *,
+    category: str | None = None,
+    output_count: int = 0,
+    configuration: dict[str, object] | None = None,
+    manifest: bool = True,
+    validation: str = "valid",
+) -> RunStorageEntry:
+    return RunStorageEntry(
+        run_id=run_id,
+        scenario_id="test-case",
+        lifecycle_state=state,
+        validation_status=validation,
+        product_state=(
+            "completed_cm1_result" if state == "completed" else "packaged_dry_run_output"
+        ),
+        run_configuration=configuration or {},
+        created_at="2026-07-27T16:00:00+00:00",
+        updated_at="2026-07-27T17:00:00+00:00",
+        output_artifact_count=output_count,
+        output_summary={"netcdf_paths": output_count},
+        size_bytes=1_024,
+        path=f"/runtime/runs/{run_id}",
+        category=category
+        or (
+            "completed_with_output"
+            if state == "completed" and output_count
+            else "dry_run_only"
+            if state == "packaged"
+            else state
+        ),
+        manifest_path=f"/runtime/runs/{run_id}/run_manifest.json" if manifest else None,
+    )
+
+
+def queue(*entries: RunQueueEntry) -> RunQueueState:
+    return RunQueueState(
+        entries=list(entries),
+        active_run_id=next(
+            (entry.run_id for entry in entries if entry.state == "running"),
+            None,
+        ),
+        queued_count=sum(entry.state == "queued" for entry in entries),
+        updated_at="2026-07-27T17:30:00+00:00",
+    )
+
+
+def queue_entry(run_id: str, state: str, *, error: str | None = None) -> RunQueueEntry:
+    return RunQueueEntry(
+        run_id=run_id,
+        manifest_path=f"/runtime/runs/{run_id}/run_manifest.json",
+        state=state,
+        queued_at="2026-07-27T16:30:00+00:00",
+        updated_at="2026-07-27T17:30:00+00:00",
+        started_at="2026-07-27T17:00:00+00:00" if state == "running" else None,
+        error=error,
+    )
+
+
+def world_source(
+    *,
+    state: str = "available",
+    trust: str = "trusted",
+    parent_eligible: str = "eligible",
+    run_id: str = "attempt-initial",
+) -> WorldLifecycleSource:
+    return WorldLifecycleSource(
+        owner_id="mountain_waves",
+        simulation_id="mountain_waves_broader_boulder_ridge",
+        display_name="Broader Boulder Ridge",
+        role="variation",
+        run_id=run_id,
+        case_id="mountain-wave-case",
+        recipe_id="boulder_moist_v1",
+        recipe_version="1",
+        parent_simulation_id="mountain_waves_boulder_moist_reference",
+        reference_simulation_id="mountain_waves_boulder_moist_reference",
+        question="How does a broader ridge change the wave cloud?",
+        differences=[
+            LifecycleDifference(
+                category="terrain",
+                label="Ridge half-width",
+                before=10_000,
+                after=15_000,
+                units="m",
+            )
+        ],
+        availability_state=state,  # type: ignore[arg-type]
+        inspectability_state=(
+            "passed" if state == "available" else "conflict" if state == "conflict" else "missing"
+        ),
+        parent_eligibility_state=parent_eligible,  # type: ignore[arg-type]
+        trust_state=trust,  # type: ignore[arg-type]
+        caveats=(
+            ["Finite underflow is retained as a visible caveat."] if trust == "caveated" else []
+        ),
+        created_at="2026-07-27T16:00:00+00:00",
+        completed_at="2026-07-27T17:00:00+00:00",
+    )
+
+
+def result_card(
+    *,
+    run_id: str,
+    result_id: str,
+    observed: bool,
+    trust: str = "trusted",
+) -> ResultCard:
+    return ResultCard.model_construct(
+        result_id=result_id,
+        run_id=run_id,
+        name="Observed Surface-Forced Evolution — Topeka",
+        tags=["topeka", "sounding"],
+        notes="Retained experiment note.",
+        scenario_id="observed-surface-forced-evolution-v0",
+        physical_question="Will this observed atmosphere form deep cloud?",
+        observed_sounding={"station_id": "USM00072456"} if observed else None,
+        run_recipe="observed_surface_forced_evolution" if observed else None,
+        recipe_id="observed_surface_forced_evolution_v0" if observed else None,
+        input_source="local_igra_period_of_record_cache" if observed else "generated_reference",
+        caveats=[],
+        runtime_integrity=RuntimeIntegrity(
+            assessed=True,
+            state=trust,  # type: ignore[arg-type]
+            reason="fixture",
+            summary="Fixture integrity.",
+        ),
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def test_projection_keeps_lifecycle_facts_distinct_and_groups_activity() -> None:
+    projection = build_lifecycle_projection(
+        storage=inventory(
+            run("packaged", "packaged"),
+            run("queued", "queued"),
+            run("running", "running"),
+            run("awaiting-ingest", "completed", output_count=2),
+            run("failed", "failed", category="failed"),
+            run("cancelled", "canceled", category="canceled"),
+            run("missing-output", "completed", category="completed_no_output"),
+        ),
+        results=[],
+        queue=queue(
+            queue_entry("queued", "queued"),
+            queue_entry("running", "running"),
+            queue_entry("failed", "failed", error="CM1 exited 2"),
+            queue_entry("cancelled", "canceled"),
+        ),
+        world_sources=[],
+        now=NOW,
+    )
+
+    by_run = {record.attempts[0].run_id: record for record in projection.records if record.attempts}
+    assert by_run["packaged"].activity_group == "ready_to_run"
+    assert by_run["packaged"].facts.package == "present"
+    assert by_run["packaged"].facts.process == "pending"
+    assert by_run["queued"].activity_group == "queued"
+    assert by_run["queued"].facts.queue == "pending"
+    assert by_run["running"].activity_group == "running"
+    assert by_run["awaiting-ingest"].activity_group == "awaiting_validation_or_ingest"
+    assert by_run["awaiting-ingest"].facts.expected_output == "present"
+    assert by_run["awaiting-ingest"].facts.ingest == "pending"
+    assert by_run["failed"].activity_group == "needs_attention"
+    assert by_run["failed"].lifecycle_detail == "CM1 exited 2"
+    assert by_run["cancelled"].activity_group == "needs_attention"
+    assert by_run["missing-output"].facts.expected_output == "missing"
+
+
+def test_projection_does_not_present_an_unmeasured_run_size_as_zero() -> None:
+    unmeasured = run("unmeasured", "completed", output_count=2).model_copy(update={"size_bytes": 0})
+
+    projection = build_lifecycle_projection(
+        storage=inventory(unmeasured),
+        results=[],
+        queue=queue(),
+        world_sources=[],
+        now=NOW,
+    )
+
+    assert projection.records[0].attempts[0].size_bytes is None
+    assert projection.records[0].size_bytes is None
+
+
+def test_projection_preserves_all_attempt_relationships_under_one_simulation() -> None:
+    source = world_source()
+    relationships = [
+        "initial",
+        "unchanged_retry",
+        "checkpoint_restart",
+        "alternate_observation_attempt",
+        "extension",
+        "later_backing_candidate",
+    ]
+    runs = [
+        run(
+            f"attempt-{relationship}",
+            "completed",
+            output_count=2,
+            configuration={
+                "cloud_world_id": "mountain_waves",
+                "simulation_id": source.simulation_id,
+                "attempt_relationship": relationship,
+            },
+        )
+        for relationship in relationships
+    ]
+    source = source.model_copy(update={"run_id": runs[0].run_id})
+
+    projection = build_lifecycle_projection(
+        storage=inventory(*runs),
+        results=[],
+        queue=queue(),
+        world_sources=[source],
+        now=NOW,
+    )
+
+    assert len(projection.records) == 1
+    record = projection.records[0]
+    assert record.record_kind == "simulation"
+    assert record.owner_id == "mountain_waves"
+    assert record.simulation_id == source.simulation_id
+    assert {attempt.relationship for attempt in record.attempts} == set(relationships)
+    assert sum(attempt.accepted_backing for attempt in record.attempts) == 1
+    assert record.parent_simulation_id == "mountain_waves_boulder_moist_reference"
+    assert record.differences[0].after == 15_000
+
+
+def test_available_caveated_and_parent_eligibility_remain_separate() -> None:
+    source = world_source(trust="caveated", parent_eligible="ineligible")
+    projection = build_lifecycle_projection(
+        storage=inventory(run(source.run_id, "completed", output_count=2)),
+        results=[],
+        queue=queue(),
+        world_sources=[source],
+        now=NOW,
+    )
+
+    record = projection.records[0]
+    assert record.lifecycle_label == "Available with caveats"
+    assert record.facts.simulation_availability == "present"
+    assert record.facts.world_inspectability == "passed"
+    assert record.facts.parent_eligibility == "ineligible"
+    assert record.trust_state == "caveated"
+    assert [action.kind for action in record.actions] == ["explore", "compare_parent"]
+
+
+def test_conflicting_and_missing_world_output_fail_closed() -> None:
+    conflict = world_source(state="conflict", run_id="conflict")
+    missing = world_source(state="missing", run_id="missing")
+    projection = build_lifecycle_projection(
+        storage=inventory(),
+        results=[],
+        queue=queue(),
+        world_sources=[
+            conflict,
+            missing.model_copy(update={"simulation_id": "missing-simulation"}),
+        ],
+        now=NOW,
+    )
+    by_id = {record.simulation_id: record for record in projection.records}
+
+    assert by_id[conflict.simulation_id].activity_group == "needs_attention"
+    assert by_id[conflict.simulation_id].facts.simulation_availability == "conflict"
+    assert by_id["missing-simulation"].facts.retained_assets == "missing"
+    assert by_id["missing-simulation"].facts.simulation_availability == "missing"
+    assert all(action.kind != "explore" for action in by_id["missing-simulation"].actions)
+
+
+def test_only_observed_result_is_soundings_owned_and_other_claims_fail_closed() -> None:
+    observed_run = run("observed", "completed", output_count=2)
+    ambiguous_run = run(
+        "ambiguous",
+        "completed",
+        output_count=2,
+        configuration={
+            "cloud_world_id": "trade_cumulus",
+            "simulation_id": "unknown-simulation",
+            "simulation_display_name": "Self-declared World simulation",
+        },
+    )
+    technical_run = run("technical", "completed", output_count=2).model_copy(
+        update={"input_source": "CM1_r21.1_analytic_isnd5_iwnd2_iinit1"}
+    )
+    technical_result = result_card(
+        run_id="technical",
+        result_id="result-technical",
+        observed=False,
+    ).model_copy(
+        update={
+            "name": "CM1 r21.1 Supercell characterization",
+            "recipe_id": "supercell_characterization_v1",
+            "run_recipe": "supercell_characterization",
+            "input_source": "CM1_r21.1_analytic_isnd5_iwnd2_iinit1",
+        }
+    )
+    projection = build_lifecycle_projection(
+        storage=inventory(observed_run, ambiguous_run, technical_run),
+        results=[
+            result_card(run_id="observed", result_id="result-observed", observed=True),
+            result_card(run_id="ambiguous", result_id="result-ambiguous", observed=False),
+            technical_result,
+        ],
+        queue=queue(),
+        world_sources=[],
+        now=NOW,
+    )
+    by_run = {record.attempts[0].run_id: record for record in projection.records}
+
+    assert by_run["observed"].owner_id == "fun_with_soundings"
+    assert by_run["observed"].record_kind == "experiment"
+    assert by_run["observed"].lifecycle_label == "Ready to inspect"
+    assert by_run["observed"].tags == ["topeka", "sounding"]
+    assert by_run["ambiguous"].owner_id == "legacy_unassigned"
+    assert "did not verify ownership" in by_run["ambiguous"].caveats[0]
+    assert by_run["technical"].owner_id == "legacy_unassigned"
+
+
+def test_dynamic_world_ownership_requires_current_mountain_waves_contract() -> None:
+    claimed = run(
+        "claimed",
+        "completed",
+        output_count=2,
+        configuration={
+            "cloud_world_id": "mountain_waves",
+            "simulation_id": "claimed-simulation",
+            "simulation_display_name": "Claimed Simulation",
+        },
+    )
+    current = run(
+        "current-variation",
+        "completed",
+        output_count=2,
+        configuration={
+            "cloud_world_id": "mountain_waves",
+            "simulation_id": "mountain-waves-broader-ridge",
+            "simulation_display_name": "Broader Ridge",
+            "parent_simulation_id": MOIST_SIMULATION_ID,
+            "reference_simulation_id": MOIST_SIMULATION_ID,
+            "mountain_waves_configuration": {"terrain": {"half_width_m": 15_000}},
+            "configuration_difference": {
+                "terrain": [
+                    {
+                        "label": "Ridge half-width",
+                        "before": 10_000,
+                        "after": 15_000,
+                        "units": "m",
+                    }
+                ]
+            },
+            "generated_input_sha256": {"namelist.input": "abc123"},
+        },
+    ).model_copy(update={"scenario_id": VARIATION_CASE_ID})
+
+    assert _variation_source(claimed, None) is None
+    source = _variation_source(current, None)
+    assert source is not None
+    assert source.owner_id == "mountain_waves"
+    assert source.simulation_id == "mountain-waves-broader-ridge"
+    assert source.differences[0].label == "Ridge half-width"
+
+
+def test_projection_is_stable_across_reload_for_same_retained_sources() -> None:
+    source = world_source()
+    storage = inventory(run(source.run_id, "completed", output_count=2))
+    first = build_lifecycle_projection(
+        storage=storage,
+        results=[],
+        queue=queue(),
+        world_sources=[source],
+        now=NOW,
+    )
+    second = build_lifecycle_projection(
+        storage=storage,
+        results=[],
+        queue=queue(),
+        world_sources=[source],
+        now=NOW,
+    )
+
+    assert first == second

--- a/app/backend/tests/test_local_run_queue.py
+++ b/app/backend/tests/test_local_run_queue.py
@@ -163,6 +163,22 @@ def test_queue_records_ingest_failure_and_still_starts_next_package(
     assert refreshed.active_run_id == "run-after-ingest-failure"
 
 
+def test_queue_snapshot_does_not_launch_or_advance_work(tmp_path: Path) -> None:
+    first = create_manifest(tmp_path, "run-snapshot-first")
+    second = create_manifest(tmp_path, "run-snapshot-second")
+    fake_manager = FakeRunManager()
+    queue = LocalRunQueueManager(settings=fake_settings(tmp_path), run_manager=fake_manager)
+    queue.enqueue(first)
+    queue.enqueue(second)
+    launched_before_snapshot = list(fake_manager.launched)
+
+    snapshot = queue.snapshot()
+
+    assert snapshot.active_run_id == "run-snapshot-first"
+    assert snapshot.queued_count == 1
+    assert fake_manager.launched == launched_before_snapshot
+
+
 def test_queue_marks_missing_active_manifest_failed_and_starts_next_package(
     tmp_path: Path,
 ) -> None:

--- a/app/backend/tests/test_runtime_storage.py
+++ b/app/backend/tests/test_runtime_storage.py
@@ -32,6 +32,7 @@ from cloud_chamber.runtime_storage import (
     RuntimeStorageError,
     delete_ingested_result,
     delete_runtime_run,
+    runtime_lifecycle_inventory,
     runtime_storage_inventory,
 )
 from cloud_chamber.settings import CloudChamberSettings
@@ -177,6 +178,27 @@ def test_inventory_reports_total_size_per_run_size_and_largest_runs(tmp_path: Pa
     assert by_id["run-small"].size_bytes >= 10
     assert by_id["run-large"].size_bytes >= 100
     assert inventory.largest_runs[0].size_bytes >= inventory.largest_runs[-1].size_bytes
+
+
+def test_lifecycle_inventory_reads_manifests_without_calculating_sizes_or_reconciling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = fake_settings(tmp_path)
+    manifest_path = create_run(tmp_path, "run-lifecycle")
+    (manifest_path.parent / "large-placeholder.bin").write_bytes(b"x" * 1_024)
+    monkeypatch.setattr(
+        "cloud_chamber.runtime_storage.reconcile_completed_run_manifest",
+        lambda _path: pytest.fail("Lifecycle inventory must not reconcile or rewrite manifests."),
+    )
+
+    inventory = runtime_lifecycle_inventory(settings)
+
+    assert inventory.total_size_bytes == 0
+    assert inventory.largest_runs == []
+    assert inventory.runs[0].run_id == "run-lifecycle"
+    assert inventory.runs[0].size_bytes == 0
+    assert inventory.runs[0].manifest_path == str(manifest_path)
 
 
 def test_inventory_classifies_valid_manifest_with_output_artifacts(tmp_path: Path) -> None:

--- a/app/frontend/e2e/fixtures.ts
+++ b/app/frontend/e2e/fixtures.ts
@@ -1223,6 +1223,197 @@ function mockPointCloudPoints(fieldName: string, dryFailed: boolean, threshold: 
   return (pointValues[fieldName] ?? pointValues.qc).filter((point) => point[3] >= threshold);
 }
 
+function mockLifecycleRecord({
+  recordId,
+  displayName,
+  ownerId,
+  ownerLabel,
+  runId,
+  resultId = null,
+  simulationId = null,
+  worldId = null,
+  lifecycleLabel = "Ready to inspect",
+  lifecycleDetail = "Retained output is ready to inspect.",
+  activityGroup = "recently_completed",
+  relationship = "initial",
+  parentSimulationId = null,
+  differences = [],
+  actions = [],
+}: {
+  recordId: string;
+  displayName: string;
+  ownerId: string;
+  ownerLabel: string;
+  runId: string;
+  resultId?: string | null;
+  simulationId?: string | null;
+  worldId?: string | null;
+  lifecycleLabel?: string;
+  lifecycleDetail?: string;
+  activityGroup?: string;
+  relationship?: string;
+  parentSimulationId?: string | null;
+  differences?: Array<Record<string, unknown>>;
+  actions?: Array<Record<string, unknown>>;
+}) {
+  const running = lifecycleLabel === "Running";
+  return {
+    record_id: recordId,
+    record_kind: simulationId ? "simulation" : "experiment",
+    owner_id: ownerId,
+    owner_label: ownerLabel,
+    simulation_id: simulationId,
+    experiment_id: simulationId ? null : (resultId ?? runId),
+    world_id: worldId,
+    recipe_id: ownerId === "fun_with_soundings" ? "observed_surface_forced_evolution_v0" : null,
+    recipe_version: null,
+    parent_simulation_id: parentSimulationId,
+    reference_simulation_id: parentSimulationId,
+    display_name: displayName,
+    question:
+      ownerId === "mountain_waves"
+        ? "How does a broader ridge change the wave cloud?"
+        : ownerId === "fun_with_soundings"
+          ? "Will this observed atmosphere support deep cloud?"
+          : null,
+    role: simulationId ? (parentSimulationId ? "variation" : "reference") : "experiment",
+    case_id: null,
+    differences,
+    attempts: [
+      {
+        attempt_id: runId,
+        run_id: runId,
+        relationship,
+        accepted_backing: Boolean(simulationId),
+        manifest_path: `/mock/${runId}/run_manifest.json`,
+        lifecycle_state: running ? "running" : "completed",
+        queue_state: running ? "running" : null,
+        product_state: running ? "configured_experiment" : "completed_cm1_result",
+        validation_status: running ? "pending" : "valid",
+        result_id: resultId,
+        output_artifact_count: running ? 0 : 2,
+        size_bytes: 2_048,
+        retained_state: "retained",
+        created_at: "2026-07-26T16:00:00Z",
+        started_at: "2026-07-26T16:01:00Z",
+        finished_at: running ? null : "2026-07-26T16:10:00Z",
+        updated_at: "2026-07-26T16:10:00Z",
+        message: running ? "CM1 is running locally." : null,
+        failure_reason: null,
+      },
+    ],
+    facts: {
+      scientific_work: "present",
+      package: "present",
+      attempt: "present",
+      queue: running ? "pending" : "not_applicable",
+      process: running ? "pending" : "passed",
+      expected_output: running ? "pending" : "present",
+      technical_integrity: running ? "unknown" : "passed",
+      ingest: resultId ? "present" : running ? "not_applicable" : "pending",
+      world_inspectability: simulationId ? "passed" : "not_applicable",
+      simulation_availability: simulationId ? "present" : "not_applicable",
+      parent_eligibility: simulationId ? "eligible" : "not_applicable",
+      retained_assets: "present",
+    },
+    trust_state: running ? "unassessed" : "trusted",
+    caveats: [],
+    tags: ownerId === "fun_with_soundings" ? ["topeka", "observed sounding"] : [],
+    notes: null,
+    lifecycle_label: lifecycleLabel,
+    lifecycle_detail: lifecycleDetail,
+    activity_group: activityGroup,
+    in_activity: true,
+    created_at: "2026-07-26T16:00:00Z",
+    updated_at: "2026-07-26T16:10:00Z",
+    size_bytes: 2_048,
+    dependencies: [],
+    actions,
+  };
+}
+
+const lifecycleProjection = {
+  schema_version: "1",
+  generated_at: "2026-07-27T18:00:00Z",
+  records: [
+    mockLifecycleRecord({
+      recordId: "simulation:trade_cumulus:trade_cumulus_canonical_bomex",
+      displayName: "Canonical BOMEX Baseline",
+      ownerId: "trade_cumulus",
+      ownerLabel: "Trade Cumulus",
+      runId: "trade-cumulus-5b-full-baseline-20260720T162342Z",
+      resultId: "result-trade-cumulus-5b-full-baseline-20260720T162342Z",
+      simulationId: "trade_cumulus_canonical_bomex",
+      worldId: "trade_cumulus",
+      lifecycleLabel: "Available",
+      lifecycleDetail: "The Simulation is inspectable in its Cloud World.",
+      actions: [
+        {
+          kind: "explore",
+          label: "Explore",
+          world_id: "trade_cumulus",
+          simulation_id: "trade_cumulus_canonical_bomex",
+          result_id: "result-trade-cumulus-5b-full-baseline-20260720T162342Z",
+        },
+      ],
+    }),
+    mockLifecycleRecord({
+      recordId: "simulation:mountain_waves:mountain_waves_broader_ridge",
+      displayName: "Broader Boulder Ridge",
+      ownerId: "mountain_waves",
+      ownerLabel: "Mountain Waves",
+      runId: "broader-boulder-ridge",
+      simulationId: "mountain_waves_broader_ridge",
+      worldId: "mountain_waves",
+      parentSimulationId: "mountain_waves_boulder_moist_reference",
+      relationship: "later_backing_candidate",
+      lifecycleLabel: "Available",
+      lifecycleDetail: "The retained variation is inspectable.",
+      differences: [
+        {
+          category: "terrain",
+          label: "Ridge half-width",
+          before: 10_000,
+          after: 15_000,
+          units: "m",
+          material: true,
+        },
+      ],
+    }),
+    mockLifecycleRecord({
+      recordId: "experiment:result-observed-sounding",
+      displayName: "Observed Surface-Forced Evolution — TOPEKA/MUN.; KS.",
+      ownerId: "fun_with_soundings",
+      ownerLabel: "Fun With Soundings",
+      runId: "run-observed-sounding",
+      resultId: "result-observed-sounding",
+      actions: [
+        {
+          kind: "explore",
+          label: "Explore",
+          run_id: "run-observed-sounding",
+          result_id: "result-observed-sounding",
+        },
+      ],
+    }),
+    mockLifecycleRecord({
+      recordId: "experiment:legacy-running",
+      displayName: "Legacy surface-forcing attempt",
+      ownerId: "legacy_unassigned",
+      ownerLabel: "Legacy / unassigned",
+      runId: "legacy-running",
+      lifecycleLabel: "Running",
+      lifecycleDetail: "CM1 is running locally.",
+      activityGroup: "running",
+      actions: [
+        { kind: "cancel", label: "Cancel", run_id: "legacy-running" },
+        { kind: "open_run_controls", label: "Open run controls", run_id: "legacy-running" },
+      ],
+    }),
+  ],
+  warnings: [],
+};
+
 export async function mockCloudChamberApis(page: Page) {
   const simulationNotes = new Map<
     string,
@@ -1288,6 +1479,8 @@ export async function mockCloudChamberApis(page: Page) {
     queued_count: 0,
     updated_at: "2026-05-22T15:15:00Z",
   };
+
+  await page.route("**/api/lifecycle", (route) => json(route, lifecycleProjection));
 
   await page.route("**/api/worlds/*/simulations/*/note", (route) => {
     const url = new URL(route.request().url());

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -928,6 +928,18 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByRole("button", { name: "Compare" })).toBeVisible();
     await page.getByRole("button", { name: "Back to Trade Cumulus" }).click();
 
+    await page.getByRole("button", { name: "Activity", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Current work" })).toBeVisible();
+    await expect(page.getByText("Canonical BOMEX Baseline")).toBeVisible();
+    await page.getByRole("button", { name: "History", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Retained scientific work" })).toBeVisible();
+    await expect(page.getByText("Trade Cumulus · Simulation")).toBeVisible();
+    await page.getByText("Technical details").click();
+    await expect(page.getByRole("region", { name: "Technical attempts" })).toContainText(
+      "Backing output",
+    );
+    await page.getByRole("button", { name: "Overview", exact: true }).click();
+
     await page.getByRole("button", { name: "Open Comparison" }).click();
     await expect(
       page.getByRole("heading", {
@@ -940,25 +952,16 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await expect(page.getByLabel("Trade Cumulus Compare")).toBeVisible();
     await expect(page.getByLabel("Canonical BOMEX Baseline comparison side")).toBeVisible();
     await expect(page.getByLabel("More Moisture comparison side")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Independent" })).toHaveClass(
-      /active-control/,
-    );
+    await expect(page.getByRole("button", { name: "Independent" })).toHaveClass(/active-control/);
     await page.getByRole("button", { name: "Aligned" }).click();
     await expect(page.getByRole("checkbox", { name: "Time", exact: true })).toBeChecked();
-    await expect(
-      page.getByRole("checkbox", { name: "Field / Lens", exact: true }),
-    ).toBeChecked();
+    await expect(page.getByRole("checkbox", { name: "Field / Lens", exact: true })).toBeChecked();
     await page.getByRole("button", { name: "Back to Trade Cumulus" }).click();
 
-    await page.getByRole("button", { name: "Lab", exact: true }).click();
-    await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
-    const labNav = page.getByRole("navigation", { name: "Trade Cumulus Lab" });
-    await labNav.getByRole("button", { name: "Build" }).click();
-    await expect(
-      page.getByRole("heading", { name: "Build and run a CM1 experiment" }),
-    ).toBeVisible();
-    await labNav.getByRole("button", { name: "Results" }).click();
-    await expect(page.getByRole("heading", { name: "Experiment Notebook" })).toBeVisible();
+    const worldNav = page.getByRole("navigation", { name: "Trade Cumulus sections" });
+    await expect(worldNav.getByRole("button", { name: "Activity" })).toBeVisible();
+    await expect(worldNav.getByRole("button", { name: "History" })).toBeVisible();
+    await expect(worldNav.getByRole("button", { name: "Lab" })).toHaveCount(0);
 
     const overflow = await page.evaluate(
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
@@ -968,7 +971,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     expect(browserErrors).toEqual([]);
   });
 
-  test("Fun With Soundings carries a selected atmosphere through runs and World ownership", async ({
+  test("Fun With Soundings carries a selected atmosphere into shared Activity and History", async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
@@ -1025,27 +1028,33 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     await page.getByRole("button", { name: "Create packages and queue selected runs" }).click();
     await expect(page.getByText("1 queued locally")).toBeVisible();
     await page.getByRole("button", { name: "Open Runs" }).click();
-    await expect(page.getByRole("heading", { name: "Past Experiments" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Refresh current work" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Refresh Experiments" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Current work" })).toBeVisible();
+    await expect(
+      page.getByText("Observed Surface-Forced Evolution — TOPEKA/MUN.; KS."),
+    ).toBeVisible();
+    await expect(page.getByText("Legacy surface-forcing attempt")).toBeVisible();
+    await page.getByRole("button", { name: "History", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Retained scientific work" })).toBeVisible();
+    await page.getByText("More filters", { exact: true }).click();
+    await expect(page.getByLabel("Owner")).toHaveValue("all");
+    await page.getByRole("searchbox", { name: "Search" }).fill("legacy");
+    await expect(page.getByText("Legacy surface-forcing attempt")).toBeVisible();
+    await expect(
+      page.getByText("Observed Surface-Forced Evolution — TOPEKA/MUN.; KS."),
+    ).toHaveCount(0);
+    await page.getByRole("button", { name: "Clear filters" }).click();
 
-    await jobs.getByRole("button", { name: "5 Explore" }).click();
+    await page.getByRole("button", { name: "Activity", exact: true }).click();
+    await page
+      .locator("article", { hasText: "Observed Surface-Forced Evolution — TOPEKA/MUN.; KS." })
+      .getByRole("button", { name: "Explore" })
+      .click();
     await expect(page).toHaveURL(/\/fun-with-soundings\/explore\/result-observed-sounding$/);
     await expect(page.getByRole("combobox", { name: "Soundings Experiment" })).toHaveValue(
       "result-observed-sounding",
     );
-    await page.getByRole("button", { name: "Back to Past Experiments" }).click();
-
-    const pastRuns = page.getByRole("region", { name: "Past Experiments" });
-    await expect(
-      pastRuns.getByRole("button", { name: "Uploaded Sounding — Valley, Nebraska" }),
-    ).toBeVisible();
-    await pastRuns.getByRole("combobox", { name: "Ownership" }).selectOption("world");
-    const runsList = pastRuns.getByRole("region", { name: "Experiments list" });
-    await expect(runsList.getByRole("button", { name: "Open Trade Cumulus" })).toHaveCount(2);
-    await runsList.getByRole("button", { name: "Open Trade Cumulus" }).first().click();
-    await expect(page.getByRole("navigation", { name: "Trade Cumulus sections" })).toBeVisible();
-    await expect(page).toHaveURL(/\/$/);
+    await page.getByRole("button", { name: "Back to Activity & History" }).click();
+    await expect(page.getByRole("heading", { name: "Current work" })).toBeVisible();
   });
 
   test("Build exposes the Golden Path scenario and creates a safe dry-run package", async ({

--- a/app/frontend/e2e/mocked-smoke/mountain-waves.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/mountain-waves.spec.ts
@@ -9,7 +9,7 @@ test.describe("mocked smoke: Mountain Waves product path", () => {
     await mockCloudChamberApis(page);
   });
 
-  test("retains a variation from Cloud Worlds through Explore and another parent", async ({
+  test("retains shared Activity and History after creating a variation", async ({
     page,
   }) => {
     await mockMountainWavesProductPath(page);
@@ -25,44 +25,34 @@ test.describe("mocked smoke: Mountain Waves product path", () => {
     await expect(page.getByLabel("Mountain Waves x-z view")).toBeVisible();
     await page.getByRole("button", { name: "Back to Mountain Waves" }).click();
 
-    await page.getByRole("button", { name: "Lab" }).click();
+    await page.getByRole("button", { name: "Create Variation", exact: true }).click();
     await expect(page.getByRole("heading", { name: /Change the terrain/ })).toBeVisible();
     await page.getByLabel("Variation name").fill("Broader Ridge");
     await page.getByLabel("Half-width").fill("11000");
     await expect(page.getByText("1 exact change")).toBeVisible();
     await page.getByRole("button", { name: "Create and queue" }).click();
 
-    await expect(page.getByText(/Queued · Waiting for the local CM1 runner/)).toBeVisible();
-    await page.getByRole("button", { name: "Refresh" }).click();
-    await expect(page.getByText(/Running · CM1 is running locally/)).toBeVisible();
-    await page.getByRole("button", { name: "Refresh" }).click();
-    await expect(page.getByRole("heading", { name: "Lab is idle" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Current work" })).toBeVisible();
+    await expect(page.locator("article", { hasText: "Broader Boulder Ridge" })).toBeVisible();
 
     await page.getByRole("button", { name: "History" }).click();
+    await expect(page.getByRole("heading", { name: "Retained scientific work" })).toBeVisible();
     const retained = page.locator("article", { hasText: "Broader Ridge" });
-    await expect(retained.getByText(/Completed · CM1 completed normally/)).toBeVisible();
-    await retained.getByRole("button", { name: "Explore" }).click();
-    await expect(page.getByRole("heading", { name: "Wave Cloud Lens" })).toBeVisible();
-    await page.getByRole("button", { name: "Back to Mountain Waves" }).click();
-
-    await page.getByRole("button", { name: "Lab" }).click();
-    await page.getByRole("button", { name: "History" }).click();
-    await page
-      .locator("article", { hasText: "Broader Ridge" })
-      .getByRole("button", { name: "Create variation" })
-      .click();
-    await expect(page.getByLabel("Parent Simulation")).toHaveValue(
-      "mountain_waves_broader_ridge_abcd1234",
+    await expect(retained.locator(".lifecycle-badge")).toHaveText("Available");
+    await retained.getByText("Technical details").click();
+    await expect(retained.getByRole("region", { name: "Technical attempts" })).toContainText(
+      "Later backing candidate",
     );
+
     expect(consoleProblems).toEqual([]);
   });
 
-  test("keeps a package failure inside the Mountain Waves Lab", async ({ page }) => {
+  test("keeps a package failure inside Mountain Waves Create Variation", async ({ page }) => {
     await mockMountainWavesProductPath(page, { failPackage: true });
 
     await gotoApp(page);
     await page.getByRole("button", { name: "Enter Mountain Waves" }).click();
-    await page.getByRole("button", { name: "Lab" }).click();
+    await page.getByRole("button", { name: "Create Variation", exact: true }).click();
     await page.getByLabel("Variation name").fill("Rejected Ridge");
     await page.getByLabel("Half-width").fill("11000");
     await page.getByRole("button", { name: "Create and queue" }).click();

--- a/app/frontend/e2e/mocked-smoke/supercells.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/supercells.spec.ts
@@ -244,6 +244,8 @@ async function gotoSupercellsExplore(page: Page) {
   await gotoApp(page);
   await page.getByRole("button", { name: "Enter Supercells" }).click();
   await expect(page.getByRole("heading", { name: "Supercells" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Activity" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "History" })).toBeVisible();
   await page.getByRole("button", { name: "Explore" }).click();
   await expect(page.getByRole("heading", { name: "Quarter-Circle Supercell" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Rotating Updraft" })).toHaveAttribute(

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -4579,6 +4579,22 @@ details[open] > summary {
   padding-top: 1.25rem;
 }
 
+.soundings-technical-run-controls {
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.7rem;
+}
+
+.soundings-technical-run-controls > summary {
+  width: fit-content;
+  cursor: pointer;
+  color: var(--color-accent-primary);
+  font-weight: 850;
+}
+
+.soundings-technical-run-controls[open] > summary {
+  margin-bottom: 1rem;
+}
+
 .soundings-runs-overview {
   display: grid;
   gap: 1rem;
@@ -5044,6 +5060,403 @@ details[open] > summary {
 .lab-content,
 .world-context-workspace {
   min-width: 0;
+}
+
+.lifecycle-workspace {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.lifecycle-heading,
+.lifecycle-heading-actions,
+.lifecycle-view-tabs,
+.lifecycle-activity-group > header,
+.lifecycle-card > header,
+.lifecycle-state-line,
+.lifecycle-card-meta,
+.lifecycle-primary-filters {
+  display: flex;
+  align-items: center;
+}
+
+.lifecycle-heading {
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.8rem;
+}
+
+.lifecycle-heading h3,
+.lifecycle-heading p,
+.lifecycle-card h4,
+.lifecycle-card p,
+.lifecycle-empty h4,
+.lifecycle-empty p {
+  margin-bottom: 0;
+}
+
+.lifecycle-heading-actions,
+.lifecycle-view-tabs {
+  gap: 0.45rem;
+}
+
+.lifecycle-view-tabs {
+  padding: 0.2rem;
+  border: 1px solid var(--color-border);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.lifecycle-view-tabs button {
+  padding: 0.45rem 0.75rem;
+  background: transparent;
+  color: var(--color-text-muted);
+  box-shadow: none;
+}
+
+.lifecycle-view-tabs .active-control {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+  box-shadow: inset 0 0 0 1px rgba(47, 116, 168, 0.16);
+}
+
+.lifecycle-activity-groups,
+.lifecycle-history-list {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.lifecycle-activity-group {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.lifecycle-activity-group > header {
+  gap: 0.55rem;
+}
+
+.lifecycle-activity-group > header h4 {
+  margin: 0;
+}
+
+.lifecycle-activity-group > header span {
+  min-width: 1.6rem;
+  border-radius: 999px;
+  padding: 0.14rem 0.42rem;
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+  font-size: 0.76rem;
+  font-weight: 850;
+  text-align: center;
+}
+
+.lifecycle-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(26rem, 1fr));
+  gap: 0.75rem;
+}
+
+.lifecycle-card {
+  display: grid;
+  align-content: start;
+  gap: 0.72rem;
+  min-width: 0;
+  border: 1px solid var(--color-border);
+  border-left: 4px solid var(--color-border-strong);
+  border-radius: 7px;
+  padding: 1rem;
+  background: var(--color-surface);
+}
+
+.lifecycle-card.lifecycle-needs_attention {
+  border-left-color: var(--color-danger);
+}
+
+.lifecycle-card.lifecycle-running,
+.lifecycle-card.lifecycle-queued {
+  border-left-color: var(--color-accent-primary);
+}
+
+.lifecycle-card.lifecycle-available_with_caveats {
+  border-left-color: var(--color-warning);
+}
+
+.lifecycle-card > header {
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.lifecycle-card .eyebrow {
+  margin-bottom: 0.15rem;
+}
+
+.lifecycle-badge {
+  flex: 0 0 auto;
+  border: 1px solid var(--color-border);
+  border-radius: 5px;
+  padding: 0.24rem 0.45rem;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+.lifecycle-badge.active {
+  border-color: rgba(47, 116, 168, 0.36);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-primary);
+}
+
+.lifecycle-badge.warning {
+  border-color: rgba(183, 121, 31, 0.4);
+  background: var(--color-warning-soft);
+  color: #80520f;
+}
+
+.lifecycle-badge.danger {
+  border-color: rgba(185, 74, 72, 0.4);
+  background: var(--color-danger-soft);
+  color: #8e302f;
+}
+
+.lifecycle-question,
+.lifecycle-state-line span,
+.lifecycle-card-meta,
+.lifecycle-relationship {
+  color: var(--color-text-muted);
+}
+
+.lifecycle-state-line {
+  align-items: baseline;
+  gap: 0.45rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.65rem;
+}
+
+.lifecycle-state-line strong {
+  color: var(--color-text-primary);
+}
+
+.lifecycle-card-meta {
+  flex-wrap: wrap;
+  gap: 0.4rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.lifecycle-difference-summary {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  border-left: 3px solid var(--color-accent-primary);
+  padding-left: 0.65rem;
+}
+
+.lifecycle-difference-summary > div {
+  display: grid;
+  grid-template-columns: minmax(9rem, 0.7fr) minmax(12rem, 1.3fr);
+  gap: 0.65rem;
+}
+
+.lifecycle-difference-summary dt {
+  color: var(--color-text-muted);
+  font-size: 0.74rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.lifecycle-difference-summary dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-weight: 750;
+}
+
+.lifecycle-actions {
+  margin-top: 0.1rem;
+}
+
+.lifecycle-details {
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.65rem;
+}
+
+.lifecycle-details > summary,
+.lifecycle-more-filters > summary {
+  width: fit-content;
+  cursor: pointer;
+  color: var(--color-accent-primary);
+  font-weight: 850;
+}
+
+.lifecycle-technical-content {
+  display: grid;
+  gap: 1rem;
+  margin-top: 0.8rem;
+}
+
+.lifecycle-facts,
+.lifecycle-identifiers {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0;
+  margin: 0;
+  border: 1px solid var(--color-border);
+}
+
+.lifecycle-card-grid .lifecycle-facts,
+.lifecycle-card-grid .lifecycle-identifiers {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.lifecycle-facts > div,
+.lifecycle-identifiers > div {
+  min-width: 0;
+  border-right: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0.55rem 0.65rem;
+}
+
+.lifecycle-facts dt,
+.lifecycle-identifiers dt {
+  color: var(--color-text-muted);
+  font-size: 0.7rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.lifecycle-facts dd,
+.lifecycle-identifiers dd {
+  margin: 0.15rem 0 0;
+  overflow-wrap: anywhere;
+  color: var(--color-text-primary);
+  font-weight: 750;
+}
+
+.lifecycle-facts .fact-failed,
+.lifecycle-facts .fact-conflict,
+.lifecycle-facts .fact-missing {
+  color: var(--color-danger);
+}
+
+.lifecycle-facts .fact-passed,
+.lifecycle-facts .fact-present,
+.lifecycle-facts .fact-eligible {
+  color: var(--color-success);
+}
+
+.lifecycle-attempts,
+.lifecycle-dependencies,
+.lifecycle-caveats,
+.lifecycle-notes {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.lifecycle-attempts h5,
+.lifecycle-dependencies h5,
+.lifecycle-caveats h5,
+.lifecycle-notes h5 {
+  margin: 0;
+}
+
+.lifecycle-attempts article {
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.8fr) minmax(14rem, 1fr) minmax(12rem, 0.8fr);
+  gap: 0.4rem 0.8rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.55rem;
+}
+
+.lifecycle-card-grid .lifecycle-attempts article {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.lifecycle-attempts article > code:last-child,
+.lifecycle-attempts article > p {
+  grid-column: 1 / -1;
+  overflow-wrap: anywhere;
+}
+
+.lifecycle-backing {
+  margin-left: 0.45rem;
+  color: var(--color-success);
+  font-size: 0.72rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.lifecycle-dependencies p {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.4rem;
+}
+
+.lifecycle-caveats ul {
+  margin: 0;
+}
+
+.lifecycle-history-toolbar {
+  display: grid;
+  gap: 0.65rem;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.8rem;
+}
+
+.lifecycle-primary-filters {
+  align-items: end;
+  gap: 0.75rem;
+}
+
+.lifecycle-primary-filters label:first-child {
+  flex: 1 1 32rem;
+}
+
+.lifecycle-primary-filters label:nth-child(2) {
+  flex: 0 1 15rem;
+}
+
+.lifecycle-primary-filters label,
+.lifecycle-more-filters label {
+  display: grid;
+  gap: 0.28rem;
+  min-width: 0;
+  color: var(--color-text-primary);
+  font-size: 0.76rem;
+  font-weight: 850;
+}
+
+.lifecycle-primary-filters p {
+  flex: 0 0 auto;
+  margin: 0 0 0.65rem;
+  color: var(--color-text-muted);
+  font-weight: 750;
+}
+
+.lifecycle-more-filters > div {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 0.65rem;
+  margin-top: 0.65rem;
+}
+
+.lifecycle-empty,
+.lifecycle-error {
+  display: grid;
+  justify-items: start;
+  gap: 0.4rem;
+  border-left: 4px solid var(--color-border-strong);
+  padding: 0.8rem 1rem;
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.lifecycle-error {
+  border-left-color: var(--color-danger);
+  background: var(--color-danger-soft);
 }
 
 .world-context-header {

--- a/app/frontend/src/App.test.tsx
+++ b/app/frontend/src/App.test.tsx
@@ -4534,6 +4534,170 @@ const tradeCumulusCompareDescriptor = {
   persistence: "transient_only",
 };
 
+function appLifecycleRecord({
+  recordId,
+  displayName,
+  ownerId,
+  ownerLabel,
+  resultId,
+  runId,
+  lifecycleLabel = "Ready to inspect",
+  lifecycleDetail = "The ingested Experiment is available in Explore.",
+  activityGroup = "ready_to_inspect",
+  worldId = null,
+  simulationId = null,
+}: {
+  recordId: string;
+  displayName: string;
+  ownerId:
+    | "trade_cumulus"
+    | "mountain_waves"
+    | "supercells"
+    | "fun_with_soundings"
+    | "legacy_unassigned";
+  ownerLabel: string;
+  resultId: string;
+  runId: string;
+  lifecycleLabel?: string;
+  lifecycleDetail?: string;
+  activityGroup?:
+    | "needs_attention"
+    | "ready_to_run"
+    | "queued"
+    | "running"
+    | "awaiting_validation_or_ingest"
+    | "ready_to_inspect"
+    | "available_with_caveats"
+    | "recently_completed";
+  worldId?: string | null;
+  simulationId?: string | null;
+}) {
+  return {
+    record_id: recordId,
+    record_kind: simulationId ? "simulation" : "experiment",
+    owner_id: ownerId,
+    owner_label: ownerLabel,
+    simulation_id: simulationId,
+    experiment_id: simulationId ? null : resultId,
+    world_id: worldId,
+    recipe_id: null,
+    recipe_version: null,
+    parent_simulation_id: null,
+    reference_simulation_id: null,
+    display_name: displayName,
+    question: null,
+    role: simulationId ? "reference" : "experiment",
+    case_id: null,
+    differences: [],
+    attempts: [
+      {
+        attempt_id: runId,
+        run_id: runId,
+        relationship: "initial",
+        accepted_backing: Boolean(simulationId),
+        manifest_path: `/tmp/${runId}/run_manifest.json`,
+        lifecycle_state: lifecycleLabel === "Running" ? "running" : "completed",
+        queue_state: lifecycleLabel === "Running" ? "running" : null,
+        product_state: "completed_cm1_result",
+        validation_status: "valid",
+        result_id: resultId,
+        output_artifact_count: 2,
+        size_bytes: 1024,
+        retained_state: "retained",
+        created_at: "2026-07-24T12:00:00Z",
+        started_at: "2026-07-24T12:01:00Z",
+        finished_at: "2026-07-24T12:10:00Z",
+        updated_at: "2026-07-24T12:10:00Z",
+        message: null,
+        failure_reason: null,
+      },
+    ],
+    facts: {
+      scientific_work: "present",
+      package: "present",
+      attempt: "present",
+      queue: lifecycleLabel === "Running" ? "pending" : "not_applicable",
+      process: lifecycleLabel === "Running" ? "pending" : "passed",
+      expected_output: "present",
+      technical_integrity: "passed",
+      ingest: "present",
+      world_inspectability: simulationId ? "passed" : "not_applicable",
+      simulation_availability: simulationId ? "present" : "not_applicable",
+      parent_eligibility: simulationId ? "eligible" : "not_applicable",
+      retained_assets: "present",
+    },
+    trust_state: "trusted",
+    caveats: [],
+    tags: [],
+    notes: null,
+    lifecycle_label: lifecycleLabel,
+    lifecycle_detail: lifecycleDetail,
+    activity_group: activityGroup,
+    in_activity: true,
+    created_at: "2026-07-24T12:00:00Z",
+    updated_at: "2026-07-24T12:10:00Z",
+    size_bytes: 1024,
+    dependencies: [],
+    actions: [
+      {
+        kind: "explore",
+        label: "Explore",
+        run_id: runId,
+        manifest_path: `/tmp/${runId}/run_manifest.json`,
+        result_id: resultId,
+        world_id: worldId,
+        simulation_id: simulationId,
+        target_simulation_id: null,
+      },
+    ],
+  };
+}
+
+const defaultLifecycleProjection = {
+  schema_version: "1",
+  generated_at: "2026-07-27T12:00:00Z",
+  records: [
+    appLifecycleRecord({
+      recordId: "experiment:observed",
+      displayName: observedSoundingResultCard.name,
+      ownerId: "fun_with_soundings",
+      ownerLabel: "Fun With Soundings",
+      resultId: observedSoundingResultCard.result_id,
+      runId: observedSoundingResultCard.run_id,
+    }),
+    appLifecycleRecord({
+      recordId: "experiment:quicklook",
+      displayName: resultCard.name,
+      ownerId: "legacy_unassigned",
+      ownerLabel: "Legacy / unassigned",
+      resultId: resultCard.result_id,
+      runId: resultCard.run_id,
+    }),
+    appLifecycleRecord({
+      recordId: "experiment:unlineaged-trade",
+      displayName: unlineagedTradeResultCard.name,
+      ownerId: "legacy_unassigned",
+      ownerLabel: "Legacy / unassigned",
+      resultId: unlineagedTradeResultCard.result_id,
+      runId: unlineagedTradeResultCard.run_id,
+    }),
+    appLifecycleRecord({
+      recordId: "simulation:trade-reference",
+      displayName: "Canonical BOMEX Baseline",
+      ownerId: "trade_cumulus",
+      ownerLabel: "Trade Cumulus",
+      resultId: comparisonBaselineResultCard.result_id,
+      runId: comparisonBaselineResultCard.run_id,
+      worldId: "trade_cumulus",
+      simulationId: "trade_cumulus_canonical_bomex",
+      lifecycleLabel: "Available",
+      lifecycleDetail: "The Simulation is inspectable in its Cloud World.",
+      activityGroup: "recently_completed",
+    }),
+  ],
+  warnings: [],
+};
+
 function mockWorldScopedApp(storyStatus = 200) {
   mockTradeCumulusComparisonApp(storyStatus);
   const defaultFetch = vi.mocked(fetch).getMockImplementation();
@@ -4550,6 +4714,11 @@ function mockWorldScopedApp(storyStatus = 200) {
     if (url.startsWith("/api/worlds/trade-cumulus/compare")) {
       return Promise.resolve(
         new Response(JSON.stringify(tradeCumulusCompareDescriptor), { status: 200 }),
+      );
+    }
+    if (url === "/api/lifecycle") {
+      return Promise.resolve(
+        new Response(JSON.stringify(defaultLifecycleProjection), { status: 200 }),
       );
     }
     return (
@@ -4584,35 +4753,18 @@ describe("App", () => {
     expect(window.location.pathname).toBe("/fun-with-soundings");
     expect(await screen.findByRole("heading", { name: "Fun With Soundings" })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "4 Runs" }));
-    const pastExperiments = (
-      await screen.findByRole("heading", {
-        name: "Past Experiments",
-      })
-    ).closest("section");
-    expect(pastExperiments).not.toBeNull();
-    expect(
-      within(pastExperiments!).getByRole("button", { name: "Refresh Experiments" }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Refresh current work" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Refresh results" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "4 Activity & History" }));
+    expect(await screen.findByRole("heading", { name: "Current work" })).toBeInTheDocument();
+    expect(screen.getByText(observedSoundingResultCard.name)).toBeInTheDocument();
+    expect(screen.getByText(resultCard.name)).toBeInTheDocument();
+    expect(screen.queryByText("Canonical BOMEX Baseline")).not.toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
     expect(
-      await screen.findByText(
-        /retained Simulations verified\. Could not check Mountain Waves, Supercells; affected Experiments remain unassigned\./,
-      ),
+      await screen.findByRole("heading", { name: "Retained scientific work" }),
     ).toBeInTheDocument();
-    fireEvent.change(within(pastExperiments!).getByRole("combobox", { name: "Ownership" }), {
-      target: { value: "world" },
-    });
-    const worldButtons = await screen.findAllByRole("button", { name: "Open Trade Cumulus" });
-    expect(worldButtons.length).toBeGreaterThan(0);
-
-    fireEvent.click(worldButtons[0]);
-    expect(
-      await screen.findByRole("navigation", { name: "Trade Cumulus sections" }),
-    ).toBeInTheDocument();
-    expect(window.location.pathname).toBe("/");
+    expect(screen.getByLabelText("Owner")).toHaveValue("all");
+    expect(screen.getByText("Legacy / unassigned")).toBeInTheDocument();
   });
 
   it("keeps unmatched World-associated metadata as an unassigned Experiment", async () => {
@@ -4630,6 +4782,28 @@ describe("App", () => {
     };
     const defaultFetch = vi.mocked(fetch).getMockImplementation();
     vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/lifecycle") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              schema_version: "1",
+              generated_at: "2026-07-27T12:00:00Z",
+              records: [
+                appLifecycleRecord({
+                  recordId: "experiment:unmatched",
+                  displayName: unmatchedAssociatedResult.name,
+                  ownerId: "legacy_unassigned",
+                  ownerLabel: "Legacy / unassigned",
+                  resultId: unmatchedAssociatedResult.result_id,
+                  runId: unmatchedAssociatedResult.run_id,
+                }),
+              ],
+              warnings: ["A World-like claim could not be verified and remains unassigned."],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
       if (String(input) === "/api/results") {
         return Promise.resolve(
           new Response(JSON.stringify({ results: [unmatchedAssociatedResult] }), { status: 200 }),
@@ -4642,21 +4816,14 @@ describe("App", () => {
 
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Open Fun With Soundings" }));
-    fireEvent.click(screen.getByRole("button", { name: "4 Runs" }));
+    fireEvent.click(screen.getByRole("button", { name: "4 Activity & History" }));
 
-    const pastExperiments = (
-      await screen.findByRole("heading", { name: "Past Experiments" })
-    ).closest("section");
-    expect(pastExperiments).not.toBeNull();
-    fireEvent.change(within(pastExperiments!).getByRole("combobox", { name: "Ownership" }), {
-      target: { value: "legacy" },
-    });
-    expect(await screen.findByText("Legacy / unassigned")).toBeInTheDocument();
+    expect(await screen.findByText("Legacy / unassigned · Experiment")).toBeInTheDocument();
     const unmatchedCard = screen
-      .getByRole("article", { name: "Unmatched World-associated output Experiment" })
+      .getByRole("heading", { name: "Unmatched World-associated output" })
       .closest("article");
     expect(unmatchedCard).not.toBeNull();
-    fireEvent.click(within(unmatchedCard!).getByRole("button", { name: "Open in Explore" }));
+    fireEvent.click(within(unmatchedCard!).getByRole("button", { name: "Explore" }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe(
@@ -4817,6 +4984,31 @@ describe("App", () => {
       if (url === "/api/runs/queue") {
         return Promise.resolve(new Response(JSON.stringify(occupiedQueue), { status: 200 }));
       }
+      if (url === "/api/lifecycle") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              schema_version: "1",
+              generated_at: "2026-07-27T12:00:00Z",
+              records: [
+                appLifecycleRecord({
+                  recordId: "experiment:mountain-waves-active-run",
+                  displayName: "World-associated work",
+                  ownerId: "legacy_unassigned",
+                  ownerLabel: "Legacy / unassigned",
+                  resultId: "result-mountain-waves-active-run",
+                  runId: worldRun.run_id,
+                  lifecycleLabel: "Running",
+                  lifecycleDetail: "CM1 execution is in progress.",
+                  activityGroup: "running",
+                }),
+              ],
+              warnings: [],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
       return (
         defaultFetch?.(input, init) ?? Promise.resolve(new Response("not found", { status: 404 }))
       );
@@ -4824,12 +5016,10 @@ describe("App", () => {
 
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Open Fun With Soundings" }));
-    fireEvent.click(screen.getByRole("button", { name: "4 Runs" }));
+    fireEvent.click(screen.getByRole("button", { name: "4 Activity & History" }));
 
-    expect(
-      await screen.findByRole("heading", { name: "Other Cloud Chamber work is running" }),
-    ).toBeInTheDocument();
-    expect(screen.getByText("World-associated work")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Running" })).toBeInTheDocument();
+    expect(screen.getByText("Legacy / unassigned · Experiment")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "CM1 is running" })).not.toBeInTheDocument();
   });
 
@@ -5032,45 +5222,38 @@ describe("App", () => {
     expect(screen.queryByLabelText("Selected Explore result")).not.toBeInTheDocument();
   });
 
-  it("keeps unrelated and unlineaged Explore entries in explicit Lab-result context", async () => {
+  it("keeps unrelated and unlineaged Explore entries in Fun With Soundings", async () => {
     mockWorldScopedApp();
     render(<App />);
-    fireEvent.click(await screen.findByRole("button", { name: "Enter Trade Cumulus" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Lab" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Open Fun With Soundings" }));
+    fireEvent.click(screen.getByRole("button", { name: "4 Activity & History" }));
 
     for (const resultName of ["Quick-look shallow cumulus", "Unlineaged Trade Cumulus output"]) {
-      fireEvent.click(await screen.findByRole("button", { name: resultName }));
-      fireEvent.click(
-        within(await screen.findByLabelText("Result detail")).getByRole("button", {
-          name: "Open in Explore",
-        }),
-      );
+      const card = (await screen.findByRole("heading", { name: resultName })).closest("article");
+      expect(card).not.toBeNull();
+      fireEvent.click(within(card!).getByRole("button", { name: "Explore" }));
 
       expect(
-        await screen.findByLabelText(`${resultName} Lab result workspace`),
+        await screen.findByLabelText(`${resultName} atmospheric experiment workspace`),
       ).toBeInTheDocument();
       expect(screen.getByRole("heading", { name: resultName })).toBeInTheDocument();
-      fireEvent.click(screen.getByRole("button", { name: "Back to Lab Results" }));
-      expect(
-        await screen.findByRole("heading", { name: "Experiment Notebook" }),
-      ).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Back to Activity & History" }));
+      expect(await screen.findByRole("heading", { name: "Current work" })).toBeInTheDocument();
     }
   });
 
-  it("retains existing Build and Results only inside Trade Cumulus Lab", async () => {
+  it("removes unrelated Build and Results from Trade Cumulus", async () => {
     mockWorldScopedApp();
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: "Enter Trade Cumulus" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Lab" }));
-
-    expect(await screen.findByRole("heading", { name: "Experiment Notebook" })).toBeInTheDocument();
-    const labNav = screen.getByRole("navigation", { name: "Trade Cumulus Lab" });
-    fireEvent.click(within(labNav).getByRole("button", { name: "Build" }));
+    const nav = await screen.findByRole("navigation", { name: "Trade Cumulus sections" });
+    expect(within(nav).queryByRole("button", { name: "Lab" })).not.toBeInTheDocument();
+    expect(within(nav).getByRole("button", { name: "Activity" })).toBeInTheDocument();
+    expect(within(nav).getByRole("button", { name: "History" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Experiment Notebook" })).not.toBeInTheDocument();
     expect(
-      await screen.findByRole("heading", { name: "Build and run a CM1 experiment" }),
-    ).toBeInTheDocument();
-    fireEvent.click(within(labNav).getByRole("button", { name: "Results" }));
-    expect(await screen.findByRole("heading", { name: "Experiment Notebook" })).toBeInTheDocument();
+      screen.queryByRole("heading", { name: "Build and run a CM1 experiment" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders guided Build setup with extensible experiment metadata", async () => {

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import {
   type SavedViewRecord,
   type TradeCumulusExploreState,
 } from "./ExploreStatePersistence";
+import { LifecycleWorkspace, type LifecycleRecord } from "./LifecycleWorkspace";
 import {
   curatedResolutionExplanation,
   resolveCuratedView,
@@ -49,7 +50,6 @@ import {
 } from "./TradeCumulusComparisonStory";
 import {
   type SimulationRecord,
-  type TradeCumulusLabSection,
   TradeCumulusWorld,
   type TradeCumulusWorldDetail,
   type TradeCumulusWorldSection,
@@ -2486,7 +2486,6 @@ export function App() {
   const [mountainWavesSimulation, setMountainWavesSimulation] =
     useState<MountainWavesSimulation | null>(null);
   const [worldSection, setWorldSection] = useState<TradeCumulusWorldSection>("overview");
-  const [worldLabSection, setWorldLabSection] = useState<TradeCumulusLabSection>("results");
   const [worldDetail, setWorldDetail] = useState<TradeCumulusWorldDetail | null>(null);
   const [worldExploreContext, setWorldExploreContext] = useState<WorldExploreContext | null>(null);
   const [worldCompareNavigation, setWorldCompareNavigation] = useState<WorldCompareNavigation>({
@@ -3971,6 +3970,16 @@ export function App() {
     navigateProduct("soundings", "/fun-with-soundings");
   }
 
+  function openLifecycleExperiment(record: LifecycleRecord) {
+    const resultId = lifecycleResultId(record);
+    if (!resultId) return;
+    selectOrdinaryResult(resultId);
+    navigateProduct(
+      "soundings-explore",
+      `/fun-with-soundings/explore/${encodeURIComponent(resultId)}`,
+    );
+  }
+
   function openSoundingsExploreSection() {
     setSoundingsSection("explore");
     const selectedSoundingsResult = soundingsExploreResults.find(
@@ -4017,8 +4026,7 @@ export function App() {
       if (section === "explore") {
         enterWorldExplore(resultId);
       } else {
-        setWorldSection("lab");
-        setWorldLabSection("results");
+        setWorldSection("activity");
       }
       return;
     }
@@ -4031,8 +4039,7 @@ export function App() {
       if (section === "explore") {
         if (selectedResultId) enterWorldExplore(selectedResultId);
       } else {
-        setWorldSection("lab");
-        setWorldLabSection(section);
+        setWorldSection(section === "results" ? "activity" : "overview");
       }
       return;
     }
@@ -4147,8 +4154,7 @@ export function App() {
   function returnToLabResults() {
     setComparisonStoryActive(false);
     setWorldExploreContext(null);
-    setWorldSection("lab");
-    setWorldLabSection("results");
+    setWorldSection("activity");
     setProductLocation("world");
   }
 
@@ -4724,8 +4730,15 @@ export function App() {
         >
           {soundingsSection === "activity" ? (
             <div className="soundings-activity-layout">
-              {buildWorkspace}
-              {resultsWorkspace}
+              <LifecycleWorkspace
+                ownerIds={["fun_with_soundings", "legacy_unassigned"]}
+                onExplore={openLifecycleExperiment}
+                onOpenRunControls={() => setSoundingsSection("build")}
+              />
+              <details className="soundings-technical-run-controls">
+                <summary>Technical run and storage controls</summary>
+                {buildWorkspace}
+              </details>
             </div>
           ) : (
             buildWorkspace
@@ -4736,9 +4749,7 @@ export function App() {
       {productLocation === "world" && (
         <TradeCumulusWorld
           section={worldSection}
-          labSection={worldLabSection}
           onSectionChange={setWorldSection}
-          onLabSectionChange={setWorldLabSection}
           onBackToWorlds={() => setProductLocation("worlds")}
           onExploreSimulation={openWorldSimulation}
           onOpenFeaturedComparison={(simulation) =>
@@ -4753,8 +4764,6 @@ export function App() {
             openSavedWorldComparison("trade-cumulus", savedComparisonId)
           }
           onWorldDetailChange={setWorldDetail}
-          buildContent={buildWorkspace}
-          resultsContent={resultsWorkspace}
         />
       )}
 
@@ -4842,14 +4851,14 @@ export function App() {
               simulationName={selectedSoundingsExploreResult.name}
               resultOptions={soundingsExploreResults}
               onSelectResult={(resultId) => openSoundingsResult(resultId, "explore")}
-              backLabel="Back to Past Experiments"
+              backLabel="Back to Activity & History"
               onBack={() => enterFunWithSoundings("activity")}
             />
           ) : (
             <ScenarioStatePanel
               title="This Soundings Experiment is not available in Explore"
               body="Choose an ingested Soundings experiment. World-owned Simulations remain available from their Cloud World."
-              actionLabel="Back to Past Experiments"
+              actionLabel="Back to Activity & History"
               onAction={() => enterFunWithSoundings("activity")}
             />
           )}
@@ -17657,6 +17666,14 @@ function soundingsExploreOptionLabel(result: ResultCard): string {
     result.observed_sounding?.station_name ?? result.input_source_label ?? result.name;
   const validTime = result.observed_sounding?.valid_time_utc;
   return validTime ? `${station} · ${formatDate(validTime)}` : station;
+}
+
+function lifecycleResultId(record: LifecycleRecord): string | null {
+  return (
+    record.actions.find((action) => action.kind === "explore" && action.result_id)?.result_id ??
+    record.attempts.find((attempt) => attempt.result_id)?.result_id ??
+    null
+  );
 }
 
 function resultCloudWorldId(

--- a/app/frontend/src/FunWithSoundings.tsx
+++ b/app/frontend/src/FunWithSoundings.tsx
@@ -32,8 +32,8 @@ const SECTIONS: Array<{
   },
   {
     id: "activity",
-    label: "Runs",
-    description: "Track active work and reopen retained runs.",
+    label: "Activity & History",
+    description: "Track current work and return to retained Experiments.",
   },
   {
     id: "explore",

--- a/app/frontend/src/LifecycleWorkspace.test.tsx
+++ b/app/frontend/src/LifecycleWorkspace.test.tsx
@@ -1,0 +1,360 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LifecycleWorkspace, type LifecycleRecord } from "./LifecycleWorkspace";
+
+const relationshipAttempts: LifecycleRecord["attempts"] = [
+  attempt("run-initial", "initial", true),
+  attempt("run-retry", "unchanged_retry"),
+  attempt("run-restart", "checkpoint_restart"),
+  attempt("run-observation", "alternate_observation_attempt"),
+  attempt("run-extension", "extension"),
+  attempt("run-backing", "later_backing_candidate"),
+];
+
+const records: LifecycleRecord[] = [
+  record({
+    record_id: "simulation:mountain_waves_broader_boulder_ridge",
+    owner_id: "mountain_waves",
+    owner_label: "Mountain Waves",
+    simulation_id: "mountain_waves_broader_boulder_ridge",
+    display_name: "Broader Boulder Ridge",
+    question: "How does broader terrain change the wave cloud?",
+    parent_simulation_id: "mountain_waves_boulder_windstorm",
+    activity_group: "available_with_caveats",
+    lifecycle_label: "Available with caveats",
+    lifecycle_detail: "Inspectable output is retained with a visible caveat.",
+    trust_state: "caveated",
+    caveats: ["Runtime integrity is caveated."],
+    tags: ["terrain"],
+    differences: [
+      {
+        category: "terrain",
+        label: "Terrain half width",
+        before: 10,
+        after: 18,
+        units: "km",
+        material: true,
+      },
+    ],
+    attempts: relationshipAttempts,
+    facts: facts({
+      simulation_availability: "present",
+      parent_eligibility: "eligible",
+      retained_assets: "present",
+      technical_integrity: "caveated",
+    }),
+    actions: [
+      action("explore", { result_id: "result-broader" }),
+      action("compare_parent", {
+        target_simulation_id: "mountain_waves_boulder_windstorm",
+      }),
+    ],
+  }),
+  record({
+    record_id: "experiment:sounding-queued",
+    owner_id: "fun_with_soundings",
+    owner_label: "Fun With Soundings",
+    record_kind: "experiment",
+    experiment_id: "sounding-queued",
+    simulation_id: null,
+    world_id: null,
+    display_name: "Topeka surface-forced evolution",
+    question: "Will the observed atmosphere sustain deep convection?",
+    activity_group: "queued",
+    lifecycle_label: "Queued",
+    lifecycle_detail: "Waiting for local execution.",
+    facts: facts({ queue: "pending", attempt: "present", retained_assets: "present" }),
+    actions: [
+      action("cancel", { run_id: "run-sounding" }),
+      action("open_run_controls", { run_id: "run-sounding" }),
+    ],
+  }),
+  record({
+    record_id: "experiment:failed",
+    owner_id: "legacy_unassigned",
+    owner_label: "Legacy / unassigned",
+    record_kind: "experiment",
+    experiment_id: "failed",
+    simulation_id: null,
+    world_id: null,
+    display_name: "Ambiguous legacy attempt",
+    activity_group: "needs_attention",
+    lifecycle_label: "Failed",
+    lifecycle_detail: "CM1 exited before expected output was complete.",
+    trust_state: "failed",
+    facts: facts({
+      process: "failed",
+      expected_output: "missing",
+      retained_assets: "missing",
+    }),
+    actions: [action("review")],
+  }),
+  record({
+    record_id: "simulation:trade-cumulus",
+    owner_id: "trade_cumulus",
+    owner_label: "Trade Cumulus",
+    simulation_id: "trade_cumulus_canonical_bomex",
+    display_name: "Canonical BOMEX Baseline",
+    activity_group: "recently_completed",
+    lifecycle_label: "Available",
+    lifecycle_detail: "Available in Trade Cumulus.",
+    trust_state: "trusted",
+    facts: facts({
+      simulation_availability: "present",
+      parent_eligibility: "eligible",
+      retained_assets: "present",
+    }),
+    actions: [action("explore", { result_id: "result-bomex" })],
+  }),
+];
+
+describe("LifecycleWorkspace", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === "/api/lifecycle") return okProjection(records);
+        if (String(input) === "/api/runs/cancel") return ok({ message: "Canceled" });
+        throw new Error(`Unexpected fetch ${String(input)}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("groups actionable work by owner and exposes every attempt relationship on demand", async () => {
+    const onExplore = vi.fn();
+    const onCompare = vi.fn();
+    render(
+      <LifecycleWorkspace
+        ownerIds={["mountain_waves"]}
+        onExplore={onExplore}
+        onCompare={onCompare}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Available with caveats" }),
+    ).toBeInTheDocument();
+    const card = screen.getByRole("heading", { name: "Broader Boulder Ridge" }).closest("article");
+    expect(card).not.toBeNull();
+    if (!card) return;
+    expect(card).toHaveTextContent("Broader Boulder Ridge");
+    expect(card).toHaveTextContent("Terrain half width");
+    expect(card).toHaveTextContent("10 km to 18 km");
+    expect(card).toHaveTextContent("Variation parent: Eligible");
+
+    fireEvent.click(within(card).getByRole("button", { name: "Explore" }));
+    expect(onExplore).toHaveBeenCalledWith(
+      expect.objectContaining({ record_id: records[0].record_id }),
+    );
+    fireEvent.click(within(card).getByRole("button", { name: "Compare to parent" }));
+    expect(onCompare).toHaveBeenCalledWith(
+      expect.objectContaining({ record_id: records[0].record_id }),
+      "mountain_waves_boulder_windstorm",
+    );
+
+    fireEvent.click(within(card).getByText("Technical details"));
+    for (const label of [
+      "Initial attempt",
+      "Unchanged retry",
+      "Checkpoint restart",
+      "Alternate observation attempt",
+      "Extension",
+      "Later backing candidate",
+    ]) {
+      expect(within(card).getByText(label)).toBeInTheDocument();
+    }
+    expect(within(card).getByText("Backing output")).toBeInTheDocument();
+  });
+
+  it("keeps History owner-aware and supports practical search and trust filters", async () => {
+    render(
+      <LifecycleWorkspace
+        ownerIds={["fun_with_soundings", "legacy_unassigned"]}
+        view="history"
+        onExplore={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Retained scientific work" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Topeka surface-forced evolution")).toBeInTheDocument();
+    expect(screen.getByText("Ambiguous legacy attempt")).toBeInTheDocument();
+    expect(screen.queryByText("Canonical BOMEX Baseline")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "Topeka" } });
+    expect(screen.getByText("Topeka surface-forced evolution")).toBeInTheDocument();
+    expect(screen.queryByText("Ambiguous legacy attempt")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("More filters"));
+    fireEvent.change(screen.getByLabelText("Trust"), { target: { value: "failed" } });
+    expect(screen.queryByText("Topeka surface-forced evolution")).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Clear filters" })[0]);
+    expect(screen.getByText("Ambiguous legacy attempt")).toBeInTheDocument();
+  });
+
+  it("executes a direct lifecycle action and refreshes from backend state", async () => {
+    render(
+      <LifecycleWorkspace
+        ownerIds={["fun_with_soundings"]}
+        onExplore={vi.fn()}
+        onOpenRunControls={vi.fn()}
+      />,
+    );
+    const cancel = await screen.findByRole("button", { name: "Cancel" });
+    fireEvent.click(cancel);
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/runs/cancel", { method: "POST" }));
+    expect(await screen.findByText("Cancel completed.")).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith("/api/lifecycle");
+  });
+
+  it("recovers from a failed projection read and reloads persisted backend state", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(errorResponse("Lifecycle unavailable"))
+      .mockResolvedValueOnce(okProjection([records[3]]));
+    const { unmount } = render(
+      <LifecycleWorkspace ownerIds={["trade_cumulus"]} onExplore={vi.fn()} />,
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent("Lifecycle unavailable");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByText("Canonical BOMEX Baseline")).toBeInTheDocument();
+
+    unmount();
+    render(<LifecycleWorkspace ownerIds={["trade_cumulus"]} onExplore={vi.fn()} />);
+    expect(await screen.findByText("Canonical BOMEX Baseline")).toBeInTheDocument();
+  });
+});
+
+function record(overrides: Partial<LifecycleRecord>): LifecycleRecord {
+  return {
+    record_id: "simulation:default",
+    record_kind: "simulation",
+    owner_id: "trade_cumulus",
+    owner_label: "Trade Cumulus",
+    simulation_id: "simulation-default",
+    experiment_id: null,
+    world_id: "trade_cumulus",
+    recipe_id: "recipe",
+    recipe_version: "1",
+    parent_simulation_id: null,
+    reference_simulation_id: null,
+    display_name: "Simulation",
+    question: null,
+    role: "variation",
+    case_id: "case",
+    differences: [],
+    attempts: [attempt("run-default", "initial", true)],
+    facts: facts(),
+    trust_state: "unassessed",
+    caveats: [],
+    tags: [],
+    notes: null,
+    lifecycle_label: "Ready",
+    lifecycle_detail: "Ready.",
+    activity_group: "ready_to_run",
+    in_activity: true,
+    created_at: "2026-07-20T12:00:00Z",
+    updated_at: "2026-07-27T12:00:00Z",
+    size_bytes: 1_024,
+    dependencies: [],
+    actions: [],
+    ...overrides,
+  };
+}
+
+function facts(overrides: Partial<LifecycleRecord["facts"]> = {}): LifecycleRecord["facts"] {
+  return {
+    scientific_work: "present",
+    package: "present",
+    attempt: "present",
+    queue: "not_applicable",
+    process: "not_applicable",
+    expected_output: "unknown",
+    technical_integrity: "unknown",
+    ingest: "unknown",
+    world_inspectability: "unknown",
+    simulation_availability: "unknown",
+    parent_eligibility: "not_applicable",
+    retained_assets: "unknown",
+    ...overrides,
+  };
+}
+
+function attempt(
+  runId: string,
+  relationship: LifecycleRecord["attempts"][number]["relationship"],
+  acceptedBacking = false,
+): LifecycleRecord["attempts"][number] {
+  return {
+    attempt_id: `attempt:${runId}`,
+    run_id: runId,
+    relationship,
+    accepted_backing: acceptedBacking,
+    manifest_path: `/runs/${runId}/run_manifest.json`,
+    lifecycle_state: "completed",
+    queue_state: null,
+    product_state: "available",
+    validation_status: "passed",
+    result_id: `result:${runId}`,
+    output_artifact_count: 12,
+    size_bytes: 1_024,
+    retained_state: "retained",
+    created_at: "2026-07-20T12:00:00Z",
+    started_at: "2026-07-20T12:01:00Z",
+    finished_at: "2026-07-20T12:20:00Z",
+    updated_at: "2026-07-20T12:20:00Z",
+    message: null,
+    failure_reason: null,
+  };
+}
+
+function action(
+  kind: LifecycleRecord["actions"][number]["kind"],
+  overrides: Partial<LifecycleRecord["actions"][number]> = {},
+): LifecycleRecord["actions"][number] {
+  return {
+    kind,
+    label: {
+      run: "Run",
+      cancel: "Cancel",
+      ingest: "Ingest",
+      explore: "Explore",
+      compare_parent: "Compare to parent",
+      compare_reference: "Compare to reference",
+      review: "Review",
+      open_run_controls: "Open run controls",
+    }[kind],
+    run_id: null,
+    manifest_path: null,
+    result_id: null,
+    world_id: null,
+    simulation_id: null,
+    target_simulation_id: null,
+    ...overrides,
+  };
+}
+
+function okProjection(projectionRecords: LifecycleRecord[]): Response {
+  return {
+    ok: true,
+    json: async () => ({
+      schema_version: "1",
+      generated_at: "2026-07-27T12:00:00Z",
+      records: projectionRecords,
+      warnings: [],
+    }),
+  } as Response;
+}
+
+function ok(payload: unknown): Response {
+  return { ok: true, json: async () => payload } as Response;
+}
+
+function errorResponse(detail: string): Response {
+  return { ok: false, json: async () => ({ detail }) } as Response;
+}

--- a/app/frontend/src/LifecycleWorkspace.tsx
+++ b/app/frontend/src/LifecycleWorkspace.tsx
@@ -1,0 +1,1035 @@
+import { useEffect, useMemo, useState } from "react";
+
+export type LifecycleOwnerId =
+  | "trade_cumulus"
+  | "mountain_waves"
+  | "supercells"
+  | "fun_with_soundings"
+  | "legacy_unassigned";
+export type LifecycleView = "activity" | "history";
+
+type LifecycleFactState =
+  | "not_applicable"
+  | "unknown"
+  | "absent"
+  | "present"
+  | "pending"
+  | "passed"
+  | "caveated"
+  | "failed"
+  | "conflict"
+  | "missing"
+  | "eligible"
+  | "ineligible";
+
+type LifecycleFacts = {
+  scientific_work: LifecycleFactState;
+  package: LifecycleFactState;
+  attempt: LifecycleFactState;
+  queue: LifecycleFactState;
+  process: LifecycleFactState;
+  expected_output: LifecycleFactState;
+  technical_integrity: LifecycleFactState;
+  ingest: LifecycleFactState;
+  world_inspectability: LifecycleFactState;
+  simulation_availability: LifecycleFactState;
+  parent_eligibility: LifecycleFactState;
+  retained_assets: LifecycleFactState;
+};
+
+type LifecycleAttempt = {
+  attempt_id: string;
+  run_id: string;
+  relationship:
+    | "initial"
+    | "unchanged_retry"
+    | "checkpoint_restart"
+    | "alternate_observation_attempt"
+    | "extension"
+    | "later_backing_candidate";
+  accepted_backing: boolean;
+  manifest_path: string | null;
+  lifecycle_state: string | null;
+  queue_state: string | null;
+  product_state: string | null;
+  validation_status: string | null;
+  result_id: string | null;
+  output_artifact_count: number;
+  size_bytes: number | null;
+  retained_state: "retained" | "missing" | "conflict" | "unknown";
+  created_at: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+  updated_at: string | null;
+  message: string | null;
+  failure_reason: string | null;
+};
+
+type LifecycleAction = {
+  kind:
+    | "run"
+    | "cancel"
+    | "ingest"
+    | "explore"
+    | "compare_parent"
+    | "compare_reference"
+    | "review"
+    | "open_run_controls";
+  label: string;
+  run_id: string | null;
+  manifest_path: string | null;
+  result_id: string | null;
+  world_id: string | null;
+  simulation_id: string | null;
+  target_simulation_id: string | null;
+};
+
+type LifecycleDifference = {
+  category: string;
+  label: string;
+  before: unknown;
+  after: unknown;
+  units: string | null;
+  material: boolean;
+};
+
+type LifecycleDependency = {
+  kind: "saved_view" | "saved_comparison";
+  dependency_id: string;
+  title: string;
+  relationship: string;
+};
+
+export type LifecycleRecord = {
+  record_id: string;
+  record_kind: "simulation" | "experiment";
+  owner_id: LifecycleOwnerId;
+  owner_label: string;
+  simulation_id: string | null;
+  experiment_id: string | null;
+  world_id: string | null;
+  recipe_id: string | null;
+  recipe_version: string | null;
+  parent_simulation_id: string | null;
+  reference_simulation_id: string | null;
+  display_name: string;
+  question: string | null;
+  role: string | null;
+  case_id: string | null;
+  differences: LifecycleDifference[];
+  attempts: LifecycleAttempt[];
+  facts: LifecycleFacts;
+  trust_state: "trusted" | "caveated" | "failed" | "unassessed" | "unavailable";
+  caveats: string[];
+  tags: string[];
+  notes: string | null;
+  lifecycle_label: string;
+  lifecycle_detail: string;
+  activity_group:
+    | "needs_attention"
+    | "ready_to_run"
+    | "queued"
+    | "running"
+    | "awaiting_validation_or_ingest"
+    | "ready_to_inspect"
+    | "available_with_caveats"
+    | "recently_completed"
+    | null;
+  in_activity: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+  size_bytes: number | null;
+  dependencies: LifecycleDependency[];
+  actions: LifecycleAction[];
+};
+
+type LifecycleProjection = {
+  schema_version: "1";
+  generated_at: string;
+  records: LifecycleRecord[];
+  warnings: string[];
+};
+
+type HistoryFilters = {
+  search: string;
+  owner: LifecycleOwnerId | "all";
+  lifecycle: string;
+  availability: LifecycleFactState | "all";
+  parentEligibility: LifecycleFactState | "all";
+  retained: LifecycleFactState | "all";
+  trust: LifecycleRecord["trust_state"] | "all";
+  relationship: string;
+  tag: string;
+  date: "all" | "7" | "30" | "365";
+  sort: "updated" | "created" | "name" | "lifecycle" | "size";
+};
+
+const DEFAULT_FILTERS: HistoryFilters = {
+  search: "",
+  owner: "all",
+  lifecycle: "all",
+  availability: "all",
+  parentEligibility: "all",
+  retained: "all",
+  trust: "all",
+  relationship: "all",
+  tag: "all",
+  date: "all",
+  sort: "updated",
+};
+
+const ACTIVITY_GROUPS: Array<{
+  id: NonNullable<LifecycleRecord["activity_group"]>;
+  label: string;
+}> = [
+  { id: "needs_attention", label: "Needs attention" },
+  { id: "running", label: "Running" },
+  { id: "queued", label: "Queued" },
+  { id: "ready_to_run", label: "Ready to run" },
+  { id: "awaiting_validation_or_ingest", label: "Awaiting validation or ingest" },
+  { id: "ready_to_inspect", label: "Ready to inspect" },
+  { id: "available_with_caveats", label: "Available with caveats" },
+  { id: "recently_completed", label: "Recently completed" },
+];
+
+export function LifecycleWorkspace({
+  ownerIds,
+  view: controlledView,
+  showViewTabs = true,
+  onViewChange,
+  onExplore,
+  onCompare,
+  onOpenRunControls,
+}: {
+  ownerIds: LifecycleOwnerId[];
+  view?: LifecycleView;
+  showViewTabs?: boolean;
+  onViewChange?: (view: LifecycleView) => void;
+  onExplore: (record: LifecycleRecord) => void;
+  onCompare?: (record: LifecycleRecord, targetSimulationId: string) => void;
+  onOpenRunControls?: (record: LifecycleRecord) => void;
+}) {
+  const [internalView, setInternalView] = useState<LifecycleView>("activity");
+  const view = controlledView ?? internalView;
+  const [projection, setProjection] = useState<LifecycleProjection | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionStatus, setActionStatus] = useState<string | null>(null);
+  const [filters, setFilters] = useState<HistoryFilters>(DEFAULT_FILTERS);
+  const [openRecordId, setOpenRecordId] = useState<string | null>(null);
+
+  async function loadProjection() {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/lifecycle");
+      if (!response.ok) {
+        throw new Error(await responseMessage(response, "Activity and History are unavailable."));
+      }
+      const payload = (await response.json()) as LifecycleProjection;
+      if (payload.schema_version !== "1" || !Array.isArray(payload.records)) {
+        throw new Error("Activity and History returned an unsupported data contract.");
+      }
+      setProjection(payload);
+    } catch (caught) {
+      setProjection(null);
+      setError(caught instanceof Error ? caught.message : "Activity and History are unavailable.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadProjection();
+  }, []);
+
+  function changeView(nextView: LifecycleView) {
+    if (controlledView === undefined) setInternalView(nextView);
+    onViewChange?.(nextView);
+  }
+
+  const scopedRecords = useMemo(
+    () => projection?.records.filter((record) => ownerIds.includes(record.owner_id)) ?? [],
+    [ownerIds, projection],
+  );
+  const historyRecords = useMemo(
+    () => filterAndSortHistory(scopedRecords, filters),
+    [filters, scopedRecords],
+  );
+  const tags = useMemo(
+    () => [...new Set(scopedRecords.flatMap((record) => record.tags))].sort(),
+    [scopedRecords],
+  );
+  const relationships = useMemo(
+    () =>
+      [
+        ...new Set(
+          scopedRecords.flatMap((record) =>
+            [record.parent_simulation_id, record.reference_simulation_id].filter(
+              (value): value is string => Boolean(value),
+            ),
+          ),
+        ),
+      ].sort(),
+    [scopedRecords],
+  );
+
+  async function runAction(record: LifecycleRecord, action: LifecycleAction) {
+    if (action.kind === "explore") {
+      onExplore(record);
+      return;
+    }
+    if (action.kind === "compare_parent" || action.kind === "compare_reference") {
+      if (action.target_simulation_id) onCompare?.(record, action.target_simulation_id);
+      return;
+    }
+    if (action.kind === "open_run_controls") {
+      onOpenRunControls?.(record);
+      return;
+    }
+    if (action.kind === "review") {
+      setOpenRecordId(record.record_id);
+      document
+        .getElementById(`lifecycle-details-${record.record_id}`)
+        ?.scrollIntoView({ block: "nearest" });
+      return;
+    }
+    const request = lifecycleActionRequest(action);
+    if (!request) return;
+    setActionStatus(`${action.label}: ${record.display_name}`);
+    setError(null);
+    try {
+      const response = await fetch(request.url, request.init);
+      if (!response.ok) {
+        throw new Error(await responseMessage(response, `${action.label} could not complete.`));
+      }
+      setActionStatus(`${action.label} completed. Refreshing Activity and History...`);
+      await loadProjection();
+      setActionStatus(`${action.label} completed.`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : `${action.label} could not complete.`);
+      setActionStatus(null);
+    }
+  }
+
+  return (
+    <section className="lifecycle-workspace" aria-label="Activity and History">
+      <header className="lifecycle-heading">
+        <div>
+          <p className="eyebrow">{view === "activity" ? "Activity" : "History"}</p>
+          <h3>{view === "activity" ? "Current work" : "Retained scientific work"}</h3>
+          <p>
+            {view === "activity"
+              ? "Work that can be run, inspected, or needs attention now."
+              : "Simulations, Experiments, and every retained technical attempt."}
+          </p>
+        </div>
+        <div className="lifecycle-heading-actions">
+          {showViewTabs && (
+            <nav className="lifecycle-view-tabs" aria-label="Lifecycle view">
+              {(["activity", "history"] as LifecycleView[]).map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  className={view === item ? "active-control" : ""}
+                  aria-current={view === item ? "page" : undefined}
+                  onClick={() => changeView(item)}
+                >
+                  {item === "activity" ? "Activity" : "History"}
+                </button>
+              ))}
+            </nav>
+          )}
+          <button type="button" className="secondary-button" onClick={() => void loadProjection()}>
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      {loading && !projection && (
+        <section className="status-panel" role="status">
+          Loading Activity and History...
+        </section>
+      )}
+      {error && (
+        <section className="lifecycle-error" role="alert">
+          <strong>Activity and History could not be loaded</strong>
+          <span>{error}</span>
+          <button type="button" onClick={() => void loadProjection()}>
+            Retry
+          </button>
+        </section>
+      )}
+      {actionStatus && <p className="inline-status">{actionStatus}</p>}
+      {projection?.warnings.map((warning) => (
+        <p key={warning} className="inline-status" role="status">
+          {warning}
+        </p>
+      ))}
+
+      {projection && view === "activity" && (
+        <ActivityView
+          records={scopedRecords.filter((record) => record.in_activity)}
+          openRecordId={openRecordId}
+          onOpenRecord={setOpenRecordId}
+          onAction={runAction}
+        />
+      )}
+      {projection && view === "history" && (
+        <>
+          <HistoryToolbar
+            filters={filters}
+            records={scopedRecords}
+            visibleCount={historyRecords.length}
+            tags={tags}
+            relationships={relationships}
+            ownerIds={ownerIds}
+            onChange={setFilters}
+            onReset={() => setFilters(DEFAULT_FILTERS)}
+          />
+          {historyRecords.length ? (
+            <div className="lifecycle-history-list">
+              {historyRecords.map((record) => (
+                <LifecycleCard
+                  key={record.record_id}
+                  record={record}
+                  records={scopedRecords}
+                  expanded={openRecordId === record.record_id}
+                  onExpandedChange={(expanded) =>
+                    setOpenRecordId(expanded ? record.record_id : null)
+                  }
+                  onAction={runAction}
+                />
+              ))}
+            </div>
+          ) : (
+            <LifecycleEmpty
+              title={scopedRecords.length ? "No records match these filters" : "History is empty"}
+              body={
+                scopedRecords.length
+                  ? "Clear filters to return to the complete retained record."
+                  : "No retained work is currently assigned to this owner."
+              }
+              actionLabel={scopedRecords.length ? "Clear filters" : undefined}
+              onAction={scopedRecords.length ? () => setFilters(DEFAULT_FILTERS) : undefined}
+            />
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function ActivityView({
+  records,
+  openRecordId,
+  onOpenRecord,
+  onAction,
+}: {
+  records: LifecycleRecord[];
+  openRecordId: string | null;
+  onOpenRecord: (recordId: string | null) => void;
+  onAction: (record: LifecycleRecord, action: LifecycleAction) => void;
+}) {
+  if (!records.length) {
+    return (
+      <LifecycleEmpty
+        title="No current work"
+        body="Nothing is queued, running, awaiting ingest, recently completed, or asking for attention."
+      />
+    );
+  }
+  return (
+    <div className="lifecycle-activity-groups">
+      {ACTIVITY_GROUPS.map((group) => {
+        const matching = records.filter((record) => record.activity_group === group.id);
+        if (!matching.length) return null;
+        return (
+          <section key={group.id} className="lifecycle-activity-group">
+            <header>
+              <h4>{group.label}</h4>
+              <span>{matching.length}</span>
+            </header>
+            <div className="lifecycle-card-grid">
+              {matching.map((record) => (
+                <LifecycleCard
+                  key={record.record_id}
+                  record={record}
+                  records={records}
+                  expanded={openRecordId === record.record_id}
+                  onExpandedChange={(expanded) => onOpenRecord(expanded ? record.record_id : null)}
+                  onAction={onAction}
+                />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function LifecycleCard({
+  record,
+  records,
+  expanded,
+  onExpandedChange,
+  onAction,
+}: {
+  record: LifecycleRecord;
+  records: LifecycleRecord[];
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+  onAction: (record: LifecycleRecord, action: LifecycleAction) => void;
+}) {
+  const primaryActions = record.actions.filter((action) => action.kind !== "review");
+  return (
+    <article className={`lifecycle-card lifecycle-${record.activity_group ?? "history"}`}>
+      <header>
+        <div>
+          <p className="eyebrow">
+            {record.owner_label} ·{" "}
+            {record.record_kind === "simulation" ? "Simulation" : "Experiment"}
+          </p>
+          <h4>{record.display_name}</h4>
+        </div>
+        <LifecycleBadge record={record} />
+      </header>
+      {record.parent_simulation_id && (
+        <p className="lifecycle-relationship">
+          Parent: <strong>{simulationDisplayName(record.parent_simulation_id, records)}</strong>
+        </p>
+      )}
+      {record.question && <p className="lifecycle-question">{record.question}</p>}
+      {record.differences.length > 0 && (
+        <dl className="lifecycle-difference-summary">
+          {record.differences.slice(0, 3).map((difference, index) => (
+            <div key={`${difference.category}-${difference.label}-${index}`}>
+              <dt>{difference.label}</dt>
+              <dd>
+                {formatValue(difference.before, difference.units)} to{" "}
+                {formatValue(difference.after, difference.units)}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      <div className="lifecycle-state-line">
+        <strong>{record.lifecycle_label}</strong>
+        <span>{record.lifecycle_detail}</span>
+      </div>
+      <div className="lifecycle-card-meta">
+        <span>{relativeDate(record.updated_at)}</span>
+        <span>
+          {record.attempts.length} attempt{record.attempts.length === 1 ? "" : "s"}
+        </span>
+        {record.facts.parent_eligibility !== "not_applicable" && (
+          <span>{factLabel("Variation parent", record.facts.parent_eligibility)}</span>
+        )}
+      </div>
+      {primaryActions.length > 0 && (
+        <div className="button-row lifecycle-actions">
+          {primaryActions.map((action) => (
+            <button
+              key={`${action.kind}-${action.target_simulation_id ?? ""}`}
+              type="button"
+              className={
+                action.kind === "cancel"
+                  ? "danger-button"
+                  : action.kind === "explore" || action.kind === "run"
+                    ? ""
+                    : "secondary-button"
+              }
+              onClick={() => void onAction(record, action)}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+      <details
+        id={`lifecycle-details-${record.record_id}`}
+        className="lifecycle-details"
+        open={expanded}
+        onToggle={(event) => onExpandedChange(event.currentTarget.open)}
+      >
+        <summary>Technical details</summary>
+        <LifecycleTechnicalDetails record={record} />
+      </details>
+    </article>
+  );
+}
+
+function simulationDisplayName(simulationId: string, records: LifecycleRecord[]): string {
+  return (
+    records.find((candidate) => candidate.simulation_id === simulationId)?.display_name ??
+    humanize(simulationId)
+  );
+}
+
+function LifecycleTechnicalDetails({ record }: { record: LifecycleRecord }) {
+  return (
+    <div className="lifecycle-technical-content">
+      <dl className="lifecycle-facts">
+        {Object.entries(record.facts).map(([label, value]) => (
+          <div key={label}>
+            <dt>{humanize(label)}</dt>
+            <dd className={`fact-${value}`}>{humanize(value)}</dd>
+          </div>
+        ))}
+      </dl>
+      <dl className="lifecycle-identifiers">
+        <Identifier label="Record" value={record.record_id} />
+        <Identifier label="Simulation" value={record.simulation_id} />
+        <Identifier label="Experiment" value={record.experiment_id} />
+        <Identifier label="Recipe" value={record.recipe_id} />
+        <Identifier label="Case" value={record.case_id} />
+        <Identifier label="Reference" value={record.reference_simulation_id} />
+      </dl>
+      {record.attempts.length > 0 && (
+        <section className="lifecycle-attempts" aria-label="Technical attempts">
+          <h5>Attempts</h5>
+          {record.attempts.map((attempt) => (
+            <article key={attempt.attempt_id}>
+              <div>
+                <strong>{attemptRelationshipLabel(attempt.relationship)}</strong>
+                {attempt.accepted_backing && (
+                  <span className="lifecycle-backing">Backing output</span>
+                )}
+              </div>
+              <code>{attempt.run_id}</code>
+              <span>
+                {humanize(attempt.queue_state ?? attempt.lifecycle_state ?? "unknown")} ·{" "}
+                {attempt.output_artifact_count.toLocaleString()} output artifacts
+              </span>
+              {attempt.failure_reason && <p role="alert">{attempt.failure_reason}</p>}
+              {attempt.manifest_path && <code>{attempt.manifest_path}</code>}
+            </article>
+          ))}
+        </section>
+      )}
+      {record.dependencies.length > 0 && (
+        <section className="lifecycle-dependencies" aria-label="Saved state dependencies">
+          <h5>Saved-state dependencies</h5>
+          {record.dependencies.map((dependency) => (
+            <p key={`${dependency.kind}-${dependency.dependency_id}`}>
+              <strong>{dependency.title}</strong>
+              <span>{dependency.relationship}</span>
+            </p>
+          ))}
+        </section>
+      )}
+      {record.caveats.length > 0 && (
+        <section className="lifecycle-caveats">
+          <h5>Caveats</h5>
+          <ul>
+            {record.caveats.map((caveat) => (
+              <li key={caveat}>{caveat}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+      {record.tags.length > 0 && <p className="lifecycle-tags">Tags: {record.tags.join(", ")}</p>}
+      {record.notes && (
+        <section className="lifecycle-notes">
+          <h5>Legacy note</h5>
+          <p>{record.notes}</p>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function HistoryToolbar({
+  filters,
+  records,
+  visibleCount,
+  tags,
+  relationships,
+  ownerIds,
+  onChange,
+  onReset,
+}: {
+  filters: HistoryFilters;
+  records: LifecycleRecord[];
+  visibleCount: number;
+  tags: string[];
+  relationships: string[];
+  ownerIds: LifecycleOwnerId[];
+  onChange: (filters: HistoryFilters) => void;
+  onReset: () => void;
+}) {
+  const update = (patch: Partial<HistoryFilters>) => onChange({ ...filters, ...patch });
+  const filtersActive = JSON.stringify(filters) !== JSON.stringify(DEFAULT_FILTERS);
+  return (
+    <section className="lifecycle-history-toolbar" aria-label="History filters">
+      <div className="lifecycle-primary-filters">
+        <label>
+          <span>Search</span>
+          <input
+            type="search"
+            value={filters.search}
+            placeholder="name, question, tag, or technical ID"
+            onChange={(event) => update({ search: event.target.value })}
+          />
+        </label>
+        <label>
+          <span>Sort</span>
+          <select
+            value={filters.sort}
+            onChange={(event) => update({ sort: event.target.value as HistoryFilters["sort"] })}
+          >
+            <option value="updated">Recently updated</option>
+            <option value="created">Recently created</option>
+            <option value="name">Name</option>
+            <option value="lifecycle">Lifecycle</option>
+            <option value="size">Retained size</option>
+          </select>
+        </label>
+        <p>
+          {visibleCount} of {records.length}
+        </p>
+      </div>
+      <details className="lifecycle-more-filters">
+        <summary>More filters</summary>
+        <div>
+          {ownerIds.length > 1 && (
+            <FilterSelect
+              label="Owner"
+              value={filters.owner}
+              options={[
+                ["all", "All owners"],
+                ...ownerIds.map((owner) => [owner, ownerLabel(owner)] as [string, string]),
+              ]}
+              onChange={(value) => update({ owner: value as HistoryFilters["owner"] })}
+            />
+          )}
+          <FilterSelect
+            label="Lifecycle"
+            value={filters.lifecycle}
+            options={[
+              ["all", "All lifecycle states"],
+              ...[...new Set(records.map((record) => record.lifecycle_label))]
+                .sort()
+                .map((value) => [value, value] as [string, string]),
+            ]}
+            onChange={(lifecycle) => update({ lifecycle })}
+          />
+          <FilterSelect
+            label="Availability"
+            value={filters.availability}
+            options={factOptions("All availability states")}
+            onChange={(value) => update({ availability: value as HistoryFilters["availability"] })}
+          />
+          <FilterSelect
+            label="Parent eligibility"
+            value={filters.parentEligibility}
+            options={factOptions("All eligibility states")}
+            onChange={(value) =>
+              update({ parentEligibility: value as HistoryFilters["parentEligibility"] })
+            }
+          />
+          <FilterSelect
+            label="Retained output"
+            value={filters.retained}
+            options={factOptions("All retained states")}
+            onChange={(value) => update({ retained: value as HistoryFilters["retained"] })}
+          />
+          <FilterSelect
+            label="Trust"
+            value={filters.trust}
+            options={[
+              ["all", "All trust states"],
+              ["trusted", "Trusted"],
+              ["caveated", "Caveated"],
+              ["failed", "Failed"],
+              ["unassessed", "Unassessed"],
+              ["unavailable", "Unavailable"],
+            ]}
+            onChange={(value) => update({ trust: value as HistoryFilters["trust"] })}
+          />
+          <FilterSelect
+            label="Parent or reference"
+            value={filters.relationship}
+            options={[
+              ["all", "All relationships"],
+              ...relationships.map((value) => [value, humanize(value)] as [string, string]),
+            ]}
+            onChange={(relationship) => update({ relationship })}
+          />
+          <FilterSelect
+            label="Existing tag"
+            value={filters.tag}
+            options={[
+              ["all", "All tags"],
+              ...tags.map((value) => [value, value] as [string, string]),
+            ]}
+            onChange={(tag) => update({ tag })}
+          />
+          <FilterSelect
+            label="Updated"
+            value={filters.date}
+            options={[
+              ["all", "Any date"],
+              ["7", "Last 7 days"],
+              ["30", "Last 30 days"],
+              ["365", "Last year"],
+            ]}
+            onChange={(value) => update({ date: value as HistoryFilters["date"] })}
+          />
+        </div>
+      </details>
+      {filtersActive && (
+        <button type="button" className="quiet-button" onClick={onReset}>
+          Clear filters
+        </button>
+      )}
+    </section>
+  );
+}
+
+function FilterSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: Array<[string, string]>;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label>
+      <span>{label}</span>
+      <select value={value} onChange={(event) => onChange(event.target.value)}>
+        {options.map(([optionValue, optionLabel]) => (
+          <option key={optionValue} value={optionValue}>
+            {optionLabel}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function LifecycleBadge({ record }: { record: LifecycleRecord }) {
+  const tone =
+    record.activity_group === "needs_attention" || record.trust_state === "failed"
+      ? "danger"
+      : record.trust_state === "caveated" || record.lifecycle_label.includes("caveat")
+        ? "warning"
+        : record.lifecycle_label === "Running"
+          ? "active"
+          : "neutral";
+  return <span className={`lifecycle-badge ${tone}`}>{record.lifecycle_label}</span>;
+}
+
+function LifecycleEmpty({
+  title,
+  body,
+  actionLabel,
+  onAction,
+}: {
+  title: string;
+  body: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}) {
+  return (
+    <section className="lifecycle-empty">
+      <h4>{title}</h4>
+      <p>{body}</p>
+      {actionLabel && onAction && (
+        <button type="button" className="secondary-button" onClick={onAction}>
+          {actionLabel}
+        </button>
+      )}
+    </section>
+  );
+}
+
+function Identifier({ label, value }: { label: string; value: string | null }) {
+  if (!value) return null;
+  return (
+    <div>
+      <dt>{label}</dt>
+      <dd>
+        <code>{value}</code>
+      </dd>
+    </div>
+  );
+}
+
+function filterAndSortHistory(
+  records: LifecycleRecord[],
+  filters: HistoryFilters,
+): LifecycleRecord[] {
+  const query = filters.search.trim().toLocaleLowerCase();
+  const cutoff =
+    filters.date === "all"
+      ? null
+      : Date.now() - Number.parseInt(filters.date, 10) * 24 * 60 * 60 * 1_000;
+  return records
+    .filter((record) => {
+      const searchable = [
+        record.display_name,
+        record.question,
+        record.record_id,
+        record.simulation_id,
+        record.experiment_id,
+        record.case_id,
+        record.recipe_id,
+        record.parent_simulation_id,
+        record.reference_simulation_id,
+        ...record.tags,
+        ...record.attempts.flatMap((attempt) => [attempt.attempt_id, attempt.run_id]),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLocaleLowerCase();
+      return (
+        (!query || searchable.includes(query)) &&
+        (filters.owner === "all" || record.owner_id === filters.owner) &&
+        (filters.lifecycle === "all" || record.lifecycle_label === filters.lifecycle) &&
+        (filters.availability === "all" ||
+          record.facts.simulation_availability === filters.availability) &&
+        (filters.parentEligibility === "all" ||
+          record.facts.parent_eligibility === filters.parentEligibility) &&
+        (filters.retained === "all" || record.facts.retained_assets === filters.retained) &&
+        (filters.trust === "all" || record.trust_state === filters.trust) &&
+        (filters.relationship === "all" ||
+          record.parent_simulation_id === filters.relationship ||
+          record.reference_simulation_id === filters.relationship) &&
+        (filters.tag === "all" || record.tags.includes(filters.tag)) &&
+        (cutoff === null ||
+          Boolean(record.updated_at && new Date(record.updated_at).getTime() >= cutoff))
+      );
+    })
+    .sort((left, right) => {
+      if (filters.sort === "name") return left.display_name.localeCompare(right.display_name);
+      if (filters.sort === "lifecycle")
+        return left.lifecycle_label.localeCompare(right.lifecycle_label);
+      if (filters.sort === "size") return (right.size_bytes ?? -1) - (left.size_bytes ?? -1);
+      const field = filters.sort === "created" ? "created_at" : "updated_at";
+      return (right[field] ?? "").localeCompare(left[field] ?? "");
+    });
+}
+
+function lifecycleActionRequest(
+  action: LifecycleAction,
+): { url: string; init: RequestInit } | null {
+  if (action.kind === "run" && action.manifest_path) {
+    return {
+      url: "/api/runs/queue",
+      init: {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ manifest_path: action.manifest_path }),
+      },
+    };
+  }
+  if (action.kind === "cancel") {
+    return { url: "/api/runs/cancel", init: { method: "POST" } };
+  }
+  if (action.kind === "ingest" && action.manifest_path) {
+    return {
+      url: "/api/results/ingest",
+      init: {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ manifest_path: action.manifest_path }),
+      },
+    };
+  }
+  return null;
+}
+
+function factOptions(firstLabel: string): Array<[string, string]> {
+  return [
+    ["all", firstLabel],
+    ["present", "Present"],
+    ["pending", "Pending"],
+    ["passed", "Passed"],
+    ["caveated", "Caveated"],
+    ["eligible", "Eligible"],
+    ["ineligible", "Ineligible"],
+    ["missing", "Missing"],
+    ["failed", "Failed"],
+    ["conflict", "Conflict"],
+    ["unknown", "Unknown"],
+    ["not_applicable", "Not applicable"],
+  ];
+}
+
+function formatValue(value: unknown, units: string | null): string {
+  const formatted =
+    typeof value === "number"
+      ? value.toLocaleString(undefined, { maximumFractionDigits: 4 })
+      : typeof value === "string"
+        ? value
+        : JSON.stringify(value);
+  return `${formatted ?? "unknown"}${units ? ` ${units}` : ""}`;
+}
+
+function relativeDate(value: string | null): string {
+  if (!value) return "Time unavailable";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: date.getFullYear() === new Date().getFullYear() ? undefined : "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function factLabel(label: string, value: LifecycleFactState): string {
+  return `${label}: ${humanize(value)}`;
+}
+
+function attemptRelationshipLabel(value: LifecycleAttempt["relationship"]): string {
+  const labels: Record<LifecycleAttempt["relationship"], string> = {
+    initial: "Initial attempt",
+    unchanged_retry: "Unchanged retry",
+    checkpoint_restart: "Checkpoint restart",
+    alternate_observation_attempt: "Alternate observation attempt",
+    extension: "Extension",
+    later_backing_candidate: "Later backing candidate",
+  };
+  return labels[value];
+}
+
+function ownerLabel(owner: LifecycleOwnerId): string {
+  const labels: Record<LifecycleOwnerId, string> = {
+    trade_cumulus: "Trade Cumulus",
+    mountain_waves: "Mountain Waves",
+    supercells: "Supercells",
+    fun_with_soundings: "Fun With Soundings",
+    legacy_unassigned: "Legacy / unassigned",
+  };
+  return labels[owner];
+}
+
+function humanize(value: string): string {
+  return value
+    .replaceAll("_", " ")
+    .replaceAll("-", " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase())
+    .replace(/\bCm1\b/g, "CM1")
+    .replace(/\bBomex\b/g, "BOMEX")
+    .replace(/\bR(\d+) (\d+)\b/g, "r$1.$2")
+    .replace(/\bV(\d+)\b/g, "v$1")
+    .replace(/\bQuarter Circle\b/g, "Quarter-Circle")
+    .replace(/\bStraight Line\b/g, "Straight-Line");
+}
+
+async function responseMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await response.json()) as { detail?: unknown };
+    return typeof payload.detail === "string" ? payload.detail : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/app/frontend/src/MountainWavesWorld.test.tsx
+++ b/app/frontend/src/MountainWavesWorld.test.tsx
@@ -165,12 +165,14 @@ describe("MountainWavesWorld", () => {
     expect(await screen.findByRole("heading", { name: "Mountain Waves" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Dry Ridge" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Boulder Windstorm" })).toBeInTheDocument();
+    expect(screen.getByText("Start a related Simulation")).toBeInTheDocument();
+    expect(screen.queryByText("Start an experiment")).not.toBeInTheDocument();
     const exploreButtons = screen.getAllByRole("button", { name: "Explore" });
     fireEvent.click(exploreButtons[1]);
     expect(onExplore).toHaveBeenCalledWith(world.simulations[1]);
   });
 
-  it("opens the shared Lab on the selected parent", async () => {
+  it("opens Create Variation on the selected parent", async () => {
     render(
       <MountainWavesWorld
         onBackToWorlds={vi.fn()}

--- a/app/frontend/src/MountainWavesWorld.tsx
+++ b/app/frontend/src/MountainWavesWorld.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { LifecycleWorkspace, type LifecycleRecord } from "./LifecycleWorkspace";
 import { MountainWavesVariationEditor } from "./MountainWavesVariationEditor";
 import { SavedComparisonsCollection } from "./SavedComparisons";
 
@@ -67,8 +68,13 @@ export type MountainWavesWorldDetail = {
   caveats: string[];
 };
 
-type WorldSection = "overview" | "simulations" | "saved_comparisons" | "lab";
-type LabSection = "activity" | "create" | "history";
+type WorldSection =
+  | "overview"
+  | "simulations"
+  | "saved_comparisons"
+  | "activity"
+  | "create"
+  | "history";
 
 export function MountainWavesWorld({
   onBackToWorlds,
@@ -85,12 +91,10 @@ export function MountainWavesWorld({
   onOpenSavedComparison: (savedComparisonId: string) => void;
 }) {
   const [section, setSection] = useState<WorldSection>("overview");
-  const [labSection, setLabSection] = useState<LabSection>("create");
   const [world, setWorld] = useState<MountainWavesWorldDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [parentSimulationId, setParentSimulationId] = useState<string | null>(null);
-  const [cancelStatus, setCancelStatus] = useState<string | null>(null);
 
   const loadWorld = useCallback(async (quiet = false) => {
     if (!quiet) setLoading(true);
@@ -115,28 +119,9 @@ export function MountainWavesWorld({
     void loadWorld();
   }, [loadWorld]);
 
-  useEffect(() => {
-    if (!world || world.activity.length === 0) return;
-    const timer = window.setInterval(() => void loadWorld(true), 2_000);
-    return () => window.clearInterval(timer);
-  }, [loadWorld, world]);
-
   function openVariation(parentId: string) {
     setParentSimulationId(parentId);
-    setLabSection("create");
-    setSection("lab");
-  }
-
-  async function cancelActiveRun() {
-    setCancelStatus("Canceling active CM1 run...");
-    try {
-      const response = await fetch("/api/runs/cancel", { method: "POST" });
-      if (!response.ok) throw new Error(await responseMessage(response, "Unable to cancel run."));
-      setCancelStatus("Run canceled.");
-      await loadWorld(true);
-    } catch (caught) {
-      setCancelStatus(caught instanceof Error ? caught.message : "Unable to cancel run.");
-    }
+    setSection("create");
   }
 
   if (loading) {
@@ -179,7 +164,16 @@ export function MountainWavesWorld({
       </header>
 
       <nav className="world-section-nav" aria-label="Mountain Waves sections">
-        {(["overview", "simulations", "saved_comparisons", "lab"] as WorldSection[]).map((item) => (
+        {(
+          [
+            "overview",
+            "simulations",
+            "saved_comparisons",
+            "activity",
+            "create",
+            "history",
+          ] as WorldSection[]
+        ).map((item) => (
           <button
             key={item}
             type="button"
@@ -224,14 +218,11 @@ export function MountainWavesWorld({
               ))}
           </div>
           <p className="world-science-note">{world.caveats[0]}</p>
-          <section className="world-lab-summary" aria-label="Mountain Waves Lab status">
+          <section className="world-lab-summary" aria-label="Create a Mountain Waves variation">
             <div>
-              <p className="eyebrow">Lab</p>
-              <h3>{labSummary(world)}</h3>
-              <p>
-                {world.lab_summary.active_run_count} active · {world.lab_summary.packaged_run_count}{" "}
-                packaged · {world.lab_summary.total_variation_count} in history
-              </p>
+              <p className="eyebrow">Experiment</p>
+              <h3>Start a related Simulation</h3>
+              <p>Use an eligible retained Simulation as the parent for a bounded variation.</p>
             </div>
             <button type="button" onClick={() => openVariation(world.default_parent_simulation_id)}>
               Create variation
@@ -277,102 +268,37 @@ export function MountainWavesWorld({
         </section>
       )}
 
-      {section === "lab" && (
-        <section className="world-section mountain-waves-lab" aria-label="Mountain Waves Lab">
-          <nav className="lab-subnav" aria-label="Mountain Waves Lab sections">
-            {(["activity", "create", "history"] as LabSection[]).map((item) => (
-              <button
-                key={item}
-                type="button"
-                className={labSection === item ? "active-control" : ""}
-                onClick={() => setLabSection(item)}
-              >
-                {item === "create" ? "Create Variation" : capitalize(item)}
-              </button>
-            ))}
-          </nav>
+      {(section === "activity" || section === "history") && (
+        <section className="world-section">
+          <LifecycleWorkspace
+            ownerIds={["mountain_waves"]}
+            view={section}
+            showViewTabs={false}
+            onExplore={(record) => {
+              const simulation = simulationForLifecycleRecord(world, record);
+              if (simulation) onExploreSimulation(simulation);
+            }}
+            onCompare={(record, targetSimulationId) => {
+              const simulation = simulationForLifecycleRecord(world, record);
+              if (simulation) onCompareSimulation?.(simulation, targetSimulationId);
+            }}
+            onOpenRunControls={(record) =>
+              openVariation(record.parent_simulation_id ?? world.default_parent_simulation_id)
+            }
+          />
+        </section>
+      )}
 
-          {labSection === "activity" && (
-            <section className="lab-content" aria-labelledby="mountain-waves-activity-title">
-              <div className="world-section-heading">
-                <div>
-                  <p className="eyebrow">Activity</p>
-                  <h3 id="mountain-waves-activity-title">Current CM1 work</h3>
-                </div>
-                <button
-                  type="button"
-                  className="secondary-button"
-                  onClick={() => void loadWorld(true)}
-                >
-                  Refresh
-                </button>
-              </div>
-              {world.activity.length ? (
-                <div className="lab-history-list mountain-waves-activity-list">
-                  {world.activity.map((attempt) => (
-                    <MountainWavesAttemptRow
-                      key={attempt.simulation_id}
-                      attempt={attempt}
-                      onExplore={onExploreSimulation}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <section className="world-empty-state">
-                  <h3>Lab is idle</h3>
-                  <p>Packaged, queued, and running variations will remain visible here.</p>
-                </section>
-              )}
-              {world.activity.some((attempt) => attempt.state === "running") && (
-                <button
-                  type="button"
-                  className="danger-button"
-                  onClick={() => void cancelActiveRun()}
-                >
-                  Cancel active run
-                </button>
-              )}
-              {cancelStatus && <p role="status">{cancelStatus}</p>}
-            </section>
-          )}
-
-          {labSection === "create" && (
-            <MountainWavesVariationEditor
-              world={world}
-              initialParentSimulationId={parentSimulationId ?? world.default_parent_simulation_id}
-              onCreated={async () => {
-                await loadWorld(true);
-                setLabSection("activity");
-              }}
-            />
-          )}
-
-          {labSection === "history" && (
-            <section className="lab-content" aria-labelledby="mountain-waves-history-title">
-              <div className="world-section-heading">
-                <div>
-                  <p className="eyebrow">History</p>
-                  <h3 id="mountain-waves-history-title">Every retained variation attempt</h3>
-                </div>
-              </div>
-              {world.history.length ? (
-                <div className="lab-history-list mountain-waves-history-list">
-                  {world.history.map((attempt) => (
-                    <MountainWavesAttemptRow
-                      key={attempt.simulation_id}
-                      attempt={attempt}
-                      onExplore={onExploreSimulation}
-                      onCreateVariation={openVariation}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <section className="world-empty-state">
-                  <p>No Mountain Waves variations have been created yet.</p>
-                </section>
-              )}
-            </section>
-          )}
+      {section === "create" && (
+        <section className="world-section mountain-waves-lab" aria-label="Create variation">
+          <MountainWavesVariationEditor
+            world={world}
+            initialParentSimulationId={parentSimulationId ?? world.default_parent_simulation_id}
+            onCreated={async () => {
+              await loadWorld(true);
+              setSection("activity");
+            }}
+          />
         </section>
       )}
     </section>
@@ -485,44 +411,6 @@ function mountainWavesCompareTarget(
   );
 }
 
-function MountainWavesAttemptRow({
-  attempt,
-  onExplore,
-  onCreateVariation,
-}: {
-  attempt: MountainWavesSimulation;
-  onExplore: (simulation: MountainWavesSimulation) => void;
-  onCreateVariation?: (simulationId: string) => void;
-}) {
-  return (
-    <article>
-      <div>
-        <strong>{attempt.display_name}</strong>
-        <span>
-          {stateLabel(attempt.state)} · {attempt.state_message}
-        </span>
-        <code>{attempt.run_id}</code>
-      </div>
-      <div className="simulation-actions">
-        {attempt.inspectable && (
-          <button type="button" onClick={() => onExplore(attempt)}>
-            Explore
-          </button>
-        )}
-        {attempt.can_create_variation && onCreateVariation && (
-          <button
-            type="button"
-            className="secondary-button"
-            onClick={() => onCreateVariation(attempt.simulation_id)}
-          >
-            Create variation
-          </button>
-        )}
-      </div>
-    </article>
-  );
-}
-
 function WorldBreadcrumb({ onBackToWorlds }: { onBackToWorlds: () => void }) {
   return (
     <nav className="world-breadcrumb" aria-label="Breadcrumb">
@@ -554,11 +442,25 @@ function sectionLabel(section: WorldSection): string {
   if (section === "overview") return "Overview";
   if (section === "simulations") return "Simulations";
   if (section === "saved_comparisons") return "Saved Comparisons";
-  return "Lab";
+  if (section === "create") return "Create Variation";
+  return section === "activity" ? "Activity" : "History";
 }
 
-function capitalize(value: string): string {
-  return value.charAt(0).toUpperCase() + value.slice(1);
+function simulationForLifecycleRecord(
+  world: MountainWavesWorldDetail,
+  record: LifecycleRecord,
+): MountainWavesSimulation | null {
+  const actionRunIds = new Set(
+    record.actions
+      .map((action) => action.run_id)
+      .filter((runId): runId is string => Boolean(runId)),
+  );
+  return (
+    world.simulations.find(
+      (simulation) =>
+        simulation.simulation_id === record.simulation_id || actionRunIds.has(simulation.run_id),
+    ) ?? null
+  );
 }
 
 function stateLabel(state: MountainWavesSimulation["state"]): string {
@@ -572,14 +474,6 @@ function stateLabel(state: MountainWavesSimulation["state"]): string {
     unavailable: "Unavailable",
     conflict: "Not inspectable",
   }[state];
-}
-
-function labSummary(world: MountainWavesWorldDetail): string {
-  if (world.lab_summary.active_run_count) return "CM1 is running";
-  if (world.lab_summary.packaged_run_count) return "A variation is ready to run";
-  return world.lab_summary.total_variation_count
-    ? "Ready for another experiment"
-    : "Start an experiment";
 }
 
 async function responseMessage(response: Response, fallback: string): Promise<string> {

--- a/app/frontend/src/SupercellsWorld.test.tsx
+++ b/app/frontend/src/SupercellsWorld.test.tsx
@@ -79,6 +79,8 @@ describe("SupercellsWorld", () => {
     expect(within(navigation).getByRole("button", { name: "Overview" })).toBeVisible();
     expect(within(navigation).getByRole("button", { name: "Simulations" })).toBeVisible();
     expect(within(navigation).getByRole("button", { name: "Saved Comparisons" })).toBeVisible();
+    expect(within(navigation).getByRole("button", { name: "Activity" })).toBeVisible();
+    expect(within(navigation).getByRole("button", { name: "History" })).toBeVisible();
     expect(within(navigation).queryByRole("button", { name: /Lab|Compare$/ })).toBeNull();
     expect(
       screen.getByRole("heading", { name: "Straight-Line Hodograph Supercell" }),
@@ -93,6 +95,38 @@ describe("SupercellsWorld", () => {
       within(screen.getByRole("navigation", { name: "Breadcrumb" })).getByRole("button"),
     );
     expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it("uses the shared Activity and History lifecycle projection", async () => {
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/api/worlds/supercells")) return ok(world);
+      if (url.endsWith("/api/lifecycle")) {
+        return ok({
+          schema_version: "1",
+          generated_at: "2026-07-28T06:00:00Z",
+          records: [],
+          warnings: [],
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+    render(
+      <SupercellsWorld
+        onBackToWorlds={vi.fn()}
+        onExploreSimulation={vi.fn()}
+        onCompare={vi.fn()}
+        onOpenSavedComparison={vi.fn()}
+      />,
+    );
+
+    const navigation = await screen.findByRole("navigation", { name: "Supercells sections" });
+    fireEvent.click(within(navigation).getByRole("button", { name: "Activity" }));
+    expect(await screen.findByRole("heading", { name: "Current work" })).toBeVisible();
+
+    fireEvent.click(within(navigation).getByRole("button", { name: "History" }));
+    expect(await screen.findByRole("heading", { name: "Retained scientific work" })).toBeVisible();
+    expect(fetch).toHaveBeenCalledWith("/api/lifecycle");
   });
 
   it("fails closed when the retained reference output is unavailable", async () => {

--- a/app/frontend/src/SupercellsWorld.tsx
+++ b/app/frontend/src/SupercellsWorld.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { LifecycleWorkspace, type LifecycleRecord } from "./LifecycleWorkspace";
 import { SavedComparisonsCollection } from "./SavedComparisons";
 
 export type SupercellSimulation = {
@@ -40,7 +41,12 @@ export type SupercellsWorldDetail = {
   caveats: string[];
 };
 
-type WorldSection = "overview" | "simulations" | "saved_comparisons";
+type WorldSection =
+  | "overview"
+  | "simulations"
+  | "saved_comparisons"
+  | "activity"
+  | "history";
 
 export function SupercellsWorld({
   onBackToWorlds,
@@ -128,27 +134,51 @@ export function SupercellsWorld({
       </header>
 
       <nav className="world-section-nav" aria-label="Supercells sections">
-        {(["overview", "simulations", "saved_comparisons"] as WorldSection[]).map((item) => (
+        {(
+          [
+            "overview",
+            "simulations",
+            "saved_comparisons",
+            "activity",
+            "history",
+          ] as WorldSection[]
+        ).map((item) => (
           <button
             key={item}
             type="button"
             className={section === item ? "active-control" : ""}
             onClick={() => setSection(item)}
           >
-            {item === "overview"
-              ? "Overview"
-              : item === "simulations"
-                ? "Simulations"
-                : "Saved Comparisons"}
+            {sectionLabel(item)}
           </button>
         ))}
       </nav>
 
-      {section === "saved_comparisons" ? (
+      {section === "saved_comparisons" && (
         <section className="world-section">
           <SavedComparisonsCollection worldSlug="supercells" onOpen={onOpenSavedComparison} />
         </section>
-      ) : (
+      )}
+
+      {(section === "activity" || section === "history") && (
+        <section className="world-section">
+          <LifecycleWorkspace
+            ownerIds={["supercells"]}
+            view={section}
+            showViewTabs={false}
+            onExplore={(record) => {
+              const simulation = simulationForLifecycleRecord(world, record);
+              if (simulation) onExploreSimulation(simulation);
+            }}
+            onCompare={(record) => {
+              const simulation = simulationForLifecycleRecord(world, record);
+              if (simulation) onCompare?.(simulation);
+            }}
+          />
+        </section>
+      )}
+
+      {(section === "overview" || section === "simulations") && (
         <section className="world-section" aria-labelledby={`supercells-${section}-title`}>
           <div className="world-section-heading">
             <div>
@@ -178,6 +208,33 @@ export function SupercellsWorld({
         </section>
       )}
     </section>
+  );
+}
+
+function sectionLabel(section: WorldSection): string {
+  return {
+    overview: "Overview",
+    simulations: "Simulations",
+    saved_comparisons: "Saved Comparisons",
+    activity: "Activity",
+    history: "History",
+  }[section];
+}
+
+function simulationForLifecycleRecord(
+  world: SupercellsWorldDetail,
+  record: LifecycleRecord,
+): SupercellSimulation | null {
+  const actionRunIds = new Set(
+    record.actions
+      .map((action) => action.run_id)
+      .filter((runId): runId is string => Boolean(runId)),
+  );
+  return (
+    world.simulations.find(
+      (simulation) =>
+        simulation.simulation_id === record.simulation_id || actionRunIds.has(simulation.run_id),
+    ) ?? null
   );
 }
 

--- a/app/frontend/src/TradeCumulusWorld.test.tsx
+++ b/app/frontend/src/TradeCumulusWorld.test.tsx
@@ -101,24 +101,46 @@ const world: TradeCumulusWorldDetail = {
 
 describe("TradeCumulusWorld", () => {
   beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(ok(world)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) =>
+        String(input) === "/api/lifecycle"
+          ? ok({
+              schema_version: "1",
+              generated_at: "2026-07-27T12:00:00Z",
+              records: [],
+              warnings: [],
+            })
+          : ok(world),
+      ),
+    );
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("shows the five approved sections and stable simulation names", async () => {
+  it("shows the owner-aware sections and stable simulation names", async () => {
     renderWorld();
     expect(await screen.findByRole("heading", { name: "Trade Cumulus" })).toBeInTheDocument();
     const nav = screen.getByRole("navigation", { name: "Trade Cumulus sections" });
-    for (const name of ["Overview", "Simulations", "Saved Views", "Comparisons", "Lab"]) {
+    for (const name of [
+      "Overview",
+      "Simulations",
+      "Saved Views",
+      "Comparisons",
+      "Saved Comparisons",
+      "Activity",
+      "History",
+    ]) {
       expect(within(nav).getByRole("button", { name })).toBeInTheDocument();
     }
     expect(screen.getAllByRole("heading", { name: "Canonical BOMEX Baseline" })).not.toHaveLength(
       0,
     );
     expect(screen.getByRole("heading", { name: "More Moisture" })).toBeInTheDocument();
+    expect(screen.getByText("Current work and retained history")).toBeInTheDocument();
+    expect(screen.queryByText("Lab is idle")).not.toBeInTheDocument();
     fireEvent.click(within(nav).getByRole("button", { name: "Simulations" }));
     expect(screen.getByRole("heading", { name: "More Moisture" })).toBeInTheDocument();
     expect(screen.getAllByRole("article", { name: /Simulation$/ })).toHaveLength(2);
@@ -142,7 +164,7 @@ describe("TradeCumulusWorld", () => {
     expect(onCompare).toHaveBeenCalledOnce();
   });
 
-  it("keeps Saved Views honest and unlineaged results in Lab history", async () => {
+  it("keeps Saved Views honest and moves lifecycle browsing to Activity and History", async () => {
     renderWorld();
     await screen.findByRole("heading", { name: "Trade Cumulus" });
     fireEvent.click(screen.getByRole("button", { name: "Saved Views" }));
@@ -150,12 +172,14 @@ describe("TradeCumulusWorld", () => {
       screen.getByText("Saved Views are not implemented in this increment."),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Lab" }));
-    expect(screen.getByText("Build workspace retained")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Results" }));
-    expect(screen.getByText("Results workspace retained")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Lab history (1)"));
-    expect(screen.getByText("result-unlineaged")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Activity" }));
+    expect(await screen.findByRole("heading", { name: "Current work" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+    expect(
+      await screen.findByRole("heading", { name: "Retained scientific work" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Build workspace retained")).not.toBeInTheDocument();
+    expect(screen.queryByText("Results workspace retained")).not.toBeInTheDocument();
   });
 
   it("shows a missing reference and disables reference Explore", async () => {
@@ -192,13 +216,13 @@ describe("TradeCumulusWorld", () => {
     expect(within(card).getByText("Caveated output")).toBeVisible();
   });
 
-  it("shows retry and retained Lab content when World detail fails", async () => {
+  it("shows retry without embedding unrelated global content when World detail fails", async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(error(500, "Trade Cumulus detail unavailable."))
       .mockResolvedValueOnce(ok(world));
     renderWorld();
     expect(await screen.findByRole("alert")).toHaveTextContent("Trade Cumulus detail unavailable.");
-    expect(screen.getByText("Build workspace retained")).toBeInTheDocument();
+    expect(screen.queryByText("Build workspace retained")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Retry Trade Cumulus" }));
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
     expect(await screen.findByRole("heading", { name: "Trade Cumulus" })).toBeInTheDocument();
@@ -217,9 +241,6 @@ function renderWorld(
       onExploreSimulation={overrides.onExploreSimulation ?? vi.fn()}
       onOpenFeaturedComparison={overrides.onOpenFeaturedComparison ?? vi.fn()}
       onOpenSavedComparison={vi.fn()}
-      buildContent={<div>Build workspace retained</div>}
-      resultsContent={<div>Results workspace retained</div>}
-      initialLabSection="build"
     />,
   );
 }

--- a/app/frontend/src/TradeCumulusWorld.tsx
+++ b/app/frontend/src/TradeCumulusWorld.tsx
@@ -1,5 +1,6 @@
-import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
+import { LifecycleWorkspace, type LifecycleRecord } from "./LifecycleWorkspace";
 import { SavedComparisonsCollection } from "./SavedComparisons";
 
 export type ConfigurationDifference = {
@@ -81,43 +82,30 @@ export type TradeCumulusWorldSection =
   | "saved_views"
   | "comparisons"
   | "saved_comparisons"
-  | "lab";
-export type TradeCumulusLabSection = "build" | "results";
+  | "activity"
+  | "history";
 
 export function TradeCumulusWorld({
   onBackToWorlds,
   onExploreSimulation,
   onOpenFeaturedComparison,
   onOpenSavedComparison,
-  buildContent,
-  resultsContent,
   section: controlledSection,
-  labSection: controlledLabSection,
   onSectionChange,
-  onLabSectionChange,
   onWorldDetailChange,
   initialSection = "overview",
-  initialLabSection = "results",
 }: {
   onBackToWorlds: () => void;
   onExploreSimulation: (simulation: SimulationRecord) => void;
   onOpenFeaturedComparison: (simulation?: SimulationRecord) => void;
   onOpenSavedComparison: (savedComparisonId: string) => void;
-  buildContent: ReactNode;
-  resultsContent: ReactNode;
   section?: TradeCumulusWorldSection;
-  labSection?: TradeCumulusLabSection;
   onSectionChange?: (section: TradeCumulusWorldSection) => void;
-  onLabSectionChange?: (section: TradeCumulusLabSection) => void;
   onWorldDetailChange?: (world: TradeCumulusWorldDetail | null) => void;
   initialSection?: TradeCumulusWorldSection;
-  initialLabSection?: TradeCumulusLabSection;
 }) {
   const [internalSection, setInternalSection] = useState<TradeCumulusWorldSection>(initialSection);
-  const [internalLabSection, setInternalLabSection] =
-    useState<TradeCumulusLabSection>(initialLabSection);
   const section = controlledSection ?? internalSection;
-  const labSection = controlledLabSection ?? internalLabSection;
   const [world, setWorld] = useState<TradeCumulusWorldDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -152,16 +140,6 @@ export function TradeCumulusWorld({
     onSectionChange?.(target);
   }
 
-  function changeLabSection(target: TradeCumulusLabSection) {
-    if (controlledLabSection === undefined) setInternalLabSection(target);
-    onLabSectionChange?.(target);
-  }
-
-  function openLab(target: TradeCumulusLabSection = "build") {
-    changeLabSection(target);
-    changeSection("lab");
-  }
-
   if (loading) {
     return (
       <section className="world-shell" aria-label="Trade Cumulus World">
@@ -181,20 +159,12 @@ export function TradeCumulusWorld({
           <div>
             <h2>Trade Cumulus could not be loaded</h2>
             <p role="alert">{error}</p>
-            <p>The existing Lab remains available while World data is retried.</p>
+            <p>Retry the World inventory without affecting retained work.</p>
           </div>
           <button type="button" onClick={() => void loadWorld()}>
             Retry Trade Cumulus
           </button>
         </section>
-        <LabWorkspace
-          labSection={labSection}
-          setLabSection={changeLabSection}
-          buildContent={buildContent}
-          resultsContent={resultsContent}
-          history={[]}
-          onExploreSimulation={onExploreSimulation}
-        />
       </section>
     );
   }
@@ -217,7 +187,8 @@ export function TradeCumulusWorld({
             "saved_views",
             "comparisons",
             "saved_comparisons",
-            "lab",
+            "activity",
+            "history",
           ] as TradeCumulusWorldSection[]
         ).map((item) => (
           <button
@@ -236,7 +207,7 @@ export function TradeCumulusWorld({
           world={world}
           onExploreSimulation={onExploreSimulation}
           onOpenFeaturedComparison={onOpenFeaturedComparison}
-          onOpenLab={() => openLab("build")}
+          onOpenActivity={() => changeSection("activity")}
         />
       )}
       {section === "simulations" && (
@@ -255,15 +226,23 @@ export function TradeCumulusWorld({
           <SavedComparisonsCollection worldSlug="trade-cumulus" onOpen={onOpenSavedComparison} />
         </section>
       )}
-      {section === "lab" && (
-        <LabWorkspace
-          labSection={labSection}
-          setLabSection={changeLabSection}
-          buildContent={buildContent}
-          resultsContent={resultsContent}
-          history={world.lab_history}
-          onExploreSimulation={onExploreSimulation}
-        />
+      {(section === "activity" || section === "history") && (
+        <section className="world-section">
+          <LifecycleWorkspace
+            ownerIds={["trade_cumulus"]}
+            view={section}
+            showViewTabs={false}
+            onExplore={(record) => {
+              const simulation = simulationForLifecycleRecord(world, record);
+              if (simulation) onExploreSimulation(simulation);
+            }}
+            onCompare={(record) => {
+              const simulation = simulationForLifecycleRecord(world, record);
+              if (simulation) onOpenFeaturedComparison(simulation);
+            }}
+            onOpenRunControls={() => changeSection("activity")}
+          />
+        </section>
       )}
     </section>
   );
@@ -285,12 +264,12 @@ function Overview({
   world,
   onExploreSimulation,
   onOpenFeaturedComparison,
-  onOpenLab,
+  onOpenActivity,
 }: {
   world: TradeCumulusWorldDetail;
   onExploreSimulation: (simulation: SimulationRecord) => void;
   onOpenFeaturedComparison: (simulation?: SimulationRecord) => void;
-  onOpenLab: () => void;
+  onOpenActivity: () => void;
 }) {
   const moreMoisture = world.simulations.find(
     (simulation) =>
@@ -331,18 +310,14 @@ function Overview({
         )}
       </div>
 
-      <section className="world-lab-summary" aria-label="Trade Cumulus Lab status">
+      <section className="world-lab-summary" aria-label="Trade Cumulus Activity status">
         <div>
-          <p className="eyebrow">Lab</p>
-          <h3>{world.lab_summary.summary}</h3>
-          <p>
-            {world.lab_summary.active_run_count} active ·{" "}
-            {world.lab_summary.completed_uninspected_run_count} awaiting inspection ·{" "}
-            {world.lab_summary.lab_history_count} in Lab history
-          </p>
+          <p className="eyebrow">Activity</p>
+          <h3>Current work and retained history</h3>
+          <p>Review active work, available Simulations, and their technical attempts.</p>
         </div>
-        <button type="button" onClick={onOpenLab}>
-          Open Trade Cumulus Lab
+        <button type="button" onClick={onOpenActivity}>
+          Open Activity
         </button>
       </section>
     </section>
@@ -532,69 +507,6 @@ function ComparisonCard({
   );
 }
 
-function LabWorkspace({
-  labSection,
-  setLabSection,
-  buildContent,
-  resultsContent,
-  history,
-  onExploreSimulation,
-}: {
-  labSection: TradeCumulusLabSection;
-  setLabSection: (section: TradeCumulusLabSection) => void;
-  buildContent: ReactNode;
-  resultsContent: ReactNode;
-  history: SimulationRecord[];
-  onExploreSimulation: (simulation: SimulationRecord) => void;
-}) {
-  return (
-    <section className="world-section world-lab" aria-labelledby="world-lab-title">
-      <div className="world-section-heading">
-        <div>
-          <p className="eyebrow">Trade Cumulus Lab</p>
-          <h3 id="world-lab-title">Build and inspect model runs</h3>
-        </div>
-        <nav className="lab-subnav" aria-label="Trade Cumulus Lab">
-          {(["build", "results"] as TradeCumulusLabSection[]).map((item) => (
-            <button
-              key={item}
-              type="button"
-              className={labSection === item ? "active-control" : ""}
-              onClick={() => setLabSection(item)}
-            >
-              {item === "build" ? "Build" : "Results"}
-            </button>
-          ))}
-        </nav>
-      </div>
-      {history.length > 0 && (
-        <details className="lab-history">
-          <summary>Lab history ({history.length})</summary>
-          <div className="lab-history-list">
-            {history.map((simulation) => (
-              <article key={simulation.result_id}>
-                <div>
-                  <strong>{simulation.display_name}</strong>
-                  <span>{simulation.technical_state_message}</span>
-                  <code>{simulation.result_id}</code>
-                </div>
-                <button
-                  type="button"
-                  disabled={!simulation.explore_available}
-                  onClick={() => onExploreSimulation(simulation)}
-                >
-                  Explore
-                </button>
-              </article>
-            ))}
-          </div>
-        </details>
-      )}
-      <div className="lab-content">{labSection === "build" ? buildContent : resultsContent}</div>
-    </section>
-  );
-}
-
 function validateWorldDetail(payload: unknown): TradeCumulusWorldDetail {
   if (!isRecord(payload) || !isSimulation(payload.reference_simulation)) {
     throw new Error("Trade Cumulus response does not match the required contract.");
@@ -716,8 +628,27 @@ function sectionLabel(section: TradeCumulusWorldSection): string {
     saved_views: "Saved Views",
     comparisons: "Comparisons",
     saved_comparisons: "Saved Comparisons",
-    lab: "Lab",
+    activity: "Activity",
+    history: "History",
   }[section];
+}
+
+function simulationForLifecycleRecord(
+  world: TradeCumulusWorldDetail,
+  record: LifecycleRecord,
+): SimulationRecord | null {
+  const actionResultIds = new Set(
+    record.actions
+      .map((action) => action.result_id)
+      .filter((resultId): resultId is string => Boolean(resultId)),
+  );
+  return (
+    world.simulations.find(
+      (simulation) =>
+        simulation.simulation_id === record.simulation_id ||
+        actionResultIds.has(simulation.result_id),
+    ) ?? null
+  );
 }
 
 function technicalStateLabel(state: "available" | "missing" | "conflict"): string {

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -48,7 +48,8 @@ Keep product approval separate from software availability:
 | Fun With Soundings | A separate first-class atmospheric workbench | Accessible with five jobs, direct non-World Explore, and conservative World ownership |
 | Saved Views | Durable user-curated views | Implemented across all three accessible Worlds as named live examinations with bounded restoration status |
 | Compare | Related Simulations can be compared | Ordinary Compare and durable Saved Comparisons are implemented for real pairs across all three Worlds |
-| Variation | Create a related Simulation from a World Simulation | Working Mountain Waves Lab path; no shared three-World workflow |
+| Variation | Create a related Simulation from a World Simulation | Approved variation contracts and a working Mountain Waves path; no shared three-World workflow |
+| Activity and History | Owner-aware current work and durable scientific records | One shared lifecycle projection is implemented for current World work, Fun With Soundings, and legacy/unassigned Experiments |
 | Explore | World-specific science in a shared application vocabulary | Implemented separately for all three accessible Worlds |
 | Curated Explore defaults | Authored Simulation and Field/Lens starting states with complete reset and visible fallback | Implemented across all three accessible Worlds as the fallback below explicit Saved Views and last-active state |
 
@@ -62,9 +63,10 @@ identical.
 
 Fun With Soundings is an approved first-class workbench, not a Cloud World.
 Issue #395 implemented its stable entrance, Find Soundings, Candidates, Build &
-Run, Runs, Explore, atmosphere continuity, and Past Experiments ownership
-boundary. Runs remain technical execution; retained non-World work remains an
-Experiment; only current inventory-verified World objects are Simulations.
+Run, Explore, and atmosphere continuity. Issue #394 replaces its separate Runs
+and Past Experiments lifecycle representations with shared Activity and
+History. Runs remain technical execution; retained non-World work remains an
+Experiment; only current contract-verified World objects are Simulations.
 
 The Trade Cumulus Product Slice remains subordinate to the North Star, Product
 Vision, approved PM decisions, Application Semantics, and the MVP. Being
@@ -93,16 +95,13 @@ named Saved Views across all three Worlds. Issue #433 completes ordinary
 World-aware Compare, including a real controlled Supercells pair. Issue #434
 adds immutable World-owned Saved Comparisons that reopen directly as live dual
 examinations, preserve missing dependencies, and record bounded restoration
-status.
+status. Issue #435 approves the Cloud World variation contracts. Issue #394
+completes the owner-aware Activity and History lifecycle foundation.
 
-Rewritten issue #394 and issues #433 through #437 record bounded
-follow-on product work for Activity and History, Compare and Saved Comparisons, variation
-contracts, and retained assets. Their presence does not
-activate them or replace the sequencing authority. Issues #389, #390, and #391
-were closed as superseded and are not current assignment authority.
-
-Issue #394 remains queued and incomplete; its dependencies and explicit PM
-activation still govern any Activity and History reconciliation.
+The next approved sequence is #436, #447, #448, and #449. Their current issue
+bodies and latest explicit PM comments control exact scope when activated.
+Issues #389, #390, and #391 were closed as superseded and are not current
+assignment authority.
 
 Keep detailed ordering in Current Product Sequence and explicit later PM
 decisions rather than duplicating a second roadmap here.
@@ -130,8 +129,8 @@ These documents describe current software and operations. They may identify
 transitional behavior and implementation limits; they do not establish product
 direction.
 
-The current embedding of legacy Build and Results under Trade Cumulus does not
-override the approved World Lab or Fun With Soundings concepts.
+The shared Activity and History implementation replaces the former embedding
+of unrelated Build, Results, and Notebook content under Trade Cumulus.
 
 Do not update Current State or Current Architecture to describe an approved
 future capability before its implementation merges. Update them when the

--- a/docs/current/CURRENT_ARCHITECTURE.md
+++ b/docs/current/CURRENT_ARCHITECTURE.md
@@ -68,9 +68,9 @@ Fun With Soundings uses stable frontend routes:
 
 Its five jobs compose existing sounding catalog, candidate screening, package,
 run, worker, ingest, storage, and visualization APIs rather than duplicating
-those execution paths. Trade Cumulus Lab still embeds some transitional Build
-and Results surfaces; that compatibility is not the intended final World Lab
-navigation model.
+those execution paths. Fun With Soundings and current World surfaces consume a
+shared lifecycle projection rather than embedding separate Results or Notebook
+models.
 
 ## World and Simulation Identity
 
@@ -102,6 +102,43 @@ World responses are kept lightweight. Deep validation is performed at
 promotion or discovery boundaries and cached against artifact fingerprints
 where implemented, rather than reopening every history during ordinary World
 polling.
+
+## Lifecycle Projection
+
+`app/backend/cloud_chamber/lifecycle.py` owns one bounded read-only projection
+over current runtime evidence:
+
+```text
+World inventory + run manifests + queue snapshot + Results + storage
+  + Saved View / Saved Comparison dependencies
+                           |
+                           v
+                    GET /api/lifecycle
+                           |
+                           v
+          owner-scoped Activity and History surfaces
+```
+
+Each record identifies a World Simulation or non-World Experiment and retains
+all known technical attempts beneath it. Attempt relationships include initial,
+unchanged retry, checkpoint restart, alternate observation attempt, extension,
+and later backing candidate.
+
+The projection does not use one status as a substitute for package, queue,
+process, output, integrity, ingest, inspectability, availability, parent
+eligibility, and retained-asset facts. It is reconstructed from backend and
+runtime state on reload; React state is not authoritative.
+
+Known built-in Simulations use exact current World and run identities. Dynamic
+World assignment currently requires the approved Mountain Waves variation
+contract evidence. Other records are classified from verified
+observed-sounding or Result evidence, with ambiguous historical World claims
+failing closed as legacy or unassigned Experiments.
+
+`app/frontend/src/LifecycleWorkspace.tsx` renders the same projection as
+actionable Activity groups or durable searchable History. World surfaces scope
+the component to their owner. Fun With Soundings scopes it to Soundings and
+legacy/unassigned Experiments.
 
 ## Explore Architecture
 
@@ -326,6 +363,7 @@ The current code keeps these states distinct:
 | Editable result sidecar | Optional local name, tag, or note state exists |
 | Backend-derived diagnostic | A quantity was calculated from CM1-derived data |
 | Visualization interpretation | A bounded browser payload or Lens represents available evidence |
+| Lifecycle projection | A read-only owner-aware view of the distinct facts above |
 
 Process success, output existence, promotion, ingest, integrity, and browser
 visibility are separate facts.
@@ -353,15 +391,15 @@ metadata, and notebook state together.
 The product language follows the same state boundary: **Run** refers to
 technical execution, **Experiment** refers to non-World scientific work, and
 **Simulation** refers to a stable World-owned object verified by current World
-inventory. The storage inventory exposes bounded manifest input-source evidence
-so the Soundings Runs job can separate workbench execution from
-World-associated or legacy/unassigned technical work after reload.
+inventory. The storage inventory exposes bounded manifest input-source and
+lifecycle evidence so Activity and History can separate workbench execution
+from World-associated or legacy/unassigned technical work after reload.
 
 See [Ingest, Results, and Runtime Cleanup Lifecycle](INGEST_RESULTS_STORAGE_LIFECYCLE.md).
 
 ## Persistence and Asset Boundaries
 
-The runtime home defaults to `~/CloudChamber` and stores:
+The configured runtime home stores:
 
 - settings and CM1 discovery;
 - generated packages and manifests;

--- a/docs/current/CURRENT_STATE.md
+++ b/docs/current/CURRENT_STATE.md
@@ -43,7 +43,7 @@ non-World Explore route at `/fun-with-soundings/explore/{result_id}`.
 The workbench organizes the existing observed-atmosphere path into five jobs:
 
 ```text
-Find Soundings → Candidates → Build & Run → Runs → Explore
+Find Soundings → Candidates → Build & Run → Activity & History → Explore
 ```
 
 Atmosphere selection remains visible across Find, Candidates, and Build & Run.
@@ -59,23 +59,50 @@ The workbench preserves explicit lifecycle language:
 - ambiguous, stale, or unavailable ownership evidence remains visibly legacy
   or unassigned.
 
-The Runs job shows Soundings execution without claiming other use of the shared
-CM1 runner as workbench-owned. Past Experiments supports Soundings,
-legacy/unassigned, and verified World ownership views. A verified Simulation
-opens in its World; other retained Experiments open directly in non-World
-Explore.
+Activity & History shows Soundings work together with broad legacy and
+genuinely unassigned Experiments without claiming every use of the shared CM1
+runner as workbench-owned. A verified Simulation opens in its World; other
+retained Experiments open directly in non-World Explore.
 
 ## Accessible Cloud Worlds
 
 | World | Current content | Current surfaces | Current limitation |
 | --- | --- | --- | --- |
-| **Trade Cumulus** | Canonical BOMEX Baseline and More Moisture retained Simulations | Overview, Simulations, featured and ordinary Compare, Saved Comparisons, Lab, Explore resume, and Saved Views | Lab still embeds transitional Build and Results |
-| **Mountain Waves** | Dry Ridge and Boulder Windstorm retained Simulations | Overview, Simulations, ordinary Compare, Saved Comparisons, variation Lab, Explore resume, and Saved Views | Variation remains World-specific |
-| **Supercells** | Quarter-Circle and Straight-Line Hodograph retained Simulations | Overview, Simulations, ordinary Compare, Saved Comparisons, Explore resume, and Saved Views | No variation Lab |
+| **Trade Cumulus** | Canonical BOMEX Baseline and More Moisture retained Simulations | Overview, Simulations, Activity, History, featured and ordinary Compare, Saved Comparisons, Explore resume, and Saved Views | Shared variation creation is not implemented |
+| **Mountain Waves** | Dry Ridge and Boulder Windstorm retained Simulations | Overview, Simulations, Activity, History, ordinary Compare, Saved Comparisons, World-specific Create Variation, Explore resume, and Saved Views | Variation creation remains World-specific |
+| **Supercells** | Quarter-Circle and Straight-Line Hodograph retained Simulations | Overview, Simulations, ordinary Compare, Saved Comparisons, Explore resume, and Saved Views | No create-variation workflow |
 
 The World Overview and Simulations surfaces use stable content identities and
 explicit availability states. Missing, invalid, or conflicting retained
 content fails closed instead of silently substituting a different run.
+
+## Activity And History
+
+Cloud Chamber exposes one typed owner-aware lifecycle projection through
+`GET /api/lifecycle`. It adapts current World inventory, retained manifests,
+queue state, Results, storage facts, and Saved View or Saved Comparison
+dependencies without rewriting historical artifacts.
+
+The projection keeps these facts separate:
+
+- intended scientific work and stable Simulation or Experiment identity;
+- package and technical attempt existence;
+- queued, running, completed, failed, or cancelled process state;
+- expected output and ingest state;
+- technical integrity and World inspectability;
+- Simulation availability and parent eligibility;
+- retained, missing, invalid, or conflicted assets.
+
+Activity groups current actionable work. History preserves all known records
+and attempt relationships with text search, practical filters, and sort.
+Technical identifiers, differences, caveats, dependencies, and attempt evidence
+remain available on demand.
+
+Current approved-contract Mountain Waves variations can be assigned to their
+World when their current contract evidence is present. A World name or
+Simulation string by itself does not establish ownership. Sounding-related
+work remains under Fun With Soundings, while ambiguous records remain visibly
+legacy or unassigned.
 
 ## Explore Experiences
 
@@ -282,9 +309,9 @@ not final:
 - trusted-LAN execution for supported paths;
 - runtime-integrity and field-quality handling.
 
-Some of this infrastructure appears inside the current Trade Cumulus Lab.
-That transitional placement does not make Build or Results the final World Lab
-information architecture.
+Global Build and Result infrastructure remains available outside the World
+surfaces. Trade Cumulus no longer embeds unrelated Build, Results, or Experiment
+Notebook content as its lifecycle model.
 
 ## Current Gaps
 
@@ -314,10 +341,10 @@ React / TypeScript / Vite frontend
 -> browser inspection
 ```
 
-Runtime assets default to `~/CloudChamber`. The application depends on those
-local assets for retained Simulations and generated Experiments. Deleting a run
-can remove the corresponding output and result sidecars; the repository is not
-a durable store for those artifacts.
+Runtime assets live under the configured runtime home. The application depends
+on those local assets for retained Simulations and generated Experiments.
+Deleting a run can remove the corresponding output and result sidecars; the
+repository is not a durable store for those artifacts.
 
 ## Interpretation Rules
 

--- a/docs/current/CURRENT_STATE.md
+++ b/docs/current/CURRENT_STATE.md
@@ -70,7 +70,7 @@ retained Experiments open directly in non-World Explore.
 | --- | --- | --- | --- |
 | **Trade Cumulus** | Canonical BOMEX Baseline and More Moisture retained Simulations | Overview, Simulations, Activity, History, featured and ordinary Compare, Saved Comparisons, Explore resume, and Saved Views | Shared variation creation is not implemented |
 | **Mountain Waves** | Dry Ridge and Boulder Windstorm retained Simulations | Overview, Simulations, Activity, History, ordinary Compare, Saved Comparisons, World-specific Create Variation, Explore resume, and Saved Views | Variation creation remains World-specific |
-| **Supercells** | Quarter-Circle and Straight-Line Hodograph retained Simulations | Overview, Simulations, ordinary Compare, Saved Comparisons, Explore resume, and Saved Views | No create-variation workflow |
+| **Supercells** | Quarter-Circle and Straight-Line Hodograph retained Simulations | Overview, Simulations, Activity, History, ordinary Compare, Saved Comparisons, Explore resume, and Saved Views | No create-variation workflow |
 
 The World Overview and Simulations surfaces use stable content identities and
 explicit availability states. Missing, invalid, or conflicting retained

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -95,6 +95,12 @@ The presentation-quality and third-World program established:
 
 #434 — durable World-owned Saved Comparisons that reopen as live dual
        examinations — complete
+
+#435 — approved Cloud World variation contracts and variation-program
+       sequencing — complete
+
+#394 — one owner-aware Activity and History model across current Worlds and
+       Fun With Soundings — complete
 ```
 
 The completed work preserves stable World and Simulation identities while allowing backing run assets to improve.
@@ -123,12 +129,12 @@ current Field or Lens without changing Simulation, erasing Notes, or starting
 playback. A visible technical fallback remains distinct from an authored
 scientific presentation.
 
-## Completed program: personal scientific memory
+## Completed program: personal scientific memory and lifecycle
 
-Issue #432 establishes one versioned, World-aware Explore-state contract before
-ordinary Compare. Issue #394 remains queued and incomplete; it still depends on
-#435 and explicit PM activation. Completing #395 satisfies only the Fun With
-Soundings dependency named by #394.
+Issues #432, #433, and #434 establish durable Explore state, ordinary Compare,
+and Saved Comparisons. Issue #435 approves the Cloud World variation contracts.
+Issue #394 then reconciles lifecycle browsing before the shared variation
+envelope is implemented.
 
 The implemented contract represents, as applicable:
 
@@ -174,6 +180,13 @@ reopen as live examinations, support rename and delete, preserve records when
 backing output is unavailable, and report healthy, partially restorable, or
 unavailable restoration. Notes remain separate.
 
+Activity and History now consume one owner-aware lifecycle projection over
+World inventory, run manifests, the queue, Results, runtime storage, and saved
+state dependencies. Activity shows current actionable work. History preserves
+the durable record and all known technical attempts. World ownership fails
+closed, and approved-contract output can become automatically available without
+a separate promotion ceremony.
+
 ## Completed program: World-aware Compare and Saved Comparisons
 
 Issue #433 establishes ordinary Compare across the three accessible Worlds.
@@ -213,41 +226,41 @@ hodograph curvature while retaining the other presentation-run contract.
 Coordinates and local evidence are comparable; storm objects are not assigned
 cross-Simulation lineage.
 
-## Variations require a fresh review
+## Current implementation sequence
 
-Do **not** execute the older general variation roadmap or copy current Trade Cumulus and Mountain Waves controls into Supercells without reconsideration.
+The approved sequence is:
 
-Review the variation model against the actual three-World product after Saved Views and ordinary Compare establish the required state and lineage contracts.
+```text
+#394 — shared Activity and History — complete
+#436 — shared variation envelope — next
+#447
+#448
+#449
+```
 
-Decide, World by World:
+Issue #435 is complete and
+`docs/product/CLOUD_WORLD_VARIATION_CONTRACTS.md` now controls the bounded
+variation-contract decisions. Issue #436 is the next queued major increment.
+The current bodies and latest explicit PM comments for #436, #447, #448, and
+#449 control their exact scope when activated.
 
-- which Simulations are eligible parents;
-- which physical and numerical settings are worth exposing;
-- which settings require profiles, grouped controls, or advanced disclosure;
-- appropriate default duration, grid, and output cadence for ordinary experiments;
-- how runtime and retained-storage cost are estimated and communicated;
-- which differences are required for lineage and Compare;
-- what makes a completed Result eligible to become a named Simulation;
-- which controls are genuinely shared and which are World-specific;
-- whether one shared variation shell with World-specific contracts is preferable;
-- what Supercells variations should initially permit.
+Do not copy current Trade Cumulus or Mountain Waves controls into another World
+without its approved contract. The user may change several supported settings
+in one variation. Do not reduce the experience to one-variable wizards or imply
+one-factor causation when several values changed.
 
-The user may change several supported settings in one variation. Do not reduce the experience to one-variable wizards or imply one-factor causation when several values changed.
-
-Existing issues #389, #390, and #391 are prior bounded plans. They must be updated or replaced before assignment; their older bodies are not current implementation authority.
+Existing issues #389, #390, and #391 are superseded and are not current
+implementation authority.
 
 ## Later durability and acceptance work
 
-After Saved Views, Compare, and refreshed variation direction are established, revisit:
+After the explicit sequence above, PM may choose bounded work such as:
 
-- Saved Comparison notes and explanations;
-- Activity and History consistency across Worlds;
-- the Result-to-Simulation promotion lifecycle;
-- protected built-in and user-created retained assets;
-- visible storage cost and dependency-aware deletion;
+- destructive cleanup;
+- protection editing;
+- backing selection;
 - repair or reimport of missing retained assets;
-- version migration for durable state;
-- measured performance and personal acceptance on the target machine.
+- personal acceptance.
 
 Do not create the entire follow-on backlog in advance. Create or rewrite the next bounded issue when preceding implementation and PM review provide the necessary evidence.
 


### PR DESCRIPTION
# Reconcile Activity and History

Closes #394.

## Summary

- add one typed, owner-aware lifecycle projection and `GET /api/lifecycle` over current World inventory, queue state, retained manifests, Results, and Saved View/Saved Comparison dependencies
- present the projection through shared Activity and History surfaces in Trade Cumulus, Mountain Waves, Supercells, and Fun With Soundings while retaining technical execution controls on demand
- keep package, attempt, queue, process, output, integrity, ingest, inspectability, availability, parent eligibility, and retained-asset facts distinct
- preserve all six attempt relationships and fail closed when current World ownership cannot be verified
- retire the unrelated Build, Results, Notebook, and stale Lab summaries embedded in Trade Cumulus and the duplicate Mountain Waves lifecycle representation
- update Current Product Sequence, Current State, Current Architecture, and Documentation Status for completed #435/#394 and the explicit #436, #447, #448, #449 sequence

## Preserved-data review

- the configured runtime home resolves to `/Volumes/ExternalHDD/CloudChamber`
- eight retained `run_manifest.json` files are present there, with the same eight retained in `/Users/timpeterson/CloudChamber.internal-backup`
- current inventory projects six available built-in World Simulations and two older Supercell technical runs as legacy/unassigned Experiments
- the prior Broader Boulder Ridge variation and prior Soundings archive are not present in either retained inventory after cleanup that predated the external-drive move; the projection does not recreate, rewrite, or guess those missing records
- the live lifecycle endpoint returned eight records with no projection warnings; a measured request returned HTTP 200, 21,970 serialized bytes, and 0.760 seconds

## Verification

- `scripts/check.sh`
  - 255 frontend tests
  - production build
  - frontend lint
  - backend format, lint, and type checks
  - 736 backend tests
  - script, artifact, and documentation checks
- `npm --prefix app/frontend run test:e2e:smoke`
  - 32 Chromium tests
- `git diff --check`
- live browser review at 1440 x 900 and 1024 x 856 for Trade Cumulus, Mountain Waves, and Fun With Soundings Activity/History plus the affected World overview surfaces
- local review screenshots: `.artifacts/issue-394/` (not committed)
- confirmed no CM1 process ran

## Review posture

This is a draft PR for manual PM/UX review. Auto-merge is not enabled.

Navigation parity for Saved Views and ordinary Comparisons across all four owners is tracked separately in #451.
